### PR TITLE
refactor(ui): remove legacy task-delta shim

### DIFF
--- a/packages/app/src/preload.ts
+++ b/packages/app/src/preload.ts
@@ -52,7 +52,7 @@ if (process.env.NODE_ENV === 'test') {
 // Event channels: each becomes (cb) => { subscribe; return unsubscribe }
 for (const channel of Object.keys(IpcEventChannels)) {
   const method = channelToEventMethod(channel);
-  if (channel === 'invoker:task-delta' || channel === 'invoker:task-graph-event') {
+  if (channel === 'invoker:task-graph-event') {
     api[method] = (cb: (...args: unknown[]) => void) => {
       const pendingBatchItems: unknown[] = [];
       let drainTimer: ReturnType<typeof setTimeout> | null = null;

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -670,9 +670,6 @@ export const IpcTestOnlyChannels = {
 // Pushed from main → renderer via webContents.send.
 
 export const IpcEventChannels = {
-  'invoker:task-delta': {} as {
-    payload: TaskDelta;
-  },
   'invoker:task-graph-event': {} as {
     payload: TaskGraphEvent;
   },

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -21,7 +21,7 @@ import type { TerminalOutputEvent } from '@invoker/contracts';
 export interface MockInvoker {
   /** The mock InvokerAPI object installed on window.invoker. */
   api: InvokerAPI;
-  /** Replace the task snapshot and fire 'created' deltas for each task. */
+  /** Replace the task snapshot and fire matching 'created' graph events. */
   setTasks: (tasks: TaskState[], workflows?: WorkflowMeta[]) => void;
   /** Directly fire a task delta to subscribers. */
   fireDelta: (delta: TaskDelta) => void;
@@ -43,7 +43,6 @@ export function createMockInvoker(
 ): MockInvoker {
   let taskSnapshot = initialTasks;
   let workflowSnapshot = initialWorkflows;
-  let deltaCallback: ((delta: TaskDelta) => void) | undefined;
   let graphEventCallback: ((event: TaskGraphEvent) => void) | undefined;
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
@@ -78,10 +77,6 @@ export function createMockInvoker(
           });
         }),
     ),
-    onTaskDelta: vi.fn((cb: (delta: TaskDelta) => void) => {
-      deltaCallback = cb;
-      return () => { deltaCallback = undefined; };
-    }),
     onTaskGraphEvent: vi.fn((cb: (event: TaskGraphEvent) => void) => {
       graphEventCallback = cb;
       return () => { graphEventCallback = undefined; };
@@ -208,16 +203,13 @@ export function createMockInvoker(
     taskSnapshot = tasks;
     if (workflows) workflowSnapshot = workflows;
 
-    // Fire created deltas for each task
+    // Fire created graph events for each task
     for (const task of tasks) {
-      const delta: TaskDelta = { type: 'created', task };
-      deltaCallback?.(delta);
-      graphEventCallback?.({ type: 'delta', delta });
+      graphEventCallback?.({ type: 'delta', delta: { type: 'created', task } });
     }
   }
 
   function fireDelta(delta: TaskDelta) {
-    deltaCallback?.(delta);
     graphEventCallback?.({ type: 'delta', delta });
   }
   function fireGraphEvent(event: TaskGraphEvent) {

--- a/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
@@ -51,7 +51,6 @@ function installInvoker(opts: {
     refreshTaskGraph: refreshTaskGraphMock,
     reportUiPerf: reportUiPerfMock,
     onTaskGraphEvent: onTaskGraphEventMock,
-    onTaskDelta: vi.fn(() => () => {}),
     onWorkflowsChanged: vi.fn(() => () => {}),
     checkPrStatuses: vi.fn(async () => {}),
   };

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -10,13 +10,11 @@ import { makeUITask } from './helpers/mock-invoker.js';
 
 describe('useTasks', () => {
   let workflowsChangedHandler: ((wfList: unknown[]) => void) | undefined;
-  let taskDeltaHandler: ((delta: unknown) => void) | undefined;
   let taskGraphEventHandler: ((event: unknown) => void) | undefined;
 
   beforeEach(() => {
     vi.useRealTimers();
     workflowsChangedHandler = undefined;
-    taskDeltaHandler = undefined;
     taskGraphEventHandler = undefined;
     (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
       tasks: [],
@@ -24,10 +22,6 @@ describe('useTasks', () => {
     };
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
       getTasks: vi.fn().mockResolvedValue({ tasks: [], workflows: [] }),
-      onTaskDelta: vi.fn((cb: (delta: unknown) => void) => {
-        taskDeltaHandler = cb;
-        return () => {};
-      }),
       onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
         taskGraphEventHandler = cb;
         return () => {};
@@ -53,7 +47,7 @@ describe('useTasks', () => {
     };
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
       getTasks: vi.fn().mockResolvedValue({ tasks: [bootTask], workflows: [] }),
-      onTaskDelta: vi.fn(() => () => {}),
+      onTaskGraphEvent: vi.fn(() => () => {}),
       onWorkflowsChanged: vi.fn(() => () => {}),
     };
 
@@ -156,7 +150,7 @@ describe('useTasks', () => {
         .fn()
         .mockReturnValueOnce(firstPending)
         .mockResolvedValue({ tasks: [t1], workflows: [] }),
-      onTaskDelta: vi.fn(() => () => {}),
+      onTaskGraphEvent: vi.fn(() => () => {}),
       onWorkflowsChanged: vi.fn(() => () => {}),
     };
 
@@ -191,7 +185,7 @@ describe('useTasks', () => {
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
       getTasks,
       reportUiPerf,
-      onTaskDelta: vi.fn(() => () => {}),
+      onTaskGraphEvent: vi.fn(() => () => {}),
       onWorkflowsChanged: vi.fn(() => () => {}),
     };
 
@@ -228,7 +222,7 @@ describe('useTasks', () => {
     };
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
       getTasks,
-      onTaskDelta: vi.fn(() => () => {}),
+      onTaskGraphEvent: vi.fn(() => () => {}),
       onWorkflowsChanged: vi.fn(() => () => {}),
     };
 
@@ -269,7 +263,6 @@ describe('useTasks', () => {
         taskGraphEventHandler = cb;
         return () => {};
       }),
-      onTaskDelta: vi.fn(() => () => {}),
       onWorkflowsChanged: vi.fn(() => () => {}),
     };
 
@@ -299,7 +292,7 @@ describe('useTasks', () => {
     };
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
       getTasks,
-      onTaskDelta: vi.fn(() => () => {}),
+      onTaskGraphEvent: vi.fn(() => () => {}),
       onWorkflowsChanged: vi.fn(() => () => {}),
     };
 
@@ -332,7 +325,7 @@ describe('useTasks', () => {
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
       getTasks,
       refreshTaskGraph,
-      onTaskDelta: vi.fn(() => () => {}),
+      onTaskGraphEvent: vi.fn(() => () => {}),
       onWorkflowsChanged: vi.fn(() => () => {}),
     };
 
@@ -360,8 +353,8 @@ describe('useTasks', () => {
         tasks: [taskA, taskB],
         workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed' }],
       }),
-      onTaskDelta: vi.fn((cb: (delta: unknown) => void) => {
-        taskDeltaHandler = cb;
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
         return () => {};
       }),
       onWorkflowsChanged: vi.fn((cb: (wfList: unknown[]) => void) => {
@@ -374,19 +367,25 @@ describe('useTasks', () => {
     expect(result.current.workflows.get('wf-1')?.status).toBe('failed');
 
     await act(async () => {
-      taskDeltaHandler!({
-        type: 'updated',
-        taskId: 'wf-1/task-a',
-        changes: { status: 'pending' },
-        taskStateVersion: 2,
-        previousTaskStateVersion: 1,
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: 'wf-1/task-a',
+          changes: { status: 'pending' },
+          taskStateVersion: 2,
+          previousTaskStateVersion: 1,
+        },
       });
-      taskDeltaHandler!({
-        type: 'updated',
-        taskId: 'wf-1/task-b',
-        changes: { status: 'pending' },
-        taskStateVersion: 2,
-        previousTaskStateVersion: 1,
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: 'wf-1/task-b',
+          changes: { status: 'pending' },
+          taskStateVersion: 2,
+          previousTaskStateVersion: 1,
+        },
       });
       await new Promise((resolve) => setTimeout(resolve, 110));
     });
@@ -459,8 +458,8 @@ describe('useTasks', () => {
         tasks: [failedTask, downstreamTask, mergeTask],
         workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'running' }],
       }),
-      onTaskDelta: vi.fn((cb: (delta: unknown) => void) => {
-        taskDeltaHandler = cb;
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
         return () => {};
       }),
       onWorkflowsChanged: vi.fn((cb: (wfList: unknown[]) => void) => {
@@ -473,12 +472,15 @@ describe('useTasks', () => {
     expect(result.current.workflows.get('wf-1')?.status).toBe('running');
 
     await act(async () => {
-      taskDeltaHandler!({
-        type: 'updated',
-        taskId: 'wf-1/add-regression-coverage',
-        changes: { status: 'failed' },
-        taskStateVersion: 2,
-        previousTaskStateVersion: 1,
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: 'wf-1/add-regression-coverage',
+          changes: { status: 'failed' },
+          taskStateVersion: 2,
+          previousTaskStateVersion: 1,
+        },
       });
       await new Promise((resolve) => setTimeout(resolve, 110));
     });

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -138,8 +138,8 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
   const refreshTasks = useCallback((): Promise<void> => fetchAll(), [fetchAll]);
   const refreshTaskGraph = useCallback((): Promise<void> => {
     if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
-    return window.invoker.refreshTaskGraph?.() ?? fetchAll();
-  }, [fetchAll]);
+    return window.invoker.refreshTaskGraph();
+  }, []);
 
 
   useEffect(() => {
@@ -315,8 +315,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       graphEventPipelineRef.current?.push(event);
     };
 
-    const unsub = window.invoker.onTaskGraphEvent?.(handleTaskGraphEvent)
-      ?? window.invoker.onTaskDelta((delta) => handleTaskGraphEvent({ type: 'delta', delta }));
+    const unsub = window.invoker.onTaskGraphEvent(handleTaskGraphEvent);
 
     const unsubWf = window.invoker.onWorkflowsChanged?.((wfList: any[]) => {
       if (Array.isArray(wfList)) {


### PR DESCRIPTION
## Summary

This removes the last `task-delta` compatibility shim from the UI stack.

Earlier stack slices kept the old event name and renderer fallback so the graph event migration could land one step at a time.

Now preload, `useTasks`, and the test mocks require `task-graph-event` and `refreshTaskGraph()` directly.

## Architecture

### Before

```mermaid
graph TD
    A[preload and useTasks] --> B[task-graph-event path]
    A --> C[legacy task-delta fallback]
```

### After

```mermaid
graph TD
    A[preload and useTasks] --> B[task-graph-event path only]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx src/__tests__/keyboard-controls.test.tsx`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 2ee74b826`
- Post-revert steps: None
- Data migration? No


Depends-On: #1389
