### PR TITLE
Fix UI refresh graph redraw

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -356,6 +356,7 @@ export function App() {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [graphRefreshSequence, setGraphRefreshSequence] = useState(0);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [stickySelectedWorkflow, setStickySelectedWorkflow] = useState<WorkflowMeta | null>(null);
   const [workflowSelectionDismissed, setWorkflowSelectionDismissed] = useState(false);
@@ -1330,9 +1331,9 @@ export function App() {
     }
   }, [contextMenu, focusKeyboardRegion, workflowContextMenu]);
 
-  const handleRefresh = useCallback(() => {
-    refreshTasks(true);
-    window.invoker?.checkPrStatuses?.();
+  const handleRefresh = useCallback(async () => {
+    await refreshTasks(true);
+    setGraphRefreshSequence((sequence) => sequence + 1);
   }, [refreshTasks]);
 
   // ── Plan loading ──────────────────────────────────────────
@@ -1816,6 +1817,7 @@ export function App() {
               ) : (
                 <>
                   <WorkflowGraph
+                    key={`workflow-graph-${graphRefreshSequence}`}
                     tasks={tasks}
                     workflows={workflows}
                     selectedWorkflowId={selectedWorkflow?.id ?? null}
@@ -1841,6 +1843,7 @@ export function App() {
                         className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
                       >
                         <TaskDAG
+                          key={`task-dag-${selectedWorkflow.id}-${graphRefreshSequence}`}
                           tasks={miniDagTasks}
                           workflows={selectedTaskDagWorkflows}
                           selectedTaskId={selectedTaskId}

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -67,6 +67,10 @@ describe('Side rail controls (component)', () => {
 
   beforeEach(() => {
     mock = createMockInvoker();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    getZoomMock.mockReset();
+    getZoomMock.mockReturnValue(1);
     mock.install();
   });
 
@@ -81,6 +85,21 @@ describe('Side rail controls (component)', () => {
     await waitFor(() => {
       expect(mock.api.getTasks).toHaveBeenCalled();
       expect(mock.api.getTasks).toHaveBeenLastCalledWith(true);
+    });
+  });
+
+  it('Refresh button remounts both graph surfaces after the forced snapshot', async () => {
+    await renderKeyboardFixture(mock);
+    await waitFor(() => expect(fitViewMock).toHaveBeenCalled());
+    fitViewMock.mockClear();
+
+    fireEvent.click(screen.getByTestId('rail-refresh'));
+
+    await waitFor(() => {
+      expect(mock.api.getTasks).toHaveBeenLastCalledWith(true);
+    });
+    await waitFor(() => {
+      expect(fitViewMock.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
   });
 
@@ -296,9 +315,9 @@ describe('Camera lock controls (component)', () => {
   });
 
   /**
-   * Render the App, wait for the first workflow node and the single initial
-   * fit, then clear the viewport spies so a test asserts only on post-mount
-   * camera moves. Seed localStorage BEFORE calling this to control the lock.
+   * Render the App, wait for both graph surfaces to finish their initial fit,
+   * then clear the viewport spies so a test asserts only on post-mount camera
+   * moves. Seed localStorage BEFORE calling this to control the lock.
    */
   async function renderAndSettle(
     wfs: WorkflowMeta[] = workflows,
@@ -307,7 +326,8 @@ describe('Camera lock controls (component)', () => {
     mock.setTasks(tks, wfs);
     render(<App />);
     await screen.findByTestId(`workflow-node-${wfs[0].id}`);
-    await waitFor(() => expect(fitViewMock).toHaveBeenCalled());
+    await screen.findByTestId('selected-workflow-mini-dag');
+    await waitFor(() => expect(fitViewMock.mock.calls.length).toBeGreaterThanOrEqual(2));
     fitViewMock.mockClear();
     setCenterMock.mockClear();
   }

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -19,7 +19,7 @@ export interface UseTasksResult {
   tasks: Map<string, TaskState>;
   workflows: Map<string, WorkflowMeta>;
   clearTasks: () => void;
-  refreshTasks: (forceRefresh?: boolean) => void;
+  refreshTasks: (forceRefresh?: boolean) => Promise<void>;
 }
 
 export function useTasks(): UseTasksResult {
@@ -75,11 +75,11 @@ export function useTasks(): UseTasksResult {
   const lastSeenSequenceRef = useRef<number>(bootstrapState?.streamSequence ?? 0);
   const isResyncInFlightRef = useRef<boolean>(false);
 
-  const fetchAll = useCallback((forceRefresh = false) => {
-    if (typeof window === 'undefined' || !window.invoker) return;
+  const fetchAll = useCallback((forceRefresh = false): Promise<void> => {
+    if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
     const gen = ++getTasksGenerationRef.current;
     const requestedAt = performance.now();
-    window.invoker.getTasks(forceRefresh).then((result) => {
+    const request = window.invoker.getTasks(forceRefresh).then((result) => {
       const requestDurationMs = performance.now() - requestedAt;
       if (gen !== getTasksGenerationRef.current) {
         return;
@@ -130,6 +130,7 @@ export function useTasks(): UseTasksResult {
       }
     });
     window.invoker.checkPrStatuses?.();
+    return request.then(() => undefined);
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

Refresh now redraws both graph views after it gets the latest backend snapshot.

The bug was that Refresh replaced task data, but React Flow kept its own drawing state. Same-shaped graphs could stay visually stale.

The fix waits for the forced snapshot, then remounts the workflow graph and selected task graph.

## Architecture

### Before

```mermaid
graph TD
    A[User clicks Refresh] --> B[getTasks true]
    B --> C[Replace tasks and workflows]
    C --> D[Reuse existing React Flow instances]
    D --> E[Internal graph drawing state may stay stale]
```

### After

```mermaid
graph TD
    A[User clicks Refresh] --> B[getTasks true]
    B --> C[Replace tasks and workflows]
    C --> D[Bump graph refresh key]
    D --> E[Remount workflow graph and task graph]
    E --> F[React Flow redraws from current state]
```

## Proof

[Refresh redraw video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260615-149073/invoker-ui-refresh-redraw-proof.webm)

The video shows a stale workflow snapshot, then Refresh requesting `getTasks(true)`, applying the forced snapshot, and redrawing the workflow and task graphs.

## Test Plan

- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/keyboard-controls.test.tsx`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 007b2653a`
- Post-revert steps: None
- Data migration? No
