### PR TITLE
Crabbox SSH step 3: runtime wiring

### DIFF
--- a/packages/execution-engine/src/__tests__/crabbox-concurrent-lease-metadata-mismatch.test.ts
+++ b/packages/execution-engine/src/__tests__/crabbox-concurrent-lease-metadata-mismatch.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import type { CrabboxResolver } from '../task-runner.js';
+import type { ResolvedCrabboxTarget } from '../crabbox-target-resolver.js';
+import { SshExecutor } from '../ssh-executor.js';
+import type { ExecutorRegistry } from '../registry.js';
+import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+
+// Regression guard for CodeRabbit PR #1403 (discussion r3458135315):
+// "Make resolved Crabbox leases launch-scoped and validity-aware."
+//
+// `resolvedCrabboxTargets` is a single in-memory entry per target. When two
+// tasks on the SAME crabbox target resolve concurrently (both miss the shared
+// map, both call the resolver, and each gets its own lease), the second
+// resolution overwrites the map after the first executor was already built from
+// its own lease. The first launch then persists/logs metadata read back from
+// the shared map — i.e. the OTHER launch's lease — even though its executor is
+// talking to the box it originally leased. Cleanup/restore then targets the
+// wrong leased box.
+//
+// This test forces that exact interleaving and asserts each task persists ITS
+// OWN lease id. On the buggy code the first task persists the second task's
+// lease id via the success-path map read.
+
+function makeTask(id: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'echo hi', runnerKind: 'ssh', poolId: 'ssh-pool' },
+    execution: { selectedAttemptId: `${id}-attempt`, generation: 0 },
+  } as unknown as TaskState; // Minimal TaskState fixture for the runner under test.
+}
+
+const crabboxTarget = {
+  type: 'crabbox' as const,
+  crabboxCommand: 'crabbox',
+  provider: 'do',
+  class: 'medium',
+  ttl: '30m',
+  idleTimeout: '10m',
+  network: 'default',
+  target: 'ubuntu-22',
+  stopAfter: 'completed',
+  keepOnFailure: false,
+};
+
+function lease(id: string, host: string): ResolvedCrabboxTarget {
+  return {
+    sshTarget: { host, user: 'crab', sshKeyPath: `/keys/${id}`, port: 2200 },
+    remoteLeaseMetadata: {
+      provider: 'crabbox',
+      leaseId: id,
+      slug: `slug-${id}`,
+      targetId: 'crab-a',
+      sshHost: host,
+      sshUser: 'crab',
+      sshPort: 2200,
+      sshKeyPath: `/keys/${id}`,
+      expiresAt: '2999-01-01T00:00:00Z',
+      stopAfter: 'completed',
+      keepOnFailure: false,
+    },
+  };
+}
+
+function deferred<T = void>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolveFn!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolveFn = res;
+  });
+  return { promise, resolve: resolveFn };
+}
+
+describe('crabbox concurrent lease metadata', () => {
+  it('persists each launch its own lease under concurrent same-target resolution', async () => {
+    const leaseA = lease('lease-a', 'leased-a.crab');
+    const leaseB = lease('lease-b', 'leased-b.crab');
+
+    const taskA = makeTask('wf/crab#a');
+    const taskB = makeTask('wf/crab#b');
+
+    // Gate the resolver so BOTH launches miss the shared map and call resolve()
+    // before either writes its lease back into the map.
+    const gateResolveA = deferred();
+    const gateResolveB = deferred();
+    let resolveCall = 0;
+    const resolve = vi.fn(async (): Promise<ResolvedCrabboxTarget> => {
+      resolveCall += 1;
+      if (resolveCall === 1) {
+        await gateResolveA.promise;
+        return leaseA;
+      }
+      await gateResolveB.promise;
+      return leaseB;
+    });
+    const resolver: CrabboxResolver = { resolve };
+
+    // Gate the FIRST launch's executor.start() so its success-path persistence
+    // runs AFTER the second launch has overwritten the shared map.
+    const gateStartA = deferred();
+    const startedActionIds = new Set<string>();
+    vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (
+      this: unknown,
+      request: { actionId: string },
+    ) {
+      startedActionIds.add(request.actionId);
+      if (request.actionId === taskA.id) {
+        await gateStartA.promise;
+      }
+      return {
+        executionId: `exec-${request.actionId}`,
+        taskId: request.actionId,
+        workspacePath: `/remote/${request.actionId}`,
+        branch: `branch-${request.actionId}`,
+      };
+    });
+    const completeByTask = new Map<string, (response: unknown) => void>();
+    vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation((handle: { taskId: string }, cb: (r: unknown) => void) => {
+      completeByTask.set(handle.taskId, cb);
+    });
+    vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+    vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+    vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+
+    try {
+      // Record every lease id persisted onto each task's execution row.
+      const leaseWritesByTask = new Map<string, string[]>();
+      const persistence = {
+        logEvent: () => {},
+        updateTask: (
+          taskId: string,
+          changes: { execution?: { remoteLeaseMetadata?: { leaseId?: string } } },
+        ) => {
+          const leaseId = changes.execution?.remoteLeaseMetadata?.leaseId;
+          if (leaseId) {
+            const list = leaseWritesByTask.get(taskId) ?? [];
+            list.push(leaseId);
+            leaseWritesByTask.set(taskId, list);
+          }
+        },
+        updateAttempt: () => {},
+        appendTaskOutput: () => {},
+        loadAttempts: () => [],
+        claimExecutionResourceLease: () => true,
+        renewExecutionResourceLease: () => {},
+        releaseExecutionResourceLease: () => {},
+      } as unknown as SQLiteAdapter;
+
+      const tasksById = new Map([taskA, taskB].map((t) => [t.id, t]));
+      const orchestrator = {
+        getTask: (id: string) => tasksById.get(id) ?? null,
+        getAllTasks: () => [taskA, taskB],
+        markTaskRunningAfterLaunch: () => true,
+        handleWorkerResponse: () => [],
+        deferTask: () => {},
+      } as unknown as Orchestrator;
+
+      const executorRegistry = {
+        getDefault: () => ({ type: 'worktree' }),
+        get: () => null,
+        getAll: () => [],
+        register: () => {},
+      } as unknown as ExecutorRegistry;
+
+      const runner = new TaskRunner({
+        orchestrator,
+        persistence,
+        executorRegistry,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({ 'crab-a': crabboxTarget }),
+        executionPoolsProvider: () => ({
+          'ssh-pool': {
+            selectionStrategy: 'leastLoaded',
+            // Two concurrent tasks may share the on-demand crabbox provisioner.
+            maxConcurrentTasksPerMember: 2,
+            members: [{ id: 'crab-a', type: 'ssh' as const, maxConcurrentTasks: 2 }],
+          },
+        }),
+        crabboxResolver: resolver,
+      });
+
+      const runA = runner.executeTask(taskA);
+      // First launch reaches resolve() and parks on the gate.
+      await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(1));
+
+      const runB = runner.executeTask(taskB);
+      // Second launch also misses the (still-empty) map and parks on resolve().
+      await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(2));
+
+      // Let the first launch resolve, build its executor from lease-a, then park
+      // inside executor.start() before it persists success-path metadata.
+      gateResolveA.resolve();
+      await vi.waitFor(() => expect(startedActionIds.has(taskA.id)).toBe(true));
+
+      // Let the second launch resolve; it overwrites the shared map with lease-b
+      // and completes fully (start is not gated for it).
+      gateResolveB.resolve();
+      await vi.waitFor(() => expect(completeByTask.has(taskB.id)).toBe(true));
+      completeByTask.get(taskB.id)?.({
+        requestId: 'rb',
+        actionId: taskB.id,
+        attemptId: taskB.execution.selectedAttemptId,
+        executionGeneration: 0,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+
+      // Now release the first launch. Its success-path persistence runs with the
+      // shared map already pointing at lease-b.
+      gateStartA.resolve();
+      await vi.waitFor(() => expect(completeByTask.has(taskA.id)).toBe(true));
+      completeByTask.get(taskA.id)?.({
+        requestId: 'ra',
+        actionId: taskA.id,
+        attemptId: taskA.execution.selectedAttemptId,
+        executionGeneration: 0,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+
+      await Promise.all([runA, runB]);
+
+      const writesA = leaseWritesByTask.get(taskA.id) ?? [];
+      const writesB = leaseWritesByTask.get(taskB.id) ?? [];
+
+      // Each task must resolve and persist a lease.
+      expect(resolve).toHaveBeenCalledTimes(2);
+      expect(writesA.length).toBeGreaterThan(0);
+      expect(writesB.length).toBeGreaterThan(0);
+
+      // The core invariant: a launch never persists another launch's lease id.
+      // Buggy code makes taskA's success-path write read lease-b from the shared
+      // map after taskB overwrote it.
+      expect(writesA).not.toContain('lease-b');
+      expect(writesA.every((id) => id === 'lease-a')).toBe(true);
+      expect(writesB.every((id) => id === 'lease-b')).toBe(true);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+});

--- a/packages/execution-engine/src/__tests__/crabbox-lease-metadata-persistence.test.ts
+++ b/packages/execution-engine/src/__tests__/crabbox-lease-metadata-persistence.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import type { CrabboxResolver } from '../task-runner.js';
+import type { ResolvedCrabboxTarget } from '../crabbox-target-resolver.js';
+import { SshExecutor } from '../ssh-executor.js';
+import type { ExecutorRegistry } from '../registry.js';
+import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+
+// Regression guard for CodeRabbit PR #1403 (discussion r3458135329):
+// once Crabbox resolution succeeds the machine is leased on the provider, so
+// the lease metadata must be persisted to the task IMMEDIATELY. If it is only
+// written on the success path (after executor.start()), a lease whose launch is
+// abandoned — pool-lease denied or executor.start() failure — leaves the leased
+// box unrecorded in task state, so cleanup/restart flows cannot find and stop
+// it and the lease leaks until its TTL.
+
+function makeTask(id: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'echo hi', runnerKind: 'ssh', poolId: 'ssh-pool' },
+    execution: { selectedAttemptId: `${id}-attempt`, generation: 0 },
+  } as unknown as TaskState; // Minimal TaskState fixture for the runner under test.
+}
+
+const crabboxTarget = {
+  type: 'crabbox' as const,
+  crabboxCommand: 'crabbox',
+  provider: 'do',
+  class: 'medium',
+  ttl: '30m',
+  idleTimeout: '10m',
+  network: 'default',
+  target: 'ubuntu-22',
+  stopAfter: 'completed',
+  keepOnFailure: false,
+};
+
+const resolvedTarget: ResolvedCrabboxTarget = {
+  sshTarget: { host: 'leased.crab', user: 'crab', sshKeyPath: '/leased/key', port: 2200 },
+  remoteLeaseMetadata: {
+    provider: 'crabbox',
+    leaseId: 'L1',
+    slug: 'lease-slug',
+    targetId: 'crab-a',
+    sshHost: 'leased.crab',
+    sshUser: 'crab',
+    sshPort: 2200,
+    sshKeyPath: '/leased/key',
+    expiresAt: '2999-01-01T00:00:00Z',
+    stopAfter: 'completed',
+    keepOnFailure: false,
+  },
+};
+
+describe('crabbox lease metadata persistence', () => {
+  it('persists lease metadata immediately when executor.start() fails after resolution', async () => {
+    // The lease resolves, but the SSH executor start fails afterwards. Use a
+    // non-transport error so the runner does not retry another pool member.
+    vi.spyOn(SshExecutor.prototype, 'start').mockRejectedValue(
+      new Error('crabbox lease executor start failed for repro'),
+    );
+    vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation(() => {});
+    vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+    vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+    vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+
+    try {
+      const task = makeTask('wf-1/crab-a');
+      const resolve = vi.fn(async (): Promise<ResolvedCrabboxTarget> => resolvedTarget);
+      const resolver: CrabboxResolver = { resolve };
+
+      // Capture every lease id the runner persists onto the task's execution row.
+      const leaseWrites: string[] = [];
+      const persistence = {
+        logEvent: () => {},
+        updateTask: (
+          _taskId: string,
+          changes: { execution?: { remoteLeaseMetadata?: { leaseId?: string } } },
+        ) => {
+          const leaseId = changes.execution?.remoteLeaseMetadata?.leaseId;
+          if (leaseId) leaseWrites.push(leaseId);
+        },
+        updateAttempt: () => {},
+        appendTaskOutput: () => {},
+        loadAttempts: () => [],
+        claimExecutionResourceLease: () => true,
+        renewExecutionResourceLease: () => {},
+        releaseExecutionResourceLease: () => {},
+      } as unknown as SQLiteAdapter;
+
+      const orchestrator = {
+        getTask: (id: string) => (id === task.id ? task : null),
+        getAllTasks: () => [task],
+        markTaskRunningAfterLaunch: () => true,
+        handleWorkerResponse: () => [],
+        deferTask: () => {},
+      } as unknown as Orchestrator;
+
+      const executorRegistry = {
+        getDefault: () => ({ type: 'worktree' }),
+        get: () => null,
+        getAll: () => [],
+        register: () => {},
+      } as unknown as ExecutorRegistry;
+
+      const runner = new TaskRunner({
+        orchestrator,
+        persistence,
+        executorRegistry,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({ 'crab-a': crabboxTarget }),
+        executionPoolsProvider: () => ({
+          'ssh-pool': {
+            selectionStrategy: 'leastLoaded',
+            maxConcurrentTasksPerMember: 1,
+            members: [{ id: 'crab-a', type: 'ssh' as const, maxConcurrentTasks: 1 }],
+          },
+        }),
+        crabboxResolver: resolver,
+      });
+
+      // executeTask swallows the start failure into a failed WorkResponse, so it
+      // resolves rather than rejecting.
+      await runner.executeTask(task);
+
+      // Resolution ran and the executor start was attempted (and failed).
+      expect(resolve).toHaveBeenCalledTimes(1);
+      expect(SshExecutor.prototype.start).toHaveBeenCalledTimes(1);
+
+      // The lease must have been persisted to the task despite the abandoned
+      // launch. On the buggy code lease metadata is only written on the success
+      // path (after a successful start), so nothing is recorded here.
+      expect(leaseWrites).toContain('L1');
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+});

--- a/packages/execution-engine/src/__tests__/crabbox-resolution-failure-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/crabbox-resolution-failure-capacity.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import type { CrabboxResolver } from '../task-runner.js';
+import type { ExecutorRegistry } from '../registry.js';
+import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+
+// Regression guard for CodeRabbit PR #1403 (discussion r3458135323):
+// when Crabbox lease resolution fails, `selectExecutor` has already stored a
+// pending pool selection, so a failed resolve must release it — otherwise
+// `poolMemberLoad()` keeps counting the dead selection and the member's
+// capacity is permanently reduced for later tasks.
+
+function makeTask(id: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'echo hi', runnerKind: 'ssh', poolId: 'ssh-pool' },
+    execution: { selectedAttemptId: `${id}-attempt`, generation: 0 },
+  } as unknown as TaskState; // Minimal TaskState fixture for the runner under test.
+}
+
+const crabboxTarget = {
+  type: 'crabbox' as const,
+  crabboxCommand: 'crabbox',
+  provider: 'do',
+  class: 'medium',
+  ttl: '30m',
+  idleTimeout: '10m',
+  network: 'default',
+  target: 'ubuntu-22',
+  stopAfter: 'completed',
+  keepOnFailure: false,
+};
+
+describe('crabbox resolution failure capacity', () => {
+  it('releases the pending pool selection when crabbox resolution fails', async () => {
+    const task = makeTask('wf-1/crab-a');
+
+    // Resolver that always fails the lease (e.g. warmup/status error).
+    const failingResolver: CrabboxResolver = {
+      resolve: async () => {
+        throw new Error('crabbox warmup failed');
+      },
+    };
+
+    // Minimal orchestrator double: only the surface executeTask's failure path
+    // touches. Cast once at the boundary — the full Orchestrator interface is
+    // far larger than this test exercises.
+    const orchestrator = {
+      getTask: (id: string) => (id === task.id ? task : null),
+      getAllTasks: () => [task],
+      handleWorkerResponse: () => [],
+      deferTask: () => {},
+    } as unknown as Orchestrator;
+
+    // Minimal persistence double: no-op writes; the runner only logs/persists.
+    const persistence = {
+      logEvent: () => {},
+      updateTask: () => {},
+      updateAttempt: () => {},
+      appendTaskOutput: () => {},
+      loadAttempts: () => [],
+    } as unknown as SQLiteAdapter;
+
+    // Executor registry double: SSH tasks never fall back to the default here.
+    const executorRegistry = {
+      getDefault: () => ({ type: 'worktree' }),
+      get: () => null,
+      getAll: () => [],
+      register: () => {},
+    } as unknown as ExecutorRegistry;
+
+    const runner = new TaskRunner({
+      orchestrator,
+      persistence,
+      executorRegistry,
+      cwd: '/tmp',
+      remoteTargetsProvider: () => ({ 'crab-a': crabboxTarget }),
+      executionPoolsProvider: () => ({
+        'ssh-pool': {
+          selectionStrategy: 'leastLoaded',
+          maxConcurrentTasksPerMember: 1,
+          members: [{ id: 'crab-a', type: 'ssh' as const, maxConcurrentTasks: 1 }],
+        },
+      }),
+      crabboxResolver: failingResolver,
+    });
+
+    // The launch fails (resolve rejects). executeTask swallows the failure into
+    // a failed WorkResponse, so it resolves rather than rejecting.
+    await runner.executeTask(task);
+
+    // Probe capacity through the public API without touching private state:
+    // a second task on the same single-slot member must still be selectable.
+    // If the failed selection leaked, selectPoolMember finds the member at
+    // capacity and throws "no member capacity available". If it was released,
+    // selection succeeds and the crabbox target reports it needs resolution.
+    const nextTask = makeTask('wf-2/crab-b');
+    expect(() => runner.selectExecutor(nextTask)).toThrow(/must be resolved before use/);
+    expect(() => runner.selectExecutor(nextTask)).not.toThrow(/no member capacity/);
+  });
+});

--- a/packages/execution-engine/src/__tests__/crabbox-resolved-target-validity.test.ts
+++ b/packages/execution-engine/src/__tests__/crabbox-resolved-target-validity.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import type { CrabboxResolver } from '../task-runner.js';
+import type { ResolvedCrabboxTarget } from '../crabbox-target-resolver.js';
+import { SshExecutor } from '../ssh-executor.js';
+import type { ExecutorRegistry } from '../registry.js';
+import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+
+function makeTask(id: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'echo hi', runnerKind: 'ssh', poolId: 'ssh-pool' },
+    execution: { selectedAttemptId: `${id}-attempt`, generation: 0 },
+  } as unknown as TaskState;
+}
+
+function makeCrabboxTarget(overrides: Record<string, unknown> = {}) {
+  return {
+    type: 'crabbox' as const,
+    crabboxCommand: 'crabbox',
+    provider: 'do',
+    class: 'medium',
+    ttl: '30m',
+    idleTimeout: '10m',
+    network: 'default',
+    target: 'ubuntu-22',
+    stopAfter: 'completed',
+    keepOnFailure: false,
+    ...overrides,
+  };
+}
+
+function lease(id: string, host: string, expiresAt: string = '2999-01-01T00:00:00Z'): ResolvedCrabboxTarget {
+  return {
+    sshTarget: { host, user: 'crab', sshKeyPath: `/keys/${id}`, port: 2200 },
+    remoteLeaseMetadata: {
+      provider: 'crabbox',
+      leaseId: id,
+      slug: `slug-${id}`,
+      targetId: 'crab-a',
+      sshHost: host,
+      sshUser: 'crab',
+      sshPort: 2200,
+      sshKeyPath: `/keys/${id}`,
+      expiresAt,
+      stopAfter: 'completed',
+      keepOnFailure: false,
+    },
+  };
+}
+
+function makeRunner(args: {
+  tasks: TaskState[];
+  remoteTargetsProvider: () => Record<string, unknown>;
+  resolver: CrabboxResolver;
+}): TaskRunner {
+  const tasksById = new Map(args.tasks.map((task) => [task.id, task]));
+  const orchestrator = {
+    getTask: (id: string) => tasksById.get(id) ?? null,
+    getAllTasks: () => args.tasks,
+    markTaskRunningAfterLaunch: () => true,
+    handleWorkerResponse: () => [],
+    deferTask: () => {},
+  } as unknown as Orchestrator;
+  const persistence = {
+    logEvent: () => {},
+    updateTask: () => {},
+    updateAttempt: () => {},
+    appendTaskOutput: () => {},
+    loadAttempts: () => [],
+    claimExecutionResourceLease: () => true,
+    renewExecutionResourceLease: () => {},
+    releaseExecutionResourceLease: () => {},
+  } as unknown as SQLiteAdapter;
+  const executorRegistry = {
+    getDefault: () => ({ type: 'worktree' }),
+    get: () => null,
+    getAll: () => [],
+    register: () => {},
+  } as unknown as ExecutorRegistry;
+
+  return new TaskRunner({
+    orchestrator,
+    persistence,
+    executorRegistry,
+    cwd: '/tmp',
+    remoteTargetsProvider: args.remoteTargetsProvider,
+    executionPoolsProvider: () => ({
+      'ssh-pool': {
+        selectionStrategy: 'leastLoaded',
+        maxConcurrentTasksPerMember: 1,
+        members: [{ id: 'crab-a', type: 'ssh' as const, maxConcurrentTasks: 1 }],
+      },
+    }),
+    crabboxResolver: args.resolver,
+  });
+}
+
+function installSshCompletionMocks(): Map<string, (response: unknown) => void> {
+  const completeByTask = new Map<string, (response: unknown) => void>();
+  vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (
+    this: unknown,
+    request: { actionId: string },
+  ) {
+    return {
+      executionId: `exec-${request.actionId}`,
+      taskId: request.actionId,
+      workspacePath: `/remote/${request.actionId}`,
+      branch: `branch-${request.actionId}`,
+    };
+  });
+  vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation((handle: { taskId: string }, cb: (response: unknown) => void) => {
+    completeByTask.set(handle.taskId, cb);
+  });
+  vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+  vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+  vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+  return completeByTask;
+}
+
+function completeTask(completeByTask: Map<string, (response: unknown) => void>, task: TaskState): void {
+  completeByTask.get(task.id)?.({
+    requestId: `r-${task.id}`,
+    actionId: task.id,
+    attemptId: task.execution.selectedAttemptId,
+    executionGeneration: task.execution.generation ?? 0,
+    status: 'completed',
+    outputs: { exitCode: 0 },
+  });
+}
+
+describe('crabbox resolved target validity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('re-resolves when the crabbox target config changes', async () => {
+    const completeByTask = installSshCompletionMocks();
+    const taskA = makeTask('wf/crab#config-a');
+    const taskB = makeTask('wf/crab#config-b');
+    let currentTarget = makeCrabboxTarget();
+    const resolve = vi.fn(async (config: { provider: string; class: string }) => {
+      return config.provider === 'do'
+        ? lease('lease-a', 'leased-a.crab')
+        : lease('lease-b', 'leased-b.crab');
+    });
+    const runner = makeRunner({
+      tasks: [taskA, taskB],
+      remoteTargetsProvider: () => ({ 'crab-a': currentTarget }),
+      resolver: { resolve },
+    });
+
+    const runA = runner.executeTask(taskA);
+    await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(completeByTask.has(taskA.id)).toBe(true));
+    completeTask(completeByTask, taskA);
+    await runA;
+
+    currentTarget = makeCrabboxTarget({ provider: 'fly', class: 'performance-4x' });
+
+    const runB = runner.executeTask(taskB);
+    await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(2));
+    expect(resolve.mock.calls[1]?.[0]).toMatchObject({
+      provider: 'fly',
+      class: 'performance-4x',
+    });
+    await vi.waitFor(() => expect(completeByTask.has(taskB.id)).toBe(true));
+    completeTask(completeByTask, taskB);
+    await runB;
+  });
+
+  it('re-resolves when the cached crabbox lease is expired', async () => {
+    const completeByTask = installSshCompletionMocks();
+    const taskA = makeTask('wf/crab#expired-a');
+    const taskB = makeTask('wf/crab#expired-b');
+    const resolve = vi.fn()
+      .mockResolvedValueOnce(lease('lease-expired', 'leased-expired.crab', '2000-01-01T00:00:00Z'))
+      .mockResolvedValueOnce(lease('lease-fresh', 'leased-fresh.crab'));
+    const runner = makeRunner({
+      tasks: [taskA, taskB],
+      remoteTargetsProvider: () => ({ 'crab-a': makeCrabboxTarget() }),
+      resolver: { resolve },
+    });
+
+    const runA = runner.executeTask(taskA);
+    await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(completeByTask.has(taskA.id)).toBe(true));
+    completeTask(completeByTask, taskA);
+    await runA;
+
+    const runB = runner.executeTask(taskB);
+    await vi.waitFor(() => expect(resolve).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(completeByTask.has(taskB.id)).toBe(true));
+    completeTask(completeByTask, taskB);
+    await runB;
+  });
+
+  it('rehydrates the resolved ssh endpoint from persisted lease metadata', () => {
+    const task = makeTask('wf/crab#restart');
+    task.execution.remoteLeaseMetadata = lease('lease-restart', 'leased-restart.crab').remoteLeaseMetadata;
+    const runner = makeRunner({
+      tasks: [task],
+      remoteTargetsProvider: () => ({ 'crab-a': makeCrabboxTarget() }),
+      resolver: { resolve: vi.fn() },
+    });
+
+    expect(runner.getRemoteTargetConfig('crab-a', task.execution)).toMatchObject({
+      host: 'leased-restart.crab',
+      user: 'crab',
+      sshKeyPath: '/keys/lease-restart',
+      port: 2200,
+    });
+  });
+});

