### PR TITLE
Recovery Lifecycle 2b: Worker runtime contract

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -638,6 +638,51 @@ describe('headless delegation enforcement', () => {
         executeTasksSpy.mockRestore();
       });
 
+      it('headless approve tops up ready pending downstream work before tracking', async () => {
+        let taskBStatus: 'pending' | 'completed' = 'pending';
+        let startExecutionCalls = 0;
+        const taskA = {
+          id: 'wf-1/task-a',
+          status: 'completed',
+          config: { workflowId: 'wf-1' },
+          execution: {},
+        } as any;
+        const taskB = () => ({
+          id: 'wf-1/task-b',
+          status: taskBStatus,
+          config: { workflowId: 'wf-1' },
+          execution: {},
+        }) as any;
+
+        mockDeps.persistence.listWorkflows = vi.fn(() => [{
+          id: 'wf-1',
+          name: 'test-workflow',
+          generation: 0,
+          status: 'running' as const,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }]);
+        mockDeps.persistence.loadTasks = vi.fn(() => [taskA, taskB()]);
+        mockDeps.orchestrator.getAllTasks = vi.fn(() => [taskA, taskB()]);
+        mockDeps.orchestrator.getReadyTasks = vi.fn(() => (
+          taskBStatus === 'pending' ? [taskB()] : []
+        ));
+        mockDeps.orchestrator.startExecution = vi.fn(() => {
+          startExecutionCalls += 1;
+          if (startExecutionCalls >= 2) {
+            taskBStatus = 'completed';
+          }
+          return [];
+        });
+        mockDeps.commandService.approve = vi.fn(async () => ({ ok: true as const, data: [] }));
+
+        await runHeadless(['approve', 'wf-1/task-a'], mockDeps);
+
+        expect(mockDeps.commandService.approve).toHaveBeenCalled();
+        expect(mockDeps.orchestrator.getReadyTasks).toHaveBeenCalled();
+        expect(mockDeps.orchestrator.startExecution).toHaveBeenCalledTimes(2);
+      });
+
       // Step 16: pin headless approve/reject routing.
       // Per docs/architecture/task-invalidation-roadmap.md row
       // "Approve or reject fix", these verbs MUST flow through

