### PR TITLE
fix(app): restore node-pty spawn-helper exec bit and surface terminal spawn failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.5",
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
-    "postinstall": "node scripts/electron.cjs --install-only",
+    "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",
     "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/workspace-test.sh",
     "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
     "test:low-resource": "pnpm run test",

--- a/packages/app/e2e/embedded-terminal-spawn-failure.spec.ts
+++ b/packages/app/e2e/embedded-terminal-spawn-failure.spec.ts
@@ -1,0 +1,75 @@
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+import {
+  E2E_REPO_URL,
+  expect,
+  injectTaskStates,
+  loadPlan,
+  test,
+} from './fixtures/electron-app.js';
+
+const SPAWN_FAIL_PLAN = {
+  name: 'Embedded PTY Spawn Failure',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'spawn-fail',
+      description: 'Completed task whose terminal backend cannot spawn',
+      command: 'echo unused',
+      dependencies: [],
+    },
+  ],
+};
+
+test.describe('Embedded terminal spawn failure', () => {
+  // Inject the synchronous spawn throw node-pty produces when its
+  // spawn-helper binary loses its exec bit (how node-pty@1.1.0 ships).
+  test.use({ breakTerminalSpawn: true });
+
+  test('a terminal spawn failure surfaces a visible error instead of a blank terminal', async ({ page, testDir }) => {
+    const dialogs: string[] = [];
+    page.on('dialog', (dialog) => {
+      dialogs.push(dialog.message());
+      dialog.dismiss().catch(() => {});
+    });
+
+    await loadPlan(page, SPAWN_FAIL_PLAN);
+    const workspacePath = path.join(testDir, 'spawn-fail-workspace');
+    mkdirSync(workspacePath, { recursive: true });
+
+    await injectTaskStates(page, [
+      {
+        taskId: 'spawn-fail',
+        changes: {
+          status: 'completed',
+          config: { runnerKind: 'worktree' },
+          execution: {
+            workspacePath,
+            completedAt: new Date('2025-01-01T00:00:00.000Z'),
+          },
+        },
+      },
+    ]);
+
+    const taskNode = page
+      .getByTestId('selected-workflow-mini-dag')
+      .locator('.react-flow__node[data-testid$="spawn-fail"]')
+      .first();
+    const box = await taskNode.boundingBox();
+    if (!box) throw new Error('spawn-fail task node has no bounding box');
+    await taskNode.locator('> div').dispatchEvent('dblclick', {
+      bubbles: true,
+      cancelable: true,
+      clientX: box.x + box.width / 2,
+      clientY: box.y + box.height / 2,
+    });
+
+    // The spawn failure must surface as a visible alert, not a silently
+    // rejected IPC promise that leaves the terminal drawer blank.
+    await expect.poll(() => dialogs.length, { timeout: 10000 }).toBeGreaterThan(0);
+    expect(dialogs[0]).toContain('Failed to start terminal session');
+    expect(dialogs[0]).toContain('posix_spawnp failed');
+    await expect(page.getByTestId('terminal-session-command')).toHaveCount(0);
+  });
+});

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -19,6 +19,8 @@ import { stringify as yamlStringify } from 'yaml';
 export type ElectronFixtures = {
   electronApp: ElectronApplication;
   guiOwnerMode: string;
+  /** When true, the app's embedded terminal backend throws on spawn (fault injection). */
+  breakTerminalSpawn: boolean;
   page: Page;
   testDir: string;
 };
