### PR TITLE
feat(ui): refresh task graph through graph events

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -71,7 +71,7 @@ import {
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { TaskGraphEvent, WorkResponse } from '@invoker/contracts';
+import type { TaskGraphEvent, WorkflowMeta, WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
@@ -2022,6 +2022,20 @@ function createEmbeddedTerminalBackendFromConfig(
       delta: taskDeltaStream.stamp(delta),
     });
   };
+  const enqueueTaskGraphSnapshotForRenderer = (
+    reason: string,
+    tasks: TaskState[],
+    workflows: WorkflowMeta[],
+  ): void => {
+    enqueueTaskGraphEventForRenderer({
+      type: 'snapshot',
+      tasks: tasks as Extract<TaskGraphEvent, { type: 'snapshot' }>['tasks'],
+      workflows,
+      reason,
+      streamSequence: getTaskDeltaStreamSequence(),
+    });
+  };
+
 
   const sendTaskDeltaToRenderer = (delta: TaskDelta): void => {
     markWorkflowMetadataFromTaskDelta(delta);
@@ -3619,6 +3633,53 @@ function createEmbeddedTerminalBackendFromConfig(
       requestWorkflowMetadataPublish('clear');
     });
 
+
+    ipcMain.handle('invoker:refresh-task-graph', async () => {
+      const startedAtMs = Date.now();
+      let tasks: TaskState[];
+      let workflows: WorkflowMeta[];
+
+      if (!ownerMode) {
+        const delegated = await messageBus.request('headless.query', {
+          kind: 'tasks',
+          forceRefresh: true,
+        }) as unknown;
+        if (!delegated || typeof delegated !== 'object') {
+          throw new Error('refresh-task-graph owner delegation returned no snapshot');
+        }
+        const snapshot = delegated as {
+          tasks?: unknown[];
+          workflows?: unknown[];
+          invokerHomeRoot?: string;
+        };
+        if (!Array.isArray(snapshot.tasks) || !Array.isArray(snapshot.workflows)) {
+          throw new Error('refresh-task-graph owner delegation returned an invalid snapshot');
+        }
+        const localInvokerHomeRoot = resolveInvokerHomeRoot();
+        if (snapshot.invokerHomeRoot && snapshot.invokerHomeRoot !== localInvokerHomeRoot) {
+          throw new Error(
+            `refresh-task-graph owner home mismatch: owner=${snapshot.invokerHomeRoot} local=${localInvokerHomeRoot}`,
+          );
+        }
+        tasks = snapshot.tasks as TaskState[];
+        workflows = snapshot.workflows as WorkflowMeta[];
+      } else {
+        orchestrator.syncAllFromDb();
+        tasks = orchestrator.getAllTasks();
+        workflows = persistence.listWorkflows() as WorkflowMeta[];
+      }
+
+      enqueueTaskGraphSnapshotForRenderer(
+        ownerMode ? 'refresh-task-graph' : 'refresh-task-graph-delegated',
+        tasks,
+        workflows,
+      );
+      recordStartupDuration('refresh-task-graph.return', startedAtMs, {
+        taskCount: tasks.length,
+        workflowCount: workflows.length,
+        streamSequence: getTaskDeltaStreamSequence(),
+      });
+    });
     registerReadOnlyIpcHandlers({
       ipcMain,
       logger,

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -405,6 +405,10 @@ export const IpcChannels = {
     request: [forceRefresh?: boolean];
     response: { tasks: TaskState[]; workflows: WorkflowMeta[]; streamSequence: number };
   },
+  'invoker:refresh-task-graph': {} as {
+    request: [];
+    response: void;
+  },
   'invoker:get-events': {} as {
     request: [taskId: string];
     response: TaskEvent[];

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -351,12 +351,17 @@ export function hasMergeConflictExecution(task: TaskState | undefined): boolean 
 }
 
 export function App() {
-  const { tasks, workflows, clearTasks, refreshTasks } = useTasks();
+  const [graphRefreshSequence, setGraphRefreshSequence] = useState(0);
+  const handleTaskGraphSnapshotApplied = useCallback(() => {
+    setGraphRefreshSequence((sequence) => sequence + 1);
+  }, []);
+  const { tasks, workflows, clearTasks, refreshTasks } = useTasks({
+    onTaskGraphSnapshotApplied: handleTaskGraphSnapshotApplied,
+  });
   const invoker = useInvoker();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
-  const [graphRefreshSequence, setGraphRefreshSequence] = useState(0);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [stickySelectedWorkflow, setStickySelectedWorkflow] = useState<WorkflowMeta | null>(null);
   const [workflowSelectionDismissed, setWorkflowSelectionDismissed] = useState(false);
@@ -1333,7 +1338,6 @@ export function App() {
 
   const handleRefresh = useCallback(async () => {
     await refreshTasks(true);
-    setGraphRefreshSequence((sequence) => sequence + 1);
   }, [refreshTasks]);
 
   // ── Plan loading ──────────────────────────────────────────

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -62,6 +62,21 @@ export function createMockInvoker(
           });
         }),
     ),
