### PR TITLE
Fix intent cancellation Step 4: durable failure diagnostics (restacked v3)

### DIFF
--- a/packages/app/src/__tests__/shutdown-diagnostic.test.ts
+++ b/packages/app/src/__tests__/shutdown-diagnostic.test.ts
@@ -215,4 +215,36 @@ describe('persistShutdownDiagnostic', () => {
     expect(output).not.toContain('forcedStopReason=');
     expect(output).toContain('error=real error');
   });
+
+  it('preserves prior execution.error and recent output tail for executing-stall scenarios', () => {
+    // Executing-stall watchdog synthetically fails a stuck task with a coarse
+    // stall marker that overwrites task.execution.error via handleWorkerResponse.
+    // The diagnostic block is appended beforehand so the durable output retains
+    // the concrete test/output context that triggered the stall investigation.
+    const stallReason =
+      'Execution stalled: task remained in running/executing for 300s ' +
+      'without a live execution handle and no completion signal from executor (remote workload heartbeat stale).';
+    const task = makeTask({
+      status: 'running',
+      execution: { error: 'previously surfaced runtime error', exitCode: undefined },
+    });
+    const db = makeDb([
+      'PASS src/a.test.ts\n',
+      'FAIL src/b.test.ts > stalled-case\n',
+      '  Error: connection reset by peer\n',
+    ]);
+
+    persistShutdownDiagnostic(task, db, {
+      forcedStopReason: stallReason,
+      label: 'Execution Stall Diagnostic',
+    });
+
+    const output = db.appended[0];
+    expect(output).toContain('[Execution Stall Diagnostic]');
+    expect(output).toContain(`forcedStopReason=${stallReason}`);
+    expect(output).toContain('error=previously surfaced runtime error');
+    expect(output).toContain('FAIL src/b.test.ts > stalled-case');
+    expect(output).toContain('connection reset by peer');
+    expect(output).toContain('--- end shutdown diagnostic ---');
+  });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2897,6 +2897,15 @@ function createEmbeddedTerminalBackendFromConfig(
                       },
                     };
                     logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
+                    // Persist a diagnostic block before the synthetic failure
+                    // overwrites task.execution.error with the coarse stall
+                    // marker; preserves the recent output tail and prior error
+                    // state for post-mortem retrieval.
+                    persistShutdownDiagnostic(task, persistence, {
+                      flushPendingOutput: flushTaskOutput,
+                      forcedStopReason: executingError,
+                      label: 'Execution Stall Diagnostic',
+                    });
                     orchestrator.handleWorkerResponse(failedResponse);
                     continue;
                   }

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2139,6 +2139,35 @@ describe('SQLiteAdapter', () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+
+    it('retains concrete executor startup stderr when spool has no streaming chunks', async () => {
+      // Executor startup failures (e.g. SSH transport fault, container spawn
+      // error) write the raw stderr/message via appendTaskOutput before the
+      // synthetic failure response collapses task.execution.error to a coarse
+      // marker. Retrieval must surface the concrete startup message even when
+      // the runner never produced spool chunks.
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-startup-diag-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const db = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        db.saveWorkflow(testWorkflow);
+        db.saveTask('wf-1', makeTask('t-startup-fail'));
+
+        db.appendTaskOutput(
+          't-startup-fail',
+          'Executor startup failed (ssh): connect ECONNREFUSED 10.0.0.5:22\n',
+        );
+
+        const output = db.getTaskOutput('t-startup-fail');
+        expect(output).toContain('Executor startup failed (ssh)');
+        expect(output).toContain('connect ECONNREFUSED 10.0.0.5:22');
+
+        db.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('pruneDuplicateTaskOutputRows', () => {


### PR DESCRIPTION
Validation passes clean. Here is the final PR body:

## Summary

When a stuck task is force-failed, the app used to throw away the real failure details. Later you would only see a generic "Application quit" message.

This change saves the real details first. Right before the stall watchdog overwrites the error, it writes the recent output tail and prior error into durable task output.

It also confirms executor startup errors survive the same way. A startup failure like an SSH connect refusal is retained even when the runner never streamed any chunks.

Task status meaning is unchanged. This only preserves diagnostics for post-mortem retrieval through the UI and API.

## Architecture

### Before

```mermaid
graph TD
    A[Executing-stall watchdog] --> B[handleWorkerResponse: synthetic failure]
    B --> C[task.execution.error overwritten with coarse stall marker]
    C --> D[Durable output: concrete failure context lost]
```

### After

```mermaid
graph TD
    A[Executing-stall watchdog] --> P[persistShutdownDiagnostic: append output tail + prior error]
    P --> B[handleWorkerResponse: synthetic failure]
    B --> C[task.execution.error overwritten with coarse stall marker]
    C --> D[Durable output retains concrete diagnostics for post-mortem]
```

## Test Plan

- [ ] `cd packages/app && pnpm test src/__tests__/shutdown-diagnostic.test.ts`
- [ ] `cd packages/data-store && pnpm test src/__tests__/sqlite-adapter.test.ts`
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No