### PR TITLE
ci: consolidate e2e into one sharded, blocking proof gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,17 @@ jobs:
       - name: Run quality check
         run: ${{ matrix.command }}
 
-  inv117-proof:
+  e2e-proof:
     needs: build-artifacts
     runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
-    timeout-minutes: 120
-    name: inv117 / deterministic proof
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    name: e2e-proof / shard ${{ matrix.shard }}
 
     steps:
       - name: Checkout
@@ -153,14 +157,55 @@ jobs:
           git update-ref refs/heads/main refs/remotes/origin/master || true
           git update-ref refs/remotes/origin/main refs/remotes/origin/master || true
 
-      - name: Run INV-117 required proof contract
+      - name: Run e2e proof shard
         env:
           INVOKER_TEST_ALL_PROOF: '1'
-          INVOKER_TEST_ALL_JOBS: '1'
+          INVOKER_TEST_ALL_SHARD_INDEX: ${{ matrix.shard }}
+          INVOKER_TEST_ALL_SHARD_TOTAL: '4'
+          INVOKER_TEST_ALL_STATE_FILE: ${{ github.workspace }}/proof-state.tsv
           TMPDIR: ${{ runner.temp }}/invoker-tmp
         run: |
           mkdir -p "$TMPDIR"
           chmod 1777 "$TMPDIR"
+          bash scripts/run-all-tests.sh
+
+      - name: Upload shard proof state
+        uses: actions/upload-artifact@v4
+        with:
+          name: proof-state-${{ matrix.shard }}
+          path: ${{ github.workspace }}/proof-state.tsv
+          if-no-files-found: error
+
+  e2e-proof-aggregate:
+    needs: e2e-proof
+    runs-on: ubuntu-latest
+    # Same container as the shards so $GITHUB_WORKSPACE (and therefore the
+    # absolute suite paths recorded in the shard state) match for state_get.
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+    timeout-minutes: 15
+    name: e2e-proof / aggregate
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Download shard proof state
+        uses: actions/download-artifact@v4
+        with:
+          pattern: proof-state-*
+          path: /tmp/shard-states
+
+      - name: Merge shard state and validate e2e proof contract
+        env:
+          INVOKER_TEST_ALL_PROOF: '1'
+          INVOKER_TEST_ALL_AGGREGATE: '1'
+          INVOKER_TEST_ALL_STATE_FILE: ${{ github.workspace }}/merged-proof-state.tsv
+        run: |
+          cat /tmp/shard-states/proof-state-*/proof-state.tsv > "$INVOKER_TEST_ALL_STATE_FILE"
           bash scripts/run-all-tests.sh
 
   required-fast:
@@ -293,71 +338,6 @@ jobs:
 
       - name: Run fix-intent repro bundle
         run: bash scripts/test-suites/required/23-fix-intent-repros.sh
