### PR TITLE
[Preserved Work] Add fix lineage guard repro to CI

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1320,6 +1320,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(capturedContext!.signal.aborted).toBe(false);
     expect(capturedContext!.workflowId).toBe('wf-1');
     expect(capturedContext!.intentId).toBe(1);
+    expect(capturedContext!.priority).toBe('normal');
+    expect(capturedContext!.channel).toBe('invoker:fix-with-agent');
+    expect(capturedContext!.args).toEqual(['wf-1/blocker-task', null]);
 
     const recreateTask = coordinator.enqueue<void>(
       'wf-1',
@@ -1554,5 +1557,122 @@ describe('PersistedWorkflowMutationCoordinator', () => {
 
     expect(iterationsBeforeAbort).toBeGreaterThan(0);
     await expect(olderRunning).rejects.toThrow(/superseded by recreate intent/i);
+  });
+
+  it('recreate-task aborts a superseded fix mutation before its deferred side effect runs', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const releaseSideEffect = deferred();
+    const fixStarted = deferred();
+    let staleWriteCount = 0;
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, _args, context) => {
+        if (channel !== 'invoker:fix-with-agent') {
+          return;
+        }
+        fixStarted.resolve();
+        await releaseSideEffect.promise;
+        if (context.signal.aborted) {
+          return;
+        }
+        staleWriteCount += 1;
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await fixStarted.promise;
+
+    const recreateTask = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:recreate-task',
+      ['wf-1/target-task'],
+    );
+    await recreateTask;
+    releaseSideEffect.resolve();
+
+    await expect(olderRunning).rejects.toThrow(/superseded by recreate intent/i);
+    expect(staleWriteCount).toBe(0);
+  });
+
+  it('delete-workflow aborts a superseded fix mutation without regressing later queued work', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const releaseSideEffect = deferred();
+    const fixStarted = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args, context) => {
+        if (channel === 'invoker:fix-with-agent') {
+          order.push('fix-start');
+          fixStarted.resolve();
+          await releaseSideEffect.promise;
+          if (!context.signal.aborted) {
+            order.push('fix-stale-write');
+          }
+          return;
+        }
+        order.push(`${channel}:${String(args[0] ?? '')}`);
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await fixStarted.promise;
+
+    const deleteWorkflow = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:delete-workflow',
+      ['wf-1'],
+    );
+    const laterQueued = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:edit-task-agent',
+      ['wf-1/task-next', 'codex'],
+    );
+
+    await deleteWorkflow;
+    releaseSideEffect.resolve();
+    await expect(olderRunning).rejects.toThrow(/superseded by delete intent/i);
+    await laterQueued;
+
+    expect(order).toEqual([
+      'fix-start',
+      'invoker:delete-workflow:wf-1',
+      'invoker:edit-task-agent:wf-1/task-next',
+    ]);
   });
 });

--- a/packages/app/src/__tests__/resolve-conflict-action.test.ts
+++ b/packages/app/src/__tests__/resolve-conflict-action.test.ts
@@ -49,9 +49,16 @@ describe('resolveConflictAction', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith(
+      'task-a',
+      expect.objectContaining({ selectedAttemptId: 'att-1', generation: 1 }),
+    );
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', 'saved-err', undefined);
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith(
+      'task-a',
+      'saved-err',
+      expect.objectContaining({ selectedAttemptId: 'att-1', generation: 1 }),
+    );
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
     expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
@@ -77,7 +84,11 @@ describe('resolveConflictAction', () => {
       autoApproveAIFixes: true,
     });
 
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith(
+      'task-a',
+      'saved-err',
+      expect.objectContaining({ selectedAttemptId: 'att-1', generation: 1 }),
+    );
     expect(approve).toHaveBeenCalledWith('task-a');
     expect(taskExecutorWithApprove.executeTasks).not.toHaveBeenCalled();
     expect(taskExecutorWithApprove.publishAfterFix).not.toHaveBeenCalled();
@@ -102,6 +113,7 @@ describe('resolveConflictAction', () => {
       'task-a',
       'saved-err',
       'claude failed',
+      expect.objectContaining({ selectedAttemptId: 'att-1', generation: 1 }),
     );
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
   });

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -608,6 +608,12 @@ describe('provideInput', () => {
 describe('finalizeAppliedFix', () => {
   it('leaves task awaiting approval when autoApproveAIFixes is disabled', async () => {
     const orchestrator = {
+      getTask: vi.fn().mockReturnValue(makeTask({
+        id: 'task-a',
+        status: 'fixing_with_ai',
+        config: { workflowId: 'wf-1' },
+        execution: { selectedAttemptId: 'att-1', generation: 3 },
+      })),
       setFixAwaitingApproval: vi.fn(),
       approve: vi.fn(),
     };
@@ -621,10 +627,18 @@ describe('finalizeAppliedFix', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       taskExecutor: taskExecutor as unknown as TaskRunner,
       autoApproveAIFixes: false,
+    }, {
+      taskId: 'task-a',
+      selectedAttemptId: 'att-1',
+      generation: 3,
     });
 
     expect(result).toEqual({ autoApproved: false, started: [] });
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-error');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith(
+      'task-a',
+      'saved-error',
+      expect.objectContaining({ selectedAttemptId: 'att-1', generation: 3 }),
+    );
     expect(orchestrator.approve).not.toHaveBeenCalled();
   });
 
@@ -652,6 +666,10 @@ describe('finalizeAppliedFix', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       taskExecutor: taskExecutor as unknown as TaskRunner,
       autoApproveAIFixes: true,
+    }, {
+      taskId: 'task-a',
+      selectedAttemptId: undefined,
+      generation: 0,
     });
 
     expect(result).toEqual({ autoApproved: true, started });
@@ -688,6 +706,10 @@ describe('finalizeAppliedFix', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       taskExecutor: taskExecutor as unknown as TaskRunner,
       autoApproveAIFixes: true,
+    }, {
+      taskId: 'merge-a',
+      selectedAttemptId: undefined,
+      generation: 0,
     });
 
     expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
@@ -795,7 +817,10 @@ describe('autoFixOnFailure', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith(
+      'task-a',
+      expect.objectContaining({ selectedAttemptId: undefined, generation: 0 }),
+    );
     expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'claude', 'boom');
     expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
@@ -886,7 +911,10 @@ describe('autoFixOnFailure', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith(
+      'task-a',
+      expect.objectContaining({ selectedAttemptId: undefined, generation: 0 }),
+    );
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
@@ -1316,7 +1344,11 @@ describe('fixWithAgentAction', () => {
 
     expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'codex', 'boom');
     expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith(
+      'task-a',
+      'boom',
+      expect.objectContaining({ selectedAttemptId: undefined, generation: 0 }),
+    );
     expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
   });
 
@@ -1355,7 +1387,11 @@ describe('fixWithAgentAction', () => {
 
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError);
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith(
+      'task-a',
+      mergeError,
+      expect.objectContaining({ selectedAttemptId: undefined, generation: 0 }),
+    );
     expect(result).toEqual({ kind: 'resolveConflict', autoApproved: false, started: [] });
   });
 
@@ -2184,6 +2220,7 @@ describe('fixWithAgentAction lineage guard', () => {
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
     // Should NOT have called revertConflictResolution either
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
 
   it('throws StaleLineageError when signal is aborted during async fix', async () => {
@@ -2258,10 +2295,11 @@ describe('fixWithAgentAction lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
-    })).rejects.toThrow('agent crashed');
+    })).rejects.toThrow(StaleLineageError);
 
     // revertConflictResolution must NOT be called when lineage is stale
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
 
   it('proceeds normally when lineage is current', async () => {
@@ -2291,7 +2329,11 @@ describe('fixWithAgentAction lineage guard', () => {
     });
 
     // Normal path should proceed
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith(
+      'task-a',
+      'boom',
+      expect.objectContaining({ selectedAttemptId: 'att-1', generation: 5 }),
+    );
     expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
   });
 });
@@ -2340,6 +2382,7 @@ describe('resolveConflictAction lineage guard', () => {
 
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
 
   it('skips revertConflictResolution when lineage changed and resolution threw', async () => {
@@ -2375,9 +2418,10 @@ describe('resolveConflictAction lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
-    })).rejects.toThrow('resolution failed');
+    })).rejects.toThrow(StaleLineageError);
 
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
 });
 
