### PR TITLE
Require CommandService in workflow facade

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -101,6 +101,8 @@ function createMocks() {
       recreateDownstream: vi.fn(() => [makeTask()]),
       retryWorkflow: vi.fn(() => [makeTask()]),
       recreateWorkflow: vi.fn(() => [makeTask()]),
+      recreateWorkflowFromFreshBase: vi.fn(async () => [makeTask()]),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
       editTaskCommand: vi.fn(() => [makeTask()]),
       editTaskPrompt: vi.fn(() => [makeTask()]),
       editTaskType: vi.fn(() => [makeTask()]),
@@ -138,10 +140,10 @@ function createMocks() {
     },
     executorRegistry: {},
     commandService: {
-      runSerializedForWorkflow: vi.fn(async (_workflowId: string, fn: () => unknown) => {
-        await fn();
-        return { ok: true, data: undefined };
-      }),
+      runSerializedForWorkflow: vi.fn(async (_workflowId: string, fn: () => Promise<unknown> | unknown) => ({
+        ok: true,
+        data: await fn(),
+      })),
       // Production CommandService routes through applyInvalidation which
       // ultimately invokes orchestrator.{retry,recreate}{Task,Workflow}
       // and (for recreateWorkflow) bumpGenerationAndRecreate which calls
@@ -200,6 +202,8 @@ function createMocks() {
       resolveConflict: vi.fn().mockResolvedValue(undefined),
       fixWithAgent: vi.fn().mockResolvedValue(undefined),
       commitApprovedFix: vi.fn().mockResolvedValue(undefined),
+      killActiveExecution: vi.fn().mockResolvedValue(undefined),
+      preparePoolForRebaseRetry: vi.fn().mockResolvedValue(undefined),
     },
     killRunningTask: vi.fn().mockResolvedValue(undefined),
     deleteWorkflow: vi.fn().mockResolvedValue(undefined),
@@ -291,8 +295,7 @@ beforeEach(() => {
   mocks.persistence.loadTask.mockImplementation((id: string) => (id === 'task-1' ? makeTask() : undefined));
   mocks.persistence.loadTasks.mockReturnValue([makeTask()]);
   mocks.commandService.runSerializedForWorkflow.mockImplementation(async (_workflowId: string, fn: () => unknown) => {
-    await fn();
-    return { ok: true, data: undefined };
+    return { ok: true, data: await fn() };
   });
   mocks.persistence.getEvents.mockReturnValue([{ taskId: 'task-1', eventType: 'started', timestamp: '2024-01-01' }]);
   mocks.persistence.getTaskOutput.mockReturnValue('hello world output');
@@ -1045,8 +1048,8 @@ describe('POST /api/workflows/:id/rebase-recreate', () => {
     }
   });
 
-  it('recreates workflow from fresh base', async () => {
-    mocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask()]);
+  it('recreates workflow', async () => {
+    mocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask({ id: 'wf-1/task-a' })]);
     const res = await request(port, 'POST', '/api/workflows/wf-1/rebase-recreate');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);

--- a/packages/app/src/__tests__/parity-regression.test.ts
+++ b/packages/app/src/__tests__/parity-regression.test.ts
@@ -88,47 +88,67 @@ function httpRequest(
 }
 
 function makeFacadeDeps(overrides: Partial<WorkflowMutationFacadeDeps> = {}): WorkflowMutationFacadeDeps {
+  const orchestrator = {
+    retryTask: vi.fn(() => [makeTask()]),
+    recreateTask: vi.fn(() => [makeTask()]),
+    recreateDownstream: vi.fn(() => [makeTask()]),
+    retryWorkflow: vi.fn(() => [makeTask()]),
+    recreateWorkflow: vi.fn(() => [makeTask()]),
+    recreateWorkflowFromFreshBase: vi.fn(async () => [makeTask()]),
+    cascadeInvalidationToDownstream: vi.fn(() => []),
+    cancelTask: vi.fn(() => ({ cancelled: ['task-1'], runningCancelled: ['task-1'] })),
+    cancelWorkflow: vi.fn(() => ({ cancelled: ['task-1'], runningCancelled: ['task-1'] })),
+    deleteWorkflow: vi.fn(),
+    detachWorkflow: vi.fn(),
+    forkWorkflow: vi.fn(() => ({
+      forkedWorkflowId: 'wf-fork',
+      sourceWorkflowId: 'wf-1',
+      started: [makeTask({ id: 'fork-t1' })],
+    })),
+    editTaskCommand: vi.fn(() => [makeTask()]),
+    editTaskPrompt: vi.fn(() => [makeTask()]),
+    editTaskType: vi.fn(() => [makeTask()]),
+    editTaskAgent: vi.fn(() => [makeTask()]),
+    setTaskExternalGatePolicies: vi.fn(() => []),
+    selectExperiment: vi.fn(() => [makeTask()]),
+    approve: vi.fn(async () => [makeTask()]),
+    reject: vi.fn(),
+    provideInput: vi.fn(),
+    getTask: vi.fn(() => makeTask()),
+    getAllTasks: vi.fn(() => []),
+    startExecution: vi.fn(() => []),
+  };
+  const persistence = {
+    loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1 })),
+    updateWorkflow: vi.fn(),
+    loadTasks: vi.fn(() => []),
+  };
+  const taskExecutor = {
+    executeTasks: vi.fn().mockResolvedValue(undefined),
+    publishAfterFix: vi.fn().mockResolvedValue(undefined),
+    resolveConflict: vi.fn().mockResolvedValue(undefined),
+    fixWithAgent: vi.fn().mockResolvedValue(undefined),
+    commitApprovedFix: vi.fn().mockResolvedValue(undefined),
+    killActiveExecution: vi.fn().mockResolvedValue(undefined),
+    preparePoolForRebaseRetry: vi.fn().mockResolvedValue(undefined),
+  };
+  const commandService = {
+    retryTask: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: orchestrator.retryTask(envelope.payload.taskId) })),
+    recreateTask: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: orchestrator.recreateTask(envelope.payload.taskId) })),
+    recreateDownstream: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: orchestrator.recreateDownstream(envelope.payload.taskId) })),
+    retryWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => ({ ok: true as const, data: orchestrator.retryWorkflow(envelope.payload.workflowId) })),
+    recreateWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => {
+      const workflow = persistence.loadWorkflow(envelope.payload.workflowId);
+      persistence.updateWorkflow(envelope.payload.workflowId, { generation: (workflow.generation ?? 0) + 1 });
+      return { ok: true as const, data: orchestrator.recreateWorkflow(envelope.payload.workflowId) };
+    }),
+    runSerializedForWorkflow: vi.fn(async (_workflowId: string | undefined, fn: () => Promise<any> | any) => ({ ok: true as const, data: await fn() })),
+  };
   return {
-    orchestrator: {
-      retryTask: vi.fn(() => [makeTask()]),
-      recreateTask: vi.fn(() => [makeTask()]),
-      retryWorkflow: vi.fn(() => [makeTask()]),
-      recreateWorkflow: vi.fn(() => [makeTask()]),
-      cancelTask: vi.fn(() => ({ cancelled: ['task-1'], runningCancelled: ['task-1'] })),
-      cancelWorkflow: vi.fn(() => ({ cancelled: ['task-1'], runningCancelled: ['task-1'] })),
-      deleteWorkflow: vi.fn(),
-      detachWorkflow: vi.fn(),
-      forkWorkflow: vi.fn(() => ({
-        forkedWorkflowId: 'wf-fork',
-        sourceWorkflowId: 'wf-1',
-        started: [makeTask({ id: 'fork-t1' })],
-      })),
-      editTaskCommand: vi.fn(() => [makeTask()]),
-      editTaskPrompt: vi.fn(() => [makeTask()]),
-      editTaskType: vi.fn(() => [makeTask()]),
-      editTaskAgent: vi.fn(() => [makeTask()]),
-      setTaskExternalGatePolicies: vi.fn(() => []),
-      selectExperiment: vi.fn(() => [makeTask()]),
-      approve: vi.fn(async () => [makeTask()]),
-      reject: vi.fn(),
-      provideInput: vi.fn(),
-      getTask: vi.fn(() => makeTask()),
-      getAllTasks: vi.fn(() => []),
-      startExecution: vi.fn(() => []),
-    } as any,
-    persistence: {
-      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1 })),
-      updateWorkflow: vi.fn(),
-      loadTasks: vi.fn(() => []),
-    } as any,
-    taskExecutor: {
-      executeTasks: vi.fn().mockResolvedValue(undefined),
-      publishAfterFix: vi.fn().mockResolvedValue(undefined),
-      resolveConflict: vi.fn().mockResolvedValue(undefined),
-      fixWithAgent: vi.fn().mockResolvedValue(undefined),
-      commitApprovedFix: vi.fn().mockResolvedValue(undefined),
-      killActiveExecution: vi.fn().mockResolvedValue(undefined),
-    } as any,
+    orchestrator: orchestrator as any,
+    persistence: persistence as any,
+    commandService: commandService as any,
+    taskExecutor: taskExecutor as any,
     killRunningTask: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
