### PR TITLE
review(invoker): gate PRs by review lane

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -117,7 +117,7 @@ Options:
   --help             Show this help
 
 PR body schema:
-  Required: ## Summary, ## Test Plan, ## Revert Plan
+  Required: ## Summary, ## Review Claim, ## Review Lane, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
   Optional: ## Architecture (must include ### Before and ### After when present)
   UI-impacting diffs require ## Visual Proof with screenshot or video proof.
   Template: scripts/pr-body-template.md`);
@@ -157,7 +157,7 @@ function assertValidPrBody(body, options = {}) {
 
   throw new Error(
     [
-      'PR body does not match the canonical schema.',
+      'PR body does not match the canonical review-compression schema.',
       ...errors.map((error) => `- ${error}`),
       '',
       options.requiresVisualProof
@@ -418,7 +418,7 @@ async function main() {
     console.error(`UI-impacting files changed; requiring visual proof: ${uiImpactingFiles.join(', ')}`);
   }
 
-  assertValidPrBody(body, { requiresVisualProof: uiImpactingFiles.length > 0 });
+  assertValidPrBody(body, { requiresVisualProof: uiImpactingFiles.length > 0, changedFiles });
   printPrBodyWarnings(body);
 
   // Inject images

--- a/scripts/pr-body-template.md
+++ b/scripts/pr-body-template.md
@@ -6,6 +6,26 @@ Write paragraphs, not bullets. Keep each paragraph under 30 words.
 
 Put one idea in each paragraph. If one idea leads to another, split them into separate short paragraphs.
 
+## Review Claim
+
+State the one thing the reviewer is being asked to approve.
+
+## Review Lane
+
+Choose exactly one: `behavior`, `refactor`, `proof`, `cleanup`, `policy`, or `docs`.
+
+## Safety Invariant
+
+Explain why this slice is safe to review locally.
+
+## Slice Rationale
+
+Explain why this work is split here instead of bundled elsewhere.
+
+## Non-goals
+
+List what this slice explicitly does not change.
+
 ## Architecture
 
 Only keep this section if the change affects component interactions, control flow, or data flow.

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { getPrBodyWarnings, validatePrBody } from './validate-pr-body.mjs';
+import { getPrBodyWarnings, validatePrBody, validatePrScope } from './validate-pr-body.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -11,6 +11,26 @@ function assert(condition, message) {
 const validMinimal = `## Summary
 
 Small fix.
+
+## Review Claim
+
+Keep the owner fallback local.
+
+## Review Lane
+
+- behavior
+
+## Safety Invariant
+
+Only the refresh path changes.
+
+## Slice Rationale
+
+Proof and cleanup stay separate.
+
+## Non-goals
+
+- Do not add repro scripts or docs in this slice.
 
 ## Test Plan
 
@@ -27,6 +47,26 @@ Small fix.
 const validArchitecture = `## Summary
 
 Flow change.
+
+## Review Claim
+
+Route refresh through one helper.
+
+## Review Lane
+
+- behavior
+
+## Safety Invariant
+
+The same callers keep the same contract.
+
+## Slice Rationale
+
+Move behavior without mixing cleanup.
+
+## Non-goals
+
+- Do not add repro scripts or docs in this slice.
 
 ## Architecture
 
@@ -81,6 +121,26 @@ const missingTestPlanErrors = validatePrBody(`## Summary
 
 Only summary.
 
+## Review Claim
+
+One claim.
+
+## Review Lane
+
+- behavior
+
+## Safety Invariant
+
+Local only.
+
+## Slice Rationale
+
+Small slice.
+
+## Non-goals
+
+- No docs.
+
 ## Revert Plan
 
 - Safe to revert? Yes
