### PR TITLE
Serialize lifecycle createdAt from Date inputs

### DIFF
--- a/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
+++ b/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
@@ -8,6 +8,7 @@ import {
 import { startLifecycleEventBridge } from '../lifecycle-event-bridge.js';
 
 const CREATED_AT = '2026-06-04T00:00:00.000Z';
+const CREATED_AT_DATE = new Date(CREATED_AT);
 
 function makeTask(overrides: Partial<TaskState> = {}): TaskState {
   return {
@@ -33,7 +34,7 @@ describe('lifecycle event bridge', () => {
   it('publishes task.created lifecycle events from created deltas', () => {
     const bus = new LocalBus();
     const events = collectLifecycleEvents(bus);
-    startLifecycleEventBridge({ messageBus: bus, now: () => CREATED_AT });
+    startLifecycleEventBridge({ messageBus: bus, now: () => CREATED_AT_DATE });
 
     bus.publish<TaskDelta>(Channels.TASK_DELTA, { type: 'created', task: makeTask() });
 
@@ -64,7 +65,7 @@ describe('lifecycle event bridge', () => {
     startLifecycleEventBridge({
       messageBus: bus,
       getInitialTasks: () => [makeTask({ status: 'running', taskStateVersion: 5 })],
-      now: () => CREATED_AT,
+      now: () => CREATED_AT_DATE,
     });
 
     bus.publish<TaskDelta>(Channels.TASK_DELTA, {
@@ -96,7 +97,7 @@ describe('lifecycle event bridge', () => {
     startLifecycleEventBridge({
       messageBus: bus,
       getInitialTasks: () => [makeTask({ status: 'running', taskStateVersion: 8 })],
-      now: () => CREATED_AT,
+      now: () => CREATED_AT_DATE,
     });
 
     bus.publish<TaskDelta>(Channels.TASK_DELTA, {
@@ -128,7 +129,7 @@ describe('lifecycle event bridge', () => {
     startLifecycleEventBridge({
       messageBus: bus,
       getInitialTasks: () => [makeTask({ status: 'failed', taskStateVersion: 9 })],
-      now: () => CREATED_AT,
+      now: () => CREATED_AT_DATE,
     });
 
     bus.publish<TaskDelta>(Channels.TASK_DELTA, {
@@ -164,7 +165,7 @@ describe('lifecycle event bridge', () => {
     startLifecycleEventBridge({
       messageBus: bus,
       getInitialTasks: () => [makeTask({ status: 'running', taskStateVersion: 5 })],
-      now: () => CREATED_AT,
+      now: () => CREATED_AT_DATE,
     });
 
     bus.publish<TaskDelta>(Channels.TASK_DELTA, {
@@ -185,7 +186,7 @@ describe('lifecycle event bridge', () => {
   it('unsubscribes cleanly', () => {
     const bus = new LocalBus();
     const events = collectLifecycleEvents(bus);
-    const bridge = startLifecycleEventBridge({ messageBus: bus, now: () => CREATED_AT });
+    const bridge = startLifecycleEventBridge({ messageBus: bus, now: () => CREATED_AT_DATE });
 
     bridge.stop();
     bus.publish<TaskDelta>(Channels.TASK_DELTA, { type: 'created', task: makeTask() });

--- a/packages/app/src/__tests__/lifecycle-events.test.ts
+++ b/packages/app/src/__tests__/lifecycle-events.test.ts
@@ -12,6 +12,7 @@ import {
 } from '../lifecycle-events.js';
 
 const CREATED_AT = '2026-06-04T00:00:00.000Z';
+const CREATED_AT_DATE = new Date(CREATED_AT);
 
 function makeTask(overrides: Partial<TaskState> = {}): TaskState {
   return {
@@ -39,7 +40,7 @@ describe('lifecycle event helpers', () => {
   it('builds task.created from created deltas', () => {
     const event = buildLifecycleEventFromTaskDelta(
       { type: 'created', task: makeTask() },
-      { createdAt: CREATED_AT },
+      { createdAt: CREATED_AT_DATE },
     );
 
     expect(event).toMatchObject({
@@ -68,7 +69,7 @@ describe('lifecycle event helpers', () => {
     const event = buildLifecycleEventFromTaskDelta(delta, {
       workflowId: 'wf-1',
       previousStatus: 'pending',
-      createdAt: CREATED_AT,
+      createdAt: CREATED_AT_DATE,
     });
 
     expect(event).toMatchObject({
@@ -97,7 +98,7 @@ describe('lifecycle event helpers', () => {
       taskStateVersion: 3,
       generation: 4,
       attemptId: 'attempt-2',
-      createdAt: CREATED_AT,
+      createdAt: CREATED_AT_DATE,
     });
     const failed = buildTaskUpdatedLifecycleEvent({
       workflowId: 'wf-1',
@@ -107,7 +108,7 @@ describe('lifecycle event helpers', () => {
       taskStateVersion: 4,
       generation: 1,
       attemptId: 'attempt-3',
-      createdAt: CREATED_AT,
+      createdAt: CREATED_AT_DATE,
     });
 
     expect(completed.kind).toBe('task.completed');
@@ -124,7 +125,7 @@ describe('lifecycle event helpers', () => {
       previousStatus: 'running',
       taskStateVersion: 5,
       generation: 2,
-      createdAt: CREATED_AT,
+      createdAt: CREATED_AT_DATE,
     });
 
     expect(reviewReady.kind).toBe('task.review_ready');
@@ -138,7 +139,7 @@ describe('lifecycle event helpers', () => {
       previousStatus: 'running',
       taskStateVersion: 6,
       generation: 2,
-      createdAt: CREATED_AT,
+      createdAt: CREATED_AT_DATE,
     });
 
     expect(lifecycleEventKindForTaskStatus('needs_input')).toBe('task.needs_input');
@@ -154,7 +155,7 @@ describe('lifecycle event helpers', () => {
         previousStatus: 'failed',
         generation: 6,
         attemptId: 'attempt-9',
-        createdAt: CREATED_AT,
+        createdAt: CREATED_AT_DATE,
       },
     );
 
@@ -188,7 +189,7 @@ describe('lifecycle event helpers', () => {
       statusText: 'CI failed',
       generation: 7,
       attemptId: 'attempt-merge',
-      createdAt: CREATED_AT,
+      createdAt: CREATED_AT_DATE,
     });
 
     expect(event).toMatchObject({
@@ -218,7 +219,7 @@ describe('lifecycle event helpers', () => {
       status: 'running',
       generation: 8,
       reason: 'stalled_workflow_recovery',
-      createdAt: CREATED_AT,
+      createdAt: CREATED_AT_DATE,
     });
 
     expect(event).toEqual({
@@ -233,13 +234,71 @@ describe('lifecycle event helpers', () => {
     expect(isWorkflowLifecycleEvent(event)).toBe(true);
   });
 
+  it('defaults omitted createdAt values to canonical UTC ISO timestamps', () => {
+    const event = buildWorkflowWakeupLifecycleEvent({
+      workflowId: 'wf-1',
+      generation: 1,
+      reason: 'manual_reconcile',
+    });
+
+    expect(event.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(isWorkflowLifecycleEvent(event)).toBe(true);
+  });
+
+  it('rejects non-Date createdAt values at lifecycle builder boundaries', () => {
+    const invalidCreatedAtValues = [
+      '2026-06-04T00:00:00Z',
+      '2026-06-04T00:00:00.000+00:00',
+      'not-a-date',
+      123,
+      new Date('not-a-date'),
+    ];
+
+    for (const createdAt of invalidCreatedAtValues) {
+      expect(() => buildTaskUpdatedLifecycleEvent({
+        workflowId: 'wf-1',
+        taskId: 'wf-1/task-a',
+        status: 'failed',
+        taskStateVersion: 1,
+        generation: 1,
+        createdAt: createdAt as Date,
+      })).toThrow(/createdAt must be a valid Date/);
+    }
+
+    expect(() => buildReviewGateCiFailedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      taskStateVersion: 12,
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      failedChecks: [],
+      statusText: 'CI failed',
+      generation: 7,
+      createdAt: '2026-06-04T00:00:00Z' as unknown as Date,
+    })).toThrow(/createdAt must be a valid Date/);
+
+    expect(() => buildWorkflowWakeupLifecycleEvent({
+      workflowId: 'wf-1',
+      generation: 1,
+      reason: 'manual_reconcile',
+      createdAt: '2026-06-04T00:00:00Z' as unknown as Date,
+    })).toThrow(/createdAt must be a valid Date/);
+  });
+
   it('rejects malformed lifecycle events', () => {
     expect(isWorkflowLifecycleEvent({ kind: 'task.failed' })).toBe(false);
     expect(isWorkflowLifecycleEvent({ ...buildWorkflowWakeupLifecycleEvent({
       workflowId: 'wf-1',
       generation: 1,
       reason: 'manual_reconcile',
-      createdAt: CREATED_AT,
+      createdAt: CREATED_AT_DATE,
     }), generation: '1' })).toBe(false);
+    expect(isWorkflowLifecycleEvent({ ...buildWorkflowWakeupLifecycleEvent({
+      workflowId: 'wf-1',
+      generation: 1,
+      reason: 'manual_reconcile',
+      createdAt: CREATED_AT_DATE,
+    }), createdAt: '2026-06-04T00:00:00Z' })).toBe(false);
   });
 });

--- a/packages/app/src/lifecycle-event-bridge.ts
+++ b/packages/app/src/lifecycle-event-bridge.ts
@@ -19,7 +19,7 @@ export interface LifecycleEventBridgeOptions {
   readonly messageBus: MessageBus;
   readonly getInitialTasks?: () => readonly TaskState[];
   readonly getTask?: (taskId: string) => TaskState | undefined;
-  readonly now?: () => string | Date;
+  readonly now?: () => Date;
   readonly logger?: {
     warn(message: string, details?: Record<string, unknown>): void;
   };

--- a/packages/app/src/lifecycle-events.ts
+++ b/packages/app/src/lifecycle-events.ts
@@ -89,7 +89,7 @@ export interface LifecycleBuildOptions {
   readonly previousStatus?: TaskStatus;
   readonly generation?: number;
   readonly attemptId?: string;
-  readonly createdAt?: string | Date;
+  readonly createdAt?: Date;
 }
 
 export interface TaskUpdatedLifecycleEventInput extends LifecycleBuildOptions {
@@ -125,7 +125,7 @@ export interface WorkflowWakeupLifecycleEventInput {
   readonly status?: WorkflowDerivedStatus;
   readonly generation?: number;
   readonly reason: WorkflowWakeupReason;
-  readonly createdAt?: string | Date;
+  readonly createdAt?: Date;
 }
 
 const STATUS_VALUES: readonly WorkflowLifecycleStatus[] = [
@@ -232,6 +232,7 @@ export function buildTaskRemovedLifecycleEvent(input: TaskRemovedLifecycleEventI
 export function buildReviewGateCiFailedLifecycleEvent(
   input: ReviewGateCiFailedLifecycleEventInput,
 ): ReviewGateCiFailedLifecycleEvent {
+  const createdAt = lifecycleCreatedAt(input.createdAt);
   const eventKey = buildLifecycleEventKey({
     kind: 'review_gate.ci_failed',
     workflowId: input.workflowId,
@@ -252,7 +253,7 @@ export function buildReviewGateCiFailedLifecycleEvent(
     generation: input.generation ?? 0,
     ...(input.previousStatus ? { previousStatus: input.previousStatus } : {}),
     ...(input.attemptId ? { attemptId: input.attemptId } : {}),
-    createdAt: normalizeCreatedAt(input.createdAt),
+    createdAt,
     reviewId: input.reviewId,
     reviewUrl: input.reviewUrl,
     ...(input.headSha ? { headSha: input.headSha } : {}),
@@ -267,6 +268,7 @@ export function buildWorkflowWakeupLifecycleEvent(
   input: WorkflowWakeupLifecycleEventInput,
 ): WorkflowWakeupLifecycleEvent {
   const generation = input.generation ?? 0;
+  const createdAt = lifecycleCreatedAt(input.createdAt);
   return {
     eventKey: buildLifecycleEventKey({
       kind: 'workflow.wakeup',
@@ -278,7 +280,7 @@ export function buildWorkflowWakeupLifecycleEvent(
     workflowId: input.workflowId,
     ...(input.status ? { status: input.status } : {}),
     generation,
-    createdAt: normalizeCreatedAt(input.createdAt),
+    createdAt,
     reason: input.reason,
   };
 }
@@ -327,6 +329,7 @@ export function isWorkflowLifecycleEvent(value: unknown): value is WorkflowLifec
   if (!isWorkflowLifecycleEventKind(value.kind)) return false;
   if (typeof value.workflowId !== 'string') return false;
   if (typeof value.createdAt !== 'string') return false;
+  if (!isCanonicalUtcIsoTimestamp(value.createdAt)) return false;
   if (typeof value.generation !== 'number') return false;
   if (value.taskId != null && typeof value.taskId !== 'string') return false;
   if (value.status != null && !isWorkflowLifecycleStatus(value.status)) return false;
@@ -372,8 +375,9 @@ function buildTaskLifecycleEvent(input: {
   readonly taskStateVersion: number;
   readonly generation: number;
   readonly attemptId?: string;
-  readonly createdAt?: string | Date;
+  readonly createdAt?: Date;
 }): TaskLifecycleEvent {
+  const createdAt = lifecycleCreatedAt(input.createdAt);
   return {
     eventKey: buildLifecycleEventKey(input),
     kind: input.kind,
@@ -384,13 +388,25 @@ function buildTaskLifecycleEvent(input: {
     taskStateVersion: input.taskStateVersion,
     generation: input.generation,
     ...(input.attemptId ? { attemptId: input.attemptId } : {}),
-    createdAt: normalizeCreatedAt(input.createdAt),
+    createdAt,
   };
 }
 
-function normalizeCreatedAt(createdAt: string | Date | undefined): string {
-  if (createdAt instanceof Date) return createdAt.toISOString();
-  return createdAt ?? new Date().toISOString();
+function lifecycleCreatedAt(createdAt: unknown): string {
+  const value = createdAt ?? new Date();
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new Error('createdAt must be a valid Date');
+  }
+  return value.toISOString();
+}
+
+function isCanonicalUtcIsoTimestamp(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) {
+    return false;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return parsed.toISOString() === value;
 }
 
 function requireWorkflowId(workflowId: string | undefined, taskId: string): string {


### PR DESCRIPTION
## Summary

Lifecycle event builders now accept `Date` inputs for explicit `createdAt` values.

The event boundary serializes those dates to canonical ISO strings, so published lifecycle payloads stay transport-safe.

Invalid runtime values are rejected by the builder functions before events are emitted.

## Test Plan

- [x] `pnpm --dir packages/app test src/__tests__/lifecycle-events.test.ts src/__tests__/lifecycle-event-bridge.test.ts`
- [x] `pnpm --dir packages/app test src/__tests__/lifecycle-events.test.ts src/__tests__/lifecycle-event-bridge.test.ts src/__tests__/review-gate-status-worker.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 19c9d3b77`
- Post-revert steps: Rebase or retarget stacked PR #1501 back to `master` if this lower PR is removed.
- Data migration? No