+    refreshTaskGraph: vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          queueMicrotask(() => {
+            graphEventCallback?.({
+              type: 'snapshot',
+              tasks: taskSnapshot,
+              workflows: workflowSnapshot,
+              reason: 'mock-refresh',
+              streamSequence: 0,
+            });
+            resolve();
+          });
+        }),
+    ),
     onTaskDelta: vi.fn((cb: (delta: TaskDelta) => void) => {
       deltaCallback = cb;
       return () => { deltaCallback = undefined; };

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -78,13 +78,12 @@ describe('Side rail controls (component)', () => {
     mock.cleanup();
   });
 
-  it('Refresh button calls getTasks with forceRefresh=true', async () => {
+  it('Refresh button calls refreshTaskGraph', async () => {
     render(<App />);
     fireEvent.click(screen.getByTestId('rail-refresh'));
 
     await waitFor(() => {
-      expect(mock.api.getTasks).toHaveBeenCalled();
-      expect(mock.api.getTasks).toHaveBeenLastCalledWith(true);
+      expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
     });
   });
 
@@ -96,7 +95,7 @@ describe('Side rail controls (component)', () => {
     fireEvent.click(screen.getByTestId('rail-refresh'));
 
     await waitFor(() => {
-      expect(mock.api.getTasks).toHaveBeenLastCalledWith(true);
+      expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
     });
     await waitFor(() => {
       expect(fitViewMock.mock.calls.length).toBeGreaterThanOrEqual(2);

--- a/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
@@ -15,10 +15,11 @@ function installInvoker(opts: {
 }): {
   getTasksMock: ReturnType<typeof vi.fn>;
   reportUiPerfMock: ReturnType<typeof vi.fn>;
-  onTaskDeltaMock: ReturnType<typeof vi.fn>;
+  onTaskGraphEventMock: ReturnType<typeof vi.fn>;
+  refreshTaskGraphMock: ReturnType<typeof vi.fn>;
   fireDelta: (delta: unknown) => void;
 } {
-  let handler: ((delta: unknown) => void) | undefined;
+  let handler: ((event: unknown) => void) | undefined;
 
   (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = opts.bootstrap
     ? { tasks: opts.bootstrap.tasks, workflows: [], streamSequence: opts.bootstrap.streamSequence }
@@ -28,15 +29,29 @@ function installInvoker(opts: {
   const lastResponse = opts.responses[opts.responses.length - 1];
   const getTasksMock = vi.fn(async () => queue.shift() ?? lastResponse);
   const reportUiPerfMock = vi.fn();
-  const onTaskDeltaMock = vi.fn((cb: (delta: unknown) => void) => {
+  const refreshTaskGraphMock = vi.fn(async () => {
+    const response = queue.shift() ?? lastResponse;
+    queueMicrotask(() => {
+      handler?.({
+        type: 'snapshot',
+        tasks: response.tasks,
+        workflows: response.workflows,
+        reason: 'test-refresh',
+        streamSequence: response.streamSequence,
+      });
+    });
+  });
+  const onTaskGraphEventMock = vi.fn((cb: (event: unknown) => void) => {
     handler = cb;
     return () => { handler = undefined; };
   });
 
   (window as unknown as { invoker: Record<string, unknown> }).invoker = {
     getTasks: getTasksMock,
+    refreshTaskGraph: refreshTaskGraphMock,
     reportUiPerf: reportUiPerfMock,
-    onTaskDelta: onTaskDeltaMock,
+    onTaskGraphEvent: onTaskGraphEventMock,
+    onTaskDelta: vi.fn(() => () => {}),
     onWorkflowsChanged: vi.fn(() => () => {}),
     checkPrStatuses: vi.fn(async () => {}),
   };
@@ -44,8 +59,9 @@ function installInvoker(opts: {
   return {
     getTasksMock,
     reportUiPerfMock,
-    onTaskDeltaMock,
-    fireDelta: (delta) => handler?.(delta),
+    onTaskGraphEventMock,
+    refreshTaskGraphMock,
+    fireDelta: (delta) => handler?.({ type: 'delta', delta }),
   };
 }
 
@@ -64,7 +80,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     const t2 = makeUITask({ id: 't2', status: 'pending' });
     const t3 = makeUITask({ id: 't3', status: 'pending' });
 
-    const { getTasksMock, reportUiPerfMock, onTaskDeltaMock, fireDelta } = installInvoker({
+    const { getTasksMock, reportUiPerfMock, onTaskGraphEventMock, fireDelta } = installInvoker({
       bootstrap: { tasks: [t1, t2, t3], streamSequence: 0 },
       responses: [{ tasks: [t1, t2, t3], workflows: [], streamSequence: 0 }],
     });
@@ -72,7 +88,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(onTaskDeltaMock).toHaveBeenCalledTimes(1);
+      expect(onTaskGraphEventMock).toHaveBeenCalledTimes(1);
     });
     expect(getTasksMock).not.toHaveBeenCalled();
 
@@ -90,7 +106,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     expect(reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected')).toHaveLength(0);
   });
 
-  it('detects a 1,2,4 gap and triggers exactly one re-sync via getTasks(true)', async () => {
+  it('detects a 1,2,4 gap and triggers exactly one re-sync via refreshTaskGraph', async () => {
     const initial = [
       makeUITask({ id: 't1', status: 'pending' }),
       makeUITask({ id: 't2', status: 'pending' }),
@@ -102,7 +118,7 @@ describe('useTasks stream-sequence gap-detect', () => {
       makeUITask({ id: 't3', status: 'running' }),
     ];
 
-    const { getTasksMock, reportUiPerfMock, onTaskDeltaMock, fireDelta } = installInvoker({
+    const { getTasksMock, refreshTaskGraphMock, reportUiPerfMock, onTaskGraphEventMock, fireDelta } = installInvoker({
       bootstrap: { tasks: initial, streamSequence: 0 },
       responses: [
         { tasks: post, workflows: [], streamSequence: 4 },
@@ -112,7 +128,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(onTaskDeltaMock).toHaveBeenCalledTimes(1);
+      expect(onTaskGraphEventMock).toHaveBeenCalledTimes(1);
     });
     expect(getTasksMock).not.toHaveBeenCalled();
 
@@ -124,8 +140,8 @@ describe('useTasks stream-sequence gap-detect', () => {
     });
 
     await waitFor(() => {
-      expect(getTasksMock).toHaveBeenCalledTimes(1);
-      expect(getTasksMock).toHaveBeenLastCalledWith(true);
+      expect(refreshTaskGraphMock).toHaveBeenCalledTimes(1);
+      expect(getTasksMock).not.toHaveBeenCalled();
     });
 
     const gapReports = reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected');
@@ -143,7 +159,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     const initial = [makeUITask({ id: 't1', status: 'pending' })];
     const post = [makeUITask({ id: 't1', status: 'completed' })];
 
-    const { getTasksMock, onTaskDeltaMock, fireDelta } = installInvoker({
+    const { getTasksMock, refreshTaskGraphMock, onTaskGraphEventMock, fireDelta } = installInvoker({
       bootstrap: { tasks: initial, streamSequence: 0 },
       responses: [
         { tasks: post, workflows: [], streamSequence: 10 },
@@ -153,7 +169,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(onTaskDeltaMock).toHaveBeenCalledTimes(1);
+      expect(onTaskGraphEventMock).toHaveBeenCalledTimes(1);
     });
     expect(getTasksMock).not.toHaveBeenCalled();
 
@@ -164,7 +180,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     });
 
     await waitFor(() => {
-      expect(getTasksMock).toHaveBeenCalledTimes(1);
+      expect(refreshTaskGraphMock).toHaveBeenCalledTimes(1);
       expect(result.current.tasks.get('t1')?.status).toBe('completed');
     });
 
@@ -174,14 +190,14 @@ describe('useTasks stream-sequence gap-detect', () => {
     });
 
     expect(result.current.tasks.get('t1')?.status).toBe('completed');
-    expect(getTasksMock).toHaveBeenCalledTimes(1);
+    expect(refreshTaskGraphMock).toHaveBeenCalledTimes(1);
   });
 
   it('triggers only ONE re-sync when multiple gaps arrive in quick succession', async () => {
     const initial = [makeUITask({ id: 't1', status: 'pending' })];
     const post = [makeUITask({ id: 't1', status: 'completed' })];
 
-    const { getTasksMock, reportUiPerfMock, onTaskDeltaMock, fireDelta } = installInvoker({
+    const { getTasksMock, refreshTaskGraphMock, reportUiPerfMock, onTaskGraphEventMock, fireDelta } = installInvoker({
       bootstrap: { tasks: initial, streamSequence: 0 },
       responses: [
         { tasks: post, workflows: [], streamSequence: 100 },
@@ -191,7 +207,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(onTaskDeltaMock).toHaveBeenCalledTimes(1);
+      expect(onTaskGraphEventMock).toHaveBeenCalledTimes(1);
     });
     expect(getTasksMock).not.toHaveBeenCalled();
 
@@ -202,7 +218,7 @@ describe('useTasks stream-sequence gap-detect', () => {
       await new Promise((resolve) => setTimeout(resolve, 150));
     });
 
-    expect(getTasksMock).toHaveBeenCalledTimes(1);
+    expect(refreshTaskGraphMock).toHaveBeenCalledTimes(1);
     const gapReports = reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected');
     expect(gapReports).toHaveLength(1);
   });
@@ -210,7 +226,7 @@ describe('useTasks stream-sequence gap-detect', () => {
   it('skips gap-check for deltas without a streamSequence (backward compatibility)', async () => {
     const t1 = makeUITask({ id: 't1', status: 'pending' });
 
-    const { getTasksMock, reportUiPerfMock, onTaskDeltaMock, fireDelta } = installInvoker({
+    const { getTasksMock, reportUiPerfMock, onTaskGraphEventMock, fireDelta } = installInvoker({
       bootstrap: { tasks: [t1], streamSequence: 0 },
       responses: [{ tasks: [t1], workflows: [], streamSequence: 0 }],
     });
@@ -218,7 +234,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(onTaskDeltaMock).toHaveBeenCalledTimes(1);
+      expect(onTaskGraphEventMock).toHaveBeenCalledTimes(1);
     });
     expect(getTasksMock).not.toHaveBeenCalled();
 

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -245,32 +245,43 @@ describe('useTasks', () => {
     });
   });
 
-  it('forced refresh after a hydrated bootstrap still calls getTasks(true) and replaces state', async () => {
+  it('forced refresh after a hydrated bootstrap requests a graph refresh and waits for the snapshot event', async () => {
     const bootTask = makeUITask({ id: 'boot-1', description: 'Boot' });
     const refreshedTask = makeUITask({ id: 'refreshed-1', description: 'Refreshed' });
-    const getTasks = vi.fn().mockResolvedValue({ tasks: [refreshedTask], workflows: [] });
+    let taskGraphEventHandler: ((event: unknown) => void) | undefined;
     (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
       tasks: [bootTask],
       workflows: [{ id: 'wf-1', name: 'WF 1', status: 'running' }],
     };
+    const refreshTaskGraph = vi.fn(async () => {
+      taskGraphEventHandler?.({
+        type: 'snapshot',
+        tasks: [refreshedTask],
+        workflows: [],
+        reason: 'test-refresh',
+        streamSequence: 0,
+      });
+    });
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
-      getTasks,
+      getTasks: vi.fn().mockResolvedValue({ tasks: [bootTask], workflows: [] }),
+      refreshTaskGraph,
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
+        return () => {};
+      }),
       onTaskDelta: vi.fn(() => () => {}),
       onWorkflowsChanged: vi.fn(() => () => {}),
     };
 
     const { result } = renderHook(() => useTasks());
 
-    expect(getTasks).not.toHaveBeenCalled();
+    expect(refreshTaskGraph).not.toHaveBeenCalled();
 
     await act(async () => {
-      result.current.refreshTasks(true);
+      await result.current.refreshTasks(true);
     });
 
-    await waitFor(() => {
-      expect(getTasks).toHaveBeenCalledTimes(1);
-      expect(getTasks).toHaveBeenLastCalledWith(true);
-    });
+    expect(refreshTaskGraph).toHaveBeenCalledTimes(1);
 
     await waitFor(() => {
       expect(result.current.tasks.has('refreshed-1')).toBe(true);
@@ -311,10 +322,16 @@ describe('useTasks', () => {
     });
   });
 
-  it('passes forceRefresh flag to getTasks when requested', async () => {
+  it('forced refresh calls refreshTaskGraph instead of getTasks', async () => {
     const getTasks = vi.fn().mockResolvedValue({ tasks: [], workflows: [] });
+    const refreshTaskGraph = vi.fn(async () => {});
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [makeUITask({ id: 'boot-1' })],
+      workflows: [],
+    };
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
       getTasks,
+      refreshTaskGraph,
       onTaskDelta: vi.fn(() => () => {}),
       onWorkflowsChanged: vi.fn(() => () => {}),
     };
@@ -322,12 +339,12 @@ describe('useTasks', () => {
     const { result } = renderHook(() => useTasks());
 
     await act(async () => {
-      result.current.refreshTasks(true);
+      await result.current.refreshTasks(true);
     });
 
     await waitFor(() => {
-      expect(getTasks).toHaveBeenCalled();
-      expect(getTasks).toHaveBeenLastCalledWith(true);
+      expect(refreshTaskGraph).toHaveBeenCalledTimes(1);
+      expect(getTasks).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -21,8 +21,12 @@ export interface UseTasksResult {
   clearTasks: () => void;
   refreshTasks: (forceRefresh?: boolean) => Promise<void>;
 }
+export interface UseTasksOptions {
+  onTaskGraphSnapshotApplied?: () => void;
+}
 
-export function useTasks(): UseTasksResult {
+
+export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): UseTasksResult {
   const traceTaskDeltas =
     typeof window !== 'undefined' &&
     window.location.search.includes('traceTaskDeltas=1');
@@ -132,6 +136,14 @@ export function useTasks(): UseTasksResult {
     window.invoker.checkPrStatuses?.();
     return request.then(() => undefined);
   }, []);
+  const refreshTasks = useCallback((forceRefresh = false): Promise<void> => {
+    if (!forceRefresh) {
+      return fetchAll(false);
+    }
+    if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
+    return window.invoker.refreshTaskGraph?.() ?? fetchAll(true);
+  }, [fetchAll]);
+
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;
@@ -210,6 +222,7 @@ export function useTasks(): UseTasksResult {
           });
           lastSeenSequenceRef.current = firstEvent.streamSequence;
           isResyncInFlightRef.current = false;
+          onTaskGraphSnapshotApplied?.();
         }
 
         setTasks((prev) => {
@@ -287,7 +300,7 @@ export function useTasks(): UseTasksResult {
           });
           isResyncInFlightRef.current = true;
           graphEventPipelineRef.current?.clear();
-          fetchAll(true);
+          refreshTasks(true);
           return;
         }
         lastSeenSequenceRef.current = seq;
@@ -320,7 +333,7 @@ export function useTasks(): UseTasksResult {
       unsub();
       unsubWf?.();
     };
-  }, [fetchAll]);
+  }, [fetchAll, onTaskGraphSnapshotApplied, refreshTasks]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;
@@ -343,5 +356,5 @@ export function useTasks(): UseTasksResult {
     setWorkflows(new Map());
   }, []);
 
-  return { tasks, workflows, clearTasks, refreshTasks: fetchAll };
+  return { tasks, workflows, clearTasks, refreshTasks };
 }


### PR DESCRIPTION
## Summary

This changes forced graph refresh to publish a graph snapshot event instead of doing a direct renderer reload.

Before this, manual refresh and gap recovery called a snapshot read path and then patched local UI state.

Now refresh goes through one command, and the UI redraw happens when the graph snapshot event arrives on the normal stream.

This slice still keeps the old `task-delta` compatibility shim so the stack lands safely.

PR #1392 removes that shim and leaves `task-graph-event` as the only UI event path.

## Architecture

### Before

```mermaid
graph TD
    A[Refresh button or gap recovery] --> B[getTasks force refresh]
    B --> C[Direct snapshot replace in renderer]
```

### After

```mermaid
graph TD
    A[Refresh button or gap recovery] --> B[refresh-task-graph command]
    B --> C[Main syncs owner snapshot]
    C --> D[task-graph-event snapshot]
    D --> E[Renderer graph-event pipeline]
    E --> F[Graph remount plus state replace]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx src/__tests__/keyboard-controls.test.tsx`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e465a8bfa`
- Post-revert steps: None
- Data migration? No


Depends-On: #1381
