### PR TITLE
refactor(app): narrow task graph event publishing

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -71,7 +71,7 @@ import {
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { TaskGraphEvent, WorkflowMeta, WorkResponse } from '@invoker/contracts';
+import type { WorkflowMeta, WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
@@ -195,6 +195,7 @@ import {
   resolveActionDiagnosticsStallThresholdMs,
 } from './action-graph-diagnostics.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
+import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import {
   registerBootstrapStateIpc,
   registerGuiMutationHandler as registerGuiMutationIpcHandler,
@@ -1828,8 +1829,6 @@ function createEmbeddedTerminalBackendFromConfig(
   };
   const pendingOutputBuffers = new Map<string, string[]>();
   const outputFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  const pendingUiTaskGraphEvents: TaskGraphEvent[] = [];
-  let uiTaskGraphEventFlushTimer: ReturnType<typeof setTimeout> | null = null;
   let workflowMetadataInvalidator: WorkflowMetadataInvalidator | null = null;
   let workflowMetadataPublisher: CoalescedWorkflowMetadataPublisher | null = null;
   let lastKnownWorkflowCount = 0;
@@ -1969,34 +1968,6 @@ function createEmbeddedTerminalBackendFromConfig(
     outputFlushTimers.set(taskId, timer);
   };
 
-  const flushUiTaskGraphEvents = (): void => {
-    if (uiTaskGraphEventFlushTimer) {
-      clearTimeout(uiTaskGraphEventFlushTimer);
-      uiTaskGraphEventFlushTimer = null;
-    }
-    if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive || pendingUiTaskGraphEvents.length === 0) {
-      pendingUiTaskGraphEvents.length = 0;
-      return;
-    }
-    const batch = pendingUiTaskGraphEvents.splice(0, Math.min(pendingUiTaskGraphEvents.length, 250));
-    if (pendingUiTaskGraphEvents.length > 0) {
-      uiTaskGraphEventFlushTimer = setTimeout(() => flushUiTaskGraphEvents(), 0);
-      uiTaskGraphEventFlushTimer.unref?.();
-    }
-    if (batch.length >= 200) {
-      uiPerfStats.largeTaskDeltaBatches += 1;
-      uiPerfStats.maxTaskDeltaBatchSize = Math.max(uiPerfStats.maxTaskDeltaBatchSize, batch.length);
-      logger.info(`large task-graph-event batch chunked size=${batch.length} remaining=${pendingUiTaskGraphEvents.length}`, {
-        module: 'ui-backpressure',
-      });
-    }
-    if (batch.length === 1) {
-      mainWindow.webContents.send('invoker:task-graph-event', batch[0]);
-      return;
-    }
-    mainWindow.webContents.send('invoker:task-graph-event-batch', batch);
-  };
-
   const taskDeltaStream = createTaskDeltaStreamSequence();
   const getTaskDeltaStreamSequence = (): number => taskDeltaStream.current();
 
@@ -2004,42 +1975,23 @@ function createEmbeddedTerminalBackendFromConfig(
     workflowMetadataInvalidator?.markFromTaskDelta(delta);
   };
 
-  const enqueueTaskGraphEventForRenderer = (event: TaskGraphEvent): void => {
-    if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) {
-      return;
-    }
-    pendingUiTaskGraphEvents.push(event);
-    if (uiTaskGraphEventFlushTimer) {
-      return;
-    }
-    uiTaskGraphEventFlushTimer = setTimeout(() => flushUiTaskGraphEvents(), 25);
-    uiTaskGraphEventFlushTimer.unref?.();
-  };
-
-  const enqueueTaskDeltaForRenderer = (delta: TaskDelta): void => {
-    enqueueTaskGraphEventForRenderer({
-      type: 'delta',
-      delta: taskDeltaStream.stamp(delta),
-    });
-  };
-  const enqueueTaskGraphSnapshotForRenderer = (
-    reason: string,
-    tasks: TaskState[],
-    workflows: WorkflowMeta[],
-  ): void => {
-    enqueueTaskGraphEventForRenderer({
-      type: 'snapshot',
-      tasks: tasks as Extract<TaskGraphEvent, { type: 'snapshot' }>['tasks'],
-      workflows,
-      reason,
-      streamSequence: getTaskDeltaStreamSequence(),
-    });
-  };
-
+  const taskGraphEventPublisher = createTaskGraphEventPublisher({
+    getMainWindow: () => mainWindow,
+    isUiInteractive: () => uiInteractive,
+    stampDelta: (delta) => taskDeltaStream.stamp(delta),
+    getStreamSequence: getTaskDeltaStreamSequence,
+    onLargeBatch: ({ batchSize, remaining }) => {
+      uiPerfStats.largeTaskDeltaBatches += 1;
+      uiPerfStats.maxTaskDeltaBatchSize = Math.max(uiPerfStats.maxTaskDeltaBatchSize, batchSize);
+      logger.info(`large task-graph-event batch chunked size=${batchSize} remaining=${remaining}`, {
+        module: 'ui-backpressure',
+      });
+    },
+  });
 
   const sendTaskDeltaToRenderer = (delta: TaskDelta): void => {
     markWorkflowMetadataFromTaskDelta(delta);
-    enqueueTaskDeltaForRenderer(delta);
+    taskGraphEventPublisher.publishDelta(delta);
   };
 
   const applyTaskDeltaToOwnerCacheOrRecover = (delta: TaskDelta): TaskDelta[] => {
@@ -3445,7 +3397,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
 
       for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(d)) {
-        enqueueTaskDeltaForRenderer(rendererDelta);
+        taskGraphEventPublisher.publishDelta(rendererDelta);
       }
     });
 
