### PR TITLE
Fix contracts native TypeScript imports

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,11 +1,11 @@
 // @invoker/contracts - Shared interfaces and type definitions
 
-export * from './types.js';
-export * from './validation.js';
-export * from './logger.js';
-export * from './command-envelope.js';
-export * from './ipc-channels.js';
-export * from './repo-root.js';
-export * from './cost-types.js';
-export * from './launch-timeouts.js';
-export * from './invoker-home.js';
+export * from './types.ts';
+export * from './validation.ts';
+export * from './logger.ts';
+export * from './command-envelope.ts';
+export * from './ipc-channels.ts';
+export * from './repo-root.ts';
+export * from './cost-types.ts';
+export * from './launch-timeouts.ts';
+export * from './invoker-home.ts';

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -3,7 +3,7 @@
  * Lightweight runtime checks (no external schema library).
  */
 
-import type { WorkRequest, WorkResponse } from './types.js';
+import type { WorkRequest, WorkResponse } from './types.ts';
 
 export interface ValidationResult {
   valid: boolean;

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "composite": false
+    "composite": false,
+    "allowImportingTsExtensions": true
   },
   "include": [
     "src/**/*.ts"

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -4,6 +4,7 @@
     "composite": false,
     "incremental": false,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "rootDir": ".",
     "outDir": "./dist-typecheck"
   },


### PR DESCRIPTION
## Summary

This fixes a startup failure in the retry flow.

One contracts file pointed at the built file name, not the source file name. When a workspace package loaded the source directly, Node stopped before the retry loop started.

The fix makes the source imports line up with the source files.

## Test Plan

- [ ] pnpm --filter @invoker/contracts build
- [ ] pnpm --filter @invoker/contracts test
- [ ] pnpm run check:types
- [ ] pnpm --filter @invoker/app build

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0db2c3788
- Post-revert steps: None
- Data migration? No
