### PR TITLE
[State Invariants](1) Add task reset rulebook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,6 +290,8 @@ jobs:
             command: bash scripts/test-suites/required/19-task-new-attempt-reset-repro.sh
           - name: Launch Dispatch Queue Repro
             command: bash scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh
+          - name: Reset Rulebook Repro
+            command: bash scripts/test-suites/required/26-reset-rulebook-proof.sh
 
     name: required-fast / ${{ matrix.name }}
 

--- a/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import type { TaskExecution } from '@invoker/workflow-graph';
+import {
+  TASK_EXECUTION_RESET_RULES,
+  buildTaskResetChanges,
+  buildTaskResetExecutionPatch,
+} from '../task-reset-policy.js';
+
+const _compileTimeCoversEveryExecutionField: Record<keyof TaskExecution, unknown> = TASK_EXECUTION_RESET_RULES;
+void _compileTimeCoversEveryExecutionField;
+
+const expectedExecutionFields = [
+  'generation',
+  'blockedBy',
+  'inputPrompt',
+  'exitCode',
+  'error',
+  'protocolErrorCode',
+  'protocolErrorMessage',
+  'startedAt',
+  'completedAt',
+  'lastHeartbeatAt',
+  'remoteHeartbeatAt',
+  'heartbeatSource',
+  'actionRequestId',
+  'branch',
+  'commit',
+  'fixedIntegrationSha',
+  'fixedIntegrationRecordedAt',
+  'fixedIntegrationSource',
+  'agentSessionId',
+  'lastAgentSessionId',
+  'agentName',
+  'lastAgentName',
+  'workspacePath',
+  'containerId',
+  'experiments',
+  'selectedExperiment',
+  'selectedExperiments',
+  'experimentResults',
+  'pendingFixError',
+  'isFixingWithAI',
+  'reviewUrl',
+  'reviewId',
+  'reviewStatus',
+  'reviewProviderId',
+  'reviewGate',
+  'phase',
+  'launchStartedAt',
+  'launchCompletedAt',
+  'mergeConflict',
+  'selectedAttemptId',
+  'autoFixAttempts',
+].sort();
+
+describe('task reset policy', () => {
+  it('has a rule for every TaskExecution field', () => {
+    expect(Object.keys(TASK_EXECUTION_RESET_RULES).sort()).toEqual(expectedExecutionFields);
+  });
+
+  it('keeps recreate as a fresh-lineage reset without clearing fix-only fields', () => {
+    const patch = buildTaskResetChanges('recreate', { config: { summary: undefined } });
+    const patchKeys = Object.keys(patch.execution ?? {});
+
+    expect(patch.status).toBe('pending');
+    expect(patch.config).toEqual({ summary: undefined });
+    expect(patch.execution).toMatchObject({
+      autoFixAttempts: 0,
+      branch: undefined,
+      commit: undefined,
+      workspacePath: undefined,
+      launchStartedAt: undefined,
+      launchCompletedAt: undefined,
+      agentSessionId: undefined,
+      containerId: undefined,
+      reviewUrl: undefined,
+      reviewId: undefined,
+      reviewStatus: undefined,
+      reviewProviderId: undefined,
+    });
+    expect(patchKeys).not.toContain('pendingFixError');
+    expect(patchKeys).not.toContain('blockedBy');
+    expect(patchKeys).not.toContain('selectedAttemptId');
+    expect(patchKeys).not.toContain('fixedIntegrationSha');
+    expect(patchKeys).not.toContain('reviewGate');
+  });
+
+  it('keeps retryTask lineage context but clears volatile task attempt state', () => {
+    const patch = buildTaskResetExecutionPatch('retryTask');
+    const patchKeys = Object.keys(patch);
+
+    expect(patch).toMatchObject({
+      autoFixAttempts: 0,
+      commit: undefined,
+      pendingFixError: undefined,
+      launchStartedAt: undefined,
+      launchCompletedAt: undefined,
+      isFixingWithAI: false,
+      agentSessionId: undefined,
+      containerId: undefined,
+    });
+    expect(patchKeys).not.toContain('branch');
+    expect(patchKeys).not.toContain('workspacePath');
+    expect(patchKeys).not.toContain('selectedAttemptId');
+    expect(patchKeys).not.toContain('reviewUrl');
+    expect(patchKeys).not.toContain('fixedIntegrationSha');
+  });
+
+  it('keeps retryWorkflow work context while clearing workflow retry failure state', () => {
+    const patch = buildTaskResetExecutionPatch('retryWorkflow');
+    const patchKeys = Object.keys(patch);
+
+    expect(patch).toMatchObject({
+      autoFixAttempts: 0,
+      pendingFixError: undefined,
+      launchStartedAt: undefined,
+      launchCompletedAt: undefined,
+      isFixingWithAI: false,
+    });
+    expect(patchKeys).not.toContain('branch');
+    expect(patchKeys).not.toContain('commit');
+    expect(patchKeys).not.toContain('workspacePath');
+    expect(patchKeys).not.toContain('agentSessionId');
+    expect(patchKeys).not.toContain('containerId');
+    expect(patchKeys).not.toContain('blockedBy');
+  });
+
+  it('keeps detach as the broad downstream reset', () => {
+    const patch = buildTaskResetExecutionPatch('detach');
+    const patchKeys = Object.keys(patch);
+
+    expect(patch).toMatchObject({
+      autoFixAttempts: 0,
+      blockedBy: undefined,
+      branch: undefined,
+      commit: undefined,
+      workspacePath: undefined,
+      pendingFixError: undefined,
+      launchStartedAt: undefined,
+      launchCompletedAt: undefined,
+      isFixingWithAI: false,
+      agentSessionId: undefined,
+      containerId: undefined,
+      reviewUrl: undefined,
+      reviewId: undefined,
+      reviewStatus: undefined,
+      reviewProviderId: undefined,
+      fixedIntegrationSha: undefined,
+      fixedIntegrationRecordedAt: undefined,
+      fixedIntegrationSource: undefined,
+    });
+    expect(patchKeys).not.toContain('selectedAttemptId');
+  });
+
+  it('lets prepareTaskForNewAttempt provide the fresh selected attempt id', () => {
+    const patch = buildTaskResetExecutionPatch('newAttempt', { selectedAttemptId: 'attempt-next' });
+    const patchKeys = Object.keys(patch);
+
+    expect(patch).toMatchObject({
+      selectedAttemptId: 'attempt-next',
+      branch: undefined,
+      commit: undefined,
+      workspacePath: undefined,
+      pendingFixError: undefined,
+      launchStartedAt: undefined,
+      launchCompletedAt: undefined,
+      isFixingWithAI: false,
+      agentSessionId: undefined,
+      containerId: undefined,
+    });
+    expect(patchKeys).not.toContain('blockedBy');
+    expect(patchKeys).not.toContain('reviewUrl');
+    expect(patchKeys).not.toContain('fixedIntegrationSha');
+  });
+
+  it('keeps pending reset paths separate from retry and recreate resets', () => {
+    expect(buildTaskResetExecutionPatch('defer')).toEqual({
+      startedAt: undefined,
+      lastHeartbeatAt: undefined,
+      phase: undefined,
+      launchStartedAt: undefined,
+      launchCompletedAt: undefined,
+    });
+    expect(buildTaskResetExecutionPatch('readyUnblock')).toEqual({
+      startedAt: undefined,
+      completedAt: undefined,
+      lastHeartbeatAt: undefined,
+      phase: undefined,
+      launchStartedAt: undefined,
+      launchCompletedAt: undefined,
+    });
+    expect(buildTaskResetExecutionPatch('externalUnblock')).toEqual({
+      blockedBy: undefined,
+      startedAt: undefined,
+      completedAt: undefined,
+      lastHeartbeatAt: undefined,
+      phase: undefined,
+      launchStartedAt: undefined,
+      launchCompletedAt: undefined,
+    });
+  });
+});

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -13,4 +13,5 @@ export * from './task-repository.js';
 export * from './invalidation-policy.js';
 export * from './invalidation-plan.js';
 export * from './attempt-policy.js';
