### PR TITLE
fix(app): poll launch dispatch in standalone headless owner

### DIFF
--- a/packages/app/src/headless-standalone-launch-dispatcher.ts
+++ b/packages/app/src/headless-standalone-launch-dispatcher.ts
@@ -1,0 +1,70 @@
+import type { TaskRunner } from '@invoker/execution-engine';
+import type { HeadlessDeps } from './headless.js';
+import { LaunchDispatcher } from './launch-dispatcher.js';
+
+export interface StandaloneLaunchDispatcherController {
+  stop(): void;
+}
+
+interface StandaloneLaunchDispatcherOptions {
+  headlessDeps: HeadlessDeps;
+  ownerId: string;
+  createTaskExecutor: () => TaskRunner;
+  setLatestTaskExecutor: (executor: TaskRunner) => void;
+}
+
+export function startStandaloneLaunchDispatcher(
+  options: StandaloneLaunchDispatcherOptions,
+): StandaloneLaunchDispatcherController | null {
+  const { headlessDeps, ownerId, createTaskExecutor, setLatestTaskExecutor } = options;
+  if (headlessDeps.invokerConfig.launchOutboxMode !== 'active') return null;
+
+  const originalProvider = headlessDeps.ownerTaskRunnerProvider;
+  headlessDeps.ownerTaskRunnerProvider = undefined;
+  let executor: TaskRunner;
+  try {
+    executor = createTaskExecutor();
+  } catch (err) {
+    headlessDeps.ownerTaskRunnerProvider = originalProvider;
+    throw err;
+  }
+  headlessDeps.ownerTaskRunnerProvider = () => executor;
+  setLatestTaskExecutor(executor);
+
+  const dispatcher = new LaunchDispatcher({
+    persistence: headlessDeps.persistence,
+    orchestrator: {
+      prepareTaskForNewAttempt: (taskId, reason) =>
+        headlessDeps.orchestrator.prepareTaskForNewAttempt(taskId, reason),
+      syncFromDb: (workflowId) => headlessDeps.orchestrator.syncFromDb(workflowId),
+      getTask: (taskId) => headlessDeps.orchestrator.getTask(taskId),
+      getTaskLaunchReadiness: (taskId) => headlessDeps.orchestrator.getTaskLaunchReadiness(taskId),
+    },
+    taskRunnerProvider: () => executor,
+    ownerId,
+    logger: headlessDeps.logger,
+    mode: 'active',
+  });
+
+  const poll = (): void => {
+    try {
+      dispatcher.poll();
+    } catch (err) {
+      headlessDeps.logger.warn(
+        `[launch-dispatcher] standalone poll failed: ${err instanceof Error ? err.message : String(err)}`,
+        { module: 'headless' },
+      );
+    }
+  };
+
+  poll();
+  const pollInterval = setInterval(poll, 2_000);
+  pollInterval.unref?.();
+
+  return {
+    stop(): void {
+      clearInterval(pollInterval);
+      headlessDeps.ownerTaskRunnerProvider = originalProvider;
+    },
+  };
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -134,6 +134,10 @@ import {
   type HeadlessDeps,
 } from './headless.js';
 import {
+  startStandaloneLaunchDispatcher,
+  type StandaloneLaunchDispatcherController,
+} from './headless-standalone-launch-dispatcher.js';
+import {
   approveTask as sharedApproveTask,
   buildInvalidationDeps,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
@@ -975,6 +979,7 @@ if (isHeadless) {
     let exitCode = 0;
     let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
     let lifecycleEventBridge: LifecycleEventBridge | null = null;
+    let standaloneLaunchDispatcherController: StandaloneLaunchDispatcherController | null = null;
     try {
       // Standalone mode: initialize services and run headless
       await initServices({
@@ -1212,6 +1217,14 @@ if (isHeadless) {
 
       // In standalone owner mode, serve delegated requests from peer headless processes.
       if (standaloneMode && messageBus) {
+        if (!readOnlyMode) {
+          standaloneLaunchDispatcherController = startStandaloneLaunchDispatcher({
+            headlessDeps,
+            ownerId: workflowMutationOwnerId,
+            createTaskExecutor: createStandaloneTaskExecutor,
+            setLatestTaskExecutor: (executor) => { latestTaskExecutor = executor; },
+          });
+        }
         const standaloneOwnerIdleTimeoutMs = Number.parseInt(
           process.env.INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '0',
           10,
@@ -1709,6 +1722,7 @@ if (isHeadless) {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
       exitCode = 1;
     } finally {
+      standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
       reviewGateStatusWorker?.stop();
       if (ownsHeadlessShutdown && executorRegistry) {

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1781538160448-3-final-regression.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1781538160448-3-final-regression.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="wf-1781538160448-3/final-regression"
+MAIN_TS="$ROOT/packages/app/src/main.ts"
+HELPER_TS="$ROOT/packages/app/src/headless-standalone-launch-dispatcher.ts"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: standalone headless owner could answer owner-ping without polling active launch dispatch rows"
+
+python3 - "$MAIN_TS" "$HELPER_TS" <<'PY'
+import pathlib
+import sys
+
+main_path = pathlib.Path(sys.argv[1])
+helper_path = pathlib.Path(sys.argv[2])
+main_source = main_path.read_text(encoding="utf-8")
+helper_source = helper_path.read_text(encoding="utf-8")
+
+task_id = "wf-1781538160448-3/final-regression"
+
+class DispatchRow:
+    def __init__(self):
+        self.state = "enqueued"
+        self.attempt_id = f"{task_id}-aa3f6940f"
+        self.runner_calls = 0
+
+def gui_db_poll_tick(row: DispatchRow, *, main_window_present: bool) -> None:
+    if not main_window_present:
+        return
+    launch_dispatcher_poll(row)
+
+def launch_dispatcher_poll(row: DispatchRow) -> None:
+    if row.state != "enqueued":
+        return
+    row.state = "leased"
+    row.runner_calls += 1
+    row.state = "completed"
+
+pre_fix = DispatchRow()
+owner_ping_ready = True
+gui_db_poll_tick(pre_fix, main_window_present=False)
+
+assert owner_ping_ready
+assert pre_fix.state == "enqueued", "pre-fix model should leave the dispatch row enqueued"
+assert pre_fix.runner_calls == 0, "pre-fix model should never call the runner"
+
+post_fix = DispatchRow()
+launch_dispatcher_poll(post_fix)
+
+assert post_fix.state == "completed", "fixed model should advance the dispatch row"
+assert post_fix.runner_calls == 1, "fixed model should hand off to a runner exactly once"
+
+main_needles = [
+    "startStandaloneLaunchDispatcher({",
+    "standaloneLaunchDispatcherController?.stop();",
+]
+helper_needles = [
+    "export function startStandaloneLaunchDispatcher",
+    "headlessDeps.ownerTaskRunnerProvider = () => executor",
+    "new LaunchDispatcher({",
+    "setInterval(poll, 2_000)",
+]
+missing_main = [needle for needle in main_needles if needle not in main_source]
+missing_helper = [needle for needle in helper_needles if needle not in helper_source]
+if missing_main or missing_helper:
+    raise SystemExit(
+        "fixed standalone owner launch-dispatcher wiring is missing: "
+        + ", ".join(missing_main + missing_helper)
+    )
+
+print("[repro] pre-fix model: owner-ping ready + no main window leaves active launch dispatch enqueued")
+print("[repro] post-fix model: standalone owner polls launch dispatcher and hands off the enqueued dispatch")
+print("[repro] source check: standalone owner installs active launch-dispatcher polling loop")
+PY
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Standalone headless owner mode now starts its own launch-dispatch poller.

The bug was that owner-ping could report ready while no GUI window existed to poll launch rows. Queued work could stay enqueued.

The polling setup now lives in a small start helper. `main.ts` only starts it and stops it.

## Architecture

### Before

```mermaid
flowchart TD
  Owner[Standalone owner] --> Ping[owner-ping ready]
  Dispatch[Launch dispatch row] -. no GUI poll .-> Stuck[stays enqueued]
```

### After

```mermaid
flowchart TD
  Main[main.ts standalone branch] --> Helper[start standalone launch dispatcher]
  Helper --> Poll[2s poll loop]
  Poll --> Dispatcher[LaunchDispatcher]
  Dispatcher --> Runner[owner TaskRunner]
```

## Test Plan

- [x] `pnpm run build` at commit `deeb9d0db`
- [x] `scripts/repro/repro-pending-task-did-not-run-wf-1781538160448-3-final-regression.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert deeb9d0db`
- Post-revert steps: Restart any standalone headless owner after reverting.
- Data migration? No