### PR TITLE
[State Invariants](4) Validate workflow writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.base_ref) || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.head_ref) || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.base_ref) || format('pr-{0}', github.event.pull_request.number) }}
+  group: ${{ github.workflow }}-${{ startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.head_ref) || format('pr-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
 
 permissions:

--- a/packages/data-store/src/__tests__/fresh-base-recreate.duress.test.ts
+++ b/packages/data-store/src/__tests__/fresh-base-recreate.duress.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+
+describe('fresh-base recreate duress', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  const DEPS = [
+    { workflowId: 'wf-upstream', taskId: '__merge__', requiredStatus: 'completed' as const },
+  ];
+
+  function stackedWorkflow(): Workflow {
+    return {
+      id: 'wf-downstream',
+      name: 'Stacked downstream workflow',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      baseBranch: 'plan/upstream',
+      externalDependencies: DEPS,
+    } as Workflow;
+  }
+
+  it('preserves externalDependencies across a storm of partial recreate writes', () => {
+    adapter.saveWorkflow(stackedWorkflow());
+
+    for (let i = 0; i < 60; i += 1) {
+      switch (i % 4) {
+        case 0:
+          adapter.updateWorkflow('wf-downstream', { baseBranch: `plan/upstream-fresh-${i}` });
+          break;
+        case 1:
+          adapter.updateWorkflow('wf-downstream', { generation: i });
+          break;
+        case 2:
+          adapter.updateWorkflow('wf-downstream', {
+            mergeMode: i % 8 === 2 ? 'automatic' : 'external_review',
+          });
+          break;
+        default:
+          adapter.updateWorkflow('wf-downstream', { branch: `integration-${i}` });
+          break;
+      }
+      expect(adapter.loadWorkflow('wf-downstream')!.externalDependencies).toEqual(DEPS);
+    }
+
+    const finalState = adapter.loadWorkflow('wf-downstream')!;
+    expect(finalState.externalDependencies).toEqual(DEPS);
+    expect(finalState.baseBranch).toBe('plan/upstream-fresh-56');
+  });
+
+  it('still rejects an undocumented dependency drop under the storm, and allows an explicit detach', () => {
+    adapter.saveWorkflow(stackedWorkflow());
+    for (let i = 0; i < 10; i += 1) {
+      adapter.updateWorkflow('wf-downstream', { baseBranch: `plan/upstream-fresh-${i}` });
+    }
+
+    expect(() => adapter.updateWorkflow('wf-downstream', { externalDependencies: undefined }))
+      .toThrow(/without externalDependencyChanges/);
+    expect(adapter.loadWorkflow('wf-downstream')!.externalDependencies).toEqual(DEPS);
+
+    adapter.updateWorkflow('wf-downstream', {
+      externalDependencies: undefined,
+      externalDependencyChanges: [{ before: DEPS[0], changedAt: '2026-06-13T00:00:00.000Z' }],
+    });
+    expect(adapter.loadWorkflow('wf-downstream')!.externalDependencies).toBeUndefined();
+  });
+});

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -114,6 +114,21 @@ describe('SQLiteAdapter', () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+
+    it('enforces low-risk workflow schema checks on fresh databases', () => {
+      expect(() => (adapter as any).db.run(
+        `INSERT INTO workflows (id, name, generation, created_at, updated_at)
+         VALUES ('wf-negative-generation', 'bad generation', -1, '2026-06-13T00:00:00.000Z', '2026-06-13T00:00:00.000Z')`,
+      )).toThrow();
+      expect(() => (adapter as any).db.run(
+        `INSERT INTO workflows (id, name, external_dependencies, created_at, updated_at)
+         VALUES ('wf-bad-json', 'bad json', 'not-json', '2026-06-13T00:00:00.000Z', '2026-06-13T00:00:00.000Z')`,
+      )).toThrow();
+      expect(() => (adapter as any).db.run(
+        `INSERT INTO workflows (id, name, external_dependency_changes, created_at, updated_at)
+         VALUES ('wf-bad-changes-json', 'bad changes json', 'not-json', '2026-06-13T00:00:00.000Z', '2026-06-13T00:00:00.000Z')`,
+      )).toThrow();
+    });
   });
 
   describe('saveTask + loadTasks', () => {
@@ -1645,17 +1660,35 @@ describe('SQLiteAdapter', () => {
       expect(loaded!.updatedAt >= before).toBe(true);
     });
 
-    it('clears externalDependencies when the key is present with undefined', () => {
+    it('rejects clearing externalDependencies without removal history', () => {
+      const deps = [
+        { workflowId: 'wf-upstream', taskId: '__merge__', requiredStatus: 'completed' as const },
+      ];
       adapter.saveWorkflow({
         ...testWorkflow,
-        externalDependencies: [
-          { workflowId: 'wf-upstream', taskId: '__merge__', requiredStatus: 'completed' },
-        ],
+        externalDependencies: deps,
       });
 
-      adapter.updateWorkflow('wf-1', { externalDependencies: undefined });
+      expect(() => adapter.updateWorkflow('wf-1', { externalDependencies: undefined })).toThrow(/without externalDependencyChanges/);
+      expect(adapter.loadWorkflow('wf-1')!.externalDependencies).toEqual(deps);
+    });
 
-      expect(adapter.loadWorkflow('wf-1')!.externalDependencies).toBeUndefined();
+    it('clears externalDependencies when detach-style removal history is present', () => {
+      const dep = { workflowId: 'wf-upstream', taskId: '__merge__', requiredStatus: 'completed' as const };
+      const changedAt = '2026-06-13T00:00:00.000Z';
+      adapter.saveWorkflow({
+        ...testWorkflow,
+        externalDependencies: [dep],
+      });
+
+      adapter.updateWorkflow('wf-1', {
+        externalDependencies: undefined,
+        externalDependencyChanges: [{ before: dep, changedAt }],
+      });
+
+      const loaded = adapter.loadWorkflow('wf-1')!;
+      expect(loaded.externalDependencies).toBeUndefined();
+      expect(loaded.externalDependencyChanges).toEqual([{ before: dep, changedAt }]);
     });
 
     it('leaves externalDependencies untouched when the key is absent', () => {
@@ -3078,6 +3111,24 @@ describe('SQLiteAdapter', () => {
 
       const workflows = adapter.listWorkflows();
       expect(workflows[0].generation).toBe(2);
+    });
+
+    it('rejects invalid generation values before writing', () => {
+      expect(() => adapter.saveWorkflow({ ...testWorkflow, generation: -1 })).toThrow(/generation/);
+      adapter.saveWorkflow(testWorkflow);
+
+      expect(() => adapter.updateWorkflow('wf-1', { generation: -1 })).toThrow(/generation/);
+      expect(adapter.loadWorkflow('wf-1')!.generation).toBe(0);
+    });
+
+    it('rejects invalid saved external dependency shapes before writing', () => {
+      expect(() => adapter.saveWorkflow({
+        ...testWorkflow,
+        externalDependencies: [
+          { workflowId: 'wf-upstream', taskId: '__merge__', requiredStatus: 'review_ready' },
+        ],
+      } as unknown as Workflow)).toThrow(/requiredStatus/);
+      expect(adapter.loadWorkflow('wf-1')).toBeUndefined();
     });
   });
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1004,6 +1004,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     applyPatchKeyToValidationCopy('reviewProvider');
     applyPatchKeyToValidationCopy('externalDependencies');
     applyPatchKeyToValidationCopy('externalDependencyChanges');
+    applyPatchKeyToValidationCopy('detachedExternalDependencies');
     applyPatchKeyToValidationCopy('generation');
 
     return after;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -35,6 +35,9 @@ import type {
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
 import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import {
+  assertTaskConsistent,
+  assertWorkflowConsistent,
+  assertWorkflowPatchConsistent,
   computeWorkflowRollupFromSummaries,
   isDiscardedAttempt,
   normalizeRunnerKind,
@@ -84,6 +87,28 @@ function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
 }
 
+type WorkflowMetadataChanges = Partial<
+  Pick<
+    Workflow,
+    | 'name'
+    | 'description'
+    | 'visualProof'
+    | 'planFile'
+    | 'repoUrl'
+    | 'intermediateRepoUrl'
+    | 'branch'
+    | 'onFinish'
+    | 'baseBranch'
+    | 'featureBranch'
+    | 'mergeMode'
+    | 'reviewProvider'
+    | 'externalDependencies'
+    | 'externalDependencyChanges'
+    | 'detachedExternalDependencies'
+    | 'generation'
+    | 'updatedAt'
+  >
+>;
 type NativeSqlite = typeof import('node:sqlite');
 
 let nativeSqlite: Promise<NativeSqlite> | undefined;
@@ -951,6 +976,39 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return Array.from(byKey.values());
   }
 
+  private buildWorkflowAfterChanges(
+    before: Workflow,
+    changes: WorkflowMetadataChanges,
+    updatedAt: string,
+  ): Workflow {
+    const after: Workflow = { ...before, updatedAt };
+    const applyPatchKeyToValidationCopy = <K extends keyof WorkflowMetadataChanges>(key: K): void => {
+      if (Object.prototype.hasOwnProperty.call(changes, key)) {
+        (after as WorkflowMetadataChanges)[key] = changes[key];
+      }
+    };
+
+    // Mirror updateWorkflow patch semantics before writing: missing key means
+    // unchanged; present key, even undefined, means apply the clear and validate it.
+    applyPatchKeyToValidationCopy('name');
+    applyPatchKeyToValidationCopy('description');
+    applyPatchKeyToValidationCopy('visualProof');
+    applyPatchKeyToValidationCopy('planFile');
+    applyPatchKeyToValidationCopy('repoUrl');
+    applyPatchKeyToValidationCopy('intermediateRepoUrl');
+    applyPatchKeyToValidationCopy('branch');
+    applyPatchKeyToValidationCopy('onFinish');
+    applyPatchKeyToValidationCopy('baseBranch');
+    applyPatchKeyToValidationCopy('featureBranch');
+    applyPatchKeyToValidationCopy('mergeMode');
+    applyPatchKeyToValidationCopy('reviewProvider');
+    applyPatchKeyToValidationCopy('externalDependencies');
+    applyPatchKeyToValidationCopy('externalDependencyChanges');
+    applyPatchKeyToValidationCopy('generation');
+
+    return after;
+  }
+
   /**
    * Promote legacy per-task external dependencies to workflow metadata.
    * This is intentionally idempotent: once task rows are cleared, later runs
@@ -1009,6 +1067,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Workflows ─────────────────────────────────────────
 
   saveWorkflow(workflow: WorkflowSaveInput): void {
+    assertWorkflowConsistent(workflow);
     this.execRun(`
       INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -1028,7 +1087,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     ]);
   }
 
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void {
+  updateWorkflow(workflowId: string, changes: WorkflowMetadataChanges): void {
     const setClauses: string[] = [];
     const values: unknown[] = [];
     const columnMap: Record<string, string> = {
@@ -1081,9 +1140,16 @@ export class SQLiteAdapter implements PersistenceAdapter {
       setClauses.push('detached_external_dependencies = ?');
       values.push(changes.detachedExternalDependencies ? JSON.stringify(changes.detachedExternalDependencies) : null);
     }
+    const updatedAt = changes.updatedAt ?? new Date().toISOString();
     setClauses.push('updated_at = ?');
-    values.push(changes.updatedAt ?? new Date().toISOString());
+    values.push(updatedAt);
     if (setClauses.length === 0) return;
+
+    const before = this.loadWorkflow(workflowId);
+    if (!before) return;
+    const after = this.buildWorkflowAfterChanges(before, changes, updatedAt);
+    assertWorkflowPatchConsistent(before, after, changes);
+
     values.push(workflowId);
     this.execRun(`UPDATE workflows SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
@@ -1288,6 +1354,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Tasks ─────────────────────────────────────────────
 
   saveTask(workflowId: string, task: TaskState): void {
+    assertTaskConsistent(task);
     const cfg = task.config;
     const exec = task.execution;
     this.execRun(`
@@ -1540,6 +1607,16 @@ export class SQLiteAdapter implements PersistenceAdapter {
         }
       }
     }
+
+
+    const beforeTask = this.loadTask(taskId);
+    if (!beforeTask) return;
+    assertTaskConsistent({
+      ...beforeTask,
+      ...changes,
+      config: changes.config ? ({ ...beforeTask.config, ...changes.config } as TaskState['config']) : beforeTask.config,
+      execution: changes.execution ? { ...beforeTask.execution, ...changes.execution } : beforeTask.execution,
+    });
 
     if (setClauses.length === 0) return;
 

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -452,6 +452,7 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         review_provider TEXT,
         external_dependencies TEXT CHECK (external_dependencies IS NULL OR json_valid(external_dependencies)),
         external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
+        detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
         generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
@@ -463,13 +464,13 @@ export const WORKFLOWS_REBUILD_INSERT_DDL = `
       INSERT INTO workflows_new (
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
-        review_provider, external_dependencies, external_dependency_changes,
+        review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
         generation, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
-        review_provider, external_dependencies, external_dependency_changes,
+        review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies,
         generation, created_at, updated_at
       FROM workflows
     `;

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -23,10 +23,10 @@ export const SCHEMA_DDL = `
         feature_branch TEXT,
         merge_mode TEXT,
         review_provider TEXT,
-        external_dependencies TEXT,
-        external_dependency_changes TEXT,
-        detached_external_dependencies TEXT,
-        generation INTEGER DEFAULT 0,
+        external_dependencies TEXT CHECK (external_dependencies IS NULL OR json_valid(external_dependencies)),
+        external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
+        detached_external_dependencies TEXT CHECK (detached_external_dependencies IS NULL OR json_valid(detached_external_dependencies)),
+        generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       );
@@ -45,7 +45,7 @@ export const SCHEMA_DDL = `
         protocol_error_code TEXT,
         protocol_error_message TEXT,
         input_prompt TEXT,
-        external_dependencies TEXT,
+        external_dependencies TEXT CHECK (external_dependencies IS NULL OR json_valid(external_dependencies)),
 
         -- Context
         summary TEXT,
@@ -450,9 +450,9 @@ export const WORKFLOWS_REBUILD_TABLE_DDL = `
         feature_branch TEXT,
         merge_mode TEXT,
         review_provider TEXT,
-        external_dependencies TEXT,
-        external_dependency_changes TEXT,
-        generation INTEGER DEFAULT 0,
+        external_dependencies TEXT CHECK (external_dependencies IS NULL OR json_valid(external_dependencies)),
+        external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
+        generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       )

--- a/packages/workflow-core/src/__tests__/state-invariants.test.ts
+++ b/packages/workflow-core/src/__tests__/state-invariants.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  assertWorkflowConsistent,
+  assertWorkflowPatchConsistent,
+} from '../state-invariants.js';
+
+const depA = {
+  workflowId: 'upstream-a',
+  taskId: '__merge__',
+  requiredStatus: 'completed' as const,
+  gatePolicy: 'review_ready' as const,
+};
+
+const depB = {
+  workflowId: 'upstream-b',
+  taskId: '__merge__',
+  requiredStatus: 'completed' as const,
+  gatePolicy: 'completed' as const,
+};
+
+function workflow(overrides = {}) {
+  return {
+    id: 'workflow-1',
+    name: 'Workflow 1',
+    generation: 0,
+    ...overrides,
+  };
+}
+
+describe('state invariants', () => {
+  it('accepts a valid workflow with external dependencies', () => {
+    expect(() => assertWorkflowConsistent(workflow({ externalDependencies: [depA] }))).not.toThrow();
+  });
+
+  it('rejects empty externalDependencies when present', () => {
+    expect(() => assertWorkflowConsistent(workflow({ externalDependencies: [] }))).toThrow(/externalDependencies must be non-empty/);
+  });
+
+  it('rejects invalid gatePolicy and requiredStatus values', () => {
+    expect(() => assertWorkflowConsistent(workflow({
+      externalDependencies: [{ ...depA, gatePolicy: 'approved' }],
+    }))).toThrow(/gatePolicy/);
+
+    expect(() => assertWorkflowConsistent(workflow({
+      externalDependencies: [{ ...depA, requiredStatus: 'review_ready' }],
+    }))).toThrow(/requiredStatus/);
+  });
+
+  it('rejects null, negative, and non-integer generations', () => {
+    expect(() => assertWorkflowConsistent(workflow({ generation: null }))).toThrow(/generation/);
+    expect(() => assertWorkflowConsistent(workflow({ generation: -1 }))).toThrow(/generation/);
+    expect(() => assertWorkflowConsistent(workflow({ generation: 1.5 }))).toThrow(/generation/);
+  });
+
+  it('rejects losing external dependencies without removal history', () => {
+    const before = workflow({ externalDependencies: [depA, depB] });
+    const after = workflow({ externalDependencies: [depB] });
+
+    expect(() => assertWorkflowPatchConsistent(before, after, {})).toThrow(/without externalDependencyChanges/);
+  });
+
+  it('accepts a detach-style clear with before-only removal records', () => {
+    const before = workflow({ externalDependencies: [depA, depB] });
+    const after = workflow();
+
+    expect(() => assertWorkflowPatchConsistent(before, after, {
+      externalDependencyChanges: [
+        { before: depA, changedAt: '2026-06-13T00:00:00.000Z' },
+        { before: depB, changedAt: '2026-06-13T00:00:00.000Z' },
+      ],
+    })).not.toThrow();
+  });
+});

--- a/packages/workflow-core/src/__tests__/state-invariants.test.ts
+++ b/packages/workflow-core/src/__tests__/state-invariants.test.ts
@@ -58,6 +58,15 @@ describe('state invariants', () => {
 
     expect(() => assertWorkflowPatchConsistent(before, after, {})).toThrow(/without externalDependencyChanges/);
   });
+  it('rejects malformed externalDependencyChanges even without removals', () => {
+    const before = workflow({ externalDependencies: [depA] });
+    const after = workflow({ externalDependencies: [depA, depB] });
+    const patch = {
+      externalDependencyChanges: [{ before: depB }],
+    };
+
+    expect(() => assertWorkflowPatchConsistent(before, after, patch)).toThrow(/changedAt/);
+  });
 
   it('accepts a detach-style clear with before-only removal records', () => {
     const before = workflow({ externalDependencies: [depA, depB] });

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -14,4 +14,5 @@ export * from './invalidation-policy.js';
 export * from './invalidation-plan.js';
 export * from './attempt-policy.js';
 export * from './task-reset-policy.js';
+export * from './state-invariants.js';
 export * from './repo-default-branch.js';

--- a/packages/workflow-core/src/state-invariants.ts
+++ b/packages/workflow-core/src/state-invariants.ts
@@ -1,0 +1,149 @@
+import type { ExternalDependency, ExternalDependencyChange, TaskState } from '@invoker/workflow-graph';
+
+export interface WorkflowInvariantLike {
+  readonly id?: unknown;
+  readonly name?: unknown;
+  readonly generation?: unknown;
+  readonly externalDependencies?: unknown;
+  readonly externalDependencyChanges?: unknown;
+}
+
+export interface WorkflowPatchLike {
+  readonly externalDependencyChanges?: unknown;
+}
+
+const VALID_GATE_POLICIES: Record<string, true> = {
+  completed: true,
+  review_ready: true,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function hasOwn(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function describeWorkflow(workflow: WorkflowInvariantLike): string {
+  return nonEmptyString(workflow.id) ? `workflow ${workflow.id}` : 'workflow';
+}
+
+function dependencyKey(dep: ExternalDependency): string {
+  return `${dep.workflowId}\u0000${dep.taskId ?? ''}`;
+}
+
+function assertDependencyConsistent(dep: unknown, path: string): asserts dep is ExternalDependency {
+  if (!isRecord(dep)) {
+    throw new Error(`${path} must be an object`);
+  }
+  if (!nonEmptyString(dep.workflowId)) {
+    throw new Error(`${path}.workflowId must be a non-empty string`);
+  }
+  if (hasOwn(dep, 'taskId') && dep.taskId !== undefined && !nonEmptyString(dep.taskId)) {
+    throw new Error(`${path}.taskId must be a non-empty string when present`);
+  }
+  if (dep.requiredStatus !== 'completed') {
+    throw new Error(`${path}.requiredStatus must be completed`);
+  }
+  if (hasOwn(dep, 'gatePolicy') && dep.gatePolicy !== undefined && VALID_GATE_POLICIES[String(dep.gatePolicy)] !== true) {
+    throw new Error(`${path}.gatePolicy must be completed or review_ready`);
+  }
+}
+
+function assertDependencyChangeConsistent(change: unknown, path: string): asserts change is ExternalDependencyChange {
+  if (!isRecord(change)) {
+    throw new Error(`${path} must be an object`);
+  }
+  const hasBefore = hasOwn(change, 'before') && change.before !== undefined;
+  const hasAfter = hasOwn(change, 'after') && change.after !== undefined;
+  if (!hasBefore && !hasAfter) {
+    throw new Error(`${path} must include before or after`);
+  }
+  if (hasBefore) {
+    assertDependencyConsistent(change.before, `${path}.before`);
+  }
+  if (hasAfter) {
+    assertDependencyConsistent(change.after, `${path}.after`);
+  }
+  if (!nonEmptyString(change.changedAt) || Number.isNaN(Date.parse(change.changedAt))) {
+    throw new Error(`${path}.changedAt must be a valid date string`);
+  }
+}
+
+function readDependencies(workflow: WorkflowInvariantLike): readonly ExternalDependency[] {
+  const deps = workflow.externalDependencies;
+  if (deps === undefined) return [];
+  if (!Array.isArray(deps)) {
+    throw new Error(`${describeWorkflow(workflow)} externalDependencies must be an array when present`);
+  }
+  if (deps.length === 0) {
+    throw new Error(`${describeWorkflow(workflow)} externalDependencies must be non-empty when present`);
+  }
+  deps.forEach((dep, index) => assertDependencyConsistent(dep, `${describeWorkflow(workflow)} externalDependencies[${index}]`));
+  return deps;
+}
+
+function readDependencyChanges(owner: WorkflowInvariantLike | WorkflowPatchLike, ownerLabel: string): readonly ExternalDependencyChange[] {
+  const changes = owner.externalDependencyChanges;
+  if (changes === undefined) return [];
+  if (!Array.isArray(changes)) {
+    throw new Error(`${ownerLabel} externalDependencyChanges must be an array when present`);
+  }
+  changes.forEach((change, index) => assertDependencyChangeConsistent(change, `${ownerLabel} externalDependencyChanges[${index}]`));
+  return changes;
+}
+
+export function assertWorkflowConsistent(workflow: WorkflowInvariantLike): void {
+  if (!nonEmptyString(workflow.id)) {
+    throw new Error('workflow.id must be a non-empty string');
+  }
+  if (!nonEmptyString(workflow.name)) {
+    throw new Error(`workflow ${String(workflow.id)} name must be a non-empty string`);
+  }
+  const generation = workflow.generation;
+  if (generation !== undefined && (typeof generation !== 'number' || !Number.isInteger(generation) || generation < 0)) {
+    throw new Error(`workflow ${workflow.id} generation must be an integer >= 0 when present`);
+  }
+  readDependencies(workflow);
+  readDependencyChanges(workflow, describeWorkflow(workflow));
+}
+
+export function assertWorkflowPatchConsistent(
+  before: WorkflowInvariantLike,
+  after: WorkflowInvariantLike,
+  patch?: WorkflowPatchLike,
+): void {
+  assertWorkflowConsistent(before);
+  assertWorkflowConsistent(after);
+
+  const beforeDeps = readDependencies(before);
+  if (beforeDeps.length === 0) return;
+
+  const afterDepsByKey = new Set(readDependencies(after).map(dependencyKey));
+  const removedDeps = beforeDeps.filter((dep) => !afterDepsByKey.has(dependencyKey(dep)));
+  if (removedDeps.length === 0) return;
+
+  if (!patch || !hasOwn(patch, 'externalDependencyChanges')) {
+    throw new Error(`workflow ${before.id} removed externalDependencies without externalDependencyChanges`);
+  }
+
+  const removals = readDependencyChanges(patch, `workflow ${before.id} patch`)
+    .filter((change) => change.before !== undefined && change.after === undefined)
+    .map((change) => dependencyKey(change.before!));
+  const removalKeys = new Set(removals);
+  const missing = removedDeps.filter((dep) => !removalKeys.has(dependencyKey(dep)));
+  if (missing.length > 0) {
+    throw new Error(`workflow ${before.id} removed externalDependencies without removal history for ${missing.map(dependencyKey).join(', ')}`);
+  }
+}
+
+export function assertTaskConsistent(task: TaskState): void {
+  if (!nonEmptyString(task.id)) {
+    throw new Error('task.id must be a non-empty string');
+  }
+}

--- a/packages/workflow-core/src/state-invariants.ts
+++ b/packages/workflow-core/src/state-invariants.ts
@@ -121,6 +121,10 @@ export function assertWorkflowPatchConsistent(
   assertWorkflowConsistent(before);
   assertWorkflowConsistent(after);
 
+  const patchChanges = patch && hasOwn(patch, 'externalDependencyChanges')
+    ? readDependencyChanges(patch, `workflow ${before.id} patch`)
+    : [];
+
   const beforeDeps = readDependencies(before);
   if (beforeDeps.length === 0) return;
 
@@ -132,7 +136,7 @@ export function assertWorkflowPatchConsistent(
     throw new Error(`workflow ${before.id} removed externalDependencies without externalDependencyChanges`);
   }
 
-  const removals = readDependencyChanges(patch, `workflow ${before.id} patch`)
+  const removals = patchChanges
     .filter((change) => change.before !== undefined && change.after === undefined)
     .map((change) => dependencyKey(change.before!));
   const removalKeys = new Set(removals);


### PR DESCRIPTION
## Summary

SQLite workflow writes now run the same consistency guard.

Bad workflow payloads fail at the database adapter boundary. Good records are saved normally, so callers get one clear write rule.

<details>
<summary>Review metadata</summary>

Review Claim: SQLite workflow writes now check state consistency before persisting workflow rows.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: The adapter blocks impossible workflow state without changing valid persisted rows.

Slice Rationale: This follows the shared state guard so the database adapter enforces the same rule as workflow core.

</details>

## Non-goals

- Does not change task reset policy.
- Does not change scheduler behavior.
- Does not add UI behavior.

## Architecture

### Before

```mermaid
graph TD
    A["SQLite workflow write"] --> B["Persist row"]
```

### After

```mermaid
graph TD
    A["SQLite workflow write"] --> B["Consistency guard"]
    B --> C["Persist row"]
```

## Test Plan

- [x] `pnpm --filter @invoker/data-store test -- sqlite-adapter.test.ts fresh-base-recreate.duress.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 409ce981b`
- Post-revert steps: None.
- Data migration? No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when saving/updating workflows and tasks with stricter input validation, preventing invalid workflow/task data from being persisted.
  * Preserved workflow external dependency data across repeated and partial updates, including “storm” scenarios.
  * Made dependency detachment clearer: clearing dependency data is only allowed when the matching change history is provided.
  * Strengthened safeguards by rejecting malformed dependency JSON and invalid generation values.
* **Tests**
  * Added stress and schema-validation coverage for external dependency update and patch consistency behavior.
* **Chores**
  * Updated CI concurrency grouping to reduce redundant/overlapping runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->