### PR TITLE
Recovery lifecycle 2a: auto-fix command context

### DIFF
--- a/packages/app/src/__tests__/auto-fix-intents.test.ts
+++ b/packages/app/src/__tests__/auto-fix-intents.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import type { WorkflowMutationIntent } from '@invoker/data-store';
-import { isFixIntentForTask, listOpenFixIntentsForTask } from '../auto-fix-intents.js';
+import {
+  buildFixWithAgentMutationArgs,
+  buildHeadlessFixArgs,
+  decodeReviewGateCiContext,
+  encodeReviewGateCiContext,
+  hasOpenFixIntentForTask,
+  isFixIntentForTask,
+  isReviewGateCiContextStale,
+  listOpenFixIntentsForTask,
+  parseFixWithAgentMutationArgs,
+  parseHeadlessFixArgs,
+  type ReviewGateCiContext,
+} from '../auto-fix-intents.js';
 
 function makeIntent(overrides: Partial<WorkflowMutationIntent>): WorkflowMutationIntent {
   return {
@@ -52,6 +64,171 @@ describe('auto-fix-intents', () => {
     ];
 
     expect(listOpenFixIntentsForTask(intents, 'wf-1/task-1').map((intent) => intent.id)).toEqual([1, 2]);
+  });
+
+  it('detects duplicate open fix intents across IPC and headless shapes', () => {
+    const ipcIntent = makeIntent({ args: ['wf-1/task-1'] });
+    const headlessIntent = makeIntent({
+      channel: 'headless.exec',
+      args: [{ args: ['fix', 'wf-1/task-1', 'claude', '--auto-fix'] }],
+    });
+    const otherTask = makeIntent({ args: ['wf-1/task-2'] });
+
+    expect(hasOpenFixIntentForTask([ipcIntent], 'wf-1/task-1')).toBe(true);
+    expect(hasOpenFixIntentForTask([headlessIntent], 'wf-1/task-1')).toBe(true);
+    expect(hasOpenFixIntentForTask([otherTask], 'wf-1/task-1')).toBe(false);
+    expect(hasOpenFixIntentForTask([], 'wf-1/task-1')).toBe(false);
+  });
+
+  it('matches structured auto-fix IPC intents (taskId stays first) for dedup', () => {
+    const structured = makeIntent({
+      args: buildFixWithAgentMutationArgs('wf-1/task-1', 'claude', { autoFix: true }) as WorkflowMutationIntent['args'],
+    });
+    expect(isFixIntentForTask(structured, 'wf-1/task-1')).toBe(true);
+    expect(isFixIntentForTask(structured, 'wf-1/task-2')).toBe(false);
+  });
+});
+
+describe('parseHeadlessFixArgs', () => {
+  it('parses a manual fix without auto-fix context', () => {
+    expect(parseHeadlessFixArgs(['fix', 'wf-1/task-1', 'codex'])).toEqual({
+      taskId: 'wf-1/task-1',
+      agentName: 'codex',
+      autoFix: false,
+      reviewGateContext: undefined,
+    });
+  });
+
+  it('parses the --auto-fix flag without disturbing positional args', () => {
+    expect(parseHeadlessFixArgs(['fix', 'wf-1/task-1', 'claude', '--auto-fix'])).toEqual({
+      taskId: 'wf-1/task-1',
+      agentName: 'claude',
+      autoFix: true,
+      reviewGateContext: undefined,
+    });
+  });
+
+  it('parses an encoded review-gate CI context and implies auto-fix', () => {
+    const ctx: ReviewGateCiContext = {
+      reviewId: 'review-9',
+      generation: 2,
+      selectedAttemptId: 'attempt-7',
+      branch: 'experiment/foo',
+    };
+    const parsed = parseHeadlessFixArgs([
+      'fix', 'wf-1/task-1', '--review-gate-ci', encodeReviewGateCiContext(ctx),
+    ]);
+    expect(parsed.taskId).toBe('wf-1/task-1');
+    expect(parsed.autoFix).toBe(true);
+    expect(parsed.reviewGateContext).toEqual(ctx);
+  });
+
+  it('ignores a malformed review-gate context payload', () => {
+    const parsed = parseHeadlessFixArgs(['fix', 'wf-1/task-1', '--review-gate-ci', 'not-json']);
+    expect(parsed.reviewGateContext).toBeUndefined();
+    expect(parsed.autoFix).toBe(false);
+  });
+});
+
+describe('buildHeadlessFixArgs', () => {
+  it('builds a manual fix command unchanged', () => {
+    expect(buildHeadlessFixArgs('wf-1/task-1', 'claude')).toEqual(['fix', 'wf-1/task-1', 'claude']);
+    expect(buildHeadlessFixArgs('wf-1/task-1', undefined)).toEqual(['fix', 'wf-1/task-1']);
+  });
+
+  it('appends --auto-fix and review-gate context that round-trips through parsing', () => {
+    const ctx: ReviewGateCiContext = { reviewId: 'r1', generation: 3, selectedAttemptId: 'a1' };
+    const args = buildHeadlessFixArgs('wf-1/task-1', 'codex', { autoFix: true, reviewGateContext: ctx });
+    expect(args.slice(0, 4)).toEqual(['fix', 'wf-1/task-1', 'codex', '--auto-fix']);
+    const parsed = parseHeadlessFixArgs(args);
+    expect(parsed).toEqual({
+      taskId: 'wf-1/task-1',
+      agentName: 'codex',
+      autoFix: true,
+      reviewGateContext: ctx,
+    });
+  });
+});
+
+describe('fix-with-agent mutation options', () => {
+  it('omits the options arg for a manual fix', () => {
+    expect(buildFixWithAgentMutationArgs('wf-1/task-1', 'claude')).toEqual(['wf-1/task-1', 'claude']);
+  });
+
+  it('round-trips structured auto-fix options through build/parse', () => {
+    const ctx: ReviewGateCiContext = { reviewId: 'r1', generation: 1 };
+    const args = buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', { autoFix: true, reviewGateContext: ctx });
+    expect(parseFixWithAgentMutationArgs(args)).toEqual({
+      taskId: 'wf-1/task-1',
+      agentName: 'codex',
+      context: { autoFix: true, reviewGateContext: ctx },
+    });
+  });
+
+  it('parses legacy two-argument calls as non-auto-fix', () => {
+    expect(parseFixWithAgentMutationArgs(['wf-1/task-1', 'claude'])).toEqual({
+      taskId: 'wf-1/task-1',
+      agentName: 'claude',
+      context: { autoFix: false, reviewGateContext: undefined },
+    });
+    expect(parseFixWithAgentMutationArgs(['wf-1/task-1'])).toEqual({
+      taskId: 'wf-1/task-1',
+      agentName: undefined,
+      context: { autoFix: false, reviewGateContext: undefined },
+    });
+  });
+});
+
+describe('review-gate CI context staleness', () => {
+  const ctx: ReviewGateCiContext = {
+    reviewId: 'review-1',
+    generation: 2,
+    selectedAttemptId: 'attempt-1',
+    branch: 'experiment/foo',
+  };
+
+  it('treats matching lineage as current', () => {
+    expect(isReviewGateCiContextStale(ctx, {
+      reviewId: 'review-1',
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'experiment/foo',
+    })).toBe(false);
+  });
+
+  it('flags a moved selected attempt, generation, review, or branch as stale', () => {
+    expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-1', generation: 2, selectedAttemptId: 'attempt-2', branch: 'experiment/foo' })).toBe(true);
+    expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-1', generation: 3, selectedAttemptId: 'attempt-1', branch: 'experiment/foo' })).toBe(true);
+    expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-2', generation: 2, selectedAttemptId: 'attempt-1', branch: 'experiment/foo' })).toBe(true);
+    expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-1', generation: 2, selectedAttemptId: 'attempt-1', branch: 'experiment/bar' })).toBe(true);
+  });
+
+  it('defaults a missing generation to 0 when comparing', () => {
+    const zeroGen: ReviewGateCiContext = { reviewId: 'r', generation: 0 };
+    expect(isReviewGateCiContextStale(zeroGen, { reviewId: 'r' })).toBe(false);
+  });
+});
+
+describe('review-gate CI context encode/decode', () => {
+  it('round-trips a full context', () => {
+    const ctx: ReviewGateCiContext = {
+      reviewId: 'r1',
+      generation: 4,
+      selectedAttemptId: 'a1',
+      branch: 'b1',
+      headSha: 'deadbeef',
+      fixContext: 'fix the failing checks',
+    };
+    expect(decodeReviewGateCiContext(encodeReviewGateCiContext(ctx))).toEqual(ctx);
+  });
+
+  it('returns undefined for empty, non-string, or invalid payloads', () => {
+    expect(decodeReviewGateCiContext(undefined)).toBeUndefined();
+    expect(decodeReviewGateCiContext('')).toBeUndefined();
+    expect(decodeReviewGateCiContext(42)).toBeUndefined();
+    expect(decodeReviewGateCiContext('{not json')).toBeUndefined();
+    expect(decodeReviewGateCiContext(JSON.stringify({ generation: 1 }))).toBeUndefined();
+    expect(decodeReviewGateCiContext(JSON.stringify({ reviewId: 'r' }))).toBeUndefined();
   });
 });
 

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -1,9 +1,25 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LocalBus } from '@invoker/transport';
 
 import { SharedMutationOwnerTimeoutError, electronCommandArgs, runHeadlessClientCommand } from '../headless-client.js';
 
 describe('headless-client', () => {
+  // These tests exercise the *client* delegation path, which only runs when the
+  // process is not itself a standalone owner. A leaked `INVOKER_HEADLESS_STANDALONE=1`
+  // from the surrounding shell would short-circuit delegation to the local runtime
+  // and make every owner-delegation assertion fail, so pin it off for the suite.
+  const savedStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
+  beforeEach(() => {
+    delete process.env.INVOKER_HEADLESS_STANDALONE;
+  });
+  afterEach(() => {
+    if (savedStandalone === undefined) {
+      delete process.env.INVOKER_HEADLESS_STANDALONE;
+    } else {
+      process.env.INVOKER_HEADLESS_STANDALONE = savedStandalone;
+    }
+  });
+
   it('passes Linux headless stability flags before the app entry point', () => {
     const args = electronCommandArgs(['query', 'workflows'], 'linux');
     const mainIndex = args.findIndex((arg) => arg.endsWith('/main.js'));
@@ -43,6 +59,26 @@ describe('headless-client', () => {
     }));
     expect(ensureStandaloneOwner).not.toHaveBeenCalled();
     expect(runElectronHeadless).not.toHaveBeenCalled();
+  });
+
+  it('delegates an auto-fix command, preserving the --auto-fix flag and stripping --no-track', async () => {
+    const bus = new LocalBus();
+    const ownerHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.exec', ownerHandler);
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-af', mode: 'standalone' }));
+
+    const exitCode = await runHeadlessClientCommand(['fix', 'wf-1/task-1', 'claude', '--auto-fix', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
+      args: ['fix', 'wf-1/task-1', 'claude', '--auto-fix'],
+      noTrack: true,
+      waitForApproval: false,
+    }));
   });
 
   it('delegates recreate-downstream as a mutating command through headless.exec, honoring --no-track', async () => {

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -4,10 +4,6 @@ import { LocalBus } from '@invoker/transport';
 import { SharedMutationOwnerTimeoutError, electronCommandArgs, runHeadlessClientCommand } from '../headless-client.js';
 
 describe('headless-client', () => {
-  // These tests exercise the *client* delegation path, which only runs when the
-  // process is not itself a standalone owner. A leaked `INVOKER_HEADLESS_STANDALONE=1`
-  // from the surrounding shell would short-circuit delegation to the local runtime
-  // and make every owner-delegation assertion fail, so pin it off for the suite.
   const savedStandalone = process.env.INVOKER_HEADLESS_STANDALONE;
   beforeEach(() => {
     delete process.env.INVOKER_HEADLESS_STANDALONE;

--- a/packages/app/src/__tests__/headless-fix-autofix-context.test.ts
+++ b/packages/app/src/__tests__/headless-fix-autofix-context.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { LocalBus } from '@invoker/transport';
+import type { MessageBus } from '@invoker/transport';
+import { encodeReviewGateCiContext } from '../auto-fix-intents.js';
+
+const { fixWithAgentActionMock, finalizeMock } = vi.hoisted(() => ({
+  fixWithAgentActionMock: vi.fn(async () => ({ kind: 'fixWithAgent', autoApproved: false, started: [] })),
+  finalizeMock: vi.fn(async () => {}),
+}));
+
+vi.mock('../workflow-actions.js', async (importActual) => {
+  const actual = await importActual<typeof import('../workflow-actions.js')>();
+  return { ...actual, fixWithAgentAction: fixWithAgentActionMock };
+});
+
+vi.mock('../global-topup.js', async (importActual) => {
+  const actual = await importActual<typeof import('../global-topup.js')>();
+  return { ...actual, finalizeMutationWithGlobalTopup: finalizeMock };
+});
+
+function makeDeps(autoFixAttempts: number | null, executionOverrides: Record<string, unknown> = {}) {
+  const updateTask = vi.fn();
+  const task = {
+    id: 'wf-1/task-1',
+    status: 'failed',
+    description: 'fail',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { workflowId: 'wf-1' },
+    execution: { error: 'boom', autoFixAttempts, ...executionOverrides },
+    taskStateVersion: 1,
+  };
+  const deps = {
+    orchestrator: {
+      getTask: vi.fn(() => task),
+      syncFromDb: vi.fn(),
+      getAllTasks: vi.fn(() => [task]),
+      getReadyTasks: vi.fn(() => []),
+    },
+    persistence: {
+      listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+      loadTasks: vi.fn(() => [task]),
+      updateTask,
+    },
+    executorRegistry: {},
+    messageBus: new LocalBus() as MessageBus,
+    repoRoot: '/fake/repo',
+    invokerConfig: { autoApproveAIFixes: false, launchOutboxMode: 'active' },
+    ownerTaskRunnerProvider: () => ({ fixWithAgent: vi.fn(), resolveConflict: vi.fn() }),
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  } as any;
+  return { deps, updateTask };
+}
+
+describe('headless fix auto-fix accounting', () => {
+  afterEach(() => {
+    fixWithAgentActionMock.mockClear();
+    finalizeMock.mockClear();
+  });
+
+  it('does not consume the auto-fix retry budget for a manual fix', async () => {
+    const { runHeadless } = await import('../headless.js');
+    const { deps, updateTask } = makeDeps(2);
+
+    await runHeadless(['fix', 'wf-1/task-1', 'claude'], deps);
+
+    // No autoFixAttempts write happened on the manual path.
+    expect(updateTask).not.toHaveBeenCalled();
+    expect(fixWithAgentActionMock).toHaveBeenCalledTimes(1);
+    expect(fixWithAgentActionMock.mock.calls[0][2]).toMatchObject({ reviewGateContext: undefined });
+  });
+
+  it('consumes exactly one retry when the request is explicitly --auto-fix', async () => {
+    const { runHeadless } = await import('../headless.js');
+    const { deps, updateTask } = makeDeps(2);
+
+    await runHeadless(['fix', 'wf-1/task-1', 'claude', '--auto-fix'], deps);
+
+    expect(updateTask).toHaveBeenCalledTimes(1);
+    expect(updateTask).toHaveBeenCalledWith('wf-1/task-1', { execution: { autoFixAttempts: 3 } });
+  });
+
+  it('starts the budget at one when no attempts have been recorded yet', async () => {
+    const { runHeadless } = await import('../headless.js');
+    const { deps, updateTask } = makeDeps(null);
+
+    await runHeadless(['fix', 'wf-1/task-1', '--auto-fix'], deps);
+
+    expect(updateTask).toHaveBeenCalledWith('wf-1/task-1', { execution: { autoFixAttempts: 1 } });
+  });
+
+  it('passes a decoded review-gate CI context through to the fix action', async () => {
+    const { runHeadless } = await import('../headless.js');
+    const reviewGateContext = { reviewId: 'review-1', generation: 0, fixContext: 'fix checks' };
+    const { deps } = makeDeps(0);
+
+    await runHeadless(
+      ['fix', 'wf-1/task-1', '--review-gate-ci', encodeReviewGateCiContext(reviewGateContext)],
+      deps,
+    );
+
+    expect(fixWithAgentActionMock).toHaveBeenCalledTimes(1);
+    expect(fixWithAgentActionMock.mock.calls[0][2]).toMatchObject({ reviewGateContext });
+  });
+});

--- a/packages/app/src/__tests__/headless-fix-autofix-context.test.ts
+++ b/packages/app/src/__tests__/headless-fix-autofix-context.test.ts
@@ -64,7 +64,6 @@ describe('headless fix auto-fix accounting', () => {
 
     await runHeadless(['fix', 'wf-1/task-1', 'claude'], deps);
 
-    // No autoFixAttempts write happened on the manual path.
     expect(updateTask).not.toHaveBeenCalled();
     expect(fixWithAgentActionMock).toHaveBeenCalledTimes(1);
     expect(fixWithAgentActionMock.mock.calls[0][2]).toMatchObject({ reviewGateContext: undefined });

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -2829,7 +2829,6 @@ describe('fixWithAgentAction review-gate CI context', () => {
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
     }, {
-      // selectedAttemptId moved on from attempt-1 → attempt-2 since CI failed
       reviewGateContext: { reviewId: 'review-1', generation: 3, selectedAttemptId: 'attempt-1', branch: 'experiment/foo' },
     })).rejects.toThrow(StaleLineageError);
 

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -2799,3 +2799,75 @@ describe('finalizeAppliedFix lineage guard', () => {
     expect(result).toEqual({ autoApproved: false, started: [] });
   });
 });
+
+describe('fixWithAgentAction review-gate CI context', () => {
+  function makeReviewGateOrchestrator(execution: Record<string, unknown>) {
+    return {
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: { error: 'ci failed', ...execution },
+      })),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'ci failed' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+  }
+
+  it('rejects a stale review-gate context before mutating', async () => {
+    const orchestrator = makeReviewGateOrchestrator({
+      selectedAttemptId: 'attempt-2',
+      generation: 3,
+      reviewId: 'review-1',
+      branch: 'experiment/foo',
+    });
+    const persistence = { getTaskOutput: vi.fn(() => 'output'), appendTaskOutput: vi.fn() };
+    const taskExecutor = { fixWithAgent: vi.fn(), resolveConflict: vi.fn() };
+
+    await expect(fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      // selectedAttemptId moved on from attempt-1 → attempt-2 since CI failed
+      reviewGateContext: { reviewId: 'review-1', generation: 3, selectedAttemptId: 'attempt-1', branch: 'experiment/foo' },
+    })).rejects.toThrow(StaleLineageError);
+
+    expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
+    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+  });
+
+  it('fixes with the carried fix context when the review-gate context is current', async () => {
+    const orchestrator = makeReviewGateOrchestrator({
+      selectedAttemptId: 'attempt-1',
+      generation: 3,
+      reviewId: 'review-1',
+      branch: 'experiment/foo',
+    });
+    const persistence = { getTaskOutput: vi.fn(() => 'output'), appendTaskOutput: vi.fn() };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn(),
+    };
+
+    const result = await fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      agentName: 'claude',
+      reviewGateContext: {
+        reviewId: 'review-1',
+        generation: 3,
+        selectedAttemptId: 'attempt-1',
+        branch: 'experiment/foo',
+        fixContext: 'make the failed checks pass',
+      },
+    });
+
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith(
+      'task-a', 'output', 'claude', 'ci failed', 'make the failed checks pass',
+    );
+    expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
+  });
+});

