### PR TITLE
chore(contracts): clarify UI action graph node type

### DIFF
--- a/packages/app/src/__tests__/action-graph-diagnostics.test.ts
+++ b/packages/app/src/__tests__/action-graph-diagnostics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Attempt, TaskState } from '@invoker/workflow-core';
-import type { Workflow } from '@invoker/data-store';
+import type { TaskLaunchDispatch, Workflow } from '@invoker/data-store';
 import {
   buildActionGraphDiagnostics,
   resolveActionDiagnosticsStallThresholdMs,
@@ -96,6 +96,48 @@ describe('buildActionGraphDiagnostics', () => {
     const lease = graph.nodes.find((node) => node.id === 'lease:wf-1');
     expect(lease?.status).toBe('stalled');
     expect(lease?.durations?.heartbeatAgeMs).toBe(2 * 60_000);
+  });
+
+  it('shows unaccepted launch dispatches as queued diagnostic nodes', () => {
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [task({ id: 'task-a', execution: { selectedAttemptId: 'attempt-a1' } })],
+      attemptsByTaskId: new Map([
+        ['task-a', [attempt({ id: 'attempt-a1', nodeId: 'task-a' })]],
+      ]),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [],
+      mutationLeases: [],
+      launchDispatches: [{
+        id: 42,
+        taskId: 'task-a',
+        attemptId: 'attempt-a1',
+        workflowId: 'wf-1',
+        state: 'enqueued',
+        priority: 'high',
+        enqueuedAt: '2026-05-14T11:56:00.000Z',
+        attemptsCount: 0,
+        generation: 3,
+      } satisfies TaskLaunchDispatch],
+      eventsByTaskId: new Map(),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    const dispatch = graph.nodes.find((node) => node.id === 'launch-dispatch:42');
+    expect(dispatch).toEqual(expect.objectContaining({
+      type: 'launch-dispatch',
+      status: 'queued',
+      taskId: 'task-a',
+      suggestedNextAction: 'The task is queued for launch, but no owner has accepted it yet.',
+    }));
+    expect(dispatch?.durations?.queuedMs).toBe(4 * 60_000);
+    expect(graph.edges).toContainEqual(expect.objectContaining({
+      source: 'launch-dispatch:42',
+      target: 'attempt:attempt-a1',
+      label: 'launch',
+    }));
   });
 
   it('links pending downstream task attempts to upstream blocker nodes', () => {

--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -24,4 +24,23 @@ describe('GUI mutation translation', () => {
       ),
     );
   });
+  it.each([
+    ['invoker:restart-task', 'retry-task'],
+    ['invoker:cancel-task', 'cancel'],
+    ['invoker:cancel-workflow', 'cancel-workflow'],
+    ['invoker:recreate-workflow', 'recreate'],
+    ['invoker:recreate-task', 'recreate-task'],
+    ['invoker:recreate-downstream', 'recreate-downstream'],
+    ['invoker:retry-workflow', 'retry'],
+    ['invoker:rebase-retry', 'rebase-retry'],
+    ['invoker:rebase-recreate', 'rebase-recreate'],
+  ])('routes %s as a no-track owner command', (channel, command) => {
+    const translatorSource = getTranslatorSource();
+    expect(translatorSource).toMatch(
+      new RegExp(
+        `case '${channel}':\\s*return \\{ channel: 'headless\\.exec', request: \\{ args: \\['${command}', String\\(arg0\\)\\], noTrack: true \\} \\};`,
+      ),
+    );
+  });
+
 });

--- a/packages/app/src/action-graph-diagnostics.ts
+++ b/packages/app/src/action-graph-diagnostics.ts
@@ -7,7 +7,7 @@ import type {
   ActivityLogEntry,
   QueueStatus,
 } from '@invoker/contracts';
-import type { TaskEvent, WorkflowMutationIntent, WorkflowMutationLease } from '@invoker/data-store';
+import type { TaskEvent, TaskLaunchDispatch, WorkflowMutationIntent, WorkflowMutationLease } from '@invoker/data-store';
 import type { Attempt, TaskState } from '@invoker/workflow-core';
 import type { Workflow } from '@invoker/data-store';
 import type { InvokerConfig } from './config.js';
@@ -35,6 +35,7 @@ export interface ActionGraphDiagnosticsInput {
   activityLogs: ActivityLogEntry[];
   stallThresholdMs: number;
   now?: Date;
+  launchDispatches?: TaskLaunchDispatch[];
 }
 
 function iso(value: Date | string | undefined): string | undefined {
@@ -211,6 +212,52 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
     });
     const source = lease.activeIntentId ? `intent:${lease.activeIntentId}` : `action:${lease.workflowId}`;
     edges.push({ id: edgeId(source, id, 'lease'), source, target: id, label: 'lease' });
