### PR TITLE
fix(execution): allocate unique merge clone paths

### DIFF
--- a/packages/execution-engine/src/__tests__/create-merge-worktree.test.ts
+++ b/packages/execution-engine/src/__tests__/create-merge-worktree.test.ts
@@ -181,6 +181,27 @@ describe('createMergeWorktree isolation (real git)', { timeout: 30_000 }, () => 
     await executor.removeMergeWorktree(clonePath);
   });
 
+  it('allocates unique clone directories for duplicate labels in the same timestamp', async () => {
+    const sandbox = createSandbox();
+    root = sandbox.root;
+    const dateNow = vi.spyOn(Date, 'now').mockReturnValue(123456789);
+
+    const executor = buildExecutor(sandbox.host);
+    const firstClonePath = await executor.createMergeWorktree('master', 'test-concurrent');
+    const secondClonePath = await executor.createMergeWorktree('master', 'test-concurrent');
+
+    try {
+      expect(firstClonePath).not.toBe(secondClonePath);
+      expect(existsSync(firstClonePath)).toBe(true);
+      expect(existsSync(secondClonePath)).toBe(true);
+      expect(git(firstClonePath, 'rev-parse HEAD')).toBe(git(secondClonePath, 'rev-parse HEAD'));
+    } finally {
+      dateNow.mockRestore();
+      await executor.removeMergeWorktree(firstClonePath);
+      await executor.removeMergeWorktree(secondClonePath);
+    }
+  });
+
   it('prefers freshly fetched origin base over stale local base branch', async () => {
     const sandbox = createSandbox();
     root = sandbox.root;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1978,8 +1978,8 @@ export class TaskRunner {
       ? resolve(process.env.INVOKER_DB_DIR)
       : resolve(homedir(), '.invoker');
     const mergeCloneRoot = resolve(invokerHomeRoot, 'merge-clones');
-    const clonePath = resolve(mergeCloneRoot, `${label}-${Date.now()}`);
     mkdirSync(mergeCloneRoot, { recursive: true });
+    const clonePath = mkdtempSync(resolve(mergeCloneRoot, `${label}-`));
 
     // Determine clone source: prefer pool mirror (has latest remote refs), fall back to host repo
     let cloneSource: string = this.cwd;

--- a/scripts/repro/repro-merge-clone-path-collision.sh
+++ b/scripts/repro/repro-merge-clone-path-collision.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-merge-clone-path-collision.XXXXXX.log")"
+trap 'rm -f "$log_file"' EXIT
+
+echo "[repro] issue: duplicate merge clone labels can collide when Date.now() returns the same value"
+
+python3 <<'PY'
+from pathlib import Path
+
+label = "gate-__merge__wf-demo"
+timestamp = 123456789
+pre_fix_first = f"{label}-{timestamp}"
+pre_fix_second = f"{label}-{timestamp}"
+assert pre_fix_first == pre_fix_second, "pre-fix Date.now path model should collide"
+
+source = Path("packages/execution-engine/src/task-runner.ts").read_text(encoding="utf-8")
+assert "mkdtempSync(resolve(mergeCloneRoot, `${label}-`))" in source, "fixed TaskRunner must allocate merge clone paths with mkdtempSync"
+print("[repro] pre-fix model: duplicate labels in the same millisecond choose the same clone directory")
+print("[repro] source check: TaskRunner now delegates suffix allocation to mkdtempSync")
+PY
+
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/create-merge-worktree.test.ts \
+  -t "allocates unique clone directories for duplicate labels" \
+  >"$log_file" 2>&1 || {
+  status=$?
+  echo "[repro] focused merge clone regression failed"
+  cat "$log_file"
+  exit "$status"
+}
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Merge gates now allocate clone folders with `mkdtempSync`, so two gates with the same label cannot pick the same path in one millisecond.

The bug was a timestamp-based path. Duplicate labels could collide before git even started.

The repro models the collision and runs the real merge worktree regression.

## Test Plan

- [x] `pnpm run build` at commit `b36a0f7d2`
- [x] `scripts/repro/repro-merge-clone-path-collision.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert b36a0f7d2`
- Post-revert steps: None
- Data migration? No