### PR TITLE
fix(github): create merge gate PRs through REST

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         env:
           INVOKER_TEST_ALL_PROOF: '1'
           INVOKER_TEST_ALL_JOBS: '1'
-          TMPDIR: ${{ runner.temp }}/invoker-tmp
+          TMPDIR: /tmp/invoker-tmp
         run: |
           mkdir -p "$TMPDIR"
           chmod 1777 "$TMPDIR"

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -44,7 +44,10 @@ describe('GitHubMergeGateProvider', () => {
           return mockSpawnResult('https://github.com/Neko-Catpital-Labs/Invoker.git', 0);
         }
         if (cmd === 'git') return mockSpawnResult('', 0);
-        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') return mockSpawnResult('[]', 0);
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+          throw new Error('gh pr list should not be used');
+        }
+        if (cmd === 'gh' && args[0] === 'api' && args[1] === 'repos/Neko-Catpital-Labs/Invoker/pulls' && args.includes('--method') && args.includes('GET')) return mockSpawnResult('[]', 0);
         return mockSpawnResult('{"html_url":"https://github.com/Neko-Catpital-Labs/Invoker/pull/42","number":42}', 0);
       }) as any);
 
@@ -59,12 +62,11 @@ describe('GitHubMergeGateProvider', () => {
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
         [
-          'pr', 'list',
-          '--repo', 'Neko-Catpital-Labs/Invoker',
-          '--head', 'feature/test',
-          '--state', 'open',
-          '--json', 'url,number',
-          '--limit', '1',
+          'api', 'repos/Neko-Catpital-Labs/Invoker/pulls',
+          '--method', 'GET',
+          '-f', 'head=Neko-Catpital-Labs:feature/test',
+          '-f', 'state=open',
+          '-f', 'per_page=1',
         ],
         expect.anything(),
       );
@@ -92,7 +94,10 @@ describe('GitHubMergeGateProvider', () => {
           return mockSpawnResult('https://github.com/owner/repo.git', 0);
         }
         if (cmd === 'git') return mockSpawnResult('', 0);
-        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') return mockSpawnResult('[]', 0);
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+          throw new Error('gh pr list should not be used');
+        }
+        if (cmd === 'gh' && args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('--method') && args.includes('GET')) return mockSpawnResult('[]', 0);
         return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
       }) as any);
 
@@ -113,12 +118,11 @@ describe('GitHubMergeGateProvider', () => {
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
         [
-          'pr', 'list',
-          '--repo', 'owner/repo',
-          '--head', 'feature/test',
-          '--state', 'open',
-          '--json', 'url,number',
-          '--limit', '1',
+          'api', 'repos/owner/repo/pulls',
+          '--method', 'GET',
+          '-f', 'head=owner:feature/test',
+          '-f', 'state=open',
+          '-f', 'per_page=1',
         ],
         expect.anything(),
       );
@@ -158,7 +162,10 @@ describe('GitHubMergeGateProvider', () => {
           return mockSpawnResult('', 0);
         }
         if (cmd === 'git' && args[0] === 'fetch') return mockSpawnResult('', 0);
-        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') return mockSpawnResult('[]', 0);
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+          throw new Error('gh pr list should not be used');
+        }
+        if (cmd === 'gh' && args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('--method') && args.includes('GET')) return mockSpawnResult('[]', 0);
         return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
       }) as any);
 
@@ -178,6 +185,86 @@ describe('GitHubMergeGateProvider', () => {
       );
     });
 