@@ -2483,7 +2527,7 @@ describe('autoFixOnFailure lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
-    })).rejects.toThrow('agent crashed');
+    })).rejects.toThrow(StaleLineageError);
 
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
   });
@@ -2544,8 +2588,18 @@ describe('finalizeAppliedFix lineage guard', () => {
     };
 
     await expect(finalizeAppliedFix('task-a', 'saved-error', {
-      orchestrator: orchestrator as unknown as Orchestrator,
+      orchestrator: {
+        ...orchestrator,
+        getTask: vi.fn(() => makeTask({
+          status: 'fixing_with_ai',
+          execution: { selectedAttemptId: 'att-1', generation: 3 },
+        })),
+      } as unknown as Orchestrator,
       taskExecutor: {} as TaskRunner,
+    }, {
+      taskId: 'task-a',
+      selectedAttemptId: 'att-1',
+      generation: 3,
     }, ac.signal)).rejects.toThrow(StaleLineageError);
 
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
@@ -2554,15 +2608,27 @@ describe('finalizeAppliedFix lineage guard', () => {
   it('proceeds normally when signal is not aborted', async () => {
     const ac = new AbortController();
     const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        status: 'fixing_with_ai',
+        execution: { selectedAttemptId: 'att-1', generation: 3 },
+      })),
       setFixAwaitingApproval: vi.fn(),
     };
 
     const result = await finalizeAppliedFix('task-a', 'saved-error', {
       orchestrator: orchestrator as unknown as Orchestrator,
       taskExecutor: {} as TaskRunner,
+    }, {
+      taskId: 'task-a',
+      selectedAttemptId: 'att-1',
+      generation: 3,
     }, ac.signal);
 
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-error');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith(
+      'task-a',
+      'saved-error',
+      expect.objectContaining({ selectedAttemptId: 'att-1', generation: 3 }),
+    );
     expect(result).toEqual({ autoApproved: false, started: [] });
   });
 });

--- a/packages/app/src/__tests__/workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-coordinator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { WorkflowMutationCoordinator } from '../workflow-mutation-coordinator.js';
+import { WorkflowMutationCoordinator, type WorkflowMutationContext } from '../workflow-mutation-coordinator.js';
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
   let resolve = () => {};
@@ -8,6 +8,22 @@ function deferred(): { promise: Promise<void>; resolve: () => void } {
 }
 
 describe('WorkflowMutationCoordinator', () => {
+  it('passes workflow mutation context metadata to queued jobs', async () => {
+    const c = new WorkflowMutationCoordinator();
+    let captured: WorkflowMutationContext | undefined;
+
+    await c.enqueue('wf-context', 'high', async (context) => {
+      captured = context;
+    });
+
+    expect(captured).toBeDefined();
+    expect(captured).toMatchObject({
+      workflowId: 'wf-context',
+      priority: 'high',
+    });
+    expect(captured?.signal.aborted).toBe(false);
+  });
+
   it('repro: normal-priority retry can leave old state visible until queued work finishes', async () => {
     const c = new WorkflowMutationCoordinator();
     const wf = 'wf-repro';
@@ -57,4 +73,3 @@ describe('WorkflowMutationCoordinator', () => {
     expect(order).toEqual(['running-normal', 'queued-high', 'queued-normal']);
   });
 });
-

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -42,6 +42,7 @@ import {
   recreateTask as sharedRecreateTask,
   forkWorkflow as sharedForkWorkflow,
   setWorkflowMergeMode,
+  StaleLineageError,
 } from './workflow-actions.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import type { CostGroupDimension } from './cost-rollup.js';
@@ -1606,6 +1607,10 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
       logger: deps.logger,
       context: 'headless.fix-with-agent.failure',
     });
+    if (err instanceof StaleLineageError) {
+      deps.logger.info(`headless.fix-with-agent discarded late result for "${taskId}": ${err.message}`, { module: 'headless' });
+      return;
+    }
     throw err;
   } finally {
     autoFix.unsubscribe();
@@ -1646,6 +1651,10 @@ async function headlessResolveConflict(taskId: string, deps: HeadlessDeps, agent
       logger: deps.logger,
       context: 'headless.resolve-conflict.failure',
     });
+    if (err instanceof StaleLineageError) {
+      deps.logger.info(`headless.resolve-conflict discarded late result for "${taskId}": ${err.message}`, { module: 'headless' });
+      return;
+    }
     throw err;
   } finally {
     autoFix.unsubscribe();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -129,6 +129,7 @@ import {
   selectFailureRecoveryRoute,
   selectExperiments as sharedSelectExperiments,
   setWorkflowMergeMode,
+  StaleLineageError,
 } from './workflow-actions.js';
 import { spawn, execSync } from 'node:child_process';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
@@ -1404,23 +1405,34 @@ if (isHeadless) {
       });
       logAutoFixDebug(taskId, 'dispatch-attempt-bumped', { attemptsBefore, attemptsAfter });
     }
-    const result = await fixWithAgentAction(
-      taskId,
-      {
-        orchestrator,
-        persistence,
-        taskExecutor: requireTaskExecutor(),
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
-      },
-      {
-        agentName,
-        recoveryRoute,
-        recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
-        failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`,
-        signal: mutationContext?.signal,
-      },
-    );
-    return result.started;
+    try {
+      const result = await fixWithAgentAction(
+        taskId,
+        {
+          orchestrator,
+          persistence,
+          taskExecutor: requireTaskExecutor(),
+          autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+        },
+        {
+          agentName,
+          recoveryRoute,
+          recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
+          failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`,
+          signal: mutationContext?.signal,
+        },
+      );
+      return result.started;
+    } catch (err) {
+      if (err instanceof StaleLineageError) {
+        logger.info(
+          `fix-with-agent discarded late result for "${taskId}": ${err.message}`,
+          { module: source === 'auto-fix' ? 'auto-fix' : 'ipc' },
+        );
+        return [];
+      }
+      throw err;
+    }
   };
 
   const scheduleAutoFix = (taskId: string): void => {
@@ -3586,6 +3598,10 @@ if (isHeadless) {
           logger,
           context: 'ipc.resolve-conflict.failure',
         });
