### PR TITLE
test: add case 4.3 failure diagnostics

### DIFF
--- a/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
+++ b/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
@@ -4,6 +4,49 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/../lib/common.sh"
+invoker_e2e_case43_task_status() {
+  local task_id="$1"
+  invoker_e2e_task_status "$task_id" 2>/dev/null || true
+}
+
+invoker_e2e_case43_dump_state() {
+  local reason="$1"
+  set +e
+  echo "DIAG case 4.3: $reason"
+  echo "DIAG case 4.3: MERGE_ID=${MERGE_ID:-<unset>} WF_ID=${WF_ID:-<unset>}"
+
+  for task_id in e2e-g443-taskA e2e-g443-taskB "${MERGE_ID:-}"; do
+    if [ -n "$task_id" ]; then
+      local status
+      status="$(invoker_e2e_case43_task_status "$task_id")"
+      echo "DIAG case 4.3: task $task_id status='${status:-<empty>}'"
+    fi
+  done
+
+  if [ -n "${GHLOG:-}" ] && [ -f "$GHLOG" ]; then
+    echo "DIAG case 4.3: gh stub log begin"
+    cat "$GHLOG" || true
+    echo "DIAG case 4.3: gh stub log end"
+  else
+    echo "DIAG case 4.3: gh stub log missing at ${GHLOG:-<unset>}"
+  fi
+
+  echo "DIAG case 4.3: headless status begin"
+  invoker_e2e_run_headless status 2>&1 || true
+  echo "DIAG case 4.3: headless status end"
+}
+
+invoker_e2e_case43_on_error() {
+  local exit_code="$1"
+  local line="$2"
+  local command="$3"
+  set +e
+  echo "FAIL case 4.3: unexpected shell error at line $line exit=$exit_code command=$command"
+  invoker_e2e_case43_dump_state "unexpected shell error"
+  exit "$exit_code"
+}
+
+trap 'invoker_e2e_case43_on_error "$?" "$LINENO" "$BASH_COMMAND"' ERR
 
 invoker_e2e_init
 trap invoker_e2e_cleanup EXIT
@@ -18,7 +61,7 @@ echo "==> case 4.3: submit plan (task A will fail)"
 invoker_e2e_submit_plan "$INVOKER_E2E_REPO_ROOT/plans/e2e-dry-run/group4-fix-merge/4.3-fix-then-pr.yaml" || true
 invoker_e2e_wait_settled e2e-g443-taskA
 
-STA=$(invoker_e2e_task_status e2e-g443-taskA)
+STA=$(invoker_e2e_case43_task_status e2e-g443-taskA)
 if [ "$STA" != "failed" ]; then
   echo "FAIL case 4.3: expected A=failed after submit, got '$STA'"
   exit 1
@@ -29,7 +72,7 @@ echo "==> case 4.3: fix A (claude-marker.sh runs)"
 invoker_e2e_run_headless fix e2e-g443-taskA
 invoker_e2e_wait_settled e2e-g443-taskA
 
-STA=$(invoker_e2e_task_status e2e-g443-taskA)
+STA=$(invoker_e2e_case43_task_status e2e-g443-taskA)
 if [ "$STA" != "awaiting_approval" ]; then
   echo "FAIL case 4.3: expected A=awaiting_approval after fix, got '$STA'"
   invoker_e2e_run_headless status 2>&1 || true
@@ -42,8 +85,8 @@ invoker_e2e_run_headless approve e2e-g443-taskA
 invoker_e2e_wait_settled e2e-g443-taskA
 invoker_e2e_wait_settled e2e-g443-taskB
 
-STA=$(invoker_e2e_task_status e2e-g443-taskA)
-STB=$(invoker_e2e_task_status e2e-g443-taskB)
+STA=$(invoker_e2e_case43_task_status e2e-g443-taskA)
+STB=$(invoker_e2e_case43_task_status e2e-g443-taskB)
 if [ "$STA" != "completed" ] || [ "$STB" != "completed" ]; then
   echo "FAIL case 4.3: expected A=completed B=completed, got A='$STA' B='$STB'"
   invoker_e2e_run_headless status 2>&1 || true
@@ -63,7 +106,7 @@ echo "==> case 4.3: merge gate ID=$MERGE_ID"
 # headlessApprove may exit before the cascading merge node finishes. Resume only
 # when the gate still needs recovery; it may already be review_ready here.
 WF_ID="${MERGE_ID#__merge__}"
-STM=$(invoker_e2e_task_status "$MERGE_ID")
+STM=$(invoker_e2e_case43_task_status "$MERGE_ID")
 if [ "$STM" != "awaiting_approval" ] && [ "$STM" != "review_ready" ]; then
   echo "==> case 4.3: resume workflow $WF_ID to let merge gate run"
   invoker_e2e_run_headless resume "$WF_ID"
@@ -72,7 +115,7 @@ else
 fi
 invoker_e2e_wait_settled "$MERGE_ID"
 
-STM=$(invoker_e2e_task_status "$MERGE_ID")
+STM=$(invoker_e2e_case43_task_status "$MERGE_ID")
 if [ "$STM" != "awaiting_approval" ] && [ "$STM" != "review_ready" ]; then
   echo "FAIL case 4.3: expected merge gate=awaiting_approval|review_ready, got '$STM'"
   invoker_e2e_run_headless status 2>&1 || true
@@ -99,16 +142,18 @@ if ! grep -q "api.*repos.*pulls.*POST" "$GHLOG"; then
   exit 1
 fi
 echo "==> case 4.3: confirmed gh PR creation calls in stub log"
+echo "DIAG case 4.3: before final approve, merge gate status='$(invoker_e2e_case43_task_status "$MERGE_ID")'"
 
 echo "==> case 4.3: approve merge gate"
 invoker_e2e_run_headless approve "$MERGE_ID"
+echo "DIAG case 4.3: final approve command completed, merge gate status='$(invoker_e2e_case43_task_status "$MERGE_ID")'"
 invoker_e2e_wait_settled "$MERGE_ID"
+echo "DIAG case 4.3: final wait settled completed, merge gate status='$(invoker_e2e_case43_task_status "$MERGE_ID")'"
 
-STM=$(invoker_e2e_task_status "$MERGE_ID")
+STM=$(invoker_e2e_case43_task_status "$MERGE_ID")
 if [ "$STM" != "completed" ]; then
   echo "FAIL case 4.3: expected merge gate=completed after approve, got '$STM'"
-  invoker_e2e_run_headless status 2>&1 || true
+  invoker_e2e_case43_dump_state "merge gate was not completed after final approve"
   exit 1
 fi
-
 echo "PASS case 4.3 (fix A → approve → B completed → PR created → gate approved)"


### PR DESCRIPTION
## Summary

Case 4.3 now leaves useful evidence when the final merge gate approval fails in CI.

The prior failure stopped after approve without saying which command died. This adds exact command, line, exit code, task status, headless status, and gh stub logs.

## Test Plan

- [x] `bash -n scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh`
- [x] `bash scripts/e2e-dry-run/run-all.sh 'case-4.3-fix-then-pr.sh'`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 97c19e92b`
- Post-revert steps: None
- Data migration? No