+    it('retries branch push after GitHub reports a stale expected-sha ref lock race', async () => {
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+      let pushAttempts = 0;
+
+      spawnMock.mockImplementation(((cmd: string, _args: string[]) => {
+        const args = _args;
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
+          return mockSpawnResult('https://github.com/owner/repo.git', 0);
+        }
+        if (cmd === 'git' && args[0] === 'push') {
+          pushAttempts++;
+          if (pushAttempts === 1) {
+            return mockSpawnResult('', 1, [
+              'To github.com:owner/repo.git',
+              " ! [remote rejected] feature/test -> feature/test (cannot lock ref 'refs/heads/feature/test': is at 1111111 but expected 2222222)",
+              "error: failed to push some refs to 'github.com:owner/repo.git'",
+            ].join('\n'));
+          }
+          return mockSpawnResult('', 0);
+        }
+        if (cmd === 'git' && args[0] === 'fetch') return mockSpawnResult('', 0);
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+          throw new Error('gh pr list should not be used');
+        }
+        if (cmd === 'gh' && args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('--method') && args.includes('GET')) return mockSpawnResult('[]', 0);
+        return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
+      }) as any);
+
+      const result = await provider.createReview({
+        baseBranch: 'main',
+        featureBranch: 'feature/test',
+        title: 'Test PR',
+        cwd: '/tmp/repo',
+      });
+
+      expect(result.url).toBe('https://github.com/owner/repo/pull/42');
+      expect(pushAttempts).toBe(2);
+      expect(spawnMock).toHaveBeenCalledWith(
+        'git',
+        ['fetch', 'origin', '+refs/heads/feature/test:refs/remotes/origin/feature/test'],
+        expect.objectContaining({ cwd: '/tmp/repo' }),
+      );
+    });
+
+    it('retries transient REST PR lookup failures before creating a PR', async () => {
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+      let lookupAttempts = 0;
+
+      spawnMock.mockImplementation(((cmd: string, _args: string[]) => {
+        const args = _args;
+        if (cmd === 'git' && args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') {
+          return mockSpawnResult('https://github.com/owner/repo.git', 0);
+        }
+        if (cmd === 'git') return mockSpawnResult('', 0);
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+          throw new Error('gh pr list should not be used');
+        }
+        if (cmd === 'gh' && args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('--method') && args.includes('GET')) {
+          lookupAttempts++;
+          if (lookupAttempts === 1) {
+            return mockSpawnResult('', 1, 'Post "https://api.github.com/graphql": dial tcp: i/o timeout');
+          }
+          return mockSpawnResult('[]', 0);
+        }
+        return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
+      }) as any);
+
+      const result = await provider.createReview({
+        baseBranch: 'main',
+        featureBranch: 'feature/test',
+        title: 'Test PR',
+        cwd: '/tmp/repo',
+      });
+
+      expect(result.url).toBe('https://github.com/owner/repo/pull/42');
+      expect(lookupAttempts).toBe(2);
+    });
+
     it('reuses an existing open PR by head and retargets its base', async () => {
       const { spawn } = await import('node:child_process');
       const spawnMock = vi.mocked(spawn);
@@ -188,7 +275,10 @@ describe('GitHubMergeGateProvider', () => {
         }
         if (cmd === 'git') return mockSpawnResult('', 0);
         if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') {
-          return mockSpawnResult('[{"url":"https://github.com/owner/repo/pull/10","number":10}]', 0);
+          throw new Error('gh pr list should not be used');
+        }
+        if (cmd === 'gh' && args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('--method') && args.includes('GET')) {
+          return mockSpawnResult('[{"html_url":"https://github.com/owner/repo/pull/10","number":10}]', 0);
         }
         return mockSpawnResult('', 0);
       }) as any);
@@ -225,7 +315,10 @@ describe('GitHubMergeGateProvider', () => {
           throw new Error('remote lookup should not run when env target is set');
         }
         if (cmd === 'git') return mockSpawnResult('', 0);
-        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') return mockSpawnResult('[]', 0);
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') {
+          throw new Error('gh pr list should not be used');
+        }
+        if (cmd === 'gh' && args[0] === 'api' && args[1] === 'repos/Neko-Catpital-Labs/Invoker/pulls' && args.includes('--method') && args.includes('GET')) return mockSpawnResult('[]', 0);
         return mockSpawnResult('{"html_url":"https://github.com/Neko-Catpital-Labs/Invoker/pull/99","number":99}', 0);
       }) as any);
 

