### PR TITLE
refactor(ui): drop unused refreshTasks hook result

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -355,7 +355,7 @@ export function App() {
   const handleTaskGraphSnapshotApplied = useCallback(() => {
     setGraphRefreshSequence((sequence) => sequence + 1);
   }, []);
-  const { tasks, workflows, clearTasks, refreshTasks, refreshTaskGraph } = useTasks({
+  const { tasks, workflows, clearTasks, refreshTaskGraph } = useTasks({
     onTaskGraphSnapshotApplied: handleTaskGraphSnapshotApplied,
   });
   const invoker = useInvoker();


### PR DESCRIPTION
## Summary

This removes the unused `refreshTasks` hook value from `App`.

All real UI refresh actions already use `refreshTaskGraph`. Keeping the dead destructure made the cleanup look unfinished.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx src/__tests__/keyboard-controls.test.tsx src/__tests__/use-tasks-guards.test.ts`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 4bb2dc717`
- Post-revert steps: None
- Data migration? No


Depends-On: #1392
