### PR TITLE
refactor(ui): keep command refreshes on command path

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1254,11 +1254,11 @@ export function App() {
       if (selectedWorkflowId === workflowId) {
         setSelectedWorkflowId(null);
       }
-      refreshTasks();
+      refreshTaskGraph();
     } catch (err) {
       console.error('Delete Workflow failed:', err);
     }
-  }, [refreshTasks, selectedWorkflowId]);
+  }, [refreshTaskGraph, selectedWorkflowId]);
 
   const handleFix = useCallback(async (taskId: string, agentName: string) => {
     setContextMenu(null);
@@ -1279,11 +1279,11 @@ export function App() {
       } else {
         await window.invoker?.fixWithAgent(taskId, agentName);
       }
-      refreshTasks();
+      refreshTaskGraph();
     } catch (err) {
       console.error('Fix failed:', err);
     }
-  }, [tasks, refreshTasks]);
+  }, [tasks, refreshTaskGraph]);
 
   const handleCancelTask = useCallback(async (taskId: string) => {
     setContextMenu(null);
@@ -1352,12 +1352,12 @@ export function App() {
         const parsed = yaml.load(planText) as any;
         setPlanName(parsed?.name ?? 'Untitled Plan');
         setOnFinish(parsed?.onFinish ?? 'merge');
-        refreshTasks();
+        refreshTaskGraph();
       } catch (err) {
         console.error('Failed to load plan:', err);
       }
     },
-    [invoker, refreshTasks],
+    [invoker, refreshTaskGraph],
   );
 
   const handleFileSelect = useCallback(
@@ -1568,12 +1568,12 @@ export function App() {
       if (!invoker) return;
       try {
         await invoker.setMergeBranch(workflowId, baseBranch);
-        refreshTasks();
+        refreshTaskGraph();
       } catch (err) {
         console.error('Failed to set merge branch:', err);
       }
     },
-    [invoker, refreshTasks],
+    [invoker, refreshTaskGraph],
   );
 
   // ── Modal triggers ────────────────────────────────────────


### PR DESCRIPTION
## Summary

This keeps command-triggered refreshes on the command path.

Before this, several UI commands ran and then forced a read snapshot with `refreshTasks()`. That mixed command follow-up work back into the read path.

Now those flows call `refreshTaskGraph()` and stay on the event-driven command path.

This slice still keeps the old `task-delta` compatibility shim so the stack lands safely.

PR #1392 removes that shim and leaves `task-graph-event` as the only UI event path.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/keyboard-controls.test.tsx`
- [x] `pnpm --filter @invoker/ui build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a1896764c`
- Post-revert steps: None
- Data migration? No


Depends-On: #1386
