### PR TITLE
Route merge-branch retries through CommandService

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -1048,15 +1048,15 @@ describe('POST /api/workflows/:id/rebase-recreate', () => {
     }
   });
 
-  it('recreates workflow', async () => {
-    mocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask({ id: 'wf-1/task-a' })]);
+  it('recreates workflow from fresh base', async () => {
+    mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn(async () => [makeTask({ id: 'wf-1/task-a' })]);
     const res = await request(port, 'POST', '/api/workflows/wf-1/rebase-recreate');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('rebase_recreated');
     expect(res.body.tasksStarted).toBe(1);
     expect(res.body.deprecated).toBeUndefined();
-    expect(mocks.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(mocks.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1', expect.any(Object));
   });
 
   it('keeps cross-workflow started tasks out of the scoped rebase-recreate runnable result', async () => {
@@ -1070,7 +1070,7 @@ describe('POST /api/workflows/:id/rebase-recreate', () => {
       config: { workflowId: 'wf-2' },
       execution: { selectedAttemptId: 'attempt-b' },
     });
-    mocks.orchestrator.recreateWorkflow = vi.fn(() => [scoped, crossWorkflow]);
+    mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn(async () => [scoped, crossWorkflow]);
     mocks.orchestrator.startExecution.mockReturnValue([]);
 
     const res = await request(port, 'POST', '/api/workflows/wf-1/rebase-recreate');

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -31,7 +31,12 @@ describe('headless delegation enforcement', () => {
         listWorkflows: vi.fn(() => []),
         loadTasks: vi.fn(() => []),
       } as unknown as SQLiteAdapter,
-      commandService: {} as CommandService,
+      commandService: {
+        runSerializedForWorkflow: vi.fn(async (_workflowId: string | undefined, fn: () => Promise<unknown> | unknown) => ({
+          ok: true as const,
+          data: await fn(),
+        })),
+      } as unknown as CommandService,
       executorRegistry: {} as any,
       messageBus: new LocalBus() as MessageBus,
       repoRoot: '/fake/repo',
@@ -1188,6 +1193,8 @@ describe('headless delegation enforcement', () => {
           mockDeps.orchestrator.retryWorkflow = vi.fn(() => []);
           mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
           mockDeps.orchestrator.recreateWorkflowFromFreshBase = vi.fn(async () => []);
+          mockDeps.orchestrator.cancelWorkflow = vi.fn(() => ({ cancelled: [], runningCancelled: [] }));
+          mockDeps.orchestrator.cascadeInvalidationToDownstream = vi.fn(() => []);
 
           // Spy on `preparePoolForRebaseRetry` to assert the app-layer
           // `recreateWorkflowFromFreshBase` actually invokes pool prep
@@ -1263,7 +1270,7 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `rebase-recreate <wfId>` routes to orchestrator.recreateWorkflow with workflowId directly', async () => {
+        it('headless `rebase-recreate <wfId>` routes to orchestrator.recreateWorkflowFromFreshBase with workflowId directly', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
 
           const depsWithNoTrack: HeadlessDeps = {
@@ -1275,8 +1282,8 @@ describe('headless delegation enforcement', () => {
           await runHeadless(['rebase-recreate', 'wf-1'], depsWithNoTrack);
 
           expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
-          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
-          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1', expect.any(Object));
+          expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(preparePoolSpy).toHaveBeenCalledWith(
             'wf-1',
             'https://example/repo.git',
@@ -1298,7 +1305,7 @@ describe('headless delegation enforcement', () => {
           await runHeadless(['rebase-recreate', '__merge__wf-1'], depsWithNoTrack);
 
           expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
-          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1', expect.any(Object));
 
           preparePoolSpy.mockRestore();
         });
@@ -1315,7 +1322,7 @@ describe('headless delegation enforcement', () => {
           await runHeadless(['rebase-recreate', 'task-1'], depsWithNoTrack);
 
           expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
-          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1', expect.any(Object));
 
           preparePoolSpy.mockRestore();
         });
@@ -1428,6 +1435,8 @@ describe('headless delegation enforcement', () => {
               return [];
             },
           ) as any;
+          mockDeps.orchestrator.cancelWorkflow = vi.fn(() => ({ cancelled: [], runningCancelled: [] }));
+          mockDeps.orchestrator.cascadeInvalidationToDownstream = vi.fn(() => []);
           (mockDeps.orchestrator as any).restartTask = vi.fn(() => []);
           mockDeps.commandService.retryTask = vi.fn(async () => ({ ok: true as const, data: [] }));
           mockDeps.commandService.retryWorkflow = vi.fn(async () => ({ ok: true as const, data: [] }));
@@ -1546,7 +1555,7 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `rebase-recreate <wfId>` routes to orchestrator.recreateWorkflow after fresh-base prep', async () => {
+        it('headless `rebase-recreate <wfId>` routes to orchestrator.recreateWorkflowFromFreshBase after fresh-base prep', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedHappyPath();
           const depsWithNoTrack: HeadlessDeps = {
             ...mockDeps,
@@ -1556,7 +1565,7 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['rebase-recreate', 'wf-1'], depsWithNoTrack);
 
-          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1', expect.any(Object));
           expect(preparePoolSpy).toHaveBeenCalledWith(
             'wf-1',
             'https://example/repo.git',
@@ -1565,7 +1574,7 @@ describe('headless delegation enforcement', () => {
           expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
           expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
-          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
+          expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
           preparePoolSpy.mockRestore();
         });

--- a/packages/app/src/__tests__/rebase-and-retry.test.ts
+++ b/packages/app/src/__tests__/rebase-and-retry.test.ts
@@ -11,7 +11,7 @@
  * Pattern: sandbox git repo + real WorktreeExecutor + real TaskRunner
  * (follows branch-chain.test.ts).
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -19,7 +19,7 @@ import { execSync } from 'node:child_process';
 import type { WorkResponse } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import { TaskRunner, ExecutorRegistry, WorktreeExecutor } from '@invoker/execution-engine';
-import { rebaseRecreate, bumpGenerationAndRecreate } from '../workflow-actions.js';
+import { rebaseRecreate } from '../workflow-actions.js';
 
 function createTempRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), 'rebase-retry-'));
@@ -156,6 +156,12 @@ describe('rebase-recreate: pool mirror cleanup before restart', { timeout: 120_0
         }
         return tasks;
       },
+      recreateWorkflowFromFreshBase: async (workflowId: string, options?: { refreshBase?: () => Promise<unknown> }): Promise<TaskState[]> => {
+        await options?.refreshBase?.();
+        return orchestrator.recreateWorkflow(workflowId);
+      },
+      cancelWorkflow: () => ({ cancelled: [], runningCancelled: [] }),
+      cascadeInvalidationToDownstream: () => [],
     };
 
     const repoUrl = `file://${tmpDir}`;
@@ -243,6 +249,12 @@ describe('rebase-recreate: pool mirror cleanup before restart', { timeout: 120_0
       persistence: persistence as any,
       repoRoot: tmpDir,
       taskExecutor: executor,
+      commandService: {
+        runSerializedForWorkflow: vi.fn(async (_workflowId: string | undefined, fn: () => Promise<unknown> | unknown) => ({
+          ok: true as const,
+          data: await fn(),
+        })),
+      } as any,
     };
     await rebaseRecreate('task-a', deps);
 
@@ -274,10 +286,8 @@ describe('rebase-recreate: pool mirror cleanup before restart', { timeout: 120_0
 
     const commitY = addCommitToMaster(tmpDir, 'new-feature.txt', 'commit Y: new feature');
 
-    bumpGenerationAndRecreate('wf-test', {
-      orchestrator: orchestrator as any,
-      persistence: persistence as any,
-    });
+    persistence.updateWorkflow('wf-test', { generation: 1 });
+    orchestrator.recreateWorkflow('wf-test');
 
     expect(branchExists(clonePath(), branchFirst)).toBe(true);
 

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -9,12 +9,7 @@ import type { Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
 import {
-  bumpGenerationAndRecreate,
-  recreateWorkflow,
-  recreateTask,
   cancelWorkflow,
-  retryTask,
-  retryWorkflow,
   recreateWorkflowFromFreshBase,
   rebaseRetry,
   rebaseRecreate,
@@ -65,167 +60,23 @@ function makeRunningTask(overrides: Record<string, unknown> = {}) {
 
 // ── Tests ────────────────────────────────────────────────────
 
-describe('bumpGenerationAndRecreate', () => {
-  let orchestrator: { recreateWorkflow: ReturnType<typeof vi.fn> };
-  let persistence: {
-    loadWorkflow: ReturnType<typeof vi.fn>;
-    updateWorkflow: ReturnType<typeof vi.fn>;
-  };
 
-  beforeEach(() => {
-    orchestrator = {
-      recreateWorkflow: vi.fn(() => [makeRunningTask()]),
-    };
-    persistence = {
-      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 2 })),
-      updateWorkflow: vi.fn(),
-    };
-  });
-
-  it('loads workflow, bumps generation, calls orchestrator.recreateWorkflow', () => {
-    const result = bumpGenerationAndRecreate('wf-1', {
-      persistence: persistence as unknown as SQLiteAdapter,
-      orchestrator: orchestrator as unknown as Orchestrator,
-    });
-
-    expect(persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 3 });
-    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(result).toHaveLength(1);
-    expect(result[0].status).toBe('running');
-  });
-
-  it('throws when workflow not found', () => {
-    persistence.loadWorkflow.mockReturnValue(undefined);
-    expect(() =>
-      bumpGenerationAndRecreate('missing', {
-        persistence: persistence as unknown as SQLiteAdapter,
-        orchestrator: orchestrator as unknown as Orchestrator,
-      }),
-    ).toThrow('Workflow missing not found');
-  });
-
-  it('handles undefined generation (defaults to 0 + 1 = 1)', () => {
-    persistence.loadWorkflow.mockReturnValue({ id: 'wf-1' });
-    bumpGenerationAndRecreate('wf-1', {
-      persistence: persistence as unknown as SQLiteAdapter,
-      orchestrator: orchestrator as unknown as Orchestrator,
-    });
-    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 1 });
-  });
-});
-
-describe('recreateWorkflow', () => {
-  it('delegates to bumpGenerationAndRecreate', () => {
-    const orchestrator = { recreateWorkflow: vi.fn(() => [makeRunningTask()]) };
-    const persistence = {
-      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 0 })),
-      updateWorkflow: vi.fn(),
-    };
-
-    const result = recreateWorkflow('wf-1', {
-      persistence: persistence as unknown as SQLiteAdapter,
-      orchestrator: orchestrator as unknown as Orchestrator,
-    });
-
-    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 1 });
-    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(result).toHaveLength(1);
-  });
-});
-
-describe('recreateTask', () => {
-  it('delegates to orchestrator.recreateTask', () => {
-    const orchestrator = {
-      recreateTask: vi.fn(() => [makeRunningTask()]),
-    };
-    const persistence = {
-      loadWorkflow: vi.fn(),
-      updateWorkflow: vi.fn(),
-    };
-
-    const result = recreateTask('task-a', {
-      persistence: persistence as unknown as SQLiteAdapter,
-      orchestrator: orchestrator as unknown as Orchestrator,
-    });
-
-    expect(orchestrator.recreateTask).toHaveBeenCalledWith('task-a');
-    expect(persistence.updateWorkflow).not.toHaveBeenCalled();
-    expect(result).toHaveLength(1);
-  });
-
-  it('passes through orchestrator errors', () => {
-    const orchestrator = {
-      recreateTask: vi.fn(() => {
-        throw new Error('Task missing-task not found');
-      }),
-    };
-    const persistence = {
-      loadWorkflow: vi.fn(),
-      updateWorkflow: vi.fn(),
-    };
-
-    expect(() =>
-      recreateTask('missing-task', {
-        persistence: persistence as unknown as SQLiteAdapter,
-        orchestrator: orchestrator as unknown as Orchestrator,
-      }),
-    ).toThrow('Task missing-task not found');
-  });
-});
-
-describe('cancelWorkflow', () => {
-  it('delegates to orchestrator.cancelWorkflow', () => {
-    const orchestrator = {
-      cancelWorkflow: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: ['task-a'] })),
-    };
-
-    const result = cancelWorkflow('wf-1', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-    });
-
-    expect(orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(result).toEqual({ cancelled: ['task-a'], runningCancelled: ['task-a'] });
-  });
-});
-
-describe('retryTask', () => {
-  it('calls orchestrator.retryTask and returns result', () => {
-    const tasks = [makeRunningTask()];
-    const orchestrator = { retryTask: vi.fn(() => tasks) };
-
-    const result = retryTask('task-a', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-    });
-
-    expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
-    expect(result).toBe(tasks);
-  });
-});
-
-describe('retryWorkflow', () => {
-  it('calls orchestrator.retryWorkflow and returns result', () => {
-    const tasks = [makeRunningTask()];
-    const orchestrator = { retryWorkflow: vi.fn(() => tasks) };
-
-    const result = retryWorkflow('wf-1', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-    });
-
-    expect(orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(result).toBe(tasks);
-  });
-});
-
-describe('recreateWorkflowFromFreshBase', () => {
-  it('bumps generation and delegates to orchestrator.recreateWorkflowFromFreshBase with refreshBase callback', async () => {
+function makeCommandService() {
+  return {
+    runSerializedForWorkflow: vi.fn(async (_workflowId: string | undefined, fn: () => Promise<unknown> | unknown) => ({
+      ok: true as const,
+      data: await fn(),
+    })),
+  } as any;
+}
+describe('fresh-base workflow lifecycle helpers', () => {
+  it('routes recreateWorkflowFromFreshBase through CommandService/applyInvalidation', async () => {
     const tasks = [makeRunningTask()];
     const orchestrator = {
-      recreateWorkflowFromFreshBase: vi.fn(async (_id: string, opts?: { refreshBase?: () => Promise<unknown> }) => {
-        // Drive the refresh callback so we exercise pool prep wiring.
-        await opts?.refreshBase?.();
-        return tasks;
-      }),
+      getTask: vi.fn(),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      recreateWorkflowFromFreshBase: vi.fn(async () => tasks),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
     };
     const persistence = {
       loadWorkflow: vi.fn(() => ({
@@ -238,49 +89,60 @@ describe('recreateWorkflowFromFreshBase', () => {
     };
     const taskExecutor = {
       preparePoolForRebaseRetry: vi.fn(async () => undefined),
+      killActiveExecution: vi.fn(async () => undefined),
     } as unknown as TaskRunner;
+    const commandService = makeCommandService();
 
     const result = await recreateWorkflowFromFreshBase('wf-1', {
+      commandService,
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor,
     });
 
+    expect(commandService.runSerializedForWorkflow).toHaveBeenCalledWith('wf-1', expect.any(Function));
     expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 5 });
-    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledTimes(1);
     expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
       'wf-1',
       expect.objectContaining({ refreshBase: expect.any(Function) }),
     );
-    // The whole reason this wrapper exists vs plain recreateWorkflow:
-    // the refreshBase callback runs preparePoolForRebaseRetry.
     expect(taskExecutor.preparePoolForRebaseRetry).toHaveBeenCalledWith(
       'wf-1',
       'https://example/repo.git',
       'main',
     );
+    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-1');
     expect(result).toBe(tasks);
   });
 
-  it('throws when workflow not found', async () => {
-    const orchestrator = { recreateWorkflowFromFreshBase: vi.fn(async () => []) };
+  it('throws when workflow not found before direct primitive use', async () => {
+    const commandService = makeCommandService();
+    const orchestrator = {
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      recreateWorkflowFromFreshBase: vi.fn(async () => []),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
+    };
     const persistence = { loadWorkflow: vi.fn(() => undefined), updateWorkflow: vi.fn() };
 
     await expect(
       recreateWorkflowFromFreshBase('missing', {
+        commandService,
         orchestrator: orchestrator as unknown as Orchestrator,
         persistence: persistence as unknown as SQLiteAdapter,
       }),
     ).rejects.toThrow('Workflow missing not found');
+    expect(orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
   });
 });
 
 describe('rebaseRetry', () => {
-  it('translates target → workflowId, prepares fresh base, and delegates to retryWorkflow', async () => {
+  it('serializes through CommandService and cascades after retryWorkflow', async () => {
     const tasks = [makeRunningTask()];
     const orchestrator = {
       getTask: vi.fn(() => makeTask({ config: { workflowId: 'wf-1' } })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
       retryWorkflow: vi.fn(() => tasks),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
     };
     const persistence = {
       loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1, repoUrl: 'https://example/repo.git', baseBranch: 'master' })),
@@ -288,14 +150,23 @@ describe('rebaseRetry', () => {
       loadTasks: vi.fn(() => []),
       updateWorkflow: vi.fn(),
     };
+    const taskExecutor = {
+      preparePoolForRebaseRetry: vi.fn(async () => undefined),
+      killActiveExecution: vi.fn(async () => undefined),
+    } as unknown as TaskRunner;
+    const commandService = makeCommandService();
 
     const result = await rebaseRetry('wf-1/task-a', {
+      commandService,
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor,
     });
 
+    expect(commandService.runSerializedForWorkflow).toHaveBeenCalledWith('wf-1', expect.any(Function));
+    expect(taskExecutor.preparePoolForRebaseRetry).toHaveBeenCalled();
     expect(orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(persistence.updateWorkflow).not.toHaveBeenCalled();
+    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-1');
     expect(result).toBe(tasks);
   });
 
@@ -308,6 +179,7 @@ describe('rebaseRetry', () => {
 
     await expect(
       rebaseRetry('missing-task', {
+        commandService: makeCommandService(),
         orchestrator: orchestrator as unknown as Orchestrator,
         persistence: persistence as unknown as SQLiteAdapter,
       }),
@@ -316,11 +188,13 @@ describe('rebaseRetry', () => {
 });
 
 describe('rebaseRecreate', () => {
-  it('prepares fresh base, then delegates to recreateWorkflow', async () => {
+  it('serializes through CommandService and cascades fresh-base recreate', async () => {
     const tasks = [makeRunningTask()];
     const orchestrator = {
       getTask: vi.fn(() => undefined),
-      recreateWorkflow: vi.fn(() => tasks),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      recreateWorkflowFromFreshBase: vi.fn(async () => tasks),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
     };
     const persistence = {
       loadWorkflow: vi.fn(() => ({
@@ -335,30 +209,34 @@ describe('rebaseRecreate', () => {
     };
     const taskExecutor = {
       preparePoolForRebaseRetry: vi.fn(async () => undefined),
+      killActiveExecution: vi.fn(async () => undefined),
     } as unknown as TaskRunner;
+    const commandService = makeCommandService();
 
     const result = await rebaseRecreate('wf-1', {
+      commandService,
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor,
     });
 
+    expect(commandService.runSerializedForWorkflow).toHaveBeenCalledWith('wf-1', expect.any(Function));
     expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 3 });
-    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(taskExecutor.preparePoolForRebaseRetry).toHaveBeenCalledWith(
+    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
       'wf-1',
-      'https://example/repo.git',
-      'main',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
     );
+    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-1');
     expect(result).toBe(tasks);
   });
 
   it('throws when workflow not found', async () => {
-    const orchestrator = { getTask: vi.fn(() => undefined), recreateWorkflow: vi.fn(() => []) };
+    const orchestrator = { getTask: vi.fn(() => undefined), recreateWorkflowFromFreshBase: vi.fn(async () => []) };
     const persistence = { loadWorkflow: vi.fn(() => undefined), listWorkflows: vi.fn(() => []), loadTasks: vi.fn(() => []), updateWorkflow: vi.fn() };
 
     await expect(
       rebaseRecreate('missing', {
+        commandService: makeCommandService(),
         orchestrator: orchestrator as unknown as Orchestrator,
         persistence: persistence as unknown as SQLiteAdapter,
       }),
@@ -366,62 +244,14 @@ describe('rebaseRecreate', () => {
   });
 });
 
-// Step 17 (`docs/architecture/task-invalidation-roadmap.md` and the
-// chart's "Proposed API Direction"): pin the canonical
-// `{retry, recreate} × {task, workflow}` matrix at the
-// app-layer wrapper surface. This is the lock-in that prevents
-// future refactors from accidentally dropping any of the five
-// canonical lifecycle wrappers (or routing a new one through a
-// legacy compat layer like `restartTask`).
-describe('Step 17: app-layer wrappers expose the 5-cell lifecycle matrix', () => {
-  it('exports retryTask, recreateTask, retryWorkflow, recreateWorkflow, recreateWorkflowFromFreshBase', () => {
-    expect(typeof retryTask).toBe('function');
-    expect(typeof recreateTask).toBe('function');
-    expect(typeof retryWorkflow).toBe('function');
-    expect(typeof recreateWorkflow).toBe('function');
-    expect(typeof recreateWorkflowFromFreshBase).toBe('function');
-  });
-
-  it('each wrapper routes to the matching orchestrator primitive (no restartTask path)', async () => {
-    const orchestrator = {
-      retryTask: vi.fn(() => []),
-      recreateTask: vi.fn(() => []),
-      retryWorkflow: vi.fn(() => []),
-      recreateWorkflow: vi.fn(() => []),
-      recreateWorkflowFromFreshBase: vi.fn(async () => []),
-      restartTask: vi.fn(() => []),
-    };
-    const persistence = {
-      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 0 })),
-      updateWorkflow: vi.fn(),
-    };
-
-    retryTask('task-a', { orchestrator: orchestrator as unknown as Orchestrator });
-    recreateTask('task-a', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-    retryWorkflow('wf-1', { orchestrator: orchestrator as unknown as Orchestrator });
-    recreateWorkflow('wf-1', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-    await recreateWorkflowFromFreshBase('wf-1', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-    });
-
-    expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
-    expect(orchestrator.recreateTask).toHaveBeenCalledWith('task-a');
-    expect(orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
-      'wf-1',
-      expect.objectContaining({ refreshBase: expect.any(Function) }),
-    );
-    // No production wrapper in the canonical matrix may route
-    // through the deprecated `restartTask` shim.
-    expect(orchestrator.restartTask).not.toHaveBeenCalled();
+describe('workflow lifecycle invariant', () => {
+  it('does not expose direct app-layer retry/recreate wrappers', async () => {
+    const actions = await import('../workflow-actions.js');
+    expect('retryTask' in actions).toBe(false);
+    expect('recreateTask' in actions).toBe(false);
+    expect('retryWorkflow' in actions).toBe(false);
+    expect('recreateWorkflow' in actions).toBe(false);
+    expect('bumpGenerationAndRecreate' in actions).toBe(false);
   });
 });
 
@@ -721,6 +551,8 @@ describe('autoFixOnFailure', () => {
         await options?.refreshBase?.();
         return started;
       }),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
       retryTask: vi.fn(() => []),
       revertConflictResolution: vi.fn(),
     };
@@ -748,6 +580,7 @@ describe('autoFixOnFailure', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     });
 
     expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
@@ -776,6 +609,8 @@ describe('autoFixOnFailure', () => {
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
       retryTask: vi.fn(() => started),
+      cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -793,6 +628,7 @@ describe('autoFixOnFailure', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     });
 
     expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
@@ -830,6 +666,7 @@ describe('autoFixOnFailure', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     });
 
     expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
@@ -867,6 +704,8 @@ describe('autoFixOnFailure', () => {
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
       retryTask: vi.fn(() => started),
+      cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -884,6 +723,7 @@ describe('autoFixOnFailure', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     });
 
     expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
@@ -926,6 +766,7 @@ describe('autoFixOnFailure', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     });
 
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
@@ -969,6 +810,7 @@ describe('autoFixOnFailure', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
       getAutoApproveAIFixes: () => true,
     });
 
@@ -1062,6 +904,7 @@ describe('autoFixOnFailure', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
       getAutoApproveAIFixes: () => true,
     });
 
@@ -1110,6 +953,7 @@ describe('autoFixOnFailure', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
       getAutoFixAgent: () => 'codex',
     });
 
@@ -1160,6 +1004,7 @@ describe('autoFixOnFailure', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
       getAutoFixAgent: () => '   ',
     });
 
@@ -1211,6 +1056,7 @@ describe('autoFixOnFailure', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
       getAutoFixAgent: () => undefined,
     });
 
@@ -1334,6 +1180,7 @@ describe('fixWithAgentAction', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     }, {
       agentName: 'codex',
     });
@@ -1373,6 +1220,7 @@ describe('fixWithAgentAction', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     }, {
       agentName: 'claude',
     });
@@ -1408,6 +1256,7 @@ describe('fixWithAgentAction', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     }, {
       agentName: 'codex',
     });
@@ -1429,7 +1278,9 @@ describe('fixWithAgentAction', () => {
       })),
       loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 2 })),
       updateWorkflow: vi.fn(),
-      recreateWorkflowFromFreshBase: vi.fn(() => [makeRunningTask({ id: 'task-a', status: 'running' })]),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      recreateWorkflowFromFreshBase: vi.fn(async () => [makeRunningTask({ id: 'task-a', status: 'running' })]),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
     };
     const persistence = {
       appendTaskOutput: vi.fn(),
@@ -1444,6 +1295,7 @@ describe('fixWithAgentAction', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     }, {
       recreateOutputLabel: 'Fix with AI',
     });
@@ -2301,6 +2153,7 @@ describe('fixWithAgentAction lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     })).rejects.toThrow(StaleLineageError);
 
     // Should NOT have called setFixAwaitingApproval (the late write)
@@ -2337,6 +2190,7 @@ describe('fixWithAgentAction lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     }, {
       signal: ac.signal,
     })).rejects.toThrow(StaleLineageError);
@@ -2381,6 +2235,7 @@ describe('fixWithAgentAction lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     })).rejects.toThrow(StaleLineageError);
 
     // revertConflictResolution must NOT be called when lineage is stale
@@ -2412,6 +2267,7 @@ describe('fixWithAgentAction lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     });
 
     // Normal path should proceed
@@ -2558,6 +2414,7 @@ describe('autoFixOnFailure lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     })).rejects.toThrow(StaleLineageError);
 
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
@@ -2611,6 +2468,7 @@ describe('autoFixOnFailure lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
     })).rejects.toThrow(StaleLineageError);
 
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
@@ -2659,6 +2517,7 @@ describe('autoFixOnFailure lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
       signal: ac.signal,
     })).rejects.toThrow(StaleLineageError);
 

--- a/packages/app/src/__tests__/workflow-mutation-facade.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-facade.test.ts
@@ -380,7 +380,7 @@ describe('WorkflowMutationFacade', () => {
         config: { workflowId: 'wf-2' },
         execution: { selectedAttemptId: 'attempt-b' },
       });
-      (deps.orchestrator.recreateWorkflow as ReturnType<typeof vi.fn>).mockReturnValue([scoped, crossWorkflow]);
+      (deps.orchestrator.recreateWorkflowFromFreshBase as ReturnType<typeof vi.fn>).mockResolvedValue([scoped, crossWorkflow]);
 
       const result = await facade.rebaseRecreate('wf-1');
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -45,8 +45,6 @@ import {
   rebaseRetry,
   rebaseRecreate,
   resolveConflictAction,
-  recreateWorkflow as sharedRecreateWorkflow,
-  recreateTask as sharedRecreateTask,
   forkWorkflow as sharedForkWorkflow,
   setWorkflowMergeMode,
 } from './workflow-actions.js';
@@ -68,7 +66,6 @@ import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './work
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
 
-export { bumpGenerationAndRecreate } from './workflow-actions.js';
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
   WORKFLOW_DELEGATION_TIMEOUT_MS,
@@ -315,14 +312,17 @@ async function dispatchHeadlessRunnableTasks(
 }
 
 export function wireHeadlessAutoFix(
-  deps: Pick<HeadlessDeps, 'messageBus' | 'orchestrator' | 'persistence'>,
+  deps: Pick<HeadlessDeps, 'logger' | 'messageBus' | 'orchestrator' | 'persistence' | 'commandService' | 'mutationTiming'>,
   taskExecutor: Pick<TaskRunner, 'executeTasks' | 'fixWithAgent' | 'resolveConflict'>,
   invokeAutoFix: (taskId: string) => Promise<void> = async (taskId) => {
     const { autoFixOnFailure } = await import('./workflow-actions.js');
     await autoFixOnFailure(taskId, {
+      logger: deps.logger,
       orchestrator: deps.orchestrator,
       persistence: deps.persistence,
+      commandService: deps.commandService,
       taskExecutor: taskExecutor as TaskRunner,
+      mutationTiming: deps.mutationTiming,
       getAutoFixAgent: () => loadConfig().autoFixAgent,
       getAutoApproveAIFixes: () => loadConfig().autoApproveAIFixes,
     });
@@ -1735,9 +1735,12 @@ async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promise<void>
   const agent = (parsed.agentName ?? 'claude').toLowerCase();
   try {
     const result = await fixWithAgentAction(taskId, {
+      logger: deps.logger,
       orchestrator: deps.orchestrator,
       persistence: deps.persistence,
+      commandService: deps.commandService,
       taskExecutor: te,
+      mutationTiming: deps.mutationTiming,
       autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
     }, {
       agentName: agent,
@@ -1834,10 +1837,15 @@ async function headlessRebaseRetry(target: string, deps: HeadlessDeps): Promise<
     context: 'headless.rebase-retry',
     mutationTiming: deps.mutationTiming,
   });
-
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
-  const started = await rebaseRetry(target, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
+  const started = await rebaseRetry(target, {
+    ...deps,
+    logger: deps.logger,
+    commandService: deps.commandService,
+    taskExecutor: te,
+    mutationTiming: deps.mutationTiming,
+  });
   const runnable = started.filter(isDispatchableLaunch);
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
@@ -1878,10 +1886,15 @@ async function headlessRebaseRecreate(workflowTarget: string, deps: HeadlessDeps
     context: 'headless.rebase-recreate',
     mutationTiming: deps.mutationTiming,
   });
-
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
-  const started = await rebaseRecreate(workflowTarget, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
+  const started = await rebaseRecreate(workflowTarget, {
+    ...deps,
+    logger: deps.logger,
+    commandService: deps.commandService,
+    taskExecutor: te,
+    mutationTiming: deps.mutationTiming,
+  });
   const runnable = started.filter(isDispatchableLaunch);
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1118,7 +1118,10 @@ function startHeadlessMode(): void {
             const mergeTask = tasks.find((task) => task.config.isMergeNode);
             if (!mergeTask) return undefined;
             const executor = createStandaloneTaskExecutor();
-            const started = orchestrator.retryTask(mergeTask.id);
+            const envelope = makeEnvelope('set-merge-branch', 'ui', 'task', { taskId: mergeTask.id });
+            const result = await commandService.retryTask(envelope);
+            if (!result.ok) throw new Error(result.error.message);
+            const started = result.data;
             await dispatchStartedTasksWithGlobalTopup({
               orchestrator,
               taskExecutor: executor,
@@ -4083,7 +4086,10 @@ function createEmbeddedTerminalBackendFromConfig(
         const tasks = persistence.loadTasks(workflowId);
         const mergeTask = tasks.find(t => t.config.isMergeNode);
         if (mergeTask) {
-          const started = orchestrator.retryTask(mergeTask.id);
+          const envelope = makeEnvelope('set-merge-branch', 'ui', 'task', { taskId: mergeTask.id });
+          const result = await commandService.retryTask(envelope);
+          if (!result.ok) throw new Error(result.error.message);
+          const started = result.data;
           await dispatchStartedTasksWithGlobalTopup({
             orchestrator,
             taskExecutor: requireTaskExecutor(),

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -146,8 +146,6 @@ import {
   fixWithAgentAction,
   rebaseRetry,
   rebaseRecreate,
-  recreateWorkflow as sharedRecreateWorkflow,
-  recreateTask as sharedRecreateTask,
   resolveConflictAction,
   selectFailureRecoveryRoute,
   selectExperiments as sharedSelectExperiments,
@@ -2081,9 +2079,12 @@ function createEmbeddedTerminalBackendFromConfig(
     const result = await fixWithAgentAction(
       taskId,
       {
+        logger,
         orchestrator,
         persistence,
+        commandService,
         taskExecutor: requireTaskExecutor(),
+        mutationTiming: activeMutationContext?.mutationTiming,
         autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
       },
       {
@@ -4004,8 +4005,10 @@ function createEmbeddedTerminalBackendFromConfig(
           mutationTiming: activeMutationContext?.mutationTiming,
         });
         const started = await rebaseRetry(target, {
+          logger,
           orchestrator,
           persistence,
+          commandService,
           repoRoot,
           taskExecutor: requireTaskExecutor(),
           mutationTiming: activeMutationContext?.mutationTiming,
@@ -4046,8 +4049,10 @@ function createEmbeddedTerminalBackendFromConfig(
           mutationTiming: activeMutationContext?.mutationTiming,
         });
         const started = await rebaseRecreate(target, {
+          logger,
           orchestrator,
           persistence,
+          commandService,
           repoRoot,
           taskExecutor: requireTaskExecutor(),
           mutationTiming: activeMutationContext?.mutationTiming,

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -142,18 +142,26 @@ export interface ApproveTaskResult {
 
 // ── Actions ──────────────────────────────────────────────────
 
-export function bumpGenerationAndRecreate(
+function bumpWorkflowGeneration(
+  workflowId: string,
+  deps: Pick<ActionDeps, 'logger' | 'persistence'>,
+  context: string,
+): LoadedWorkflow {
+  const workflow = deps.persistence.loadWorkflow(workflowId);
+  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
+  const nextGen = (workflow.generation ?? 0) + 1;
+  deps.persistence.updateWorkflow(workflowId, { generation: nextGen });
+  deps.logger?.info(`${context}: bumped generation to ${nextGen} for ${workflowId}`, { module: 'workflow' });
+  return workflow;
+}
+
+function recreateWorkflowWithGeneration(
   workflowId: string,
   deps: Pick<ActionDeps, 'logger' | 'persistence' | 'orchestrator'>,
 ): TaskState[] {
-  const { persistence, orchestrator } = deps;
-  const workflow = persistence.loadWorkflow(workflowId);
-  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
-  const nextGen = (workflow.generation ?? 0) + 1;
-  persistence.updateWorkflow(workflowId, { generation: nextGen });
-  deps.logger?.info(`bumped generation to ${nextGen} for ${workflowId}`, { module: 'workflow' });
-  deps.logger?.info(`bumpGenerationAndRecreate: calling recreateWorkflow(${workflowId})`, { module: 'agent-session-trace' });
-  return orchestrator.recreateWorkflow(workflowId);
+  bumpWorkflowGeneration(workflowId, deps, 'recreateWorkflow');
+  deps.logger?.info(`recreateWorkflow: calling orchestrator.recreateWorkflow(${workflowId})`, { module: 'agent-session-trace' });
+  return deps.orchestrator.recreateWorkflow(workflowId);
 }
 
 export async function approveTask(
@@ -216,32 +224,76 @@ export function provideInput(
   deps.orchestrator.provideInput(taskId, text);
 }
 
-export function retryTask(
-  taskId: string,
-  deps: Pick<ActionDeps, 'orchestrator'>,
-): TaskState[] {
-  return deps.orchestrator.retryTask(taskId);
+function commandResultError(error: { code: string; message: string }): Error {
+  const known = (Object.values(OrchestratorErrorCode) as string[]).includes(error.code);
+  return known
+    ? new OrchestratorError(error.code as OrchestratorErrorCode, error.message)
+    : new Error(error.message);
 }
 
-export function restartTask(
-  taskId: string,
-  deps: Pick<ActionDeps, 'orchestrator'>,
-): TaskState[] {
-  return deps.orchestrator.recreateTask(taskId);
-}
-
-export function retryWorkflow(
+async function runWorkflowInvalidationThroughCommandService(
   workflowId: string,
-  deps: Pick<ActionDeps, 'orchestrator'>,
-): TaskState[] {
-  return deps.orchestrator.retryWorkflow(workflowId);
+  action: Extract<InvalidationAction, 'retryWorkflow' | 'recreateWorkflow' | 'recreateWorkflowFromFreshBase'>,
+  deps: CommandActionDeps,
+  options: {
+    timingLabel: string;
+    beforeApply?: () => Promise<void>;
+  },
+): Promise<TaskState[]> {
+  const result = await deps.commandService.runSerializedForWorkflow(
+    workflowId,
+    async () => {
+      if (options.beforeApply) await options.beforeApply();
+      const run = () => applyInvalidation(
+        'workflow',
+        action,
+        workflowId,
+        buildInvalidationDeps({
+          logger: deps.logger,
+          orchestrator: deps.orchestrator,
+          persistence: deps.persistence,
+          taskExecutor: deps.taskExecutor,
+          mutationTiming: deps.mutationTiming,
+        }),
+      );
+      return deps.mutationTiming
+        ? deps.mutationTiming.span(options.timingLabel, undefined, run)
+        : run();
+    },
+  );
+  if (!result.ok) throw commandResultError(result.error);
+  return result.data;
 }
 
-export function recreateWorkflow(
-  workflowId: string,
-  deps: Pick<ActionDeps, 'logger' | 'persistence' | 'orchestrator'>,
-): TaskState[] {
-  return bumpGenerationAndRecreate(workflowId, deps);
+async function runTaskInvalidationThroughCommandService(
+  taskId: string,
+  action: Extract<InvalidationAction, 'retryTask' | 'recreateTask'>,
+  deps: CommandActionDeps,
+  timingLabel: string,
+): Promise<TaskState[]> {
+  const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
+  const result = await deps.commandService.runSerializedForWorkflow(
+    workflowId,
+    async () => {
+      const run = () => applyInvalidation(
+        'task',
+        action,
+        taskId,
+        buildInvalidationDeps({
+          logger: deps.logger,
+          orchestrator: deps.orchestrator,
+          persistence: deps.persistence,
+          taskExecutor: deps.taskExecutor,
+          mutationTiming: deps.mutationTiming,
+        }),
+      );
+      return deps.mutationTiming
+        ? deps.mutationTiming.span(timingLabel, undefined, run)
+        : run();
+    },
+  );
+  if (!result.ok) throw commandResultError(result.error);
+  return result.data;
 }
 
 function workflowIdFromMergeTaskId(target: string): string | undefined {
@@ -277,19 +329,6 @@ export function resolveWorkflowIdForRebaseTarget(
   );
 }
 
-export function recreateTask(
-  taskId: string,
-  deps: Pick<ActionDeps, 'persistence' | 'orchestrator'>,
-): TaskState[] {
-  return deps.orchestrator.recreateTask(taskId);
-}
-
-export function recreateDownstream(
-  taskId: string,
-  deps: Pick<ActionDeps, 'orchestrator'>,
-): TaskState[] {
-  return deps.orchestrator.recreateDownstream(taskId);
-}
 
 export function cancelWorkflow(
   workflowId: string,
@@ -403,7 +442,7 @@ export async function deleteAllWorkflowsBulk(
  * it with a single primitive is a follow-up):
  *
  *   1. Bump the workflow's generation counter (matches
- *      `bumpGenerationAndRecreate` so any downstream observers that
+ *      `recreateWorkflowWithGeneration` so any downstream observers that
  *      key off `workflow.generation` notice the new round).
  *   2. Delegate to `Orchestrator.recreateWorkflowFromFreshBase` with
  *      a `refreshBase` callback that runs
@@ -456,23 +495,18 @@ async function prepareWorkflowFreshBase(
   return { workflow, freshBase };
 }
 
-export async function recreateWorkflowFromFreshBase(
+async function recreateWorkflowFromFreshBasePrimitive(
   workflowId: string,
   deps: ActionDeps,
 ): Promise<TaskState[]> {
   const { workflow, freshBase } = await prepareWorkflowFreshBase(workflowId, deps);
-  const nextGen = (workflow.generation ?? 0) + 1;
   deps.mutationTiming?.mark('workflow-actions.recreateWorkflowFromFreshBase.bumpGeneration', 'started', {
-    nextGeneration: nextGen,
+    nextGeneration: (workflow.generation ?? 0) + 1,
   });
-  deps.persistence.updateWorkflow(workflowId, { generation: nextGen });
+  bumpWorkflowGeneration(workflowId, deps, 'recreateWorkflowFromFreshBase');
   deps.mutationTiming?.mark('workflow-actions.recreateWorkflowFromFreshBase.bumpGeneration', 'completed', {
-    nextGeneration: nextGen,
+    nextGeneration: (workflow.generation ?? 0) + 1,
   });
-  deps.logger?.info(
-    `recreateWorkflowFromFreshBase: workflowId=${workflowId} bumped generation to ${nextGen}`,
-    { module: 'workflow' },
-  );
   deps.logger?.info(
     `recreateWorkflowFromFreshBase: workflowId=${workflowId} → orchestrator.recreateWorkflowFromFreshBase`,
     { module: 'agent-session-trace' },
@@ -490,21 +524,37 @@ export async function recreateWorkflowFromFreshBase(
     : recreate();
 }
 
+export async function recreateWorkflowFromFreshBase(
+  workflowId: string,
+  deps: CommandActionDeps,
+): Promise<TaskState[]> {
+  return runWorkflowInvalidationThroughCommandService(
+    workflowId,
+    'recreateWorkflowFromFreshBase',
+    deps,
+    { timingLabel: 'workflow-actions.recreateWorkflowFromFreshBase.applyInvalidation' },
+  );
+}
+
 export async function rebaseRetry(
   target: string,
-  deps: ActionDeps,
+  deps: CommandActionDeps,
 ): Promise<TaskState[]> {
   const workflowId = resolveWorkflowIdForRebaseTarget(target, deps);
   deps.mutationTiming?.mark('workflow-actions.rebaseRetry', 'started', { target, workflowId });
   deps.logger?.info(
-    `rebaseRetry: target=${target} workflowId=${workflowId} → prepare fresh base + retryWorkflow`,
+    `rebaseRetry: target=${target} workflowId=${workflowId} → CommandService/applyInvalidation retryWorkflow`,
     { module: 'agent-session-trace' },
   );
-  await prepareWorkflowFreshBase(workflowId, deps);
-  const retry = async (): Promise<TaskState[]> => Promise.resolve(deps.orchestrator.retryWorkflow(workflowId));
-  const started = deps.mutationTiming
-    ? await deps.mutationTiming.span('workflow-actions.rebaseRetry.orchestrator', undefined, retry)
-    : await retry();
+  const started = await runWorkflowInvalidationThroughCommandService(
+    workflowId,
+    'retryWorkflow',
+    deps,
+    {
+      timingLabel: 'workflow-actions.rebaseRetry.applyInvalidation',
+      beforeApply: () => prepareWorkflowFreshBase(workflowId, deps).then(() => undefined),
+    },
+  );
   deps.mutationTiming?.mark('workflow-actions.rebaseRetry', 'completed', {
     target,
     workflowId,
@@ -515,19 +565,20 @@ export async function rebaseRetry(
 
 export async function rebaseRecreate(
   target: string,
-  deps: ActionDeps,
+  deps: CommandActionDeps,
 ): Promise<TaskState[]> {
   const workflowId = resolveWorkflowIdForRebaseTarget(target, deps);
   deps.mutationTiming?.mark('workflow-actions.rebaseRecreate', 'started', { target, workflowId });
   deps.logger?.info(
-    `rebaseRecreate: target=${target} workflowId=${workflowId} → prepare fresh base + recreateWorkflow`,
+    `rebaseRecreate: target=${target} workflowId=${workflowId} → CommandService/applyInvalidation recreateWorkflowFromFreshBase`,
     { module: 'agent-session-trace' },
   );
-  await prepareWorkflowFreshBase(workflowId, deps);
-  const recreate = async (): Promise<TaskState[]> => Promise.resolve(bumpGenerationAndRecreate(workflowId, deps));
-  const started = deps.mutationTiming
-    ? await deps.mutationTiming.span('workflow-actions.rebaseRecreate.orchestrator', undefined, recreate)
-    : await recreate();
+  const started = await runWorkflowInvalidationThroughCommandService(
+    workflowId,
+    'recreateWorkflowFromFreshBase',
+    deps,
+    { timingLabel: 'workflow-actions.rebaseRecreate.applyInvalidation' },
+  );
   deps.mutationTiming?.mark('workflow-actions.rebaseRecreate', 'completed', {
     target,
     workflowId,
@@ -583,13 +634,13 @@ export function buildInvalidationDeps(deps: BuildInvalidationDepsArgs): Invalida
     recreateDownstream: (taskId: string) => deps.orchestrator.recreateDownstream(taskId),
     retryWorkflow: (workflowId: string) => deps.orchestrator.retryWorkflow(workflowId),
     recreateWorkflow: (workflowId: string) =>
-      bumpGenerationAndRecreate(workflowId, {
+      recreateWorkflowWithGeneration(workflowId, {
         logger: deps.logger,
         orchestrator: deps.orchestrator,
         persistence: deps.persistence,
       }),
     recreateWorkflowFromFreshBase: (workflowId: string) =>
-      recreateWorkflowFromFreshBase(workflowId, {
+      recreateWorkflowFromFreshBasePrimitive(workflowId, {
         logger: deps.logger,
         orchestrator: deps.orchestrator,
         persistence: deps.persistence,
@@ -865,7 +916,7 @@ export type FixWithAgentActionResult =
 
 export async function fixWithAgentAction(
   taskId: string,
-  deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
+  deps: Pick<CommandActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'autoApproveAIFixes' | 'commandService' | 'mutationTiming'> & { taskExecutor: TaskRunner },
   options: {
     agentName?: string;
     recoveryRoute?: FailureRecoveryRoute;
@@ -1108,9 +1159,12 @@ async function recordFixedIntegrationAnchor(
 export async function autoFixOnFailure(
   taskId: string,
   deps: {
+    logger?: Logger;
     orchestrator: Orchestrator;
     persistence: SQLiteAdapter;
+    commandService: CommandService;
     taskExecutor: TaskRunner;
+    mutationTiming?: WorkflowMutationTiming;
     getAutoFixAgent?: () => string | undefined;
     getAutoApproveAIFixes?: () => boolean | undefined;
     signal?: AbortSignal;
@@ -1179,9 +1233,12 @@ export async function autoFixOnFailure(
         `\n[Auto-fix] Startup merge conflict detected; recreating workflow ${recoveryRoute.workflowId} from a fresh base.`,
       );
       const started = await recreateWorkflowFromFreshBase(recoveryRoute.workflowId, {
+        logger: deps.logger,
         orchestrator,
         persistence,
+        commandService: deps.commandService,
         taskExecutor,
+        mutationTiming: deps.mutationTiming,
       });
       const runnable = started.filter(isDispatchableLaunch);
       persistence.logEvent?.(taskId, 'debug.auto-fix', {
@@ -1262,7 +1319,19 @@ export async function autoFixOnFailure(
       return;
     }
     assertLineageCurrent(lineage, orchestrator, deps.signal);
-    const started = orchestrator.retryTask(taskId);
+    const started = await runTaskInvalidationThroughCommandService(
+      taskId,
+      'retryTask',
+      {
+        logger: deps.logger,
+        orchestrator,
+        persistence,
+        commandService: deps.commandService,
+        taskExecutor,
+        mutationTiming: deps.mutationTiming,
+      },
+      'workflow-actions.autoFixOnFailure.retryTask.applyInvalidation',
+    );
     const runnable = started.filter(isDispatchableLaunch);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-post-route-restart',

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -423,8 +423,10 @@ export class WorkflowMutationFacade {
     const detail = await sharedFixWithAgentAction(
       taskId,
       {
+        logger: this.deps.logger,
         orchestrator: this.deps.orchestrator,
         persistence: this.deps.persistence,
+        commandService: this.deps.commandService,
         taskExecutor: this.deps.taskExecutor,
         autoApproveAIFixes: this.deps.autoApproveAIFixes,
       },


### PR DESCRIPTION
## Summary

This routes the remaining merge-branch retry path through `CommandService` too.

That removes the last direct app-side retry call left in `main.ts`, so merge-branch edits use the same serialized mutation path as the rest of lifecycle invalidation.

It is safe because the change is narrow: same user action, same retry target, new owner for the mutation.

## Review metadata

- Review claim: merge-branch retries now use CommandService instead of calling `orchestrator.retryTask` directly.
- Safety invariant: the merge task id and dispatch behavior stay the same; only mutation ownership changes.
- Slice rationale: keep the last direct caller separate so reviewers can verify the invariant is closed with a tiny diff.
- Architectural effect: `main.ts` no longer owns a bespoke retry path for merge-branch edits.
- Alternative considerations: folding this into the helper-routing slice would bury the final direct caller removal inside a larger behavior patch.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/api-server.test.ts src/__tests__/parity-regression.test.ts src/__tests__/workflow-mutation-facade.test.ts src/__tests__/headless-delegation.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert fdb1b4866`
- Post-revert steps: None
- Data migration? No

Depends-On: #1508