### PR TITLE
Fix completed task terminal agent resume

### DIFF
--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -1222,7 +1222,9 @@ describe('fix-with-agent → open-terminal produces correct agent resume command
       status: string;
       runnerKind: string;
       agentSessionId?: string;
+      lastAgentSessionId?: string;
       agentName?: string;
+      lastAgentName?: string;
       workspacePath?: string;
     }>();
     return {
@@ -1239,8 +1241,14 @@ describe('fix-with-agent → open-terminal produces correct agent resume command
       // Read side — what openExternalTerminalForTask calls
       getTaskStatus(taskId: string) { return store.get(taskId)?.status ?? null; },
       getRunnerKind(taskId: string) { return store.get(taskId)?.runnerKind ?? null; },
-      getAgentSessionId(taskId: string) { return store.get(taskId)?.agentSessionId ?? null; },
-      getExecutionAgent(taskId: string) { return store.get(taskId)?.agentName ?? null; },
+      getAgentSessionId(taskId: string) {
+        const row = store.get(taskId);
+        return row?.agentSessionId ?? row?.lastAgentSessionId ?? null;
+      },
+      getExecutionAgent(taskId: string) {
+        const row = store.get(taskId);
+        return row?.agentName ?? row?.lastAgentName ?? null;
+      },
       getContainerId() { return null; },
       getWorkspacePath(taskId: string) { return store.get(taskId)?.workspacePath ?? null; },
       getBranch() { return null; },
@@ -1288,6 +1296,42 @@ describe('fix-with-agent → open-terminal produces correct agent resume command
     expect(spec.command).toBe('codex');
     expect(spec.args).toContain('resume');
     expect(spec.args).toContain('codex-sess-42');
+    expect(spec.command).not.toBe('claude');
+  });
+
+  it('completed command task with only last agent metadata launches codex resume', () => {
+    vi.mocked(existsSync).mockReturnValue(true);
+    const agentRegistry = registerBuiltinAgents();
+    const wt = new WorktreeExecutor({
+      worktreeBaseDir: '/tmp/wt',
+      cacheDir: '/tmp/cache',
+      agentRegistry,
+    });
+
+    const persistence = createMockPersistence();
+    persistence.store.set('task-completed-last-codex', {
+      status: 'completed',
+      runnerKind: 'worktree',
+      workspacePath: '/tmp/workspace',
+      lastAgentSessionId: 'codex-sess-last',
+      lastAgentName: 'codex',
+    });
+
+    const meta: PersistedTaskMeta = {
+      taskId: 'task-completed-last-codex',
+      runnerKind: persistence.getRunnerKind('task-completed-last-codex') ?? 'worktree',
+      agentSessionId: persistence.getAgentSessionId('task-completed-last-codex') ?? undefined,
+      executionAgent: persistence.getExecutionAgent('task-completed-last-codex') ?? undefined,
+      workspacePath: persistence.getWorkspacePath('task-completed-last-codex') ?? undefined,
+    };
+
+    expect(meta.executionAgent).toBe('codex');
+    expect(meta.agentSessionId).toBe('codex-sess-last');
+
+    const spec = wt.getRestoredTerminalSpec(meta);
+    expect(spec.command).toBe('codex');
+    expect(spec.args).toContain('resume');
+    expect(spec.args).toContain('codex-sess-last');
     expect(spec.command).not.toBe('claude');
   });
 

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2959,6 +2959,23 @@ describe('SQLiteAdapter', () => {
       expect(adapter.getExecutionAgent('t-agent-3')).toBe('codex');
     });
 
+    it('falls back to lastAgentName when a completed command task keeps only the last session', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const task = makeTask('t-agent-last-only', {
+        status: 'completed',
+        config: { workflowId: 'wf-1', command: 'pnpm test' },
+        execution: {
+          lastAgentSessionId: 'sess-codex-last',
+          lastAgentName: 'codex',
+          workspacePath: '/tmp/worktree-last',
+        },
+      });
+      adapter.saveTask('wf-1', task);
+
+      expect(adapter.getAgentSessionId('t-agent-last-only')).toBe('sess-codex-last');
+      expect(adapter.getExecutionAgent('t-agent-last-only')).toBe('codex');
+    });
+
     it('returns null when neither agent_name nor execution_agent is set', () => {
       adapter.saveWorkflow(testWorkflow);
       const task = makeTask('t-agent-4', {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2153,8 +2153,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
       `
       SELECT
         CASE
-          WHEN prompt IS NOT NULL AND TRIM(prompt) != '' THEN COALESCE(execution_agent, agent_name)
-          ELSE COALESCE(agent_name, execution_agent)
+          WHEN prompt IS NOT NULL AND TRIM(prompt) != '' THEN COALESCE(execution_agent, agent_name, last_agent_name)
+          ELSE COALESCE(agent_name, last_agent_name, execution_agent)
         END AS agent
       FROM tasks
       WHERE id = ?


### PR DESCRIPTION
## Summary

Completed task terminals now resume with the agent that created the saved session.

The bug came from reading `lastAgentSessionId` without the matching `lastAgentName`. That could reopen a Codex session through Claude.

This keeps the current safety patch small. INV-199 tracks the cleaner design: store resumable session id and agent name together as attempt-owned metadata.

## Architecture

### Before

```mermaid
graph TD
    UI[Double-click completed task] --> Session[Read agentSessionId or lastAgentSessionId]
    Session --> Agent[Read agentName or configured agent]
    Agent --> Default[Missing agent defaults to Claude]
    Default --> Resume[Agent class builds resume command]
```

### After

```mermaid
graph TD
    UI[Double-click completed task] --> Session[Read agentSessionId or lastAgentSessionId]
    Session --> Agent[Read agentName, lastAgentName, or configured agent]
    Agent --> Resume[Matching agent class builds resume command]
```

## Test Plan

- [x] `pnpm --filter @invoker/data-store test src/__tests__/sqlite-adapter.test.ts -- --runInBand`
- [x] `pnpm --filter @invoker/app test src/__tests__/open-terminal.test.ts -- --runInBand`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 7fd52d3de`
- Post-revert steps: None
- Data migration? No
