### PR TITLE
Fix intent cancellation Step 8: merge-gate side-effect lineage guard (restacked v3)

### DIFF
--- a/packages/execution-engine/src/__tests__/merge-gate-stale-lineage-guard.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-gate-stale-lineage-guard.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Regression coverage for the merge-gate direct-write lineage guard.
+ *
+ * The MergeGateExecutor writes execution metadata (branch, workspacePath,
+ * review fields) straight to persistence after `runMergeGateActionImpl`
+ * returns — a path that bypasses the worker-response lineage guard in
+ * `Orchestrator.handleWorkerResponse`. A merge-gate run can take a long time,
+ * so if the merge task is relaunched meanwhile (newer selectedAttemptId or
+ * executionGeneration) the stale run must NOT clobber the fresh launch's state.
+ *
+ * These tests prove:
+ *   1. a stale merge-gate run cannot write direct execution metadata;
+ *   2. the eventual stale worker response is still rejected by the orchestrator;
+ *   3. a valid (current) merge-gate run still persists review-ready metadata.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import type { Logger, WorkRequest, WorkResponse } from '@invoker/contracts';
+import {
+  Orchestrator,
+  type Attempt,
+  type TaskState,
+  type TaskStateChanges,
+  type OrchestratorPersistence,
+  type OrchestratorMessageBus,
+} from '@invoker/workflow-core';
+import { MergeGateExecutor } from '../merge-gate-executor.js';
+import type { MergeRunnerHost } from '../merge-runner.js';
+import type { ExecutorHandle } from '../executor.js';
+
+const GATE_WORKSPACE = '/tmp/gate-clone-fake';
+const FEATURE_BRANCH = 'plan/feature';
+const MERGE_TASK_ID = '__merge__wf-gate';
+
+function makeMergeTask(execution: Partial<TaskState['execution']>): TaskState {
+  return {
+    id: MERGE_TASK_ID,
+    description: 'Merge gate',
+    status: 'running',
+    dependencies: ['t1'],
+    createdAt: new Date(),
+    config: { isMergeNode: true, workflowId: 'wf-gate' } as TaskState['config'],
+    execution: { ...execution } as TaskState['execution'],
+  } as TaskState;
+}
+
+/**
+ * Minimal MergeRunnerHost that drives a real MergeGateExecutor without touching
+ * git: with onFinish='none' and mergeMode='manual', runMergeGateActionImpl
+ * takes the no-consolidation review_ready branch and never shells out.
+ */
+function makeHost(opts: {
+  liveTask: TaskState;
+  updateTask: ReturnType<typeof vi.fn>;
+}): MergeRunnerHost {
+  return {
+    cwd: '/tmp/host-repo',
+    defaultBranch: 'master',
+    persistence: {
+      loadWorkflow: () => ({
+        id: 'wf-gate',
+        onFinish: 'none',
+        mergeMode: 'manual',
+        baseBranch: 'master',
+        featureBranch: FEATURE_BRANCH,
+        name: 'Gate Workflow',
+      }),
+      updateTask: opts.updateTask,
+      getWorkspacePath: () => GATE_WORKSPACE,
+    },
+    orchestrator: {
+      getTask: (id: string) => (id === opts.liveTask.id ? opts.liveTask : undefined),
+      getAllTasks: () => [opts.liveTask],
+    },
+    async createMergeWorktree() {
+      return GATE_WORKSPACE;
+    },
+    async detectDefaultBranch() {
+      return 'master';
+    },
+    async buildMergeSummary() {
+      return '## Summary';
+    },
+  } as unknown as MergeRunnerHost;
+}
+
+function makeRequest(attemptId: string | undefined, executionGeneration: number): WorkRequest {
+  return {
+    requestId: `merge-${MERGE_TASK_ID}`,
+    actionId: MERGE_TASK_ID,
+    attemptId,
+    executionGeneration,
+    actionType: 'merge_gate',
+    inputs: {},
+    callbackUrl: '',
+    timestamps: { createdAt: new Date(2026, 0, 1).toISOString() },
+  } as WorkRequest;
+}
+
+async function runToCompletion(
+  executor: MergeGateExecutor,
+  request: WorkRequest,
+): Promise<WorkResponse> {
+  const handle: ExecutorHandle = await executor.start(request);
+  return new Promise<WorkResponse>((resolve) => {
+    executor.onComplete(handle, resolve);
+  });
+}
+
+// ── In-memory OrchestratorPersistence for the real-orchestrator assertion ──
+
+class TestPersistence implements OrchestratorPersistence {
+  workflows = new Map<string, Record<string, unknown>>();
+  tasks = new Map<string, { workflowId: string; task: TaskState }>();
+  attempts = new Map<string, Attempt>();
+
+  saveWorkflow(wf: Record<string, unknown>): void {
+    this.workflows.set(wf.id as string, {
+      ...wf,
+      createdAt: wf.createdAt ?? new Date().toISOString(),
+      updatedAt: wf.updatedAt ?? new Date().toISOString(),
+    });
+  }
+  updateWorkflow(id: string, changes: Record<string, unknown>): void {
+    const wf = this.workflows.get(id);
+    if (wf) Object.assign(wf, changes);
+  }
+  saveTask(workflowId: string, task: TaskState): void {
+    this.tasks.set(task.id, { workflowId, task });
+  }
+  updateTask(taskId: string, changes: TaskStateChanges): void {
+    const entry = this.tasks.get(taskId);
+    if (entry) {
+      entry.task = {
+        ...entry.task,
+        ...(changes.status !== undefined ? { status: changes.status } : {}),
+        ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
+        config: { ...entry.task.config, ...changes.config },
+        execution: { ...entry.task.execution, ...changes.execution },
+      } as TaskState;
+    }
+  }
+  listWorkflows() { return Array.from(this.workflows.values()); }
+  loadTasks(wfId: string) {
+    return Array.from(this.tasks.values()).filter((e) => e.workflowId === wfId).map((e) => e.task);
+  }
+  loadWorkflow(id: string) { return this.workflows.get(id) as never; }
+  getWorkspacePath(taskId: string) {
+    return this.tasks.get(taskId)?.task.execution.workspacePath ?? null;
+  }
+  logEvent(): void {}
+  saveAttempt(attempt: Attempt): void { this.attempts.set(attempt.id, { ...attempt }); }
+  loadAttempts(nodeId: string): Attempt[] {
+    return Array.from(this.attempts.values()).filter((a) => a.nodeId === nodeId);
+  }
+  loadAttempt(attemptId: string): Attempt | undefined {
+    const a = this.attempts.get(attemptId);
+    return a ? { ...a } : undefined;
+  }
+  updateAttempt(attemptId: string, changes: Partial<Attempt>): void {
+    const a = this.attempts.get(attemptId);
+    if (a) this.attempts.set(attemptId, { ...a, ...changes });
+  }
+}
+
+class TestBus implements OrchestratorMessageBus {
+  publish(): void {}
+}
+
+describe('merge-gate stale-lineage direct-write guard', () => {
+  let executor: MergeGateExecutor | undefined;
+
+  afterEach(async () => {
+    await executor?.destroyAll();
+    executor = undefined;
+  });
+
+  it('does not write direct execution metadata when the merge task advanced to a newer attempt', async () => {
+    // Launch lineage: attempt-1 / gen 0. By the time the run finishes, the
+    // live merge task has been relaunched as attempt-2 / gen 1.
+    const liveTask = makeMergeTask({ selectedAttemptId: 'attempt-2', generation: 1 });
+    const updateTask = vi.fn();
+    const host = makeHost({ liveTask, updateTask });
+    executor = new MergeGateExecutor(host);
+
+    const response = await runToCompletion(executor, makeRequest('attempt-1', 0));
+
+    // The stale run must not have written branch / workspacePath / review
+    // metadata directly to persistence — neither the up-front review clear nor
+    // the post-run handoff.
+    expect(updateTask).not.toHaveBeenCalled();
+
+    // The run still emits a completion, and it carries the STALE launch lineage
+    // so the worker-response guard (asserted below) will reject it.
+    expect(response.status).toBe('review_ready');
+    expect(response.attemptId).toBe('attempt-1');
+    expect(response.executionGeneration).toBe(0);
+  });
+
+  it('does not write direct execution metadata when the merge task advanced to a newer generation', async () => {
+    // Same attempt id, but the live generation has moved past the launch one.
+    const liveTask = makeMergeTask({ selectedAttemptId: 'attempt-1', generation: 2 });
+    const updateTask = vi.fn();
+    const host = makeHost({ liveTask, updateTask });
+    executor = new MergeGateExecutor(host);
+
+    const response = await runToCompletion(executor, makeRequest('attempt-1', 0));
+
+    expect(updateTask).not.toHaveBeenCalled();
+    expect(response.status).toBe('review_ready');
+    expect(response.executionGeneration).toBe(0);
+  });
+
+  it('persists review-ready metadata when the launch lineage is still current', async () => {
+    // Live merge task matches the launch lineage (attempt-1 / gen 0).
+    const liveTask = makeMergeTask({ selectedAttemptId: 'attempt-1', generation: 0 });
+    const updateTask = vi.fn();
+    const host = makeHost({ liveTask, updateTask });
+    executor = new MergeGateExecutor(host);
+
+    const response = await runToCompletion(executor, makeRequest('attempt-1', 0));
+
+    expect(response.status).toBe('review_ready');
+
+    // The branch + gate workspace handoff must persist for a current run.
+    const handoff = updateTask.mock.calls.find(
+      ([, changes]) =>
+        (changes as TaskStateChanges).execution?.branch === FEATURE_BRANCH,
+    );
+    expect(handoff).toBeDefined();
+    expect((handoff![1] as TaskStateChanges).execution).toMatchObject({
+      branch: FEATURE_BRANCH,
+      workspacePath: GATE_WORKSPACE,
+    });
+  });
+
+  it('worker-response guard still rejects the eventual stale merge-gate response', () => {
+    const warn = vi.fn();
+    const logger: Logger = {
+      debug: () => {},
+      info: () => {},
+      warn,
+      error: () => {},
+      child: () => logger,
+    };
+    {
+      const persistence = new TestPersistence();
+      const orchestrator = new Orchestrator({
+        persistence,
+        messageBus: new TestBus(),
+        maxConcurrency: 1,
+        logger,
+      });
+      orchestrator.loadPlan({
+        name: 'gate-wf',
+        onFinish: 'none',
+        tasks: [{ id: 'gate', description: 'Merge gate', command: 'true' }],
+      });
+      orchestrator.startExecution();
+
+      const taskId = orchestrator
+        .getAllTasks()
+        .find((t) => t.id === 'gate' || t.id.endsWith('/gate'))!.id;
+
+      // Relaunch the task: bumps generation to 1 and selects a fresh attempt.
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      orchestrator.recreateWorkflow(workflowId);
+
+      const current = orchestrator.getTask(taskId)!;
+      const currentAttemptId = current.execution.selectedAttemptId;
+      expect(current.execution.generation).toBe(1);
+      const branchBefore = current.execution.branch;
+
+      // The stale merge-gate completion carries the prior generation (0).
+      const staleResponse: WorkResponse = {
+        requestId: `merge-${taskId}`,
+        actionId: taskId,
+        attemptId: currentAttemptId,
+        executionGeneration: 0,
+        status: 'review_ready',
+        outputs: { exitCode: 0, branch: 'stale/feature' },
+      };
+      const newlyStarted = orchestrator.handleWorkerResponse(staleResponse);
+
+      expect(newlyStarted).toEqual([]);
+      // The stale branch must not have landed on the live task.
+      expect(orchestrator.getTask(taskId)!.execution.branch).toBe(branchBefore);
+      expect(warn).toHaveBeenCalledWith(
+        '[worker-response] STALE_GENERATION_REJECTED',
+        expect.objectContaining({
+          taskId,
+          responseGeneration: 0,
+          activeGeneration: 1,
+          workerResponseStatus: 'review_ready',
+        }),
+      );
+    }
+  });
+});