--- a/packages/app/src/auto-fix-intents.ts
+++ b/packages/app/src/auto-fix-intents.ts
@@ -1,5 +1,14 @@
 import type { WorkflowMutationIntent } from '@invoker/data-store';
 
+// ── Duplicate fix-intent detection ──────────────────────────
+//
+// A "fix intent" is any queued/running mutation that will run the shared fix
+// behavior for a task, regardless of whether it arrived as a structured IPC
+// mutation (`invoker:fix-with-agent`) or as a headless `fix` command wrapped in
+// a `headless.exec` payload. Detecting duplicates across both shapes lets the
+// auto-fix worker submit a normal fix command and rely on the accepted-command
+// boundary to suppress redundant retries.
+
 type HeadlessExecPayload = {
   args?: unknown[];
 };
@@ -28,3 +37,230 @@ export function listOpenFixIntentsForTask(
   return intents.filter((intent) => isFixIntentForTask(intent, taskId));
 }
 
+export function hasOpenFixIntentForTask(
+  intents: WorkflowMutationIntent[],
+  taskId: string,
+): boolean {
+  return intents.some((intent) => isFixIntentForTask(intent, taskId));
+}
+
+// ── Review-gate CI auto-fix context ─────────────────────────
+//
+// When a fix is triggered by a failed review-gate CI run, the worker carries an
+// explicit snapshot of the lineage it observed. The accepted-command boundary
+// re-checks that snapshot against the live task before fixing so a stale retry
+// (the task moved on, was re-selected, or got a new review) is rejected instead
+// of clobbering newer work.
+
+export interface ReviewGateCiContext {
+  /** Provider review identifier the CI failure was observed against. */
+  reviewId: string;
+  /** Task generation observed when the failure was captured. */
+  generation: number;
+  /** Selected attempt observed when the failure was captured. */
+  selectedAttemptId?: string;
+  /** Branch observed when the failure was captured. */
+  branch?: string;
+  /** Head commit observed when the failure was captured. */
+  headSha?: string;
+  /** Pre-formatted fix instructions handed to the executor, if any. */
+  fixContext?: string;
+}
+
+/** Lineage fields read off a live task when validating review-gate context. */
+export interface ReviewGateLineageFields {
+  generation?: number;
+  reviewId?: string;
+  selectedAttemptId?: string;
+  branch?: string;
+}
+
+export function encodeReviewGateCiContext(context: ReviewGateCiContext): string {
+  return JSON.stringify(context);
+}
+
+export function decodeReviewGateCiContext(encoded: unknown): ReviewGateCiContext | undefined {
+  if (typeof encoded !== 'string' || encoded.length === 0) {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(encoded);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') {
+    return undefined;
+  }
+  const candidate = parsed as Record<string, unknown>;
+  if (typeof candidate.reviewId !== 'string' || typeof candidate.generation !== 'number') {
+    return undefined;
+  }
+  return {
+    reviewId: candidate.reviewId,
+    generation: candidate.generation,
+    selectedAttemptId: typeof candidate.selectedAttemptId === 'string' ? candidate.selectedAttemptId : undefined,
+    branch: typeof candidate.branch === 'string' ? candidate.branch : undefined,
+    headSha: typeof candidate.headSha === 'string' ? candidate.headSha : undefined,
+    fixContext: typeof candidate.fixContext === 'string' ? candidate.fixContext : undefined,
+  };
+}
+
+/**
+ * True when the captured review-gate context no longer matches the live task —
+ * mirrors the lineage fields the review-gate worker guards on (selected attempt,
+ * generation, review id, branch).
+ */
+export function isReviewGateCiContextStale(
+  context: ReviewGateCiContext,
+  current: ReviewGateLineageFields,
+): boolean {
+  return (
+    current.selectedAttemptId !== context.selectedAttemptId ||
+    (current.generation ?? 0) !== context.generation ||
+    current.reviewId !== context.reviewId ||
+    current.branch !== context.branch
+  );
+}
+
+// ── Explicit auto-fix command context ───────────────────────
+//
+// The auto-fix worker submits the same `fix` command a human would, plus a
+// machine-readable marker. Carrying the marker through the command lets the
+// accepted-command boundary (not the worker) own attempt accounting and lets a
+// review-gate failure ride along without a side channel.
+
+const AUTO_FIX_FLAG = '--auto-fix';
+const REVIEW_GATE_CI_FLAG = '--review-gate-ci';
+
+export interface AutoFixCommandContext {
+  /** Whether the fix request was explicitly issued by the auto-fix worker. */
+  autoFix: boolean;
+  /** Review-gate CI context, when the fix was triggered by a failed CI run. */
+  reviewGateContext?: ReviewGateCiContext;
+}
+
+export interface ParsedHeadlessFixArgs extends AutoFixCommandContext {
+  taskId?: string;
+  agentName?: string;
+}
+
+/**
+ * Parse a headless `fix` command: `fix <taskId> [agent] [--auto-fix]
+ * [--review-gate-ci <encoded>]`. Positional order and the manual default agent
+ * are unchanged when no auto-fix flags are present, so manual `fix` keeps its
+ * existing behavior.
+ */
+export function parseHeadlessFixArgs(args: readonly string[]): ParsedHeadlessFixArgs {
+  const rest = args[0] === 'fix' ? args.slice(1) : args.slice();
+  let taskId: string | undefined;
+  let agentName: string | undefined;
+  let autoFix = false;
+  let reviewGateContext: ReviewGateCiContext | undefined;
+
+  for (let i = 0; i < rest.length; i += 1) {
+    const token = rest[i];
+    if (token === AUTO_FIX_FLAG) {
+      autoFix = true;
+      continue;
+    }
+    if (token === REVIEW_GATE_CI_FLAG) {
+      const decoded = decodeReviewGateCiContext(rest[i + 1]);
+      if (decoded) {
+        reviewGateContext = decoded;
+        autoFix = true;
+      }
+      i += 1;
+      continue;
+    }
+    if (taskId === undefined) {
+      taskId = token;
+      continue;
+    }
+    if (agentName === undefined) {
+      agentName = token;
+    }
+  }
+
+  return { taskId, agentName, autoFix, reviewGateContext };
+}
+
+/**
+ * Build a headless `fix` command argument vector from structured fix options.
+ * Used when converting a structured `invoker:fix-with-agent` mutation into the
+ * headless command the shared owner actually runs.
+ */
+export function buildHeadlessFixArgs(
+  taskId: string,
+  agentName: string | undefined,
+  context: AutoFixCommandContext = { autoFix: false },
+): string[] {
+  const args = ['fix', taskId];
+  if (agentName !== undefined && agentName.length > 0) {
+    args.push(agentName);
+  }
+  if (context.autoFix || context.reviewGateContext) {
+    args.push(AUTO_FIX_FLAG);
+  }
+  if (context.reviewGateContext) {
+    args.push(REVIEW_GATE_CI_FLAG, encodeReviewGateCiContext(context.reviewGateContext));
+  }
+  return args;
+}
+
+// ── Structured IPC mutation options ─────────────────────────
+//
+// `invoker:fix-with-agent` historically carried `[taskId, agentName]`. The
+// auto-fix worker adds a third structured-options argument so explicit auto-fix
+// context survives owner delegation without changing the manual two-argument
+// call shape.
+
+export interface FixWithAgentMutationOptions {
+  autoFix?: boolean;
+  reviewGateContext?: ReviewGateCiContext;
+}
+
+export interface ParsedFixWithAgentMutationArgs {
+  taskId: string;
+  agentName?: string;
+  context: AutoFixCommandContext;
+}
+
+export function buildFixWithAgentMutationArgs(
+  taskId: string,
+  agentName?: string,
+  options?: FixWithAgentMutationOptions,
+): unknown[] {
+  const args: unknown[] = [taskId, agentName];
+  if (options && (options.autoFix || options.reviewGateContext)) {
+    args.push({
+      autoFix: Boolean(options.autoFix || options.reviewGateContext),
+      ...(options.reviewGateContext ? { reviewGateContext: options.reviewGateContext } : {}),
+    });
+  }
+  return args;
+}
+
+export function parseFixWithAgentMutationArgs(args: unknown[]): ParsedFixWithAgentMutationArgs {
+  const taskId = String(args[0]);
+  const agentName = args[1] === undefined || args[1] === null ? undefined : String(args[1]);
+  const optionsArg = args[2];
+  let autoFix = false;
+  let reviewGateContext: ReviewGateCiContext | undefined;
+
+  if (optionsArg && typeof optionsArg === 'object') {
+    const candidate = optionsArg as Record<string, unknown>;
+    autoFix = Boolean(candidate.autoFix);
+    if (candidate.reviewGateContext) {
+      const ctx = candidate.reviewGateContext;
+      reviewGateContext = typeof ctx === 'string'
+        ? decodeReviewGateCiContext(ctx)
+        : decodeReviewGateCiContext(JSON.stringify(ctx));
+      if (reviewGateContext) {
+        autoFix = true;
+      }
+    }
+  }
+
+  return { taskId, agentName, context: { autoFix, reviewGateContext } };
+}

