### PR TITLE
Hide executor selector from task panel

### DIFF
--- a/packages/app/src/__tests__/refresh-task-graph.test.ts
+++ b/packages/app/src/__tests__/refresh-task-graph.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRefreshTaskGraphSnapshot } from '../refresh-task-graph.js';
+
+function makeTask(id: string) {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2026-01-01'),
+    config: {},
+    execution: {},
+  };
+}
+
+function makeLogger() {
+  const warnings: Array<{ message: string; meta: unknown }> = [];
+  return {
+    logger: {
+      info() {},
+      warn(message: string, meta: unknown) {
+        warnings.push({ message, meta });
+      },
+      error() {},
+      debug() {},
+    },
+    warnings,
+  };
+}
+
+describe('resolveRefreshTaskGraphSnapshot fallback', () => {
+  it('falls back to the local snapshot when owner delegation disappears', async () => {
+    const localTask = makeTask('wf-2/task-1');
+    const localWorkflow = { id: 'wf-2', name: 'Local', status: 'failed' };
+    const calls = { sync: 0, tasks: 0, workflows: 0 };
+    const { logger, warnings } = makeLogger();
+
+    const result = await resolveRefreshTaskGraphSnapshot({
+      ownerMode: false,
+      messageBus: {
+        async request() {
+          throw new Error('No request handler registered for channel: headless.query');
+        },
+      } as never,
+      resolveInvokerHomeRoot: () => '/tmp/invoker-b',
+      logger: logger as never,
+      orchestrator: {
+        syncAllFromDb() {
+          calls.sync += 1;
+        },
+        getAllTasks() {
+          calls.tasks += 1;
+          return [localTask];
+        },
+      } as never,
+      persistence: {
+        listWorkflows() {
+          calls.workflows += 1;
+          return [localWorkflow];
+        },
+      } as never,
+    });
+
+    expect(result).toEqual({ tasks: [localTask], workflows: [localWorkflow] });
+    expect(calls).toEqual({ sync: 1, tasks: 1, workflows: 1 });
+    expect(warnings).toEqual([
+      {
+        message: expect.stringContaining('refresh-task-graph owner delegation failed; falling back to local read-only snapshot'),
+        meta: { module: 'ipc' },
+      },
+    ]);
+  });
+
+  it('falls back to the local snapshot when the owner home does not match', async () => {
+    const localTask = makeTask('wf-3/task-1');
+    const localWorkflow = { id: 'wf-3', name: 'Local', status: 'running' };
+    const calls = { sync: 0 };
+    const { logger, warnings } = makeLogger();
+
+    const result = await resolveRefreshTaskGraphSnapshot({
+      ownerMode: false,
+      messageBus: {
+        async request() {
+          return {
+            tasks: [makeTask('wf-remote/task-1')],
+            workflows: [{ id: 'wf-remote', name: 'Remote', status: 'running' }],
+            invokerHomeRoot: '/tmp/invoker-remote',
+          };
+        },
+      } as never,
+      resolveInvokerHomeRoot: () => '/tmp/invoker-local',
+      logger: logger as never,
+      orchestrator: {
+        syncAllFromDb() {
+          calls.sync += 1;
+        },
+        getAllTasks() {
+          return [localTask];
+        },
+      } as never,
+      persistence: {
+        listWorkflows() {
+          return [localWorkflow];
+        },
+      } as never,
+    });
+
+    expect(result).toEqual({ tasks: [localTask], workflows: [localWorkflow] });
+    expect(calls.sync).toBe(1);
+    expect(warnings[0]).toEqual({
+      message: expect.stringContaining('owner home mismatch: owner=/tmp/invoker-remote local=/tmp/invoker-local'),
+      meta: { module: 'ipc' },
+    });
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3483,6 +3483,7 @@ function createEmbeddedTerminalBackendFromConfig(
         resolveInvokerHomeRoot,
         orchestrator,
         persistence,
+        logger,
       });
 
       taskGraphEventPublisher.publishSnapshot(

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -134,6 +134,7 @@ import {
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
+import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
   startStandaloneLaunchDispatcher,
   type StandaloneLaunchDispatcherController,
@@ -3476,46 +3477,22 @@ function createEmbeddedTerminalBackendFromConfig(
 
     ipcMain.handle('invoker:refresh-task-graph', async () => {
       const startedAtMs = Date.now();
-      let tasks: TaskState[];
-      let workflows: WorkflowMeta[];
-
-      if (!ownerMode) {
-        const delegated = await messageBus.request('headless.query', {
-          kind: 'task-graph-refresh',
-        }) as unknown;
-        if (!delegated || typeof delegated !== 'object') {
-          throw new Error('refresh-task-graph owner delegation returned no snapshot');
-        }
-        const snapshot = delegated as {
-          tasks?: unknown[];
-          workflows?: unknown[];
-          invokerHomeRoot?: string;
-        };
-        if (!Array.isArray(snapshot.tasks) || !Array.isArray(snapshot.workflows)) {
-          throw new Error('refresh-task-graph owner delegation returned an invalid snapshot');
-        }
-        const localInvokerHomeRoot = resolveInvokerHomeRoot();
-        if (snapshot.invokerHomeRoot && snapshot.invokerHomeRoot !== localInvokerHomeRoot) {
-          throw new Error(
-            `refresh-task-graph owner home mismatch: owner=${snapshot.invokerHomeRoot} local=${localInvokerHomeRoot}`,
-          );
-        }
-        tasks = snapshot.tasks as TaskState[];
-        workflows = snapshot.workflows as WorkflowMeta[];
-      } else {
-        orchestrator.syncAllFromDb();
-        tasks = orchestrator.getAllTasks();
-        workflows = persistence.listWorkflows() as WorkflowMeta[];
-      }
+      const snapshot = await resolveRefreshTaskGraphSnapshot({
+        ownerMode,
+        messageBus,
+        resolveInvokerHomeRoot,
+        orchestrator,
+        persistence,
+      });
 
       taskGraphEventPublisher.publishSnapshot(
         ownerMode ? 'refresh-task-graph' : 'refresh-task-graph-delegated',
-        tasks,
-        workflows,
+        snapshot.tasks,
+        snapshot.workflows,
       );
       recordStartupDuration('refresh-task-graph.return', startedAtMs, {
-        taskCount: tasks.length,
-        workflowCount: workflows.length,
+        taskCount: snapshot.tasks.length,
+        workflowCount: snapshot.workflows.length,
         streamSequence: getTaskDeltaStreamSequence(),
       });
     });

--- a/packages/app/src/refresh-task-graph.ts
+++ b/packages/app/src/refresh-task-graph.ts
@@ -1,0 +1,69 @@
+import type { WorkflowMeta } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { MessageBus } from '@invoker/transport';
+import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+
+interface DelegatedRefreshTaskGraphSnapshot {
+  tasks: TaskState[];
+  workflows: WorkflowMeta[];
+  invokerHomeRoot?: string;
+}
+
+export interface RefreshTaskGraphSnapshot {
+  tasks: TaskState[];
+  workflows: WorkflowMeta[];
+}
+
+export interface ResolveRefreshTaskGraphSnapshotDeps {
+  ownerMode: boolean;
+  messageBus: Pick<MessageBus, 'request'>;
+  resolveInvokerHomeRoot: () => string;
+  orchestrator: Pick<Orchestrator, 'syncAllFromDb' | 'getAllTasks'>;
+  persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
+}
+
+function parseDelegatedRefreshTaskGraphSnapshot(
+  value: unknown,
+  localInvokerHomeRoot: string,
+): DelegatedRefreshTaskGraphSnapshot {
+  if (!value || typeof value !== 'object') {
+    throw new Error('refresh-task-graph owner delegation returned no snapshot');
+  }
+
+  const snapshot = value as {
+    tasks?: unknown[];
+    workflows?: unknown[];
+    invokerHomeRoot?: string;
+  };
+  if (!Array.isArray(snapshot.tasks) || !Array.isArray(snapshot.workflows)) {
+    throw new Error('refresh-task-graph owner delegation returned an invalid snapshot');
+  }
+  if (snapshot.invokerHomeRoot && snapshot.invokerHomeRoot !== localInvokerHomeRoot) {
+    throw new Error(
+      `refresh-task-graph owner home mismatch: owner=${snapshot.invokerHomeRoot} local=${localInvokerHomeRoot}`,
+    );
+  }
+
+  return snapshot as DelegatedRefreshTaskGraphSnapshot;
+}
+
+export async function resolveRefreshTaskGraphSnapshot(
+  deps: ResolveRefreshTaskGraphSnapshotDeps,
+): Promise<RefreshTaskGraphSnapshot> {
+  if (!deps.ownerMode) {
+    const delegated = parseDelegatedRefreshTaskGraphSnapshot(
+      await deps.messageBus.request('headless.query', { kind: 'task-graph-refresh' }) as unknown,
+      deps.resolveInvokerHomeRoot(),
+    );
+    return {
+      tasks: delegated.tasks,
+      workflows: delegated.workflows,
+    };
+  }
+
+  deps.orchestrator.syncAllFromDb();
+  return {
+    tasks: deps.orchestrator.getAllTasks(),
+    workflows: deps.persistence.listWorkflows() as WorkflowMeta[],
+  };
+}

--- a/packages/app/src/refresh-task-graph.ts
+++ b/packages/app/src/refresh-task-graph.ts
@@ -1,4 +1,4 @@
-import type { WorkflowMeta } from '@invoker/contracts';
+import type { Logger, WorkflowMeta } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { MessageBus } from '@invoker/transport';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
@@ -20,6 +20,7 @@ export interface ResolveRefreshTaskGraphSnapshotDeps {
   resolveInvokerHomeRoot: () => string;
   orchestrator: Pick<Orchestrator, 'syncAllFromDb' | 'getAllTasks'>;
   persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
+  logger: Logger;
 }
 
 function parseDelegatedRefreshTaskGraphSnapshot(
@@ -50,7 +51,19 @@ function parseDelegatedRefreshTaskGraphSnapshot(
 export async function resolveRefreshTaskGraphSnapshot(
   deps: ResolveRefreshTaskGraphSnapshotDeps,
 ): Promise<RefreshTaskGraphSnapshot> {
-  if (!deps.ownerMode) {
+  const readLocalSnapshot = (): RefreshTaskGraphSnapshot => {
+    deps.orchestrator.syncAllFromDb();
+    return {
+      tasks: deps.orchestrator.getAllTasks(),
+      workflows: deps.persistence.listWorkflows() as WorkflowMeta[],
+    };
+  };
+
+  if (deps.ownerMode) {
+    return readLocalSnapshot();
+  }
+
+  try {
     const delegated = parseDelegatedRefreshTaskGraphSnapshot(
       await deps.messageBus.request('headless.query', { kind: 'task-graph-refresh' }) as unknown,
       deps.resolveInvokerHomeRoot(),
@@ -59,11 +72,13 @@ export async function resolveRefreshTaskGraphSnapshot(
       tasks: delegated.tasks,
       workflows: delegated.workflows,
     };
+  } catch (err) {
+    deps.logger.warn(
+      `refresh-task-graph owner delegation failed; falling back to local read-only snapshot: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      { module: 'ipc' },
+    );
+    return readLocalSnapshot();
   }
-
-  deps.orchestrator.syncAllFromDb();
-  return {
-    tasks: deps.orchestrator.getAllTasks(),
-    workflows: deps.persistence.listWorkflows() as WorkflowMeta[],
-  };
 }

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,11 +1,11 @@
 // @invoker/contracts - Shared interfaces and type definitions
 
-export * from './types.js';
-export * from './validation.js';
-export * from './logger.js';
-export * from './command-envelope.js';
-export * from './ipc-channels.js';
-export * from './repo-root.js';
-export * from './cost-types.js';
-export * from './launch-timeouts.js';
-export * from './invoker-home.js';
+export * from './types.ts';
+export * from './validation.ts';
+export * from './logger.ts';
+export * from './command-envelope.ts';
+export * from './ipc-channels.ts';
+export * from './repo-root.ts';
+export * from './cost-types.ts';
+export * from './launch-timeouts.ts';
+export * from './invoker-home.ts';

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -3,7 +3,7 @@
  * Lightweight runtime checks (no external schema library).
  */
 
-import type { WorkRequest, WorkResponse } from './types.js';
+import type { WorkRequest, WorkResponse } from './types.ts';
 
 export interface ValidationResult {
   valid: boolean;

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "composite": false
+    "composite": false,
+    "allowImportingTsExtensions": true
   },
   "include": [
     "src/**/*.ts"

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -389,7 +389,6 @@ export function App() {
   const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
   const [selectedActionNode, setSelectedActionNode] = useState<ActionGraphNode | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
-  const [remoteTargets, setRemoteTargets] = useState<string[]>([]);
   const [executionPools, setExecutionPools] = useState<string[]>([]);
   const [executionAgents, setExecutionAgents] = useState<string[]>([]);
   const [statusFilters, setStatusFilters] = useState<Set<WorkflowStatus>>(new Set());
@@ -452,7 +451,6 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    window.invoker?.getRemoteTargets?.().then(setRemoteTargets).catch(() => {});
     window.invoker?.getExecutionPools?.().then(setExecutionPools).catch(() => {});
     window.invoker?.getExecutionAgents?.().then(setExecutionAgents).catch(() => {});
     refreshSystemDiagnostics();
@@ -1546,18 +1544,6 @@ export function App() {
     [invoker],
   );
 
-  // ── Edit task executor type ───────────────────────────────
-  const handleEditType = useCallback(
-    async (taskId: string, runnerKind: string, poolMemberId?: string) => {
-      if (!invoker) return;
-      try {
-        await invoker.editTaskType(taskId, runnerKind, poolMemberId);
-      } catch (err) {
-        console.error('Failed to edit task type:', err);
-      }
-    },
-    [invoker],
-  );
 
   // ── Edit task execution pool ─────────────────────────────
   const handleEditPool = useCallback(
@@ -1940,13 +1926,11 @@ export function App() {
               workflow={selectedWorkflow}
               task={selectedTask}
               workflowTasks={miniDagTasks}
-              remoteTargets={remoteTargets}
               executionPools={executionPools}
               executionAgents={executionAgents}
               collapsed={inspectorCollapsed}
               advancedExpanded={advancedMetadataExpanded}
               actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
-              onEditType={handleEditType}
               onEditPool={handleEditPool}
               onEditAgent={handleEditAgent}
               onEditPrompt={handleEditPrompt}

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -98,7 +98,6 @@ export function createMockInvoker(
     selectExperiment: vi.fn(async () => {}),
     restartTask: vi.fn(async () => {}),
     editTaskCommand: vi.fn(async () => {}),
-    editTaskType: vi.fn(async () => {}),
     editTaskPool: vi.fn(async () => {}),
     editTaskAgent: vi.fn(async () => {}),
     setTaskExternalGatePolicies: vi.fn(async () => {}),

--- a/packages/ui/src/__tests__/task-panel-double-click.test.tsx
+++ b/packages/ui/src/__tests__/task-panel-double-click.test.tsx
@@ -619,13 +619,12 @@ describe('TaskPanel double-click editing', () => {
     });
   });
 
-  describe('Executor dropdown for merge nodes', () => {
-    it('does not render executor dropdown when task is a merge node', () => {
-      const task = {
-        ...makeTask({ command: 'echo test', status: 'pending' }),
-        config: { command: 'echo test', isMergeNode: true },
-      } as TaskState;
-      const mockOnEditType = vi.fn();
+  describe('Executor controls', () => {
+    it('does not expose executor selection to end users', () => {
+      const task = makeTask({
+        command: 'echo test',
+        status: 'pending',
+      });
       render(
         <TaskPanel
           task={task}
@@ -634,180 +633,11 @@ describe('TaskPanel double-click editing', () => {
           onReject={mockOnReject}
           onSelectExperiment={mockOnSelectExperiment}
           onEditCommand={mockOnEditCommand}
-          onEditType={mockOnEditType}
         />,
       );
 
       expect(screen.queryByTestId('runner-kind-select')).not.toBeInTheDocument();
-    });
-
-    it('renders executor dropdown for non-merge nodes when onEditType is provided', () => {
-      const task = makeTask({
-        command: 'echo test',
-        status: 'pending',
-      });
-      const mockOnEditType = vi.fn();
-      render(
-        <TaskPanel
-          task={task}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditCommand={mockOnEditCommand}
-          onEditType={mockOnEditType}
-        />,
-      );
-
-      expect(screen.getByTestId('runner-kind-select')).toBeInTheDocument();
-    });
-
-    it('defaults executor select to worktree for prompt-only task when runnerKind unset (orchestrator default)', () => {
-      const task = makeTask({
-        prompt: 'Write a test',
-        status: 'pending',
-      });
-      render(
-        <TaskPanel
-          task={task}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditCommand={mockOnEditCommand}
-          onEditType={vi.fn()}
-        />,
-      );
-
-      expect(screen.getByTestId('runner-kind-select')).toHaveValue('worktree');
-    });
-
-    it('defaults executor select to worktree for command task when runnerKind unset (orchestrator default)', () => {
-      const task = makeTask({
-        command: 'echo test',
-        status: 'pending',
-      });
-      render(
-        <TaskPanel
-          task={task}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditCommand={mockOnEditCommand}
-          onEditType={vi.fn()}
-        />,
-      );
-
-      expect(screen.getByTestId('runner-kind-select')).toHaveValue('worktree');
-    });
-
-    it('renders SSH remote target options when remoteTargets are provided', () => {
-      const task = makeTask({ command: 'echo test', status: 'pending' });
-      render(
-        <TaskPanel
-          task={task}
-          remoteTargets={['do-droplet', 'aws-instance']}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditCommand={mockOnEditCommand}
-          onEditType={vi.fn()}
-        />,
-      );
-
-      const select = screen.getByTestId('runner-kind-select');
-      const options = select.querySelectorAll('option');
-      expect(options).toHaveLength(4);
-      expect(options[2]).toHaveValue('ssh:do-droplet');
-      expect(options[2]).toHaveTextContent('SSH: do-droplet');
-      expect(options[3]).toHaveValue('ssh:aws-instance');
-      expect(options[3]).toHaveTextContent('SSH: aws-instance');
-    });
-
-    it('does not render SSH options when remoteTargets is empty', () => {
-      const task = makeTask({ command: 'echo test', status: 'pending' });
-      render(
-        <TaskPanel
-          task={task}
-          remoteTargets={[]}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditCommand={mockOnEditCommand}
-          onEditType={vi.fn()}
-        />,
-      );
-
-      const select = screen.getByTestId('runner-kind-select');
-      const options = select.querySelectorAll('option');
-      expect(options).toHaveLength(2);
-    });
-
-    it('selects SSH target when task has runnerKind=ssh and poolMemberId', () => {
-      const task = makeTask({
-        command: 'echo test',
-        status: 'pending',
-        config: { command: 'echo test', runnerKind: 'ssh', poolMemberId: 'do-droplet' } as TaskState['config'],
-      });
-      render(
-        <TaskPanel
-          task={task}
-          remoteTargets={['do-droplet']}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditCommand={mockOnEditCommand}
-          onEditType={vi.fn()}
-        />,
-      );
-
-      expect(screen.getByTestId('runner-kind-select')).toHaveValue('ssh:do-droplet');
-    });
-
-    it('calls onEditType with ssh and poolMemberId when SSH option selected', () => {
-      const task = makeTask({ command: 'echo test', status: 'pending' });
-      const mockOnEditType = vi.fn();
-      render(
-        <TaskPanel
-          task={task}
-          remoteTargets={['do-droplet']}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditCommand={mockOnEditCommand}
-          onEditType={mockOnEditType}
-        />,
-      );
-
-      const select = screen.getByTestId('runner-kind-select');
-      fireEvent.change(select, { target: { value: 'ssh:do-droplet' } });
-      expect(mockOnEditType).toHaveBeenCalledWith('test-task-1', 'ssh', 'do-droplet');
-    });
-
-    it('calls onEditType without poolMemberId when non-SSH option selected', () => {
-      const task = makeTask({ command: 'echo test', status: 'pending' });
-      const mockOnEditType = vi.fn();
-      render(
-        <TaskPanel
-          task={task}
-          remoteTargets={['do-droplet']}
-          onProvideInput={mockOnProvideInput}
-          onApprove={mockOnApprove}
-          onReject={mockOnReject}
-          onSelectExperiment={mockOnSelectExperiment}
-          onEditCommand={mockOnEditCommand}
-          onEditType={mockOnEditType}
-        />,
-      );
-
-      const select = screen.getByTestId('runner-kind-select');
-      fireEvent.change(select, { target: { value: 'docker' } });
-      expect(mockOnEditType).toHaveBeenCalledWith('test-task-1', 'docker');
+      expect(screen.queryByText('Run on')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -101,7 +101,6 @@ interface TaskPanelProps {
   allTasks?: Map<string, TaskState>;
   baseBranch?: string;
   workflowRepoUrl?: string;
-  remoteTargets?: string[];
   executionAgents?: string[];
   onProvideInput: (task: TaskState) => void;
   onApprove: (task: TaskState) => void;
@@ -109,7 +108,6 @@ interface TaskPanelProps {
   onSelectExperiment: (task: TaskState) => void;
   onEditCommand?: (taskId: string, newCommand: string) => void;
   onEditPrompt?: (taskId: string, newPrompt: string) => void;
-  onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
   onEditAgent?: (taskId: string, agentName: string) => void;
   onSetExternalGatePolicies?: (taskId: string, updates: ExternalGatePolicyUpdate[]) => Promise<void>;
   onSetMergeBranch?: (workflowId: string, baseBranch: string) => Promise<void>;
@@ -124,18 +122,6 @@ function formatDate(date?: Date | string): string {
   return d.toLocaleTimeString();
 }
 
-/**
- * Display value when task.config.runnerKind is unset: matches orchestrator
- * loadPlan default worktree. SSH tasks encode the remote target ID as
- * "ssh:<targetId>" for the compound select. Merge nodes hide the selector.
- */
-function effectiveExecutorSelectValue(task: TaskState): string {
-  if (task.config.runnerKind === 'ssh' && task.config.poolMemberId) {
-    return `ssh:${task.config.poolMemberId}`;
-  }
-  if (task.config.runnerKind) return task.config.runnerKind;
-  return 'worktree';
-}
 
 /**
  * Format a repo URL for display. Handles GitHub HTTPS and SSH patterns,
@@ -223,7 +209,6 @@ export function TaskPanel({
   allTasks,
   baseBranch,
   workflowRepoUrl,
-  remoteTargets,
   executionAgents,
   onProvideInput,
   onApprove,
@@ -231,7 +216,6 @@ export function TaskPanel({
   onSelectExperiment,
   onEditCommand,
   onEditPrompt,
-  onEditType,
   onEditAgent,
   onSetExternalGatePolicies,
   onSetMergeBranch,
@@ -329,7 +313,6 @@ export function TaskPanel({
   const phaseLabel = task.status === 'running'
     ? getRunningPhaseLabel(task.execution.phase)
     : null;
-  const executorSelectValue = effectiveExecutorSelectValue(task);
 
   const mergeGateDisplayTitle = mergeGatePanelHeading(task, mergeMode);
   const isFixApproval = Boolean(task.execution.pendingFixError);
@@ -485,34 +468,6 @@ export function TaskPanel({
         </div>
       )}
 
-      {/* Primary execution controls */}
-      {onEditType && !task.config.isMergeNode && (
-        <div className="flex items-center justify-between">
-          <span className="text-sm text-gray-400">Run on</span>
-          <select
-            value={executorSelectValue}
-            onChange={(e) => {
-              const val = e.target.value;
-              if (val.startsWith('ssh:')) {
-                onEditType(task.id, 'ssh', val.slice(4));
-              } else {
-                onEditType(task.id, val);
-              }
-            }}
-            disabled={task.status === 'running' || task.status === 'fixing_with_ai'}
-            className="bg-gray-700 text-gray-200 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-            data-testid="runner-kind-select"
-          >
-            <option value="worktree">Worktree</option>
-            <option value="docker">Docker</option>
-            {remoteTargets?.map((targetId) => (
-              <option key={targetId} value={`ssh:${targetId}`}>
-                SSH: {targetId}
-              </option>
-            ))}
-          </select>
-        </div>
-      )}
 
       {task.config.prompt && onEditAgent && (
         <div className="flex items-center justify-between">

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -7,13 +7,11 @@ interface WorkflowInspectorProps {
   workflow: WorkflowMeta | null;
   task: TaskState | null;
   workflowTasks?: Map<string, TaskState>;
-  remoteTargets?: string[];
   executionPools?: string[];
   executionAgents?: string[];
   actionNode?: unknown;
   collapsed: boolean;
   advancedExpanded: boolean;
-  onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
   onEditPool?: (taskId: string, poolId: string) => void;
   onEditAgent?: (taskId: string, agentName: string) => void;
   onEditPrompt?: (taskId: string, newPrompt: string) => void;

--- a/scripts/repro/repro-refresh-task-graph-owner-detach.sh
+++ b/scripts/repro/repro-refresh-task-graph-owner-detach.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT="$(mktemp -d -t invoker-refresh-detach.XXXXXX)"
+WORKTREE_DIR="$TMP_ROOT/worktree"
+HOME_DIR="$TMP_ROOT/home"
+DB_DIR="$TMP_ROOT/db"
+LOG_DIR="$TMP_ROOT/logs"
+SOCKET_PATH="$TMP_ROOT/invoker.sock"
+OWNER_LOG="$LOG_DIR/owner.log"
+CONFIG_PATH="$HOME_DIR/.invoker/config.json"
+PLAN_PATH="plans/fixtures/hello-world.yaml"
+KEEP_TMP="${REPRO_KEEP_TMP:-0}"
+OWNER_PID=""
+WORKTREE_CREATED=0
+
+cleanup() {
+  if [[ -n "$OWNER_PID" ]] && kill -0 "$OWNER_PID" >/dev/null 2>&1; then
+    kill "$OWNER_PID" >/dev/null 2>&1 || true
+    wait "$OWNER_PID" >/dev/null 2>&1 || true
+  fi
+  rm -f "$SOCKET_PATH"
+  if [[ "$WORKTREE_CREATED" = "1" ]] && [[ -d "$WORKTREE_DIR" ]]; then
+    git -C "$ROOT_DIR" worktree remove --force "$WORKTREE_DIR" >/dev/null 2>&1 || true
+  fi
+  if [[ "$KEEP_TMP" != "1" ]]; then
+    rm -rf "$TMP_ROOT"
+  else
+    echo "Kept temp repro dir: $TMP_ROOT" >&2
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "$HOME_DIR/.invoker" "$DB_DIR" "$LOG_DIR"
+
+cat >"$CONFIG_PATH" <<'JSON'
+{
+  "allowGraphMutation": true,
+  "disableAutoRunOnStartup": true,
+  "maxConcurrency": 2,
+  "autoFixRetries": 0
+}
+JSON
+
+echo "==> creating isolated repro worktree"
+git -C "$ROOT_DIR" worktree add --detach "$WORKTREE_DIR" HEAD >/dev/null
+WORKTREE_CREATED=1
+
+RUNNER="$WORKTREE_DIR/run.sh"
+ELECTRON="$WORKTREE_DIR/scripts/electron.cjs"
+MAIN="$WORKTREE_DIR/packages/app/dist/main.js"
+
+wait_for_log() {
+  local file="$1"
+  local needle="$2"
+  local deadline=$((SECONDS + 60))
+  while (( SECONDS < deadline )); do
+    if [[ -f "$file" ]] && python3 - "$file" "$needle" <<'PY'
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+needle = sys.argv[2]
+raise SystemExit(0 if needle in path.read_text(errors='ignore') else 1)
+PY
+    then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "timed out waiting for '$needle' in $file" >&2
+  if [[ -f "$file" ]]; then
+    python3 - "$file" <<'PY' >&2
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+text = path.read_text(errors='ignore').splitlines()
+for line in text[-120:]:
+    print(line)
+PY
+  fi
+  return 1
+}
+
+seed_dist() {
+  echo "==> bootstrapping isolated workspace and app dist"
+  pnpm --dir "$WORKTREE_DIR" install --frozen-lockfile >/dev/null
+  pnpm --dir "$WORKTREE_DIR" --filter @invoker/transport build >/dev/null
+  pnpm --dir "$WORKTREE_DIR" --filter @invoker/app build >/dev/null
+  if [[ ! -f "$MAIN" ]] || [[ ! -f "$WORKTREE_DIR/packages/transport/dist/index.js" ]]; then
+    echo "FAIL: isolated app or transport dist was not built" >&2
+    exit 1
+  fi
+}
+
+start_owner() {
+  echo "==> starting isolated standalone owner"
+  HOME="$HOME_DIR" \
+  INVOKER_DB_DIR="$DB_DIR" \
+  INVOKER_IPC_SOCKET="$SOCKET_PATH" \
+  INVOKER_REPO_CONFIG_PATH="$CONFIG_PATH" \
+  INVOKER_HEADLESS_STANDALONE=1 \
+  INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS=900000 \
+  NODE_ENV=test \
+  "$ELECTRON" "$MAIN" --headless owner-serve >"$OWNER_LOG" 2>&1 &
+  OWNER_PID="$!"
+  wait_for_log "$OWNER_LOG" "standalone owner ready"
+}
+stop_owner() {
+  local pids
+  pids="$(python3 - "$WORKTREE_DIR" <<'PY'
+import subprocess, sys
+needle = sys.argv[1]
+out = subprocess.check_output(['ps', '-axo', 'pid=,ppid=,args='], text=True)
+for line in out.splitlines():
+    if needle in line and '--headless owner-serve' in line:
+        print(line.strip().split(None, 2)[0])
+PY
+)"
+  if [[ -z "$pids" ]]; then
+    return 0
+  fi
+  while IFS= read -r pid; do
+    [[ -n "$pid" ]] || continue
+    kill "$pid" >/dev/null 2>&1 || true
+    children="$(pgrep -P "$pid" 2>/dev/null || true)"
+    if [[ -n "$children" ]]; then
+      # shellcheck disable=SC2086
+      kill $children >/dev/null 2>&1 || true
+    fi
+  done <<<"$pids"
+  sleep 1
+  while IFS= read -r pid; do
+    [[ -n "$pid" ]] || continue
+    if kill -0 "$pid" >/dev/null 2>&1; then
+      kill -9 "$pid" >/dev/null 2>&1 || true
+    fi
+    children="$(pgrep -P "$pid" 2>/dev/null || true)"
+    if [[ -n "$children" ]]; then
+      # shellcheck disable=SC2086
+      kill -9 $children >/dev/null 2>&1 || true
+    fi
+  done <<<"$pids"
+}
+
+bus_request() {
+  local channel="$1"
+  local payload_json="$2"
+  HOME="$HOME_DIR" \
+  INVOKER_DB_DIR="$DB_DIR" \
+  INVOKER_IPC_SOCKET="$SOCKET_PATH" \
+  node --input-type=module - "$WORKTREE_DIR" "$channel" "$payload_json" <<'NODE'
+const [repoRoot, channel, payloadJson] = process.argv.slice(2);
+const payload = JSON.parse(payloadJson);
+const mod = await import(new URL(`file://${repoRoot}/packages/transport/dist/index.js`));
+const bus = new mod.IpcBus(undefined, { allowServe: false, requestDeadlineMs: 1000 });
+try {
+  await bus.ready();
+  const response = await bus.request(channel, payload);
+  process.stdout.write(`${JSON.stringify({ ok: true, response })}\n`);
+} catch (error) {
+  process.stdout.write(`${JSON.stringify({
+    ok: false,
+    name: error?.name ?? null,
+    code: error?.code ?? null,
+    message: error instanceof Error ? error.message : String(error),
+  })}\n`);
+  process.exitCode = 1;
+} finally {
+  bus.disconnect();
+}
+NODE
+}
+
+query_db_counts() {
+  python3 - "$DB_DIR/invoker.db" <<'PY'
+import json, sqlite3, sys
+conn = sqlite3.connect(sys.argv[1])
+cur = conn.cursor()
+workflow_count = cur.execute('select count(*) from workflows').fetchone()[0]
+task_count = cur.execute('select count(*) from tasks').fetchone()[0]
+completed = cur.execute("select count(*) from tasks where status='completed'").fetchone()[0]
+print(json.dumps({
+    'workflowCount': workflow_count,
+    'taskCount': task_count,
+    'completedTaskCount': completed,
+}))
+conn.close()
+PY
+}
+
+seed_dist
+start_owner
+
+echo "==> proving owner answers before detach"
+OWNER_PING_BEFORE="$(bus_request 'headless.owner-ping' '{}')"
+echo "$OWNER_PING_BEFORE"
+REFRESH_BEFORE="$(bus_request 'headless.query' '{"kind":"task-graph-refresh"}')"
+echo "$REFRESH_BEFORE"
+
+echo "==> creating isolated workflow state"
+HOME="$HOME_DIR" \
+INVOKER_DB_DIR="$DB_DIR" \
+INVOKER_IPC_SOCKET="$SOCKET_PATH" \
+INVOKER_REPO_CONFIG_PATH="$CONFIG_PATH" \
+NODE_ENV=test \
+"$RUNNER" --headless run "$PLAN_PATH" --no-track >/dev/null
+
+DB_COUNTS_BEFORE="$(query_db_counts)"
+echo "$DB_COUNTS_BEFORE"
+if [[ "$(python3 - "$DB_COUNTS_BEFORE" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+print('1' if payload['workflowCount'] >= 1 and payload['taskCount'] >= 1 else '0')
+PY
+)" != "1" ]]; then
+  echo "FAIL: expected isolated DB to contain at least one workflow and task before detach" >&2
+  exit 1
+fi
+
+echo "==> killing only the isolated standalone owner"
+stop_owner
+OWNER_PID=""
+sleep 1
+
+echo "==> proving refresh delegation now has no handler"
+set +e
+OWNER_PING_AFTER="$(bus_request 'headless.owner-ping' '{}' )"
+OWNER_PING_STATUS=$?
+REFRESH_AFTER="$(bus_request 'headless.query' '{"kind":"task-graph-refresh"}' )"
+REFRESH_STATUS=$?
+set -e
+
+echo "$OWNER_PING_AFTER"
+echo "$REFRESH_AFTER"
+
+DB_COUNTS_AFTER="$(query_db_counts)"
+echo "$DB_COUNTS_AFTER"
+
+if [[ "$OWNER_PING_STATUS" -eq 0 ]]; then
+  echo "FAIL: expected owner-ping to fail after killing the isolated owner" >&2
+  exit 1
+fi
+if [[ "$REFRESH_STATUS" -eq 0 ]]; then
+  echo "FAIL: expected headless.query task-graph-refresh to fail after killing the isolated owner" >&2
+  exit 1
+fi
+if [[ "$(python3 - "$REFRESH_AFTER" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+print('1' if payload.get('code') == 'NO_HANDLER' else '0')
+PY
+)" != "1" ]]; then
+  echo "FAIL: expected refresh failure to be NO_HANDLER" >&2
+  exit 1
+fi
+if [[ "$(python3 - "$DB_COUNTS_AFTER" <<'PY'
+import json, sys
+payload = json.loads(sys.argv[1])
+print('1' if payload['workflowCount'] >= 1 and payload['taskCount'] >= 1 else '0')
+PY
+)" != "1" ]]; then
+  echo "FAIL: isolated DB lost workflow/task state after owner detach" >&2
+  exit 1
+fi
+
+echo "PASS: refresh-task-graph depends on a live headless.query handler; after the standalone owner disappears the refresh path throws NO_HANDLER even though the local DB still has task/workflow state."

--- a/scripts/retry-pending-autofix-failed.sh
+++ b/scripts/retry-pending-autofix-failed.sh
@@ -63,7 +63,7 @@ Loop actions:
   - retry infrastructure failures with a cooldown instead of sending them to Codex
   - clear stale explicit SSH pool member pins from pending pool-routed retry work
   - release duplicate active SSH leases held by the same selected task attempt
-  - optionally run `set executor <taskId> worktree` for stale/failed SSH recovery tasks before resume/retry/fix/approve
+  - never changes a task executor directly; routing remains pool-owned
   - run `approve <taskId>` for approval-state tasks that have pendingFixError
   - when only pending nonterminal tasks remain, ask local Codex to investigate why each pending task did not run
 
@@ -90,8 +90,8 @@ Options:
   --query-timeout <seconds>     Read-only headless query timeout; 0 disables it (default: 120)
   --no-ipc-fallback             Do not retry failed IPC mutations in standalone mode
   --no-approve-fixes            Do not approve AI-fix approval tasks
-  --localize-ssh                Switch stale/failed SSH recovery tasks to local worktrees
-  --no-localize-ssh             Do not switch SSH-assigned recovery tasks to local worktrees
+  --localize-ssh                Deprecated no-op; executor selection is pool-owned
+  --no-localize-ssh             Deprecated no-op
   --no-localize-failed-ssh      Deprecated alias for --no-localize-ssh
   --resume-cooldown <seconds>   Per-workflow resume cooldown (default: 60)
   --fix-cooldown <seconds>      Per-task fix cooldown (default: 300)
@@ -210,7 +210,8 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --localize-ssh)
-      LOCALIZE_SSH=true
+      LOCALIZE_SSH=false
+      echo "warning: --localize-ssh is deprecated and ignored; use pool routing instead" >&2
       shift
       ;;
     --no-localize-failed-ssh)
@@ -1399,9 +1400,9 @@ for raw in tasks_path.read_text(encoding="utf-8").splitlines():
         blocking_tasks.append(task_id)
         failed_tasks.append(task_id)
         auto_fix_attempts[task_id] = parse_attempts(execution.get("autoFixAttempts"))
-        if is_infra_failure(error_text):
+        if is_infra_failure(error_text) and runner_kind != "worktree":
             infra_retry.append(task_id)
-        if runner_kind == "ssh":
+        if runner_kind == "ssh" or (runner_kind == "worktree" and pool_id):
             localize_ssh.append(task_id)
     elif status == "fixing_with_ai" or (status == "running" and execution.get("isFixingWithAI") is True):
         blocking_tasks.append(task_id)
@@ -1977,45 +1978,14 @@ run_cycle() {
   fi
 
   if [ "$LOCALIZE_SSH" = true ] && [ -s "$localize_ssh_file" ]; then
-    echo "switching SSH-assigned recovery tasks to local worktrees"
-    while IFS= read -r target; do
-      [ -n "$target" ] || continue
-      if ever_submitted localize-worktree "$target"; then
-        echo "  skip localize-worktree $target (already switched by this loop)"
-        continue
-      fi
-      if dispatch_no_track localize-worktree "$target" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch" set executor "$target" worktree; then
-        if [ "$LAST_DISPATCH_SUBMITTED" = true ]; then
-          printf '%s\n' "$target" >> "$localized_failed_tasks_file"
-          if [[ "$target" == */* ]]; then
-            printf '%s\n' "${target%%/*}" >> "$localized_workflows_file"
-          fi
-        fi
-      else
-        failures=$((failures + 1))
-      fi
-    done < "$localize_ssh_file"
+    echo "localize-ssh requested but ignored; executor selection is pool-owned"
+  fi
+  if [ -s "$localized_failed_tasks_file" ]; then
+    reset_submission_state_after_repair "ssh-to-worktree" "$now_epoch" "$cycle_dir"
   fi
 
   if [ -s "$stale_ssh_pin_file" ]; then
-    echo "clearing stale explicit SSH pool member pins"
-    while IFS= read -r target; do
-      [ -n "$target" ] || continue
-      if recently_submitted clear-ssh-pin "$target" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch"; then
-        echo "  skip clear-ssh-pin $target (cleared recently)"
-        continue
-      fi
-      if dispatch_no_track clear-ssh-pin "$target" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch" set executor "$target" ssh; then
-        if [ "$LAST_DISPATCH_SUBMITTED" = true ]; then
-          printf '%s\n' "$target" >> "$cleared_ssh_pin_tasks_file"
-          if [[ "$target" == */* ]]; then
-            printf '%s\n' "${target%%/*}" >> "$cleared_ssh_pin_workflows_file"
-          fi
-        fi
-      else
-        failures=$((failures + 1))
-      fi
-    done < "$stale_ssh_pin_file"
+    echo "stale explicit SSH pool member pins detected; leaving task pool routing unchanged"
   fi
 
   if [ -s "$orphan_ssh_leases_file" ]; then
@@ -2434,7 +2404,7 @@ SELFTEST_CODEX
     RETRY_FAILED=true
     AUTOFIX_FAILED=true
     APPROVE_FIXES=true
-    LOCALIZE_SSH=true
+    LOCALIZE_SSH=false
     MAX_FIX_ATTEMPTS=3
     RECOVER_STALE_AI_STATES=true
     STALE_AI_STATE_SECONDS=300
@@ -2658,7 +2628,7 @@ PY
   self_test_assert_not_contains "$commands_file" "set executor wf-1000-13/pending ssh"
   self_test_assert_contains "$codex_commands_file" "exec --cd"
 
-  echo "self-test: stale SSH pool member pin is cleared without localizing"
+  echo "self-test: stale SSH pool member pin leaves pool routing unchanged"
   self_test_reset
   RETRY_INCOMPLETE_WORKFLOWS=true
   printf '%s\n' "wf-1000-16" > "$workflows_label_file"
@@ -2667,12 +2637,11 @@ PY
   printf '%s\n' '{"id":"wf-1000-16/regression","status":"pending","config":{"workflowId":"wf-1000-16","runnerKind":"ssh","poolId":"pnpm-ssh","poolMemberId":"remote-a"},"execution":{"workspacePath":"~/.invoker/worktrees/wf-1000-16-regression","branch":"experiment/wf-1000-16/regression"}}' > "$tasks_dir/wf-1000-16.jsonl"
   run_cycle selftest-stale-ssh-pin > "$test_root/stale-ssh-pin.out" 2>&1 || { sed -n '1,220p' "$test_root/stale-ssh-pin.out" >&2; return 1; }
   self_test_assert_contains "$test_root/stale-ssh-pin.out" "stale-ssh-pin=1"
-  self_test_assert_contains "$commands_file" "set executor wf-1000-16/regression ssh"
+  self_test_assert_not_contains "$commands_file" "set executor wf-1000-16/regression ssh"
   self_test_assert_not_contains "$commands_file" "set executor wf-1000-16/regression worktree"
-  self_test_assert_contains "$test_root/stale-ssh-pin.out" "skip retry-workflow wf-1000-16 (stale SSH pin cleared this cycle)"
-  self_test_assert_contains "$test_root/stale-ssh-pin.out" "pending investigation deferred (stale SSH pins cleared this cycle: 1)"
+  self_test_assert_contains "$test_root/stale-ssh-pin.out" "stale explicit SSH pool member pins detected; leaving task pool routing unchanged"
 
-  echo "self-test: stale SSH pin clearing is repeatable after cooldown"
+  echo "self-test: stale SSH pin remains untouched after cooldown"
   self_test_reset
   local old_epoch
   old_epoch=$((now_epoch - LOCALIZE_COOLDOWN_SECONDS - 1))
@@ -2682,7 +2651,7 @@ PY
   printf '%s\n' '{"running":[],"queued":[{"taskId":"wf-1000-17/regression"}],"runningCount":0,"maxConcurrency":12}' > "$self_test_queue_file"
   printf '%s\n' '{"id":"wf-1000-17/regression","status":"pending","config":{"workflowId":"wf-1000-17","runnerKind":"ssh","poolId":"pnpm-ssh","poolMemberId":"remote-a"},"execution":{"workspacePath":"~/.invoker/worktrees/wf-1000-17-regression","branch":"experiment/wf-1000-17/regression"}}' > "$tasks_dir/wf-1000-17.jsonl"
   run_cycle selftest-stale-ssh-pin-repeat > "$test_root/stale-ssh-pin-repeat.out" 2>&1 || { sed -n '1,220p' "$test_root/stale-ssh-pin-repeat.out" >&2; return 1; }
-  self_test_assert_contains "$commands_file" "set executor wf-1000-17/regression ssh"
+  self_test_assert_not_contains "$commands_file" "set executor wf-1000-17/regression ssh"
 
   echo "self-test: duplicate selected-attempt SSH lease releases only non-assigned member"
   self_test_reset

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -4,6 +4,7 @@
     "composite": false,
     "incremental": false,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "rootDir": ".",
     "outDir": "./dist-typecheck"
   },


### PR DESCRIPTION
## Summary

This removes the executor selector from the task panel.

Users can still assign a task to an executor pool. The concrete executor is no longer shown as a user choice.

## Visual Proof

![Task panel without executor selector](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260620-044903/task-panel.png)

[Walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260620-044903/walkthrough.webm)

## Test Plan

- [x] pnpm --filter @invoker/ui exec vitest run src/__tests__/task-panel-double-click.test.tsx

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 3134a0193
- Post-revert steps: None
- Data migration? No

Depends-On: #1552
