### PR TITLE
Add graph drag benchmark and stop dispatch failure loops

### DIFF
--- a/packages/app/e2e/ui-graph-drag-performance.spec.ts
+++ b/packages/app/e2e/ui-graph-drag-performance.spec.ts
@@ -1,0 +1,239 @@
+import { expect, test, E2E_REPO_URL } from './fixtures/electron-app.js';
+import { stringify as yamlStringify } from 'yaml';
+import type { Page } from '@playwright/test';
+
+const WORKFLOW_COUNT = 50;
+const TASKS_PER_WORKFLOW = 8;
+const DRAG_STEPS = 60;
+const DRAG_STEP_DELAY_MS = 16;
+const RECORDING_DURATION_MS = 1_400;
+const UPDATE_BURSTS = 12;
+const UPDATES_PER_BURST = 24;
+const UPDATE_BURST_DELAY_MS = 40;
+const MIN_FRAME_COUNT = 35;
+const MAX_P95_FRAME_GAP_MS = 80;
+const MAX_FRAME_GAP_MS = 250;
+const MIN_TRANSFORM_CHANGES = 12;
+
+interface DragPerfResult {
+  frameCount: number;
+  maxFrameGapMs: number;
+  p95FrameGapMs: number;
+  transformChanges: number;
+  transformChanged: boolean;
+  durationMs: number;
+}
+
+declare global {
+  interface Window {
+    __invokerDragPerf?: {
+      done: boolean;
+      startedAt: number;
+      finishedAt: number;
+      frames: number[];
+      transforms: string[];
+    };
+  }
+}
+
+function buildPlan(index: number) {
+  return {
+    name: `UI Drag Perf Plan ${index}`,
+    repoUrl: E2E_REPO_URL,
+    onFinish: 'none' as const,
+    tasks: Array.from({ length: TASKS_PER_WORKFLOW }, (_, taskIndex) => ({
+      id: `task-${index}-${taskIndex}`,
+      description: `Task ${index}-${taskIndex}`,
+      command: `echo task-${index}-${taskIndex}`,
+      dependencies: taskIndex === 0 ? [] : [`task-${index}-${taskIndex - 1}`],
+    })),
+  };
+}
+
+
+async function seedLargeWorkflowGraph(page: Page): Promise<void> {
+  const plans = Array.from({ length: WORKFLOW_COUNT }, (_, index) => yamlStringify(buildPlan(index)));
+  await page.evaluate(async (planTexts) => {
+    for (const planText of planTexts) {
+      await window.invoker.loadPlan(planText);
+    }
+  }, plans);
+  await page.waitForFunction(
+    (expected) => window.invoker.listWorkflows().then((workflows) => workflows.length >= expected),
+    WORKFLOW_COUNT,
+    { timeout: 30_000 },
+  );
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({ state: 'visible', timeout: 10_000 });
+}
+
+async function recordDragPerformance(
+  page: Page,
+  paneSelector: string,
+  viewportSelector: string,
+  duringDrag?: () => Promise<unknown>,
+): Promise<DragPerfResult> {
+  await page.evaluate(({ durationMs, viewportSelector: selector }) => {
+    const viewport = document.querySelector(selector) as HTMLElement | null;
+    if (!viewport) throw new Error(`Missing viewport: ${selector}`);
+    const state = {
+      done: false,
+      startedAt: performance.now(),
+      finishedAt: 0,
+      frames: [] as number[],
+      transforms: [] as string[],
+    };
+    window.__invokerDragPerf = state;
+
+    const sample = (timestamp: number) => {
+      state.frames.push(timestamp);
+      state.transforms.push(getComputedStyle(viewport).transform);
+      if (timestamp - state.startedAt >= durationMs) {
+        state.done = true;
+        state.finishedAt = timestamp;
+        return;
+      }
+      requestAnimationFrame(sample);
+    };
+    requestAnimationFrame(sample);
+  }, { durationMs: RECORDING_DURATION_MS, viewportSelector });
+
+  const pane = page.locator(paneSelector).first();
+  const box = await pane.boundingBox();
+  if (!box) throw new Error(`Graph pane is not visible: ${paneSelector}`);
+
+  const startX = box.x + box.width * 0.5;
+  const startY = box.y + box.height * 0.5;
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  const updateWork = duringDrag?.() ?? Promise.resolve();
+  for (let step = 1; step <= DRAG_STEPS; step += 1) {
+    const progress = step / DRAG_STEPS;
+    await page.mouse.move(startX + 360 * progress, startY + Math.sin(progress * Math.PI * 2) * 24);
+    await page.waitForTimeout(DRAG_STEP_DELAY_MS);
+  }
+  await page.mouse.up();
+  await updateWork;
+
+  await page.waitForFunction(() => window.__invokerDragPerf?.done === true, null, { timeout: RECORDING_DURATION_MS + 2_000 });
+
+  return page.evaluate(() => {
+    const state = window.__invokerDragPerf;
+    if (!state) throw new Error('Missing drag performance samples');
+    const gaps: number[] = [];
+    for (let i = 1; i < state.frames.length; i += 1) {
+      gaps.push(state.frames[i] - state.frames[i - 1]);
+    }
+    let transformChanges = 0;
+    for (let i = 1; i < state.transforms.length; i += 1) {
+      if (state.transforms[i] !== state.transforms[i - 1]) transformChanges += 1;
+    }
+    const sorted = [...gaps].sort((a, b) => a - b);
+    const p95Index = sorted.length === 0 ? 0 : Math.ceil(sorted.length * 0.95) - 1;
+    return {
+      frameCount: state.frames.length,
+      maxFrameGapMs: Math.max(0, ...gaps),
+      p95FrameGapMs: sorted[p95Index] ?? 0,
+      transformChanges,
+      transformChanged: new Set(state.transforms).size > 1,
+      durationMs: state.finishedAt - state.startedAt,
+    };
+  });
+}
+
+async function streamTaskUpdatesDuringDrag(page: Page): Promise<number> {
+  const taskIds = await page.evaluate(async () => {
+    const result = await window.invoker.getTasks();
+    const tasks = Array.isArray(result) ? result : result.tasks;
+    return tasks.map((task: { id: string }) => task.id);
+  });
+  let updateCount = 0;
+  const statuses = ['running', 'completed', 'failed', 'pending'] as const;
+
+  for (let burst = 0; burst < UPDATE_BURSTS; burst += 1) {
+    const updates = Array.from({ length: UPDATES_PER_BURST }, (_, offset) => {
+      const taskId = taskIds[(burst * UPDATES_PER_BURST + offset) % taskIds.length];
+      const status = statuses[(burst + offset) % statuses.length];
+      const now = new Date();
+      return {
+        taskId,
+        changes: {
+          status,
+          execution: {
+            startedAt: now,
+            completedAt: status === 'completed' || status === 'failed' ? now : undefined,
+            exitCode: status === 'completed' ? 0 : status === 'failed' ? 1 : undefined,
+            error: status === 'failed' ? `drag update burst ${burst}` : undefined,
+          },
+        },
+      };
+    });
+    await page.evaluate((burstUpdates) => window.invoker.injectTaskStates!(burstUpdates), updates);
+    updateCount += updates.length;
+    await page.waitForTimeout(UPDATE_BURST_DELAY_MS);
+  }
+
+  return updateCount;
+}
+
+function expectSmoothDrag(result: DragPerfResult): void {
+  expect(result.transformChanged, JSON.stringify(result)).toBe(true);
+  expect(result.transformChanges, JSON.stringify(result)).toBeGreaterThanOrEqual(MIN_TRANSFORM_CHANGES);
+  expect(result.frameCount, JSON.stringify(result)).toBeGreaterThanOrEqual(MIN_FRAME_COUNT);
+  expect(result.p95FrameGapMs, JSON.stringify(result)).toBeLessThanOrEqual(MAX_P95_FRAME_GAP_MS);
+  expect(result.maxFrameGapMs, JSON.stringify(result)).toBeLessThanOrEqual(MAX_FRAME_GAP_MS);
+}
+
+test('workflow graph pan stays responsive under a large persisted graph', async ({ page }) => {
+  await seedLargeWorkflowGraph(page);
+
+  const result = await recordDragPerformance(
+    page,
+    '[data-testid="workflow-graph-react-flow"] .react-flow__pane',
+    '[data-testid="workflow-graph-react-flow"] .react-flow__viewport',
+  );
+
+  console.log(`UI_GRAPH_DRAG_BENCH_RESULT=${JSON.stringify({
+    ...result,
+    workflowCount: WORKFLOW_COUNT,
+    taskCount: WORKFLOW_COUNT * TASKS_PER_WORKFLOW,
+    thresholds: {
+      minFrameCount: MIN_FRAME_COUNT,
+      maxP95FrameGapMs: MAX_P95_FRAME_GAP_MS,
+      maxFrameGapMs: MAX_FRAME_GAP_MS,
+      minTransformChanges: MIN_TRANSFORM_CHANGES,
+    },
+  })}`);
+  expectSmoothDrag(result);
+});
+
+test('workflow graph pan stays responsive while task updates arrive', async ({ page }) => {
+  await seedLargeWorkflowGraph(page);
+
+  let updateCount = 0;
+  const result = await recordDragPerformance(
+    page,
+    '[data-testid="workflow-graph-react-flow"] .react-flow__pane',
+    '[data-testid="workflow-graph-react-flow"] .react-flow__viewport',
+    async () => {
+      updateCount = await streamTaskUpdatesDuringDrag(page);
+    },
+  );
+
+  console.log(`UI_GRAPH_DRAG_WITH_UPDATES_BENCH_RESULT=${JSON.stringify({
+    ...result,
+    workflowCount: WORKFLOW_COUNT,
+    taskCount: WORKFLOW_COUNT * TASKS_PER_WORKFLOW,
+    updateCount,
+    updateBursts: UPDATE_BURSTS,
+    updatesPerBurst: UPDATES_PER_BURST,
+    thresholds: {
+      minFrameCount: MIN_FRAME_COUNT,
+      maxP95FrameGapMs: MAX_P95_FRAME_GAP_MS,
+      maxFrameGapMs: MAX_FRAME_GAP_MS,
+      minTransformChanges: MIN_TRANSFORM_CHANGES,
+    },
+  })}`);
+  expect(updateCount).toBe(UPDATE_BURSTS * UPDATES_PER_BURST);
+  expectSmoothDrag(result);
+});

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -177,6 +177,35 @@ describe('LaunchDispatcher', () => {
       expect(after?.dispatchOwner).toBeUndefined();
       expect(after?.fencedUntil).toBeUndefined();
     });
