### PR TITLE
Crabbox SSH step 2: resolver

### DIFF
--- a/packages/execution-engine/src/__tests__/crabbox-target-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/crabbox-target-resolver.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CrabboxTargetResolver,
+  buildCrabboxWarmupArgs,
+  buildCrabboxStatusArgs,
+  type CrabboxCommandResult,
+  type CrabboxCommandRunner,
+  type CrabboxResolverTargetConfig,
+} from '../crabbox-target-resolver.js';
+
+const baseConfig: CrabboxResolverTargetConfig = {
+  id: 'crab1',
+  crabboxCommand: '/usr/local/bin/crabbox',
+  provider: 'fly',
+  class: 'performance-4x',
+  ttl: '30m',
+  idleTimeout: '10m',
+  network: 'invoker-net',
+  target: 'us-east',
+  stopAfter: 'completed',
+  keepOnFailure: true,
+  warmupArgs: ['--warm'],
+  statusArgs: ['--region', 'iad'],
+};
+
+function ok(stdout: string): CrabboxCommandResult {
+  return { stdout, stderr: '', exitCode: 0 };
+}
+
+const STATUS_JSON = JSON.stringify({
+  id: 'lease-123',
+  slug: 'happy-crab',
+  provider: 'fly',
+  status: 'ready',
+  expiresAt: '2026-01-01T00:30:00.000Z',
+  sshHost: '10.0.0.5',
+  sshUser: 'invoker',
+  sshPort: 2222,
+  sshKey: '/home/me/.ssh/crabbox',
+});
+
+/** Records each invocation and replays scripted results in order. */
+function scriptRunner(results: CrabboxCommandResult[]): {
+  runner: CrabboxCommandRunner;
+  calls: Array<{ command: string; args: readonly string[] }>;
+} {
+  const calls: Array<{ command: string; args: readonly string[] }> = [];
+  let i = 0;
+  const runner: CrabboxCommandRunner = async (command, args) => {
+    calls.push({ command, args });
+    const result = results[i];
+    i += 1;
+    return result;
+  };
+  return { runner, calls };
+}
+
+describe('buildCrabboxWarmupArgs', () => {
+  it('builds warmup args from config plus explicit warmupArgs', () => {
+    expect(buildCrabboxWarmupArgs(baseConfig)).toEqual([
+      'warmup',
+      '--provider',
+      'fly',
+      '--class',
+      'performance-4x',
+      '--ttl',
+      '30m',
+      '--idle-timeout',
+      '10m',
+      '--network',
+      'invoker-net',
+      '--target',
+      'us-east',
+      '--warm',
+    ]);
+  });
+});
+
+describe('buildCrabboxStatusArgs', () => {
+  it('requests JSON status, waits, and appends explicit statusArgs', () => {
+    expect(buildCrabboxStatusArgs(baseConfig, 'lease-123')).toEqual([
+      'status',
+      '--id',
+      'lease-123',
+      '--json',
+      '--wait',
+      '--region',
+      'iad',
+    ]);
+  });
+});
+
+describe('CrabboxTargetResolver.resolve', () => {
+  it('warms up, polls status, and returns an SSH target plus lease metadata', async () => {
+    const { runner, calls } = scriptRunner([
+      ok(JSON.stringify({ id: 'lease-123', slug: 'happy-crab' })),
+      ok(STATUS_JSON),
+    ]);
+    const resolver = new CrabboxTargetResolver(runner);
+
+    const result = await resolver.resolve(baseConfig);
+
+    expect(calls[0]).toEqual({
+      command: '/usr/local/bin/crabbox',
+      args: buildCrabboxWarmupArgs(baseConfig),
+    });
+    expect(calls[1]).toEqual({
+      command: '/usr/local/bin/crabbox',
+      args: buildCrabboxStatusArgs(baseConfig, 'lease-123'),
+    });
+
+    expect(result.sshTarget).toEqual({
+      host: '10.0.0.5',
+      user: 'invoker',
+      sshKeyPath: '/home/me/.ssh/crabbox',
+      port: 2222,
+    });
+    expect(result.remoteLeaseMetadata).toEqual({
+      provider: 'crabbox',
+      leaseId: 'lease-123',
+      slug: 'happy-crab',
+      targetId: 'crab1',
+      sshHost: '10.0.0.5',
+      sshUser: 'invoker',
+      sshPort: 2222,
+      sshKeyPath: '/home/me/.ssh/crabbox',
+      expiresAt: '2026-01-01T00:30:00.000Z',
+      stopAfter: 'completed',
+      keepOnFailure: true,
+    });
+  });
+
+  it('accepts a plain id/slug printed by warmup', async () => {
+    const { runner, calls } = scriptRunner([ok('lease-999\n'), ok(STATUS_JSON)]);
+    const resolver = new CrabboxTargetResolver(runner);
+
+    await resolver.resolve(baseConfig);
+
+    expect(calls[1].args).toEqual(buildCrabboxStatusArgs(baseConfig, 'lease-999'));
+  });
+
+  it('falls back to the slug as lease ref when warmup omits id', async () => {
+    const { runner, calls } = scriptRunner([
+      ok(JSON.stringify({ slug: 'only-slug' })),
+      ok(STATUS_JSON),
+    ]);
+    const resolver = new CrabboxTargetResolver(runner);
+
+    await resolver.resolve(baseConfig);
+
+    expect(calls[1].args).toEqual(buildCrabboxStatusArgs(baseConfig, 'only-slug'));
+  });
+
+  it('falls back to configured port when status omits sshPort', async () => {
+    const status = JSON.stringify({
+      id: 'lease-123',
+      slug: 'happy-crab',
+      sshHost: '10.0.0.5',
+      sshUser: 'invoker',
+      sshKey: '/home/me/.ssh/crabbox',
+    });
+    const { runner } = scriptRunner([ok('lease-123'), ok(status)]);
+
+    const result = await new CrabboxTargetResolver(runner).resolve({
+      ...baseConfig,
+      port: 2200,
+    });
+
+    expect(result.sshTarget.port).toBe(2200);
+    expect(result.remoteLeaseMetadata.sshPort).toBe(2200);
+  });
+
+  it('defaults to port 22 when neither status nor config supply a port', async () => {
+    const status = JSON.stringify({
+      id: 'lease-123',
+      slug: 'happy-crab',
+      sshHost: '10.0.0.5',
+      sshUser: 'invoker',
+      sshKey: '/home/me/.ssh/crabbox',
+    });
+    const { runner } = scriptRunner([ok('lease-123'), ok(status)]);
+
+    const result = await new CrabboxTargetResolver(runner).resolve(baseConfig);
+
+    expect(result.sshTarget.port).toBe(22);
+  });
+
+  it('rejects missing sshHost/sshUser/sshKey with an error naming the target id', async () => {
+    const status = JSON.stringify({
+      id: 'lease-123',
+      slug: 'happy-crab',
+      sshUser: 'invoker',
+    });
+    const { runner } = scriptRunner([ok('lease-123'), ok(status)]);
+
+    await expect(
+      new CrabboxTargetResolver(runner).resolve(baseConfig),
+    ).rejects.toThrow(/crab1.*sshHost.*sshKey/s);
+  });
+
+  it('throws an actionable error when warmup exits non-zero', async () => {
+    const { runner } = scriptRunner([
+      { stdout: '', stderr: 'no capacity', exitCode: 1 },
+    ]);
+
+    await expect(
+      new CrabboxTargetResolver(runner).resolve(baseConfig),
+    ).rejects.toThrow(/Crabbox warmup failed for remote target "crab1".*no capacity/s);
+  });
+
+  it('throws an actionable error when status exits non-zero', async () => {
+    const { runner } = scriptRunner([
+      ok('lease-123'),
+      { stdout: '', stderr: 'lease expired', exitCode: 2 },
+    ]);
+
+    await expect(
+      new CrabboxTargetResolver(runner).resolve(baseConfig),
+    ).rejects.toThrow(/Crabbox status failed for remote target "crab1".*lease expired/s);
+  });
+
+  it('throws when warmup returns no lease id or slug', async () => {
+    const { runner } = scriptRunner([ok('   '), ok(STATUS_JSON)]);
+
+    await expect(
+      new CrabboxTargetResolver(runner).resolve(baseConfig),
+    ).rejects.toThrow(/did not return a lease id or slug/);
+  });
+
+  it('throws when status output is not valid JSON', async () => {
+    const { runner } = scriptRunner([ok('lease-123'), ok('not json')]);
+
+    await expect(
+      new CrabboxTargetResolver(runner).resolve(baseConfig),
+    ).rejects.toThrow(/did not return valid JSON/);
+  });
+});