@@ -3668,7 +3620,7 @@ function createEmbeddedTerminalBackendFromConfig(
         workflows = persistence.listWorkflows() as WorkflowMeta[];
       }
 
-      enqueueTaskGraphSnapshotForRenderer(
+      taskGraphEventPublisher.publishSnapshot(
         ownerMode ? 'refresh-task-graph' : 'refresh-task-graph-delegated',
         tasks,
         workflows,

--- a/packages/app/src/task-graph-event-publisher.ts
+++ b/packages/app/src/task-graph-event-publisher.ts
@@ -1,0 +1,87 @@
+import type { BrowserWindow } from 'electron';
+import type { TaskGraphEvent, WorkflowMeta } from '@invoker/contracts';
+import type { TaskDelta, TaskState } from '@invoker/workflow-core';
+
+const UI_TASK_GRAPH_FLUSH_DELAY_MS = 25;
+const UI_TASK_GRAPH_BATCH_LIMIT = 250;
+const UI_TASK_GRAPH_LARGE_BATCH_THRESHOLD = 200;
+
+type SnapshotTaskStates = Extract<TaskGraphEvent, { type: 'snapshot' }>['tasks'];
+
+export interface TaskGraphEventPublisher {
+  publishDelta(delta: TaskDelta): void;
+  publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[]): void;
+}
+
+export interface CreateTaskGraphEventPublisherOptions {
+  getMainWindow: () => BrowserWindow | null;
+  isUiInteractive: () => boolean;
+  stampDelta: (delta: TaskDelta) => TaskDelta;
+  getStreamSequence: () => number;
+  onLargeBatch?: (stats: { batchSize: number; remaining: number }) => void;
+}
+
+export function createTaskGraphEventPublisher(
+  options: CreateTaskGraphEventPublisherOptions,
+): TaskGraphEventPublisher {
+  const pendingEvents: TaskGraphEvent[] = [];
+  let flushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const flush = (): void => {
+    if (flushTimer) {
+      clearTimeout(flushTimer);
+      flushTimer = null;
+    }
+
+    const mainWindow = options.getMainWindow();
+    if (!mainWindow || mainWindow.isDestroyed() || !options.isUiInteractive() || pendingEvents.length === 0) {
+      pendingEvents.length = 0;
+      return;
+    }
+
+    const batch = pendingEvents.splice(0, Math.min(pendingEvents.length, UI_TASK_GRAPH_BATCH_LIMIT));
+    if (pendingEvents.length > 0) {
+      flushTimer = setTimeout(flush, 0);
+      flushTimer.unref?.();
+    }
+    if (batch.length >= UI_TASK_GRAPH_LARGE_BATCH_THRESHOLD) {
+      options.onLargeBatch?.({ batchSize: batch.length, remaining: pendingEvents.length });
+    }
+    if (batch.length === 1) {
+      mainWindow.webContents.send('invoker:task-graph-event', batch[0]);
+      return;
+    }
+    mainWindow.webContents.send('invoker:task-graph-event-batch', batch);
+  };
+
+  const publishEvent = (event: TaskGraphEvent): void => {
+    const mainWindow = options.getMainWindow();
+    if (!mainWindow || mainWindow.isDestroyed() || !options.isUiInteractive()) {
+      return;
+    }
+    pendingEvents.push(event);
+    if (flushTimer) {
+      return;
+    }
+    flushTimer = setTimeout(flush, UI_TASK_GRAPH_FLUSH_DELAY_MS);
+    flushTimer.unref?.();
+  };
+
+  return {
+    publishDelta(delta: TaskDelta): void {
+      publishEvent({
+        type: 'delta',
+        delta: options.stampDelta(delta),
+      });
+    },
+    publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[]): void {
+      publishEvent({
+        type: 'snapshot',
+        tasks: tasks as SnapshotTaskStates,
+        workflows,
+        reason,
+        streamSequence: options.getStreamSequence(),
+      });
+    },
+  };
+}


### PR DESCRIPTION
## Summary

This moves task graph event publishing behind one small module.

Before this, batching, stamping, and renderer sends all lived inline in `main.ts`. That made it easy for more code paths to reach directly into the UI event surface.

Now `main.ts` uses one publisher object for graph deltas and graph snapshots.

This slice still keeps the old `task-delta` compatibility shim so the stack lands safely.

PR #1392 removes that shim and leaves `task-graph-event` as the only UI event path.

## Architecture

### Before

```mermaid
graph TD
    A[main.ts call site] --> B[inline queue logic]
    B --> C[inline batch flush]
    C --> D[webContents.send]
```

### After

```mermaid
graph TD
    A[main.ts call site] --> B[task graph event publisher]
    B --> C[queue and batch flush]
    C --> D[webContents.send]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx src/__tests__/keyboard-controls.test.tsx`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 94e79da23`
- Post-revert steps: None
- Data migration? No


Depends-On: #1388
