### PR TITLE
Fix intent cancellation Step 4: durable failure diagnostics (regression gated v2)

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2959,12 +2959,6 @@ function createEmbeddedTerminalBackendFromConfig(
                       },
                     };
                     logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
-                    // Snapshot the concrete failure context into durable output
-                    // before the synthetic stall failure overwrites
-                    // task.execution.error with the coarse stall reason. Tasks
-                    // stalled while still launching collapse a real executor
-                    // startup failure; preserve its recent output tail / startup
-                    // stderr so post-mortem retrieval keeps the concrete details.
                     if (persistence) {
                       persistShutdownDiagnostic(task, persistence, {
                         flushPendingOutput: flushTaskOutput,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2933,6 +2933,21 @@ function createEmbeddedTerminalBackendFromConfig(
                       },
                     };
                     logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
+                    // Snapshot the concrete failure context into durable output
+                    // before the synthetic stall failure overwrites
+                    // task.execution.error with the coarse stall reason. Tasks
+                    // stalled while still launching collapse a real executor
+                    // startup failure; preserve its recent output tail / startup
+                    // stderr so post-mortem retrieval keeps the concrete details.
+                    if (persistence) {
+                      persistShutdownDiagnostic(task, persistence, {
+                        flushPendingOutput: flushTaskOutput,
+                        forcedStopReason: executingError,
+                        label: task.execution.phase === 'launching'
+                          ? 'Startup Failure Diagnostic'
+                          : 'Shutdown Diagnostic',
+                      });
+                    }
                     orchestrator.handleWorkerResponse(failedResponse);
                     continue;
                   }

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2350,6 +2350,63 @@ describe('SQLiteAdapter', () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+
+    it('folds durable diagnostic content into the output tail', async () => {
+      // Executor startup failures append concrete startup stderr via
+      // appendTaskOutput, which lands only in the diagnostic file (never the
+      // spool). getOutputTail — the source persistShutdownDiagnostic snapshots
+      // and the live-tail IPC reads — must surface it so a synthetic
+      // owner-shutdown / startup-stall failure retains the concrete context
+      // instead of a coarse terminal error alone.
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-tail-diag-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const db = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        db.saveWorkflow(testWorkflow);
+        db.saveTask('wf-1', makeTask('t-tail-diag'));
+
+        db.appendOutputChunk('t-tail-diag', 'streaming line\n');
+        db.appendTaskOutput(
+          't-tail-diag',
+          'Executor startup failed (worktree): posix_spawnp ENOENT\n',
+        );
+
+        const tail = db.getOutputTail('t-tail-diag');
+        const joined = tail.map((c) => c.data).join('');
+        expect(joined).toContain('streaming line');
+        expect(joined).toContain('Executor startup failed (worktree): posix_spawnp ENOENT');
+
+        db.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns a startup diagnostic tail even with no spool output', async () => {
+      // An executor that dies before streaming anything leaves only the
+      // diagnostic file; the tail must still surface its concrete message.
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-tail-diag-only-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const db = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        db.saveWorkflow(testWorkflow);
+        db.saveTask('wf-1', makeTask('t-tail-diag-only'));
+
+        db.appendTaskOutput(
+          't-tail-diag-only',
+          'Executor startup failed (docker): image pull timed out\n',
+        );
+
+        const tail = db.getOutputTail('t-tail-diag-only');
+        expect(tail.map((c) => c.data).join('')).toContain('image pull timed out');
+
+        db.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('pruneDuplicateTaskOutputRows', () => {
@@ -3833,7 +3890,12 @@ describe('SQLiteAdapter', () => {
         expect(sqliteScalar(db, 'SELECT COUNT(*) FROM task_output')).toBe(0);
         expect(sqliteScalar(db, 'SELECT COUNT(*) FROM output_spool')).toBe(0);
         expect(db.listWorkflows()).toHaveLength(1);
-        expect(db.getOutputTail('t-large-output')).toHaveLength(5);
+        // 5 spool chunks (bounded by outputTailLimit) plus a single bounded
+        // diagnostic chunk folded in from the large full/*.log file.
+        const tail = db.getOutputTail('t-large-output');
+        expect(tail).toHaveLength(6);
+        // The diagnostic chunk must be bounded, not the multi-MB raw file.
+        expect(tail[tail.length - 1].data.length).toBeLessThan(64 * 1024);
 
         db.close();
       } finally {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2352,12 +2352,6 @@ describe('SQLiteAdapter', () => {
     });
 
     it('folds durable diagnostic content into the output tail', async () => {
-      // Executor startup failures append concrete startup stderr via
-      // appendTaskOutput, which lands only in the diagnostic file (never the
-      // spool). getOutputTail — the source persistShutdownDiagnostic snapshots
-      // and the live-tail IPC reads — must surface it so a synthetic
-      // owner-shutdown / startup-stall failure retains the concrete context
-      // instead of a coarse terminal error alone.
       const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-tail-diag-'));
       const dbPath = join(dir, 'invoker.db');
 
@@ -2384,8 +2378,6 @@ describe('SQLiteAdapter', () => {
     });
 
     it('returns a startup diagnostic tail even with no spool output', async () => {
-      // An executor that dies before streaming anything leaves only the
-      // diagnostic file; the tail must still surface its concrete message.
       const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-tail-diag-only-'));
       const dbPath = join(dir, 'invoker.db');
 
@@ -3890,11 +3882,8 @@ describe('SQLiteAdapter', () => {
         expect(sqliteScalar(db, 'SELECT COUNT(*) FROM task_output')).toBe(0);
         expect(sqliteScalar(db, 'SELECT COUNT(*) FROM output_spool')).toBe(0);
         expect(db.listWorkflows()).toHaveLength(1);
-        // 5 spool chunks (bounded by outputTailLimit) plus a single bounded
-        // diagnostic chunk folded in from the large full/*.log file.
         const tail = db.getOutputTail('t-large-output');
         expect(tail).toHaveLength(6);
-        // The diagnostic chunk must be bounded, not the multi-MB raw file.
         expect(tail[tail.length - 1].data.length).toBeLessThan(64 * 1024);
 
         db.close();

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -63,12 +63,6 @@ function loadNativeSqlite(): Promise<NativeSqlite> {
 }
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
-/**
- * Max characters of the durable diagnostic file (full/*.log) folded into a
- * tail read. Bounds the memory footprint of getOutputTail when a task has a
- * large diagnostic file while still surfacing concrete startup/shutdown
- * failure details to live-tail and post-mortem snapshots.
- */
 const OUTPUT_DIAGNOSTIC_TAIL_CHARS = 8_000;
 
 
@@ -2449,16 +2443,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
   getOutputTail(taskId: string): OutputChunk[] {
     const spoolTail = this.getSpoolOutputTail(taskId);
 
-    // Fold in the durable diagnostic file (full/*.log). Executor startup
-    // failures append their concrete startup stderr/message there via
-    // appendTaskOutput, and that content never reaches the output spool. A
-    // tail read for a synthetic owner-shutdown or startup-stall failure would
-    // otherwise snapshot an empty tail and lose the concrete startup context.
-    // Append it as a single trailing chunk so both the live tail and
-    // post-mortem diagnostic snapshots surface it. Read fresh each call
-    // (never cached) so it stays current as diagnostics are appended at
-    // terminal time, and bound the read so a large diagnostic file can't blow
-    // up the tail's memory footprint.
     const diagnostic = this.readDiagnosticTail(taskId, OUTPUT_DIAGNOSTIC_TAIL_CHARS);
     if (!diagnostic) return spoolTail;
     const lastOffset = spoolTail.length > 0
@@ -2467,12 +2451,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return [...spoolTail, { offset: lastOffset, data: diagnostic }];
   }
 
-  /**
-   * Read at most `maxChars` from the end of the durable diagnostic file
-   * (full/*.log). Returns '' when the file is missing or empty. A leading
-   * marker is added when the file is truncated so readers know earlier
-   * diagnostic content exists.
-   */
   private readDiagnosticTail(taskId: string, maxChars: number): string {
     const file = this.taskOutputFile(taskId);
     if (!existsSync(file)) return '';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -63,6 +63,14 @@ function loadNativeSqlite(): Promise<NativeSqlite> {
 }
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
+/**
+ * Max characters of the durable diagnostic file (full/*.log) folded into a
+ * tail read. Bounds the memory footprint of getOutputTail when a task has a
+ * large diagnostic file while still surfacing concrete startup/shutdown
+ * failure details to live-tail and post-mortem snapshots.
+ */
+const OUTPUT_DIAGNOSTIC_TAIL_CHARS = 8_000;
+
 
 /**
  * Rewrite `pnpm test packages/<pkg>/...` (incorrect root-level invocation)
@@ -2439,6 +2447,49 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   getOutputTail(taskId: string): OutputChunk[] {
+    const spoolTail = this.getSpoolOutputTail(taskId);
+
+    // Fold in the durable diagnostic file (full/*.log). Executor startup
+    // failures append their concrete startup stderr/message there via
+    // appendTaskOutput, and that content never reaches the output spool. A
+    // tail read for a synthetic owner-shutdown or startup-stall failure would
+    // otherwise snapshot an empty tail and lose the concrete startup context.
+    // Append it as a single trailing chunk so both the live tail and
+    // post-mortem diagnostic snapshots surface it. Read fresh each call
+    // (never cached) so it stays current as diagnostics are appended at
+    // terminal time, and bound the read so a large diagnostic file can't blow
+    // up the tail's memory footprint.
+    const diagnostic = this.readDiagnosticTail(taskId, OUTPUT_DIAGNOSTIC_TAIL_CHARS);
+    if (!diagnostic) return spoolTail;
+    const lastOffset = spoolTail.length > 0
+      ? spoolTail[spoolTail.length - 1].offset + 1
+      : 0;
+    return [...spoolTail, { offset: lastOffset, data: diagnostic }];
+  }
+
+  /**
+   * Read at most `maxChars` from the end of the durable diagnostic file
+   * (full/*.log). Returns '' when the file is missing or empty. A leading
+   * marker is added when the file is truncated so readers know earlier
+   * diagnostic content exists.
+   */
+  private readDiagnosticTail(taskId: string, maxChars: number): string {
+    const file = this.taskOutputFile(taskId);
+    if (!existsSync(file)) return '';
+    const size = statSync(file).size;
+    if (size === 0) return '';
+    if (size <= maxChars) return readFileSync(file, 'utf8');
+    const fd = openSync(file, 'r');
+    try {
+      const buffer = Buffer.allocUnsafe(maxChars);
+      readSync(fd, buffer, 0, maxChars, size - maxChars);
+      return '...' + buffer.toString('utf8');
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  private getSpoolOutputTail(taskId: string): OutputChunk[] {
     // Return from cache if available
     const cached = this.outputTailCache.get(taskId);
     if (cached && cached.length > 0) {


### PR DESCRIPTION
## Summary

Startup failures now keep concrete stderr and stdout details in durable task output instead of collapsing later reads to a generic terminal error.

Forced-stop handling now records the same kind of diagnostics for every task state that can be shut down.

The test-only no-op provision hook keeps the regression suite bounded while covering the durable-output path.

<details>
<summary>Review metadata</summary>

Review Claim: Approve routing startup and forced-stop failures into durable task output as concrete diagnostic blocks.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Task status and exit semantics stay unchanged. The slice only adds durable diagnostic text and a bounded test-only provisioning hook.

Slice Rationale: This slice isolates the durable-output wiring and tests from the verification repro, so reviewers can inspect the observability change independently.

</details>

## Non-goals

- No change to task status, terminal state, or exit-code semantics.
- No change to the executor spawn path itself.
- Does not touch the shared repro script or the Step 5 verification slice.
- No data migration.

## Architecture

### Before

```mermaid
graph TD
    A["Startup or forced-stop failure"] --> B["Transient executor output"]
    B --> C["Terminal task state"]
    C --> D["Later inspection sees generic failure"]
```

### After

```mermaid
graph TD
    A["Startup or forced-stop failure"] --> B["Diagnostic formatter"]
    B --> C["Durable task output"]
    C --> D["SQLite output reader"]
    D --> E["Later inspection sees concrete failure details"]
```

## Test Plan

- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge commit sha>`
- Post-revert steps: Re-run `pnpm run test:all`.
- Data migration? No
