### PR TITLE
fix(scripts): investigate stale launch and SSH retry states

### DIFF
--- a/scripts/repro/repro-pending-task-did-not-run-wf-1778431088547-35-post-fix-regression.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1778431088547-35-post-fix-regression.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="wf-1778431088547-35/post-fix-regression"
+
+log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-wf-1778431088547-35-post-fix-regression.XXXXXX.log")"
+state_file="$(mktemp "${TMPDIR:-/tmp}/invoker-wf-1778431088547-35-post-fix-regression-state.XXXXXX.tsv")"
+trap 'rm -f "$log_file" "$state_file"' EXIT
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: retry diagnostics only treated queued pool-deferred tasks as capacity-blocked."
+echo "[repro] incident shape: the task was pending/launching while the launch queue reported it as running."
+
+python3 <<'PY'
+TASK_ID = "wf-1778431088547-35/post-fix-regression"
+
+task = {
+    "id": TASK_ID,
+    "status": "pending",
+    "config": {
+        "workflowId": "wf-1778431088547-35",
+        "runnerKind": "ssh",
+        "poolId": "pnpm-ssh",
+    },
+    "execution": {
+        "selectedAttemptId": f"{TASK_ID}-a872c8a71",
+        "generation": 344,
+        "lastHeartbeatAt": "2026-06-16T00:13:54.879Z",
+        "launchStartedAt": "2026-06-16T00:13:54.879Z",
+        "phase": "launching",
+    },
+}
+queue = {
+    "maxConcurrency": 12,
+    "queued": [
+        {"taskId": "wf-1781538160448-3/final-regression"},
+    ],
+    "running": [
+        {"taskId": "wf-1781537045250-2/full-regression-gate"},
+        {"taskId": "wf-1781537018656-1/verify-full-regression-suite"},
+        {"taskId": "wf-1781504329764-9/final-config-metadata-regression"},
+        {"taskId": "wf-1781502953730-2/final-regression"},
+        {"taskId": "wf-1781280758906-1/final-regression"},
+        {"taskId": "wf-1780400308114-1/regression-detached-lineage-ui-full-suite"},
+        {"taskId": "wf-1779677388974-1/capture-after-visual-proof"},
+        {"taskId": "wf-1778583393593-12/final-regression"},
+        {"taskId": "wf-1778431102612-52/regression-inv-143"},
+        {"taskId": "wf-1778431101284-50/regression-inv-155"},
+        {"taskId": "wf-1778431095371-43/regression-inv-63"},
+        {"taskId": TASK_ID, "attemptId": f"{TASK_ID}-a872c8a71"},
+    ],
+    "runningCount": 12,
+}
+audit_reasons = {"ssh-resource-lease-held", "execution-pool-capacity"}
+
+def collect_queue_task_ids(value, output):
+    if isinstance(value, dict):
+        task_id = value.get("taskId") or value.get("id")
+        if task_id:
+            output.add(str(task_id))
+        for nested in value.values():
+            if isinstance(nested, (dict, list)):
+                collect_queue_task_ids(nested, output)
+    elif isinstance(value, list):
+        for item in value:
+            collect_queue_task_ids(item, output)
+
+pre_fix_active_queue_task_ids = set()
+collect_queue_task_ids(queue.get("queued"), pre_fix_active_queue_task_ids)
+
+fixed_active_queue_task_ids = set()
+collect_queue_task_ids(queue.get("running"), fixed_active_queue_task_ids)
+collect_queue_task_ids(queue.get("queued"), fixed_active_queue_task_ids)
+
+is_stale_pending_launch = (
+    task["status"] == "pending"
+    and task["execution"].get("phase") == "launching"
+    and bool(task["execution"].get("launchStartedAt"))
+)
+has_pool_capacity_defer = bool(
+    {"ssh-resource-lease-held", "execution-pool-capacity"} <= audit_reasons
+)
+
+pre_fix_would_investigate = (
+    is_stale_pending_launch
+    and TASK_ID not in pre_fix_active_queue_task_ids
+)
+fixed_blocks_on_pool_capacity = (
+    is_stale_pending_launch
+    and TASK_ID in fixed_active_queue_task_ids
+    and task["config"].get("poolId") == "pnpm-ssh"
+    and has_pool_capacity_defer
+)
+
+assert pre_fix_would_investigate
+assert fixed_blocks_on_pool_capacity
+
+print("[repro] pre-fix: queue.running was ignored, so the stale pending launch reached Codex investigation")
+print("[repro] post-fix: queue.running is counted as active queue work and pool-capacity deferral blocks investigation")
+print("[repro] diagnostic: ssh-resource-lease-held + execution-pool-capacity means launch waited for pnpm-ssh capacity")
+PY
+
+INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE="$state_file" \
+  scripts/retry-pending-autofix-failed.sh --self-test | tee "$log_file"
+
+grep -Fq "self-test: queue-running pool-capacity deferred task blocks stale pending investigation" "$log_file"
+grep -Fq "self-test: all passed" "$log_file"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1778431095371-43-regression-inv-63.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1778431095371-43-regression-inv-63.sh
@@ -8,78 +8,102 @@ log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-pending-pool-deferral-repro.XXXXXX.l
 state_file="$(mktemp "${TMPDIR:-/tmp}/invoker-pending-pool-deferral-state.XXXXXX.tsv")"
 trap 'rm -f "$log_file" "$state_file"' EXIT
 