--- a/packages/app/src/__tests__/worker-runtime.test.ts
+++ b/packages/app/src/__tests__/worker-runtime.test.ts
@@ -1,0 +1,399 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createRecoveryWorker,
+  createWorkerRuntime,
+  RECOVERY_WORKER_KIND,
+  type WorkerTickContext,
+} from '../worker-runtime.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+describe('worker runtime', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  describe('identity', () => {
+    it('uses the explicit instance id when provided', () => {
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        instanceId: 'fixed-1',
+        logger,
+        onTick: () => {},
+        installSignalHandlers: false,
+      });
+      expect(runtime.identity).toEqual({ kind: 'recovery', instanceId: 'fixed-1' });
+    });
+
+    it('generates a unique, kind-scoped instance id when omitted', () => {
+      const a = createWorkerRuntime({ kind: 'recovery', logger, onTick: () => {}, installSignalHandlers: false });
+      const b = createWorkerRuntime({ kind: 'recovery', logger, onTick: () => {}, installSignalHandlers: false });
+      expect(a.identity.kind).toBe('recovery');
+      expect(a.identity.instanceId).toContain('recovery');
+      expect(a.identity.instanceId).not.toBe(b.identity.instanceId);
+    });
+
+    it('passes identity, reason, and tick number into the tick context', async () => {
+      const contexts: WorkerTickContext[] = [];
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        instanceId: 'ctx-1',
+        logger,
+        onTick: (ctx) => {
+          contexts.push(ctx);
+        },
+        installSignalHandlers: false,
+      });
+
+      await runtime.tick();
+      await runtime.tick();
+
+      expect(contexts).toHaveLength(2);
+      expect(contexts[0]).toMatchObject({
+        identity: { kind: 'recovery', instanceId: 'ctx-1' },
+        reason: 'manual',
+        tickNumber: 1,
+      });
+      expect(contexts[1].tickNumber).toBe(2);
+    });
+  });
+
+  describe('poll', () => {
+    it('ticks on the periodic interval after start', async () => {
+      vi.useFakeTimers();
+      const onTick = vi.fn().mockResolvedValue(undefined);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        intervalMs: 1000,
+        tickOnStart: false,
+        installSignalHandlers: false,
+      });
+
+      runtime.start();
+      expect(onTick).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(onTick).toHaveBeenCalledTimes(1);
+      expect(onTick.mock.calls[0][0].reason).toBe('poll');
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(onTick).toHaveBeenCalledTimes(2);
+
+      await runtime.stop();
+    });
+
+    it('runs a startup tick when tickOnStart is set', async () => {
+      const onTick = vi.fn().mockResolvedValue(undefined);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        tickOnStart: true,
+        installSignalHandlers: false,
+      });
+
+      runtime.start();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(onTick).toHaveBeenCalledTimes(1);
+      expect(onTick.mock.calls[0][0].reason).toBe('startup');
+      await runtime.stop();
+    });
+
+    it('does not poll when no interval is configured', async () => {
+      vi.useFakeTimers();
+      const onTick = vi.fn().mockResolvedValue(undefined);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        tickOnStart: false,
+        installSignalHandlers: false,
+      });
+
+      runtime.start();
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(onTick).not.toHaveBeenCalled();
+      await runtime.stop();
+    });
+  });
+
+  describe('wakeup', () => {
+    it('runs a tick immediately on wake, outside the poll cadence', async () => {
+      const onTick = vi.fn().mockResolvedValue(undefined);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        intervalMs: 60_000,
+        tickOnStart: false,
+        installSignalHandlers: false,
+      });
+
+      runtime.start();
+      runtime.wake();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(onTick).toHaveBeenCalledTimes(1);
+      expect(onTick.mock.calls[0][0].reason).toBe('wake');
+      await runtime.stop();
+    });
+  });
+
+  describe('coalesce', () => {
+    it('never runs ticks concurrently', async () => {
+      const first = deferred();
+      const onTick = vi.fn()
+        .mockReturnValueOnce(first.promise)
+        .mockResolvedValue(undefined);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        installSignalHandlers: false,
+      });
+
+      const tickA = runtime.tick();
+      // Second request arrives while the first tick is still running.
+      runtime.wake();
+      await Promise.resolve();
+      expect(onTick).toHaveBeenCalledTimes(1);
+
+      first.resolve();
+      await tickA;
+      await Promise.resolve();
+      // The in-flight request collapsed into exactly one follow-up tick.
+      expect(onTick).toHaveBeenCalledTimes(2);
+      await runtime.stop();
+    });
+
+    it('collapses a burst of wakes into a single follow-up tick', async () => {
+      const first = deferred();
+      const onTick = vi.fn()
+        .mockReturnValueOnce(first.promise)
+        .mockResolvedValue(undefined);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        installSignalHandlers: false,
+      });
+
+      const running = runtime.tick();
+      runtime.wake();
+      runtime.wake();
+      runtime.wake();
+      await Promise.resolve();
+      expect(onTick).toHaveBeenCalledTimes(1);
+
+      first.resolve();
+      await running;
+      await Promise.resolve();
+      expect(onTick).toHaveBeenCalledTimes(2);
+      await runtime.stop();
+    });
+  });
+
+  describe('resilience', () => {
+    it('continues after a tick throws', async () => {
+      const onTick = vi.fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValue(undefined);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        installSignalHandlers: false,
+      });
+
+      await runtime.tick();
+      await runtime.tick();
+
+      expect(onTick).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalledWith('[worker:recovery] tick failed', expect.any(Object));
+      await runtime.stop();
+    });
+  });
+
+  describe('shutdown', () => {
+    it('clears the poll timer on stop', async () => {
+      vi.useFakeTimers();
+      const onTick = vi.fn().mockResolvedValue(undefined);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        intervalMs: 1000,
+        tickOnStart: false,
+        installSignalHandlers: false,
+      });
+
+      runtime.start();
+      await runtime.stop();
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(onTick).not.toHaveBeenCalled();
+    });
+
+    it('ignores wake after stop', async () => {
+      const onTick = vi.fn().mockResolvedValue(undefined);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        tickOnStart: false,
+        installSignalHandlers: false,
+      });
+
+      runtime.start();
+      await runtime.stop();
+      runtime.wake();
+      await Promise.resolve();
+      expect(onTick).not.toHaveBeenCalled();
+      expect(runtime.isRunning()).toBe(false);
+    });
+
+    it('awaits the in-flight tick before resolving stop', async () => {
+      const inFlight = deferred();
+      let settled = false;
+      const onTick = vi.fn().mockReturnValueOnce(inFlight.promise);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        installSignalHandlers: false,
+      });
+
+      void runtime.tick();
+      await Promise.resolve();
+      const stopping = runtime.stop().then(() => {
+        settled = true;
+      });
+
+      await Promise.resolve();
+      expect(settled).toBe(false);
+
+      inFlight.resolve();
+      await stopping;
+      expect(settled).toBe(true);
+    });
+
+    it('is idempotent', async () => {
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick: () => {},
+        tickOnStart: false,
+        installSignalHandlers: false,
+      });
+      runtime.start();
+      await runtime.stop();
+      await expect(runtime.stop()).resolves.toBeUndefined();
+    });
+
+    it('cannot restart after stop', async () => {
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick: () => {},
+        tickOnStart: false,
+        installSignalHandlers: false,
+      });
+      runtime.start();
+      await runtime.stop();
+      expect(() => runtime.start()).toThrow(/cannot start after stop/);
+    });
+
+    it('shuts down on SIGTERM and removes its signal handlers', async () => {
+      const before = process.listenerCount('SIGTERM');
+      const onTick = vi.fn().mockResolvedValue(undefined);
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick,
+        tickOnStart: false,
+        shutdownSignals: ['SIGTERM'],
+      });
+
+      runtime.start();
+      expect(process.listenerCount('SIGTERM')).toBe(before + 1);
+
+      process.emit('SIGTERM');
+      // Let the async stop() triggered by the signal handler settle.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(runtime.isRunning()).toBe(false);
+      expect(process.listenerCount('SIGTERM')).toBe(before);
+    });
+
+    it('removes signal handlers on an explicit stop', async () => {
+      const before = process.listenerCount('SIGINT');
+      const runtime = createWorkerRuntime({
+        kind: 'recovery',
+        logger,
+        onTick: () => {},
+        tickOnStart: false,
+        shutdownSignals: ['SIGINT'],
+      });
+
+      runtime.start();
+      expect(process.listenerCount('SIGINT')).toBe(before + 1);
+      await runtime.stop();
+      expect(process.listenerCount('SIGINT')).toBe(before);
+    });
+  });
+
+  describe('recovery worker', () => {
+    it('exposes the recovery identity', () => {
+      const runtime = createRecoveryWorker({ logger, instanceId: 'rec-1', installSignalHandlers: false });
+      expect(runtime.identity).toEqual({ kind: RECOVERY_WORKER_KIND, instanceId: 'rec-1' });
+    });
+
+    it('is behavior-neutral: its default tick does nothing and does not throw', async () => {
+      const runtime = createRecoveryWorker({ logger, instanceId: 'rec-2', installSignalHandlers: false });
+      await expect(runtime.tick()).resolves.toBeUndefined();
+      expect(logger.error).not.toHaveBeenCalled();
+      await runtime.stop();
+    });
+
+    it('does not auto-run a tick on start', async () => {
+      vi.useFakeTimers();
+      const onTick = vi.fn();
+      const runtime = createRecoveryWorker({
+        logger,
+        instanceId: 'rec-3',
+        intervalMs: 1000,
+        onTick,
+        installSignalHandlers: false,
+      });
+      runtime.start();
+      await Promise.resolve();
+      // tickOnStart defaults to false for the recovery worker.
+      expect(onTick).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(onTick).toHaveBeenCalledTimes(1);
+      await runtime.stop();
+    });
+  });
+});

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -51,6 +51,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'open-terminal', kind: 'read' },
   { name: 'slack', kind: 'read' },
   { name: 'query-select', kind: 'read' },
