### PR TITLE
fix(task-runner): release ssh capacity on preempt

### DIFF
--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -3,6 +3,7 @@ import type { TaskState } from '@invoker/workflow-core';
 import { autoFixOnReviewGateFailure } from '../workflow-actions.js';
 import { loadConfig, resolveSecretsFilePath } from '../config.js';
 import {
+  killRunningTaskExecution,
   rebuildTaskRunner,
   requireWiredTaskRunner,
 } from '../execution/task-runner-wiring.js';
@@ -193,6 +194,59 @@ describe('task-runner-wiring', () => {
     expect(currentRunner.approveMerge).toHaveBeenCalledTimes(1);
   });
 
+
+  it('kills preempted tasks through TaskRunner so SSH pool capacity is released', async () => {
+    const handle = { executionId: 'exec-1', taskId: 'task-1' };
+    const executor = { type: 'ssh', kill: vi.fn(async () => undefined) };
+    const taskHandles = new Map([[handle.taskId, { handle, executor }]]);
+    const taskRunner = {
+      killActiveExecution: vi.fn(async () => true),
+    };
+
+    await killRunningTaskExecution({
+      getTaskRunner: () => taskRunner as any,
+      logger: createLogger() as any,
+      taskHandles: taskHandles as any,
+    }, handle.taskId);
+
+    expect(taskRunner.killActiveExecution).toHaveBeenCalledWith(handle.taskId);
+    expect(executor.kill).not.toHaveBeenCalled();
+    expect(taskHandles.has(handle.taskId)).toBe(false);
+  });
+
+  it('still asks TaskRunner to kill when the app handle map missed the spawned task', async () => {
+    const taskHandles = new Map();
+    const taskRunner = {
+      killActiveExecution: vi.fn(async () => true),
+    };
+
+    await killRunningTaskExecution({
+      getTaskRunner: () => taskRunner as any,
+      logger: createLogger() as any,
+      taskHandles: taskHandles as any,
+    }, 'task-1');
+
+    expect(taskRunner.killActiveExecution).toHaveBeenCalledWith('task-1');
+  });
+
+  it('falls back to the stored handle when TaskRunner no longer has the active entry', async () => {
+    const handle = { executionId: 'exec-1', taskId: 'task-1' };
+    const executor = { type: 'ssh', kill: vi.fn(async () => undefined) };
+    const taskHandles = new Map([[handle.taskId, { handle, executor }]]);
+    const taskRunner = {
+      killActiveExecution: vi.fn(async () => false),
+    };
+
+    await killRunningTaskExecution({
+      getTaskRunner: () => taskRunner as any,
+      logger: createLogger() as any,
+      taskHandles: taskHandles as any,
+    }, handle.taskId);
+
+    expect(taskRunner.killActiveExecution).toHaveBeenCalledWith(handle.taskId);
+    expect(executor.kill).toHaveBeenCalledWith(handle);
+    expect(taskHandles.has(handle.taskId)).toBe(false);
+  });
   it('throws the existing follower-mode execution error before dispatch', () => {
     expect(() => requireWiredTaskRunner(() => null)).toThrow(
       'Mutation execution is unavailable in read-only follower mode',

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -40,6 +40,27 @@ export function requireWiredTaskRunner(getTaskRunner: () => TaskRunner | null): 
   return taskRunner;
 }
 
+export async function killRunningTaskExecution(deps: Pick<
+  TaskRunnerWiringDeps,
+  'getTaskRunner' | 'logger' | 'taskHandles'
+>, taskId: string): Promise<void> {
+  const taskRunner = deps.getTaskRunner();
+  const killedByTaskRunner = taskRunner
+    ? await taskRunner.killActiveExecution(taskId)
+    : false;
+  const entry = deps.taskHandles.get(taskId);
+  if (!killedByTaskRunner && !entry) return;
+  deps.logger.info(`Killing running task "${taskId}" before restart`, { module: 'kill' });
+  if (!killedByTaskRunner && entry) {
+    try {
+      await entry.executor.kill(entry.handle);
+    } catch {
+      /* process may already have exited */
+    }
+  }
+  deps.taskHandles.delete(taskId);
+}
+
 export function wireTaskRunnerApproveHook(deps: Pick<
   TaskRunnerWiringDeps,
   'orchestrator' | 'persistence' | 'getTaskRunner'

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -157,7 +157,9 @@ function buildHeadlessApiServerDeps(
       taskExecutor,
       dispatchMode: deps.mutationTiming ? 'fire-and-forget' : 'await',
       autoApproveAIFixes: deps.invokerConfig?.autoApproveAIFixes,
-      killRunningTask: (taskId: string) => taskExecutor.killActiveExecution(taskId),
+      killRunningTask: async (taskId: string) => {
+        await taskExecutor.killActiveExecution(taskId);
+      },
       commandService: deps.commandService,
     }),
     deleteWorkflow: async (workflowId: string) => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -221,6 +221,7 @@ import {
 } from './headless-owner-bootstrap.js';
 import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
 import {
+  killRunningTaskExecution,
   rebuildTaskRunner as rebuildTaskRunnerWiring,
   requireWiredTaskRunner,
   type TaskHandleMap,
@@ -2191,11 +2192,11 @@ function createEmbeddedTerminalBackendFromConfig(
   }
 
   async function killRunningTask(taskId: string): Promise<void> {
-    const entry = taskHandles.get(taskId);
-    if (!entry) return;
-    logger.info(`Killing running task "${taskId}" before restart`, { module: 'kill' });
-    await entry.executor.kill(entry.handle);
-    taskHandles.delete(taskId);
+    await killRunningTaskExecution({
+      getTaskRunner: () => taskExecutor,
+      logger,
+      taskHandles,
+    }, taskId);
   }
 
   /** Cancel a task and cascade-kill all downstream DAG dependents. Shared by IPC, headless, and API. */

--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -153,6 +153,151 @@ describe('SSH pool member capacity', () => {
     expect(sshExecutor.start).not.toHaveBeenCalled();
   });
 
+
+  it('releases in-memory SSH pool capacity when a preempted task is killed through TaskRunner', async () => {
+    const firstTask = makeTask('wf-1/task-a');
+    const secondTask = makeTask('wf-2/task-b');
+    const thirdTask = makeTask('wf-3/task-c');
+    const tasks = new Map([firstTask, secondTask, thirdTask].map((task) => [task.id, task]));
+    const handlesByTaskId = new Map<string, any>();
+    const completeByTaskId = new Map<string, (response: any) => void>();
+    const sshExecutor = {
+      type: 'ssh',
+      start: vi.fn(async (request: any) => {
+        const handle = {
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: `/remote/${request.actionId}`,
+        };
+        handlesByTaskId.set(request.actionId, handle);
+        return handle;
+      }),
+      onComplete: vi.fn((handle: any, cb: any) => {
+        completeByTaskId.set(handle.taskId, cb);
+      }),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(async () => undefined),
+      destroyAll: vi.fn(),
+    };
+    const deferTask = vi.fn();
+    const runner = makeRunner({
+      members: [
+        { id: 'remote-a', type: 'ssh', maxConcurrentTasks: 1 },
+        { id: 'remote-b', type: 'ssh', maxConcurrentTasks: 1 },
+      ],
+      sshExecutor,
+      orchestrator: {
+        getTask: (id: string) => tasks.get(id) ?? null,
+        getAllTasks: () => [...tasks.values()],
+        markTaskRunningAfterLaunch: () => true,
+        handleWorkerResponse: () => [],
+        deferTask,
+      },
+      persistence: {
+        logEvent: vi.fn(),
+        updateTask: vi.fn(),
+        updateAttempt: vi.fn(),
+        appendTaskOutput: vi.fn(),
+      },
+    });
+
+    const firstRun = runner.executeTask(firstTask);
+    const secondRun = runner.executeTask(secondTask);
+    await vi.waitFor(() => expect(sshExecutor.start).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(completeByTaskId.has(firstTask.id)).toBe(true));
+    await vi.waitFor(() => expect(completeByTaskId.has(secondTask.id)).toBe(true));
+
+    const firstAttemptId = firstTask.execution.selectedAttemptId;
+    const secondAttemptId = secondTask.execution.selectedAttemptId;
+    await sshExecutor.kill(handlesByTaskId.get(firstTask.id));
+    await sshExecutor.kill(handlesByTaskId.get(secondTask.id));
+    firstTask.execution = { ...firstTask.execution, selectedAttemptId: `${firstTask.id}-retry-attempt` };
+    secondTask.execution = { ...secondTask.execution, selectedAttemptId: `${secondTask.id}-retry-attempt` };
+    await runner.executeTask(thirdTask);
+    expect(deferTask).toHaveBeenCalledWith(thirdTask.id);
+    expect(sshExecutor.start).toHaveBeenCalledTimes(2);
+
+    expect(await runner.killActiveExecution(firstTask.id)).toBe(true);
+    expect(await runner.killActiveExecution(secondTask.id)).toBe(true);
+    completeByTaskId.get(firstTask.id)?.({
+      requestId: `kill-${firstTask.id}`,
+      actionId: firstTask.id,
+      attemptId: firstAttemptId,
+      status: 'failed',
+      outputs: { exitCode: 130 },
+    });
+    completeByTaskId.get(secondTask.id)?.({
+      requestId: `kill-${secondTask.id}`,
+      actionId: secondTask.id,
+      attemptId: secondAttemptId,
+      status: 'failed',
+      outputs: { exitCode: 130 },
+    });
+    await firstRun;
+    await secondRun;
+
+    const thirdRun = runner.executeTask(thirdTask);
+    await vi.waitFor(() => expect(sshExecutor.start).toHaveBeenCalledTimes(3));
+    await vi.waitFor(() => expect(completeByTaskId.has(thirdTask.id)).toBe(true));
+    completeByTaskId.get(thirdTask.id)?.({
+      requestId: `complete-${thirdTask.id}`,
+      actionId: thirdTask.id,
+      attemptId: thirdTask.execution.selectedAttemptId,
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    });
+    await thirdRun;
+  });
+
+  it('logs when killActiveExecution cannot kill the executor handle', async () => {
+    const task = makeTask('wf-1/task-a');
+    const killErr = new Error('ssh gone');
+    const sshExecutor = {
+      type: 'ssh',
+      start: vi.fn(),
+      onComplete: vi.fn(),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(async () => {
+        throw killErr;
+      }),
+      destroyAll: vi.fn(),
+    };
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    };
+    const runner = makeRunner({
+      sshExecutor,
+      orchestrator: {
+        getTask: (id: string) => id === task.id ? task : null,
+        getAllTasks: () => [task],
+      },
+      persistence: {
+        logEvent: vi.fn(),
+      },
+    });
+
+    (runner as any).logger = logger;
+    (runner as any).activeExecutions.set(task.execution.selectedAttemptId, {
+      handle: {
+        executionId: 'exec-1',
+        taskId: task.id,
+      },
+      executor: sshExecutor,
+      taskId: task.id,
+    });
+
+    await expect(runner.killActiveExecution(task.id)).resolves.toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      `[TaskRunner] killActiveExecution failed for task=${task.id}`,
+      { err: killErr },
+    );
+  });
   it('uses execution resource leases to defer across TaskRunner instances', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     try {

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -454,14 +454,15 @@ describe('TaskRunner', () => {
     await Promise.all([oldExecution, selectedExecution]);
   });
 
-  it('does not kill an older active attempt when the selected attempt has no live execution', async () => {
+  it('kills an older active attempt when the selected attempt has no live execution', async () => {
     let completeCallback: ((response: WorkResponse) => void) | undefined;
-    const kill = vi.fn();
+    const kill = vi.fn().mockResolvedValue(undefined);
     const executorImpl = {
       type: 'worktree',
       start: vi.fn().mockImplementation(async (request: any) => ({
         executionId: `exec-${request.attemptId}`,
         taskId: request.actionId,
+        attemptId: request.attemptId,
         workspacePath: `/tmp/mock-worktree-${request.attemptId}`,
         branch: `experiment/${request.attemptId}-mock`,
       })),
@@ -504,8 +505,11 @@ describe('TaskRunner', () => {
     }));
     await vi.waitFor(() => expect(executorImpl.start).toHaveBeenCalledTimes(1));
 
-    await runner.killActiveExecution(currentTask.id);
-    expect(kill).not.toHaveBeenCalled();
+    await expect(runner.killActiveExecution(currentTask.id)).resolves.toBe(true);
+    expect(kill).toHaveBeenCalledWith(expect.objectContaining({
+      attemptId: 'stale-active-task-a1',
+      taskId: currentTask.id,
+    }));
 
     completeCallback?.({
       requestId: 'req-stale-active',

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -439,18 +439,19 @@ export class TaskRunner {
   /**
    * Stop the executor child for a task that is currently in-flight (after orchestrator.cancelTask).
    */
-  async killActiveExecution(taskId: string): Promise<void> {
+  async killActiveExecution(taskId: string): Promise<boolean> {
     const resolved = this.resolveActiveExecution(taskId);
-    if (!resolved) return;
+    if (!resolved) return false;
     this.activeExecutions.delete(resolved.attemptId);
     if (resolved.entry.leaseResourceKey && resolved.entry.leaseHolderId) {
       this.persistence.releaseExecutionResourceLease?.(resolved.entry.leaseResourceKey, resolved.entry.leaseHolderId);
     }
     try {
       await resolved.entry.executor.kill(resolved.entry.handle);
-    } catch {
-      /* process may already have exited */
+    } catch (killErr) {
+      this.logger.warn(`[TaskRunner] killActiveExecution failed for task=${taskId}`, { err: killErr });
     }
+    return true;
   }
 
   private loadLatestAttemptId(taskId: string): string | undefined {
@@ -473,7 +474,6 @@ export class TaskRunner {
     if (selectedAttemptId) {
       const entry = this.activeExecutions.get(selectedAttemptId);
       if (entry) return { attemptId: selectedAttemptId, entry };
-      return undefined;
     }
 
     const latestAttemptId = this.loadLatestAttemptId(taskId);

--- a/scripts/repro/repro-stale-ssh-pool-capacity-after-preempt.sh
+++ b/scripts/repro/repro-stale-ssh-pool-capacity-after-preempt.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] stale SSH pool capacity after retry preempt"
+
+echo "[repro] asserting app preempt kill routes through TaskRunner first"
+python3 - "$ROOT" <<'PY'
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1])
+main = root / "packages" / "app" / "src" / "main.ts"
+text = main.read_text(encoding="utf-8")
+if "killRunningTaskExecution" not in text:
+    raise SystemExit("main kill path does not use killRunningTaskExecution")
+if "await entry.executor.kill(entry.handle);" in text:
+    raise SystemExit("main kill path still bypasses TaskRunner active execution cleanup")
+wiring = root / "packages" / "app" / "src" / "execution" / "task-runner-wiring.ts"
+wiring_text = wiring.read_text(encoding="utf-8")
+if re.search(r"const entry = deps\\.taskHandles\\.get\\(taskId\\);\\s*if \\(!entry\\) return;", wiring_text):
+    raise SystemExit("app kill path still skips TaskRunner when taskHandles missed the task")
+runner = root / "packages" / "execution-engine" / "src" / "task-runner.ts"
+runner_text = runner.read_text(encoding="utf-8")
+if "async killActiveExecution(taskId: string): Promise<boolean>" not in runner_text:
+    raise SystemExit("TaskRunner.killActiveExecution does not report whether it cleaned an active entry")
+if re.search(r"if \\(selectedAttemptId\\).*?return undefined;", runner_text, re.S):
+    raise SystemExit("TaskRunner active lookup still stops at stale selectedAttemptId")
+PY
+
+echo "[repro] running app preempt-kill wiring regression"
+pnpm --filter @invoker/app exec vitest run src/__tests__/task-runner-wiring.test.ts
+
+echo "[repro] running SSH pool capacity regression"
+pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-pool-member-capacity.test.ts
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Restarting a running task could stop its process without telling `TaskRunner` that the SSH slot was free. The database looked idle, but the SSH pool still looked full.

That left recreated regression tasks stuck in `pending` even after the old task was gone.

This change sends the preempt kill through `TaskRunner` first and lets cleanup find the old active attempt after `selectedAttemptId` changes.

## Architecture

### Before

```mermaid
graph TD
  A["App restart path"] --> B["taskHandles lookup"]
  B --> C["Kill child process"]
  C -.-> D["TaskRunner active execution stays in memory"]
  D --> E["SSH pool still marks the member busy"]
```

### After

```mermaid
graph TD
  A["App restart path"] --> B["killRunningTaskExecution"]
  B --> C["TaskRunner.killActiveExecution"]
  C --> D["Clear active execution"]
  C --> E["Release SSH lease"]
  C --> F["Kill child process"]
  D --> G["SSH pool slot becomes free"]
  E --> G
```

## Test Plan

- [ ] `pnpm --filter @invoker/execution-engine test -- src/__tests__/ssh-pool-member-capacity.test.ts src/__tests__/task-runner.test.ts`
- [ ] `pnpm check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0e346bd5b`
- Post-revert steps: None
- Data migration? No
