### PR TITLE
Recovery lifecycle 2c: auto-fix worker

### DIFF
--- a/packages/app/src/__tests__/autofix-worker.test.ts
+++ b/packages/app/src/__tests__/autofix-worker.test.ts
@@ -1,0 +1,341 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Channels, LocalBus } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+import type { WorkflowMutationIntent } from '@invoker/data-store';
+
+import {
+  buildReviewGateCiContext,
+  isReviewGateCiCandidateEligible,
+  scanAutoFixCandidates,
+  startAutoFixWorker,
+  type AutoFixCandidate,
+  type AutoFixWorkerStateView,
+} from '../autofix-worker.js';
+import { buildReviewGateCiFailedLifecycleEvent } from '../lifecycle-events.js';
+
+const logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn(() => logger),
+};
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id: 'wf-1/task-a',
+    status: 'failed',
+    config: { workflowId: 'wf-1' },
+    execution: { autoFixAttempts: 0, error: 'boom' },
+    ...overrides,
+  } as unknown as TaskState;
+}
+
+function execIntent(args: unknown[]): WorkflowMutationIntent {
+  return {
+    channel: 'headless.exec',
+    args: [{ args }],
+  } as unknown as WorkflowMutationIntent;
+}
+
+/** Minimal fake state view backed by a flat task list. */
+function makeState(tasks: TaskState[], overrides: Partial<AutoFixWorkerStateView> = {}): AutoFixWorkerStateView {
+  const byId = new Map(tasks.map((t) => [t.id, t]));
+  return {
+    getAllTasks: () => tasks,
+    getTask: (id) => byId.get(id),
+    shouldAutoFix: (id) => {
+      const t = byId.get(id);
+      return Boolean(t && t.status === 'failed' && (t.execution.autoFixAttempts ?? 0) < 3);
+    },
+    getAutoFixRetryBudget: () => 3,
+    ...overrides,
+  };
+}
+
+function ciEvent(overrides: Record<string, unknown> = {}) {
+  return buildReviewGateCiFailedLifecycleEvent({
+    workflowId: 'wf-1',
+    taskId: 'wf-1/task-a',
+    status: 'review_ready',
+    taskStateVersion: 1,
+    generation: 2,
+    reviewId: 'pr-7',
+    reviewUrl: 'https://example/pr/7',
+    branch: 'task-a',
+    headSha: 'deadbeef',
+    failedChecks: [{ name: 'build', conclusion: 'failure', detailsUrl: 'https://ci/1' }],
+    statusText: 'CI failed',
+    ...overrides,
+  });
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Pure scan: failed-task auto-fix ──────────────────────────
+
+describe('scanAutoFixCandidates — failed tasks', () => {
+  it('builds an --auto-fix command for an eligible failed task', () => {
+    const state = makeState([makeTask()]);
+    const candidates = scanAutoFixCandidates({
+      state,
+      openIntents: [],
+      reviewGateContexts: new Map(),
+      config: { autoFixAgent: 'codex' },
+    });
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      taskId: 'wf-1/task-a',
+      workflowId: 'wf-1',
+      source: 'task_failed',
+      args: ['fix', 'wf-1/task-a', 'codex', '--auto-fix'],
+    });
+  });
+
+  it('omits the agent token when no auto-fix agent is configured', () => {
+    const candidates = scanAutoFixCandidates({
+      state: makeState([makeTask()]),
+      openIntents: [],
+      reviewGateContexts: new Map(),
+      config: {},
+    });
+    expect(candidates[0]?.args).toEqual(['fix', 'wf-1/task-a', '--auto-fix']);
+  });
+
+  it('skips tasks the state deems ineligible for auto-fix', () => {
+    const state = makeState([makeTask()], { shouldAutoFix: () => false });
+    expect(
+      scanAutoFixCandidates({ state, openIntents: [], reviewGateContexts: new Map(), config: {} }),
+    ).toEqual([]);
+  });
+
+  it('skips user-cancelled/terminated errors', () => {
+    const state = makeState([makeTask({ execution: { autoFixAttempts: 0, error: 'Cancelled by user' } } as any)]);
+    expect(
+      scanAutoFixCandidates({ state, openIntents: [], reviewGateContexts: new Map(), config: {} }),
+    ).toEqual([]);
+  });
+
+  it('skips a task that already has an open fix intent (headless.exec)', () => {
+    const state = makeState([makeTask()]);
+    const candidates = scanAutoFixCandidates({
+      state,
+      openIntents: [execIntent(['fix', 'wf-1/task-a'])],
+      reviewGateContexts: new Map(),
+      config: {},
+    });
+    expect(candidates).toEqual([]);
+  });
+
+  it('skips a task that has no resolvable workflow id', () => {
+    const state = makeState([makeTask({ config: { workflowId: '   ' } } as any)]);
+    expect(
+      scanAutoFixCandidates({ state, openIntents: [], reviewGateContexts: new Map(), config: {} }),
+    ).toEqual([]);
+  });
+});
+
+// ── Pure scan: review-gate CI failures ───────────────────────
+
+describe('scanAutoFixCandidates — review-gate CI', () => {
+  const reviewReadyTask = makeTask({
+    status: 'review_ready',
+    execution: { autoFixAttempts: 0, generation: 2, selectedAttemptId: 'att-1', branch: 'task-a', reviewId: 'pr-7' },
+  } as any);
+  const context = buildReviewGateCiContext(ciEvent(), reviewReadyTask);
+
+  it('builds a fix command carrying the review-gate context when autoFixCi is on', () => {
+    const state = makeState([reviewReadyTask]);
+    const candidates = scanAutoFixCandidates({
+      state,
+      openIntents: [],
+      reviewGateContexts: new Map([[reviewReadyTask.id, context]]),
+      config: { autoFixCi: true },
+    });
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.source).toBe('review_gate_ci');
+    expect(candidates[0]?.args.slice(0, 3)).toEqual(['fix', 'wf-1/task-a', '--auto-fix']);
+    expect(candidates[0]?.args).toContain('--review-gate-ci');
+    const encoded = candidates[0]?.args[candidates[0].args.indexOf('--review-gate-ci') + 1] ?? '';
+    expect(JSON.parse(encoded)).toMatchObject({ reviewId: 'pr-7', generation: 2 });
+  });
+
+  it('ignores review-gate CI failures when autoFixCi is disabled', () => {
+    const state = makeState([reviewReadyTask]);
+    expect(
+      scanAutoFixCandidates({
+        state,
+        openIntents: [],
+        reviewGateContexts: new Map([[reviewReadyTask.id, context]]),
+        config: { autoFixCi: false },
+      }),
+    ).toEqual([]);
+  });
+
+  it('drops a stale review-gate context (live lineage moved on)', () => {
+    const moved = makeTask({
+      status: 'review_ready',
+      execution: { autoFixAttempts: 0, generation: 9, selectedAttemptId: 'att-2', branch: 'task-a', reviewId: 'pr-7' },
+    } as any);
+    const state = makeState([moved]);
+    expect(
+      scanAutoFixCandidates({
+        state,
+        openIntents: [],
+        reviewGateContexts: new Map([[moved.id, context]]),
+        config: { autoFixCi: true },
+      }),
+    ).toEqual([]);
+  });
+
+  it('prefers the review-gate candidate over a plain failed-task candidate for the same task', () => {
+    const failingReview = makeTask({
+      status: 'failed',
+      execution: { autoFixAttempts: 0, error: 'boom', generation: 2, selectedAttemptId: 'att-1', branch: 'task-a', reviewId: 'pr-7' },
+    } as any);
+    const ctx = buildReviewGateCiContext(ciEvent({ status: 'failed' }), failingReview);
+    const state = makeState([failingReview]);
+    const candidates = scanAutoFixCandidates({
+      state,
+      openIntents: [],
+      reviewGateContexts: new Map([[failingReview.id, ctx]]),
+      config: { autoFixCi: true },
+    });
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.source).toBe('review_gate_ci');
+  });
+});
+
+describe('isReviewGateCiCandidateEligible', () => {
+  const task = makeTask({
+    status: 'review_ready',
+    execution: { autoFixAttempts: 0, generation: 2, selectedAttemptId: 'att-1', branch: 'task-a', reviewId: 'pr-7' },
+  } as any);
+  const context = buildReviewGateCiContext(ciEvent(), task);
+
+  it('is eligible for a current review_ready task within budget', () => {
+    expect(isReviewGateCiCandidateEligible(task, context, makeState([task]))).toBe(true);
+  });
+
+  it('is ineligible when the retry budget is exhausted', () => {
+    const exhausted = makeTask({
+      status: 'review_ready',
+      execution: { autoFixAttempts: 3, generation: 2, selectedAttemptId: 'att-1', branch: 'task-a', reviewId: 'pr-7' },
+    } as any);
+    expect(isReviewGateCiCandidateEligible(exhausted, context, makeState([exhausted]))).toBe(false);
+  });
+
+  it('is ineligible for a status that is not fixable', () => {
+    const running = makeTask({ status: 'running' } as any);
+    expect(isReviewGateCiCandidateEligible(running, context, makeState([running]))).toBe(false);
+  });
+});
+
+// ── Integration through the runtime ──────────────────────────
+
+describe('startAutoFixWorker', () => {
+  it('submits a fix when a failed-task lifecycle event wakes the worker', async () => {
+    const bus = new LocalBus();
+    const submitted: AutoFixCandidate[] = [];
+    const state = makeState([makeTask()]);
+
+    const worker = startAutoFixWorker({
+      messageBus: bus,
+      state,
+      listOpenFixIntents: () => [],
+      config: { autoFixAgent: 'codex' },
+      submit: (c) => { submitted.push(c); },
+      logger,
+      scanOnStartup: false,
+      handleSignals: false,
+      pollIntervalMs: 1_000_000,
+    });
+
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, buildReviewGateCiFailedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/other',
+      status: 'failed',
+      taskStateVersion: 1,
+      reviewId: 'pr-x',
+      reviewUrl: 'u',
+      failedChecks: [],
+      statusText: 's',
+    }));
+    // The failed-task scan still finds the eligible task in state.
+    await worker.waitForIdle();
+
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0]?.args).toEqual(['fix', 'wf-1/task-a', 'codex', '--auto-fix']);
+
+    worker.stop();
+  });
+
+  it('records review-gate CI context from the event and consumes it after one submit', async () => {
+    const bus = new LocalBus();
+    const submitted: AutoFixCandidate[] = [];
+    const task = makeTask({
+      status: 'review_ready',
+      execution: { autoFixAttempts: 0, generation: 2, selectedAttemptId: 'att-1', branch: 'task-a', reviewId: 'pr-7' },
+    } as any);
+    const state = makeState([task]);
+
+    const worker = startAutoFixWorker({
+      messageBus: bus,
+      state,
+      listOpenFixIntents: () => [],
+      config: { autoFixCi: true },
+      submit: (c) => { submitted.push(c); },
+      logger,
+      scanOnStartup: false,
+      handleSignals: false,
+      pollIntervalMs: 1_000_000,
+    });
+
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, ciEvent());
+    await worker.waitForIdle();
+
+    expect(submitted).toHaveLength(1);
+    expect(submitted[0]?.source).toBe('review_gate_ci');
+
+    // A second wake must not resubmit: the context was consumed.
+    worker.wake();
+    await worker.waitForIdle();
+    expect(submitted).toHaveLength(1);
+
+    worker.stop();
+  });
+
+  it('stops cleanly and detaches its review-gate subscription', async () => {
+    const bus = new LocalBus();
+    const submitted: AutoFixCandidate[] = [];
+    const task = makeTask({
+      status: 'review_ready',
+      execution: { autoFixAttempts: 0, generation: 2, selectedAttemptId: 'att-1', branch: 'task-a', reviewId: 'pr-7' },
+    } as any);
+
+    const worker = startAutoFixWorker({
+      messageBus: bus,
+      state: makeState([task]),
+      listOpenFixIntents: () => [],
+      config: { autoFixCi: true },
+      submit: (c) => { submitted.push(c); },
+      logger,
+      scanOnStartup: false,
+      handleSignals: false,
+      pollIntervalMs: 1_000_000,
+    });
+
+    worker.stop();
+    expect(worker.isStopped()).toBe(true);
+
+    // Events after stop are ignored.
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, ciEvent());
+    worker.wake();
+    await worker.waitForIdle();
+    expect(submitted).toEqual([]);
+  });
+});