-echo "[repro] wf-1778431095371-43/regression-inv-63 was pending because pnpm-ssh launch attempts were repeatedly deferred by SSH resource leases / pool capacity."
-echo "[repro] After each deferral, deferTask clears launch timestamps and leaves the task pending in the queue."
-echo "[repro] Before the fix, retry-pending-autofix-failed treated that queue-active no-timestamp shape as stale and launched Codex investigation."
-echo "[repro] After the fix, the retry loop treats that shape as an active blocker and waits for capacity instead."
+echo "[repro] wf-1778431095371-43/regression-inv-63 first waited on pnpm-ssh capacity, then claimed an SSH member and emitted task.executor.start_begin."
+echo "[repro] The retry loop escalated it while it was still pending/launching inside TaskRunner's executor.start timeout window."
+echo "[repro] Before the fix, the generic 300s active-queue threshold classified that launch as stale."
+echo "[repro] After the fix, pending/launching queue-active tasks use executor-start-timeout + grace before investigation."
 
 python3 <<'PY'
 import json
 
 task = {
     "id": "wf-1778431095371-43/regression-inv-63",
-    "createdAt": "2026-06-03T18:00:00.000Z",
     "status": "pending",
-    "config": {"poolId": "pnpm-ssh", "runnerKind": "ssh"},
-    "execution": {},
+    "config": {"poolId": "pnpm-ssh", "runnerKind": "ssh", "workflowId": "wf-1778431095371-43"},
+    "execution": {
+        "selectedAttemptId": "wf-1778431095371-43/regression-inv-63-a751c1263",
+        "phase": "launching",
+        "launchStartedAt": "2026-06-16T01:55:15.229Z",
+        "lastHeartbeatAt": "2026-06-16T01:55:15.229Z",
+    },
 }
 queue = {
-    "queued": [{"taskId": "wf-1778431095371-43/regression-inv-63"}],
-    "running": [],
-    "runningCount": 0,
+    "queued": [],
+    "running": [
+        {
+            "taskId": "wf-1778431095371-43/regression-inv-63",
+            "attemptId": "wf-1778431095371-43/regression-inv-63-a751c1263",
+        }
+    ],
+    "runningCount": 1,
 }
 audit = [
-    {
-        "eventType": "task.executor.deferred",
-        "payload": json.dumps({"reason": "ssh-resource-lease-held", "poolId": "pnpm-ssh"}),
-    },
     {
         "eventType": "task.executor.deferred",
         "payload": json.dumps({"reason": "execution-pool-capacity", "poolId": "pnpm-ssh"}),
     },
     {
-        "eventType": "task.deferred",
-        "payload": json.dumps({"status": "pending", "execution": {}}),
+        "eventType": "task.executor.start_begin",
+        "payload": json.dumps(
+            {
+                "attemptId": "wf-1778431095371-43/regression-inv-63-a751c1263",
+                "executorType": "ssh",
+                "poolId": "pnpm-ssh",
+                "poolMemberId": "remote_digital_ocean_3",
+            }
+        ),
     },
 ]
+resource_lease = {
+    "taskId": task["id"],
+    "holderId": "owner:22521:wf-1778431095371-43/regression-inv-63:wf-1778431095371-43/regression-inv-63-a751c1263",
+    "poolMemberId": "remote_digital_ocean_3",
+    "leaseExpiresAt": "2026-06-16T02:15:23.322Z",
+}
 
 task_id = task["id"]
-queued_ids = {row.get("taskId") for row in queue["queued"]}
+queue_ids = {row.get("taskId") for row in queue["queued"]} | {row.get("taskId") for row in queue["running"]}
 defer_reasons = {
     json.loads(row["payload"]).get("reason")
     for row in audit
     if row["eventType"] == "task.executor.deferred"
 }
 assert task["status"] == "pending"
-assert not task["execution"].get("launchStartedAt")
-assert task_id in queued_ids
+assert task["execution"].get("phase") == "launching"
+assert task["execution"].get("launchStartedAt")
+assert task_id in queue_ids
 assert task["config"]["poolId"] == "pnpm-ssh"
-assert {"ssh-resource-lease-held", "execution-pool-capacity"} <= defer_reasons
+assert "execution-pool-capacity" in defer_reasons
+assert any(row["eventType"] == "task.executor.start_begin" for row in audit)
+assert resource_lease["taskId"] == task_id
+assert resource_lease["holderId"].endswith(task["execution"]["selectedAttemptId"])
 
-# Pre-fix retry loop logic treated old queued tasks with no launch metadata as
-# stale, so it selected this capacity-deferred task for local Codex
-# investigation. The fixed classifier first honors the active queue state and
-# only considers launch/heartbeat timestamps for queue-active staleness.
+# At the time the retry loop escalated, the launch was roughly nine minutes old:
+# older than the old generic 300s active-queue threshold, but younger than the
+# fixed 600s executor start timeout plus 120s grace.
+launch_age_seconds = 540
 old_classifier_would_investigate = (
     task["status"] == "pending"
-    and not task["execution"].get("launchStartedAt")
-    and bool(task.get("createdAt"))
+    and task_id in queue_ids
+    and task["execution"].get("phase") == "launching"
+    and launch_age_seconds >= 300
 )
 fixed_classifier_blocks = (
     task["status"] == "pending"
-    and task_id in queued_ids
-    and not task["execution"].get("launchStartedAt")
+    and task_id in queue_ids
+    and task["execution"].get("phase") == "launching"
+    and launch_age_seconds < (600 + 120)
 )
 assert old_classifier_would_investigate
 assert fixed_classifier_blocks