--- a/packages/execution-engine/src/__tests__/merge-gate-stale-lineage-guard.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-gate-stale-lineage-guard.test.ts
@@ -1,18 +1,7 @@
-/**
- * Regression coverage for the merge-gate direct-write lineage guard.
- *
- * The MergeGateExecutor writes execution metadata (branch, workspacePath,
- * review fields) straight to persistence after `runMergeGateActionImpl`
- * returns — a path that bypasses the worker-response lineage guard in
- * `Orchestrator.handleWorkerResponse`. A merge-gate run can take a long time,
- * so if the merge task is relaunched meanwhile (newer selectedAttemptId or
- * executionGeneration) the stale run must NOT clobber the fresh launch's state.
- *
- * These tests prove:
- *   1. a stale merge-gate run cannot write direct execution metadata;
- *   2. the eventual stale worker response is still rejected by the orchestrator;
- *   3. a valid (current) merge-gate run still persists review-ready metadata.
- */
+// Regression coverage for the merge-gate direct-write lineage guard: a stale
+// (relaunched) merge-gate run must not clobber the fresh launch's metadata,
+// the eventual stale worker response is still rejected, and a current run
+// still persists review-ready metadata.
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import type { Logger, WorkRequest, WorkResponse } from '@invoker/contracts';
@@ -44,11 +33,8 @@ function makeMergeTask(execution: Partial<TaskState['execution']>): TaskState {
   } as TaskState;
 }
 
