### PR TITLE
refactor(ui): keep getTasks startup-only

### DIFF
--- a/packages/app/e2e/fix-with-agent-transition.spec.ts
+++ b/packages/app/e2e/fix-with-agent-transition.spec.ts
@@ -7,8 +7,8 @@
  * The underlying bug: when the setFixAwaitingApproval delta is missed by the
  * renderer (e.g. webContents.send silently fails for an unresponsive window),
  * the node stays stuck on "FIXING WITH AI" until a full app restart. The fix
- * adds a refreshTasks() call after the fixWithAgent IPC resolves as a safety
- * net, and uses isFixingWithAI: false (instead of undefined) so the value
+ * now relies on the graph refresh event path after the fixWithAgent IPC resolves,
+ * and uses isFixingWithAI: false (instead of undefined) so the value
  * survives IPC serialization.
  *
  * This test exercises the real UI action path to verify the end-to-end

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -48,8 +48,8 @@ export function createMockInvoker(
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
 
   const api: InvokerAPI = {
-    // Defer resolution one microtask so snapshot is read after synchronous setTasks()
-    // in tests (useTasks fetchAll races mount vs setTasks; real IPC resolves later too).
+    // Defer resolution one microtask so the startup snapshot is read after synchronous setTasks()
+    // in tests (real IPC resolves later too).
     getTasks: vi.fn(
       () =>
         new Promise<{ tasks: TaskState[]; workflows: WorkflowMeta[]; streamSequence: number }>((resolve) => {
@@ -169,7 +169,7 @@ export function createMockInvoker(
     }),
     onTerminalExit: vi.fn(() => () => {}),
     resumeWorkflow: vi.fn(async () => null),
-    listWorkflows: vi.fn(async () => []),
+    listWorkflows: vi.fn(async () => workflowSnapshot),
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),
     deleteAllWorkflows: vi.fn(async () => {}),
     deleteAllWorkflowsBulk: vi.fn(async () => {}),
@@ -201,12 +201,20 @@ export function createMockInvoker(
 
   function setTasks(tasks: TaskState[], workflows?: WorkflowMeta[]) {
     taskSnapshot = tasks;
-    if (workflows) workflowSnapshot = workflows;
-
-    // Fire created graph events for each task
-    for (const task of tasks) {
-      graphEventCallback?.({ type: 'delta', delta: { type: 'created', task } });
+    if (workflows) {
+      workflowSnapshot = workflows;
     }
+
+    queueMicrotask(() => {
+      if (workflows) {
+        workflowsCallback?.(workflows);
+      }
+
+      // Fire created graph events for each task after subscribers attach.
+      for (const task of tasks) {
+        graphEventCallback?.({ type: 'delta', delta: { type: 'created', task } });
+      }
+    });
   }
 
   function fireDelta(delta: TaskDelta) {

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -175,7 +175,7 @@ describe('useTasks', () => {
     expect(result.current.workflows.size).toBe(1);
   });
 
-  it('falls back to fetchAll on mount when bootstrap is empty', async () => {
+  it('loads the startup snapshot on mount when bootstrap is empty', async () => {
     const fetched = makeUITask({ id: 'fetched-1', description: 'Fetched' });
     const getTasks = vi.fn().mockResolvedValue({
       tasks: [fetched],
@@ -202,6 +202,55 @@ describe('useTasks', () => {
       expect(result.current.tasks.get('fetched-1')?.description).toBe('Fetched');
       expect(result.current.workflows.get('wf-x')?.name).toBe('WF X');
     });
+  });
+
+  it('ignores a stale startup snapshot after a graph event arrives first', async () => {
+    let releaseStartupSnapshot: (value: { tasks: ReturnType<typeof makeUITask>[]; workflows: unknown[]; streamSequence: number }) => void;
+    let taskGraphEventHandler: ((event: unknown) => void) | undefined;
+    const startupSnapshot = new Promise<{ tasks: ReturnType<typeof makeUITask>[]; workflows: unknown[]; streamSequence: number }>((resolve) => {
+      releaseStartupSnapshot = resolve;
+    });
+    const liveTask = makeUITask({ id: 'live-1', description: 'Live task' });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [],
+      workflows: [],
+    };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks: vi.fn().mockReturnValue(startupSnapshot),
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(taskGraphEventHandler).toBeDefined();
+    });
+
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'snapshot',
+        tasks: [liveTask],
+        workflows: [],
+        reason: 'test-live-snapshot',
+        streamSequence: 7,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 130));
+    });
+
+    await waitFor(() => {
+      expect(result.current.tasks.get('live-1')?.description).toBe('Live task');
+    });
+
+    await act(async () => {
+      releaseStartupSnapshot!({ tasks: [], workflows: [], streamSequence: 0 });
+    });
+
+    expect(result.current.tasks.get('live-1')?.description).toBe('Live task');
+    expect(result.current.tasks.size).toBe(1);
   });
 
   it('forced refresh after a hydrated bootstrap requests a graph refresh and waits for the snapshot event', async () => {
@@ -271,6 +320,50 @@ describe('useTasks', () => {
     await waitFor(() => {
       expect(refreshTaskGraph).toHaveBeenCalledTimes(1);
       expect(getTasks).not.toHaveBeenCalled();
+    });
+  });
+
+  it('refreshes workflow metadata via listWorkflows when a created delta introduces a new workflow', async () => {
+    let taskGraphEventHandler: ((event: unknown) => void) | undefined;
+    const getTasks = vi.fn().mockResolvedValue({ tasks: [], workflows: [] });
+    const listWorkflows = vi.fn().mockResolvedValue([
+      { id: 'wf-2', name: 'Workflow 2', status: 'running' },
+    ]);
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [makeUITask({ id: 'boot-1', description: 'Boot task' })],
+      workflows: [],
+    };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks,
+      listWorkflows,
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(taskGraphEventHandler).toBeDefined();
+    });
+
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'created',
+          task: makeUITask({ id: 'wf-2/task-1', workflowId: 'wf-2', status: 'pending' }),
+        },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 130));
+    });
+
+    await waitFor(() => {
+      expect(listWorkflows).toHaveBeenCalledTimes(1);
+      expect(getTasks).not.toHaveBeenCalled();
+      expect(result.current.workflows.get('wf-2')?.name).toBe('Workflow 2');
     });
   });
 

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -72,20 +72,23 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     applyTotalMs: 0,
     applyMaxMs: 0,
   });