+export * from './task-reset-policy.js';
 export * from './repo-default-branch.js';

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -132,6 +132,7 @@ import {
   isDiscardedAttempt,
   isOutcomeTerminalAttempt,
 } from './attempt-policy.js';
+import { buildTaskResetChanges } from './task-reset-policy.js';
 
 // ── Channel Constants ───────────────────────────────────────
 
@@ -158,30 +159,9 @@ function workflowTimestamp(): Date {
   return new Date();
 }
 /** Recreate-class reset: fresh lineage, cleared attempt/session/container metadata. */
-const RECREATE_RESET_CHANGES: TaskStateChanges = {
-  status: 'pending',
+const RECREATE_RESET_CHANGES: TaskStateChanges = buildTaskResetChanges('recreate', {
   config: { summary: undefined },
-  execution: {
-    autoFixAttempts: 0,
-    startedAt: undefined,
-    completedAt: undefined,
-    error: undefined,
-    exitCode: undefined,
-    commit: undefined,
-    branch: undefined,
-    workspacePath: undefined,
-    lastHeartbeatAt: undefined,
-    phase: undefined,
-    launchStartedAt: undefined,
-    launchCompletedAt: undefined,
-    reviewUrl: undefined,
-    reviewId: undefined,
-    reviewStatus: undefined,
-    reviewProviderId: undefined,
-    agentSessionId: undefined,
-    containerId: undefined,
-  },
-};
+});
 
 const TRACE_PERSIST_SYNC = process.env.INVOKER_TRACE_PERSIST_SYNC === '1';
 const TRACE_WORKER_RESPONSE = process.env.INVOKER_TRACE_WORKER_RESPONSE === '1';