@@ -299,6 +319,10 @@ describe('Parity: API endpoints wire to facade methods', () => {
         setFixAwaitingApproval: vi.fn(),
         retryTask: vi.fn(() => [makeTask()]),
         recreateTask: vi.fn(() => [makeTask()]),
+        recreateDownstream: vi.fn(() => [makeTask()]),
+        retryWorkflow: vi.fn(() => [makeTask()]),
+        recreateWorkflowFromFreshBase: vi.fn(async () => [makeTask()]),
+        cascadeInvalidationToDownstream: vi.fn(() => []),
         editTaskCommand: vi.fn(() => [makeTask()]),
         editTaskPrompt: vi.fn(() => [makeTask()]),
         editTaskType: vi.fn(() => [makeTask()]),
@@ -334,6 +358,8 @@ describe('Parity: API endpoints wire to facade methods', () => {
         resolveConflict: vi.fn().mockResolvedValue(undefined),
         fixWithAgent: vi.fn().mockResolvedValue(undefined),
         commitApprovedFix: vi.fn().mockResolvedValue(undefined),
+        killActiveExecution: vi.fn().mockResolvedValue(undefined),
+        preparePoolForRebaseRetry: vi.fn().mockResolvedValue(undefined),
       },
       killRunningTask: vi.fn().mockResolvedValue(undefined),
       deleteWorkflow: vi.fn().mockResolvedValue(undefined),
@@ -344,9 +370,21 @@ describe('Parity: API endpoints wire to facade methods', () => {
 
   beforeAll(async () => {
     mocks = createApiMocks();
+    const commandService = {
+      retryTask: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: mocks.orchestrator.retryTask(envelope.payload.taskId) })),
+      recreateTask: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: mocks.orchestrator.recreateTask(envelope.payload.taskId) })),
+      retryWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => ({ ok: true as const, data: mocks.orchestrator.retryWorkflow(envelope.payload.workflowId) })),
+      recreateWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => {
+        const workflow = mocks.persistence.loadWorkflow(envelope.payload.workflowId);
+        mocks.persistence.updateWorkflow(envelope.payload.workflowId, { generation: (workflow.generation ?? 0) + 1 });
+        return { ok: true as const, data: mocks.orchestrator.recreateWorkflow(envelope.payload.workflowId) };
+      }),
+      runSerializedForWorkflow: vi.fn(async (_workflowId: string | undefined, fn: () => Promise<any> | any) => ({ ok: true as const, data: await fn() })),
+    };
     const facade = new WorkflowMutationFacade({
       orchestrator: mocks.orchestrator as any,
       persistence: mocks.persistence as any,
+      commandService: commandService as any,
       taskExecutor: mocks.taskExecutor as any,
       killRunningTask: mocks.killRunningTask,
     });

