### PR TITLE
[State Invariants](2) Assert reset postconditions

### DIFF
--- a/packages/app/src/__tests__/reset-storm.duress.test.ts
+++ b/packages/app/src/__tests__/reset-storm.duress.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestHarness, type TestHarness } from '@invoker/test-kit';
+import type { PlanDefinition } from '@invoker/workflow-core';
+
+const STORM_PLAN: PlanDefinition = {
+  name: 'Reset Storm Duress',
+  onFinish: 'merge',
+  mergeMode: 'automatic',
+  baseBranch: 'master',
+  featureBranch: 'plan/reset-storm',
+  tasks: [
+    { id: 'A', description: 'Task A', command: 'echo a' },
+    { id: 'B', description: 'Task B', command: 'echo b' },
+    { id: 'C', description: 'Task C', command: 'echo c', dependencies: ['A'] },
+    { id: 'D', description: 'Task D', command: 'echo d', dependencies: ['A', 'B'] },
+  ],
+};
+
+// assertResetComplete throws messages of the form "Incomplete <kind> reset ...".
+const RESET_INVARIANT = /Incomplete .* reset/;
+
+function completeAllRunning(h: TestHarness): void {
+  for (let guard = 0; guard < 100; guard += 1) {
+    const running = h.getAllTasks().filter((t) => t.status === 'running');
+    if (running.length === 0) return;
+    for (const t of running) h.completeTask(t.id);
+  }
+}
+
+describe('reset storm duress', () => {
+  let h: TestHarness;
+  beforeEach(() => {
+    h = createTestHarness();
+  });
+
+  it('never leaves stale state across a storm of interleaved resets', () => {
+    h.loadAndStart(STORM_PLAN);
+    completeAllRunning(h);
+    const wfId = h.getAllTasks()[0]?.config.workflowId;
+    expect(wfId).toBeTruthy();
+
+    const nonMerge = () => h.getAllTasks().filter((t) => !t.config.isMergeNode);
+
+    for (let i = 0; i < 40; i += 1) {
+      const targets = nonMerge();
+      const target = targets[i % targets.length];
+      try {
+        switch (i % 5) {
+          case 0:
+            h.orchestrator.retryTask(target.id);
+            break;
+          case 1:
+            h.orchestrator.recreateTask(target.id);
+            break;
+          case 2:
+            h.orchestrator.retryWorkflow(wfId!);
+            break;
+          case 3:
+            h.orchestrator.recreateWorkflow(wfId!);
+            break;
+          default:
+            h.orchestrator.prepareTaskForNewAttempt(target.id, 'reset-storm');
+            break;
+        }
+      } catch (err) {
+        // A reset-completeness violation must fail the test. Benign
+        // state-machine rejections under chaos (e.g. resetting an
+        // already-pending task) are tolerated — they are not the boundary
+        // under test.
+        if (RESET_INVARIANT.test(String(err))) throw err;
+      }
+      // Re-drive whatever became runnable so the next reset acts on a task that
+      // has accumulated execution state (branch, commit, timing) to clear.
+      completeAllRunning(h);
+    }
+
+    // Final explicit proof: a recreate after the storm yields a fully clean
+    // task — fresh-lineage fields cleared per the rulebook.
+    const victim = nonMerge()[0];
+    h.completeTask(victim.id);
+    h.orchestrator.recreateTask(victim.id);
+    const after = h.getTask(victim.id)!;
+    expect(after.execution.branch).toBeUndefined();
+    expect(after.execution.commit).toBeUndefined();
+    expect(after.execution.workspacePath).toBeUndefined();
+    expect(after.execution.error).toBeUndefined();
+  });
+});

--- a/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import type { TaskExecution } from '@invoker/workflow-graph';
+import { createTaskState, type TaskExecution, type TaskState } from '@invoker/workflow-graph';
 import {
   TASK_EXECUTION_RESET_RULES,
+  assertResetComplete,
   buildTaskResetChanges,
   buildTaskResetExecutionPatch,
 } from '../task-reset-policy.js';
