### PR TITLE
fix(ui): remount graphs after forced task refresh

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -351,12 +351,17 @@ export function hasMergeConflictExecution(task: TaskState | undefined): boolean 
 }
 
 export function App() {
-  const { tasks, workflows, clearTasks, refreshTasks } = useTasks();
   const invoker = useInvoker();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
-  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [graphRefreshSequence, setGraphRefreshSequence] = useState(0);
+  const handleForcedRefreshApplied = useCallback(() => {
+    setGraphRefreshSequence((sequence) => sequence + 1);
+  }, []);
+  const { tasks, workflows, clearTasks, refreshTasks } = useTasks({
+    onForcedRefreshApplied: handleForcedRefreshApplied,
+  });
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [stickySelectedWorkflow, setStickySelectedWorkflow] = useState<WorkflowMeta | null>(null);
   const [workflowSelectionDismissed, setWorkflowSelectionDismissed] = useState(false);
@@ -1333,7 +1338,6 @@ export function App() {
 
   const handleRefresh = useCallback(async () => {
     await refreshTasks(true);
-    setGraphRefreshSequence((sequence) => sequence + 1);
   }, [refreshTasks]);
 
   // ── Plan loading ──────────────────────────────────────────

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, type Mock } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { vi } from 'vitest';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import { CAMERA_LOCK_PREFERENCE_STORAGE_KEY } from '../lib/graph-camera.js';
@@ -102,6 +102,31 @@ describe('Side rail controls (component)', () => {
       expect(fitViewMock.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
   });
+  it('stream gap recovery remounts both graph surfaces after the forced snapshot', async () => {
+    await renderKeyboardFixture(mock);
+    await waitFor(() => expect(fitViewMock).toHaveBeenCalled());
+    fitViewMock.mockClear();
+
+    await act(async () => {
+      mock.fireDelta({
+        type: 'updated',
+        taskId: 'wf-a/task-a',
+        changes: { status: 'running' },
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
+        streamSequence: 2,
+      });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mock.api.getTasks).toHaveBeenLastCalledWith(true);
+    });
+    await waitFor(() => {
+      expect(fitViewMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
 
   it('Clear button calls clear', async () => {
     render(<App />);

--- a/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
@@ -90,7 +90,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     expect(reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected')).toHaveLength(0);
   });
 
-  it('detects a 1,2,4 gap and triggers exactly one re-sync via getTasks(true)', async () => {
+  it('detects a 1,2,4 gap, re-syncs, and reports that a forced refresh applied', async () => {
     const initial = [
       makeUITask({ id: 't1', status: 'pending' }),
       makeUITask({ id: 't2', status: 'pending' }),
@@ -108,8 +108,10 @@ describe('useTasks stream-sequence gap-detect', () => {
         { tasks: post, workflows: [], streamSequence: 4 },
       ],
     });
+    const onForcedRefreshApplied = vi.fn();
 
-    const { result } = renderHook(() => useTasks());
+
+    const { result } = renderHook(() => useTasks({ onForcedRefreshApplied }));
 
     await waitFor(() => {
       expect(onTaskDeltaMock).toHaveBeenCalledTimes(1);
@@ -127,6 +129,10 @@ describe('useTasks stream-sequence gap-detect', () => {
       expect(getTasksMock).toHaveBeenCalledTimes(1);
       expect(getTasksMock).toHaveBeenLastCalledWith(true);
     });
+    await waitFor(() => {
+      expect(onForcedRefreshApplied).toHaveBeenCalledTimes(1);
+    });
+
 
     const gapReports = reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected');
     expect(gapReports).toHaveLength(1);

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -21,8 +21,12 @@ export interface UseTasksResult {
   clearTasks: () => void;
   refreshTasks: (forceRefresh?: boolean) => Promise<void>;
 }
+export interface UseTasksOptions {
+  onForcedRefreshApplied?: () => void;
+}
 
-export function useTasks(): UseTasksResult {
+
+export function useTasks({ onForcedRefreshApplied }: UseTasksOptions = {}): UseTasksResult {
   const traceTaskDeltas =
     typeof window !== 'undefined' &&
     window.location.search.includes('traceTaskDeltas=1');
@@ -116,6 +120,9 @@ export function useTasks(): UseTasksResult {
         replaceDurationMs,
         jsonSizeBytes: new Blob([JSON.stringify(result)]).size,
       });
+      if (forceRefresh) {
+        onForcedRefreshApplied?.();
+      }
       if (!reportedStartupSnapshotRef.current) {
         reportedStartupSnapshotRef.current = true;
         void window.invoker.reportUiPerf?.('startup_snapshot_applied', {
@@ -131,7 +138,7 @@ export function useTasks(): UseTasksResult {
     });
     window.invoker.checkPrStatuses?.();
     return request.then(() => undefined);
-  }, []);
+  }, [onForcedRefreshApplied]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;


### PR DESCRIPTION
## Summary

Forced task refresh now also resets the graph view. This makes automatic stream-gap recovery behave like the manual Refresh button.

The old path reloaded data but kept the same React Flow instance. A stuck graph could stay visually blank after rapid invalidations.

The fix lets `useTasks` report when a forced snapshot lands. `App` uses that signal to remount both graph surfaces.

## Architecture

### Before

```mermaid
graph TD
    A[Stream gap] --> B[fetchAll true]
    B --> C[Replace tasks and workflows]
    C --> D[Same graph instance rerenders]
    E[Refresh button] --> B
    E --> F[Increment graph key]
    F --> G[Graph remounts]
```

### After

```mermaid
graph TD
    A[Stream gap] --> B[fetchAll true]
    E[Refresh button] --> B
    B --> C[Replace tasks and workflows]
    C --> D[Notify forced refresh applied]
    D --> F[Increment graph key]
    F --> G[Graph remounts]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui test -- packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx packages/ui/src/__tests__/keyboard-controls.test.tsx`
- [x] `pnpm --filter @invoker/ui build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f3d5ad26806ef2371bbc615828e3ed9dfced6aeb`
- Post-revert steps: None
- Data migration? No