@@ -661,37 +641,9 @@ export class Orchestrator {
    */
   private knownFreshBaseCommits = new Map<string, string>();
 
-  private static readonly DETACH_RESET_CHANGES: TaskStateChanges = {
-    status: 'pending',
+  private static readonly DETACH_RESET_CHANGES: TaskStateChanges = buildTaskResetChanges('detach', {
     config: { summary: undefined },
-    execution: {
-      autoFixAttempts: 0,
-      blockedBy: undefined,
-      startedAt: undefined,
-      completedAt: undefined,
-      error: undefined,
-      exitCode: undefined,
-      commit: undefined,
-      branch: undefined,
-      workspacePath: undefined,
-      pendingFixError: undefined,
-      inputPrompt: undefined,
-      lastHeartbeatAt: undefined,
-      phase: undefined,
-      launchStartedAt: undefined,
-      launchCompletedAt: undefined,
-      isFixingWithAI: false,
-      reviewUrl: undefined,
-      reviewId: undefined,
-      reviewStatus: undefined,
-      reviewProviderId: undefined,
-      fixedIntegrationSha: undefined,
-      fixedIntegrationRecordedAt: undefined,
-      fixedIntegrationSource: undefined,
-      agentSessionId: undefined,
-      containerId: undefined,
-    },
-  };
+  });
 
   constructor(config: OrchestratorConfig) {
     this.maxConcurrency = config.maxConcurrency ?? 3;
@@ -1297,28 +1249,9 @@ export class Orchestrator {
       supersedesAttemptId: activeAttempt?.id,
     });
 
-    const changes = this.withBumpedExecutionGeneration(task, {
-      status: 'pending',
-      execution: {
-        selectedAttemptId: freshAttempt.id,
-        phase: undefined,
-        startedAt: undefined,
-        completedAt: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-        lastHeartbeatAt: undefined,
-        error: undefined,
-        exitCode: undefined,
-        branch: undefined,
-        commit: undefined,
-        inputPrompt: undefined,
-        pendingFixError: undefined,
-        agentSessionId: undefined,
-        workspacePath: undefined,
-        containerId: undefined,
-        isFixingWithAI: false,
-      },
-    });
+    const changes = this.withBumpedExecutionGeneration(task, buildTaskResetChanges('newAttempt', {
+      execution: { selectedAttemptId: freshAttempt.id },
+    }));
 
     let updated!: TaskState;
     this.taskRepository.runInTransaction(() => {
@@ -2205,26 +2138,9 @@ export class Orchestrator {
       });
     }
 
-    const resetChanges: TaskStateChanges = {
-      status: 'pending',
+    const resetChanges: TaskStateChanges = buildTaskResetChanges('retryTask', {
       config: { summary: undefined },
-      execution: {
-        autoFixAttempts: 0,
-        startedAt: undefined,
-        completedAt: undefined,
-        error: undefined,
-        exitCode: undefined,
-        pendingFixError: undefined,
-        commit: undefined,
-        lastHeartbeatAt: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-        phase: undefined,
-        isFixingWithAI: false,
-        agentSessionId: undefined,
-        containerId: undefined,
-      },
-    };
+    });
     const t0 = this.stateGetTask(id)!;
     this.logger.info('[agent-session-trace] retryTask: before writeAndSync', {
       taskId: id,
@@ -2329,24 +2245,9 @@ export class Orchestrator {
     });
     this.lastInvalidationPlan = plan;
 
-    const resetChanges: TaskStateChanges = {
-      status: 'pending',
+    const resetChanges: TaskStateChanges = buildTaskResetChanges('retryWorkflow', {
       config: { summary: undefined },
-      execution: {
-        autoFixAttempts: 0,
-        startedAt: undefined,
-        completedAt: undefined,
-        error: undefined,
-        exitCode: undefined,
-        pendingFixError: undefined,
-        phase: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-        isFixingWithAI: false,
-        // Preserve branch/commit/workspacePath — they contain valid work context
-        // Only clear error-related and timing fields
-      },
-    };
+    });
 
     const retryRootIds = allTasks
       .filter((task) => retryStatuses.has(task.status))
@@ -2519,10 +2420,9 @@ export class Orchestrator {
     });
     this.lastInvalidationPlan = plan;
 
-    const resetChanges: TaskStateChanges = {
-      ...RECREATE_RESET_CHANGES,
+    const resetChanges: TaskStateChanges = buildTaskResetChanges('recreate', {
       config: { summary: undefined, poolMemberId: undefined },
-    };
+    });
 
     this.logger.info('[orchestrator] recreateWorkflow reset', {
       workflowId,
@@ -4077,16 +3977,7 @@ export class Orchestrator {
     // Transition running → pending. A deferred launch must not retain the
     // launch-claimed phase; otherwise it can be mistaken for an actively
     // dispatchable launch with no executor owner.
-    const changes: TaskStateChanges = {
-      status: 'pending',
-      execution: {
-        startedAt: undefined,
-        lastHeartbeatAt: undefined,
-        phase: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-      },
-    };
+    const changes: TaskStateChanges = buildTaskResetChanges('defer');
     const deferUpdated = this.writeAndSync(id, changes);
     const delta: TaskDelta = this.buildUpdateDelta(task, deferUpdated, changes);
     this.persistence.logEvent?.(id, 'task.deferred', changes);

--- a/packages/workflow-core/src/orchestrator/scheduler-domain.ts
+++ b/packages/workflow-core/src/orchestrator/scheduler-domain.ts
@@ -16,6 +16,7 @@ import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '@invoker/w
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import type { Logger } from '@invoker/contracts';
 import { isDiscardedAttempt } from '../attempt-policy.js';
+import { buildTaskResetChanges } from '../task-reset-policy.js';
 import type { TaskStateMachine } from '../state-machine.js';
 import type { TaskScheduler } from '../scheduler.js';
 import type { TaskRepository } from '../task-repository.js';
@@ -88,17 +89,7 @@ export function autoStartReadyTasksImpl(
         taskId,
       });
       host.replaceSelectedAttempt(task, { status: 'pending' });
-      host.writeAndSync(taskId, {
-        status: 'pending',
-        execution: {
-          startedAt: undefined,
-          completedAt: undefined,
-          lastHeartbeatAt: undefined,
-          launchStartedAt: undefined,
-          launchCompletedAt: undefined,
-          phase: undefined,
-        },
-      });
+      host.writeAndSync(taskId, buildTaskResetChanges('readyUnblock'));
       task = host.stateGetTask(taskId);
       if (!task) continue;
     }
@@ -180,18 +171,7 @@ export function autoStartUnblockedTasksImpl(host: SchedulerDomainHost): TaskStat
     if (host.getExternalDependencyBlocker(task) !== undefined) continue;
 
     host.replaceSelectedAttempt(task, { status: 'pending' });
-    host.writeAndSync(task.id, {
-      status: 'pending',
-      execution: {
-        blockedBy: undefined,
-        startedAt: undefined,
-        completedAt: undefined,
-        lastHeartbeatAt: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-        phase: undefined,
-      },
-    });
+    host.writeAndSync(task.id, buildTaskResetChanges('externalUnblock'));
     enqueueIfNotScheduledImpl(host, task.id);
   }
   return drainSchedulerImpl(host);

--- a/packages/workflow-core/src/task-reset-policy.ts
+++ b/packages/workflow-core/src/task-reset-policy.ts
@@ -1,0 +1,131 @@
+import type { TaskExecution, TaskStateChanges } from '@invoker/workflow-graph';
+
+export const TASK_RESET_KINDS = [
+  'recreate',
+  'detach',
+  'retryTask',
+  'retryWorkflow',
+  'newAttempt',
+  'defer',
+  'readyUnblock',
+  'externalUnblock',
+] as const;
+
+export type TaskResetKind = (typeof TASK_RESET_KINDS)[number];
+
+type ResetRule = 'preserve' | 'clear' | 'false' | 'zero';
+type TaskExecutionResetRulebook = Record<keyof TaskExecution, Record<TaskResetKind, ResetRule>>;
+
+const preserve = {
+  recreate: 'preserve',
+  detach: 'preserve',
+  retryTask: 'preserve',
+  retryWorkflow: 'preserve',
+  newAttempt: 'preserve',
+  defer: 'preserve',
+  readyUnblock: 'preserve',
+  externalUnblock: 'preserve',
+} as const satisfies Record<TaskResetKind, ResetRule>;
+
+const clearFor = (kinds: readonly TaskResetKind[]): Record<TaskResetKind, ResetRule> => {
+  const rules: Record<TaskResetKind, ResetRule> = { ...preserve };
+  for (const kind of kinds) rules[kind] = 'clear';
+  return rules;
+};
+
+const falseFor = (kinds: readonly TaskResetKind[]): Record<TaskResetKind, ResetRule> => {
+  const rules: Record<TaskResetKind, ResetRule> = { ...preserve };
+  for (const kind of kinds) rules[kind] = 'false';
+  return rules;
+};
+
+const zeroFor = (kinds: readonly TaskResetKind[]): Record<TaskResetKind, ResetRule> => {
+  const rules: Record<TaskResetKind, ResetRule> = { ...preserve };
+  for (const kind of kinds) rules[kind] = 'zero';
+  return rules;
+};
+
+const recreateDetachNewAttempt = ['recreate', 'detach', 'newAttempt'] as const;
+const retryRecreateDetachNewAttempt = ['recreate', 'detach', 'retryTask', 'retryWorkflow', 'newAttempt'] as const;
+const launchReset = ['recreate', 'detach', 'retryTask', 'retryWorkflow', 'newAttempt', 'defer', 'readyUnblock', 'externalUnblock'] as const;
+const detachOnly = ['detach'] as const;
+
+export const TASK_EXECUTION_RESET_RULES = {
+  generation: preserve,
+  blockedBy: clearFor(['detach', 'externalUnblock']),
+  inputPrompt: clearFor(['detach', 'newAttempt']),
+  exitCode: clearFor(retryRecreateDetachNewAttempt),
+  error: clearFor(retryRecreateDetachNewAttempt),
+  protocolErrorCode: preserve,
+  protocolErrorMessage: preserve,
+  startedAt: clearFor(launchReset),
+  completedAt: clearFor(['recreate', 'detach', 'retryTask', 'retryWorkflow', 'newAttempt', 'readyUnblock', 'externalUnblock']),
+  lastHeartbeatAt: clearFor(['recreate', 'detach', 'retryTask', 'newAttempt', 'defer', 'readyUnblock', 'externalUnblock']),
+  remoteHeartbeatAt: preserve,
+  heartbeatSource: preserve,
+  actionRequestId: preserve,
+  branch: clearFor(recreateDetachNewAttempt),
+  commit: clearFor(['recreate', 'detach', 'retryTask', 'newAttempt']),
+  fixedIntegrationSha: clearFor(detachOnly),
+  fixedIntegrationRecordedAt: clearFor(detachOnly),
+  fixedIntegrationSource: clearFor(detachOnly),
+  agentSessionId: clearFor(['recreate', 'detach', 'retryTask', 'newAttempt']),
+  lastAgentSessionId: preserve,
+  agentName: preserve,
+  lastAgentName: preserve,
+  workspacePath: clearFor(recreateDetachNewAttempt),
+  containerId: clearFor(['recreate', 'detach', 'retryTask', 'newAttempt']),
+  experiments: preserve,
+  selectedExperiment: preserve,
+  selectedExperiments: preserve,
+  experimentResults: preserve,
+  pendingFixError: clearFor(['detach', 'retryTask', 'retryWorkflow', 'newAttempt']),
+  isFixingWithAI: falseFor(['detach', 'retryTask', 'retryWorkflow', 'newAttempt']),
+  reviewUrl: clearFor(['recreate', 'detach']),
+  reviewId: clearFor(['recreate', 'detach']),
+  reviewStatus: clearFor(['recreate', 'detach']),
+  reviewProviderId: clearFor(['recreate', 'detach']),
+  reviewGate: preserve,
+  phase: clearFor(launchReset),
+  launchStartedAt: clearFor(launchReset),
+  launchCompletedAt: clearFor(launchReset),
+  mergeConflict: preserve,
+  selectedAttemptId: preserve,
+  autoFixAttempts: zeroFor(['recreate', 'detach', 'retryTask', 'retryWorkflow']),
+} satisfies TaskExecutionResetRulebook;
+
+export function buildTaskResetExecutionPatch(
+  kind: TaskResetKind,
+  overrides?: Partial<TaskExecution>,
+): Partial<TaskExecution> {
+  const execution: Partial<TaskExecution> = {};
+  const writableExecution = execution as Record<string, unknown>;
+  for (const [field, rules] of Object.entries(TASK_EXECUTION_RESET_RULES) as Array<[
+    keyof TaskExecution,
+    Record<TaskResetKind, ResetRule>,
+  ]>) {
+    const rule = rules[kind];
+    if (rule === 'clear') {
+      writableExecution[field] = undefined;
+    } else if (rule === 'false') {
+      writableExecution[field] = false;
+    } else if (rule === 'zero') {
+      writableExecution[field] = 0;
+    }
+  }
+  return overrides ? { ...execution, ...overrides } : execution;
+}
+
+export function buildTaskResetChanges(
+  kind: TaskResetKind,
+  options?: {
+    config?: TaskStateChanges['config'];
+    execution?: Partial<TaskExecution>;
+  },
+): TaskStateChanges {
+  return {
+    status: 'pending',
+    ...(options?.config !== undefined ? { config: options.config } : {}),
+    execution: buildTaskResetExecutionPatch(kind, options?.execution),
+  };
+}

--- a/scripts/repro/prove-reset-rulebook.sh
+++ b/scripts/repro/prove-reset-rulebook.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+exec bash scripts/e2e-dry-run/run-all.sh case-2.16-retry-vs-recreate-five-second-window.sh

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -91,13 +91,13 @@ expected_executed_for_mode() {
 expected_discovered_for_mode() {
   case "$MODE_KEY" in
     required)
-      printf '19'
+      printf '20'
       ;;
     extended)
-      printf '26'
+      printf '27'
       ;;
     dangerous)
