### PR TITLE
Fix intent cancellation Step 4: durable failure diagnostics (restacked v3)

### DIFF
--- a/packages/app/src/__tests__/shutdown-diagnostic.test.ts
+++ b/packages/app/src/__tests__/shutdown-diagnostic.test.ts
@@ -163,4 +163,56 @@ describe('persistShutdownDiagnostic', () => {
     const output = db.appended[0];
     expect(output).toContain('status=fixing_with_ai');
   });
+
+  it('records syntheticError in the diagnostic block', () => {
+    // Synthetic shutdown errors like "Application quit" or "Stopped by user"
+    // are emitted via handleWorkerResponse after the diagnostic is appended.
+    // Capturing them here preserves the concrete terminal reason in durable
+    // task output for post-mortem retrieval, instead of leaving only a coarse
+    // collapsed marker.
+    const task = makeTask({
+      status: 'running',
+      execution: { error: 'real runtime error message' },
+    });
+    const db = makeDb(['streaming output\n']);
+
+    persistShutdownDiagnostic(task, db, { syntheticError: 'Application quit' });
+
+    const output = db.appended[0];
+    expect(output).toContain('syntheticError=Application quit');
+    expect(output).toContain('error=real runtime error message');
+    expect(output).toContain('streaming output');
+  });
+
+  it('records syntheticError when execution.error is absent', () => {
+    const task = makeTask({ status: 'running', execution: {} });
+    const db = makeDb();
+
+    persistShutdownDiagnostic(task, db, { syntheticError: 'Stopped by user' });
+
+    const output = db.appended[0];
+    expect(output).toContain('syntheticError=Stopped by user');
+    expect(output).not.toContain('error=');
+  });
+
+  it('honours a custom label override', () => {
+    const task = makeTask();
+    const db = makeDb();
+
+    persistShutdownDiagnostic(task, db, { label: 'Startup Failure Diagnostic' });
+
+    const output = db.appended[0];
+    expect(output).toContain('[Startup Failure Diagnostic]');
+  });
+
+  it('omits syntheticError line when not provided', () => {
+    const task = makeTask({ execution: { error: 'real error' } });
+    const db = makeDb();
+
+    persistShutdownDiagnostic(task, db);
+
+    const output = db.appended[0];
+    expect(output).not.toContain('syntheticError=');
+    expect(output).toContain('error=real error');
+  });
 });

--- a/packages/app/src/__tests__/shutdown-diagnostic.test.ts
+++ b/packages/app/src/__tests__/shutdown-diagnostic.test.ts
@@ -164,9 +164,9 @@ describe('persistShutdownDiagnostic', () => {
     expect(output).toContain('status=fixing_with_ai');
   });
 
