### PR TITLE
[Recovery Lifecycle][Auto-fix Worker Policy][D3] List auto-fix recovery scan candidates

### DIFF
--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { TaskState } from '@invoker/workflow-core';
+
 import {
   createRecoveryWorker,
+  listAutoFixRecoveryScanCandidates,
   RECOVERY_WORKER_KIND,
 } from '../workers/auto-fix-recovery.js';
 
@@ -13,6 +16,27 @@ const logger = {
   trace: vi.fn(),
   child: vi.fn(),
 };
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/task-1',
+    description: 'failed task',
+    status: 'failed',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', ...(config ?? {}) },
+    execution: {
+      error: 'boom',
+      autoFixAttempts: 0,
+      generation: 1,
+      selectedAttemptId: 'attempt-1',
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 4,
+    ...rest,
+  };
+}
 
 describe('auto-fix recovery worker', () => {
   afterEach(() => {
@@ -49,5 +73,31 @@ describe('auto-fix recovery worker', () => {
     await vi.advanceTimersByTimeAsync(1000);
     expect(onTick).toHaveBeenCalledTimes(1);
     await runtime.stop();
+  });
+});
+
+describe('auto-fix recovery scan candidates', () => {
+  it('lists failed persisted tasks with version metadata', () => {
+    const failedTask = makeTask();
+    const completedTask = makeTask({ id: 'wf-1/task-2', status: 'completed' });
+
+    const candidates = listAutoFixRecoveryScanCandidates({
+      store: {
+        listWorkflows: () => [{ id: 'wf-1' }],
+        loadTasks: () => [failedTask, completedTask],
+        listWorkflowMutationIntents: () => [],
+      },
+    });
+
+    expect(candidates).toEqual([
+      {
+        taskId: 'wf-1/task-1',
+        workflowId: 'wf-1',
+        generation: 1,
+        taskStateVersion: 4,
+        attemptId: 'attempt-1',
+        source: 'scan',
+      },
+    ]);
   });
 });

--- a/packages/app/src/workers/auto-fix-recovery.ts
+++ b/packages/app/src/workers/auto-fix-recovery.ts
@@ -44,6 +44,46 @@ export interface AutoFixRecoveryPolicyOptions {
   getRetryBudget?: (task: TaskState) => number;
 }
 
+export type AutoFixRecoveryCandidate = {
+  taskId: string;
+  workflowId: string;
+  generation: number;
+  taskStateVersion: number;
+  attemptId?: string;
+  source: 'scan';
+};
+
+function workflowIdForTask(task: TaskState): string | undefined {
+  return task.config.workflowId ?? task.id.split('/')[0];
+}
+
+function candidateFromTask(task: TaskState): AutoFixRecoveryCandidate | undefined {
+  const workflowId = workflowIdForTask(task);
+  if (!workflowId) return undefined;
+  return {
+    taskId: task.id,
+    workflowId,
+    generation: task.execution.generation ?? 0,
+    taskStateVersion: task.taskStateVersion,
+    attemptId: task.execution.selectedAttemptId,
+    source: 'scan',
+  };
+}
+
+export function listAutoFixRecoveryScanCandidates(
+  options: Pick<AutoFixRecoveryPolicyOptions, 'store'>,
+): AutoFixRecoveryCandidate[] {
+  const candidates: AutoFixRecoveryCandidate[] = [];
+  for (const workflow of options.store.listWorkflows()) {
+    for (const task of options.store.loadTasks(workflow.id)) {
+      if (task.status !== 'failed') continue;
+      const candidate = candidateFromTask(task);
+      if (candidate) candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+
 export interface RecoveryWorkerOptions {
   logger: Logger;
   instanceId?: string;


### PR DESCRIPTION
Review claim: Auto-fix recovery can enumerate failed persisted tasks as versioned scan candidates.

Safety invariant: This slice only reads persisted workflow/task state and does not validate eligibility or submit commands.

Slice rationale: Candidate discovery is separate from retry/stale-state policy and mutation submission.

Architectural effect: Durable workflow state is projected into worker-local auto-fix recovery candidate records.

Alternative considerations: Bundling scan discovery with validation made the previous policy diff too broad to review.