### PR TITLE
Prevent Delete Workflow kill hangs

### DIFF
--- a/packages/execution-engine/src/__tests__/process-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/process-utils.test.ts
@@ -161,3 +161,65 @@ describe('process-utils shell environment resolution', () => {
     }
   });
 });
+
+describe('childProcessHasExited', () => {
+  it('treats unset mock exit fields as still running', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const child = createMockProcess();
+
+    expect(processUtils.childProcessHasExited(child)).toBe(false);
+  });
+
+  it('detects exited and signaled child processes', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const exited = createMockProcess();
+    const signaled = createMockProcess();
+    (exited as any).exitCode = 0;
+    (signaled as any).exitCode = null;
+    (signaled as any).signalCode = 'SIGTERM';
+
+    expect(processUtils.childProcessHasExited(exited)).toBe(true);
+    expect(processUtils.childProcessHasExited(signaled)).toBe(true);
+  });
+});
+
+describe('terminateChildProcessGroup', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns without signaling an already exited child process', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const child = createMockProcess();
+    (child as any).exitCode = 0;
+
+    await processUtils.terminateChildProcessGroup(child, () => false);
+
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('sends SIGTERM and resolves when the child closes', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const child = createMockProcess();
+
+    const killed = processUtils.terminateChildProcessGroup(child, () => false);
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    child.emit('close', null, 'SIGTERM');
+    await expect(killed).resolves.toBeUndefined();
+  });
+
+  it('escalates to SIGKILL when the child does not close', async () => {
+    vi.useFakeTimers();
+    const { processUtils } = await loadProcessUtils();
+    const child = createMockProcess();
+
+    const killed = processUtils.terminateChildProcessGroup(child, () => false);
+
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    await vi.advanceTimersByTimeAsync(processUtils.SIGKILL_TIMEOUT_MS);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    child.emit('close', null, 'SIGKILL');
+    await expect(killed).resolves.toBeUndefined();
+  });
+});

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -408,6 +408,21 @@ describe('WorktreeExecutor', () => {
     vi.mocked(process.kill).mockRestore();
   });
 
+  it('kill returns when process close already fired during finalization', async () => {
+    const { taskProcess } = setupSpawnMock();
+
+    const request = makeRequest({ inputs: { command: 'echo done' } });
+    const handle = await executor.start(request);
+
+    (taskProcess as any).exitCode = 0;
+    taskProcess.emit('close', 0, null);
+
+    await expect(Promise.race([
+      executor.kill(handle).then(() => 'resolved'),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('kill hung')), 50)),
+    ])).resolves.toBe('resolved');
+  });
+
   it('destroyAll kills processes without removing worktrees', async () => {
     const taskProcesses: Array<ChildProcess & EventEmitter> = [];
 

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -7,6 +7,7 @@ import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { checkStaleness } from './git-staleness-detector.js';
 import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
+import { childProcessHasExited, terminateChildProcessGroup } from './process-utils.js';
 
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -40,6 +41,8 @@ export interface BaseEntry {
    * orchestrator lease does not expire in this post-close window.
    */
   finalizingAfterClose?: boolean;
+  /** Child process owned by process-backed executors. */
+  process?: ChildProcess | null;
 }
 
 interface HeartbeatOptions {
@@ -219,7 +222,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         return;
       }
 
-      if (child.exitCode !== null || child.killed) {
+      if (childProcessHasExited(child) || child.killed) {
         if (entry.finalizingAfterClose) {
           this.emitHeartbeat(executionId);
           return;
@@ -1109,9 +1112,15 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     return { sessionId, cliArgs, fullPrompt };
   }
 
+  async kill(handle: ExecutorHandle): Promise<void> {
+    const entry = this.getEntry(handle);
+    if (!entry || entry.completed || !entry.process) return;
+
+    await terminateChildProcessGroup(entry.process, () => entry.completed);
+  }
+
   // Abstract methods that subclasses must implement
   abstract start(request: WorkRequest): Promise<ExecutorHandle>;
-  abstract kill(handle: ExecutorHandle): Promise<void>;
   abstract sendInput(handle: ExecutorHandle, input: string): void;
   abstract getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null;
   abstract getRestoredTerminalSpec(meta: PersistedTaskMeta): TerminalSpec;

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -4,7 +4,7 @@ import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import { loadSecretsFile } from './secrets-loader.js';
-import { killProcessGroup, cleanElectronEnv, SIGKILL_TIMEOUT_MS } from './process-utils.js';
+import { killProcessGroup, cleanElectronEnv } from './process-utils.js';
 import { computeContentHash, buildExperimentBranchName } from './branch-utils.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { traceExecution } from './exec-trace.js';
@@ -485,30 +485,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
     const entry = this.entries.get(handle.executionId);
     if (!entry || entry.completed) return;
 
-    // Kill the task process (docker exec) if running
-    if (entry.process && !entry.process.killed) {
-      await new Promise<void>((resolve) => {
-        const child = entry.process!;
-        const killTimer = setTimeout(() => {
-          if (!entry.completed) {
-            killProcessGroup(child, 'SIGKILL');
-          }
-        }, SIGKILL_TIMEOUT_MS);
-
-        child.on('close', () => {
-          clearTimeout(killTimer);
-          resolve();
-        });
-
-        if (entry.completed) {
-          clearTimeout(killTimer);
-          resolve();
-          return;
-        }
-
-        killProcessGroup(child, 'SIGTERM');
-      });
-    }
+    await super.kill(handle);
 
     // Stop and remove the container
     const docker = await this.getDocker();

--- a/packages/execution-engine/src/process-utils.ts
+++ b/packages/execution-engine/src/process-utils.ts
@@ -47,6 +47,41 @@ export function killProcessGroup(child: ChildProcess, signal: NodeJS.Signals): b
   }
 }
 
+export function childProcessHasExited(child: ChildProcess): boolean {
+  return child.exitCode != null || child.signalCode != null;
+}
+
+export async function terminateChildProcessGroup(
+  child: ChildProcess,
+  isComplete: () => boolean,
+): Promise<void> {
+  if (childProcessHasExited(child) || isComplete()) return;
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const killTimer = setTimeout(() => {
+      if (!isComplete()) {
+        killProcessGroup(child, 'SIGKILL');
+      }
+    }, SIGKILL_TIMEOUT_MS);
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(killTimer);
+      resolve();
+    };
+
+    child.once('close', finish);
+
+    if (childProcessHasExited(child) || isComplete()) {
+      finish();
+      return;
+    }
+
+    killProcessGroup(child, 'SIGTERM');
+  });
+}
+
 function splitPathEntries(rawPath?: string): string[] {
   if (!rawPath) return [];
   return rawPath.split(':').map((entry) => entry.trim()).filter(Boolean);

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -1133,33 +1133,6 @@ ${runProvisionSection}stop_bootstrap_heartbeat
     return handle;
   }
 
