### PR TITLE
Require visual proof for UI-impacting PRs

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -29,7 +29,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { basename, extname, join } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import aws4 from 'aws4';
 import { getPrBodyWarnings, validatePrBody } from './validate-pr-body.mjs';
 
@@ -119,6 +119,7 @@ Options:
 PR body schema:
   Required: ## Summary, ## Test Plan, ## Revert Plan
   Optional: ## Architecture (must include ### Before and ### After when present)
+  UI-impacting diffs require ## Visual Proof with screenshot or video proof.
   Template: scripts/pr-body-template.md`);
   process.exit(1);
 }
@@ -150,14 +151,18 @@ function parseArgs() {
   return parsed;
 }
 
-function assertValidPrBody(body) {
-  const errors = validatePrBody(body);
+function assertValidPrBody(body, options = {}) {
+  const errors = validatePrBody(body, options);
   if (errors.length === 0) return;
 
   throw new Error(
     [
       'PR body does not match the canonical schema.',
       ...errors.map((error) => `- ${error}`),
+      '',
+      options.requiresVisualProof
+        ? 'UI-impacting files changed. Add ## Visual Proof with screenshot or video links, or run the visual-proof capture first.'
+        : '',
       '',
       'Start from scripts/pr-body-template.md and validate with:',
       '  node scripts/validate-pr-body.mjs --body-file <file>',
@@ -286,6 +291,34 @@ function shortOneLine(sha) {
   }
 }
 
+export function isUiImpactingPath(filePath) {
+  const path = filePath.replace(/\\/g, '/');
+  if (path.startsWith('packages/ui/')) return true;
+  if (path.startsWith('packages/app/src/window/')) return true;
+  if (path === 'packages/app/src/main.ts') return true;
+  if (path === 'packages/app/src/preload.ts') return true;
+  if (path === 'packages/app/src/app-menu.ts') return true;
+  return false;
+}
+
+export function getUiImpactingFiles(files) {
+  return files.filter(isUiImpactingPath);
+}
+
+function changedFilesSinceBase(baseBranch) {
+  try {
+    const output = execFileSync(
+      'git',
+      ['diff', '--name-only', `${DEFAULT_PARENT_REMOTE}/${baseBranch}...HEAD`],
+      { encoding: 'utf-8' },
+    ).trim();
+    return output ? output.split('\n').filter(Boolean) : [];
+  } catch {
+    return [];
+  }
+}
+
+
 function assertCleanPrBase(baseBranch) {
   if (!hasRemote(DEFAULT_PARENT_REMOTE)) {
     throw new Error(
@@ -379,7 +412,13 @@ async function main() {
     body = args.body;
   }
 
-  assertValidPrBody(body);
+  const changedFiles = changedFilesSinceBase(args.base);
+  const uiImpactingFiles = getUiImpactingFiles(changedFiles);
+  if (uiImpactingFiles.length > 0) {
+    console.error(`UI-impacting files changed; requiring visual proof: ${uiImpactingFiles.join(', ')}`);
+  }
+
+  assertValidPrBody(body, { requiresVisualProof: uiImpactingFiles.length > 0 });
   printPrBodyWarnings(body);
 
   // Inject images
@@ -402,7 +441,9 @@ async function main() {
   console.log(prUrl);
 }
 
-main().catch((error) => {
-  console.error(`Error: ${error.message}`);
-  process.exit(1);
-});
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/pr-body-template.md
+++ b/scripts/pr-body-template.md
@@ -29,6 +29,10 @@ graph TD
 - [ ] `exact command`
 - [ ] `exact command`
 
+## Visual Proof
+
+Required when the diff changes UI-impacting files. Include before/after screenshots or a video link.
+
 ## Revert Plan
 
 - Safe to revert? Yes/No

--- a/scripts/test-create-pr-visual-proof.mjs
+++ b/scripts/test-create-pr-visual-proof.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+import { getUiImpactingFiles, isUiImpactingPath } from './create-pr.mjs';
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+assert(isUiImpactingPath('packages/ui/src/App.tsx'), 'packages/ui changes should require visual proof');
+assert(isUiImpactingPath('packages/app/src/window/window-lifecycle.ts'), 'Electron window changes should require visual proof');
+assert(isUiImpactingPath('packages/app/src/preload.ts'), 'preload bridge changes should require visual proof');
+assert(isUiImpactingPath('packages/app/src/main.ts'), 'main window wiring changes should require visual proof');
+assert(isUiImpactingPath('packages/app/src/app-menu.ts'), 'app menu changes should require visual proof');
+assert(!isUiImpactingPath('packages/execution-engine/src/merge-runner.ts'), 'non-UI engine changes should not require visual proof');
+assert(!isUiImpactingPath('scripts/create-pr.mjs'), 'PR tooling changes should not require visual proof');
+
+const uiFiles = getUiImpactingFiles([
+  'scripts/create-pr.mjs',
+  'packages/ui/src/components/TaskPanel.tsx',
+  'packages/app/src/window/window-lifecycle.ts',
+]);
+assert(uiFiles.length === 2, 'only UI-impacting files should be returned');
+assert(uiFiles.includes('packages/ui/src/components/TaskPanel.tsx'), 'UI component file should be returned');
+assert(uiFiles.includes('packages/app/src/window/window-lifecycle.ts'), 'window file should be returned');
+
+console.log('OK: create-pr visual proof checks passed');

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -136,4 +136,35 @@ const longSummaryWarnings = getPrBodyWarnings(longSummary);
 assert(validatePrBody(longSummary).length === 0, 'summary readability warnings should not fail validation');
 assert(longSummaryWarnings.some((warning) => warning.includes('Summary paragraph 1')), 'long summary paragraph should warn');
 
+
+const missingVisualProofErrors = validatePrBody(validMinimal, { requiresVisualProof: true });
+assert(
+  missingVisualProofErrors.some((error) => error.includes('UI-impacting changes require a ## Visual Proof section')),
+  'UI-impacting changes should require visual proof media',
+);
+
+const validVisualProof = `${validMinimal}
+
+## Visual Proof
+
+| Before | After |
+|--------|-------|
+| ![before](before.png) | ![after](after.png) |
+`;
+assert(
+  validatePrBody(validVisualProof, { requiresVisualProof: true }).length === 0,
+  'visual proof with screenshots should satisfy UI proof requirement',
+);
+
+const warningOnlyVisualProofErrors = validatePrBody(`${validMinimal}
+
+## Visual Proof
+
+> Warning: visual proof capture failed.
+`, { requiresVisualProof: true });
+assert(
+  warningOnlyVisualProofErrors.some((error) => error.includes('UI-impacting changes require a ## Visual Proof section')),
+  'warning-only visual proof should not satisfy UI proof requirement',
+);
+
 console.log('OK: PR body validator checks passed');

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -27,6 +27,16 @@ function countWords(text) {
     .filter(Boolean).length;
 }
 
+function hasVisualProofMedia(body) {
+  const visualProof = getSectionBody(body, '## Visual Proof');
+  if (!visualProof) return false;
+
+  return /!\[[^\]]*\]\([^)]+\)/.test(visualProof)
+    || /\[[^\]]*(?:video|walkthrough|recording)[^\]]*\]\([^)]+\)/i.test(visualProof)
+    || /\bhttps?:\/\/\S+\.(?:png|jpe?g|gif|webp|webm|mp4)\b/i.test(visualProof);
+}
+
+
 export function getPrBodyWarnings(body) {
   const warnings = [];
   const summary = getSectionBody(body, '## Summary');
@@ -45,7 +55,7 @@ export function getPrBodyWarnings(body) {
   return warnings;
 }
 
-export function validatePrBody(body) {
+export function validatePrBody(body, options = {}) {
   const errors = [];
   const trimmed = body.trim();
 
@@ -77,22 +87,29 @@ export function validatePrBody(body) {
     }
   }
 
+
+  if (options.requiresVisualProof && !hasVisualProofMedia(trimmed)) {
+    errors.push(
+      'UI-impacting changes require a ## Visual Proof section with at least one screenshot image or video/walkthrough link.',
+    );
+  }
   return errors;
 }
 
 function usage() {
-  console.error(`Usage: node scripts/validate-pr-body.mjs (--body-file <file> | --body <markdown>)
+  console.error(`Usage: node scripts/validate-pr-body.mjs (--body-file <file> | --body <markdown>) [--require-visual-proof]
 
 Validates the canonical PR schema:
   Required: ## Summary, ## Test Plan, ## Revert Plan
-  Optional: ## Architecture (must include ### Before and ### After when present)`);
+  Optional: ## Architecture (must include ### Before and ### After when present)
+  UI changes: pass --require-visual-proof to require screenshot or video proof.`);
   process.exit(1);
 }
 
 function parseArgs(argv) {
   let body = '';
   let bodyFile = '';
-
+  let requiresVisualProof = false;
   for (let i = 0; i < argv.length; i++) {
     switch (argv[i]) {
       case '--body':
@@ -100,6 +117,9 @@ function parseArgs(argv) {
         break;
       case '--body-file':
         bodyFile = argv[++i] || '';
+        break;
+      case '--require-visual-proof':
+        requiresVisualProof = true;
         break;
       case '--help':
         usage();
@@ -115,13 +135,13 @@ function parseArgs(argv) {
     usage();
   }
 
-  return { body, bodyFile };
+  return { body, bodyFile, requiresVisualProof };
 }
 
 function main() {
   const args = parseArgs(process.argv.slice(2));
   const body = args.bodyFile ? readFileSync(args.bodyFile, 'utf-8') : args.body;
-  const errors = validatePrBody(body);
+  const errors = validatePrBody(body, { requiresVisualProof: args.requiresVisualProof });
   const warnings = getPrBodyWarnings(body);
 
   if (errors.length > 0) {

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -58,6 +58,10 @@ Only include this section when the change modifies component interactions, contr
 - [ ] exact command
 - [ ] exact command
 
+## Visual Proof
+
+Required when the diff changes UI-impacting files. Include before/after screenshots or a video link.
+
 ## Revert Plan
 
 - Safe to revert? Yes/No
@@ -68,7 +72,9 @@ Only include this section when the change modifies component interactions, contr
 
 If the change is small and has no architectural impact, omit `## Architecture` rather than forcing filler.
 
-Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Test Plan / ## Revert Plan` as the floor, and add `## Architecture` when the change affects component interactions or data/control flow.
+If the change touches UI-impacting files, use `skills/visual-proof/SKILL.md` first and include its screenshot/video markdown in `## Visual Proof`. UI-impacting files include `packages/ui/**`, Electron window lifecycle files, preload, main process window wiring, and app menu changes.
+
+Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Test Plan / ## Revert Plan` as the floor, add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.
 
 ## Command surface
 
@@ -97,7 +103,7 @@ Update an existing PR with:
 node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-pr.md --update <pr-number>
 ```
 
-This script handles local image path upload/injection when configured.
+This script handles local image path upload/injection when configured. It also rejects UI-impacting diffs unless the body includes visual proof media.
 
 ## Upstream-first workflow
 
@@ -135,6 +141,7 @@ Before creating a PR:
 - ensure test commands are real commands that were actually run when possible
 - ensure revert guidance is honest
 - validate the body with `node scripts/validate-pr-body.mjs --body-file <file>`
+- for UI-impacting diffs, include `## Visual Proof` with screenshot or video proof before `node scripts/create-pr.mjs`
 
 If you include `## Architecture`, keep the diagrams renderable by GitHub Mermaid.
 Reference:

--- a/skills/plan-to-invoker/references/schema.md
+++ b/skills/plan-to-invoker/references/schema.md
@@ -8,7 +8,7 @@ Source of truth: `packages/app/src/plan-parser.ts` (interfaces + validation, lin
 |-------|------|---------|-------------|
 | `name` | string | *required* | Always. Short, descriptive. |
 | `description` | string | — | **Required** when onFinish is pull_request or merge. Validator rejects plans without it. 1-3 paragraphs: architecture, motivations, tradeoffs. Include mermaid before/after architecture diagrams when the change modifies component interactions or data flow (GitHub renders them natively in the PR body). See `examples.md` Example 4. |
-| `visualProof` | boolean | false | Set true when plan modifies UI packages (packages/ui/). Triggers automatic before/after screenshot capture in the merge gate. |
+| `visualProof` | boolean | false | Set true when the plan modifies UI-impacting files, including `packages/ui/**` and Electron window/preload/main UI wiring. Triggers automatic before/after screenshot capture in the merge gate. |
 | `onFinish` | `pull_request` \| `merge` \| `none` | `pull_request` | `pull_request` for code changes needing review. `none` for tests/diagnostics/verification. `merge` rarely — auto-merge after completion. |
 | `baseBranch` | string | auto-detected | Omit unless targeting a non-default branch. |
 | `featureBranch` | string | auto-generated from name | Omit — auto-generates as `plan/<slug>`. Set only to target a specific branch. |

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -18,7 +18,7 @@ Source of truth: `packages/surfaces/src/slack/plan-conversation.ts:100-116`
 | "Check file exists" | `command` | `test -f <path>` |
 | "Check pattern in file" | `command` | `grep -q '<pattern>' <path>` |
 | **Post-fix / regression** (standalone or terminal stack gate) | `command` | `pnpm run test:all` — keep focused repro commands earlier in the plan, and reserve the full-suite gate for standalone plans or the terminal stack workflow |
-| "Modify UI component" / "Fix layout" | `prompt` + `visualProof: true` | Set `visualProof: true` at plan level; include `description` |
+| "Modify UI component" / "Fix layout" / "Change Electron window UI" | `prompt` + `visualProof: true` | Set `visualProof: true` at plan level; include `description` |
 | **Add visual proof E2E test case** | `prompt` | Add a test to `packages/app/e2e/visual-proof.spec.ts` that sets up the exact UI state being changed and calls `captureScreenshot(page, '<plan-slug>-<state>')`. See `skills/visual-proof/SKILL.md`. |
 | **Capture visual proof (after)** | `command` | `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after` — depends on **all** implementation tasks |
 | **Invoker-on-Invoker PR publication** | repo-level workflow note | Keep `onFinish: pull_request` + `mergeMode: github`, then publish/update the commit stack with `mergify stack push` once the branch is ready |
@@ -229,7 +229,7 @@ When writing `command` fields:
 
 ## UI Change Plans
 
-Plans that modify UI components (`packages/ui/`) must:
+Plans that modify UI-impacting files (`packages/ui/**`, Electron window lifecycle, preload/main window wiring, or app menu surface) must:
 1. Set `visualProof: true` at the plan level
 2. Include a `description` with architecture context
 3. Include a `prompt` task that adds a **plan-specific** E2E test case to `visual-proof.spec.ts`


### PR DESCRIPTION
## Summary

PR creation now blocks UI-impacting diffs unless the body includes screenshot or video proof.

The old path only uploaded proof that was already present. It did not notice UI changes or require the visual-proof skill.

This adds diff-based detection, stricter body validation, and skill docs so missing proof fails before a PR is opened.

## Architecture

### Before

```mermaid
graph TD
    A[create-pr] --> B[Validate canonical sections]
    B --> C[Upload linked images]
    C --> D[Create PR]
```

### After

```mermaid
graph TD
    A[create-pr] --> B[Read changed files vs upstream base]
    B --> C{UI-impacting diff?}
    C -->|No| D[Validate canonical sections]
    C -->|Yes| E[Require Visual Proof media]
    E --> D
    D --> F[Upload linked images]
    F --> G[Create PR]
```

## Test Plan

- [x] `node scripts/test-pr-body-validator.mjs && node scripts/test-create-pr-visual-proof.mjs`
- [x] `node scripts/validate-pr-body.mjs --body '## Summary\n\nSmall fix.\n\n## Test Plan\n\n- [x] \`node scripts/test-pr-body-validator.mjs\`\n\n## Revert Plan\n\n- Safe to revert? Yes' --require-visual-proof` exits 1 with the expected missing-proof error
- [x] `node scripts/validate-pr-body.mjs --body '## Summary\n\nSmall fix.\n\n## Test Plan\n\n- [x] \`node scripts/test-pr-body-validator.mjs\`\n\n## Visual Proof\n\n![after](after.png)\n\n## Revert Plan\n\n- Safe to revert? Yes' --require-visual-proof`
- [x] `node scripts/create-pr.mjs --dry-run --title 'Dry run visual proof enforcement' --base master --body-file scripts/pr-body-template.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <PR commit SHA>`
- Post-revert steps: None
- Data migration? No