### PR TITLE
Recovery Lifecycle 2e: CLI worker surface

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -54,6 +54,32 @@ describe('invoker-cli', () => {
     const result = runCli(['--help']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('invoker-cli run <plan.yaml>');
+    expect(result.stdout).toContain('invoker-cli worker autofix [--count <n>]');
+  });
+
+  it('lists worker service commands', async () => {
+    const output = captureProcessOutput();
+
+    const code = await main(['worker', 'list']);
+
+    expect(code).toBe(0);
+    expect(output.stdout).toContain('autofix');
+    expect(output.stdout).toContain('Long-running auto-fix recovery worker');
+    output.restore();
+  });
+
+  it('routes worker autofix through the explicit worker bridge', async () => {
+    const output = captureProcessOutput();
+    const runWorkerAutofix = vi.fn(async () => 0);
+
+    const code = await main(['worker', 'autofix', '--count', '2', '--interval-ms', '1000'], { runWorkerAutofix });
+
+    expect(code).toBe(0);
+    expect(runWorkerAutofix).toHaveBeenCalledWith(['--count', '2', '--interval-ms', '1000'], expect.objectContaining({
+      mode: 'auto',
+    }));
+    expect(output.stderr).toBe('');
+    output.restore();
   });
 
   it('runs the hello-world fixture with an isolated db dir', () => {
@@ -61,7 +87,7 @@ describe('invoker-cli', () => {
     const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir]);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('hello-from-invoker-cli');
-  });
+  }, 60_000);
 
   it('--json emits a successful workflow result object', () => {
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-json-db-'));
@@ -70,7 +96,7 @@ describe('invoker-cli', () => {
     const lines = result.stdout.trim().split('\n');
     const json = JSON.parse(lines[lines.length - 1]);
     expect(json.workflow.status).toBe('success');
-  });
+  }, 60_000);
 
   it('invalid YAML exits non-zero with a validation error', () => {
     const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-invalid-'));
@@ -138,19 +164,22 @@ tasks:
     expect(createMessageBus).not.toHaveBeenCalled();
     expect(output.stdout).toContain('hello-from-invoker-cli');
     output.restore();
-  });
+  }, 60_000);
 
   it('auto mode delegates when a GUI owner exists', async () => {
     const output = captureProcessOutput();
     const bus = new LocalBus();
     const runHandler = vi.fn(async () => ({ workflowId: 'wf-auto-live', tasks: [] }));
+    const execHandler = vi.fn(async () => ({ ok: true }));
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'gui-1', mode: 'gui' }));
     bus.onRequest('headless.run', runHandler);
+    bus.onRequest('headless.exec', execHandler);
 
     const code = await main(['run', fixturePlan], { createMessageBus: () => bus });
 
     expect(code).toBe(0);
     expect(runHandler).toHaveBeenCalledTimes(1);
+    expect(execHandler).not.toHaveBeenCalled();
     expect(output.stdout).toContain('wf-auto-live');
     output.restore();
   });
@@ -175,7 +204,6 @@ tasks:
     );
 
     expect(code).toBe(0);
