### PR TITLE
Fix intent cancellation Step 2: fix flow lineage guards (regression gated v2)

### DIFF
--- a/packages/app/src/__tests__/owner-endpoint.test.ts
+++ b/packages/app/src/__tests__/owner-endpoint.test.ts
@@ -1,8 +1,13 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import { describe, it, expect } from 'vitest';
-import { LocalBus } from '@invoker/transport';
+import { IpcBus, LocalBus } from '@invoker/transport';
 
 import {
   discoverOwner,
+  discoverStandaloneOwner,
   isOwnerReachable,
   isStandaloneCapable,
   type OwnerEndpointInfo,
@@ -69,6 +74,52 @@ describe('owner-endpoint contract', () => {
       expect(result).not.toBeNull();
       expect(result!.ownerId).toBe('');
       expect(result!.canAcceptStandaloneMutations).toBe(true);
+    });
+
+    it('discovers a standalone peer when a GUI owner is the IPC server', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'owner-endpoint-'));
+      const socketPath = join(dir, 'ipc.sock');
+      const guiServer = new IpcBus(socketPath);
+      let standalonePeer: IpcBus | null = null;
+      let client: IpcBus | null = null;
+
+      try {
+        await guiServer.ready();
+        guiServer.onRequest('headless.owner-ping', async () => ({
+          ok: true,
+          ownerId: 'owner-gui',
+          mode: 'gui',
+        }));
+
+        standalonePeer = new IpcBus(socketPath);
+        await standalonePeer.ready();
+        standalonePeer.onRequest('headless.owner-ping', async () => ({
+          ok: true,
+          ownerId: 'owner-daemon',
+          mode: 'standalone',
+        }));
+        standalonePeer.onRequest('headless.owner-ping.standalone', async () => ({
+          ok: true,
+          ownerId: 'owner-daemon',
+          mode: 'standalone',
+        }));
+
+        client = new IpcBus(socketPath, { allowServe: false });
+        await client.ready();
+
+        const generic = await discoverOwner(client, 1_000);
+        expect(generic?.ownerId).toBe('owner-gui');
+        expect(generic?.canAcceptStandaloneMutations).toBe(false);
+
+        const standalone = await discoverStandaloneOwner(client, 1_000);
+        expect(standalone?.ownerId).toBe('owner-daemon');
+        expect(standalone?.canAcceptStandaloneMutations).toBe(true);
+      } finally {
+        client?.disconnect();
+        standalonePeer?.disconnect();
+        guiServer.disconnect();
+        rmSync(dir, { recursive: true, force: true });
+      }
     });
   });
 

--- a/packages/app/src/__tests__/resolve-conflict-action.test.ts
+++ b/packages/app/src/__tests__/resolve-conflict-action.test.ts
@@ -49,9 +49,10 @@ describe('resolveConflictAction', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    const lineage = { taskId: 'task-a', selectedAttemptId: 'att-1', generation: 1 };
+    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a', lineage);
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', 'saved-err', undefined);
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err', lineage);
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
     expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
@@ -77,7 +78,11 @@ describe('resolveConflictAction', () => {
       autoApproveAIFixes: true,
     });
 
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err', {
+      taskId: 'task-a',
+      selectedAttemptId: 'att-1',
+      generation: 1,
+    });
     expect(approve).toHaveBeenCalledWith('task-a');
     expect(taskExecutorWithApprove.executeTasks).not.toHaveBeenCalled();
     expect(taskExecutorWithApprove.publishAfterFix).not.toHaveBeenCalled();
@@ -102,6 +107,7 @@ describe('resolveConflictAction', () => {
       'task-a',
       'saved-err',
       'claude failed',
+      { taskId: 'task-a', selectedAttemptId: 'att-1', generation: 1 },
     );
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
   });

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -795,7 +795,11 @@ describe('autoFixOnFailure', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a', {
+      taskId: 'task-a',
+      selectedAttemptId: undefined,
+      generation: 0,
+    });
     expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'claude', 'boom');
     expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
@@ -886,7 +890,11 @@ describe('autoFixOnFailure', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a', {
+      taskId: 'task-a',
+      selectedAttemptId: undefined,
+      generation: 0,
+    });
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
@@ -1340,7 +1348,11 @@ describe('fixWithAgentAction', () => {
 
     expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'codex', 'boom');
     expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom', {
+      taskId: 'task-a',
+      selectedAttemptId: undefined,
+      generation: 0,
+    });
     expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
   });
 