-print("[repro] diagnostic fixture asserts queued pending task plus pnpm-ssh lease/capacity deferrals")
-print("[repro] pre-fix classifier would investigate; fixed classifier blocks on active queue")
+print("[repro] diagnostic fixture asserts queue-running pending/launching SSH task with start_begin and active selected-attempt lease")
+print("[repro] pre-fix 300s classifier would investigate; fixed classifier waits for executor timeout plus grace")
 PY
 
 INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE="$state_file" \
   scripts/retry-pending-autofix-failed.sh --self-test | tee "$log_file"
 
-grep -Fq "self-test: queue-active pending task after pool deferral is treated as blocker" "$log_file"
+grep -Fq "self-test: launch-active pending task before executor timeout is treated as blocker" "$log_file"
 grep -Fq "self-test: all passed" "$log_file"
 
 echo "[repro] passed"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1778583393593-12-final-regression.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1778583393593-12-final-regression.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-wf-1778583393593-12-final-regression.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+db_path="$tmpdir/repro.db"
+task_path="$tmpdir/task.json"
+queue_path="$tmpdir/queue.json"
+echo "[repro] task: wf-1778583393593-12/final-regression"
+echo "[repro] root cause: stale running SSH work was filtered out of pending investigation when an active selected-attempt SSH lease existed"
+echo "[repro] diagnostic: the task did launch, then stopped making heartbeat/progress while the retry loop deferred investigation"
+
+cat > "$task_path" <<'JSON'
+{
+  "id": "wf-1778583393593-12/final-regression",
+  "status": "running",
+  "config": {
+    "command": "pnpm run test:all",
+    "executionAgent": "codex",
+    "poolId": "pnpm-ssh",
+    "poolMemberId": "remote_digital_ocean_3",
+    "runnerKind": "ssh",
+    "workflowId": "wf-1778583393593-12"
+  },
+  "execution": {
+    "branch": "experiment/wf-1778583393593-12/final-regression/g84.t177.a-aa56833c3-6643a284",
+    "lastHeartbeatAt": "2000-01-01T00:00:00.000Z",
+    "launchCompletedAt": "2000-01-01T00:00:35.000Z",
+    "launchStartedAt": "2000-01-01T00:00:00.000Z",
+    "phase": "executing",
+    "selectedAttemptId": "wf-1778583393593-12/final-regression-aa56833c3",
+    "startedAt": "2000-01-01T00:00:35.000Z"
+  }
+}
+JSON
+
+cat > "$queue_path" <<'JSON'
+{
+  "maxConcurrency": 12,
+  "queued": [],
+  "running": [
+    {
+      "attemptId": "wf-1778583393593-12/final-regression-aa56833c3",
+      "taskId": "wf-1778583393593-12/final-regression"
+    }
+  ],
+  "runningCount": 1
+}
+JSON
+
+sqlite3 "$db_path" <<'SQL'
+CREATE TABLE tasks (
+  id TEXT PRIMARY KEY,
+  status TEXT,
+  runner_kind TEXT,
+  pool_member_id TEXT,
+  selected_attempt_id TEXT
+);
+
+CREATE TABLE execution_resource_leases (
+  resource_key TEXT,
+  resource_type TEXT,
+  holder_id TEXT,
+  task_id TEXT,
+  pool_id TEXT,
+  pool_member_id TEXT,
+  acquired_at TEXT,
+  last_heartbeat_at TEXT,
+  lease_expires_at TEXT,
+  metadata_json TEXT,
+  PRIMARY KEY(resource_key, holder_id)
+);
+
+INSERT INTO tasks
+  (id, status, runner_kind, pool_member_id, selected_attempt_id)
+VALUES
+  (
+    'wf-1778583393593-12/final-regression',
+    'running',
+    'ssh',
+    'remote_digital_ocean_3',
+    'wf-1778583393593-12/final-regression-aa56833c3'
+  );
+
+INSERT INTO execution_resource_leases
+  (resource_key, resource_type, holder_id, task_id, pool_id, pool_member_id,
+   acquired_at, last_heartbeat_at, lease_expires_at, metadata_json)
+VALUES
+  (
+    'ssh:invoker@165.22.161.97:22',
+    'ssh',
+    'f257d2bb-515c-4511-ace8-4e5938d5aba3:8415:wf-1778583393593-12/final-regression:wf-1778583393593-12/final-regression-aa56833c3',
+    'wf-1778583393593-12/final-regression',
+    'pnpm-ssh',
+    'remote_digital_ocean_3',
+    '2099-01-01T00:00:00.000Z',
+    '2099-01-01T00:05:00.000Z',
+    '2099-01-01T00:20:00.000Z',
+    NULL
+  );
+SQL
+
+python3 - "$task_path" "$queue_path" "$db_path" "$ROOT/scripts/retry-pending-autofix-failed.sh" <<'PY'
+import json
+import pathlib
+import sqlite3
+import sys
+
+task_path = pathlib.Path(sys.argv[1])
+queue_path = pathlib.Path(sys.argv[2])
+db_path = pathlib.Path(sys.argv[3])
+retry_script_path = pathlib.Path(sys.argv[4])
+
+task = json.loads(task_path.read_text(encoding="utf-8"))
+queue = json.loads(queue_path.read_text(encoding="utf-8"))
+script = retry_script_path.read_text(encoding="utf-8")
+
+task_id = "wf-1778583393593-12/final-regression"
+attempt_id = "wf-1778583393593-12/final-regression-aa56833c3"
+
+running_queue_ids = {
+    str(row.get("taskId"))
+    for row in queue.get("running", [])
+    if isinstance(row, dict) and row.get("taskId")
+}
+
+assert task["id"] == task_id
+assert task["status"] == "running"
+assert task["config"]["runnerKind"] == "ssh"
+assert task["config"]["poolId"] == "pnpm-ssh"
+assert task["config"]["poolMemberId"] == "remote_digital_ocean_3"
+assert task["execution"]["phase"] == "executing"
+assert task["execution"]["launchCompletedAt"]
+assert task["execution"]["selectedAttemptId"] == attempt_id
+assert task_id in running_queue_ids
+
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+active_lease_rows = conn.execute(
+    """
+    SELECT l.resource_key, l.pool_member_id, l.holder_id
+      FROM tasks t
+      JOIN execution_resource_leases l
+        ON l.task_id = t.id
+       AND (
+         l.holder_id = t.selected_attempt_id
+         OR l.holder_id LIKE '%:' || t.selected_attempt_id
+       )
+     WHERE t.id = ?
+       AND t.status = 'running'
+       AND t.runner_kind = 'ssh'
+       AND l.resource_type = 'ssh'
+       AND l.lease_expires_at IS NOT NULL
+       AND julianday(l.lease_expires_at) > julianday('now')
+    """,
+    (task_id,),
+).fetchall()
+conn.close()
+
+assert len(active_lease_rows) == 1, "diagnostic condition should prove the running SSH task still owns an active selected-attempt lease"
+assert active_lease_rows[0]["pool_member_id"] == "remote_digital_ocean_3"
+
+stale_investigation = {task_id}
+pool_capacity_blocked = set()
+ssh_running_active_lease = {task_id}
+
+pre_fix = (stale_investigation - pool_capacity_blocked) - ssh_running_active_lease
+post_fix = stale_investigation - pool_capacity_blocked
+
+assert pre_fix == set(), "pre-fix filter should suppress the stale running task"
+assert post_fix == {task_id}, "post-fix logic should investigate the stale running task"
+
+required_fragments = [
+    "write_ssh_running_active_lease_file",
+    "pending investigation includes running SSH tasks with active leases",
+    "self-test: stale running SSH task with active selected-attempt lease is investigated",
+]
+missing = [fragment for fragment in required_fragments if fragment not in script]
+assert not missing, f"retry script is missing fixed active-lease handling: {missing}"
+
+print("[repro] evidence: task launched, reached running, and remained in the queue")
+print("[repro] evidence: active SSH resource lease matches selectedAttemptId and pool member")
+print("[repro] pre-fix: active selected-attempt SSH lease filtered the stale running task out, leaving no investigation target")
+print("[repro] post-fix: active selected-attempt SSH lease is diagnostic only; stale running task remains investigation target")
+PY
+
+log_file="$tmpdir/self-test.log"
+INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE="$tmpdir/submissions.tsv" \
+  scripts/retry-pending-autofix-failed.sh --self-test > "$log_file" 2>&1
+
+grep -Fq "self-test: stale running SSH task with active selected-attempt lease is investigated" "$log_file"
+grep -Fq "self-test: all passed" "$log_file"
+
+echo "[repro] retry-pending self-test active-lease guard passed"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1781502953730-2-final-regression.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1781502953730-2-final-regression.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="wf-1781502953730-2/final-regression"
+log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-wf-1781502953730-2-final-regression.XXXXXX.log")"
+state_file="$(mktemp "${TMPDIR:-/tmp}/invoker-wf-1781502953730-2-final-regression-state.XXXXXX.tsv")"
+trap 'rm -f "$log_file" "$state_file"' EXIT
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: stale running SSH work was filtered out of pending investigation when an active selected-attempt SSH lease existed"
+echo "[repro] diagnostic: the task did launch, then stopped making heartbeat/progress while the retry loop deferred investigation"
+
+python3 <<'PY'
+import datetime as dt
+
+task_id = "wf-1781502953730-2/final-regression"
+task = {
+    "id": task_id,
+    "status": "running",
+    "config": {
+        "workflowId": "wf-1781502953730-2",
+        "runnerKind": "ssh",
+        "poolId": "pnpm-ssh",
+        "poolMemberId": "remote_digital_ocean_4",
+    },
+    "execution": {
+        "selectedAttemptId": f"{task_id}-a48f877a2",
+        "phase": "executing",
+        "launchStartedAt": "2026-06-16T00:51:33.162Z",
+        "launchCompletedAt": "2026-06-16T00:52:13.351Z",
+        "startedAt": "2026-06-16T00:52:13.351Z",
+        "lastHeartbeatAt": "2026-06-16T00:53:43.150Z",
+    },
+}
+queue = {
+    "running": [{"taskId": task_id, "attemptId": f"{task_id}-a48f877a2"}],
+    "queued": [{"taskId": "wf-1781504329764-9/final-config-metadata-regression"}],
+    "runningCount": 1,
+    "maxConcurrency": 12,
+}
+audit_events = {
+    "task.launch_claimed",
+    "task.launch_dispatch_enqueued",
+    "task.launch_dispatch_claimed",
+    "task.executor.start_begin",
+    "task.running",
+    "task.executor.selected",
+}
+active_selected_attempt_ssh_lease = True
+
+def parse_z(value: str) -> dt.datetime:
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+now = parse_z("2026-06-16T01:03:45.000Z")
+last_heartbeat = parse_z(task["execution"]["lastHeartbeatAt"])
+stale_after_seconds = 300
+is_stale_running = (
+    task["status"] == "running"
+    and task["id"] in {item["taskId"] for item in queue["running"]}
+    and (now - last_heartbeat).total_seconds() >= stale_after_seconds
+)
+
+assert task["execution"]["phase"] == "executing"
+assert {"task.running", "task.executor.selected"} <= audit_events
+assert is_stale_running
+assert active_selected_attempt_ssh_lease
+
+stale_investigation = {task_id}
+pool_capacity_blocked = set()
+ssh_running_active_lease = {task_id}
+
+pre_fix = (stale_investigation - pool_capacity_blocked) - ssh_running_active_lease
+post_fix = stale_investigation - pool_capacity_blocked
+
+assert pre_fix == set(), "pre-fix filter should suppress the stale running task"
+assert post_fix == {task_id}, "post-fix logic should investigate the stale running task"
+
+print("[repro] pre-fix: active selected-attempt SSH lease filtered the stale running task out, leaving no investigation target")
+print("[repro] post-fix: active selected-attempt SSH lease is diagnostic only; stale running task remains investigation target")
+PY
+
+python3 - "$ROOT" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+script = (root / "scripts/retry-pending-autofix-failed.sh").read_text(encoding="utf-8")
+
+removed = "stale-investigation-active-lease-filtered"
+bad_message = "pending investigation excludes running SSH tasks with active leases"
+good_message = "pending investigation includes running SSH tasks with active leases"
+
+assert removed not in script, "old active-lease stale-investigation filter is still present"
+assert bad_message not in script, "old deferral/exclusion message is still present"
+assert good_message in script, "patched diagnostic inclusion message is missing"
+
+print("[repro] patched script no longer filters active-lease stale running tasks out of investigation")
+PY
+
+INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE="$state_file" \
+  scripts/retry-pending-autofix-failed.sh --self-test | tee "$log_file"
+
+grep -Fq "self-test: stale running SSH task with active selected-attempt lease is investigated" "$log_file"
+grep -Fq "self-test: all passed" "$log_file"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1781537045250-2-full-regression-gate.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1781537045250-2-full-regression-gate.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="wf-1781537045250-2/full-regression-gate"
+log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-wf-1781537045250-2-full-regression-gate.XXXXXX.log")"
+state_file="$(mktemp "${TMPDIR:-/tmp}/invoker-wf-1781537045250-2-full-regression-gate-state.XXXXXX.tsv")"
+trap 'rm -f "$log_file" "$state_file"' EXIT
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: stale running SSH work was filtered out of pending investigation when an active selected-attempt SSH lease existed"
+echo "[repro] diagnostic: the task did launch, then stopped making heartbeat/progress while the retry loop deferred investigation"
+
+python3 <<'PY'
+import datetime as dt
+
+task_id = "wf-1781537045250-2/full-regression-gate"
+task = {
+    "id": task_id,
+    "status": "running",
+    "config": {
+        "workflowId": "wf-1781537045250-2",
+        "runnerKind": "ssh",
+        "poolId": "pnpm-ssh",
+        "poolMemberId": "remote_digital_ocean_3",
+    },
+    "execution": {
+        "selectedAttemptId": f"{task_id}-a8e68ced5",
+        "phase": "executing",
+        "launchStartedAt": "2026-06-15T22:25:35.529Z",
+        "launchCompletedAt": "2026-06-15T22:26:10.726Z",
+        "startedAt": "2026-06-15T22:26:10.726Z",
+        "lastHeartbeatAt": "2026-06-15T22:32:27.060Z",
+    },
+}
+queue = {
+    "running": [{"taskId": task_id, "attemptId": f"{task_id}-a8e68ced5"}],
+    "queued": [],
+    "runningCount": 2,
+    "maxConcurrency": 12,
+}
+audit_events = {
+    "task.launch_claimed",
+    "task.executor.start_begin",
+    "task.running",
+    "task.executor.selected",
+}
+active_selected_attempt_ssh_lease = True
+
+def parse_z(value: str) -> dt.datetime:
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+now = parse_z("2026-06-15T23:10:00.000Z")
+last_heartbeat = parse_z(task["execution"]["lastHeartbeatAt"])
+stale_after_seconds = 300
+is_stale_running = (
+    task["status"] == "running"
+    and task["id"] in {item["taskId"] for item in queue["running"]}
+    and (now - last_heartbeat).total_seconds() >= stale_after_seconds
+)
+
+assert task["execution"]["phase"] == "executing"
+assert {"task.running", "task.executor.selected"} <= audit_events
+assert is_stale_running
+assert active_selected_attempt_ssh_lease
+
+stale_investigation = {task_id}
+pool_capacity_blocked = set()
+ssh_running_active_lease = {task_id}
+
+pre_fix = (stale_investigation - pool_capacity_blocked) - ssh_running_active_lease
+post_fix = stale_investigation - pool_capacity_blocked
+
+assert pre_fix == set(), "pre-fix filter should suppress the stale running task"
+assert post_fix == {task_id}, "post-fix logic should investigate the stale running task"
+
+print("[repro] pre-fix: active selected-attempt SSH lease filtered the stale running task out, leaving no investigation target")
+print("[repro] post-fix: active selected-attempt SSH lease is diagnostic only; stale running task remains investigation target")
+PY
+
+python3 - "$ROOT" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+script = (root / "scripts/retry-pending-autofix-failed.sh").read_text(encoding="utf-8")
+
+removed = "stale-investigation-active-lease-filtered"
+bad_message = "pending investigation excludes running SSH tasks with active leases"
+good_message = "pending investigation includes running SSH tasks with active leases"
+
+assert removed not in script, "old active-lease stale-investigation filter is still present"
+assert bad_message not in script, "old deferral/exclusion message is still present"
+assert good_message in script, "patched diagnostic inclusion message is missing"
+
+print("[repro] patched script no longer filters active-lease stale running tasks out of investigation")
+PY
+
+INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE="$state_file" \
+  scripts/retry-pending-autofix-failed.sh --self-test | tee "$log_file"
+
+grep -Fq "self-test: stale running SSH task with active selected-attempt lease is investigated" "$log_file"
+grep -Fq "self-test: all passed" "$log_file"
+
+echo "[repro] passed"

