### PR TITLE
Fix intent cancellation Step 3: SSH startup lineage guards (regression gated v2)

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
@@ -190,6 +190,8 @@ describe('SSH worktree metadata repro', () => {
 
     const updateSpy = vi.fn();
     const handleResponseSpy = vi.fn();
+    const onLaunchFailed = vi.fn();
+    const logEvent = vi.fn();
 
     const runner = new TaskRunner({
       orchestrator: {
@@ -200,6 +202,7 @@ describe('SSH worktree metadata repro', () => {
       persistence: {
         updateTask: updateSpy,
         appendTaskOutput: vi.fn(),
+        logEvent,
       } as any,
       executorRegistry: {
         getDefault: () => failingExecutor,
@@ -207,6 +210,7 @@ describe('SSH worktree metadata repro', () => {
         getAll: () => [failingExecutor],
       } as any,
       cwd: '/tmp',
+      callbacks: { onLaunchFailed },
     });
 
     await runner.executeTask(staleLaunchTask);
@@ -220,5 +224,15 @@ describe('SSH worktree metadata repro', () => {
     }));
     // And no failed response may be emitted against the newer selected attempt.
     expect(handleResponseSpy).not.toHaveBeenCalled();
+    expect(onLaunchFailed).not.toHaveBeenCalled();
+    expect(logEvent).toHaveBeenCalledWith('wf-1/test-execution-engine', 'task.executor.stale_startup_failure', {
+      attemptId: 'attempt-1',
+      executorType: 'ssh',
+      error: expect.stringContaining('SSH remote script failed'),
+      workspacePath: ownerPath,
+      branch: staleBranch,
+      hasAgentSessionId: false,
+      hasContainerId: false,
+    });
   });
 });

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1163,12 +1163,14 @@ describe('TaskRunner', () => {
         get: () => throwingExecutor,
         getAll: () => [throwingExecutor],
       };
+      const onLaunchFailed = vi.fn();
 
       const runner = new TaskRunner({
         orchestrator: orchestrator as any,
-        persistence: { updateTask } as any,
+        persistence: { updateTask, logEvent: vi.fn() } as any,
         executorRegistry: registry as any,
         cwd: '/tmp',
+        callbacks: { onLaunchFailed },
       });
 
       // Task was launched with attempt-1 but orchestrator now shows attempt-2
@@ -1189,6 +1191,7 @@ describe('TaskRunner', () => {
       );
       // Failed WorkResponse must NOT be emitted
       expect(handleWorkerResponse).not.toHaveBeenCalled();
+      expect(onLaunchFailed).not.toHaveBeenCalled();
     });
 
     it('suppresses metadata write and failed response when generation has advanced', async () => {
@@ -1217,12 +1220,14 @@ describe('TaskRunner', () => {
         get: () => throwingExecutor,
         getAll: () => [throwingExecutor],
       };
+      const onLaunchFailed = vi.fn();
 
       const runner = new TaskRunner({
         orchestrator: orchestrator as any,
-        persistence: { updateTask } as any,
+        persistence: { updateTask, logEvent: vi.fn() } as any,
         executorRegistry: registry as any,
         cwd: '/tmp',
+        callbacks: { onLaunchFailed },
       });
 
       const task = makeTask({
@@ -1241,6 +1246,7 @@ describe('TaskRunner', () => {
         }),
       );
       expect(handleWorkerResponse).not.toHaveBeenCalled();
+      expect(onLaunchFailed).not.toHaveBeenCalled();
     });
 
     it('still persists metadata and emits response when lineage is current', async () => {
@@ -1269,12 +1275,14 @@ describe('TaskRunner', () => {
         get: () => throwingExecutor,
         getAll: () => [throwingExecutor],
       };
+      const onLaunchFailed = vi.fn();
 
       const runner = new TaskRunner({
         orchestrator: orchestrator as any,
         persistence: { updateTask } as any,
         executorRegistry: registry as any,
         cwd: '/tmp',
+        callbacks: { onLaunchFailed },
       });
 
       const task = makeTask({
@@ -1299,6 +1307,11 @@ describe('TaskRunner', () => {
           actionId: 'current-1',
           status: 'failed',
         }),
+      );
+      expect(onLaunchFailed).toHaveBeenCalledWith(
+        'current-1',
+        expect.objectContaining({ message: expect.stringContaining('Executor startup failed (ssh)') }),
+        throwingExecutor,
       );
     });
 
@@ -1328,12 +1341,14 @@ describe('TaskRunner', () => {
         get: () => throwingExecutor,
         getAll: () => [throwingExecutor],
       };
+      const onLaunchFailed = vi.fn();
 
       const runner = new TaskRunner({
         orchestrator: orchestrator as any,
-        persistence: { updateTask } as any,
+        persistence: { updateTask, logEvent: vi.fn() } as any,
         executorRegistry: registry as any,
         cwd: '/tmp',
+        callbacks: { onLaunchFailed },
       });
 
       const task = makeTask({
@@ -1352,6 +1367,7 @@ describe('TaskRunner', () => {
         }),
       );
       expect(handleWorkerResponse).not.toHaveBeenCalled();
+      expect(onLaunchFailed).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -992,13 +992,14 @@ export class TaskRunner {
         } catch {
           // Preserve the original startup failure if output persistence also fails.
         }
+        const launchStale = this.isLaunchStale(task.id, attemptId, startGeneration);
         // Only persist startup-failure metadata when the launch is still
         // current.  If the task has moved to a newer attempt or generation
         // (e.g. via recreate-task), writing old workspace/branch metadata
         // would corrupt the live attempt's state.
         if (
           (meta.workspacePath || meta.branch || meta.agentSessionId || meta.containerId)
-          && !this.isLaunchStale(task.id, attemptId, task.execution.generation ?? 0)
+          && !launchStale
         ) {
           const execution: Record<string, string> = {};
           if (meta.workspacePath) execution.workspacePath = meta.workspacePath;
@@ -1020,13 +1021,26 @@ export class TaskRunner {
             execution: execution as any,
           });
         }
+        if (launchStale) {
+          this.persistence.logEvent?.(task.id, 'task.executor.stale_startup_failure', {
+            attemptId,
+            executorType: executor.type,
+            error: err instanceof Error ? err.message : String(err),
+            workspacePath: meta.workspacePath,
+            branch: meta.branch,
+            hasAgentSessionId: Boolean(meta.agentSessionId),
+            hasContainerId: Boolean(meta.containerId),
+          });
+        }
         this.pendingPoolSelections.delete(task.id);
         this.releasePoolSelectionLease(poolSelectionForStart);
         const wrapped = new Error(
           `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}`,
           { cause: err },
         );
-        this.callbacks.onLaunchFailed?.(task.id, wrapped, executor);
+        if (!launchStale) {
+          this.callbacks.onLaunchFailed?.(task.id, wrapped, executor);
+        }
         throw wrapped;
       } finally {
         clearInterval(preStartHeartbeatTimer);


### PR DESCRIPTION
## Summary

SSH startup failures now check the launch lineage before writing executor metadata back to the task row.

Stale failures are kept as diagnostics without overwriting the current attempt's workspace, branch, session, or container metadata.

Older failed launches also stop emitting launch-failure callbacks against a newer selected attempt.

## Architecture

### Before

```mermaid
graph TD
    A[SSH launch attempt starts] --> B[Attempt advances or generation changes]
    B --> C[Old startup failure returns]
    C --> D[Persist old executor metadata]
    C --> E[Emit launch failure callback]
    D --> F[Live task row points at stale worktree]
    E --> G[Newer attempt receives old failure]
```

### After

```mermaid
graph TD
    A[SSH launch attempt starts] --> B[Attempt advances or generation changes]
    B --> C[Old startup failure returns]
    C --> D{Launch lineage current?}
    D -- Yes --> E[Persist executor metadata]
    D -- Yes --> F[Emit launch failure callback]
    D -- No --> G[Log stale startup diagnostic]
    G --> H[Leave live task metadata unchanged]
```

## Test Plan

- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <pr-merge-commit>`
- Post-revert steps: Re-run `pnpm run test:all`
- Data migration? No