### PR TITLE
[Recovery Lifecycle][Auto-fix Worker Policy][D5] Submit validated auto-fix recovery intents

### DIFF
--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -1,11 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import type { WorkflowMutationIntent } from '@invoker/data-store';
+import type { WorkflowMutationIntent, WorkflowMutationPriority } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 
 import { buildFixWithAgentMutationArgs } from '../auto-fix-intents.js';
 import {
   collectValidatedAutoFixRecoveryCandidates,
+  createAutoFixRecoveryTick,
   createRecoveryWorker,
   listAutoFixRecoveryScanCandidates,
   RECOVERY_WORKER_KIND,
@@ -46,6 +47,19 @@ function makeRecoveryPolicyHarness(task: TaskState = makeTask(), existingIntents
   const tasks = new Map<string, TaskState>([[task.id, task]]);
   const intents: WorkflowMutationIntent[] = [...existingIntents];
   const logEvent = vi.fn();
+  const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
+    const id = intents.length + 1;
+    intents.push({
+      id,
+      workflowId,
+      priority,
+      channel,
+      args,
+      status: 'queued',
+      createdAt: new Date().toISOString(),
+    });
+    return id;
+  });
   const options = {
     store: {
       listWorkflows: vi.fn(() => workflows),
@@ -57,12 +71,12 @@ function makeRecoveryPolicyHarness(task: TaskState = makeTask(), existingIntents
       ))),
       logEvent,
     },
-    submitter: { submit: vi.fn() },
+    submitter: { submit },
     logger,
     defaultAutoFixRetries: 3,
     getAutoFixAgent: () => 'codex',
   };
-  return { options, logEvent, tasks, intents };
+  return { options, submit, logEvent, tasks, intents };
 }
 
 describe('auto-fix recovery worker', () => {
@@ -219,6 +233,27 @@ describe('auto-fix recovery candidate validation', () => {
         phase: 'worker-autofix-skip',
         reason: 'already-queued-intent',
       }),
+    );
+  });
+});
+
+describe('auto-fix recovery scan submission', () => {
+  it('submits eligible failed tasks through the command route', async () => {
+    const harness = makeRecoveryPolicyHarness();
+    const tick = createAutoFixRecoveryTick(harness.options);
+
+    await tick({
+      identity: { kind: 'recovery', instanceId: 'test' },
+      reason: 'startup',
+      tickNumber: 1,
+    });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.submit).toHaveBeenCalledWith(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', { autoFix: true }),
     );
   });
 });

--- a/packages/app/src/workers/auto-fix-recovery.ts
+++ b/packages/app/src/workers/auto-fix-recovery.ts
@@ -6,7 +6,10 @@ import type {
 } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 
-import { listOpenFixIntentsForTask } from '../auto-fix-intents.js';
+import {
+  buildFixWithAgentMutationArgs,
+  listOpenFixIntentsForTask,
+} from '../auto-fix-intents.js';
 import { shouldSkipAutoFixForError } from '../auto-fix-gating.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
 
@@ -263,26 +266,51 @@ export function collectValidatedAutoFixRecoveryCandidates(
     .filter((candidate): candidate is ValidatedAutoFixRecoveryCandidate => Boolean(candidate));
 }
 
+export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions): WorkerTick {
+  return async () => {
+    for (const candidate of collectValidatedAutoFixRecoveryCandidates(options)) {
+      const configuredAgent = options.getAutoFixAgent?.()?.trim();
+      const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
+      const args = buildFixWithAgentMutationArgs(candidate.task.id, selectedAgent, { autoFix: true });
+      const intentId = options.submitter.submit(candidate.workflowId, 'normal', AUTO_FIX_COMMAND_CHANNEL, args);
+      logAutoFixWorkerEvent(options, candidate.taskId, 'worker-autofix-submitted', {
+        workflowId: candidate.workflowId,
+        intentId,
+        channel: AUTO_FIX_COMMAND_CHANNEL,
+        generation: candidate.generation,
+        taskStateVersion: candidate.taskStateVersion,
+        attemptId: candidate.attemptId ?? null,
+        agent: selectedAgent ?? null,
+        autoFixAttempts: candidate.task.execution.autoFixAttempts ?? 0,
+        maxRetries: retryBudgetForTask(candidate.task, options),
+      });
+    }
+  };
+}
+
 export interface RecoveryWorkerOptions {
   logger: Logger;
   instanceId?: string;
   intervalMs?: number;
   installSignalHandlers?: boolean;
   tickOnStart?: boolean;
+  autoFix?: Omit<AutoFixRecoveryPolicyOptions, 'logger'>;
   /**
-   * Behavior-neutral override for the tick. Defaults to a no-op for this slice:
-   * the recovery worker does not submit recovery commands yet, and existing
-   * auto-fix paths continue to run through their current owner.
+   * Test hook or alternate worker policy. Takes precedence over `autoFix`.
    */
   onTick?: WorkerTick;
 }
 
 /**
- * Create the recovery worker runtime. By default its tick is a no-op so that
- * standing up the worker is behavior-neutral: no recovery commands are
- * submitted and no existing auto-fix path is rerouted in this slice.
+ * Create the recovery worker runtime. By default its tick is a no-op; supplying
+ * `autoFix` installs the dormant auto-fix scan policy.
  */
 export function createRecoveryWorker(options: RecoveryWorkerOptions): WorkerRuntime {
+  const onTick = options.onTick ?? (
+    options.autoFix
+      ? createAutoFixRecoveryTick({ ...options.autoFix, logger: options.logger })
+      : (() => {})
+  );
   return createWorkerRuntime({
     kind: RECOVERY_WORKER_KIND,
     instanceId: options.instanceId,
@@ -290,6 +318,6 @@ export function createRecoveryWorker(options: RecoveryWorkerOptions): WorkerRunt
     intervalMs: options.intervalMs ?? DEFAULT_RECOVERY_POLL_INTERVAL_MS,
     tickOnStart: options.tickOnStart ?? false,
     installSignalHandlers: options.installSignalHandlers,
-    onTick: options.onTick ?? (() => {}),
+    onTick,
   });
 }


### PR DESCRIPTION
Review claim: A validated auto-fix recovery candidate submits the existing fix-with-agent mutation intent.

Safety invariant: Submission still goes through the existing workflow mutation channel and no fix executes directly in the worker.

Slice rationale: Command submission is separate from contracts, candidate scanning, validation policy, wakeups, and CLI exposure.

Architectural effect: The recovery worker can install an auto-fix tick that bridges validated candidates to the mutation intent submitter port.

Alternative considerations: Calling autoFixOnFailure directly from the worker was rejected because it bypasses mutation coordination.