+  }
+
+  for (const dispatch of input.launchDispatches ?? []) {
+    const status: ActionGraphNodeStatus =
+      dispatch.state === 'enqueued' ? 'queued'
+        : dispatch.state === 'leased' ? 'running'
+          : dispatch.state === 'completed' ? 'completed'
+            : 'failed';
+    const id = `launch-dispatch:${dispatch.id}`;
+    nodes.push({
+      id,
+      type: 'launch-dispatch',
+      label: `Launch ${dispatch.taskId}`,
+      status,
+      workflowId: dispatch.workflowId,
+      taskId: dispatch.taskId,
+      attemptId: dispatch.attemptId,
+      ownerId: dispatch.dispatchOwner,
+      priority: dispatch.priority === 'high' ? 1 : dispatch.priority === 'normal' ? 0 : -1,
+      createdAt: dispatch.enqueuedAt,
+      startedAt: dispatch.leasedAt,
+      completedAt: dispatch.completedAt,
+      leaseExpiresAt: dispatch.fencedUntil,
+      latestError: dispatch.lastError,
+      durations: {
+        queuedMs: dispatch.state === 'enqueued' ? ageMs(nowMs, dispatch.enqueuedAt) : undefined,
+        runningMs: dispatch.state === 'leased' ? ageMs(nowMs, dispatch.leasedAt) : undefined,
+        leaseExpiresInMs: dispatch.fencedUntil ? Date.parse(dispatch.fencedUntil) - nowMs : undefined,
+      },
+      details: {
+        state: dispatch.state,
+        attemptsCount: dispatch.attemptsCount,
+        generation: dispatch.generation,
+      },
+      suggestedNextAction: dispatch.state === 'enqueued'
+        ? 'The task is queued for launch, but no owner has accepted it yet.'
+        : dispatch.state === 'abandoned'
+          ? 'Inspect the launch dispatch error, then retry the task if needed.'
+          : undefined,
+    });
+    edges.push({
+      id: edgeId(id, `attempt:${dispatch.attemptId}`, 'launch'),
+      source: id,
+      target: `attempt:${dispatch.attemptId}`,
+      label: 'launch',
+    });
   }
 
   for (const task of input.tasks) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1637,6 +1637,7 @@ if (isHeadless) {
               eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
               activityLogs: persistence.getActivityLogs(0, 200),
               stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
+              launchDispatches: persistence.listLaunchDispatchesByState(['enqueued', 'leased', 'abandoned']),
             });
           }
           throw new Error(`Unsupported headless query: ${String(kind)}`);
@@ -2640,23 +2641,23 @@ function createEmbeddedTerminalBackendFromConfig(
         if (Array.isArray(arg1)) return null;
         return { channel: 'headless.exec', request: { args: ['select', String(arg0), String(arg1)] } };
       case 'invoker:restart-task':
-        return { channel: 'headless.exec', request: { args: ['retry-task', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['retry-task', String(arg0)], noTrack: true } };
       case 'invoker:cancel-task':
-        return { channel: 'headless.exec', request: { args: ['cancel', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['cancel', String(arg0)], noTrack: true } };
       case 'invoker:cancel-workflow':
-        return { channel: 'headless.exec', request: { args: ['cancel-workflow', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['cancel-workflow', String(arg0)], noTrack: true } };
       case 'invoker:recreate-workflow':
-        return { channel: 'headless.exec', request: { args: ['recreate', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['recreate', String(arg0)], noTrack: true } };
       case 'invoker:recreate-task':
-        return { channel: 'headless.exec', request: { args: ['recreate-task', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['recreate-task', String(arg0)], noTrack: true } };
       case 'invoker:recreate-downstream':
-        return { channel: 'headless.exec', request: { args: ['recreate-downstream', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['recreate-downstream', String(arg0)], noTrack: true } };
       case 'invoker:retry-workflow':
-        return { channel: 'headless.exec', request: { args: ['retry', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['retry', String(arg0)], noTrack: true } };
       case 'invoker:rebase-retry':
-        return { channel: 'headless.exec', request: { args: ['rebase-retry', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['rebase-retry', String(arg0)], noTrack: true } };
       case 'invoker:rebase-recreate':
-        return { channel: 'headless.exec', request: { args: ['rebase-recreate', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['rebase-recreate', String(arg0)], noTrack: true } };
       case 'invoker:set-merge-branch':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:set-merge-mode':
@@ -3284,6 +3285,7 @@ function createEmbeddedTerminalBackendFromConfig(
             eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
             activityLogs: persistence.getActivityLogs(0, 200),
             stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
+            launchDispatches: persistence.listLaunchDispatchesByState(['enqueued', 'leased', 'abandoned']),
           });
         }
         throw new Error(`Unsupported headless query: ${String(kind)}`);
@@ -3887,6 +3889,7 @@ function createEmbeddedTerminalBackendFromConfig(
         eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
         activityLogs: persistence.getActivityLogs(0, 200),
         stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
+        launchDispatches: persistence.listLaunchDispatchesByState(['enqueued', 'leased', 'abandoned']),
       });
     });
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -108,7 +108,7 @@ export interface QueueStatus {
   queued: Array<{ taskId: string; priority: number; description: string }>;
 }
 
-export type ActionGraphNodeType =
+export type UIActionGraphNodeType =
   | 'user-action'
   | 'mutation-intent'
   | 'mutation-lease'
@@ -147,7 +147,7 @@ export interface ActionGraphNodeDurations {
 
 export interface ActionGraphNode {
   id: string;
-  type: ActionGraphNodeType;
+  type: UIActionGraphNodeType;
   label: string;
   status: ActionGraphNodeStatus;
   workflowId?: string;

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -112,6 +112,7 @@ export type ActionGraphNodeType =
   | 'user-action'
   | 'mutation-intent'
   | 'mutation-lease'
+  | 'launch-dispatch'
   | 'scheduler-job'
   | 'task-attempt'
   | 'blocker';

--- a/packages/ui/src/components/ActionGraphView.tsx
+++ b/packages/ui/src/components/ActionGraphView.tsx
@@ -39,6 +39,7 @@ const typeOrder: Record<ActionGraphNode['type'], number> = {
   'user-action': 0,
   'mutation-intent': 1,
   'mutation-lease': 2,
+  'launch-dispatch': 2,
   'scheduler-job': 2,
   'task-attempt': 3,
   blocker: 4,


### PR DESCRIPTION
## Summary

Action Graph node types are now named as UI-specific contract types.

This keeps today’s small cleanup separate from the bigger graph model refactor. The old name made the diagnostic UI shape sound like execution state.

## Test Plan

- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e20d51ec1`
- Post-revert steps: None
- Data migration? No
