### PR TITLE
Add workflow consistency checker

### DIFF
--- a/scripts/check-workflow-consistency.mjs
+++ b/scripts/check-workflow-consistency.mjs
@@ -1,0 +1,304 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { assertWorkflowConsistent } from '../packages/workflow-core/src/state-invariants.ts';
+
+function usage() {
+  return `Usage: node scripts/check-workflow-consistency.mjs [--db <path>] [--repair] [--json]\n\nChecks persisted workflow rows for state-invariant problems.\n`;
+}
+
+function parseArgs(argv) {
+  const opts = {
+    db: join(process.env.INVOKER_DB_DIR || join(homedir(), '.invoker'), 'invoker.db'),
+    repair: false,
+    json: false,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--db') {
+      const value = argv[i + 1];
+      if (!value) throw new Error('--db requires a path');
+      opts.db = value;
+      i += 1;
+    } else if (arg === '--repair') {
+      opts.repair = true;
+    } else if (arg === '--json') {
+      opts.json = true;
+    } else if (arg === '--help' || arg === '-h') {
+      opts.help = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+  opts.db = resolve(opts.db);
+  return opts;
+}
+
+function dependencyKey(dep) {
+  return `${dep.workflowId}\u0000${dep.taskId ?? ''}`;
+}
+
+function parseJsonColumn(raw, workflowId, column, problems) {
+  if (raw === null || raw === undefined) return { ok: true, value: undefined };
+  if (typeof raw !== 'string' || raw.length === 0) {
+    problems.push({ workflowId, type: 'malformed_json', column, message: `${column} is not valid JSON text` });
+    return { ok: false };
+  }
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch (err) {
+    problems.push({ workflowId, type: 'malformed_json', column, message: `${column} contains malformed JSON: ${err instanceof Error ? err.message : String(err)}` });
+    return { ok: false };
+  }
+}
+
+function tableColumns(db, tableName) {
+  try {
+    return new Set(db.prepare(`PRAGMA table_info(${tableName})`).all().map((row) => String(row.name)));
+  } catch {
+    return new Set();
+  }
+}
+
+function hasTable(db, tableName) {
+  const row = db.prepare(`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`).get(tableName);
+  return row !== undefined;
+}
+
+function addProblem(problems, workflowId, type, column, message, repairable = false) {
+  problems.push({ workflowId, type, column, message, repairable, repaired: false });
+}
+
+function addWorkflowInvariantProblem(db, columns, opts, repairs, problems, workflowId, message) {
+  if (/\bgeneration\b/.test(message)) {
+    addProblem(problems, workflowId, 'invalid_generation', 'generation', message, true);
+    if (opts.repair && columns.has('generation')) {
+      db.prepare('UPDATE workflows SET generation = 0 WHERE id = ?').run(workflowId);
+      repairs.push({ workflowId, type: 'invalid_generation', column: 'generation', action: 'set generation to 0' });
+      problems[problems.length - 1].repaired = true;
+    }
+    return;
+  }
+
+  if (/externalDependencies must be non-empty/.test(message)) {
+    addProblem(problems, workflowId, 'empty_external_dependencies', 'external_dependencies', message, true);
+    if (opts.repair && columns.has('external_dependencies')) {
+      db.prepare('UPDATE workflows SET external_dependencies = NULL WHERE id = ?').run(workflowId);
+      repairs.push({ workflowId, type: 'empty_external_dependencies', column: 'external_dependencies', action: 'normalized [] to NULL' });
+      problems[problems.length - 1].repaired = true;
+    }
+    return;
+  }
+
+  if (/external_dependency_changes|externalDependencyChanges/.test(message)) {
+    addProblem(problems, workflowId, 'invalid_dependency_entries', 'external_dependency_changes', message);
+    return;
+  }
+
+  if (/external_dependencies|externalDependencies|workflowId|taskId|requiredStatus|gatePolicy/.test(message)) {
+    addProblem(problems, workflowId, 'invalid_dependency_entries', 'external_dependencies', message);
+    return;
+  }
+
+  addProblem(problems, workflowId, 'invalid_workflow_state', 'workflows', message);
+}
+
+function workflowInvariantMessage(workflow) {
+  try {
+    assertWorkflowConsistent(workflow);
+    return undefined;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+function dependencyListIsConsistent(workflowId, deps) {
+  return workflowInvariantMessage({
+    id: workflowId || 'workflow',
+    name: workflowId || 'workflow',
+    generation: 0,
+    externalDependencies: deps,
+  }) === undefined;
+}
+
+
+function selectWorkflowRows(db, columns) {
+  const fields = ['id'];
+  fields.push(columns.has('name') ? 'name' : 'NULL AS name');
+  fields.push(columns.has('generation') ? 'generation' : 'NULL AS generation');
+  fields.push(columns.has('external_dependencies') ? 'external_dependencies' : 'NULL AS external_dependencies');
+  fields.push(columns.has('external_dependency_changes') ? 'external_dependency_changes' : 'NULL AS external_dependency_changes');
+  return db.prepare(`SELECT ${fields.join(', ')} FROM workflows ORDER BY id`).all();
+}
+
+function validateWorkflowRows(db, columns, opts, problems, repairs) {
+  if (!columns.has('generation')) {
+    addProblem(problems, '*', 'missing_generation_column', 'generation', 'workflows.generation column is missing', true);
+    if (opts.repair) {
+      db.exec('ALTER TABLE workflows ADD COLUMN generation INTEGER DEFAULT 0');
+      repairs.push({ workflowId: '*', type: 'missing_generation_column', column: 'generation', action: 'added generation column with default 0' });
+      columns.add('generation');
+      problems[problems.length - 1].repaired = true;
+    }
+  }
+
+  const rows = selectWorkflowRows(db, columns);
+  const dependencyKeysByWorkflow = new Map();
+  for (const row of rows) {
+    const workflowId = String(row.id ?? '');
+    const depsParsed = parseJsonColumn(row.external_dependencies, workflowId, 'external_dependencies', problems);
+    const changesParsed = parseJsonColumn(row.external_dependency_changes, workflowId, 'external_dependency_changes', problems);
+    const workflow = {
+      id: workflowId,
+      name: row.name,
+      generation: row.generation,
+      ...(depsParsed.ok && depsParsed.value !== undefined ? { externalDependencies: depsParsed.value } : {}),
+      ...(changesParsed.ok && changesParsed.value !== undefined ? { externalDependencyChanges: changesParsed.value } : {}),
+    };
+
+    const message = workflowInvariantMessage(workflow);
+    if (message) {
+      addWorkflowInvariantProblem(db, columns, opts, repairs, problems, workflowId, message);
+    }
+
+    if (
+      depsParsed.ok
+      && Array.isArray(depsParsed.value)
+      && depsParsed.value.length > 0
+      && dependencyListIsConsistent(workflowId, depsParsed.value)
+    ) {
+      dependencyKeysByWorkflow.set(workflowId, new Set(depsParsed.value.map(dependencyKey)));
+    }
+  }
+  return dependencyKeysByWorkflow;
+}
+
+function scanLegacyTaskDependencyEvidence(db, workflowDependencyKeys, problems) {
+  if (!hasTable(db, 'tasks')) return;
+  const taskColumns = tableColumns(db, 'tasks');
+  if (!taskColumns.has('workflow_id') || !taskColumns.has('external_dependencies')) return;
+  const rows = db.prepare(
+    `SELECT id, workflow_id, external_dependencies
+       FROM tasks
+      WHERE external_dependencies IS NOT NULL AND external_dependencies != ''
+      ORDER BY workflow_id, id`,
+  ).all();
+  const affected = new Map();
+  for (const row of rows) {
+    const workflowId = String(row.workflow_id ?? '');
+    let parsed;
+    try {
+      parsed = JSON.parse(String(row.external_dependencies));
+    } catch {
+      if (!affected.has(workflowId)) affected.set(workflowId, { taskIds: [], messages: [] });
+      affected.get(workflowId).messages.push(`task ${String(row.id)} has malformed legacy external_dependencies`);
+      continue;
+    }
+    if (!Array.isArray(parsed) || parsed.length === 0) continue;
+    const dependencyMessage = dependencyListIsConsistent(workflowId, parsed)
+      ? undefined
+      : workflowInvariantMessage({
+        id: workflowId || 'workflow',
+        name: workflowId || 'workflow',
+        generation: 0,
+        externalDependencies: parsed,
+      });
+    if (!affected.has(workflowId)) affected.set(workflowId, { taskIds: [], messages: [] });
+    affected.get(workflowId).taskIds.push(String(row.id));
+    if (dependencyMessage) {
+      affected.get(workflowId).messages.push(`task ${String(row.id)} ${dependencyMessage}`);
+      continue;
+    }
+    const workflowKeys = workflowDependencyKeys.get(workflowId) ?? new Set();
+    const missing = parsed.filter((dep) => !workflowKeys.has(dependencyKey(dep)));
+    if (missing.length > 0) {
+      affected.get(workflowId).messages.push(`task ${String(row.id)} has dependency evidence not present on workflow metadata`);
+    }
+  }
+  for (const [workflowId, info] of affected) {
+    const messages = info.messages.length > 0 ? info.messages : ['legacy task-level external dependency evidence remains'];
+    problems.push({
+      workflowId,
+      type: 'ambiguous_dependency_loss',
+      column: 'tasks.external_dependencies',
+      taskIds: [...new Set(info.taskIds)],
+      message: messages.join('; '),
+      repairable: false,
+      repaired: false,
+    });
+  }
+}
+
+function summarize(problems, repairs) {
+  const remaining = problems.filter((problem) => !problem.repaired);
+  return { clean: remaining.length === 0, problems, repairs, remaining };
+}
+
+function printText(result, opts) {
+  if (result.clean) {
+    if (result.repairs.length > 0) {
+      console.log(`Workflow consistency check repaired ${result.repairs.length} problem(s) in ${opts.db}.`);
+      for (const repair of result.repairs) console.log(`- ${repair.workflowId}: ${repair.action}`);
+    } else {
+      console.log(`Workflow consistency check clean: ${opts.db}`);
+    }
+    return;
+  }
+  console.error(`Workflow consistency check found ${result.remaining.length} unrepaired problem(s) in ${opts.db}:`);
+  for (const problem of result.remaining) {
+    const suffix = problem.taskIds?.length ? ` tasks=${problem.taskIds.join(',')}` : '';
+    const repair = problem.repairable ? ' (run with --repair to fix safely)' : '';
+    console.error(`- ${problem.workflowId}: ${problem.type} ${problem.column}: ${problem.message}${suffix}${repair}`);
+  }
+  if (result.repairs.length > 0) {
+    console.error(`Repaired ${result.repairs.length} safe problem(s).`);
+  }
+}
+
+function main() {
+  let opts;
+  try {
+    opts = parseArgs(process.argv.slice(2));
+    if (opts.help) {
+      process.stdout.write(usage());
+      process.exit(0);
+    }
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.stderr.write(usage());
+    process.exit(2);
+  }
+
+  const problems = [];
+  const repairs = [];
+  if (!existsSync(opts.db)) {
+    addProblem(problems, '*', 'missing_database', 'database', `database does not exist: ${opts.db}`);
+    const result = summarize(problems, repairs);
+    if (opts.json) console.log(JSON.stringify({ db: opts.db, repair: opts.repair, ...result }, null, 2));
+    else printText(result, opts);
+    process.exit(1);
+  }
+
+  let db;
+  try {
+    db = new DatabaseSync(opts.db, { readOnly: !opts.repair });
+    if (!hasTable(db, 'workflows')) {
+      addProblem(problems, '*', 'missing_workflows_table', 'workflows', 'workflows table is missing');
+    } else {
+      const columns = tableColumns(db, 'workflows');
+      const workflowDependencyKeys = validateWorkflowRows(db, columns, opts, problems, repairs);
+      scanLegacyTaskDependencyEvidence(db, workflowDependencyKeys, problems);
+    }
+  } finally {
+    db?.close();
+  }
+
+  const result = summarize(problems, repairs);
+  if (opts.json) console.log(JSON.stringify({ db: opts.db, repair: opts.repair, ...result }, null, 2));
+  else printText(result, opts);
+  process.exit(result.clean ? 0 : 1);
+}
+
+main();

--- a/scripts/repro/prove-workflow-consistency-script.sh
+++ b/scripts/repro/prove-workflow-consistency-script.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+DB="$TMP_DIR/invoker.db"
+
+cd "$ROOT_DIR"
+
+node --input-type=module - "$DB" <<'NODE'
+import { DatabaseSync } from 'node:sqlite';
+
+const dbPath = process.argv[2];
+const db = new DatabaseSync(dbPath);
+db.exec(`
+  CREATE TABLE workflows (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    external_dependencies TEXT CHECK (external_dependencies IS NULL OR json_valid(external_dependencies)),
+    external_dependency_changes TEXT CHECK (external_dependency_changes IS NULL OR json_valid(external_dependency_changes)),
+    generation INTEGER DEFAULT 0 CHECK (typeof(generation) = 'integer' AND generation >= 0),
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+  );
+  CREATE TABLE tasks (
+    id TEXT PRIMARY KEY,
+    workflow_id TEXT NOT NULL,
+    external_dependencies TEXT,
+    FOREIGN KEY (workflow_id) REFERENCES workflows(id)
+  );
+`);
+db.exec('PRAGMA ignore_check_constraints = ON');
+const insertWorkflow = db.prepare(`
+  INSERT INTO workflows (id, name, external_dependencies, external_dependency_changes, generation)
+  VALUES (?, ?, ?, ?, ?)
+`);
+insertWorkflow.run(
+  'wf-clean',
+  'Clean workflow',
+  JSON.stringify([{ workflowId: 'wf-upstream', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' }]),
+  null,
+  2,
+);
+insertWorkflow.run('wf-empty-deps', 'Empty deps', JSON.stringify([]), null, 4);
+insertWorkflow.run('wf-null-generation', 'Null generation', null, null, null);
+insertWorkflow.run(
+  'wf-bad-entry',
+  'Bad dependency entry',
+  JSON.stringify([{ workflowId: '', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' }]),
+  null,
+  0,
+);
+insertWorkflow.run('wf-loss-evidence', 'Loss evidence', null, null, 0);
+db.prepare(`
+  INSERT INTO tasks (id, workflow_id, external_dependencies) VALUES (?, ?, ?)
+`).run(
+  'wf-loss-evidence/root',
+  'wf-loss-evidence',
+  JSON.stringify([{ workflowId: 'wf-vanished', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' }]),
+);
+db.exec('PRAGMA ignore_check_constraints = OFF');
+db.close();
+NODE
+
+set +e
+node scripts/check-workflow-consistency.mjs --db "$DB" --json > "$TMP_DIR/check-before.json" 2> "$TMP_DIR/check-before.err"
+BEFORE_STATUS=$?
+set -e
+if [[ "$BEFORE_STATUS" -eq 0 ]]; then
+  echo "expected checker without --repair to fail" >&2
+  exit 1
+fi
+node --input-type=module - "$TMP_DIR/check-before.json" <<'NODE'
+import { readFileSync } from 'node:fs';
+const result = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+const types = new Set(result.remaining.map((problem) => problem.type));
+for (const type of ['empty_external_dependencies', 'invalid_generation', 'invalid_dependency_entries', 'ambiguous_dependency_loss']) {
+  if (!types.has(type)) throw new Error(`missing problem type before repair: ${type}`);
+}
+NODE
+
+set +e
+node scripts/check-workflow-consistency.mjs --db "$DB" --repair --json > "$TMP_DIR/check-repair.json" 2> "$TMP_DIR/check-repair.err"
+REPAIR_STATUS=$?
+set -e
+if [[ "$REPAIR_STATUS" -eq 0 ]]; then
+  echo "expected checker with --repair to keep ambiguous/bad rows non-zero" >&2
+  exit 1
+fi
+node --input-type=module - "$TMP_DIR/check-repair.json" "$DB" <<'NODE'
+import { readFileSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+const result = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+if (!result.repairs.some((repair) => repair.workflowId === 'wf-empty-deps' && repair.action === 'normalized [] to NULL')) {
+  throw new Error('empty dependency array repair was not reported');
+}
+if (!result.repairs.some((repair) => repair.workflowId === 'wf-null-generation' && repair.action === 'set generation to 0')) {
+  throw new Error('generation repair was not reported');
+}
+const remaining = new Set(result.remaining.map((problem) => `${problem.workflowId}:${problem.type}`));
+if (!remaining.has('wf-bad-entry:invalid_dependency_entries')) throw new Error('bad dependency entry should remain');
+if (!remaining.has('wf-loss-evidence:ambiguous_dependency_loss')) throw new Error('ambiguous dependency loss should remain');
+const db = new DatabaseSync(process.argv[3], { readOnly: true });
+const repaired = db.prepare(`
+  SELECT id, external_dependencies, generation
+    FROM workflows
+   WHERE id IN ('wf-empty-deps', 'wf-null-generation')
+   ORDER BY id
+`).all();
+db.close();
+const byId = new Map(repaired.map((row) => [row.id, row]));
+if (byId.get('wf-empty-deps').external_dependencies !== null) throw new Error('empty dependencies were not normalized to NULL');
+if (byId.get('wf-null-generation').generation !== 0) throw new Error('invalid generation was not set to 0');
+NODE
+
+node --input-type=module - "$DB" <<'NODE'
+import { DatabaseSync } from 'node:sqlite';
+const db = new DatabaseSync(process.argv[2]);
+db.prepare(`DELETE FROM tasks WHERE workflow_id = ?`).run('wf-loss-evidence');
+db.prepare(`DELETE FROM workflows WHERE id = ?`).run('wf-bad-entry');
+db.close();
+NODE
+
+node scripts/check-workflow-consistency.mjs --db "$DB" --json > "$TMP_DIR/check-clean.json"
+node --input-type=module - "$TMP_DIR/check-clean.json" <<'NODE'
+import { readFileSync } from 'node:fs';
+const result = JSON.parse(readFileSync(process.argv[2], 'utf8'));
+if (result.clean !== true || result.remaining.length !== 0) throw new Error('expected clean result after removing unrepaired rows');
+NODE
+
+echo "workflow consistency script proof passed"

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -77,16 +77,16 @@ expected_executed_for_mode() {
   if [ "$PROOF" = "1" ] && [ -f "$PROOF_MANIFEST" ]; then manifest_count; return; fi
   case "$MODE_KEY" in
     required)
-      printf '22'
+      printf '23'
       ;;
     extended)
-      printf '29'
+      printf '30'
       ;;
     dangerous)
       if [ "${#SKIPPED_UNAVAILABLE[@]}" -eq 1 ] && [ "${SKIPPED_UNAVAILABLE[0]}" = "dangerous/10-docker-comprehensive.sh" ]; then
-        printf '29'
-      else
         printf '30'
+      else
+        printf '31'
       fi
       ;;
   esac
@@ -96,13 +96,13 @@ expected_discovered_for_mode() {
   if [ "$PROOF" = "1" ] && [ -f "$PROOF_MANIFEST" ]; then manifest_count; return; fi
   case "$MODE_KEY" in
     required)
-      printf '22'
+      printf '23'
       ;;
     extended)
-      printf '29'
+      printf '30'
       ;;
     dangerous)
-      printf '30'
+      printf '31'
       ;;
   esac
 }

--- a/scripts/test-suites/required/30-workflow-consistency-checker.sh
+++ b/scripts/test-suites/required/30-workflow-consistency-checker.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Required proof coverage for workflow consistency scanning and repair.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+if [[ "${INVOKER_TEST_ALL_PROOF:-0}" == "1" ]]; then
+  echo "SKIP: required-fast runs workflow consistency checker repro separately."
+  exit 0
+fi
+
+exec bash scripts/repro/prove-workflow-consistency-script.sh


### PR DESCRIPTION
## Summary

This adds a script to find and safely repair old bad workflow rows.

The bug was that existing databases could already contain inconsistent metadata, and adapter hard gates only help on future writes.

The checker now calls the shared workflow invariant code from `#1306`. It only maps those failures to repair/report actions.

Ambiguous dependency loss still stays a loud error.

## Test Plan

- [x] `bash scripts/repro/prove-workflow-consistency-script.sh`
- [ ] GitHub Actions runs `required/30-workflow-consistency-checker.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 504a9d5f`
- Post-revert steps: None.
- Data migration? No.

Depends-On: #1307
