### PR TITLE
feat(ui): add task graph event channel

### DIFF
--- a/packages/app/src/preload.ts
+++ b/packages/app/src/preload.ts
@@ -52,7 +52,7 @@ if (process.env.NODE_ENV === 'test') {
 // Event channels: each becomes (cb) => { subscribe; return unsubscribe }
 for (const channel of Object.keys(IpcEventChannels)) {
   const method = channelToEventMethod(channel);
-  if (channel === 'invoker:task-delta') {
+  if (channel === 'invoker:task-delta' || channel === 'invoker:task-graph-event') {
     api[method] = (cb: (...args: unknown[]) => void) => {
       const pendingBatchItems: unknown[] = [];
       let drainTimer: ReturnType<typeof setTimeout> | null = null;
@@ -67,6 +67,7 @@ for (const channel of Object.keys(IpcEventChannels)) {
         }
       };
       const singleHandler = (_event: Electron.IpcRendererEvent, ...data: unknown[]) => cb(...data);
+      const batchChannel = `${channel}-batch`;
       const batchHandler = (_event: Electron.IpcRendererEvent, batch: unknown[]) => {
         if (!Array.isArray(batch)) return;
         pendingBatchItems.push(...batch);
@@ -75,10 +76,10 @@ for (const channel of Object.keys(IpcEventChannels)) {
         }
       };
       ipcRenderer.on(channel, singleHandler);
-      ipcRenderer.on('invoker:task-delta-batch', batchHandler);
+      ipcRenderer.on(batchChannel, batchHandler);
       return () => {
         ipcRenderer.removeListener(channel, singleHandler);
-        ipcRenderer.removeListener('invoker:task-delta-batch', batchHandler);
+        ipcRenderer.removeListener(batchChannel, batchHandler);
         if (drainTimer) {
           clearTimeout(drainTimer);
           drainTimer = null;

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -47,6 +47,19 @@ export interface WorkflowMeta {
   createdAt?: string;
   updatedAt?: string;
 }
+export type TaskGraphEvent =
+  | {
+      type: 'delta';
+      delta: TaskDelta;
+    }
+  | {
+      type: 'snapshot';
+      tasks: TaskState[];
+      workflows: WorkflowMeta[];
+      reason: string;
+      streamSequence: number;
+    };
+
 
 export interface WorkflowStatus {
   total: number;
@@ -655,6 +668,9 @@ export const IpcTestOnlyChannels = {
 export const IpcEventChannels = {
   'invoker:task-delta': {} as {
     payload: TaskDelta;
+  },
+  'invoker:task-graph-event': {} as {
+    payload: TaskGraphEvent;
   },
   'invoker:task-output': {} as {
     payload: TaskOutputData;

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -10,6 +10,7 @@ import type {
   InvokerAPI,
   TaskState,
   TaskDelta,
+  TaskGraphEvent,
   WorkflowMeta,
   TaskStatus,
   TaskConfig,
@@ -24,6 +25,8 @@ export interface MockInvoker {
   setTasks: (tasks: TaskState[], workflows?: WorkflowMeta[]) => void;
   /** Directly fire a task delta to subscribers. */
   fireDelta: (delta: TaskDelta) => void;
+  /** Directly fire a task graph event to subscribers. */
+  fireGraphEvent: (event: TaskGraphEvent) => void;
   /** Fire a workflows-changed event. */
   fireWorkflowsChanged: (workflows: WorkflowMeta[]) => void;
   /** Fire an embedded terminal output event to subscribers. */
@@ -41,6 +44,7 @@ export function createMockInvoker(
   let taskSnapshot = initialTasks;
   let workflowSnapshot = initialWorkflows;
   let deltaCallback: ((delta: TaskDelta) => void) | undefined;
+  let graphEventCallback: ((event: TaskGraphEvent) => void) | undefined;
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
 
@@ -61,6 +65,10 @@ export function createMockInvoker(
     onTaskDelta: vi.fn((cb: (delta: TaskDelta) => void) => {
       deltaCallback = cb;
       return () => { deltaCallback = undefined; };
+    }),
+    onTaskGraphEvent: vi.fn((cb: (event: TaskGraphEvent) => void) => {
+      graphEventCallback = cb;
+      return () => { graphEventCallback = undefined; };
     }),
     onWorkflowsChanged: vi.fn((cb: (workflows: unknown[]) => void) => {
       workflowsCallback = cb;
@@ -193,6 +201,10 @@ export function createMockInvoker(
   function fireDelta(delta: TaskDelta) {
     deltaCallback?.(delta);
   }
+  function fireGraphEvent(event: TaskGraphEvent) {
+    graphEventCallback?.(event);
+  }
+
 
   function fireWorkflowsChanged(workflows: WorkflowMeta[]) {
     workflowSnapshot = workflows;
@@ -219,7 +231,7 @@ export function createMockInvoker(
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
   }
 
-  return { api, setTasks, fireDelta, fireWorkflowsChanged, fireTerminalOutput, install, cleanup };
+  return { api, setTasks, fireDelta, fireGraphEvent, fireWorkflowsChanged, fireTerminalOutput, install, cleanup };
 }
 
 /** Create a minimal TaskState for testing. */

--- a/packages/ui/src/__tests__/task-graph-event-pipeline.test.ts
+++ b/packages/ui/src/__tests__/task-graph-event-pipeline.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createTaskGraphEventPipeline } from '../lib/task-graph-event-pipeline.js';
+import type { TaskGraphEvent, TaskState } from '../types.js';
+
+function makeTask(id: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2025-01-01'),
+    config: {},
+    execution: {},
+  };
+}
+
+describe('task-graph-event-pipeline', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('batches delta and snapshot events in FIFO order', () => {
+    vi.useFakeTimers();
+    const onBatch = vi.fn<(batch: TaskGraphEvent[]) => void>();
+    const pipeline = createTaskGraphEventPipeline({ flushMs: 100, onBatch });
+    const deltaEvent: TaskGraphEvent = { type: 'delta', delta: { type: 'created', task: makeTask('t1') } };
+    const snapshotEvent: TaskGraphEvent = {
+      type: 'snapshot',
+      tasks: [makeTask('t2')],
+      workflows: [],
+      reason: 'test',
+      streamSequence: 3,
+    };
+
+    pipeline.push(deltaEvent);
+    pipeline.push(snapshotEvent);
+    vi.advanceTimersByTime(100);
+
+    expect(onBatch).toHaveBeenCalledTimes(1);
+    expect(onBatch.mock.calls[0][0]).toEqual([deltaEvent, snapshotEvent]);
+
+    pipeline.dispose();
+  });
+
+  it('clear drops pending graph events', () => {
+    vi.useFakeTimers();
+    const onBatch = vi.fn<(batch: TaskGraphEvent[]) => void>();
+    const pipeline = createTaskGraphEventPipeline({ flushMs: 100, onBatch });
+
+    pipeline.push({ type: 'delta', delta: { type: 'created', task: makeTask('t1') } });
+    pipeline.clear();
+    vi.advanceTimersByTime(100);
+
+    expect(onBatch).not.toHaveBeenCalled();
+
+    pipeline.dispose();
+  });
+});

--- a/packages/ui/src/lib/task-graph-event-pipeline.ts
+++ b/packages/ui/src/lib/task-graph-event-pipeline.ts
@@ -1,0 +1,117 @@
+import { merge, queueScheduler, Subject, Subscription, timer } from 'rxjs';
+import { observeOn, takeUntil } from 'rxjs/operators';
+import type { TaskGraphEvent } from '../types.js';
+
+export interface TaskGraphEventPipeline {
+  push: (event: TaskGraphEvent) => void;
+  flushNow: () => void;
+  clear: () => void;
+  dispose: () => void;
+}
+
+export interface CreateTaskGraphEventPipelineOptions {
+  flushMs?: number;
+  maxBatchSize?: number;
+  onBatch: (batch: TaskGraphEvent[]) => void;
+  onLargeBatch?: (stats: { batchSize: number; remaining: number }) => void;
+}
+
+/**
+ * UI-local FIFO batching pipeline for task graph events.
+ *
+ * A task graph event can be either an incremental task delta or a full graph
+ * snapshot. Keeping both in one FIFO preserves reset ordering at the renderer
+ * boundary.
+ */
+export function createTaskGraphEventPipeline(
+  options: CreateTaskGraphEventPipelineOptions,
+): TaskGraphEventPipeline {
+  const flushMs = options.flushMs ?? 100;
+  const maxBatchSize = options.maxBatchSize ?? 250;
+  const inboundEvents$ = new Subject<TaskGraphEvent>();
+  const timerFlush$ = new Subject<void>();
+  const flushNow$ = new Subject<void>();
+  const clear$ = new Subject<void>();
+  const dispose$ = new Subject<void>();
+  const stopTimer$ = merge(flushNow$, clear$, dispose$);
+  const flushRequests$ = merge(timerFlush$, flushNow$);
+  const subscriptions = new Subscription();
+  let queue: TaskGraphEvent[] = [];
+  let timerSubscription: Subscription | null = null;
+  let disposed = false;
+
+  const cancelTimer = (): void => {
+    timerSubscription?.unsubscribe();
+    timerSubscription = null;
+  };
+
+  const schedule = (): void => {
+    if (timerSubscription || disposed) return;
+    timerSubscription = timer(flushMs).pipe(takeUntil(stopTimer$)).subscribe(() => {
+      timerSubscription = null;
+      timerFlush$.next();
+    });
+  };
+
+  const flushQueue = (): void => {
+    if (queue.length === 0) return;
+    const batchSize = Math.min(maxBatchSize, queue.length);
+    const batch = queue.splice(0, batchSize);
+    cancelTimer();
+    if (queue.length > 0) {
+      options.onLargeBatch?.({ batchSize: batch.length, remaining: queue.length });
+      schedule();
+    }
+    options.onBatch(batch);
+  };
+
+  subscriptions.add(
+    inboundEvents$.pipe(observeOn(queueScheduler), takeUntil(dispose$)).subscribe((event) => {
+      queue.push(event);
+      schedule();
+    }),
+  );
+  subscriptions.add(
+    flushRequests$.pipe(takeUntil(dispose$)).subscribe(() => {
+      flushQueue();
+    }),
+  );
+  subscriptions.add(
+    clear$.pipe(takeUntil(dispose$)).subscribe(() => {
+      cancelTimer();
+      queue = [];
+    }),
+  );
+  subscriptions.add(
+    dispose$.subscribe(() => {
+      disposed = true;
+      cancelTimer();
+      queue = [];
+    }),
+  );
+
+  return {
+    push(event: TaskGraphEvent): void {
+      if (disposed) return;
+      inboundEvents$.next(event);
+    },
+    flushNow(): void {
+      if (disposed) return;
+      flushNow$.next();
+    },
+    clear(): void {
+      if (disposed) return;
+      clear$.next();
+    },
+    dispose(): void {
+      if (disposed) return;
+      dispose$.next();
+      dispose$.complete();
+      subscriptions.unsubscribe();
+      inboundEvents$.complete();
+      timerFlush$.complete();
+      flushNow$.complete();
+      clear$.complete();
+    },
+  };
+}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -174,6 +174,19 @@ export interface WorkflowMeta {
   createdAt?: string;
   updatedAt?: string;
 }
+export type TaskGraphEvent =
+  | {
+      readonly type: 'delta';
+      readonly delta: TaskDelta;
+    }
+  | {
+      readonly type: 'snapshot';
+      readonly tasks: readonly TaskState[];
+      readonly workflows: readonly WorkflowMeta[];
+      readonly reason: string;
+      readonly streamSequence: number;
+    };
+
 
 export type WorkflowStatus =
   | 'pending'


### PR DESCRIPTION
## Summary

This adds a real task graph event channel for the UI.

Before this, the renderer only had task deltas. There was no first-class event for a full graph snapshot.

Now the UI can receive either a delta or a whole graph snapshot through one channel.

This slice still keeps the old `task-delta` compatibility shim so the stack lands safely.

PR #1392 removes that shim and leaves `task-graph-event` as the only UI event path.

## Architecture

### Before

```mermaid
graph TD
    A[Main process] --> B[task-delta event]
    B --> C[Renderer delta pipeline]
    C --> D[React state]
```

### After

```mermaid
graph TD
    A[Main process] --> B[task-graph-event]
    B --> C[Renderer graph-event pipeline]
    C --> D[Delta event]
    C --> E[Snapshot event]
    D --> F[React state]
    E --> F
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx src/__tests__/keyboard-controls.test.tsx`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert c4e79c2f4`
- Post-revert steps: None
- Data migration? No