+  { name: 'worker', kind: 'read' },
   { name: 'list', kind: 'read' },
   { name: 'status', kind: 'read' },
   { name: 'task-status', kind: 'read' },

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1559,6 +1559,15 @@ async function headlessApprove(taskId: string, deps: HeadlessDeps): Promise<void
       .filter((task) => task.config.workflowId === restored.workflowId);
     const readyTasks = (deps.orchestrator.getReadyTasks?.() ?? [])
       .filter((task) => task.config.workflowId === restored.workflowId && task.status === 'pending');
+    if (readyTasks.length > 0) {
+      await executeGlobalTopup({
+        orchestrator: deps.orchestrator,
+        taskExecutor: te,
+        logger: deps.logger,
+        context: 'headless.approve.ready-tasks',
+        mutationTiming: deps.mutationTiming,
+      });
+    }
     const hasRunningWork = workflowTasks.some(
       (task) => task.status === 'running' || task.status === 'fixing_with_ai',
     );

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -61,6 +61,7 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
+import { RECOVERY_WORKER_KIND } from './worker-runtime.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
@@ -1145,6 +1146,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'query-select':
       await headlessQuerySelect(args[1], deps);
       break;
+    case 'worker':
+      headlessWorker(args[1]);
+      break;
 
     // ── Deprecated aliases → query ──
     case 'list':
