### PR TITLE
feat(ops): add safe task retry skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,11 @@ tasks:
     dependencies: [api, ui]
 ```
 
-If you need to turn a product or implementation plan into an Invoker workflow, use the `invoker-plan-to-invoker` skill. Source checkouts can install prefixed skill copies with `bash scripts/setup-agent-skills.sh`. Packaged installs can install the bundled `invoker-plan-to-invoker` copy from the first-run System Setup prompt or, for npm launcher installs, with `invoker-ui --install-skills`.
+If you need to turn a product or implementation plan into an Invoker workflow, use the `invoker-plan-to-invoker` skill. If you need to operate existing workflows or tasks, use the `invoker-ops` skill.
 
-Use `--output text|label|json|jsonl` on headless `query` commands. Only **one** process should **write** the workflow database at a time; see [docs/persistence-architecture-single-writer.md](docs/persistence-architecture-single-writer.md).
+Source checkouts can install prefixed skill copies with `bash scripts/setup-agent-skills.sh`. Packaged installs can install bundled skills from the first-run System Setup prompt or, for npm launcher installs, with `invoker-ui --install-skills`.
+
+Use `--output text|label|json|jsonl` on headless `query` commands. Use `./run.sh --headless retry-tasks --status pending|failed --parallel 8` for bulk safe retries. Only **one** process should **write** the workflow database at a time; see [docs/persistence-architecture-single-writer.md](docs/persistence-architecture-single-writer.md).
 
 ## Architecture (at a glance)
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",
-    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/workspace-test.sh",
-    "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
+    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/workspace-test.sh",
+    "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
     "test:low-resource": "pnpm run test",
     "test:low-resource:packages": "bash scripts/workspace-test.sh",
     "test:guarded": "bash scripts/run-with-resource-guard.sh bash scripts/workspace-test.sh",

--- a/run.sh
+++ b/run.sh
@@ -88,6 +88,10 @@ if [ "$1" = "--headless" ]; then
       exit 1
     fi
   fi
+  if [ "${2:-}" = "retry-tasks" ]; then
+    shift 2
+    exec bash "$REPO_ROOT/scripts/retry-tasks-by-status.sh" "$@"
+  fi
 
   # Build app and dependencies if headless entry point is missing (e.g. fresh worktree).
   if [ ! -f "$REPO_ROOT/packages/app/dist/headless-client.js" ]; then

--- a/scripts/retry-tasks-by-status.sh
+++ b/scripts/retry-tasks-by-status.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+# Safely retry tasks selected by Invoker's headless query surface.
+# This script intentionally does not inspect the SQLite database directly.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=scripts/headless-lib.sh
+source "$REPO_ROOT/scripts/headless-lib.sh"
+RUNNER="${INVOKER_RETRY_TASKS_RUNNER:-$RUNNER}"
+
+STATUS_FILTER=""
+WORKFLOW_FILTER=""
+PARALLELISM=8
+DRY_RUN=false
+SELF_TEST=false
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/retry-tasks-by-status.sh --status <status> [--workflow <id>] [--parallel <n>] [--dry-run]
+  ./run.sh --headless retry-tasks --status <status> [--workflow <id>] [--parallel <n>] [--dry-run]
+
+Examples:
+  ./run.sh --headless retry-tasks --status failed --parallel 8
+  ./run.sh --headless retry-tasks --status pending --parallel 8
+
+Notes:
+  - Uses Invoker headless query commands to list tasks.
+  - Uses `retry-task <taskId> --no-track` for each selected task.
+  - Does not read or write the SQLite database directly.
+USAGE
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --status)
+        STATUS_FILTER="${2:-}"
+        [[ -n "$STATUS_FILTER" ]] || fail "Missing value for --status"
+        shift 2
+        ;;
+      --workflow)
+        WORKFLOW_FILTER="${2:-}"
+        [[ -n "$WORKFLOW_FILTER" ]] || fail "Missing value for --workflow"
+        shift 2
+        ;;
+      --parallel)
+        PARALLELISM="${2:-}"
+        [[ -n "$PARALLELISM" ]] || fail "Missing value for --parallel"
+        shift 2
+        ;;
+      --dry-run)
+        DRY_RUN=true
+        shift
+        ;;
+      --self-test)
+        SELF_TEST=true
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        fail "Unknown argument: $1"
+        ;;
+    esac
+  done
+}
+
+validate_args() {
+  if $SELF_TEST; then
+    return
+  fi
+  [[ -n "$STATUS_FILTER" ]] || fail "Missing required --status <status>"
+  [[ "$PARALLELISM" =~ ^[1-9][0-9]*$ ]] || fail "Invalid --parallel value: $PARALLELISM"
+}
+
+query_workflows() {
+  if [[ -n "$WORKFLOW_FILTER" ]]; then
+    printf '%s\n' "$WORKFLOW_FILTER"
+    return
+  fi
+  "$RUNNER" --headless query workflows --output label
+}
+
+query_tasks_for_workflow() {
+  local workflow_id="$1"
+  "$RUNNER" --headless query tasks --workflow "$workflow_id" --status "$STATUS_FILTER" --output label
+}
+
+collect_tasks() {
+  local output_file="$1"
+  local raw_file
+  raw_file="$(mktemp -t invoker-retry-tasks-raw.XXXXXX)"
+
+  while IFS= read -r workflow_id; do
+    [[ -n "$workflow_id" ]] || continue
+    while IFS= read -r task_id; do
+      [[ -n "$task_id" ]] || continue
+      printf '%s\t%s\n' "$workflow_id" "$task_id" >> "$raw_file"
+    done < <(query_tasks_for_workflow "$workflow_id")
+  done < <(query_workflows)
+
+  sort -u "$raw_file" > "$output_file"
+  rm -f "$raw_file"
+}
+
+run_dry_run() {
+  local tasks_file="$1"
+  local total="$2"
+  echo "Found $total task(s) with status '$STATUS_FILTER'."
+  while IFS=$'\t' read -r workflow_id task_id; do
+    [[ -n "$task_id" ]] || continue
+    echo "[dry-run] workflow=$workflow_id retry-task $task_id --no-track"
+  done < "$tasks_file"
+}
+
+run_retry_task() {
+  local index="$1"
+  local total="$2"
+  local workflow_id="$3"
+  local task_id="$4"
+  local results_file="$5"
+  local log_file="$6"
+
+  if "$RUNNER" --headless retry-task "$task_id" --no-track > "$log_file" 2>&1; then
+    printf '%s\tSUCCEEDED\n' "$task_id" >> "$results_file"
+    echo "[$index/$total] OK workflow=$workflow_id task=$task_id"
+    return 0
+  fi
+
+  printf '%s\tFAILED\n' "$task_id" >> "$results_file"
+  echo "[$index/$total] FAILED workflow=$workflow_id task=$task_id log=$log_file" >&2
+  return 1
+}
+
+dispatch_retries() {
+  local tasks_file="$1"
+  local total="$2"
+  local results_file="$3"
+  local log_dir="$4"
+  local idx=0
+  local pids=()
+
+  while IFS=$'\t' read -r workflow_id task_id; do
+    [[ -n "$task_id" ]] || continue
+    idx=$((idx + 1))
+    local log_file="$log_dir/task-$idx.log"
+    (
+      run_retry_task "$idx" "$total" "$workflow_id" "$task_id" "$results_file" "$log_file"
+    ) &
+    pids+=("$!")
+
+    while [[ "$(jobs -pr | wc -l | tr -d ' ')" -ge "$PARALLELISM" ]]; do
+      sleep 0.2
+    done
+  done < "$tasks_file"
+
+  for pid in "${pids[@]}"; do
+    wait "$pid" || true
+  done
+}
+
+run_main() {
+  local tasks_file results_file log_dir total succeeded failed _skipped
+  tasks_file="$(mktemp -t invoker-retry-tasks.XXXXXX)"
+  results_file="$(mktemp -t invoker-retry-tasks-results.XXXXXX)"
+  log_dir="$(mktemp -d -t invoker-retry-tasks-logs.XXXXXX)"
+
+  collect_tasks "$tasks_file"
+  total="$(wc -l < "$tasks_file" | tr -d ' ')"
+
+  if [[ "$total" -eq 0 ]]; then
+    echo "No task(s) found with status '$STATUS_FILTER'."
+    rm -f "$tasks_file" "$results_file"
+    return 0
+  fi
+
+  if $DRY_RUN; then
+    run_dry_run "$tasks_file" "$total"
+    rm -f "$tasks_file" "$results_file"
+    return 0
+  fi
+
+  echo "Found $total task(s) with status '$STATUS_FILTER'."
+  echo "Dispatching retry-task --no-track with parallelism $PARALLELISM."
+  dispatch_retries "$tasks_file" "$total" "$results_file" "$log_dir"
+
+  read -r succeeded failed _skipped < <(count_results "$results_file")
+  echo "---"
+  echo "Submitted $succeeded task retry request(s); $failed failed to submit. Logs: $log_dir"
+
+  rm -f "$tasks_file" "$results_file"
+  if [[ "$failed" -ne 0 ]]; then
+    return 1
+  fi
+}
+
+run_self_tests() {
+  local test_root fake_runner command_log output
+  test_root="$(mktemp -d -t invoker-retry-tasks-self-test.XXXXXX)"
+  fake_runner="$test_root/fake-runner.sh"
+  command_log="$test_root/commands.log"
+
+  cat > "$fake_runner" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+: "${INVOKER_RETRY_TASKS_COMMAND_LOG:?}"
+[[ "${1:-}" == "--headless" ]] || exit 64
+shift
+case "${1:-}" in
+  query)
+    case "${2:-}" in
+      workflows)
+        printf '%s\n' wf-1 wf-2
+        ;;
+      tasks)
+        workflow=""
+        status=""
+        shift 2
+        while [[ $# -gt 0 ]]; do
+          case "$1" in
+            --workflow) workflow="${2:-}"; shift 2 ;;
+            --status) status="${2:-}"; shift 2 ;;
+            --output) shift 2 ;;
+            *) shift ;;
+          esac
+        done
+        if [[ "$status" == "pending" && "$workflow" == "wf-1" ]]; then
+          printf '%s\n' wf-1/task-a __merge__wf-1
+        elif [[ "$status" == "pending" && "$workflow" == "wf-2" ]]; then
+          printf '%s\n' wf-2/task-b
+        elif [[ "$status" == "failed" && "$workflow" == "wf-2" ]]; then
+          printf '%s\n' wf-2/task-failed
+        fi
+        ;;
+      *) exit 65 ;;
+    esac
+    ;;
+  retry-task)
+    printf '%s %s\n' "${2:-}" "${3:-}" >> "$INVOKER_RETRY_TASKS_COMMAND_LOG"
+    printf 'accepted\n'
+    ;;
+  *)
+    exit 66
+    ;;
+esac
+FAKE
+  chmod +x "$fake_runner"
+
+  echo "self-test: pending tasks include merge and normal task ids"
+  : > "$command_log"
+  output="$(INVOKER_RETRY_TASKS_RUNNER="$fake_runner" INVOKER_RETRY_TASKS_COMMAND_LOG="$command_log" bash "$0" --status pending --parallel 2)"
+  printf '%s\n' "$output" | grep -qF "Submitted 3 task retry request(s); 0 failed" || fail "pending self-test summary missing"
+  sort "$command_log" > "$test_root/commands.sorted"
+  cat > "$test_root/expected.sorted" <<'EXPECTED'
+__merge__wf-1 --no-track
+wf-1/task-a --no-track
+wf-2/task-b --no-track
+EXPECTED
+  diff -u "$test_root/expected.sorted" "$test_root/commands.sorted"
+
+  echo "self-test: workflow filter narrows retries"
+  : > "$command_log"
+  INVOKER_RETRY_TASKS_RUNNER="$fake_runner" INVOKER_RETRY_TASKS_COMMAND_LOG="$command_log" bash "$0" --status failed --workflow wf-2 --parallel 1 >/dev/null
+  printf '%s\n' "wf-2/task-failed --no-track" > "$test_root/expected-filtered"
+  diff -u "$test_root/expected-filtered" "$command_log"
+
+  echo "self-test: dry-run does not dispatch"
+  : > "$command_log"
+  INVOKER_RETRY_TASKS_RUNNER="$fake_runner" INVOKER_RETRY_TASKS_COMMAND_LOG="$command_log" bash "$0" --status pending --dry-run >/dev/null
+  [[ ! -s "$command_log" ]] || fail "dry-run dispatched retry commands"
+
+  rm -rf "$test_root"
+  echo "self-test: all passed"
+}
+
+parse_args "$@"
+validate_args
+if $SELF_TEST; then
+  run_self_tests
+else
+  run_main
+fi

--- a/scripts/test-invoker-ops-skill.sh
+++ b/scripts/test-invoker-ops-skill.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Contract tests for the invoker-ops skill and safe bulk retry wrapper.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SKILL_MD="$REPO_ROOT/skills/invoker-ops/SKILL.md"
+RETRY_SCRIPT="$REPO_ROOT/scripts/retry-tasks-by-status.sh"
+RUN_SH="$REPO_ROOT/run.sh"
+README="$REPO_ROOT/README.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+must_contain() {
+  local file="$1"
+  local needle="$2"
+  local hint="$3"
+  if ! grep -qF -- "$needle" "$file"; then
+    fail "$hint — missing in $file: $needle"
+  fi
+}
+
+[[ -f "$SKILL_MD" ]] || fail "expected $SKILL_MD"
+[[ -x "$RETRY_SCRIPT" ]] || fail "expected executable $RETRY_SCRIPT"
+
+must_contain "$SKILL_MD" "Do not query or mutate the SQLite database directly" "skill must forbid normal direct DB operations"
+must_contain "$SKILL_MD" "./run.sh --headless retry-tasks --status failed --parallel 8" "skill must document failed retry command"
+must_contain "$SKILL_MD" "./run.sh --headless retry-tasks --status pending --parallel 8" "skill must document pending retry command"
+must_contain "$SKILL_MD" "Bulk retry commands must use \`--no-track\`" "skill must document acknowledgement boundary"
+must_contain "$SKILL_MD" "Do not invent SQL as the fallback" "skill must reject SQL fallback"
+
+must_contain "$RETRY_SCRIPT" "--no-track" "retry wrapper must dispatch no-track task retries"
+must_contain "$RETRY_SCRIPT" "query tasks --workflow" "retry wrapper must use Invoker query surface"
+must_contain "$RUN_SH" "retry-tasks" "run.sh must expose the retry-tasks headless wrapper"
+must_contain "$README" "invoker-ops" "README must mention the operator skill"
+
+bash "$RETRY_SCRIPT" --self-test
+
+echo "OK: invoker-ops skill contract checks passed"

--- a/skills/invoker-ops/SKILL.md
+++ b/skills/invoker-ops/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: invoker-ops
+description: >
+  Safely operate existing Invoker workflows and tasks from natural-language requests.
+  Trigger when asked to list, inspect, retry, restart, resume, cancel, approve,
+  reject, or check pending/failed/running Invoker tasks or workflows.
+---
+
+# invoker-ops
+
+Use this skill for operator requests against existing Invoker state.
+
+Examples:
+
+- "restart all failing tasks"
+- "retry all pending tasks"
+- "what is blocked?"
+- "show me running workflows"
+- "cancel this task"
+
+## Hard rule
+
+Do not query or mutate the SQLite database directly for normal operations.
+
+Use Invoker commands first. Direct database reads are only allowed when the user explicitly asks to debug persistence/storage internals, or when the Invoker command surface itself is the broken thing being investigated.
+
+## Safe command map
+
+### List workflows
+
+```bash
+./run.sh --headless query workflows --output text
+./run.sh --headless query workflows --status failed --output json
+```
+
+### List tasks
+
+```bash
+./run.sh --headless query tasks --workflow <workflowId> --output text
+./run.sh --headless query tasks --workflow <workflowId> --status pending --output json
+./run.sh --headless query tasks --workflow <workflowId> --status failed --output json
+./run.sh --headless query tasks --workflow <workflowId> --status running --output json
+```
+
+If the request says "all workflows", first list workflows, then query each workflow through `query tasks --workflow <workflowId>`.
+
+### Retry failed tasks
+
+```bash
+./run.sh --headless retry-tasks --status failed --parallel 8
+```
+
+### Retry pending tasks
+
+```bash
+./run.sh --headless retry-tasks --status pending --parallel 8
+```
+
+### Dry-run a bulk retry
+
+```bash
+./run.sh --headless retry-tasks --status pending --parallel 8 --dry-run
+```
+
+### Retry one task
+
+```bash
+./run.sh --headless retry-task <taskId> --no-track
+```
+
+### Retry one workflow
+
+```bash
+./run.sh --headless retry <workflowId> --no-track
+```
+
+## Acknowledgement boundary
+
+Bulk retry commands must use `--no-track`.
+
+The operator acknowledgement means the retry request was accepted for dispatch. It does not mean the task finished.
+
+After submitting, verify with query commands, not database reads.
+
+## Workflow for "retry/restart all failed or pending tasks"
+
+1. Run a dry-run if the request is broad or destructive-looking.
+2. Run `./run.sh --headless retry-tasks --status <status> --parallel 8`.
+3. Report accepted and failed submission counts from command output.
+4. Verify remaining tasks with `query tasks` commands when the user asks for current state.
+
+## If a command is missing
+
+Do not invent SQL as the fallback.
+
+Report the missing command surface and add/fix the command if the user asked for a durable production-safe path.


### PR DESCRIPTION
## Summary

Operators now have a safe path for retrying existing Invoker work without reading the database.

The new `invoker-ops` skill maps plain requests like “retry pending tasks” to supported headless commands.

`./run.sh --headless retry-tasks` queries tasks through Invoker, then submits `retry-task --no-track` for each match.

## Architecture

### Before

```mermaid
sequenceDiagram
    participant Agent as Operator agent
    participant DB as SQLite database
    participant Invoker as Invoker commands
    Agent->>DB: inspect task rows directly
    Agent-->>Invoker: sometimes retry by hand
```

### After

```mermaid
sequenceDiagram
    participant Agent as Operator agent
    participant Skill as invoker-ops skill
    participant Query as headless query
    participant Retry as retry-task no-track
    Agent->>Skill: retry pending or failed tasks
    Skill->>Query: list workflows and tasks
    Skill->>Retry: submit safe retry requests
```

## Test Plan

- [x] `bash scripts/test-invoker-ops-skill.sh`
- [x] `./run.sh --headless retry-tasks --help`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/bundled-skills.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No
