### PR TITLE
test(ui): keep task recreation actions task scoped

### DIFF
--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -183,6 +183,7 @@ describe('Context menu (component)', () => {
 
     await waitFor(() => expect(mock.api.recreateDownstream).toHaveBeenCalledWith('task-alpha'));
     expect(mock.api.recreateTask).not.toHaveBeenCalled();
+    expect(mock.api.recreateWorkflow).not.toHaveBeenCalled();
   });
 
   it('task context menu disables Recreate Downstream while the task is running', async () => {
@@ -222,6 +223,7 @@ describe('Context menu (component)', () => {
 
     await waitFor(() => expect(mock.api.recreateTask).toHaveBeenCalledWith('task-alpha'));
     expect(mock.api.recreateDownstream).not.toHaveBeenCalled();
+    expect(mock.api.recreateWorkflow).not.toHaveBeenCalled();
   });
 
   it('workflow context menu retries workflow', async () => {


### PR DESCRIPTION
## Summary

This keeps the task context menu honest.

Clicking task recreation actions must call task APIs, not the workflow recreate API.

This preserved PR is intentionally tiny and last in the stack.

## Review Claim

Task recreation menu actions should stay task-scoped in the UI regression test.

## Review Lane

proof

## Safety Invariant

Only test expectations change. Product behavior is unchanged in this slice.

## Slice Rationale

This remains last because it preserves the original PR number while lower PRs carry the behavior fixes.

## Non-goals

This does not change UI behavior, API behavior, or workflow behavior.

## Test Plan

- [x] `pnpm --filter @invoker/ui test -- context-menu-e2e.test.tsx`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-mutation-startup.test.ts src/__tests__/api-server.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 283c919e41c9b5e394f0f7ece784944a6a25f54f`
- Post-revert steps: None
- Data migration? No