--- a/packages/app/src/__tests__/workflow-mutation-facade.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-facade.test.ts
@@ -30,44 +30,65 @@ function makeRunningTask(overrides: Record<string, unknown> = {}) {
 }
 
 function makeDeps(overrides: Partial<WorkflowMutationFacadeDeps> = {}): WorkflowMutationFacadeDeps {
+  const orchestrator = {
+    retryTask: vi.fn(() => [makeRunningTask()]),
+    recreateTask: vi.fn(() => [makeRunningTask()]),
+    recreateDownstream: vi.fn(() => [makeRunningTask({ id: 'task-b' })]),
+    cancelTask: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: [] })),
+    cancelWorkflow: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: ['task-a'] })),
+    deleteWorkflow: vi.fn(),
+    detachWorkflow: vi.fn(),
+    forkWorkflow: vi.fn(() => ({
+      forkedWorkflowId: 'wf-fork',
+      sourceWorkflowId: 'wf-1',
+      started: [makeRunningTask({ id: 'fork-t1' })],
+    })),
+    editTaskCommand: vi.fn(() => [makeRunningTask()]),
+    editTaskPrompt: vi.fn(() => [makeRunningTask()]),
+    editTaskType: vi.fn(() => [makeRunningTask()]),
+    editTaskAgent: vi.fn(() => [makeRunningTask()]),
+    setTaskExternalGatePolicies: vi.fn(() => []),
+    selectExperiment: vi.fn(() => [makeRunningTask()]),
+    approve: vi.fn(async () => [makeRunningTask()]),
+    reject: vi.fn(),
+    provideInput: vi.fn(),
+    getTask: vi.fn(),
+    getAllTasks: vi.fn(() => []),
+    startExecution: vi.fn(() => []),
+    retryWorkflow: vi.fn(() => [makeRunningTask()]),
+    recreateWorkflow: vi.fn(() => [makeRunningTask()]),
+    recreateWorkflowFromFreshBase: vi.fn(async () => [makeRunningTask()]),
+    cascadeInvalidationToDownstream: vi.fn(() => []),
+    cancelWorkflowExecution: vi.fn(),
+  };
+  const persistence = {
+    loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1 })),
+    updateWorkflow: vi.fn(),
+    loadTasks: vi.fn(() => []),
+  };
+  const taskExecutor = {
+    executeTasks: vi.fn(),
+    killActiveExecution: vi.fn(),
+    closeWorkflowReview: vi.fn(),
+    preparePoolForRebaseRetry: vi.fn(async () => undefined),
+  };
+  const commandService = {
+    retryTask: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: orchestrator.retryTask(envelope.payload.taskId) })),
+    recreateTask: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: orchestrator.recreateTask(envelope.payload.taskId) })),
+    recreateDownstream: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: orchestrator.recreateDownstream(envelope.payload.taskId) })),
+    retryWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => ({ ok: true as const, data: orchestrator.retryWorkflow(envelope.payload.workflowId) })),
+    recreateWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => {
+      const workflow = persistence.loadWorkflow(envelope.payload.workflowId);
+      persistence.updateWorkflow(envelope.payload.workflowId, { generation: (workflow.generation ?? 0) + 1 });
+      return { ok: true as const, data: orchestrator.recreateWorkflow(envelope.payload.workflowId) };
+    }),
+    runSerializedForWorkflow: vi.fn(async (_workflowId: string | undefined, fn: () => Promise<TaskState[]> | TaskState[]) => ({ ok: true as const, data: await fn() })),
+  };
   return {
-    orchestrator: {
-      retryTask: vi.fn(() => [makeRunningTask()]),
-      recreateTask: vi.fn(() => [makeRunningTask()]),
-      cancelTask: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: [] })),
-      cancelWorkflow: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: ['task-a'] })),
-      deleteWorkflow: vi.fn(),
-      detachWorkflow: vi.fn(),
-      forkWorkflow: vi.fn(() => ({
-        forkedWorkflowId: 'wf-fork',
-        sourceWorkflowId: 'wf-1',
-        started: [makeRunningTask({ id: 'fork-t1' })],
-      })),
-      editTaskCommand: vi.fn(() => [makeRunningTask()]),
-      editTaskPrompt: vi.fn(() => [makeRunningTask()]),
-      editTaskType: vi.fn(() => [makeRunningTask()]),
-      editTaskAgent: vi.fn(() => [makeRunningTask()]),
-      setTaskExternalGatePolicies: vi.fn(() => []),
-      selectExperiment: vi.fn(() => [makeRunningTask()]),
-      approve: vi.fn(async () => [makeRunningTask()]),
-      reject: vi.fn(),
-      provideInput: vi.fn(),
-      getTask: vi.fn(),
-      getAllTasks: vi.fn(() => []),
-      startExecution: vi.fn(() => []),
-      retryWorkflow: vi.fn(() => [makeRunningTask()]),
-      recreateWorkflow: vi.fn(() => [makeRunningTask()]),
-    } as unknown as Orchestrator,
-    persistence: {
-      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1 })),
-      updateWorkflow: vi.fn(),
-      loadTasks: vi.fn(() => []),
-    } as unknown as SQLiteAdapter,
-    taskExecutor: {
-      executeTasks: vi.fn(),
-      killActiveExecution: vi.fn(),
-      closeWorkflowReview: vi.fn(),
-    } as unknown as TaskRunner,
+    orchestrator: orchestrator as unknown as Orchestrator,
+    persistence: persistence as unknown as SQLiteAdapter,
+    commandService: commandService as unknown as WorkflowMutationFacadeDeps['commandService'],
+    taskExecutor: taskExecutor as unknown as TaskRunner,
     ...overrides,
   };
 }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -7,16 +7,20 @@
  */
 
 import type { Logger } from '@invoker/contracts';