--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -425,6 +425,7 @@ describe('SSH pool member capacity', () => {
         requestId: 'r',
         actionId: task.id,
         attemptId: task.execution.selectedAttemptId,
+        executionGeneration: task.execution.generation ?? 0,
         status: 'completed',
         outputs: { exitCode: 0 },
       });

--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
+import { SshExecutor } from '../ssh-executor.js';
 import { ResourceLimitError } from '../repo-pool.js';
 import { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
@@ -298,6 +299,141 @@ describe('SSH pool member capacity', () => {
       { err: killErr },
     );
   });
+  it('does not resolve crabbox for a static pool member (resolver untouched)', () => {
+    const resolve = vi.fn();
+    // A registry with no pre-registered ssh executor so the lazy SSH path runs.
+    const staticRunner = new TaskRunner({
+      orchestrator: { getTask: () => null, getAllTasks: () => [], deferTask: vi.fn() } as any,
+      persistence: { logEvent: vi.fn() } as any,
+      executorRegistry: {
+        getDefault: () => ({ type: 'worktree' }),
+        get: () => null,
+        getAll: () => [],
+        register: vi.fn(),
+      } as any,
+      cwd: '/tmp',
+      remoteTargetsProvider: () => ({
+        'remote-a': { host: 'remote-a.example.com', user: 'invoker', sshKeyPath: '/tmp/fake-a' },
+      }),
+      executionPoolsProvider: () => ({
+        'ssh-pool': { selectionStrategy: 'leastLoaded', maxConcurrentTasksPerMember: 1, members: [{ id: 'remote-a', type: 'ssh' as const, maxConcurrentTasks: 1 }] },
+      }),
+      crabboxResolver: { resolve },
+    });
+
+    const executor = staticRunner.selectExecutor(makeTask('wf-1/task-a'));
+    expect(executor.type).toBe('ssh');
+    expect((executor as any).host).toBe('remote-a.example.com');
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('keys the execution resource lease on the resolved crabbox endpoint while keeping the pool member id', async () => {
+    vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (this: any, request: any) {
+      return {
+        executionId: `exec-${request.actionId}`,
+        taskId: request.actionId,
+        workspacePath: `/remote/${request.actionId}`,
+        branch: `branch-${request.actionId}`,
+      };
+    });
+    const completeByTask = new Map<string, (response: any) => void>();
+    vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation((handle: any, cb: any) => {
+      completeByTask.set(handle.taskId, cb);
+    });
+    vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+    vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+    vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+
+    try {
+      const resolve = vi.fn(async (config: any) => ({
+        sshTarget: { host: 'leased.crab', user: 'crab', sshKeyPath: '/leased/key', port: 2200 },
+        remoteLeaseMetadata: {
+          provider: 'crabbox' as const,
+          leaseId: 'L1',
+          slug: 'lease-slug',
+          targetId: config.id,
+          sshHost: 'leased.crab',
+          sshUser: 'crab',
+          sshPort: 2200,
+          sshKeyPath: '/leased/key',
+          expiresAt: '',
+          stopAfter: config.stopAfter,
+          keepOnFailure: config.keepOnFailure,
+        },
+      }));
+      const claimCalls: any[] = [];
+      const task = makeTask('wf/crab');
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => (id === task.id ? task : null),
+          getAllTasks: () => [task],
+          markTaskRunningAfterLaunch: () => true,
+          handleWorkerResponse: () => [],
+          deferTask: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask: vi.fn(),
+          updateAttempt: vi.fn(),
+          appendTaskOutput: vi.fn(),
+          logEvent: vi.fn(),
+          loadAttempts: () => [],
+          claimExecutionResourceLease: (args: any) => { claimCalls.push(args); return true; },
+          renewExecutionResourceLease: vi.fn(),
+          releaseExecutionResourceLease: vi.fn(),
+        } as any,
+        executorRegistry: {
+          getDefault: () => ({ type: 'worktree' }),
+          get: () => null,
+          getAll: () => [],
+          register: vi.fn(),
+        } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'crab-a': {
+            type: 'crabbox' as const,
+            crabboxCommand: 'crabbox',
+            provider: 'do',
+            class: 'medium',
+            ttl: '30m',
+            idleTimeout: '10m',
+            network: 'default',
+            target: 'ubuntu-22',
+            stopAfter: 'completed',
+            keepOnFailure: false,
+          },
+        }),
+        executionPoolsProvider: () => ({
+          'ssh-pool': {
+            selectionStrategy: 'leastLoaded',
+            maxConcurrentTasksPerMember: 1,
+            members: [{ id: 'crab-a', type: 'ssh' as const, maxConcurrentTasks: 1 }],
+          },
+        }),
+        crabboxResolver: { resolve },
+      });
+
+      const run = runner.executeTask(task);
+      await vi.waitFor(() => expect(SshExecutor.prototype.start).toHaveBeenCalledTimes(1));
+
+      expect(resolve).toHaveBeenCalledTimes(1);
+      expect(claimCalls).toHaveLength(1);
+      // Resource key uses the RESOLVED endpoint; the pool member id is preserved.
+      expect(claimCalls[0].resourceKey).toBe('ssh:crab@leased.crab:2200');
+      expect(claimCalls[0].poolMemberId).toBe('crab-a');
+
+      completeByTask.get(task.id)?.({
+        requestId: 'r',
+        actionId: task.id,
+        attemptId: task.execution.selectedAttemptId,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+      await run;
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
   it('uses execution resource leases to defer across TaskRunner instances', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     try {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2309,6 +2309,16 @@ describe('TaskRunner', () => {
       });
 
       // selected payload reports the resolved endpoint + lease metadata.
+      completeByTask.get(task.id)?.({
+        requestId: 'r',
+        actionId: task.id,
+        attemptId: 'crab-task-attempt',
+        executionGeneration: task.execution.generation ?? 0,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      } as WorkResponse);
+      await run;
+
       const selected = logEvent.mock.calls.find(
         ([, event]: [string, string]) => event === 'task.executor.selected',
       );
@@ -2318,15 +2328,6 @@ describe('TaskRunner', () => {
         port: 2222,
         remoteLeaseMetadata: { leaseId: 'lease-123' },
       });
-
-      completeByTask.get(task.id)?.({
-        requestId: 'r',
-        actionId: task.id,
-        attemptId: 'crab-task-attempt',
-        status: 'completed',
-        outputs: { exitCode: 0 },
-      } as WorkResponse);
-      await run;
     });
   });
 

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2155,6 +2155,181 @@ describe('TaskRunner', () => {
     });
   });
 