--- a/packages/app/src/auto-fix-intents.ts
+++ b/packages/app/src/auto-fix-intents.ts
@@ -1,13 +1,5 @@
 import type { WorkflowMutationIntent } from '@invoker/data-store';
 
-// ── Duplicate fix-intent detection ──────────────────────────
-//
-// A "fix intent" is any queued/running mutation that will run the shared fix
-// behavior for a task, regardless of whether it arrived as a structured IPC
-// mutation (`invoker:fix-with-agent`) or as a headless `fix` command wrapped in
-// a `headless.exec` payload. Detecting duplicates across both shapes lets the
-// auto-fix worker submit a normal fix command and rely on the accepted-command
-// boundary to suppress redundant retries.
 
 type HeadlessExecPayload = {
   args?: unknown[];
@@ -44,30 +36,15 @@ export function hasOpenFixIntentForTask(
   return intents.some((intent) => isFixIntentForTask(intent, taskId));
 }
 
-// ── Review-gate CI auto-fix context ─────────────────────────
-//
-// When a fix is triggered by a failed review-gate CI run, the worker carries an
-// explicit snapshot of the lineage it observed. The accepted-command boundary
-// re-checks that snapshot against the live task before fixing so a stale retry
-// (the task moved on, was re-selected, or got a new review) is rejected instead
-// of clobbering newer work.
-
 export interface ReviewGateCiContext {
-  /** Provider review identifier the CI failure was observed against. */
   reviewId: string;
-  /** Task generation observed when the failure was captured. */
   generation: number;
-  /** Selected attempt observed when the failure was captured. */
   selectedAttemptId?: string;
-  /** Branch observed when the failure was captured. */
   branch?: string;
-  /** Head commit observed when the failure was captured. */
   headSha?: string;
-  /** Pre-formatted fix instructions handed to the executor, if any. */
   fixContext?: string;
 }
 
-/** Lineage fields read off a live task when validating review-gate context. */
 export interface ReviewGateLineageFields {
   generation?: number;
   reviewId?: string;
@@ -106,11 +83,6 @@ export function decodeReviewGateCiContext(encoded: unknown): ReviewGateCiContext
   };
 }
 