-
 const _compileTimeCoversEveryExecutionField: Record<keyof TaskExecution, unknown> = TASK_EXECUTION_RESET_RULES;
 void _compileTimeCoversEveryExecutionField;
 
@@ -53,6 +53,29 @@ const expectedExecutionFields = [
   'autoFixAttempts',
 ].sort();
 
+
+
+function taskWithExecution(status: TaskState['status'], execution: Partial<TaskExecution>): TaskState {
+  const task = createTaskState('task-1', 'Task 1', []);
+  return {
+    ...task,
+    status,
+    execution: { ...task.execution, ...execution },
+  };
+}
+
+function applyReset(
+  before: TaskState,
+  changes: ReturnType<typeof buildTaskResetChanges>,
+): TaskState {
+  return {
+    ...before,
+    status: changes.status ?? before.status,
+    config: { ...before.config, ...changes.config },
+    execution: { ...before.execution, ...changes.execution },
+    taskStateVersion: before.taskStateVersion + 1,
+  };
+}
 describe('task reset policy', () => {
   it('has a rule for every TaskExecution field', () => {
     expect(Object.keys(TASK_EXECUTION_RESET_RULES).sort()).toEqual(expectedExecutionFields);
@@ -199,4 +222,77 @@ describe('task reset policy', () => {
       launchCompletedAt: undefined,
     });
   });
+
+  it('throws with the reset kind and field name when a cleared field survives', () => {
+    const before = taskWithExecution('failed', {
+      generation: 1,
+      error: 'boom',
+      agentSessionId: 'session-stale',
+    });
+    const after = applyReset(before, buildTaskResetChanges('retryTask', {
+      execution: { generation: 2 },
+    }));
+    const badAfter = {
+      ...after,
+      execution: { ...after.execution, error: 'boom' },
+    };
+
+    expect(() => assertResetComplete(before, badAfter, 'retryTask', { execution: { generation: 2 } }))
+      .toThrow(/retryTask.*execution\.error/);
+  });
+
+  it('throws with the reset kind and field name when status is not pending', () => {
+    const before = taskWithExecution('failed', { generation: 1, error: 'boom' });
+    const after = applyReset(before, buildTaskResetChanges('retryTask', {
+      execution: { generation: 2 },
+    }));
+    const badAfter = { ...after, status: 'failed' as const };
+
+    expect(() => assertResetComplete(before, badAfter, 'retryTask', { execution: { generation: 2 } }))
+      .toThrow(/retryTask.*status/);
+  });
+
+  it('accepts a complete retry reset with a generation override', () => {
+    const before = taskWithExecution('failed', {
+      generation: 4,
+      branch: 'feature',
+      workspacePath: '/tmp/work',
+      error: 'boom',
+      exitCode: 1,
+      pendingFixError: 'fix failed',
+      isFixingWithAI: true,
+      agentSessionId: 'session-stale',
+      containerId: 'container-stale',
+      autoFixAttempts: 3,
+    });
+    const changes = buildTaskResetChanges('retryTask', {
+      execution: { generation: 5 },
+    });
+    const after = applyReset(before, changes);
+
+    expect(() => assertResetComplete(before, after, 'retryTask', { execution: changes.execution }))
+      .not.toThrow();
+  });
+
+  it('accepts a newAttempt reset with fresh selectedAttemptId and generation overrides', () => {
+    const before = taskWithExecution('running', {
+      generation: 7,
+      selectedAttemptId: 'attempt-old',
+      inputPrompt: 'question',
+      branch: 'old-branch',
+      workspacePath: '/tmp/old',
+      isFixingWithAI: true,
+    });
+    const changes = buildTaskResetChanges('newAttempt', {
+      execution: {
+        generation: 8,
+        selectedAttemptId: 'attempt-new',
+      },
+    });
+    const after = applyReset(before, changes);
+
+    expect(() => assertResetComplete(before, after, 'newAttempt', { execution: changes.execution }))
+      .not.toThrow();
+  });
 });