-
-  dry-run:
-    needs: build-artifacts
-    runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.58.2-noble
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: case-1
-            suite: scripts/test-suites/required/20-e2e-dry-run.sh
-          - name: case-2
-            suite: scripts/test-suites/required/21-e2e-dry-run-downstream.sh
-          - name: case-4
-            suite: scripts/test-suites/required/22-e2e-dry-run-github.sh
-
-    name: dry-run / ${{ matrix.name }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-          cache-dependency-path: |
-            pnpm-lock.yaml
-            .node-version
-
-      - name: Install native build tools
-        run: apt-get update && apt-get install -y unzip make g++ python3
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: app-build-dist
-          path: /tmp/invoker-build-artifacts
-
-      - name: Extract build artifacts
-        run: tar -xzf /tmp/invoker-build-artifacts/app-build-dist.tgz -C .
-
-      - name: Configure git identity and HTTPS auth
-        run: |
-          git config --global user.name "CI Bot"
-          git config --global user.email "ci@invoker.dev"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "git@github.com:"
-          git config --global --add url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
-          git update-ref refs/heads/main refs/remotes/origin/master || true
-          git update-ref refs/remotes/origin/main refs/remotes/origin/master || true
-
-      - name: Run dry-run shard
-        run: bash ${{ matrix.suite }}
 
   playwright:
     needs: build-artifacts

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,9 +17,7 @@ queue_rules:
       - check-success = required-fast / Guardrails
       - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
-      - check-success = dry-run / case-1
-      - check-success = dry-run / case-2
-      - check-success = dry-run / case-4
+      - check-success = e2e-proof / aggregate
       - check-success = playwright / 1-of-3
       - check-success = playwright / 2-of-3
       - check-success = playwright / 3-of-3
@@ -41,9 +39,7 @@ queue_rules:
       - check-success = required-fast / Guardrails
       - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
-      - check-success = dry-run / case-1
-      - check-success = dry-run / case-2
-      - check-success = dry-run / case-4
+      - check-success = e2e-proof / aggregate
       - check-success = playwright / 1-of-3
       - check-success = playwright / 2-of-3
       - check-success = playwright / 3-of-3

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -13,6 +13,21 @@ JOBS="${INVOKER_TEST_ALL_JOBS:-1}"
 PROOF="${INVOKER_TEST_ALL_PROOF:-0}"
 PROOF_CONTRACT="INV-117"
 
+# In proof mode the suite set is an explicit manifest of true e2e-on-mock-DB
+# suites (not a glob of everything under required/). The manifest is the single
+# reviewable source of what the e2e proof gate runs.
+PROOF_MANIFEST="${INVOKER_TEST_ALL_PROOF_MANIFEST:-$ROOT/scripts/test-suites/proof-e2e.manifest}"
+manifest_count() { grep -cvE '^[[:space:]]*(#|$)' "$PROOF_MANIFEST"; }
+
+# Sharding: each shard runs a disjoint slice of the proof manifest and records
+# its results to its own STATE_FILE; an aggregate run merges the per-shard state
+# and validates the proof contract over the union.
+SHARD_INDEX="${INVOKER_TEST_ALL_SHARD_INDEX:-}"
+SHARD_TOTAL="${INVOKER_TEST_ALL_SHARD_TOTAL:-1}"
+AGGREGATE="${INVOKER_TEST_ALL_AGGREGATE:-0}"
+SHARDED=0
+if [ -n "$SHARD_INDEX" ] && [ "$SHARD_TOTAL" -gt 1 ]; then SHARDED=1; fi
+
 if [ "$PROOF" = "1" ]; then
   FORCE_RERUN=1
   RESUME=0
@@ -59,6 +74,7 @@ declare -a FAILED=()
 declare -a SUITES=()
 
 expected_executed_for_mode() {
+  if [ "$PROOF" = "1" ] && [ -f "$PROOF_MANIFEST" ]; then manifest_count; return; fi
   case "$MODE_KEY" in
     required)
       printf '18'
@@ -77,6 +93,7 @@ expected_executed_for_mode() {
 }
 
 expected_discovered_for_mode() {
+  if [ "$PROOF" = "1" ] && [ -f "$PROOF_MANIFEST" ]; then manifest_count; return; fi
   case "$MODE_KEY" in
     required)
       printf '18'
@@ -297,6 +314,17 @@ flush_parallel() {
 
 collect_suites() {
   local dir
+  # Proof mode: the suite set is the explicit e2e manifest, not the required/ glob.
+  if [ "$PROOF" = "1" ] && [ -f "$PROOF_MANIFEST" ]; then
+    local rel
+    while IFS= read -r rel; do
+      rel="${rel%%#*}"
+      rel="$(printf '%s' "$rel" | tr -d '[:space:]')"
+      [ -n "$rel" ] || continue
+      SUITES+=( "$ROOT/scripts/test-suites/$rel" )
+    done < "$PROOF_MANIFEST"
+    return
+  fi
   for dir in required optional dangerous; do
     case "$dir" in
       required) ;;
@@ -416,8 +444,40 @@ validate_proof_inventory() {
 
 load_state
 collect_suites
-if ! validate_proof_inventory; then
-  exit 1
+
+# Shard mode: run only this shard's disjoint slice of the manifest. Defer all
+# proof validation to the aggregate run, which sees the union of shard state.
+if [ "$SHARDED" = "1" ] && [ "$AGGREGATE" != "1" ]; then
+  shard_suites=()
+  for i in "${!SUITES[@]}"; do
+    if [ $(( i % SHARD_TOTAL )) -eq "$SHARD_INDEX" ]; then
+      shard_suites+=( "${SUITES[$i]}" )
+    fi
+  done
+  SUITES=( "${shard_suites[@]+"${shard_suites[@]}"}" )
+fi
+
+# Aggregate mode: do not execute. Derive results from the merged shard STATE_FILE
+# and validate the proof contract (inventory + thresholds) over the union.
+if [ "$AGGREGATE" = "1" ]; then
+  for suite in "${SUITES[@]}"; do
+    case "$(state_get "$suite")" in
+      passed)              EXECUTED+=( "$suite" );;
+      failed)              EXECUTED+=( "$suite" ); FAILED+=( "$suite" );;
+      skipped-unavailable) SKIPPED_UNAVAILABLE+=( "$(suite_relpath "$suite")" );;
+      *) ;;   # missing from merged state => not executed => threshold check fails (correct)
+    esac
+  done
+  print_summary
+  validate_proof_inventory || exit 1
+  validate_proof_thresholds || exit 1
+  exit 0
+fi
+
+if [ "$SHARDED" != "1" ]; then
+  if ! validate_proof_inventory; then
+    exit 1
+  fi
 fi
 
 if [ "$PROOF" = "1" ]; then
