### PR TITLE
fix(execution-engine): ignore stale completion callbacks

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -3732,6 +3732,75 @@ describe('TaskRunner', () => {
       // handleWorkerResponse called 3 times: 1st (throws), 2nd (catch re-submit for task-1), 3rd (task-2 normal)
       expect(handleWorkerResponse).toHaveBeenCalledTimes(3);
     });
+
+    it('does not submit fallback failure when completion becomes stale after handler error', async () => {
+      let currentTask = makeTask({
+        id: 'task-stale-completion',
+        status: 'running',
+        config: { command: 'echo hi' },
+        execution: { selectedAttemptId: 'attempt-old', generation: 1 },
+      });
+      const handleWorkerResponse = vi.fn(() => {
+        currentTask = makeTask({
+          id: 'task-stale-completion',
+          status: 'running',
+          config: { command: 'echo hi' },
+          execution: { selectedAttemptId: 'attempt-new', generation: 2 },
+        });
+        throw new Error('stale handler failure');
+      });
+      const onCompleteCb = vi.fn();
+
+      const completeCallbacks = new Map<string, (response: WorkResponse) => void>();
+      const manualExecutor = {
+        type: 'worktree',
+        start: vi.fn(async (request: any) => ({
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/tmp/mock-worktree',
+          branch: `invoker/${request.actionId}`,
+        })),
+        onComplete: vi.fn((handle: any, cb: any) => {
+          completeCallbacks.set(handle.taskId, cb);
+        }),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+      };
+
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: () => currentTask,
+          handleWorkerResponse,
+          getAllTasks: () => [currentTask],
+        } as any,
+        persistence: { updateTask: vi.fn() } as any,
+        executorRegistry: {
+          getDefault: () => manualExecutor,
+          get: () => manualExecutor,
+          getAll: () => [manualExecutor],
+        } as any,
+        cwd: '/tmp',
+        callbacks: { onComplete: onCompleteCb },
+      });
+
+      const done = runner.executeTask(currentTask);
+      await flush();
+
+      completeCallbacks.get('task-stale-completion')!({
+        requestId: 'r1',
+        actionId: 'task-stale-completion',
+        attemptId: 'attempt-old',
+        executionGeneration: 1,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+
+      await done;
+
+      expect(handleWorkerResponse).toHaveBeenCalledTimes(1);
+      expect(onCompleteCb).not.toHaveBeenCalled();
+    });
   });
 
   // ── PR-authoring regression coverage ──────────────────────

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1233,9 +1233,21 @@ export class TaskRunner {
               traceExecution(
                 `${RESTART_TO_BRANCH_TRACE} resolvePromise | task.config.isMergeNode = ${task.config.isMergeNode}`,
               );
+              if (this.isLaunchStale(task.id, attemptId, task.execution.generation ?? 0)) {
+                this.logger.warn(
+                  `[TaskRunner] suppressing stale completion response for task=${task.id} attemptId=${attemptId}`,
+                );
+                return;
+              }
               newlyStarted = this.orchestrator.handleWorkerResponse(normalizedResponse) ?? [];
             } catch (err) {
               this.logger.error(`[TaskRunner] worker response handling failed for task=${task.id}`, { err });
+              if (this.isLaunchStale(task.id, attemptId, task.execution.generation ?? 0)) {
+                this.logger.warn(
+                  `[TaskRunner] suppressing fallback failure response for stale completion task=${task.id} attemptId=${attemptId}`,
+                );
+                return;
+              }
               const errResponse: WorkResponse = {
                 requestId: response.requestId,
                 actionId: task.id,


### PR DESCRIPTION
## Summary

An old task-runner callback can arrive after a newer attempt already exists.

When that happens, we ignore the old fallback failure.

The new test proves the old callback does not write that failure.

## Review Claim

Late stale completion callbacks should not submit fallback failures for superseded attempts.

## Review Lane

behavior

## Safety Invariant

The new guard only drops responses whose selected attempt or generation no longer matches launch time.

## Slice Rationale

This is separate from startup recovery because it fixes an in-memory late-callback race.

## Non-goals

This does not change normal completion handling, active attempts, or non-stale fallback failures.

## Architecture

### Before

```mermaid
flowchart LR
  OldCallback[Old completion callback] --> Handler[handleWorkerResponse throws]
  Handler --> Fallback[Submit failed response]
  Fallback --> NewAttempt[New attempt gets old failure]
```

### After

```mermaid
flowchart LR
  OldCallback[Old completion callback] --> Handler[handleWorkerResponse throws]
  Handler --> StaleCheck[Check attempt and generation]
  StaleCheck --> Drop[Drop old fallback failure]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- task-runner-fix-publish-and-ssh.test.ts auto-commit.test.ts branch-utils.test.ts publish-after-fix.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 9d21d4bdc559e2b61d9a0a9f0a13e39f48df93fa`
- Post-revert steps: None
- Data migration? No