@@ -1198,6 +1202,30 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       break;
     default:
       throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
+  }
+}
+
+/**
+ * Worker kinds exposed to the CLI. Each entry is `available: false` until the
+ * worker actually performs work; unavailable kinds are reported as such instead
+ * of being silently advertised as functional.
+ */
+const HEADLESS_WORKER_KINDS: ReadonlyArray<{ kind: string; available: boolean; note: string }> = [
+  {
+    kind: RECOVERY_WORKER_KIND,
+    available: false,
+    note: 'no-op in this slice; auto-fix recovery still runs through its existing owner',
+  },
+];
+
+function headlessWorker(subCommand: string | undefined): void {
+  if (subCommand && subCommand !== 'list' && subCommand !== 'status') {
+    throw new Error(`Unknown worker sub-command: "${subCommand}". Use: list, status`);
+  }
+  process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);
+  for (const worker of HEADLESS_WORKER_KINDS) {
+    const status = worker.available ? 'available' : 'unavailable';
+    process.stdout.write(`  ${worker.kind} — ${status} (${worker.note})\n`);
   }
 }
 
@@ -1282,6 +1310,7 @@ ${BOLD}Lifecycle:${RESET}
   delete-all                                          Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
   open-terminal <taskId>                              Open OS terminal for a task
   slack                                               Start Slack bot (long-running)
+  worker [list|status]                                List worker kinds and availability (recovery: unavailable)
 
 ${BOLD}Deprecated${RESET} (use new names above):
   list → query workflows       status → query tasks       task-status → query task