+    it('fail abandons after fast failures reach the dispatch retry limit', () => {
+      seedWorkflowAndTask('attempt-fast-fail');
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-1/t1',
+        attemptId: 'attempt-fast-fail',
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+      adapter.claimLaunchDispatchAtomic({
+        ownerId: 'owner-test',
+      });
+      const prepare = vi.fn();
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-test',
+        maxAttempts: 1,
+        orchestrator: {
+          prepareTaskForNewAttempt: prepare,
+        },
+      });
+
+      expect(dispatcher.failDispatch(enqueued.id, new Error('ssh pool unavailable'))).toBe(true);
+
+      const after = adapter.loadLaunchDispatchById(enqueued.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/ssh pool unavailable/);
+      expect(prepare).not.toHaveBeenCalled();
+      expect(adapter.getEvents('wf-1/t1').some((event) => event.eventType === 'task.failed')).toBe(false);
+    });
 
     it('fail coerces a non-Error value to its string form', () => {
       seedWorkflowAndTask('attempt-fail-string');

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -15,6 +15,7 @@ import { DISPATCH_MAX_ATTEMPTS, type Logger } from '@invoker/contracts';
 
 export type LaunchDispatcherPersistence = Pick<
   SQLiteAdapter,
+  | 'loadLaunchDispatchById'
   | 'markLaunchDispatchCompleted'
   | 'markLaunchDispatchFailed'
   | 'markLaunchDispatchAbandoned'
@@ -287,37 +288,13 @@ export class LaunchDispatcher {
     if (candidates.length === 0) return 0;
     let abandoned = 0;
     for (const row of candidates) {
-      const message =
-        `Launch dispatch abandoned after ${row.attemptsCount} attempt(s); ` +
-        `last error: ${row.lastError ?? 'no concrete error recorded'}`;
-      const ok = this.persistence.markLaunchDispatchAbandoned(row.id, message, nowIso);
-      if (!ok) continue;
+      const message = this.launchDispatchAbandonedMessage(
+        row,
+        row.lastError ?? 'no concrete error recorded',
+      );
+      if (!this.abandonDispatch(row, message, nowIso)) continue;
       abandoned += 1;
-      this.persistence.logEvent?.(row.taskId, 'task.failed', {
-        source: 'launch-dispatcher',
-        dispatchId: row.id,
-        attemptId: row.attemptId,
-        attemptsCount: row.attemptsCount,
-        error: message,
-      });
-      // CD.2 / Issue 14: release any execution-resource leases (SSH
-      // pool slots, worktree pool entries, etc.) the task acquired
-      // during executor selection but never released because the
-      // launch never completed. Without this, a launch abandoned
-      // during SSH selection leaves the pool slot reserved until its
-      // own lease expiry, which can starve the next launch.
-      this.releaseTaskResourceLeases(row.taskId, row.id);
-      try {
-        this.orchestrator?.prepareTaskForNewAttempt(row.taskId, 'launch-dispatch-abandoned');
-      } catch (err) {
-        this.logger?.warn?.('[launch-dispatcher] prepareTaskForNewAttempt failed', {
-          ownerId: this.ownerId,
-          taskId: row.taskId,
-          dispatchId: row.id,
-          error: err instanceof Error ? err.message : String(err),
-          module: 'launch-dispatcher',
-        });
-      }
+      this.recordAbandonedStuckLease(row, message);
     }
     if (abandoned > 0) {
       this.logger?.warn?.('[launch-dispatcher] abandoned', {
@@ -328,6 +305,52 @@ export class LaunchDispatcher {
       });
     }
     return abandoned;
+  }
+
+
+  private shouldAbandonAfterFastFailure(row: TaskLaunchDispatch): boolean {
+    const isTerminal = row.state === 'completed' || row.state === 'abandoned';
+    return !isTerminal && row.attemptsCount >= this.maxAttempts;
+  }
+
+  private launchDispatchAbandonedMessage(
+    row: Pick<TaskLaunchDispatch, 'attemptsCount'>,
+    lastError: string,
+  ): string {
+    return `Launch dispatch abandoned after ${row.attemptsCount} attempt(s); last error: ${lastError}`;
+  }
+
+  private abandonDispatch(row: TaskLaunchDispatch, message: string, nowIso?: string): boolean {
+    const accepted = this.persistence.markLaunchDispatchAbandoned(row.id, message, nowIso);
+    if (!accepted) return false;
+
+    this.releaseTaskResourceLeases(row.taskId, row.id);
+    return true;
+  }
+
+  private recordAbandonedStuckLease(row: TaskLaunchDispatch, message: string): void {
+    this.persistence.logEvent?.(row.taskId, 'task.failed', {
+      source: 'launch-dispatcher',
+      dispatchId: row.id,
+      attemptId: row.attemptId,
+      attemptsCount: row.attemptsCount,
+      error: message,
+    });
+    this.prepareTaskForNewAttempt(row.taskId, row.id);
+  }
+
+  private prepareTaskForNewAttempt(taskId: string, dispatchId: number): void {
+    try {
+      this.orchestrator?.prepareTaskForNewAttempt(taskId, 'launch-dispatch-abandoned');
+    } catch (err) {
+      this.logger?.warn?.('[launch-dispatcher] prepareTaskForNewAttempt failed', {
+        ownerId: this.ownerId,
+        taskId,
+        dispatchId,
+        error: err instanceof Error ? err.message : String(err),
+        module: 'launch-dispatcher',
+      });
+    }
   }
 
   /**
@@ -418,23 +441,41 @@ export class LaunchDispatcher {
   }
 
   /**
-   * Record a launch failure by re-enqueuing the dispatch row and storing
-   * the error message in `last_error`. The dispatcher's reaper /
-   * abandon-after-N-attempts logic decides whether to retry or abandon.
-   * Returns false when the row is already terminal.
+   * Record a launch failure. Normal failures are retried by re-enqueuing
+   * the row. A row that has already used its retry budget is abandoned
+   * instead. The TaskRunner still owns the task failure response, so this
+   * path must not prepare a fresh attempt here.
    */
   failDispatch(dispatchId: number, error: unknown): boolean {
     const message =
       error instanceof Error ? error.message : String(error ?? 'unknown launch error');
-    const ok = this.persistence.markLaunchDispatchFailed(dispatchId, message);
+    const row = this.persistence.loadLaunchDispatchById(dispatchId);
+
+    if (row && this.shouldAbandonAfterFastFailure(row)) {
+      const accepted = this.abandonDispatch(
+        row,
+        this.launchDispatchAbandonedMessage(row, message),
+      );
+      this.logger?.warn?.('[launch-dispatcher] abandoned after fast failures', {
+        ownerId: this.ownerId,
+        dispatchId,
+        attemptsCount: row.attemptsCount,
+        error: message,
+        accepted,
+        module: 'launch-dispatcher',
+      });
+      return accepted;
+    }
+
+    const accepted = this.persistence.markLaunchDispatchFailed(dispatchId, message);
     this.logger?.info?.('[launch-dispatcher] fail', {
       ownerId: this.ownerId,
       dispatchId,
       error: message,
-      accepted: ok,
+      accepted,
       module: 'launch-dispatcher',
     });
-    return ok;
+    return accepted;
   }
 }
 


### PR DESCRIPTION
## Summary

Graph dragging now has a CI check for smooth movement on a large saved graph.

The old check only proved the graph opened. It did not measure whether dragging stayed responsive, or what happened when task updates arrived mid-drag.

This adds two browser benchmarks. One drags a 50-workflow graph. The other streams 288 task updates during the same drag and uses the same frame-gap limits.

The freeze also came from fast launch failures being retried forever. Those now stop at the dispatch retry limit instead of flooding the app.

## Architecture

### Before

```mermaid
flowchart TD
  A[Launch dispatch fails] --> B[Mark failed]
  B --> C[Requeue immediately]
  C --> D[Claim again]
  D --> A
  C --> E[Renderer receives more updates]
  E --> F[Graph drag can stall]
```

### After

```mermaid
flowchart TD
  A[Launch dispatch fails] --> B{Retry limit reached?}
  B -- No --> C[Requeue dispatch]
  C --> D[Claim again]
  D --> A
  B -- Yes --> E[Abandon dispatch]
  E --> F[Release held resources]
  G[TaskRunner] --> H[Owns task failure response]
  I[CI graph drag benchmark] --> J[Measure frame gaps and pan movement]
  K[Task update stream] --> J
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatcher.test.ts`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/ui-graph-drag-performance.spec.ts`
- [x] `bash scripts/test-suites/required/05-delete-all-prod-db-guard.sh && bash scripts/test-suites/required/06-large-file-guardrail.sh && bash scripts/test-suites/required/07-invalid-config-json.sh && bash scripts/test-suites/required/15-owner-boundary-policy.sh && bash scripts/test-suites/required/50-verify-executor-routing.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 3aa74fe21df6758375bf79c5f6f7150ce98cfff0`
- Post-revert steps: None
- Data migration? No