--- a/packages/app/src/autofix-worker.ts
+++ b/packages/app/src/autofix-worker.ts
@@ -1,0 +1,320 @@
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type { Logger } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
+import type { WorkflowMutationIntent } from '@invoker/data-store';
+
+import {
+  buildHeadlessFixArgs,
+  hasOpenFixIntentForTask,
+  isReviewGateCiContextStale,
+  type ReviewGateCiContext,
+} from './auto-fix-intents.js';
+import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
+import {
+  type ReviewGateCiFailedLifecycleEvent,
+  type WorkflowLifecycleEvent,
+} from './lifecycle-events.js';
+import {
+  startWorkerRuntime,
+  type WorkerRuntime,
+} from './worker-runtime.js';
+
+/**
+ * Lifecycle event kinds that wake the auto-fix worker.
+ *
+ * `task.failed` covers the ordinary "task failed, retry it with an agent"
+ * recovery path; `review_gate.ci_failed` covers a failed CI run on an
+ * Invoker-created review-gate PR. Both are *wakeups only* — the worker never
+ * trusts the event payload as the source of truth for a fix decision. The
+ * authoritative state always comes from a fresh read of persisted
+ * workflow/task/review state at scan time.
+ */
+export const AUTO_FIX_WORKER_EVENT_KINDS = ['task.failed', 'review_gate.ci_failed'] as const;
+
+const REVIEW_GATE_FIXABLE_STATUSES = new Set<TaskState['status']>([
+  'review_ready',
+  'awaiting_approval',
+  'failed',
+]);
+
+/**
+ * Read-only view of orchestrator/persistence state the worker consults to
+ * decide what to fix. Kept structural so the worker stays decoupled from the
+ * concrete `Orchestrator` and is trivially faked in tests.
+ */
+export interface AutoFixWorkerStateView {
+  getAllTasks(): readonly TaskState[];
+  getTask(taskId: string): TaskState | undefined;
+  /** True when the task is a failed, auto-fix-eligible task within its retry budget. */
+  shouldAutoFix(taskId: string): boolean;
+  /** Per-task auto-fix retry budget (0 disables auto-fix). */
+  getAutoFixRetryBudget(taskId: string): number;
+}
+
+/** Auto-fix-relevant config slice (mirrors {@link InvokerConfig}). */
+export interface AutoFixWorkerConfig {
+  /** Preferred fix agent; empty/undefined lets the fix path pick its default. */
+  readonly autoFixAgent?: string;
+  /** When true, failed review-gate CI runs are also recovered. */
+  readonly autoFixCi?: boolean;
+}
+
+/** A single fix the worker has decided to submit. */
+export interface AutoFixCandidate {
+  readonly taskId: string;
+  readonly workflowId: string;
+  /** Headless `fix` command argument vector (tagged `--auto-fix`). */
+  readonly args: string[];
+  /** What triggered this candidate, for logging/telemetry. */
+  readonly source: 'task_failed' | 'review_gate_ci';
+}
+
+export interface AutoFixWorkerOptions {
+  /** Bus carrying `Channels.WORKFLOW_LIFECYCLE` events. */
+  readonly messageBus: MessageBus;
+  /** Authoritative state the worker scans for fixable work. */
+  readonly state: AutoFixWorkerStateView;
+  /**
+   * Open (queued/running) workflow mutation intents, read fresh each call.
+   * Used to suppress a redundant fix when one is already in flight for a task.
+   */
+  readonly listOpenFixIntents: () => readonly WorkflowMutationIntent[];
+  readonly config: AutoFixWorkerConfig;
+  /**
+   * Submit one discovered fix. The worker never runs the fix itself: it hands
+   * the built `fix` command to the accepted-command boundary, which owns
+   * attempt accounting and the actual Fix-with-AI route — exactly the path a
+   * user action takes.
+   */
+  readonly submit: (candidate: AutoFixCandidate) => Promise<void> | void;
+  readonly logger?: Logger;
+  /** Poll fallback interval; forwarded to the runtime. */
+  readonly pollIntervalMs?: number;
+  /** Run one scan on startup. Default: true. */
+  readonly scanOnStartup?: boolean;
+  /** Register SIGINT/SIGTERM handlers. Default: true. */
+  readonly handleSignals?: boolean;
+}
+
+// ── Review-gate CI fix context formatting ────────────────────
+//
+// A review-gate CI failure carries its detail in the lifecycle event, not in
+// `task.execution.error`. The worker formats that detail into the fix context
+// that rides along the normal `fix` command so the agent sees which checks
+// failed and where — the same information the legacy callback path produced.
+
+function formatReviewGateCiFixContext(event: ReviewGateCiFailedLifecycleEvent): string {
+  const checkLines = event.failedChecks.map((check) => {
+    const details = [
+      check.conclusion ? `conclusion=${check.conclusion}` : undefined,
+      check.detailsUrl ? `details=${check.detailsUrl}` : undefined,
+    ].filter(Boolean).join(' ');
+    return `- ${check.name}${details ? `: ${details}` : ''}`;
+  });
+  return [
+    'This auto-fix was triggered by failed CI on an external review gate PR.',
+    `PR: ${event.reviewUrl}`,
+    `Review ID: ${event.reviewId}`,
+    event.headRef ? `PR head ref: ${event.headRef}` : undefined,
+    event.headSha ? `PR head SHA: ${event.headSha}` : undefined,
+    event.branch ? `Invoker branch: ${event.branch}` : undefined,
+    '',
+    'Fix the code on this task branch so the failed PR checks pass.',
+    'Preserve the original task intent and do not recreate the PR manually.',
+    '',
+    'Failed checks:',
+    ...checkLines,
+  ].filter((line): line is string => line !== undefined).join('\n');
+}
+
+/**
+ * Build the review-gate context snapshot the fix command carries. Lineage
+ * fields (`generation`, `selectedAttemptId`, `branch`) come from the *live*
+ * task so the accepted-command boundary can reject a stale retry; the failing
+ * review detail comes from the event.
+ */
+export function buildReviewGateCiContext(
+  event: ReviewGateCiFailedLifecycleEvent,
+  task: TaskState,
+): ReviewGateCiContext {
+  return {
+    reviewId: event.reviewId,
+    generation: task.execution.generation ?? event.generation ?? 0,
+    ...(task.execution.selectedAttemptId !== undefined
+      ? { selectedAttemptId: task.execution.selectedAttemptId }
+      : {}),
+    ...(task.execution.branch ?? event.branch
+      ? { branch: task.execution.branch ?? event.branch }
+      : {}),
+    ...(event.headSha ? { headSha: event.headSha } : {}),
+    fixContext: formatReviewGateCiFixContext(event),
+  };
+}
+
+// ── Candidate scanning + eligibility ─────────────────────────
+
+function fixAgent(config: AutoFixWorkerConfig): string | undefined {
+  const trimmed = config.autoFixAgent?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}
+
+function workflowIdForTask(task: TaskState): string | undefined {
+  return task.config.workflowId?.trim() || undefined;
+}
+
+/**
+ * True when a captured review-gate CI failure is still actionable against the
+ * live task: an eligible status, retry budget remaining, attempts not
+ * exhausted, and lineage unchanged since the failure was captured.
+ */
+export function isReviewGateCiCandidateEligible(
+  task: TaskState,
+  context: ReviewGateCiContext,
+  state: AutoFixWorkerStateView,
+): boolean {
+  if (!REVIEW_GATE_FIXABLE_STATUSES.has(task.status)) return false;
+  const max = state.getAutoFixRetryBudget(task.id);
+  if (max <= 0) return false;
+  if ((task.execution.autoFixAttempts ?? 0) >= max) return false;
+  if (isReviewGateCiContextStale(context, task.execution)) return false;
+  return true;
+}
+
+/**
+ * Inputs for a pure scan: snapshots taken at scan entry so the policy is
+ * deterministic and unit-testable.
+ */
+export interface AutoFixScanInputs {
+  readonly state: AutoFixWorkerStateView;
+  readonly openIntents: readonly WorkflowMutationIntent[];
+  readonly reviewGateContexts: ReadonlyMap<string, ReviewGateCiContext>;
+  readonly config: AutoFixWorkerConfig;
+}
+
+/**
+ * Discover the batch of fixes to submit. Pure over its inputs: same snapshots
+ * in, same candidates out. Review-gate candidates take precedence over a plain
+ * failed-task candidate for the same task (they carry richer fix context).
+ */
+export function scanAutoFixCandidates(inputs: AutoFixScanInputs): AutoFixCandidate[] {
+  const { state, openIntents, reviewGateContexts, config } = inputs;
+  const agent = fixAgent(config);
+  const candidates: AutoFixCandidate[] = [];
+  const seen = new Set<string>();
+
+  // Review-gate CI failures first so they win the per-task dedupe.
+  if (config.autoFixCi) {
+    for (const [taskId, context] of reviewGateContexts) {
+      const task = state.getTask(taskId);
+      if (!task) continue;
+      if (!isReviewGateCiCandidateEligible(task, context, state)) continue;
+      const workflowId = workflowIdForTask(task);
+      if (!workflowId) continue;
+      if (hasOpenFixIntentForTask(openIntents as WorkflowMutationIntent[], taskId)) continue;
+      seen.add(taskId);
+      candidates.push({
+        taskId,
+        workflowId,
+        source: 'review_gate_ci',
+        args: buildHeadlessFixArgs(taskId, agent, { autoFix: true, reviewGateContext: context }),
+      });
+    }
+  }
+
+  // Ordinary failed-task auto-fix.
+  for (const task of state.getAllTasks()) {
+    if (seen.has(task.id)) continue;
+    if (!state.shouldAutoFix(task.id)) continue;
+    if (shouldSkipAutoFixForError(task.execution.error)) continue;
+    const workflowId = workflowIdForTask(task);
+    if (!workflowId) continue;
+    if (hasOpenFixIntentForTask(openIntents as WorkflowMutationIntent[], task.id)) continue;
+    seen.add(task.id);
+    candidates.push({
+      taskId: task.id,
+      workflowId,
+      source: 'task_failed',
+      args: buildHeadlessFixArgs(task.id, agent, { autoFix: true }),
+    });
+  }
+
+  return candidates;
+}
+
+function isReviewGateCiFailedEvent(
+  event: WorkflowLifecycleEvent,
+): event is ReviewGateCiFailedLifecycleEvent {
+  return event.kind === 'review_gate.ci_failed';
+}
+
+/**
+ * Start the headless auto-fix worker.
+ *
+ * The worker converts failed tasks and failed review-gate CI runs into the
+ * same `fix --auto-fix` command a user action issues, then submits it through
+ * the accepted-command boundary. It owns *policy* only — which tasks are
+ * eligible and what the fix command should be — and delegates *mechanics*
+ * (wakeups, coalescing, polling, shutdown) to the shared worker runtime.
+ *
+ * Lifecycle events are wakeups; the only event payload the worker retains is a
+ * review-gate CI failure's detail, which it stashes until a scan can validate
+ * it against live task lineage and turn it into a fix.
+ */
+export function startAutoFixWorker(options: AutoFixWorkerOptions): WorkerRuntime {
+  const logger = options.logger;
+  const logModule = 'autofix-worker';
+  const reviewGateContexts = new Map<string, ReviewGateCiContext>();
+
+  // Record review-gate CI failure detail before the runtime's own wakeup
+  // subscription fires. Subscribing here first guarantees the context is
+  // present by the time the resulting scan runs.
+  const unsubscribeReviewGate: Unsubscribe = options.messageBus.subscribe<WorkflowLifecycleEvent>(
+    Channels.WORKFLOW_LIFECYCLE,
+    (event) => {
+      if (!isReviewGateCiFailedEvent(event)) return;
+      const task = options.state.getTask(event.taskId);
+      if (!task) return;
+      reviewGateContexts.set(event.taskId, buildReviewGateCiContext(event, task));
+      logger?.info(`recorded review-gate CI failure for ${event.taskId} review=${event.reviewId}`, {
+        module: logModule,
+      });
+    },
+  );
+
+  const runtime = startWorkerRuntime<AutoFixCandidate>({
+    name: 'autofix-worker',
+    messageBus: options.messageBus,
+    logger,
+    pollIntervalMs: options.pollIntervalMs,
+    scanOnStartup: options.scanOnStartup,
+    handleSignals: options.handleSignals,
+    eventKinds: AUTO_FIX_WORKER_EVENT_KINDS,
+    scan: () =>
+      scanAutoFixCandidates({
+        state: options.state,
+        openIntents: options.listOpenFixIntents(),
+        reviewGateContexts,
+        config: options.config,
+      }),
+    submit: async (candidate) => {
+      // A review-gate context is consumed once: the accepted-command boundary
+      // now owns the retry, so re-submitting on the next poll would duplicate.
+      if (candidate.source === 'review_gate_ci') {
+        reviewGateContexts.delete(candidate.taskId);
+      }
+      logger?.info(
+        `submitting auto-fix for ${candidate.taskId} source=${candidate.source}`,
+        { module: logModule },
+      );
+      await options.submit(candidate);
+    },
+  });
+
+  return {
+    ...runtime,
+    stop: () => {
+      unsubscribeReviewGate();
+      runtime.stop();
+    },
+  };
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -63,6 +63,8 @@ import {
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { startWorkerRuntime, type WorkerRuntime } from './worker-runtime.js';
+import { startAutoFixWorker, type AutoFixCandidate } from './autofix-worker.js';
+import { tryDelegateExec, isDelegated } from './headless-delegation.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
@@ -1255,13 +1257,14 @@ function isHeadlessWorkerKind(value: string | undefined): value is HeadlessWorke
  *
  * Each worker is an explicitly-owned, long-running process (routed like
  * `owner-serve`) rather than a subscription hidden inside another command.
- * `autofix` is a placeholder runtime until its real scan/submit policy lands;
+ * `autofix` recovers failed tasks and failed review-gate CI runs by submitting
+ * the same `fix --auto-fix` command a user action issues;
  * `external-recovery` is a no-op runtime until its worker exists. `all` runs
  * every worker in the same process.
  */
 async function headlessWorker(
   subcommand: string | undefined,
-  deps: Pick<HeadlessDeps, 'logger' | 'messageBus' | 'invokerConfig'>,
+  deps: Pick<HeadlessDeps, 'logger' | 'messageBus' | 'invokerConfig' | 'orchestrator' | 'persistence'>,
 ): Promise<void> {
   if (!isHeadlessWorkerKind(subcommand)) {
     throw new Error(
@@ -1273,15 +1276,29 @@ async function headlessWorker(
   const runtimes: WorkerRuntime[] = [];
 
   const startAutofix = (): void => {
-    runtimes.push(startWorkerRuntime({
-      name: 'autofix-worker',
+    runtimes.push(startAutoFixWorker({
       messageBus: deps.messageBus,
       logger: deps.logger,
       pollIntervalMs,
-      eventKinds: ['task.failed', 'review_gate.ci_failed'],
-      // Placeholder until the auto-fix scan/submit policy lands.
-      scan: () => [],
-      submit: () => {},
+      state: deps.orchestrator,
+      listOpenFixIntents: () =>
+        deps.persistence.listWorkflowMutationIntents(undefined, ['queued', 'running']),
+      config: {
+        autoFixAgent: deps.invokerConfig.autoFixAgent,
+        autoFixCi: deps.invokerConfig.autoFixCi,
+      },
+      // Submit through the accepted-command boundary: delegate a normal
+      // `fix --auto-fix` command to the shared owner, exactly like a user
+      // action. The owner enqueues it and owns attempt accounting.
+      submit: async (candidate: AutoFixCandidate) => {
+        const outcome = await tryDelegateExec(candidate.args, deps.messageBus, false, true);
+        if (!isDelegated(outcome)) {
+          deps.logger.warn(
+            `autofix-worker could not delegate fix for ${candidate.taskId}: ${outcome.kind}`,
+            { module: 'autofix-worker' },
+          );
+        }
+      },
     }));
   };
 


### PR DESCRIPTION
Validation passes with no warnings. Here is the final PR body:

## Summary

Auto-fix now runs as its own start/stop worker instead of firing from hidden callbacks. You launch it with `./run.sh --headless worker autofix`.

Lifecycle events wake it up, then it reads the saved workflow and task state to decide what needs fixing. The event is only a nudge, not the source of truth.

For an eligible failed task, or a failed review-gate CI run, it submits a normal `fix <taskId> <agent> --auto-fix` command. The same path a person's "Fix with AI" uses.

The worker owns policy only. It never calls the fix execution functions directly, so retry accounting and the actual fix route stay in one place: the accepted-command boundary.

If no owner is reachable, the worker skips and tries again later through a saved intent fallback or a later scan. Polling also recovers any lifecycle event it missed.

## Architecture

This moves failed-task and review-gate CI recovery out of scattered callbacks and into one explicit worker process, changing how recovery is triggered and routed.

### Before

```mermaid
graph TD
    F[Task fails / CI fails] --> CB[TaskRunner review-gate callback]
    F --> SUB[GUI / headless failed-delta subscription]
    CB --> FIX[fixWithAgent / resolveConflict called directly]
    SUB --> FIX
    FIX --> RUN[Fix runs]
```

### After

```mermaid
graph TD
    F[Task fails / CI fails] --> EVT[Workflow lifecycle event]
    EVT --> W[Auto-fix worker wakes]
    POLL[Poll fallback] --> W
    W --> SCAN[Scan persisted state for eligible work]
    SCAN --> CMD[Submit normal fix --auto-fix command]
    CMD --> BND[Accepted-command boundary]
    BND --> RUN[Fix with AI route]
```

## Test Plan

- [ ] `cd packages/app && pnpm test -- src/__tests__/autofix-worker.test.ts src/__tests__/task-runner-wiring.test.ts src/__tests__/workflow-actions.test.ts`
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>` (or drop this stacked branch)
- Post-revert steps: None. Auto-fix returns to the prior callback-driven path on the base branch.
- Data migration? No