### PR TITLE
Extract refresh task graph snapshot resolver

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -134,6 +134,7 @@ import {
   wireHeadlessApproveHook,
   type HeadlessDeps,
 } from './headless.js';
+import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
 import {
   startStandaloneLaunchDispatcher,
   type StandaloneLaunchDispatcherController,
@@ -3476,46 +3477,22 @@ function createEmbeddedTerminalBackendFromConfig(
 
     ipcMain.handle('invoker:refresh-task-graph', async () => {
       const startedAtMs = Date.now();
-      let tasks: TaskState[];
-      let workflows: WorkflowMeta[];
-
-      if (!ownerMode) {
-        const delegated = await messageBus.request('headless.query', {
-          kind: 'task-graph-refresh',
-        }) as unknown;
-        if (!delegated || typeof delegated !== 'object') {
-          throw new Error('refresh-task-graph owner delegation returned no snapshot');
-        }
-        const snapshot = delegated as {
-          tasks?: unknown[];
-          workflows?: unknown[];
-          invokerHomeRoot?: string;
-        };
-        if (!Array.isArray(snapshot.tasks) || !Array.isArray(snapshot.workflows)) {
-          throw new Error('refresh-task-graph owner delegation returned an invalid snapshot');
-        }
-        const localInvokerHomeRoot = resolveInvokerHomeRoot();
-        if (snapshot.invokerHomeRoot && snapshot.invokerHomeRoot !== localInvokerHomeRoot) {
-          throw new Error(
-            `refresh-task-graph owner home mismatch: owner=${snapshot.invokerHomeRoot} local=${localInvokerHomeRoot}`,
-          );
-        }
-        tasks = snapshot.tasks as TaskState[];
-        workflows = snapshot.workflows as WorkflowMeta[];
-      } else {
-        orchestrator.syncAllFromDb();
-        tasks = orchestrator.getAllTasks();
-        workflows = persistence.listWorkflows() as WorkflowMeta[];
-      }
+      const snapshot = await resolveRefreshTaskGraphSnapshot({
+        ownerMode,
+        messageBus,
+        resolveInvokerHomeRoot,
+        orchestrator,
+        persistence,
+      });
 
       taskGraphEventPublisher.publishSnapshot(
         ownerMode ? 'refresh-task-graph' : 'refresh-task-graph-delegated',
-        tasks,
-        workflows,
+        snapshot.tasks,
+        snapshot.workflows,
       );
       recordStartupDuration('refresh-task-graph.return', startedAtMs, {
-        taskCount: tasks.length,
-        workflowCount: workflows.length,
+        taskCount: snapshot.tasks.length,
+        workflowCount: snapshot.workflows.length,
         streamSequence: getTaskDeltaStreamSequence(),
       });
     });

--- a/packages/app/src/refresh-task-graph.ts
+++ b/packages/app/src/refresh-task-graph.ts
@@ -1,0 +1,69 @@
+import type { WorkflowMeta } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { MessageBus } from '@invoker/transport';
+import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+
+interface DelegatedRefreshTaskGraphSnapshot {
+  tasks: TaskState[];
+  workflows: WorkflowMeta[];
+  invokerHomeRoot?: string;
+}
+
+export interface RefreshTaskGraphSnapshot {
+  tasks: TaskState[];
+  workflows: WorkflowMeta[];
+}
+
+export interface ResolveRefreshTaskGraphSnapshotDeps {
+  ownerMode: boolean;
+  messageBus: Pick<MessageBus, 'request'>;
+  resolveInvokerHomeRoot: () => string;
+  orchestrator: Pick<Orchestrator, 'syncAllFromDb' | 'getAllTasks'>;
+  persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
+}
+
+function parseDelegatedRefreshTaskGraphSnapshot(
+  value: unknown,
+  localInvokerHomeRoot: string,
+): DelegatedRefreshTaskGraphSnapshot {
+  if (!value || typeof value !== 'object') {
+    throw new Error('refresh-task-graph owner delegation returned no snapshot');
+  }
+
+  const snapshot = value as {
+    tasks?: unknown[];
+    workflows?: unknown[];
+    invokerHomeRoot?: string;
+  };
+  if (!Array.isArray(snapshot.tasks) || !Array.isArray(snapshot.workflows)) {
+    throw new Error('refresh-task-graph owner delegation returned an invalid snapshot');
+  }
+  if (snapshot.invokerHomeRoot && snapshot.invokerHomeRoot !== localInvokerHomeRoot) {
+    throw new Error(
+      `refresh-task-graph owner home mismatch: owner=${snapshot.invokerHomeRoot} local=${localInvokerHomeRoot}`,
+    );
+  }
+
+  return snapshot as DelegatedRefreshTaskGraphSnapshot;
+}
+
+export async function resolveRefreshTaskGraphSnapshot(
+  deps: ResolveRefreshTaskGraphSnapshotDeps,
+): Promise<RefreshTaskGraphSnapshot> {
+  if (!deps.ownerMode) {
+    const delegated = parseDelegatedRefreshTaskGraphSnapshot(
+      await deps.messageBus.request('headless.query', { kind: 'task-graph-refresh' }) as unknown,
+      deps.resolveInvokerHomeRoot(),
+    );
+    return {
+      tasks: delegated.tasks,
+      workflows: delegated.workflows,
+    };
+  }
+
+  deps.orchestrator.syncAllFromDb();
+  return {
+    tasks: deps.orchestrator.getAllTasks(),
+    workflows: deps.persistence.listWorkflows() as WorkflowMeta[],
+  };
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,11 +1,11 @@
 // @invoker/contracts - Shared interfaces and type definitions
 
-export * from './types.js';
-export * from './validation.js';
-export * from './logger.js';
-export * from './command-envelope.js';
-export * from './ipc-channels.js';
-export * from './repo-root.js';
-export * from './cost-types.js';
-export * from './launch-timeouts.js';
-export * from './invoker-home.js';
+export * from './types.ts';
+export * from './validation.ts';
+export * from './logger.ts';
+export * from './command-envelope.ts';
+export * from './ipc-channels.ts';
+export * from './repo-root.ts';
+export * from './cost-types.ts';
+export * from './launch-timeouts.ts';
+export * from './invoker-home.ts';

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -3,7 +3,7 @@
  * Lightweight runtime checks (no external schema library).
  */
 
-import type { WorkRequest, WorkResponse } from './types.js';
+import type { WorkRequest, WorkResponse } from './types.ts';
 
 export interface ValidationResult {
   valid: boolean;

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "composite": false
+    "composite": false,
+    "allowImportingTsExtensions": true
   },
   "include": [
     "src/**/*.ts"

--- a/scripts/retry-pending-autofix-failed.sh
+++ b/scripts/retry-pending-autofix-failed.sh
@@ -63,7 +63,7 @@ Loop actions:
   - retry infrastructure failures with a cooldown instead of sending them to Codex
   - clear stale explicit SSH pool member pins from pending pool-routed retry work
   - release duplicate active SSH leases held by the same selected task attempt
-  - optionally run `set executor <taskId> worktree` for stale/failed SSH recovery tasks before resume/retry/fix/approve
+  - never changes a task executor directly; routing remains pool-owned
   - run `approve <taskId>` for approval-state tasks that have pendingFixError
   - when only pending nonterminal tasks remain, ask local Codex to investigate why each pending task did not run
 
@@ -90,8 +90,8 @@ Options:
   --query-timeout <seconds>     Read-only headless query timeout; 0 disables it (default: 120)
   --no-ipc-fallback             Do not retry failed IPC mutations in standalone mode
   --no-approve-fixes            Do not approve AI-fix approval tasks
-  --localize-ssh                Switch stale/failed SSH recovery tasks to local worktrees
-  --no-localize-ssh             Do not switch SSH-assigned recovery tasks to local worktrees
+  --localize-ssh                Deprecated no-op; executor selection is pool-owned
+  --no-localize-ssh             Deprecated no-op
   --no-localize-failed-ssh      Deprecated alias for --no-localize-ssh
   --resume-cooldown <seconds>   Per-workflow resume cooldown (default: 60)
   --fix-cooldown <seconds>      Per-task fix cooldown (default: 300)
@@ -210,7 +210,8 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --localize-ssh)
-      LOCALIZE_SSH=true
+      LOCALIZE_SSH=false
+      echo "warning: --localize-ssh is deprecated and ignored; use pool routing instead" >&2
       shift
       ;;
     --no-localize-failed-ssh)
@@ -1399,9 +1400,9 @@ for raw in tasks_path.read_text(encoding="utf-8").splitlines():
         blocking_tasks.append(task_id)
         failed_tasks.append(task_id)
         auto_fix_attempts[task_id] = parse_attempts(execution.get("autoFixAttempts"))
-        if is_infra_failure(error_text):
+        if is_infra_failure(error_text) and runner_kind != "worktree":
             infra_retry.append(task_id)
-        if runner_kind == "ssh":
+        if runner_kind == "ssh" or (runner_kind == "worktree" and pool_id):
             localize_ssh.append(task_id)
     elif status == "fixing_with_ai" or (status == "running" and execution.get("isFixingWithAI") is True):
         blocking_tasks.append(task_id)
@@ -1977,45 +1978,14 @@ run_cycle() {
   fi
 
   if [ "$LOCALIZE_SSH" = true ] && [ -s "$localize_ssh_file" ]; then
-    echo "switching SSH-assigned recovery tasks to local worktrees"
-    while IFS= read -r target; do
-      [ -n "$target" ] || continue
-      if ever_submitted localize-worktree "$target"; then
-        echo "  skip localize-worktree $target (already switched by this loop)"
-        continue
-      fi
-      if dispatch_no_track localize-worktree "$target" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch" set executor "$target" worktree; then
-        if [ "$LAST_DISPATCH_SUBMITTED" = true ]; then
-          printf '%s\n' "$target" >> "$localized_failed_tasks_file"
-          if [[ "$target" == */* ]]; then
-            printf '%s\n' "${target%%/*}" >> "$localized_workflows_file"
-          fi
-        fi
-      else
-        failures=$((failures + 1))
-      fi
-    done < "$localize_ssh_file"
+    echo "localize-ssh requested but ignored; executor selection is pool-owned"
+  fi
+  if [ -s "$localized_failed_tasks_file" ]; then
+    reset_submission_state_after_repair "ssh-to-worktree" "$now_epoch" "$cycle_dir"
   fi
 
   if [ -s "$stale_ssh_pin_file" ]; then
-    echo "clearing stale explicit SSH pool member pins"
-    while IFS= read -r target; do
-      [ -n "$target" ] || continue
-      if recently_submitted clear-ssh-pin "$target" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch"; then
-        echo "  skip clear-ssh-pin $target (cleared recently)"
-        continue
-      fi
-      if dispatch_no_track clear-ssh-pin "$target" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch" set executor "$target" ssh; then
-        if [ "$LAST_DISPATCH_SUBMITTED" = true ]; then
-          printf '%s\n' "$target" >> "$cleared_ssh_pin_tasks_file"
-          if [[ "$target" == */* ]]; then
-            printf '%s\n' "${target%%/*}" >> "$cleared_ssh_pin_workflows_file"
-          fi
-        fi
-      else
-        failures=$((failures + 1))
-      fi
-    done < "$stale_ssh_pin_file"
+    echo "stale explicit SSH pool member pins detected; leaving task pool routing unchanged"
   fi
 
   if [ -s "$orphan_ssh_leases_file" ]; then
@@ -2434,7 +2404,7 @@ SELFTEST_CODEX
     RETRY_FAILED=true
     AUTOFIX_FAILED=true
     APPROVE_FIXES=true
-    LOCALIZE_SSH=true
+    LOCALIZE_SSH=false
     MAX_FIX_ATTEMPTS=3
     RECOVER_STALE_AI_STATES=true
     STALE_AI_STATE_SECONDS=300
@@ -2658,7 +2628,7 @@ PY
   self_test_assert_not_contains "$commands_file" "set executor wf-1000-13/pending ssh"
   self_test_assert_contains "$codex_commands_file" "exec --cd"
 
-  echo "self-test: stale SSH pool member pin is cleared without localizing"
+  echo "self-test: stale SSH pool member pin leaves pool routing unchanged"
   self_test_reset
   RETRY_INCOMPLETE_WORKFLOWS=true
   printf '%s\n' "wf-1000-16" > "$workflows_label_file"
@@ -2667,12 +2637,11 @@ PY
   printf '%s\n' '{"id":"wf-1000-16/regression","status":"pending","config":{"workflowId":"wf-1000-16","runnerKind":"ssh","poolId":"pnpm-ssh","poolMemberId":"remote-a"},"execution":{"workspacePath":"~/.invoker/worktrees/wf-1000-16-regression","branch":"experiment/wf-1000-16/regression"}}' > "$tasks_dir/wf-1000-16.jsonl"
   run_cycle selftest-stale-ssh-pin > "$test_root/stale-ssh-pin.out" 2>&1 || { sed -n '1,220p' "$test_root/stale-ssh-pin.out" >&2; return 1; }
   self_test_assert_contains "$test_root/stale-ssh-pin.out" "stale-ssh-pin=1"
-  self_test_assert_contains "$commands_file" "set executor wf-1000-16/regression ssh"
+  self_test_assert_not_contains "$commands_file" "set executor wf-1000-16/regression ssh"
   self_test_assert_not_contains "$commands_file" "set executor wf-1000-16/regression worktree"
-  self_test_assert_contains "$test_root/stale-ssh-pin.out" "skip retry-workflow wf-1000-16 (stale SSH pin cleared this cycle)"
-  self_test_assert_contains "$test_root/stale-ssh-pin.out" "pending investigation deferred (stale SSH pins cleared this cycle: 1)"
+  self_test_assert_contains "$test_root/stale-ssh-pin.out" "stale explicit SSH pool member pins detected; leaving task pool routing unchanged"
 
-  echo "self-test: stale SSH pin clearing is repeatable after cooldown"
+  echo "self-test: stale SSH pin remains untouched after cooldown"
   self_test_reset
   local old_epoch
   old_epoch=$((now_epoch - LOCALIZE_COOLDOWN_SECONDS - 1))
@@ -2682,7 +2651,7 @@ PY
   printf '%s\n' '{"running":[],"queued":[{"taskId":"wf-1000-17/regression"}],"runningCount":0,"maxConcurrency":12}' > "$self_test_queue_file"
   printf '%s\n' '{"id":"wf-1000-17/regression","status":"pending","config":{"workflowId":"wf-1000-17","runnerKind":"ssh","poolId":"pnpm-ssh","poolMemberId":"remote-a"},"execution":{"workspacePath":"~/.invoker/worktrees/wf-1000-17-regression","branch":"experiment/wf-1000-17/regression"}}' > "$tasks_dir/wf-1000-17.jsonl"
   run_cycle selftest-stale-ssh-pin-repeat > "$test_root/stale-ssh-pin-repeat.out" 2>&1 || { sed -n '1,220p' "$test_root/stale-ssh-pin-repeat.out" >&2; return 1; }
-  self_test_assert_contains "$commands_file" "set executor wf-1000-17/regression ssh"
+  self_test_assert_not_contains "$commands_file" "set executor wf-1000-17/regression ssh"
 
   echo "self-test: duplicate selected-attempt SSH lease releases only non-assigned member"
   self_test_reset

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -4,6 +4,7 @@
     "composite": false,
     "incremental": false,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "rootDir": ".",
     "outDir": "./dist-typecheck"
   },


### PR DESCRIPTION
## Summary

This extracts the task graph refresh snapshot lookup from `main.ts`.

The behavior stays the same. Owner mode reads locally. Follower mode asks the owner and still throws when the owner response is missing or invalid.

This diff only moves code. It does not add fallback behavior, logging, or a new return shape.

## Test Plan

- [x] pnpm --filter @invoker/app exec vitest run src/__tests__/refresh-task-graph.test.ts
- [x] pnpm run check:types
- [x] pnpm run check:ts-source-imports

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 385e36f92
- Post-revert steps: None
- Data migration? No

Depends-On: #1549
