### PR TITLE
test(execution-engine): stabilize real-git tests

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -1049,7 +1049,7 @@ describe('merge gate commit topology (real git)', () => {
       { cwd: tmpDir },
     ).toString().trim().split('\n').filter(l => l.length > 0);
     expect(newCommits.length).toBe(1);
-  });
+  }, 60_000);
 
   it('automatic mode produces same topology in a single step', async () => {
     const masterHead = execSync('git rev-parse HEAD', { cwd: tmpDir }).toString().trim();

--- a/packages/execution-engine/src/__tests__/branch-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-utils.test.ts
@@ -737,7 +737,7 @@ describe('bashMergeUpstreams', () => {
       rmSync(seedDir, { recursive: true, force: true });
       rmSync(originDir, { recursive: true, force: true });
     }
-  });
+  }, 60_000);
 
   it('fetches and merges dependency branches from intermediate', async () => {
     const originDir = join(repoDir, '..', `origin-intermediate-${Date.now()}.git`);
@@ -774,7 +774,7 @@ describe('bashMergeUpstreams', () => {
       rmSync(intermediateDir, { recursive: true, force: true });
       rmSync(originDir, { recursive: true, force: true });
     }
-  });
+  }, 60_000);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
+++ b/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
@@ -6,6 +6,8 @@ import { execSync, execFileSync } from 'node:child_process';
 import type { TaskState } from '@invoker/workflow-core';
 import { publishAfterFixImpl, type MergeRunnerHost } from '../merge-runner.js';
 
+const REAL_GIT_TIMEOUT_MS = 60_000;
+
 /** Shell-based git for simple setup commands (no special chars in args). */
 function git(args: string, cwd: string): string {
   return execSync(`git ${args}`, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
@@ -176,7 +178,7 @@ describe('publishAfterFixImpl integration (real git)', () => {
     expect(host.orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-int', expect.objectContaining({
       execution: expect.objectContaining({ branch: 'plan/feature' }),
     }));
-  });
+  }, REAL_GIT_TIMEOUT_MS);
 
   it('retries feature branch push after a remote ref lock already-exists race', async () => {
     const sandbox = createSandbox();
@@ -242,7 +244,7 @@ describe('publishAfterFixImpl integration (real git)', () => {
     git('checkout plan/feature', sandbox.hostDir);
     expect(existsSync(join(sandbox.hostDir, 't1.txt'))).toBe(true);
     expect(existsSync(join(sandbox.hostDir, 'fix.txt'))).toBe(true);
-  });
+  }, REAL_GIT_TIMEOUT_MS);
 
   it('uses fixedIntegrationSha anchor when present instead of current gate HEAD', async () => {
     const sandbox = createSandbox();
@@ -290,7 +292,7 @@ describe('publishAfterFixImpl integration (real git)', () => {
         }),
       }),
     );
-  });
+  }, REAL_GIT_TIMEOUT_MS);
 
   it('fails without detach (regression proof): fetch into checked-out branch is rejected by git', async () => {
     const sandbox = createSandbox();
@@ -303,7 +305,7 @@ describe('publishAfterFixImpl integration (real git)', () => {
     expect(() => {
       git('fetch origin +refs/heads/*:refs/heads/*', sandbox.gateDir);
     }).toThrow(/refusing to fetch into branch.*checked out/);
-  });
+  }, REAL_GIT_TIMEOUT_MS);
 
   it('succeeds with detach (the fix): fetch after detaching HEAD works', async () => {
     const sandbox = createSandbox();
@@ -316,7 +318,7 @@ describe('publishAfterFixImpl integration (real git)', () => {
     expect(() => {
       git('fetch origin +refs/heads/*:refs/heads/*', sandbox.gateDir);
     }).not.toThrow();
-  });
+  }, REAL_GIT_TIMEOUT_MS);
 
   it('merges pre-pushed plan/feature tip in one step when present (avoids re-merging task branches)', async () => {
     const sandbox = createSandbox();
@@ -364,7 +366,7 @@ describe('publishAfterFixImpl integration (real git)', () => {
     const featureSha = git('rev-parse plan/feature', sandbox.hostDir);
     const isAncestor = gitSilent(`merge-base --is-ancestor ${fixCommit} ${featureSha}`, sandbox.hostDir);
     expect(isAncestor).toBe('');
-  });
+  }, REAL_GIT_TIMEOUT_MS);
 
   /**
    * Regression coverage for deleted repro repro-post-fix-merge-conflict (scenario 14):
@@ -437,7 +439,7 @@ describe('publishAfterFixImpl integration (real git)', () => {
         execution: expect.objectContaining({ branch: 'plan/feature' }),
       }),
     );
-  });
+  }, REAL_GIT_TIMEOUT_MS);
 
   it('emits merge_conflict JSON when post-fix consolidation merge conflicts', async () => {
     const sandbox = createSandbox();
@@ -492,5 +494,5 @@ describe('publishAfterFixImpl integration (real git)', () => {
     expect(parsedError.type).toBe('merge_conflict');
     expect(parsedError.failedBranch).toBe('invoker/t2');
     expect(Array.isArray(parsedError.conflictFiles)).toBe(true);
-  });
+  }, REAL_GIT_TIMEOUT_MS);
 });

--- a/packages/execution-engine/vitest.config.ts
+++ b/packages/execution-engine/vitest.config.ts
@@ -13,5 +13,18 @@ export default mergeConfig(sharedConfig, defineConfig({
       '**/dist/**',
       '**/*.integration.test.ts',
     ],
+    env: {
+      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_KEY_0: 'init.defaultBranch',
+      GIT_CONFIG_VALUE_0: 'master',
+      GIT_CONFIG_KEY_1: 'advice.detachedHead',
+      GIT_CONFIG_VALUE_1: 'false',
+    },
+    poolOptions: {
+      forks: {
+        maxForks: 1,
+      },
+    },
+    silent: 'passed-only',
   },
 }));


### PR DESCRIPTION
## Summary

Some real-git tests are slow on busy machines.

This gives them more time and makes the execution-engine Vitest worker run in one lane.

No app behavior changes.

## Review Claim

The execution-engine real-git tests should be less flaky without changing product behavior.

## Review Lane

cleanup

## Safety Invariant

Only test timing and Vitest execution settings change.

## Slice Rationale

This goes first because it makes the slower proof tests less noisy for later PRs.

## Non-goals

This does not change runtime behavior, app behavior, or workflow behavior.

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- task-runner-fix-publish-and-ssh.test.ts auto-commit.test.ts branch-utils.test.ts publish-after-fix.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 6b8bfdce50fb1a8f078c289080c120c26712db33`
- Post-revert steps: None
- Data migration? No
