### PR TITLE
Crabbox SSH step 1: config and metadata

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -181,6 +181,70 @@ describe('loadConfig', () => {
     expect(config.remoteTargets?.ci1?.maxConcurrentTasks).toBe(2);
   });
 
+  it('reads a static remote target (no type) from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({
+        remoteTargets: {
+          ci1: {
+            host: '10.0.0.1',
+            user: 'invoker',
+            sshKeyPath: '/tmp/key',
+            port: 2222,
+            managedWorkspaces: true,
+            remoteInvokerHome: '/home/invoker/.invoker',
+            provisionCommand: 'pnpm install --frozen-lockfile',
+            use_api_key: true,
+            secretsFile: '/tmp/secrets.env',
+            remoteHeartbeatIntervalSeconds: 45,
+          },
+        },
+      }),
+    );
+    const config = loadConfig();
+    const target = config.remoteTargets?.ci1;
+    expect(target).toMatchObject({
+      host: '10.0.0.1',
+      user: 'invoker',
+      sshKeyPath: '/tmp/key',
+      port: 2222,
+      managedWorkspaces: true,
+      remoteInvokerHome: '/home/invoker/.invoker',
+      provisionCommand: 'pnpm install --frozen-lockfile',
+      use_api_key: true,
+      secretsFile: '/tmp/secrets.env',
+      remoteHeartbeatIntervalSeconds: 45,
+    });
+    // No type means static SSH.
+    expect((target as { type?: string }).type).toBeUndefined();
+  });
+
+  it('reads a crabbox remote target from user config', () => {
+    const crabbox = {
+      type: 'crabbox',
+      crabboxCommand: '/usr/local/bin/crabbox',
+      provider: 'fly',
+      class: 'performance-4x',
+      ttl: '30m',
+      idleTimeout: '10m',
+      network: 'invoker-net',
+      target: 'us-east',
+      stopAfter: 'completed',
+      keepOnFailure: true,
+      managedWorkspaces: true,
+      remoteHeartbeatIntervalSeconds: 30,
+      warmupArgs: ['--warm'],
+      statusArgs: ['--json'],
+      stopArgs: ['--force'],
+    };
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ remoteTargets: { crab1: crabbox } }),
+    );
+    const config = loadConfig();
+    expect(config.remoteTargets?.crab1).toEqual(crabbox);
+  });
+
   it('reads executionPools from user config', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),

--- a/packages/app/src/__tests__/headless-session.test.ts
+++ b/packages/app/src/__tests__/headless-session.test.ts
@@ -6,13 +6,17 @@ import type { TaskState } from '@invoker/workflow-core';
 /**
  * Mock config module so resolveAgentSession can import loadConfig().
  */
