### PR TITLE
Isolate IPC socket by Invoker home

### DIFF
--- a/packages/app/src/delete-all-snapshot.ts
+++ b/packages/app/src/delete-all-snapshot.ts
@@ -1,16 +1,8 @@
 import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
 import * as path from 'node:path';
+import { resolveInvokerHomeRoot } from '@invoker/contracts';
 
-/** Single root for DB, repos cache, and worktrees (must stay consistent). */
-export function resolveInvokerHomeRoot(): string {
-  return (
-    process.env.INVOKER_DB_DIR
-    ?? (process.env.NODE_ENV === 'test'
-      ? path.join(homedir(), '.invoker', 'test')
-      : path.join(homedir(), '.invoker'))
-  );
-}
+export { resolveInvokerHomeRoot };
 
 function utcTimestampCompact(): string {
   // 2026-04-06T12:34:56.789Z -> 20260406-123456-789Z

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -1,5 +1,6 @@
 import type { BrowserWindow, IpcMain } from 'electron';
 import type { Logger, SearchOptions } from '@invoker/contracts';
+import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
 import type { Orchestrator, TaskDelta, TaskState } from '@invoker/workflow-core';
@@ -30,6 +31,27 @@ export interface RegisterReadOnlyIpcHandlersContext {
   timeStartupPhase: <T>(label: string, fn: () => T, fields?: () => Record<string, unknown>) => T;
   recordStartupDuration: (label: string, startedAtMs: number, fields?: Record<string, unknown>) => void;
   getTaskDeltaStreamSequence: () => number;
+}
+
+type DelegatedTasksSnapshot = {
+  tasks: TaskState[];
+  workflows: unknown[];
+  streamSequence: number;
+  invokerHomeRoot?: string;
+};
+
+function asDelegatedTasksSnapshot(value: unknown): DelegatedTasksSnapshot | null {
+  if (!value || typeof value !== 'object') return null;
+
+  const snapshot = value as Partial<DelegatedTasksSnapshot>;
+  if (!Array.isArray(snapshot.tasks) || !Array.isArray(snapshot.workflows)) {
+    return null;
+  }
+  return snapshot as DelegatedTasksSnapshot;
+}
+
+function hasInvokerHomeMismatch(snapshot: DelegatedTasksSnapshot, localInvokerHomeRoot: string): boolean {
+  return Boolean(snapshot.invokerHomeRoot && snapshot.invokerHomeRoot !== localInvokerHomeRoot);
 }
 
 export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlersContext): void {
@@ -91,15 +113,18 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
   ipcMain.handle('invoker:get-tasks', async (_event, forceRefresh?: boolean) => {
     const startedAtMs = Date.now();
     const orchestrator = getOrchestrator();
-    const delegated = await delegateOwnerQuery<{
-      tasks: TaskState[];
-      workflows: unknown[];
-      streamSequence: number;
-    }>('tasks', { forceRefresh: forceRefresh === true });
-    if (delegated && Array.isArray(delegated.tasks) && Array.isArray(delegated.workflows)) {
+    const delegatedSnapshot = asDelegatedTasksSnapshot(await delegateOwnerQuery<DelegatedTasksSnapshot>(
+      'tasks',
+      { forceRefresh: forceRefresh === true },
+    ));
+    const localInvokerHomeRoot = resolveInvokerHomeRoot();
+    const delegatedHomeMismatch = delegatedSnapshot
+      ? hasInvokerHomeMismatch(delegatedSnapshot, localInvokerHomeRoot)
+      : false;
+    if (delegatedSnapshot && !delegatedHomeMismatch) {
       const previousTaskIds = new Set(lastKnownTaskStates.keys());
       lastKnownTaskStates.clear();
-      for (const task of delegated.tasks) {
+      for (const task of delegatedSnapshot.tasks) {
         lastKnownTaskStates.set(task.id, JSON.stringify(task));
         previousTaskIds.delete(task.id);
         const mainWindow = getMainWindow();
@@ -114,14 +139,20 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
         }
         requestWorkflowMetadataPublish(forceRefresh ? 'get-tasks-force-refresh-delegated' : 'get-tasks-delegated');
       }
-      setLastKnownWorkflowCount(delegated.workflows.length);
+      setLastKnownWorkflowCount(delegatedSnapshot.workflows.length);
       recordStartupDuration(forceRefresh ? 'get-tasks.force-refresh.delegated-return' : 'get-tasks.delegated-return', startedAtMs, {
-        taskCount: delegated.tasks.length,
-        workflowCount: delegated.workflows.length,
-        jsonSizeBytes: Buffer.byteLength(JSON.stringify(delegated), 'utf8'),
-        streamSequence: delegated.streamSequence,
+        taskCount: delegatedSnapshot.tasks.length,
+        workflowCount: delegatedSnapshot.workflows.length,
+        jsonSizeBytes: Buffer.byteLength(JSON.stringify(delegatedSnapshot), 'utf8'),
+        streamSequence: delegatedSnapshot.streamSequence,
       });
-      return delegated;
+      return delegatedSnapshot;
+    }
+    if (delegatedSnapshot && delegatedHomeMismatch) {
+      logger.error(
+        `tasks owner delegation ignored mismatched home root: owner="${delegatedSnapshot.invokerHomeRoot}" local="${localInvokerHomeRoot}"`,
+        { module: 'ipc' },
+      );
     }
     if (forceRefresh) {
       timeStartupPhase('get-tasks.force-refresh.syncAllFromDb', () => orchestrator.syncAllFromDb(), () => ({

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -65,9 +65,13 @@ import type {
   TaskState,
   TaskStateChanges,
 } from '@invoker/workflow-core';
-import { makeEnvelope, CommandError } from '@invoker/contracts';
+import {
+  makeEnvelope,
+  CommandError,
+  resolveInvokerIpcSocketPath,
+  resolveRepoRoot,
+} from '@invoker/contracts';
 import type { WorkResponse } from '@invoker/contracts';
-import { resolveRepoRoot } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
@@ -1616,6 +1620,7 @@ if (isHeadless) {
               tasks: orchestrator.getAllTasks(),
               workflows: persistence.listWorkflows(),
               streamSequence: 0,
+              invokerHomeRoot: resolveInvokerHomeRoot(),
             };
           }
           if (kind === 'action-graph') {
@@ -3262,6 +3267,7 @@ function createEmbeddedTerminalBackendFromConfig(
             tasks: orchestrator.getAllTasks(),
             workflows: persistence.listWorkflows(),
             streamSequence: getTaskDeltaStreamSequence(),
+            invokerHomeRoot: resolveInvokerHomeRoot(),
           };
         }
         if (kind === 'action-graph') {
@@ -3382,6 +3388,7 @@ function createEmbeddedTerminalBackendFromConfig(
     }
 
     const dbPath = path.join(resolveInvokerHomeRoot(), 'invoker.db');
+    logger.info(`IPC socket: ${resolveInvokerIpcSocketPath()}`, { module: 'init' });
     logger.info(`Database: ${dbPath}`, { module: 'init' });
     logger.info(`Repo root: ${repoRoot}`, { module: 'init' });
     logger.info(`Config: disableAutoRunOnStartup=${invokerConfig.disableAutoRunOnStartup ?? false}`, { module: 'init' });
@@ -3889,6 +3896,16 @@ function createEmbeddedTerminalBackendFromConfig(
         metric,
         ...(data ?? {}),
       };
+      if (
+        metric === 'startup_bootstrap_state' ||
+        metric === 'startup_snapshot_applied' ||
+        metric === 'startup_snapshot_skipped_bootstrap_complete' ||
+        metric === 'startup_workflow_graph_visible' ||
+        metric === 'ui_delta_stream_gap_detected' ||
+        (metric === 'useTasks_snapshot_replace' && data?.workflowCount === 0)
+      ) {
+        logger.info(`ui metric ${metric} ${JSON.stringify(data ?? {})}`, { module: 'ui-state' });
+      }
       if (metric === 'renderer_event_loop_lag' && typeof data?.lagMs === 'number') {
         const hiddenOrUnfocused = data.visibilityState === 'hidden' || data.hasFocus === false;
         if (hiddenOrUnfocused) {

--- a/packages/contracts/src/__tests__/invoker-home.test.ts
+++ b/packages/contracts/src/__tests__/invoker-home.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+
+import { resolveInvokerHomeRoot, resolveInvokerIpcSocketPath } from '../invoker-home.js';
+
+describe('Invoker home resolution', () => {
+  it('uses INVOKER_DB_DIR as the home root', () => {
+    expect(resolveInvokerHomeRoot({ INVOKER_DB_DIR: '/tmp/invoker-a' }, '/home/user')).toBe('/tmp/invoker-a');
+  });
+
+  it('uses the live home root by default', () => {
+    expect(resolveInvokerHomeRoot({}, '/home/user')).toBe(join('/home/user', '.invoker'));
+  });
+
+  it('uses an isolated test home root in test mode', () => {
+    expect(resolveInvokerHomeRoot({ NODE_ENV: 'test' }, '/home/user')).toBe(join('/home/user', '.invoker', 'test'));
+  });
+
+  it('places the default IPC socket under the resolved home root', () => {
+    expect(resolveInvokerIpcSocketPath({ INVOKER_DB_DIR: '/tmp/invoker-b' }, '/home/user')).toBe(
+      join('/tmp/invoker-b', 'ipc-transport.sock'),
+    );
+  });
+
+  it('keeps INVOKER_IPC_SOCKET as an explicit override', () => {
+    expect(resolveInvokerIpcSocketPath({
+      INVOKER_DB_DIR: '/tmp/invoker-c',
+      INVOKER_IPC_SOCKET: '/tmp/custom.sock',
+    }, '/home/user')).toBe('/tmp/custom.sock');
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -8,3 +8,4 @@ export * from './ipc-channels.js';
 export * from './repo-root.js';
 export * from './cost-types.js';
 export * from './launch-timeouts.js';
+export * from './invoker-home.js';

--- a/packages/contracts/src/invoker-home.ts
+++ b/packages/contracts/src/invoker-home.ts
@@ -1,0 +1,27 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export interface InvokerHomeEnv {
+  INVOKER_DB_DIR?: string;
+  INVOKER_IPC_SOCKET?: string;
+  NODE_ENV?: string;
+}
+
+export function resolveInvokerHomeRoot(
+  env: InvokerHomeEnv = process.env,
+  homeDir: string = homedir(),
+): string {
+  return (
+    env.INVOKER_DB_DIR
+    ?? (env.NODE_ENV === 'test'
+      ? join(homeDir, '.invoker', 'test')
+      : join(homeDir, '.invoker'))
+  );
+}
+
+export function resolveInvokerIpcSocketPath(
+  env: InvokerHomeEnv = process.env,
+  homeDir: string = homedir(),
+): string {
+  return env.INVOKER_IPC_SOCKET || join(resolveInvokerHomeRoot(env, homeDir), 'ipc-transport.sock');
+}

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -16,6 +16,9 @@
     "test": "vitest run",
     "clean": "rm -rf dist"
   },
+  "dependencies": {
+    "@invoker/contracts": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^25.3.3",
     "tsup": "^8.0.0",

--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { join, dirname } from 'node:path';
 import { existsSync, mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { createConnection } from 'node:net';
@@ -9,6 +9,7 @@ import {
   IpcBus,
   DEFAULT_REQUEST_DEADLINE_MS,
   MALFORMED_FRAME_RATE_LIMIT_MS,
+  resolveDefaultSocketPath,
   type MalformedFrameEvent,
 } from '../ipc-bus.js';
 import { TransportError, TransportErrorCode } from '../transport-error.js';
@@ -24,6 +25,55 @@ function tempSocketPath(): string {
   const dir = mkdtempSync(join(tmpdir(), 'ipc-bus-test-'));
   return join(dir, 'test.sock');
 }
+
+describe('resolveDefaultSocketPath', () => {
+  const originalInvokerDbDir = process.env.INVOKER_DB_DIR;
+  const originalInvokerIpcSocket = process.env.INVOKER_IPC_SOCKET;
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    if (originalInvokerDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = originalInvokerDbDir;
+    }
+    if (originalInvokerIpcSocket === undefined) {
+      delete process.env.INVOKER_IPC_SOCKET;
+    } else {
+      process.env.INVOKER_IPC_SOCKET = originalInvokerIpcSocket;
+    }
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = originalNodeEnv;
+    }
+  });
+
+  it('scopes the default socket to INVOKER_DB_DIR', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-ipc-root-'));
+    process.env.INVOKER_DB_DIR = dir;
+    delete process.env.INVOKER_IPC_SOCKET;
+
+    expect(resolveDefaultSocketPath()).toBe(join(dir, 'ipc-transport.sock'));
+  });
+
+  it('keeps explicit INVOKER_IPC_SOCKET as the strongest override', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-ipc-root-'));
+    const socket = join(dir, 'custom.sock');
+    process.env.INVOKER_DB_DIR = dir;
+    process.env.INVOKER_IPC_SOCKET = socket;
+
+    expect(resolveDefaultSocketPath()).toBe(socket);
+  });
+
+  it('keeps test mode away from the live Invoker socket when no DB dir is set', () => {
+    delete process.env.INVOKER_DB_DIR;
+    delete process.env.INVOKER_IPC_SOCKET;
+    process.env.NODE_ENV = 'test';
+
+    expect(resolveDefaultSocketPath()).toBe(join(homedir(), '.invoker', 'test', 'ipc-transport.sock'));
+  });
+});
 
 describe('IpcBus', () => {
   const buses: IpcBus[] = [];

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -1,9 +1,8 @@
 /**
  * IpcBus — Cross-process MessageBus over Unix domain sockets.
- *
- * Uses a deterministic socket path (`~/.invoker/ipc-transport.sock`) so all
- * processes in the same user session converge on a single bus without
- * discovery.
+ * Uses a deterministic socket path scoped to the Invoker home directory so
+ * processes for the same DB converge on one bus, while temp/test DBs cannot
+ * attach to the user's live UI.
  *
  * ## Server election
  *
@@ -33,8 +32,7 @@
  */
 
 import { createServer, createConnection, type Server, type Socket } from 'node:net';
-import { homedir } from 'node:os';
-import { join, dirname } from 'node:path';
+import { dirname } from 'node:path';
 import { mkdirSync, unlinkSync } from 'node:fs';
 
 import type {
@@ -43,6 +41,7 @@ import type {
   RequestHandler,
   Unsubscribe,
 } from './message-bus.js';
+import { resolveInvokerIpcSocketPath } from '@invoker/contracts';
 import { TransportError, TransportErrorCode } from './transport-error.js';
 
 // ---------------------------------------------------------------------------
@@ -230,8 +229,11 @@ export const SUBSCRIBER_ERROR_RATE_LIMIT_MS = 1_000;
 // Default socket path
 // ---------------------------------------------------------------------------
 
-export const DEFAULT_SOCKET_PATH =
-  process.env.INVOKER_IPC_SOCKET || join(homedir(), '.invoker', 'ipc-transport.sock');
+export function resolveDefaultSocketPath(): string {
+  return resolveInvokerIpcSocketPath();
+}
+
+export const DEFAULT_SOCKET_PATH = resolveDefaultSocketPath();
 
 /** Default request deadline in milliseconds (30 s). */
 export const DEFAULT_REQUEST_DEADLINE_MS = 30_000;
@@ -290,7 +292,7 @@ export class IpcBus implements MessageBus {
     { source: Socket; awaiting: Set<Socket>; channel: string }
   >();
 
-  constructor(socketPath: string = DEFAULT_SOCKET_PATH, options: IpcBusOptions = {}) {
+  constructor(socketPath: string = resolveDefaultSocketPath(), options: IpcBusOptions = {}) {
     this.socketPath = socketPath;
     this.allowServe = options.allowServe ?? true;
     this.requestDeadlineMs = options.requestDeadlineMs ?? DEFAULT_REQUEST_DEADLINE_MS;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,6 +434,10 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
   packages/transport:
+    dependencies:
+      '@invoker/contracts':
+        specifier: workspace:*
+        version: link:../contracts
     devDependencies:
       '@types/node':
         specifier: ^25.3.3


### PR DESCRIPTION
## Summary

Temp and test Invoker instances no longer share the live app IPC socket by default.

The blank graph happened because another process could answer the real UI with an empty temp database snapshot.

There is now one shared home/socket resolver in `@invoker/contracts`. The socket lives under the same Invoker home root as the database.

The UI also ignores delegated task snapshots from a different root, and logs key startup and graph state changes.

## Architecture

### Before

```mermaid
graph TD
    LiveUI[Live Invoker UI] --> Socket[~/.invoker/ipc-transport.sock]
    TestApp[Test or temp Invoker] --> Socket
    Socket --> TempSnapshot[Empty temp DB snapshot]
    TempSnapshot --> LiveUI
```

### After

```mermaid
graph TD
    Resolver[Shared Invoker home resolver] --> LiveRoot[Live home root]
    Resolver --> TempRoot[Temp or test home root]
    LiveRoot --> LiveSocket[Live ipc-transport.sock]
    TempRoot --> TempSocket[Temp ipc-transport.sock]
    LiveSocket --> LiveUI[Live Invoker UI]
    TempSocket --> TestApp[Test or temp Invoker]
    LiveUI --> RootCheck[Reject delegated snapshots from another home root]
```

## Test Plan

- [x] `pnpm --filter @invoker/contracts test -- src/__tests__/invoker-home.test.ts`
- [x] `pnpm --filter @invoker/transport test -- src/__tests__/ipc-bus.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/delete-all-snapshot.test.ts src/__tests__/headless-client.test.ts src/__tests__/ipc-registration.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert cd196103e`
- Post-revert steps: Restart Invoker so the old IPC socket behavior is active again.
- Data migration? No