@@ -479,8 +539,10 @@ if [ "${#JOB_SUITE[@]}" -gt 0 ]; then
 fi
 
 print_summary
-if ! validate_proof_thresholds; then
-  exit 1
+if [ "$SHARDED" != "1" ]; then
+  if ! validate_proof_thresholds; then
+    exit 1
+  fi
 fi
 
 if [ "$overall_failed" -ne 0 ]; then

--- a/scripts/test-suites/proof-e2e.manifest
+++ b/scripts/test-suites/proof-e2e.manifest
@@ -1,0 +1,11 @@
+# True e2e tests on a mock/temp DB — the ONLY suites the e2e proof gate runs.
+# One line per suite, relative to scripts/test-suites/. Blank lines and # comments ignored.
+# Everything else (vitest, static checks, UI playwright, node loaders) is covered by its own
+# dedicated CI job (Vitest Workspace, quality/*, required-fast/*, playwright/*) and is NOT run here.
+required/08-electron-preprovision-repro.sh
+required/15-submit-workflow-chain.sh
+required/20-e2e-dry-run.sh
+required/21-e2e-dry-run-downstream.sh
+required/22-e2e-dry-run-github.sh
+required/23-fix-intent-repros.sh
+required/50-verify-executor-routing.sh


### PR DESCRIPTION
## Summary

Collapses the e2e CI surface into a single sharded, blocking gate. Today the same e2e-on-mock-DB suites run twice: in the blocking `dry-run / case-*` jobs **and** in the 17-min, non-blocking `inv117 / deterministic proof`, which globs all of `required/` (vitest, static checks, e2e — a dumping ground) and doesn't even gate merges.

This replaces both with **`e2e-proof`** (4 shards) + a blocking **`e2e-proof / aggregate`** gate, driven by an explicit `proof-e2e.manifest` of the 7 true e2e-on-mock-DB suites. Vitest/static/UI keep their own dedicated jobs. The aggregate validates the full proof contract (exact inventory + zero failures) over the merged per-shard state, so coverage is preserved while wall-clock drops from ~17 min serial to the slowest shard.

## Notes

- `run-all-tests.sh` proof mode now reads the manifest instead of globbing `required/`, derives its inventory count from the manifest (no more hardcoded counts), and supports shard slicing + an aggregate pass.
- `.mergify.yml`: the `dry-run / case-*` merge gates are replaced by `e2e-proof / aggregate`. The `master` ruleset pins no status checks, so the swap is safe.
- Base of the state-invariants stack — #1304 depends on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)