--- a/packages/execution-engine/src/__tests__/crabbox-target-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/crabbox-target-resolver.test.ts
@@ -155,6 +155,7 @@ describe('CrabboxTargetResolver.resolve', () => {
     const status = JSON.stringify({
       id: 'lease-123',
       slug: 'happy-crab',
+      expiresAt: '2026-01-01T00:30:00.000Z',
       sshHost: '10.0.0.5',
       sshUser: 'invoker',
       sshKey: '/home/me/.ssh/crabbox',
@@ -174,6 +175,7 @@ describe('CrabboxTargetResolver.resolve', () => {
     const status = JSON.stringify({
       id: 'lease-123',
       slug: 'happy-crab',
+      expiresAt: '2026-01-01T00:30:00.000Z',
       sshHost: '10.0.0.5',
       sshUser: 'invoker',
       sshKey: '/home/me/.ssh/crabbox',
@@ -233,5 +235,62 @@ describe('CrabboxTargetResolver.resolve', () => {
     await expect(
       new CrabboxTargetResolver(runner).resolve(baseConfig),
     ).rejects.toThrow(/did not return valid JSON/);
+  });
+
+  it('treats whitespace-only sshHost/sshUser/sshKey as missing values', async () => {
+    const status = JSON.stringify({
+      id: 'lease-123',
+      slug: 'happy-crab',
+      expiresAt: '2026-01-01T00:30:00.000Z',
+      sshHost: '   ',
+      sshUser: '\t',
+      sshPort: 2222,
+      sshKey: '  ',
+    });
+    const { runner } = scriptRunner([ok('lease-123'), ok(status)]);
+
+    await expect(
+      new CrabboxTargetResolver(runner).resolve(baseConfig),
+    ).rejects.toThrow(/crab1.*sshHost.*sshUser.*sshKey/s);
+  });
+
+  it('rejects an out-of-range or non-integer sshPort and falls back to the default port', async () => {
+    const build = (sshPort: unknown) =>
+      JSON.stringify({
+        id: 'lease-123',
+        slug: 'happy-crab',
+        expiresAt: '2026-01-01T00:30:00.000Z',
+        sshHost: '10.0.0.5',
+        sshUser: 'invoker',
+        sshPort,
+        sshKey: '/home/me/.ssh/crabbox',
+      });
+
+    for (const badPort of [0, -1, 2222.5, 70000]) {
+      const { runner } = scriptRunner([ok('lease-123'), ok(build(badPort))]);
+      const result = await new CrabboxTargetResolver(runner).resolve(baseConfig);
+      expect(result.sshTarget.port).toBe(22);
+      expect(result.remoteLeaseMetadata.sshPort).toBe(22);
+    }
+  });
+
+  it('throws when status omits expiresAt instead of persisting an empty string', async () => {
+    const build = (expiresAt?: unknown) =>
+      JSON.stringify({
+        id: 'lease-123',
+        slug: 'happy-crab',
+        sshHost: '10.0.0.5',
+        sshUser: 'invoker',
+        sshPort: 2222,
+        sshKey: '/home/me/.ssh/crabbox',
+        ...(expiresAt === undefined ? {} : { expiresAt }),
+      });
+
+    for (const status of [build(), build('   ')]) {
+      const { runner } = scriptRunner([ok('lease-123'), ok(status)]);
+      await expect(
+        new CrabboxTargetResolver(runner).resolve(baseConfig),
+      ).rejects.toThrow(/crab1.*expiresAt/s);
+    }
   });
 });

--- a/packages/execution-engine/src/crabbox-target-resolver.ts
+++ b/packages/execution-engine/src/crabbox-target-resolver.ts
@@ -1,0 +1,296 @@
+import { spawn } from 'node:child_process';
+import type { CrabboxRemoteLeaseMetadata } from '@invoker/workflow-core';
+
+/**
+ * Resolve a Crabbox-leased machine into a ready-to-use SSH endpoint.
+ *
+ * Crabbox owns machine supply: a warmup call creates or finds the leased
+ * machine, then a status call (with `--wait`) blocks until the lease is
+ * reachable and reports its SSH coordinates. This resolver runs those two
+ * Crabbox subcommands and turns the result into a static SSH target plus the
+ * durable lease metadata Invoker persists for cleanup and terminal restore.
+ *
+ * It does NOT create an SshExecutor or run any task; callers feed the returned
+ * target into the normal SSH execution path. Crabbox stays a machine supplier;
+ * Invoker stays the workflow and SSH executor owner.
+ */
+
+/** Result of running a single Crabbox CLI invocation. */
+export interface CrabboxCommandResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+/**
+ * Runs one Crabbox CLI invocation. Injected so tests can drive the resolver
+ * without spawning a real process. Defaults to {@link spawnCrabboxCommand}.
+ */
+export type CrabboxCommandRunner = (
+  command: string,
+  args: readonly string[],
+) => Promise<CrabboxCommandResult>;
+
+/**
+ * Crabbox lease inputs the resolver needs to warm up and inspect a target.
+ *
+ * Mirrors the configured `type: 'crabbox'` remote target, but is declared
+ * locally so execution-engine does not depend on the app config package.
+ */
+export interface CrabboxResolverTargetConfig {
+  /** Config key of the remote target. Named in errors and lease metadata. */
+  readonly id: string;
+  /** CLI entrypoint that creates/inspects Crabbox leases. */
+  readonly crabboxCommand: string;
+  /** Crabbox provider to lease from. */
+  readonly provider: string;
+  /** Machine class/size to lease. */
+  readonly class: string;
+  /** Lease time-to-live (e.g. '30m'). */
+  readonly ttl: string;
+  /** Idle timeout before the lease auto-stops (e.g. '10m'). */
+  readonly idleTimeout: string;
+  /** Network to attach the leased machine to. */
+  readonly network: string;
+  /** Crabbox target selector for the lease. */
+  readonly target: string;
+  /** When to stop the lease after the task settles (e.g. 'completed', 'never'). */
+  readonly stopAfter: string;
+  /** Keep the lease alive on failure for debugging instead of stopping it. */
+  readonly keepOnFailure: boolean;
+  /** SSH port to fall back to when the lease status omits one. Default: 22. */
+  readonly port?: number;
+  /** Optional extra args appended to the warmup subcommand. */
+  readonly warmupArgs?: readonly string[];
+  /** Optional extra args appended to the status subcommand. */
+  readonly statusArgs?: readonly string[];
+}
+
+/** A fixed SSH host the SSH executor can connect to directly. */
+export interface ResolvedSshTarget {
+  readonly host: string;
+  readonly user: string;
+  /** Path to the SSH identity file (private key). */
+  readonly sshKeyPath: string;
+  readonly port: number;
+}
+
+/** A resolved Crabbox lease: a ready SSH target plus durable lease metadata. */
+export interface ResolvedCrabboxTarget {
+  readonly sshTarget: ResolvedSshTarget;
+  readonly remoteLeaseMetadata: CrabboxRemoteLeaseMetadata;
+}
+
+/** Subset of Crabbox `status --json` fields the resolver reads. */
+interface CrabboxStatusJson {
+  id?: unknown;
+  slug?: unknown;
+  provider?: unknown;
+  status?: unknown;
+  expiresAt?: unknown;
+  sshHost?: unknown;
+  sshUser?: unknown;
+  sshPort?: unknown;
+  sshKey?: unknown;
+}
+
+const DEFAULT_SSH_PORT = 22;
+
+/** Default runner: spawn the Crabbox CLI and collect its output. */
+export function spawnCrabboxCommand(
+  command: string,
+  args: readonly string[],
+): Promise<CrabboxCommandResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args as string[], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      resolve({ stdout, stderr, exitCode: code ?? 0 });
+    });
+  });
+}
+
+/**
+ * Build the warmup args that create or find the leased machine.
+ *
+ * Includes only the lease shape (provider/class/ttl/idle/network/target) plus
+ * any caller-supplied warmupArgs — status flags belong on the status call.
+ */
+export function buildCrabboxWarmupArgs(
+  config: CrabboxResolverTargetConfig,
+): string[] {
+  return [
+    'warmup',
+    '--provider',
+    config.provider,
+    '--class',
+    config.class,
+    '--ttl',
+    config.ttl,
+    '--idle-timeout',
+    config.idleTimeout,
+    '--network',
+    config.network,
+    '--target',
+    config.target,
+    ...(config.warmupArgs ?? []),
+  ];
+}
+
+/**
+ * Build the status args that block until the lease is reachable and print its
+ * SSH coordinates as JSON. `leaseRef` is the id or slug returned by warmup.
+ */
+export function buildCrabboxStatusArgs(
+  config: CrabboxResolverTargetConfig,
+  leaseRef: string,
+): string[] {
+  return [
+    'status',
+    '--id',
+    leaseRef,
+    '--json',
+    '--wait',
+    ...(config.statusArgs ?? []),
+  ];
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Resolves Crabbox remote targets into ready SSH endpoints.
+ *
+ * The command runner is injectable so tests (and alternate transports) can
+ * supply Crabbox output without spawning a process.
+ */
+export class CrabboxTargetResolver {
+  private readonly run: CrabboxCommandRunner;
+
+  constructor(run: CrabboxCommandRunner = spawnCrabboxCommand) {
+    this.run = run;
+  }
+
+  async resolve(
+    config: CrabboxResolverTargetConfig,
+  ): Promise<ResolvedCrabboxTarget> {
+    const warmup = await this.run(
+      config.crabboxCommand,
+      buildCrabboxWarmupArgs(config),
+    );
+    if (warmup.exitCode !== 0) {
+      throw new Error(
+        `Crabbox warmup failed for remote target "${config.id}" (exit ${warmup.exitCode}): ${warmup.stderr.trim() || warmup.stdout.trim()}`,
+      );
+    }
+    const leaseRef = this.parseLeaseRef(config, warmup);
+
+    const status = await this.run(
+      config.crabboxCommand,
+      buildCrabboxStatusArgs(config, leaseRef),
+    );
+    if (status.exitCode !== 0) {
+      throw new Error(
+        `Crabbox status failed for remote target "${config.id}" (exit ${status.exitCode}): ${status.stderr.trim() || status.stdout.trim()}`,
+      );
+    }
+    return this.buildResolvedTarget(config, status, leaseRef);
+  }
+
+  /** Read the lease id (or slug) that warmup printed for the status call. */
+  private parseLeaseRef(
+    config: CrabboxResolverTargetConfig,
+    warmup: CrabboxCommandResult,
+  ): string {
+    const text = warmup.stdout.trim();
+    const parsed = tryParseJson(text);
+    if (parsed) {
+      const ref = asNonEmptyString(parsed.id) ?? asNonEmptyString(parsed.slug);
+      if (ref) return ref;
+    } else if (text.length > 0) {
+      // Tolerate a plain id/slug printed on stdout.
+      return text;
+    }
+    throw new Error(
+      `Crabbox warmup for remote target "${config.id}" did not return a lease id or slug.`,
+    );
+  }
+
+  private buildResolvedTarget(
+    config: CrabboxResolverTargetConfig,
+    status: CrabboxCommandResult,
+    leaseRef: string,
+  ): ResolvedCrabboxTarget {
+    const json = tryParseJson(status.stdout.trim());
+    if (!json) {
+      throw new Error(
+        `Crabbox status for remote target "${config.id}" did not return valid JSON.`,
+      );
+    }
+
+    const sshHost = asNonEmptyString(json.sshHost);
+    const sshUser = asNonEmptyString(json.sshUser);
+    const sshKeyPath = asNonEmptyString(json.sshKey);
+    const missing: string[] = [];
+    if (!sshHost) missing.push('sshHost');
+    if (!sshUser) missing.push('sshUser');
+    if (!sshKeyPath) missing.push('sshKey');
+    if (missing.length > 0) {
+      throw new Error(
+        `Crabbox status for remote target "${config.id}" is missing required SSH field(s): ${missing.join(', ')}. ` +
+          `Cannot build an SSH endpoint for this lease.`,
+      );
+    }
+
+    const sshPort =
+      typeof json.sshPort === 'number' && Number.isFinite(json.sshPort)
+        ? json.sshPort
+        : (config.port ?? DEFAULT_SSH_PORT);
+    const leaseId = asNonEmptyString(json.id) ?? leaseRef;
+    const slug = asNonEmptyString(json.slug) ?? leaseId;
+    const expiresAt = asNonEmptyString(json.expiresAt) ?? '';
+
+    return {
+      sshTarget: {
+        host: sshHost as string,
+        user: sshUser as string,
+        sshKeyPath: sshKeyPath as string,
+        port: sshPort,
+      },
+      remoteLeaseMetadata: {
+        provider: 'crabbox',
+        leaseId,
+        slug,
+        targetId: config.id,
+        sshHost: sshHost as string,
+        sshUser: sshUser as string,
+        sshPort,
+        sshKeyPath: sshKeyPath as string,
+        expiresAt,
+        stopAfter: config.stopAfter,
+        keepOnFailure: config.keepOnFailure,
+      },
+    };
+  }
+}
+
+function tryParseJson(text: string): CrabboxStatusJson | null {
+  if (!text.startsWith('{') && !text.startsWith('[')) return null;
+  try {
+    const value = JSON.parse(text);
+    return value && typeof value === 'object' ? (value as CrabboxStatusJson) : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/execution-engine/src/crabbox-target-resolver.ts
+++ b/packages/execution-engine/src/crabbox-target-resolver.ts
@@ -166,7 +166,19 @@ export function buildCrabboxStatusArgs(
 }
 
 function asNonEmptyString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.length > 0 ? value : undefined;
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/** Accept a value only when it is an integer in the valid TCP port range. */
+function asValidPort(value: unknown): number | undefined {
+  return typeof value === 'number' &&
+    Number.isInteger(value) &&
+    value >= 1 &&
+    value <= 65535
+    ? value
+    : undefined;
 }
 
 /**
@@ -254,12 +266,15 @@ export class CrabboxTargetResolver {
     }
 
     const sshPort =
-      typeof json.sshPort === 'number' && Number.isFinite(json.sshPort)
-        ? json.sshPort
-        : (config.port ?? DEFAULT_SSH_PORT);
+      asValidPort(json.sshPort) ?? asValidPort(config.port) ?? DEFAULT_SSH_PORT;
     const leaseId = asNonEmptyString(json.id) ?? leaseRef;
     const slug = asNonEmptyString(json.slug) ?? leaseId;
-    const expiresAt = asNonEmptyString(json.expiresAt) ?? '';
+    const expiresAt = asNonEmptyString(json.expiresAt);
+    if (!expiresAt) {
+      throw new Error(
+        `Crabbox status for remote target "${config.id}" is missing required field: expiresAt.`,
+      );
+    }
 
     return {
       sshTarget: {

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -15,6 +15,7 @@ export * from './docker-executor.js';
 export * from './worktree-executor.js';
 export * from './merge-gate-executor.js';
 export * from './ssh-executor.js';
+export * from './crabbox-target-resolver.js';
 export * from './repo-pool.js';
 export * from './registry.js';
 export * from './task-runner.js';

--- a/scripts/repro/repro-coderabbit-pr1401-empty-expiresat.sh
+++ b/scripts/repro/repro-coderabbit-pr1401-empty-expiresat.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Repro: Crabbox lease metadata must never persist an empty `expiresAt`.
+#
+# CodeRabbit PR #1401 (packages/execution-engine/src/crabbox-target-resolver.ts):
+#   `expiresAt` fell back to '' when status omitted it, but the durable
+#   CrabboxRemoteLeaseMetadata contract documents `expiresAt` as an ISO timestamp.
+#   Persisting '' risks downstream lease parsing/cleanup failures.
+#
+# Fixed behavior:
+#   The resolver fails loudly with an actionable error naming the target id when
+#   status omits (or supplies a whitespace-only) `expiresAt`, instead of writing ''.
+#
+# Guarded by the vitest case below; this script fails (non-zero) on buggy code.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT/packages/execution-engine"
+
+TEST_FILE="src/__tests__/crabbox-target-resolver.test.ts"
+FILTER="throws when status omits expiresAt"
+
+echo "==> Repro: missing/empty expiresAt must throw, not persist an empty string"
+if pnpm exec vitest run "$TEST_FILE" -t "$FILTER"; then
+  echo "PASS: missing expiresAt is rejected instead of persisted as ''"
+else
+  echo "FAIL: empty expiresAt persisted into lease metadata (CodeRabbit PR#1401)" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr1401-ssh-port-validation.sh
+++ b/scripts/repro/repro-coderabbit-pr1401-ssh-port-validation.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Repro: Crabbox status sshPort must be a real TCP port before it is accepted.
+#
+# CodeRabbit PR #1401 (packages/execution-engine/src/crabbox-target-resolver.ts):
+#   sshPort was accepted whenever `Number.isFinite(json.sshPort)` was true, which
+#   admits 0, negatives, out-of-range (>65535), and non-integers. Any of these
+#   yields an unusable SSH target at runtime instead of falling back sensibly.
+#
+# Fixed behavior:
+#   Only integers in [1, 65535] are accepted from status or config; otherwise the
+#   resolver falls back to config.port (when valid) then to the default port 22.
+#
+# Guarded by the vitest case below; this script fails (non-zero) on buggy code.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT/packages/execution-engine"
+
+TEST_FILE="src/__tests__/crabbox-target-resolver.test.ts"
+FILTER="rejects an out-of-range or non-integer sshPort"
+
+echo "==> Repro: invalid sshPort (0/negative/non-integer/>65535) must fall back"
+if pnpm exec vitest run "$TEST_FILE" -t "$FILTER"; then
+  echo "PASS: invalid sshPort values are rejected and fall back to a valid port"
+else
+  echo "FAIL: invalid sshPort accepted, producing an unusable target (CodeRabbit PR#1401)" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr1401-whitespace-ssh-fields.sh
+++ b/scripts/repro/repro-coderabbit-pr1401-whitespace-ssh-fields.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Repro: Crabbox status SSH fields that are whitespace-only must be rejected.
+#
+# CodeRabbit PR #1401 (packages/execution-engine/src/crabbox-target-resolver.ts):
+#   `asNonEmptyString` accepted any string with length > 0, so status values like
+#   "   " (sshHost/sshUser/sshKey) passed the required-field check and produced an
+#   unusable SSH target that only failed later at connect time.
+#
+# Fixed behavior:
+#   `asNonEmptyString` trims first, so whitespace-only values are treated as
+#   missing and `resolve()` throws an actionable error naming the target id.
+#
+# Guarded by the vitest case below; this script fails (non-zero) on buggy code.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT/packages/execution-engine"
+
+TEST_FILE="src/__tests__/crabbox-target-resolver.test.ts"
+FILTER="treats whitespace-only sshHost"
+
+echo "==> Repro: whitespace-only sshHost/sshUser/sshKey must be treated as missing"
+if pnpm exec vitest run "$TEST_FILE" -t "$FILTER"; then
+  echo "PASS: whitespace-only SSH fields are rejected as missing"
+else
+  echo "FAIL: whitespace-only SSH fields accepted as valid (CodeRabbit PR#1401)" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

This adds a small module that turns Crabbox config into a ready-to-use SSH target. Crabbox supplies the machine; Invoker stays the workflow and SSH executor.

The module shells out to the Crabbox CLI. It warms up a box, then waits for status to report a reachable SSH endpoint.

It reads the status JSON and maps the SSH host, user, port, and key into Invoker's normal SSH target shape, plus durable lease metadata for later cleanup.

It fails loudly with clear errors when a CLI step exits non-zero, when status JSON cannot be parsed, or when host, user, or key are missing.

This keeps raw Crabbox process handling out of TaskRunner. The runtime executor stays a plain SSH target, so nothing else changes.

## Test Plan

- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Crabbox-based target resolver that provisions leased remote machines and returns SSH connection details with durable lease metadata.
  * Supports warmup + status command flow, intelligent SSH port selection (with validation and sensible defaults), and robust parsing of warmup/status outputs.

* **Tests**
  * Added comprehensive Vitest coverage for CLI argument generation, successful resolution, parsing variations, port validation, and failure handling.
  * Added reproducible regression scripts for missing/empty `expiresAt` and whitespace-only SSH fields, plus SSH port rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->