@@ -1379,7 +1391,11 @@ describe('fixWithAgentAction', () => {
 
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError);
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError, {
+      taskId: 'task-a',
+      selectedAttemptId: undefined,
+      generation: 0,
+    });
     expect(result).toEqual({ kind: 'resolveConflict', autoApproved: false, started: [] });
   });
 
@@ -1414,7 +1430,11 @@ describe('fixWithAgentAction', () => {
 
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError);
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError, {
+      taskId: 'task-a',
+      selectedAttemptId: undefined,
+      generation: 0,
+    });
     expect(result).toEqual({ kind: 'resolveConflict', autoApproved: false, started: [] });
   });
 
@@ -2415,7 +2435,11 @@ describe('fixWithAgentAction lineage guard', () => {
     });
 
     // Normal path should proceed
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom', {
+      taskId: 'task-a',
+      selectedAttemptId: 'att-1',
+      generation: 5,
+    });
     expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
   });
 });
@@ -2736,7 +2760,11 @@ describe('autoFixOnReviewGateFailure', () => {
       expect.stringContaining('This auto-fix was triggered by failed CI'),
     );
     expect(taskExecutor.fixWithAgent.mock.calls[0]?.[4]).toContain('test-all');
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('merge-a', 'Review-gate CI failed');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('merge-a', 'Review-gate CI failed', {
+      taskId: 'merge-a',
+      selectedAttemptId: 'att-1',
+      generation: 7,
+    });
   });
 
   it('does not start when review-gate lineage is stale', async () => {

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -136,7 +136,22 @@ export async function tryPingHeadlessOwner(
   messageBus: MessageBus,
   timeoutMs = 1_000,
 ): Promise<{ ownerId?: string; mode?: string } | null> {
-  const traceId = createTraceId('headless.owner-ping');
+  return tryPingOwner('headless.owner-ping', messageBus, timeoutMs);
+}
+
+export async function tryPingStandaloneHeadlessOwner(
+  messageBus: MessageBus,
+  timeoutMs = 1_000,
+): Promise<{ ownerId?: string; mode?: string } | null> {
+  return tryPingOwner('headless.owner-ping.standalone', messageBus, timeoutMs);
+}
+
+async function tryPingOwner(
+  channel: 'headless.owner-ping' | 'headless.owner-ping.standalone',
+  messageBus: MessageBus,
+  timeoutMs: number,
+): Promise<{ ownerId?: string; mode?: string } | null> {
+  const traceId = createTraceId(channel);
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
@@ -148,7 +163,7 @@ export async function tryPingHeadlessOwner(
     const startedAt = Date.now();
     delegationLog(`${traceId} send timeoutMs=${timeoutMs}`);
     const response = await Promise.race([
-      messageBus.request('headless.owner-ping', {}),
+      messageBus.request(channel, {}),
       timeoutPromise,
     ]) as { ownerId?: string; mode?: string } | null;
     if (!response || typeof response !== 'object') {

--- a/packages/app/src/headless-transport.ts
+++ b/packages/app/src/headless-transport.ts
@@ -22,6 +22,7 @@ import {
   tryDelegateRun,
   tryDelegateResume,
   tryPingHeadlessOwner,
+  tryPingStandaloneHeadlessOwner,
 } from './headless-delegation.js';
 
 // ---------------------------------------------------------------------------
@@ -211,6 +212,14 @@ export class HeadlessTransport {
     return null;
   }
 
+  private async pingStandaloneCompatibleOwner(bus: MessageBus, timeoutMs: number): Promise<boolean> {
+    const standalone = await tryPingStandaloneHeadlessOwner(bus, timeoutMs);
+    if (standalone?.mode === 'standalone') return true;
+
+    const legacy = await tryPingHeadlessOwner(bus, timeoutMs);
+    return legacy?.mode === 'standalone';
+  }
+
   private async delegateMutating(
     args: string[],
     command: string,
@@ -220,6 +229,17 @@ export class HeadlessTransport {
     let bus = this.messageBus;
 
     // Check for an existing standalone owner.
+    const standalone = await tryPingStandaloneHeadlessOwner(bus, 2_000);
+    if (standalone?.mode === 'standalone') {
+      const ok = await this.dispatchToOwner(
+        args,
+        command,
+        bus,
+        { noTrack, waitForApproval, timeoutMs },
+      );
+      if (ok) return { response: { delegated: true } };
+    }
+
     const owner = await tryPingHeadlessOwner(bus, 2_000);
     if (owner?.mode === 'standalone') {
       const ok = await this.dispatchToOwner(
@@ -231,13 +251,11 @@ export class HeadlessTransport {
       if (ok) return { response: { delegated: true } };
     }
 
-    // If a GUI owner responded (not standalone), refresh and look for a
-    // standalone owner (the GUI cannot handle mutations).
+    // If a non-standalone owner responded, refresh and look for a standalone route.
     if (owner && owner.mode !== 'standalone' && this.deps.refreshMessageBus) {
       bus = await this.deps.refreshMessageBus();
       this.messageBus = bus;
-      const refreshed = await tryPingHeadlessOwner(bus, 1_000);
-      if (refreshed?.mode === 'standalone') {
+      if (await this.pingStandaloneCompatibleOwner(bus, 1_000)) {
         const ok = await this.dispatchToOwner(
           args,
           command,
@@ -258,6 +276,9 @@ export class HeadlessTransport {
       if (this.deps.refreshMessageBus) {
         bus = await this.deps.refreshMessageBus();
         this.messageBus = bus;
+      }
+      if (!await this.pingStandaloneCompatibleOwner(bus, 2_000)) {
+        return null;
       }
       const ok = await this.dispatchToOwner(
         args,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1592,6 +1592,14 @@ if (isHeadless) {
             mode: 'standalone',
           };
         });
+        messageBus.onRequest('headless.owner-ping.standalone', async () => {
+          noteStandaloneOwnerActivity();
+          return {
+            ok: true,
+            ownerId: workflowMutationOwnerId,
+            mode: 'standalone',
+          };
+        });
         messageBus.onRequest('headless.query', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { kind, reset } = req as { kind?: string; reset?: boolean };

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -131,7 +131,9 @@ import {
 } from './headless.js';
 import {
   approveTask as sharedApproveTask,
+  assertLineageCurrent,
   buildInvalidationDeps,
+  captureTaskLineage,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
   fixWithAgentAction,
@@ -2108,6 +2110,7 @@ function createEmbeddedTerminalBackendFromConfig(
     if (!task) {
       throw new Error(`Task ${taskId} not found`);
     }
+    const entryLineage = captureTaskLineage(taskId, orchestrator);
     const savedError = task.execution.error ?? '';
     const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
     logger.info(
@@ -2116,6 +2119,7 @@ function createEmbeddedTerminalBackendFromConfig(
     );
 
     if (source === 'auto-fix') {
+      assertLineageCurrent(entryLineage, orchestrator, activeMutationContext?.signal);
       const attemptsBefore = task?.execution.autoFixAttempts ?? 0;
       const attemptsAfter = attemptsBefore + 1;
       persistence.updateTask(taskId, {

--- a/packages/app/src/owner-endpoint.ts
+++ b/packages/app/src/owner-endpoint.ts
@@ -14,7 +14,10 @@
 
 import type { MessageBus } from '@invoker/transport';
 
-import { tryPingHeadlessOwner } from './headless-delegation.js';
+import {
+  tryPingHeadlessOwner,
+  tryPingStandaloneHeadlessOwner,
+} from './headless-delegation.js';
 
 // ── Contract types ──────────────────────────────────────────
 
@@ -54,6 +57,28 @@ export async function discoverOwner(
   timeoutMs?: number,
 ): Promise<OwnerDiscoveryResult> {
   const raw = await tryPingHeadlessOwner(messageBus, timeoutMs);
+  return ownerInfoFromPing(raw);
+}
+
+/**
+ * Discover a standalone-capable owner without being masked by a GUI process
+ * that happens to own the IPC server socket. Standalone owners register this
+ * dedicated probe channel; GUI owners intentionally do not.
+ */
+export async function discoverStandaloneOwner(
+  messageBus: MessageBus,
+  timeoutMs?: number,
+): Promise<OwnerDiscoveryResult> {
+  const standaloneRaw = await tryPingStandaloneHeadlessOwner(messageBus, timeoutMs);
+  if (standaloneRaw) {
+    return ownerInfoFromPing(standaloneRaw);
+  }
+  const raw = await tryPingHeadlessOwner(messageBus, timeoutMs);
+  const owner = ownerInfoFromPing(raw);
+  return isStandaloneCapable(owner) ? owner : null;
+}
+
+function ownerInfoFromPing(raw: { ownerId?: string; mode?: string } | null): OwnerDiscoveryResult {
   if (!raw) return null;
   return {
     ownerId: raw.ownerId ?? '',

--- a/packages/app/src/owner-resolver.ts
+++ b/packages/app/src/owner-resolver.ts
@@ -14,6 +14,7 @@ import type { MessageBus } from '@invoker/transport';
 
 import {
   discoverOwner,
+  discoverStandaloneOwner,
   isOwnerReachable,
   isStandaloneCapable,
   type OwnerDiscoveryResult,
@@ -144,13 +145,13 @@ export function createOwnerResolver(
 
   const resolver: OwnerResolver = {
     async discover(): Promise<OwnerResolveResult> {
-      const owner = await discoverOwner(currentBus, discoveryTimeoutMs);
+      const owner = await discoverStandaloneOwner(currentBus, discoveryTimeoutMs);
       return toStandaloneResult(owner, currentBus);
     },
 
     async refreshAndDiscover(): Promise<OwnerResolveResult> {
       const bus = await refreshBus();
-      const owner = await discoverOwner(bus, refreshDiscoveryTimeoutMs);
+      const owner = await discoverStandaloneOwner(bus, refreshDiscoveryTimeoutMs);
       return toStandaloneResult(owner, bus);
     },
 
@@ -175,7 +176,7 @@ export function createOwnerResolver(
     async waitForStandalone(timeoutMs: number): Promise<OwnerResolveResult> {
       const deadline = Date.now() + timeoutMs;
       while (Date.now() < deadline) {
-        const owner = await discoverOwner(currentBus, 1_000);
+        const owner = await discoverStandaloneOwner(currentBus, 1_000);
         if (isStandaloneCapable(owner)) {
           return { resolved: true, owner, bus: currentBus };
         }
@@ -187,7 +188,9 @@ export function createOwnerResolver(
 
     async resolve(requireStandalone = true): Promise<ResolvedOwner> {
       // Phase 1: Try immediate discovery
-      const immediate = await discoverOwner(currentBus, discoveryTimeoutMs);
+      const immediate = requireStandalone
+        ? await discoverStandaloneOwner(currentBus, discoveryTimeoutMs)
+        : await discoverOwner(currentBus, discoveryTimeoutMs);
       if (acceptsOwner(immediate, requireStandalone)) {
         return { owner: immediate, bus: currentBus };
       }
@@ -195,7 +198,9 @@ export function createOwnerResolver(
       // Phase 2: Refresh and retry
       if (deps.refreshMessageBus) {
         currentBus = await deps.refreshMessageBus();
-        const refreshed = await discoverOwner(currentBus, refreshDiscoveryTimeoutMs);
+        const refreshed = requireStandalone
+          ? await discoverStandaloneOwner(currentBus, refreshDiscoveryTimeoutMs)
+          : await discoverOwner(currentBus, refreshDiscoveryTimeoutMs);
         if (acceptsOwner(refreshed, requireStandalone)) {
           return { owner: refreshed, bus: currentBus };
         }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -61,7 +61,7 @@ export function captureTaskLineage(
 ): TaskLineageSnapshot {
   const task = orchestrator.getTask(taskId);
   return {
-    taskId,
+    taskId: task?.id ?? taskId,
     selectedAttemptId: task?.execution.selectedAttemptId,
     generation: task?.execution.generation ?? 0,
   };
@@ -92,6 +92,25 @@ export function assertLineageCurrent(
       + `(attempt ${snapshot.selectedAttemptId} → ${current.selectedAttemptId}, `
       + `gen ${snapshot.generation} → ${current.generation})`,
     );
+  }
+}
+
+function rethrowCoreStaleLineage(err: unknown, taskId: string): never {
+  if (err instanceof Error && err.message.includes('lineage is stale')) {
+    throw new StaleLineageError(`Task ${taskId} lineage changed during fix mutation: ${err.message}`);
+  }
+  throw err;
+}
+
+function beginConflictResolutionCurrent(
+  taskId: string,
+  orchestrator: Pick<Orchestrator, 'beginConflictResolution'>,
+  lineage: TaskLineageSnapshot,
+): { savedError: string } {
+  try {
+    return orchestrator.beginConflictResolution(taskId, lineage);
+  } catch (err) {
+    rethrowCoreStaleLineage(err, taskId);
   }
 }
 
@@ -817,7 +836,7 @@ export async function resolveConflictAction(
   const { orchestrator, persistence, taskExecutor } = deps;
   const entryLineage = captureTaskLineage(taskId, orchestrator);
   assertLineageCurrent(entryLineage, orchestrator, signal);
-  const { savedError } = orchestrator.beginConflictResolution(taskId);
+  const { savedError } = beginConflictResolutionCurrent(taskId, orchestrator, entryLineage);
   const lineage = captureTaskLineage(taskId, orchestrator);
   try {
     assertLineageCurrent(lineage, orchestrator, signal);
@@ -830,7 +849,7 @@ export async function resolveConflictAction(
     assertLineageCurrent(lineage, orchestrator, signal);
     persistence.appendTaskOutput(taskId, `\n[Resolve Conflict] Failed: ${msg}`);
     assertLineageCurrent(lineage, orchestrator, signal);
-    orchestrator.revertConflictResolution(taskId, savedError, msg);
+    orchestrator.revertConflictResolution(taskId, savedError, msg, lineage);
     throw err;
   }
 }
@@ -873,7 +892,7 @@ export async function fixWithAgentAction(
 
   const entryLineage = captureTaskLineage(taskId, orchestrator);
   assertLineageCurrent(entryLineage, orchestrator, options.signal);
-  const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
+  const { savedError: persistedSavedError } = beginConflictResolutionCurrent(taskId, orchestrator, entryLineage);
   const lineage = captureTaskLineage(taskId, orchestrator);
   try {
     assertLineageCurrent(lineage, orchestrator, options.signal);
@@ -898,7 +917,7 @@ export async function fixWithAgentAction(
     assertLineageCurrent(lineage, orchestrator, options.signal);
     persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
     assertLineageCurrent(lineage, orchestrator, options.signal);
-    orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
+    orchestrator.revertConflictResolution(taskId, persistedSavedError, msg, lineage);
     throw err;
   }
 }
@@ -915,8 +934,12 @@ export async function finalizeAppliedFix(
       `Fix mutation for ${taskId} aborted before finalize: ${signal.reason instanceof Error ? signal.reason.message : String(signal.reason ?? 'unknown')}`,
     );
   }
-  if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
-  deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
+  if (lineage) {
+    assertLineageCurrent(lineage, deps.orchestrator, signal);
+    deps.orchestrator.setFixAwaitingApproval(taskId, savedError, lineage);
+  } else {
+    deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
+  }
   if (!deps.autoApproveAIFixes) {
     return { autoApproved: false, started: [] };
   }
@@ -1107,6 +1130,7 @@ export async function autoFixOnFailure(
   });
 
   // Increment counter FIRST (before any delta can re-trigger)
+  assertLineageCurrent(entryLineage, orchestrator, deps.signal);
   persistence.updateTask(taskId, { execution: { autoFixAttempts: attempts } });
 
   const agentSelection = resolveAutoFixAgent(deps.getAutoFixAgent?.());
@@ -1120,6 +1144,7 @@ export async function autoFixOnFailure(
       selectedAgentSource: agentSelection.selectedAgentSource,
       fallbackChain: agentSelection.fallbackChain,
     });
+    assertLineageCurrent(entryLineage, orchestrator, deps.signal);
     persistence.appendTaskOutput(
       taskId,
       `\n[Auto-fix Agent] selected=${agentSelection.selectedAgent} source=${agentSelection.selectedAgentSource} fallback=${agentSelection.fallbackChain}`,
@@ -1140,6 +1165,7 @@ export async function autoFixOnFailure(
         : persistence.getTaskOutput(taskId).length,
     });
     if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
+      assertLineageCurrent(entryLineage, orchestrator, deps.signal);
       persistence.appendTaskOutput(
         taskId,
         `\n[Auto-fix] Startup merge conflict detected; recreating workflow ${recoveryRoute.workflowId} from a fresh base.`,
@@ -1172,11 +1198,13 @@ export async function autoFixOnFailure(
         attempts,
         maxRetries: max,
       });
+      assertLineageCurrent(entryLineage, orchestrator, deps.signal);
       persistence.appendTaskOutput(taskId, `\n[Auto-fix] ${skipReason}`);
       return;
     }
 
-    ({ savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId));
+    assertLineageCurrent(entryLineage, orchestrator, deps.signal);
+    ({ savedError: persistedSavedError } = beginConflictResolutionCurrent(taskId, orchestrator, entryLineage));
     lineage = captureTaskLineage(taskId, orchestrator);
     assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
@@ -1253,13 +1281,15 @@ export async function autoFixOnFailure(
       diagnostics: diagnostics ?? null,
     });
     if (diagnostics) {
+      if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
       persistence.appendTaskOutput(taskId, `\n[Auto-fix Diagnostics]\n${diagnostics}`);
     }
+    if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.appendTaskOutput(taskId, `\n[Auto-fix] Agent failed (attempt ${attempts}/${max}): ${msg}`);
     const detailedMsg = diagnostics ? `${msg}\n\n${diagnostics}` : msg;
     if (persistedSavedError !== undefined) {
       if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
-      orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg);
+      orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg, lineage);
     }
   }
 }
@@ -1349,6 +1379,7 @@ export async function autoFixOnReviewGateFailure(
       `Review-gate CI auto-fix for ${trigger.taskId} aborted: ${deps.signal.reason instanceof Error ? deps.signal.reason.message : String(deps.signal.reason ?? 'unknown')}`,
     );
   }
+  assertReviewGateTriggerCurrent(trigger, orchestrator);
   persistence.updateTask(trigger.taskId, { execution: { autoFixAttempts: attempts } });
   const savedError = formatReviewGateCiSavedError(trigger);
   const fixContext = formatReviewGateCiFixContext(trigger);
@@ -1357,14 +1388,18 @@ export async function autoFixOnReviewGateFailure(
   let persistedSavedError: string | undefined;
   let lineage: TaskLineageSnapshot | undefined;
   try {
-    ({ savedError: persistedSavedError } = orchestrator.beginAutoFixSession(trigger.taskId, {
-      savedError,
-      expectedLineage: {
-        taskId: trigger.taskId,
-        selectedAttemptId: trigger.selectedAttemptId,
-        generation: trigger.generation,
-      },
-    }));
+    try {
+      ({ savedError: persistedSavedError } = orchestrator.beginAutoFixSession(trigger.taskId, {
+        savedError,
+        expectedLineage: {
+          taskId: trigger.taskId,
+          selectedAttemptId: trigger.selectedAttemptId,
+          generation: trigger.generation,
+        },
+      }));
+    } catch (err) {
+      rethrowCoreStaleLineage(err, trigger.taskId);
+    }
     lineage = captureTaskLineage(trigger.taskId, orchestrator);
     assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.logEvent?.(trigger.taskId, 'debug.auto-fix', {
@@ -1413,7 +1448,7 @@ export async function autoFixOnReviewGateFailure(
     );
     if (persistedSavedError !== undefined) {
       if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
-      orchestrator.revertConflictResolution(trigger.taskId, persistedSavedError, msg);
+      orchestrator.revertConflictResolution(trigger.taskId, persistedSavedError, msg, lineage);
     }
   }
 }

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1070,6 +1070,37 @@ describe('TaskRunner', () => {
       expect(editCall).toBeUndefined();
     });
 
+    it('execPr still creates a PR when the existing PR lookup is unavailable', async () => {
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+      });
+
+      const ghCalls: string[][] = [];
+      (executor as any).execGh = async (args: string[]) => {
+        ghCalls.push(args);
+        if (args[0] === 'pr' && args[1] === 'list') {
+          throw new Error('gh pr list failed (code 1): GraphQL: API rate limit already exceeded');
+        }
+        if (args[0] === 'pr' && args[1] === 'create') {
+          return 'https://github.com/owner/repo/pull/100';
+        }
+        return '';
+      };
+
+      const url = await (executor as any).execPr('main', 'feature/rate-limited', 'Rate Limited Workflow');
+      expect(url).toBe('https://github.com/owner/repo/pull/100');
+
+      const listCall = ghCalls.find(c => c[0] === 'pr' && c[1] === 'list');
+      expect(listCall).toBeDefined();
+      const createCall = ghCalls.find(c => c[0] === 'pr' && c[1] === 'create');
+      expect(createCall).toBeDefined();
+      expect(createCall).toContain('main');
+      expect(createCall).toContain('feature/rate-limited');
+    });
+
     it('execPr passes normalized branch names to gh when base uses origin/ remote-tracking form', async () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null } as any,

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -2182,12 +2182,20 @@ export class TaskRunner {
     const ghBase = normalizeBranchForGithubCli(baseBranch);
     const ghHead = normalizeBranchForGithubCli(featureBranch);
 
-    const listOutput = await this.execGh([
-      'pr', 'list', '--head', ghHead, '--base', ghBase,
-      '--state', 'open', '--json', 'url,number', '--limit', '1',
-    ], cwd);
+    let existing: Array<{ url: string; number: number }> = [];
+    try {
+      const listOutput = await this.execGh([
+        'pr', 'list', '--head', ghHead, '--base', ghBase,
+        '--state', 'open', '--json', 'url,number', '--limit', '1',
+      ], cwd);
+      existing = JSON.parse(listOutput || '[]');
+    } catch (err) {
+      this.logger.warn(
+        `[merge-gate] Existing PR lookup failed for ${ghHead}; attempting PR creation`,
+        { err },
+      );
+    }
 
-    const existing: Array<{ url: string; number: number }> = JSON.parse(listOutput || '[]');
     if (existing.length > 0) {
       const pr = existing[0];
       const editArgs = ['pr', 'edit', String(pr.number), '--title', title];

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -618,6 +618,25 @@ describe('Orchestrator', () => {
       expect(fixDeltas).toHaveLength(1);
     });
 
+    it('does not start conflict resolution when the expected lineage is stale', () => {
+      const before = orchestrator.getTask('t2')!;
+      const failedAttemptId = before.execution.selectedAttemptId;
+
+      expect(() => orchestrator.beginConflictResolution('t2', {
+        taskId: before.id,
+        selectedAttemptId: 'stale-attempt',
+        generation: before.execution.generation ?? 0,
+      })).toThrow('lineage is stale');
+
+      const after = orchestrator.getTask('t2')!;
+      expect(after.status).toBe('failed');
+      expect(after.execution.selectedAttemptId).toBe(failedAttemptId);
+      expect(after.execution.generation ?? 0).toBe(before.execution.generation ?? 0);
+      expect(after.execution.error).toBe(before.execution.error);
+      expect(persistence.loadAttempt(failedAttemptId!)?.status).toBe('failed');
+      expect(publishedDeltas).toEqual([]);
+    });
+
     it('resets startedAt and lastHeartbeatAt timestamps', () => {
       const before = Date.now();
       orchestrator.beginConflictResolution('t2');
@@ -662,6 +681,26 @@ describe('Orchestrator', () => {
           d.changes.status === 'failed',
       );
       expect(failedDeltas).toHaveLength(1);
+    });
+
+    it('revertConflictResolution no-ops when the expected lineage is stale', () => {
+      const { savedError } = orchestrator.beginConflictResolution('t2');
+      const fixingTask = orchestrator.getTask('t2')!;
+      const fixAttemptId = fixingTask.execution.selectedAttemptId;
+      publishedDeltas = [];
+
+      orchestrator.revertConflictResolution('t2', savedError, 'late failure', {
+        taskId: fixingTask.id,
+        selectedAttemptId: 'stale-attempt',
+        generation: fixingTask.execution.generation ?? 0,
+      });
+
+      const after = orchestrator.getTask('t2')!;
+      expect(after.status).toBe('fixing_with_ai');
+      expect(after.execution.selectedAttemptId).toBe(fixAttemptId);
+      expect(after.execution.error).toBeUndefined();
+      expect(persistence.loadAttempt(fixAttemptId!)?.status).toBe('running');
+      expect(publishedDeltas).toEqual([]);
     });
 
     it('revertConflictResolution uses agent-agnostic fix failure prefix', () => {
@@ -753,6 +792,26 @@ describe('Orchestrator', () => {
       expect(task.execution.pendingFixError).toBe('test failed: expected 1 to be 2');
       expect(task.execution.isFixingWithAI).toBeFalsy();
       expect(persistence.loadAttempt(fixAttemptId!)?.status).toBe('needs_input');
+    });
+
+    it('setFixAwaitingApproval no-ops when the expected lineage is stale', () => {
+      orchestrator.beginConflictResolution('f2');
+      const fixingTask = orchestrator.getTask('f2')!;
+      const fixAttemptId = fixingTask.execution.selectedAttemptId;
+      publishedDeltas = [];
+
+      orchestrator.setFixAwaitingApproval('f2', 'test failed: expected 1 to be 2', {
+        taskId: fixingTask.id,
+        selectedAttemptId: 'stale-attempt',
+        generation: fixingTask.execution.generation ?? 0,
+      });
+
+      const after = orchestrator.getTask('f2')!;
+      expect(after.status).toBe('fixing_with_ai');
+      expect(after.execution.pendingFixError).toBeUndefined();
+      expect(after.execution.selectedAttemptId).toBe(fixAttemptId);
+      expect(persistence.loadAttempt(fixAttemptId!)?.status).toBe('running');
+      expect(publishedDeltas).toEqual([]);
     });
 
     it('setFixAwaitingApproval delta includes agentSessionId from DB', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2589,6 +2589,12 @@ export class Orchestrator {
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (!this.taskMatchesLineageExpectation(task, expectedLineage)) {
+      this.logger.info('[beginConflictResolution] discarded stale start', {
+        taskId,
+        selectedAttemptId: task.execution.selectedAttemptId,
+        generation: task.execution.generation ?? 0,
+        expectedLineage,
+      });
       throw new Error(`Task ${taskId} lineage is stale for conflict resolution start`);
     }
     if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
@@ -2645,6 +2651,12 @@ export class Orchestrator {
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (!this.taskMatchesLineageExpectation(task, opts.expectedLineage)) {
+      this.logger.info('[beginAutoFixSession] discarded stale start', {
+        taskId,
+        selectedAttemptId: task.execution.selectedAttemptId,
+        generation: task.execution.generation ?? 0,
+        expectedLineage: opts.expectedLineage,
+      });
       throw new Error(`Task ${taskId} lineage is stale for auto-fix start`);
     }
     if (

--- a/packages/workflow-graph/src/dag.ts
+++ b/packages/workflow-graph/src/dag.ts
@@ -45,9 +45,11 @@ export function topologicalSort(tasks: TaskState[]): TaskState[] {
   }
 
   const sorted: TaskState[] = [];
+  let queueHead = 0;
 
-  while (queue.length > 0) {
-    const id = queue.shift()!;
+  while (queueHead < queue.length) {
+    const id = queue[queueHead]!;
+    queueHead += 1;
     sorted.push(taskMap.get(id)!);
 
     for (const neighbor of adjacency.get(id)!) {


### PR DESCRIPTION
## Summary

Adds lineage checks around fix-with-agent and conflict-resolution mutations so late async results stop before writing stale task state.

The guards now cover start, persistence, approval, revert, and review-gate fix boundaries after a task changes attempt or generation.

Standalone owner discovery now uses a dedicated ping so GUI processes cannot mask mutation delegation.

Merge-gate PR creation now continues when the existing PR lookup fails.

## Architecture

### Before

```mermaid
graph TD
    A[Fix or resolve starts] --> B[Async agent or conflict work]
    B --> C[Persist output and approval state]
    C --> D[Revert or cleanup on failure]
    E[Task attempt changes] -. no stale guard .-> C

    F[Mutation delegation] --> G[Generic owner ping]
    G --> H[GUI or standalone owner]
    H --> I[May miss standalone route]
```

### After

```mermaid
graph TD
    A[Fix or resolve starts] --> B[Capture task lineage]
    B --> C[Async agent or conflict work]
    C --> D{Lineage and signal current?}
    D -- Yes --> E[Persist output and approval state]
    D -- No --> F[Discard stale mutation]
    E --> G{Failure path current?}
    G -- Yes --> H[Revert or cleanup]
    G -- No --> F

    I[Mutation delegation] --> J[Standalone owner ping]
    J --> K{Standalone found?}
    K -- Yes --> L[Dispatch mutation]
    K -- No --> M[Fallback generic owner discovery]
```

## Test Plan

- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No