### PR TITLE
Harden review unit file guardrails

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -170,8 +170,8 @@ function assertValidPrBody(body, options = {}) {
   );
 }
 
-function printPrBodyWarnings(body) {
-  const warnings = getPrBodyWarnings(body);
+function printPrBodyWarnings(body, options = {}) {
+  const warnings = getPrBodyWarnings(body, options);
   if (warnings.length === 0) return;
 
   console.error('PR body validation warnings:');
@@ -305,6 +305,15 @@ export function getUiImpactingFiles(files) {
   return files.filter(isUiImpactingPath);
 }
 
+export function parsePorcelainChangedFiles(statusText) {
+  return statusText
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter(Boolean)
+    .map((line) => line.slice(3).replace(/^"|"$/g, ''))
+    .filter(Boolean);
+}
+
 function changedFilesSinceBase(baseBranch) {
   try {
     const output = execFileSync(
@@ -316,6 +325,32 @@ function changedFilesSinceBase(baseBranch) {
   } catch {
     return [];
   }
+}
+
+function uncommittedFiles() {
+  try {
+    const output = execFileSync(
+      'git',
+      ['status', '--porcelain', '--untracked-files=all'],
+      { encoding: 'utf-8' },
+    );
+    return parsePorcelainChangedFiles(output);
+  } catch {
+    return [];
+  }
+}
+
+function assertNoUncommittedFiles() {
+  const files = uncommittedFiles();
+  if (files.length === 0) return;
+
+  throw new Error(
+    [
+      'Refusing to create/update PR with uncommitted changes.',
+      'Commit, split, or stash these files first; uncommitted files are not included in review-lane validation.',
+      ...files.map((file) => `  - ${file}`),
+    ].join('\n'),
+  );
 }
 
 
@@ -363,6 +398,7 @@ function assertCleanPrBase(baseBranch) {
   );
 }
 
+
 async function createPr(nwo, title, base, body, dryRun) {
   const head = getCurrentBranch();
 
@@ -403,6 +439,7 @@ async function main() {
   const args = parseArgs();
 
   assertCleanPrBase(args.base);
+  assertNoUncommittedFiles();
 
   // Read body
   let body = '';
@@ -419,7 +456,7 @@ async function main() {
   }
 
   assertValidPrBody(body, { requiresVisualProof: uiImpactingFiles.length > 0, changedFiles });
-  printPrBodyWarnings(body);
+  printPrBodyWarnings(body, { changedFiles });
 
   // Inject images
   body = await injectImages(body, args.dryRun);

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -1,4 +1,4 @@
-const PRODUCT_REVIEW_UNITS = new Set([
+export const VALID_REVIEW_UNITS = [
   'contract',
   'ownership-refactor',
   'read-path',
@@ -7,6 +7,20 @@ const PRODUCT_REVIEW_UNITS = new Set([
   'routing',
   'activation-surface',
   'tooling-policy',
+  'proof',
+  'docs',
+  'cleanup',
+];
+
+const VALID_REVIEW_UNIT_SET = new Set(VALID_REVIEW_UNITS);
+const PRODUCT_REVIEW_UNITS = new Set([
+  'contract',
+  'ownership-refactor',
+  'read-path',
+  'validation-policy',
+  'write-path',
+  'routing',
+  'activation-surface',
   'cleanup',
 ]);
 
@@ -116,6 +130,7 @@ const ALLOWED_CHANGE_OPERATIONS = new Set([
 ]);
 
 const PATH_LIKE = /^(?:packages|scripts|skills|docs|plans|\.github|[A-Za-z0-9_.-]+\/)[^:]+/;
+const APP_SRC_PREFIX = 'packages/app/src/';
 
 export function firstMeaningfulLine(value = '') {
   return String(value)
@@ -149,6 +164,10 @@ export function getLabelSection(text, label) {
   return (nextHeading ? rest.slice(0, nextHeading.index) : rest).trim();
 }
 
+export function normalizeReviewUnit(value = '') {
+  return firstMeaningfulLine(value).replace(/^[-*]\s*/, '').trim().toLowerCase();
+}
+
 export function detectReviewUnits(text) {
   const haystack = String(text).toLowerCase();
   const detected = new Set();
@@ -180,7 +199,7 @@ export function validateSingleReviewUnitFocus({ texts = [], context }) {
   const detectedProductUnits = Array.from(detected).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
   if (detectedProductUnits.length > 1) {
     errors.push(
-      `${context} mentions multiple review units (${detectedProductUnits.sort().join(', ')}); split into one conceptual unit per diff/task.`,
+      `${context} mentions multiple review units (${formatReviewUnits(detectedProductUnits)}); split into one conceptual unit per diff/task.`,
     );
   }
 
@@ -189,6 +208,146 @@ export function validateSingleReviewUnitFocus({ texts = [], context }) {
   }
 
   return errors;
+}
+
+export function validateReviewUnitValue(reviewUnit, context) {
+  if (!reviewUnit) return [];
+  if (VALID_REVIEW_UNIT_SET.has(reviewUnit)) return [];
+
+  return [`Invalid review unit: ${reviewUnit}. Expected one of ${VALID_REVIEW_UNITS.join(', ')}.`];
+}
+
+export function validateReviewLaneUnitCompatibility({ reviewLane = '', reviewUnit = '', context }) {
+  if (!reviewLane || !VALID_REVIEW_UNIT_SET.has(reviewUnit)) return [];
+
+  const productUnits = new Set([
+    'contract',
+    'ownership-refactor',
+    'read-path',
+    'validation-policy',
+    'write-path',
+    'routing',
+    'activation-surface',
+  ]);
+
+  if ((reviewLane === 'behavior' || reviewLane === 'refactor') && productUnits.has(reviewUnit)) return [];
+  if (reviewLane === 'cleanup' && reviewUnit === 'cleanup') return [];
+  if (reviewLane === 'policy' && reviewUnit === 'tooling-policy') return [];
+  if (reviewLane === 'proof' && reviewUnit === 'proof') return [];
+  if (reviewLane === 'docs' && reviewUnit === 'docs') return [];
+
+  return [`${context} Review Lane "${reviewLane}" is not compatible with Review Unit "${reviewUnit}".`];
+}
+
+export function validateReviewUnitFocus({ declaredReviewUnit, texts = [], context }) {
+  const errors = validateSingleReviewUnitFocus({ texts, context });
+  if (!VALID_REVIEW_UNIT_SET.has(declaredReviewUnit)) return errors;
+
+  const detected = new Set();
+  for (const text of texts) {
+    for (const unit of detectReviewUnits(includedWorkText(text))) {
+      detected.add(unit);
+    }
+  }
+
+  const detectedProductUnits = Array.from(detected).filter((unit) => PRODUCT_REVIEW_UNITS.has(unit));
+  if (detectedProductUnits.length === 1 && PRODUCT_REVIEW_UNITS.has(declaredReviewUnit) && detectedProductUnits[0] !== declaredReviewUnit) {
+    errors.push(
+      `${context} Review Unit "${declaredReviewUnit}" does not match the described ${detectedProductUnits[0]} work.`,
+    );
+  }
+
+  return errors;
+}
+
+export function classifyReviewUnitsForPath(filePath) {
+  const path = String(filePath).replace(/\\/g, '/');
+  const lowerPath = path.toLowerCase();
+  const basename = path.split('/').pop() ?? '';
+
+  if (path.startsWith('scripts/repro/')) return ['proof'];
+  if (path === 'scripts/test-create-pr-visual-proof.mjs') return ['tooling-policy'];
+  if (/(benchmark|performance|visual-proof)/.test(lowerPath)) return ['proof'];
+  if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
+  if (path.startsWith('.github/')) return ['tooling-policy'];
+  if (
+    path === 'package.json'
+    || path === 'pnpm-lock.yaml'
+    || path === 'run.sh'
+    || /^tsconfig.*\.json$/.test(path)
+    || /^packages\/[^/]+\/package\.json$/.test(path)
+  ) {
+    return ['tooling-policy'];
+  }
+  if (path.startsWith('scripts/')) return ['tooling-policy'];
+  if (
+    path.startsWith('packages/')
+    && (path.includes('/e2e/') || path.includes('/__tests__/') || /\.(spec|test)\.[^.]+$/.test(path))
+  ) {
+    return [];
+  }
+  if (path.startsWith('packages/contracts/')) return ['contract'];
+  if (
+    path.startsWith('packages/cli/')
+    || path.startsWith('packages/npm-cli/')
+    || path.startsWith('packages/npm-ui/bin/')
+    || path.startsWith('packages/ui/')
+    || path.startsWith('packages/app/src/window/')
+    || path === 'packages/app/src/preload.ts'
+    || path === 'packages/app/src/app-menu.ts'
+    || path === 'packages/app/src/headless.ts'
+    || /^packages\/app\/src\/headless-[^/]+\.ts$/.test(path)
+    || path === 'packages/app/src/api-server.ts'
+    || path === 'packages/app/src/workflow-actions.ts'
+    || path.startsWith('packages/app/src/ipc/')
+  ) {
+    return ['activation-surface'];
+  }
+  if (
+    path.startsWith('packages/workflow-core/')
+    || path.startsWith('packages/execution-engine/')
+    || path === 'packages/app/src/launch-dispatcher.ts'
+    || path === 'packages/app/src/global-topup.ts'
+    || path === 'packages/app/src/main.ts'
+    || path === 'packages/app/src/workflow-mutation-facade.ts'
+    || path === 'packages/app/src/headless-standalone-launch-dispatcher.ts'
+  ) {
+    return ['routing'];
+  }
+  if (path.startsWith(APP_SRC_PREFIX) && /(gating|policy|validator|validation|eligibility|config)/.test(basename)) {
+    return ['validation-policy'];
+  }
+  if (path.startsWith(APP_SRC_PREFIX) && /(recovery|scanner|store|persistence)/.test(basename)) {
+    return ['read-path'];
+  }
+  if (path.startsWith(APP_SRC_PREFIX)) return ['routing'];
+  return [];
+}
+
+export function reviewUnitsForChangedFiles(changedFiles = []) {
+  const units = new Set();
+  for (const changedFile of changedFiles) {
+    for (const unit of classifyReviewUnitsForPath(changedFile)) {
+      units.add(unit);
+    }
+  }
+  return VALID_REVIEW_UNITS.filter((unit) => units.has(unit));
+}
+
+export function formatReviewUnits(units) {
+  const unitSet = new Set(units);
+  return VALID_REVIEW_UNITS.filter((unit) => unitSet.has(unit)).join(', ');
+}
+
+export function validateReviewUnitChangedFiles({ declaredReviewUnit, changedFiles = [], context }) {
+  if (!VALID_REVIEW_UNIT_SET.has(declaredReviewUnit) || changedFiles.length === 0) return [];
+
+  const forbidden = reviewUnitsForChangedFiles(changedFiles).filter((unit) => unit !== declaredReviewUnit);
+  if (forbidden.length === 0) return [];
+
+  return [
+    `${context} Review Unit "${declaredReviewUnit}" cannot ship with ${formatReviewUnits(forbidden)} files in the same PR. Split this into one Review Unit per PR.`,
+  ];
 }
 
 export function parseChangeTypeItems(section) {

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -91,13 +91,13 @@ expected_executed_for_mode() {
 expected_discovered_for_mode() {
   case "$MODE_KEY" in
     required)
-      printf '18'
+      printf '19'
       ;;
     extended)
-      printf '25'
+      printf '26'
       ;;
     dangerous)
-      printf '26'
+      printf '27'
       ;;
   esac
 }
@@ -148,7 +148,7 @@ suite_name() {
 
 is_parallel_safe() {
   case "$(suite_relpath "$1")" in
-    required/05-delete-all-prod-db-guard.sh|required/06-large-file-guardrail.sh|required/07-invalid-config-json.sh|required/10-vitest-workspace.sh|required/15-owner-boundary-policy.sh|required/15-submit-workflow-chain.sh|required/20-e2e-dry-run.sh|required/21-e2e-dry-run-downstream.sh|required/22-e2e-dry-run-github.sh|required/50-verify-executor-routing.sh|optional/40-playwright-app.sh|optional/60-worktree-provisioning.sh|optional/70-ui-visual-proof-validate.sh)
+    required/05-delete-all-prod-db-guard.sh|required/06-large-file-guardrail.sh|required/07-invalid-config-json.sh|required/10-vitest-workspace.sh|required/11-pr-authoring-guardrails.sh|required/15-owner-boundary-policy.sh|required/15-submit-workflow-chain.sh|required/20-e2e-dry-run.sh|required/21-e2e-dry-run-downstream.sh|required/22-e2e-dry-run-github.sh|required/50-verify-executor-routing.sh|optional/40-playwright-app.sh|optional/60-worktree-provisioning.sh|optional/70-ui-visual-proof-validate.sh)
       return 0
       ;;
     *)

--- a/scripts/test-create-pr-visual-proof.mjs
+++ b/scripts/test-create-pr-visual-proof.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { getUiImpactingFiles, isUiImpactingPath } from './create-pr.mjs';
+import { getUiImpactingFiles, isUiImpactingPath, parsePorcelainChangedFiles } from './create-pr.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -25,4 +25,18 @@ assert(uiFiles.length === 2, 'only UI-impacting files should be returned');
 assert(uiFiles.includes('packages/ui/src/components/TaskPanel.tsx'), 'UI component file should be returned');
 assert(uiFiles.includes('packages/app/src/window/window-lifecycle.ts'), 'window file should be returned');
 
+
+const porcelainFiles = parsePorcelainChangedFiles(` M scripts/validate-pr-body.mjs
+A  scripts/test-pr-body-validator.mjs
+?? packages/app/src/local-refactor.ts
+`);
+const expectedPorcelainFiles = [
+  'scripts/validate-pr-body.mjs',
+  'scripts/test-pr-body-validator.mjs',
+  'packages/app/src/local-refactor.ts',
+];
+assert(
+  JSON.stringify(porcelainFiles) === JSON.stringify(expectedPorcelainFiles),
+  'porcelain parser should return exact changed file paths',
+);
 console.log('OK: create-pr visual proof checks passed');

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -8,17 +8,22 @@ function assert(condition, message) {
   }
 }
 
-const validMinimal = `## Summary
+function bodyWith({ lane = 'behavior', unit = 'routing', claim = 'Route one owner fallback.', summary = 'Small fix.', slice = 'Small slice.', nonGoals = '- Do not add repro scripts or docs in this slice.' } = {}) {
+  return `## Summary
 
-Small fix.
+${summary}
 
 ## Review Claim
 
-Keep the owner fallback local.
+${claim}
 
 ## Review Lane
 
-- behavior
+- ${lane}
+
+## Review Unit
+
+- ${unit}
 
 ## Safety Invariant
 
@@ -26,11 +31,11 @@ Only the refresh path changes.
 
 ## Slice Rationale
 
-Proof and cleanup stay separate.
+${slice}
 
 ## Non-goals
 
-- Do not add repro scripts or docs in this slice.
+${nonGoals}
 
 ## Test Plan
 
@@ -43,6 +48,9 @@ Proof and cleanup stay separate.
 - Post-revert steps: None
 - Data migration? No
 `;
+}
+
+const validMinimal = bodyWith();
 
 const validArchitecture = `## Summary
 
@@ -55,6 +63,10 @@ Route refresh through one helper.
 ## Review Lane
 
 - behavior
+
+## Review Unit
+
+- routing
 
 ## Safety Invariant
 
@@ -129,6 +141,10 @@ One claim.
 
 - behavior
 
+## Review Unit
+
+- routing
+
 ## Safety Invariant
 
 Local only.
@@ -156,11 +172,15 @@ Flow change.
 
 ## Review Claim
 
-One claim.
+Route one path.
 
 ## Review Lane
 
 - behavior
+
+## Review Unit
+
+- routing
 
 ## Safety Invariant
 
@@ -204,6 +224,10 @@ Small fix.
 
 One claim.
 
+## Review Unit
+
+- routing
+
 ## Safety Invariant
 
 Local only.
@@ -232,127 +256,38 @@ assert(missingReviewLaneErrors.some((error) => error.includes('Missing required 
 const invalidReviewLaneErrors = validatePrBody(validMinimal.replace('- behavior', '- impossible'));
 assert(invalidReviewLaneErrors.some((error) => error.includes('Invalid review lane: impossible')), 'invalid review lane should fail');
 
-const broad1574Body = `## Summary
+const missingReviewUnitErrors = validatePrBody(validMinimal.replace('## Review Unit\n\n- routing\n\n', ''));
+assert(missingReviewUnitErrors.some((error) => error.includes('Missing required section: ## Review Unit')), 'missing review unit should fail');
 
-This adds the dormant auto-fix recovery policy.
-
-It scans persisted failed tasks, validates retry and stale-state eligibility, suppresses duplicate open fix intents, and submits fix-with-agent mutation intents.
-
-## Review Claim
-
-Auto-fix recovery can scan persisted failed tasks and enqueue the normal fix intent without a CLI surface.
-
-## Review Lane
-
-- behavior
-
-## Safety Invariant
-
-The policy only submits through the existing mutation route and skips stale or already queued candidates.
-
-## Slice Rationale
-
-Durable-state scan behavior is reviewable separately from lifecycle wakeup routing and CLI activation.
-
-## Non-goals
-
-- No lifecycle wakeup routing, CLI exposure, or worker registry.
-
-## Test Plan
-
-- [ ] \`pnpm test\`
-
-## Revert Plan
-
-- Safe to revert? Yes
-- Revert command: \`git revert <sha>\`
-- Post-revert steps: None
-- Data migration? No
-`;
+const broad1574Body = bodyWith({
+  unit: 'validation-policy',
+  summary: 'This adds the dormant auto-fix recovery policy.\n\nIt scans persisted failed tasks, validates retry and stale-state eligibility, suppresses duplicate open fix intents, and submits fix-with-agent mutation intents.',
+  claim: 'Auto-fix recovery can scan persisted failed tasks and enqueue the normal fix intent without a CLI surface.',
+  slice: 'Durable-state scan behavior is reviewable separately from lifecycle wakeup routing and CLI activation.',
+  nonGoals: '- No lifecycle wakeup routing, CLI exposure, or worker registry.',
+});
 const broad1574Errors = validatePrBody(broad1574Body);
 assert(
   broad1574Errors.some((error) => error.includes('mentions multiple review units')),
   'broad #1574-shaped PR body should fail review-unit focus',
 );
 
-const originalAllInOneBody = `## Summary
-
-This moves the recovery worker out of the generic runtime.
-
-It scans persisted failed tasks, validates candidates, submits fix intents, routes lifecycle wakeups, and exposes the headless worker command.
-
-## Review Claim
-
-The recovery worker owns auto-fix recovery end to end.
-
-## Review Lane
-
-- behavior
-
-## Safety Invariant
-
-Every submitted fix still goes through the existing mutation route.
-
-## Slice Rationale
-
-The complete auto-fix recovery path lands together for one rollout.
-
-## Non-goals
-
-- No worker registry.
-
-## Test Plan
-
-- [ ] \`pnpm test\`
-
-## Revert Plan
-
-- Safe to revert? Yes
-- Revert command: \`git revert <sha>\`
-- Post-revert steps: None
-- Data migration? No
-`;
+const originalAllInOneBody = bodyWith({
+  unit: 'read-path',
+  summary: 'This moves the recovery worker out of the generic runtime.\n\nIt scans persisted failed tasks, validates candidates, submits fix intents, routes lifecycle wakeups, and exposes the headless worker command.',
+  claim: 'The recovery worker owns auto-fix recovery end to end.',
+  slice: 'The complete auto-fix recovery path lands together for one rollout.',
+  nonGoals: '- No worker registry.',
+});
 const originalAllInOneErrors = validatePrBody(originalAllInOneBody);
 assert(
   originalAllInOneErrors.some((error) => error.includes('mentions multiple review units')),
   'original all-in-one auto-fix PR body should fail review-unit focus',
 );
 
-const longSummary = `## Summary
-
-This summary paragraph uses too many words because it tries to explain several related implementation details at the same time instead of giving a tired reviewer one clear idea they can understand immediately.
-
-## Review Claim
-
-One claim.
-
-## Review Lane
-
-- behavior
-
-## Safety Invariant
-
-Local only.
-
-## Slice Rationale
-
-Small slice.
-
-## Non-goals
-
-- No docs.
-
-## Test Plan
-
-- [ ] \`pnpm test\`
-
-## Revert Plan
-
-- Safe to revert? Yes
-- Revert command: \`git revert <sha>\`
-- Post-revert steps: None
-- Data migration? No
-`;
+const longSummary = bodyWith({
+  summary: 'This summary paragraph uses too many words because it tries to explain several related implementation details at the same time instead of giving a tired reviewer one clear idea they can understand immediately.',
+});
 
 const longSummaryWarnings = getPrBodyWarnings(longSummary);
 assert(validatePrBody(longSummary).length === 0, 'summary readability warnings should not fail validation');
@@ -400,7 +335,7 @@ assert(
   'behavior lane should reject repro/benchmark files in the same PR',
 );
 
-const policyScopeErrors = validatePrBody(validMinimal.replace('- behavior', '- policy'), {
+const policyScopeErrors = validatePrBody(bodyWith({ lane: 'policy', unit: 'tooling-policy', claim: 'Keep PR tooling policy local.' }), {
   changedFiles: [
     'scripts/create-pr.mjs',
     'scripts/validate-pr-body.mjs',
@@ -412,7 +347,7 @@ assert(
   'policy lane should reject product files in the same PR',
 );
 
-const proofScopeErrors = validatePrBody(validMinimal.replace('- behavior', '- proof'), {
+const proofScopeErrors = validatePrBody(bodyWith({ lane: 'proof', unit: 'proof', claim: 'Keep regression proof separate.' }), {
   changedFiles: [
     'packages/app/e2e/ui-graph-drag-performance.spec.ts',
     'packages/app/src/launch-dispatcher.ts',
@@ -423,7 +358,7 @@ assert(
   'proof lane should reject runtime behavior changes in the same PR',
 );
 
-const docsScopeErrors = validatePrBody(validMinimal.replace('- behavior', '- docs'), {
+const docsScopeErrors = validatePrBody(bodyWith({ lane: 'docs', unit: 'docs', claim: 'Update docs only.' }), {
   changedFiles: [
     'skills/make-pr/SKILL.md',
     'scripts/create-pr.mjs',
@@ -434,42 +369,109 @@ assert(
   'docs lane should reject policy/tooling files in the same PR',
 );
 
-const refactorBody = `## Summary
+const launchOutboxAlwaysActiveFiles = [
+  'docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md',
+  'packages/app/src/config.ts',
+  'packages/app/src/global-topup.ts',
+  'packages/app/src/headless.ts',
+  'packages/app/src/launch-dispatcher.ts',
+  'packages/app/src/main.ts',
+  'packages/cli/src/index.ts',
+  'packages/workflow-core/src/orchestrator.ts',
+  'scripts/repro/repro-launch-outbox-active-only.sh',
+];
+const launchOutboxErrors = validatePrBody(validMinimal, { changedFiles: launchOutboxAlwaysActiveFiles });
+assert(
+  launchOutboxErrors.some((error) => error.includes('Review Unit "routing" cannot ship with')),
+  'launch outbox fixture should fail review-unit changed-file validation',
+);
+for (const unit of ['docs', 'validation-policy', 'activation-surface', 'proof']) {
+  assert(launchOutboxErrors.some((error) => error.includes(unit)), `launch outbox fixture should mention ${unit}`);
+}
 
-Extract a helper first.
+const releaseInstallerFiles = [
+  '.github/workflows/ci.yml',
+  '.github/workflows/release.yml',
+  'package.json',
+  'packages/app/src/app-menu.ts',
+  'packages/app/src/cli-installer.ts',
+  'packages/app/src/main.ts',
+  'packages/cli/src/index.ts',
+  'packages/contracts/src/ipc-channels.ts',
+  'packages/npm-ui/bin/invoker-cli.js',
+  'packages/ui/src/components/SystemSetupModal.tsx',
+  'scripts/e2e-dmg-cli-install.sh',
+  'scripts/e2e-npm-cli-install.sh',
+];
+const releaseInstallerErrors = validatePrBody(bodyWith({ lane: 'policy', unit: 'tooling-policy', claim: 'Keep PR tooling policy local.' }), {
+  changedFiles: releaseInstallerFiles,
+});
+assert(
+  releaseInstallerErrors.some((error) => error.includes('Review Unit "tooling-policy" cannot ship with')),
+  'release installer fixture should fail review-unit changed-file validation',
+);
+for (const unit of ['activation-surface', 'contract', 'routing']) {
+  assert(releaseInstallerErrors.some((error) => error.includes(unit)), `release installer fixture should mention ${unit}`);
+}
 
-## Review Claim
+const headlessAutoFixSurfaceFiles = [
+  'packages/app/src/headless.ts',
+  'packages/app/src/__tests__/headless-autofix.test.ts',
+];
+assert(
+  validatePrBody(bodyWith({ unit: 'activation-surface', claim: 'Expose one headless command.' }), { changedFiles: headlessAutoFixSurfaceFiles }).length === 0,
+  'headless command exposure plus its direct test should pass as one activation-surface unit',
+);
 
-Move refresh logic into a helper module.
+const surfaceRuntimeMixedFiles = [
+  'packages/app/src/headless.ts',
+  'packages/app/src/auto-fix-recovery.ts',
+  'packages/app/src/__tests__/headless-autofix.test.ts',
+];
+const surfaceRuntimeMixedErrors = validatePrBody(bodyWith({ unit: 'activation-surface', claim: 'Expose one headless command.' }), {
+  changedFiles: surfaceRuntimeMixedFiles,
+});
+assert(
+  surfaceRuntimeMixedErrors.some((error) => error.includes('read-path')),
+  'surface plus recovery policy should fail as mixed review units',
+);
 
-## Review Lane
+const uiDocsFixtureDriftFiles = [
+  'packages/ui/src/components/TaskPanel.tsx',
+  'skills/plan-to-invoker/SKILL.md',
+  'skills/plan-to-invoker/fixtures/positive/05-ui-change-with-visual-proof.yaml',
+  'skills/plan-to-invoker/scripts/validate-plan.mjs',
+];
+const uiDocsFixtureDriftErrors = validatePrBody(bodyWith({ unit: 'activation-surface', claim: 'Expose one UI surface.' }), {
+  changedFiles: uiDocsFixtureDriftFiles,
+});
+assert(
+  uiDocsFixtureDriftErrors.some((error) => error.includes('docs')),
+  'skill fixtures and helpers should review as docs/skill changes',
+);
 
-- refactor
+const elevenFileWarnings = getPrBodyWarnings(validMinimal, {
+  changedFiles: Array.from({ length: 11 }, (_, index) => `scripts/generated-${index}.mjs`),
+});
+assert(
+  elevenFileWarnings.some((warning) => warning.includes('PR changes 11 files')),
+  'large changed-file count should warn without blocking',
+);
 
-## Safety Invariant
+const multiUnitWarnings = getPrBodyWarnings(validMinimal, { changedFiles: launchOutboxAlwaysActiveFiles });
+assert(
+  multiUnitWarnings.some((warning) => warning.includes('PR spans') && warning.includes('review units')),
+  'multi-review-unit changed-file shape should warn',
+);
 
-Behavior stays unchanged.
-
-## Slice Rationale
-
-Field additions land in a later behavior PR.
-
-## Non-goals
-
-- No behavior change.
-- No new fields in this slice.
-
-## Test Plan
-
-- [ ] \`pnpm test\`
-
-## Revert Plan
-
-- Safe to revert? Yes
-- Revert command: \`git revert <sha>\`
-- Post-revert steps: None
-- Data migration? No
-`;
+const refactorBody = bodyWith({
+  lane: 'refactor',
+  unit: 'routing',
+  claim: 'Route refresh logic through a helper module.',
+  summary: 'Route a helper first.',
+  slice: 'Field additions land in a later behavior PR.',
+  nonGoals: '- No behavior change.\n- No new fields in this slice.',
+});
 assert(
   validatePrBody(refactorBody, { changedFiles: ['packages/app/src/main.ts', 'packages/app/src/refresh-task-graph.ts'] }).length === 0,
   'refactor lane with explicit no-behavior non-goals should pass for product-only files',
@@ -483,41 +485,13 @@ assert(
   'refactor lane should require an explicit unchanged-behavior non-goal',
 );
 
-const validationPolicyBody = `## Summary
-
-Validate stale recovery candidates.
-
-## Review Claim
-
-Reject stale auto-fix recovery candidates before submission.
-
-## Review Lane
-
-- behavior
-
-## Safety Invariant
-
-The slice returns validated candidates only.
-
-## Slice Rationale
-
-Validation policy stays separate from command submission.
-
-## Non-goals
-
-- Does not submit mutation intents.
-
-## Test Plan
-
-- [ ] \`pnpm test\`
-
-## Revert Plan
-
-- Safe to revert? Yes
-- Revert command: \`git revert <sha>\`
-- Post-revert steps: None
-- Data migration? No
-`;
+const validationPolicyBody = bodyWith({
+  unit: 'validation-policy',
+  summary: 'Validate stale recovery candidates.',
+  claim: 'Reject stale auto-fix recovery candidates before submission.',
+  slice: 'Validation policy stays separate from command submission.',
+  nonGoals: '- Does not submit mutation intents.',
+});
 assert(validatePrBody(validationPolicyBody).length === 0, 'validation policy non-goal mentioning submit should pass');
 
 const directScopeErrors = validatePrScope({

--- a/scripts/test-suites/required/11-pr-authoring-guardrails.sh
+++ b/scripts/test-suites/required/11-pr-authoring-guardrails.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+node scripts/test-pr-body-validator.mjs
+node scripts/test-create-pr-visual-proof.mjs

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -2,14 +2,21 @@
 
 import { readFileSync } from 'node:fs';
 import {
+  formatReviewUnits,
   getMarkdownSection,
-  validateSingleReviewUnitFocus,
+  normalizeReviewUnit,
+  reviewUnitsForChangedFiles,
+  validateReviewLaneUnitCompatibility,
+  validateReviewUnitChangedFiles,
+  validateReviewUnitFocus,
+  validateReviewUnitValue,
 } from './review-unit-rules.mjs';
 
 const REQUIRED_SECTIONS = [
   '## Summary',
   '## Review Claim',
   '## Review Lane',
+  '## Review Unit',
   '## Safety Invariant',
   '## Slice Rationale',
   '## Non-goals',
@@ -41,13 +48,7 @@ function hasVisualProofMedia(body) {
 }
 
 function normalizeSectionValue(sectionBody) {
-  const firstLine = sectionBody
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(Boolean);
-
-  if (!firstLine) return '';
-  return firstLine.replace(/^[-*]\s*/, '').trim().toLowerCase();
+  return normalizeReviewUnit(sectionBody);
 }
 
 function classifyScopeKind(filePath) {
@@ -125,20 +126,30 @@ export function validatePrScope({ changedFiles = [], reviewLane = '', body = '' 
   return errors;
 }
 
-export function getPrBodyWarnings(body) {
+export function getPrBodyWarnings(body, options = {}) {
   const warnings = [];
   const summary = getSectionBody(body, '## Summary');
-  if (!summary) return warnings;
+  if (summary) {
+    const paragraphs = summary.split(/\n\s*\n/).map((paragraph) => paragraph.trim()).filter(Boolean);
+    paragraphs.forEach((paragraph, index) => {
+      const wordCount = countWords(paragraph);
+      if (wordCount > SUMMARY_WORD_LIMIT) {
+        warnings.push(
+          `Summary paragraph ${index + 1} is ${wordCount} words. Keep each Summary paragraph under ${SUMMARY_WORD_LIMIT} words.`,
+        );
+      }
+    });
+  }
 
-  const paragraphs = summary.split(/\n\s*\n/).map((paragraph) => paragraph.trim()).filter(Boolean);
-  paragraphs.forEach((paragraph, index) => {
-    const wordCount = countWords(paragraph);
-    if (wordCount > SUMMARY_WORD_LIMIT) {
-      warnings.push(
-        `Summary paragraph ${index + 1} is ${wordCount} words. Keep each Summary paragraph under ${SUMMARY_WORD_LIMIT} words.`,
-      );
-    }
-  });
+  const changedFiles = options.changedFiles ?? [];
+  if (changedFiles.length > 10) {
+    warnings.push(`PR changes ${changedFiles.length} files. Split before review unless this is one mechanical/generated slice.`);
+  }
+
+  const units = reviewUnitsForChangedFiles(changedFiles);
+  if (units.length > 2) {
+    warnings.push(`PR spans ${units.length} review units: ${formatReviewUnits(units)}.`);
+  }
 
   return warnings;
 }
@@ -149,7 +160,7 @@ export function validatePrBody(body, options = {}) {
 
   if (!trimmed) {
     return [
-      'PR body is empty. Use the canonical schema: ## Summary, ## Review Claim, ## Review Lane, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, and ## Revert Plan.',
+      'PR body is empty. Use the canonical schema: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, and ## Revert Plan.',
     ];
   }
 
@@ -180,11 +191,20 @@ export function validatePrBody(body, options = {}) {
     errors.push(`Invalid review lane: ${reviewLane}. Expected one of ${Array.from(VALID_REVIEW_LANES).join(', ')}.`);
   }
 
+  const reviewUnit = normalizeReviewUnit(getSectionBody(trimmed, '## Review Unit'));
+  errors.push(...validateReviewUnitValue(reviewUnit, 'PR body'));
+  errors.push(...validateReviewLaneUnitCompatibility({
+    reviewLane,
+    reviewUnit,
+    context: 'PR body',
+  }));
+
   const reviewClaim = getSectionBody(trimmed, '## Review Claim');
   if (reviewClaim && !reviewClaim.trim()) {
     errors.push('## Review Claim must not be empty.');
   }
-  errors.push(...validateSingleReviewUnitFocus({
+  errors.push(...validateReviewUnitFocus({
+    declaredReviewUnit: reviewUnit,
     context: 'PR body',
     texts: [
       getSectionBody(trimmed, '## Summary'),
@@ -201,6 +221,11 @@ export function validatePrBody(body, options = {}) {
 
   if (reviewLane && options.changedFiles?.length) {
     errors.push(...validatePrScope({ changedFiles: options.changedFiles, reviewLane, body: trimmed }));
+    errors.push(...validateReviewUnitChangedFiles({
+      declaredReviewUnit: reviewUnit,
+      changedFiles: options.changedFiles,
+      context: 'PR body',
+    }));
   }
 
   return errors;
@@ -210,7 +235,7 @@ function usage() {
   console.error(`Usage: node scripts/validate-pr-body.mjs (--body-file <file> | --body <markdown>) [--require-visual-proof]
 
 Validates the canonical PR schema:
-  Required: ## Summary, ## Review Claim, ## Review Lane, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
+  Required: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
   Optional: ## Architecture (must include ### Before and ### After when present)
   UI changes: pass --require-visual-proof to require screenshot or video proof.`);
   process.exit(1);
@@ -220,6 +245,7 @@ function parseArgs(argv) {
   let body = '';
   let bodyFile = '';
   let requiresVisualProof = false;
+
   for (let i = 0; i < argv.length; i++) {
     switch (argv[i]) {
       case '--body':


### PR DESCRIPTION
## Summary

PR authoring now checks changed files against the declared Review Unit before publication.

The old text check could miss bad shapes when unrelated files were already committed or sitting local. This adds file-based checks, dirty-tree blocking, and required tests.

## Review Claim

PR authoring now blocks changed-file shapes that cross Review Unit boundaries.

## Review Lane

- policy

## Review Unit

- tooling-policy

## Safety Invariant

Only PR authoring scripts and their required-suite wrapper change; product runtime, UI, and workflow execution stay untouched.

## Slice Rationale

This stacks on the Review Unit enforcement PR and adds the changed-file checks that text-only Review Unit lint cannot see.

## Non-goals

Do not change Invoker runtime behavior, workflow execution, UI behavior, plan YAML schema, or Mergify stack behavior.

## Test Plan

- [ ] `node scripts/test-pr-body-validator.mjs`
- [ ] `node scripts/test-create-pr-visual-proof.mjs`
- [ ] `bash scripts/test-suites/required/11-pr-authoring-guardrails.sh`
- [ ] `INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_FORCE_RERUN=1 INVOKER_TEST_ALL_EXCLUDE='required/05-delete-all-prod-db-guard.sh,required/06-large-file-guardrail.sh,required/07-invalid-config-json.sh,required/08-electron-preprovision-repro.sh,required/10-vitest-workspace.sh,required/15-owner-boundary-policy.sh,required/15-submit-workflow-chain.sh,required/16-branch-carry-forward.sh,required/17-merge-gate-concurrency-repro.sh,required/18-start-running-mece-repros.sh,required/19-task-new-attempt-reset-repro.sh,required/20-e2e-dry-run.sh,required/21-e2e-dry-run-downstream.sh,required/22-e2e-dry-run-github.sh,required/23-fix-intent-repros.sh,required/24-start-running-mece-repros.sh,required/25-launch-dispatch-queue-handoff-repro.sh,required/50-verify-executor-routing.sh' bash scripts/run-all-tests.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 4736e699a12d55ef07a6314b2db24177853a8147`
- Post-revert steps: None
- Data migration? No