-vi.mock('../config.js', () => ({
-  loadConfig: () => ({
-    remoteTargets: {
-      remote_do_1: { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
-    },
-  }),
-}));
+vi.mock('../config.js', async (importActual) => {
+  const actual = await importActual<typeof import('../config.js')>();
+  return {
+    ...actual,
+    loadConfig: () => ({
+      remoteTargets: {
+        remote_do_1: { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
+      },
+    }),
+  };
+});
 
 function makeSshTask(overrides: Partial<TaskState['config']> = {}): TaskState {
   return {

--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -47,15 +47,19 @@ vi.mock('../workflow-actions.js', () => ({
   autoFixOnReviewGateFailure: vi.fn(async () => undefined),
 }));
 
-vi.mock('../config.js', () => ({
-  loadConfig: vi.fn(() => ({
-    remoteTargets: { remote: { host: 'host' } },
-    executionPools: { pool: { members: [] } },
-    autoFixAgent: 'codex',
-    autoApproveAIFixes: true,
-  })),
-  resolveSecretsFilePath: vi.fn(() => '/tmp/secrets.env'),
-}));
+vi.mock('../config.js', async (importActual) => {
+  const actual = await importActual<typeof import('../config.js')>();
+  return {
+    ...actual,
+    loadConfig: vi.fn(() => ({
+      remoteTargets: { remote: { host: 'host' } },
+      executionPools: { pool: { members: [] } },
+      autoFixAgent: 'codex',
+      autoApproveAIFixes: true,
+    })),
+    resolveSecretsFilePath: vi.fn(() => '/tmp/secrets.env'),
+  };
+});
 
 function createLogger() {
   return {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -9,6 +9,100 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 
+/** Fields shared by every remote SSH target regardless of how the host is provisioned. */
+export interface BaseRemoteTargetConfig {
+  /** SSH port. Default: 22. */
+  port?: number;
+  /**
+   * When true, use managed workspace mode: clone/fetch repo, create/reset worktrees,
+   * and provision per-task workspaces. When false (default), BYO mode: user provides
+   * pre-cloned repo path and handles all git/setup operations.
+   */
+  managedWorkspaces?: boolean;
+  /**
+   * Remote invoker home directory (e.g., ~/.invoker). Only used in managed mode.
+   * Default: ~/.invoker
+   */
+  remoteInvokerHome?: string;
+  /**
+   * Optional provision command to run in the worktree after creation (e.g., pnpm install).
+   * Only used in managed mode. Default: pnpm install --frozen-lockfile
+   */
+  provisionCommand?: string;
+  /**
+   * When true, export agent API keys from the local secrets file into SSH task/fix
+   * shells. Default false so remote Claude/Codex CLI account auth is preserved.
+   */
+  use_api_key?: boolean;
+  /**
+   * Optional local KEY=value secrets file used when use_api_key is true.
+   * Defaults to docker.secretsFile/fallback when unset.
+   */
+  secretsFile?: string;
+  /**
+   * Remote workload heartbeat interval (seconds) emitted by the SSH payload wrapper.
+   * Used for SSH executing-stall liveness checks. Default: 30.
+   */
+  remoteHeartbeatIntervalSeconds?: number;
+  /**
+   * Max concurrent tasks allowed on this target when used inside an execution pool.
+   * Default for pooled SSH members: 1.
+   */
+  maxConcurrentTasks?: number;
+}
+
+/**
+ * A fixed SSH host reachable by key auth. This is the default target shape:
+ * a remote target with no `type` (or `type: 'static'`) is a static SSH host.
+ */
+export interface StaticRemoteTargetConfig extends BaseRemoteTargetConfig {
+  /** Discriminant. Omit, or set to 'static', for a fixed SSH host. */
+  type?: 'static';
+  host: string;
+  user: string;
+  /** Path to SSH identity file (private key). */
+  sshKeyPath: string;
+}
+
+/**
+ * A Crabbox-provisioned ephemeral SSH target. The host is leased on demand,
+ * so `host`/`user`/`sshKeyPath` are discovered from the lease rather than
+ * configured here. Durable lease details are recorded as RemoteLeaseMetadata.
+ */
+export interface CrabboxRemoteTargetConfig extends BaseRemoteTargetConfig {
+  type: 'crabbox';
+  /** CLI entrypoint that creates/inspects/stops Crabbox leases. */
+  crabboxCommand: string;
+  /** Crabbox provider to lease from. */
+  provider: string;
+  /** Machine class/size to lease. */
+  class: string;
+  /** Lease time-to-live (e.g. '30m'). */
+  ttl: string;
+  /** Idle timeout before the lease auto-stops (e.g. '10m'). */
+  idleTimeout: string;
+  /** Network to attach the leased machine to. */
+  network: string;
+  /** Crabbox target selector for the lease. */
+  target: string;
+  /** When to stop the lease after the task settles (e.g. 'completed', 'never'). */
+  stopAfter: string;
+  /** Keep the lease alive on failure for debugging instead of stopping it. */
+  keepOnFailure: boolean;
+  /** Optional extra args appended to the warmup/create subcommand. */
+  warmupArgs?: string[];
+  /** Optional extra args appended to the status subcommand. */
+  statusArgs?: string[];
+  /** Optional extra args appended to the stop subcommand. */
+  stopArgs?: string[];
+}
+
+/**
+ * Typed remote target. A target with no `type` (or `type: 'static'`) is a
+ * static SSH host; `type: 'crabbox'` is an on-demand Crabbox lease.
+ */
+export type RemoteTargetConfig = StaticRemoteTargetConfig | CrabboxRemoteTargetConfig;
+
 export interface InvokerConfig {
   defaultBranch?: string;
   /**
@@ -97,50 +191,7 @@ export interface InvokerConfig {
     secretsFile?: string;
   };
   /** Named remote SSH targets for running tasks on remote machines via SSH key auth. */
-  remoteTargets?: Record<string, {
-    host: string;
-    user: string;
-    /** Path to SSH identity file (private key). */
-    sshKeyPath: string;
-    /** SSH port. Default: 22. */
-    port?: number;
-    /**
-     * When true, use managed workspace mode: clone/fetch repo, create/reset worktrees,
-     * and provision per-task workspaces. When false (default), BYO mode: user provides
-     * pre-cloned repo path and handles all git/setup operations.
-     */
-    managedWorkspaces?: boolean;
-    /**
-     * Remote invoker home directory (e.g., ~/.invoker). Only used in managed mode.
-     * Default: ~/.invoker
-     */
-    remoteInvokerHome?: string;
-    /**
-     * Optional provision command to run in the worktree after creation (e.g., pnpm install).
-     * Only used in managed mode. Default: pnpm install --frozen-lockfile
-     */
-    provisionCommand?: string;
-    /**
-     * When true, export agent API keys from the local secrets file into SSH task/fix
-     * shells. Default false so remote Claude/Codex CLI account auth is preserved.
-     */
-    use_api_key?: boolean;
-    /**
-     * Optional local KEY=value secrets file used when use_api_key is true.
-     * Defaults to docker.secretsFile/fallback when unset.
-     */
-    secretsFile?: string;
-    /**
-     * Remote workload heartbeat interval (seconds) emitted by the SSH payload wrapper.
-     * Used for SSH executing-stall liveness checks. Default: 30.
-     */
-    remoteHeartbeatIntervalSeconds?: number;
-    /**
-     * Max concurrent tasks allowed on this target when used inside an execution pool.
-     * Default for pooled SSH members: 1.
-     */
-    maxConcurrentTasks?: number;
-  }>;
+  remoteTargets?: Record<string, RemoteTargetConfig>;
   /**
    * Named execution pools used by routing rules.
    * Pools provide shared queue + drain semantics with per-member capacity limits.

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -103,6 +103,28 @@ export interface CrabboxRemoteTargetConfig extends BaseRemoteTargetConfig {
  */
 export type RemoteTargetConfig = StaticRemoteTargetConfig | CrabboxRemoteTargetConfig;
 
+/** True when a remote target is a fixed SSH host (no `type`, or `type: 'static'`). */
+export function isStaticRemoteTarget(
+  target: RemoteTargetConfig,
+): target is StaticRemoteTargetConfig {
+  return target.type === undefined || target.type === 'static';
+}
+
+/**
+ * Narrow configured remote targets to the static SSH hosts the runtime can
+ * execute on today. Crabbox targets are leased on demand and are not yet a
+ * runtime executor shape, so they are excluded here until that path lands.
+ */
+export function staticRemoteTargets(
+  config: InvokerConfig,
+): Record<string, StaticRemoteTargetConfig> {
+  const result: Record<string, StaticRemoteTargetConfig> = {};
+  for (const [id, target] of Object.entries(config.remoteTargets ?? {})) {
+    if (isStaticRemoteTarget(target)) result[id] = target;
+  }
+  return result;
+}
+
 export interface InvokerConfig {
   defaultBranch?: string;
   /**

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -10,7 +10,7 @@ import {
   type ExecutorRegistry,
 } from '@invoker/execution-engine';
 import type { Logger } from '@invoker/contracts';
-import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from '../config.js';
+import { loadConfig, resolveSecretsFilePath, staticRemoteTargets, type InvokerConfig } from '../config.js';
 import { autoFixOnReviewGateFailure } from '../workflow-actions.js';
 
 export type TaskHandleMap = Map<string, { handle: ExecutorHandle; executor: Executor }>;
@@ -86,7 +86,7 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
       imageName: deps.invokerConfig.docker?.imageName,
       secretsFile: resolveSecretsFilePath(deps.invokerConfig),
     },
-    remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
+    remoteTargetsProvider: () => staticRemoteTargets(loadConfig()),
     executionPoolsProvider: () => loadConfig().executionPools ?? {},
     onReviewGateCiFailure: deps.invokerConfig.autoFixCi
       ? async (trigger) => {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -28,7 +28,7 @@ import {
   type AgentRegistry,
   type TaskHeartbeatEvent,
 } from '@invoker/execution-engine';
-import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from './config.js';
+import { loadConfig, resolveSecretsFilePath, staticRemoteTargets, type InvokerConfig } from './config.js';
 import { backupPlan } from './plan-backup.js';
 import { startApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
@@ -235,7 +235,7 @@ export function createHeadlessExecutor(
       imageName: deps.invokerConfig.docker?.imageName,
       secretsFile: resolveSecretsFilePath(deps.invokerConfig),
     },
-    remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
+    remoteTargetsProvider: () => staticRemoteTargets(loadConfig()),
     executionPoolsProvider: () => deps.invokerConfig.executionPools ?? {},
     onReviewGateCiFailure: deps.invokerConfig.autoFixCi
       ? async (trigger) => {
@@ -2533,8 +2533,8 @@ export async function resolveAgentSession(
         && t.config.runnerKind === 'ssh',
     );
     if (sshTask) {
-      const { loadConfig } = await import('./config.js');
-      const targets = loadConfig().remoteTargets ?? {};
+      const { loadConfig, staticRemoteTargets } = await import('./config.js');
+      const targets = staticRemoteTargets(loadConfig());
       const targetId = (sshTask.config as { poolMemberId?: string }).poolMemberId;
       const target = targetId
         ? targets[targetId]

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -17,7 +17,7 @@ import {
   type PersistedTaskMeta,
   type TerminalSpec,
 } from '@invoker/execution-engine';
-import { loadConfig } from './config.js';
+import { loadConfig, staticRemoteTargets } from './config.js';
 import {
   buildLinuxXTerminalBashScript,
   buildMacOSOsascriptArgs,
@@ -198,7 +198,7 @@ export function resolveTaskTerminalSpec(
 
   if (repairedMeta.runnerKind === 'ssh') {
     const targetId = persistence.getPoolMemberId?.(taskId)?.trim();
-    const target = targetId ? loadConfig().remoteTargets?.[targetId] : undefined;
+    const target = targetId ? staticRemoteTargets(loadConfig())[targetId] : undefined;
     if (!targetId) {
       return {
         ok: false,

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -992,6 +992,77 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  describe('remote lease metadata persistence', () => {
+    const crabboxLease = {
+      provider: 'crabbox',
+      leaseId: 'lease-abc123',
+      slug: 'happy-otter',
+      targetId: 'crab1',
+      sshHost: '10.0.0.42',
+      sshUser: 'invoker',
+      sshPort: 2222,
+      sshKeyPath: '/tmp/crabbox-key',
+      expiresAt: '2026-06-22T12:00:00.000Z',
+      stopAfter: 'completed',
+      keepOnFailure: true,
+    } as const;
+
+    it('round-trips remoteLeaseMetadata through task save and load', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t-lease', {
+        config: { runnerKind: 'ssh' },
+        execution: { remoteLeaseMetadata: crabboxLease },
+      }));
+
+      const loaded = adapter.loadTask('t-lease');
+      expect(loaded?.execution.remoteLeaseMetadata).toEqual(crabboxLease);
+    });
+
+    it('persists remoteLeaseMetadata via updateTask and clears it on undefined', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t-lease-update'));
+
+      adapter.updateTask('t-lease-update', { execution: { remoteLeaseMetadata: crabboxLease } });
+      expect(adapter.loadTask('t-lease-update')?.execution.remoteLeaseMetadata).toEqual(crabboxLease);
+
+      adapter.updateTask('t-lease-update', { execution: { remoteLeaseMetadata: undefined } });
+      const stored = (adapter as any).db.exec(
+        "SELECT remote_lease_metadata FROM tasks WHERE id = 't-lease-update'",
+      ) as Array<{ values: unknown[][] }>;
+      expect(adapter.loadTask('t-lease-update')?.execution.remoteLeaseMetadata).toBeUndefined();
+      expect(stored[0]?.values[0]?.[0]).toBeNull();
+    });
+
+    it('round-trips remoteLeaseMetadata through attempt save and load', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t-lease-attempt'));
+      const attempt = createAttempt('t-lease-attempt', {
+        status: 'running',
+        remoteLeaseMetadata: crabboxLease,
+      });
+      adapter.saveAttempt(attempt);
+
+      expect(adapter.loadAttempt(attempt.id)?.remoteLeaseMetadata).toEqual(crabboxLease);
+    });
+
+    it('persists remoteLeaseMetadata via updateAttempt and leaves it intact on unrelated updates', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t-lease-attempt-update'));
+      const attempt = createAttempt('t-lease-attempt-update', { status: 'running' });
+      adapter.saveAttempt(attempt);
+
+      adapter.updateAttempt(attempt.id, { remoteLeaseMetadata: crabboxLease });
+      expect(adapter.loadAttempt(attempt.id)?.remoteLeaseMetadata).toEqual(crabboxLease);
+
+      // updateAttempt treats an omitted field as "no change", so a later
+      // unrelated update must not drop the lease metadata.
+      adapter.updateAttempt(attempt.id, { status: 'completed' });
+      const reloaded = adapter.loadAttempt(attempt.id);
+      expect(reloaded?.status).toBe('completed');
+      expect(reloaded?.remoteLeaseMetadata).toEqual(crabboxLease);
+    });
+  });
+
   describe('task-state version persistence', () => {
     it('saves task-state version 1 for new tasks and round-trips it', () => {
       adapter.saveWorkflow(testWorkflow);

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1038,6 +1038,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
       'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
       'ALTER TABLE tasks ADD COLUMN task_state_version INTEGER NOT NULL DEFAULT 1',
+      // remote_lease_metadata: durable on-demand remote lease details for cleanup/terminal restore
+      'ALTER TABLE tasks ADD COLUMN remote_lease_metadata TEXT',
+      'ALTER TABLE attempts ADD COLUMN remote_lease_metadata TEXT',
     ];
     for (const sql of migrations) {
       try {
@@ -1536,6 +1539,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         docker_image,
         execution_agent,
         agent_name,
+        remote_lease_metadata,
         task_state_version
       ) VALUES (
         ?, ?, ?, ?, ?, ?,
@@ -1552,6 +1556,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ?, ?, ?, ?,
         ?, ?,
         ?, ?, ?, ?, ?,
+        ?,
         ?,
         ?,
         ?,
@@ -1614,6 +1619,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       cfg.dockerImage ?? null,
       cfg.executionAgent ?? null,
       exec.agentName ?? null,
+      exec.remoteLeaseMetadata ? JSON.stringify(exec.remoteLeaseMetadata) : null,
       task.taskStateVersion ?? 1,
     ]);
   }
@@ -1728,6 +1734,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         selectedExperiments: 'selected_experiments',
         experimentResults: 'experiment_results',
         reviewGate: 'review_gate',
+        remoteLeaseMetadata: 'remote_lease_metadata',
       };
 
       for (const [key, col] of Object.entries(execMap)) {
@@ -2477,14 +2484,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
         command_override, prompt_override,
         claimed_at, started_at, completed_at, exit_code, error, last_heartbeat_at, lease_expires_at,
         branch, commit_hash, summary, workspace_path, agent_session_id, container_id,
-        supersedes_attempt_id, created_at, merge_conflict
+        supersedes_attempt_id, created_at, merge_conflict, remote_lease_metadata
       ) VALUES (
         ?, ?, ?, ?, ?, ?, ?,
         ?, ?, ?,
         ?, ?,
         ?, ?, ?, ?, ?,
         ?, ?, ?, ?, ?, ?,
-        ?, ?, ?
+        ?, ?, ?, ?
       )
     `, [
       attempt.id, attempt.nodeId, 0, attempt.queuePriority, attempt.status,
@@ -2503,6 +2510,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       attempt.supersedesAttemptId ?? null,
       attempt.createdAt.toISOString(),
       attempt.mergeConflict ? JSON.stringify(attempt.mergeConflict) : null,
+      attempt.remoteLeaseMetadata ? JSON.stringify(attempt.remoteLeaseMetadata) : null,
     ]);
   }
 
@@ -2548,7 +2556,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.rowToAttempt(row);
   }
 
-  updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
+  updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'queuePriority' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict' | 'remoteLeaseMetadata'>>): void {
     const setClauses: string[] = [];
     const values: any[] = [];
 
@@ -2568,6 +2576,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if (changes.agentSessionId !== undefined) { setClauses.push('agent_session_id = ?'); values.push(changes.agentSessionId); }
     if (changes.containerId !== undefined) { setClauses.push('container_id = ?'); values.push(changes.containerId); }
     if (changes.mergeConflict !== undefined) { setClauses.push('merge_conflict = ?'); values.push(changes.mergeConflict ? JSON.stringify(changes.mergeConflict) : null); }
+    if (changes.remoteLeaseMetadata !== undefined) { setClauses.push('remote_lease_metadata = ?'); values.push(changes.remoteLeaseMetadata ? JSON.stringify(changes.remoteLeaseMetadata) : null); }
 
     if (setClauses.length === 0) return;
     values.push(attemptId);
@@ -2825,6 +2834,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         generation: row.execution_generation ?? 0,
         selectedAttemptId: row.selected_attempt_id ?? undefined,
         autoFixAttempts: row.auto_fix_attempts ?? undefined,
+        remoteLeaseMetadata: row.remote_lease_metadata ? JSON.parse(row.remote_lease_metadata) : undefined,
       },
       taskStateVersion: row.task_state_version ?? 1,
     };
@@ -2932,6 +2942,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       supersedesAttemptId: row.supersedes_attempt_id ?? undefined,
       createdAt: new Date(row.created_at),
       mergeConflict: row.merge_conflict ? JSON.parse(row.merge_conflict) : undefined,
+      remoteLeaseMetadata: row.remote_lease_metadata ? JSON.parse(row.remote_lease_metadata) : undefined,
     };
   }
 

--- a/packages/execution-engine/src/executor.ts
+++ b/packages/execution-engine/src/executor.ts
@@ -1,4 +1,5 @@
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import type { RemoteLeaseMetadata } from '@invoker/workflow-core';
 
 export type Unsubscribe = () => void;
 
@@ -31,6 +32,8 @@ export interface PersistedTaskMeta {
   containerId?: string;
   workspacePath?: string;
   branch?: string;
+  /** Durable remote lease details, used to restore a terminal to a leased host. */
+  remoteLeaseMetadata?: RemoteLeaseMetadata;
 }
 
 export interface Executor {

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -131,6 +131,45 @@ export interface DetachedExternalDependency {
 export type TaskRunPhase = 'launching' | 'executing';
 export type TaskHeartbeatSource = 'executor' | 'remote_workload';
 
+// ── Remote lease metadata ───────────────────────────────────
+// Durable record of an on-demand remote target lease so cleanup and
+// terminal restore can find the host after a restart. Provider-tagged so
+// new lease providers can be added without changing existing readers.
+
+/**
+ * Lease details for a Crabbox-provisioned ephemeral SSH target.
+ *
+ * Persisted on the task/attempt that owns the lease so that, after an
+ * Invoker restart, we can re-open a terminal to the leased host and stop
+ * the lease during cleanup without re-deriving it from the executor.
+ */
+export interface CrabboxRemoteLeaseMetadata {
+  readonly provider: 'crabbox';
+  /** Crabbox lease identifier used for status/stop calls. */
+  readonly leaseId: string;
+  /** Human-readable lease slug (e.g. for logs/terminals). */
+  readonly slug: string;
+  /** Config key of the remote target that created this lease. */
+  readonly targetId: string;
+  /** Reachable SSH host for the leased machine. */
+  readonly sshHost: string;
+  /** SSH user for the leased machine. */
+  readonly sshUser: string;
+  /** SSH port for the leased machine. */
+  readonly sshPort: number;
+  /** Path to the SSH identity file used to reach the leased machine. */
+  readonly sshKeyPath: string;
+  /** ISO timestamp when the lease expires. */
+  readonly expiresAt: string;
+  /** When to stop the lease after the task settles (e.g. 'completed', 'never'). */
+  readonly stopAfter: string;
+  /** Keep the lease alive on failure for debugging instead of stopping it. */
+  readonly keepOnFailure: boolean;
+}
+
+/** Provider-tagged durable lease metadata for a remote target. */
+export type RemoteLeaseMetadata = CrabboxRemoteLeaseMetadata;
+
 export type ReviewGateArtifactStatus =
   | 'pending'
   | 'open'
@@ -214,6 +253,12 @@ export interface TaskExecution {
   };
   readonly selectedAttemptId?: string;
   readonly autoFixAttempts?: number;
+  /**
+   * Durable lease metadata for an on-demand remote target (e.g. Crabbox),
+   * kept so cleanup and terminal restore can find the leased host after a
+   * restart. Absent for static SSH and local executors.
+   */
+  readonly remoteLeaseMetadata?: RemoteLeaseMetadata;
 }
 
 // ── Task State ──────────────────────────────────────────────
@@ -335,6 +380,8 @@ export interface Attempt {
   readonly workspacePath?: string;
   readonly agentSessionId?: string;
   readonly containerId?: string;
+  /** Durable lease metadata for an on-demand remote target (e.g. Crabbox). */
+  readonly remoteLeaseMetadata?: RemoteLeaseMetadata;
 
   // ── Lineage ──
   readonly supersedesAttemptId?: string;


### PR DESCRIPTION
## Summary

This adds the config types and saved data that Crabbox-backed SSH targets will need later. Nothing changes how work runs yet.

Invoker can now read a `type: crabbox` remote target with provider, class, ttl, idle timeout, stop-after, keep-on-failure, and managed workspace fields.

Old static SSH targets with no `type` still parse exactly as before.

It also lets a task and its attempts store remote lease details, so a later step can find and clean up a leased machine.

Crabbox only hands out a machine. Invoker still owns the workflow, and `runnerKind: ssh` stays the only way that machine is driven.

This is the first stacked step. Wiring the executor to actually lease and use a Crabbox machine comes in downstream PRs.

## Test Plan

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/data-store && pnpm test`
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No. The new lease metadata is additive and optional; existing rows and configs are unaffected.