-/**
- * True when the captured review-gate context no longer matches the live task —
- * mirrors the lineage fields the review-gate worker guards on (selected attempt,
- * generation, review id, branch).
- */
 export function isReviewGateCiContextStale(
   context: ReviewGateCiContext,
   current: ReviewGateLineageFields,
@@ -123,20 +95,11 @@ export function isReviewGateCiContextStale(
   );
 }
 
-// ── Explicit auto-fix command context ───────────────────────
-//
-// The auto-fix worker submits the same `fix` command a human would, plus a
-// machine-readable marker. Carrying the marker through the command lets the
-// accepted-command boundary (not the worker) own attempt accounting and lets a
-// review-gate failure ride along without a side channel.
-
 const AUTO_FIX_FLAG = '--auto-fix';
 const REVIEW_GATE_CI_FLAG = '--review-gate-ci';
 
 export interface AutoFixCommandContext {
-  /** Whether the fix request was explicitly issued by the auto-fix worker. */
   autoFix: boolean;
-  /** Review-gate CI context, when the fix was triggered by a failed CI run. */
   reviewGateContext?: ReviewGateCiContext;
 }
 
@@ -145,12 +108,6 @@ export interface ParsedHeadlessFixArgs extends AutoFixCommandContext {
   agentName?: string;
 }
 