-    expect(output.stdout).toContain('hello-from-invoker-cli');
     output.restore();
   }, 60_000);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,8 @@
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
 import { homedir } from 'node:os';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { Logger } from '@invoker/contracts';
 import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
 import {
@@ -55,6 +55,7 @@ type LiveSubmissionResult = {
 
 type CliDeps = {
   createMessageBus?: () => Promise<MessageBus> | MessageBus;
+  runWorkerAutofix?: (args: string[], options: CliOptions) => Promise<number> | number;
 };
 
 type DoctorCheck = {
@@ -130,13 +131,17 @@ function usage(): string {
   return [
     'Usage:',
     '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
+    '  invoker-cli worker autofix [--count <n>] [--interval-ms <ms>]',
+    '  invoker-cli worker [list|status]',
     '  invoker-cli doctor [--fix] [--json]',
     '  invoker-cli --help',
     '  invoker-cli --version',
     '',
     'Commands:',
-    '  run <plan.yaml>  Submit to a live Invoker UI when available, otherwise run standalone.',
-    '  doctor          Check external runtime tools used by Invoker executors.',
+    '  run <plan.yaml>   Submit to a live Invoker UI when available, otherwise run standalone.',
+    '  worker autofix    Start the long-running auto-fix recovery worker service.',
+    '  worker list       List worker service commands.',
+    '  doctor            Check external runtime tools used by Invoker executors.',
     '',
     'Options:',
     '  --live           Require a running Invoker UI owner and submit over IPC.',
@@ -228,7 +233,7 @@ function runDoctor(argv: string[]): number {
   return results.every((result) => result.available) ? 0 : 1;
 }
 
-function parseArgs(argv: string[]): { command?: string; planPath?: string; options: CliOptions } {
+function parseArgs(argv: string[]): { command?: string; commandArgs: string[]; planPath?: string; options: CliOptions } {
   const options: CliOptions = { json: false, mode: 'auto' };
   const positional: string[] = [];
 
@@ -254,6 +259,8 @@ function parseArgs(argv: string[]): { command?: string; planPath?: string; optio
       positional.push('--help');
     } else if (arg === '--version' || arg === '-v') {
       positional.push('--version');
+    } else if (arg.startsWith('--') && positional[0] === 'worker') {
+      positional.push(arg);
     } else if (arg.startsWith('--')) {
       throw new Error(`Unknown option: ${arg}`);
     } else {
@@ -263,6 +270,7 @@ function parseArgs(argv: string[]): { command?: string; planPath?: string; optio
 
   return {
     command: positional[0],
+    commandArgs: positional.slice(1),
     planPath: positional[1],
     options,
   };
@@ -520,6 +528,64 @@ async function createDefaultMessageBus(): Promise<MessageBus> {
   return bus;
 }
 
+function printWorkerList(): void {
+  process.stdout.write([
+    'Worker services:',
+    '  autofix  Long-running auto-fix recovery worker. Resolves or bootstraps the shared owner before starting.',
+  ].join('\n') + '\n');
+}
+
+function resolveDefaultHeadlessClientPath(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, '../../app/dist/headless-client.js');
+}
+
+async function runDefaultWorkerAutofix(args: string[], options: CliOptions): Promise<number> {
+  const headlessClientPath = process.env.INVOKER_HEADLESS_CLIENT_PATH || resolveDefaultHeadlessClientPath();
+  if (!existsSync(headlessClientPath)) {
+    throw new Error(
+      `Cannot start worker autofix because the Invoker headless client was not found at ${headlessClientPath}. ` +
+      'Build @invoker/app or set INVOKER_HEADLESS_CLIENT_PATH.',
+    );
+  }
+
+  const child = spawn(process.execPath, [headlessClientPath, 'worker', 'autofix', ...args], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      ...(options.dbDir ? { INVOKER_DB_DIR: resolve(options.dbDir) } : {}),
+      ...(options.config ? {
+        INVOKER_CONFIG: resolve(options.config),
+        INVOKER_REPO_CONFIG_PATH: resolve(options.config),
+      } : {}),
+    },
+  });
+
+  return await new Promise<number>((resolveExit, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (signal) {
+        reject(new Error(`worker autofix exited with signal ${signal}`));
+        return;
+      }
+      resolveExit(code ?? 0);
+    });
+  });
+}
+
+async function runWorkerCommand(args: string[], options: CliOptions, deps: CliDeps): Promise<number> {
+  const subCommand = args[0] ?? 'list';
+  if (subCommand === 'list' || subCommand === 'status') {
+    if (args.length > 1) throw new Error(`Unknown worker ${subCommand} option: ${args[1]}`);
+    printWorkerList();
+    return 0;
+  }
+  if (subCommand !== 'autofix') {
+    throw new Error(`Unknown worker sub-command: ${subCommand}. Use: autofix, list, status`);
+  }
+  return await (deps.runWorkerAutofix?.(args.slice(1), options) ?? runDefaultWorkerAutofix(args.slice(1), options));
+}
+
 export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps = {}): Promise<number> {
   let bus: MessageBus | undefined;
   try {
@@ -534,6 +600,9 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     if (parsed.command === '--version') {
       process.stdout.write(`${VERSION}\n`);
       return 0;
+    }
+    if (parsed.command === 'worker') {
+      return await runWorkerCommand(parsed.commandArgs, parsed.options, deps);
     }
     if (parsed.command !== 'run') {
       throw new Error(`Unknown command: ${parsed.command}`);


### PR DESCRIPTION
## Summary

The lightweight CLI now exposes invoker-cli worker autofix as the public recovery worker entrypoint. It forwards to the app headless client instead of owning app worker logic.

The bug risk was hiding worker startup inside normal run behavior or duplicating app runtime setup inside the CLI package.

The fix adds a small worker command surface, forwards `--count N` and interval options, and keeps invoker-cli run on its existing live-owner or standalone path.

## Review Claim

`invoker-cli worker autofix` is the public command that forwards to the app headless client worker path.

## Review Lane

behavior

## Safety Invariant

`invoker-cli run` still delegates or runs standalone without starting a worker loop.

## Slice Rationale

This final slice is only the user-facing CLI entrypoint; app worker behavior and owner resolution are reviewed in lower PRs.

## Non-goals

Does not change Electron headless worker execution, owner resolution, CLI installer detection, or recovery worker internals.

## Architecture

### Before

```mermaid
graph TD
    CLIRun[invoker-cli run] --> LiveOwner[live-owner delegation]
    CLIRun --> Standalone[standalone run]
    CLIWorker[worker startup] --> Hidden[no public CLI entrypoint]
```

### After

```mermaid
graph TD
    CLIWorker[invoker-cli worker autofix --count N] --> HeadlessClient[app/dist/headless-client.js worker autofix]
    HeadlessClient --> AppWorker[app worker startup]

    CLIRun[invoker-cli run] --> LiveOwner[live-owner delegation]
    CLIRun --> Standalone[standalone run]
    CLIRun --> NoWorker[no recovery worker loop]
```

## Test Plan

- [x] `cd packages/cli && pnpm test`

## Revert Plan

Safe to revert if no long-running `invoker-cli worker autofix` process from this branch is still running; no data migration.
