### PR TITLE
Add GUI controls for approving AI fixes

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -674,13 +674,13 @@ test.describe('Visual proof capture', () => {
     await expect(mergeGateNode).toBeVisible({ timeout: 15000 });
     await expect(mergeGateNode.getByText('APPROVE', { exact: true })).toBeVisible();
 
-    // Inline chip button must be gone — approval lives in the TaskPanel now.
+    // Inline chip button must be gone — approval lives in the side panel now.
     await expect(mergeGateNode.locator('[data-testid="approve-merge-button"]')).toHaveCount(0);
 
     await mergeGateNode.click();
     await expect(page.getByRole('heading', { name: /Merge gate for/i })).toBeVisible();
     await expect(page.getByText('Task Status')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Approve Merge' })).toHaveCount(0);
+    await expect(page.getByTestId('inspector-approve-button')).toHaveText('Approve Merge');
 
     await captureScreenshot(page, 'merge-gate-no-inline-approve');
     await assertPageScreenshot(page, 'merge-gate-no-inline-approve');
@@ -1266,7 +1266,7 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'closed-review-pr-status');
   });
 
-  test('approve-fix modal — no Fix Context panel', async ({ page }) => {
+  test('approve-fix task panel — exposes approval controls', async ({ page }) => {
     await loadPlan(page, TEST_PLAN);
     await injectTaskStates(page, [
       {
@@ -1278,15 +1278,14 @@ test.describe('Visual proof capture', () => {
       },
     ]);
 
-    // Click the task-beta node to open task panel
     await page.locator('.react-flow__node[data-testid$="task-beta"]').click();
     await expect(page.getByRole('heading', { name: 'Second test task depending on alpha' })).toBeVisible();
-
-    await expect(page.getByRole('button', { name: 'Approve Fix' })).toHaveCount(0);
+    await expect(page.getByTestId('inspector-approve-button')).toHaveText('Approve Fix');
+    await expect(page.getByTestId('inspector-reject-button')).toHaveText('Reject Fix');
     await expect(page.getByText('Fix Context')).not.toBeVisible();
 
-    await captureScreenshot(page, 'approve-fix-modal-simplified');
-    await assertPageScreenshot(page, 'approve-fix-modal-simplified');
+    await captureScreenshot(page, 'approve-fix-task-panel-actions');
+    await assertPageScreenshot(page, 'approve-fix-task-panel-actions');
   });
 
   test('approve-fix modal — renders current-cycle session log', async ({ page, testDir }) => {
@@ -1325,8 +1324,10 @@ test.describe('Visual proof capture', () => {
 
     await page.locator('.react-flow__node[data-testid$="task-beta"]').click();
     await expect(page.getByRole('heading', { name: 'Second test task depending on alpha' })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Approve Fix' })).toHaveCount(0);
-    await expect(page.getByText('Second test task depending on alpha')).toBeVisible();
+    await expect(page.getByTestId('inspector-approve-button')).toHaveText('Approve Fix');
+    await page.getByTestId('inspector-approve-button').click();
+    await expect(page.getByRole('heading', { name: 'Approve AI Fix' })).toBeVisible();
+    await expect(page.locator('.fixed').getByText('Second test task depending on alpha')).toBeVisible();
 
     await captureScreenshot(page, 'approve-fix-modal-with-session-log');
     await assertPageScreenshot(page, 'approve-fix-modal-with-session-log');

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1616,8 +1616,11 @@ export function App() {
   }, []);
 
   const openApprovalModal = useCallback((task: TaskState) => {
-    console.log(`[openApprovalModal] taskId=${task.id} agentSessionId=${task.execution.agentSessionId} pendingFixError=${!!task.execution.pendingFixError}`);
     setModal({ type: 'approval', task, action: 'approve' });
+  }, []);
+
+  const openRejectModal = useCallback((task: TaskState) => {
+    setModal({ type: 'approval', task, action: 'reject' });
   }, []);
 
   const openExperimentModal = useCallback((task: TaskState) => {
@@ -1948,6 +1951,8 @@ export function App() {
               onEditAgent={handleEditAgent}
               onEditPrompt={handleEditPrompt}
               onEditCommand={handleEditCommand}
+              onApprove={openApprovalModal}
+              onReject={openRejectModal}
               onSetMergeBranch={handleSetMergeBranch}
               onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
               onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}

--- a/packages/ui/src/__tests__/merge-gate-approval-flow.test.tsx
+++ b/packages/ui/src/__tests__/merge-gate-approval-flow.test.tsx
@@ -70,4 +70,40 @@ describe('Merge gate approval flow (integration)', () => {
     fireEvent.click(screen.getByText('Retry Workflow'));
     await waitFor(() => expect(mock.api.retryWorkflow).toHaveBeenCalledWith('wf-merge'));
   });
+
+  it('opens the fix approval modal from the selected task inspector', async () => {
+    const fixedTask = makeUITask({
+      id: 'fix-task',
+      description: 'Fix failing test',
+      status: 'awaiting_approval',
+      workflowId: 'wf-merge',
+      prompt: 'Fix the failing test',
+      execution: { pendingFixError: 'test failed' },
+    });
+
+    render(<App />);
+    act(() => mock.setTasks([fixedTask], [wfA]));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-merge')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-merge'));
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-fix-task')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rf__node-fix-task'));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Approve Fix' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve Fix' }));
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Approve AI Fix' })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Approve Fix' }).at(-1)!);
+    await waitFor(() => expect(mock.api.approve).toHaveBeenCalledWith('fix-task'));
+  });
 });

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -326,4 +326,32 @@ describe('WorkflowInspector', () => {
     expect(onEditPool).toHaveBeenCalledWith('task-1', 'pnpm-ssh');
     expect(screen.queryByText(/executor:/i)).not.toBeInTheDocument();
   });