-      printf '27'
+      printf '28'
       ;;
   esac
 }

--- a/scripts/test-suites/required/26-reset-rulebook-proof.sh
+++ b/scripts/test-suites/required/26-reset-rulebook-proof.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Required proof coverage for the shared task reset rulebook.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+if [[ "${INVOKER_TEST_ALL_PROOF:-0}" == "1" ]]; then
+  echo "SKIP: required-fast runs reset rulebook repro separately."
+  exit 0
+fi
+
+exec bash scripts/repro/prove-reset-rulebook.sh


### PR DESCRIPTION
## Summary

Task resets now use one shared rulebook instead of copied field sets.

The old copies could drift as task state grew. This makes each reset caller ask the same owner what to clear.

<details>
<summary>Review metadata</summary>

Review Claim: The reset rulebook correctly replaces duplicated task reset field sets.

Review Lane: refactor

Review Unit: ownership-refactor

Safety Invariant: Each caller still selects the same reset kind and writes the same task shape.

Slice Rationale: This is the base slice because later checks depend on one reset owner.

</details>

## Non-goals

- Does not change scheduling behavior.
- Does not change stored task shape.
- Does not change workflow invalidation planning.

## Architecture

### Before

```mermaid
graph TD
    A["Reset caller"] --> B["Local copied field set"]
    B --> C["TaskStateChanges"]
```

### After

```mermaid
graph TD
    A["Reset caller"] --> B["buildTaskResetChanges(kind)"]
    B --> C["Shared reset rulebook"]
    C --> D["TaskStateChanges"]
```

## Test Plan

- [x] `pnpm --filter @invoker/workflow-core test -- task-reset-policy.test.ts`
- [x] `pnpm --filter @invoker/workflow-core build`
- [x] `pnpm run check:types`
- [x] `bash scripts/test-suites/required/26-reset-rulebook-proof.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 1622e8bfc`
- Post-revert steps: None.
- Data migration? No.