@@ -45,6 +47,7 @@ async function removeTestDir(dir: string): Promise<void> {
 
 export const test = base.extend<ElectronFixtures>({
   guiOwnerMode: [process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui', { option: true }],
+  breakTerminalSpawn: [false, { option: true }],
 
   testDir: async ({}, use) => {
     const dir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-'));
@@ -54,7 +57,7 @@ export const test = base.extend<ElectronFixtures>({
     }
   },
 
-  electronApp: async ({ guiOwnerMode, testDir }, use) => {
+  electronApp: async ({ guiOwnerMode, breakTerminalSpawn, testDir }, use) => {
     // Dummy `claude` on PATH + fix command — same as scripts/e2e-dry-run (no real CLI).
     const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
     const stubDir = path.join(testDir, 'claude-stub');
@@ -127,6 +130,7 @@ exit 64
         INVOKER_TEST_FIXED_NOW: '2025-01-01T00:00:00.000Z',
         INVOKER_CLAUDE_COMMAND: claudeMarker,
         INVOKER_CLAUDE_FIX_COMMAND: claudeMarker,
+        ...(breakTerminalSpawn ? { INVOKER_E2E_BREAK_TERMINAL_SPAWN: '1' } : {}),
         PATH: pathEnv,
       },
     });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1758,6 +1758,17 @@ if (isHeadless) {
 function createEmbeddedTerminalBackendFromConfig(
   backend: EmbeddedTerminalBackendConfig,
 ): EmbeddedTerminalBackend {
+  // E2E fault injection: reproduce node-pty's synchronous spawn throw (e.g.
+  // a spawn-helper binary without its exec bit) without mutating the shared
+  // node_modules that parallel tests rely on.
+  if (process.env.INVOKER_E2E_BREAK_TERMINAL_SPAWN === '1') {
+    return {
+      name: 'pty',
+      spawn() {
+        throw new Error('posix_spawnp failed. (injected by INVOKER_E2E_BREAK_TERMINAL_SPAWN)');
+      },
+    };
+  }
   if (backend === 'bash') return createBashTerminalBackend();
   return createPtyTerminalBackend();
 }
@@ -4586,13 +4597,22 @@ function createEmbeddedTerminalBackendFromConfig(
       if (!resolved.ok) {
         return { opened: false, reason: resolved.reason };
       }
-      const session = embeddedTerminalManager.openOrReuse({
-        taskId,
-        spec: resolved.spec,
-        cwd: resolved.cwd,
-        attach: liveHandle ? { handle: liveHandle.handle, executor: liveHandle.executor } : undefined,
-      });
-      return { opened: true, session };
+      try {
+        const session = embeddedTerminalManager.openOrReuse({
+          taskId,
+          spec: resolved.spec,
+          cwd: resolved.cwd,
+          attach: liveHandle ? { handle: liveHandle.handle, executor: liveHandle.executor } : undefined,
+        });
+        return { opened: true, session };
+      } catch (err) {
+        // A backend spawn failure (e.g. node-pty's spawn-helper missing its
+        // exec bit) must surface as a visible refusal, not a rejected IPC
+        // promise the renderer drops silently.
+        const reason = err instanceof Error ? err.message : String(err);
+        logger.warn(`terminal session spawn failed for task="${taskId}": ${reason}`, { module: 'open-terminal' });
+        return { opened: false, reason: `Failed to start terminal session: ${reason}` };
+      }
     });
 
     ipcMain.handle('invoker:terminal-list', async () => {

--- a/scripts/fix-node-pty-spawn-helper.mjs
+++ b/scripts/fix-node-pty-spawn-helper.mjs
@@ -1,0 +1,45 @@
+//@ts-check
+// node-pty@1.1.0 publishes its prebuilt `spawn-helper` binaries without the
+// executable bit (the npm tarball entry is mode 0644), so every fresh
+// `pnpm install` materializes a helper that posix_spawnp cannot exec. The
+// embedded terminal then fails to spawn any session. Re-apply the bit after
+// install. See https://github.com/microsoft/node-pty for the upstream package.
+//
+// Usage: node scripts/fix-node-pty-spawn-helper.mjs [rootDir]
+
+import { globSync, chmodSync, statSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+if (process.platform === 'win32') {
+  process.exit(0);
+}
+
+const root = path.resolve(process.argv[2] ?? process.cwd());
+const patterns = [
+  'node_modules/.pnpm/node-pty@*/node_modules/node-pty/prebuilds/*/spawn-helper',
+  'node_modules/node-pty/prebuilds/*/spawn-helper',
+  'node_modules/.pnpm/node-pty@*/node_modules/node-pty/build/Release/spawn-helper',
+  'node_modules/node-pty/build/Release/spawn-helper',
+];
+
+let fixed = 0;
+for (const pattern of patterns) {
+  for (const file of globSync(pattern, { cwd: root })) {
+    const target = path.join(root, file);
+    try {
+      const mode = statSync(target).mode;
+      if ((mode & 0o111) === 0o111) continue;
+      chmodSync(target, mode | 0o111);
+      fixed += 1;
+      console.log(`[fix-node-pty] restored exec permission: ${file}`);
+    } catch (err) {
+      // A missed chmod degrades embedded terminals but must not fail install.
+      console.warn(`[fix-node-pty] could not fix ${file}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+}
+
+if (fixed === 0) {
+  console.log('[fix-node-pty] spawn-helper permissions already correct (or node-pty absent)');
+}

--- a/scripts/repro/repro-blank-terminal-on-noexec-spawn-helper.sh
+++ b/scripts/repro/repro-blank-terminal-on-noexec-spawn-helper.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Reproduces the "blank terminal" bug: when node-pty's prebuilt spawn-helper
+# loses its exec bit (which is how node-pty@1.1.0 ships in its npm tarball),
+# double-clicking a task in the GUI opened no terminal session and showed no
+# error — the spawn failure rejected the IPC promise and the renderer dropped
+# it silently.
+#
+# This script strips the exec bit from the repo's spawn-helper (restoring it
+# on exit), launches the real Electron app via the Playwright e2e harness,
+# double-clicks a completed task node in the DAG, and then requires that ONE
+# of the two acceptable outcomes happened:
+#   - a terminal session actually opened, or
+#   - a visible error alert was shown.
+#
+# Exit 1 ("BUG REPRODUCED") means neither happened: the blank terminal.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SPEC_FILE="$ROOT_DIR/packages/app/e2e/tmp-repro-blank-terminal.spec.ts"
+
+PLATFORM_ARCH="$(node -p 'process.platform + "-" + process.arch')"
+HELPERS=()
+while IFS= read -r helper; do
+  HELPERS+=("$helper")
+done < <(find "$ROOT_DIR/node_modules/.pnpm" -path "*node-pty*/prebuilds/$PLATFORM_ARCH/spawn-helper" 2>/dev/null)
+
+if [ "${#HELPERS[@]}" -eq 0 ]; then
+  echo "No node-pty spawn-helper found under $ROOT_DIR/node_modules — run pnpm install first." >&2
+  exit 2
+fi
+
+cleanup() {
+  local ec=$?
+  rm -f "$SPEC_FILE"
+  for helper in "${HELPERS[@]}"; do
+    chmod +x "$helper" || true
+  done
+  return "$ec"
+}
+trap cleanup EXIT
+
+echo "Stripping exec bit from:"
+for helper in "${HELPERS[@]}"; do
+  echo "  $helper"
+  chmod a-x "$helper"
+done
+
+cat > "$SPEC_FILE" <<'TS'
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+import {
+  E2E_REPO_URL,
+  expect,
+  injectTaskStates,
+  loadPlan,
+  test,
+} from './fixtures/electron-app.js';
+
+const PLAN = {
+  name: 'Blank Terminal Repro',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'shell-task',
+      description: 'Completed task whose terminal restores a plain shell',
+      command: 'echo unused',
+      dependencies: [],
+    },
+  ],
+};
+
+test('double-clicking a task opens a terminal session or shows a visible error', async ({ page, testDir }) => {
+  const dialogs: string[] = [];
+  page.on('dialog', (dialog) => {
+    dialogs.push(dialog.message());
+    dialog.dismiss().catch(() => {});
+  });
+
+  await loadPlan(page, PLAN);
+  const workspacePath = path.join(testDir, 'shell-task-workspace');
+  mkdirSync(workspacePath, { recursive: true });
+
+  await injectTaskStates(page, [
+    {
+      taskId: 'shell-task',
+      changes: {
+        status: 'completed',
+        config: { runnerKind: 'worktree' },
+        execution: {
+          workspacePath,
+          completedAt: new Date('2025-01-01T00:00:00.000Z'),
+        },
+      },
+    },
+  ]);
+
+  const taskNode = page
+    .getByTestId('selected-workflow-mini-dag')
+    .locator('.react-flow__node[data-testid$="shell-task"]')
+    .first();
+  const box = await taskNode.boundingBox();
+  if (!box) throw new Error('shell-task node has no bounding box');
+  await taskNode.locator('> div').dispatchEvent('dblclick', {
+    bubbles: true,
+    cancelable: true,
+    clientX: box.x + box.width / 2,
+    clientY: box.y + box.height / 2,
+  });
+
+  // Give the renderer time to either open a session tab or alert.
+  const deadline = Date.now() + 10000;
+  let sessionOpened = false;
+  while (Date.now() < deadline) {
+    sessionOpened = await page
+      .getByTestId('terminal-session-command')
+      .first()
+      .isVisible()
+      .catch(() => false);
+    if (sessionOpened || dialogs.length > 0) break;
+    await page.waitForTimeout(250);
+  }
+
+  const drawerVisible = await page
+    .getByTestId('terminal-drawer-body')
+    .isVisible()
+    .catch(() => false);
+  console.log(
+    `[repro] sessionOpened=${sessionOpened} alerts=${JSON.stringify(dialogs)} drawerVisible=${drawerVisible}`,
+  );
+
+  expect(
+    sessionOpened || dialogs.length > 0,
+    'Double-click produced neither a terminal session nor a visible error — blank terminal.',
+  ).toBeTruthy();
+});
+TS
+
+echo
+echo "Building UI and app..."
+(cd "$ROOT_DIR" && pnpm --filter @invoker/ui build >/dev/null && pnpm --filter @invoker/app build >/dev/null)
+
+echo "Running GUI repro (real Electron app, real double-click)..."
+set +e
+(cd "$ROOT_DIR/packages/app" && pnpm run test:e2e e2e/tmp-repro-blank-terminal.spec.ts)
+ec=$?
+set -e
+
+echo
+if [ "$ec" -ne 0 ]; then
+  echo "BUG REPRODUCED: double-click opened no terminal session and showed no error (blank terminal)."
+  exit 1
+fi
+echo "No blank terminal: double-click surfaced a terminal session or a visible error alert."


### PR DESCRIPTION
## Summary

Double-clicking a task or review gate could open no terminal and show no error. The app looked dead.

node-pty publishes its `spawn-helper` binary without run permission, so every fresh `pnpm install` produces a helper the OS refuses to execute, breaking all embedded terminal spawns.

When the spawn failed, the `invoker:open-terminal` handler rejected the IPC call. The renderer drops rejections silently, so nothing appeared.

A postinstall step now restores the permission after every install. The handler catches spawn failures and returns a refusal the UI shows as a normal alert.

## Test Plan

- [x] `cd packages/app && pnpm run test:e2e e2e/embedded-terminal-spawn-failure.spec.ts` — new UI regression test: with spawn failure injected (`INVOKER_E2E_BREAK_TERMINAL_SPAWN=1`), double-clicking a task node must show the error alert and create no session tab. Fails (silent blank drawer) when the handler rethrows; passes with this fix
- [x] `cd packages/app && pnpm run test:e2e e2e/embedded-terminal-pty.spec.ts` — existing terminal e2e still passes with the fixture change

- [x] `bash scripts/repro/repro-blank-terminal-on-noexec-spawn-helper.sh` — strips the exec bit, launches the real Electron app, double-clicks a task node. On master it fails with "BUG REPRODUCED" (no session, no error); with this PR it passes via the alert "Failed to start terminal session: posix_spawnp failed."
- [x] `node scripts/fix-node-pty-spawn-helper.mjs /tmp/pty-fixture` — fixture with mode-0644 helpers in both pnpm and hoisted layouts gets the exec bit restored; a second run is a no-op
- [x] `pnpm install --frozen-lockfile && ls -l node_modules/.pnpm/node-pty@1.1.0/node_modules/node-pty/prebuilds/darwin-arm64/spawn-helper` — mode is `-rwxr-xr-x` after a fresh install
- [x] `cd packages/app && pnpm test` — 78 files, 1091 tests pass

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: embedded terminals silently fail again after any fresh install on macOS/Linux until `spawn-helper` is chmodded by hand
- Data migration? No

🤖 Generated with [Claude Code](https://claude.com/claude-code)