-/**
- * Parse a headless `fix` command: `fix <taskId> [agent] [--auto-fix]
- * [--review-gate-ci <encoded>]`. Positional order and the manual default agent
- * are unchanged when no auto-fix flags are present, so manual `fix` keeps its
- * existing behavior.
- */
 export function parseHeadlessFixArgs(args: readonly string[]): ParsedHeadlessFixArgs {
   const rest = args[0] === 'fix' ? args.slice(1) : args.slice();
   let taskId: string | undefined;
@@ -185,11 +142,6 @@ export function parseHeadlessFixArgs(args: readonly string[]): ParsedHeadlessFix
   return { taskId, agentName, autoFix, reviewGateContext };
 }
 
-/**
- * Build a headless `fix` command argument vector from structured fix options.
- * Used when converting a structured `invoker:fix-with-agent` mutation into the
- * headless command the shared owner actually runs.
- */
 export function buildHeadlessFixArgs(
   taskId: string,
   agentName: string | undefined,
@@ -208,12 +160,6 @@ export function buildHeadlessFixArgs(
   return args;
 }
 
-// ── Structured IPC mutation options ─────────────────────────
-//
-// `invoker:fix-with-agent` historically carried `[taskId, agentName]`. The
-// auto-fix worker adds a third structured-options argument so explicit auto-fix
-// context survives owner delegation without changing the manual two-argument
-// call shape.
 
 export interface FixWithAgentMutationOptions {
   autoFix?: boolean;

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -51,6 +51,7 @@ import {
   setWorkflowMergeMode,
 } from './workflow-actions.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
+import { parseHeadlessFixArgs } from './auto-fix-intents.js';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
 import {
@@ -1109,7 +1110,7 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessRebaseRecreate(args[1], deps);
       break;
     case 'fix':
-      await headlessFix(args[1], deps, args[2]);
+      await headlessFix(args, deps);
       break;
     case 'resolve-conflict':
       await headlessResolveConflict(args[1], deps, args[2]);
@@ -1697,15 +1698,26 @@ async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<vo
   });
 }
 