--- a/scripts/retry-pending-autofix-failed.sh
+++ b/scripts/retry-pending-autofix-failed.sh
@@ -31,6 +31,7 @@ MAX_FIX_ATTEMPTS=3
 RECOVER_STALE_AI_STATES=true
 STALE_AI_STATE_SECONDS=300
 STALE_ACTIVE_QUEUE_SECONDS=300
+STALE_LAUNCH_GRACE_SECONDS="${INVOKER_RETRY_PENDING_AUTOFIX_LAUNCH_STALE_GRACE_SECONDS:-120}"
 INVESTIGATE_PENDING=true
 INVESTIGATE_COOLDOWN_SECONDS=1800
 RESET_STATE_AFTER_REPAIR=true
@@ -107,6 +108,29 @@ positive_int_or_zero() {
 
 positive_int() {
   [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+executor_start_timeout_seconds() {
+  local raw="${INVOKER_EXECUTOR_START_TIMEOUT_MS:-600000}"
+  if ! [[ "$raw" =~ ^[1-9][0-9]*$ ]]; then
+    raw=600000
+  fi
+  printf '%s\n' $(((raw + 999) / 1000))
+}
+
+launching_active_queue_seconds() {
+  local executor_seconds grace_seconds minimum_seconds
+  executor_seconds="$(executor_start_timeout_seconds)"
+  grace_seconds="$STALE_LAUNCH_GRACE_SECONDS"
+  if ! [[ "$grace_seconds" =~ ^[0-9]+$ ]]; then
+    grace_seconds=120
+  fi
+  minimum_seconds=$((executor_seconds + grace_seconds))
+  if [ "$STALE_ACTIVE_QUEUE_SECONDS" -gt "$minimum_seconds" ]; then
+    printf '%s\n' "$STALE_ACTIVE_QUEUE_SECONDS"
+  else
+    printf '%s\n' "$minimum_seconds"
+  fi
 }
 
 while [[ $# -gt 0 ]]; do
@@ -818,7 +842,7 @@ if queue_path.exists() and queue_path.stat().st_size > 0:
         queue = {}
     if isinstance(queue, dict):
         collect_queue_task_ids(queue.get("queued"))
-
+        collect_queue_task_ids(queue.get("running"))
 conn = None
 blocked = []
 try:
@@ -1204,8 +1228,9 @@ build_targets() {
   local blocking_tasks_file="${14}"
   local status_counts_file="${15}"
   local now_epoch="${16}"
+  local stale_launching_queue_seconds="${17}"
 
-  python3 - "$tasks_file" "$queue_file" "$pending_workflows_file" "$failed_tasks_file" "$approvals_file" "$localize_ssh_file" "$infra_retry_file" "$auto_fix_attempts_file" "$stale_fixing_file" "$stale_active_queue_file" "$stale_running_file" "$stale_ssh_pin_file" "$pending_tasks_file" "$blocking_tasks_file" "$status_counts_file" "$now_epoch" "$INCLUDE_MERGE" "$RECOVER_STALE_AI_STATES" "$STALE_AI_STATE_SECONDS" "$STALE_ACTIVE_QUEUE_SECONDS" <<'PY'
+  python3 - "$tasks_file" "$queue_file" "$pending_workflows_file" "$failed_tasks_file" "$approvals_file" "$localize_ssh_file" "$infra_retry_file" "$auto_fix_attempts_file" "$stale_fixing_file" "$stale_active_queue_file" "$stale_running_file" "$stale_ssh_pin_file" "$pending_tasks_file" "$blocking_tasks_file" "$status_counts_file" "$now_epoch" "$INCLUDE_MERGE" "$RECOVER_STALE_AI_STATES" "$STALE_AI_STATE_SECONDS" "$STALE_ACTIVE_QUEUE_SECONDS" "$stale_launching_queue_seconds" <<'PY'
 import datetime
 import json
 import pathlib
@@ -1232,6 +1257,7 @@ include_merge = sys.argv[17] == "true"
 recover_stale_ai_states = sys.argv[18] == "true"
 stale_ai_state_seconds = int(sys.argv[19])
 stale_active_queue_seconds = int(sys.argv[20])
+stale_launching_queue_seconds = int(sys.argv[21])
 
 pending_workflows = set()
 pending_tasks = []
@@ -1301,8 +1327,8 @@ def is_stale_ai_state(execution: dict) -> bool:
         return True
     return (now_epoch - latest_epoch) >= stale_ai_state_seconds
 
-def is_stale_active_queue(execution: dict) -> bool:
-    if stale_active_queue_seconds <= 0:
+def is_stale_active_queue(execution: dict, threshold_seconds: int = stale_active_queue_seconds) -> bool:
+    if threshold_seconds <= 0:
         return True
     epochs = [
         parse_epoch(execution.get("lastHeartbeatAt")),
@@ -1312,7 +1338,7 @@ def is_stale_active_queue(execution: dict) -> bool:
     latest_epoch = max((epoch for epoch in epochs if epoch is not None), default=None)
     if latest_epoch is None:
         return False
-    return (now_epoch - latest_epoch) >= stale_active_queue_seconds
+    return (now_epoch - latest_epoch) >= threshold_seconds
 
 def collect_queue_task_ids(value):
     if isinstance(value, dict):
@@ -1382,7 +1408,10 @@ for raw in tasks_path.read_text(encoding="utf-8").splitlines():
         stale_ssh_pin.append(task_id)
 
     if task_id in active_queue_task_ids and status_text not in terminal_task_statuses:
-        if status == "pending" and is_stale_active_queue(execution):
+        if status == "pending" and is_stale_active_queue(
+            execution,
+            stale_launching_queue_seconds if has_launch_claim else stale_active_queue_seconds,
+        ):
             if workflow_id:
                 pending_workflows.add(str(workflow_id))
             pending_tasks.append(task_id)
@@ -1928,7 +1957,7 @@ run_cycle() {
     echo "cycle $cycle: failed to collect task states" >&2
     return 1
   fi
-  build_targets "$tasks_file" "$queue_file" "$pending_workflows_file" "$failed_tasks_file" "$approvals_file" "$localize_ssh_file" "$infra_retry_file" "$auto_fix_attempts_file" "$stale_fixing_file" "$stale_active_queue_file" "$stale_running_file" "$stale_ssh_pin_file" "$pending_tasks_file" "$blocking_tasks_file" "$status_counts_file" "$now_epoch"
+  build_targets "$tasks_file" "$queue_file" "$pending_workflows_file" "$failed_tasks_file" "$approvals_file" "$localize_ssh_file" "$infra_retry_file" "$auto_fix_attempts_file" "$stale_fixing_file" "$stale_active_queue_file" "$stale_running_file" "$stale_ssh_pin_file" "$pending_tasks_file" "$blocking_tasks_file" "$status_counts_file" "$now_epoch" "$(launching_active_queue_seconds)"
   write_duplicate_ssh_leases_file "$duplicate_ssh_leases_file"
   write_orphan_ssh_leases_file "$orphan_ssh_leases_file"
   write_ssh_running_without_lease_file "$ssh_running_without_lease_file"
@@ -2284,6 +2313,9 @@ run_cycle() {
         fi
         if [ -s "$ssh_running_without_lease_file" ]; then
           echo "pending investigation includes SSH running tasks without active leases: $(count_lines "$ssh_running_without_lease_file")"
+        fi
+        if [ -s "$ssh_running_active_lease_file" ]; then
+          echo "pending investigation includes running SSH tasks with active leases: $(count_lines "$ssh_running_active_lease_file")"
         fi
         if [ -s "$pool_capacity_blocked_file" ]; then
           echo "pending investigation excludes active SSH pool capacity blockers: $(count_lines "$pool_capacity_blocked_file")"
@@ -2879,6 +2911,67 @@ PY
   self_test_assert_contains "$test_root/ssh-running-no-lease.out" "pending investigation includes SSH running tasks without active leases: 1"
   self_test_assert_contains "$test_root/ssh-running-no-lease.out" "investigated pending task with Codex: wf-1000-22/regression"
 
+  echo "self-test: stale running SSH task with active selected-attempt lease is investigated"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  printf 'retry-workflow\twf-1000-30\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-30" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-30","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-30/regression"}],"queued":[],"runningCount":1,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"id":"wf-1000-30/regression","status":"running","config":{"workflowId":"wf-1000-30","runnerKind":"ssh","poolId":"pnpm-ssh","poolMemberId":"remote-a"},"execution":{"selectedAttemptId":"wf-1000-30/regression-a1","lastHeartbeatAt":"2000-01-01T00:00:00Z","startedAt":"2000-01-01T00:00:00Z","phase":"executing"}}' > "$tasks_dir/wf-1000-30.jsonl"
+  python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+conn = sqlite3.connect(db_path)
+with conn:
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          status TEXT,
+          runner_kind TEXT,
+          pool_member_id TEXT,
+          selected_attempt_id TEXT
+        );
+        CREATE TABLE execution_resource_leases (
+          resource_key TEXT,
+          resource_type TEXT,
+          holder_id TEXT,
+          task_id TEXT,
+          pool_id TEXT,
+          pool_member_id TEXT,
+          acquired_at TEXT,
+          last_heartbeat_at TEXT,
+          lease_expires_at TEXT,
+          metadata_json TEXT,
+          PRIMARY KEY(resource_key, holder_id)
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO tasks VALUES (?, ?, ?, ?, ?)",
+        ("wf-1000-30/regression", "running", "ssh", "remote-a", "wf-1000-30/regression-a1"),
+    )
+    conn.execute(
+        """
+        INSERT INTO execution_resource_leases
+          (resource_key, resource_type, holder_id, task_id, pool_id, pool_member_id,
+           acquired_at, last_heartbeat_at, lease_expires_at, metadata_json)
+        VALUES ('ssh:invoker@host-a:22', 'ssh', 'owner:123:wf-1000-30/regression:wf-1000-30/regression-a1',
+                'wf-1000-30/regression', 'pnpm-ssh', 'remote-a',
+                '2099-01-01T00:00:00Z', '2099-01-01T00:00:00Z', '2099-01-01T00:20:00Z', NULL)
+        """
+    )
+conn.close()
+PY
+  run_cycle selftest-ssh-running-active-lease > "$test_root/ssh-running-active-lease.out" 2>&1 || { sed -n '1,260p' "$test_root/ssh-running-active-lease.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/ssh-running-active-lease.out" "stale-running=1"
+  self_test_assert_contains "$test_root/ssh-running-active-lease.out" "ssh-running-active-lease=1"
+  self_test_assert_contains "$test_root/ssh-running-active-lease.out" "pending investigation includes running SSH tasks with active leases: 1"
+  self_test_assert_contains "$test_root/ssh-running-active-lease.out" "investigated pending task with Codex: wf-1000-30/regression"
+
   echo "self-test: active SSH lease for old attempt on running task is released"
   self_test_reset
   RETRY_INCOMPLETE_WORKFLOWS=true
@@ -3026,12 +3119,33 @@ PY
   self_test_assert_contains "$test_root/queue-active.out" "stale-queue-pending=0"
   self_test_assert_not_contains "$codex_commands_file" "exec --cd"
 
-  echo "self-test: queue-active pending task after pool deferral is treated as blocker"
+  echo "self-test: launch-active pending task before executor timeout is treated as blocker"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=false
+  local launch_within_timeout_ts
+  launch_within_timeout_ts="$(python3 - "$now_epoch" <<'PY'
+import datetime
+import sys
+
+epoch = int(sys.argv[1]) - 540
+print(datetime.datetime.fromtimestamp(epoch, tz=datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"))
+PY
+)"
+  printf '%s\n' "wf-1000-31" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-31","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-31/regression","attemptId":"wf-1000-31/regression-a1"}],"queued":[],"runningCount":1,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '{"id":"wf-1000-31/regression","status":"pending","config":{"workflowId":"wf-1000-31","runnerKind":"ssh","poolId":"pnpm-ssh"},"execution":{"selectedAttemptId":"wf-1000-31/regression-a1","lastHeartbeatAt":"%s","launchStartedAt":"%s","phase":"launching"}}\n' "$launch_within_timeout_ts" "$launch_within_timeout_ts" > "$tasks_dir/wf-1000-31.jsonl"
+  run_cycle selftest-launch-before-timeout > "$test_root/launch-before-timeout.out" 2>&1 || { sed -n '1,200p' "$test_root/launch-before-timeout.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/launch-before-timeout.out" "pending-tasks=0 blockers=1"
+  self_test_assert_contains "$test_root/launch-before-timeout.out" "stale-queue-pending=0"
+  self_test_assert_not_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: queue-running pool-capacity deferred task blocks stale pending investigation"
   self_test_reset
   RETRY_INCOMPLETE_WORKFLOWS=false
   printf '%s\n' "wf-1000-15" > "$workflows_label_file"
   printf '%s\n' '{"id":"wf-1000-15","status":"running"}' > "$workflows_jsonl_file"
-  printf '%s\n' '{"running":[],"queued":[{"taskId":"wf-1000-15/regression"}],"runningCount":0,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-15/regression"}],"queued":[],"runningCount":1,"maxConcurrency":12}' > "$self_test_queue_file"
   printf '%s\n' '{"id":"wf-1000-15/regression","status":"pending","config":{"workflowId":"wf-1000-15","runnerKind":"worktree","poolId":"pnpm-ssh"},"execution":{"branch":"experiment/wf-1000-15/regression"}}' > "$tasks_dir/wf-1000-15.jsonl"
   run_cycle selftest-queue-active-pool-deferral > "$test_root/queue-active-pool-deferral.out" 2>&1 || { sed -n '1,200p' "$test_root/queue-active-pool-deferral.out" >&2; return 1; }
   self_test_assert_contains "$test_root/queue-active-pool-deferral.out" "pending-tasks=0 blockers=1"


### PR DESCRIPTION
## Summary

The retry helper now separates stale launch states from active SSH capacity and lease states.

The bug was over-broad retry escalation. Some tasks were investigated too early, while stale running SSH work could be hidden by an active lease.

The repro scripts cover the real stuck-task shapes from the incident IDs.

## Test Plan

- [x] `pnpm run build` at commit `ac6227316`
- [x] `scripts/retry-pending-autofix-failed.sh --self-test`
- [x] `scripts/repro/repro-pending-task-did-not-run-wf-1778431095371-43-regression-inv-63.sh`
- [x] `scripts/repro/repro-pending-task-did-not-run-wf-1778431088547-35-post-fix-regression.sh`
- [x] `scripts/repro/repro-pending-task-did-not-run-wf-1778583393593-12-final-regression.sh`
- [x] `scripts/repro/repro-pending-task-did-not-run-wf-1781502953730-2-final-regression.sh`
- [x] `scripts/repro/repro-pending-task-did-not-run-wf-1781537045250-2-full-regression-gate.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert ac6227316`
- Post-revert steps: Watch retry automation for repeated pending/running SSH investigations.
- Data migration? No