-/**
- * Minimal MergeRunnerHost that drives a real MergeGateExecutor without touching
- * git: with onFinish='none' and mergeMode='manual', runMergeGateActionImpl
- * takes the no-consolidation review_ready branch and never shells out.
- */
+// Minimal host: with onFinish='none' and mergeMode='manual' the run takes the
+// no-consolidation review_ready branch and never shells out to git.
 function makeHost(opts: {
   liveTask: TaskState;
   updateTask: ReturnType<typeof vi.fn>;
@@ -176,8 +162,7 @@ describe('merge-gate stale-lineage direct-write guard', () => {
   });
 
   it('does not write direct execution metadata when the merge task advanced to a newer attempt', async () => {
-    // Launch lineage: attempt-1 / gen 0. By the time the run finishes, the
-    // live merge task has been relaunched as attempt-2 / gen 1.
+    // Launch is attempt-1/gen 0; the live task has relaunched to attempt-2/gen 1.
     const liveTask = makeMergeTask({ selectedAttemptId: 'attempt-2', generation: 1 });
     const updateTask = vi.fn();
     const host = makeHost({ liveTask, updateTask });
@@ -185,20 +170,15 @@ describe('merge-gate stale-lineage direct-write guard', () => {
 
     const response = await runToCompletion(executor, makeRequest('attempt-1', 0));
 
-    // The stale run must not have written branch / workspacePath / review
-    // metadata directly to persistence — neither the up-front review clear nor
-    // the post-run handoff.
     expect(updateTask).not.toHaveBeenCalled();
-
-    // The run still emits a completion, and it carries the STALE launch lineage
-    // so the worker-response guard (asserted below) will reject it.
+    // Completion carries the stale lineage so the worker-response guard rejects it.
     expect(response.status).toBe('review_ready');
     expect(response.attemptId).toBe('attempt-1');
     expect(response.executionGeneration).toBe(0);
   });
 
   it('does not write direct execution metadata when the merge task advanced to a newer generation', async () => {
-    // Same attempt id, but the live generation has moved past the launch one.
+    // Same attempt id, but the live generation moved past the launch one.
     const liveTask = makeMergeTask({ selectedAttemptId: 'attempt-1', generation: 2 });
     const updateTask = vi.fn();
     const host = makeHost({ liveTask, updateTask });
@@ -212,7 +192,7 @@ describe('merge-gate stale-lineage direct-write guard', () => {
   });
 
   it('persists review-ready metadata when the launch lineage is still current', async () => {
-    // Live merge task matches the launch lineage (attempt-1 / gen 0).
+    // Live task matches the launch lineage (attempt-1/gen 0).
     const liveTask = makeMergeTask({ selectedAttemptId: 'attempt-1', generation: 0 });
     const updateTask = vi.fn();
     const host = makeHost({ liveTask, updateTask });

--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -151,10 +151,8 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
 
     try {
       this.emitOutput(handle.executionId, `[merge] Starting merge gate action: ${task.id}\n`);
-      // Launch lineage from the dispatched request. If the merge task is
-      // relaunched while this long-running action is in flight, the direct
-      // metadata write below must be suppressed so stale work cannot overwrite
-      // the newer launch's branch/workspacePath/review fields.
+      // Capture launch lineage so a stale (relaunched) run's direct metadata
+      // write is suppressed.
       const lineage: MergeGateLineage = {
         selectedAttemptId: entry.request.attemptId,
         generation: entry.request.executionGeneration ?? 0,

--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -5,8 +5,8 @@ import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
-import type { MergeRunnerHost } from './merge-runner.js';
-import { runMergeGateActionImpl } from './merge-runner.js';
+import type { MergeRunnerHost, MergeGateLineage } from './merge-runner.js';
+import { runMergeGateActionImpl, updateMergeGateMetadataIfCurrent } from './merge-runner.js';
 
 interface MergeGateEntry extends BaseEntry {
   killed?: boolean;
@@ -151,7 +151,15 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
 
     try {
       this.emitOutput(handle.executionId, `[merge] Starting merge gate action: ${task.id}\n`);
-      const result = await runMergeGateActionImpl(this.host, task);
+      // Launch lineage from the dispatched request. If the merge task is
+      // relaunched while this long-running action is in flight, the direct
+      // metadata write below must be suppressed so stale work cannot overwrite
+      // the newer launch's branch/workspacePath/review fields.
+      const lineage: MergeGateLineage = {
+        selectedAttemptId: entry.request.attemptId,
+        generation: entry.request.executionGeneration ?? 0,
+      };
+      const result = await runMergeGateActionImpl(this.host, task, { lineage });
       const executionChanges = result.taskChanges.execution
         ? {
           ...result.taskChanges.execution,
@@ -175,9 +183,18 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
         handle.branch = executionChanges.branch;
       }
       if (executionChanges) {
-        this.host.persistence.updateTask(task.id, {
-          execution: executionChanges,
-        });
+        const applied = updateMergeGateMetadataIfCurrent(
+          this.host,
+          task.id,
+          { execution: executionChanges },
+          lineage,
+        );
+        if (!applied) {
+          this.emitOutput(
+            handle.executionId,
+            `[merge] Skipped stale merge-gate metadata write for ${task.id} (merge task advanced to a newer launch)\n`,
+          );
+        }
       }
       this.cleanupLaunchWorkspace(launchWorkspacePath, executionChanges?.workspacePath);
       this.emitOutput(handle.executionId, `[merge] Merge gate action finished: ${task.id} status=${result.response.status}\n`);

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -454,18 +454,9 @@ export function collectDirectNonMergeTaskIds(
 
 // ── Stale-lineage guard for direct execution-metadata writes ──────────────
 
-/**
- * Lineage of a merge task captured when a merge-gate run begins.
- *
- * Direct `persistence.updateTask` writes of execution metadata (branch,
- * workspacePath, review fields, fixed-integration fields) bypass the
- * worker-response lineage guard in {@link Orchestrator.handleWorkerResponse}.
- * A merge-gate run can take a long time (consolidation, PR creation); if the
- * merge task is relaunched meanwhile (a newer `selectedAttemptId` or
- * `executionGeneration` now owns it), the stale run must not clobber the fresh
- * launch's state. Capture the launch lineage up front and gate every such
- * direct write on it.
- */
+// Direct updateTask writes of merge-gate metadata bypass the worker-response
+// lineage guard. A merge-gate run can be long-lived, so if the merge task is
+// relaunched meanwhile, capture the launch lineage up front and gate the write.
 export interface MergeGateLineage {
   selectedAttemptId: string | undefined;
   generation: number;
@@ -478,22 +469,14 @@ export function captureMergeGateLineage(task: TaskState): MergeGateLineage {
   };
 }
 
-/**
- * True when the live merge task still matches the captured launch lineage.
- * Mirrors {@link Orchestrator.taskMatchesLineageExpectation} /
- * `TaskRunner.isLaunchStale` so the direct-write guard and the worker-response
- * guard agree on what "stale" means.
- */
+// True when the live merge task still matches the captured launch lineage.
 export function mergeGateLineageIsCurrent(
   host: MergeRunnerHost,
   taskId: string,
   expected: MergeGateLineage,
 ): boolean {
   const current = host.orchestrator.getTask(taskId);
-  // If the task is no longer in the graph we cannot positively confirm the
-  // lineage advanced, so do not suppress the write (matches the not-stale
-  // fall-through in `TaskRunner.isLaunchStale`). The guard only blocks a write
-  // when a newer attempt/generation is actually observed.
+  // Task gone from the graph: can't confirm it advanced, so don't suppress.
   if (!current) return true;
   const currentAttempt = current.execution.selectedAttemptId;
   if (currentAttempt !== undefined && currentAttempt !== expected.selectedAttemptId) {
@@ -503,13 +486,8 @@ export function mergeGateLineageIsCurrent(
   return true;
 }
 
-/**
- * Lineage-guarded direct write of merge-gate execution metadata. Skips (and
- * traces) the write when the merge task has advanced past `expected`, so stale
- * merge-gate work cannot overwrite branch / workspacePath / review /
- * fixed-integration fields belonging to a newer launch. Returns true when the
- * write was applied.
- */
+// Lineage-guarded direct write; skips (and traces) when the task advanced past
+// `expected`. Returns true when the write was applied.
 export function updateMergeGateMetadataIfCurrent(
   host: MergeRunnerHost,
   taskId: string,
@@ -543,9 +521,8 @@ export async function runMergeGateActionImpl(
   task: TaskState,
   opts: { gateWorkspacePath?: string; lineage?: MergeGateLineage } = {},
 ): Promise<MergeGateActionResult> {
-  // Launch lineage for gating direct execution-metadata writes. The executor
-  // passes the dispatched request's lineage; legacy callers fall back to the
-  // task snapshot they were handed.
+  // Executor passes the dispatched request's lineage; legacy callers fall back
+  // to the task snapshot.
   const launchLineage = opts.lineage ?? captureMergeGateLineage(task);
   const workflowId = task.config.workflowId;
   const workflow = workflowId

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -452,6 +452,85 @@ export function collectDirectNonMergeTaskIds(
   return out;
 }
 
+// ── Stale-lineage guard for direct execution-metadata writes ──────────────
+
+/**
+ * Lineage of a merge task captured when a merge-gate run begins.
+ *
+ * Direct `persistence.updateTask` writes of execution metadata (branch,
+ * workspacePath, review fields, fixed-integration fields) bypass the
+ * worker-response lineage guard in {@link Orchestrator.handleWorkerResponse}.
+ * A merge-gate run can take a long time (consolidation, PR creation); if the
+ * merge task is relaunched meanwhile (a newer `selectedAttemptId` or
+ * `executionGeneration` now owns it), the stale run must not clobber the fresh
+ * launch's state. Capture the launch lineage up front and gate every such
+ * direct write on it.
+ */
+export interface MergeGateLineage {
+  selectedAttemptId: string | undefined;
+  generation: number;
+}
+
+export function captureMergeGateLineage(task: TaskState): MergeGateLineage {
+  return {
+    selectedAttemptId: task.execution.selectedAttemptId,
+    generation: task.execution.generation ?? 0,
+  };
+}
+
+/**
+ * True when the live merge task still matches the captured launch lineage.
+ * Mirrors {@link Orchestrator.taskMatchesLineageExpectation} /
+ * `TaskRunner.isLaunchStale` so the direct-write guard and the worker-response
+ * guard agree on what "stale" means.
+ */
+export function mergeGateLineageIsCurrent(
+  host: MergeRunnerHost,
+  taskId: string,
+  expected: MergeGateLineage,
+): boolean {
+  const current = host.orchestrator.getTask(taskId);
+  // If the task is no longer in the graph we cannot positively confirm the
+  // lineage advanced, so do not suppress the write (matches the not-stale
+  // fall-through in `TaskRunner.isLaunchStale`). The guard only blocks a write
+  // when a newer attempt/generation is actually observed.
+  if (!current) return true;
+  const currentAttempt = current.execution.selectedAttemptId;
+  if (currentAttempt !== undefined && currentAttempt !== expected.selectedAttemptId) {
+    return false;
+  }
+  if ((current.execution.generation ?? 0) !== expected.generation) return false;
+  return true;
+}
+
+/**
+ * Lineage-guarded direct write of merge-gate execution metadata. Skips (and
+ * traces) the write when the merge task has advanced past `expected`, so stale
+ * merge-gate work cannot overwrite branch / workspacePath / review /
+ * fixed-integration fields belonging to a newer launch. Returns true when the
+ * write was applied.
+ */
+export function updateMergeGateMetadataIfCurrent(
+  host: MergeRunnerHost,
+  taskId: string,
+  changes: TaskStateChanges,
+  expected: MergeGateLineage,
+): boolean {
+  if (!mergeGateLineageIsCurrent(host, taskId, expected)) {
+    const current = host.orchestrator.getTask(taskId);
+    mergeTrace('DIRECT_WRITE_STALE_LINEAGE_SKIPPED', {
+      taskId,
+      expectedSelectedAttemptId: expected.selectedAttemptId ?? null,
+      expectedGeneration: expected.generation,
+      currentSelectedAttemptId: current?.execution.selectedAttemptId ?? null,
+      currentGeneration: current ? current.execution.generation ?? 0 : null,
+    });
+    return false;
+  }
+  host.persistence.updateTask(taskId, changes);
+  return true;
+}
+
 // ── Extracted functions ──────────────────────────────────
 
 export interface MergeGateActionResult {
@@ -462,8 +541,12 @@ export interface MergeGateActionResult {
 export async function runMergeGateActionImpl(
   host: MergeRunnerHost,
   task: TaskState,
-  opts: { gateWorkspacePath?: string } = {},
+  opts: { gateWorkspacePath?: string; lineage?: MergeGateLineage } = {},
 ): Promise<MergeGateActionResult> {
+  // Launch lineage for gating direct execution-metadata writes. The executor
+  // passes the dispatched request's lineage; legacy callers fall back to the
+  // task snapshot they were handed.
+  const launchLineage = opts.lineage ?? captureMergeGateLineage(task);
   const workflowId = task.config.workflowId;
   const workflow = workflowId
     ? host.persistence.loadWorkflow(workflowId)
@@ -495,13 +578,13 @@ export async function runMergeGateActionImpl(
       `mergeMode=${mergeMode} onFinish=${onFinish} dbWorkspacePath=${safeGetWorkspacePath(host.persistence, task.id) ?? 'NULL'}`,
   );
 
-  host.persistence.updateTask(task.id, {
+  updateMergeGateMetadataIfCurrent(host, task.id, {
     execution: {
       reviewUrl: undefined,
       reviewId: undefined,
       reviewStatus: undefined,
     },
-  });
+  }, launchLineage);
 
   // Create a persistent gate worktree so workspacePath is never the main repo.
   // Use baseBranch as the ref because featureBranch may not exist yet
@@ -806,7 +889,7 @@ export async function executeMergeNodeImpl(
     config: legacyConfig,
   };
 
-  host.persistence.updateTask(task.id, legacyChanges);
+  updateMergeGateMetadataIfCurrent(host, task.id, legacyChanges, captureMergeGateLineage(task));
 
   if (response.status === 'review_ready') {
     setMergeGateReviewReady(host, task.id, legacyChanges, {
@@ -1286,10 +1369,10 @@ export async function publishAfterFixImpl(
       });
       const reviewUrl = await host.execPr(baseBranch, featureBranch, workflow?.name ?? 'Workflow', prBody, consolidateDir);
       console.log(`[merge] Post-fix: created pull request ${reviewUrl}`);
-      host.persistence.updateTask(task.id, {
+      updateMergeGateMetadataIfCurrent(host, task.id, {
         config: { summary },
         execution: { reviewUrl },
-      });
+      }, captureMergeGateLineage(task));
     }
 
     setMergeGateReviewReady(host, task.id, {


### PR DESCRIPTION
## Summary

The merge gate no longer lets old, in-flight work overwrite a newer launch's task state.

A merge gate run can take a while; it consolidates branches and opens a pull request.

If that merge task is relaunched mid-run, the old run used to write its branch and review fields straight to the database.

That out-of-date write clobbered the fresh launch. Now every such direct write first checks the merge task's captured launch lineage.

If a newer attempt or generation now owns the task, the write is dropped and traced instead.

<details>
<summary>Review metadata</summary>

Review Claim: Gate the merge gate's direct execution-metadata writes on its captured launch lineage so an out-of-date, relaunched run cannot overwrite a newer launch's state.

Review Lane: behavior

Review Unit: routing

Safety Invariant: When the live merge task still matches the captured lineage, the write happens exactly as it does today, so the happy path is unchanged. The guard only adds a drop-and-trace branch when a newer attempt or generation is observed, and it never blocks a write for a task that has left the graph. The existing worker-response lineage guard is left untouched and still rejects the eventual completion.

Slice Rationale: This slice closes only the merge-gate direct-write path. The worker-response lineage guard already covers the completion path; bundling both would mix two separate guards in one review.

</details>

## Non-goals

- Does not change the worker-response lineage guard or how completions are accepted.
- Does not change how merge tasks are relaunched, or how attempt and generation values are assigned.
- Does not touch the polling or approval runtime in `task-runner.ts`.

## Test Plan

- [ ] `cd packages/execution-engine && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved merge-gate handling so task updates are only applied when they match the latest run state.
  * Prevented older merge results from overwriting newer task details, reducing cases where review info or branch data could be replaced incorrectly.
  * Added safer handling for merge completion responses so valid reviews still finish normally even when stale updates are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->