-  it('records syntheticError in the diagnostic block', () => {
-    // Synthetic shutdown errors like "Application quit" or "Stopped by user"
-    // are emitted via handleWorkerResponse after the diagnostic is appended.
+  it('records forcedStopReason in the diagnostic block', () => {
+    // Forced-stop reasons like "Application quit" or "Stopped by user" are
+    // emitted via handleWorkerResponse after the diagnostic is appended.
     // Capturing them here preserves the concrete terminal reason in durable
     // task output for post-mortem retrieval, instead of leaving only a coarse
     // collapsed marker.
@@ -176,22 +176,22 @@ describe('persistShutdownDiagnostic', () => {
     });
     const db = makeDb(['streaming output\n']);
 
-    persistShutdownDiagnostic(task, db, { syntheticError: 'Application quit' });
+    persistShutdownDiagnostic(task, db, { forcedStopReason: 'Application quit' });
 
     const output = db.appended[0];
-    expect(output).toContain('syntheticError=Application quit');
+    expect(output).toContain('forcedStopReason=Application quit');
     expect(output).toContain('error=real runtime error message');
     expect(output).toContain('streaming output');
   });
 
-  it('records syntheticError when execution.error is absent', () => {
+  it('records forcedStopReason when execution.error is absent', () => {
     const task = makeTask({ status: 'running', execution: {} });
     const db = makeDb();
 
-    persistShutdownDiagnostic(task, db, { syntheticError: 'Stopped by user' });
+    persistShutdownDiagnostic(task, db, { forcedStopReason: 'Stopped by user' });
 
     const output = db.appended[0];
-    expect(output).toContain('syntheticError=Stopped by user');
+    expect(output).toContain('forcedStopReason=Stopped by user');
     expect(output).not.toContain('error=');
   });
 
@@ -205,14 +205,14 @@ describe('persistShutdownDiagnostic', () => {
     expect(output).toContain('[Startup Failure Diagnostic]');
   });
 
-  it('omits syntheticError line when not provided', () => {
+  it('omits forcedStopReason line when not provided', () => {
     const task = makeTask({ execution: { error: 'real error' } });
     const db = makeDb();
 
     persistShutdownDiagnostic(task, db);
 
     const output = db.appended[0];
-    expect(output).not.toContain('syntheticError=');
+    expect(output).not.toContain('forcedStopReason=');
     expect(output).toContain('error=real error');
   });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1101,6 +1101,7 @@ if (isHeadless) {
               for (const task of allTasks) {
                 if (isTaskInFlightForForcedStop(task)) {
                   logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc-delegate' });
+                  persistShutdownDiagnostic(task, persistence, { syntheticError: 'Stopped by user' });
                   orchestrator.handleWorkerResponse({
                     requestId: `stop-${task.id}`,
                     actionId: task.id,
@@ -1716,7 +1717,9 @@ if (isHeadless) {
       if (ownsHeadlessShutdown && orchestrator) {
         for (const task of orchestrator.getAllTasks()) {
           if (isTaskInFlightForForcedStop(task)) {
-            if (persistence) persistShutdownDiagnostic(task, persistence);
+            if (persistence) {
+              persistShutdownDiagnostic(task, persistence, { syntheticError: 'Application quit' });
+            }
             orchestrator.handleWorkerResponse({
               requestId: `quit-${task.id}`,
               actionId: task.id,
@@ -3563,6 +3566,10 @@ function createEmbeddedTerminalBackendFromConfig(
         for (const task of allTasks) {
           if (isTaskInFlightForForcedStop(task)) {
             logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc' });
+            persistShutdownDiagnostic(task, persistence, {
+              flushPendingOutput: flushTaskOutput,
+              syntheticError: 'Stopped by user',
+            });
             orchestrator.handleWorkerResponse({
               requestId: `stop-${task.id}`,
               actionId: task.id,
@@ -4732,6 +4739,7 @@ function createEmbeddedTerminalBackendFromConfig(
               if (persistence) {
                 persistShutdownDiagnostic(task, persistence, {
                   flushPendingOutput: flushTaskOutput,
+                  syntheticError: 'Application quit',
                 });
               }
               orchestrator.handleWorkerResponse({

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1101,7 +1101,7 @@ if (isHeadless) {
               for (const task of allTasks) {
                 if (isTaskInFlightForForcedStop(task)) {
                   logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc-delegate' });
-                  persistShutdownDiagnostic(task, persistence, { syntheticError: 'Stopped by user' });
+                  persistShutdownDiagnostic(task, persistence, { forcedStopReason: 'Stopped by user' });
                   orchestrator.handleWorkerResponse({
                     requestId: `stop-${task.id}`,
                     actionId: task.id,
@@ -1718,7 +1718,7 @@ if (isHeadless) {
         for (const task of orchestrator.getAllTasks()) {
           if (isTaskInFlightForForcedStop(task)) {
             if (persistence) {
-              persistShutdownDiagnostic(task, persistence, { syntheticError: 'Application quit' });
+              persistShutdownDiagnostic(task, persistence, { forcedStopReason: 'Application quit' });
             }
             orchestrator.handleWorkerResponse({
               requestId: `quit-${task.id}`,
@@ -3568,7 +3568,7 @@ function createEmbeddedTerminalBackendFromConfig(
             logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc' });
             persistShutdownDiagnostic(task, persistence, {
               flushPendingOutput: flushTaskOutput,
-              syntheticError: 'Stopped by user',
+              forcedStopReason: 'Stopped by user',
             });
             orchestrator.handleWorkerResponse({
               requestId: `stop-${task.id}`,
@@ -4739,7 +4739,7 @@ function createEmbeddedTerminalBackendFromConfig(
               if (persistence) {
                 persistShutdownDiagnostic(task, persistence, {
                   flushPendingOutput: flushTaskOutput,
-                  syntheticError: 'Application quit',
+                  forcedStopReason: 'Application quit',
                 });
               }
               orchestrator.handleWorkerResponse({

--- a/packages/app/src/shutdown-diagnostic.ts
+++ b/packages/app/src/shutdown-diagnostic.ts
@@ -8,10 +8,27 @@ export interface ShutdownDiagnosticDb {
 /** Max characters of recent output tail included in shutdown diagnostics. */
 export const SHUTDOWN_DIAGNOSTIC_TAIL_CHARS = 4_000;
 
+export interface PersistShutdownDiagnosticOptions {
+  flushPendingOutput?: (taskId: string) => void;
+  /**
+   * The synthetic terminal-error string that will be written to the task
+   * record alongside this diagnostic (e.g. "Application quit",
+   * "Stopped by user"). Captured here so post-mortem inspection retains
+   * the concrete reason in the durable output even after the coarse
+   * `task.execution.error` field is overwritten.
+   */
+  syntheticError?: string;
+  /**
+   * Diagnostic block header label. Defaults to "Shutdown Diagnostic".
+   * Use to distinguish e.g. user-stop vs application-quit if needed.
+   */
+  label?: string;
+}
+
 /**
  * Persist a compact diagnostic block into durable task output so that
  * post-mortem inspection retains concrete context instead of collapsing
- * to "Application quit".
+ * to a coarse synthetic error like "Application quit" or "Stopped by user".
  *
  * Called from both headless and GUI shutdown paths before the synthetic
  * failure response is emitted.
@@ -19,7 +36,7 @@ export const SHUTDOWN_DIAGNOSTIC_TAIL_CHARS = 4_000;
 export function persistShutdownDiagnostic(
   task: TaskState,
   db: ShutdownDiagnosticDb,
-  opts?: { flushPendingOutput?: (taskId: string) => void },
+  opts?: PersistShutdownDiagnosticOptions,
 ): void {
   try {
     // Flush any buffered output so the spool is up-to-date.
@@ -32,8 +49,12 @@ export function persistShutdownDiagnostic(
       tail = '...' + tail.slice(tail.length - SHUTDOWN_DIAGNOSTIC_TAIL_CHARS);
     }
 
-    const parts: string[] = ['\n[Shutdown Diagnostic]'];
+    const label = opts?.label ?? 'Shutdown Diagnostic';
+    const parts: string[] = [`\n[${label}]`];
     parts.push(`status=${task.status}`);
+    if (opts?.syntheticError) {
+      parts.push(`syntheticError=${opts.syntheticError}`);
+    }
     if (task.execution.error) {
       parts.push(`error=${task.execution.error}`);
     }

--- a/packages/app/src/shutdown-diagnostic.ts
+++ b/packages/app/src/shutdown-diagnostic.ts
@@ -11,13 +11,12 @@ export const SHUTDOWN_DIAGNOSTIC_TAIL_CHARS = 4_000;
 export interface PersistShutdownDiagnosticOptions {
   flushPendingOutput?: (taskId: string) => void;
   /**
-   * The synthetic terminal-error string that will be written to the task
-   * record alongside this diagnostic (e.g. "Application quit",
-   * "Stopped by user"). Captured here so post-mortem inspection retains
-   * the concrete reason in the durable output even after the coarse
-   * `task.execution.error` field is overwritten.
+   * The forced-stop reason that will be written to the task record alongside
+   * this diagnostic (e.g. "Application quit", "Stopped by user"). Captured
+   * here so post-mortem inspection retains the concrete reason in the durable
+   * output even after the coarse `task.execution.error` field is overwritten.
    */
-  syntheticError?: string;
+  forcedStopReason?: string;
   /**
    * Diagnostic block header label. Defaults to "Shutdown Diagnostic".
    * Use to distinguish e.g. user-stop vs application-quit if needed.
@@ -28,9 +27,9 @@ export interface PersistShutdownDiagnosticOptions {
 /**
  * Persist a compact diagnostic block into durable task output so that
  * post-mortem inspection retains concrete context instead of collapsing
- * to a coarse synthetic error like "Application quit" or "Stopped by user".
+ * to a coarse forced-stop reason like "Application quit" or "Stopped by user".
  *
- * Called from both headless and GUI shutdown paths before the synthetic
+ * Called from both headless and GUI shutdown paths before the forced-stop
  * failure response is emitted.
  */
 export function persistShutdownDiagnostic(
@@ -52,8 +51,8 @@ export function persistShutdownDiagnostic(
     const label = opts?.label ?? 'Shutdown Diagnostic';
     const parts: string[] = [`\n[${label}]`];
     parts.push(`status=${task.status}`);
-    if (opts?.syntheticError) {
-      parts.push(`syntheticError=${opts.syntheticError}`);
+    if (opts?.forcedStopReason) {
+      parts.push(`forcedStopReason=${opts.forcedStopReason}`);
     }
     if (task.execution.error) {
       parts.push(`error=${task.execution.error}`);

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2104,6 +2104,41 @@ describe('SQLiteAdapter', () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+
+    it('surfaces appendTaskOutput diagnostic content alongside spool stream', async () => {
+      // Regression: synthetic shutdown / executor startup failures append a
+      // diagnostic block via appendTaskOutput. Without this, getTaskOutput
+      // would discard the diagnostic when any spool chunks exist and post-
+      // mortem inspection would see only the coarse synthetic error.
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-output-diag-tail-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const db = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        db.saveWorkflow(testWorkflow);
+        db.saveTask('wf-1', makeTask('t-diag-tail'));
+
+        db.appendOutputChunk('t-diag-tail', 'FAIL src/foo.test.ts\n');
+        db.appendOutputChunk('t-diag-tail', 'Error: assertion failed\n');
+        db.appendTaskOutput(
+          't-diag-tail',
+          '\n[Shutdown Diagnostic]\nstatus=running\nsyntheticError=Application quit\n--- end shutdown diagnostic ---\n',
+        );
+
+        const output = db.getTaskOutput('t-diag-tail');
+        expect(output).toContain('FAIL src/foo.test.ts');
+        expect(output).toContain('Error: assertion failed');
+        expect(output).toContain('[Shutdown Diagnostic]');
+        expect(output).toContain('syntheticError=Application quit');
+        // Diagnostic block must come after the streaming output, not before.
+        expect(output.indexOf('FAIL src/foo.test.ts'))
+          .toBeLessThan(output.indexOf('[Shutdown Diagnostic]'));
+
+        db.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('pruneDuplicateTaskOutputRows', () => {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2106,10 +2106,10 @@ describe('SQLiteAdapter', () => {
     });
 
     it('surfaces appendTaskOutput diagnostic content alongside spool stream', async () => {
-      // Regression: synthetic shutdown / executor startup failures append a
+      // Regression: forced stops / executor startup failures append a
       // diagnostic block via appendTaskOutput. Without this, getTaskOutput
       // would discard the diagnostic when any spool chunks exist and post-
-      // mortem inspection would see only the coarse synthetic error.
+      // mortem inspection would see only the coarse forced-stop reason.
       const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-output-diag-tail-'));
       const dbPath = join(dir, 'invoker.db');
 
@@ -2122,14 +2122,14 @@ describe('SQLiteAdapter', () => {
         db.appendOutputChunk('t-diag-tail', 'Error: assertion failed\n');
         db.appendTaskOutput(
           't-diag-tail',
-          '\n[Shutdown Diagnostic]\nstatus=running\nsyntheticError=Application quit\n--- end shutdown diagnostic ---\n',
+          '\n[Shutdown Diagnostic]\nstatus=running\nforcedStopReason=Application quit\n--- end shutdown diagnostic ---\n',
         );
 
         const output = db.getTaskOutput('t-diag-tail');
         expect(output).toContain('FAIL src/foo.test.ts');
         expect(output).toContain('Error: assertion failed');
         expect(output).toContain('[Shutdown Diagnostic]');
-        expect(output).toContain('syntheticError=Application quit');
+        expect(output).toContain('forcedStopReason=Application quit');
         // Diagnostic block must come after the streaming output, not before.
         expect(output.indexOf('FAIL src/foo.test.ts'))
           .toBeLessThan(output.indexOf('[Shutdown Diagnostic]'));

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2307,11 +2307,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
     // stores contain the same data.
     //
     // The diagnostic file (written via appendTaskOutput) is always appended.
-    // It is reserved for post-mortem diagnostic blocks (e.g. synthetic shutdown
-    // or executor startup failures); the streaming runner output goes through
-    // the spool. Concatenating it lets retrieval surface concrete failure
-    // details that would otherwise be hidden behind a coarse synthetic error
-    // like "Application quit".
+    // It is reserved for post-mortem diagnostic blocks (e.g. forced stops or
+    // executor startup failures); the streaming runner output goes through the
+    // spool. Concatenating it lets retrieval surface concrete failure details
+    // that would otherwise be hidden behind a coarse forced-stop reason like
+    // "Application quit".
     const diagnosticFile = this.readTaskOutputFile(taskId);
     const spoolChunks = this.getOutputChunks(taskId);
     if (spoolChunks.length > 0) {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2303,17 +2303,25 @@ export class SQLiteAdapter implements PersistenceAdapter {
   getTaskOutput(taskId: string): string {
     // Prefer the output spool (DB + file) when it has any chunks for this task —
     // it is the canonical streaming-output store. Otherwise fall back to
-    // task_output (legacy DB rows + diagnostic file), which avoids returning a
-    // duplicated stream when both stores contain the same data.
+    // task_output DB rows, which avoids returning a duplicated stream when both
+    // stores contain the same data.
+    //
+    // The diagnostic file (written via appendTaskOutput) is always appended.
+    // It is reserved for post-mortem diagnostic blocks (e.g. synthetic shutdown
+    // or executor startup failures); the streaming runner output goes through
+    // the spool. Concatenating it lets retrieval surface concrete failure
+    // details that would otherwise be hidden behind a coarse synthetic error
+    // like "Application quit".
+    const diagnosticFile = this.readTaskOutputFile(taskId);
     const spoolChunks = this.getOutputChunks(taskId);
     if (spoolChunks.length > 0) {
-      return spoolChunks.map((chunk) => chunk.data).join('');
+      return spoolChunks.map((chunk) => chunk.data).join('') + diagnosticFile;
     }
     const rows = this.queryAll(
       'SELECT data FROM task_output WHERE task_id = ? ORDER BY id ASC',
       [taskId],
     ) as Array<{ data: string }>;
-    return rows.map((r) => r.data).join('') + this.readTaskOutputFile(taskId);
+    return rows.map((r) => r.data).join('') + diagnosticFile;
   }
 
   /**

--- a/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
@@ -144,4 +144,81 @@ describe('SSH worktree metadata repro', () => {
       }),
     }));
   });
+
+  it('blocks a stale SSH startup failure from rewriting metadata once the task advanced to a newer attempt', async () => {
+    const ownerPath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-bc7a0b71';
+    const staleBranch = 'experiment/wf-1/test-execution-engine-b68b146f';
+
+    // Attempt-1's SSH launch fails *after* the task has already advanced to
+    // attempt-2.  Without the lineage guard this stale failure would overwrite
+    // the live task's workspace/branch metadata and emit a failed response
+    // against the newer selected attempt.
+    const failingExecutor = {
+      type: 'ssh',
+      start: vi.fn().mockRejectedValue(Object.assign(
+        new Error(
+          'SSH remote script failed (exit=128)\n' +
+            `STDERR:\nPreparing worktree (checking out '${staleBranch}')\n` +
+            `fatal: '${staleBranch}' is already used by worktree at '${ownerPath}'\n`,
+        ),
+        {
+          workspacePath: ownerPath,
+          branch: staleBranch,
+        },
+      )),
+      onComplete: vi.fn(),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+
+    // The launch we kick off belongs to attempt-1.
+    const staleLaunchTask = makeTask({
+      id: 'wf-1/test-execution-engine',
+      status: 'running',
+      config: { command: 'pnpm test', runnerKind: 'ssh' },
+      execution: { selectedAttemptId: 'attempt-1' },
+    });
+    // The orchestrator's live view has already moved on to attempt-2.
+    const liveTask = makeTask({
+      id: 'wf-1/test-execution-engine',
+      status: 'running',
+      config: { command: 'pnpm test', runnerKind: 'ssh' },
+      execution: { selectedAttemptId: 'attempt-2' },
+    });
+
+    const updateSpy = vi.fn();
+    const handleResponseSpy = vi.fn();
+
+    const runner = new TaskRunner({
+      orchestrator: {
+        getTask: () => liveTask,
+        getAllTasks: () => [liveTask],
+        handleWorkerResponse: handleResponseSpy,
+      } as any,
+      persistence: {
+        updateTask: updateSpy,
+        appendTaskOutput: vi.fn(),
+      } as any,
+      executorRegistry: {
+        getDefault: () => failingExecutor,
+        get: () => failingExecutor,
+        getAll: () => [failingExecutor],
+      } as any,
+      cwd: '/tmp',
+    });
+
+    await runner.executeTask(staleLaunchTask);
+
+    // The stale owner path / branch must never reach the live task row.
+    expect(updateSpy).not.toHaveBeenCalledWith('wf-1/test-execution-engine', expect.objectContaining({
+      execution: expect.objectContaining({ workspacePath: ownerPath }),
+    }));
+    expect(updateSpy).not.toHaveBeenCalledWith('wf-1/test-execution-engine', expect.objectContaining({
+      execution: expect.objectContaining({ branch: staleBranch }),
+    }));
+    // And no failed response may be emitted against the newer selected attempt.
+    expect(handleResponseSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

When a task is stopped or the app quits while it is still running, saved output now keeps the useful failure details.

Before this, Invoker could save streaming output in one place and a shutdown note in another. Reading the output back could drop the note.

The fix always appends the diagnostic note after the saved stream. The note now says `forcedStopReason`, so it is clear Invoker stopped the task.

This only changes what we save for later inspection. Task status and stop behavior stay the same.

## Architecture

### Before

```mermaid
graph TD
    Q[Shutdown or forced stop] --> D[persistShutdownDiagnostic writes tail and status]
    D --> F[(diagnostic file)]
    G[getTaskOutput] --> S{spool has chunks?}
    S -->|yes| SP[return spool only]
    S -->|no| DB[return DB rows plus diagnostic file]
    SP --> X[diagnostic dropped]
```

### After

```mermaid
graph TD
    Q[Shutdown or forced stop] --> D[persistShutdownDiagnostic writes tail, status, forcedStopReason]
    D --> F[(diagnostic file)]
    G[getTaskOutput] --> S{spool has chunks?}
    S -->|yes| SP[return spool plus diagnostic file]
    S -->|no| DB[return DB rows plus diagnostic file]
    SP --> X[original output plus stop reason visible]
    DB --> X
```

## Test Plan

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/shutdown-diagnostic.test.ts`
- [x] `cd packages/data-store && pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 89a9e616 8d481453`
- Post-revert steps: None
- Data migration? No

## Files

- packages/app/src/__tests__/shutdown-diagnostic.test.ts
- packages/app/src/main.ts
- packages/app/src/shutdown-diagnostic.ts
- packages/data-store/src/__tests__/sqlite-adapter.test.ts
- packages/data-store/src/sqlite-adapter.ts