+

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -132,7 +132,7 @@ import {
   isDiscardedAttempt,
   isOutcomeTerminalAttempt,
 } from './attempt-policy.js';
-import { buildTaskResetChanges } from './task-reset-policy.js';
+import { assertResetComplete, buildTaskResetChanges, type TaskResetKind } from './task-reset-policy.js';
 
 // ── Channel Constants ───────────────────────────────────────
 
@@ -744,6 +744,17 @@ export class Orchestrator {
     return updated;
   }
 
+  private writeResetAndSync(
+    before: TaskState,
+    kind: TaskResetKind,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): TaskState {
+    const updated = this.writeAndSync(before.id, changes, opts);
+    assertResetComplete(before, updated, kind, { execution: changes.execution });
+    return updated;
+  }
+
   /**
    * Build an 'updated' TaskDelta with task-state continuity metadata.
    * `before` is the task state before the mutation, `after` is the state
@@ -856,6 +867,7 @@ export class Orchestrator {
    */
   private resetSubgraphToPending(
     rootTaskIds: string[],
+    kind: TaskResetKind,
     resetChanges: TaskStateChanges,
     opts?: { forceResetIds?: Set<string> },
   ): { affectedIds: string[]; readyIds: string[] } {
@@ -891,7 +903,7 @@ export class Orchestrator {
           resetChanges,
           'task subgraph reset to pending',
         );
-        const updated = this.writeAndSync(id, changesWithGeneration, { skipWorkflowStatusSync: true });
+        const updated = this.writeResetAndSync(current, kind, changesWithGeneration, { skipWorkflowStatusSync: true });
         const priorAttemptId = current.execution.selectedAttemptId;
         this.replaceSelectedAttempt(current, {}, { skipWorkflowStatusSync: true });
         this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
@@ -1264,7 +1276,7 @@ export class Orchestrator {
         this.taskRepository.updateAttempt(activeAttempt.id, { status: 'superseded' });
       }
       this.taskRepository.saveAttempt(freshAttempt);
-      updated = this.writeAndSync(task.id, changes);
+      updated = this.writeResetAndSync(task, 'newAttempt', changes);
     });
     this.clearQueuedSchedulerEntries(task.id, task.execution.selectedAttemptId);
     this.persistence.logEvent?.(task.id, 'task.prepared_for_new_attempt', {
@@ -2152,10 +2164,9 @@ export class Orchestrator {
       agentSessionId: t0.execution.agentSessionId ?? 'null',
       note: 'reset clears agentSessionId/containerId; branch/workspacePath unchanged',
     });
-    const { affectedIds } = this.resetSubgraphToPending([id], resetChanges, {
+    const { affectedIds } = this.resetSubgraphToPending([id], 'retryTask', resetChanges, {
       forceResetIds: new Set([id]),
     });
-    plan = withSchedulerEnqueueCandidates(plan, affectedIds);
     this.lastInvalidationPlan = plan;
     const afterRt = this.stateGetTask(id)!;
     this.logger.info('[agent-session-trace] retryTask: after writeAndSync', {
@@ -2257,7 +2268,7 @@ export class Orchestrator {
     const retryRootIds = allTasks
       .filter((task) => retryStatuses.has(task.status))
       .map((task) => task.id);
-    const { affectedIds } = this.resetSubgraphToPending(retryRootIds, resetChanges);
+    const { affectedIds } = this.resetSubgraphToPending(retryRootIds, 'retryWorkflow', resetChanges);
     plan = withSchedulerEnqueueCandidates(plan, affectedIds);
     this.lastInvalidationPlan = plan;
     const afterResetMs = Date.now();
@@ -2344,7 +2355,7 @@ export class Orchestrator {
         RECREATE_RESET_CHANGES,
         artifactReason,
       );
-      const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
+      const recreateUpdated = this.writeResetAndSync(current, 'recreate', changesWithGeneration);
       const priorAttemptId = current.execution.selectedAttemptId;
       this.replaceSelectedAttempt(current);
       this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
@@ -2470,7 +2481,7 @@ export class Orchestrator {
         resetChanges,
         'workflow recreation reset',
       );
-      const after = this.writeAndSync(task.id, changesWithGeneration);
+      const after = this.writeResetAndSync(task, 'recreate', changesWithGeneration);
       const priorAttemptId = task.execution.selectedAttemptId;
       this.replaceSelectedAttempt(task);
     this.logger.info('[agent-session-trace] recreateWorkflow: after writeAndSync', {
@@ -4061,7 +4072,7 @@ export class Orchestrator {
     // launch-claimed phase; otherwise it can be mistaken for an actively
     // dispatchable launch with no executor owner.
     const changes: TaskStateChanges = buildTaskResetChanges('defer');
-    const deferUpdated = this.writeAndSync(id, changes);
+    const deferUpdated = this.writeResetAndSync(task, 'defer', changes);
     const delta: TaskDelta = this.buildUpdateDelta(task, deferUpdated, changes);
     this.persistence.logEvent?.(id, 'task.deferred', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
@@ -4444,6 +4455,7 @@ export class Orchestrator {
     const forceResetIds = new Set(affectedTaskIds);
     const { affectedIds } = this.resetSubgraphToPending(
       affectedTaskIds,
+      'detach',
       Orchestrator.DETACH_RESET_CHANGES,
       { forceResetIds },
     );
@@ -4564,6 +4576,7 @@ export class Orchestrator {
     const forceResetIds = new Set(affectedTaskIds);
     const { affectedIds } = this.resetSubgraphToPending(
       affectedTaskIds,
+      'detach',
       Orchestrator.DETACH_RESET_CHANGES,
       { forceResetIds },
     );

--- a/packages/workflow-core/src/orchestrator/scheduler-domain.ts
+++ b/packages/workflow-core/src/orchestrator/scheduler-domain.ts
@@ -16,7 +16,7 @@ import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '@invoker/w
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import type { Logger } from '@invoker/contracts';
 import { isDiscardedAttempt } from '../attempt-policy.js';
-import { buildTaskResetChanges } from '../task-reset-policy.js';
+import { assertResetComplete, buildTaskResetChanges } from '../task-reset-policy.js';
 import type { TaskStateMachine } from '../state-machine.js';
 import type { TaskScheduler } from '../scheduler.js';
 import type { TaskRepository } from '../task-repository.js';
@@ -89,7 +89,11 @@ export function autoStartReadyTasksImpl(
         taskId,
       });
       host.replaceSelectedAttempt(task, { status: 'pending' });
-      host.writeAndSync(taskId, buildTaskResetChanges('readyUnblock'));
+      const resetBefore = host.stateGetTask(taskId);
+      if (!resetBefore) continue;
+      const changes = buildTaskResetChanges('readyUnblock');
+      const updated = host.writeAndSync(taskId, changes);
+      assertResetComplete(resetBefore, updated, 'readyUnblock', { execution: changes.execution });
       task = host.stateGetTask(taskId);
       if (!task) continue;
     }
@@ -171,7 +175,11 @@ export function autoStartUnblockedTasksImpl(host: SchedulerDomainHost): TaskStat
     if (host.getExternalDependencyBlocker(task) !== undefined) continue;
 
     host.replaceSelectedAttempt(task, { status: 'pending' });
-    host.writeAndSync(task.id, buildTaskResetChanges('externalUnblock'));
+    const resetBefore = host.stateGetTask(task.id);
+    if (!resetBefore) continue;
+    const changes = buildTaskResetChanges('externalUnblock');
+    const updated = host.writeAndSync(task.id, changes);
+    assertResetComplete(resetBefore, updated, 'externalUnblock', { execution: changes.execution });
     enqueueIfNotScheduledImpl(host, task.id);
   }
   return drainSchedulerImpl(host);

--- a/packages/workflow-core/src/task-reset-policy.ts
+++ b/packages/workflow-core/src/task-reset-policy.ts
@@ -1,4 +1,4 @@
-import type { TaskExecution, TaskStateChanges } from '@invoker/workflow-graph';
+import type { TaskExecution, TaskState, TaskStateChanges } from '@invoker/workflow-graph';
 
 export const TASK_RESET_KINDS = [
   'recreate',
@@ -114,6 +114,42 @@ export function buildTaskResetExecutionPatch(
     }
   }
   return overrides ? { ...execution, ...overrides } : execution;
+}
+
+export function assertResetComplete(
+  before: TaskState,
+  after: TaskState,
+  kind: TaskResetKind,
+  options?: { execution?: Partial<TaskExecution> },
+): void {
+  if (after.status !== 'pending') {
+    throw new Error(`Incomplete ${kind} reset for status: expected pending, got ${after.status}`);
+  }
+
+  const overrides = options?.execution;
+  const hasOverride = (field: keyof TaskExecution) =>
+    Object.prototype.hasOwnProperty.call(overrides ?? {}, field);
+
+  for (const [field, rules] of Object.entries(TASK_EXECUTION_RESET_RULES) as Array<[
+    keyof TaskExecution,
+    Record<TaskResetKind, ResetRule>,
+  ]>) {
+    const expected = hasOverride(field)
+      ? overrides?.[field]
+      : rules[kind] === 'clear'
+        ? undefined
+        : rules[kind] === 'false'
+          ? false
+          : rules[kind] === 'zero'
+            ? 0
+            : before.execution[field];
+
+    if (!Object.is(after.execution[field], expected)) {
+      throw new Error(
+        `Incomplete ${kind} reset for execution.${String(field)}: expected ${String(expected)}, got ${String(after.execution[field])}`,
+      );
+    }
+  }
 }
 
 export function buildTaskResetChanges(

--- a/scripts/repro/prove-reset-assertions.sh
+++ b/scripts/repro/prove-reset-assertions.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+exec bash scripts/e2e-dry-run/run-all.sh case-2.15-recreate-preempt-attempt-refresh.sh

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -91,13 +91,13 @@ expected_executed_for_mode() {
 expected_discovered_for_mode() {
   case "$MODE_KEY" in
     required)
-      printf '20'
+      printf '21'
       ;;
     extended)
-      printf '27'
+      printf '28'
       ;;
     dangerous)
-      printf '28'
+      printf '29'
       ;;
   esac
 }

--- a/scripts/test-suites/required/27-reset-assertions-proof.sh
+++ b/scripts/test-suites/required/27-reset-assertions-proof.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Required proof coverage for reset postcondition assertions.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+if [[ "${INVOKER_TEST_ALL_PROOF:-0}" == "1" ]]; then
+  echo "SKIP: required-fast runs reset assertion repro separately."
+  exit 0
+fi
+
+exec bash scripts/repro/prove-reset-assertions.sh


### PR DESCRIPTION
## Summary

Reset writes now check their own result before the next task can run.

This catches a broken reset immediately. It also proves the shared reset rulebook is being applied after persistence writes.

<details>
<summary>Review metadata</summary>

Review Claim: Reset postcondition checks correctly reject incomplete reset writes.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: The checks run after existing writes and only compare fields owned by the selected reset kind.

Slice Rationale: This sits after the rulebook so the checker can use the same reset meaning as the writer.

</details>

## Non-goals

- Does not add new reset kinds.
- Does not change task scheduling order.
- Does not change workflow metadata rules.

## Architecture

### Before

```mermaid
graph TD
    A["Build reset patch"] --> B["Write task"]
    B --> C["Continue scheduling"]
```

### After

```mermaid
graph TD
    A["Build reset patch"] --> B["Write task"]
    B --> C["Assert reset postconditions"]
    C --> D["Continue scheduling"]
```

## Test Plan

- [x] `pnpm --filter @invoker/workflow-core test -- task-reset-policy.test.ts state-invariants.test.ts orchestrator.test.ts`
- [x] `pnpm --filter @invoker/app test -- workflow-actions.test.ts workflow-mutation-facade.test.ts parity-regression.test.ts api-server.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 84baa4ce9`
- Post-revert steps: None.
- Data migration? No.
