### PR TITLE
fix(ipc): make getTasks read-only

### DIFF
--- a/packages/app/e2e/embedded-terminal-pty.spec.ts
+++ b/packages/app/e2e/embedded-terminal-pty.spec.ts
@@ -73,7 +73,7 @@ test.describe('Embedded terminal PTY', () => {
       },
     ]);
 
-    const tasksResult = await page.evaluate(() => window.invoker.getTasks(true));
+    const tasksResult = await page.evaluate(() => window.invoker.getTasks());
     const tasks = Array.isArray(tasksResult) ? tasksResult : tasksResult.tasks;
     const task = tasks.find((candidate) => candidate.id.endsWith('/codex-resume'));
     const fullTaskId = task?.id;
@@ -131,7 +131,7 @@ test.describe('Embedded terminal PTY', () => {
       },
     ]);
 
-    const tasksResult = await page.evaluate(() => window.invoker.getTasks(true));
+    const tasksResult = await page.evaluate(() => window.invoker.getTasks());
     const tasks = Array.isArray(tasksResult) ? tasksResult : tasksResult.tasks;
     const task = tasks.find((candidate) => candidate.id.endsWith('/claude-resume'));
     const fullTaskId = task?.id;

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -231,7 +231,7 @@ export async function loadPlan(page: Page, plan: { tasks: readonly { id: string 
     return created?.id ?? workflows[workflows.length - 1]?.id ?? null;
   }, beforeIds);
   await page.waitForFunction(
-    (expectedTaskCount) => window.invoker.getTasks(true).then((result) => {
+    (expectedTaskCount) => window.invoker.getTasks().then((result) => {
       const tasks = Array.isArray(result) ? result : result.tasks;
       const workflows = Array.isArray(result) ? [] : result.workflows ?? [];
       return tasks.length >= expectedTaskCount && workflows.length > 0;
@@ -309,7 +309,7 @@ export async function waitForTaskStatus(
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const result = await page.evaluate(() => window.invoker.getTasks(true));
+    const result = await page.evaluate(() => window.invoker.getTasks());
     const tasks = Array.isArray(result) ? result : result.tasks;
     const task = tasks.find((t: any) => matchesTaskId(t.id, taskId));
     if (task && task.status === status) return;
@@ -326,7 +326,7 @@ export async function waitForTaskStarted(
 ): Promise<string> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const result = await page.evaluate(() => window.invoker.getTasks(true));
+    const result = await page.evaluate(() => window.invoker.getTasks());
     const tasks = Array.isArray(result) ? result : result.tasks;
     const task = tasks.find((t: any) => matchesTaskId(t.id, taskId));
     if (task && task.status !== 'pending') return task.status;

--- a/packages/app/e2e/gap-recovery-bench.spec.ts
+++ b/packages/app/e2e/gap-recovery-bench.spec.ts
@@ -195,7 +195,7 @@ test('gap-recovery bench: 5 iterations of synthetic-gap → resync at 30 workflo
         }, planYaml);
       }
 
-      const seeded = await page.evaluate(() => window.invoker.getTasks(true));
+      const seeded = await page.evaluate(() => window.invoker.getTasks());
       const seededTasks = Array.isArray(seeded) ? seeded : seeded.tasks;
       expect(seededTasks.length).toBe(expectedTaskCount);
     } finally {

--- a/packages/app/e2e/launching-stall-watchdog.spec.ts
+++ b/packages/app/e2e/launching-stall-watchdog.spec.ts
@@ -73,14 +73,14 @@ base.describe('Launch stall watchdog', () => {
       });
       await page.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(WATCHDOG_PLAN));
 
-      const initial = await page.evaluate(() => window.invoker.getTasks(true));
+      const initial = await page.evaluate(() => window.invoker.getTasks());
       const initialTasks = Array.isArray(initial) ? initial : initial.tasks;
       const stalled = findTask(initialTasks, 'stall-task');
       expect(stalled).toBeDefined();
 
       const settleDeadline = Date.now() + 10_000;
       while (Date.now() < settleDeadline) {
-        const snapshot = await page.evaluate(() => window.invoker.getTasks(true));
+        const snapshot = await page.evaluate(() => window.invoker.getTasks());
         const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
         const current = findTask(tasks, 'stall-task');
         if (current && current.status !== 'running') break;
@@ -105,7 +105,7 @@ base.describe('Launch stall watchdog', () => {
       const deadline = Date.now() + 15_000;
       let stalledTask: any | undefined;
       while (Date.now() < deadline) {
-        const snapshot = await page.evaluate(() => window.invoker.getTasks(true));
+        const snapshot = await page.evaluate(() => window.invoker.getTasks());
         const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
         stalledTask = findTask(tasks, 'stall-task');
         if (
@@ -180,14 +180,14 @@ base.describe('Launch stall watchdog', () => {
       });
       await page.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(WATCHDOG_PLAN));
 
-      const initial = await page.evaluate(() => window.invoker.getTasks(true));
+      const initial = await page.evaluate(() => window.invoker.getTasks());
       const initialTasks = Array.isArray(initial) ? initial : initial.tasks;
       const stalled = findTask(initialTasks, 'stall-task');
       expect(stalled).toBeDefined();
 
       const settleDeadline = Date.now() + 10_000;
       while (Date.now() < settleDeadline) {
-        const snapshot = await page.evaluate(() => window.invoker.getTasks(true));
+        const snapshot = await page.evaluate(() => window.invoker.getTasks());
         const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
         const current = findTask(tasks, 'stall-task');
         if (current && current.status !== 'running') break;
@@ -213,7 +213,7 @@ base.describe('Launch stall watchdog', () => {
         },
       }]);
 
-      const postInjectSnapshot = await page.evaluate(() => window.invoker.getTasks(true));
+      const postInjectSnapshot = await page.evaluate(() => window.invoker.getTasks());
       const postInjectTasks = Array.isArray(postInjectSnapshot) ? postInjectSnapshot : postInjectSnapshot.tasks;
       const postInjectTask = findTask(postInjectTasks, 'stall-task');
       expect(postInjectTask?.config?.runnerKind).toBe('ssh');
@@ -221,7 +221,7 @@ base.describe('Launch stall watchdog', () => {
       const deadline = Date.now() + 15_000;
       let stalledTask: any | undefined;
       while (Date.now() < deadline) {
-        const snapshot = await page.evaluate(() => window.invoker.getTasks(true));
+        const snapshot = await page.evaluate(() => window.invoker.getTasks());
         const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
         stalledTask = findTask(tasks, 'stall-task');
         if (

--- a/packages/app/e2e/orphan-relaunch.spec.ts
+++ b/packages/app/e2e/orphan-relaunch.spec.ts
@@ -84,7 +84,7 @@ base.describe('Orphan task relaunch on restart', () => {
 
     // Load the plan and synthesize an orphaned running task with no live handle.
     await page1.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(RELAUNCH_PLAN));
-    const loadedResult = await page1.evaluate(() => window.invoker.getTasks(true));
+    const loadedResult = await page1.evaluate(() => window.invoker.getTasks());
     const loadedTasks = Array.isArray(loadedResult) ? loadedResult : loadedResult.tasks;
     const loadedSlow = findTask(loadedTasks, 'slow-task');
     expect(loadedSlow).toBeDefined();
@@ -112,7 +112,7 @@ base.describe('Orphan task relaunch on restart', () => {
     const deadline2 = Date.now() + 60_000;
     let observedSlow: any;
     while (Date.now() < deadline2) {
-      const snapshot = await page1.evaluate(() => window.invoker.getTasks(true));
+      const snapshot = await page1.evaluate(() => window.invoker.getTasks());
       const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
       observedSlow = findTask(tasks, 'slow-task');
       if (observedSlow?.status === 'running' && observedSlow?.execution?.phase !== 'launching') {
@@ -124,7 +124,7 @@ base.describe('Orphan task relaunch on restart', () => {
     expect(observedSlow?.status).toBe('running');
     expect(observedSlow?.execution?.phase).not.toBe('launching');
 
-    const postResult = await page1.evaluate(() => window.invoker.getTasks(true));
+    const postResult = await page1.evaluate(() => window.invoker.getTasks());
     const postTasks = Array.isArray(postResult) ? postResult : postResult.tasks;
     const postSlow = findTask(postTasks, 'slow-task');
     expect(postSlow).toBeDefined();

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -117,7 +117,7 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
         }, planYaml);
       }
 
-      const seeded = await page.evaluate(() => window.invoker.getTasks(true));
+      const seeded = await page.evaluate(() => window.invoker.getTasks());
       const seededTasks = Array.isArray(seeded) ? seeded : seeded.tasks;
       expect(seededTasks.length).toBe(expectedTaskCount);
     } finally {
@@ -138,7 +138,7 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
       await dragGraphAndAssertViewportMoves(page);
 
       const result = await page.evaluate(async () => {
-        const tasksResult = await window.invoker.getTasks(true);
+        const tasksResult = await window.invoker.getTasks();
         const tasks = Array.isArray(tasksResult) ? tasksResult : tasksResult.tasks;
         const perf = await window.invoker.getUiPerfStats();
         const activityLogs = await window.invoker.getActivityLogs();

--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -47,7 +47,7 @@ function findTask(tasks: Array<{ id: string; status: string }>, taskId: string) 
 }
 
 async function getTasks(page: Page): Promise<any[]> {
-  const result = await page.evaluate(() => window.invoker.getTasks(true));
+  const result = await page.evaluate(() => window.invoker.getTasks());
   return Array.isArray(result) ? result : result.tasks;
 }
 

--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from 'vitest';
+import { registerReadOnlyIpcHandlers } from '../ipc-read-handlers.js';
+import { TaskSnapshotCache } from '../delta-merge.js';
+
+function makeTask(id: string) {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2026-01-01'),
+    config: {},
+    execution: {},
+  };
+}
+
+describe('registerReadOnlyIpcHandlers', () => {
+  it('get-tasks returns a snapshot without publishing renderer deltas', async () => {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler);
+      }),
+    };
+    const task = makeTask('wf-1/task-1');
+    const cache = new TaskSnapshotCache();
+    const sendTaskDeltaToRenderer = vi.fn();
+
+    registerReadOnlyIpcHandlers({
+      ipcMain: ipcMain as never,
+      logger: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+      } as never,
+      persistence: {
+        listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }]),
+      } as never,
+      getOrchestrator: () => ({
+        getAllTasks: () => [task],
+        getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
+      }) as never,
+      agentRegistry: {} as never,
+      lastKnownTaskStates: cache,
+      getMainWindow: () => ({ isDestroyed: () => false } as never),
+      sendTaskDeltaToRenderer,
+      loadTaskByIdFromPersistence: () => undefined,
+      resolveAgentSession: vi.fn(async () => null),
+      getOwnerMode: () => true,
+      getMessageBus: () => ({ request: vi.fn() }),
+      recordStartupDuration: vi.fn(),
+      getTaskDeltaStreamSequence: () => 42,
+    });
+
+    const result = await handlers.get('invoker:get-tasks')?.({});
+
+    expect(result).toEqual({
+      tasks: [task],
+      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
+      streamSequence: 42,
+    });
+    expect(sendTaskDeltaToRenderer).not.toHaveBeenCalled();
+    expect(Array.from(cache.keys())).toEqual([]);
+  });
+});

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -17,8 +17,6 @@ export interface RegisterReadOnlyIpcHandlersContext {
   lastKnownTaskStates: TaskSnapshotCache;
   getMainWindow: () => BrowserWindow | null;
   sendTaskDeltaToRenderer: (delta: TaskDelta) => void;
-  requestWorkflowMetadataPublish: (reason: string) => void;
-  setLastKnownWorkflowCount: (count: number) => void;
   loadTaskByIdFromPersistence: (taskId: string) => TaskState | undefined;
   resolveAgentSession: (
     sessionId: string,
@@ -28,7 +26,6 @@ export interface RegisterReadOnlyIpcHandlersContext {
   ) => Promise<unknown>;
   getOwnerMode?: () => boolean;
   getMessageBus?: () => Pick<MessageBus, 'request'>;
-  timeStartupPhase: <T>(label: string, fn: () => T, fields?: () => Record<string, unknown>) => T;
   recordStartupDuration: (label: string, startedAtMs: number, fields?: Record<string, unknown>) => void;
   getTaskDeltaStreamSequence: () => number;
 }
@@ -64,13 +61,10 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     lastKnownTaskStates,
     getMainWindow,
     sendTaskDeltaToRenderer,
-    requestWorkflowMetadataPublish,
-    setLastKnownWorkflowCount,
     loadTaskByIdFromPersistence,
     resolveAgentSession,
     getOwnerMode,
     getMessageBus,
-    timeStartupPhase,
     recordStartupDuration,
     getTaskDeltaStreamSequence,
   } = context;
@@ -110,37 +104,16 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     return { workflow, tasks };
   });
 
-  ipcMain.handle('invoker:get-tasks', async (_event, forceRefresh?: boolean) => {
+  ipcMain.handle('invoker:get-tasks', async () => {
     const startedAtMs = Date.now();
     const orchestrator = getOrchestrator();
-    const delegatedSnapshot = asDelegatedTasksSnapshot(await delegateOwnerQuery<DelegatedTasksSnapshot>(
-      'tasks',
-      { forceRefresh: forceRefresh === true },
-    ));
+    const delegatedSnapshot = asDelegatedTasksSnapshot(await delegateOwnerQuery<DelegatedTasksSnapshot>('tasks'));
     const localInvokerHomeRoot = resolveInvokerHomeRoot();
     const delegatedHomeMismatch = delegatedSnapshot
       ? hasInvokerHomeMismatch(delegatedSnapshot, localInvokerHomeRoot)
       : false;
     if (delegatedSnapshot && !delegatedHomeMismatch) {
-      const previousTaskIds = new Set(lastKnownTaskStates.keys());
-      lastKnownTaskStates.clear();
-      for (const task of delegatedSnapshot.tasks) {
-        lastKnownTaskStates.set(task.id, JSON.stringify(task));
-        previousTaskIds.delete(task.id);
-        const mainWindow = getMainWindow();
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          sendTaskDeltaToRenderer({ type: 'created', task });
-        }
-      }
-      const mainWindow = getMainWindow();
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        for (const removedTaskId of previousTaskIds) {
-          sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
-        }
-        requestWorkflowMetadataPublish(forceRefresh ? 'get-tasks-force-refresh-delegated' : 'get-tasks-delegated');
-      }
-      setLastKnownWorkflowCount(delegatedSnapshot.workflows.length);
-      recordStartupDuration(forceRefresh ? 'get-tasks.force-refresh.delegated-return' : 'get-tasks.delegated-return', startedAtMs, {
+      recordStartupDuration('get-tasks.delegated-return', startedAtMs, {
         taskCount: delegatedSnapshot.tasks.length,
         workflowCount: delegatedSnapshot.workflows.length,
         jsonSizeBytes: Buffer.byteLength(JSON.stringify(delegatedSnapshot), 'utf8'),
@@ -154,46 +127,14 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
         { module: 'ipc' },
       );
     }
-    if (forceRefresh) {
-      timeStartupPhase('get-tasks.force-refresh.syncAllFromDb', () => orchestrator.syncAllFromDb(), () => ({
-        taskCount: orchestrator.getAllTasks().length,
-      }));
-    }
+
     const tasks = orchestrator.getAllTasks();
     const workflows = persistence.listWorkflows();
-    if (forceRefresh) {
-      const previousTaskIds = new Set(lastKnownTaskStates.keys());
-      lastKnownTaskStates.clear();
-      for (const task of tasks) {
-        lastKnownTaskStates.set(task.id, JSON.stringify(task));
-        previousTaskIds.delete(task.id);
-        const mainWindow = getMainWindow();
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          sendTaskDeltaToRenderer({ type: 'created', task });
-        }
-      }
-      const mainWindow = getMainWindow();
-      if (mainWindow && !mainWindow.isDestroyed()) {
-        for (const removedTaskId of previousTaskIds) {
-          sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
-        }
-        requestWorkflowMetadataPublish('get-tasks-force-refresh');
-      }
-      setLastKnownWorkflowCount(workflows.length);
-    }
+    const streamSequence = getTaskDeltaStreamSequence();
     logger.info(
-      `get-tasks(forceRefresh=${forceRefresh ? 'true' : 'false'}) returning ${tasks.length} tasks, ${workflows.length} workflows`,
+      `get-tasks returning ${tasks.length} tasks, ${workflows.length} workflows`,
       { module: 'ipc' },
     );
-    const streamSequence = getTaskDeltaStreamSequence();
-    if (forceRefresh) {
-      recordStartupDuration('get-tasks.force-refresh.return', startedAtMs, {
-        taskCount: tasks.length,
-        workflowCount: workflows.length,
-        jsonSizeBytes: Buffer.byteLength(JSON.stringify({ tasks, workflows }), 'utf8'),
-        streamSequence,
-      });
-    }
     return { tasks, workflows, streamSequence };
   });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1612,8 +1612,8 @@ if (isHeadless) {
           if (kind === 'workflow-status') {
             return orchestrator.getWorkflowStatus();
           }
-          if (kind === 'tasks') {
-            if ((req as { forceRefresh?: boolean }).forceRefresh) {
+          if (kind === 'tasks' || kind === 'task-graph-refresh') {
+            if (kind === 'task-graph-refresh') {
               orchestrator.syncAllFromDb();
             }
             return {
@@ -3281,8 +3281,8 @@ function createEmbeddedTerminalBackendFromConfig(
         if (kind === 'workflow-status') {
           return orchestrator.getWorkflowStatus();
         }
-        if (kind === 'tasks') {
-          if ((req as { forceRefresh?: boolean }).forceRefresh) {
+        if (kind === 'tasks' || kind === 'task-graph-refresh') {
+          if (kind === 'task-graph-refresh') {
             orchestrator.syncAllFromDb();
           }
           return {
@@ -3641,8 +3641,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
       if (!ownerMode) {
         const delegated = await messageBus.request('headless.query', {
-          kind: 'tasks',
-          forceRefresh: true,
+          kind: 'task-graph-refresh',
         }) as unknown;
         if (!delegated || typeof delegated !== 'object') {
           throw new Error('refresh-task-graph owner delegation returned no snapshot');
@@ -3689,13 +3688,10 @@ function createEmbeddedTerminalBackendFromConfig(
       lastKnownTaskStates,
       getMainWindow: () => mainWindow,
       sendTaskDeltaToRenderer,
-      requestWorkflowMetadataPublish,
-      setLastKnownWorkflowCount: (count) => { lastKnownWorkflowCount = count; },
       loadTaskByIdFromPersistence,
       resolveAgentSession,
       getOwnerMode: () => ownerMode,
       getMessageBus: () => messageBus,
-      timeStartupPhase,
       recordStartupDuration,
       getTaskDeltaStreamSequence,
     });

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -402,7 +402,7 @@ export const IpcChannels = {
 
   // Task Queries
   'invoker:get-tasks': {} as {
-    request: [forceRefresh?: boolean];
+    request: [];
     response: { tasks: TaskState[]; workflows: WorkflowMeta[]; streamSequence: number };
   },
   'invoker:refresh-task-graph': {} as {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -355,7 +355,7 @@ export function App() {
   const handleTaskGraphSnapshotApplied = useCallback(() => {
     setGraphRefreshSequence((sequence) => sequence + 1);
   }, []);
-  const { tasks, workflows, clearTasks, refreshTasks } = useTasks({
+  const { tasks, workflows, clearTasks, refreshTasks, refreshTaskGraph } = useTasks({
     onTaskGraphSnapshotApplied: handleTaskGraphSnapshotApplied,
   });
   const invoker = useInvoker();
@@ -1337,8 +1337,8 @@ export function App() {
   }, [contextMenu, focusKeyboardRegion, workflowContextMenu]);
 
   const handleRefresh = useCallback(async () => {
-    await refreshTasks(true);
-  }, [refreshTasks]);
+    await refreshTaskGraph();
+  }, [refreshTaskGraph]);
 
   // ── Plan loading ──────────────────────────────────────────
   const handleLoadPlan = useCallback(

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -52,12 +52,13 @@ export function createMockInvoker(
     // Defer resolution one microtask so snapshot is read after synchronous setTasks()
     // in tests (useTasks fetchAll races mount vs setTasks; real IPC resolves later too).
     getTasks: vi.fn(
-      (_forceRefresh?: boolean) =>
-        new Promise<{ tasks: TaskState[]; workflows: WorkflowMeta[] }>((resolve) => {
+      () =>
+        new Promise<{ tasks: TaskState[]; workflows: WorkflowMeta[]; streamSequence: number }>((resolve) => {
           queueMicrotask(() => {
             resolve({
               tasks: taskSnapshot,
               workflows: workflowSnapshot,
+              streamSequence: 0,
             });
           });
         }),

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -236,7 +236,7 @@ describe('useTasks', () => {
 
     await waitFor(() => {
       expect(getTasks).toHaveBeenCalledTimes(1);
-      expect(getTasks).toHaveBeenLastCalledWith(false);
+      expect(getTasks).toHaveBeenLastCalledWith();
     });
 
     await waitFor(() => {
@@ -278,7 +278,7 @@ describe('useTasks', () => {
     expect(refreshTaskGraph).not.toHaveBeenCalled();
 
     await act(async () => {
-      await result.current.refreshTasks(true);
+      await result.current.refreshTaskGraph();
     });
 
     expect(refreshTaskGraph).toHaveBeenCalledTimes(1);
@@ -313,7 +313,7 @@ describe('useTasks', () => {
 
     await waitFor(() => {
       expect(getTasks).toHaveBeenCalledTimes(1);
-      expect(getTasks).toHaveBeenLastCalledWith(false);
+      expect(getTasks).toHaveBeenLastCalledWith();
     });
 
     await waitFor(() => {
@@ -339,7 +339,7 @@ describe('useTasks', () => {
     const { result } = renderHook(() => useTasks());
 
     await act(async () => {
-      await result.current.refreshTasks(true);
+      await result.current.refreshTaskGraph();
     });
 
     await waitFor(() => {

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -19,7 +19,8 @@ export interface UseTasksResult {
   tasks: Map<string, TaskState>;
   workflows: Map<string, WorkflowMeta>;
   clearTasks: () => void;
-  refreshTasks: (forceRefresh?: boolean) => Promise<void>;
+  refreshTasks: () => Promise<void>;
+  refreshTaskGraph: () => Promise<void>;
 }
 export interface UseTasksOptions {
   onTaskGraphSnapshotApplied?: () => void;
@@ -79,11 +80,11 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
   const lastSeenSequenceRef = useRef<number>(bootstrapState?.streamSequence ?? 0);
   const isResyncInFlightRef = useRef<boolean>(false);
 
-  const fetchAll = useCallback((forceRefresh = false): Promise<void> => {
+  const fetchAll = useCallback((): Promise<void> => {
     if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
     const gen = ++getTasksGenerationRef.current;
     const requestedAt = performance.now();
-    const request = window.invoker.getTasks(forceRefresh).then((result) => {
+    const request = window.invoker.getTasks().then((result) => {
       const requestDurationMs = performance.now() - requestedAt;
       if (gen !== getTasksGenerationRef.current) {
         return;
@@ -115,7 +116,6 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       void window.invoker.reportUiPerf?.('useTasks_snapshot_replace', {
         taskCount: taskList.length,
         workflowCount: wfList.length,
-        forceRefresh,
         requestDurationMs,
         replaceDurationMs,
         jsonSizeBytes: new Blob([JSON.stringify(result)]).size,
@@ -125,7 +125,6 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
         void window.invoker.reportUiPerf?.('startup_snapshot_applied', {
           taskCount: taskList.length,
           workflowCount: wfList.length,
-          forceRefresh,
           elapsedMs: Math.round(performance.now()),
           processElapsedMs: bootstrapState?.appStartedAtEpochMs
             ? Date.now() - bootstrapState.appStartedAtEpochMs
@@ -136,12 +135,10 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     window.invoker.checkPrStatuses?.();
     return request.then(() => undefined);
   }, []);
-  const refreshTasks = useCallback((forceRefresh = false): Promise<void> => {
-    if (!forceRefresh) {
-      return fetchAll(false);
-    }
+  const refreshTasks = useCallback((): Promise<void> => fetchAll(), [fetchAll]);
+  const refreshTaskGraph = useCallback((): Promise<void> => {
     if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
-    return window.invoker.refreshTaskGraph?.() ?? fetchAll(true);
+    return window.invoker.refreshTaskGraph?.() ?? fetchAll();
   }, [fetchAll]);
 
 
@@ -167,7 +164,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     // Preload bootstrap already hydrated tasks/workflows synchronously, so
     // the immediate non-forced snapshot would be a redundant full payload.
     // Skip it when bootstrap is populated; deltas keep state live, and
-    // explicit refreshTasks() / refreshTasks(true) callers still run fetchAll.
+    // explicit refreshTasks() callers still run fetchAll.
     if (bootstrapHasState) {
       reportedStartupSnapshotRef.current = true;
       void window.invoker.reportUiPerf?.('startup_snapshot_skipped_bootstrap_complete', {
@@ -210,6 +207,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
             for (const task of firstEvent.tasks) next.set(task.id, task);
             return next;
           });
+          const replaceStartedAt = performance.now();
           setWorkflows(() => {
             const wfMap = new Map<string, WorkflowMeta>();
             for (const wf of firstEvent.workflows) {
@@ -223,6 +221,14 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
           lastSeenSequenceRef.current = firstEvent.streamSequence;
           isResyncInFlightRef.current = false;
           onTaskGraphSnapshotApplied?.();
+          void window.invoker.reportUiPerf?.('useTasks_snapshot_replace', {
+            taskCount: firstEvent.tasks.length,
+            workflowCount: firstEvent.workflows.length,
+            source: 'task-graph-event',
+            reason: firstEvent.reason,
+            replaceDurationMs: performance.now() - replaceStartedAt,
+            jsonSizeBytes: new Blob([JSON.stringify(firstEvent)]).size,
+          });
         }
 
         setTasks((prev) => {
@@ -300,7 +306,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
           });
           isResyncInFlightRef.current = true;
           graphEventPipelineRef.current?.clear();
-          refreshTasks(true);
+          refreshTaskGraph();
           return;
         }
         lastSeenSequenceRef.current = seq;
@@ -333,7 +339,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       unsub();
       unsubWf?.();
     };
-  }, [fetchAll, onTaskGraphSnapshotApplied, refreshTasks]);
+  }, [fetchAll, onTaskGraphSnapshotApplied, refreshTaskGraph]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;
@@ -356,5 +362,5 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     setWorkflows(new Map());
   }, []);
 
-  return { tasks, workflows, clearTasks, refreshTasks };
+  return { tasks, workflows, clearTasks, refreshTasks, refreshTaskGraph };
 }


### PR DESCRIPTION
## Summary

This makes `getTasks` a read-only snapshot call again.

Before this, `getTasks(true)` both read state and published fake UI updates. That broke the rule that screen changes must come from the event stream.

Now `getTasks` only returns the current snapshot. Forced refresh moved to the graph refresh command.

This slice still keeps the old `task-delta` compatibility shim so the stack lands safely.

PR #1392 removes that shim and leaves `task-graph-event` as the only UI event path.

## Architecture

### Before

```mermaid
graph TD
    A[getTasks true] --> B[Return snapshot]
    A --> C[Emit created and removed deltas]
    B --> D[Renderer snapshot replace]
    C --> E[Renderer delta pipeline]
```

### After

```mermaid
graph TD
    A[getTasks] --> B[Return snapshot only]
    C[refresh-task-graph] --> D[Owner sync]
    D --> E[task-graph-event snapshot]
    E --> F[Renderer graph-event pipeline]
    F --> G[UI redraw]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx src/__tests__/keyboard-controls.test.tsx`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/ipc-read-handlers.test.ts`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f27aba455`
- Post-revert steps: None
- Data migration? No


Depends-On: #1382