@@ -93,6 +153,26 @@ assert(missingTestPlanErrors.some((error) => error.includes('Missing required se
 const malformedArchitectureErrors = validatePrBody(`## Summary
 
 Flow change.
+
+## Review Claim
+
+One claim.
+
+## Review Lane
+
+- behavior
+
+## Safety Invariant
+
+Local only.
+
+## Slice Rationale
+
+Small slice.
+
+## Non-goals
+
+- No docs.
 
 ## Architecture
 
@@ -116,9 +196,65 @@ graph TD
 `);
 assert(malformedArchitectureErrors.some((error) => error.includes('Architecture section is missing required subsection: ### After')), 'missing architecture after section should fail');
 
+const missingReviewLaneErrors = validatePrBody(`## Summary
+
+Small fix.
+
+## Review Claim
+
+One claim.
+
+## Safety Invariant
+
+Local only.
+
+## Slice Rationale
+
+Small slice.
+
+## Non-goals
+
+- No docs.
+
+## Test Plan
+
+- [ ] \`pnpm test\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`);
+assert(missingReviewLaneErrors.some((error) => error.includes('Missing required section: ## Review Lane')), 'missing review lane should fail');
+
+const invalidReviewLaneErrors = validatePrBody(validMinimal.replace('- behavior', '- impossible'));
+assert(invalidReviewLaneErrors.some((error) => error.includes('Invalid review lane: impossible')), 'invalid review lane should fail');
+
 const longSummary = `## Summary
 
 This summary paragraph uses too many words because it tries to explain several related implementation details at the same time instead of giving a tired reviewer one clear idea they can understand immediately.
+
+## Review Claim
+
+One claim.
+
+## Review Lane
+
+- behavior
+
+## Safety Invariant
+
+Local only.
+
+## Slice Rationale
+
+Small slice.
+
+## Non-goals
+
+- No docs.
 
 ## Test Plan
 
@@ -135,7 +271,6 @@ This summary paragraph uses too many words because it tries to explain several r
 const longSummaryWarnings = getPrBodyWarnings(longSummary);
 assert(validatePrBody(longSummary).length === 0, 'summary readability warnings should not fail validation');
 assert(longSummaryWarnings.some((warning) => warning.includes('Summary paragraph 1')), 'long summary paragraph should warn');
-
 
 const missingVisualProofErrors = validatePrBody(validMinimal, { requiresVisualProof: true });
 assert(
@@ -165,6 +300,111 @@ const warningOnlyVisualProofErrors = validatePrBody(`${validMinimal}
 assert(
   warningOnlyVisualProofErrors.some((error) => error.includes('UI-impacting changes require a ## Visual Proof section')),
   'warning-only visual proof should not satisfy UI proof requirement',
+);
+
+const behaviorScopeErrors = validatePrBody(validMinimal, {
+  changedFiles: [
+    'packages/app/src/main.ts',
+    'packages/app/src/refresh-task-graph.ts',
+    'scripts/repro/repro-refresh-task-graph-owner-detach.sh',
+  ],
+});
+assert(
+  behaviorScopeErrors.some((error) => error.includes('Review lane behavior cannot ship with proof files')),
+  'behavior lane should reject repro/benchmark files in the same PR',
+);
+
+const policyScopeErrors = validatePrBody(validMinimal.replace('- behavior', '- policy'), {
+  changedFiles: [
+    'scripts/create-pr.mjs',
+    'scripts/validate-pr-body.mjs',
+    'packages/app/src/main.ts',
+  ],
+});
+assert(
+  policyScopeErrors.some((error) => error.includes('Review lane policy cannot ship with product files')),
+  'policy lane should reject product files in the same PR',
+);
+
+const proofScopeErrors = validatePrBody(validMinimal.replace('- behavior', '- proof'), {
+  changedFiles: [
+    'packages/app/e2e/ui-graph-drag-performance.spec.ts',
+    'packages/app/src/launch-dispatcher.ts',
+  ],
+});
+assert(
+  proofScopeErrors.some((error) => error.includes('Review lane proof cannot ship with product files')),
+  'proof lane should reject runtime behavior changes in the same PR',
+);
+
+const docsScopeErrors = validatePrBody(validMinimal.replace('- behavior', '- docs'), {
+  changedFiles: [
+    'skills/make-pr/SKILL.md',
+    'scripts/create-pr.mjs',
+  ],
+});
+assert(
+  docsScopeErrors.some((error) => error.includes('Review lane docs cannot ship with policy files')),
+  'docs lane should reject policy/tooling files in the same PR',
+);
+
+const refactorBody = `## Summary
+
+Extract a helper first.
+
+## Review Claim
+
+Move refresh logic into a helper module.
+
+## Review Lane
+
+- refactor
+
+## Safety Invariant
+
+Behavior stays unchanged.
+
+## Slice Rationale
+
+Field additions land in a later behavior PR.
+
+## Non-goals
+
+- No behavior change.
+- No new fields in this slice.
+
+## Test Plan
+
+- [ ] \`pnpm test\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`;
+assert(
+  validatePrBody(refactorBody, { changedFiles: ['packages/app/src/main.ts', 'packages/app/src/refresh-task-graph.ts'] }).length === 0,
+  'refactor lane with explicit no-behavior non-goals should pass for product-only files',
+);
+
+const refactorNonGoalErrors = validatePrBody(refactorBody.replace('No behavior change.', 'No docs changes.'), {
+  changedFiles: ['packages/app/src/main.ts', 'packages/app/src/refresh-task-graph.ts'],
+});
+assert(
+  refactorNonGoalErrors.some((error) => error.includes('Review lane refactor must state in ## Non-goals that behavior stays unchanged')),
+  'refactor lane should require an explicit unchanged-behavior non-goal',
+);
+
+const directScopeErrors = validatePrScope({
+  reviewLane: 'behavior',
+  changedFiles: ['packages/app/src/main.ts', 'docs/incidents/example.md'],
+  body: validMinimal,
+});
+assert(
+  directScopeErrors.some((error) => error.includes('Review lane behavior cannot ship with docs files')),
+  'direct scope validator should reject product plus docs mixing',
 );
 
 console.log('OK: PR body validator checks passed');

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -2,9 +2,19 @@
 
 import { readFileSync } from 'node:fs';
 
-const REQUIRED_SECTIONS = ['## Summary', '## Test Plan', '## Revert Plan'];
+const REQUIRED_SECTIONS = [
+  '## Summary',
+  '## Review Claim',
+  '## Review Lane',
+  '## Safety Invariant',
+  '## Slice Rationale',
+  '## Non-goals',
+  '## Test Plan',
+  '## Revert Plan',
+];
 const DISCOURAGED_HEADINGS = ['## Testing', '## Notes'];
 const SUMMARY_WORD_LIMIT = 30;
+const VALID_REVIEW_LANES = new Set(['behavior', 'refactor', 'proof', 'cleanup', 'policy', 'docs']);
 
 function getSectionBody(body, heading) {
   const lines = body.split(/\r?\n/);
@@ -36,6 +46,90 @@ function hasVisualProofMedia(body) {
     || /\bhttps?:\/\/\S+\.(?:png|jpe?g|gif|webp|webm|mp4)\b/i.test(visualProof);
 }
 
+function normalizeSectionValue(sectionBody) {
+  const firstLine = sectionBody
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+
+  if (!firstLine) return '';
+  return firstLine.replace(/^[-*]\s*/, '').trim().toLowerCase();
+}
+
+function classifyScopeKind(filePath) {
+  const path = filePath.replace(/\\/g, '/');
+
+  if (path.startsWith('scripts/repro/')) return 'proof';
+  if (path.startsWith('skills/') || path.startsWith('docs/') || path.endsWith('.md')) return 'docs';
+  if (path.startsWith('scripts/')) return 'policy';
+  if (
+    path.includes('/e2e/')
+    || path.includes('/__tests__/')
+    || /\.(spec|test)\.[jt]sx?$/.test(path)
+  ) {
+    if (/(benchmark|performance|visual-proof)/.test(path)) return 'proof';
+    return 'product-test';
+  }
+  if (/(benchmark|performance|visual-proof)/.test(path)) return 'proof';
+  if (path.startsWith('packages/')) return 'product';
+  return 'other';
+}
+
+function formatKinds(kinds) {
+  return Array.from(kinds).sort().join(', ');
+}
+
+export function validatePrScope({ changedFiles = [], reviewLane = '', body = '' } = {}) {
+  const errors = [];
+  if (!reviewLane || changedFiles.length === 0) return errors;
+
+  const kinds = new Set(changedFiles.map(classifyScopeKind).filter((kind) => kind !== 'other'));
+  const nonGoals = getSectionBody(body, '## Non-goals').toLowerCase();
+
+  if (reviewLane === 'behavior' || reviewLane === 'refactor' || reviewLane === 'cleanup') {
+    const forbidden = ['docs', 'policy', 'proof'].filter((kind) => kinds.has(kind));
+    if (forbidden.length > 0) {
+      errors.push(
+        `Review lane ${reviewLane} cannot ship with ${forbidden.join(', ')} files in the same PR. Split behavior or cleanup from docs, policy, repro, and benchmark slices.`,
+      );
+    }
+  }
+
+  if (reviewLane === 'proof') {
+    const forbidden = ['product', 'docs', 'policy'].filter((kind) => kinds.has(kind));
+    if (forbidden.length > 0) {
+      errors.push(
+        `Review lane proof cannot ship with ${forbidden.join(', ')} files in the same PR. Keep benchmarks, repros, and regression proof separate from behavior or policy changes.`,
+      );
+    }
+  }
+
+  if (reviewLane === 'policy') {
+    const forbidden = ['product', 'proof'].filter((kind) => kinds.has(kind));
+    if (forbidden.length > 0) {
+      errors.push(
+        `Review lane policy cannot ship with ${forbidden.join(', ')} files in the same PR. Keep tooling/runtime policy separate from behavior and proof changes.`,
+      );
+    }
+  }
+
+  if (reviewLane === 'docs') {
+    const forbidden = ['product', 'policy', 'proof', 'product-test'].filter((kind) => kinds.has(kind));
+    if (forbidden.length > 0) {
+      errors.push(
+        `Review lane docs cannot ship with ${forbidden.join(', ')} files in the same PR. Keep docs and skill updates in their own slice.`,
+      );
+    }
+  }
+
+  if (reviewLane === 'refactor') {
+    if (!/(no behavior change|behavior unchanged|unchanged behavior|pass unchanged)/.test(nonGoals)) {
+      errors.push('Review lane refactor must state in ## Non-goals that behavior stays unchanged.');
+    }
+  }
+
+  return errors;
+}
 
 export function getPrBodyWarnings(body) {
   const warnings = [];
@@ -61,7 +155,7 @@ export function validatePrBody(body, options = {}) {
 
   if (!trimmed) {
     return [
-      'PR body is empty. Use the canonical schema: ## Summary, ## Test Plan, ## Revert Plan, plus optional ## Architecture.',
+      'PR body is empty. Use the canonical schema: ## Summary, ## Review Claim, ## Review Lane, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, and ## Revert Plan.',
     ];
   }
 
@@ -74,7 +168,7 @@ export function validatePrBody(body, options = {}) {
   for (const heading of DISCOURAGED_HEADINGS) {
     if (trimmed.includes(heading)) {
       errors.push(
-        `Unsupported section: ${heading}. Do not use the lightweight PR format; use ## Test Plan and ## Revert Plan instead.`,
+        `Unsupported section: ${heading}. Do not use the lightweight PR format; use the canonical review-compression schema instead.`,
       );
     }
   }
@@ -87,12 +181,26 @@ export function validatePrBody(body, options = {}) {
     }
   }
 
+  const reviewLane = normalizeSectionValue(getSectionBody(trimmed, '## Review Lane'));
+  if (reviewLane && !VALID_REVIEW_LANES.has(reviewLane)) {
+    errors.push(`Invalid review lane: ${reviewLane}. Expected one of ${Array.from(VALID_REVIEW_LANES).join(', ')}.`);
+  }
+
+  const reviewClaim = getSectionBody(trimmed, '## Review Claim');
+  if (reviewClaim && !reviewClaim.trim()) {
+    errors.push('## Review Claim must not be empty.');
+  }
 
   if (options.requiresVisualProof && !hasVisualProofMedia(trimmed)) {
     errors.push(
       'UI-impacting changes require a ## Visual Proof section with at least one screenshot image or video/walkthrough link.',
     );
   }
+
+  if (reviewLane && options.changedFiles?.length) {
+    errors.push(...validatePrScope({ changedFiles: options.changedFiles, reviewLane, body: trimmed }));
+  }
+
   return errors;
 }
 
@@ -100,7 +208,7 @@ function usage() {
   console.error(`Usage: node scripts/validate-pr-body.mjs (--body-file <file> | --body <markdown>) [--require-visual-proof]
 
 Validates the canonical PR schema:
-  Required: ## Summary, ## Test Plan, ## Revert Plan
+  Required: ## Summary, ## Review Claim, ## Review Lane, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
   Optional: ## Architecture (must include ### Before and ### After when present)
   UI changes: pass --require-visual-proof to require screenshot or video proof.`);
   process.exit(1);

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -37,6 +37,26 @@ Put one idea in each paragraph. If one idea leads to another, split them into se
 
 Avoid implementation jargon unless it is necessary for understanding the change.
 
+## Review Claim
+
+State the one thing the reviewer is being asked to approve.
+
+## Review Lane
+
+Choose exactly one: `behavior`, `refactor`, `proof`, `cleanup`, `policy`, or `docs`.
+
+## Safety Invariant
+
+Explain why this slice is safe to review locally.
+
+## Slice Rationale
+
+Explain why this work is split here instead of bundled elsewhere.
+
+## Non-goals
+
+List what this slice explicitly does not change.
+
 ## Architecture
 
 Only include this section when the change modifies component interactions, control flow, state flow, or data flow.
@@ -74,7 +94,7 @@ If the change is small and has no architectural impact, omit `## Architecture` r
 
 If the change touches UI-impacting files, use `skills/visual-proof/SKILL.md` first and include its screenshot/video markdown in `## Visual Proof`. UI-impacting files include `packages/ui/**`, Electron window lifecycle files, preload, main process window wiring, and app menu changes.
 
-Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Test Plan / ## Revert Plan` as the floor, add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.
+Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Review Claim / ## Review Lane / ## Safety Invariant / ## Slice Rationale / ## Non-goals / ## Test Plan / ## Revert Plan` as the floor, add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.
 
 ## Command surface
 


### PR DESCRIPTION
## Summary

Invoker PR publication now checks review-lane scope before opening or updating a PR.

The old PR validator only checked the basic body schema and UI visual proof. It did not stop behavior-plus-proof, refactor-plus-behavior, or wide mixed-scope publication.

This requires review metadata in PR bodies, validates the declared lane against changed files, and adds regression checks for the wide PR shapes we want to stop.

## Review Claim

Block PR publication when the body omits review-lane metadata or when the declared lane does not match the changed-file scope.

## Review Lane

- policy

## Safety Invariant

This only changes PR tooling, the PR body template, and validator tests. It does not change Invoker workflow execution or application runtime behavior.

## Slice Rationale

The planning slice teaches workflows how to split. This publication slice stops wide diffs from slipping through when the plan still drifts or a PR is hand-authored.

## Non-goals

- Do not change Invoker's workflow unit or add synthetic workflow behavior.
- Do not auto-split running workflows.
- Do not require UI visual proof for non-UI diffs.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh`
- [x] `node scripts/test-pr-body-validator.mjs`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 00f096cbe`
- Post-revert steps: None
- Data migration? No
