### PR TITLE
fix(app): requeue orphaned workflow mutations on startup

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-startup.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-startup.test.ts
@@ -12,7 +12,8 @@ function makeLogger() {
 describe('recoverWorkflowMutationsOnStartup', () => {
   it('requeues and resumes pending mutations for owner startup without env gating', async () => {
     const persistence = {
-      requeueExpiredWorkflowMutationLeases: vi.fn(),
+      requeueExpiredWorkflowMutationLeases: vi.fn(() => 0),
+      requeueOrphanedWorkflowMutationIntents: vi.fn(() => 0),
     };
     const workflowMutationCoordinator = {
       resumePending: vi.fn(async () => {}),
@@ -29,9 +30,14 @@ describe('recoverWorkflowMutationsOnStartup', () => {
     });
 
     expect(persistence.requeueExpiredWorkflowMutationLeases).toHaveBeenCalledTimes(1);
+    expect(persistence.requeueOrphanedWorkflowMutationIntents).toHaveBeenCalledTimes(1);
     expect(maybeDelayResume).toHaveBeenCalledTimes(1);
     expect(workflowMutationCoordinator.resumePending).toHaveBeenCalledTimes(1);
-    expect(logger.info).toHaveBeenCalledWith('requeued expired workflow mutation leases on startup', { module: 'init' });
+    expect(logger.info).toHaveBeenCalledWith('requeued expired workflow mutation leases on startup', {
+      module: 'init',
+      expired: 0,
+      orphaned: 0,
+    });
     expect(logger.info).toHaveBeenCalledWith('resuming pending workflow mutations on startup', { module: 'init' });
     expect(logger.info).toHaveBeenCalledWith('workflow mutation recovery finished on startup', { module: 'init' });
   });

--- a/packages/app/src/workflow-mutation-startup.ts
+++ b/packages/app/src/workflow-mutation-startup.ts
@@ -2,9 +2,12 @@ import type { Logger } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
 
+type RecoveryPersistence = Pick<SQLiteAdapter, 'requeueExpiredWorkflowMutationLeases'>
+  & Partial<Pick<SQLiteAdapter, 'requeueOrphanedWorkflowMutationIntents'>>;
+
 type RecoveryDeps = {
   ownerMode: boolean;
-  persistence: Pick<SQLiteAdapter, 'requeueExpiredWorkflowMutationLeases'>;
+  persistence: RecoveryPersistence;
   workflowMutationCoordinator?: Pick<PersistedWorkflowMutationCoordinator, 'resumePending'>;
   logger: Logger;
   maybeDelayResume?: () => Promise<void>;
@@ -22,8 +25,13 @@ export async function recoverWorkflowMutationsOnStartup({
   }
 
   try {
-    persistence.requeueExpiredWorkflowMutationLeases();
-    logger.info('requeued expired workflow mutation leases on startup', { module: 'init' });
+    const expired = persistence.requeueExpiredWorkflowMutationLeases();
+    const orphaned = persistence.requeueOrphanedWorkflowMutationIntents?.() ?? 0;
+    logger.info('requeued expired workflow mutation leases on startup', {
+      module: 'init',
+      expired,
+      orphaned,
+    });
   } catch (err) {
     logger.error(
       `requeueExpiredWorkflowMutationLeases failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2980,6 +2980,34 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return Number(running?.count ?? 0);
   }
 
+  requeueOrphanedWorkflowMutationIntents(now: Date = new Date()): number {
+    const rows = this.queryAll(
+      `SELECT i.id
+         FROM workflow_mutation_intents i
+         LEFT JOIN workflow_mutation_leases l
+           ON l.workflow_id = i.workflow_id
+          AND l.active_intent_id = i.id
+          AND l.lease_expires_at >= ?
+        WHERE i.status = 'running'
+          AND l.workflow_id IS NULL`,
+      [now.toISOString()],
+    );
+    const ids = rows
+      .map((row) => Number(row.id))
+      .filter((id) => Number.isFinite(id));
+    if (ids.length === 0) {
+      return 0;
+    }
+    this.execRun(
+      `UPDATE workflow_mutation_intents
+         SET status = 'queued', owner_id = NULL, started_at = NULL, completed_at = NULL, error = NULL
+       WHERE status = 'running'
+         AND id IN (${ids.map(() => '?').join(', ')})`,
+      ids,
+    );
+    return ids.length;
+  }
+
   claimNextWorkflowMutationIntent(
     workflowId: string,
     ownerId: string,


### PR DESCRIPTION
## Summary

A workflow mutation can get stuck as running if the app restarts after its lease is gone.

On startup, we now put those orphaned running mutations back in the queue.

Normal mutation execution is unchanged.

## Review Claim

Startup recovery should requeue running workflow mutation intents that no longer have a valid lease.

## Review Lane

behavior

## Safety Invariant

The new query only touches running mutation intents with no unexpired matching lease.

## Slice Rationale

This is separate from task-runner callback handling because it fixes persisted startup recovery only.

## Non-goals

This does not change mutation ordering, active lease claiming, or task execution.

## Architecture

### Before

```mermaid
flowchart LR
  AppRestart[App restart] --> Expired[Requeue expired leases]
  Expired --> Resume[Resume queued mutations]
  Orphan[Running intent without lease] --> Stuck[Stays stuck]
```

### After

```mermaid
flowchart LR
  AppRestart[App restart] --> Expired[Requeue expired leases]
  Expired --> Orphans[Requeue orphaned running intents]
  Orphans --> Resume[Resume queued mutations]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-mutation-startup.test.ts src/__tests__/api-server.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 2acc6a03ac03f2680384daf041b3e28e7c8eee0d`
- Post-revert steps: Restart the app if debugging a stuck mutation
- Data migration? No
