### PR TITLE
refactor(ui): remove refreshTasks hook API

### DIFF
--- a/packages/ui/src/__tests__/use-tasks-guards.test.ts
+++ b/packages/ui/src/__tests__/use-tasks-guards.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for useTasks behaviors:
- * - refreshTasks replaces tasks/workflows from getTasks snapshot (including empty)
+ * - startup snapshot replace clears/rebuilds task maps from getTasks
  * - delta handler should warn when tasks map drops to 0
  */
 
@@ -21,7 +21,7 @@ function makeTask(overrides: Partial<TaskState> & { id: string }): TaskState {
 }
 
 describe('useTasks guard logic', () => {
-  describe('refreshTasks snapshot replace', () => {
+  describe('startup snapshot replace', () => {
     it('simulates empty getTasks snapshot clearing UI state (e.g. after delete workflow)', () => {
       const taskList: TaskState[] = [];
       const next = new Map<string, TaskState>();

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -1,6 +1,5 @@
 /**
  * useTasks — workflows-changed must clear workflow metadata when main sends [].
- * Overlapping getTasks responses: older empty snapshot must not wipe after refreshTasks.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -138,40 +137,6 @@ describe('useTasks', () => {
     expect(result.current.workflows.get('wf-b')?.status).toBe('failed');
   });
 
-  it('ignores stale getTasks when a newer refresh returned tasks', async () => {
-    let releaseFirst: (v: { tasks: ReturnType<typeof makeUITask>[]; workflows: unknown[] }) => void;
-    const firstPending = new Promise<{ tasks: ReturnType<typeof makeUITask>[]; workflows: unknown[] }>((resolve) => {
-      releaseFirst = resolve;
-    });
-
-    const t1 = makeUITask({ id: 't1', description: 'Alpha' });
-    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
-      getTasks: vi
-        .fn()
-        .mockReturnValueOnce(firstPending)
-        .mockResolvedValue({ tasks: [t1], workflows: [] }),
-      onTaskGraphEvent: vi.fn(() => () => {}),
-      onWorkflowsChanged: vi.fn(() => () => {}),
-    };
-
-    const { result } = renderHook(() => useTasks());
-
-    await act(async () => {
-      result.current.refreshTasks();
-    });
-
-    await waitFor(() => {
-      expect(result.current.tasks.size).toBe(1);
-      expect(result.current.tasks.get('t1')?.description).toBe('Alpha');
-    });
-
-    await act(async () => {
-      releaseFirst!({ tasks: [], workflows: [] });
-    });
-
-    expect(result.current.tasks.size).toBe(1);
-    expect(result.current.tasks.get('t1')?.id).toBe('t1');
-  });
 
   it('skips the immediate non-forced snapshot when bootstrap already hydrated state', async () => {
     const bootA = makeUITask({ id: 'boot-a', description: 'Bootstrap A' });
@@ -282,38 +247,6 @@ describe('useTasks', () => {
     });
   });
 
-  it('non-forced refresh after a hydrated bootstrap still calls getTasks and replaces state', async () => {
-    const bootTask = makeUITask({ id: 'boot-1', description: 'Boot' });
-    const updated = makeUITask({ id: 'boot-1', description: 'Updated' });
-    const getTasks = vi.fn().mockResolvedValue({ tasks: [updated], workflows: [] });
-    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
-      tasks: [bootTask],
-      workflows: [{ id: 'wf-1', name: 'WF 1', status: 'running' }],
-    };
-    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
-      getTasks,
-      onTaskGraphEvent: vi.fn(() => () => {}),
-      onWorkflowsChanged: vi.fn(() => () => {}),
-    };
-
-    const { result } = renderHook(() => useTasks());
-
-    expect(getTasks).not.toHaveBeenCalled();
-
-    await act(async () => {
-      result.current.refreshTasks();
-    });
-
-    await waitFor(() => {
-      expect(getTasks).toHaveBeenCalledTimes(1);
-      expect(getTasks).toHaveBeenLastCalledWith();
-    });
-
-    await waitFor(() => {
-      expect(result.current.tasks.get('boot-1')?.description).toBe('Updated');
-      expect(result.current.workflows.size).toBe(0);
-    });
-  });
 
   it('forced refresh calls refreshTaskGraph instead of getTasks', async () => {
     const getTasks = vi.fn().mockResolvedValue({ tasks: [], workflows: [] });

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -19,7 +19,6 @@ export interface UseTasksResult {
   tasks: Map<string, TaskState>;
   workflows: Map<string, WorkflowMeta>;
   clearTasks: () => void;
-  refreshTasks: () => Promise<void>;
   refreshTaskGraph: () => Promise<void>;
 }
 export interface UseTasksOptions {
@@ -135,7 +134,6 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     window.invoker.checkPrStatuses?.();
     return request.then(() => undefined);
   }, []);
-  const refreshTasks = useCallback((): Promise<void> => fetchAll(), [fetchAll]);
   const refreshTaskGraph = useCallback((): Promise<void> => {
     if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
     return window.invoker.refreshTaskGraph();
@@ -162,9 +160,8 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     }
 
     // Preload bootstrap already hydrated tasks/workflows synchronously, so
-    // the immediate non-forced snapshot would be a redundant full payload.
-    // Skip it when bootstrap is populated; deltas keep state live, and
-    // explicit refreshTasks() callers still run fetchAll.
+    // the immediate startup snapshot would be a redundant full payload.
+    // Skip it when bootstrap is populated; deltas keep state live.
     if (bootstrapHasState) {
       reportedStartupSnapshotRef.current = true;
       void window.invoker.reportUiPerf?.('startup_snapshot_skipped_bootstrap_complete', {
@@ -361,5 +358,5 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     setWorkflows(new Map());
   }, []);
 
-  return { tasks, workflows, clearTasks, refreshTasks, refreshTaskGraph };
+  return { tasks, workflows, clearTasks, refreshTaskGraph };
 }


### PR DESCRIPTION
## Summary

This removes `refreshTasks` from the public `useTasks` API.

Command refreshes already go through `refreshTaskGraph`, and startup snapshot loading now stays an internal hook detail.

This also drops tests that only exercised the removed API surface.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx src/__tests__/keyboard-controls.test.tsx src/__tests__/use-tasks-guards.test.ts`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 87ad07067`
- Post-revert steps: None
- Data migration? No


Depends-On: #1395
