### PR TITLE
test(ipc): lock read handler context to queries

### DIFF
--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { RegisterReadOnlyIpcHandlersContext } from '../ipc-read-handlers.js';
 import { registerReadOnlyIpcHandlers } from '../ipc-read-handlers.js';
 
 function makeTask(id: string) {
@@ -12,6 +13,17 @@ function makeTask(id: string) {
     execution: {},
   };
 }
+
+function expectReadContextWriteToolsAreAbsent(): void {
+  const exposesTaskDeltaPublisher: 'sendTaskDeltaToRenderer' extends keyof RegisterReadOnlyIpcHandlersContext ? true : false = false;
+  const exposesMainWindow: 'getMainWindow' extends keyof RegisterReadOnlyIpcHandlersContext ? true : false = false;
+  const exposesTaskSnapshotCache: 'lastKnownTaskStates' extends keyof RegisterReadOnlyIpcHandlersContext ? true : false = false;
+
+  expect(exposesTaskDeltaPublisher).toBe(false);
+  expect(exposesMainWindow).toBe(false);
+  expect(exposesTaskSnapshotCache).toBe(false);
+}
+
 
 describe('registerReadOnlyIpcHandlers', () => {
   it('get-tasks returns a snapshot', async () => {
@@ -55,4 +67,8 @@ describe('registerReadOnlyIpcHandlers', () => {
       streamSequence: 42,
     });
   });
+  it('does not expose renderer write tools to read handlers', () => {
+    expectReadContextWriteToolsAreAbsent();
+  });
+
 });


### PR DESCRIPTION
## Summary

This adds a regression test that locks the read handler context to query-only dependencies.

If someone re-adds renderer write tools like `sendTaskDeltaToRenderer`, `getMainWindow`, or `lastKnownTaskStates`, this test stops compiling and fails the suite.

That makes the query-only boundary structural instead of tribal knowledge.

This slice still keeps the old `task-delta` compatibility shim so the stack lands safely.

PR #1392 removes that shim and leaves `task-graph-event` as the only UI event path.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/ipc-read-handlers.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert b2207bf28`
- Post-revert steps: None
- Data migration? No


Depends-On: #1387
