### PR TITLE
Contain broken pipe process errors

### DIFF
--- a/packages/app/src/__tests__/process-error-handling.test.ts
+++ b/packages/app/src/__tests__/process-error-handling.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { logProcessError } from '../process-error-handling.js';
+
+describe('process error handling', () => {
+  it('suppresses broken-pipe uncaught exceptions instead of feeding a log loop', () => {
+    const logger = {
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    const fallbackConsole = { error: vi.fn() };
+    const error = Object.assign(new Error('write EPIPE'), { code: 'EPIPE' });
+
+    logProcessError('uncaughtException', error, { logger, fallbackConsole });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      'uncaughtException: suppressed broken pipe (write EPIPE)',
+      { module: 'process', code: 'EPIPE' },
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+    expect(fallbackConsole.error).not.toHaveBeenCalled();
+  });
+
+  it('still logs non-pipe process failures as errors', () => {
+    const logger = {
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+
+    logProcessError('unhandledRejection', new Error('boom'), { logger });
+
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('unhandledRejection: Error: boom'), { module: 'process' });
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -236,6 +236,7 @@ import {
   registerMainWindowActivateHandler,
   registerMainWindowSecondInstanceHandler,
 } from './window/window-lifecycle.js';
+import { logProcessError } from './process-error-handling.js';
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -419,19 +420,11 @@ const buildVersion = typeof __BUILD_VERSION__ !== 'undefined' ? __BUILD_VERSION_
 logger.info(`Invoker ${buildVersion} (${buildSha})`, { module: 'startup' });
 
 process.on('uncaughtException', (err) => {
-  try {
-    logger.error(`uncaughtException: ${err instanceof Error ? err.stack ?? err.message : String(err)}`, { module: 'process' });
-  } catch {
-    console.error('[process] uncaughtException:', err);
-  }
+  logProcessError('uncaughtException', err, { logger, fallbackConsole: console });
 });
 
 process.on('unhandledRejection', (reason) => {
-  try {
-    logger.error(`unhandledRejection: ${reason instanceof Error ? reason.stack ?? reason.message : String(reason)}`, { module: 'process' });
-  } catch {
-    console.error('[process] unhandledRejection:', reason);
-  }
+  logProcessError('unhandledRejection', reason, { logger, fallbackConsole: console });
 });
 
 const repoRoot = resolveRepoRoot(__dirname, { fallback: process.resourcesPath });

--- a/packages/app/src/process-error-handling.ts
+++ b/packages/app/src/process-error-handling.ts
@@ -1,0 +1,36 @@
+import type { Logger } from '@invoker/contracts';
+
+function isNodeErrnoException(value: unknown): value is NodeJS.ErrnoException {
+  return value instanceof Error && typeof (value as NodeJS.ErrnoException).code === 'string';
+}
+
+export function isBrokenPipeError(value: unknown): boolean {
+  if (!isNodeErrnoException(value)) return false;
+  return value.code === 'EPIPE' || value.code === 'ERR_STREAM_DESTROYED';
+}
+
+export interface ProcessErrorHandlerDeps {
+  logger: Pick<Logger, 'error' | 'warn'>;
+  fallbackConsole?: Pick<Console, 'error'>;
+}
+
+export function logProcessError(
+  kind: 'uncaughtException' | 'unhandledRejection',
+  reason: unknown,
+  deps: ProcessErrorHandlerDeps,
+): void {
+  const message = reason instanceof Error ? reason.stack ?? reason.message : String(reason);
+  if (isBrokenPipeError(reason)) {
+    deps.logger.warn(`${kind}: suppressed broken pipe (${reason instanceof Error ? reason.message : String(reason)})`, {
+      module: 'process',
+      code: isNodeErrnoException(reason) ? reason.code : undefined,
+    });
+    return;
+  }
+
+  try {
+    deps.logger.error(`${kind}: ${message}`, { module: 'process' });
+  } catch {
+    deps.fallbackConsole?.error('[process] error handler failed:', reason);
+  }
+}


### PR DESCRIPTION
## Summary

Invoker no longer treats a closed stdout or stderr pipe as an app crash.

Repro: run a process that keeps writing after its reader exits: `node -e 'setInterval(() => process.stdout.write("line\n"), 1)' | true`.

Before this change, Node reports `Error: write EPIPE`, and Invoker logs it as `uncaughtException: Error: write EPIPE`.

That is not a real app failure. It means the output reader disappeared, like a closed terminal, wrapper, or pipe.

This change downgrades `EPIPE` and destroyed-stream errors to warnings. Other uncaught errors still log as errors.

## Test Plan

- [x] `pnpm --filter @invoker/app test src/__tests__/process-error-handling.test.ts src/__tests__/gui-instance-lock.test.ts src/__tests__/app-bootstrap.test.ts src/__tests__/window-lifecycle.test.ts -- --runInBand`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 36b64f3e8`
- Post-revert steps: None
- Data migration? No
