### PR TITLE
Fix intent cancellation Step 7: post-start generation guard (restacked v3)

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1439,6 +1439,188 @@ describe('TaskRunner', () => {
     });
   });
 
+  describe('post-start lineage guard (generation)', () => {
+    // Builds a runner whose executor.start() RESOLVES with a handle (the
+    // success path), with a mutable live task so the test can advance its
+    // generation while keeping selectedAttemptId fixed.
+    function makePostStartEnv(launchGeneration: number) {
+      const handle = {
+        executionId: 'exec-post-start',
+        taskId: 'gen-task',
+        workspacePath: '/tmp/post-start-ws',
+        branch: 'experiment/post-start-branch',
+        agentSessionId: 'sess-post-start',
+        containerId: 'container-post-start',
+      };
+      let completeCallback: ((response: WorkResponse) => void) | undefined;
+      let resolveStart: (() => void) | undefined;
+      const executor = {
+        type: 'worktree',
+        // Default: resolve immediately. Tests that need to advance the
+        // generation mid-start override `start` before launching.
+        start: vi.fn(async () => handle),
+        startDeferred: () => {
+          executor.start = vi.fn(() => new Promise((res) => {
+            resolveStart = () => res(handle);
+          }));
+        },
+        resolveStart: () => resolveStart?.(),
+        onComplete: vi.fn((_h: any, cb: any) => { completeCallback = cb; }),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn().mockResolvedValue(undefined),
+        destroyAll: vi.fn(),
+      };
+      const liveTask = makeTask({
+        id: 'gen-task',
+        status: 'running',
+        config: { command: 'echo hi', runnerKind: 'worktree' as any },
+        execution: { selectedAttemptId: 'attempt-1', generation: launchGeneration },
+      });
+      const markTaskRunningAfterLaunch = vi.fn(() => true);
+      const handleWorkerResponse = vi.fn(() => []);
+      const orchestrator = {
+        getTask: () => liveTask,
+        getAllTasks: () => [liveTask],
+        markTaskRunningAfterLaunch,
+        handleWorkerResponse,
+      };
+      const updateTask = vi.fn();
+      const updateAttempt = vi.fn();
+      const logEvent = vi.fn();
+      const onSpawned = vi.fn();
+      const runner = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: {
+          updateTask,
+          updateAttempt,
+          logEvent,
+          loadAttempts: () => [],
+          appendTaskOutput: vi.fn(),
+        } as any,
+        executorRegistry: {
+          getDefault: () => executor,
+          get: () => executor,
+          getAll: () => [executor],
+        } as any,
+        cwd: '/tmp',
+        callbacks: { onSpawned },
+      });
+      const launchTask = makeTask({
+        id: 'gen-task',
+        status: 'running',
+        config: { command: 'echo hi', runnerKind: 'worktree' as any },
+        execution: { selectedAttemptId: 'attempt-1', generation: launchGeneration },
+      });
+      const triggerComplete = () => completeCallback?.({
+        requestId: 'req-post-start',
+        actionId: 'gen-task',
+        attemptId: 'attempt-1',
+        executionGeneration: launchGeneration,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+      return {
+        runner, executor, handle, liveTask, launchTask, triggerComplete,
+        markTaskRunningAfterLaunch, handleWorkerResponse, updateTask, updateAttempt,
+        logEvent, onSpawned,
+      };
+    }
+
+    const tick = () => new Promise<void>((r) => setImmediate(r));
+
+    it('rejects a launch whose start resolves after the generation advances (attempt unchanged)', async () => {
+      const env = makePostStartEnv(1);
+      env.executor.startDeferred();
+
+      const run = env.runner.executeTask(env.launchTask);
+      await tick();
+      expect(env.executor.start).toHaveBeenCalledTimes(1);
+
+      // Generation advances to N+1 while the attempt id is unchanged, then
+      // the in-flight start resolves.
+      env.liveTask.execution.generation = 2;
+      env.executor.resolveStart();
+      await run;
+
+      // Stale post-start metadata must NOT be written to the task row.
+      expect(env.updateTask).not.toHaveBeenCalledWith(
+        'gen-task',
+        expect.objectContaining({
+          execution: expect.objectContaining({ workspacePath: '/tmp/post-start-ws' }),
+        }),
+      );
+      expect(env.updateAttempt).not.toHaveBeenCalledWith(
+        'attempt-1',
+        expect.objectContaining({ workspacePath: '/tmp/post-start-ws' }),
+      );
+      // A stale generation must never be marked running.
+      expect(env.markTaskRunningAfterLaunch).not.toHaveBeenCalled();
+      // The spawned handle is killed, consistent with the stale-attempt path.
+      expect(env.executor.kill).toHaveBeenCalledWith(env.handle);
+      // No active execution is registered, and no completion is processed.
+      expect((env.runner as any).activeExecutions.size).toBe(0);
+      expect(env.onSpawned).not.toHaveBeenCalled();
+      expect(env.handleWorkerResponse).not.toHaveBeenCalled();
+      expect(env.logEvent).toHaveBeenCalledWith(
+        'gen-task',
+        'task.executor.stale_post_start',
+        expect.objectContaining({ startGeneration: 1, currentGeneration: 2 }),
+      );
+    });
+
+    it('fails the dispatch and kills the handle when generation advances during start', async () => {
+      const env = makePostStartEnv(1);
+      env.executor.startDeferred();
+      const completeCalls: number[] = [];
+      const failCalls: Array<[number, unknown]> = [];
+      const launchOutbox = {
+        completeDispatch(id: number) { completeCalls.push(id); return true; },
+        failDispatch(id: number, err: unknown) { failCalls.push([id, err]); return true; },
+      };
+
+      const run = env.runner.executeTask(env.launchTask, { dispatchId: 55, launchOutbox });
+      await tick();
+      env.liveTask.execution.generation = 2;
+      env.executor.resolveStart();
+      await run;
+
+      expect(env.executor.kill).toHaveBeenCalledWith(env.handle);
+      expect(completeCalls).toHaveLength(0);
+      expect(failCalls).toHaveLength(1);
+      expect(failCalls[0][0]).toBe(55);
+      expect((failCalls[0][1] as Error).message).toMatch(/Launch rejected/);
+    });
+
+    it('persists metadata and registers the active execution when lineage is current', async () => {
+      const env = makePostStartEnv(1); // launch and live both at generation 1
+
+      const run = env.runner.executeTask(env.launchTask);
+      await tick();
+
+      // Valid launch persists workspace/branch/session metadata.
+      expect(env.updateTask).toHaveBeenCalledWith(
+        'gen-task',
+        expect.objectContaining({
+          execution: expect.objectContaining({
+            workspacePath: '/tmp/post-start-ws',
+            branch: 'experiment/post-start-branch',
+            agentSessionId: 'sess-post-start',
+            containerId: 'container-post-start',
+          }),
+        }),
+      );
+      expect(env.markTaskRunningAfterLaunch).toHaveBeenCalledWith('gen-task', 'attempt-1');
+      expect(env.onSpawned).toHaveBeenCalled();
+      expect((env.runner as any).activeExecutions.size).toBe(1);
+      expect(env.executor.kill).not.toHaveBeenCalled();
+
+      env.triggerComplete();
+      await run;
+      expect(env.handleWorkerResponse).toHaveBeenCalled();
+    });
+  });
+
   describe('upstream branch metadata guard', () => {
     it('fails task when a completed worktree dep has no branch', async () => {
       const tasks = new Map<string, TaskState>();

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1071,15 +1071,20 @@ export class TaskRunner {
       hasWorkspacePath: Boolean(handle.workspacePath),
       hasAgentSessionId: Boolean(handle.agentSessionId),
     });
-    const launchStale = this.isLaunchStale(task.id, attemptId, startGeneration);
+    // markTaskRunningAfterLaunch already rejects a mismatched attempt; also
+    // reject a stale launch-time generation (a slow start can resolve after a
+    // recreate advanced the live task on the same attempt).
+    const live = this.orchestrator.getTask(task.id);
+    const staleGeneration =
+      live !== undefined && (live.execution.generation ?? 0) !== startGeneration;
     const launchAccepted =
-      !launchStale && (this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true);
+      !staleGeneration && (this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true);
     if (!launchAccepted) {
       this.logger.warn(
         `[TaskRunner] launch rejected as stale/non-executable for task=${task.id} attemptId=${attemptId} ` +
-          `startGeneration=${startGeneration} staleLineage=${launchStale}; killing spawned process`,
+          `startGeneration=${startGeneration} staleGeneration=${staleGeneration}; killing spawned process`,
       );
-      if (launchStale) {
+      if (staleGeneration) {
         this.persistence.logEvent?.(task.id, 'task.executor.stale_post_start', {
           attemptId,
           executorType: executor.type,
@@ -1105,7 +1110,7 @@ export class TaskRunner {
           new Error('Launch rejected as stale or non-executable after executor start'),
         );
       }
-      bench('markTaskRunningAfterLaunch.rejected', { staleLineage: launchStale });
+      bench('markTaskRunningAfterLaunch.rejected', { staleGeneration });
       return;
     }
     bench('markTaskRunningAfterLaunch.accepted');

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1071,16 +1071,6 @@ export class TaskRunner {
       hasWorkspacePath: Boolean(handle.workspacePath),
       hasAgentSessionId: Boolean(handle.agentSessionId),
     });
-    // Post-start lineage guard. `executor.start()` can resolve minutes after
-    // launch (SSH provisioning is slow); by the time it returns, recreate-task
-    // may have advanced the live task to a newer generation while keeping the
-    // same `selectedAttemptId`. `markTaskRunningAfterLaunch` rejects a
-    // mismatched attempt but does NOT validate the launch-time generation
-    // captured here, so a launch accepted at generation N could still persist
-    // workspacePath/branch/agentSessionId/containerId/heartbeat metadata and
-    // register an active execution over the live attempt now at N+1. Validate
-    // the captured `startGeneration` first, and short-circuit
-    // `markTaskRunningAfterLaunch` so a stale generation is never marked running.
     const launchStale = this.isLaunchStale(task.id, attemptId, startGeneration);
     const launchAccepted =
       !launchStale && (this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true);

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1071,12 +1071,36 @@ export class TaskRunner {
       hasWorkspacePath: Boolean(handle.workspacePath),
       hasAgentSessionId: Boolean(handle.agentSessionId),
     });
+    // Post-start lineage guard. `executor.start()` can resolve minutes after
+    // launch (SSH provisioning is slow); by the time it returns, recreate-task
+    // may have advanced the live task to a newer generation while keeping the
+    // same `selectedAttemptId`. `markTaskRunningAfterLaunch` rejects a
+    // mismatched attempt but does NOT validate the launch-time generation
+    // captured here, so a launch accepted at generation N could still persist
+    // workspacePath/branch/agentSessionId/containerId/heartbeat metadata and
+    // register an active execution over the live attempt now at N+1. Validate
+    // the captured `startGeneration` first, and short-circuit
+    // `markTaskRunningAfterLaunch` so a stale generation is never marked running.
+    const launchStale = this.isLaunchStale(task.id, attemptId, startGeneration);
     const launchAccepted =
-      this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true;
+      !launchStale && (this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true);
     if (!launchAccepted) {
       this.logger.warn(
-        `[TaskRunner] launch rejected as stale/non-executable for task=${task.id} attemptId=${attemptId}; killing spawned process`,
+        `[TaskRunner] launch rejected as stale/non-executable for task=${task.id} attemptId=${attemptId} ` +
+          `startGeneration=${startGeneration} staleLineage=${launchStale}; killing spawned process`,
       );
+      if (launchStale) {
+        this.persistence.logEvent?.(task.id, 'task.executor.stale_post_start', {
+          attemptId,
+          executorType: executor.type,
+          startGeneration,
+          currentGeneration: this.orchestrator.getTask(task.id)?.execution.generation ?? null,
+          workspacePath: handle.workspacePath,
+          branch: handle.branch,
+          hasAgentSessionId: Boolean(handle.agentSessionId),
+          hasContainerId: Boolean(handle.containerId),
+        });
+      }
       try {
         await executor.kill(handle);
       } catch (killErr) {
@@ -1091,7 +1115,7 @@ export class TaskRunner {
           new Error('Launch rejected as stale or non-executable after executor start'),
         );
       }
-      bench('markTaskRunningAfterLaunch.rejected');
+      bench('markTaskRunningAfterLaunch.rejected', { staleLineage: launchStale });
       return;
     }
     bench('markTaskRunningAfterLaunch.accepted');

--- a/scripts/repro/repro-slow-start-stale-generation-guard.sh
+++ b/scripts/repro/repro-slow-start-stale-generation-guard.sh
@@ -202,8 +202,11 @@ set -e
 
 if [[ "$STATUS" -eq 0 ]]; then
   OBSERVED="fixed"
-else
+elif [[ "$STATUS" -eq 1 ]]; then
   OBSERVED="bug"
+else
+  echo "repro: vitest exited $STATUS (runner/setup failure, not a test result)" >&2
+  exit 2
 fi
 
 echo "slow_start_stale_generation_exit     : $STATUS"

--- a/scripts/repro/repro-slow-start-stale-generation-guard.sh
+++ b/scripts/repro/repro-slow-start-stale-generation-guard.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_FILE="$ROOT_DIR/packages/execution-engine/src/__tests__/slow-start-stale-generation-guard.repro.test.ts"
+EXPECTATION=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-slow-start-stale-generation-guard.sh --expect bug|fixed
+
+What it proves:
+  A slow executor.start() (remote provisioning can take minutes) can resolve
+  AFTER recreate-task has advanced the live task to a newer generation while
+  keeping the same selectedAttemptId. Without the post-start generation guard,
+  that stale launch persists workspace/branch/session metadata and registers an
+  active execution over the live attempt now at N+1. The guard validates the
+  launch-time generation, so a stale generation is never marked running: the
+  spawned handle is killed, no metadata is written, and a
+  `task.executor.stale_post_start` diagnostic is logged.
+
+Exit codes:
+  0  observed behavior matches --expect
+  1  observed behavior does not match --expect
+  2  repro setup or assertion was invalid / unexpected
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  echo "repro: --expect requires bug|fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+cleanup() {
+  rm -f "$TEST_FILE"
+}
+trap cleanup EXIT
+
+cat > "$TEST_FILE" <<'TS'
+import { describe, expect, it, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import type { TaskState } from '@invoker/workflow-core';
+
+// Models a slow startup: executor.start() returns a promise that does NOT
+// resolve until the test calls resolveStart(), standing in for minutes-long
+// remote/SSH provisioning. While that start is in flight, recreate-task
+// advances the live task's generation (N -> N+1) while keeping the same
+// selectedAttemptId.
+describe('slow-start stale-generation post-start guard repro', () => {
+  it('never marks a slow start running once the generation has advanced', async () => {
+    const handle = {
+      executionId: 'exec-slow-start',
+      taskId: 'slow-task',
+      workspacePath: '/remote/worktrees/slow-task',
+      branch: 'experiment/slow-task',
+      agentSessionId: 'sess-slow-start',
+      containerId: 'container-slow-start',
+    };
+
+    let resolveStart: (() => void) | undefined;
+    const executor = {
+      type: 'worktree',
+      start: vi.fn(() => new Promise((res) => { resolveStart = () => res(handle); })),
+      onComplete: vi.fn(),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn().mockResolvedValue(undefined),
+      destroyAll: vi.fn(),
+    };
+
+    // The live task the orchestrator sees; its generation is mutated mid-start.
+    const liveTask: TaskState = {
+      id: 'slow-task',
+      description: 'Slow startup task',
+      status: 'running',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { command: 'echo hi', runnerKind: 'worktree' },
+      execution: { selectedAttemptId: 'attempt-1', generation: 1 },
+    } as TaskState;
+
+    const markTaskRunningAfterLaunch = vi.fn(() => true);
+    const handleWorkerResponse = vi.fn(() => []);
+    const updateTask = vi.fn();
+    const updateAttempt = vi.fn();
+    const logEvent = vi.fn();
+    const onSpawned = vi.fn();
+
+    const runner = new TaskRunner({
+      orchestrator: {
+        getTask: () => liveTask,
+        getAllTasks: () => [liveTask],
+        markTaskRunningAfterLaunch,
+        handleWorkerResponse,
+      } as any,
+      persistence: {
+        updateTask,
+        updateAttempt,
+        logEvent,
+        loadAttempts: () => [],
+        appendTaskOutput: vi.fn(),
+      } as any,
+      executorRegistry: {
+        getDefault: () => executor,
+        get: () => executor,
+        getAll: () => [executor],
+      } as any,
+      cwd: '/tmp',
+      callbacks: { onSpawned },
+    });
+
+    // Launch is accepted at generation 1.
+    const launchTask: TaskState = {
+      id: 'slow-task',
+      description: 'Slow startup task',
+      status: 'running',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { command: 'echo hi', runnerKind: 'worktree' },
+      execution: { selectedAttemptId: 'attempt-1', generation: 1 },
+    } as TaskState;
+
+    const run = runner.executeTask(launchTask);
+    // Don't surface a rejection if the launch is torn down; we assert on the
+    // observable side effects, not on how the promise settles.
+    run.catch(() => {});
+    await vi.waitFor(() => expect(executor.start).toHaveBeenCalledTimes(1));
+
+    // recreate-task advances the generation while the slow start is in flight.
+    liveTask.execution.generation = 2;
+
+    // Slow provisioning finally returns its handle, at the stale generation.
+    resolveStart?.();
+
+    // Wait until the post-start path settles in EITHER outcome: the fix kills
+    // the handle and returns; the bug marks the launch running. Never await
+    // `run` — in the bug case the accepted launch leaves it pending on a
+    // completion that never fires (a 20s timeout instead of a fast assertion).
+    await vi.waitFor(() => {
+      const settled =
+        executor.kill.mock.calls.length > 0 || markTaskRunningAfterLaunch.mock.calls.length > 0;
+      expect(settled).toBe(true);
+    });
+
+    // A stale generation must never be marked running.
+    expect(markTaskRunningAfterLaunch).not.toHaveBeenCalled();
+    // The spawned handle is killed.
+    expect(executor.kill).toHaveBeenCalledWith(handle);
+    // No stale workspace metadata is persisted to the task or attempt row.
+    expect(updateTask).not.toHaveBeenCalledWith(
+      'slow-task',
+      expect.objectContaining({
+        execution: expect.objectContaining({ workspacePath: '/remote/worktrees/slow-task' }),
+      }),
+    );
+    expect(updateAttempt).not.toHaveBeenCalledWith(
+      'attempt-1',
+      expect.objectContaining({ workspacePath: '/remote/worktrees/slow-task' }),
+    );
+    // No active execution is registered and no completion is processed.
+    expect((runner as any).activeExecutions.size).toBe(0);
+    expect(onSpawned).not.toHaveBeenCalled();
+    expect(handleWorkerResponse).not.toHaveBeenCalled();
+    // A diagnostic records the stale launch-time vs live generation.
+    expect(logEvent).toHaveBeenCalledWith(
+      'slow-task',
+      'task.executor.stale_post_start',
+      expect.objectContaining({ startGeneration: 1, currentGeneration: 2 }),
+    );
+  });
+});
+TS
+
+cd "$ROOT_DIR"
+
+set +e
+pnpm --filter @invoker/execution-engine exec vitest run \
+  --reporter verbose \
+  "$TEST_FILE"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  OBSERVED="fixed"
+else
+  OBSERVED="bug"
+fi
+
+echo "slow_start_stale_generation_exit     : $STATUS"
+echo "slow_start_stale_generation_observed : $OBSERVED"
+echo "expected                             : $EXPECTATION"
+
+if [[ "$OBSERVED" != "$EXPECTATION" ]]; then
+  exit 1
+fi
+
+echo "==> repro matched expectation"


### PR DESCRIPTION
## Summary

A slow executor launch can no longer overwrite a fresh task with old data.

When a task starts, the executor can take minutes to come up because remote provisioning is slow.

While it boots, a recreate can advance the task to a newer run while keeping the same attempt id.

Before this fix, the old launch returned and still wrote its workspace path, branch, session, container, and heartbeat onto the now-newer run.

This change checks the launch's captured generation first. If that generation is older, the launch is discarded, the spawned process is killed, and an audit event is logged.

<details>
<summary>Review metadata</summary>

Review Claim: A launch whose captured generation is older than the live task's generation is discarded before any running state or metadata is written.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The guard adds only a pre-check on the already-captured generation; an accepted launch follows the exact prior path, so behavior changes for outdated launches alone.

Slice Rationale: This is the single Step 7 follow-up that closes the post-start generation hole; the prior guard checked only the attempt id, not the launch generation.

</details>

## Non-goals

- Does not change `markTaskRunningAfterLaunch` attempt-id validation.
- Does not change the pre-start generation checks already in place.
- Does not change executor provisioning, SSH, or recreate-task timing.

## Test Plan

- [ ] `cd packages/execution-engine && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale post-start launches from being marked as running when task generation changes during startup.
  * Ensured rejected slow-start launches clean up the spawned executor, avoid persisting outdated workspace/attempt metadata, and skip completion/workflow processing.
  * Added more specific diagnostics for stale post-start generation and improved the captured rejection details.
* **Tests / Repro**
  * Added coverage for the “post-start generation lineage guard” and a reproducible slow-start race-condition harness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->