### PR TITLE
Clear pool routing when switching to worktree

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -4091,7 +4091,7 @@ describe('Orchestrator', () => {
       expect(persisted?.task.config.poolMemberId).toBe('remote_digital_ocean');
     });
 
-    it('clears poolMemberId when switching away from ssh', () => {
+    it('clears pool placement when switching away from ssh', () => {
       orchestrator.loadPlan({
         name: 'edit-type-clear-remote',
         tasks: [{ id: 't1', description: 'Task 1', command: 'echo hello', poolId: 'ssh-light' }],
@@ -4105,6 +4105,7 @@ describe('Orchestrator', () => {
       orchestrator.editTaskType('t1', 'worktree');
 
       const task = orchestrator.getTask('t1');
+      expect(task?.config.poolId).toBeUndefined();
       expect(task?.config.runnerKind).toBe('worktree');
       expect(task?.config.poolMemberId).toBeUndefined();
     });
@@ -4281,6 +4282,7 @@ describe('Orchestrator', () => {
       orchestrator.editTaskType(taskId, 'worktree');
 
       const task = orchestrator.getTask(taskId)!;
+      expect(task.config.poolId).toBeUndefined();
       expect(task.config.runnerKind).toBe('worktree');
       expect(task.config.poolMemberId).toBeUndefined();
       expect(task.execution.branch).toBeUndefined();

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2842,6 +2842,7 @@ export class Orchestrator {
     if (effectiveType === 'ssh') {
       configPatch.poolMemberId = poolMemberId;
     } else {
+      configPatch.poolId = undefined;
       configPatch.poolMemberId = undefined;
     }
     const typeChanges: TaskStateChanges = { config: configPatch };


### PR DESCRIPTION
## Summary

This makes "switch to worktree" actually stop using SSH.

The task kept old SSH routing data after the switch. So even though the UI said worktree, the runner could still send the task back to SSH.

The fix clears the leftover SSH routing data when the task moves to worktree.

## Architecture

### Before

```mermaid
flowchart LR
  A[editTaskType to worktree] --> B[Clear poolMemberId only]
  B --> C[poolId still set]
  C --> D[TaskRunner keeps SSH pool routing]
```

### After

```mermaid
flowchart LR
  A[editTaskType to worktree] --> B[Clear poolMemberId and poolId]
  B --> C[No SSH placement remains]
  C --> D[TaskRunner selects worktree]
```

## Test Plan

- [ ] pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts -t "clears pool placement|switching ssh → worktree"
- [ ] pnpm run check:types

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 44d6cc335`
- Post-revert steps: None
- Data migration? No