+
+  it('shows fix approval actions for an awaiting approval fix', () => {
+    const onApprove = vi.fn();
+    const onReject = vi.fn();
+    const task = makeTask({
+      status: 'awaiting_approval',
+      execution: { pendingFixError: 'tests failed' },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={task}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={onApprove}
+        onReject={onReject}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve Fix' }));
+    expect(onApprove).toHaveBeenCalledWith(task);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reject Fix' }));
+    expect(onReject).toHaveBeenCalledWith(task);
+  });
 });

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -18,6 +18,8 @@ interface WorkflowInspectorProps {
   onEditAgent?: (taskId: string, agentName: string) => void;
   onEditPrompt?: (taskId: string, newPrompt: string) => void;
   onEditCommand?: (taskId: string, newCommand: string) => void;
+  onApprove?: (task: TaskState) => void;
+  onReject?: (task: TaskState) => void;
   onSetMergeBranch?: (workflowId: string, baseBranch: string) => Promise<void>;
   onToggleCollapsed: () => void;
   onToggleAdvanced: () => void;
@@ -59,6 +61,8 @@ export function WorkflowInspector({
   onEditAgent,
   onEditPrompt,
   onEditCommand,
+  onApprove,
+  onReject,
   onSetMergeBranch,
   onToggleCollapsed,
   onToggleAdvanced,
@@ -115,6 +119,13 @@ export function WorkflowInspector({
   const statusBorder = taskColors?.border ?? workflowVisual?.borderClass ?? 'border-gray-700';
   const statusText = taskColors?.text ?? workflowVisual?.textClass ?? 'text-gray-300';
   const statusDot = taskColors?.dot ?? '';
+  const isFixApproval = Boolean(task?.execution.pendingFixError);
+  const showApprovalActions = Boolean(
+    task
+    && (task.status === 'awaiting_approval' || task.status === 'review_ready')
+    && onApprove
+    && onReject,
+  );
   const statusHeading = task ? 'Task Status' : 'Status';
 
   const savePrompt = () => {
@@ -204,6 +215,30 @@ export function WorkflowInspector({
           )}
           {!task?.execution.error && task?.execution.exitCode !== undefined && task.execution.exitCode !== 0 && (
             <p className="mt-2 text-xs text-red-300">Exit code: {task.execution.exitCode}</p>
+          )}
+          {showApprovalActions && task && (
+            <div className="mt-3 flex gap-2 border-t border-gray-700 pt-3">
+              <button
+                type="button"
+                onClick={() => onApprove?.(task)}
+                data-testid="inspector-approve-button"
+                data-sidebar-nav-item
+                data-sidebar-nav-order="15"
+                className="flex-1 rounded bg-green-600 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-green-500"
+              >
+                {isFixApproval ? 'Approve Fix' : task.config.isMergeNode ? 'Approve Merge' : 'Approve'}
+              </button>
+              <button
+                type="button"
+                onClick={() => onReject?.(task)}
+                data-testid="inspector-reject-button"
+                data-sidebar-nav-item
+                data-sidebar-nav-order="16"
+                className="flex-1 rounded bg-red-600 px-3 py-2 text-xs font-medium text-white transition-colors hover:bg-red-500"
+              >
+                {isFixApproval ? 'Reject Fix' : task.config.isMergeNode ? 'Reject Merge' : 'Reject'}
+              </button>
+            </div>
           )}
         </section>
 


### PR DESCRIPTION
## Summary

Awaiting approval fixes now have a clear GUI path from the right panel.

The old screen showed the task state, but the approval action was not reachable there.

This adds approve and reject buttons for fix approval tasks, then opens the existing review modal.

## Architecture

### Before

```mermaid
graph TD
    A[Select task awaiting fix approval] --> B[Right panel shows status]
    B --> C[No approve fix action]
```

### After

```mermaid
graph TD
    A[Select task awaiting fix approval] --> B[Right panel shows Approve Fix and Reject Fix]
    B --> C[Existing approval modal]
    C --> D[invoker.approve or invoker.reject]
```

## Visual Proof

Right panel approval controls:

![Approve Fix in right panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260619-bcb54c/approve-fix-task-panel-actions.png)

Existing review modal still opens from that button:

![Approve Fix modal](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260619-bcb54c/approve-fix-modal-with-session-log.png)

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-inspector.test.tsx src/__tests__/merge-gate-approval-flow.test.tsx`
- [x] `pnpm run check:types`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e34887a19`
- Post-revert steps: None
- Data migration? No
