### PR TITLE
Move invalidation deps into workflow-core

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -5,7 +5,7 @@
  * following the pattern from resolve-conflict-action.test.ts.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { Orchestrator } from '@invoker/workflow-core';
+import { buildCancelInFlight, buildWorkflowInvalidationDeps, type Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
 import {
@@ -25,8 +25,6 @@ import {
   finalizeAppliedFix,
   autoFixOnFailure,
   autoFixOnReviewGateFailure,
-  buildCancelInFlight,
-  buildInvalidationDeps,
   selectFailureRecoveryRoute,
   deleteAllWorkflows,
   resolveConflictAction,
@@ -1495,7 +1493,7 @@ describe('buildCancelInFlight', () => {
 
     const cancel = buildCancelInFlight({
       orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
+      killActiveExecution: taskExecutor.killActiveExecution,
     });
     await cancel('task', 'task-a');
 
@@ -1521,27 +1519,23 @@ describe('buildCancelInFlight', () => {
 
     const cancel = buildCancelInFlight({
       orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
+      killActiveExecution: taskExecutor.killActiveExecution,
     });
     await cancel('workflow', 'wf-1');
 
     expect(orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(taskExecutor.killActiveExecution).toHaveBeenCalledTimes(2);
     expect(taskExecutor.killActiveExecution).toHaveBeenNthCalledWith(1, 'task-a');
     expect(taskExecutor.killActiveExecution).toHaveBeenNthCalledWith(2, 'task-b');
-    expect(orchestrator.cancelWorkflow.mock.invocationCallOrder[0]).toBeLessThan(
-      taskExecutor.killActiveExecution.mock.invocationCallOrder[0],
-    );
     expect(orchestrator.cancelTask).not.toHaveBeenCalled();
   });
 
-  it('is a no-op when scope is "none"', async () => {
+  it('is a no-op when scope is none', async () => {
     const orchestrator = { cancelTask: vi.fn(), cancelWorkflow: vi.fn() };
     const taskExecutor = { killActiveExecution: vi.fn() };
 
     const cancel = buildCancelInFlight({
       orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
+      killActiveExecution: taskExecutor.killActiveExecution,
     });
     await cancel('none', 'whatever');
 
@@ -1549,32 +1543,37 @@ describe('buildCancelInFlight', () => {
     expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
     expect(taskExecutor.killActiveExecution).not.toHaveBeenCalled();
   });
-
-  it('still cancels orchestrator state when no taskExecutor is provided', async () => {
-    const orchestrator = {
-      cancelTask: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: ['task-a'] })),
-      cancelWorkflow: vi.fn(),
-    };
-    const cancel = buildCancelInFlight({
-      orchestrator: orchestrator as unknown as Orchestrator,
-    });
-    await cancel('task', 'task-a');
-
-    expect(orchestrator.cancelTask).toHaveBeenCalledWith('task-a');
-  });
 });
 
-describe('buildInvalidationDeps', () => {
+describe('buildWorkflowInvalidationDeps', () => {
   function makeBaseOrchestrator() {
     return {
       retryTask: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
       recreateTask: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
+      recreateDownstream: vi.fn(() => [makeRunningTask({ id: 'task-b' })]),
       retryWorkflow: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
       recreateWorkflow: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
       cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
       cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      autoStartExternallyUnblockedReadyTasks: vi.fn(() => [makeRunningTask({ id: 'task-c' })]),
+      approve: vi.fn(async () => [makeRunningTask({ id: 'task-a' })]),
+      reject: vi.fn(),
+      getTask: vi.fn(() => ({ id: 'task-a', config: { workflowId: 'wf-1' }, execution: {} })),
+      forkWorkflow: vi.fn((workflowId: string) => ({
+        sourceWorkflowId: workflowId,
+        forkedWorkflowId: `${workflowId}-fork`,
+        started: [makeRunningTask({ id: `${workflowId}-fork/task-a`, config: { workflowId: `${workflowId}-fork` } as any })],
+      })),
+      cascadeInvalidationToDownstream: vi.fn(() => [makeRunningTask({ id: 'wf-2/leaf' })]),
+      recreateWorkflowFromFreshBase: vi.fn(async (_id: string, options?: any) => {
+        await options?.refreshBase?.(_id);
+        return [makeRunningTask({ id: 'task-a' })];
+      }),
+      resumeTaskAfterFixApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
     };
   }
+
   function makePersistence() {
     return {
       loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 0 })),
@@ -1582,55 +1581,67 @@ describe('buildInvalidationDeps', () => {
     };
   }
 
-  it('routes retryTask to orchestrator.retryTask', async () => {
+  function buildDeps(
+    orchestrator: ReturnType<typeof makeBaseOrchestrator>,
+    persistence: ReturnType<typeof makePersistence>,
+    taskExecutor?: Partial<TaskRunner>,
+  ) {
+    return buildWorkflowInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      requireWorkflow: (workflowId) => {
+        const workflow = persistence.loadWorkflow(workflowId);
+        if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+        return workflow as any;
+      },
+      setWorkflowGeneration: (workflowId, generation) => {
+        persistence.updateWorkflow(workflowId, { generation });
+      },
+      killActiveExecution: taskExecutor?.killActiveExecution?.bind(taskExecutor),
+      prepareFreshBase: taskExecutor?.preparePoolForRebaseRetry
+        ? async (workflowId, workflow) => {
+          if (!workflow.repoUrl) return undefined;
+          return taskExecutor.preparePoolForRebaseRetry!(
+            workflowId,
+            workflow.repoUrl,
+            workflow.baseBranch,
+          ) as any;
+        }
+        : undefined,
+      fixApprove: async (taskId) => {
+        const result = await approveTask(taskId, {
+          orchestrator: orchestrator as unknown as Orchestrator,
+          taskExecutor: taskExecutor as TaskRunner | undefined,
+        });
+        return result.started;
+      },
+      fixReject: (taskId) => {
+        rejectTask(taskId, { orchestrator: orchestrator as unknown as Orchestrator });
+        return [];
+      },
+    });
+  }
+
+  it('routes retry and recreate primitives through the orchestrator', async () => {
     const orchestrator = makeBaseOrchestrator();
     const persistence = makePersistence();
+    const deps = buildDeps(orchestrator, persistence);
 
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-    const result = await deps.retryTask('task-a');
+    await deps.retryTask('task-a');
+    await deps.recreateTask('task-a');
+    await deps.retryWorkflow('wf-1');
+    await deps.recreateDownstream!('task-a');
 
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
-    expect(orchestrator.recreateTask).not.toHaveBeenCalled();
-    expect(result).toHaveLength(1);
-  });
-
-  it('routes recreateTask to orchestrator.recreateTask', async () => {
-    const orchestrator = makeBaseOrchestrator();
-    const persistence = makePersistence();
-
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-    await deps.recreateTask('task-a');
-
     expect(orchestrator.recreateTask).toHaveBeenCalledWith('task-a');
-  });
-
-  it('routes retryWorkflow to orchestrator.retryWorkflow', async () => {
-    const orchestrator = makeBaseOrchestrator();
-    const persistence = makePersistence();
-
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-    await deps.retryWorkflow('wf-1');
-
     expect(orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(orchestrator.recreateDownstream).toHaveBeenCalledWith('task-a');
   });
 
-  it('routes recreateWorkflow through bumpGenerationAndRecreate', async () => {
+  it('bumps generation before recreateWorkflow', async () => {
     const orchestrator = makeBaseOrchestrator();
     const persistence = makePersistence();
+    const deps = buildDeps(orchestrator, persistence);
 
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
     await deps.recreateWorkflow('wf-1');
 
     expect(persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
@@ -1638,254 +1649,68 @@ describe('buildInvalidationDeps', () => {
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
   });
 
-  it('wires recreateWorkflowFromFreshBase to the orchestrator method', async () => {
-    const orchestrator = {
-      ...makeBaseOrchestrator(),
-      // The real orchestrator drives the `refreshBase` callback; mirror
-      // that here so the test exercises the app-layer's pool-prep wiring.
-      recreateWorkflowFromFreshBase: vi.fn(async (_id: string, options?: any) => {
-        await options?.refreshBase?.(_id);
-        return [makeRunningTask({ id: 'task-a' })];
-      }),
-    };
+  it('prepares fresh base and bumps generation before recreateWorkflowFromFreshBase', async () => {
+    const orchestrator = makeBaseOrchestrator();
     const persistence = makePersistence();
-    const taskExecutor = {
-      preparePoolForRebaseRetry: vi.fn(async () => undefined),
-    };
-
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
-    });
-
-    // Step 12 promotes this dep — the policy router's
-    // "not yet wired (Step 12)" error path is dead code in production.
-    expect(deps.recreateWorkflowFromFreshBase).toBeDefined();
-
     persistence.loadWorkflow = vi.fn(() => ({
       id: 'wf-1',
       generation: 4,
       repoUrl: 'https://example/repo.git',
       baseBranch: 'main',
     } as any));
+    const taskExecutor = {
+      preparePoolForRebaseRetry: vi.fn(async () => undefined),
+    };
+    const deps = buildDeps(orchestrator, persistence, taskExecutor);
 
     const result = await deps.recreateWorkflowFromFreshBase!('wf-1');
 
-    // Workflow generation bumped (matches recreateWorkflow's wrapper semantics).
     expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 5 });
-    // Pool prep ran before delegating to the orchestrator's first-class method.
     expect(taskExecutor.preparePoolForRebaseRetry).toHaveBeenCalledWith(
       'wf-1',
       'https://example/repo.git',
       'main',
     );
-    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledTimes(1);
-    expect(orchestrator.recreateWorkflowFromFreshBase.mock.calls[0]?.[0]).toBe('wf-1');
-    expect(result).toHaveLength(1);
-  });
-
-  it('recreateWorkflowFromFreshBase wire still calls orchestrator method when no taskExecutor is supplied', async () => {
-    const orchestrator = {
-      ...makeBaseOrchestrator(),
-      recreateWorkflowFromFreshBase: vi.fn(async () => []),
-    };
-    const persistence = makePersistence();
-    persistence.loadWorkflow = vi.fn(() => ({ id: 'wf-1', generation: 0, repoUrl: 'https://example/repo.git', baseBranch: 'main' } as any));
-
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-      // taskExecutor intentionally omitted — the orchestrator method
-      // still runs (refreshBase callback is a no-op without an executor).
-    });
-
-    await deps.recreateWorkflowFromFreshBase!('wf-1');
-
     expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
       'wf-1',
       expect.objectContaining({ refreshBase: expect.any(Function) }),
     );
+    expect(result).toHaveLength(1);
   });
 
-  // Step 14 (`docs/architecture/task-invalidation-roadmap.md`,
-  // chart "Topology inconsistency"): `workflowFork` is wired to
-  // `Orchestrator.forkWorkflow`. The policy router only consumes
-  // the `started` task list, so the wire adapts the orchestrator's
-  // richer `ForkWorkflowResult` to `TaskState[]`. The forked
-  // workflow id remains discoverable via `started[0].config.workflowId`
-  // for callers that need it.
-  it('routes workflowFork to orchestrator.forkWorkflow and returns started tasks', async () => {
-    const orchestrator = {
-      ...makeBaseOrchestrator(),
-      forkWorkflow: vi.fn((workflowId: string) => ({
-        sourceWorkflowId: workflowId,
-        forkedWorkflowId: `${workflowId}-fork`,
-        started: [makeRunningTask({ id: `${workflowId}-fork/task-a`, config: { workflowId: `${workflowId}-fork` } as any })],
-      })),
-    };
+  it('routes workflowFork and scheduleOnly through orchestrator defaults', async () => {
+    const orchestrator = makeBaseOrchestrator();
     const persistence = makePersistence();
+    const deps = buildDeps(orchestrator, persistence);
 
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-
-    expect(deps.workflowFork).toBeDefined();
-    const result = await deps.workflowFork!('wf-1');
+    const forked = await deps.workflowFork!('wf-1');
+    const scheduled = await deps.scheduleOnly!('task-a');
 
     expect(orchestrator.forkWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(result).toHaveLength(1);
-    // The forked workflow id is discoverable from the returned tasks.
-    expect((result as any[])[0].config.workflowId).toBe('wf-1-fork');
+    expect(forked[0]?.config.workflowId).toBe('wf-1-fork');
+    expect(orchestrator.autoStartExternallyUnblockedReadyTasks).toHaveBeenCalledTimes(1);
+    expect(scheduled).toHaveLength(1);
   });
 
-  // Step 16 (`docs/architecture/task-invalidation-roadmap.md`,
-  // chart row "Approve or reject fix"): `fixApprove` and
-  // `fixReject` are wired to the existing `approveTask` /
-  // `rejectTask` action wrappers in this file. Per the chart
-  // these are non-invalidating control flow over an existing
-  // fix attempt's output, so the wires must:
-  //
-  //   - reach the orchestrator's approve/reject primitives
-  //     (NOT retry/recreate);
-  //   - never call `orchestrator.cancelTask` /
-  //     `orchestrator.cancelWorkflow` (the policy router skips
-  //     `cancelInFlight` for these actions);
-  //   - return `TaskState[]` (approve returns the started
-  //     follow-on tasks; reject returns `[]` because the
-  //     wrapper is `void` today).
-  //
-  // The Step 1 scaffolding test pattern above wires the deps
-  // through `buildInvalidationDeps` and invokes them directly
-  // with a partial orchestrator mock; we follow that pattern.
-  it('routes fixApprove through approveTask (non-fix path → orchestrator.approve, returns started, never retry/recreate/cancel)', async () => {
+  it('routes fixApprove and fixReject through the action wrappers', async () => {
     const started = [makeRunningTask({ id: 'task-a' })];
-    const approvedTask = makeTask({ id: 'task-a', status: 'awaiting_approval', execution: {} });
-    const orchestrator = {
-      ...makeBaseOrchestrator(),
-      getTask: vi.fn().mockReturnValue(approvedTask),
-      approve: vi.fn().mockResolvedValue(started),
-      resumeTaskAfterFixApproval: vi.fn(),
-    };
+    const orchestrator = makeBaseOrchestrator();
+    orchestrator.getTask = vi.fn()
+      .mockReturnValueOnce(makeTask({ id: 'task-a', status: 'awaiting_approval', execution: {} }))
+      .mockReturnValueOnce(makeTask({ id: 'task-a', execution: { pendingFixError: 'merge conflict' } }));
+    orchestrator.approve = vi.fn().mockResolvedValue(started);
     const persistence = makePersistence();
+    const deps = buildDeps(orchestrator, persistence);
 
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-
-    expect(deps.fixApprove).toBeDefined();
-    const result = await deps.fixApprove!('task-a');
-
+    expect(await deps.fixApprove!('task-a')).toEqual(started);
+    expect(await deps.fixReject!('task-a')).toEqual([]);
     expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
-    expect(orchestrator.resumeTaskAfterFixApproval).not.toHaveBeenCalled();
-    expect(result).toEqual(started);
-    expect(orchestrator.retryTask).not.toHaveBeenCalled();
-    expect(orchestrator.recreateTask).not.toHaveBeenCalled();
-    expect(orchestrator.retryWorkflow).not.toHaveBeenCalled();
-    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
-    expect(orchestrator.cancelTask).not.toHaveBeenCalled();
-    expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('routes fixApprove through approveTask (fix path → commitApprovedFix + orchestrator.approve)', async () => {
-    const started = [makeRunningTask({ id: 'task-a' })];
-    const approvedTask = makeTask({
-      id: 'task-a',
-      status: 'awaiting_approval',
-      config: { workflowId: 'wf-1' },
-      execution: { pendingFixError: 'plain failure', branch: 'task-a', workspacePath: '/tmp/task-a' },
-    });
-    const orchestrator = {
-      ...makeBaseOrchestrator(),
-      getTask: vi.fn().mockReturnValue(approvedTask),
-      approve: vi.fn().mockResolvedValue(started),
-      resumeTaskAfterFixApproval: vi.fn(),
-    };
-    const persistence = makePersistence();
-    const taskExecutor = {
-      commitApprovedFix: vi.fn(),
-      publishAfterFix: vi.fn(),
-      executeTasks: vi.fn(),
-    };
-
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
-    });
-
-    const result = await deps.fixApprove!('task-a');
-
-    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(approvedTask);
-    expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
-    expect(orchestrator.resumeTaskAfterFixApproval).not.toHaveBeenCalled();
-    expect(result).toEqual(started);
-    expect(orchestrator.cancelTask).not.toHaveBeenCalled();
-    expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('routes fixReject through rejectTask (fix-flow path → orchestrator.revertConflictResolution, returns [], never retry/recreate/cancel)', async () => {
-    const orchestrator = {
-      ...makeBaseOrchestrator(),
-      getTask: vi.fn().mockReturnValue(
-        makeTask({ id: 'task-a', execution: { pendingFixError: 'merge conflict' } }),
-      ),
-      reject: vi.fn(),
-      revertConflictResolution: vi.fn(),
-    };
-    const persistence = makePersistence();
-
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-
-    expect(deps.fixReject).toBeDefined();
-    const result = await deps.fixReject!('task-a');
-
     expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-a', 'merge conflict');
-    expect(orchestrator.reject).not.toHaveBeenCalled();
-    // `rejectTask` is `void` today; the wire returns `[]` so the
-    // policy router's `TaskState[]` contract is satisfied.
-    expect(result).toEqual([]);
-    expect(orchestrator.retryTask).not.toHaveBeenCalled();
-    expect(orchestrator.recreateTask).not.toHaveBeenCalled();
-    expect(orchestrator.retryWorkflow).not.toHaveBeenCalled();
-    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
     expect(orchestrator.cancelTask).not.toHaveBeenCalled();
     expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
   });
 
-  it('routes fixReject through rejectTask (non-fix path → orchestrator.reject)', async () => {
-    const orchestrator = {
-      ...makeBaseOrchestrator(),
-      getTask: vi.fn().mockReturnValue(
-        makeTask({ id: 'task-a', execution: {} }),
-      ),
-      reject: vi.fn(),
-      revertConflictResolution: vi.fn(),
-    };
-    const persistence = makePersistence();
-
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-
-    const result = await deps.fixReject!('task-a');
-
-    // `rejectTask` is invoked without a reason from the wire, so
-    // `orchestrator.reject` is called as `(taskId, undefined)`.
-    expect(orchestrator.reject).toHaveBeenCalledWith('task-a', undefined);
-    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
-    expect(result).toEqual([]);
-    expect(orchestrator.cancelTask).not.toHaveBeenCalled();
-    expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('builds a cancel-first hook that cancels orchestrator state and kills runners', async () => {
+  it('kills active executions via cancelInFlight hook', async () => {
     const orchestrator = makeBaseOrchestrator();
     orchestrator.cancelTask = vi.fn(() => ({
       cancelled: ['task-a'],
@@ -1895,86 +1720,24 @@ describe('buildInvalidationDeps', () => {
     const taskExecutor = {
       killActiveExecution: vi.fn().mockResolvedValue(undefined),
     };
+    const deps = buildDeps(orchestrator, persistence, taskExecutor);
 
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
-    });
     await deps.cancelInFlight('task', 'task-a');
 
     expect(orchestrator.cancelTask).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('task-a');
-    expect(orchestrator.cancelTask.mock.invocationCallOrder[0]).toBeLessThan(
-      taskExecutor.killActiveExecution.mock.invocationCallOrder[0],
-    );
   });
 
-  // Cross-workflow cascade wiring: a task-scoped id resolves to its
-  // owning workflowId via `orchestrator.getTask(id)?.config.workflowId`,
-  // then delegates to `Orchestrator.cascadeInvalidationToDownstream`.
-  it('exposes cascadeDownstream that delegates to orchestrator.cascadeInvalidationToDownstream for workflow scope', async () => {
-    const cascaded = [makeRunningTask({ id: 'wf-2/leaf' })];
-    const orchestrator = {
-      ...makeBaseOrchestrator(),
-      cascadeInvalidationToDownstream: vi.fn(() => cascaded),
-      getTask: vi.fn(() => undefined),
-    };
+  it('delegates cascadeDownstream through workflow and task scope', async () => {
+    const orchestrator = makeBaseOrchestrator();
     const persistence = makePersistence();
+    const deps = buildDeps(orchestrator, persistence);
 
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-
-    expect(deps.cascadeDownstream).toBeDefined();
-    const result = await deps.cascadeDownstream!('workflow', 'wf-1');
-
-    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-1');
-    expect(orchestrator.getTask).not.toHaveBeenCalled();
-    expect(result).toEqual(cascaded);
-  });
-
-  it('cascadeDownstream resolves task scope to workflowId via orchestrator.getTask', async () => {
-    const orchestrator = {
-      ...makeBaseOrchestrator(),
-      cascadeInvalidationToDownstream: vi.fn(() => []),
-      getTask: vi.fn(() => ({
-        id: 'task-a',
-        config: { workflowId: 'wf-resolved' },
-      })),
-    };
-    const persistence = makePersistence();
-
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-
+    expect(await deps.cascadeDownstream!('workflow', 'wf-1')).toHaveLength(1);
     await deps.cascadeDownstream!('task', 'task-a');
 
+    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-1');
     expect(orchestrator.getTask).toHaveBeenCalledWith('task-a');
-    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-resolved');
-  });
-
-  it('cascadeDownstream returns [] without calling orchestrator when task is not found', async () => {
-    const orchestrator = {
-      ...makeBaseOrchestrator(),
-      cascadeInvalidationToDownstream: vi.fn(() => []),
-      getTask: vi.fn(() => undefined),
-    };
-    const persistence = makePersistence();
-
-    const deps = buildInvalidationDeps({
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-
-    const result = await deps.cascadeDownstream!('task', 'unknown-task');
-
-    expect(orchestrator.getTask).toHaveBeenCalledWith('unknown-task');
-    expect(orchestrator.cascadeInvalidationToDownstream).not.toHaveBeenCalled();
-    expect(result).toEqual([]);
   });
 });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -58,7 +58,7 @@ if (process.env.INVOKER_USER_DATA_DIR) {
   app.setPath('userData', process.env.INVOKER_USER_DATA_DIR);
 }
 
-import { Orchestrator, CommandService, OrchestratorErrorCode } from '@invoker/workflow-core';
+import { Orchestrator, CommandService, OrchestratorError, OrchestratorErrorCode, buildWorkflowInvalidationDeps } from '@invoker/workflow-core';
 import type {
   PlanDefinition,
   TaskDelta,
@@ -140,12 +140,12 @@ import {
 } from './headless-standalone-launch-dispatcher.js';
 import {
   approveTask as sharedApproveTask,
-  buildInvalidationDeps,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
   fixWithAgentAction,
   rebaseRetry,
   rebaseRecreate,
+  rejectTask as sharedRejectTask,
   resolveConflictAction,
   selectFailureRecoveryRoute,
   selectExperiments as sharedSelectExperiments,
@@ -304,6 +304,47 @@ let commandService: CommandService;
 // constructed in initServices before TaskRunner exists, so the deps
 // resolve via this getter at cancel-in-flight time.
 let latestTaskExecutor: TaskRunner | null = null;
+
+function buildCommandServiceInvalidationDeps() {
+  return buildWorkflowInvalidationDeps({
+    orchestrator,
+    requireWorkflow: (workflowId) => {
+      const workflow = persistence.loadWorkflow(workflowId);
+      if (!workflow) {
+        throw new OrchestratorError(
+          OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
+          `Workflow ${workflowId} not found`,
+        );
+      }
+      return workflow;
+    },
+    setWorkflowGeneration: (workflowId, generation) => {
+      persistence.updateWorkflow(workflowId, { generation });
+    },
+    killActiveExecution: async (taskId) => {
+      await latestTaskExecutor?.killActiveExecution(taskId);
+    },
+    prepareFreshBase: async (workflowId, workflow) => {
+      if (!latestTaskExecutor || !workflow.repoUrl) return undefined;
+      return latestTaskExecutor.preparePoolForRebaseRetry(
+        workflowId,
+        workflow.repoUrl,
+        workflow.baseBranch,
+      );
+    },
+    fixApprove: async (taskId) => {
+      const result = await sharedApproveTask(taskId, {
+        orchestrator,
+        taskExecutor: latestTaskExecutor ?? undefined,
+      });
+      return result.started;
+    },
+    fixReject: (taskId) => {
+      sharedRejectTask(taskId, { orchestrator });
+      return [];
+    },
+  });
+}
 let runtimeServices: RuntimeServices;
 let workflowMutationCoordinator: PersistedWorkflowMutationCoordinator | null = null;
 let launchDispatcher: LaunchDispatcher | null = null;
@@ -683,12 +724,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
   });
   commandService = new CommandService(
     orchestrator,
-    buildInvalidationDeps({
-      logger,
-      orchestrator,
-      persistence,
-      taskExecutor: () => latestTaskExecutor,
-    }),
+    buildCommandServiceInvalidationDeps(),
   );
 
   const startupSyncMode = options?.startupSyncMode ?? 'all';
@@ -1061,12 +1097,7 @@ function startHeadlessMode(): void {
             });
             commandService = new CommandService(
               orchestrator,
-              buildInvalidationDeps({
-                logger,
-                orchestrator,
-                persistence,
-                taskExecutor: () => latestTaskExecutor,
-              }),
+              buildCommandServiceInvalidationDeps(),
             );
             return undefined;
           }
@@ -3428,12 +3459,7 @@ function createEmbeddedTerminalBackendFromConfig(
       });
       commandService = new CommandService(
         orchestrator,
-        buildInvalidationDeps({
-          logger,
-          orchestrator,
-          persistence,
-          taskExecutor: () => latestTaskExecutor,
-        }),
+        buildCommandServiceInvalidationDeps(),
       );
       rebuildTaskRunner();
       taskHandles.clear();

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -12,16 +12,13 @@ import type {
   Orchestrator,
   ExternalGatePolicyUpdate,
   InvalidationAction,
-  InvalidationScope,
   TaskState,
-  CancelInFlightFn,
-  InvalidationDeps,
 } from '@invoker/workflow-core';
 import {
   OrchestratorError,
   OrchestratorErrorCode,
   applyInvalidation,
-  buildCancelInFlight as buildCoreCancelInFlight,
+  buildWorkflowInvalidationDeps,
   parseMergeConflictError,
 } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -37,6 +34,7 @@ import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import { isDispatchableLaunch } from './global-topup.js';
 
 type LoadedWorkflow = NonNullable<ReturnType<SQLiteAdapter['loadWorkflow']>>;
+type FreshBaseState = { branch: string; commit: string };
 
 // ── Lineage guard ─────────────────────────────────────────────
 
@@ -142,26 +140,18 @@ export interface ApproveTaskResult {
 
 // ── Actions ──────────────────────────────────────────────────
 
-function bumpWorkflowGeneration(
+function requireWorkflowRecord(
   workflowId: string,
-  deps: Pick<ActionDeps, 'logger' | 'persistence'>,
-  context: string,
+  persistence: Pick<ActionDeps, 'persistence'>['persistence'],
 ): LoadedWorkflow {
-  const workflow = deps.persistence.loadWorkflow(workflowId);
-  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
-  const nextGen = (workflow.generation ?? 0) + 1;
-  deps.persistence.updateWorkflow(workflowId, { generation: nextGen });
-  deps.logger?.info(`${context}: bumped generation to ${nextGen} for ${workflowId}`, { module: 'workflow' });
+  const workflow = persistence.loadWorkflow(workflowId);
+  if (!workflow) {
+    throw new OrchestratorError(
+      OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
+      `Workflow ${workflowId} not found`,
+    );
+  }
   return workflow;
-}
-
-function recreateWorkflowWithGeneration(
-  workflowId: string,
-  deps: Pick<ActionDeps, 'logger' | 'persistence' | 'orchestrator'>,
-): TaskState[] {
-  bumpWorkflowGeneration(workflowId, deps, 'recreateWorkflow');
-  deps.logger?.info(`recreateWorkflow: calling orchestrator.recreateWorkflow(${workflowId})`, { module: 'agent-session-trace' });
-  return deps.orchestrator.recreateWorkflow(workflowId);
 }
 
 export async function approveTask(
@@ -248,7 +238,7 @@ async function runWorkflowInvalidationThroughCommandService(
         'workflow',
         action,
         workflowId,
-        buildInvalidationDeps({
+        createInvalidationDeps({
           logger: deps.logger,
           orchestrator: deps.orchestrator,
           persistence: deps.persistence,
@@ -279,7 +269,7 @@ async function runTaskInvalidationThroughCommandService(
         'task',
         action,
         taskId,
-        buildInvalidationDeps({
+        createInvalidationDeps({
           logger: deps.logger,
           orchestrator: deps.orchestrator,
           persistence: deps.persistence,
@@ -440,88 +430,95 @@ export async function deleteAllWorkflowsBulk(
  * `docs/architecture/task-invalidation-roadmap.md` "Out of scope":
  * the composite implementation is preserved semantically — replacing
  * it with a single primitive is a follow-up):
- *
- *   1. Bump the workflow's generation counter (matches
- *      `recreateWorkflowWithGeneration` so any downstream observers that
- *      key off `workflow.generation` notice the new round).
+ *   1. Bump the workflow's generation counter so downstream observers
+ *      that key off `workflow.generation` notice the new round.
  *   2. Delegate to `Orchestrator.recreateWorkflowFromFreshBase` with
  *      a `refreshBase` callback that runs
- *      `taskExecutor.preparePoolForRebaseRetry` when both
- *      `taskExecutor` and `workflow.repoUrl` are available. The
- *      orchestrator method is the seam that records the fresh-base
- *      effect (`knownFreshBaseCommits`) and then runs the same reset
- *      as `recreateWorkflow`. Cancel-first is supplied by
- *      `applyInvalidation`'s `cancelInFlight` dep
- *      (`buildCancelInFlight` → `Orchestrator.cancelWorkflow` +
- *      `taskExecutor.killActiveExecution`) when invoked through that
- *      route — this wrapper does not add a parallel cancel call.
+ *      `preparePoolForRebaseRetry(workflowId, repoUrl, baseBranch, …)`
+ *      first when both `taskExecutor` and `workflow.repoUrl` are
+ *      available.
+ *   3. Rely on `applyInvalidation`'s `cancelInFlight` dep for the
+ *      cancel-first invariant. This wrapper does not add a parallel
+ *      cancel call.
  *
  * `preparePoolForRebaseRetry` resolves the fresh upstream HEAD once.
  * The explicit fresh-base lifecycle entrypoint can pass that commit
  * through to the orchestrator callback when available.
  */
+async function prepareFreshBaseWithWorkflow(
+  workflowId: string,
+  workflow: LoadedWorkflow,
+  deps: ActionDeps,
+): Promise<FreshBaseState | undefined> {
+  if (!deps.taskExecutor || !workflow.repoUrl) return undefined;
+  const prepare = () => deps.mutationTiming
+    ? deps.taskExecutor!.preparePoolForRebaseRetry(
+      workflowId,
+      workflow.repoUrl,
+      workflow.baseBranch,
+      deps.mutationTiming,
+    )
+    : deps.taskExecutor!.preparePoolForRebaseRetry(
+      workflowId,
+      workflow.repoUrl,
+      workflow.baseBranch,
+    );
+  if (deps.mutationTiming) {
+    return deps.mutationTiming.span(
+      'workflow-actions.prepareWorkflowFreshBase.preparePoolForRebaseRetry',
+      { repoUrl: workflow.repoUrl, baseBranch: workflow.baseBranch },
+      prepare,
+    );
+  }
+  return prepare();
+}
+
 async function prepareWorkflowFreshBase(
   workflowId: string,
   deps: ActionDeps,
-): Promise<{ workflow: LoadedWorkflow; freshBase?: { branch: string; commit: string } }> {
-  const workflow = deps.persistence.loadWorkflow(workflowId);
-  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
-
-  let freshBase: { branch: string; commit: string } | undefined;
-  if (deps.taskExecutor && workflow.repoUrl) {
-    const prepare = () => deps.mutationTiming
-      ? deps.taskExecutor!.preparePoolForRebaseRetry(
-        workflowId,
-        workflow.repoUrl,
-        workflow.baseBranch,
-        deps.mutationTiming,
-      )
-      : deps.taskExecutor!.preparePoolForRebaseRetry(
-        workflowId,
-        workflow.repoUrl,
-        workflow.baseBranch,
-      );
-    if (deps.mutationTiming) {
-      freshBase = await deps.mutationTiming.span(
-        'workflow-actions.prepareWorkflowFreshBase.preparePoolForRebaseRetry',
-        { repoUrl: workflow.repoUrl, baseBranch: workflow.baseBranch },
-        prepare,
-      );
-    } else {
-      freshBase = await prepare();
-    }
-  }
-
+): Promise<{ workflow: LoadedWorkflow; freshBase?: FreshBaseState }> {
+  const workflow = requireWorkflowRecord(workflowId, deps.persistence);
+  const freshBase = await prepareFreshBaseWithWorkflow(workflowId, workflow, deps);
   return { workflow, freshBase };
 }
 
-async function recreateWorkflowFromFreshBasePrimitive(
-  workflowId: string,
-  deps: ActionDeps,
-): Promise<TaskState[]> {
-  const { workflow, freshBase } = await prepareWorkflowFreshBase(workflowId, deps);
-  deps.mutationTiming?.mark('workflow-actions.recreateWorkflowFromFreshBase.bumpGeneration', 'started', {
-    nextGeneration: (workflow.generation ?? 0) + 1,
-  });
-  bumpWorkflowGeneration(workflowId, deps, 'recreateWorkflowFromFreshBase');
-  deps.mutationTiming?.mark('workflow-actions.recreateWorkflowFromFreshBase.bumpGeneration', 'completed', {
-    nextGeneration: (workflow.generation ?? 0) + 1,
-  });
-  deps.logger?.info(
-    `recreateWorkflowFromFreshBase: workflowId=${workflowId} → orchestrator.recreateWorkflowFromFreshBase`,
-    { module: 'agent-session-trace' },
-  );
-
-  const recreate = () => deps.orchestrator.recreateWorkflowFromFreshBase(workflowId, {
-    refreshBase: async () => {
-      // Pool preparation already ran above. The callback is kept so the
-      // orchestrator still sees the fresh-base lifecycle entrypoint.
-      return freshBase;
+function createInvalidationDeps(
+  deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'mutationTiming'> & {
+    logger?: Logger;
+    taskExecutor?: TaskExecutorRef;
+  },
+) {
+  return buildWorkflowInvalidationDeps({
+    orchestrator: deps.orchestrator,
+    requireWorkflow: (workflowId) => requireWorkflowRecord(workflowId, deps.persistence),
+    setWorkflowGeneration: (workflowId, generation) => {
+      deps.persistence.updateWorkflow(workflowId, { generation });
+    },
+    killActiveExecution: async (taskId) => {
+      const taskExecutor = resolveTaskExecutor(deps.taskExecutor);
+      if (!taskExecutor) return;
+      await taskExecutor.killActiveExecution(taskId);
+    },
+    prepareFreshBase: (workflowId, workflow) =>
+      prepareFreshBaseWithWorkflow(workflowId, workflow as LoadedWorkflow, {
+        logger: deps.logger,
+        orchestrator: deps.orchestrator,
+        persistence: deps.persistence,
+        taskExecutor: resolveTaskExecutor(deps.taskExecutor),
+        mutationTiming: deps.mutationTiming,
+      }),
+    fixApprove: async (taskId) => {
+      const result = await approveTask(taskId, {
+        orchestrator: deps.orchestrator,
+        taskExecutor: resolveTaskExecutor(deps.taskExecutor),
+      });
+      return result.started;
+    },
+    fixReject: (taskId) => {
+      rejectTask(taskId, { orchestrator: deps.orchestrator });
+      return [];
     },
   });
-  return deps.mutationTiming
-    ? deps.mutationTiming.span('workflow-actions.recreateWorkflowFromFreshBase.orchestrator', undefined, recreate)
-    : recreate();
 }
 
 export async function recreateWorkflowFromFreshBase(
@@ -601,88 +598,6 @@ function resolveTaskExecutor(ref: TaskExecutorRef | undefined): TaskRunner | und
   return ref;
 }
 
-export interface BuildCancelInFlightDeps {
-  orchestrator: Orchestrator;
-  taskExecutor?: TaskExecutorRef;
-}
-
-export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
-  return buildCoreCancelInFlight({
-    orchestrator: deps.orchestrator,
-    killActiveExecution: async (id) => {
-      const taskExecutor = resolveTaskExecutor(deps.taskExecutor);
-      if (!taskExecutor) return;
-      await taskExecutor.killActiveExecution(id);
-    },
-  });
-}
-
-export type BuildInvalidationDepsArgs = Omit<
-  Pick<ActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'mutationTiming'>,
-  'taskExecutor'
-> & { taskExecutor?: TaskExecutorRef };
-
-export function buildInvalidationDeps(deps: BuildInvalidationDepsArgs): InvalidationDeps {
-  const cancelInFlight = buildCancelInFlight({
-    orchestrator: deps.orchestrator,
-    taskExecutor: deps.taskExecutor,
-  });
-  return {
-    cancelInFlight,
-    retryTask: (taskId: string) => deps.orchestrator.retryTask(taskId),
-    recreateTask: (taskId: string) => deps.orchestrator.recreateTask(taskId),
-    recreateDownstream: (taskId: string) => deps.orchestrator.recreateDownstream(taskId),
-    retryWorkflow: (workflowId: string) => deps.orchestrator.retryWorkflow(workflowId),
-    recreateWorkflow: (workflowId: string) =>
-      recreateWorkflowWithGeneration(workflowId, {
-        logger: deps.logger,
-        orchestrator: deps.orchestrator,
-        persistence: deps.persistence,
-      }),
-    recreateWorkflowFromFreshBase: (workflowId: string) =>
-      recreateWorkflowFromFreshBasePrimitive(workflowId, {
-        logger: deps.logger,
-        orchestrator: deps.orchestrator,
-        persistence: deps.persistence,
-        taskExecutor: resolveTaskExecutor(deps.taskExecutor),
-        mutationTiming: deps.mutationTiming,
-      }),
-    workflowFork: (workflowId: string) => {
-      const result = deps.orchestrator.forkWorkflow(workflowId);
-      deps.logger?.info(
-        `workflowFork: source=${workflowId} fork=${result.forkedWorkflowId} started=${result.started.length}`,
-        { module: 'workflow' },
-      );
-      return result.started;
-    },
-    // `scheduleOnly` is invoked by applyInvalidation WITHOUT a
-    // preceding cancelInFlight; the underlying primitive is
-    // workflow-agnostic and ignores the taskId argument.
-    scheduleOnly: (_taskId: string) =>
-      deps.orchestrator.autoStartExternallyUnblockedReadyTasks(),
-    fixApprove: async (taskId: string) => {
-      const result = await approveTask(taskId, {
-        orchestrator: deps.orchestrator,
-        taskExecutor: resolveTaskExecutor(deps.taskExecutor),
-      });
-      return result.started;
-    },
-    fixReject: (taskId: string) => {
-      rejectTask(taskId, { orchestrator: deps.orchestrator });
-      return [];
-    },
-    // For task scope, resolve the owning workflow first; if the task
-    // is gone (detached), the cascade is a no-op.
-    cascadeDownstream: (scope, id) => {
-      const workflowId =
-        scope === 'workflow'
-          ? id
-          : deps.orchestrator.getTask(id)?.config.workflowId;
-      if (!workflowId) return [];
-      return deps.orchestrator.cascadeInvalidationToDownstream(workflowId);
-    },
-  };
-}
 
 export function forkWorkflow(
   workflowId: string,
@@ -778,14 +693,10 @@ export async function selectExperiments(
  * (`MUTATION_POLICIES.mergeMode` → `retryTask` / task scope, scoped
  * to the merge node).
  *
- * Step 9 migrates this surface from an app-layer-only special case
- * to a proper orchestrator policy seam. Prior to Step 9 this wrapper
- * persisted the new mergeMode unconditionally and only restarted the
- * merge node when its status was `completed` / `awaiting_approval` /
- * `review_ready` — the chart's "Merge-mode inconsistency" section
- * explicitly flagged that as the bug ("only at the app layer, and
- * only when the merge node is already terminal or waiting … no
- * general active invalidation rule for an in-flight merge node").
+ * Step 9 moved this surface out of the old app-layer special case and
+ * into the shared invalidation pipeline. The merge node now restarts
+ * through the same cancel-first rule as the rest of the lifecycle
+ * matrix, including when it was already terminal or waiting.
  *
  * The substantive routing — same-mode no-op detection, cancel-first
  * interruption when the merge node is actively executing or waiting
@@ -844,28 +755,14 @@ export async function setWorkflowMergeMode(
  * Decision Table row "Change fix prompt or fix context while
  * `fixing_with_ai`" in
  * `docs/architecture/task-invalidation-chart.md`
- * (`MUTATION_POLICIES.fixContext` → `retryTask` / task scope).
- *
- * Step 10 introduces this wrapper as a thin async delegate around
- * `Orchestrator.editTaskFixContext` (mirrors the Step 2–9 wrapper
- * pattern). Prior to Step 10 the fix-session mutation surface had
- * **no general policy** at all — the chart's "Fix-session
- * inconsistency" section flagged the bespoke
- * `beginConflictResolution` / `revertConflictResolution` rollback
- * as "one special active invalidation mechanism, not a general
- * one". The substantive routing — same-content no-op detection,
- * cancel-first interruption when the task is in an active fix
- * session (`fixing_with_ai`), `fixPrompt` / `fixContext`
- * persistence on the task config, and the retry-class reset via
- * `restartTask` (today's `retryTask` compatibility wire — see
- * `MUTATION_POLICIES.fixContext` and `buildInvalidationDeps`) —
- * lives in `Orchestrator.editTaskFixContext`. That method is the
- * synchronous orchestrator-internal seam of `applyInvalidation`'s
- * Hard Invariant (cancel BEFORE authoritative reset) and reuses
- * `restartTask`'s reset shape so the task's `agentSessionId` /
- * `containerId` / `error` / `exitCode` / timing fields are cleared
- * while branch / workspacePath lineage survives — the chart's
- * retry-class semantics for fix-context mutations.
+ * Step 10 routes this through the shared invalidation pipeline instead
+ * of a one-off app-layer path. `Orchestrator.editTaskFixContext`
+ * remains the synchronous orchestrator seam reused by that pipeline.
+ * That seam owns same-content no-op detection, cancel-first behavior
+ * while the task is `fixing_with_ai`, config persistence, and the
+ * retry-class reset. It reuses `restartTask`'s reset shape so
+ * `agentSessionId`, `containerId`, `error`, `exitCode`, and timing
+ * fields are cleared while branch / workspacePath lineage survives.
  *
  * Cancel-first is enforced inside the orchestrator method — this
  * wrapper MUST NOT add a parallel cancel call.

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -365,8 +365,8 @@ async function invokePrimitive(
       if (!deps.scheduleOnly) {
         throw new Error(
           "applyInvalidation: 'scheduleOnly' dep is missing. " +
-            'Production callers wire this via buildInvalidationDeps in ' +
-            '@invoker/app/workflow-actions; tests must supply ' +
+            'Production callers wire this via buildWorkflowInvalidationDeps in ' +
+            '@invoker/workflow-core; tests must supply ' +
             'deps.scheduleOnly to use this action.',
         );
       }
@@ -378,8 +378,8 @@ async function invokePrimitive(
       if (!dep) {
         throw new Error(
           `applyInvalidation: '${ctx.action}' dep is missing. ` +
-            'Production callers wire this via buildInvalidationDeps in ' +
-            '@invoker/app/workflow-actions; tests must supply the dep to use this action.',
+            'Production callers wire this via buildWorkflowInvalidationDeps in ' +
+            '@invoker/workflow-core; tests must supply the dep to use this action.',
         );
       }
       return await dep(ctx.id);
@@ -392,8 +392,8 @@ async function invokePrimitive(
       if (!deps.recreateDownstream) {
         throw new Error(
           "applyInvalidation: 'recreateDownstream' dep is missing. " +
-            'Production callers wire this via buildInvalidationDeps in ' +
-            '@invoker/app/workflow-actions; tests must supply ' +
+            'Production callers wire this via buildWorkflowInvalidationDeps in ' +
+            '@invoker/workflow-core; tests must supply ' +
             'deps.recreateDownstream to use this action.',
         );
       }
@@ -416,8 +416,8 @@ async function invokePrimitive(
       if (!deps.workflowFork) {
         throw new Error(
           "applyInvalidation: 'workflowFork' dep is missing. " +
-            'Production callers wire this via buildInvalidationDeps in ' +
-            '@invoker/app/workflow-actions; tests must supply ' +
+            'Production callers wire this via buildWorkflowInvalidationDeps in ' +
+            '@invoker/workflow-core; tests must supply ' +
             'deps.workflowFork to use this action.',
         );
       }
@@ -450,7 +450,9 @@ export interface InvalidationDepsOrchestrator {
   recreateDownstream(taskId: string): TaskState[];
   retryWorkflow(workflowId: string): TaskState[];
   recreateWorkflow(workflowId: string): TaskState[];
-  recreateWorkflowFromFreshBase(workflowId: string): Promise<TaskState[]>;
+  recreateWorkflowFromFreshBase(workflowId: string, options?: {
+    refreshBase?: () => Promise<{ branch: string; commit: string } | undefined>;
+  }): Promise<TaskState[]>;
   forkWorkflow(workflowId: string): { started: TaskState[] };
   autoStartExternallyUnblockedReadyTasks(): TaskState[];
   approve(taskId: string): Promise<TaskState[]>;
@@ -476,9 +478,91 @@ export interface BuildCancelInFlightDeps {
   killActiveExecution?: (taskId: string) => void | Promise<void>;
 }
 
+export interface InvalidationWorkflowRecord {
+  generation?: number;
+  repoUrl?: string;
+  baseBranch?: string;
+}
+
+export interface BuildWorkflowInvalidationDepsArgs {
+  orchestrator: InvalidationDepsOrchestrator;
+  requireWorkflow: (workflowId: string) => InvalidationWorkflowRecord;
+  setWorkflowGeneration: (workflowId: string, generation: number) => void;
+  killActiveExecution?: (taskId: string) => void | Promise<void>;
+  prepareFreshBase?: (
+    workflowId: string,
+    workflow: InvalidationWorkflowRecord,
+  ) => Promise<{ branch: string; commit: string } | undefined>;
+  workflowFork?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
+  scheduleOnly?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  fixApprove?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  fixReject?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  cascadeDownstream?: (
+    scope: InvalidationScope,
+    id: string,
+  ) => TaskState[] | Promise<TaskState[]>;
+}
+
+function bumpWorkflowGeneration(
+  workflowId: string,
+  deps: Pick<BuildWorkflowInvalidationDepsArgs, 'requireWorkflow' | 'setWorkflowGeneration'>,
+): InvalidationWorkflowRecord {
+  const workflow = deps.requireWorkflow(workflowId);
+  deps.setWorkflowGeneration(workflowId, (workflow.generation ?? 0) + 1);
+  return workflow;
+}
+
+function defaultCascadeDownstream(
+  orchestrator: InvalidationDepsOrchestrator,
+  scope: InvalidationScope,
+  id: string,
+): TaskState[] {
+  const workflowId =
+    scope === 'workflow'
+      ? id
+      : orchestrator.getTask(id)?.config?.workflowId;
+  if (!workflowId) return [];
+  return orchestrator.cascadeInvalidationToDownstream(workflowId);
+}
+
+export function buildWorkflowInvalidationDeps(
+  deps: BuildWorkflowInvalidationDepsArgs,
+): InvalidationDeps {
+  return {
+    cancelInFlight: buildCancelInFlight({
+      orchestrator: deps.orchestrator,
+      killActiveExecution: deps.killActiveExecution,
+    }),
+    retryTask: (taskId) => deps.orchestrator.retryTask(taskId),
+    recreateTask: (taskId) => deps.orchestrator.recreateTask(taskId),
+    recreateDownstream: (taskId) => deps.orchestrator.recreateDownstream(taskId),
+    retryWorkflow: (workflowId) => deps.orchestrator.retryWorkflow(workflowId),
+    recreateWorkflow: (workflowId) => {
+      bumpWorkflowGeneration(workflowId, deps);
+      return deps.orchestrator.recreateWorkflow(workflowId);
+    },
+    recreateWorkflowFromFreshBase: async (workflowId) => {
+      const workflow = bumpWorkflowGeneration(workflowId, deps);
+      const freshBase = await deps.prepareFreshBase?.(workflowId, workflow);
+      return deps.orchestrator.recreateWorkflowFromFreshBase(workflowId, {
+        refreshBase: async () => freshBase,
+      });
+    },
+    workflowFork: deps.workflowFork ?? ((workflowId) => deps.orchestrator.forkWorkflow(workflowId).started),
+    scheduleOnly: deps.scheduleOnly ?? (() => deps.orchestrator.autoStartExternallyUnblockedReadyTasks()),
+    fixApprove: deps.fixApprove ?? ((taskId) => deps.orchestrator.approve(taskId)),
+    fixReject: deps.fixReject ?? ((taskId) => {
+      deps.orchestrator.reject(taskId);
+      return [];
+    }),
+    cascadeDownstream: deps.cascadeDownstream ?? ((scope, id) =>
+      defaultCascadeDownstream(deps.orchestrator, scope, id)),
+  };
+}
+
 /**
  * Single cancel-in-flight implementation shared by the orchestrator-only
- * fallback and the production `buildInvalidationDeps`. Tolerates
+ * fallback and the production invalidation-deps builders. Tolerates
  * already-terminal targets (the rest of the pipeline still runs) and
  * fans out the optional executor-kill hook for every running task that
  * was cancelled.
@@ -506,29 +590,9 @@ export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlig
 export function buildOrchestratorOnlyInvalidationDeps(
   orchestrator: InvalidationDepsOrchestrator,
 ): InvalidationDeps {
-  return {
-    cancelInFlight: buildCancelInFlight({ orchestrator }),
-    retryTask: (taskId) => orchestrator.retryTask(taskId),
-    recreateTask: (taskId) => orchestrator.recreateTask(taskId),
-    recreateDownstream: (taskId) => orchestrator.recreateDownstream(taskId),
-    retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
-    recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
-    recreateWorkflowFromFreshBase: (workflowId) =>
-      orchestrator.recreateWorkflowFromFreshBase(workflowId),
-    workflowFork: (workflowId) => orchestrator.forkWorkflow(workflowId).started,
-    scheduleOnly: () => orchestrator.autoStartExternallyUnblockedReadyTasks(),
-    fixApprove: (taskId) => orchestrator.approve(taskId),
-    fixReject: (taskId) => {
-      orchestrator.reject(taskId);
-      return [];
-    },
-    cascadeDownstream: (scope, id) => {
-      const workflowId =
-        scope === 'workflow'
-          ? id
-          : orchestrator.getTask(id)?.config?.workflowId;
-      if (!workflowId) return [];
-      return orchestrator.cascadeInvalidationToDownstream(workflowId);
-    },
-  };
+  return buildWorkflowInvalidationDeps({
+    orchestrator,
+    requireWorkflow: () => ({}),
+    setWorkflowGeneration: () => {},
+  });
 }


### PR DESCRIPTION
## Summary

This moves the invalidation dep builder out of `packages/app` and into `@invoker/workflow-core`.

That keeps the lifecycle invariant from the lower layer instead of rebuilding it in app code.

App now passes only the small hooks that are truly app-specific, like fresh-base pool prep and fix approve or reject behavior.

## Architecture

### Before

```mermaid
graph TD
    A[main / workflow-actions] --> B[app buildInvalidationDeps]
    B --> C[applyInvalidation]
    B --> D[generation bump]
    B --> E[fresh-base prep]
    B --> F[fix approve/reject hooks]
```

### After

```mermaid
graph TD
    A[main / workflow-actions] --> B[buildWorkflowInvalidationDeps in workflow-core]
    B --> C[applyInvalidation]
    B --> D[generation bump]
    B --> E[fresh-base callback hook]
    B --> F[app-specific approve/reject hooks]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts src/__tests__/workflow-mutation-facade.test.ts src/__tests__/parity-regression.test.ts src/__tests__/api-server.test.ts src/__tests__/headless-delegation.test.ts src/__tests__/rebase-and-retry.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/invalidation-policy.test.ts src/__tests__/command-service-routing.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 85d5e6375`
- Post-revert steps: None
- Data migration? No