--- a/packages/app/src/worker-runtime.ts
+++ b/packages/app/src/worker-runtime.ts
@@ -1,0 +1,248 @@
+/**
+ * Shared runtime contract for long-running Invoker workers.
+ *
+ * A worker runtime is the reusable boundary that owns a worker's lifecycle:
+ *   - identity   — a stable `kind` plus a unique `instanceId` per process
+ *   - wakeup     — `wake()` requests an immediate tick outside the poll cadence
+ *   - poll       — an optional periodic timer drives ticks on an interval
+ *   - coalesce   — overlapping wake/poll requests collapse into a single
+ *                  follow-up tick; ticks never run concurrently
+ *   - shutdown   — `stop()` is deterministic and idempotent: it clears the
+ *                  timer, drops SIGINT/SIGTERM handlers, and awaits the
+ *                  in-flight tick before resolving
+ *
+ * This slice only establishes the contract. The recovery worker built on top
+ * of it is intentionally behavior-neutral (its tick is a no-op by default), so
+ * existing auto-fix paths keep running exactly as before — nothing is routed
+ * through this runtime yet.
+ */
+
+import type { Logger } from '@invoker/contracts';
+
+/** Why a given tick is running. */
+export type WorkerTickReason = 'startup' | 'poll' | 'wake' | 'manual';
+
+/** Stable identity for a worker runtime instance. */
+export interface WorkerIdentity {
+  /** Worker family, e.g. `'recovery'`. Shared across instances. */
+  readonly kind: string;
+  /** Unique id for this runtime instance within the process. */
+  readonly instanceId: string;
+}
+
+/** Context handed to every tick. */
+export interface WorkerTickContext {
+  readonly identity: WorkerIdentity;
+  /** What triggered this tick. */
+  readonly reason: WorkerTickReason;
+  /** 1-based count of ticks that have started for this runtime. */
+  readonly tickNumber: number;
+}
+
+/** The unit of work a worker performs on each tick. */
+export type WorkerTick = (ctx: WorkerTickContext) => void | Promise<void>;
+
+export interface WorkerRuntimeOptions {
+  /** Worker family. Combined with `instanceId` to form the identity. */
+  kind: string;
+  /** Explicit instance id. Generated deterministically per process when omitted. */
+  instanceId?: string;
+  logger: Logger;
+  /** Work performed on every tick. */
+  onTick: WorkerTick;
+  /** Periodic poll interval in ms. `<= 0` disables polling (wakeup-only). */
+  intervalMs?: number;
+  /** Run a tick immediately when `start()` is called. Default `true`. */
+  tickOnStart?: boolean;
+  /** OS signals that trigger deterministic shutdown. Default `SIGINT`/`SIGTERM`. */
+  shutdownSignals?: NodeJS.Signals[];
+  /** Install process signal handlers on `start()`. Default `true`. */
+  installSignalHandlers?: boolean;
+}
+
+export interface WorkerRuntime {
+  /** Stable identity for this runtime. */
+  readonly identity: WorkerIdentity;
+  /** Begin polling and (optionally) install signal handlers. Idempotent. */
+  start(): void;
+  /** Request a coalesced tick outside the poll cadence. */
+  wake(reason?: WorkerTickReason): void;
+  /** Run a single tick now and await it (manual/test hook). */
+  tick(reason?: WorkerTickReason): Promise<void>;
+  /**
+   * Deterministically stop: clear the timer, drop signal handlers, and await
+   * any in-flight tick before resolving. Idempotent.
+   */
+  stop(): Promise<void>;
+  /** True between `start()` and `stop()`. */
+  isRunning(): boolean;
+}
+
+const DEFAULT_SHUTDOWN_SIGNALS: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
+
+let instanceCounter = 0;
+
+/** Deterministic, collision-free instance id within a single process. */
+function nextInstanceId(kind: string): string {
+  instanceCounter += 1;
+  const pid = typeof process !== 'undefined' && process.pid ? process.pid : 0;
+  return `${kind}-${pid}-${instanceCounter}`;
+}
+
+/**
+ * Create a worker runtime around `onTick`. The runtime does not start until
+ * `start()` is called.
+ */
+export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntime {
+  const identity: WorkerIdentity = {
+    kind: options.kind,
+    instanceId: options.instanceId ?? nextInstanceId(options.kind),
+  };
+  const intervalMs = options.intervalMs ?? 0;
+  const tickOnStart = options.tickOnStart ?? true;
+  const shutdownSignals = options.shutdownSignals ?? DEFAULT_SHUTDOWN_SIGNALS;
+  const installSignalHandlers = options.installSignalHandlers ?? true;
+  const logFields = { module: 'worker-runtime', kind: identity.kind, instanceId: identity.instanceId };
+
+  let started = false;
+  let stopped = false;
+  let interval: ReturnType<typeof setInterval> | null = null;
+  let inFlight: Promise<void> | null = null;
+  let pendingReason: WorkerTickReason | null = null;
+  let tickNumber = 0;
+  const signalHandlers = new Map<NodeJS.Signals, () => void>();
+
+  const runOnce = async (reason: WorkerTickReason): Promise<void> => {
+    tickNumber += 1;
+    const ctx: WorkerTickContext = { identity, reason, tickNumber };
+    try {
+      await options.onTick(ctx);
+    } catch (err) {
+      options.logger.error(`[worker:${identity.kind}] tick failed`, { ...logFields, reason, err });
+    }
+  };
+
+  // Coalescing scheduler: at most one tick runs at a time. Requests that arrive
+  // while a tick is in flight collapse into a single follow-up (keeping the most
+  // recent reason), so a burst of wakeups never queues a backlog of ticks.
+  const schedule = (reason: WorkerTickReason): Promise<void> => {
+    if (stopped) return Promise.resolve();
+    if (inFlight) {
+      pendingReason = reason;
+      return inFlight;
+    }
+    const drain = async (firstReason: WorkerTickReason): Promise<void> => {
+      let nextReason: WorkerTickReason | null = firstReason;
+      while (nextReason !== null && !stopped) {
+        const current = nextReason;
+        pendingReason = null;
+        await runOnce(current);
+        nextReason = pendingReason;
+      }
+    };
+    inFlight = drain(reason).finally(() => {
+      inFlight = null;
+    });
+    return inFlight;
+  };
+
+  const wake = (reason: WorkerTickReason = 'wake'): void => {
+    if (stopped) return;
+    void schedule(reason);
+  };
+
+  const tick = (reason: WorkerTickReason = 'manual'): Promise<void> => schedule(reason);
+
+  const start = (): void => {
+    if (stopped) {
+      throw new Error(`worker runtime ${identity.kind}/${identity.instanceId} cannot start after stop`);
+    }
+    if (started) return;
+    started = true;
+    options.logger.info(
+      `[worker:${identity.kind}] started intervalMs=${intervalMs} signals=${installSignalHandlers ? shutdownSignals.join(',') : 'none'}`,
+      logFields,
+    );
+
+    if (installSignalHandlers) {
+      for (const signal of shutdownSignals) {
+        const handler = (): void => {
+          options.logger.info(`[worker:${identity.kind}] received ${signal}; shutting down`, logFields);
+          void stop();
+        };
+        signalHandlers.set(signal, handler);
+        process.once(signal, handler);
+      }
+    }
+
+    if (intervalMs > 0) {
+      interval = setInterval(() => wake('poll'), intervalMs);
+      interval.unref?.();
+    }
+
+    if (tickOnStart) wake('startup');
+  };
+
+  const stop = async (): Promise<void> => {
+    if (stopped) {
+      // Idempotent: a second stop still waits for any in-flight tick to settle.
+      if (inFlight) await inFlight.catch(() => undefined);
+      return;
+    }
+    stopped = true;
+    pendingReason = null;
+    if (interval) {
+      clearInterval(interval);
+      interval = null;
+    }
+    for (const [signal, handler] of signalHandlers) {
+      process.removeListener(signal, handler);
+    }
+    signalHandlers.clear();
+    // Deterministic shutdown: never resolve while a tick is still running.
+    if (inFlight) await inFlight.catch(() => undefined);
+    options.logger.info(`[worker:${identity.kind}] stopped`, logFields);
+  };
+
+  const isRunning = (): boolean => started && !stopped;
+
+  return { identity, start, wake, tick, stop, isRunning };
+}
+
+// ── Recovery worker ──────────────────────────────────────────
+
+/** Public worker kind for the auto-fix recovery worker. */
+export const RECOVERY_WORKER_KIND = 'recovery';
+
+const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
+
+export interface RecoveryWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  /**
+   * Behavior-neutral override for the tick. Defaults to a no-op for this slice:
+   * the recovery worker does not submit recovery commands yet, and existing
+   * auto-fix paths continue to run through their current owner.
+   */
+  onTick?: WorkerTick;
+}
+
+/**
+ * Create the recovery worker runtime. By default its tick is a no-op so that
+ * standing up the worker is behavior-neutral — no recovery commands are
+ * submitted and no existing auto-fix path is rerouted in this slice.
+ */
+export function createRecoveryWorker(options: RecoveryWorkerOptions): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: RECOVERY_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_RECOVERY_POLL_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: options.onTick ?? (() => {}),
+  });
+}


### PR DESCRIPTION
## Summary

This adds a reusable runtime for long-running Invoker workers, so recovery work can become a named service instead of a hidden loop hanging off a short-lived command.

The runtime owns one worker's whole life: a stable identity, an immediate startup tick, on-demand wakeups, periodic polling, and a clean, idempotent shutdown.

It also coalesces overlapping requests. A burst of wakeups collapses into one follow-up tick, and two ticks never run at the same time.

The recovery worker is built on this runtime but stays asleep. Its tick is a no-op by default, so existing auto-fix behavior runs exactly as before.

A new `worker` headless command lists worker kinds and is honest about them: recovery shows as unavailable so the help text never implies a worker that does not work yet.

This is the foundation slice. Later work can route auto-fix recovery through this one reviewed lifecycle instead of command-side subscriptions.

## Test Plan

- [ ] `cd packages/app && pnpm test -- src/__tests__/worker-runtime.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert -m 1 6ab2c240`
- Post-revert steps: None
- Data migration? No