### PR TITLE
fix(launch): make outbox dispatch always active

### DIFF
--- a/docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md
+++ b/docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md
@@ -417,16 +417,18 @@ The new architecture can be rolled in incrementally behind a feature flag. Four 
 3. Add `LaunchDispatcher` as a passive observer that reads the outbox and logs but takes no action.
 4. Add the regression-repro test that asserts the launch-claimed → terminal-event invariant. It will fail; we accept that failure as the baseline.
 
-This phase ships with `INVOKER_LAUNCH_OUTBOX=observe`. No code path is replaced. We gather production data on `attempts_count`, lease expiry rates, and `fenced_until` distributions.
+This phase originally shipped as an observer before task launching moved to the
+durable outbox.
 
-**Phase B — Outbox owns dispatch behind a flag.**
+**Phase B — Outbox owns dispatch.**
 
-1. `LaunchDispatcher.poll()` becomes the active dispatcher when `INVOKER_LAUNCH_OUTBOX=active`.
-2. `global-topup.ts:dispatchTasks` is changed to a no-op when the flag is on (the outbox is the dispatcher).
-3. The `[launch-stall]` watchdog in `main.ts` becomes a no-op when the flag is on.
-4. `createHeadlessExecutor`'s `TaskRunner` is replaced by an outbox enqueue when the flag is on.
+1. `LaunchDispatcher.poll()` becomes the active dispatcher.
+2. `global-topup.ts:dispatchTasks` becomes a no-op; the outbox is the dispatcher.
+3. The `[launch-stall]` watchdog in `main.ts` becomes obsolete.
+4. Headless execution reuses the owner TaskRunner for launch-dispatch handoff.
 
