### PR TITLE
fix(ui): keep workflow graph stable across refresh gaps

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1371,7 +1371,8 @@ export function App() {
 
   const handleRefresh = useCallback(async () => {
     await refreshTaskGraph();
-  }, [refreshTaskGraph]);
+    issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason: 'manual-refresh' });
+  }, [issueCameraCommand, refreshTaskGraph]);
 
   // ── Plan loading ──────────────────────────────────────────
   const handleLoadPlan = useCallback(
@@ -1854,7 +1855,6 @@ export function App() {
               ) : (
                 <>
                   <WorkflowGraph
-                    key={`workflow-graph-${graphRefreshSequence}`}
                     tasks={tasks}
                     workflows={workflows}
                     selectedWorkflowId={selectedWorkflow?.id ?? null}
@@ -1880,7 +1880,6 @@ export function App() {
                         className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
                       >
                         <TaskDAG
-                          key={`task-dag-${selectedWorkflow.id}-${graphRefreshSequence}`}
                           tasks={miniDagTasks}
                           workflows={selectedTaskDagWorkflows}
                           selectedTaskId={selectedTaskId}

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -87,7 +87,7 @@ describe('Side rail controls (component)', () => {
     });
   });
 
-  it('Refresh button remounts both graph surfaces after the forced snapshot', async () => {
+  it('Refresh button forced-snapshots tasks and refits the workflow graph without remounting it', async () => {
     await renderKeyboardFixture(mock);
     await waitFor(() => expect(fitViewMock).toHaveBeenCalled());
     fitViewMock.mockClear();
@@ -98,8 +98,10 @@ describe('Side rail controls (component)', () => {
       expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
     });
     await waitFor(() => {
-      expect(fitViewMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+      expect(fitViewMock.mock.calls.length).toBeGreaterThanOrEqual(1);
     });
+    expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
   });
 
   it('Clear button calls clear', async () => {

--- a/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
+++ b/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
@@ -1,6 +1,6 @@
 /**
- * Regression: the selected workflow mini-DAG remains visible when workflows-changed
- * transiently omits the selected workflow metadata while its tasks remain.
+ * Regression: the workflow graph and selected mini-DAG remain visible when
+ * workflows-changed transiently omits workflow metadata while tasks remain.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -71,8 +71,8 @@ describe('selected workflow graph metadata-gap regression', () => {
     });
 
     expect(screen.getByText('Total:')).toHaveTextContent('Total: 2');
+    expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
     expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
-    expect(screen.queryByTestId('workflow-node-wf-a')).not.toBeInTheDocument();
     expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
     expect(screen.getByTestId('rf__node-task-beta')).toBeInTheDocument();
   });

--- a/packages/ui/src/lib/workflow-graph.test.ts
+++ b/packages/ui/src/lib/workflow-graph.test.ts
@@ -96,6 +96,19 @@ describe('deriveWorkflowGraph', () => {
     expect(graph.edges).toEqual([]);
   });
 
+  it('keeps workflow nodes visible from tasks when metadata is temporarily missing', () => {
+    const tasks = new Map<string, TaskState>([
+      ['wf-a/task-a', makeTask('wf-a/task-a', 'wf-a')],
+      ['wf-a/task-b', { ...makeTask('wf-a/task-b', 'wf-a'), status: 'failed' }],
+    ]);
+
+    const graph = deriveWorkflowGraph(new Map(), tasks);
+    expect(graph.nodes).toHaveLength(1);
+    expect(graph.nodes[0].id).toBe('wf-a');
+    expect(graph.nodes[0].workflow.status).toBe('failed');
+    expect(graph.edges).toEqual([]);
+  });
+
   it('derives dependency-change lineage separately from active dependency edges', () => {
     const workflows = new Map([
       ['A', makeWorkflow('A')],

--- a/packages/ui/src/lib/workflow-graph.ts
+++ b/packages/ui/src/lib/workflow-graph.ts
@@ -1,3 +1,4 @@
+import { computeWorkflowRollupFromSummaries } from '@invoker/workflow-graph';
 import type { TaskState, WorkflowMeta } from '../types.js';
 
 export interface WorkflowGraphNode {
@@ -27,7 +28,37 @@ export function deriveWorkflowGraph(
   workflows: Map<string, WorkflowMeta>,
   tasks: Map<string, TaskState>,
 ): WorkflowGraph {
-  const nodes: WorkflowGraphNode[] = [...workflows.values()].map((workflow) => ({
+  const workflowNodes = new Map(workflows);
+  const fallbackTasksByWorkflow = new Map<string, TaskState[]>();
+
+  for (const task of tasks.values()) {
+    const workflowId = task.config.workflowId;
+    if (!workflowId || workflowNodes.has(workflowId)) continue;
+    const workflowTasks = fallbackTasksByWorkflow.get(workflowId);
+    if (workflowTasks) {
+      workflowTasks.push(task);
+    } else {
+      fallbackTasksByWorkflow.set(workflowId, [task]);
+    }
+  }
+
+  for (const [workflowId, workflowTasks] of fallbackTasksByWorkflow) {
+    const rollup = computeWorkflowRollupFromSummaries(workflowTasks.map((task) => ({
+      id: task.id,
+      description: task.description,
+      status: task.status,
+      dependencies: task.dependencies,
+      execution: task.execution,
+    })));
+    workflowNodes.set(workflowId, {
+      id: workflowId,
+      name: workflowId,
+      status: rollup.status,
+      rollup,
+    });
+  }
+
+  const nodes: WorkflowGraphNode[] = [...workflowNodes.values()].map((workflow) => ({
     id: workflow.id,
     name: workflow.name,
     workflow,
@@ -37,13 +68,11 @@ export function deriveWorkflowGraph(
   const edges: WorkflowGraphEdge[] = [];
   const missingDependencies = new Set<string>();
 
-  void tasks;
-
-  for (const workflow of workflows.values()) {
+  for (const workflow of workflowNodes.values()) {
     const targetWorkflowId = workflow.id;
     for (const dep of workflow.externalDependencies ?? []) {
       const sourceWorkflowId = dep.workflowId;
-      if (!workflows.has(sourceWorkflowId)) {
+      if (!workflowNodes.has(sourceWorkflowId)) {
         missingDependencies.add(`${sourceWorkflowId}->${targetWorkflowId}`);
         continue;
       }
@@ -57,7 +86,7 @@ export function deriveWorkflowGraph(
       for (const dependency of [change.before, change.after]) {
         if (!dependency) continue;
         const sourceWorkflowId = dependency.workflowId;
-        if (!workflows.has(sourceWorkflowId)) {
+        if (!workflowNodes.has(sourceWorkflowId)) {
           missingDependencies.add(`${sourceWorkflowId}->${targetWorkflowId}`);
           continue;
         }


### PR DESCRIPTION
## Summary

The workflow graph now stays visible when workflow metadata briefly disappears but task state is still present.

The bug was a refresh gap. The selected workflow could vanish from the graph even though its tasks were still loaded.

Refresh now refits the graph instead of remounting it.

## Test Plan

- [x] `pnpm run build` at commit `a93403e40`
- [x] `scripts/repro/repro-selected-workflow-graph-disappears-on-workflow-metadata-gap.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a93403e40`
- Post-revert steps: None
- Data migration? No