-async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string): Promise<void> {
-  if (!taskId) throw new Error('Missing taskId. Usage: --headless fix <taskId> [claude|codex]');
+async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promise<void> {
+  const parsed = parseHeadlessFixArgs(rawArgs);
+  let taskId = parsed.taskId;
+  if (!taskId) throw new Error('Missing taskId. Usage: --headless fix <taskId> [claude|codex] [--auto-fix]');
   const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'fix');
   if (!restored) return;
   taskId = restored.resolvedTaskId;
 
+  // The accepted command boundary owns auto-fix attempt accounting: the worker
+  // submits a normal `fix` command tagged `--auto-fix`, and only then does a
+  // retry consume the budget. Manual `fix` never increments.
+  if (parsed.autoFix) {
+    const task = deps.orchestrator.getTask(taskId);
+    const attemptsBefore = task?.execution.autoFixAttempts ?? 0;
+    deps.persistence.updateTask(taskId, { execution: { autoFixAttempts: attemptsBefore + 1 } });
+  }
+
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
-  const agent = (agentArg ?? 'claude').toLowerCase();
+  const agent = (parsed.agentName ?? 'claude').toLowerCase();
   try {
     const result = await fixWithAgentAction(taskId, {
       orchestrator: deps.orchestrator,
@@ -1716,6 +1728,7 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
       agentName: agent,
       recreateOutputLabel: 'Fix with AI',
       failureOutputLabel: 'Fix with AI',
+      reviewGateContext: parsed.reviewGateContext,
       signal: deps.signal,
     });
     await finalizeMutationWithGlobalTopup({

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1706,9 +1706,6 @@ async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promise<void>
   if (!restored) return;
   taskId = restored.resolvedTaskId;
 
-  // The accepted command boundary owns auto-fix attempt accounting: the worker
-  // submits a normal `fix` command tagged `--auto-fix`, and only then does a
-  // retry consume the budget. Manual `fix` never increments.
   if (parsed.autoFix) {
     const task = deps.orchestrator.getTask(taskId);
     const attemptsBefore = task?.execution.autoFixAttempts ?? 0;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -184,7 +184,12 @@ import {
 import { computeDeferredLaunchTiming } from './deferred-runnable.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { evaluateExecutingStall } from './executing-stall.js';
-import { listOpenFixIntentsForTask } from './auto-fix-intents.js';
+import {
+  buildFixWithAgentMutationArgs,
+  buildHeadlessFixArgs,
+  listOpenFixIntentsForTask,
+  parseFixWithAgentMutationArgs,
+} from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import {
   buildActionGraphDiagnostics,
@@ -1320,11 +1325,9 @@ if (isHeadless) {
           });
         }
         if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
-          workflowMutationDispatcher.set('invoker:fix-with-agent', async (taskIdArg: unknown, agentNameArg?: unknown) => {
-            const args = ['fix', String(taskIdArg)];
-            if (typeof agentNameArg === 'string' && agentNameArg.length > 0) {
-              args.push(agentNameArg);
-            }
+          workflowMutationDispatcher.set('invoker:fix-with-agent', async (...fixArgs: unknown[]) => {
+            const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
+            const args = buildHeadlessFixArgs(taskId, agentName, context);
             await runHeadless(args, {
               ...headlessDeps,
               waitForApproval: false,
@@ -1454,7 +1457,7 @@ if (isHeadless) {
             workflowId,
             'normal',
             'invoker:fix-with-agent',
-            [taskId, selectedAgent],
+            buildFixWithAgentMutationArgs(taskId, selectedAgent, { autoFix: true }),
           )
             .then(() => {
               logStandaloneAutoFixDebug(taskId, 'schedule-dispatch-finished');
@@ -2670,10 +2673,10 @@ function createEmbeddedTerminalBackendFromConfig(
         return arg1 === undefined
           ? { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0)] } }
           : { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0), String(arg1)] } };
-      case 'invoker:fix-with-agent':
-        return arg1 === undefined
-          ? { channel: 'headless.exec', request: { args: ['fix', String(arg0)] } }
-          : { channel: 'headless.exec', request: { args: ['fix', String(arg0), String(arg1)] } };
+      case 'invoker:fix-with-agent': {
+        const { taskId, agentName, context } = parseFixWithAgentMutationArgs(payload.args);
+        return { channel: 'headless.exec', request: { args: buildHeadlessFixArgs(taskId, agentName, context) } };
+      }
       case 'invoker:edit-task-command':
         return { channel: 'headless.exec', request: { args: ['set', 'command', String(arg0), String(arg1)] } };
       case 'invoker:edit-task-prompt':

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -23,6 +23,10 @@ import {
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner, ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
+import {
+  isReviewGateCiContextStale,
+  type ReviewGateCiContext,
+} from './auto-fix-intents.js';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import { isDispatchableLaunch } from './global-topup.js';
@@ -847,12 +851,22 @@ export async function fixWithAgentAction(
     recoveryRoute?: FailureRecoveryRoute;
     recreateOutputLabel?: string;
     failureOutputLabel?: string;
+    reviewGateContext?: ReviewGateCiContext;
     signal?: AbortSignal;
   } = {},
 ): Promise<FixWithAgentActionResult> {
   const { orchestrator, persistence, taskExecutor } = deps;
   const task = orchestrator.getTask(taskId);
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+
+  // Reject a stale review-gate CI auto-fix before mutating: if the task moved on
+  // (re-selected attempt, new generation/review/branch) since the CI failure was
+  // captured, the carried context is stale and the fix must not clobber newer work.
+  if (options.reviewGateContext && isReviewGateCiContextStale(options.reviewGateContext, task.execution)) {
+    throw new StaleLineageError(
+      `Review-gate CI auto-fix for ${taskId} is stale (review=${options.reviewGateContext.reviewId})`,
+    );
+  }
 
   const savedError = task.execution.error ?? '';
   const recoveryRoute = options.recoveryRoute ?? selectFailureRecoveryRoute(task, savedError);
@@ -881,7 +895,12 @@ export async function fixWithAgentAction(
       await taskExecutor.resolveConflict(taskId, persistedSavedError, options.agentName);
     } else {
       const output = persistence.getTaskOutput(taskId);
-      await taskExecutor.fixWithAgent(taskId, output, options.agentName, persistedSavedError);
+      const fixContext = options.reviewGateContext?.fixContext;
+      if (fixContext !== undefined) {
+        await taskExecutor.fixWithAgent(taskId, output, options.agentName, persistedSavedError, fixContext);
+      } else {
+        await taskExecutor.fixWithAgent(taskId, output, options.agentName, persistedSavedError);
+      }
     }
     assertLineageCurrent(lineage, orchestrator, options.signal);
     const result = await finalizeAppliedFix(taskId, persistedSavedError, deps, options.signal, lineage);

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -26,6 +26,7 @@ import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import {
   isReviewGateCiContextStale,
   type ReviewGateCiContext,
+  type ReviewGateLineageFields,
 } from './auto-fix-intents.js';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
@@ -97,6 +98,17 @@ export function assertLineageCurrent(
       + `gen ${snapshot.generation} → ${current.generation})`,
     );
   }
+}
+
+function assertReviewGateCiContextCurrent(
+  taskId: string,
+  context: ReviewGateCiContext,
+  current: ReviewGateLineageFields,
+): void {
+  if (!isReviewGateCiContextStale(context, current)) return;
+  throw new StaleLineageError(
+    `Review-gate CI auto-fix for ${taskId} is stale (review=${context.reviewId})`,
+  );
 }
 
 // ── Deps interfaces ──────────────────────────────────────────
@@ -859,13 +871,8 @@ export async function fixWithAgentAction(
   const task = orchestrator.getTask(taskId);
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
-  // Reject a stale review-gate CI auto-fix before mutating: if the task moved on
-  // (re-selected attempt, new generation/review/branch) since the CI failure was
-  // captured, the carried context is stale and the fix must not clobber newer work.
-  if (options.reviewGateContext && isReviewGateCiContextStale(options.reviewGateContext, task.execution)) {
-    throw new StaleLineageError(
-      `Review-gate CI auto-fix for ${taskId} is stale (review=${options.reviewGateContext.reviewId})`,
-    );
+  if (options.reviewGateContext) {
+    assertReviewGateCiContextCurrent(taskId, options.reviewGateContext, task.execution);
   }
 
   const savedError = task.execution.error ?? '';
@@ -1332,14 +1339,13 @@ function assertReviewGateTriggerCurrent(
   if (!task) {
     throw new StaleLineageError(`Review-gate CI auto-fix task ${trigger.taskId} no longer exists`);
   }
-  if (
-    task.execution.selectedAttemptId !== trigger.selectedAttemptId ||
-    (task.execution.generation ?? 0) !== trigger.generation ||
-    task.execution.reviewId !== trigger.reviewId ||
-    task.execution.branch !== trigger.branch
-  ) {
-    throw new StaleLineageError(`Review-gate CI auto-fix for ${trigger.taskId} is stale`);
-  }
+  assertReviewGateCiContextCurrent(trigger.taskId, {
+    reviewId: trigger.reviewId,
+    generation: trigger.generation,
+    selectedAttemptId: trigger.selectedAttemptId,
+    branch: trigger.branch,
+    headSha: trigger.headSha,
+  }, task.execution);
 }
 
 export async function autoFixOnReviewGateFailure(


### PR DESCRIPTION
Validation passed. Here is the final PR body:

## Summary

Workers can now ask Invoker to fix a failed task by sending a normal `fix` command tagged as auto-fix, instead of going through a separate execution path.

Manual "Fix with AI" stays the default and behaves exactly as before. Only requests tagged `--auto-fix` count against the auto-fix retry budget.

The command boundary now owns attempt accounting. An auto-fix request bumps the attempt counter exactly once when accepted; manual fixes and skipped duplicates never bump it.

Duplicate fix requests for a task that already has a queued or running fix are detected and skipped, so a retrying worker cannot pile up redundant work.

Headless, IPC owner delegation, and the worker scheduler all carry the same auto-fix and review-gate CI context, so they share one mutation route.

A stale review-gate fix is rejected before it can clobber newer work.

## Architecture

### Before

```mermaid
graph TD
    Manual[Manual Fix with AI] --> Fix[fixWithAgentAction]
    Worker[Auto-fix worker] --> Direct[Direct executor path]
```

### After

```mermaid
graph TD
    Manual[Manual Fix with AI] --> Route[fix command route]
    Worker[Auto-fix worker] -->|fix taskId --auto-fix| Route
    Route --> Dup{Open fix intent?}
    Dup -->|yes| Skip[Skip duplicate]
    Dup -->|no| Acct[Account auto-fix attempt once]
    Acct --> Fix[fixWithAgentAction]
    Fix --> Stale{Review-gate context stale?}
    Stale -->|yes| Reject[Reject stale fix]
    Stale -->|no| Apply[Apply fix]
```

## Test Plan

- [ ] `cd packages/app && pnpm test -- src/__tests__/auto-fix-intents.test.ts src/__tests__/headless-client.test.ts src/__tests__/workflow-actions.test.ts`
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No