--- a/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
+++ b/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
@@ -218,7 +218,7 @@ describe('publishAfterFixImpl integration (real git)', () => {
         if (pushAttempts === 1) {
           throw new Error(
             "git push --force origin plan/feature:refs/heads/plan/feature failed (code 1): " +
-              "remote rejected: cannot lock ref 'refs/heads/plan/feature': reference already exists",
+              "remote rejected: cannot lock ref 'refs/heads/plan/feature': is at 1111111 but expected 2222222",
           );
         }
       }

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -98,6 +98,7 @@ function createMockLogger(): Logger {
 }
 
 const tempWorkspaces: string[] = [];
+const originalGithubTargetRepo = process.env.INVOKER_GITHUB_TARGET_REPO;
 function createTempWorkspace(): string {
   const dir = mkdtempSync(join(tmpdir(), 'invoker-task-executor-test-'));
   tempWorkspaces.push(dir);
@@ -105,6 +106,11 @@ function createTempWorkspace(): string {
 }
 
 afterEach(() => {
+  if (originalGithubTargetRepo === undefined) {
+    delete process.env.INVOKER_GITHUB_TARGET_REPO;
+  } else {
+    process.env.INVOKER_GITHUB_TARGET_REPO = originalGithubTargetRepo;
+  }
   while (tempWorkspaces.length > 0) {
     const dir = tempWorkspaces.pop();
     if (dir) rmSync(dir, { recursive: true, force: true });
@@ -992,6 +998,7 @@ describe('TaskRunner', () => {
     });
 
     it('execPr reuses existing open PR instead of creating new one', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null } as any,
         persistence: {} as any,
@@ -1003,9 +1010,12 @@ describe('TaskRunner', () => {
       (executor as any).execGh = async (args: string[]) => {
         ghCalls.push(args);
         if (args[0] === 'pr' && args[1] === 'list') {
-          return JSON.stringify([{ url: 'https://github.com/owner/repo/pull/42', number: 42 }]);
+          throw new Error('gh pr list should not be used');
         }
-        if (args[0] === 'pr' && args[1] === 'edit') {
+        if (args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('GET')) {
+          return JSON.stringify([{ html_url: 'https://github.com/owner/repo/pull/42', number: 42 }]);
+        }
+        if (args[0] === 'api' && args[1] === 'repos/owner/repo/pulls/42' && args.includes('PATCH')) {
           return '';
         }
         return '';
@@ -1014,24 +1024,24 @@ describe('TaskRunner', () => {
       const url = await (executor as any).execPr('main', 'feature/test', 'My Workflow');
       expect(url).toBe('https://github.com/owner/repo/pull/42');
 
-      // Should have called gh pr list with correct args
-      const listCall = ghCalls.find(c => c[0] === 'pr' && c[1] === 'list');
+      // Should have called REST PR lookup with correct args
+      const listCall = ghCalls.find(c => c[0] === 'api' && c[1] === 'repos/owner/repo/pulls');
       expect(listCall).toBeDefined();
-      expect(listCall).toContain('feature/test');
-      expect(listCall).toContain('main');
+      expect(listCall).toContain('head=owner:feature/test');
+      expect(listCall).toContain('state=open');
 
-      // Should have called gh pr edit to update title
-      const editCall = ghCalls.find(c => c[0] === 'pr' && c[1] === 'edit');
+      // Should have called REST PR update to update title
+      const editCall = ghCalls.find(c => c[0] === 'api' && c[1] === 'repos/owner/repo/pulls/42');
       expect(editCall).toBeDefined();
-      expect(editCall).toContain('42');
-      expect(editCall).toContain('My Workflow');
+      expect(editCall).toContain('title=My Workflow');
 
-      // Should NOT have called gh pr create
-      const createCall = ghCalls.find(c => c[0] === 'pr' && c[1] === 'create');
+      // Should NOT have called REST PR create
+      const createCall = ghCalls.find(c => c[0] === 'api' && c[1] === 'repos/owner/repo/pulls' && c.includes('POST'));
       expect(createCall).toBeUndefined();
     });
 
     it('execPr creates new PR when no open PR exists', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null } as any,
         persistence: {} as any,
@@ -1043,10 +1053,13 @@ describe('TaskRunner', () => {
       (executor as any).execGh = async (args: string[]) => {
         ghCalls.push(args);
         if (args[0] === 'pr' && args[1] === 'list') {
+          throw new Error('gh pr list should not be used');
+        }
+        if (args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('GET')) {
           return '[]';
         }
-        if (args[0] === 'pr' && args[1] === 'create') {
-          return 'https://github.com/owner/repo/pull/99';
+        if (args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('POST')) {
+          return '{"html_url":"https://github.com/owner/repo/pull/99","number":99}';
         }
         return '';
       };
@@ -1054,23 +1067,57 @@ describe('TaskRunner', () => {
       const url = await (executor as any).execPr('main', 'feature/new', 'New Workflow');
       expect(url).toBe('https://github.com/owner/repo/pull/99');
 
-      // Should have called gh pr list
-      const listCall = ghCalls.find(c => c[0] === 'pr' && c[1] === 'list');
+      // Should have called REST PR lookup
+      const listCall = ghCalls.find(c => c[0] === 'api' && c[1] === 'repos/owner/repo/pulls' && c.includes('GET'));
       expect(listCall).toBeDefined();
 
-      // Should have called gh pr create with correct args
-      const createCall = ghCalls.find(c => c[0] === 'pr' && c[1] === 'create');
+      // Should have called REST PR create with correct args
+      const createCall = ghCalls.find(c => c[0] === 'api' && c[1] === 'repos/owner/repo/pulls' && c.includes('POST'));
       expect(createCall).toBeDefined();
-      expect(createCall).toContain('main');
-      expect(createCall).toContain('feature/new');
-      expect(createCall).toContain('New Workflow');
+      expect(createCall).toContain('base=main');
+      expect(createCall).toContain('head=feature/new');
+      expect(createCall).toContain('title=New Workflow');
 
-      // Should NOT have called gh pr edit
-      const editCall = ghCalls.find(c => c[0] === 'pr' && c[1] === 'edit');
+      // Should NOT have called REST PR update
+      const editCall = ghCalls.find(c => c[0] === 'api' && /\/pulls\/\d+$/.test(c[1]));
       expect(editCall).toBeUndefined();
     });
 
+    it('execPr retries transient REST PR lookup failures', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+      });
+
+      let lookupAttempts = 0;
+      (executor as any).execGh = async (args: string[]) => {
+        if (args[0] === 'pr' && args[1] === 'list') {
+          throw new Error('gh pr list should not be used');
+        }
+        if (args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('GET')) {
+          lookupAttempts++;
+          if (lookupAttempts === 1) {
+            throw new Error('gh api repos/owner/repo/pulls failed (code 1): GraphQL: API rate limit already exceeded for user ID 1916223.');
+          }
+          return '[]';
+        }
+        if (args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('POST')) {
+          return '{"html_url":"https://github.com/owner/repo/pull/99","number":99}';
+        }
+        return '';
+      };
+
+      const url = await (executor as any).execPr('main', 'feature/new', 'New Workflow');
+
+      expect(url).toBe('https://github.com/owner/repo/pull/99');
+      expect(lookupAttempts).toBe(2);
+    });
+
     it('execPr passes normalized branch names to gh when base uses origin/ remote-tracking form', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null } as any,
         persistence: {} as any,
@@ -1081,8 +1128,9 @@ describe('TaskRunner', () => {
       const ghCalls: string[][] = [];
       (executor as any).execGh = async (args: string[]) => {
         ghCalls.push(args);
-        if (args[0] === 'pr' && args[1] === 'list') return '[]';
-        if (args[0] === 'pr' && args[1] === 'create') return 'https://github.com/owner/repo/pull/200';
+        if (args[0] === 'pr' && args[1] === 'list') throw new Error('gh pr list should not be used');
+        if (args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('GET')) return '[]';
+        if (args[0] === 'api' && args[1] === 'repos/owner/repo/pulls' && args.includes('POST')) return '{"html_url":"https://github.com/owner/repo/pull/200","number":200}';
         return '';
       };
 
@@ -1093,15 +1141,12 @@ describe('TaskRunner', () => {
         'Body',
       );
 
-      const listCall = ghCalls.find(c => c[0] === 'pr' && c[1] === 'list');
-      expect(listCall?.indexOf('--base')).toBeGreaterThan(-1);
-      expect(listCall?.[listCall.indexOf('--base') + 1]).toBe('fix/my-work');
-      expect(listCall?.[listCall.indexOf('--head') + 1]).toBe('plan/experiment');
+      const listCall = ghCalls.find(c => c[0] === 'api' && c[1] === 'repos/owner/repo/pulls' && c.includes('GET'));
+      expect(listCall).toContain('head=owner:plan/experiment');
 
-      const createCall = ghCalls.find(c => c[0] === 'pr' && c[1] === 'create');
-      expect(createCall?.indexOf('--base')).toBeGreaterThan(-1);
-      expect(createCall?.[createCall.indexOf('--base') + 1]).toBe('fix/my-work');
-      expect(createCall?.[createCall.indexOf('--head') + 1]).toBe('plan/experiment');
+      const createCall = ghCalls.find(c => c[0] === 'api' && c[1] === 'repos/owner/repo/pulls' && c.includes('POST'));
+      expect(createCall).toContain('base=fix/my-work');
+      expect(createCall).toContain('head=plan/experiment');
     });
 
     it('authorPrBodyWithSkill uses the configured workflow agent when available', async () => {

--- a/packages/execution-engine/src/git-utils.ts
+++ b/packages/execution-engine/src/git-utils.ts
@@ -53,3 +53,44 @@ function githubKey(owner: string, repo: string): string {
 export function sanitizeBranchForPath(branch: string): string {
   return branch.replace(/\//g, '-');
 }
+
+export function isGitRefLockRace(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /cannot lock ref\b/i.test(message)
+    && (
+      /reference already exists/i.test(message)
+      || /\bis at\b.+\bbut expected\b/i.test(message)
+    );
+}
+
+export function isTransientGitHubCliError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /\bi\/o timeout\b/i.test(message)
+    || /\bcontext deadline exceeded\b/i.test(message)
+    || /\bconnection (?:reset|refused|timed out)\b/i.test(message)
+    || /\bECONNRESET\b|\bETIMEDOUT\b|\bEAI_AGAIN\b|\bENOTFOUND\b/i.test(message)
+    || /\b(?:502|503|504)\b/.test(message)
+    || /\bbad gateway\b|\bservice unavailable\b|\bgateway timeout\b/i.test(message)
+    || /\brate limit\b/i.test(message);
+}
+
+export async function retryTransientGitHubCli<T>(
+  operation: () => Promise<T>,
+  opts: { attempts?: number; delayMs?: number } = {},
+): Promise<T> {
+  const attempts = opts.attempts ?? 3;
+  const delayMs = opts.delayMs ?? 250;
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await operation();
+    } catch (err) {
+      lastErr = err;
+      if (attempt >= attempts || !isTransientGitHubCliError(err)) {
+        throw err;
+      }
+      await new Promise(resolve => setTimeout(resolve, delayMs * attempt));
+    }
+  }
+  throw lastErr;
+}

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -7,6 +7,7 @@ import type {
   MergeGateFailedCheck,
 } from './merge-gate-provider.js';
 import { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
+import { isGitRefLockRace, retryTransientGitHubCli } from './git-utils.js';
 
 export class GitHubMergeGateProvider implements MergeGateProvider {
   readonly name = 'github';
@@ -32,17 +33,16 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
 
     await this.pushFeatureBranch(cwd, featureBranch);
 
-    const listOutput = await this.exec('gh', [
-      'pr', 'list',
-      '--repo', targetRepo,
-      '--head', ghHead,
-      '--state', 'open',
-      '--json', 'url,number',
-      '--limit', '1',
-    ], cwd);
+    const listOutput = await retryTransientGitHubCli(() => this.exec('gh', [
+      'api', `repos/${targetRepo}/pulls`,
+      '--method', 'GET',
+      '-f', `head=${targetRepo.split('/')[0]}:${ghHead}`,
+      '-f', 'state=open',
+      '-f', 'per_page=1',
+    ], cwd));
     console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview listOutput=${listOutput}`);
 
-    const existing = JSON.parse(listOutput) as { url: string; number: number }[];
+    const existing = JSON.parse(listOutput) as { html_url?: string; url?: string; number: number }[];
     console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview existing=${existing}`);
 
     if (existing.length > 0) {
@@ -53,10 +53,10 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
         '-f', `title=${title}`,
       ];
       if (body) apiArgs.push('-f', `body=${body}`);
-      const ghResult = await this.exec('gh', apiArgs, cwd);
+      const ghResult = await retryTransientGitHubCli(() => this.exec('gh', apiArgs, cwd));
       console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview update existing gh_result=${ghResult}`);
 
-      return { url: existing[0].url, identifier: String(existing[0].number) };
+      return { url: existing[0].html_url ?? existing[0].url ?? '', identifier: String(existing[0].number) };
     }
 
     const createArgs = [
@@ -78,11 +78,11 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
   }): Promise<void> {
     const { identifier, cwd } = opts;
     const targetRepo = await this.resolveTargetRepo(cwd);
-    await this.exec('gh', [
+    await retryTransientGitHubCli(() => this.exec('gh', [
       'api', `repos/${targetRepo}/pulls/${identifier}`,
       '--method', 'PATCH',
       '-f', 'state=closed',
-    ], cwd);
+    ], cwd));
   }
 
   async checkApproval(opts: {
@@ -92,11 +92,11 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     const { identifier, cwd } = opts;
     const targetRepo = await this.resolveTargetRepo(cwd);
 
-    const stdout = await this.exec('gh', [
+    const stdout = await retryTransientGitHubCli(() => this.exec('gh', [
       'pr', 'view', identifier,
       '--repo', targetRepo,
       '--json', 'state,reviewDecision,url,headRefOid,headRefName,mergeStateStatus,statusCheckRollup',
-    ], cwd);
+    ], cwd));
 
     const data = JSON.parse(stdout) as {
       state: string;
@@ -166,7 +166,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     try {
       await this.exec('git', pushArgs, cwd);
     } catch (err) {
-      if (!isGitRefAlreadyExistsLockRace(err)) throw err;
+      if (!isGitRefLockRace(err)) throw err;
       await this.exec('git', [
         'fetch',
         'origin',
@@ -195,11 +195,6 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       });
     });
   }
-}
-
-function isGitRefAlreadyExistsLockRace(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err);
-  return /cannot lock ref\b/i.test(message) && /reference already exists/i.test(message);
 }
 
 function normalizeMergeState(value: string | undefined): 'clean' | 'dirty' | 'unknown' {

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -19,6 +19,7 @@ import type { MergeGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 import type { PrAuthoringContext, PrAuthoringTaskEntry } from './pr-authoring.js';
+import { isGitRefLockRace } from './git-utils.js';
 
 // ── Trace logging ────────────────────────────────────────
 
@@ -126,7 +127,7 @@ async function pushFeatureBranchWithRefLockRetry(
   try {
     await execGitInMergeSafe(host, pushArgs, dir);
   } catch (err) {
-    if (!isGitRefAlreadyExistsLockRace(err)) throw err;
+    if (!isGitRefLockRace(err)) throw err;
     mergeTrace('GIT_PUSH_REF_LOCK_RACE_RETRY', {
       featureBranch,
       dir,
@@ -139,11 +140,6 @@ async function pushFeatureBranchWithRefLockRetry(
     ], dir);
     await execGitInMergeSafe(host, pushArgs, dir);
   }
-}
-
-function isGitRefAlreadyExistsLockRace(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err);
-  return /cannot lock ref\b/i.test(message) && /reference already exists/i.test(message);
 }
 
 async function syncGateWorkspaceToFeatureBranch(

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -60,6 +60,7 @@ import {
 } from './pr-authoring.js';
 import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
 import { killProcessGroup, SIGKILL_TIMEOUT_MS } from './process-utils.js';
+import { retryTransientGitHubCli } from './git-utils.js';
 
 export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-callbacks.js';
 
@@ -67,6 +68,7 @@ export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-call
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_EXECUTOR_START_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_GIT_OPERATION_TIMEOUT_MS = 15 * 60 * 1000;
+const GITHUB_TARGET_REPO_ENV = 'INVOKER_GITHUB_TARGET_REPO';
 
 type StartupFailureMetadata = {
   workspacePath?: string;
@@ -2181,25 +2183,74 @@ export class TaskRunner {
   /** @internal */ async execPr(baseBranch: string, featureBranch: string, title: string, body?: string, cwd?: string): Promise<string> {
     const ghBase = normalizeBranchForGithubCli(baseBranch);
     const ghHead = normalizeBranchForGithubCli(featureBranch);
+    const effectiveCwd = cwd ?? this.cwd;
+    const targetRepo = await this.resolveGithubTargetRepo(effectiveCwd);
+    const repoOwner = targetRepo.split('/')[0];
 
-    const listOutput = await this.execGh([
-      'pr', 'list', '--head', ghHead, '--base', ghBase,
-      '--state', 'open', '--json', 'url,number', '--limit', '1',
-    ], cwd);
+    const listOutput = await retryTransientGitHubCli(() => this.execGh([
+      'api', `repos/${targetRepo}/pulls`,
+      '--method', 'GET',
+      '-f', `head=${repoOwner}:${ghHead}`,
+      '-f', 'state=open',
+      '-f', 'per_page=1',
+    ], effectiveCwd));
 
-    const existing: Array<{ url: string; number: number }> = JSON.parse(listOutput || '[]');
+    const existing: Array<{ html_url?: string; url?: string; number: number }> = JSON.parse(listOutput || '[]');
     if (existing.length > 0) {
       const pr = existing[0];
-      const editArgs = ['pr', 'edit', String(pr.number), '--title', title];
-      if (body) editArgs.push('--body', body);
-      await this.execGh(editArgs, cwd);
-      return pr.url;
+      const editArgs = [
+        'api', `repos/${targetRepo}/pulls/${pr.number}`,
+        '--method', 'PATCH',
+        '-f', `base=${ghBase}`,
+        '-f', `title=${title}`,
+      ];
+      if (body) editArgs.push('-f', `body=${body}`);
+      await retryTransientGitHubCli(() => this.execGh(editArgs, effectiveCwd));
+      return pr.html_url ?? pr.url ?? '';
     }
 
-    return this.execGh([
-      'pr', 'create', '--base', ghBase,
-      '--head', ghHead, '--title', title, '--body', body ?? '',
-    ], cwd);
+    const createOutput = await this.execGh([
+      'api', `repos/${targetRepo}/pulls`,
+      '--method', 'POST',
+      '-f', `base=${ghBase}`,
+      '-f', `head=${ghHead}`,
+      '-f', `title=${title}`,
+      '-f', `body=${body ?? ''}`,
+    ], effectiveCwd);
+    try {
+      const pr = JSON.parse(createOutput) as { html_url?: string; url?: string };
+      return pr.html_url ?? pr.url ?? createOutput;
+    } catch {
+      return createOutput;
+    }
+  }
+
+  private async resolveGithubTargetRepo(cwd: string): Promise<string> {
+    const explicitTarget = process.env[GITHUB_TARGET_REPO_ENV]?.trim();
+    if (explicitTarget) {
+      if (/^[^/\s]+\/[^/\s]+$/.test(explicitTarget)) return explicitTarget;
+      throw new Error(
+        `Invalid ${GITHUB_TARGET_REPO_ENV}="${explicitTarget}". Expected format "owner/repo".`,
+      );
+    }
+
+    try {
+      const url = await this.execGitIn(['remote', 'get-url', 'origin'], cwd);
+      const parsed = this.parseGitHubRepoNwo(url);
+      if (parsed) return parsed;
+    } catch {
+      // fall through
+    }
+
+    throw new Error(
+      'Unable to resolve GitHub target repo. ' +
+      `Set ${GITHUB_TARGET_REPO_ENV}=owner/repo or configure a parseable origin GitHub remote.`,
+    );
+  }
+
+  private parseGitHubRepoNwo(url: string): string | undefined {
+    const m = url.trim().match(/github\.com[:/]([^/]+\/[^/.]+?)(?:\.git)?\/?$/i);
+    return m?.[1];
   }
 
   // ── Experiment Branch Merging ────────────────────────────

--- a/scripts/e2e-dry-run/cases/case-4.2-github-pr.sh
+++ b/scripts/e2e-dry-run/cases/case-4.2-github-pr.sh
@@ -51,12 +51,12 @@ if [ ! -f "$GHLOG" ]; then
   exit 1
 fi
 
-if ! grep -q "pr list" "$GHLOG" && ! grep -q "api .*repos.*/pulls.*--method GET" "$GHLOG"; then
-  echo "FAIL case 4.2: gh stub log missing PR lookup call"
+if ! grep -q "api.*repos.*pulls.*GET" "$GHLOG"; then
+  echo "FAIL case 4.2: gh stub log missing REST PR lookup call"
   cat "$GHLOG"
   exit 1
 fi
-echo "==> case 4.2: confirmed gh PR lookup was called"
+echo "==> case 4.2: confirmed REST PR lookup was called"
 
 if ! grep -q "api.*repos.*pulls.*POST" "$GHLOG"; then
   echo "FAIL case 4.2: gh stub log missing PR creation API call"

--- a/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
+++ b/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
@@ -130,8 +130,8 @@ if [ ! -f "$GHLOG" ]; then
   exit 1
 fi
 
-if ! grep -q "pr list" "$GHLOG" && ! grep -q "api .*repos.*/pulls.*--method GET" "$GHLOG"; then
-  echo "FAIL case 4.3: gh stub log missing PR lookup call"
+if ! grep -q "api.*repos.*pulls.*GET" "$GHLOG"; then
+  echo "FAIL case 4.3: gh stub log missing REST PR lookup call"
   cat "$GHLOG"
   exit 1
 fi

--- a/scripts/e2e-dry-run/fixtures/gh-marker.sh
+++ b/scripts/e2e-dry-run/fixtures/gh-marker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Stub gh CLI for e2e-dry-run: no network, instant responses.
 # Handles the exact calls made by GitHubMergeGateProvider:
-#   - gh pr list --head ... --base ... --state open --json url,number --limit 1
+#   - gh api repos/{owner}/{repo}/pulls --method GET -f head=... -f state=open
 #   - gh api repos/{owner}/{repo}/pulls --method POST -f base=... -f head=... -f title=... -f body=...
 #   - gh api repos/{owner}/{repo}/pulls/N --method PATCH ...
 #   - gh pr view N --json state,reviewDecision,url
@@ -31,9 +31,8 @@ case "$SUBCMD" in
     shift || true
     case "$ACTION" in
       list)
-        # gh pr list --head ... --base ... --state open --json url,number --limit 1
-        # Return empty array (no existing PR)
-        echo '[]'
+        echo "ERROR: gh pr list should not be used; use REST gh api pulls lookup" >&2
+        exit 1
         ;;
       view)
         # gh pr view N --json state,reviewDecision,url
@@ -45,13 +44,25 @@ case "$SUBCMD" in
     esac
     ;;
   api)
-    # gh api repos/{owner}/{repo}/pulls --method POST ...
+    # gh api repos/{owner}/{repo}/pulls --method GET/POST ...
     # or gh api repos/{owner}/{repo}/pulls/N --method PATCH ...
     ENDPOINT="${1:-}"
     shift || true
     if echo "$ENDPOINT" | grep -qE 'pulls$'; then
-      # POST — create new PR
-      echo '{"html_url":"https://github.com/test/repo/pull/99","number":99}'
+      METHOD="GET"
+      prev=""
+      for arg in "$@"; do
+        if [ "$prev" = "--method" ]; then
+          METHOD="$arg"
+          break
+        fi
+        prev="$arg"
+      done
+      if [ "$METHOD" = "GET" ]; then
+        echo '[]'
+      else
+        echo '{"html_url":"https://github.com/test/repo/pull/99","number":99}'
+      fi
     else
       # PATCH — update existing PR
       echo '{}'

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -286,8 +286,11 @@ invoker_e2e_run_headless() {
   local max_attempts=2
   local status=0
   while :; do
-    invoker_e2e_run_with_timeout "$INVOKER_E2E_REPO_ROOT/run.sh" --headless "$@"
-    status=$?
+    if invoker_e2e_run_with_timeout "$INVOKER_E2E_REPO_ROOT/run.sh" --headless "$@"; then
+      status=0
+    else
+      status=$?
+    fi
     if [ "$status" -eq 0 ]; then
       return 0
     fi
@@ -318,8 +321,11 @@ invoker_e2e_submit_plan() {
   max_attempts=2
   status=0
   while :; do
-    invoker_e2e_run_with_timeout "$INVOKER_E2E_REPO_ROOT/submit-plan.sh" "$patched" "$@"
-    status=$?
+    if invoker_e2e_run_with_timeout "$INVOKER_E2E_REPO_ROOT/submit-plan.sh" "$patched" "$@"; then
+      status=0
+    else
+      status=$?
+    fi
     if [ "$status" -eq 0 ]; then
       rm -f "$patched"
       return 0

--- a/scripts/e2e-ssh/cases/case-3.6-ssh-merge-gate.sh
+++ b/scripts/e2e-ssh/cases/case-3.6-ssh-merge-gate.sh
@@ -50,12 +50,12 @@ if [ ! -f "$GHLOG" ]; then
   exit 1
 fi
 
-if ! grep -q "pr list" "$GHLOG"; then
-  echo "FAIL case 3.6: gh stub log missing 'pr list' call"
+if ! grep -q "api.*repos.*pulls.*GET" "$GHLOG"; then
+  echo "FAIL case 3.6: gh stub log missing REST PR lookup call"
   cat "$GHLOG"
   exit 1
 fi
-echo "==> case 3.6: confirmed gh pr list was called"
+echo "==> case 3.6: confirmed REST PR lookup was called"
 
 if ! grep -q "api.*repos.*pulls.*POST" "$GHLOG"; then
   echo "FAIL case 3.6: gh stub log missing PR creation API call"

--- a/scripts/repro/repro-github-merge-gate-gh-api.sh
+++ b/scripts/repro/repro-github-merge-gate-gh-api.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] issue: merge-gate PR creation used gh pr list/create paths that are harder to stub and retry"
+
+gh_stub="$ROOT/scripts/e2e-dry-run/fixtures/gh-marker.sh"
+log_dir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-gh-api-repro.XXXXXX")"
+trap 'rm -rf "$log_dir"' EXIT
+
+if INVOKER_E2E_MARKER_ROOT="$log_dir" "$gh_stub" pr list >/"$log_dir/pr-list.out" 2>/"$log_dir/pr-list.err"; then
+  echo "[repro] expected gh pr list to be rejected by the marker stub"
+  exit 1
+fi
+
+grep -Fq "gh pr list should not be used" "$log_dir/pr-list.err"
+echo "[repro] source check: marker rejects the old gh pr list path"
+
+bash scripts/e2e-dry-run/cases/case-4.2-github-pr.sh
+
+echo "[repro] passed"

--- a/scripts/verify-pr-authoring-fallback-headless.sh
+++ b/scripts/verify-pr-authoring-fallback-headless.sh
@@ -8,7 +8,7 @@
 # Asserts:
 #   1. Both command tasks reach "completed".
 #   2. The merge gate reaches "awaiting_approval" or "review_ready".
-#   3. The gh stub was called with "pr list" and a PR creation API call.
+#   3. The gh stub was called with REST PR lookup and a PR creation API call.
 #   4. The PR body passed to gh contains the canonical sections:
 #      ## Summary, ## Test Plan, ## Revert Plan.
 #
@@ -65,7 +65,7 @@ if [ "$STM" != "awaiting_approval" ] && [ "$STM" != "review_ready" ]; then
 fi
 echo "PASS: merge gate status=$STM"
 
-# ── Assert 3: gh stub was invoked for PR list + PR creation ────────
+# ── Assert 3: gh stub was invoked for REST PR lookup + PR creation ────────
 
 GHLOG="$INVOKER_E2E_MARKER_ROOT/gh-calls.log"
 if [ ! -f "$GHLOG" ]; then
@@ -73,12 +73,12 @@ if [ ! -f "$GHLOG" ]; then
   exit 1
 fi
 
-if ! grep -q "pr list" "$GHLOG"; then
-  echo "FAIL: gh stub log missing 'pr list' call"
+if ! grep -q "api.*repos.*pulls.*GET" "$GHLOG"; then
+  echo "FAIL: gh stub log missing REST PR lookup call"
   cat "$GHLOG"
   exit 1
 fi
-echo "PASS: gh pr list was called"
+echo "PASS: REST PR lookup was called"
 
 if ! grep -q "api.*repos.*pulls.*POST" "$GHLOG"; then
   echo "FAIL: gh stub log missing PR creation API call"


### PR DESCRIPTION
## Summary

Merge-gate PR creation now uses `gh api` for pull request lookup, create, and update.

The old `gh pr list/create/edit` path was harder to stub and less resilient to GitHub CLI flakes.

The e2e marker now rejects the old lookup path and proves the REST path creates the gate PR.

## Architecture

### Before

```mermaid
flowchart TD
  Gate[Merge gate] --> CLI[gh pr list/create/edit]
  CLI --> GitHub[GitHub]
```

### After

```mermaid
flowchart TD
  Gate[Merge gate] --> API[gh api repos/:repo/pulls]
  API --> Retry[transient retry]
  Retry --> GitHub[GitHub]
```

## Test Plan

- [x] `pnpm run build` at commit `97ca529b0`
- [x] `scripts/repro/repro-github-merge-gate-gh-api.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 97ca529b0`
- Post-revert steps: Re-run the dry-run PR e2e case if PR gate behavior changes again.
- Data migration? No