-import type { Orchestrator, ExternalGatePolicyUpdate } from '@invoker/workflow-core';
 import type {
-  CancelInFlightFn,
-  InvalidationDeps,
+  CommandService,
+  Orchestrator,
+  ExternalGatePolicyUpdate,
+  InvalidationAction,
   InvalidationScope,
   TaskState,
+  CancelInFlightFn,
+  InvalidationDeps,
 } from '@invoker/workflow-core';
 import {
   OrchestratorError,
   OrchestratorErrorCode,
+  applyInvalidation,
   buildCancelInFlight as buildCoreCancelInFlight,
   parseMergeConflictError,
 } from '@invoker/workflow-core';
@@ -124,6 +128,10 @@ export interface ActionDeps {
   mutationTiming?: WorkflowMutationTiming;
   /** When true, successful AI-applied fixes are approved immediately. */
   autoApproveAIFixes?: boolean;
+}
+
+export interface CommandActionDeps extends ActionDeps {
+  commandService: CommandService;
 }
 
 export interface ApproveTaskResult {

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -25,11 +25,6 @@ import {
   approveTask as sharedApproveTask,
   rejectTask as sharedRejectTask,
   provideInput as sharedProvideInput,
-  retryTask as sharedRetryTask,
-  retryWorkflow as sharedRetryWorkflow,
-  recreateWorkflow as sharedRecreateWorkflow,
-  recreateTask as sharedRecreateTask,
-  recreateDownstream as sharedRecreateDownstream,
   recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
   rebaseRetry as sharedRebaseRetry,
   rebaseRecreate as sharedRebaseRecreate,
@@ -50,7 +45,7 @@ import {
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   type FailureRecoveryRoute,
   type FixWithAgentActionResult,
-  type ActionDeps,
+  type CommandActionDeps,
 } from './workflow-actions.js';
 import {
   dispatchStartedTasksWithGlobalTopup,
@@ -111,7 +106,7 @@ export interface WorkflowMutationFacadeDeps {
   logger?: Logger;
   orchestrator: Orchestrator;
   persistence: SQLiteAdapter;
-  commandService?: CommandService;
+  commandService: CommandService;
   taskExecutor: TaskRunner;
   dispatchMode?: 'await' | 'fire-and-forget';
   autoApproveAIFixes?: boolean;
@@ -157,33 +152,21 @@ export class WorkflowMutationFacade {
 
   async retryTask(taskId: string): Promise<MutationResult> {
     const started = await this.runViaCommandService(
-      'task',
-      taskId,
       (cs) => cs.retryTask(makeEnvelope('facade.retry-task', 'surface', 'task', { taskId })),
-      () => sharedRetryTask(taskId, { orchestrator: this.deps.orchestrator }),
     );
     return this.finalizeWithTopup(started, 'facade.retry-task', { scopedTaskIds: [taskId] });
   }
 
   async recreateTask(taskId: string): Promise<MutationResult> {
     const started = await this.runViaCommandService(
-      'task',
-      taskId,
       (cs) => cs.recreateTask(makeEnvelope('facade.recreate-task', 'surface', 'task', { taskId })),
-      () => sharedRecreateTask(taskId, {
-        orchestrator: this.deps.orchestrator,
-        persistence: this.deps.persistence,
-      }),
     );
     return this.finalizeWithTopup(started, 'facade.recreate-task', { scopedTaskIds: [taskId] });
   }
 
   async recreateDownstream(taskId: string): Promise<MutationResult> {
     const started = await this.runViaCommandService(
-      'task',
-      taskId,
       (cs) => cs.recreateDownstream(makeEnvelope('facade.recreate-downstream', 'surface', 'task', { taskId })),
-      () => sharedRecreateDownstream(taskId, { orchestrator: this.deps.orchestrator }),
     );
     // `started` contains only descendants (the target is preserved), so a
     // [taskId] dispatch scope would filter every launch out.
@@ -290,24 +273,14 @@ export class WorkflowMutationFacade {
 
   async retryWorkflow(workflowId: string): Promise<MutationResult> {
     const started = await this.runViaCommandService(
-      'workflow',
-      workflowId,
       (cs) => cs.retryWorkflow(makeEnvelope('facade.retry-workflow', 'surface', 'workflow', { workflowId })),
-      () => sharedRetryWorkflow(workflowId, { orchestrator: this.deps.orchestrator }),
     );
     return this.finalizeWithTopup(started, 'facade.retry-workflow', { scopedWorkflowId: workflowId });
   }
 
   async recreateWorkflow(workflowId: string): Promise<MutationResult> {
     const started = await this.runViaCommandService(
-      'workflow',
-      workflowId,
       (cs) => cs.recreateWorkflow(makeEnvelope('facade.recreate-workflow', 'surface', 'workflow', { workflowId })),
-      () => sharedRecreateWorkflow(workflowId, {
-        logger: this.deps.logger,
-        persistence: this.deps.persistence,
-        orchestrator: this.deps.orchestrator,
-      }),
     );
     return this.finalizeWithTopup(started, 'facade.recreate-workflow', { scopedWorkflowId: workflowId });
   }
@@ -473,11 +446,12 @@ export class WorkflowMutationFacade {
 
   // ── Internal helpers ─────────────────────────────────────
 
-  private actionDeps(): ActionDeps {
+  private actionDeps(): CommandActionDeps {
     return {
       logger: this.deps.logger,
       orchestrator: this.deps.orchestrator,
       persistence: this.deps.persistence,
+      commandService: this.deps.commandService,
       taskExecutor: this.deps.taskExecutor,
       autoApproveAIFixes: this.deps.autoApproveAIFixes,
     };
@@ -510,32 +484,22 @@ export class WorkflowMutationFacade {
   }
 
   /**
-   * Route through the production CommandService when available so the
-   * mutation gets mutex serialization, executor kill on cancel-in-flight,
-   * and the cross-workflow cascade. Falls back to the shared action when
-   * no CommandService is wired (legacy entrypoints / tests).
+   * Route lifecycle mutations through CommandService so they get mutex
+   * serialization, executor kill on cancel-in-flight, and cross-workflow
+   * cascade. There is intentionally no direct orchestrator fallback.
    */
   private async runViaCommandService(
-    _scope: 'task' | 'workflow',
-    _id: string,
     routed: (cs: CommandService) => Promise<{ ok: true; data: TaskState[] } | { ok: false; error: { code: string; message: string } }>,
-    fallback: () => TaskState[] | Promise<TaskState[]>,
   ): Promise<TaskState[]> {
-    if (this.deps.commandService) {
-      const result = await routed(this.deps.commandService);
-      if (!result.ok) {
-        // Surface OrchestratorError when CommandService bubbles a known
-        // domain code (e.g. WORKFLOW_NOT_FOUND -> HTTP 404). Plain Error
-        // is the fallback for unmapped codes.
-        const known = (Object.values(OrchestratorErrorCode) as string[]).includes(result.error.code);
-        if (known) {
-          throw new OrchestratorError(result.error.code as OrchestratorErrorCode, result.error.message);
-        }
-        throw new Error(result.error.message);
+    const result = await routed(this.deps.commandService);
+    if (!result.ok) {
+      const known = (Object.values(OrchestratorErrorCode) as string[]).includes(result.error.code);
+      if (known) {
+        throw new OrchestratorError(result.error.code as OrchestratorErrorCode, result.error.message);
       }
-      return result.data;
+      throw new Error(result.error.message);
     }
-    return Promise.resolve(fallback());
+    return result.data;
   }
 
   private assertSingleDispatchScope(scope: DispatchScope): void {


### PR DESCRIPTION
## Summary

This makes `WorkflowMutationFacade` require `CommandService` instead of silently falling back to direct orchestrator lifecycle calls.

That turns the facade into a hard boundary: production callers must bring the serialized mutation path with them.

It is safe because the real app entrypoints already construct the facade with `commandService`; this change mostly removes test-only and legacy fallback behavior.

## Review metadata

- Review claim: the workflow mutation facade is now CommandService-only for lifecycle mutations.
- Safety invariant: real app wiring already passes `commandService`, so behavior only changes for bypass-style callers.
- Slice rationale: do the facade boundary first so later slices can delete old app-layer lifecycle helpers without breaking imports.
- Architectural effect: ownership for retry/recreate routing shifts from facade-local fallback logic to the serialized mutation service.
- Alternative considerations: bundling this with the helper-routing slice would make it harder to tell whether a failure came from the boundary change or the behavior change.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-mutation-facade.test.ts src/__tests__/parity-regression.test.ts src/__tests__/api-server.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert ce44d7626`
- Post-revert steps: None
- Data migration? No