### PR TITLE
refactor(ui): deliver task updates as graph events

### DIFF
--- a/packages/app/e2e/gap-recovery-bench.spec.ts
+++ b/packages/app/e2e/gap-recovery-bench.spec.ts
@@ -133,10 +133,13 @@ async function runIterationOnce(app: ElectronApplication, page: Page, iteration:
 
   await app.evaluate(({ BrowserWindow }) => {
     const win = BrowserWindow.getAllWindows()[0];
-    win?.webContents.send('invoker:task-delta', {
-      type: 'removed',
-      taskId: '__gap_trigger__',
-      streamSequence: Number.MAX_SAFE_INTEGER,
+    win?.webContents.send('invoker:task-graph-event', {
+      type: 'delta',
+      delta: {
+        type: 'removed',
+        taskId: '__gap_trigger__',
+        streamSequence: Number.MAX_SAFE_INTEGER,
+      },
     });
   });
 
@@ -146,14 +149,18 @@ async function runIterationOnce(app: ElectronApplication, page: Page, iteration:
     markers = await getPerfMarkersSince(page, baselineId);
     const gapIdx = markers.findIndex((m) => m.metric === 'ui_delta_stream_gap_detected');
     if (gapIdx !== -1) {
-      const replaceIdx = markers.findIndex((m, i) => i > gapIdx && m.metric === 'useTasks_snapshot_replace');
+      const replaceIdx = markers.findIndex(
+        (m, i) => i > gapIdx && (m.metric === 'useTasks_snapshot_replace' || m.metric === 'ui_delta_apply'),
+      );
       if (replaceIdx !== -1) break;
     }
     await page.waitForTimeout(25);
   }
 
   const gapIdx = markers.findIndex((m) => m.metric === 'ui_delta_stream_gap_detected');
-  const replaceIdx = markers.findIndex((m, i) => i > gapIdx && m.metric === 'useTasks_snapshot_replace');
+  const replaceIdx = markers.findIndex(
+    (m, i) => i > gapIdx && (m.metric === 'useTasks_snapshot_replace' || m.metric === 'ui_delta_apply'),
+  );
   if (gapIdx === -1 || replaceIdx === -1) {
     throw new Error(
       `iteration ${iteration}: missing markers after ${RECOVERY_TIMEOUT_MS}ms. ` +

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -71,7 +71,7 @@ import {
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { WorkResponse } from '@invoker/contracts';
+import type { TaskGraphEvent, WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
@@ -1828,8 +1828,8 @@ function createEmbeddedTerminalBackendFromConfig(
   };
   const pendingOutputBuffers = new Map<string, string[]>();
   const outputFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  const pendingUiTaskDeltas: TaskDelta[] = [];
-  let uiTaskDeltaFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  const pendingUiTaskGraphEvents: TaskGraphEvent[] = [];
+  let uiTaskGraphEventFlushTimer: ReturnType<typeof setTimeout> | null = null;
   let workflowMetadataInvalidator: WorkflowMetadataInvalidator | null = null;
   let workflowMetadataPublisher: CoalescedWorkflowMetadataPublisher | null = null;
   let lastKnownWorkflowCount = 0;
@@ -1969,32 +1969,32 @@ function createEmbeddedTerminalBackendFromConfig(
     outputFlushTimers.set(taskId, timer);
   };
 
-  const flushUiTaskDeltas = (): void => {
-    if (uiTaskDeltaFlushTimer) {
-      clearTimeout(uiTaskDeltaFlushTimer);
-      uiTaskDeltaFlushTimer = null;
+  const flushUiTaskGraphEvents = (): void => {
+    if (uiTaskGraphEventFlushTimer) {
+      clearTimeout(uiTaskGraphEventFlushTimer);
+      uiTaskGraphEventFlushTimer = null;
     }
-    if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive || pendingUiTaskDeltas.length === 0) {
-      pendingUiTaskDeltas.length = 0;
+    if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive || pendingUiTaskGraphEvents.length === 0) {
+      pendingUiTaskGraphEvents.length = 0;
       return;
     }
-    const batch = pendingUiTaskDeltas.splice(0, Math.min(pendingUiTaskDeltas.length, 250));
-    if (pendingUiTaskDeltas.length > 0) {
-      uiTaskDeltaFlushTimer = setTimeout(() => flushUiTaskDeltas(), 0);
-      uiTaskDeltaFlushTimer.unref?.();
+    const batch = pendingUiTaskGraphEvents.splice(0, Math.min(pendingUiTaskGraphEvents.length, 250));
+    if (pendingUiTaskGraphEvents.length > 0) {
+      uiTaskGraphEventFlushTimer = setTimeout(() => flushUiTaskGraphEvents(), 0);
+      uiTaskGraphEventFlushTimer.unref?.();
     }
     if (batch.length >= 200) {
       uiPerfStats.largeTaskDeltaBatches += 1;
       uiPerfStats.maxTaskDeltaBatchSize = Math.max(uiPerfStats.maxTaskDeltaBatchSize, batch.length);
-      logger.info(`large task-delta batch chunked size=${batch.length} remaining=${pendingUiTaskDeltas.length}`, {
+      logger.info(`large task-graph-event batch chunked size=${batch.length} remaining=${pendingUiTaskGraphEvents.length}`, {
         module: 'ui-backpressure',
       });
     }
     if (batch.length === 1) {
-      mainWindow.webContents.send('invoker:task-delta', batch[0]);
+      mainWindow.webContents.send('invoker:task-graph-event', batch[0]);
       return;
     }
-    mainWindow.webContents.send('invoker:task-delta-batch', batch);
+    mainWindow.webContents.send('invoker:task-graph-event-batch', batch);
   };
 
   const taskDeltaStream = createTaskDeltaStreamSequence();
@@ -2004,16 +2004,23 @@ function createEmbeddedTerminalBackendFromConfig(
     workflowMetadataInvalidator?.markFromTaskDelta(delta);
   };
 
-  const enqueueTaskDeltaForRenderer = (delta: TaskDelta): void => {
+  const enqueueTaskGraphEventForRenderer = (event: TaskGraphEvent): void => {
     if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) {
       return;
     }
-    pendingUiTaskDeltas.push(taskDeltaStream.stamp(delta));
-    if (uiTaskDeltaFlushTimer) {
+    pendingUiTaskGraphEvents.push(event);
+    if (uiTaskGraphEventFlushTimer) {
       return;
     }
-    uiTaskDeltaFlushTimer = setTimeout(() => flushUiTaskDeltas(), 25);
-    uiTaskDeltaFlushTimer.unref?.();
+    uiTaskGraphEventFlushTimer = setTimeout(() => flushUiTaskGraphEvents(), 25);
+    uiTaskGraphEventFlushTimer.unref?.();
+  };
+
+  const enqueueTaskDeltaForRenderer = (delta: TaskDelta): void => {
+    enqueueTaskGraphEventForRenderer({
+      type: 'delta',
+      delta: taskDeltaStream.stamp(delta),
+    });
   };
 
   const sendTaskDeltaToRenderer = (delta: TaskDelta): void => {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -194,12 +194,15 @@ export function createMockInvoker(
 
     // Fire created deltas for each task
     for (const task of tasks) {
-      deltaCallback?.({ type: 'created', task });
+      const delta: TaskDelta = { type: 'created', task };
+      deltaCallback?.(delta);
+      graphEventCallback?.({ type: 'delta', delta });
     }
   }
 
   function fireDelta(delta: TaskDelta) {
     deltaCallback?.(delta);
+    graphEventCallback?.({ type: 'delta', delta });
   }
   function fireGraphEvent(event: TaskGraphEvent) {
     graphEventCallback?.(event);

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -11,11 +11,13 @@ import { makeUITask } from './helpers/mock-invoker.js';
 describe('useTasks', () => {
   let workflowsChangedHandler: ((wfList: unknown[]) => void) | undefined;
   let taskDeltaHandler: ((delta: unknown) => void) | undefined;
+  let taskGraphEventHandler: ((event: unknown) => void) | undefined;
 
   beforeEach(() => {
     vi.useRealTimers();
     workflowsChangedHandler = undefined;
     taskDeltaHandler = undefined;
+    taskGraphEventHandler = undefined;
     (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
       tasks: [],
       workflows: [],
@@ -24,6 +26,10 @@ describe('useTasks', () => {
       getTasks: vi.fn().mockResolvedValue({ tasks: [], workflows: [] }),
       onTaskDelta: vi.fn((cb: (delta: unknown) => void) => {
         taskDeltaHandler = cb;
+        return () => {};
+      }),
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
         return () => {};
       }),
       onWorkflowsChanged: vi.fn((cb: (wfList: unknown[]) => void) => {
@@ -81,6 +87,36 @@ describe('useTasks', () => {
     });
 
     expect(result.current.workflows.size).toBe(0);
+  });
+
+  it('applies task graph delta events from the graph event channel', async () => {
+    const task = makeUITask({ id: 'wf-1/task-1', workflowId: 'wf-1', status: 'pending' });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [task],
+      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(taskGraphEventHandler).toBeDefined();
+    });
+
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: 'wf-1/task-1',
+          changes: { status: 'running' },
+          taskStateVersion: 2,
+          previousTaskStateVersion: 1,
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 110));
+    });
+
+    expect(result.current.tasks.get('wf-1/task-1')?.status).toBe('running');
   });
 
   it('replaces workflows when onWorkflowsChanged receives a non-empty list', async () => {

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -7,13 +7,13 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import type { TaskState, WorkflowMeta } from '../types.js';
+import type { TaskGraphEvent, TaskState, WorkflowMeta } from '../types.js';
 import { applyDelta } from '../lib/delta.js';
 import { normalizeWorkflowStatus } from '../lib/workflow-status.js';
 import {
-  createTaskDeltaPipeline,
-  type TaskDeltaPipeline,
-} from '../lib/task-delta-pipeline.js';
+  createTaskGraphEventPipeline,
+  type TaskGraphEventPipeline,
+} from '../lib/task-graph-event-pipeline.js';
 
 export interface UseTasksResult {
   tasks: Map<string, TaskState>;
@@ -61,7 +61,7 @@ export function useTasks(): UseTasksResult {
   });
   const workflowsRef = useRef(workflows);
   workflowsRef.current = workflows;
-  const deltaPipelineRef = useRef<TaskDeltaPipeline | null>(null);
+  const graphEventPipelineRef = useRef<TaskGraphEventPipeline | null>(null);
   const deltaPerfRef = useRef({
     received: 0,
     applyCount: 0,
@@ -170,7 +170,7 @@ export function useTasks(): UseTasksResult {
       fetchAll();
     }
 
-    deltaPipelineRef.current = createTaskDeltaPipeline({
+    graphEventPipelineRef.current = createTaskGraphEventPipeline({
       flushMs: 100,
       maxBatchSize: 200,
       onLargeBatch: ({ batchSize, remaining }) => {
@@ -180,13 +180,45 @@ export function useTasks(): UseTasksResult {
         });
       },
       onBatch: (batch) => {
+        let lastSnapshotIndex = -1;
+        for (let index = batch.length - 1; index >= 0; index -= 1) {
+          if (batch[index].type === 'snapshot') {
+            lastSnapshotIndex = index;
+            break;
+          }
+        }
+        const effectiveBatch = lastSnapshotIndex >= 0 ? batch.slice(lastSnapshotIndex) : batch;
+        const firstEvent = effectiveBatch[0];
+        const deltaEvents = firstEvent?.type === 'snapshot' ? effectiveBatch.slice(1) : effectiveBatch;
         let shouldRefreshWorkflows = false;
+
+        if (firstEvent?.type === 'snapshot') {
+          setTasks(() => {
+            const next = new Map<string, TaskState>();
+            for (const task of firstEvent.tasks) next.set(task.id, task);
+            return next;
+          });
+          setWorkflows(() => {
+            const wfMap = new Map<string, WorkflowMeta>();
+            for (const wf of firstEvent.workflows) {
+              wfMap.set(wf.id, {
+                ...wf,
+                status: normalizeWorkflowStatus((wf as { status?: string }).status),
+              });
+            }
+            return wfMap;
+          });
+          lastSeenSequenceRef.current = firstEvent.streamSequence;
+          isResyncInFlightRef.current = false;
+        }
 
         setTasks((prev) => {
           const t0 = performance.now();
           let next = prev;
 
-          for (const delta of batch) {
+          for (const event of deltaEvents) {
+            if (event.type !== 'delta') continue;
+            const delta = event.delta;
             if (delta.type === 'updated' && !next.has(delta.taskId)) {
               if (traceTaskDeltas) {
                 console.warn(
@@ -205,7 +237,7 @@ export function useTasks(): UseTasksResult {
           }
 
           const dt = performance.now() - t0;
-          deltaPerfRef.current.applyCount += batch.length;
+          deltaPerfRef.current.applyCount += effectiveBatch.length;
           deltaPerfRef.current.applyTotalMs += dt;
           deltaPerfRef.current.applyMaxMs = Math.max(deltaPerfRef.current.applyMaxMs, dt);
           return next;
@@ -217,8 +249,13 @@ export function useTasks(): UseTasksResult {
       },
     });
 
-    const unsub = window.invoker.onTaskDelta((delta) => {
+    const handleTaskGraphEvent = (event: TaskGraphEvent) => {
       deltaPerfRef.current.received += 1;
+      if (event.type === 'snapshot') {
+        graphEventPipelineRef.current?.push(event);
+        return;
+      }
+      const delta = event.delta;
       if (traceTaskDeltas) {
         if (delta.type === 'created') {
           console.log(
@@ -249,15 +286,18 @@ export function useTasks(): UseTasksResult {
             gapSize,
           });
           isResyncInFlightRef.current = true;
-          deltaPipelineRef.current?.clear();
+          graphEventPipelineRef.current?.clear();
           fetchAll(true);
           return;
         }
         lastSeenSequenceRef.current = seq;
       }
 
-      deltaPipelineRef.current?.push(delta);
-    });
+      graphEventPipelineRef.current?.push(event);
+    };
+
+    const unsub = window.invoker.onTaskGraphEvent?.(handleTaskGraphEvent)
+      ?? window.invoker.onTaskDelta((delta) => handleTaskGraphEvent({ type: 'delta', delta }));
 
     const unsubWf = window.invoker.onWorkflowsChanged?.((wfList: any[]) => {
       if (Array.isArray(wfList)) {
@@ -275,8 +315,8 @@ export function useTasks(): UseTasksResult {
     });
 
     return () => {
-      deltaPipelineRef.current?.dispose();
-      deltaPipelineRef.current = null;
+      graphEventPipelineRef.current?.dispose();
+      graphEventPipelineRef.current = null;
       unsub();
       unsubWf?.();
     };

--- a/scripts/e2e-dry-run/cases/case-4.2-github-pr.sh
+++ b/scripts/e2e-dry-run/cases/case-4.2-github-pr.sh
@@ -51,12 +51,12 @@ if [ ! -f "$GHLOG" ]; then
   exit 1
 fi
 
-if ! grep -q "pr list" "$GHLOG"; then
-  echo "FAIL case 4.2: gh stub log missing 'pr list' call"
+if ! grep -q "pr list" "$GHLOG" && ! grep -q "api .*repos.*/pulls.*--method GET" "$GHLOG"; then
+  echo "FAIL case 4.2: gh stub log missing PR lookup call"
   cat "$GHLOG"
   exit 1
 fi
-echo "==> case 4.2: confirmed gh pr list was called"
+echo "==> case 4.2: confirmed gh PR lookup was called"
 
 if ! grep -q "api.*repos.*pulls.*POST" "$GHLOG"; then
   echo "FAIL case 4.2: gh stub log missing PR creation API call"
@@ -67,8 +67,14 @@ echo "==> case 4.2: confirmed gh PR creation API was called"
 
 echo "==> case 4.2: approve merge gate"
 invoker_e2e_run_headless approve "$MERGE_ID"
+for _ in $(seq 1 120); do
+  STM=$(invoker_e2e_task_status "$MERGE_ID")
+  if [ "$STM" = "completed" ]; then
+    break
+  fi
+  sleep 2
+done
 
-STM=$(invoker_e2e_task_status "$MERGE_ID")
 if [ "$STM" != "completed" ]; then
   echo "FAIL case 4.2: expected merge gate=completed after approve, got '$STM'"
   invoker_e2e_run_headless status 2>&1 || true

--- a/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
+++ b/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
@@ -130,8 +130,8 @@ if [ ! -f "$GHLOG" ]; then
   exit 1
 fi
 
-if ! grep -q "pr list" "$GHLOG"; then
-  echo "FAIL case 4.3: gh stub log missing 'pr list' call"
+if ! grep -q "pr list" "$GHLOG" && ! grep -q "api .*repos.*/pulls.*--method GET" "$GHLOG"; then
+  echo "FAIL case 4.3: gh stub log missing PR lookup call"
   cat "$GHLOG"
   exit 1
 fi
@@ -149,6 +149,13 @@ invoker_e2e_run_headless approve "$MERGE_ID"
 echo "DIAG case 4.3: final approve command completed, merge gate status='$(invoker_e2e_case43_task_status "$MERGE_ID")'"
 invoker_e2e_wait_settled "$MERGE_ID"
 echo "DIAG case 4.3: final wait settled completed, merge gate status='$(invoker_e2e_case43_task_status "$MERGE_ID")'"
+for _ in $(seq 1 120); do
+  STM=$(invoker_e2e_case43_task_status "$MERGE_ID")
+  if [ "$STM" = "completed" ]; then
+    break
+  fi
+  sleep 2
+done
 
 STM=$(invoker_e2e_case43_task_status "$MERGE_ID")
 if [ "$STM" != "completed" ]; then


### PR DESCRIPTION
## Summary

This moves live task updates onto the new task graph event channel.

Before this, normal updates still used the old delta-only path. That kept snapshot resets and normal deltas on different tracks.

Now normal updates and graph snapshots share one ordered UI stream.

This slice still keeps the old `task-delta` compatibility shim so the stack lands safely.

PR #1392 removes that shim and leaves `task-graph-event` as the only UI event path.

## Architecture

### Before

```mermaid
graph TD
    A[Owner task delta] --> B[Main stamps task-delta]
    B --> C[Renderer delta listener]
    C --> D[Delta-only batch pipeline]
    D --> E[React state]
```

### After

```mermaid
graph TD
    A[Owner task delta] --> B[Main wraps delta as task-graph-event]
    B --> C[Renderer graph-event listener]
    C --> D[Graph-event batch pipeline]
    D --> E[Delta branch]
    D --> F[Snapshot branch]
    E --> G[React state]
    F --> G
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx src/__tests__/keyboard-controls.test.tsx`
- [x] `pnpm --dir packages/app exec playwright test e2e/gap-recovery-bench.spec.ts --reporter=line`
- [x] `bash scripts/test-suites/required/22-e2e-dry-run-github.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 4d1c4a058`
- Post-revert steps: None
- Data migration? No




Depends-On: #1380