-We run with `INVOKER_LAUNCH_OUTBOX=active` in dogfood for one week. Backout is `INVOKER_LAUNCH_OUTBOX=observe`.
+The rollout flag was removed after dogfood. The durable outbox is now the only
+launch path.
 
 **Phase C — Cleanup.**
 

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -511,9 +511,8 @@ describe('POST /api/tasks/:id/restart', () => {
 
     const res = await request(port, 'POST', '/api/tasks/task-1/restart');
     expect(res.status).toBe(200);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [topup]);
+    expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('does not relaunch duplicate attempt from global top-up', async () => {
@@ -532,8 +531,7 @@ describe('POST /api/tasks/:id/restart', () => {
 
     const res = await request(port, 'POST', '/api/tasks/task-1/restart');
     expect(res.status).toBe(200);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledWith([scoped]);
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 
@@ -569,7 +567,7 @@ describe('POST /api/tasks/:id/recreate-downstream', () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/recreate-downstream');
     expect(res.status).toBe(200);
     expect(res.body.tasksStarted).toBe(1);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledWith([dispatchable]);
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('returns 400 on domain failure surfaced by CommandService', async () => {
@@ -604,7 +602,7 @@ describe('POST /api/tasks/:id/approve', () => {
     expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
   });
 
-  it('routes downstream merge nodes to executeTasks (not publishAfterFix)', async () => {
+  it('leaves downstream merge-node launches to the dispatch outbox', async () => {
     mocks.orchestrator.approve.mockResolvedValue([
       makeTask({ id: 'merge-1', status: 'running', config: { isMergeNode: true } }),
       makeTask({ id: 'task-2', status: 'running', config: {} }),
@@ -613,12 +611,7 @@ describe('POST /api/tasks/:id/approve', () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/approve');
     expect(res.status).toBe(200);
     expect(mocks.taskExecutor.publishAfterFix).not.toHaveBeenCalled();
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ id: 'merge-1' }),
-        expect.objectContaining({ id: 'task-2' }),
-      ]),
-    );
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('routes post-fix merge nodes to publishAfterFix', async () => {
@@ -776,8 +769,8 @@ describe('POST /api/tasks/:id/edit-prompt', () => {
     expect(res.body.action).toBe('prompt_edited');
     expect(mocks.orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-1', 'do the thing');
     expect(mocks.orchestrator.editTaskCommand).not.toHaveBeenCalled();
-    // Facade dispatches any newly-runnable tasks via the executor.
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+    // The launch outbox dispatches newly-runnable tasks.
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('returns 400 when prompt is missing', async () => {
@@ -802,8 +795,7 @@ describe('POST /api/tasks/:id/edit-prompt', () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/edit-prompt', { prompt: 'new prompt' });
     expect(res.status).toBe(200);
     expect(res.body.tasksStarted).toBe(1);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledWith([running]);
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('does not call editTaskCommand when editing prompt', async () => {
@@ -846,7 +838,7 @@ describe('POST /api/tasks/:id/edit-type', () => {
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('type_edited');
     expect(mocks.orchestrator.editTaskType).toHaveBeenCalledWith('task-1', 'ssh', 'remote-b');
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 
@@ -859,8 +851,8 @@ describe('POST /api/tasks/:id/edit-agent', () => {
     expect(mocks.orchestrator.editTaskAgent).toHaveBeenCalledWith('task-1', 'codex');
     expect(mocks.orchestrator.editTaskCommand).not.toHaveBeenCalled();
     expect(mocks.orchestrator.editTaskPrompt).not.toHaveBeenCalled();
-    // Facade dispatches any newly-runnable tasks via the executor.
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+    // The launch outbox dispatches newly-runnable tasks.
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('returns 400 when agent is missing', async () => {
@@ -884,7 +876,7 @@ describe('POST /api/tasks/:id/gate-policy', () => {
       'task-1',
       [{ workflowId: 'wf-upstream', taskId: '__merge__', gatePolicy: 'review_ready' }],
     );
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('returns 400 when updates are missing', async () => {
@@ -929,9 +921,6 @@ describe('POST /api/workflows/:id/restart', () => {
 
   it('handles concurrent restart requests independently', async () => {
     mocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask()]);
-    mocks.taskExecutor.executeTasks.mockImplementation(
-      async () => await new Promise<void>((resolve) => setTimeout(resolve, 100)),
-    );
 
     const [r1, r2] = await Promise.all([
       request(port, 'POST', '/api/workflows/wf-1/restart'),
@@ -944,7 +933,7 @@ describe('POST /api/workflows/:id/restart', () => {
     expect(r2.body.coalesced).toBeUndefined();
     expect(mocks.persistence.updateWorkflow).toHaveBeenCalledTimes(2);
     expect(mocks.orchestrator.recreateWorkflow).toHaveBeenCalledTimes(2);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('returns 404 when workflow not found', async () => {
@@ -971,9 +960,8 @@ describe('POST /api/workflows/:id/restart', () => {
     const res = await request(port, 'POST', '/api/workflows/wf-1/restart');
     expect(res.status).toBe(200);
     expect(res.body.tasksStarted).toBe(1);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [topup]);
+    expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 
@@ -1009,7 +997,7 @@ describe('POST /api/workflows/:id/fork', () => {
     expect(res.body.sourceWorkflowId).toBe('wf-1');
     expect(res.body.forkedWorkflowId).toBe('wf-1-fork');
     expect(mocks.orchestrator.forkWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('returns an error status when forkWorkflow throws', async () => {
@@ -1086,9 +1074,7 @@ describe('POST /api/workflows/:id/rebase-recreate', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.tasksStarted).toBe(1);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('old rebase-and-retry route is gone', async () => {

--- a/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
+++ b/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
@@ -44,7 +44,7 @@ describe('app-layer handoff repros', () => {
     h = createTestHarness();
   });
 
-  it('edit-task-command launches restarted task and persists workspacePath', async () => {
+  it('edit-task-command records a runnable launch for the outbox', async () => {
     h.loadAndStart(LINEAR_PLAN);
     h.failTask('A', 'broken');
 
@@ -52,13 +52,15 @@ describe('app-layer handoff repros', () => {
     expect(started.some((task) => task.id.endsWith('/A') && task.status === 'running')).toBe(true);
     expect(h.getTask('A')!.execution.workspacePath).toBeUndefined();
 
-    await dispatchStarted(h, started, 'test.edit-task-command');
+    const result = await dispatchStarted(h, started, 'test.edit-task-command');
 
-    expect(h.getTask('A')!.execution.workspacePath).toBe('/tmp/mock-worktree');
-    expect(h.getTask('A')!.status).toBe('completed');
+    expect(result.runnable.map((task) => task.id)).toEqual([h.getTask('A')!.id]);
+    expect(result.topup).toEqual([]);
+    expect(h.getTask('A')!.execution.workspacePath).toBeUndefined();
+    expect(h.getTask('A')!.status).toBe('running');
   });
 
-  it('edit-task-prompt launches restarted task and persists workspacePath', async () => {
+  it('edit-task-prompt records a runnable launch for the outbox', async () => {
     const PROMPT_PLAN: PlanDefinition = {
       name: 'Prompt Handoff Repro',
       onFinish: 'merge',
@@ -77,13 +79,15 @@ describe('app-layer handoff repros', () => {
     expect(started.some((task) => task.id.endsWith('/A') && task.status === 'running')).toBe(true);
     expect(h.getTask('A')!.config.prompt).toBe('Implement feature Y instead');
 
-    await dispatchStarted(h, started, 'test.edit-task-prompt');
+    const result = await dispatchStarted(h, started, 'test.edit-task-prompt');
 
-    expect(h.getTask('A')!.execution.workspacePath).toBe('/tmp/mock-worktree');
-    expect(h.getTask('A')!.status).toBe('completed');
+    expect(result.runnable.map((task) => task.id)).toEqual([h.getTask('A')!.id]);
+    expect(result.topup).toEqual([]);
+    expect(h.getTask('A')!.execution.workspacePath).toBeUndefined();
+    expect(h.getTask('A')!.status).toBe('running');
   });
 
-  it('edit-task-type launches restarted task and persists workspacePath', async () => {
+  it('edit-task-type records a runnable launch for the outbox', async () => {
     h.loadAndStart(LINEAR_PLAN);
     h.failTask('A', 'broken');
 
@@ -91,13 +95,15 @@ describe('app-layer handoff repros', () => {
     expect(started.some((task) => task.id.endsWith('/A') && task.status === 'running')).toBe(true);
     expect(h.getTask('A')!.execution.workspacePath).toBeUndefined();
 
-    await dispatchStarted(h, started, 'test.edit-task-type');
+    const result = await dispatchStarted(h, started, 'test.edit-task-type');
 
-    expect(h.getTask('A')!.execution.workspacePath).toBe('/tmp/mock-worktree');
-    expect(h.getTask('A')!.status).toBe('completed');
+    expect(result.runnable.map((task) => task.id)).toEqual([h.getTask('A')!.id]);
+    expect(result.topup).toEqual([]);
+    expect(h.getTask('A')!.execution.workspacePath).toBeUndefined();
+    expect(h.getTask('A')!.status).toBe('running');
   });
 
-  it('edit-task-agent launches restarted task and persists workspacePath', async () => {
+  it('edit-task-agent records a runnable launch for the outbox', async () => {
     h.loadAndStart(LINEAR_PLAN);
     h.failTask('A', 'broken');
 
@@ -105,13 +111,15 @@ describe('app-layer handoff repros', () => {
     expect(started.some((task) => task.id.endsWith('/A') && task.status === 'running')).toBe(true);
     expect(h.getTask('A')!.execution.workspacePath).toBeUndefined();
 
-    await dispatchStarted(h, started, 'test.edit-task-agent');
+    const result = await dispatchStarted(h, started, 'test.edit-task-agent');
 
-    expect(h.getTask('A')!.execution.workspacePath).toBe('/tmp/mock-worktree');
-    expect(h.getTask('A')!.status).toBe('completed');
+    expect(result.runnable.map((task) => task.id)).toEqual([h.getTask('A')!.id]);
+    expect(result.topup).toEqual([]);
+    expect(h.getTask('A')!.execution.workspacePath).toBeUndefined();
+    expect(h.getTask('A')!.status).toBe('running');
   });
 
-  it('set-task-external-gate-policies launches newly unblocked task and persists workspacePath', async () => {
+  it('set-task-external-gate-policies records the newly unblocked task for the outbox', async () => {
     h.orchestrator.loadPlan({
       name: 'upstream-workflow',
       tasks: [{ id: 'verify', description: 'prereq task', command: 'echo verify' }],
@@ -149,24 +157,18 @@ describe('app-layer handoff repros', () => {
     expect(started.some((task) => task.id === leafId && task.status === 'running')).toBe(true);
     expect(h.getTask('leaf')!.execution.workspacePath).toBeUndefined();
 
-    await dispatchStarted(h, started, 'test.set-task-external-gate-policies');
+    const result = await dispatchStarted(h, started, 'test.set-task-external-gate-policies');
 
-    expect(h.getTask('leaf')!.execution.workspacePath).toBe('/tmp/mock-worktree');
-    expect(h.getTask('leaf')!.status).toBe('completed');
+    expect(result.runnable.map((task) => task.id)).toEqual([leafId]);
+    expect(result.topup).toEqual([]);
+    expect(h.getTask('leaf')!.execution.workspacePath).toBeUndefined();
+    expect(h.getTask('leaf')!.status).toBe('running');
   });
 
-  it('replace-task launches replacement tasks and persists workspacePath', async () => {
+  it('replace-task records replacement launches for the outbox', async () => {
     h.loadAndStart(LINEAR_PLAN);
     h.failTask('A', 'broken');
 
-    // Steps 11 → 14 (`docs/architecture/task-invalidation-roadmap.md`):
-    // `replaceTask` on a *live* workflow now routes through
-    // `forkWorkflow` (Step 14) instead of throwing
-    // `TopologyForkRequired` (Step 11). This test exercises the
-    // **in-place** handoff path on purpose, so it cancels the live
-    // downstream task to make the workflow terminal first; then
-    // `replaceTask` lands in-place on the same workflow and the
-    // workspacePath handoff assertions below are unchanged.
     h.orchestrator.cancelTask('B');
 
     const started = h.orchestrator.replaceTask('A', [
@@ -176,13 +178,15 @@ describe('app-layer handoff repros', () => {
     expect(started.some((task) => task.id.endsWith('/A-fix-1') && task.status === 'running')).toBe(true);
     expect(h.getTask('A-fix-1')!.execution.workspacePath).toBeUndefined();
 
-    await dispatchStarted(h, started, 'test.replace-task');
+    const result = await dispatchStarted(h, started, 'test.replace-task');
 
-    expect(h.getTask('A-fix-1')!.execution.workspacePath).toBe('/tmp/mock-worktree');
-    expect(h.getTask('A-fix-1')!.status).toBe('completed');
+    expect(result.runnable.map((task) => task.id)).toEqual([h.getTask('A-fix-1')!.id]);
+    expect(result.topup).toEqual([]);
+    expect(h.getTask('A-fix-1')!.execution.workspacePath).toBeUndefined();
+    expect(h.getTask('A-fix-1')!.status).toBe('running');
   });
 
-  it('set-merge-branch relaunches merge task and persists workspacePath', async () => {
+  it('set-merge-branch leaves merge relaunch for the outbox', async () => {
     h.loadAndStart(PARALLEL_PLAN);
     h.completeTask('A');
     h.completeTask('B');
@@ -198,14 +202,16 @@ describe('app-layer handoff repros', () => {
     expect(started.some((task) => task.id === mergeTaskId && task.status === 'running')).toBe(true);
     expect(h.getTask(mergeTaskId)!.execution.workspacePath).toBe('/tmp/mock-merge-worktree');
 
-    await dispatchStarted(h, started, 'test.set-merge-branch');
+    const result = await dispatchStarted(h, started, 'test.set-merge-branch');
 
+    expect(result.runnable.map((task) => task.id)).toEqual([mergeTaskId]);
+    expect(result.topup).toEqual([]);
     expect(h.getTask(mergeTaskId)!.execution.workspacePath).toBe('/tmp/mock-merge-worktree');
-    expect(h.getTask(mergeTaskId)!.status).toBe('completed');
+    expect(h.getTask(mergeTaskId)!.status).toBe('running');
     expect(h.persistence.loadWorkflow(workflowId).baseBranch).toBe('develop');
   });
 
-  it('standalone-owner set-merge-branch uses the same handoff and persists workspacePath', async () => {
+  it('standalone-owner set-merge-branch leaves merge relaunch for the outbox', async () => {
     h.loadAndStart(PARALLEL_PLAN);
     h.completeTask('A');
     h.completeTask('B');
@@ -217,10 +223,12 @@ describe('app-layer handoff repros', () => {
 
     h.persistence.updateWorkflow(workflowId, { baseBranch: 'release' });
     const started = h.orchestrator.retryTask(mergeTaskId);
-    await dispatchStarted(h, started, 'test.standalone.set-merge-branch');
+    const result = await dispatchStarted(h, started, 'test.standalone.set-merge-branch');
 
+    expect(result.runnable.map((task) => task.id)).toEqual([mergeTaskId]);
+    expect(result.topup).toEqual([]);
     expect(h.getTask(mergeTaskId)!.execution.workspacePath).toBe('/tmp/mock-merge-worktree');
-    expect(h.getTask(mergeTaskId)!.status).toBe('completed');
+    expect(h.getTask(mergeTaskId)!.status).toBe('running');
     expect(h.persistence.loadWorkflow(workflowId).baseBranch).toBe('release');
   });
 });

--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -100,9 +100,7 @@ describe('global top-up dispatch', () => {
       alreadyDispatched: [duplicate],
     });
 
-    expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
-    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([newTask]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(topup.map((task) => task.id)).toEqual(['wf-2/task-b']);
   });
 
@@ -153,9 +151,7 @@ describe('global top-up dispatch', () => {
     });
 
     expect(topup.map((task) => task.id)).toEqual([taskB.id]);
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([
-      expect.objectContaining({ id: taskB.id, status: 'running' }),
-    ]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   loadConfig,
   resolveEmbeddedTerminalBackendConfig,
-  resolveLaunchOutboxMode,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -28,9 +27,9 @@ vi.mock('node:os', async (importOriginal) => {
 });
 
 describe('loadConfig', () => {
-  it('returns config with default launchOutboxMode when no files exist', () => {
+  it('returns empty config when no files exist', () => {
     const config = loadConfig();
-    expect(config).toEqual({ launchOutboxMode: 'active' });
+    expect(config).toEqual({});
   });
 
   it('reads user-level ~/.invoker/config.json', () => {
@@ -255,45 +254,3 @@ describe('resolveEmbeddedTerminalBackendConfig', () => {
   });
 });
 
-describe('resolveLaunchOutboxMode', () => {
-  it('defaults to active when INVOKER_LAUNCH_OUTBOX is unset', () => {
-    expect(resolveLaunchOutboxMode({})).toBe('active');
-  });
-
-  it('returns disabled when INVOKER_LAUNCH_OUTBOX=disabled', () => {
-    expect(
-      resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'disabled' }),
-    ).toBe('disabled');
-  });
-
-  it('returns observe when INVOKER_LAUNCH_OUTBOX=observe', () => {
-    expect(
-      resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'observe' }),
-    ).toBe('observe');
-  });
-
-  it('returns active when INVOKER_LAUNCH_OUTBOX=active', () => {
-    expect(
-      resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'active' }),
-    ).toBe('active');
-  });
-
-  it('falls back to active with a warning for unknown values', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      expect(
-        resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'on' }),
-      ).toBe('active');
-      expect(warnSpy).toHaveBeenCalledOnce();
-      expect(warnSpy.mock.calls[0]?.[0]).toMatch(/Unknown INVOKER_LAUNCH_OUTBOX/);
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('is case- and whitespace-insensitive', () => {
-    expect(
-      resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: '  Observe  ' }),
-    ).toBe('observe');
-  });
-});

--- a/packages/app/src/__tests__/global-topup.test.ts
+++ b/packages/app/src/__tests__/global-topup.test.ts
@@ -21,12 +21,6 @@ function makeTask(
   } as TaskState;
 }
 
-async function waitForCondition(condition: () => boolean): Promise<void> {
-  for (let i = 0; i < 20; i += 1) {
-    if (condition()) return;
-    await Promise.resolve();
-  }
-}
 
 describe('global-topup helpers', () => {
   it('keeps cross-workflow prestarted tasks in top-up when a workflow scope is explicit', async () => {
@@ -47,9 +41,7 @@ describe('global-topup helpers', () => {
       scopedWorkflowId: 'wf-1',
     });
 
-    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
     expect(result.runnable).toEqual([scoped]);
     expect(result.topup).toEqual([crossWorkflow]);
@@ -74,15 +66,12 @@ describe('global-topup helpers', () => {
       scopedWorkflowId: 'wf-1',
     });
 
-    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(3);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(3, [extraTopup]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(result.runnable).toEqual([scoped]);
     expect(result.topup).toEqual([crossWorkflow, extraTopup]);
   });
 
-  it('dispatches scoped started tasks before running global top-up', async () => {
+  it('returns scoped started tasks before running global top-up', async () => {
     const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
     const topupTask = makeTask('topup-task', 'running', 'attempt-topup');
     const orchestrator = {
@@ -99,45 +88,13 @@ describe('global-topup helpers', () => {
       started: [scoped],
     });
 
-    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [topupTask]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
     expect(result.runnable).toEqual([scoped]);
     expect(result.topup).toEqual([topupTask]);
   });
 
-  it('awaited dispatch waits for executeTasks to finish', async () => {
-    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
-    const release = vi.fn();
-    let resolveDispatch!: () => void;
-    const taskExecutor = {
-      executeTasks: vi.fn(() => new Promise<void>((resolve) => {
-        resolveDispatch = () => {
-          release();
-          resolve();
-        };
-      })),
-    };
-    const dispatch = dispatchStartedTasksWithGlobalTopup({
-      orchestrator: { startExecution: vi.fn().mockReturnValue([]) } as any,
-      taskExecutor: taskExecutor as any,
-      context: 'test.awaited-dispatch',
-      started: [scoped],
-    });
-
-    await Promise.resolve();
-    let completed = false;
-    void dispatch.then(() => { completed = true; });
-    await Promise.resolve();
-
-    expect(completed).toBe(false);
-    resolveDispatch();
-    await dispatch;
-    expect(release).toHaveBeenCalledTimes(1);
-  });
-
-  it('fire-and-forget dispatch returns before executeTasks finishes', async () => {
+  it('fire-and-forget mode still returns the runnable set without in-process dispatch', async () => {
     const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
     const taskExecutor = {
       executeTasks: vi.fn(() => new Promise<void>(() => {})),
@@ -151,31 +108,9 @@ describe('global-topup helpers', () => {
       dispatchMode: 'fire-and-forget',
     });
 
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([scoped]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(result.runnable).toEqual([scoped]);
     expect(result.topup).toEqual([]);
-  });
-
-  it('fire-and-forget dispatch logs asynchronous executeTasks rejection', async () => {
-    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
-    const logger = { error: vi.fn(), info: vi.fn() };
-    const taskExecutor = {
-      executeTasks: vi.fn().mockRejectedValue(new Error('dispatch failed')),
-    };
-
-    await dispatchStartedTasksWithGlobalTopup({
-      orchestrator: { startExecution: vi.fn().mockReturnValue([]) } as any,
-      taskExecutor: taskExecutor as any,
-      logger: logger as any,
-      context: 'test.fire-and-forget-rejection',
-      started: [scoped],
-      dispatchMode: 'fire-and-forget',
-    });
-
-    await waitForCondition(() => logger.error.mock.calls.length > 0);
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining('asynchronous task dispatch failed'),
-    );
   });
 
   it('executeGlobalTopup skips tasks already marked as dispatched', async () => {
@@ -195,12 +130,11 @@ describe('global-topup helpers', () => {
       alreadyDispatched: [scoped],
     });
 
-    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([topupTask]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(topup).toEqual([topupTask]);
   });
 
-  it('finalizeMutationWithGlobalTopup dispatches started runnable work', async () => {
+  it('finalizeMutationWithGlobalTopup returns started runnable work', async () => {
     const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
     const orchestrator = {
       startExecution: vi.fn().mockReturnValue([]),
@@ -216,7 +150,7 @@ describe('global-topup helpers', () => {
       started: [scoped],
     });
 
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([scoped]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(result.started).toEqual([scoped]);
     expect(result.topup).toEqual([]);
   });

--- a/packages/app/src/__tests__/headless-create-executor.test.ts
+++ b/packages/app/src/__tests__/headless-create-executor.test.ts
@@ -1,11 +1,8 @@
 /**
- * CB.7 acceptance: verifies createHeadlessExecutor's active-mode
- * short-circuit. In `INVOKER_LAUNCH_OUTBOX=active` mode the owner's
- * long-lived TaskRunner is the single launch path (it services the
- * task_launch_dispatch outbox via LaunchDispatcher), so headless
- * commands must reuse it instead of constructing a per-command
- * TaskRunner — that was the root of Issue 6 (multi-TaskRunner
- * blindness from per-instance `launchingAttemptIds` Sets).
+ * Verifies createHeadlessExecutor reuses the owner's long-lived
+ * TaskRunner when one is available. That owner runner services the
+ * durable launch outbox, so headless commands must not create a second
+ * independent runner.
  */
 import { describe, expect, it, vi } from 'vitest';
 import type { Logger } from '@invoker/contracts';
@@ -45,9 +42,7 @@ function makeDeps(overrides: Partial<HeadlessDeps>): HeadlessDeps {
     executorRegistry: {} as any,
     messageBus: {} as any,
     commandService: {} as any,
-    repoRoot: '/tmp/repo',
     invokerConfig: {
-      launchOutboxMode: 'disabled',
       defaultBranch: 'main',
       docker: {},
       executionPools: {},
@@ -59,17 +54,10 @@ function makeDeps(overrides: Partial<HeadlessDeps>): HeadlessDeps {
   };
 }
 
-describe('createHeadlessExecutor (CB.7 active-mode short-circuit)', () => {
-  it('returns the owner TaskRunner when launchOutboxMode=active and the provider yields one', () => {
+describe('createHeadlessExecutor owner-runner reuse', () => {
+  it('returns the owner TaskRunner when the provider yields one', () => {
     const owner = fakeOwnerTaskRunner();
     const deps = makeDeps({
-      invokerConfig: {
-        launchOutboxMode: 'active',
-        defaultBranch: 'main',
-        docker: {},
-        executionPools: {},
-        remoteTargets: {},
-      } as any,
       ownerTaskRunnerProvider: () => owner,
     });
 
@@ -82,13 +70,6 @@ describe('createHeadlessExecutor (CB.7 active-mode short-circuit)', () => {
     const logger = makeLogger();
     const deps = makeDeps({
       logger,
-      invokerConfig: {
-        launchOutboxMode: 'active',
-        defaultBranch: 'main',
-        docker: {},
-        executionPools: {},
-        remoteTargets: {},
-      } as any,
       ownerTaskRunnerProvider: () => owner,
     });
 
@@ -100,61 +81,15 @@ describe('createHeadlessExecutor (CB.7 active-mode short-circuit)', () => {
     expect(debugRecord).toBeDefined();
   });
 
-  it('warns and falls back to constructing a fresh TaskRunner when active but no owner is available', () => {
-    const logger = makeLogger();
-    const deps = makeDeps({
-      logger,
-      invokerConfig: {
-        launchOutboxMode: 'active',
-        defaultBranch: 'main',
-        docker: {},
-        executionPools: {},
-        remoteTargets: {},
-      } as any,
-      // No ownerTaskRunnerProvider — simulates a true standalone owner
-      // that hasn't initialised its TaskRunner yet.
-    });
+  it('falls back to constructing a fresh TaskRunner when no owner is available', () => {
+    const deps = makeDeps({});
 
-    // The constructor of TaskRunner requires real shared services to
-    // succeed; for this test we only care that the active branch took
-    // the fallback path (warning emitted) before any throw. We catch
-    // any constructor-time error so we can assert on the warning
-    // independently.
-    let threw = false;
     try {
       createHeadlessExecutor(deps);
     } catch {
-      threw = true;
+      // The constructor needs real services in production. This assertion only
+      // covers the absence of an owner runner.
     }
-    void threw; // either outcome is acceptable for this assertion
-    const warn = logger.records.find(
-      (r) => r.level === 'warn' && r.msg.includes('ownerTaskRunnerProvider is unavailable'),
-    );
-    expect(warn).toBeDefined();
   });
 
-  it('does not short-circuit when launchOutboxMode is not active', () => {
-    const owner = fakeOwnerTaskRunner();
-    const providerCalls = vi.fn(() => owner);
-    const deps = makeDeps({
-      invokerConfig: {
-        launchOutboxMode: 'observe',
-        defaultBranch: 'main',
-        docker: {},
-        executionPools: {},
-        remoteTargets: {},
-      } as any,
-      ownerTaskRunnerProvider: providerCalls,
-    });
-
-    // We expect a real TaskRunner construction to fail in this minimal
-    // env; that's fine — what we're asserting is that the provider was
-    // *not* consulted (the legacy code path was taken).
-    try {
-      createHeadlessExecutor(deps);
-    } catch {
-      // swallow — verifying the provider call below
-    }
-    expect(providerCalls).not.toHaveBeenCalled();
-  });
 });

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -509,8 +509,8 @@ describe('headless delegation enforcement', () => {
           .rejects.toThrow(/not allowed/);
       });
 
-      it('headless set mutations dispatch runnable tasks before waiting for completion', async () => {
-        let taskStatus: 'running' | 'completed' = 'running';
+      it('headless set mutations accept runnable tasks without direct executor dispatch', async () => {
+        let taskStatus: 'running' | 'completed' = 'completed';
         mockDeps.persistence.listWorkflows = vi.fn(() => [{
           id: 'wf-1',
           name: 'test-workflow',
@@ -545,19 +545,13 @@ describe('headless delegation enforcement', () => {
         mockDeps.commandService.setTaskExternalGatePolicies = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
         const executeTasksSpy = vi
           .spyOn(TaskRunner.prototype, 'executeTasks')
-          .mockImplementation(async () => {
-            taskStatus = 'completed';
-          });
+          .mockResolvedValue(undefined);
 
         await runHeadless(['set', 'command', 'wf-1/task-1', 'echo ok'], mockDeps);
-        taskStatus = 'running';
         await runHeadless(['set', 'executor', 'wf-1/task-1', 'shell'], mockDeps);
-        taskStatus = 'running';
         await runHeadless(['set', 'agent', 'wf-1/task-1', 'codex'], mockDeps);
-        taskStatus = 'running';
         await runHeadless(['set', 'gate-policy', 'wf-1/task-1', 'wf-upstream', 'review_ready'], mockDeps);
 
-        expect(executeTasksSpy).toHaveBeenCalledTimes(4);
         expect(mockDeps.commandService.editTaskCommand).toHaveBeenCalled();
         expect(mockDeps.commandService.editTaskType).toHaveBeenCalled();
         expect(mockDeps.commandService.editTaskAgent).toHaveBeenCalled();
@@ -579,7 +573,7 @@ describe('headless delegation enforcement', () => {
         expect(mockDeps.commandService.replaceTask).not.toHaveBeenCalled();
       });
 
-      it('headless approve waits for downstream runnable tasks to settle', async () => {
+      it('headless approve waits for downstream outbox work to settle', async () => {
         let taskBStatus: 'running' | 'completed' = 'running';
         mockDeps.persistence.listWorkflows = vi.fn(() => [{
           id: 'wf-1',
@@ -625,18 +619,20 @@ describe('headless delegation enforcement', () => {
           config: { workflowId: 'wf-1' },
           execution: {},
         } as any;
-        mockDeps.commandService.approve = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
+        mockDeps.commandService.approve = vi.fn(async () => {
+          setTimeout(() => {
+            taskBStatus = 'completed';
+          }, 10);
+          return { ok: true as const, data: [runnableTask] };
+        });
 
         const executeTasksSpy = vi
           .spyOn(TaskRunner.prototype, 'executeTasks')
-          .mockImplementation(async () => {
-            taskBStatus = 'completed';
-          });
+          .mockResolvedValue(undefined);
 
         await runHeadless(['approve', 'wf-1/task-a'], mockDeps);
 
-        expect(executeTasksSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-        expect(executeTasksSpy).toHaveBeenCalledWith([runnableTask]);
+        expect(executeTasksSpy).not.toHaveBeenCalled();
         expect(mockDeps.commandService.approve).toHaveBeenCalled();
 
         executeTasksSpy.mockRestore();
@@ -752,17 +748,18 @@ describe('headless delegation enforcement', () => {
           config: { workflowId: 'wf-1' },
           execution: {},
         } as any;
-        mockDeps.commandService.approve = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
+        mockDeps.commandService.approve = vi.fn(async () => {
+          taskBStatus = 'pending';
+          return { ok: true as const, data: [runnableTask] };
+        });
 
         const executeTasksSpy = vi
           .spyOn(TaskRunner.prototype, 'executeTasks')
-          .mockImplementation(async () => {
-            taskBStatus = 'pending';
-          });
+          .mockResolvedValue(undefined);
 
         await expect(runHeadless(['approve', 'wf-1/task-a'], mockDeps)).resolves.toBeUndefined();
 
-        expect(executeTasksSpy).toHaveBeenCalledTimes(1);
+        expect(executeTasksSpy).not.toHaveBeenCalled();
         expect(mockDeps.orchestrator.getReadyTasks).toHaveBeenCalled();
 
         executeTasksSpy.mockRestore();

--- a/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
+++ b/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
@@ -11,17 +11,9 @@
  *    before the watchdog failed them with the misleading
  *    "60 seconds" error message.
  *
- * This test reproduces the steady-state shape in-process: 38 single-task
- * plans are loaded, `startExecution()` is called to claim every
- * attempt, and **no TaskRunner is wired in** — exactly the fragile
- * seam the re-architecture is meant to eliminate.
- *
- * The test is marked `it.fails` so CI stays green while the bug is
- * documented. The Phase B definition of done (see
- * .cursor/plans/launch_handoff_rearchitecture_c13d3ffc.plan.md) calls
- * for removing the `.fails` marker once the durable
- * `task_launch_dispatch` outbox dispatcher is active and resolves
- * every claim.
+ * The durable outbox is now always on. The first test proves every
+ * claim gets a dispatch row. The second wires the dispatcher and proves
+ * every claim reaches a terminal launch event.
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -31,7 +23,6 @@ import { InMemoryBus } from '@invoker/test-kit';
 import { LaunchDispatcher } from '../launch-dispatcher.js';
 import {
   LAUNCH_CLAIM_EVENT_TYPE,
-  LaunchInvariantViolationError,
   TERMINAL_LAUNCH_EVENT_TYPES,
   assertLaunchInvariant,
 } from './launch-invariant.js';
@@ -49,8 +40,8 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
     }
   });
 
-  it.fails(
-    'a 38-claim rebase-recreate storm without a dispatcher orphans every claim',
+  it(
+    'a 38-claim rebase-recreate storm writes one dispatch row per claim',
     async () => {
       const persistence = await SQLiteAdapter.create(':memory:');
       adapters.push(persistence);
@@ -59,9 +50,6 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
         persistence: persistence as any,
         messageBus: new InMemoryBus(),
         maxConcurrency: STORM_SIZE,
-        // Mirror production wiring (packages/app/src/main.ts:502) — without
-        // this flag the orchestrator writes `task.running` directly and skips
-        // the two-phase claim/launch hand-off that the bug lives in.
         deferRunningUntilLaunch: true,
       });
 
@@ -95,40 +83,12 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
           0,
         );
       expect(claimCount).toBe(STORM_SIZE);
-
-      const terminalCount = persistence
-        .getAllTaskIds()
-        .reduce(
-          (acc, taskId) =>
-            acc +
-            persistence
-              .getEvents(taskId)
-              .filter((event) => TERMINAL_LAUNCH_EVENT_TYPES.has(event.eventType))
-              .length,
-          0,
-        );
-      expect(terminalCount).toBe(0);
-
-      try {
-        assertLaunchInvariant(persistence, {
-          maxGapMs: TIGHT_MAX_GAP_MS,
-          nowMs: Date.now() + PRETEND_LATER_MS,
-        });
-      } catch (err) {
-        expect(err).toBeInstanceOf(LaunchInvariantViolationError);
-        const violation = err as LaunchInvariantViolationError;
-        expect(violation.summary.claimCount).toBe(STORM_SIZE);
-        expect(violation.violations).toHaveLength(STORM_SIZE);
-        for (const v of violation.violations) {
-          expect(v.reason).toBe('no_terminal_event');
-        }
-        throw err;
-      }
+      expect(persistence.listLaunchDispatchesByState(['enqueued'])).toHaveLength(STORM_SIZE);
     },
   );
 
   it(
-    'with INVOKER_LAUNCH_OUTBOX=active, the LaunchDispatcher resolves every claim into a terminal event',
+    'the LaunchDispatcher resolves every claim into a terminal event',
     async () => {
       // CB.5 acceptance: wire the same 38-claim storm through the durable
       // outbox dispatcher (orchestrator -> task_launch_dispatch ->
@@ -142,10 +102,8 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
         messageBus: new InMemoryBus(),
         maxConcurrency: STORM_SIZE,
         deferRunningUntilLaunch: true,
-        // Active mode causes drainScheduler to write the outbox row alongside
-        // the durable launch claim — that row is what the LaunchDispatcher
-        // polls below.
-        launchOutboxMode: 'active',
+        // drainScheduler writes the outbox row alongside the durable launch
+        // claim — that row is what the LaunchDispatcher polls below.
       });
 
       const startedTasks: TaskState[] = [];
@@ -175,7 +133,6 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
         },
         taskRunnerProvider: () => fakeTaskRunner,
         ownerId: 'cb5-test-owner',
-        mode: 'active',
         maxLeasesPerPoll: STORM_SIZE,
       });
 

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -38,91 +38,25 @@ describe('LaunchDispatcher', () => {
     expect(() => new LaunchDispatcher({
       persistence: adapter,
       ownerId: 'owner-test',
-      mode: 'observe',
     })).not.toThrow();
   });
 
-  it('observer mode logs state counts and does not mutate rows', () => {
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
-    adapter.saveTask('wf-1', {
-      id: 'wf-1/t1',
-      description: 'one',
-      status: 'pending',
-      dependencies: [],
-      createdAt: new Date(),
-      config: { workflowId: 'wf-1' },
-      execution: {},
-      taskStateVersion: 1,
-    });
-    const enqueued = adapter.enqueueLaunchDispatch({
-      taskId: 'wf-1/t1',
-      attemptId: 'attempt-1',
-      workflowId: 'wf-1',
-      generation: 0,
-    });
 
-    const logger = makeLogger();
-    const dispatcher = new LaunchDispatcher({
-      persistence: adapter,
-      ownerId: 'owner-test',
-      logger,
-      mode: 'observe',
-    });
-
-    dispatcher.poll();
-
-    const observed = logger.records.find((entry) => entry.msg.includes('observed'));
-    expect(observed).toBeDefined();
-    expect(observed?.fields?.total).toBe(1);
-    const counts = observed?.fields?.counts as Record<string, number> | undefined;
-    expect(counts?.enqueued).toBe(1);
-    expect(counts?.leased).toBe(0);
-
-    const afterPoll = adapter.loadLaunchDispatchById(enqueued.id);
-    expect(afterPoll).toMatchObject({ state: 'enqueued' });
-  });
-
-  it('active mode without a taskRunnerProvider warns and does not dispatch', () => {
-    const listSpy = vi.spyOn(adapter, 'listLaunchDispatchesByState');
+  it('without a taskRunnerProvider warns and does not dispatch', () => {
     const claimSpy = vi.spyOn(adapter, 'claimLaunchDispatchAtomic');
     const logger = makeLogger();
     const dispatcher = new LaunchDispatcher({
       persistence: adapter,
       ownerId: 'owner-test',
       logger,
-      mode: 'active',
     });
     expect(() => dispatcher.poll()).not.toThrow();
     expect(claimSpy).not.toHaveBeenCalled();
     const warn = logger.records.find((entry) => entry.level === 'warn');
-    expect(warn?.msg).toMatch(/active mode without taskRunner/);
-    // Active mode never observes (no aggregate log) — observation is the
-    // observer-mode tail and the reapers don't need it.
-    expect(listSpy).not.toHaveBeenCalled();
-    listSpy.mockRestore();
+    expect(warn?.msg).toMatch(/without taskRunner/);
     claimSpy.mockRestore();
   });
 
-  it('observer mode reports zero counts when the outbox is empty', () => {
-    const logger = makeLogger();
-    const dispatcher = new LaunchDispatcher({
-      persistence: adapter,
-      ownerId: 'owner-test',
-      logger,
-      mode: 'observe',
-    });
-
-    dispatcher.poll();
-
-    const observed = logger.records.find((entry) => entry.msg.includes('observed'));
-    expect(observed?.fields?.total).toBe(0);
-  });
 
   describe('complete / fail transitions', () => {
     function seedWorkflowAndTask(selectedAttemptId?: string): void {
@@ -157,7 +91,6 @@ describe('LaunchDispatcher', () => {
           persistence: adapter,
           ownerId: 'owner-test',
           logger,
-          mode: 'observe',
         }),
       };
     }
@@ -306,7 +239,6 @@ describe('LaunchDispatcher', () => {
         orchestrator,
         ownerId: 'owner-test',
         logger,
-        mode: 'observe',
         maxAttempts: 2,
       });
       return { dispatcher, logger };
@@ -525,7 +457,7 @@ describe('LaunchDispatcher', () => {
       expect(prepare).not.toHaveBeenCalled();
     });
 
-    it('poll() runs reapers in both observer and active modes', () => {
+    it('poll() runs reapers before dispatching new work', () => {
       seed();
       const row = adapter.enqueueLaunchDispatch({
         taskId: 'wf-r/t1',
@@ -539,17 +471,16 @@ describe('LaunchDispatcher', () => {
         [pastIso, row.id],
       );
 
-      const observer = new LaunchDispatcher({
+      const dispatcher = new LaunchDispatcher({
         persistence: adapter,
-        ownerId: 'observer',
-        mode: 'observe',
+        ownerId: 'owner',
       });
-      observer.poll();
+      dispatcher.poll();
       expect(adapter.loadLaunchDispatchById(row.id)?.state).toBe('enqueued');
     });
   });
 
-  describe('active mode dispatch (CB.5)', () => {
+  describe('dispatch', () => {
     function seedWorkflowAndTask(
       taskId: string,
       workflowId = 'wf-a',
@@ -584,7 +515,7 @@ describe('LaunchDispatcher', () => {
       return task;
     }
 
-    it('active mode leases an enqueued row and hands it to the TaskRunner', () => {
+    it('leases an enqueued row and hands it to the TaskRunner', () => {
       const task = seedWorkflowAndTask('wf-a/t1', 'wf-a', {
         selectedAttemptId: 'attempt-active-1',
         generation: 0,
@@ -607,7 +538,6 @@ describe('LaunchDispatcher', () => {
           getTask,
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
       });
       dispatcher.poll();
 
@@ -625,7 +555,7 @@ describe('LaunchDispatcher', () => {
       expect(after?.dispatchOwner).toBe('owner-a');
     });
 
-    it('active mode loops until maxLeasesPerPoll is reached', () => {
+    it('loops until maxLeasesPerPoll is reached', () => {
       for (let i = 0; i < 3; i += 1) {
         seedWorkflowAndTask(`wf-a/t${i}`, 'wf-a', {
           selectedAttemptId: `attempt-multi-${i}`,
@@ -663,20 +593,18 @@ describe('LaunchDispatcher', () => {
           getTask,
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
         maxLeasesPerPoll: 2,
       });
       dispatcher.poll();
       expect(executeTask).toHaveBeenCalledTimes(2);
     });
 
-    it('active mode hydrates the workflow before treating a dispatch row as missing', () => {
+    it('hydrates the workflow before treating a dispatch row as missing', () => {
       const writer = new Orchestrator({
         persistence: adapter as any,
         messageBus: new InMemoryBus(),
         maxConcurrency: 1,
         deferRunningUntilLaunch: true,
-        launchOutboxMode: 'active',
       });
       writer.loadPlan({
         name: 'cold-cache-dispatch',
@@ -696,7 +624,6 @@ describe('LaunchDispatcher', () => {
         messageBus: new InMemoryBus(),
         maxConcurrency: 1,
         deferRunningUntilLaunch: true,
-        launchOutboxMode: 'active',
       });
       expect(cold.getTask(started!.id)).toBeUndefined();
 
@@ -711,7 +638,6 @@ describe('LaunchDispatcher', () => {
           getTask: (taskId) => cold.getTask(taskId),
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
       });
 
       dispatcher.poll();
@@ -722,7 +648,7 @@ describe('LaunchDispatcher', () => {
       expect(adapter.loadLaunchDispatchById(1)?.lastError).toBeUndefined();
     });
 
-    it('active mode abandons a dispatch row when the selected attempt changed after lease', () => {
+    it('abandons a dispatch row when the selected attempt changed after lease', () => {
       const task = seedWorkflowAndTask('wf-a/t-stale', 'wf-a', {
         selectedAttemptId: 'attempt-old',
         generation: 0,
@@ -750,7 +676,6 @@ describe('LaunchDispatcher', () => {
           getTask: vi.fn().mockReturnValue(currentTask as any),
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
       });
 
       dispatcher.poll();
@@ -763,7 +688,7 @@ describe('LaunchDispatcher', () => {
       expect(events.some((event) => event.eventType === 'task.launch_dispatch_invalidated')).toBe(true);
     });
 
-    it('active mode abandons the dispatch when readiness is blocked', () => {
+    it('abandons the dispatch when readiness is blocked', () => {
       const task = seedWorkflowAndTask('wf-a/t-blocked', 'wf-a', {
         selectedAttemptId: 'attempt-blocked',
         generation: 0,
@@ -794,7 +719,6 @@ describe('LaunchDispatcher', () => {
           }),
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
       });
 
       dispatcher.poll();
@@ -819,7 +743,7 @@ describe('LaunchDispatcher', () => {
       });
     });
 
-    it('active mode abandons the dispatch when the orchestrator has no matching task', () => {
+    it('abandons the dispatch when the orchestrator has no matching task', () => {
       seedWorkflowAndTask('wf-a/t-missing', 'wf-a', {
         selectedAttemptId: 'attempt-missing',
         generation: 0,
@@ -839,7 +763,6 @@ describe('LaunchDispatcher', () => {
           getTask: vi.fn().mockReturnValue(undefined),
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
       });
       dispatcher.poll();
 
@@ -849,7 +772,7 @@ describe('LaunchDispatcher', () => {
       expect(after?.lastError).toMatch(/missing from orchestrator state/);
     });
 
-    it('active mode is a no-op when the queue is empty', () => {
+    it('is a no-op when the queue is empty', () => {
       const executeTask = vi.fn();
       const dispatcher = new LaunchDispatcher({
         persistence: adapter,
@@ -859,13 +782,12 @@ describe('LaunchDispatcher', () => {
           getTask: vi.fn(),
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
       });
       dispatcher.poll();
       expect(executeTask).not.toHaveBeenCalled();
     });
 
-    it('active mode catches runner promise rejections via failDispatch backstop', async () => {
+    it('catches runner promise rejections via failDispatch backstop', async () => {
       const task = seedWorkflowAndTask('wf-a/t-throw', 'wf-a', {
         selectedAttemptId: 'attempt-throw',
         generation: 0,
@@ -885,7 +807,6 @@ describe('LaunchDispatcher', () => {
           getTask: vi.fn().mockReturnValue(task as any),
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
       });
       dispatcher.poll();
       // Wait one microtask tick for the .catch backstop to run.

--- a/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
+++ b/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
@@ -33,7 +33,6 @@ async function makeHarness(name: string): Promise<Harness> {
     messageBus: new InMemoryBus(),
     maxConcurrency: 1,
     deferRunningUntilLaunch: true,
-    launchOutboxMode: 'active',
   });
   const harness = { dir, persistence, orchestrator };
   harnesses.push(harness);
@@ -116,7 +115,6 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
       },
     }),
     ownerId: 'pool-owner',
-    mode: 'active',
     maxLeasesPerPoll: 1,
   });
 

--- a/packages/app/src/__tests__/parity-regression.test.ts
+++ b/packages/app/src/__tests__/parity-regression.test.ts
@@ -9,7 +9,7 @@
  *
  * Test groups:
  *   1. Facade dispatch+topup lifecycle — every mutation method
- *      filters runnable tasks, dispatches via taskExecutor, then
+ *      filters runnable tasks, records accepted launches, then
  *      calls startExecution for global topup with deduplication.
  *   2. API server → facade wiring — HTTP endpoints call the correct
  *      facade method and return the structured result.
@@ -146,8 +146,7 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
   });
 
   /**
-   * Every mutation that returns a MutationResult must follow the same
-   * lifecycle: call orchestrator → filter runnable → executeTasks →
+   * lifecycle: call orchestrator → filter runnable →
    * startExecution (topup) → return { started, runnable, topup }.
    */
   const mutationCases: Array<{
@@ -173,8 +172,8 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
       // Correct orchestrator method was called
       expect((deps.orchestrator as any)[orchestratorMethod]).toHaveBeenCalled();
 
-      // Runnable tasks dispatched via executor
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      // Runnable tasks are returned for the durable dispatch outbox.
+      expect(result.runnable.length).toBeGreaterThan(0);
 
       // Global topup invoked (startExecution)
       expect(deps.orchestrator.startExecution).toHaveBeenCalled();
@@ -200,9 +199,7 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
     // Only the running task should be dispatched
     expect(result.runnable).toHaveLength(1);
     expect(result.runnable[0].id).toBe('task-1');
-    expect(deps.taskExecutor.executeTasks).toHaveBeenCalledWith([
-      expect.objectContaining({ id: 'task-1', status: 'running' }),
-    ]);
+    expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('topup deduplicates tasks already dispatched in scoped phase', async () => {
@@ -220,7 +217,7 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
     const result = await facade.retryTask('task-1');
 
     // Scoped dispatch happens, but topup should NOT re-dispatch
-    expect(deps.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
+    expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(result.topup).toHaveLength(0);
   });
 
@@ -240,8 +237,7 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
 
     const result = await facade.retryTask('task-1');
 
-    // Two dispatch calls: scoped + topup
-    expect(deps.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
+    expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(result.topup).toHaveLength(1);
     expect(result.topup[0].id).toBe('wf-2/task-9');
   });

--- a/packages/app/src/__tests__/workflow-mutation-facade.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-facade.test.ts
@@ -84,43 +84,47 @@ describe('WorkflowMutationFacade', () => {
   });
 
   describe('retryTask', () => {
-    it('calls orchestrator.retryTask and dispatches runnable tasks', async () => {
+    it('calls orchestrator.retryTask and returns accepted runnable tasks', async () => {
       const result = await facade.retryTask('task-a');
 
       expect(deps.orchestrator.retryTask).toHaveBeenCalledWith('task-a');
       expect(result.started).toHaveLength(1);
       expect(result.started[0].status).toBe('running');
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(result.runnable).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 
   describe('recreateTask', () => {
-    it('calls orchestrator.recreateTask and dispatches runnable tasks', async () => {
+    it('calls orchestrator.recreateTask and returns accepted runnable tasks', async () => {
       const result = await facade.recreateTask('task-a');
 
       expect(deps.orchestrator.recreateTask).toHaveBeenCalledWith('task-a');
       expect(result.started).toHaveLength(1);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(result.runnable).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 
   describe('editTaskCommand', () => {
-    it('calls orchestrator.editTaskCommand and dispatches runnable tasks', async () => {
+    it('calls orchestrator.editTaskCommand and returns accepted runnable tasks', async () => {
       const result = await facade.editTaskCommand('task-a', 'new-cmd');
 
       expect(deps.orchestrator.editTaskCommand).toHaveBeenCalledWith('task-a', 'new-cmd');
       expect(result.started).toHaveLength(1);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(result.runnable).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 
   describe('editTaskPrompt', () => {
-    it('calls orchestrator.editTaskPrompt and dispatches runnable tasks', async () => {
+    it('calls orchestrator.editTaskPrompt and returns accepted runnable tasks', async () => {
       const result = await facade.editTaskPrompt('task-a', 'new prompt');
 
       expect(deps.orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-a', 'new prompt');
       expect(result.started).toHaveLength(1);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(result.runnable).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 
@@ -134,11 +138,13 @@ describe('WorkflowMutationFacade', () => {
   });
 
   describe('editTaskAgent', () => {
-    it('calls orchestrator.editTaskAgent and dispatches', async () => {
+    it('calls orchestrator.editTaskAgent and returns accepted runnable tasks', async () => {
       const result = await facade.editTaskAgent('task-a', 'claude');
 
       expect(deps.orchestrator.editTaskAgent).toHaveBeenCalledWith('task-a', 'claude');
       expect(result.started).toHaveLength(1);
+      expect(result.runnable).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 
@@ -231,14 +237,14 @@ describe('WorkflowMutationFacade', () => {
   });
 
   describe('forkWorkflow', () => {
-    it('forks and dispatches runnable tasks', async () => {
+    it('forks and returns accepted runnable tasks', async () => {
       const result = await facade.forkWorkflow('wf-1');
 
       expect(deps.orchestrator.forkWorkflow).toHaveBeenCalledWith('wf-1');
       expect(result.forkedWorkflowId).toBe('wf-fork');
       expect(result.sourceWorkflowId).toBe('wf-1');
       expect(result.runnable).toHaveLength(1);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 
@@ -294,11 +300,13 @@ describe('WorkflowMutationFacade', () => {
   });
 
   describe('retryWorkflow', () => {
-    it('calls orchestrator.retryWorkflow and dispatches', async () => {
+    it('calls orchestrator.retryWorkflow and returns accepted runnable tasks', async () => {
       const result = await facade.retryWorkflow('wf-1');
 
       expect(deps.orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
       expect(result.started).toHaveLength(1);
+      expect(result.runnable).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
 
     it('can return after launch acceptance without waiting for task runtime', async () => {
@@ -315,7 +323,7 @@ describe('WorkflowMutationFacade', () => {
 
       expect(result.started).toHaveLength(1);
       expect(result.runnable).toHaveLength(1);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 
@@ -337,8 +345,7 @@ describe('WorkflowMutationFacade', () => {
 
       expect(result.runnable).toEqual([scoped]);
       expect(result.topup).toEqual([crossWorkflow]);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
 
     it('keeps cross-workflow starts in topup for rebase-recreate', async () => {
@@ -358,8 +365,7 @@ describe('WorkflowMutationFacade', () => {
 
       expect(result.runnable).toEqual([scoped]);
       expect(result.topup).toEqual([crossWorkflow]);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -206,34 +206,7 @@ export interface InvokerConfig {
     /** Routing strategy. Defaults to "enforce". */
     strategy?: 'enforce' | 'route';
   }>;
-  /**
-   * Launch-handoff outbox mode (Phase A of the launch-handoff
-   * re-architecture). Resolved from the INVOKER_LAUNCH_OUTBOX env var:
-   * - "disabled" (default): legacy in-memory dispatch only.
-   * - "observe": orchestrator writes task_launch_dispatch rows alongside
-   *   the existing claim path; LaunchDispatcher polls and logs counts but
-   *   does not own dispatch.
-   * - "active": LaunchDispatcher is the source of truth for dispatch
-   *   (Phase B, default in production).
-   *
-   * Unknown values fall back to "disabled" with a console warning.
-   *
-   * CC.6 deferral: the plan's Phase C calls for removing this flag
-   * entirely once the outbox has dogfooded clean. That deletion is
-   * left as a follow-up because the test surface still flips between
-   * 'observe' / 'active' / 'disabled' to exercise both code paths
-   * (see launch-dispatcher.test.ts active-mode suite,
-   * launch-claim-orphan-regression.test.ts active-mode passing test,
-   * and several headless-delegation parity cases). Each Phase C
-   * cleanup is independently revertable per the plan; CC.6 stays
-   * documented-but-deferred so the production env-var rollout (and
-   * the ability to flip back to observe mode in a hot incident) is
-   * preserved while the dispatcher matures.
-   */
-  launchOutboxMode?: LaunchOutboxMode;
 }
-
-export type LaunchOutboxMode = 'disabled' | 'observe' | 'active';
 
 function readJsonSafe(path: string): InvokerConfig {
   if (!existsSync(path)) {
@@ -257,35 +230,11 @@ function readJsonSafe(path: string): InvokerConfig {
 }
 
 export function loadConfig(): InvokerConfig {
-  const base = process.env.INVOKER_REPO_CONFIG_PATH
+  return process.env.INVOKER_REPO_CONFIG_PATH
     ? readJsonSafe(process.env.INVOKER_REPO_CONFIG_PATH)
     : readJsonSafe(join(homedir(), '.invoker', 'config.json'));
-  base.launchOutboxMode = resolveLaunchOutboxMode();
-  return base;
 }
 
-/**
- * Resolve the launch-outbox feature-flag mode from the
- * `INVOKER_LAUNCH_OUTBOX` env var.
- *
- * Returns `'active'` when the var is unset, empty, or holds an
- * unrecognised value (with a console warning for unknown values so
- * operators notice typos like `INVOKER_LAUNCH_OUTBOX=on`).
- */
-export function resolveLaunchOutboxMode(
-  env: NodeJS.ProcessEnv = process.env,
-): LaunchOutboxMode {
-  const raw = env.INVOKER_LAUNCH_OUTBOX;
-  if (typeof raw !== 'string' || raw.trim() === '') return 'active';
-  const normalized = raw.trim().toLowerCase();
-  if (normalized === 'disabled' || normalized === 'observe' || normalized === 'active') {
-    return normalized;
-  }
-  console.warn(
-    `[config] Unknown INVOKER_LAUNCH_OUTBOX value "${raw}"; falling back to "active".`,
-  );
-  return 'active';
-}
 
 export type EmbeddedTerminalBackendConfig = 'bash' | 'pty';
 

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -1,35 +1,10 @@
 /**
  * Post-mutation scheduler refill helpers.
  *
- * Phase B (CB.5) short-circuited the in-process dispatch path:
- * when the launch outbox is `'active'` the helpers stop at
- * `orchestrator.startExecution()` (which writes
- * task_launch_dispatch rows via drainScheduler). The
- * LaunchDispatcher's poll loop is the single launch path from
- * there, so `taskExecutor.executeTasks(runnable)` is no longer
- * invoked in that mode.
- *
- * Phase C (CC.4) was meant to delete the legacy fire-and-forget
- * fallback wholesale. That deletion has been left as a follow-up
- * because the existing test surface (~40 cases in
- * api-server.test.ts, parity-regression.test.ts,
- * app-layer-handoff-repro.test.ts, workflow-mutation-facade.test.ts,
- * bridge-orchestrator-executor.test.ts, headless-delegation.test.ts)
- * still asserts on `taskExecutor.executeTasks` being called via
- * these helpers, and CB.4's duplicate-launch suppression already
- * makes the in-process call functionally idempotent. Each Phase C
- * cleanup commit is independently revertable per the plan's
- * Risks-and-Mitigations note; CC.4's full deletion remains
- * available behind a follow-up PR once those callers have been
- * updated.
- *
- * What still happens here, mode-by-mode:
- *   - `'active'`: helpers call `orchestrator.startExecution()` and
- *     return; the in-process executeTasks call is skipped (see
- *     CB.5).
- *   - `'observe'` / `'disabled'`: helpers preserve the legacy
- *     fire-and-forget behaviour so a flag rollback has zero other
- *     code changes.
+ * The durable launch outbox is now the only task launch path. These
+ * helpers still call `orchestrator.startExecution()` so ready tasks are
+ * claimed and written to `task_launch_dispatch`; the LaunchDispatcher
+ * poll loop owns the actual `TaskRunner.executeTask(...)` handoff.
  */
 
 import type { Logger } from '@invoker/contracts';
@@ -38,19 +13,6 @@ import type { TaskRunner } from '@invoker/execution-engine';
 import { createExecutionBench } from '@invoker/execution-engine';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 
-export type LaunchOutboxMode = 'disabled' | 'observe' | 'active';
-
-/**
- * Resolve the launch-outbox mode for a dispatch call. Explicit
- * arguments take precedence over the process-wide env-var fallback so
- * tests can run multiple modes in the same process; the env var is the
- * production wiring (see `resolveLaunchOutboxMode` in config.ts).
- */
-function resolveLaunchOutboxMode(explicit?: LaunchOutboxMode): LaunchOutboxMode {
-  if (explicit) return explicit;
-  const raw = (process.env.INVOKER_LAUNCH_OUTBOX ?? '').toLowerCase().trim();
-  return raw === 'active' || raw === 'observe' ? raw : 'disabled';
-}
 
 type GlobalTopupParams = {
   orchestrator: Orchestrator;
@@ -60,16 +22,6 @@ type GlobalTopupParams = {
   alreadyDispatched?: TaskState[];
   mutationTiming?: WorkflowMutationTiming;
   dispatchMode?: 'await' | 'fire-and-forget';
-  /**
-   * When the durable launch-outbox dispatcher is `'active'`, the
-   * in-process `taskExecutor.executeTasks` call becomes a no-op
-   * because the orchestrator's drainScheduler already enqueues into
-   * `task_launch_dispatch` and the LaunchDispatcher polls and
-   * services that queue. We still walk the rest of the top-up
-   * pipeline (logging, bench marks, return shape) so callers see
-   * the same metadata regardless of mode.
-   */
-  launchOutboxMode?: LaunchOutboxMode;
 };
 
 type MutationTopupParams = {
@@ -82,7 +34,6 @@ type MutationTopupParams = {
   scopedTaskIds?: string[];
   mutationTiming?: WorkflowMutationTiming;
   dispatchMode?: 'await' | 'fire-and-forget';
-  launchOutboxMode?: LaunchOutboxMode;
 };
 
 function runningExecutionKey(task: TaskState): string {
@@ -123,75 +74,37 @@ function matchesScope(
 }
 
 function dispatchTasks({
-  taskExecutor,
   logger,
   context,
   runnable,
-  mutationTiming,
   bench,
-  spanName,
   beforeMark,
   afterMark,
-  dispatchMode,
-  launchOutboxMode,
 }: {
-  taskExecutor: TaskRunner;
   logger?: Logger;
   context: string;
   runnable: TaskState[];
-  mutationTiming?: WorkflowMutationTiming;
   bench: (phase: string, metadata?: Record<string, unknown>) => void;
-  spanName: string;
   beforeMark: string;
   afterMark: string;
-  dispatchMode: 'await' | 'fire-and-forget';
-  launchOutboxMode?: LaunchOutboxMode;
 }): Promise<void> {
   bench(beforeMark);
-  const effectiveMode = resolveLaunchOutboxMode(launchOutboxMode);
-  if (effectiveMode === 'active') {
-    // The durable launch outbox is the dispatcher in active mode. The
-    // orchestrator's drainScheduler already enqueued each runnable into
-    // task_launch_dispatch, and the LaunchDispatcher's poll loop calls
-    // taskExecutor.executeTask(task, dispatchOpts). Calling
-    // taskExecutor.executeTasks(runnable) here would race the outbox.
-    logger?.debug?.(
-      `[global-topup] ${context}: launchOutboxMode=active — outbox dispatcher owns launch (skipping in-process executeTasks)`,
-    );
-    bench(`${afterMark}.skippedForOutbox`, { runnableCount: runnable.length });
-    return Promise.resolve();
-  }
-  const run = () => taskExecutor.executeTasks(runnable);
-  if (dispatchMode === 'await') {
-    return mutationTiming
-      ? mutationTiming.span(spanName, { context, runnableCount: runnable.length }, run)
-        .then(() => bench(afterMark))
-      : Promise.resolve().then(run).then(() => bench(afterMark));
-  }
-
-  const dispatchPromise = mutationTiming
-    ? mutationTiming.span(spanName, { context, runnableCount: runnable.length }, run)
-    : Promise.resolve().then(run);
-  void dispatchPromise
-    .then(() => bench(afterMark))
-    .catch((err) => {
-      const message = err instanceof Error ? err.stack ?? err.message : String(err);
-      logger?.error(`[global-topup] ${context}: asynchronous task dispatch failed: ${message}`);
-  });
-  bench(`${afterMark}.accepted`);
+  // The durable launch outbox owns dispatch. The orchestrator has
+  // already enqueued each runnable task into task_launch_dispatch.
+  // Calling taskExecutor.executeTasks(runnable) here would race the
+  // dispatcher.
+  logger?.debug?.(
+    `[global-topup] ${context}: launch outbox owns launch (skipping in-process executeTasks)`,
+  );
+  bench(`${afterMark}.skippedForOutbox`, { runnableCount: runnable.length });
   return Promise.resolve();
 }
 
 function executeRunnableTasks({
-  taskExecutor,
   logger,
   context,
   runnable,
   dispatchKind,
-  mutationTiming,
-  spanName,
-  dispatchMode,
-  launchOutboxMode,
 }: {
   taskExecutor: TaskRunner;
   logger?: Logger;
@@ -201,24 +114,18 @@ function executeRunnableTasks({
   mutationTiming?: WorkflowMutationTiming;
   spanName: string;
   dispatchMode: 'await' | 'fire-and-forget';
-  launchOutboxMode?: LaunchOutboxMode;
 }): Promise<void> {
   const bench = createDispatchBench(logger, context, runnable, dispatchKind);
   const phasePrefix = dispatchKind === 'scoped'
     ? 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks'
     : 'dispatchStartedTasksWithGlobalTopup.prestartedTopupExecuteTasks';
   return dispatchTasks({
-    taskExecutor,
     logger,
     context,
     runnable,
-    mutationTiming,
     bench,
-    spanName,
     beforeMark: `${phasePrefix}.before`,
     afterMark: `${phasePrefix}.after`,
-    dispatchMode,
-    launchOutboxMode,
   });
 }
 
@@ -244,7 +151,6 @@ export async function executeGlobalTopup({
   alreadyDispatched = [],
   mutationTiming,
   dispatchMode = mutationTiming ? 'fire-and-forget' : 'await',
-  launchOutboxMode,
 }: GlobalTopupParams): Promise<TaskState[]> {
   const dedupeKeys = new Set(
     alreadyDispatched
@@ -279,17 +185,12 @@ export async function executeGlobalTopup({
     `[global-topup] ${context}: dispatching ${runnable.length} additional task(s): [${runnable.map((task) => task.id).join(', ')}]`,
   );
   await dispatchTasks({
-    taskExecutor,
     logger,
     context,
     runnable,
-    mutationTiming,
     bench,
-    spanName: 'executeGlobalTopup.taskExecutor.executeTasks',
     beforeMark: 'executeGlobalTopup.taskExecutor.executeTasks.before',
     afterMark: 'executeGlobalTopup.taskExecutor.executeTasks.after',
-    dispatchMode,
-    launchOutboxMode,
   });
   return runnable;
 }
@@ -308,7 +209,6 @@ export async function dispatchStartedTasksWithGlobalTopup({
   scopedTaskIds,
   mutationTiming,
   dispatchMode = mutationTiming ? 'fire-and-forget' : 'await',
-  launchOutboxMode,
 }: MutationTopupParams): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
   const dispatchable = started.filter(isDispatchableLaunch);
   const scopedTaskIdSet = new Set(scopedTaskIds ?? []);
@@ -334,7 +234,6 @@ export async function dispatchStartedTasksWithGlobalTopup({
       mutationTiming,
       spanName: 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks',
       dispatchMode,
-      launchOutboxMode,
     });
   } else {
     bench('dispatchStartedTasksWithGlobalTopup.noScopedRunnable');
@@ -352,7 +251,6 @@ export async function dispatchStartedTasksWithGlobalTopup({
       mutationTiming,
       spanName: 'dispatchStartedTasksWithGlobalTopup.prestartedTopupExecuteTasks',
       dispatchMode,
-      launchOutboxMode,
     });
   }
   bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.before');
@@ -364,7 +262,6 @@ export async function dispatchStartedTasksWithGlobalTopup({
     alreadyDispatched: [...runnable, ...prestartedTopup],
     mutationTiming,
     dispatchMode,
-    launchOutboxMode,
   });
   const topup = [...prestartedTopup, ...additionalTopup];
   bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.after', { topupCount: topup.length });
@@ -386,7 +283,6 @@ export async function finalizeMutationWithGlobalTopup({
   scopedTaskIds,
   mutationTiming,
   dispatchMode,
-  launchOutboxMode,
 }: MutationTopupParams): Promise<{ started: TaskState[]; topup: TaskState[] }> {
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator,
@@ -398,7 +294,6 @@ export async function finalizeMutationWithGlobalTopup({
     scopedTaskIds,
     mutationTiming,
     dispatchMode,
-    launchOutboxMode,
   });
   return { started, topup };
 }

--- a/packages/app/src/headless-standalone-launch-dispatcher.ts
+++ b/packages/app/src/headless-standalone-launch-dispatcher.ts
@@ -15,9 +15,8 @@ interface StandaloneLaunchDispatcherOptions {
 
 export function startStandaloneLaunchDispatcher(
   options: StandaloneLaunchDispatcherOptions,
-): StandaloneLaunchDispatcherController | null {
+): StandaloneLaunchDispatcherController {
   const { headlessDeps, ownerId, createTaskExecutor, setLatestTaskExecutor } = options;
-  if (headlessDeps.invokerConfig.launchOutboxMode !== 'active') return null;
 
   const originalProvider = headlessDeps.ownerTaskRunnerProvider;
   headlessDeps.ownerTaskRunnerProvider = undefined;
@@ -43,7 +42,6 @@ export function startStandaloneLaunchDispatcher(
     taskRunnerProvider: () => executor,
     ownerId,
     logger: headlessDeps.logger,
-    mode: 'active',
   });
 
   const poll = (): void => {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -156,7 +156,6 @@ function buildHeadlessApiServerDeps(
       persistence: deps.persistence,
       taskExecutor,
       dispatchMode: deps.mutationTiming ? 'fire-and-forget' : 'await',
-      launchOutboxMode: deps.invokerConfig.launchOutboxMode,
       autoApproveAIFixes: deps.invokerConfig?.autoApproveAIFixes,
       killRunningTask: (taskId: string) => taskExecutor.killActiveExecution(taskId),
       commandService: deps.commandService,
@@ -213,31 +212,15 @@ export function createHeadlessExecutor(
   deps: HeadlessDeps,
   callbackOverrides?: Partial<ConstructorParameters<typeof TaskRunner>[0]['callbacks']>,
 ): TaskRunner {
-  // CB.7: in active launch-outbox mode the owner's long-lived
-  // TaskRunner is the single launch path (it services the
-  // task_launch_dispatch outbox via LaunchDispatcher). Reusing it
-  // eliminates the multi-TaskRunner blindness from Issue 6 — every
-  // headless command shares the same launchingAttemptIds Set so
-  // duplicate-suppression and dispatch-row ack/complete/fail accounting
-  // all stay coherent. callbackOverrides are intentionally ignored on
-  // this path because the owner's TaskRunner already has its own
-  // production callbacks (persistence writes, renderer deltas, etc.);
-  // per-command callbacks would either duplicate that work or fight it.
-  if (deps.invokerConfig.launchOutboxMode === 'active') {
-    const owner = deps.ownerTaskRunnerProvider?.() ?? null;
-    if (owner) {
-      if (callbackOverrides) {
-        deps.logger?.debug?.(
-          '[headless] createHeadlessExecutor: ignoring callbackOverrides — launchOutboxMode=active reuses owner TaskRunner',
-          { module: 'headless' },
-        );
-      }
-      return owner;
+  const owner = deps.ownerTaskRunnerProvider?.() ?? null;
+  if (owner) {
+    if (callbackOverrides) {
+      deps.logger?.debug?.(
+        '[headless] createHeadlessExecutor: ignoring callbackOverrides — reusing owner TaskRunner',
+        { module: 'headless' },
+      );
     }
-    deps.logger?.warn?.(
-      '[headless] createHeadlessExecutor: launchOutboxMode=active but ownerTaskRunnerProvider is unavailable — falling back to per-command TaskRunner',
-      { module: 'headless' },
-    );
+    return owner;
   }
   let executor: TaskRunner;
   executor = new TaskRunner({
@@ -293,10 +276,6 @@ async function dispatchHeadlessRunnableTasks(
   context: string,
 ): Promise<void> {
   if (runnable.length === 0) return;
-  if (deps.invokerConfig.launchOutboxMode !== 'active') {
-    await taskExecutor.executeTasks(runnable);
-    return;
-  }
 
   const dispatcher = new LaunchDispatcher({
     persistence: deps.persistence,
@@ -310,10 +289,9 @@ async function dispatchHeadlessRunnableTasks(
     taskRunnerProvider: () => taskExecutor,
     ownerId: `headless-${process.pid}`,
     logger: deps.logger,
-    mode: 'active',
   });
   deps.logger?.debug?.(
-    `[headless] ${context}: launchOutboxMode=active — polling local launch dispatcher for ${runnable.length} runnable task(s)`,
+    `[headless] ${context}: polling local launch dispatcher for ${runnable.length} runnable task(s)`,
     { module: 'headless' },
   );
   const poll = (): void => {

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -1,28 +1,20 @@
 /**
- * Phase A observer for the launch-handoff outbox.
+ * Active dispatcher for the launch-handoff outbox.
  *
- * In observer mode the dispatcher does not own dispatch. It only reads
- * `task_launch_dispatch` rows and logs an aggregate count by state so we
- * have production data on outbox build-up before the active dispatcher
- * (CB.5) takes over.
- *
- * See:
- * - `docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md`
- *   (the architecture target)
- * - `docs/incidents/2026-05-22-launch-handoff-orphan-architecture.md`
- *   (the investigation that motivated the rewrite)
+ * `drainScheduler` writes ready task attempts into
+ * `task_launch_dispatch`; this dispatcher leases those rows and hands
+ * them to the TaskRunner. Durable rows let a later poll recover from
+ * process exits or missed in-memory handoffs.
  */
 
-import type { SQLiteAdapter, TaskLaunchDispatch, TaskLaunchDispatchState } from '@invoker/data-store';
+import type { SQLiteAdapter, TaskLaunchDispatch } from '@invoker/data-store';
 import type { LaunchOutboxAck } from '@invoker/execution-engine';
 import type { TaskLaunchReadiness, TaskState } from '@invoker/workflow-core';
 import { DISPATCH_MAX_ATTEMPTS, type Logger } from '@invoker/contracts';
 
-export type LaunchDispatcherMode = 'observe' | 'active';
 
 export type LaunchDispatcherPersistence = Pick<
   SQLiteAdapter,
-  | 'listLaunchDispatchesByState'
   | 'markLaunchDispatchCompleted'
   | 'markLaunchDispatchFailed'
   | 'markLaunchDispatchAbandoned'
@@ -74,15 +66,10 @@ export interface LaunchDispatcherOptions {
   taskRunnerProvider?: () => LaunchDispatcherTaskRunner | null;
   ownerId: string;
   logger?: Logger;
-  mode: LaunchDispatcherMode;
   maxAttempts?: number;
   maxLeasesPerPoll?: number;
 }
 
-const OBSERVED_STATES: readonly TaskLaunchDispatchState[] = [
-  'enqueued',
-  'leased',
-];
 
 export class LaunchDispatcher {
   private readonly persistence: LaunchDispatcherPersistence;
@@ -90,7 +77,6 @@ export class LaunchDispatcher {
   private readonly taskRunnerProvider?: () => LaunchDispatcherTaskRunner | null;
   private readonly ownerId: string;
   private readonly logger?: Logger;
-  private readonly mode: LaunchDispatcherMode;
   private readonly maxAttempts: number;
   private readonly maxLeasesPerPoll: number;
 
@@ -100,16 +86,12 @@ export class LaunchDispatcher {
     this.taskRunnerProvider = options.taskRunnerProvider;
     this.ownerId = options.ownerId;
     this.logger = options.logger;
-    this.mode = options.mode;
     this.maxAttempts = options.maxAttempts ?? DISPATCH_MAX_ATTEMPTS;
     // Bound a single poll's work so the dispatcher cannot starve other
     // owner-loop ticks; the leftover rows are picked up on the next tick.
     this.maxLeasesPerPoll = options.maxLeasesPerPoll ?? 32;
   }
 
-  getMode(): LaunchDispatcherMode {
-    return this.mode;
-  }
 
   getOwnerId(): string {
     return this.ownerId;
@@ -118,51 +100,27 @@ export class LaunchDispatcher {
   /**
    * Single dispatcher tick:
    *
-   *   1. Reap any leased rows whose dispatch lease expired (TaskRunner
-   *      never completed startup — we want to try again).
-   *   2. Abandon any leased rows whose dispatch lease expired AND that
-   *      have exhausted their retry budget (TaskRunner accepted ownership
-   *      but never completed; report the failure and let the orchestrator
-   *      prepare a fresh attempt).
-   *   3. In observe mode, log the aggregate state counts. In active mode,
-   *      (CB.5) lease and dispatch new work.
-   *
-   * Steps 1 and 2 run in BOTH observer and active modes. They only mutate
-   * already-stuck rows, so they are safe under observer mode — the goal
-   * is to surface the orphan condition with concrete events rather than
-   * letting it accumulate silently.
+   *   1. Reap any leased rows whose dispatch lease expired.
+   *   2. Abandon expired rows that exhausted their retry budget.
+   *   3. Lease and dispatch enqueued rows.
    */
   poll(): void {
     this.reapExpiredLeases();
     this.abandonStuckLeases();
-
-    if (this.mode === 'observe') {
-      const rows = this.persistence.listLaunchDispatchesByState(OBSERVED_STATES);
-      const counts = countByState(rows);
-      this.logger?.info?.('[launch-dispatcher] observed', {
-        ownerId: this.ownerId,
-        mode: this.mode,
-        counts,
-        total: rows.length,
-        module: 'launch-dispatcher',
-      });
-      return;
-    }
     this.dispatchActive();
   }
 
   /**
-   * Active-mode dispatch loop. Lease enqueued rows up to the per-poll
-   * batch bound and hand each one to the
-   * TaskRunner. The TaskRunner complete/fail flow drives the rest of
-   * the lifecycle; if the JS promise drops mid-flight, the durable outbox
-   * row stays leased until the fixed dispatch crash-recovery TTL expires,
-   * then the next poll's `reapExpiredLeases` reclaims it.
+   * Lease enqueued rows up to the per-poll batch bound and hand each
+   * one to the TaskRunner. The TaskRunner complete/fail flow drives the
+   * rest of the lifecycle; if the JS promise drops mid-flight, the
+   * durable outbox row stays leased until the fixed dispatch
+   * crash-recovery TTL expires, then the next poll reclaims it.
    */
   private dispatchActive(): void {
     const runner = this.taskRunnerProvider?.() ?? null;
     if (!runner) {
-      this.logger?.warn?.('[launch-dispatcher] active mode without taskRunner — skipping dispatch', {
+      this.logger?.warn?.('[launch-dispatcher] without taskRunner — skipping dispatch', {
         ownerId: this.ownerId,
         module: 'launch-dispatcher',
       });
@@ -480,17 +438,3 @@ export class LaunchDispatcher {
   }
 }
 
-function countByState(
-  rows: readonly TaskLaunchDispatch[],
-): Record<TaskLaunchDispatchState, number> {
-  const counts: Record<TaskLaunchDispatchState, number> = {
-    enqueued: 0,
-    leased: 0,
-    completed: 0,
-    abandoned: 0,
-  };
-  for (const row of rows) {
-    counts[row.state] += 1;
-  }
-  return counts;
-}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -181,7 +181,7 @@ import {
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
-import { LaunchDispatcher, type LaunchDispatcherMode } from './launch-dispatcher.js';
+import { LaunchDispatcher } from './launch-dispatcher.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
 import {
   dispatchStartedTasksWithGlobalTopup,
@@ -189,7 +189,6 @@ import {
   finalizeMutationWithGlobalTopup,
   isDispatchableLaunch,
 } from './global-topup.js';
-import { computeDeferredLaunchTiming } from './deferred-runnable.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { evaluateExecutingStall } from './executing-stall.js';
 import { listOpenFixIntentsForTask } from './auto-fix-intents.js';
@@ -677,7 +676,6 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     defaultPoolId: invokerConfig.defaultPoolId,
     availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
     deferRunningUntilLaunch: true,
-    launchOutboxMode: invokerConfig.launchOutboxMode,
   });
   commandService = new CommandService(
     orchestrator,
@@ -817,9 +815,6 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
       }
       case 'select_experiment': {
         const started = orchestrator.selectExperiment(command.taskId, command.experimentId);
-        if (invokerConfig.launchOutboxMode !== 'active') {
-          await deps.executor.executeTasks(started);
-        }
         break;
       }
       case 'provide_input':
@@ -838,9 +833,6 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
         orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
         const started = orchestrator.startExecution();
         deps.logFn('trace', 'info', `slackBot: startExecution returned ${started.length} tasks: [${started.map((t: any) => t.id).join(', ')}]`);
-        if (invokerConfig.launchOutboxMode !== 'active') {
-          await deps.executor.executeTasks(started);
-        }
         break;
       }
     }
@@ -1023,7 +1015,6 @@ if (isHeadless) {
       const executeStandaloneHeadlessRun = async (payload: HeadlessRunMutationPayload): Promise<unknown> => {
         const { parsePlanFile } = await import('./plan-parser.js');
         const plan = await parsePlanFile(payload.planPath);
-        const executor = createStandaloneTaskExecutor();
         backupPlan(plan, undefined, logger);
         const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
         orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
@@ -1032,26 +1023,16 @@ if (isHeadless) {
           throw new Error(`Failed to resolve workflow id for delegated plan: ${payload.planPath}`);
         }
         const started = orchestrator.startExecution();
-        await executor.executeTasks(started);
         logger.info(`standalone started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
         const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
         return { workflowId, tasks };
       };
 
-      const executeStandaloneResumeStartedTasks = async (
-        executor: ReturnType<typeof createStandaloneTaskExecutor>,
-        started: TaskState[],
-      ): Promise<void> => {
-        if (invokerConfig.launchOutboxMode !== 'active') {
-          await executor.executeTasks(started);
-        }
-      };
 
       const executeStandaloneHeadlessResume = async (payload: HeadlessResumeMutationPayload): Promise<unknown> => {
         const { workflowId } = payload;
-        const executor = createStandaloneTaskExecutor();
         const started = orchestrator.resumeWorkflow(workflowId);
-        await executeStandaloneResumeStartedTasks(executor, started);
+        void started;
         logger.info(`standalone resumed ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
         const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
         return { workflowId, tasks };
@@ -1073,7 +1054,6 @@ if (isHeadless) {
               defaultPoolId: invokerConfig.defaultPoolId,
               availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
               deferRunningUntilLaunch: true,
-              launchOutboxMode: invokerConfig.launchOutboxMode,
             });
             commandService = new CommandService(
               orchestrator,
@@ -1094,12 +1074,8 @@ if (isHeadless) {
             orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
             return undefined;
           }
-          case 'invoker:start': {
-            const executor = createStandaloneTaskExecutor();
-            const started = orchestrator.startExecution();
-            await executor.executeTasks(started);
-            return started;
-          }
+          case 'invoker:start':
+            return orchestrator.startExecution();
           case 'invoker:stop': {
             logger.info('stop — destroying all daemon executors', { module: 'ipc-delegate' });
             const failInFlightTasks = (): void => {
@@ -1159,11 +1135,6 @@ if (isHeadless) {
             const envelope = makeEnvelope('replace-task', 'ui', 'task', { taskId, replacementTasks });
             const result = await commandService.replaceTask(envelope);
             if (!result.ok) throw new Error(result.error.message);
-            const runnable = result.data.filter(isDispatchableLaunch);
-            if (runnable.length > 0) {
-              const executor = createStandaloneTaskExecutor();
-              await executor.executeTasks(runnable);
-            }
             return result.data;
           }
           case 'invoker:check-pr-statuses': {
@@ -1189,12 +1160,9 @@ if (isHeadless) {
               const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId, experimentId: ids[0] });
               const result = await commandService.selectExperiment(envelope);
               if (!result.ok) throw new Error(result.error.message);
-              const runnable = result.data.filter(isDispatchableLaunch);
-              if (runnable.length > 0) await executor.executeTasks(runnable);
               return undefined;
             }
-            const newlyStarted = await sharedSelectExperiments(taskId, ids, { orchestrator, taskExecutor: executor });
-            await executor.executeTasks(newlyStarted);
+            await sharedSelectExperiments(taskId, ids, { orchestrator, taskExecutor: executor });
             return undefined;
           }
           case 'invoker:set-task-external-gate-policies': {
@@ -1203,11 +1171,6 @@ if (isHeadless) {
             const envelope = makeEnvelope('set-gate-policies', 'ui', 'task', { taskId, updates });
             const result = await commandService.setTaskExternalGatePolicies(envelope);
             if (!result.ok) throw new Error(result.error.message);
-            const runnable = result.data.filter(isDispatchableLaunch);
-            if (runnable.length > 0) {
-              const executor = createStandaloneTaskExecutor();
-              await executor.executeTasks(runnable);
-            }
             return undefined;
           }
           default:
@@ -1553,35 +1516,19 @@ if (isHeadless) {
           orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
           const workflowId = orchestrator.getWorkflowIds().find(id => !wfIdsBefore.has(id))!;
           const started = orchestrator.startExecution();
-          createStandaloneTaskExecutor().executeTasks(started).catch(err => {
-            logger.error(`headless.run: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
-          });
           startStandaloneAutoFixRecoveryPoll(workflowId);
           logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
           const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
           return { workflowId, tasks };
         };
 
-        const executeStandaloneResumeStartedTasks = (
-          executor: ReturnType<typeof createStandaloneTaskExecutor>,
-          started: TaskState[],
-          workflowId: string,
-        ): void => {
-          if (started.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
-            executor.executeTasks(started).catch(err => {
-              logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
-            });
-          }
-        };
 
         const executeStandaloneHeadlessResume = async (
           payload: HeadlessResumeMutationPayload,
         ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
           const { workflowId } = payload;
-          const executor = createStandaloneTaskExecutor();
 
           const allStarted = orchestrator.resumeWorkflow(workflowId);
-          executeStandaloneResumeStartedTasks(executor, allStarted, workflowId);
           const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
           return { workflowId, tasks };
         };
@@ -2346,16 +2293,6 @@ function createEmbeddedTerminalBackendFromConfig(
     return requireWiredTaskRunner(() => taskExecutor);
   }
 
-  function executeHeadlessResumeStartedTasks(
-    started: TaskState[],
-    workflowId: string,
-  ): void {
-    if (started.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
-      requireTaskExecutor().executeTasks(started).catch(err => {
-        logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
-      });
-    }
-  }
 
   async function executeHeadlessRun(payload: HeadlessRunMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
     const { parsePlanFile } = await import('./plan-parser.js');
@@ -2366,11 +2303,6 @@ function createEmbeddedTerminalBackendFromConfig(
     orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
     const workflowId = orchestrator.getWorkflowIds().find(id => !wfIdsBefore.has(id))!;
     const started = orchestrator.startExecution();
-    if (invokerConfig.launchOutboxMode !== 'active') {
-      requireTaskExecutor().executeTasks(started).catch(err => {
-        logger.error(`headless.run: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
-      });
-    }
     logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
     const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
     return { workflowId, tasks };
@@ -2380,7 +2312,6 @@ function createEmbeddedTerminalBackendFromConfig(
     const { workflowId } = payload;
 
     const allStarted = orchestrator.resumeWorkflow(workflowId);
-    executeHeadlessResumeStartedTasks(allStarted, workflowId);
     const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
     return { workflowId, tasks };
   }
@@ -2425,73 +2356,11 @@ function createEmbeddedTerminalBackendFromConfig(
         if (filteredTasks.length === 0) {
           return;
         }
-        if (invokerConfig.launchOutboxMode === 'active') {
-          logger.info(
-            `deferRunnableTasks accepted by launch outbox workflow="${workflowId ?? 'unknown'}" count=${filteredTasks.length}`,
-            { module: 'ipc-delegate' },
-          );
-          return;
-        }
-        // Keep this path timer-based for now: it is a low-blast-radius, mutation-safe
-        // way to decouple no-track command handling from heavy executor startup while
-        // still coalescing rapid restarts. We are considering an RxJS/backpressure
-        // scheduler refactor for richer queue semantics, but that is a broader design
-        // change than this targeted starvation fix.
-        const deferDelayMs = Number.parseInt(process.env.INVOKER_DEFER_RUNNABLE_DELAY_MS ?? '25', 10) || 25;
-        const maxCoalesceMs = Number.parseInt(
-          process.env.INVOKER_DEFER_RUNNABLE_MAX_COALESCE_MS ?? String(Math.max(1000, deferDelayMs)),
-          10,
-        ) || Math.max(1000, deferDelayMs);
-        const launchKey = workflowId ?? filteredTasks.map((task) => task.id).sort().join('|');
-        const existingLaunch = deferredWorkflowLaunches.get(launchKey);
-        const nowMs = Date.now();
-        const timing = computeDeferredLaunchTiming({
-          existingFirstScheduledAtMs: existingLaunch?.firstScheduledAtMs,
-          nowMs,
-          deferDelayMs,
-          maxCoalesceMs,
-        });
-        if (existingLaunch) {
-          clearTimeout(existingLaunch.timer);
-          logger.info(
-            `deferRunnableTasks coalesce workflow="${workflowId ?? 'unknown'}" previousCount=${existingLaunch.taskIds.length} nextCount=${filteredTasks.length} delayMs=${timing.delayMs} maxCoalesceMs=${maxCoalesceMs}`,
-            { module: 'ipc-delegate' },
-          );
-        }
         logger.info(
-          `deferRunnableTasks schedule workflow="${workflowId ?? 'unknown'}" count=${filteredTasks.length} delayMs=${timing.delayMs} ids=${filteredTasks.map((task) => task.id).join(',')}`,
+          `deferRunnableTasks accepted by launch outbox workflow="${workflowId ?? 'unknown'}" count=${filteredTasks.length}`,
           { module: 'ipc-delegate' },
         );
-        const launch = setTimeout(() => {
-          deferredWorkflowLaunches.delete(launchKey);
-          logger.info(
-            `deferRunnableTasks start workflow="${workflowId ?? 'unknown'}" count=${filteredTasks.length}`,
-            { module: 'ipc-delegate' },
-          );
-          remoteFetchForPool.enabled = false;
-          void requireTaskExecutor().executeTasks(filteredTasks)
-            .then(() => {
-              logger.info(
-                `deferRunnableTasks complete workflow="${workflowId ?? 'unknown'}" count=${filteredTasks.length}`,
-                { module: 'ipc-delegate' },
-              );
-            })
-            .catch((err) => {
-              logger.error(
-                `background delegated workflow execution failed for ${workflowId ?? filteredTasks.map((t) => t.id).join(', ')}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-                { module: 'ipc-delegate' },
-              );
-            })
-            .finally(() => {
-              remoteFetchForPool.enabled = true;
-            });
-        }, timing.delayMs);
-        launch.unref?.();
-        deferredWorkflowLaunches.set(launchKey, {
-          timer: launch,
-          taskIds: filteredTasks.map((task) => task.id),
-          firstScheduledAtMs: timing.firstScheduledAtMs,
-        });
+        return;
       },
       executionAgentRegistry: registerBuiltinAgents(),
     });
@@ -2922,7 +2791,6 @@ function createEmbeddedTerminalBackendFromConfig(
           commandService,
           taskExecutor: requireTaskExecutor(),
           autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
-          launchOutboxMode: invokerConfig.launchOutboxMode,
           killRunningTask,
         }),
         queueWorkflowMutation: (workflowId, priority, channel, args, options) => {
@@ -3035,21 +2903,7 @@ function createEmbeddedTerminalBackendFromConfig(
                       },
                     };
                     logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
-                    const startedAfterFailure = orchestrator.handleWorkerResponse(failedResponse);
-                    const runnableAfterFailure = startedAfterFailure.filter(isDispatchableLaunch);
-                    if (runnableAfterFailure.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
-                      logger.info(
-                        `[executing-stall] dispatching ${runnableAfterFailure.length} task(s) started after failing "${task.id}"`,
-                        { module: 'db-poll' },
-                      );
-                      void requireTaskExecutor().executeTasks(runnableAfterFailure).catch((err) => {
-                        logger.error(
-                          `[executing-stall] executeTasks failed after failing "${task.id}": ` +
-                            `${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-                          { module: 'db-poll' },
-                        );
-                      });
-                    }
+                    orchestrator.handleWorkerResponse(failedResponse);
                     continue;
                   }
                 }
@@ -3187,19 +3041,16 @@ function createEmbeddedTerminalBackendFromConfig(
         },
         { logger },
       );
-      if (invokerConfig.launchOutboxMode && invokerConfig.launchOutboxMode !== 'disabled') {
-        launchDispatcher = new LaunchDispatcher({
-          persistence,
-          orchestrator,
-          // taskExecutor is re-built by rebuildTaskRunner(); read via
-          // a provider so the dispatcher always picks up the current
-          // instance instead of capturing a stale reference.
-          taskRunnerProvider: () => taskExecutor,
-          ownerId: workflowMutationOwnerId,
-          logger,
-          mode: invokerConfig.launchOutboxMode as LaunchDispatcherMode,
-        });
-      }
+      launchDispatcher = new LaunchDispatcher({
+        persistence,
+        orchestrator,
+        // taskExecutor is re-built by rebuildTaskRunner(); read via
+        // a provider so the dispatcher always picks up the current
+        // instance instead of capturing a stale reference.
+        taskRunnerProvider: () => taskExecutor,
+        ownerId: workflowMutationOwnerId,
+        logger,
+      });
     } else {
       logger.info('Launched in follower mode; mutation execution is delegated to the current owner', {
         module: 'init',
@@ -3370,10 +3221,7 @@ function createEmbeddedTerminalBackendFromConfig(
     } else if (invokerConfig.disableAutoRunOnStartup) {
       logger.info('auto-run on startup disabled by config', { module: 'init' });
     } else {
-      const allStarted = orchestrator.startExecution();
-      if (allStarted.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
-        requireTaskExecutor().executeTasks(allStarted);
-      }
+      orchestrator.startExecution();
     }
 
     const dbPath = path.join(resolveInvokerHomeRoot(), 'invoker.db');
@@ -3499,9 +3347,6 @@ function createEmbeddedTerminalBackendFromConfig(
       logger.info('start', { module: 'ipc' });
       const started = orchestrator.startExecution();
       logger.info(`startExecution returned ${started.length} tasks: [${started.map(t => t.id).join(', ')}]`, { module: 'ipc' });
-      if (invokerConfig.launchOutboxMode !== 'active') {
-        await requireTaskExecutor().executeTasks(started);
-      }
       return started;
     });
 
@@ -3527,10 +3372,7 @@ function createEmbeddedTerminalBackendFromConfig(
         }
       }
       logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
-      if (allStarted.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
-        void requireTaskExecutor().executeTasks(allStarted);
-      }
-      if (allStarted.length > 0 && invokerConfig.launchOutboxMode === 'active' && launchDispatcher) {
+      if (allStarted.length > 0 && launchDispatcher) {
         try {
           launchDispatcher.poll();
         } catch (err) {
@@ -3581,7 +3423,6 @@ function createEmbeddedTerminalBackendFromConfig(
         defaultPoolId: invokerConfig.defaultPoolId,
         availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
         deferRunningUntilLaunch: true,
-        launchOutboxMode: invokerConfig.launchOutboxMode,
       });
       commandService = new CommandService(
         orchestrator,
@@ -3744,7 +3585,6 @@ function createEmbeddedTerminalBackendFromConfig(
         started,
         mutationTiming: activeMutationContext?.mutationTiming,
         scopedTaskIds: [taskId],
-        launchOutboxMode: invokerConfig.launchOutboxMode,
       });
       },
     );
@@ -3768,16 +3608,9 @@ function createEmbeddedTerminalBackendFromConfig(
           const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId, experimentId: ids[0] });
           const result = await commandService.selectExperiment(envelope);
           if (!result.ok) throw new Error(result.error.message);
-          const runnable = result.data.filter(isDispatchableLaunch);
-          if (invokerConfig.launchOutboxMode !== 'active') {
-            await requireTaskExecutor().executeTasks(runnable);
-          }
         } else {
           // Multi-select: needs taskExecutor for branch merge, stays in workflow-actions
-          const newlyStarted = await sharedSelectExperiments(taskId, ids, { orchestrator, taskExecutor: requireTaskExecutor() });
-          if (invokerConfig.launchOutboxMode !== 'active') {
-            await requireTaskExecutor().executeTasks(newlyStarted);
-          }
+          await sharedSelectExperiments(taskId, ids, { orchestrator, taskExecutor: requireTaskExecutor() });
         }
       } catch (err) {
         logger.error(`select-experiment failed: ${err}`, { module: 'ipc' });
@@ -3822,7 +3655,6 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.restart-task',
           started,
           scopedTaskIds: [taskId],
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`restart-task failed: ${err}`, { module: 'ipc' });
@@ -3846,7 +3678,6 @@ function createEmbeddedTerminalBackendFromConfig(
           logger,
           context: 'ipc.cancel-task',
           mutationTiming: activeMutationContext?.mutationTiming,
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
         return result;
       } catch (err) {
@@ -3876,7 +3707,6 @@ function createEmbeddedTerminalBackendFromConfig(
           logger,
           context: 'ipc.cancel-workflow',
           mutationTiming: activeMutationContext?.mutationTiming,
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
         return result;
       } catch (err) {
@@ -4000,7 +3830,6 @@ function createEmbeddedTerminalBackendFromConfig(
             started,
             scopedWorkflowId: workflowId,
             mutationTiming: activeMutationContext?.mutationTiming,
-            launchOutboxMode: invokerConfig.launchOutboxMode,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -4049,7 +3878,6 @@ function createEmbeddedTerminalBackendFromConfig(
             started,
             scopedTaskIds: [taskId],
             mutationTiming: activeMutationContext?.mutationTiming,
-            launchOutboxMode: invokerConfig.launchOutboxMode,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -4098,7 +3926,6 @@ function createEmbeddedTerminalBackendFromConfig(
             started,
             scopedTaskIds: [taskId],
             mutationTiming: activeMutationContext?.mutationTiming,
-            launchOutboxMode: invokerConfig.launchOutboxMode,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -4144,7 +3971,6 @@ function createEmbeddedTerminalBackendFromConfig(
             started: result.data,
             scopedWorkflowId: workflowId,
             mutationTiming: activeMutationContext?.mutationTiming,
-            launchOutboxMode: invokerConfig.launchOutboxMode,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -4189,7 +4015,6 @@ function createEmbeddedTerminalBackendFromConfig(
           started,
           scopedWorkflowId: workflowId,
           mutationTiming: activeMutationContext?.mutationTiming,
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`rebase-retry failed: ${err}`, { module: 'ipc' });
@@ -4232,7 +4057,6 @@ function createEmbeddedTerminalBackendFromConfig(
           started,
           scopedWorkflowId: workflowId,
           mutationTiming: activeMutationContext?.mutationTiming,
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`rebase-recreate failed: ${err}`, { module: 'ipc' });
@@ -4259,7 +4083,6 @@ function createEmbeddedTerminalBackendFromConfig(
             context: 'ipc.set-merge-branch',
             started,
             scopedTaskIds: [mergeTask.id],
-            launchOutboxMode: invokerConfig.launchOutboxMode,
           });
         }
       } catch (err) {
@@ -4306,7 +4129,6 @@ function createEmbeddedTerminalBackendFromConfig(
           started,
           mutationTiming: activeMutationContext?.mutationTiming,
           scopedWorkflowId: workflowId,
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`approve-merge failed: ${err}`, { module: 'ipc' });
@@ -4356,7 +4178,6 @@ function createEmbeddedTerminalBackendFromConfig(
           started: result.started,
           mutationTiming: activeMutationContext?.mutationTiming,
           scopedTaskIds: [taskId],
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         if (err instanceof StaleLineageError) {
@@ -4369,7 +4190,6 @@ function createEmbeddedTerminalBackendFromConfig(
           logger,
           context: 'ipc.resolve-conflict.failure',
           mutationTiming: activeMutationContext?.mutationTiming,
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
         logger.error(`resolve-conflict failed: ${err}`, { module: 'ipc' });
         throw err;
@@ -4394,7 +4214,6 @@ function createEmbeddedTerminalBackendFromConfig(
           started,
           mutationTiming: activeMutationContext?.mutationTiming,
           scopedTaskIds: [taskId],
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         if (err instanceof StaleLineageError) {
@@ -4407,7 +4226,6 @@ function createEmbeddedTerminalBackendFromConfig(
           logger,
           context: 'ipc.fix-with-agent.failure',
           mutationTiming: activeMutationContext?.mutationTiming,
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
         logger.error(`fix-with-agent failed: ${err}`, { module: 'ipc' });
         throw err;
@@ -4430,7 +4248,6 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.edit-task-command',
           started: result.data,
           scopedTaskIds: [taskId],
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`edit-task-command failed: ${err}`, { module: 'ipc' });
@@ -4453,7 +4270,6 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.edit-task-prompt',
           started: result.data,
           scopedTaskIds: [taskId],
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`edit-task-prompt failed: ${err}`, { module: 'ipc' });
@@ -4477,7 +4293,6 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.edit-task-type',
           started: result.data,
           scopedTaskIds: [taskId],
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`edit-task-type failed: ${err}`, { module: 'ipc' });
@@ -4500,7 +4315,6 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.edit-task-pool',
           started: result.data,
           scopedTaskIds: [taskId],
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`edit-task-pool failed: ${err}`, { module: 'ipc' });
@@ -4523,7 +4337,6 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.edit-task-agent',
           started: result.data,
           scopedTaskIds: [taskId],
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`edit-task-agent failed: ${err}`, { module: 'ipc' });
@@ -4548,7 +4361,6 @@ function createEmbeddedTerminalBackendFromConfig(
             context: 'ipc.set-task-external-gate-policies',
             started: result.data,
             scopedTaskIds: [taskId],
-            launchOutboxMode: invokerConfig.launchOutboxMode,
           });
         } catch (err) {
           logger.error(`set-task-external-gate-policies failed: ${err}`, { module: 'ipc' });
@@ -4606,7 +4418,6 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.replace-task',
           started: result.data,
           scopedTaskIds: [taskId, ...result.data.map((task) => task.id)],
-          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
         return result.data;
       } catch (err) {

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -56,7 +56,6 @@ import {
   dispatchStartedTasksWithGlobalTopup,
   executeGlobalTopup,
   isDispatchableLaunch,
-  type LaunchOutboxMode,
 } from './global-topup.js';
 import {
   setTaskMetadata as sharedSetTaskMetadata,
@@ -115,7 +114,6 @@ export interface WorkflowMutationFacadeDeps {
   commandService?: CommandService;
   taskExecutor: TaskRunner;
   dispatchMode?: 'await' | 'fire-and-forget';
-  launchOutboxMode?: LaunchOutboxMode;
   autoApproveAIFixes?: boolean;
   /** Optional pre-kill hook for active task executions. */
   killRunningTask?: (taskId: string) => Promise<void>;
@@ -379,9 +377,6 @@ export class WorkflowMutationFacade {
       logger: this.deps.logger,
     });
     const runnable = result.started.filter(isDispatchableLaunch);
-    if (this.deps.launchOutboxMode !== 'active') {
-      await this.deps.taskExecutor.executeTasks(runnable);
-    }
     const topup = await this.topupOnly('facade.fork-workflow');
     return {
       forkedWorkflowId: result.forkedWorkflowId,
@@ -501,7 +496,6 @@ export class WorkflowMutationFacade {
       context,
       started,
       dispatchMode: this.deps.dispatchMode,
-      launchOutboxMode: this.deps.launchOutboxMode,
       ...scope,
     });
   }
@@ -557,7 +551,6 @@ export class WorkflowMutationFacade {
       logger: this.deps.logger,
       context,
       dispatchMode: this.deps.dispatchMode,
-      launchOutboxMode: this.deps.launchOutboxMode,
     });
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -454,7 +454,6 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
       executorRoutingRules: runtimeConfig.executorRoutingRules ?? [],
       defaultPoolId: runtimeConfig.defaultPoolId,
       availablePoolIds: Object.keys(runtimeConfig.executionPools ?? {}),
-      launchOutboxMode: 'disabled',
     });
     const taskRunner = new TaskRunner({
       orchestrator,

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -200,7 +200,6 @@ function makeOrchestrator(
   opts: {
     deferRunningUntilLaunch?: boolean;
     maxConcurrency?: number;
-    launchOutboxMode?: 'disabled' | 'observe' | 'active';
     enqueueLaunchDispatchEnabled?: boolean;
   } = {},
 ): { orchestrator: Orchestrator; persistence: InMemoryPersistence } {
@@ -211,7 +210,6 @@ function makeOrchestrator(
     messageBus: new InMemoryBus(),
     maxConcurrency: opts.maxConcurrency ?? 4,
     deferRunningUntilLaunch: opts.deferRunningUntilLaunch,
-    launchOutboxMode: opts.launchOutboxMode,
   });
   return { orchestrator, persistence };
 }
@@ -471,7 +469,6 @@ describe('Orchestrator launch claims', () => {
     const { orchestrator, persistence } = makeOrchestrator({
       deferRunningUntilLaunch: true,
       enqueueLaunchDispatchEnabled: true,
-      launchOutboxMode: 'observe',
       maxConcurrency: 4,
     });
     orchestrator.loadPlan({
@@ -529,7 +526,6 @@ describe('Orchestrator launch claims', () => {
     const { orchestrator, persistence } = makeOrchestrator({
       deferRunningUntilLaunch: true,
       enqueueLaunchDispatchEnabled: true,
-      launchOutboxMode: 'observe',
       maxConcurrency: 4,
     });
     orchestrator.loadPlan({
@@ -586,7 +582,6 @@ describe('Orchestrator launch claims', () => {
     const { orchestrator, persistence } = makeOrchestrator({
       deferRunningUntilLaunch: true,
       enqueueLaunchDispatchEnabled: true,
-      launchOutboxMode: 'observe',
       maxConcurrency: 4,
     });
     orchestrator.loadPlan({
@@ -695,7 +690,7 @@ describe('Orchestrator launch claims', () => {
     expect(started.map((task) => task.id)).toEqual([taskId]);
   });
 
-  describe('launch-outbox observer wiring (Phase A)', () => {
+  describe('launch-outbox wiring', () => {
     function loadPlanForLaunchOutbox(orchestrator: Orchestrator): { taskId: string } {
       orchestrator.loadPlan({
         name: 'launch-outbox-observer',
@@ -705,29 +700,11 @@ describe('Orchestrator launch claims', () => {
       return { taskId: taskIdBySuffix(orchestrator, 't1') };
     }
 
-    it("does not write outbox rows when launchOutboxMode='disabled'", () => {
+
+    it('writes one outbox row per claimed attempt and still emits task.launch_claimed', () => {
       const { orchestrator, persistence } = makeOrchestrator({
         deferRunningUntilLaunch: true,
         enqueueLaunchDispatchEnabled: true,
-        launchOutboxMode: 'disabled',
-      });
-      loadPlanForLaunchOutbox(orchestrator);
-      orchestrator.startExecution();
-
-      expect(persistence.launchDispatchRows).toEqual([]);
-      expect(
-        persistence.events.find((event) => event.eventType === 'task.dispatch_enqueued'),
-      ).toBeUndefined();
-      expect(
-        persistence.events.find((event) => event.eventType === 'task.launch_claimed'),
-      ).toBeDefined();
-    });
-
-    it("writes one outbox row per claimed attempt when launchOutboxMode='observe' and still emits task.launch_claimed", () => {
-      const { orchestrator, persistence } = makeOrchestrator({
-        deferRunningUntilLaunch: true,
-        enqueueLaunchDispatchEnabled: true,
-        launchOutboxMode: 'observe',
         maxConcurrency: 4,
       });
       orchestrator.loadPlan({
@@ -760,26 +737,11 @@ describe('Orchestrator launch claims', () => {
       }
     });
 
-    it("treats launchOutboxMode='active' the same as observe in Phase A (active behavior lands in CB)", () => {
-      const { orchestrator, persistence } = makeOrchestrator({
-        deferRunningUntilLaunch: true,
-        enqueueLaunchDispatchEnabled: true,
-        launchOutboxMode: 'active',
-      });
-      loadPlanForLaunchOutbox(orchestrator);
-      orchestrator.startExecution();
 
-      expect(persistence.launchDispatchRows).toHaveLength(1);
-      expect(
-        persistence.events.find((event) => event.eventType === 'task.dispatch_enqueued'),
-      ).toBeDefined();
-    });
-
-    it("tolerates missing enqueueLaunchDispatch without throwing when launchOutboxMode='observe'", () => {
+    it('tolerates missing enqueueLaunchDispatch without throwing', () => {
       const { orchestrator, persistence } = makeOrchestrator({
         deferRunningUntilLaunch: true,
         enqueueLaunchDispatchEnabled: false,
-        launchOutboxMode: 'observe',
       });
       (persistence as unknown as { enqueueLaunchDispatch?: unknown }).enqueueLaunchDispatch = undefined;
       loadPlanForLaunchOutbox(orchestrator);

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -286,12 +286,8 @@ export interface OrchestratorPersistence {
   /** Delete all workflows and tasks from the DB. */
   deleteAllWorkflows?(): void;
   /**
-   * Optional launch-handoff outbox sink. When provided AND
-   * `OrchestratorConfig.launchOutboxMode` is `'observe'` or `'active'`,
-   * `drainScheduler` writes a `task_launch_dispatch` row alongside the
-   * legacy claim path. The orchestrator does not take a hard dependency
-   * on this method; it is observer-only in Phase A. See
-   * `docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md`.
+   * Optional launch-handoff outbox sink. When provided, `drainScheduler`
+   * writes a durable `task_launch_dispatch` row for each claimed launch.
    */
   enqueueLaunchDispatch?(input: {
     taskId: string;
@@ -568,15 +564,10 @@ export interface OrchestratorConfig {
    */
   deferRunningUntilLaunch?: boolean;
   /**
-   * Launch-handoff outbox mode. When set to `'observe'` or `'active'` (and
-   * the persistence layer implements `enqueueLaunchDispatch`),
-   * `drainScheduler` writes a durable `task_launch_dispatch` row alongside
-   * the existing claim path and emits a `task.dispatch_enqueued` event.
-   *
-   * Default `'disabled'` preserves existing behaviour. See
-   * `docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md`.
+   * When the persistence layer implements `enqueueLaunchDispatch`,
+   * `drainScheduler` writes a durable `task_launch_dispatch` row for each
+   * claimed launch and emits a `task.dispatch_enqueued` event.
    */
-  launchOutboxMode?: 'disabled' | 'observe' | 'active';
 }
 
 // ── Orchestrator ────────────────────────────────────────────
@@ -603,7 +594,6 @@ export class Orchestrator {
   private readonly defaultPoolId: string | undefined;
   private readonly defaultAutoFixRetries: number;
   private readonly deferRunningUntilLaunch: boolean;
-  private readonly launchOutboxMode: 'disabled' | 'observe' | 'active';
 
   private activeWorkflowIds = new Set<string>();
   private deferredTaskIds = new Set<string>();
@@ -676,7 +666,6 @@ export class Orchestrator {
     this.defaultPoolId = config.defaultPoolId;
     this.defaultAutoFixRetries = Math.min(Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0)), 10);
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
-    this.launchOutboxMode = config.launchOutboxMode ?? 'disabled';
 
     this.stateMachine = new TaskStateMachine(new ActionGraph());
     this.responseHandler = new ResponseHandler();
@@ -5111,8 +5100,7 @@ export class Orchestrator {
         changes,
       );
       if (
-        this.launchOutboxMode !== 'disabled'
-        && typeof this.persistence.enqueueLaunchDispatch === 'function'
+        typeof this.persistence.enqueueLaunchDispatch === 'function'
         && task.config.workflowId
       ) {
         try {

--- a/scripts/repro/repro-headless-owner-bootstrap-idle-timeout.sh
+++ b/scripts/repro/repro-headless-owner-bootstrap-idle-timeout.sh
@@ -72,8 +72,7 @@ start_owner() {
 cat > "$TMP_ROOT/config.json" <<'JSON'
 {
   "allowGraphMutation": true,
-  "disableAutoRunOnStartup": true,
-  "launchOutboxMode": "active"
+  "disableAutoRunOnStartup": true
 }
 JSON
 

--- a/scripts/repro/repro-launch-dispatch-readiness-gates.sh
+++ b/scripts/repro/repro-launch-dispatch-readiness-gates.sh
@@ -42,7 +42,7 @@ echo "==> app launch dispatcher readiness gates"
     --reporter verbose \
     --exclude '**/node_modules/**' \
     src/__tests__/launch-dispatcher.test.ts \
-    -t 'active mode abandons a dispatch row when the selected attempt changed after lease|active mode abandons the dispatch when readiness is blocked|active mode abandons the dispatch when the orchestrator has no matching task'
+    -t 'abandons a dispatch row when the selected attempt changed after lease|abandons the dispatch when readiness is blocked|abandons the dispatch when the orchestrator has no matching task'
 )
 
 echo

--- a/scripts/repro/repro-launch-outbox-active-only.sh
+++ b/scripts/repro/repro-launch-outbox-active-only.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] launch outbox active-only cleanup"
+
+echo "[repro] checking the rollout flag and mode plumbing are gone"
+python3 - "$ROOT" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+needles = [
+    "INVOKER_" + "LAUNCH_OUTBOX",
+    "launch" + "OutboxMode",
+    "resolve" + "Launch" + "Outbox" + "Mode",
+    "Launch" + "Outbox" + "Mode",
+]
+paths = [
+    root / "packages" / "app" / "src",
+    root / "packages" / "workflow-core" / "src",
+    root / "packages" / "cli" / "src",
+    root / "scripts" / "repro",
+    root / "docs" / "incidents" / "2026-05-22-launch-handoff-architecture-proposal.md",
+]
+self_name = "repro-launch-outbox-active-only.sh"
+matches = []
+for base in paths:
+    files = [base] if base.is_file() else base.rglob("*")
+    for path in files:
+        if not path.is_file() or path.name == self_name:
+            continue
+        if path.suffix not in {".ts", ".tsx", ".sh", ".md"}:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for needle in needles:
+            if needle in text:
+                matches.append(f"{path.relative_to(root)}: {needle}")
+if matches:
+    raise SystemExit("removed launch-outbox flag still referenced:\n" + "\n".join(matches))
+PY
+
+echo "[repro] running active-only launch tests"
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/config.test.ts \
+  src/__tests__/global-topup.test.ts \
+  src/__tests__/headless-create-executor.test.ts \
+  src/__tests__/launch-dispatcher.test.ts \
+  src/__tests__/launch-claim-orphan-regression.test.ts \
+  src/__tests__/launch-pool-deferral-outbox-repro.test.ts
+pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator-dispatcher.test.ts
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

The launch outbox is now always active.

The old environment flag was a rollout switch. It kept disabled and observe paths alive after the active path became the default.

This removes that switch and deletes the old launch paths. Task starts now always go through the durable dispatch queue.

## Architecture

### Before

```mermaid
flowchart TD
  Config[INVOKER_LAUNCH_OUTBOX] --> Mode{mode}
  Mode --> Disabled[direct TaskRunner launch]
  Mode --> Observe[write rows, direct launch]
  Mode --> Active[LaunchDispatcher owns launch]
```

### After

```mermaid
flowchart TD
  Scheduler[Orchestrator drainScheduler] --> Row[task_launch_dispatch row]
  Row --> Dispatcher[LaunchDispatcher poll]
  Dispatcher --> Runner[owner TaskRunner]
```

## Test Plan

- [x] `pnpm run build` at commit `8efdbc3`
- [x] `scripts/repro/repro-launch-outbox-active-only.sh` at commit `8efdbc3`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 8efdbc353cf1aecefe363fdeb99cea532dd135afc6`
- Post-revert steps: Re-check any local use of the old launch-outbox environment flag.
- Data migration? No
