### PR TITLE
Enforce TS-safe imports for source-export packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,10 +41,11 @@
     "check:required-builds": "bash scripts/required-builds.sh",
     "check:deps": "depcruise packages --config .dependency-cruiser.js",
     "check:types": "tsc -p tsconfig.typecheck.json",
+    "check:ts-source-imports": "node scripts/check-ts-source-imports.mjs",
     "check:large-files": "node scripts/check-large-files.mjs",
     "check:versions": "node scripts/check-version-sync.mjs",
     "bump-version": "node scripts/bump-version.mjs",
-    "check:all": "pnpm run check:deps && pnpm run check:types && pnpm run check:required-builds && pnpm run check:large-files && pnpm run check:versions && bash scripts/check-owner-boundary.sh",
+    "check:all": "pnpm run check:deps && pnpm run check:types && pnpm run check:required-builds && pnpm run check:ts-source-imports && pnpm run check:large-files && pnpm run check:versions && bash scripts/check-owner-boundary.sh",
     "lint": "pnpm run check:all"
   },
   "pnpm": {

--- a/scripts/check-ts-source-imports.mjs
+++ b/scripts/check-ts-source-imports.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const SOURCE_EXTENSIONS = new Set(['.ts', '.tsx']);
+const IGNORED_DIRS = new Set([
+  '.git',
+  'build',
+  'coverage',
+  'dist',
+  'e2e',
+  'fixtures',
+  'node_modules',
+  'out',
+  '__generated__',
+  '__tests__',
+]);
+const TEMPORARY_LEGACY_JS_IMPORT_EXCEPTIONS = new Set([
+  'data-store',
+  'execution-engine',
+  'graph',
+  'runtime-adapters',
+  'runtime-domain',
+  'runtime-service',
+  'svc-api',
+  'test-kit',
+  'transport',
+  'workflow-core',
+  'workflow-graph',
+]);
+const RELATIVE_JS_IMPORT = /(?:from\s+['\"](\.{1,2}\/[^'\"]*\.js)['\"]|import\s+['\"](\.{1,2}\/[^'\"]*\.js)['\"])/g;
+
+function usage() {
+  console.error('Usage: node scripts/check-ts-source-imports.mjs [--root <path>]');
+}
+
+function parseArgs(argv) {
+  let root = process.cwd();
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--root') {
+      root = argv[index + 1];
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--root=')) {
+      root = arg.slice('--root='.length);
+      continue;
+    }
+    if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    }
+    console.error(`[ts-source-imports] Unknown argument: ${arg}`);
+    usage();
+    process.exit(2);
+  }
+  return path.resolve(root);
+}
+
+function pathExists(targetPath) {
+  try {
+    statSync(targetPath);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isTestSource(filePath) {
+  const basename = path.basename(filePath);
+  return basename.includes('.test.') || basename.includes('.spec.') || basename.includes('.stories.');
+}
+
+function walk(dir, visit) {
+  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRS.has(entry.name)) {
+        walk(entryPath, visit);
+      }
+      continue;
+    }
+    if (entry.isFile()) {
+      visit(entryPath);
+    }
+  }
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, 'utf8'));
+}
+
+function findTsExportedPackages(root) {
+  const packagesRoot = path.join(root, 'packages');
+  if (!pathExists(packagesRoot)) {
+    return [];
+  }
+
+  const packages = [];
+  for (const entry of readdirSync(packagesRoot, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const packageRoot = path.join(packagesRoot, entry.name);
+    const packageJsonPath = path.join(packageRoot, 'package.json');
+    if (!pathExists(packageJsonPath)) {
+      continue;
+    }
+    const packageJson = readJson(packageJsonPath);
+    if (typeof packageJson.main !== 'string' || !packageJson.main.startsWith('src/')) {
+      continue;
+    }
+    packages.push({
+      name: entry.name,
+      root: packageRoot,
+      exempt: TEMPORARY_LEGACY_JS_IMPORT_EXCEPTIONS.has(entry.name),
+    });
+  }
+  return packages;
+}
+
+function collectViolations(root, packageInfo) {
+  const srcRoot = path.join(packageInfo.root, 'src');
+  if (!pathExists(srcRoot) || packageInfo.exempt) {
+    return [];
+  }
+
+  const violations = [];
+  walk(srcRoot, (filePath) => {
+    if (!SOURCE_EXTENSIONS.has(path.extname(filePath)) || isTestSource(filePath)) {
+      return;
+    }
+    const content = readFileSync(filePath, 'utf8');
+    const imports = [...content.matchAll(RELATIVE_JS_IMPORT)].map((match) => match[1] ?? match[2]).filter(Boolean);
+    if (imports.length === 0) {
+      return;
+    }
+    violations.push({
+      path: path.relative(root, filePath),
+      imports,
+    });
+  });
+  return violations;
+}
+
+const root = parseArgs(process.argv.slice(2));
+const packages = findTsExportedPackages(root);
+const violations = [];
+for (const packageInfo of packages) {
+  violations.push(...collectViolations(root, packageInfo));
+}
+
+violations.sort((a, b) => a.path.localeCompare(b.path));
+
+if (violations.length > 0) {
+  console.error('[ts-source-imports] TS-exported packages must not use relative .js imports in non-test source.');
+  console.error('[ts-source-imports] Migrate source imports to TS-safe paths or move the package to built-JS exports.');
+  for (const violation of violations) {
+    console.error(`[ts-source-imports] ${violation.path}: ${violation.imports.join(', ')}`);
+  }
+  process.exit(1);
+}
+
+console.log(`[ts-source-imports] Checked ${packages.length} TS-exported package(s); no forbidden relative .js imports in enforced non-test source.`);

--- a/scripts/test-suites/required/16-ts-source-import-guard.sh
+++ b/scripts/test-suites/required/16-ts-source-import-guard.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Deterministic TS source import guard proof.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+node "$ROOT/scripts/check-ts-source-imports.mjs"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/packages/clean-lib/src" \
+         "$TMP_ROOT/packages/execution-engine/src" \
+         "$TMP_ROOT/packages/runtime-app/src"
+
+cat > "$TMP_ROOT/packages/clean-lib/package.json" <<'JSON'
+{
+  "name": "clean-lib",
+  "main": "src/index.ts"
+}
+JSON
+
+cat > "$TMP_ROOT/packages/execution-engine/package.json" <<'JSON'
+{
+  "name": "execution-engine",
+  "main": "src/index.ts"
+}
+JSON
+
+cat > "$TMP_ROOT/packages/runtime-app/package.json" <<'JSON'
+{
+  "name": "runtime-app",
+  "main": "dist/main.js"
+}
+JSON
+
+cat > "$TMP_ROOT/packages/clean-lib/src/index.ts" <<'TS'
+import './bad.js';
+export const clean = true;
+TS
+
+cat > "$TMP_ROOT/packages/clean-lib/src/index.test.ts" <<'TS'
+import './test-only.js';
+export const cleanTest = true;
+TS
+
+cat > "$TMP_ROOT/packages/execution-engine/src/index.ts" <<'TS'
+import './legacy.js';
+export const legacy = true;
+TS
+
+cat > "$TMP_ROOT/packages/runtime-app/src/index.ts" <<'TS'
+import './runtime.js';
+export const runtime = true;
+TS
+
+if node "$ROOT/scripts/check-ts-source-imports.mjs" --root "$TMP_ROOT" >"$TMP_ROOT/stdout.log" 2>"$TMP_ROOT/stderr.log"; then
+  echo "[ts-source-imports] Expected TS-exported package with production .js import to fail" >&2
+  exit 1
+fi
+
+if ! grep -F "packages/clean-lib/src/index.ts: ./bad.js" "$TMP_ROOT/stderr.log" >/dev/null; then
+  echo "[ts-source-imports] Forbidden production .js import was not reported deterministically" >&2
+  cat "$TMP_ROOT/stderr.log" >&2
+  exit 1
+fi
+
+if grep -F "index.test.ts" "$TMP_ROOT/stderr.log" >/dev/null; then
+  echo "[ts-source-imports] Test-only .js import should be ignored" >&2
+  cat "$TMP_ROOT/stderr.log" >&2
+  exit 1
+fi
+
+if grep -F "legacy.js" "$TMP_ROOT/stderr.log" >/dev/null; then
+  echo "[ts-source-imports] Temporary legacy exception package should be skipped" >&2
+  cat "$TMP_ROOT/stderr.log" >&2
+  exit 1
+fi
+
+if grep -F "runtime.js" "$TMP_ROOT/stderr.log" >/dev/null; then
+  echo "[ts-source-imports] Built-JS runtime package should not be enforced" >&2
+  cat "$TMP_ROOT/stderr.log" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

This adds a guardrail for workspace packages that export `src/index.ts` directly.

Those packages load from TypeScript source, so non-test source files should not point at relative `.js` paths. The new check enforces that rule where the repo is already clean.

It also keeps a short temporary exception list for packages we still need to migrate, adds the check to `check:all`, and covers the allowed exceptions with a deterministic required suite.

## Test Plan

- [ ] node scripts/check-ts-source-imports.mjs
- [ ] bash scripts/test-suites/required/16-ts-source-import-guard.sh
- [ ] pnpm run check:ts-source-imports

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert fa68652ea`
- Post-revert steps: None
- Data migration? No