+  describe('crabbox target resolution', () => {
+    function makeFakeResolver() {
+      const resolve = vi.fn(async (config: any) => ({
+        sshTarget: {
+          host: 'lease-host.crabbox.dev',
+          user: 'crab',
+          sshKeyPath: '/leased/key',
+          port: 2222,
+        },
+        remoteLeaseMetadata: {
+          provider: 'crabbox' as const,
+          leaseId: 'lease-123',
+          slug: 'happy-lease',
+          targetId: config.id,
+          sshHost: 'lease-host.crabbox.dev',
+          sshUser: 'crab',
+          sshPort: 2222,
+          sshKeyPath: '/leased/key',
+          expiresAt: '2099-01-01T00:00:00Z',
+          stopAfter: config.stopAfter,
+          keepOnFailure: config.keepOnFailure,
+        },
+      }));
+      return { resolve };
+    }
+
+    const crabboxTarget = {
+      type: 'crabbox' as const,
+      crabboxCommand: 'crabbox',
+      provider: 'do',
+      class: 'medium',
+      ttl: '30m',
+      idleTimeout: '10m',
+      network: 'default',
+      target: 'ubuntu-22',
+      stopAfter: 'completed',
+      keepOnFailure: false,
+    };
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('does not call the resolver for a static SSH target', () => {
+      const resolver = makeFakeResolver();
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'static-a': { host: 'static.example.com', user: 'deployer', sshKeyPath: '/keys/static' },
+        }),
+        crabboxResolver: resolver,
+      });
+
+      const task = makeTask({
+        id: 'static-task',
+        config: { runnerKind: 'ssh', poolMemberId: 'static-a' },
+      });
+
+      const executor = runner.selectExecutor(task);
+      expect(executor.type).toBe('ssh');
+      expect((executor as any).host).toBe('static.example.com');
+      expect(resolver.resolve).not.toHaveBeenCalled();
+    });
+
+    it('resolves a crabbox target through the injected resolver and uses the leased endpoint', async () => {
+      const completeByTask = new Map<string, (response: WorkResponse) => void>();
+      const starts: Array<{ host: string; user: string; sshKeyPath: string; port: number }> = [];
+      vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (this: any, request: any) {
+        starts.push({ host: this.host, user: this.user, sshKeyPath: this.sshKeyPath, port: this.port });
+        return {
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: `/remote/${request.actionId}`,
+          branch: `branch-${request.actionId}`,
+        };
+      });
+      vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation((handle: any, cb: any) => {
+        completeByTask.set(handle.taskId, cb);
+      });
+      vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+
+      const resolver = makeFakeResolver();
+      const task = makeTask({
+        id: 'wf/crab-task',
+        config: { runnerKind: 'ssh', poolMemberId: 'crab-target' },
+        execution: { selectedAttemptId: 'crab-task-attempt', generation: 0 },
+      });
+      const updateTask = vi.fn();
+      const updateAttempt = vi.fn();
+      const logEvent = vi.fn();
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => (id === task.id ? task : null),
+          getAllTasks: () => [task],
+          markTaskRunningAfterLaunch: () => true,
+          handleWorkerResponse: () => [],
+          deferTask: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask,
+          updateAttempt,
+          appendTaskOutput: vi.fn(),
+          logEvent,
+          loadAttempts: () => [],
+        } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({ 'crab-target': crabboxTarget }),
+        crabboxResolver: resolver,
+      });
+
+      const run = runner.executeTask(task);
+      await vi.waitFor(() => expect(starts.length).toBe(1));
+
+      // Resolver called exactly once, with the configured crabbox lease inputs.
+      expect(resolver.resolve).toHaveBeenCalledTimes(1);
+      expect(resolver.resolve.mock.calls[0][0]).toMatchObject({
+        id: 'crab-target',
+        crabboxCommand: 'crabbox',
+        provider: 'do',
+        class: 'medium',
+        ttl: '30m',
+        idleTimeout: '10m',
+        network: 'default',
+        target: 'ubuntu-22',
+        stopAfter: 'completed',
+        keepOnFailure: false,
+      });
+
+      // SshExecutor was built from the resolved (leased) endpoint.
+      expect(starts[0]).toMatchObject({
+        host: 'lease-host.crabbox.dev',
+        user: 'crab',
+        sshKeyPath: '/leased/key',
+        port: 2222,
+      });
+
+      // Lease metadata persisted with the start-metadata update.
+      const persisted = updateTask.mock.calls.find(
+        ([, changes]: [string, any]) => changes.execution?.remoteLeaseMetadata,
+      );
+      expect(persisted?.[1].execution.remoteLeaseMetadata).toMatchObject({
+        provider: 'crabbox',
+        leaseId: 'lease-123',
+        targetId: 'crab-target',
+        sshHost: 'lease-host.crabbox.dev',
+      });
+
+      // selected payload reports the resolved endpoint + lease metadata.
+      const selected = logEvent.mock.calls.find(
+        ([, event]: [string, string]) => event === 'task.executor.selected',
+      );
+      expect(selected?.[2]).toMatchObject({
+        remoteHost: 'lease-host.crabbox.dev',
+        remoteUser: 'crab',
+        port: 2222,
+        remoteLeaseMetadata: { leaseId: 'lease-123' },
+      });
+
+      completeByTask.get(task.id)?.({
+        requestId: 'r',
+        actionId: task.id,
+        attemptId: 'crab-task-attempt',
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      } as WorkResponse);
+      await run;
+    });
+  });
+
   describe('publishAfterFix', () => {
     function setupPublishAfterFix(opts: {
       mergeMode?: string;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -32,6 +32,11 @@ import { MergeGateExecutor } from './merge-gate-executor.js';
 import { isInvokerManagedPoolBranch } from './plan-base-remote.js';
 import { formatLifecycleTag, extractAttemptSuffix } from './branch-utils.js';
 import { SshExecutor } from './ssh-executor.js';
+import {
+  CrabboxTargetResolver,
+  type CrabboxResolverTargetConfig,
+  type ResolvedCrabboxTarget,
+} from './crabbox-target-resolver.js';
 
 import {
   executeMergeNodeImpl,
@@ -134,9 +139,14 @@ type FreshBaseCommit = {
 };
 
 type RemoteTargetDisplay = {
-  host: string;
-  user: string;
-  sshKeyPath: string;
+  /** Target shape. Omit (or 'static') for a fixed SSH host; 'crabbox' for an on-demand lease. */
+  type?: 'static' | 'crabbox';
+  /** Present for static targets; resolved from the lease for crabbox targets. */
+  host?: string;
+  /** Present for static targets; resolved from the lease for crabbox targets. */
+  user?: string;
+  /** Present for static targets; resolved from the lease for crabbox targets. */
+  sshKeyPath?: string;
   port?: number;
   managedWorkspaces?: boolean;
   remoteInvokerHome?: string;
@@ -144,7 +154,44 @@ type RemoteTargetDisplay = {
   use_api_key?: boolean;
   secretsFile?: string;
   remoteHeartbeatIntervalSeconds?: number;
+  // ── Crabbox lease inputs (only present when type === 'crabbox') ──
+  crabboxCommand?: string;
+  provider?: string;
+  class?: string;
+  ttl?: string;
+  idleTimeout?: string;
+  network?: string;
+  target?: string;
+  stopAfter?: string;
+  keepOnFailure?: boolean;
+  warmupArgs?: readonly string[];
+  statusArgs?: readonly string[];
 };
+
+/**
+ * Injectable dependency that turns a Crabbox remote target into a ready SSH
+ * endpoint plus durable lease metadata. Defaults to {@link CrabboxTargetResolver}.
+ */
+export interface CrabboxResolver {
+  resolve(config: CrabboxResolverTargetConfig): Promise<ResolvedCrabboxTarget>;
+}
+
+/**
+ * Thrown by {@link TaskRunner.selectExecutor} when a `type: 'crabbox'` target
+ * has not been resolved yet. `executeTaskInner` catches it, runs the async
+ * resolver once, caches the result, and builds the SSH executor from the
+ * resolved endpoint — keeping `selectExecutor` synchronous (and static SSH
+ * behavior byte-for-byte equivalent) while still leasing on demand.
+ */
+class CrabboxResolutionRequiredError extends Error {
+  constructor(
+    readonly targetId: string,
+    readonly resolverConfig: CrabboxResolverTargetConfig,
+  ) {
+    super(`Crabbox remote target "${targetId}" must be resolved before use`);
+    this.name = 'CrabboxResolutionRequiredError';
+  }
+}
 
 export interface ReviewGateCiFailureTrigger {
   taskId: string;
@@ -289,9 +336,11 @@ export interface TaskRunnerConfig {
    * Called at task-execution time so config file changes take effect on retry.
    */
   remoteTargetsProvider?: () => Record<string, {
-    host: string;
-    user: string;
-    sshKeyPath: string;
+    /** Target shape. Omit (or 'static') for a fixed SSH host; 'crabbox' for an on-demand lease. */
+    type?: 'static' | 'crabbox';
+    host?: string;
+    user?: string;
+    sshKeyPath?: string;
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
@@ -299,7 +348,24 @@ export interface TaskRunnerConfig {
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;
+    // Crabbox lease inputs (only present when type === 'crabbox').
+    crabboxCommand?: string;
+    provider?: string;
+    class?: string;
+    ttl?: string;
+    idleTimeout?: string;
+    network?: string;
+    target?: string;
+    stopAfter?: string;
+    keepOnFailure?: boolean;
+    warmupArgs?: readonly string[];
+    statusArgs?: readonly string[];
   }>;
+  /**
+   * Resolves `type: 'crabbox'` remote targets into ready SSH endpoints.
+   * Defaults to a real {@link CrabboxTargetResolver}; tests inject a fake.
+   */
+  crabboxResolver?: CrabboxResolver;
   executionPoolsProvider?: () => Record<string, {
     members: Array<
       | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
@@ -341,6 +407,10 @@ export class TaskRunner {
   private readonly runnerInstanceId = randomUUID();
   /** Cache for SSH executors, keyed by poolMemberId. One instance per target for correct git locking. */
   private sshExecutorCache = new Map<string, SshExecutor>();
+  /** Resolves crabbox targets into SSH endpoints. */
+  private crabboxResolver: CrabboxResolver;
+  /** Resolved crabbox leases, keyed by remote target id. One lease per target until cleared. */
+  private resolvedCrabboxTargets = new Map<string, ResolvedCrabboxTarget>();
   private poolRoundRobinCursor = new Map<string, number>();
   private pendingPoolSelections = new Map<string, PoolSelection>();
   private freshBaseCommits = new Map<string, FreshBaseCommit>();
@@ -437,6 +507,7 @@ export class TaskRunner {
     this.reviewProviderRegistry = config.reviewProviderRegistry;
     this.onReviewGateCiFailure = config.onReviewGateCiFailure;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
+    this.crabboxResolver = config.crabboxResolver ?? new CrabboxTargetResolver();
     this.getExecutionPools = config.executionPoolsProvider ?? (() => ({}));
     this.dockerConfig = config.dockerConfig ?? {};
     this.executionAgentRegistry = config.executionAgentRegistry;
@@ -901,7 +972,32 @@ export class TaskRunner {
     let handle!: ExecutorHandle;
     while (true) {
       bench('selectExecutor.start');
-      executor = this.selectExecutor(task, attemptedPoolMemberKeys);
+      try {
+        executor = this.selectExecutor(task, attemptedPoolMemberKeys);
+      } catch (err) {
+        if (!(err instanceof CrabboxResolutionRequiredError)) throw err;
+        // The pool member was already selected (pendingPoolSelections is set);
+        // lease the machine once, cache it, then build the executor from the
+        // resolved endpoint WITHOUT re-running selection (which would advance
+        // round-robin / re-pick a different member).
+        bench('crabbox.resolve.start', { targetId: err.targetId });
+        const resolved = await this.crabboxResolver.resolve(err.resolverConfig);
+        this.resolvedCrabboxTargets.set(err.targetId, resolved);
+        bench('crabbox.resolve.end', {
+          targetId: err.targetId,
+          host: resolved.sshTarget.host,
+          leaseId: resolved.remoteLeaseMetadata.leaseId,
+        });
+        this.persistence.logEvent?.(task.id, 'task.executor.crabbox_resolved', {
+          targetId: err.targetId,
+          leaseId: resolved.remoteLeaseMetadata.leaseId,
+          slug: resolved.remoteLeaseMetadata.slug,
+          sshHost: resolved.sshTarget.host,
+          sshPort: resolved.sshTarget.port,
+        });
+        const target = this.getRemoteTargets()[err.targetId];
+        executor = this.buildSshExecutorForTarget(task.id, err.targetId, target, resolved);
+      }
       const poolSelectionForStart = this.pendingPoolSelections.get(task.id);
       if (!this.acquirePoolSelectionLease(task, attemptId, poolSelectionForStart)) {
         if (poolSelectionForStart) {
@@ -1115,6 +1211,11 @@ export class TaskRunner {
       const selectedSshTargetId = executor.type === 'ssh'
         ? this.selectedRemoteTargetId(task, poolSelection)
         : undefined;
+      // Crabbox-backed SSH tasks carry durable lease metadata so cleanup and
+      // terminal restore can find the leased host after a restart.
+      const remoteLeaseMetadata = selectedSshTargetId
+        ? this.resolvedCrabboxTargets.get(selectedSshTargetId)?.remoteLeaseMetadata
+        : undefined;
       const changes = {
         config: {
           runnerKind: executor.type as RunnerKind,
@@ -1128,6 +1229,7 @@ export class TaskRunner {
           agentName: actionType === 'ai_task' ? executionAgent : undefined,
           lastAgentName: actionType === 'ai_task' ? executionAgent : undefined,
           containerId: handle.containerId ?? undefined,
+          remoteLeaseMetadata: remoteLeaseMetadata ?? undefined,
         },
       };
       this.persistence.updateTask(task.id, changes);
@@ -1139,6 +1241,7 @@ export class TaskRunner {
         this.persistence.updateAttempt?.(attemptId, {
           branch: handle.branch ?? undefined,
           workspacePath: handle.workspacePath,
+          remoteLeaseMetadata: remoteLeaseMetadata ?? undefined,
         } as any);
       } catch (err) {
         traceExecution(
@@ -1426,7 +1529,20 @@ export class TaskRunner {
     if (!selection || selection.member.type !== 'ssh') return true;
     const target = this.getRemoteTargets()[selection.member.id];
     if (!target) return true;
-    const resourceKey = this.sshResourceKey(target);
+    // For crabbox targets the resource key must reflect the resolved (leased)
+    // SSH endpoint, not the empty config host/user, so two tasks on the same
+    // leased machine contend on the same lease. The pool member id is still
+    // used as the holder/poolMemberId below.
+    const resolved = this.resolvedCrabboxTargets.get(selection.member.id);
+    const resourceKey = this.sshResourceKey(
+      resolved
+        ? {
+          host: resolved.sshTarget.host,
+          user: resolved.sshTarget.user,
+          port: resolved.sshTarget.port,
+        }
+        : target,
+    );
     const holderId = this.leaseHolderId(task.id, attemptId);
     const acquired = this.persistence.claimExecutionResourceLease?.({
       resourceKey,
@@ -1483,12 +1599,21 @@ export class TaskRunner {
 
     if (executor.type === 'ssh') {
       const targetId = this.selectedRemoteTargetId(task, poolSelection);
-      const target = targetId ? this.getRemoteTargets()[targetId] : undefined;
       if (targetId) payload.poolMemberId = targetId;
-      if (target) {
-        payload.remoteHost = target.host;
-        payload.remoteUser = target.user;
-        payload.port = target.port;
+      const resolved = targetId ? this.resolvedCrabboxTargets.get(targetId) : undefined;
+      if (resolved) {
+        // Crabbox: report the resolved (leased) endpoint plus durable lease metadata.
+        payload.remoteHost = resolved.sshTarget.host;
+        payload.remoteUser = resolved.sshTarget.user;
+        payload.port = resolved.sshTarget.port;
+        payload.remoteLeaseMetadata = resolved.remoteLeaseMetadata;
+      } else {
+        const target = targetId ? this.getRemoteTargets()[targetId] : undefined;
+        if (target) {
+          payload.remoteHost = target.host;
+          payload.remoteUser = target.user;
+          payload.port = target.port;
+        }
       }
     }
 
@@ -1654,58 +1779,135 @@ export class TaskRunner {
           );
         }
 
-        // Build a config fingerprint so cache invalidates when target config changes.
-        const configFingerprint = JSON.stringify({
-          host: target.host,
-          user: target.user,
-          sshKeyPath: target.sshKeyPath,
-          port: target.port,
-          managedWorkspaces: target.managedWorkspaces,
-          remoteInvokerHome: target.remoteInvokerHome,
-          provisionCommand: target.provisionCommand,
-          use_api_key: target.use_api_key === true,
-          secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
-          remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
-        });
-        const cacheKey = `${targetId}|${configFingerprint}`;
-
-        // Return cached executor if it exists for this target+config combo
-        const cached = this.sshExecutorCache.get(cacheKey);
-        if (cached) {
-          traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (cached)`);
-          return cached;
-        }
-
-        // Drop any stale entries for this targetId so we don't accumulate dead caches.
-        for (const key of this.sshExecutorCache.keys()) {
-          if (key.startsWith(`${targetId}|`)) {
-            this.sshExecutorCache.delete(key);
+        // Crabbox targets supply a machine on demand: resolve the lease into a
+        // ready SSH endpoint before building the fingerprint/executor. Resolution
+        // is async, so if it hasn't run yet we signal executeTaskInner to run the
+        // resolver once and retry the build with the cached endpoint. Static SSH
+        // targets skip all of this and behave exactly as before.
+        let resolvedCrabbox: ResolvedCrabboxTarget | undefined;
+        if (target.type === 'crabbox') {
+          resolvedCrabbox = this.resolvedCrabboxTargets.get(targetId);
+          if (!resolvedCrabbox) {
+            throw new CrabboxResolutionRequiredError(
+              targetId,
+              this.buildCrabboxResolverConfig(targetId, target),
+            );
           }
         }
 
-        const ssh = new SshExecutor({
-          host: target.host,
-          user: target.user,
-          sshKeyPath: target.sshKeyPath,
-          port: target.port,
-          agentRegistry: this.executionAgentRegistry,
-          managedWorkspaces: target.managedWorkspaces,
-          remoteInvokerHome: target.remoteInvokerHome,
-          provisionCommand: target.provisionCommand,
-          useApiKey: target.use_api_key === true,
-          secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
-          remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
-        });
-
-        this.sshExecutorCache.set(cacheKey, ssh);
-        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (new, cached)`);
-        return ssh;
+        return this.buildSshExecutorForTarget(task.id, targetId, target, resolvedCrabbox);
       }
     }
 
     const defaultExecutor = this.executorRegistry.getDefault();
     traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=${effectiveType ?? 'none'} → ${defaultExecutor.type} (default)`);
     return defaultExecutor;
+  }
+
+  /**
+   * Build (and cache) the SSH executor for a remote target. For static targets
+   * the endpoint is the target's own host/user/key; for resolved crabbox leases
+   * it is the leased machine's SSH coordinates. The fingerprint includes the
+   * effective endpoint, so a new lease (different host/key) replaces the cached
+   * executor. Shared by the cache-hit path inside selectExecutor and the
+   * post-resolution path in executeTaskInner.
+   */
+  private buildSshExecutorForTarget(
+    taskId: string,
+    targetId: string,
+    target: RemoteTargetDisplay,
+    resolved: ResolvedCrabboxTarget | undefined,
+  ): SshExecutor {
+    const host = resolved?.sshTarget.host ?? target.host;
+    const user = resolved?.sshTarget.user ?? target.user;
+    const sshKeyPath = resolved?.sshTarget.sshKeyPath ?? target.sshKeyPath;
+    const port = resolved?.sshTarget.port ?? target.port;
+    if (!host || !user || !sshKeyPath) {
+      throw new Error(
+        `Task ${taskId} references remote target "${targetId}" but it has no usable ` +
+        `SSH endpoint (host/user/sshKeyPath missing).`,
+      );
+    }
+
+    // Build a config fingerprint so cache invalidates when target config changes.
+    const configFingerprint = JSON.stringify({
+      host,
+      user,
+      sshKeyPath,
+      port,
+      managedWorkspaces: target.managedWorkspaces,
+      remoteInvokerHome: target.remoteInvokerHome,
+      provisionCommand: target.provisionCommand,
+      use_api_key: target.use_api_key === true,
+      secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
+      remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
+    });
+    const cacheKey = `${targetId}|${configFingerprint}`;
+
+    // Return cached executor if it exists for this target+config combo
+    const cached = this.sshExecutorCache.get(cacheKey);
+    if (cached) {
+      traceExecution(`[trace] TaskRunner.selectExecutor: task=${taskId} effectiveType=ssh remoteTarget=${targetId} → ssh (cached)`);
+      return cached;
+    }
+
+    // Drop any stale entries for this targetId so we don't accumulate dead caches.
+    for (const key of this.sshExecutorCache.keys()) {
+      if (key.startsWith(`${targetId}|`)) {
+        this.sshExecutorCache.delete(key);
+      }
+    }
+
+    const ssh = new SshExecutor({
+      host,
+      user,
+      sshKeyPath,
+      port,
+      agentRegistry: this.executionAgentRegistry,
+      managedWorkspaces: target.managedWorkspaces,
+      remoteInvokerHome: target.remoteInvokerHome,
+      provisionCommand: target.provisionCommand,
+      useApiKey: target.use_api_key === true,
+      secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
+      remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
+    });
+
+    this.sshExecutorCache.set(cacheKey, ssh);
+    traceExecution(`[trace] TaskRunner.selectExecutor: task=${taskId} effectiveType=ssh remoteTarget=${targetId} → ssh (new, cached)`);
+    return ssh;
+  }
+
+  /** Map a configured crabbox remote target into the resolver's input config. */
+  private buildCrabboxResolverConfig(
+    targetId: string,
+    target: RemoteTargetDisplay,
+  ): CrabboxResolverTargetConfig {
+    const missing: string[] = [];
+    const require = (value: string | undefined, name: string): string => {
+      if (!value) missing.push(name);
+      return value ?? '';
+    };
+    const config: CrabboxResolverTargetConfig = {
+      id: targetId,
+      crabboxCommand: require(target.crabboxCommand, 'crabboxCommand'),
+      provider: require(target.provider, 'provider'),
+      class: require(target.class, 'class'),
+      ttl: require(target.ttl, 'ttl'),
+      idleTimeout: require(target.idleTimeout, 'idleTimeout'),
+      network: require(target.network, 'network'),
+      target: require(target.target, 'target'),
+      stopAfter: require(target.stopAfter, 'stopAfter'),
+      keepOnFailure: target.keepOnFailure === true,
+      port: target.port,
+      warmupArgs: target.warmupArgs,
+      statusArgs: target.statusArgs,
+    };
+    if (missing.length > 0) {
+      throw new Error(
+        `Crabbox remote target "${targetId}" is missing required field(s): ${missing.join(', ')}.`,
+      );
+    }
+    return config;
   }
 
   /**
@@ -2901,8 +3103,20 @@ export class TaskRunner {
   } | undefined {
     const target = this.getRemoteTargets()[targetId];
     if (!target) return undefined;
+    // Overlay the resolved crabbox endpoint so post-execution flows (publish,
+    // conflict resolution, terminal restore) reach the leased machine, not the
+    // empty config host. Static targets pass through unchanged.
+    const resolved = this.resolvedCrabboxTargets.get(targetId);
+    const host = resolved?.sshTarget.host ?? target.host;
+    const user = resolved?.sshTarget.user ?? target.user;
+    const sshKeyPath = resolved?.sshTarget.sshKeyPath ?? target.sshKeyPath;
+    if (!host || !user || !sshKeyPath) return undefined;
     return {
       ...target,
+      host,
+      user,
+      sshKeyPath,
+      port: resolved?.sshTarget.port ?? target.port,
       secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
     };
   }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -126,6 +126,11 @@ type PoolSelection = {
    */
   resolvedCrabbox?: ResolvedCrabboxTarget;
 };
+type CachedResolvedCrabboxTarget = {
+  resolverConfig: CrabboxResolverTargetConfig;
+  resolved: ResolvedCrabboxTarget;
+};
+
 
 function isRetryableSshStartupTransportError(err: unknown): boolean {
   const message = err instanceof Error ? `${err.message}\n${err.stack ?? ''}` : String(err);
@@ -200,6 +205,39 @@ class CrabboxResolutionRequiredError extends Error {
     this.name = 'CrabboxResolutionRequiredError';
   }
 }
+function sameOptionalStringArray(a: readonly string[] | undefined, b: readonly string[] | undefined): boolean {
+  if (!a && !b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every((value, index) => value === b[index]);
+}
+
+function crabboxResolverConfigMatches(
+  cached: CrabboxResolverTargetConfig,
+  next: CrabboxResolverTargetConfig,
+): boolean {
+  return cached.id === next.id
+    && cached.crabboxCommand === next.crabboxCommand
+    && cached.provider === next.provider
+    && cached.class === next.class
+    && cached.ttl === next.ttl
+    && cached.idleTimeout === next.idleTimeout
+    && cached.network === next.network
+    && cached.target === next.target
+    && cached.stopAfter === next.stopAfter
+    && cached.keepOnFailure === next.keepOnFailure
+    && cached.port === next.port
+    && sameOptionalStringArray(cached.warmupArgs, next.warmupArgs)
+    && sameOptionalStringArray(cached.statusArgs, next.statusArgs);
+}
+
+function isResolvedCrabboxExpired(
+  resolved: ResolvedCrabboxTarget,
+  nowMs: number = Date.now(),
+): boolean {
+  const expiresAtMs = Date.parse(resolved.remoteLeaseMetadata.expiresAt);
+  return Number.isFinite(expiresAtMs) && expiresAtMs <= nowMs;
+}
+
 
 export interface ReviewGateCiFailureTrigger {
   taskId: string;
@@ -417,8 +455,9 @@ export class TaskRunner {
   private sshExecutorCache = new Map<string, SshExecutor>();
   /** Resolves crabbox targets into SSH endpoints. */
   private crabboxResolver: CrabboxResolver;
-  /** Resolved crabbox leases, keyed by remote target id. One lease per target until cleared. */
-  private resolvedCrabboxTargets = new Map<string, ResolvedCrabboxTarget>();
+  /** Resolved crabbox leases, keyed by target id and invalidated on config drift or expiry. */
+  private resolvedCrabboxTargets = new Map<string, CachedResolvedCrabboxTarget>();
+
   private poolRoundRobinCursor = new Map<string, number>();
   private pendingPoolSelections = new Map<string, PoolSelection>();
   private freshBaseCommits = new Map<string, FreshBaseCommit>();
@@ -996,7 +1035,11 @@ export class TaskRunner {
         try {
           bench('crabbox.resolve.start', { targetId: err.targetId });
           const resolved = await this.crabboxResolver.resolve(err.resolverConfig);
-          this.resolvedCrabboxTargets.set(err.targetId, resolved);
+          this.resolvedCrabboxTargets.set(err.targetId, {
+            resolverConfig: err.resolverConfig,
+            resolved,
+          });
+
           bench('crabbox.resolve.end', {
             targetId: err.targetId,
             host: resolved.sshTarget.host,
@@ -1252,10 +1295,14 @@ export class TaskRunner {
       // launch-scoped lease bound to this selection over the shared map, which a
       // concurrent same-target resolution may have overwritten with another
       // launch's lease.
+      const selectedTarget = selectedSshTargetId
+        ? this.getRemoteTargets()[selectedSshTargetId]
+        : undefined;
       const remoteLeaseMetadata = poolSelection?.resolvedCrabbox?.remoteLeaseMetadata
-        ?? (selectedSshTargetId
-          ? this.resolvedCrabboxTargets.get(selectedSshTargetId)?.remoteLeaseMetadata
+        ?? (selectedSshTargetId && selectedTarget
+          ? this.getCachedResolvedCrabboxTarget(selectedSshTargetId, selectedTarget)?.remoteLeaseMetadata
           : undefined);
+
       const changes = {
         config: {
           runnerKind: executor.type as RunnerKind,
@@ -1564,6 +1611,41 @@ export class TaskRunner {
   private leaseHolderId(taskId: string, attemptId: string): string {
     return `${this.runnerInstanceId}:${process.pid}:${taskId}:${attemptId}`;
   }
+  private getCachedResolvedCrabboxTarget(
+    targetId: string,
+    target: RemoteTargetDisplay,
+  ): ResolvedCrabboxTarget | undefined {
+    if (target.type !== 'crabbox') return undefined;
+    const cached = this.resolvedCrabboxTargets.get(targetId);
+    if (!cached) return undefined;
+    const resolverConfig = this.buildCrabboxResolverConfig(targetId, target);
+    if (
+      !crabboxResolverConfigMatches(cached.resolverConfig, resolverConfig)
+      || isResolvedCrabboxExpired(cached.resolved)
+    ) {
+      this.resolvedCrabboxTargets.delete(targetId);
+      return undefined;
+    }
+    return cached.resolved;
+  }
+
+  private rehydrateResolvedCrabboxTarget(
+    targetId: string,
+    execution: TaskState['execution'] | undefined,
+  ): ResolvedCrabboxTarget | undefined {
+    const metadata = execution?.remoteLeaseMetadata;
+    if (!metadata || metadata.provider !== 'crabbox' || metadata.targetId !== targetId) return undefined;
+    return {
+      sshTarget: {
+        host: metadata.sshHost,
+        user: metadata.sshUser,
+        sshKeyPath: metadata.sshKeyPath,
+        port: metadata.sshPort,
+      },
+      remoteLeaseMetadata: metadata,
+    };
+  }
+
 
   private acquirePoolSelectionLease(task: TaskState, attemptId: string, selection: PoolSelection | undefined): boolean {
     if (!selection || selection.member.type !== 'ssh') return true;
@@ -1575,7 +1657,8 @@ export class TaskRunner {
     // used as the holder/poolMemberId below. Prefer the launch-scoped lease so
     // the key matches the box this executor actually uses even if a concurrent
     // same-target launch has since rewritten the shared map.
-    const resolved = selection.resolvedCrabbox ?? this.resolvedCrabboxTargets.get(selection.member.id);
+    const resolved = selection.resolvedCrabbox ?? this.getCachedResolvedCrabboxTarget(selection.member.id, target);
+
     const resourceKey = this.sshResourceKey(
       resolved
         ? {
@@ -1645,8 +1728,9 @@ export class TaskRunner {
       // Prefer the launch-scoped lease bound to this selection so the logged
       // endpoint matches the executor's lease even under concurrent same-target
       // resolution; fall back to the shared map for pre-selection callers.
+      const target = targetId ? this.getRemoteTargets()[targetId] : undefined;
       const resolved = poolSelection?.resolvedCrabbox
-        ?? (targetId ? this.resolvedCrabboxTargets.get(targetId) : undefined);
+        ?? (targetId && target ? this.getCachedResolvedCrabboxTarget(targetId, target) : undefined);
       if (resolved) {
         // Crabbox: report the resolved (leased) endpoint plus durable lease metadata.
         payload.remoteHost = resolved.sshTarget.host;
@@ -1654,7 +1738,6 @@ export class TaskRunner {
         payload.port = resolved.sshTarget.port;
         payload.remoteLeaseMetadata = resolved.remoteLeaseMetadata;
       } else {
-        const target = targetId ? this.getRemoteTargets()[targetId] : undefined;
         if (target) {
           payload.remoteHost = target.host;
           payload.remoteUser = target.user;
@@ -1832,7 +1915,8 @@ export class TaskRunner {
         // targets skip all of this and behave exactly as before.
         let resolvedCrabbox: ResolvedCrabboxTarget | undefined;
         if (target.type === 'crabbox') {
-          resolvedCrabbox = this.resolvedCrabboxTargets.get(targetId);
+          resolvedCrabbox = this.getCachedResolvedCrabboxTarget(targetId, target);
+
           if (!resolvedCrabbox) {
             throw new CrabboxResolutionRequiredError(
               targetId,
@@ -2032,7 +2116,7 @@ export class TaskRunner {
     let publishWorkspacePath = workspacePath;
     if (task.config.runnerKind === 'ssh') {
       const poolMemberId = resolveSelectedRemoteTargetId(this, task.id, task);
-      const target = poolMemberId ? this.getRemoteTargetConfig(poolMemberId) : undefined;
+      const target = poolMemberId ? this.getRemoteTargetConfig(poolMemberId, task.execution) : undefined;
       if (target) {
         const repairedWorkspacePath = await resolveRemoteBranchOwnerPath(branch, workspacePath, target);
         if (repairedWorkspacePath && repairedWorkspacePath !== workspacePath) {
@@ -3144,7 +3228,7 @@ export class TaskRunner {
     return this.executionAgentRegistry;
   }
 
-  getRemoteTargetConfig(targetId: string): {
+  getRemoteTargetConfig(targetId: string, execution?: TaskState['execution']): {
     host: string;
     user: string;
     sshKeyPath: string;
@@ -3160,8 +3244,11 @@ export class TaskRunner {
     if (!target) return undefined;
     // Overlay the resolved crabbox endpoint so post-execution flows (publish,
     // conflict resolution, terminal restore) reach the leased machine, not the
-    // empty config host. Static targets pass through unchanged.
-    const resolved = this.resolvedCrabboxTargets.get(targetId);
+    // empty config host. Static targets pass through unchanged. When a runner is
+    // restarted and the in-memory cache is gone, fall back to the persisted
+    // lease metadata on the task so cleanup/publish still reach the right box.
+    const resolved = this.getCachedResolvedCrabboxTarget(targetId, target)
+      ?? this.rehydrateResolvedCrabboxTarget(targetId, execution);
     const host = resolved?.sshTarget.host ?? target.host;
     const user = resolved?.sshTarget.user ?? target.user;
     const sshKeyPath = resolved?.sshTarget.sshKeyPath ?? target.sshKeyPath;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -117,6 +117,14 @@ type PoolSelection = {
   selectionStrategy: 'roundRobin' | 'leastLoaded';
   leaseResourceKey?: string;
   leaseHolderId?: string;
+  /**
+   * Launch-scoped Crabbox lease for this selection. Stamped from the exact
+   * lease the executor was built from so resource keys, logs, and persisted
+   * metadata never read a concurrently-overwritten `resolvedCrabboxTargets`
+   * entry (a same-target launch resolving in parallel would otherwise swap the
+   * shared map out from under this launch).
+   */
+  resolvedCrabbox?: ResolvedCrabboxTarget;
 };
 
 function isRetryableSshStartupTransportError(err: unknown): boolean {
@@ -1013,6 +1021,12 @@ export class TaskRunner {
           });
           const target = this.getRemoteTargets()[err.targetId];
           executor = this.buildSshExecutorForTarget(task.id, err.targetId, target, resolved);
+          // Bind the resolved lease to THIS launch's pending selection so the
+          // resource key, selected-event, and start-metadata reads below use the
+          // exact lease this executor was built from, never a shared-map entry a
+          // concurrent same-target launch may have overwritten in the meantime.
+          const pendingSelection = this.pendingPoolSelections.get(task.id);
+          if (pendingSelection) pendingSelection.resolvedCrabbox = resolved;
         } catch (resolveErr) {
           const pending = this.pendingPoolSelections.get(task.id);
           this.releasePoolSelectionLease(pending);
@@ -1234,10 +1248,14 @@ export class TaskRunner {
         ? this.selectedRemoteTargetId(task, poolSelection)
         : undefined;
       // Crabbox-backed SSH tasks carry durable lease metadata so cleanup and
-      // terminal restore can find the leased host after a restart.
-      const remoteLeaseMetadata = selectedSshTargetId
-        ? this.resolvedCrabboxTargets.get(selectedSshTargetId)?.remoteLeaseMetadata
-        : undefined;
+      // terminal restore can find the leased host after a restart. Prefer the
+      // launch-scoped lease bound to this selection over the shared map, which a
+      // concurrent same-target resolution may have overwritten with another
+      // launch's lease.
+      const remoteLeaseMetadata = poolSelection?.resolvedCrabbox?.remoteLeaseMetadata
+        ?? (selectedSshTargetId
+          ? this.resolvedCrabboxTargets.get(selectedSshTargetId)?.remoteLeaseMetadata
+          : undefined);
       const changes = {
         config: {
           runnerKind: executor.type as RunnerKind,
@@ -1554,8 +1572,10 @@ export class TaskRunner {
     // For crabbox targets the resource key must reflect the resolved (leased)
     // SSH endpoint, not the empty config host/user, so two tasks on the same
     // leased machine contend on the same lease. The pool member id is still
-    // used as the holder/poolMemberId below.
-    const resolved = this.resolvedCrabboxTargets.get(selection.member.id);
+    // used as the holder/poolMemberId below. Prefer the launch-scoped lease so
+    // the key matches the box this executor actually uses even if a concurrent
+    // same-target launch has since rewritten the shared map.
+    const resolved = selection.resolvedCrabbox ?? this.resolvedCrabboxTargets.get(selection.member.id);
     const resourceKey = this.sshResourceKey(
       resolved
         ? {
@@ -1622,7 +1642,11 @@ export class TaskRunner {
     if (executor.type === 'ssh') {
       const targetId = this.selectedRemoteTargetId(task, poolSelection);
       if (targetId) payload.poolMemberId = targetId;
-      const resolved = targetId ? this.resolvedCrabboxTargets.get(targetId) : undefined;
+      // Prefer the launch-scoped lease bound to this selection so the logged
+      // endpoint matches the executor's lease even under concurrent same-target
+      // resolution; fall back to the shared map for pre-selection callers.
+      const resolved = poolSelection?.resolvedCrabbox
+        ?? (targetId ? this.resolvedCrabboxTargets.get(targetId) : undefined);
       if (resolved) {
         // Crabbox: report the resolved (leased) endpoint plus durable lease metadata.
         payload.remoteHost = resolved.sshTarget.host;
@@ -1815,6 +1839,15 @@ export class TaskRunner {
               this.buildCrabboxResolverConfig(targetId, target),
             );
           }
+        }
+
+        // A later launch reuses the already-resolved endpoint (map hit above).
+        // Bind it to this launch's pending selection too, so its metadata/logs/
+        // resource key stay matched to the exact lease its executor uses even if
+        // a concurrent same-target resolution rewrites the shared map afterward.
+        if (resolvedCrabbox) {
+          const pendingSelection = this.pendingPoolSelections.get(task.id);
+          if (pendingSelection) pendingSelection.resolvedCrabbox = resolvedCrabbox;
         }
 
         return this.buildSshExecutorForTarget(task.id, targetId, target, resolvedCrabbox);

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -980,23 +980,35 @@ export class TaskRunner {
         // lease the machine once, cache it, then build the executor from the
         // resolved endpoint WITHOUT re-running selection (which would advance
         // round-robin / re-pick a different member).
-        bench('crabbox.resolve.start', { targetId: err.targetId });
-        const resolved = await this.crabboxResolver.resolve(err.resolverConfig);
-        this.resolvedCrabboxTargets.set(err.targetId, resolved);
-        bench('crabbox.resolve.end', {
-          targetId: err.targetId,
-          host: resolved.sshTarget.host,
-          leaseId: resolved.remoteLeaseMetadata.leaseId,
-        });
-        this.persistence.logEvent?.(task.id, 'task.executor.crabbox_resolved', {
-          targetId: err.targetId,
-          leaseId: resolved.remoteLeaseMetadata.leaseId,
-          slug: resolved.remoteLeaseMetadata.slug,
-          sshHost: resolved.sshTarget.host,
-          sshPort: resolved.sshTarget.port,
-        });
-        const target = this.getRemoteTargets()[err.targetId];
-        executor = this.buildSshExecutorForTarget(task.id, err.targetId, target, resolved);
+        // selectExecutor already stored a pending pool selection for this task
+        // (poolMemberLoad counts it). If the lease resolution or the
+        // post-resolution executor build throws, release that pending selection
+        // so the member's capacity is restored — otherwise the failed launch
+        // permanently reduces capacity for later tasks.
+        try {
+          bench('crabbox.resolve.start', { targetId: err.targetId });
+          const resolved = await this.crabboxResolver.resolve(err.resolverConfig);
+          this.resolvedCrabboxTargets.set(err.targetId, resolved);
+          bench('crabbox.resolve.end', {
+            targetId: err.targetId,
+            host: resolved.sshTarget.host,
+            leaseId: resolved.remoteLeaseMetadata.leaseId,
+          });
+          this.persistence.logEvent?.(task.id, 'task.executor.crabbox_resolved', {
+            targetId: err.targetId,
+            leaseId: resolved.remoteLeaseMetadata.leaseId,
+            slug: resolved.remoteLeaseMetadata.slug,
+            sshHost: resolved.sshTarget.host,
+            sshPort: resolved.sshTarget.port,
+          });
+          const target = this.getRemoteTargets()[err.targetId];
+          executor = this.buildSshExecutorForTarget(task.id, err.targetId, target, resolved);
+        } catch (resolveErr) {
+          const pending = this.pendingPoolSelections.get(task.id);
+          this.releasePoolSelectionLease(pending);
+          this.pendingPoolSelections.delete(task.id);
+          throw resolveErr;
+        }
       }
       const poolSelectionForStart = this.pendingPoolSelections.get(task.id);
       if (!this.acquirePoolSelectionLease(task, attemptId, poolSelectionForStart)) {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1001,6 +1001,16 @@ export class TaskRunner {
             sshHost: resolved.sshTarget.host,
             sshPort: resolved.sshTarget.port,
           });
+          // The machine is now leased on the provider. Persist the lease
+          // immediately so that if pool-lease acquisition or executor.start()
+          // fails below, cleanup/restart flows can still find and stop the
+          // leased box instead of orphaning it. Uses the launch-local
+          // `resolved`, so this durable record always matches the lease this
+          // launch built its executor from. The success path re-writes the
+          // same metadata alongside workspace/branch details.
+          this.persistence.updateTask(task.id, {
+            execution: { remoteLeaseMetadata: resolved.remoteLeaseMetadata },
+          });
           const target = this.getRemoteTargets()[err.targetId];
           executor = this.buildSshExecutorForTarget(task.id, err.targetId, target, resolved);
         } catch (resolveErr) {

--- a/scripts/repro/repro-coderabbit-pr1403-crabbox-lease-metadata-not-persisted-on-abandoned-launch.sh
+++ b/scripts/repro/repro-coderabbit-pr1403-crabbox-lease-metadata-not-persisted-on-abandoned-launch.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro for CodeRabbit PR #1403 review finding (discussion r3458135329):
+#
+#   "Persist lease metadata immediately after successful resolution."
+#
+# TaskRunner resolves a Crabbox lease (the machine is now leased on the
+# provider), then acquires a pool lease and calls executor.start(). Lease
+# metadata was only persisted onto the task AFTER a successful start. If the
+# launch is abandoned after resolution — pool lease denied or executor.start()
+# fails — the leased box is never recorded in task state, so cleanup/restart
+# flows cannot find and stop it and the lease leaks until its TTL.
+#
+# The regression test drives a real TaskRunner with a succeeding resolver and an
+# SSH executor whose start() rejects, then asserts the resolved lease id was
+# persisted to the task. On the buggy code nothing is persisted (no lease write);
+# the fix persists the lease immediately after resolution.
+#
+# Exits NON-ZERO on the buggy behavior (test fails), zero once fixed.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TEST_FILE="src/__tests__/crabbox-lease-metadata-persistence.test.ts"
+
+echo "[repro] pr1403 crabbox lease metadata not persisted on abandoned launch"
+echo "[repro] running ${TEST_FILE} in @invoker/execution-engine"
+
+if pnpm --filter @invoker/execution-engine exec vitest run "$TEST_FILE"; then
+  echo "PASS: crabbox lease metadata is persisted immediately after resolution (recoverable on abandoned launch)"
+else
+  echo "FAIL: crabbox lease metadata is only persisted on the success path, leaking abandoned leases" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr1403-crabbox-lease-not-launch-scoped.sh
+++ b/scripts/repro/repro-coderabbit-pr1403-crabbox-lease-not-launch-scoped.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro for CodeRabbit PR #1403 review finding (discussion r3458135315):
+#
+#   "Make resolved Crabbox leases launch-scoped and validity-aware."
+#
+# TaskRunner keeps a single in-memory lease per crabbox target in
+# `resolvedCrabboxTargets` (keyed by targetId). When two tasks on the SAME
+# crabbox target resolve concurrently, both miss the shared map, both call the
+# resolver, and each is handed its own lease. The second resolution overwrites
+# the shared map AFTER the first launch already built its executor from its own
+# lease. The first launch then persists/logs metadata read back from the shared
+# map — the OTHER launch's lease — so cleanup/restore later targets the wrong
+# leased box.
+#
+# The regression test drives a real TaskRunner and forces that exact
+# interleaving (gated resolver + gated executor.start on the first launch), then
+# asserts each launch persists ITS OWN lease id. On the buggy code the first
+# launch's success-path metadata write records the second launch's lease id.
+# The fix binds the resolved lease to the launch's pending pool selection and
+# reads it (not the shared map) for resource keys, logs, and persistence.
+#
+# Exits NON-ZERO on the buggy behavior (test fails), zero once fixed.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TEST_FILE="src/__tests__/crabbox-concurrent-lease-metadata-mismatch.test.ts"
+
+echo "[repro] pr1403 crabbox lease not launch-scoped (concurrent metadata mismatch)"
+echo "[repro] running ${TEST_FILE} in @invoker/execution-engine"
+
+if pnpm --filter @invoker/execution-engine exec vitest run "$TEST_FILE"; then
+  echo "PASS: each concurrent same-target launch persists its own crabbox lease (launch-scoped)"
+else
+  echo "FAIL: a launch persists another concurrent launch's lease via the shared resolvedCrabboxTargets map" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr1403-crabbox-resolution-failure-pool-capacity-leak.sh
+++ b/scripts/repro/repro-coderabbit-pr1403-crabbox-resolution-failure-pool-capacity-leak.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro for CodeRabbit PR #1403 review finding (discussion r3458135323):
+#
+#   "Clear the selected pool member if Crabbox resolution fails."
+#
+# TaskRunner.selectExecutor() stores a pending pool selection BEFORE it throws
+# CrabboxResolutionRequiredError. executeTaskInner() then runs the async
+# resolver. If crabboxResolver.resolve() (or the post-resolution executor
+# build) throws, the pending selection was never released, so poolMemberLoad()
+# keeps counting the dead launch and the pool member's capacity is permanently
+# reduced for later tasks.
+#
+# The regression test drives a real TaskRunner with a rejecting resolver and a
+# single-slot crabbox pool member, then asserts a second task can still be
+# selected on that member. On the buggy code the leaked pending selection makes
+# the member look full ("no member capacity available"); the fix releases the
+# pending selection so resolution can be retried.
+#
+# Exits NON-ZERO on the buggy behavior (test fails), zero once fixed.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TEST_FILE="src/__tests__/crabbox-resolution-failure-capacity.test.ts"
+
+echo "[repro] pr1403 crabbox resolution failure pool capacity leak"
+echo "[repro] running ${TEST_FILE} in @invoker/execution-engine"
+
+if pnpm --filter @invoker/execution-engine exec vitest run "$TEST_FILE"; then
+  echo "PASS: failed crabbox resolution releases the pending pool selection (capacity restored)"
+else
+  echo "FAIL: crabbox resolution failure leaks the pending pool selection, starving pool member capacity" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr1403-crabbox-resolved-target-validity.sh
+++ b/scripts/repro/repro-coderabbit-pr1403-crabbox-resolved-target-validity.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro for the still-valid part of CodeRabbit PR #1403 discussion r3458135315:
+# the shared Crabbox lease cache must be invalidated on config drift / expiry,
+# and restart-time remote target lookup must fall back to persisted lease
+# metadata when the in-memory cache is gone.
+#
+# Exits NON-ZERO on the buggy behavior (test fails), zero once fixed.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TEST_FILE="src/__tests__/crabbox-resolved-target-validity.test.ts"
+
+echo "[repro] pr1403 crabbox cache validity and restart hydration"
+echo "[repro] running ${TEST_FILE} in @invoker/execution-engine"
+
+if pnpm --filter @invoker/execution-engine exec vitest run "$TEST_FILE"; then
+  echo "PASS: crabbox cache re-resolves on drift/expiry and restart rehydrates the leased ssh endpoint"
+else
+  echo "FAIL: crabbox cache reused a stale lease or restart-time remote target lookup lost the leased endpoint" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr1403-work-response-mocks-missing-execution-generation.sh
+++ b/scripts/repro/repro-coderabbit-pr1403-work-response-mocks-missing-execution-generation.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Repro for CodeRabbit PR #1403 review findings (discussion r3458135296 and
+# r3458135299): the mocked completion payloads were missing WorkResponse
+# `executionGeneration`, so these tests could silently stop exercising the
+# generation-aware response contract.
+#
+# Exits NON-ZERO when either targeted mock omits `executionGeneration`.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] pr1403 work response mocks include executionGeneration"
+
+node <<'NODE'
+const { readFileSync } = require('node:fs');
+
+const checks = [
+  {
+    file: 'packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts',
+    needles: [
+      "completeByTask.get(task.id)?.({",
+      "attemptId: task.execution.selectedAttemptId,",
+      "executionGeneration: task.execution.generation ?? 0,",
+    ],
+  },
+  {
+    file: 'packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts',
+    needles: [
+      "completeByTask.get(task.id)?.({",
+      "attemptId: 'crab-task-attempt',",
+      "executionGeneration: task.execution.generation ?? 0,",
+    ],
+  },
+];
+
+let ok = true;
+for (const check of checks) {
+  const text = readFileSync(check.file, 'utf8');
+  const missing = check.needles.filter((needle) => !text.includes(needle));
+  if (missing.length > 0) {
+    ok = false;
+    console.error(`FAIL: ${check.file} is missing expected mock fields:`);
+    for (const needle of missing) console.error(`  - ${needle}`);
+  }
+}
+
+if (!ok) process.exit(1);
+console.log('PASS: targeted WorkResponse mocks include executionGeneration');
+NODE


### PR DESCRIPTION
## Summary

TaskRunner now routes Crabbox-backed SSH work through the resolver before it builds the SSH executor. Static SSH targets keep the direct route.

Crabbox stays outside the executor. The runner turns the lease result into ordinary SSH connection settings first.

The selected executor event now includes the pool member and resolved endpoint. Task start metadata also persists the remote lease details.

This is step 3 of the Crabbox SSH stack. Step 2 added the resolver; this step wires it into runtime routing.

<details>
<summary>Review metadata</summary>

Review Claim: TaskRunner routes Crabbox pool members through endpoint resolution before starting `SshExecutor`, while static SSH targets keep their existing route.

Review Lane: behavior

Review Unit: routing

Safety Invariant: `runnerKind: ssh` remains the only runtime executor shape for Crabbox-backed work; Crabbox only supplies machine details.

Slice Rationale: This slice only connects the existing resolver to TaskRunner so downstream work can handle later lease release behavior separately.

</details>

## Non-goals

- This does not add a Crabbox executor.
- This does not change static SSH target configuration or selection semantics.
- This does not implement later lease release policy.
- This does not change workflow graph scheduling.

## Architecture

This change inserts async target resolution between pool selection and SSH executor startup.

### Before

```mermaid
graph TD
    A["TaskRunner starts SSH task"] --> B["Select pool member"]
    B --> C["Read static SSH target"]
    C --> D["Start SshExecutor"]
    D --> E["Run task"]
```

### After

```mermaid
graph TD
    A["TaskRunner starts SSH task"] --> B["Select pool member"]
    B --> C{"Remote target"}
    C -->|"static"| E["Start SshExecutor"]
    C -->|"crabbox"| D["Resolve Crabbox lease"]
    D --> F["Record endpoint and lease metadata"]
    F --> E
    E --> G["Run task"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/ssh-pool-member-capacity.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/crabbox-step3-pr.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Static SSH targets remain on their pre-existing route.
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for remote “crabbox” SSH targets with async, on-demand lease resolution and runtime connection details.
  * Remote lease metadata is now persisted and included in task execution logging when leased targets are used.

* **Bug Fixes**
  * Prevented pool capacity leaks when lease resolution fails.
  * Improved executor/lease behavior to use the resolved leased endpoint for resource keying and selection, avoiding mismatches.

* **Tests / Repro**
  * Added Vitest regression coverage for resolution behavior, lease metadata persistence, concurrency edge cases, and failure recovery.
  * Added reproducibility scripts for the reported scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->