-  async kill(handle: ExecutorHandle): Promise<void> {
-    const entry = this.entries.get(handle.executionId);
-    if (!entry || entry.completed || !entry.process) return;
-
-    await new Promise<void>((resolve) => {
-      const child = entry.process!;
-
-      const killTimer = setTimeout(() => {
-        if (!entry.completed) {
-          killProcessGroup(child, 'SIGKILL');
-        }
-      }, SIGKILL_TIMEOUT_MS);
-
-      child.on('close', () => {
-        clearTimeout(killTimer);
-        resolve();
-      });
-
-      if (entry.completed) {
-        clearTimeout(killTimer);
-        resolve();
-        return;
-      }
-
-      killProcessGroup(child, 'SIGTERM');
-    });
-  }
 
   sendInput(handle: ExecutorHandle, input: string): void {
     const entry = this.entries.get(handle.executionId);

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -559,33 +559,9 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
 
   async kill(handle: ExecutorHandle): Promise<void> {
     const entry = this.entries.get(handle.executionId);
-    if (!entry || entry.completed) return;
+    if (!entry || entry.completed || !entry.process) return;
 
-    if (!entry.process) return;
-
-    await new Promise<void>((resolve) => {
-      const child = entry.process!;
-
-      const killTimer = setTimeout(() => {
-        if (!entry.completed) {
-          killProcessGroup(child, 'SIGKILL');
-        }
-      }, SIGKILL_TIMEOUT_MS);
-
-      child.on('close', () => {
-        clearTimeout(killTimer);
-        resolve();
-      });
-
-      if (entry.completed) {
-        clearTimeout(killTimer);
-        this.softReleasePoolSlot(entry);
-        resolve();
-        return;
-      }
-
-      killProcessGroup(child, 'SIGTERM');
-    });
+    await super.kill(handle);
 
     this.softReleasePoolSlot(entry);
   }


### PR DESCRIPTION
## Summary

Delete Workflow no longer times out when a task process has already closed but is still finishing cleanup.

The old kill path waited for a close event even if that event had already fired. The request could hang until the 30 second IPC timeout.

The fix puts process killing in `BaseExecutor.kill()`. SSH inherits it directly; worktree and Docker call `super.kill()` before their own cleanup.

## Architecture

### Before

```mermaid
graph TD
    A[Delete workflow] --> B[Cancel running tasks]
    B --> C[Worktree kill copy]
    B --> D[SSH kill copy]
    B --> E[Docker kill copy]
    C --> F[Wait for close event]
    D --> F
    E --> F
    G[Close already fired] --> F
    F --> H[IPC timeout]
```

### After

```mermaid
graph TD
    A[Delete workflow] --> B[Cancel running tasks]
    B --> C[BaseExecutor.kill]
    C --> D[terminateChildProcessGroup]
    D --> E{Child already exited?}
    E -->|Yes| F[Return immediately]
    E -->|No| G[Send SIGTERM]
    G --> H[Return on close]
    G --> I[Escalate to SIGKILL after timeout]
    B --> J[Worktree extra cleanup]
    B --> K[Docker extra cleanup]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/process-utils.test.ts src/__tests__/worktree-executor.test.ts`
- [x] `pnpm --filter @invoker/execution-engine build && pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a73888b6e`
- Post-revert steps: Rebuild `@invoker/execution-engine` and `@invoker/app`.
- Data migration? No