-  /** Bumps on each refresh so stale getTasks IPC (e.g. mount snapshot before loadPlan) cannot wipe newer state. */
-  const getTasksGenerationRef = useRef(0);
+  /** Bumps when newer UI activity supersedes the startup getTasks snapshot. */
+  const startupSnapshotGenerationRef = useRef(0);
   const reportedStartupBootstrapRef = useRef(false);
   const reportedStartupSnapshotRef = useRef(false);
   const lastSeenSequenceRef = useRef<number>(bootstrapState?.streamSequence ?? 0);
   const isResyncInFlightRef = useRef<boolean>(false);
 
-  const fetchAll = useCallback((): Promise<void> => {
+  const invalidateStartupSnapshot = useCallback(() => {
+    startupSnapshotGenerationRef.current += 1;
+  }, []);
+  const loadStartupSnapshot = useCallback((): Promise<void> => {
     if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
-    const gen = ++getTasksGenerationRef.current;
+    const gen = ++startupSnapshotGenerationRef.current;
     const requestedAt = performance.now();
     const request = window.invoker.getTasks().then((result) => {
       const requestDurationMs = performance.now() - requestedAt;
-      if (gen !== getTasksGenerationRef.current) {
+      if (gen !== startupSnapshotGenerationRef.current) {
         return;
       }
       const taskList = result.tasks ?? [];
@@ -134,10 +137,33 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     window.invoker.checkPrStatuses?.();
     return request.then(() => undefined);
   }, []);
+  const refreshWorkflowMetadata = useCallback((): Promise<void> => {
+    if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
+    const requestedAt = performance.now();
+    const request = window.invoker.listWorkflows().then((wfList) => {
+      setWorkflows(() => {
+        const wfMap = new Map<string, WorkflowMeta>();
+        for (const wf of wfList) {
+          wfMap.set(wf.id, {
+            ...wf,
+            status: normalizeWorkflowStatus((wf as { status?: string }).status),
+          });
+        }
+        return wfMap;
+      });
+      void window.invoker.reportUiPerf?.('useTasks_workflow_metadata_refresh', {
+        workflowCount: wfList.length,
+        requestDurationMs: performance.now() - requestedAt,
+        jsonSizeBytes: new Blob([JSON.stringify(wfList)]).size,
+      });
+    });
+    return request.then(() => undefined);
+  }, []);
   const refreshTaskGraph = useCallback((): Promise<void> => {
     if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
+    invalidateStartupSnapshot();
     return window.invoker.refreshTaskGraph();
-  }, []);
+  }, [invalidateStartupSnapshot]);
 
 
   useEffect(() => {
@@ -173,7 +199,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
           : undefined,
       });
     } else {
-      fetchAll();
+      void loadStartupSnapshot();
     }
 
     graphEventPipelineRef.current = createTaskGraphEventPipeline({
@@ -258,14 +284,14 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
           deltaPerfRef.current.applyMaxMs = Math.max(deltaPerfRef.current.applyMaxMs, dt);
           return next;
         });
-
         if (shouldRefreshWorkflows) {
-          fetchAll();
+          void refreshWorkflowMetadata();
         }
       },
     });
 
     const handleTaskGraphEvent = (event: TaskGraphEvent) => {
+      invalidateStartupSnapshot();
       deltaPerfRef.current.received += 1;
       if (event.type === 'snapshot') {
         graphEventPipelineRef.current?.push(event);
@@ -315,6 +341,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     const unsub = window.invoker.onTaskGraphEvent(handleTaskGraphEvent);
 
     const unsubWf = window.invoker.onWorkflowsChanged?.((wfList: any[]) => {
+      invalidateStartupSnapshot();
       if (Array.isArray(wfList)) {
         setWorkflows(() => {
           const wfMap = new Map<string, WorkflowMeta>();
@@ -335,7 +362,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       unsub();
       unsubWf?.();
     };
-  }, [fetchAll, onTaskGraphSnapshotApplied, refreshTaskGraph]);
+  }, [invalidateStartupSnapshot, loadStartupSnapshot, onTaskGraphSnapshotApplied, refreshTaskGraph, refreshWorkflowMetadata]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;


### PR DESCRIPTION
## Summary

This keeps `getTasks()` on the startup path only.

Later workflow metadata refreshes now read `listWorkflows()`, and later graph events invalidate any pending startup snapshot before it can overwrite live state.

The UI test mock now delivers seeded workflow metadata through the same async event path, so startup-only reads do not hide missing workflow updates.

## Architecture

### Before

```mermaid
graph TD
    A[getTasks startup snapshot] --> D[task and workflow replace]
    B[created delta for new workflow] --> A
    C[live graph event] --> D
```

### After

```mermaid
graph TD
    A[getTasks startup snapshot] --> D[startup-only replace]
    B[created delta for new workflow] --> E[listWorkflows metadata refresh]
    C[live graph event] --> F[invalidate startup snapshot]
    E --> G[workflow metadata replace]
    C --> H[task graph pipeline]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/ui exec vitest run`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert bde64c924`
- Post-revert steps: None
- Data migration? No


Depends-On: #1396
