### PR TITLE
Terminal Drawer Three States

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -507,7 +507,7 @@ test.describe('Visual proof capture', () => {
     await assertPageScreenshot(page, 'task-panel');
   });
 
-  test('embedded-tabbed-terminal — drawer expands with active task tab', async ({ page, testDir }) => {
+  test('embedded-tabbed-terminal — drawer opens partial with active task tab', async ({ page, testDir }) => {
     await loadPlan(page, TEST_PLAN);
 
     // Materialise a real workspace dir so the main-process executor can resolve
@@ -527,16 +527,16 @@ test.describe('Visual proof capture', () => {
       },
     ]);
 
-    // Drawer starts collapsed.
-    await expect(page.getByRole('button', { name: 'Expand terminal drawer' })).toBeVisible();
+    // Drawer starts minimized.
+    await expect(page.getByRole('button', { name: 'Partial terminal drawer' })).toBeVisible();
     await expect(page.getByTestId('terminal-drawer-body')).toHaveCount(0);
 
     const taskCard = page.locator('[title$="task-alpha"]').first();
     await expect(taskCard).toBeVisible({ timeout: 10000 });
     await taskCard.dispatchEvent('dblclick');
 
-    // Drawer expands; one active tab for task-alpha; terminal pane rendered.
-    await expect(page.getByRole('button', { name: 'Collapse terminal drawer' })).toBeVisible({ timeout: 10000 });
+    // Drawer opens partial; one active tab for task-alpha; terminal pane rendered.
+    await expect(page.getByRole('button', { name: 'Maximize terminal drawer' })).toBeVisible({ timeout: 10000 });
     await expect(page.getByTestId('terminal-drawer-body')).toBeVisible();
     const tabs = page.getByTestId('terminal-tab-strip').locator('[data-testid^="terminal-tab-"]');
     await expect(tabs).toHaveCount(1);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -30,7 +30,7 @@ import { FloatingGraphPanel } from './components/FloatingGraphPanel.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
 import { StatusBar } from './components/StatusBar.js';
-import { TerminalDrawer } from './components/TerminalDrawer.js';
+import { TerminalDrawer, type TerminalDrawerState } from './components/TerminalDrawer.js';
 import {
   isExperimentSpawnPivotTask,
   EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE,
@@ -381,7 +381,7 @@ export function App() {
   const [updateCliError, setUpdateCliError] = useState<string | null>(null);
   const [inspectorCollapsed, setInspectorCollapsed] = useState(false);
   const [advancedMetadataExpanded, setAdvancedMetadataExpanded] = useState(false);
-  const [terminalCollapsed, setTerminalCollapsed] = useState(true);
+  const [terminalDrawerState, setTerminalDrawerState] = useState<TerminalDrawerState>('minimized');
   const [terminalSessions, setTerminalSessions] = useState<TerminalSessionDescriptor[]>([]);
   const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null);
   const [workflowContextMenu, setWorkflowContextMenu] = useState<WorkflowContextMenuState | null>(null);
@@ -980,10 +980,10 @@ export function App() {
       if (keyboardRegion === 'bottomBar') {
         if (event.key === 'ArrowUp') {
           event.preventDefault();
-          setTerminalCollapsed(false);
+          setTerminalDrawerState('partial');
         } else if (event.key === 'ArrowDown') {
           event.preventDefault();
-          setTerminalCollapsed(true);
+          setTerminalDrawerState('minimized');
         } else if (event.key === 'ArrowRight') {
           event.preventDefault();
           setBottomStatusIndex((index) => Math.min(visibleStatusKeys.length - 1, index + 1));
@@ -1046,7 +1046,7 @@ export function App() {
       window.alert(EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE);
       return;
     }
-    setTerminalCollapsed(false);
+    setTerminalDrawerState('partial');
     const result = await (window.__INVOKER_TEST_OPEN_TERMINAL__ ?? window.invoker?.openTerminal)?.(taskId);
     if (!result) return;
     if (!result.opened) {
@@ -1875,8 +1875,12 @@ export function App() {
                   onStatusClick={(filterKey, event) => handleStatusClick(filterKey as WorkflowStatus, event)}
                 />
                 <TerminalDrawer
-                  collapsed={terminalCollapsed}
-                  onToggle={() => setTerminalCollapsed((prev) => !prev)}
+                  state={terminalDrawerState}
+                  onCycle={() =>
+                    setTerminalDrawerState((prev) =>
+                      prev === 'minimized' ? 'partial' : prev === 'partial' ? 'maximized' : 'minimized',
+                    )
+                  }
                   sessions={terminalSessions}
                   activeSessionId={activeTerminalSessionId}
                   onSelectSession={setActiveTerminalSessionId}

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -51,7 +51,7 @@ describe('App launch (component)', () => {
   it('shows workflow status chips and terminal drawer controls in home view', () => {
     render(<App />);
     expect(screen.getByTestId('workflow-status-pill-running')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Expand terminal drawer' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
   });
 
   it('opens system setup from left rail settings', async () => {

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -3,7 +3,9 @@
  *
  * Covers the renderer-side acceptance criteria for the
  * `implement-terminal-drawer-tabs` task:
- *   - opening a terminal expands the drawer
+ *   - the drawer has three explicit states: minimized, partial, maximized
+ *   - opening a terminal puts the drawer in the partial state
+ *   - the single cycling button advances minimized → partial → maximized → minimized
  *   - the same task id reuses a single tab
  *   - failures from openTerminal surface as an alert
  */
@@ -132,15 +134,17 @@ describe('Terminal drawer (component)', () => {
     vi.restoreAllMocks();
   });
 
-  it('starts collapsed with no terminal pane visible', async () => {
+  it('starts minimized: header is shown but no terminal body', async () => {
     render(<App />);
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Expand terminal drawer' })).toBeInTheDocument();
+      // From minimized, the single button's next action is "Partial".
+      expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
     });
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
     expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
   });
 
-  it('expands the drawer and adds a tab when opening a terminal via double-click', async () => {
+  it('opens the drawer in the partial state (not maximized) when opening a terminal via double-click', async () => {
     render(<App />);
     act(() => mock.setTasks([taskAlpha, taskBeta], workflows));
     await selectWorkflow();
@@ -148,11 +152,42 @@ describe('Terminal drawer (component)', () => {
     fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Collapse terminal drawer' })).toBeInTheDocument();
+      // Partial drawer's next action is "Maximize".
+      expect(screen.getByRole('button', { name: 'Maximize terminal drawer' })).toBeInTheDocument();
       expect(screen.getByTestId('terminal-drawer-body')).toBeInTheDocument();
       expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument();
     });
+    const drawer = screen.getByTestId('terminal-drawer');
+    expect(drawer).toHaveAttribute('data-state', 'partial');
+    expect(drawer).not.toHaveClass('fixed');
+    // Partial keeps today's 280px body height.
+    expect(screen.getByTestId('terminal-drawer-body')).toHaveStyle({ height: '280px' });
     expect(mock.api.openTerminal).toHaveBeenCalledWith('task-alpha');
+  });
+
+  it('cycles minimized → partial → maximized → minimized via the single button', async () => {
+    render(<App />);
+    act(() => mock.setTasks([taskAlpha], workflows));
+    await selectWorkflow();
+
+    const drawer = screen.getByTestId('terminal-drawer');
+    expect(drawer).toHaveAttribute('data-state', 'minimized');
+
+    // minimized → partial
+    fireEvent.click(screen.getByRole('button', { name: 'Partial terminal drawer' }));
+    expect(drawer).toHaveAttribute('data-state', 'partial');
+    expect(screen.getByTestId('terminal-drawer-body')).toHaveStyle({ height: '280px' });
+
+    // partial → maximized: body covers app content via fixed inset positioning.
+    fireEvent.click(screen.getByRole('button', { name: 'Maximize terminal drawer' }));
+    expect(drawer).toHaveAttribute('data-state', 'maximized');
+    expect(drawer).toHaveClass('fixed');
+    expect(screen.getByTestId('terminal-drawer-body')).toBeInTheDocument();
+
+    // maximized → minimized: body flattens away.
+    fireEvent.click(screen.getByRole('button', { name: 'Minimize terminal drawer' }));
+    expect(drawer).toHaveAttribute('data-state', 'minimized');
+    expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
   });
 
   it('reuses an existing tab when opening the same task twice', async () => {
@@ -165,12 +200,16 @@ describe('Terminal drawer (component)', () => {
       expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument();
     });
 
-    // Collapse, then re-open — should not duplicate the tab.
-    fireEvent.click(screen.getByRole('button', { name: 'Collapse terminal drawer' }));
+    // Minimize (cycle partial → maximized → minimized), then re-open —
+    // should not duplicate the tab.
+    fireEvent.click(screen.getByRole('button', { name: 'Maximize terminal drawer' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Minimize terminal drawer' }));
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
+
     fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Collapse terminal drawer' })).toBeInTheDocument();
+      expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
     });
     const tabs = screen.getAllByTestId('terminal-tab-task-alpha');
     expect(tabs).toHaveLength(1);
@@ -204,9 +243,9 @@ describe('Terminal drawer (component)', () => {
     fireEvent.doubleClick(screen.getByTestId('rf__node-task-beta'));
     await waitFor(() => expect(screen.getByTestId('terminal-tab-task-beta')).toBeInTheDocument());
 
-    // Tab strip and toggle live in the same flex row so the toggle stays visible.
+    // Tab strip and cycle button live in the same flex row so the control stays visible.
     const tabStrip = screen.getByTestId('terminal-tab-strip');
-    const toggle = screen.getByRole('button', { name: 'Collapse terminal drawer' });
+    const toggle = screen.getByRole('button', { name: 'Maximize terminal drawer' });
     expect(tabStrip).toBeInTheDocument();
     expect(toggle).toBeInTheDocument();
     expect(tabStrip.compareDocumentPosition(toggle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
@@ -241,7 +280,8 @@ describe('Terminal drawer (component)', () => {
     fireEvent.click(openTerminalItem);
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Collapse terminal drawer' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Maximize terminal drawer' })).toBeInTheDocument();
+      expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
       expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument();
     });
     expect(mock.api.openTerminal).toHaveBeenCalledWith('task-alpha');

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -16,9 +16,26 @@ import type { TerminalSessionDescriptor } from '@invoker/contracts';
 const DRAWER_BODY_HEIGHT_PX = 280;
 const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
 
+/**
+ * The drawer has one explicit state model:
+ *   - `minimized`: only the header/tab strip; no terminal body.
+ *   - `partial`: today's expanded drawer with a fixed 280px body.
+ *   - `maximized`: the drawer covers all app content (graph + side panels)
+ *     from under the title bar to the bottom of the window.
+ * A single button cycles minimized → partial → maximized → minimized.
+ */
+export type TerminalDrawerState = 'minimized' | 'partial' | 'maximized';
+
+/** Label/next-state for the single cycling button, keyed by current state. */
+const NEXT_STATE_BY_STATE: Record<TerminalDrawerState, { next: TerminalDrawerState; label: string }> = {
+  minimized: { next: 'partial', label: 'Partial' },
+  partial: { next: 'maximized', label: 'Maximize' },
+  maximized: { next: 'minimized', label: 'Minimize' },
+};
+
 interface TerminalDrawerProps {
-  collapsed: boolean;
-  onToggle: () => void;
+  state: TerminalDrawerState;
+  onCycle: () => void;
   sessions: TerminalSessionDescriptor[];
   activeSessionId: string | null;
   onSelectSession: (sessionId: string) => void;
@@ -199,14 +216,17 @@ function TerminalSessionPane({ session, isActive, hasHeader, onOutput }: Termina
 }
 
 export function TerminalDrawer({
-  collapsed,
-  onToggle,
+  state,
+  onCycle,
   sessions,
   activeSessionId,
   onSelectSession,
   onCloseSession,
   taskLabels,
 }: TerminalDrawerProps): JSX.Element {
+  const isMaximized = state === 'maximized';
+  const showBody = state !== 'minimized';
+  const cycleLabel = NEXT_STATE_BY_STATE[state].label;
   const [latestOutputBySession, setLatestOutputBySession] = useState<Map<string, string>>(() => new Map());
   const activeSession = sessions.find((session) => session.sessionId === activeSessionId) ?? null;
   const activeCommand = activeSession?.command
@@ -227,7 +247,12 @@ export function TerminalDrawer({
   return (
     <div
       data-testid="terminal-drawer"
-      className="border-t border-gray-800 bg-gray-950"
+      data-state={state}
+      className={
+        isMaximized
+          ? 'fixed inset-0 z-40 flex flex-col border-t border-gray-800 bg-gray-950'
+          : 'border-t border-gray-800 bg-gray-950'
+      }
     >
       <div className="flex items-center gap-2 border-b border-gray-800 px-3 py-2">
         <div
@@ -282,18 +307,18 @@ export function TerminalDrawer({
         </div>
         <button
           type="button"
-          onClick={onToggle}
-          aria-label={collapsed ? 'Expand terminal drawer' : 'Collapse terminal drawer'}
+          onClick={onCycle}
+          aria-label={`${cycleLabel} terminal drawer`}
           className="shrink-0 rounded border border-gray-700 px-2 py-1 text-[11px] text-gray-300 hover:bg-gray-800"
         >
-          {collapsed ? 'Expand' : 'Minimize'}
+          {cycleLabel}
         </button>
       </div>
-      {!collapsed && (
+      {showBody && (
         <div
           data-testid="terminal-drawer-body"
-          className="relative bg-black"
-          style={{ height: DRAWER_BODY_HEIGHT_PX }}
+          className={isMaximized ? 'relative flex-1 bg-black' : 'relative bg-black'}
+          style={isMaximized ? undefined : { height: DRAWER_BODY_HEIGHT_PX }}
         >
           {sessions.length === 0 && (
             <div className="absolute inset-0 flex items-center justify-center px-3 text-xs text-gray-500">


### PR DESCRIPTION
## Summary

The terminal drawer now has three sizes: minimized, partial, and maximized.

Partial keeps the existing bottom drawer. Maximized covers the app content over the graph and side panels, without using browser fullscreen.

One button moves through the states in order. Its label shows the next action.

Before, the drawer only had a true or false collapsed flag. The new explicit state keeps the behavior clear and testable.

Opening a terminal still starts in the partial drawer. Terminal tabs, output, input, resize, and close behavior stay unchanged.

## Architecture

The app now owns a terminal drawer state and passes it to `TerminalDrawer`. The maximized state renders as a fixed overlay over app content.

### Before

```mermaid
flowchart LR
  Flag[collapsed boolean] --> Drawer[TerminalDrawer]
  Drawer --> Terminal[xterm panes]
```

### After

```mermaid
flowchart LR
  State[minimized / partial / maximized] --> Drawer[TerminalDrawer]
  Drawer --> Terminal[xterm panes]
```

## Screenshots

Minimized:

![Terminal drawer minimized](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260616-91c05f/terminal-drawer-minimized.png)

Partial:

![Terminal drawer partial](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260616-91c05f/terminal-drawer-partial.png)

Maximized:

![Terminal drawer maximized](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260616-91c05f/terminal-drawer-maximized.png)

## Test Plan

- [x] `cd packages/ui && pnpm test src/__tests__/terminal-drawer.test.tsx`
- [x] `pnpm run test:all`
- [x] `pnpm --dir packages/app test:e2e e2e/visual-proof.spec.ts:510 --reporter=line`
- [x] Screenshot proof captured for minimized, partial, and maximized drawer states.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge commit created by Mergify>`
- Post-revert steps: None
- Data migration? No