+        if (err instanceof StaleLineageError) {
+          logger.info(`resolve-conflict discarded late result for "${taskId}": ${err.message}`, { module: 'ipc' });
+          return;
+        }
         logger.error(`resolve-conflict failed: ${err}`, { module: 'ipc' });
         throw err;
       }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -140,7 +140,7 @@ import { applyDelta, resolveQuarantine, TaskSnapshotCache } from './delta-merge.
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
-import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
+import { PersistedWorkflowMutationCoordinator, type WorkflowMutationContext } from './persisted-workflow-mutation-coordinator.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
 import {
   dispatchStartedTasksWithGlobalTopup,
@@ -214,14 +214,14 @@ let orchestrator: Orchestrator;
 let commandService: CommandService;
 let runtimeServices: RuntimeServices;
 let workflowMutationCoordinator: PersistedWorkflowMutationCoordinator | null = null;
-const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+const workflowMutationDispatcher = new Map<string, (context: WorkflowMutationContext, ...args: unknown[]) => Promise<unknown>>();
 /**
  * The mutation context for the currently executing workflow mutation.
- * Set by the coordinator dispatch callback before invoking the handler,
- * cleared afterward. Allows fix-with-agent and conflict-resolution
- * handlers to read the AbortSignal without changing every handler signature.
+ * Set by the coordinator dispatch callback before invoking a workflow-scoped
+ * handler and cleared afterward. A few shared helpers still read it
+ * indirectly while the explicit dispatcher context is being threaded through.
  */
-let activeMutationContext: import('./persisted-workflow-mutation-coordinator.js').WorkflowMutationContext | undefined;
+let activeMutationContext: WorkflowMutationContext | undefined;
 let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
 let writerLock: DbWriterLockResult | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
@@ -943,14 +943,14 @@ if (isHeadless) {
         };
 
         if (!workflowMutationDispatcher.has('headless.exec')) {
-          workflowMutationDispatcher.set('headless.exec', async (payloadArg: unknown) => {
+          workflowMutationDispatcher.set('headless.exec', async (context, payloadArg: unknown) => {
             const payload = payloadArg as HeadlessExecMutationPayload;
             await runHeadless(payload.args, {
               ...headlessDeps,
               waitForApproval: payload.waitForApproval,
               noTrack: payload.noTrack,
-              signal: activeMutationContext?.signal,
-              mutationTiming: activeMutationContext?.mutationTiming,
+              signal: context.signal,
+              mutationTiming: context.mutationTiming,
             });
             return { ok: true };
           });
@@ -966,7 +966,7 @@ if (isHeadless) {
               }
               activeMutationContext = context;
               try {
-                return await handler(...args);
+                return await handler(context, ...args);
               } finally {
                 activeMutationContext = undefined;
               }
@@ -1381,6 +1381,7 @@ if (isHeadless) {
     taskId: string,
     agentName?: string,
     source: 'ipc' | 'auto-fix' = 'ipc',
+    mutationContext?: WorkflowMutationContext,
   ): Promise<TaskState[]> => {
     const task = orchestrator.getTask(taskId);
     if (!task) {
@@ -1416,7 +1417,7 @@ if (isHeadless) {
         recoveryRoute,
         recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
         failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`,
-        signal: activeMutationContext?.signal,
+        signal: mutationContext?.signal,
       },
     );
     return result.started;
@@ -1716,7 +1717,10 @@ if (isHeadless) {
     return { workflowId, tasks };
   }
 
-  async function executeHeadlessExec(payload: HeadlessExecMutationPayload): Promise<unknown> {
+  async function executeHeadlessExec(
+    payload: HeadlessExecMutationPayload,
+    mutationContext?: WorkflowMutationContext,
+  ): Promise<unknown> {
     logger.info(`executeHeadlessExec begin args="${payload.args.join(' ')}" noTrack=${payload.noTrack ? 'true' : 'false'}`, {
       module: 'ipc-delegate',
     });
@@ -1734,8 +1738,8 @@ if (isHeadless) {
       orchestrator, persistence, executorRegistry, messageBus,
       commandService,
       repoRoot, invokerConfig, initServices, wireSlackBot,
-      signal: activeMutationContext?.signal,
-      mutationTiming: activeMutationContext?.mutationTiming,
+      signal: mutationContext?.signal,
+      mutationTiming: mutationContext?.mutationTiming,
       cancelTask: (taskId: string) => performCancelTask(taskId),
       cancelWorkflow: (workflowId: string) => performCancelWorkflow(workflowId),
       waitForApproval: payload.waitForApproval,
@@ -2038,12 +2042,19 @@ if (isHeadless) {
     channel: string,
     resolveWorkflowId: (...args: unknown[]) => string | undefined,
     priority: WorkflowMutationPriority,
-    handler: (...args: unknown[]) => Promise<TResult>,
+    handler: (context: WorkflowMutationContext, ...args: unknown[]) => Promise<TResult>,
   ): void {
-    workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
+    workflowMutationDispatcher.set(channel, (context, ...args: unknown[]) => handler(context, ...args));
     registerGuiMutationHandler(channel, async (...args: unknown[]) => {
       const workflowId = resolveWorkflowId(...args);
-      return runWorkflowMutation(workflowId, priority, channel, args, () => handler(...args));
+      const fallbackContext: WorkflowMutationContext = {
+        signal: new AbortController().signal,
+        workflowId: workflowId ?? 'unknown-workflow',
+        priority,
+        channel,
+        args,
+      };
+      return runWorkflowMutation(workflowId, priority, channel, args, () => handler(fallbackContext, ...args));
     });
   }
 
@@ -2561,7 +2572,7 @@ if (isHeadless) {
           }
           activeMutationContext = context;
           try {
-            return await handler(...args);
+            return await handler(context, ...args);
           } finally {
             activeMutationContext = undefined;
           }
@@ -2577,20 +2588,20 @@ if (isHeadless) {
     // ── IPC Delegation Handlers — peer → owner ────────────────
     // Peer processes delegate write-heavy commands to the owner process via IpcBus.
     if (ownerMode) {
-      workflowMutationDispatcher.set('headless.exec', async (payloadArg: unknown) => {
-        return executeHeadlessExec(payloadArg as HeadlessExecMutationPayload);
+      workflowMutationDispatcher.set('headless.exec', async (context, payloadArg: unknown) => {
+        return executeHeadlessExec(payloadArg as HeadlessExecMutationPayload, context);
       });
-      workflowMutationDispatcher.set('api:approve-task', async (taskIdArg: unknown) => {
+      workflowMutationDispatcher.set('api:approve-task', async (_context, taskIdArg: unknown) => {
         await performSharedApproveTask(String(taskIdArg), 'api');
       });
-      workflowMutationDispatcher.set('api:reject-task', async (taskIdArg: unknown, reasonArg?: unknown) => {
+      workflowMutationDispatcher.set('api:reject-task', async (_context, taskIdArg: unknown, reasonArg?: unknown) => {
         const taskId = String(taskIdArg);
         const reason = reasonArg === undefined ? undefined : String(reasonArg);
         const envelope = makeEnvelope('reject', 'surface', 'task', { taskId, reason });
         const result = await commandService.reject(envelope);
         if (!result.ok) throw new Error(result.error.message);
       });
-      workflowMutationDispatcher.set('surface:approve-task', async (taskIdArg: unknown) => {
+      workflowMutationDispatcher.set('surface:approve-task', async (_context, taskIdArg: unknown) => {
         await performSharedApproveTask(String(taskIdArg), 'surface');
       });
       messageBus.onRequest('headless.owner-ping', async () => ({
@@ -3253,7 +3264,7 @@ if (isHeadless) {
       'invoker:recreate-workflow',
       (workflowIdArg: unknown) => String(workflowIdArg),
       'high',
-      async (workflowIdArg: unknown) => {
+      async (context, workflowIdArg: unknown) => {
       const workflowId = String(workflowIdArg);
       cancelDeferredWorkflowLaunch(workflowId, 'ipc.recreate-workflow');
       logger.info(`recreate-workflow: "${workflowId}"`, { module: 'ipc' });
@@ -3262,10 +3273,10 @@ if (isHeadless) {
           preemptWorkflowExecution,
           logger,
           context: 'ipc.recreate-workflow',
-          mutationTiming: activeMutationContext?.mutationTiming,
+          mutationContext: context,
         });
-        const started = activeMutationContext?.mutationTiming
-          ? await activeMutationContext.mutationTiming.span(
+        const started = context.mutationTiming
+          ? await context.mutationTiming.span(
             'main.ipc.recreate-workflow.sharedRecreateWorkflow',
             undefined,
             async () => sharedRecreateWorkflow(workflowId, { persistence, orchestrator }),
@@ -3279,7 +3290,7 @@ if (isHeadless) {
             logger,
             context: 'ipc.recreate-workflow',
             started,
-            mutationTiming: activeMutationContext?.mutationTiming,
+            mutationTiming: context.mutationTiming,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -3295,12 +3306,12 @@ if (isHeadless) {
       'invoker:recreate-task',
       (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
       'high',
-      async (taskIdArg: unknown) => {
+      async (context, taskIdArg: unknown) => {
       const taskId = String(taskIdArg);
       logger.info(`recreate-task: "${taskId}"`, { module: 'ipc' });
       try {
-        if (activeMutationContext?.mutationTiming) {
-          await activeMutationContext.mutationTiming.span(
+        if (context.mutationTiming) {
+          await context.mutationTiming.span(
             'main.ipc.recreate-task.preemptTaskSubgraph',
             { taskId },
             () => preemptTaskSubgraph(taskId),
@@ -3308,8 +3319,8 @@ if (isHeadless) {
         } else {
           await preemptTaskSubgraph(taskId);
         }
-        const started = activeMutationContext?.mutationTiming
-          ? await activeMutationContext.mutationTiming.span(
+        const started = context.mutationTiming
+          ? await context.mutationTiming.span(
             'main.ipc.recreate-task.sharedRecreateTask',
             { taskId },
             async () => sharedRecreateTask(taskId, { persistence, orchestrator }),
@@ -3323,7 +3334,7 @@ if (isHeadless) {
             logger,
             context: 'ipc.recreate-task',
             started,
-            mutationTiming: activeMutationContext?.mutationTiming,
+            mutationTiming: context.mutationTiming,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -3339,7 +3350,7 @@ if (isHeadless) {
       'invoker:retry-workflow',
       (workflowIdArg: unknown) => String(workflowIdArg),
       'high',
-      async (workflowIdArg: unknown) => {
+      async (context, workflowIdArg: unknown) => {
       const workflowId = String(workflowIdArg);
       cancelDeferredWorkflowLaunch(workflowId, 'ipc.retry-workflow');
       logger.info(`retry-workflow: "${workflowId}"`, { module: 'ipc' });
@@ -3348,11 +3359,11 @@ if (isHeadless) {
           preemptWorkflowExecution,
           logger,
           context: 'ipc.retry-workflow',
-          mutationTiming: activeMutationContext?.mutationTiming,
+          mutationContext: context,
         });
         const envelope = makeEnvelope('retry-workflow', 'ui', 'workflow', { workflowId });
-        const result = activeMutationContext?.mutationTiming
-          ? await activeMutationContext.mutationTiming.span(
+        const result = context.mutationTiming
+          ? await context.mutationTiming.span(
             'main.ipc.retry-workflow.commandService.retryWorkflow',
             undefined,
             () => commandService.retryWorkflow(envelope),
@@ -3367,7 +3378,7 @@ if (isHeadless) {
             logger,
             context: 'ipc.retry-workflow',
             started: result.data,
-            mutationTiming: activeMutationContext?.mutationTiming,
+            mutationTiming: context.mutationTiming,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -3383,7 +3394,7 @@ if (isHeadless) {
       'invoker:rebase-and-retry',
       (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
       'high',
-      async (taskIdArg: unknown) => {
+      async (context, taskIdArg: unknown) => {
       const taskId = String(taskIdArg);
       logger.info(`rebase-and-retry: "${taskId}"`, { module: 'ipc' });
       try {
@@ -3393,7 +3404,7 @@ if (isHeadless) {
             preemptWorkflowExecution,
             logger,
             context: 'ipc.rebase-and-retry',
-            mutationTiming: activeMutationContext?.mutationTiming,
+            mutationContext: context,
           });
         }
         const started = await rebaseAndRetry(taskId, {
@@ -3401,7 +3412,7 @@ if (isHeadless) {
           persistence,
           repoRoot,
           taskExecutor: requireTaskExecutor(),
-          mutationTiming: activeMutationContext?.mutationTiming,
+          mutationTiming: context.mutationTiming,
         });
         await dispatchStartedTasksWithGlobalTopup({
           orchestrator,
@@ -3409,7 +3420,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.rebase-and-retry',
           started,
-          mutationTiming: activeMutationContext?.mutationTiming,
+          mutationTiming: context.mutationTiming,
         });
       } catch (err) {
         logger.error(`rebase-and-retry failed: ${err}`, { module: 'ipc' });
@@ -3422,7 +3433,7 @@ if (isHeadless) {
       'invoker:recreate-with-rebase',
       (workflowIdArg: unknown) => workflowIdForTargetArg(workflowIdArg),
       'high',
-      async (workflowIdArg: unknown) => {
+      async (context, workflowIdArg: unknown) => {
       const workflowId = workflowIdForTargetArg(workflowIdArg);
       if (!workflowId) {
         throw new Error(`Could not resolve workflow for recreate-with-rebase target "${String(workflowIdArg)}"`);
@@ -3434,14 +3445,14 @@ if (isHeadless) {
           preemptWorkflowExecution,
           logger,
           context: 'ipc.recreate-with-rebase',
-          mutationTiming: activeMutationContext?.mutationTiming,
+          mutationContext: context,
         });
         const started = await recreateWithRebase(workflowId, {
           orchestrator,
           persistence,
           repoRoot,
           taskExecutor: requireTaskExecutor(),
-          mutationTiming: activeMutationContext?.mutationTiming,
+          mutationTiming: context.mutationTiming,
         });
         await dispatchStartedTasksWithGlobalTopup({
           orchestrator,
@@ -3449,7 +3460,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.recreate-with-rebase',
           started,
-          mutationTiming: activeMutationContext?.mutationTiming,
+          mutationTiming: context.mutationTiming,
         });
       } catch (err) {
         logger.error(`recreate-with-rebase failed: ${err}`, { module: 'ipc' });
@@ -3547,7 +3558,7 @@ if (isHeadless) {
       'invoker:resolve-conflict',
       (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
       'normal',
-      async (taskIdArg: unknown, agentNameArg?: unknown) => {
+      async (context, taskIdArg: unknown, agentNameArg?: unknown) => {
       const taskId = String(taskIdArg);
       const agentName = agentNameArg === undefined ? undefined : String(agentNameArg);
       logger.info(
@@ -3560,7 +3571,7 @@ if (isHeadless) {
           persistence,
           taskExecutor: requireTaskExecutor(),
           autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
-        }, agentName, activeMutationContext?.signal);
+        }, agentName, context.signal);
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
@@ -3585,11 +3596,11 @@ if (isHeadless) {
       'invoker:fix-with-agent',
       (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
       'normal',
-      async (taskIdArg: unknown, agentNameArg?: unknown) => {
+      async (context, taskIdArg: unknown, agentNameArg?: unknown) => {
       const taskId = String(taskIdArg);
       const agentName = agentNameArg === undefined ? undefined : String(agentNameArg);
       try {
-        const started = await executeFixWithAgentMutation(taskId, agentName, 'ipc');
+        const started = await executeFixWithAgentMutation(taskId, agentName, 'ipc', context);
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -6,6 +6,7 @@ import {
 } from '@invoker/data-store';
 import type { Logger } from '@invoker/contracts';
 import { createWorkflowMutationTiming, type WorkflowMutationTiming } from './workflow-mutation-timing.js';
+import type { WorkflowMutationContext as BaseWorkflowMutationContext } from './workflow-mutation-coordinator.js';
 
 type Deferred<T> = {
   resolve: (value: T) => void;
@@ -18,10 +19,10 @@ type InvalidationSignal = {
   abortController: AbortController;
 };
 
-export type WorkflowMutationContext = {
-  signal: AbortSignal;
-  intentId: number;
-  workflowId: string;
+export type WorkflowMutationContext = BaseWorkflowMutationContext & {
+  channel: string;
+  args: unknown[];
+  intentId?: number;
   mutationTiming?: WorkflowMutationTiming;
 };
 
@@ -237,6 +238,9 @@ export class PersistedWorkflowMutationCoordinator {
         signal: invalidation.abortController.signal,
         intentId: intent.id,
         workflowId,
+        priority: intent.priority,
+        channel: intent.channel,
+        args: intent.args,
         mutationTiming: timing,
       };
       const dispatchPromise = timing.span(

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -45,6 +45,13 @@ export interface TaskLineageSnapshot {
   generation: number;
 }
 
+function toExpectedTaskLineage(snapshot: TaskLineageSnapshot): { selectedAttemptId: string | undefined; generation: number } {
+  return {
+    selectedAttemptId: snapshot.selectedAttemptId,
+    generation: snapshot.generation,
+  };
+}
+
 /**
  * Capture the current lineage for a task.
  */
@@ -749,22 +756,21 @@ export async function resolveConflictAction(
   signal?: AbortSignal,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
   const { orchestrator, persistence, taskExecutor } = deps;
-  const { savedError } = orchestrator.beginConflictResolution(taskId);
+  const entryLineage = captureTaskLineage(taskId, orchestrator);
+  assertLineageCurrent(entryLineage, orchestrator, signal);
+  const { savedError } = orchestrator.beginConflictResolution(taskId, toExpectedTaskLineage(entryLineage));
   const lineage = captureTaskLineage(taskId, orchestrator);
   try {
     await taskExecutor.resolveConflict(taskId, savedError, agentName);
     assertLineageCurrent(lineage, orchestrator, signal);
-    return await finalizeAppliedFix(taskId, savedError, deps, signal);
+    return await finalizeAppliedFix(taskId, savedError, deps, lineage, signal);
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
     const msg = err instanceof Error ? err.message : String(err);
+    assertLineageCurrent(lineage, orchestrator, signal);
     persistence.appendTaskOutput(taskId, `\n[Resolve Conflict] Failed: ${msg}`);
-    try {
-      assertLineageCurrent(lineage, orchestrator, signal);
-    } catch {
-      throw err;
-    }
-    orchestrator.revertConflictResolution(taskId, savedError, msg);
+    assertLineageCurrent(lineage, orchestrator, signal);
+    orchestrator.revertConflictResolution(taskId, savedError, msg, toExpectedTaskLineage(lineage));
     throw err;
   }
 }
@@ -805,7 +811,12 @@ export async function fixWithAgentAction(
     };
   }
 
-  const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
+  const entryLineage = captureTaskLineage(taskId, orchestrator);
+  assertLineageCurrent(entryLineage, orchestrator, options.signal);
+  const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(
+    taskId,
+    toExpectedTaskLineage(entryLineage),
+  );
   const lineage = captureTaskLineage(taskId, orchestrator);
   try {
     if (recoveryRoute.kind === 'resolveConflict') {
@@ -815,7 +826,7 @@ export async function fixWithAgentAction(
       await taskExecutor.fixWithAgent(taskId, output, options.agentName, persistedSavedError);
     }
     assertLineageCurrent(lineage, orchestrator, options.signal);
-    const result = await finalizeAppliedFix(taskId, persistedSavedError, deps, options.signal);
+    const result = await finalizeAppliedFix(taskId, persistedSavedError, deps, lineage, options.signal);
     return {
       kind: recoveryRoute.kind,
       autoApproved: result.autoApproved,
@@ -826,13 +837,15 @@ export async function fixWithAgentAction(
     const msg = err instanceof Error ? err.message : String(err);
     const errorLabel = options.failureOutputLabel
       ?? (recoveryRoute.kind === 'resolveConflict' ? 'Resolve Conflict' : `Fix with ${options.agentName ?? 'Claude'}`);
+    assertLineageCurrent(lineage, orchestrator, options.signal);
     persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
-    try {
-      assertLineageCurrent(lineage, orchestrator, options.signal);
-    } catch {
-      throw err;
-    }
-    orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
+    assertLineageCurrent(lineage, orchestrator, options.signal);
+    orchestrator.revertConflictResolution(
+      taskId,
+      persistedSavedError,
+      msg,
+      toExpectedTaskLineage(lineage),
+    );
     throw err;
   }
 }
@@ -841,18 +854,16 @@ export async function finalizeAppliedFix(
   taskId: string,
   savedError: string,
   deps: Pick<ActionDeps, 'orchestrator' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
+  lineage: TaskLineageSnapshot,
   signal?: AbortSignal,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
-  if (signal?.aborted) {
-    throw new StaleLineageError(
-      `Fix mutation for ${taskId} aborted before finalize: ${signal.reason instanceof Error ? signal.reason.message : String(signal.reason ?? 'unknown')}`,
-    );
-  }
-  deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
+  assertLineageCurrent(lineage, deps.orchestrator, signal);
+  deps.orchestrator.setFixAwaitingApproval(taskId, savedError, toExpectedTaskLineage(lineage));
   if (!deps.autoApproveAIFixes) {
     return { autoApproved: false, started: [] };
   }
 
+  assertLineageCurrent(lineage, deps.orchestrator, signal);
   const { started } = await approveTask(taskId, deps);
   return { autoApproved: true, started };
 }
@@ -975,9 +986,12 @@ async function recordFixedIntegrationAnchor(
   taskId: string,
   task: TaskState,
   deps: {
+    orchestrator: Orchestrator;
     persistence: SQLiteAdapter;
     taskExecutor: TaskRunner;
   },
+  lineage: TaskLineageSnapshot,
+  signal?: AbortSignal,
 ): Promise<void> {
   const workspacePath = task.execution.workspacePath?.trim();
   if (!workspacePath) {
@@ -989,6 +1003,7 @@ async function recordFixedIntegrationAnchor(
   }
   try {
     const fixedIntegrationSha = (await deps.taskExecutor.execGitIn(['rev-parse', 'HEAD'], workspacePath)).trim();
+    assertLineageCurrent(lineage, deps.orchestrator, signal);
     const fixedIntegrationRecordedAt = new Date();
     deps.persistence.updateTask(taskId, {
       execution: {
@@ -1118,7 +1133,12 @@ export async function autoFixOnFailure(
       return;
     }
 
-    ({ savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId));
+    const entryLineage = captureTaskLineage(taskId, orchestrator);
+    assertLineageCurrent(entryLineage, orchestrator, deps.signal);
+    ({ savedError: persistedSavedError } = orchestrator.beginConflictResolution(
+      taskId,
+      toExpectedTaskLineage(entryLineage),
+    ));
     lineage = captureTaskLineage(taskId, orchestrator);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-begin-conflict-resolution',
@@ -1138,14 +1158,15 @@ export async function autoFixOnFailure(
     });
     if (postRouteStrategy === 'resume_from_fixed_tip') {
       await recordFixedIntegrationAnchor(taskId, task, {
+        orchestrator,
         persistence,
         taskExecutor,
-      });
+      }, lineage, deps.signal);
       const finalizeResult = await finalizeAppliedFix(taskId, persistedSavedError, {
         orchestrator,
         taskExecutor,
         autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
-      }, deps.signal);
+      }, lineage, deps.signal);
       persistence.logEvent?.(taskId, 'debug.auto-fix', {
         phase: 'auto-fix-post-route-finalize',
         autoApproved: finalizeResult.autoApproved,
@@ -1189,19 +1210,20 @@ export async function autoFixOnFailure(
       diagnostics: diagnostics ?? null,
     });
     if (diagnostics) {
+      if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
       persistence.appendTaskOutput(taskId, `\n[Auto-fix Diagnostics]\n${diagnostics}`);
     }
+    if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.appendTaskOutput(taskId, `\n[Auto-fix] Agent failed (attempt ${attempts}/${max}): ${msg}`);
     const detailedMsg = diagnostics ? `${msg}\n\n${diagnostics}` : msg;
     if (persistedSavedError !== undefined) {
-      if (lineage) {
-        try {
-          assertLineageCurrent(lineage, orchestrator, deps.signal);
-        } catch {
-          throw err;
-        }
-      }
-      orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg);
+      if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
+      orchestrator.revertConflictResolution(
+        taskId,
+        persistedSavedError,
+        detailedMsg,
+        lineage ? toExpectedTaskLineage(lineage) : undefined,
+      );
     }
   }
 }

--- a/packages/app/src/workflow-mutation-coordinator.ts
+++ b/packages/app/src/workflow-mutation-coordinator.ts
@@ -1,7 +1,20 @@
 export type WorkflowMutationPriority = 'high' | 'normal';
 
+import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
+
+export type WorkflowMutationContext = {
+  signal: AbortSignal;
+  workflowId: string;
+  priority: WorkflowMutationPriority;
+  channel?: string;
+  args?: unknown[];
+  intentId?: number;
+  mutationTiming?: WorkflowMutationTiming;
+};
+
 type Job<T> = {
-  run: () => Promise<T>;
+  context: WorkflowMutationContext;
+  run: (context: WorkflowMutationContext) => Promise<T>;
   resolve: (value: T) => void;
   reject: (error: unknown) => void;
 };
@@ -24,12 +37,21 @@ export class WorkflowMutationCoordinator {
   enqueue<T>(
     workflowId: string,
     priority: WorkflowMutationPriority,
-    run: () => Promise<T>,
+    run: (context: WorkflowMutationContext) => Promise<T>,
   ): Promise<T> {
     return new Promise<T>((resolve, reject) => {
       const state = this.queues.get(workflowId) ?? { running: false, high: [], normal: [] };
       this.queues.set(workflowId, state);
-      const job: Job<T> = { run, resolve, reject };
+      const job: Job<T> = {
+        context: {
+          signal: new AbortController().signal,
+          workflowId,
+          priority,
+        },
+        run,
+        resolve,
+        reject,
+      };
       if (priority === 'high') {
         state.high.push(job as Job<unknown>);
       } else {
@@ -50,7 +72,7 @@ export class WorkflowMutationCoordinator {
     }
 
     state.running = true;
-    void next.run()
+    void next.run(next.context)
       .then((value) => next.resolve(value))
       .catch((err) => next.reject(err))
       .finally(() => {
@@ -61,4 +83,3 @@ export class WorkflowMutationCoordinator {
       });
   }
 }
-

--- a/packages/app/src/workflow-preemption.ts
+++ b/packages/app/src/workflow-preemption.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@invoker/contracts';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
+import type { WorkflowMutationContext } from './workflow-mutation-coordinator.js';
 
 export type WorkflowCancelResult = {
   cancelled: string[];
@@ -8,6 +9,15 @@ export type WorkflowCancelResult = {
 
 type PreemptWorkflowExecution = (workflowId: string) => Promise<WorkflowCancelResult | void>;
 
+function throwIfMutationAborted(context: WorkflowMutationContext | undefined, stage: string): void {
+  if (!context?.signal.aborted) {
+    return;
+  }
+  const reason = context.signal.reason;
+  const detail = reason instanceof Error ? reason.message : String(reason ?? 'unknown');
+  throw new Error(`Workflow mutation ${stage} aborted: ${detail}`);
+}
+
 export async function preemptWorkflowBeforeMutation(
   workflowId: string,
   deps: {
@@ -15,18 +25,22 @@ export async function preemptWorkflowBeforeMutation(
     logger?: Logger;
     context: string;
     mutationTiming?: WorkflowMutationTiming;
+    mutationContext?: WorkflowMutationContext;
   },
 ): Promise<WorkflowCancelResult> {
+  throwIfMutationAborted(deps.mutationContext, `${deps.context}.before-preempt`);
   deps.logger?.info(`preempt begin context="${deps.context}" workflow="${workflowId}"`, { module: 'preempt' });
-  const raw = deps.mutationTiming
-    ? await deps.mutationTiming.span(
+  const timing = deps.mutationContext?.mutationTiming ?? deps.mutationTiming;
+  const raw = timing
+    ? await timing.span(
       'preemptWorkflowBeforeMutation',
       { context: deps.context },
       () => deps.preemptWorkflowExecution(workflowId),
     )
     : await deps.preemptWorkflowExecution(workflowId);
   const result: WorkflowCancelResult = raw ?? { cancelled: [], runningCancelled: [] };
-  deps.mutationTiming?.mark('preemptWorkflowBeforeMutation.result', 'completed', {
+  throwIfMutationAborted(deps.mutationContext, `${deps.context}.after-preempt`);
+  timing?.mark('preemptWorkflowBeforeMutation.result', 'completed', {
     context: deps.context,
     cancelledCount: result.cancelled.length,
     runningCancelledCount: result.runningCancelled.length,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -150,6 +150,11 @@ export class PlanConflictError extends Error {
   }
 }
 
+export interface ExpectedTaskLineage {
+  selectedAttemptId: string | undefined;
+  generation: number;
+}
+
 // ── Adapter Interfaces ──────────────────────────────────────
 
 export interface OrchestratorPersistence {
@@ -1696,10 +1701,27 @@ export class Orchestrator {
     this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', additionalChanges);
   }
 
-  setFixAwaitingApproval(taskId: string, originalError: string): void {
+  private assertExpectedTaskLineage(task: TaskState, expected?: ExpectedTaskLineage): void {
+    if (!expected) return;
+    const currentAttemptId = task.execution.selectedAttemptId;
+    const currentGeneration = task.execution.generation ?? 0;
+    if (
+      currentAttemptId !== expected.selectedAttemptId
+      || currentGeneration !== expected.generation
+    ) {
+      throw new Error(
+        `Task ${task.id} lineage changed `
+        + `(attempt ${expected.selectedAttemptId} → ${currentAttemptId}, `
+        + `gen ${expected.generation} → ${currentGeneration})`,
+      );
+    }
+  }
+
+  setFixAwaitingApproval(taskId: string, originalError: string, expectedLineage?: ExpectedTaskLineage): void {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    this.assertExpectedTaskLineage(task, expectedLineage);
     const tid = task.id;
     if (task.status !== 'running' && task.status !== 'fixing_with_ai') {
       throw new Error(`Task ${tid} is not running or fixing with AI (status: ${task.status})`);
@@ -2614,10 +2636,11 @@ export class Orchestrator {
    * Clears terminal failure fields on the row so SQLite does not show stale error/exit/completed.
    * Returns the saved error string so the caller can revert on failure.
    */
-  beginConflictResolution(taskId: string): { savedError: string } {
+  beginConflictResolution(taskId: string, expectedLineage?: ExpectedTaskLineage): { savedError: string } {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    this.assertExpectedTaskLineage(task, expectedLineage);
     if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
 
     const savedError = task.execution.error ?? '';
@@ -2663,12 +2686,18 @@ export class Orchestrator {
    * Revert a conflict resolution attempt: restore the task to failed
    * with its original error and re-parsed mergeConflict field.
    */
-  revertConflictResolution(taskId: string, savedError: string, fixError?: string): void {
+  revertConflictResolution(
+    taskId: string,
+    savedError: string,
+    fixError?: string,
+    expectedLineage?: ExpectedTaskLineage,
+  ): void {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) {
       throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     }
+    this.assertExpectedTaskLineage(task, expectedLineage);
     const id = task.id;
 
     const normalizedSavedError = stripFixFailureWrapper(savedError);

--- a/scripts/repro/repro-fix-flow-lineage-guards.sh
+++ b/scripts/repro/repro-fix-flow-lineage-guards.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION="fixed"
+TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-120}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-fix-flow-lineage-guards.sh [--expect bug|fixed]
+
+What it proves:
+  Product-path repro for the fix-with-agent finalization guard. It starts a
+  real GUI owner, runs a real headless fix command with a slow fake Claude
+  process, then runs a real headless recreate-task while the fix is still in
+  flight. The assertion is that the stale fix result does not write
+  awaiting_approval after the recreate-task intent starts.
+
+This is the Step 2 repro for:
+  Fix intent cancellation Step 2: fix flow lineage guards.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  echo "repro: --expect requires bug|fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$seconds" "$@"
+    return $?
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$seconds" "$@"
+    return $?
+  fi
+  "$@"
+}
+
+cd "$ROOT_DIR"
+
+run_with_timeout "$TIMEOUT_SECONDS" \
+  bash scripts/repro/repro-fix-intent-cancellation-e2e.sh --expect "$EXPECTATION"

--- a/scripts/repro/repro-fix-intent-cancellation-e2e.sh
+++ b/scripts/repro/repro-fix-intent-cancellation-e2e.sh
@@ -1,0 +1,350 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION="fixed"
+KEEP_TEMP=false
+TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-120}"
+AGENT_SLEEP_SECONDS="${REPRO_AGENT_SLEEP_SECONDS:-15}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-fix-intent-cancellation-e2e.sh [--expect bug|fixed] [--keep-temp]
+
+What it proves:
+  This is a product-path repro, not a unit-test wrapper.
+
+  1. Starts a real GUI owner against an isolated SQLite DB.
+  2. Submits a real workflow with a task that fails in a managed worktree.
+  3. Starts a real headless `fix <task>` command delegated to the GUI owner.
+  4. The fix runs a slow fake Claude command that sleeps, edits the worktree,
+     then exits 0.
+  5. While the fix is still in flight, starts a real headless
+     `recreate-task <task>` command.
+  6. Asserts that the stale fix result does not put the recreated task back
+     into awaiting_approval after the recreate-task intent starts.
+
+Bug expectation:
+  The stale fix finalization wins after recreate-task and writes a fresh
+  awaiting_approval event after the recreate intent.
+
+Fixed expectation:
+  The fix intent is superseded or failed, and no awaiting_approval event is
+  written after the recreate-task intent begins.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --keep-temp)
+      KEEP_TEMP=true
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  echo "repro: --expect requires bug|fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "repro: missing required command: $1" >&2
+    exit 2
+  }
+}
+
+require_cmd node
+require_cmd pnpm
+require_cmd sqlite3
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-fix-intent-e2e.XXXXXX")"
+HOME_DIR="$TMP_DIR/home"
+DB_DIR="$HOME_DIR/.invoker"
+REPO_FIXTURE_DIR="$TMP_DIR/repro-repo"
+PLAN_PATH="$TMP_DIR/repro-plan.yaml"
+CONFIG_PATH="$DB_DIR/config.json"
+IPC_SOCKET_PATH="$TMP_DIR/i.sock"
+STUB_DIR="$TMP_DIR/stub"
+CLAUDE_STUB="$STUB_DIR/claude"
+AGENT_STARTED="$TMP_DIR/agent-started.marker"
+AGENT_DONE="$TMP_DIR/agent-done.marker"
+OWNER_STDOUT="$TMP_DIR/owner.stdout.log"
+OWNER_STDERR="$TMP_DIR/owner.stderr.log"
+SUBMIT_STDOUT="$TMP_DIR/submit.stdout.log"
+SUBMIT_STDERR="$TMP_DIR/submit.stderr.log"
+FIX_STDOUT="$TMP_DIR/fix.stdout.log"
+FIX_STDERR="$TMP_DIR/fix.stderr.log"
+RECREATE_STDOUT="$TMP_DIR/recreate.stdout.log"
+RECREATE_STDERR="$TMP_DIR/recreate.stderr.log"
+
+cleanup() {
+  if [[ -n "${FIX_PID:-}" ]]; then
+    kill "$FIX_PID" >/dev/null 2>&1 || true
+    wait "$FIX_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${RECREATE_PID:-}" ]]; then
+    kill "$RECREATE_PID" >/dev/null 2>&1 || true
+    wait "$RECREATE_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${OWNER_PID:-}" ]]; then
+    kill "$OWNER_PID" >/dev/null 2>&1 || true
+    wait "$OWNER_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ "$KEEP_TEMP" != true ]]; then
+    rm -rf "$TMP_DIR" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+query_sqlite_value() {
+  local sql="$1"
+  sqlite3 -noheader "$DB_DIR/invoker.db" "$sql"
+}
+
+sqlite_schema_ready() {
+  [[ -f "$DB_DIR/invoker.db" ]] || return 1
+  local exists
+  exists="$(sqlite3 -noheader "$DB_DIR/invoker.db" "select count(*) from sqlite_master where type='table' and name='tasks';" 2>/dev/null || true)"
+  [[ "$exists" == "1" ]]
+}
+
+wait_for_query_status() {
+  local task_id="$1"
+  local expected_status="$2"
+  local timeout="$3"
+  local started_at
+  started_at="$(date +%s)"
+  while true; do
+    if sqlite_schema_ready; then
+      local status
+      status="$(query_sqlite_value "select coalesce(status,'') from tasks where id = '$task_id' limit 1;")"
+      if [[ "$status" == "$expected_status" ]]; then
+        return 0
+      fi
+    fi
+    if (( $(date +%s) - started_at >= timeout )); then
+      echo "repro: timed out waiting for $task_id to reach $expected_status" >&2
+      return 1
+    fi
+    sleep 0.2
+  done
+}
+
+wait_for_file() {
+  local file="$1"
+  local timeout="$2"
+  local started_at
+  started_at="$(date +%s)"
+  while [[ ! -f "$file" ]]; do
+    if (( $(date +%s) - started_at >= timeout )); then
+      echo "repro: timed out waiting for file $file" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+}
+
+wait_for_owner_ready() {
+  local timeout="$1"
+  local started_at
+  started_at="$(date +%s)"
+  while true; do
+    if [[ -S "$IPC_SOCKET_PATH" ]] || grep -q 'owner-ipc-ready' "$DB_DIR/invoker.log" 2>/dev/null; then
+      return 0
+    fi
+    if (( $(date +%s) - started_at >= timeout )); then
+      echo "repro: timed out waiting for GUI owner IPC readiness" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+}
+
+cd "$ROOT_DIR"
+
+if [[ ! -f packages/app/dist/main.js ]]; then
+  pnpm --filter @invoker/app build >/dev/null
+fi
+
+ELECTRON_BIN="$ROOT_DIR/scripts/electron.cjs"
+MAIN_JS="$ROOT_DIR/packages/app/dist/main.js"
+HEADLESS_CLIENT_JS="$ROOT_DIR/packages/app/dist/headless-client.js"
+
+mkdir -p "$DB_DIR" "$REPO_FIXTURE_DIR" "$STUB_DIR"
+
+git -C "$REPO_FIXTURE_DIR" init -b main >/dev/null 2>&1
+git -C "$REPO_FIXTURE_DIR" config user.name "Invoker Repro"
+git -C "$REPO_FIXTURE_DIR" config user.email "repro@example.com"
+printf 'fix intent cancellation repro fixture\n' > "$REPO_FIXTURE_DIR/README.md"
+git -C "$REPO_FIXTURE_DIR" add README.md
+git -C "$REPO_FIXTURE_DIR" commit -m "Initial fixture" >/dev/null 2>&1
+
+cat > "$CONFIG_PATH" <<'EOF'
+{
+  "maxConcurrency": 1,
+  "autoFixRetries": 0
+}
+EOF
+
+cat > "$CLAUDE_STUB" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+printf 'started\n' > "$AGENT_STARTED"
+printf 'slow fake claude started\n'
+sleep "$AGENT_SLEEP_SECONDS"
+printf 'late fix write\n' >> fix-intent-late-write.txt
+git add fix-intent-late-write.txt >/dev/null 2>&1 || true
+printf 'done\n' > "$AGENT_DONE"
+printf 'slow fake claude done\n'
+EOF
+chmod +x "$CLAUDE_STUB"
+
+cat > "$PLAN_PATH" <<EOF
+name: Fix Intent Cancellation E2E Repro
+repoUrl: $REPO_FIXTURE_DIR
+tasks:
+  - id: target
+    description: Fails once so a real fix command can run in the managed worktree
+    command: >-
+      bash -lc 'echo ORIGINAL_FAIL; exit 1'
+EOF
+
+HOME="$HOME_DIR" \
+INVOKER_DB_DIR="$DB_DIR" \
+INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" \
+INVOKER_CLAUDE_FIX_COMMAND="$CLAUDE_STUB" \
+NODE_ENV=test \
+  "$ELECTRON_BIN" "$MAIN_JS" >"$OWNER_STDOUT" 2>"$OWNER_STDERR" &
+OWNER_PID=$!
+
+wait_for_owner_ready 20
+
+set +e
+HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" \
+INVOKER_CLAUDE_FIX_COMMAND="$CLAUDE_STUB" NODE_ENV=test \
+  node "$HEADLESS_CLIENT_JS" --no-track run "$PLAN_PATH" >"$SUBMIT_STDOUT" 2>"$SUBMIT_STDERR"
+SUBMIT_STATUS=$?
+set -e
+
+WORKFLOW_ID="$(
+  {
+    sed -n 's/^Workflow ID: //p' "$SUBMIT_STDOUT"
+    sed -n 's/^Delegated to owner .*workflow: //p' "$SUBMIT_STDOUT"
+    sed -n 's/^Delegated to GUI .*workflow: //p' "$SUBMIT_STDOUT"
+  } | head -n1
+)"
+
+if [[ "$SUBMIT_STATUS" -ne 0 || -z "${WORKFLOW_ID:-}" ]]; then
+  echo "repro: failed to submit workflow" >&2
+  cat "$SUBMIT_STDOUT" >&2 || true
+  cat "$SUBMIT_STDERR" >&2 || true
+  exit 1
+fi
+
+TASK_ID="$WORKFLOW_ID/target"
+wait_for_query_status "$TASK_ID" "failed" "$TIMEOUT_SECONDS"
+
+echo "repro: seeded failed task"
+echo "workflow: $WORKFLOW_ID"
+echo "task: $TASK_ID"
+
+HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" \
+INVOKER_CLAUDE_FIX_COMMAND="$CLAUDE_STUB" NODE_ENV=test \
+  node "$HEADLESS_CLIENT_JS" fix "$TASK_ID" >"$FIX_STDOUT" 2>"$FIX_STDERR" &
+FIX_PID=$!
+
+wait_for_file "$AGENT_STARTED" 30
+
+FIX_INTENT_ID=""
+for _ in {1..100}; do
+  FIX_INTENT_ID="$(query_sqlite_value "select coalesce(max(id),'') from workflow_mutation_intents where workflow_id = '$WORKFLOW_ID' and (channel = 'invoker:fix-with-agent' or args_json like '%\"fix\",\"$TASK_ID\"%');")"
+  if [[ -n "$FIX_INTENT_ID" && "$FIX_INTENT_ID" != "0" ]]; then
+    break
+  fi
+  sleep 0.1
+done
+
+if [[ -z "$FIX_INTENT_ID" || "$FIX_INTENT_ID" == "0" ]]; then
+  echo "repro: failed to capture fix intent" >&2
+  exit 1
+fi
+
+HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" \
+INVOKER_CLAUDE_FIX_COMMAND="$CLAUDE_STUB" NODE_ENV=test \
+  node "$HEADLESS_CLIENT_JS" recreate-task "$TASK_ID" >"$RECREATE_STDOUT" 2>"$RECREATE_STDERR" &
+RECREATE_PID=$!
+
+RECREATE_INTENT_ID=""
+for _ in {1..100}; do
+  RECREATE_INTENT_ID="$(query_sqlite_value "select coalesce(max(id),'') from workflow_mutation_intents where workflow_id = '$WORKFLOW_ID' and args_json like '%\"recreate-task\",\"$TASK_ID\"%';")"
+  if [[ -n "$RECREATE_INTENT_ID" && "$RECREATE_INTENT_ID" != "0" && "$RECREATE_INTENT_ID" != "$FIX_INTENT_ID" ]]; then
+    break
+  fi
+  sleep 0.1
+done
+
+if [[ -z "$RECREATE_INTENT_ID" || "$RECREATE_INTENT_ID" == "0" ]]; then
+  echo "repro: failed to capture recreate-task intent" >&2
+  cat "$RECREATE_STDERR" >&2 || true
+  exit 1
+fi
+
+wait_for_file "$AGENT_DONE" "$TIMEOUT_SECONDS"
+wait "$FIX_PID" >/dev/null 2>&1 || true
+FIX_PID=""
+wait "$RECREATE_PID" >/dev/null 2>&1 || true
+RECREATE_PID=""
+sleep 1
+
+FIX_STATUS="$(query_sqlite_value "select coalesce(status,'') from workflow_mutation_intents where id = $FIX_INTENT_ID;")"
+RECREATE_STATUS="$(query_sqlite_value "select coalesce(status,'') from workflow_mutation_intents where id = $RECREATE_INTENT_ID;")"
+TASK_STATUS="$(query_sqlite_value "select coalesce(status,'') from tasks where id = '$TASK_ID';")"
+AWAITING_AFTER_RECREATE="$(
+  query_sqlite_value "select count(*) from events where task_id = '$TASK_ID' and event_type = 'task.awaiting_approval' and created_at >= (select created_at from workflow_mutation_intents where id = $RECREATE_INTENT_ID);"
+)"
+FIXING_AFTER_RECREATE="$(
+  query_sqlite_value "select count(*) from events where task_id = '$TASK_ID' and event_type = 'task.fixing_with_ai' and created_at >= (select created_at from workflow_mutation_intents where id = $RECREATE_INTENT_ID);"
+)"
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  if [[ "$AWAITING_AFTER_RECREATE" == "0" ]]; then
+    echo "repro: expected stale fix to write awaiting_approval after recreate-task, but it did not" >&2
+    exit 1
+  fi
+  echo "repro: confirmed bug"
+else
+  if [[ "$AWAITING_AFTER_RECREATE" != "0" ]]; then
+    echo "repro: stale fix wrote awaiting_approval after recreate-task" >&2
+    exit 1
+  fi
+  if [[ "$FIX_STATUS" != "failed" && "$FIX_STATUS" != "completed" ]]; then
+    echo "repro: expected fix intent to be terminal after preemption, got $FIX_STATUS" >&2
+    exit 1
+  fi
+  echo "repro: confirmed fix"
+fi
+
+echo "workflow: $WORKFLOW_ID"
+echo "task: $TASK_ID status=$TASK_STATUS"
+echo "fix intent: $FIX_INTENT_ID status=$FIX_STATUS"
+echo "recreate-task intent: $RECREATE_INTENT_ID status=$RECREATE_STATUS"
+echo "awaiting_approval events after recreate-task: $AWAITING_AFTER_RECREATE"
+echo "fixing_with_ai events after recreate-task: $FIXING_AFTER_RECREATE"
+echo "tmp-dir: $TMP_DIR"

--- a/scripts/repro/repro-fix-intent-cancellation-stack.sh
+++ b/scripts/repro/repro-fix-intent-cancellation-stack.sh
@@ -32,6 +32,7 @@ What it proves:
     Recreate-task authority must survive repeated owner restart churn.
 
 This wrapper runs the committed repros for that stack:
+  - scripts/repro/repro-workflow-mutation-cancellation-hardening.sh
   - scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
   - scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh
   - scripts/repro/repro-stale-late-completion-after-reset.sh
@@ -70,6 +71,7 @@ fi
 
 cd "$ROOT_DIR"
 
+step_args=(--expect "$EXPECTATION")
 queue_args=()
 shared_args=(--expect "$EXPECTATION")
 late_completion_args=()
@@ -86,6 +88,10 @@ if [[ "$KEEP_ARTIFACTS" == "1" ]]; then
   late_completion_args+=(--keep-temp)
 fi
 
+echo "==> stack repro: Step 1 — workflow mutation cancellation hardening"
+bash scripts/repro/repro-workflow-mutation-cancellation-hardening.sh "${step_args[@]}"
+
+echo
 echo "==> stack repro: Scenario 1 — recreate-task queue authority"
 bash scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh "${queue_args[@]}"
 

--- a/scripts/repro/repro-fix-intent-cancellation-stack.sh
+++ b/scripts/repro/repro-fix-intent-cancellation-stack.sh
@@ -33,6 +33,7 @@ What it proves:
 
 This wrapper runs the committed repros for that stack:
   - scripts/repro/repro-workflow-mutation-cancellation-hardening.sh
+  - scripts/repro/repro-fix-flow-lineage-guards.sh
   - scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
   - scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh
   - scripts/repro/repro-stale-late-completion-after-reset.sh
@@ -90,6 +91,10 @@ fi
 
 echo "==> stack repro: Step 1 — workflow mutation cancellation hardening"
 bash scripts/repro/repro-workflow-mutation-cancellation-hardening.sh "${step_args[@]}"
+
+echo
+echo "==> stack repro: Step 2 — fix flow lineage guards"
+bash scripts/repro/repro-fix-flow-lineage-guards.sh "${step_args[@]}"
 
 echo
 echo "==> stack repro: Scenario 1 — recreate-task queue authority"

--- a/scripts/repro/repro-workflow-mutation-cancellation-hardening.sh
+++ b/scripts/repro/repro-workflow-mutation-cancellation-hardening.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION="fixed"
+TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-120}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-workflow-mutation-cancellation-hardening.sh [--expect bug|fixed]
+
+What it proves:
+  Product-path repro for the recreate-task preemption case. It starts a real
+  GUI owner, runs a real headless fix command with a slow fake Claude process,
+  then runs a real headless recreate-task while the fix is still in flight.
+
+This is the Step 1 repro for:
+  Fix intent cancellation Step 1: workflow mutation cancellation hardening.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  echo "repro: --expect requires bug|fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$seconds" "$@"
+    return $?
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$seconds" "$@"
+    return $?
+  fi
+  "$@"
+}
+
+cd "$ROOT_DIR"
+
+run_with_timeout "$TIMEOUT_SECONDS" \
+  bash scripts/repro/repro-fix-intent-cancellation-e2e.sh --expect "$EXPECTATION"


### PR DESCRIPTION
## Summary

Preserves local branch work that was reachable from `plan/fix-intent-cancellation-step-2-fix-lineage-guards-regression-gated-v2` but not reachable from fetched remote refs during the local branch audit.

- Source branch: `plan/fix-intent-cancellation-step-2-fix-lineage-guards-regression-gated-v2`
- Source tip: `720280899d8326de73bd12b234e31ab70ff8aeb2`
- Source tip date: `2026-05-15`
- Patch-equivalent commits not in `upstream/master`: `4`
- Preservation branch: `preserved-work/plan-fix-intent-cancellation-step-2-fix-lineage-guards-regression-gated-72028089`

This PR is intentionally opened as a preservation handle so the work is visible in GitHub before local cleanup. It has not been rebased or rewritten.

## Test Plan

- [ ] Not run; preservation PR created from existing local branch state only.

## Revert Plan

- Safe to revert? Yes, if this preserved work is not needed.
- Revert command: close this PR, or delete branch `preserved-work/plan-fix-intent-cancellation-step-2-fix-lineage-guards-regression-gated-72028089` after confirming no review is needed.
- Post-revert steps: None.
- Data migration? No.
