### PR TITLE
Crabbox SSH step 5: terminal restore

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -494,7 +494,7 @@ describe('EmbeddedTerminalManager', () => {
 // ── Deterministic GUI route: resolveTaskTerminalSpec + EmbeddedTerminalManager ──
 
 describe('GUI open-terminal embedded route', () => {
-  it('returns an opened embedded session descriptor for an existing task', () => {
+  it('returns an opened embedded session descriptor for an existing task', async () => {
     const wtBase = join(tmpdir(), `embedded-wt-${randomUUID()}`);
     const workspacePath = join(wtBase, 'task-workspace');
     mkdirSync(workspacePath, { recursive: true });
@@ -515,7 +515,7 @@ describe('GUI open-terminal embedded route', () => {
         getBranch: vi.fn(() => null),
       };
 
-      const resolved = resolveTaskTerminalSpec({
+      const resolved = await resolveTaskTerminalSpec({
         taskId: 'task-X',
         persistence: persistence as never,
         executorRegistry: registry,
@@ -552,7 +552,7 @@ describe('GUI open-terminal embedded route', () => {
     }
   });
 
-  it('propagates the resolved reason when workspace metadata is missing', () => {
+  it('propagates the resolved reason when workspace metadata is missing', async () => {
     const registry = new ExecutorRegistry();
     registry.register('worktree', new WorktreeExecutor({
       cacheDir: join(tmpdir(), `cache-${randomUUID()}`),
@@ -567,7 +567,7 @@ describe('GUI open-terminal embedded route', () => {
       getBranch: vi.fn(() => null),
     };
 
-    const resolved = resolveTaskTerminalSpec({
+    const resolved = await resolveTaskTerminalSpec({
       taskId: 'task-no-workspace',
       persistence: persistence as never,
       executorRegistry: registry,
@@ -579,7 +579,7 @@ describe('GUI open-terminal embedded route', () => {
     expect(resolved.reason).toContain('workspace metadata is missing');
   });
 
-  it('allows running tasks when allowRunning=true (attach path)', () => {
+  it('allows running tasks when allowRunning=true (attach path)', async () => {
     const wtBase = join(tmpdir(), `embedded-wt-${randomUUID()}`);
     const workspacePath = join(wtBase, 'task-workspace');
     mkdirSync(workspacePath, { recursive: true });
@@ -598,7 +598,7 @@ describe('GUI open-terminal embedded route', () => {
         getBranch: vi.fn(() => null),
       };
 
-      const refused = resolveTaskTerminalSpec({
+      const refused = await resolveTaskTerminalSpec({
         taskId: 'task-running',
         persistence: persistence as never,
         executorRegistry: registry,
@@ -606,7 +606,7 @@ describe('GUI open-terminal embedded route', () => {
       });
       expect(refused.ok).toBe(false);
 
-      const allowed = resolveTaskTerminalSpec({
+      const allowed = await resolveTaskTerminalSpec({
         taskId: 'task-running',
         persistence: persistence as never,
         executorRegistry: registry,

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -28,8 +28,10 @@ import {
   DockerExecutor, WorktreeExecutor, ExecutorRegistry, SshExecutor,
   MergeGateExecutor,
   BaseExecutor,
+  CrabboxTargetResolver,
   getEffectivePath,
   type ExecutorHandle, type TerminalSpec, type PersistedTaskMeta,
+  type CrabboxCommandResult,
 } from '@invoker/execution-engine';
 import type { WorkResponse, WorkRequest } from '@invoker/contracts';
 vi.mock('../terminal-external-launch.js', async (importOriginal) => {
@@ -1028,6 +1030,230 @@ describe('SshExecutor getRestoredTerminalSpec', () => {
   });
 });
 
+// ── Crabbox-backed SSH terminal restore ───────────────────────
+// After restart, an SSH task whose remoteLeaseMetadata.provider is 'crabbox'
+// must rebuild its SshExecutor by refreshing the persisted lease (status call),
+// not from a stale static target. Static SSH restore must be unchanged when no
+// lease metadata is present.
+
+describe('Crabbox SSH terminal restore', () => {
+  /** A single scripted Crabbox status result, replayed for the refresh call. */
+  function scriptedResolver(result: CrabboxCommandResult): {
+    resolver: CrabboxTargetResolver;
+    calls: Array<{ command: string; args: readonly string[] }>;
+  } {
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    const resolver = new CrabboxTargetResolver(async (command, args) => {
+      calls.push({ command, args });
+      return result;
+    });
+    return { resolver, calls };
+  }
+
+  const CRABBOX_TARGET_CONFIG = {
+    'crab-1': {
+      type: 'crabbox' as const,
+      crabboxCommand: '/usr/local/bin/crabbox',
+      provider: 'fly',
+      class: 'performance-4x',
+      ttl: '30m',
+      idleTimeout: '10m',
+      network: 'invoker-net',
+      target: 'us-east',
+      stopAfter: 'success',
+      keepOnFailure: true,
+      statusArgs: ['--region', 'iad'],
+    },
+  };
+
+  const leaseMetadata = {
+    provider: 'crabbox' as const,
+    leaseId: 'lease-abc',
+    slug: 'happy-crab',
+    targetId: 'crab-1',
+    // Stale coordinates persisted at task time — refresh must override these.
+    sshHost: '10.0.0.1',
+    sshUser: 'invoker',
+    sshPort: 2222,
+    sshKeyPath: '/home/me/.ssh/old',
+    expiresAt: '2026-01-01T00:30:00.000Z',
+    stopAfter: 'success',
+    keepOnFailure: true,
+  };
+
+  function crabboxPersistence(overrides: Record<string, unknown> = {}) {
+    return {
+      getTaskStatus: vi.fn(() => 'completed'),
+      getRunnerKind: vi.fn(() => 'ssh'),
+      getAgentSessionId: vi.fn(() => null),
+      getContainerId: vi.fn(() => null),
+      getWorkspacePath: vi.fn(() => '~/.invoker/worktrees/abc/experiment-crab-task'),
+      getBranch: vi.fn(() => 'experiment/crab-task'),
+      getPoolMemberId: vi.fn(() => null),
+      getExecutionAgent: vi.fn(() => 'claude'),
+      getRemoteLeaseMetadata: vi.fn(() => leaseMetadata),
+      ...overrides,
+    };
+  }
+
+  afterEach(() => {
+    vi.mocked(existsSync).mockReset();
+  });
+
+  it('static SSH restore is unchanged and never refreshes a lease when metadata is absent', async () => {
+    const mockSpawnDetached = vi.fn(async () => ({ opened: true } as const));
+    const terminalLaunch = await import('../terminal-external-launch.js');
+    vi.spyOn(terminalLaunch, 'spawnDetachedTerminal').mockImplementation(mockSpawnDetached as any);
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: {
+        'static-1': { host: 'static.example', user: 'ubuntu', sshKeyPath: '/k', port: 22 },
+      },
+    } as any);
+
+    // Resolver runner throws if touched — static restore must not refresh a lease.
+    const resolver = new CrabboxTargetResolver(async () => {
+      throw new Error('crabbox refresh must not run for static SSH restore');
+    });
+
+    const persistence = {
+      getTaskStatus: vi.fn(() => 'completed'),
+      getRunnerKind: vi.fn(() => 'ssh'),
+      getAgentSessionId: vi.fn(() => null),
+      getContainerId: vi.fn(() => null),
+      getWorkspacePath: vi.fn(() => '~/.invoker/worktrees/abc/experiment-static'),
+      getBranch: vi.fn(() => 'experiment/static'),
+      getPoolMemberId: vi.fn(() => 'static-1'),
+      getExecutionAgent: vi.fn(() => 'claude'),
+      getRemoteLeaseMetadata: vi.fn(() => null),
+    };
+
+    const result = await openExternalTerminalForTask({
+      taskId: 'static-ssh-task',
+      persistence: persistence as any,
+      executorRegistry: new ExecutorRegistry(),
+      repoRoot: '/repo',
+      crabboxResolver: resolver,
+    });
+
+    expect(result.opened).toBe(true);
+    const spawned = mockSpawnDetached.mock.calls[0];
+    expect(JSON.stringify(spawned?.[1])).toContain('static.example');
+    expect(JSON.stringify(spawned?.[1])).toContain('experiment/static');
+
+    loadConfigSpy.mockRestore();
+    vi.mocked(terminalLaunch.spawnDetachedTerminal).mockReset();
+    vi.mocked(terminalLaunch.spawnDetachedTerminal).mockImplementation(
+      async () => ({ opened: true } as const),
+    );
+  });
+
+  it('refreshes the lease and opens a terminal to the refreshed Crabbox SSH host', async () => {
+    const mockSpawnDetached = vi.fn(async () => ({ opened: true } as const));
+    const terminalLaunch = await import('../terminal-external-launch.js');
+    vi.spyOn(terminalLaunch, 'spawnDetachedTerminal').mockImplementation(mockSpawnDetached as any);
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: CRABBOX_TARGET_CONFIG,
+    } as any);
+
+    // Refreshed status reports NEW coordinates that must override the persisted ones.
+    const { resolver, calls } = scriptedResolver({
+      stdout: JSON.stringify({
+        id: 'lease-abc',
+        slug: 'happy-crab',
+        status: 'ready',
+        expiresAt: '2026-12-01T00:00:00.000Z',
+        sshHost: '203.0.113.9',
+        sshUser: 'runner',
+        sshPort: 2200,
+        sshKey: '/home/me/.ssh/fresh',
+      }),
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const result = await openExternalTerminalForTask({
+      taskId: 'crab-ssh-task',
+      persistence: crabboxPersistence() as any,
+      executorRegistry: new ExecutorRegistry(),
+      repoRoot: '/repo',
+      crabboxResolver: resolver,
+    });
+
+    expect(result.opened).toBe(true);
+
+    // Status call ran against the persisted lease id, without --wait.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe('/usr/local/bin/crabbox');
+    expect(calls[0].args).toEqual([
+      'status', '--id', 'lease-abc', '--json', '--region', 'iad',
+    ]);
+
+    const spawned = mockSpawnDetached.mock.calls[0];
+    const argsJson = JSON.stringify(spawned?.[1]);
+    expect(argsJson).toContain('203.0.113.9');
+    expect(argsJson).toContain('runner@203.0.113.9');
+    expect(argsJson).toContain('experiment/crab-task');
+    // Stale persisted host must not leak through.
+    expect(argsJson).not.toContain('10.0.0.1');
+
+    loadConfigSpy.mockRestore();
+    vi.mocked(terminalLaunch.spawnDetachedTerminal).mockReset();
+    vi.mocked(terminalLaunch.spawnDetachedTerminal).mockImplementation(
+      async () => ({ opened: true } as const),
+    );
+  });
+
+  it('refuses with a clear reason when the lease has expired', async () => {
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: CRABBOX_TARGET_CONFIG,
+    } as any);
+
+    const { resolver } = scriptedResolver({
+      stdout: JSON.stringify({ id: 'lease-abc', slug: 'happy-crab', status: 'expired' }),
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const result = await openExternalTerminalForTask({
+      taskId: 'crab-expired-task',
+      persistence: crabboxPersistence() as any,
+      executorRegistry: new ExecutorRegistry(),
+      repoRoot: '/repo',
+      crabboxResolver: resolver,
+    });
+
+    expect(result.opened).toBe(false);
+    expect(result.reason).toContain('Crabbox SSH task "crab-expired-task"');
+    expect(result.reason).toMatch(/expired or been stopped/);
+    loadConfigSpy.mockRestore();
+  });
+
+  it('refuses with a clear reason when the lease is missing (status exits non-zero)', async () => {
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: CRABBOX_TARGET_CONFIG,
+    } as any);
+
+    const { resolver } = scriptedResolver({
+      stdout: '',
+      stderr: 'lease not found',
+      exitCode: 4,
+    });
+
+    const result = await openExternalTerminalForTask({
+      taskId: 'crab-missing-task',
+      persistence: crabboxPersistence() as any,
+      executorRegistry: new ExecutorRegistry(),
+      repoRoot: '/repo',
+      crabboxResolver: resolver,
+    });
+
+    expect(result.opened).toBe(false);
+    expect(result.reason).toMatch(/missing or unreachable/);
+    expect(result.reason).toContain('lease not found');
+    loadConfigSpy.mockRestore();
+  });
+});
+
 // ── Codex vs Claude session resume ───────────────────────────
 // Proves that getRestoredTerminalSpec with agentRegistry and
 // executionAgent='codex' opens a codex session, not claude.
@@ -1396,7 +1622,7 @@ describe('fix-with-agent → open-terminal produces correct agent resume command
       loadAttempts: () => [],
     };
 
-    const resolved = resolveTaskTerminalSpec({
+    const resolved = await resolveTaskTerminalSpec({
       taskId: 'wf-1778431089965-37/experiment-inv-130',
       persistence,
       executorRegistry,

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -1252,6 +1252,46 @@ describe('Crabbox SSH terminal restore', () => {
     expect(result.reason).toContain('lease not found');
     loadConfigSpy.mockRestore();
   });
+
+  it('attaches to a live executor without refreshing the Crabbox lease for a running task', async () => {
+    const { resolveTaskTerminalSpec } = await import('../open-terminal-for-task.js');
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: CRABBOX_TARGET_CONFIG,
+    } as any);
+
+    // The refresh runner throws if touched — a live attach must never run
+    // `crabbox status`, so a transient status failure / missing CLI cannot
+    // block opening a terminal for an actually running Crabbox SSH task.
+    const resolver = new CrabboxTargetResolver(async () => {
+      throw new Error('crabbox status must not run when attaching to a live executor');
+    });
+
+    const liveExecutor = new SshExecutor({
+      host: 'live.example',
+      user: 'runner',
+      sshKeyPath: '/home/me/.ssh/live',
+      port: 22,
+    });
+
+    // Running task with a live handle: main.ts sets allowRunning + liveExecutor.
+    const persistence = crabboxPersistence({ getTaskStatus: vi.fn(() => 'running') });
+
+    const resolved = await resolveTaskTerminalSpec({
+      taskId: 'crab-live-task',
+      persistence: persistence as any,
+      executorRegistry: new ExecutorRegistry(),
+      repoRoot: '/repo',
+      allowRunning: true,
+      liveExecutor,
+      crabboxResolver: resolver,
+    });
+
+    expect(resolved.ok).toBe(true);
+    if (resolved.ok) {
+      expect(resolved.executor).toBe(liveExecutor);
+    }
+    loadConfigSpy.mockRestore();
+  });
 });
 
 // ── Codex vs Claude session resume ───────────────────────────

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -4431,7 +4431,7 @@ function createEmbeddedTerminalBackendFromConfig(
     ipcMain.handle('invoker:open-terminal', async (_event, taskId: string) => {
       logger.info(`invoked for task="${taskId}"`, { module: 'open-terminal' });
       const liveHandle = taskHandles.get(taskId);
-      const resolved = resolveTaskTerminalSpec({
+      const resolved = await resolveTaskTerminalSpec({
         taskId,
         persistence,
         executorRegistry,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -4439,8 +4439,11 @@ function createEmbeddedTerminalBackendFromConfig(
         repoRoot,
         logger,
         // If a live executor handle exists we can safely attach instead of
-        // refusing — embedded mode is designed for this case.
+        // refusing — embedded mode is designed for this case. Passing the live
+        // executor also skips the Crabbox lease refresh so a transient
+        // `crabbox status` failure cannot block attaching to a running task.
         allowRunning: Boolean(liveHandle),
+        liveExecutor: liveHandle?.executor,
         runningTaskReason:
           'Task is still running or being fixed with AI. View output in the terminal panel below.',
       });

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -11,12 +11,14 @@ import {
   getEffectivePath,
   WorktreeExecutor,
   SshExecutor,
+  CrabboxTargetResolver,
   type Executor,
   type ExecutorRegistry,
   type AgentRegistry,
   type PersistedTaskMeta,
   type TerminalSpec,
 } from '@invoker/execution-engine';
+import type { RemoteLeaseMetadata } from '@invoker/workflow-core';
 import { loadConfig, staticRemoteTargets } from './config.js';
 import {
   buildLinuxXTerminalBashScript,
@@ -37,6 +39,8 @@ export interface OpenTerminalPersistence {
   getWorkspacePath(taskId: string): string | null;
   getBranch(taskId: string): string | null;
   getPoolMemberId?(taskId: string): string | null;
+  /** Durable remote lease details persisted for on-demand (e.g. Crabbox) SSH targets. */
+  getRemoteLeaseMetadata?(taskId: string): RemoteLeaseMetadata | null;
   loadAttempts?(taskId: string): Array<{ id: string; agentSessionId?: string }>;
   updateTask?(taskId: string, changes: { execution?: { agentSessionId?: string; lastAgentSessionId?: string } }): void;
   updateAttempt?(attemptId: string, changes: { agentSessionId?: string }): void;
@@ -50,6 +54,8 @@ export interface OpenExternalTerminalForTaskOptions {
   repoRoot: string;
   /** Shown when task status is `running`. */
   runningTaskReason?: string;
+  /** Resolver used to refresh Crabbox leases for SSH terminal restore. Injectable for tests. */
+  crabboxResolver?: CrabboxTargetResolver;
   logger?: Logger;
 }
 
@@ -152,7 +158,72 @@ export interface ResolveTaskTerminalSpecOptions {
   runningTaskReason?: string;
   /** When true, allow resolution even if the task status is `running` / `fixing_with_ai` — used by the embedded manager which can attach to a live executor handle. */
   allowRunning?: boolean;
+  /** Resolver used to refresh Crabbox leases for SSH terminal restore. Injectable for tests. */
+  crabboxResolver?: CrabboxTargetResolver;
   logger?: Logger;
+}
+
+type CrabboxSshExecutorResult =
+  | { ok: true; executor: Executor }
+  | { ok: false; reason: string };
+
+/**
+ * Rebuild an {@link SshExecutor} for a Crabbox-leased task after restart.
+ *
+ * The lease's in-memory target resolution is gone, so we re-inspect the lease
+ * by its persisted id/slug (no warmup) and rebuild the SSH endpoint from the
+ * refreshed coordinates. Refuses with a clear reason — never silently falling
+ * back to the host repo — when the target is no longer configured or the lease
+ * is missing, expired, not ready, or lacks SSH fields.
+ */
+async function resolveCrabboxSshExecutor(
+  taskId: string,
+  lease: RemoteLeaseMetadata,
+  opts: ResolveTaskTerminalSpecOptions,
+): Promise<CrabboxSshExecutorResult> {
+  const leaseRef = (lease.leaseId || lease.slug || '').trim();
+  if (!leaseRef) {
+    return {
+      ok: false,
+      reason: `Cannot open terminal for Crabbox SSH task "${taskId}": persisted lease is missing a lease id.`,
+    };
+  }
+
+  const target = loadConfig().remoteTargets?.[lease.targetId];
+  if (!target || target.type !== 'crabbox') {
+    return {
+      ok: false,
+      reason: `Cannot open terminal for Crabbox SSH task "${taskId}": remote target "${lease.targetId}" is no longer configured as a Crabbox target.`,
+    };
+  }
+
+  const resolver = opts.crabboxResolver ?? new CrabboxTargetResolver();
+  try {
+    const sshTarget = await resolver.refreshLease(
+      {
+        id: lease.targetId,
+        crabboxCommand: target.crabboxCommand,
+        statusArgs: target.statusArgs,
+        port: lease.sshPort ?? target.port,
+      },
+      leaseRef,
+    );
+    const executor = new SshExecutor({
+      host: sshTarget.host,
+      user: sshTarget.user,
+      sshKeyPath: sshTarget.sshKeyPath,
+      port: sshTarget.port,
+      agentRegistry: opts.executionAgentRegistry,
+    });
+    return { ok: true, executor };
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    opts.logger?.info(`crabbox lease refresh failed for task=${taskId}: ${reason}`);
+    return {
+      ok: false,
+      reason: `Cannot open terminal for Crabbox SSH task "${taskId}": ${reason}`,
+    };
+  }
 }
 
 /**
@@ -160,9 +231,9 @@ export interface ResolveTaskTerminalSpecOptions {
  * without launching anything. Shared between the external launcher and the embedded
  * terminal manager so workspace metadata and session-repair checks stay in one place.
  */
-export function resolveTaskTerminalSpec(
+export async function resolveTaskTerminalSpec(
   opts: ResolveTaskTerminalSpecOptions,
-): ResolveTaskTerminalSpecResult {
+): Promise<ResolveTaskTerminalSpecResult> {
   const { taskId, persistence, executorRegistry, repoRoot, runningTaskReason, allowRunning, logger: termLogger } = opts;
 
   const taskStatus = persistence.getTaskStatus(taskId);
@@ -187,6 +258,7 @@ export function resolveTaskTerminalSpec(
     containerId: persistence.getContainerId(taskId) ?? undefined,
     workspacePath: persistence.getWorkspacePath(taskId) ?? undefined,
     branch: persistence.getBranch(taskId) ?? undefined,
+    remoteLeaseMetadata: persistence.getRemoteLeaseMetadata?.(taskId) ?? undefined,
   };
   const repairedMeta = repairCodexResumeSessionMeta(meta, persistence, opts.executionAgentRegistry);
   termLogger?.info(
@@ -196,7 +268,11 @@ export function resolveTaskTerminalSpec(
   let executor = repairedMeta.runnerKind === 'ssh' ? undefined : executorRegistry.get(repairedMeta.runnerKind);
   termLogger?.info(`executorRegistry.get("${repairedMeta.runnerKind}") → ${executor ? executor.type : 'null (will lazy-create)'}`);
 
-  if (repairedMeta.runnerKind === 'ssh') {
+  if (repairedMeta.runnerKind === 'ssh' && repairedMeta.remoteLeaseMetadata?.provider === 'crabbox') {
+    const crabboxResult = await resolveCrabboxSshExecutor(taskId, repairedMeta.remoteLeaseMetadata, opts);
+    if (!crabboxResult.ok) return crabboxResult;
+    executor = crabboxResult.executor;
+  } else if (repairedMeta.runnerKind === 'ssh') {
     const targetId = persistence.getPoolMemberId?.(taskId)?.trim();
     const target = targetId ? staticRemoteTargets(loadConfig())[targetId] : undefined;
     if (!targetId) {
@@ -292,13 +368,14 @@ export async function openExternalTerminalForTask(
 ): Promise<OpenTerminalResult> {
   const { repoRoot, logger: termLogger } = opts;
 
-  const resolved = resolveTaskTerminalSpec({
+  const resolved = await resolveTaskTerminalSpec({
     taskId: opts.taskId,
     persistence: opts.persistence,
     executorRegistry: opts.executorRegistry,
     executionAgentRegistry: opts.executionAgentRegistry,
     repoRoot: opts.repoRoot,
     runningTaskReason: opts.runningTaskReason,
+    crabboxResolver: opts.crabboxResolver,
     logger: opts.logger,
   });
   if (!resolved.ok) {

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -158,6 +158,14 @@ export interface ResolveTaskTerminalSpecOptions {
   runningTaskReason?: string;
   /** When true, allow resolution even if the task status is `running` / `fixing_with_ai` — used by the embedded manager which can attach to a live executor handle. */
   allowRunning?: boolean;
+  /**
+   * Live executor handle for a task that is currently running. When present the
+   * embedded manager attaches to this executor directly, so restore MUST NOT run
+   * a Crabbox lease refresh (or re-resolve a static SSH target): a transient
+   * `crabbox status` failure, expired persisted lease, or missing CLI must not
+   * block opening a terminal for an actually running task.
+   */
+  liveExecutor?: Executor;
   /** Resolver used to refresh Crabbox leases for SSH terminal restore. Injectable for tests. */
   crabboxResolver?: CrabboxTargetResolver;
   logger?: Logger;
@@ -265,14 +273,20 @@ export async function resolveTaskTerminalSpec(
     `meta from DB: runnerKind=${repairedMeta.runnerKind} workspacePath=${repairedMeta.workspacePath ?? 'undefined'} branch=${repairedMeta.branch ?? 'undefined'} agentSessionId=${repairedMeta.agentSessionId ?? 'undefined'} executionAgent=${repairedMeta.executionAgent ?? 'undefined'} containerId=${repairedMeta.containerId ?? 'undefined'}`,
   );
 
-  let executor = repairedMeta.runnerKind === 'ssh' ? undefined : executorRegistry.get(repairedMeta.runnerKind);
+  let executor =
+    opts.liveExecutor ??
+    (repairedMeta.runnerKind === 'ssh' ? undefined : executorRegistry.get(repairedMeta.runnerKind));
   termLogger?.info(`executorRegistry.get("${repairedMeta.runnerKind}") → ${executor ? executor.type : 'null (will lazy-create)'}`);
 
-  if (repairedMeta.runnerKind === 'ssh' && repairedMeta.remoteLeaseMetadata?.provider === 'crabbox') {
+  if (
+    !opts.liveExecutor &&
+    repairedMeta.runnerKind === 'ssh' &&
+    repairedMeta.remoteLeaseMetadata?.provider === 'crabbox'
+  ) {
     const crabboxResult = await resolveCrabboxSshExecutor(taskId, repairedMeta.remoteLeaseMetadata, opts);
     if (!crabboxResult.ok) return crabboxResult;
     executor = crabboxResult.executor;
-  } else if (repairedMeta.runnerKind === 'ssh') {
+  } else if (!opts.liveExecutor && repairedMeta.runnerKind === 'ssh') {
     const targetId = persistence.getPoolMemberId?.(taskId)?.trim();
     const target = targetId ? staticRemoteTargets(loadConfig())[targetId] : undefined;
     if (!targetId) {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1061,6 +1061,47 @@ describe('SQLiteAdapter', () => {
       expect(reloaded?.status).toBe('completed');
       expect(reloaded?.remoteLeaseMetadata).toEqual(crabboxLease);
     });
+
+    it('getRemoteLeaseMetadata returns the lease for well-formed metadata', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t-lease-read', {
+        config: { runnerKind: 'ssh' },
+        execution: { remoteLeaseMetadata: crabboxLease },
+      }));
+
+      expect(adapter.getRemoteLeaseMetadata('t-lease-read')).toEqual(crabboxLease);
+    });
+
+    it('getRemoteLeaseMetadata returns null without throwing for malformed or drifted metadata', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t-lease-bad'));
+
+      // Untrusted persisted content must never crash restore. Each of these
+      // would otherwise either throw in JSON.parse or throw downstream at a
+      // `.trim()` on a non-string lease field.
+      const badRows = [
+        '{',                                                       // malformed JSON
+        'null',                                                     // valid JSON, not an object
+        '"just a string"',                                          // valid JSON, not an object
+        JSON.stringify({ provider: 'unknown', targetId: 'crab1' }), // wrong provider
+        JSON.stringify({ provider: 'crabbox' }),                    // missing targetId
+        JSON.stringify({ provider: 'crabbox', targetId: '  ' }),    // blank targetId
+        JSON.stringify({ provider: 'crabbox', targetId: 'crab1', leaseId: 123 }), // non-string leaseId
+        JSON.stringify({ provider: 'crabbox', targetId: 'crab1', slug: 42 }),     // non-string slug
+      ];
+
+      for (const raw of badRows) {
+        (adapter as any).db.run(
+          'UPDATE tasks SET remote_lease_metadata = ? WHERE id = ?',
+          [raw, 't-lease-bad'],
+        );
+        let result: unknown;
+        expect(() => {
+          result = adapter.getRemoteLeaseMetadata('t-lease-bad');
+        }, `raw=${raw}`).not.toThrow();
+        expect(result, `raw=${raw}`).toBeNull();
+      }
+    });
   });
 
   describe('task-state version persistence', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -31,6 +31,7 @@ import type {
   ExternalDependency,
   ExternalDependencyChange,
   DetachedExternalDependency,
+  RemoteLeaseMetadata,
 } from '@invoker/workflow-core';
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
 import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
@@ -2206,6 +2207,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
       [taskId],
     );
     return (row?.pool_member_id as string) ?? null;
+  }
+
+  getRemoteLeaseMetadata(taskId: string): RemoteLeaseMetadata | null {
+    const row = this.queryOne(
+      'SELECT remote_lease_metadata FROM tasks WHERE id = ?',
+      [taskId],
+    );
+    const raw = (row?.remote_lease_metadata as string) ?? null;
+    return raw ? (JSON.parse(raw) as RemoteLeaseMetadata) : null;
   }
 
   // ── Conversations ───────────────────────────────────────

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2215,7 +2215,23 @@ export class SQLiteAdapter implements PersistenceAdapter {
       [taskId],
     );
     const raw = (row?.remote_lease_metadata as string) ?? null;
-    return raw ? (JSON.parse(raw) as RemoteLeaseMetadata) : null;
+    if (!raw) return null;
+    // Persisted content is untrusted: malformed JSON or a drifted shape
+    // (e.g. a non-string leaseId/slug) must yield a clean null so restore
+    // falls back to a refusal path instead of crashing at a later `.trim()`.
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return null;
+    }
+    if (!parsed || typeof parsed !== 'object') return null;
+    const candidate = parsed as Partial<RemoteLeaseMetadata>;
+    if (candidate.provider !== 'crabbox') return null;
+    if (typeof candidate.targetId !== 'string' || candidate.targetId.trim() === '') return null;
+    if (candidate.leaseId !== undefined && typeof candidate.leaseId !== 'string') return null;
+    if (candidate.slug !== undefined && typeof candidate.slug !== 'string') return null;
+    return candidate as RemoteLeaseMetadata;
   }
 
   // ── Conversations ───────────────────────────────────────

--- a/packages/execution-engine/src/crabbox-target-resolver.ts
+++ b/packages/execution-engine/src/crabbox-target-resolver.ts
@@ -82,6 +82,24 @@ export interface CrabboxStopConfig {
   readonly stopArgs?: readonly string[];
 }
 
+/**
+ * Inputs needed to refresh (re-inspect) an existing Crabbox lease for terminal
+ * restore. Unlike {@link resolve}, this never warms up a new machine: it only
+ * runs a status call against a lease id/slug persisted earlier, so it needs
+ * just the CLI entrypoint, the target id (for errors), any status args, and a
+ * fallback SSH port.
+ */
+export interface CrabboxRefreshConfig {
+  /** Config key of the remote target. Named in errors. */
+  readonly id: string;
+  /** CLI entrypoint that inspects Crabbox leases. */
+  readonly crabboxCommand: string;
+  /** Optional extra args appended to the status subcommand. */
+  readonly statusArgs?: readonly string[];
+  /** SSH port to fall back to when the lease status omits one. Default: 22. */
+  readonly port?: number;
+}
+
 /** When to stop a Crabbox lease relative to the task's final status. */
 export type CrabboxStopAfter = 'success' | 'failure' | 'always' | 'never';
 
@@ -180,6 +198,18 @@ interface CrabboxStatusJson {
 
 const DEFAULT_SSH_PORT = 22;
 
+/** Lease states that are still SSH-reachable and safe to restore a terminal to. */
+const CRABBOX_READY_STATES = new Set(['ready', 'running', 'active']);
+/** Lease states meaning the machine is gone and cannot be restored. */
+const CRABBOX_DEAD_STATES = new Set([
+  'expired',
+  'stopped',
+  'terminated',
+  'deleted',
+  'gone',
+  'released',
+]);
+
 /** Default runner: spawn the Crabbox CLI and collect its output. */
 export function spawnCrabboxCommand(
   command: string,
@@ -232,19 +262,24 @@ export function buildCrabboxWarmupArgs(
 }
 
 /**
- * Build the status args that block until the lease is reachable and print its
- * SSH coordinates as JSON. `leaseRef` is the id or slug returned by warmup.
+ * Build the status args that report a lease's SSH coordinates as JSON.
+ * `leaseRef` is the id or slug returned by warmup. By default the call blocks
+ * (`--wait`) until the lease is reachable, which is what initial resolution
+ * wants. Terminal restore passes `{ wait: false }` so a dead or not-ready lease
+ * is reported immediately instead of blocking the terminal open.
  */
 export function buildCrabboxStatusArgs(
-  config: CrabboxResolverTargetConfig,
+  config: { readonly statusArgs?: readonly string[] },
   leaseRef: string,
+  opts: { readonly wait?: boolean } = {},
 ): string[] {
+  const wait = opts.wait ?? true;
   return [
     'status',
     '--id',
     leaseRef,
     '--json',
-    '--wait',
+    ...(wait ? ['--wait'] : []),
     ...(config.statusArgs ?? []),
   ];
 }
@@ -319,6 +354,77 @@ export class CrabboxTargetResolver {
           `(exit ${result.exitCode}): ${result.stderr.trim() || result.stdout.trim()}`,
       );
     }
+  }
+
+  /**
+   * Re-inspect an already-leased machine and return a fresh SSH endpoint,
+   * without warming up a new one. Used to restore a terminal after restart:
+   * the lease id/slug was persisted, so a single status call (no `--wait`)
+   * gives the current SSH coordinates.
+   *
+   * Throws an actionable error — caught by the terminal opener and surfaced as
+   * a refusal — when the lease is missing/unreachable, expired or stopped, not
+   * yet ready, or no longer reports the SSH fields needed to connect.
+   */
+  async refreshLease(
+    config: CrabboxRefreshConfig,
+    leaseRef: string,
+  ): Promise<ResolvedSshTarget> {
+    const status = await this.run(
+      config.crabboxCommand,
+      buildCrabboxStatusArgs(config, leaseRef, { wait: false }),
+    );
+    if (status.exitCode !== 0) {
+      throw new Error(
+        `Crabbox lease "${leaseRef}" for remote target "${config.id}" is missing or unreachable ` +
+          `(exit ${status.exitCode}): ${status.stderr.trim() || status.stdout.trim() || 'no output'}.`,
+      );
+    }
+
+    const json = tryParseJson(status.stdout.trim());
+    if (!json) {
+      throw new Error(
+        `Crabbox status for lease "${leaseRef}" on remote target "${config.id}" did not return valid JSON.`,
+      );
+    }
+
+    const state = asNonEmptyString(json.status)?.toLowerCase();
+    if (state && CRABBOX_DEAD_STATES.has(state)) {
+      throw new Error(
+        `Crabbox lease "${leaseRef}" for remote target "${config.id}" has expired or been stopped (status: ${state}).`,
+      );
+    }
+    if (state && !CRABBOX_READY_STATES.has(state)) {
+      throw new Error(
+        `Crabbox lease "${leaseRef}" for remote target "${config.id}" is not ready (status: ${state}).`,
+      );
+    }
+
+    const sshHost = asNonEmptyString(json.sshHost);
+    const sshUser = asNonEmptyString(json.sshUser);
+    const sshKeyPath = asNonEmptyString(json.sshKey);
+    const missing: string[] = [];
+    if (!sshHost) missing.push('sshHost');
+    if (!sshUser) missing.push('sshUser');
+    if (!sshKeyPath) missing.push('sshKey');
+    if (missing.length > 0) {
+      throw new Error(
+        `Crabbox lease "${leaseRef}" for remote target "${config.id}" is missing required SSH field(s): ${missing.join(', ')}. ` +
+          `Cannot rebuild an SSH endpoint for this lease.`,
+      );
+    }
+
+    const sshPort =
+      typeof json.sshPort === 'number' && Number.isFinite(json.sshPort)
+        ? json.sshPort
+        : (config.port ?? DEFAULT_SSH_PORT);
+
+    return {
+      host: sshHost as string,
+      user: sshUser as string,
+      sshKeyPath: sshKeyPath as string,
+      port: sshPort,
+    };
   }
 
   /** Read the lease id (or slug) that warmup printed for the status call. */

--- a/scripts/repro/repro-coderabbit-pr1527-lease-metadata-parse.sh
+++ b/scripts/repro/repro-coderabbit-pr1527-lease-metadata-parse.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# CodeRabbit PR #1527 — Harden remote lease metadata parsing.
+#
+# Finding: SQLiteAdapter.getRemoteLeaseMetadata did `JSON.parse(raw) as
+# RemoteLeaseMetadata`, trusting DB content without validation. Malformed JSON
+# threw inside the getter, and a drifted shape (e.g. a non-string leaseId/slug)
+# was returned as-is and later crashed restore at `.trim()` instead of returning
+# a clean refusal path.
+#
+# Fix: validate the parsed value (object, provider === 'crabbox', non-empty
+# string targetId, string-or-undefined leaseId/slug) and return null on any
+# malformed / drifted content, catching JSON.parse errors.
+#
+# This repro drives the guard tests. On buggy code the malformed-JSON case
+# throws and the non-string-field cases return a non-null object, so the test
+# fails (non-zero); on fixed code both return null and it passes (zero).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TEST_FILE="src/__tests__/sqlite-adapter.test.ts"
+TEST_NAME="getRemoteLeaseMetadata"
+
+echo "==> repro: getRemoteLeaseMetadata must not crash / trust malformed metadata"
+echo "    package : @invoker/data-store"
+echo "    test    : $TEST_NAME"
+
+set +e
+pnpm --filter @invoker/data-store exec vitest run --reporter dot -t "$TEST_NAME" "$TEST_FILE"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: getRemoteLeaseMetadata throws or trusts malformed/drifted lease metadata (bug present)."
+  exit 1
+fi
+
+echo "PASS: getRemoteLeaseMetadata returns null for malformed / drifted metadata."

--- a/scripts/repro/repro-coderabbit-pr1527-live-attach-crabbox-refresh.sh
+++ b/scripts/repro/repro-coderabbit-pr1527-live-attach-crabbox-refresh.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# CodeRabbit PR #1527 — Bypass Crabbox refresh when attaching to a live executor.
+#
+# Finding: when the embedded terminal attaches to a still-running Crabbox SSH
+# task (main.ts already holds a `liveHandle`), `resolveTaskTerminalSpec` still
+# ran a `crabbox status` refresh. A transient status failure, expired persisted
+# lease, or missing CLI would refuse to open a terminal for an actually running
+# task, even though a live executor was available to attach to.
+#
+# Fix: pass the live executor into `resolveTaskTerminalSpec`; when present, skip
+# the Crabbox lease refresh (and the static SSH re-resolution) and attach to it
+# directly. Cold restore after restart keeps refreshing.
+#
+# This repro drives the guard test that asserts the live-attach path never runs
+# the refresh runner. On buggy code the refusal makes the test fail (non-zero);
+# on fixed code it passes (zero).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TEST_FILE="src/__tests__/open-terminal.test.ts"
+TEST_NAME="attaches to a live executor without refreshing the Crabbox lease for a running task"
+
+echo "==> repro: live-attach must not refresh the Crabbox lease"
+echo "    package : @invoker/app"
+echo "    test    : $TEST_NAME"
+
+set +e
+pnpm --filter @invoker/app exec vitest run --reporter dot -t "$TEST_NAME" "$TEST_FILE"
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: live-attach path still runs the Crabbox refresh and refuses to open the terminal (bug present)."
+  exit 1
+fi
+
+echo "PASS: live executor attaches without a Crabbox lease refresh."


### PR DESCRIPTION
## Summary

When you reopen a terminal for a finished Crabbox SSH task, the app now asks Crabbox for the box's current address before it connects.

Before, restore reused an in-memory SSH endpoint. After an app restart or a box change, that address was wrong and the connection failed.

Now restore routes through the Crabbox resolver: it reads the saved lease, refreshes the box status, and rebuilds the live SSH endpoint.

Static SSH terminal restore is unchanged. It still routes through the configured remote target directly.

If the lease is missing, expired, or not ready, restore stops with a clear error naming the lease id and target id.

<details>
<summary>Review metadata</summary>

Review Claim: Crabbox terminal restore routes through the resolver to fetch the live lease endpoint before opening SSH.

Review Lane: behavior

Review Unit: routing

Safety Invariant: runnerKind ssh stays the only runtime executor shape for Crabbox-backed work.

Slice Rationale: This slice owns one routing change for Crabbox terminal restore and leaves the other stacked steps to their own workflows.

</details>

## Non-goals

This slice does not change static SSH terminal restore.

This slice does not change how Crabbox leases are created or stopped.

This slice does not change any rendered UI.

## Architecture

### Before

```mermaid
graph TD
    A[Open terminal for SSH task] --> B[Read pool member + remoteTargets config]
    B --> C[Build SshExecutor from static endpoint]
    C --> D[Open terminal]
```

### After

```mermaid
graph TD
    A[Open terminal for SSH task] --> B{Has Crabbox lease metadata?}
    B -->|No| C[Read remoteTargets config]
    C --> D[Build SshExecutor from static endpoint]
    B -->|Yes| E[Refresh Crabbox lease via resolver]
    E -->|ok| F[Build SshExecutor from refreshed endpoint]
    E -->|expired / missing / not ready| G[Refuse with lease id + target id]
    D --> H[Open terminal]
    F --> H
```

## Test Plan

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/execution-engine && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None — terminal restore returns to the static-endpoint path.
- Data migration? No — persisted lease metadata is read-only here and stays compatible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal reopening now supports restoring SSH sessions after restart using saved remote connection details.
  * Live-running tasks can attach to the existing terminal without rechecking remote status.

* **Bug Fixes**
  * Improved handling for expired or unreachable remote terminals, with clearer failure outcomes.
  * Added safer fallback behavior when stored remote connection data is missing, invalid, or malformed.
  * Ensures restored terminals use refreshed connection details instead of stale saved values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->