### PR TITLE
Support dynamic review gate artifacts

### DIFF
--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestHarness, type TestHarness, InMemoryBus, InMemoryPersistence, MockGit } from '@invoker/test-kit';
 import { Orchestrator, type PlanDefinition, type TaskState } from '@invoker/workflow-core';
-import { TaskRunner, ExecutorRegistry, type MergeGateProvider } from '@invoker/execution-engine';
+import { TaskRunner, ExecutorRegistry, type ReviewGateProvider } from '@invoker/execution-engine';
 import { setWorkflowMergeMode } from '../workflow-actions.js';
 import { executeGlobalTopup } from '../global-topup.js';
 
@@ -511,6 +511,24 @@ describe('Flow 4: edit/fork mutations', () => {
     expect(h.getAllTasks().find((t) => t.id.endsWith('/C-v2'))).toBeUndefined();
   });
 
+  it('editTaskType does NOT fork subtree', () => {
+    h.loadAndStart(LINEAR_PLAN);
+    h.completeTask('A');
+    h.completeTask('B');
+
+    // Edit A's type
+    h.orchestrator.editTaskType('A', 'worktree');
+
+    // A restarted
+    const a = h.getTask('A')!;
+    expect(a.config.runnerKind).toBe('worktree');
+    expect(a.status === 'pending' || a.status === 'running').toBe(true);
+
+    // B should still be the original (not forked), no B-v2 created
+    expect(h.getAllTasks().find((t) => t.id.endsWith('/B-v2'))).toBeUndefined();
+    // B is invalidated since editTaskType restarts in-place and resets downstream
+    expect(h.getTask('B')!.status).toBe('pending');
+  });
 
   it('replaceTask creates subgraph and wires dependencies', () => {
     h.loadAndStart(LINEAR_PLAN);
@@ -1139,13 +1157,20 @@ const MANUAL_MERGE_ONFINISH_NONE_PLAN: PlanDefinition = {
 // ── Flow 9c: UI external_review merge mode ───────────────────
 
 describe('Flow 9c: set-merge-mode external_review', () => {
-  const mockMergeGate: MergeGateProvider = {
+  const mockMergeGate: ReviewGateProvider = {
     name: 'mock',
-    createReview: async () => ({
-      url: 'https://github.com/owner/repo/pull/99',
-      identifier: 'owner/repo#99',
+    publishReviewGate: async () => ({
+      sealed: true,
+      relationship: { kind: 'unknown', managedBy: 'external' },
+      artifacts: [{
+        id: 'github:pull_request:99',
+        provider: 'github',
+        type: 'pull_request',
+        url: 'https://github.com/owner/repo/pull/99',
+        identifier: 'owner/repo#99',
+      }],
     }),
-    checkApproval: async () => ({
+    checkArtifact: async () => ({
       approved: false,
       rejected: false,
       statusText: 'Open',
@@ -1171,7 +1196,7 @@ describe('Flow 9c: set-merge-mode external_review', () => {
 
     expect(h.persistence.loadWorkflow(wfId)!.mergeMode).toBe('external_review');
     expect(h.getTask(mergeId)!.status).toBe('review_ready');
-    expect(h.getTask(mergeId)!.execution.reviewUrl).toBe('https://github.com/owner/repo/pull/99');
+    expect(h.getTask(mergeId)!.execution.reviewGate?.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/99');
   });
 });
 

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -321,6 +321,44 @@ describe('headless delegation enforcement', () => {
         await runHeadless(['approve', 'wf-1/task-1'], mockDeps);
         expect(mockDeps.commandService.approve).toHaveBeenCalled();
       });
+
+      it('routes review-gate attach, seal, and check through the new headless commands', async () => {
+        mockDeps.commandService.attachReviewArtifact = vi.fn(async () => ({
+          ok: true as const,
+          data: {
+            sealed: false,
+            completion: { required: 'all', state: 'merged' },
+            relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+            artifacts: [{ id: 'github:pull_request:41', provider: 'github', type: 'pull_request', url: 'https://github.com/acme/repo/pull/41', identifier: '41' }],
+            statusText: 'Waiting for review artifacts',
+          },
+        }));
+        mockDeps.commandService.sealReviewGate = vi.fn(async () => ({
+          ok: true as const,
+          data: {
+            sealed: true,
+            completion: { required: 'all', state: 'merged' },
+            relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+            artifacts: [{ id: 'github:pull_request:41', provider: 'github', type: 'pull_request', url: 'https://github.com/acme/repo/pull/41', identifier: '41' }],
+            statusText: 'Awaiting review',
+          },
+        }));
+        const checkPrApprovalNow = vi.fn(async () => {});
+        mockDeps.ownerTaskRunnerProvider = () => ({ checkPrApprovalNow } as unknown as TaskRunner);
+        mockDeps.orchestrator.getMergeNode = vi.fn(() => ({
+          id: '__merge__wf-1',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+        } as any));
+
+        await runHeadless(['review-gate', 'attach', 'wf-1', 'https://github.com/acme/repo/pull/41'], mockDeps);
+        await runHeadless(['review-gate', 'seal', 'wf-1'], mockDeps);
+        await runHeadless(['review-gate', 'check', 'wf-1'], mockDeps);
+
+        expect(mockDeps.commandService.attachReviewArtifact).toHaveBeenCalled();
+        expect(mockDeps.commandService.sealReviewGate).toHaveBeenCalled();
+        expect(mockDeps.orchestrator.getMergeNode).toHaveBeenCalledWith('wf-1');
+        expect(checkPrApprovalNow).toHaveBeenCalledWith('__merge__wf-1');
+      });
     });
 
     /**
@@ -545,7 +583,7 @@ describe('headless delegation enforcement', () => {
           execution: {},
         } as any;
         mockDeps.commandService.editTaskCommand = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
-        mockDeps.commandService.editTaskPool = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
+        mockDeps.commandService.editTaskType = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
         mockDeps.commandService.editTaskAgent = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
         mockDeps.commandService.setTaskExternalGatePolicies = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
         const executeTasksSpy = vi
@@ -553,12 +591,12 @@ describe('headless delegation enforcement', () => {
           .mockResolvedValue(undefined);
 
         await runHeadless(['set', 'command', 'wf-1/task-1', 'echo ok'], mockDeps);
-        await runHeadless(['set', 'pool', 'wf-1/task-1', 'mixed-local-ssh'], mockDeps);
+        await runHeadless(['set', 'executor', 'wf-1/task-1', 'shell'], mockDeps);
         await runHeadless(['set', 'agent', 'wf-1/task-1', 'codex'], mockDeps);
         await runHeadless(['set', 'gate-policy', 'wf-1/task-1', 'wf-upstream', 'review_ready'], mockDeps);
 
         expect(mockDeps.commandService.editTaskCommand).toHaveBeenCalled();
-        expect(mockDeps.commandService.editTaskPool).toHaveBeenCalled();
+        expect(mockDeps.commandService.editTaskType).toHaveBeenCalled();
         expect(mockDeps.commandService.editTaskAgent).toHaveBeenCalled();
         expect(mockDeps.commandService.setTaskExternalGatePolicies).toHaveBeenCalled();
 
@@ -1045,7 +1083,7 @@ describe('headless delegation enforcement', () => {
         expect(mockDeps.commandService.recreateWorkflow).toHaveBeenCalled();
       });
 
-      it('headless recreate dispatches runnable tasks before waiting for completion', async () => {
+      it('headless recreate hands runnable tasks to the launch outbox instead of waiting for completion', async () => {
         let taskStatus: 'running' | 'completed' = 'running';
         (mockDeps.commandService as any).recreateWorkflow = vi.fn(async () => ({
           ok: true as const,
@@ -1054,7 +1092,7 @@ describe('headless delegation enforcement', () => {
               id: 'wf-1/task-1',
               status: 'running',
               config: { workflowId: 'wf-1' },
-              execution: {},
+              execution: { selectedAttemptId: 'attempt-1' },
             } as any,
           ],
         }));
@@ -1072,27 +1110,29 @@ describe('headless delegation enforcement', () => {
           id: 'wf-1/task-1',
           status: taskStatus,
           config: { workflowId: 'wf-1' },
-          execution: {},
+          execution: { selectedAttemptId: 'attempt-1' },
         } as any]);
         mockDeps.orchestrator.getAllTasks = vi.fn(() => [{
           id: 'wf-1/task-1',
           status: taskStatus,
           config: { workflowId: 'wf-1' },
-          execution: {},
+          execution: { selectedAttemptId: 'attempt-1' },
         } as any]);
         mockDeps.orchestrator.getReadyTasks = vi.fn(() => []);
 
-        const executeTasksSpy = vi
-          .spyOn(TaskRunner.prototype, 'executeTasks')
-          .mockImplementation(async () => {
-            taskStatus = 'completed';
-          });
+        const executeTasksSpy = vi.spyOn(TaskRunner.prototype, 'executeTasks');
 
-        await runHeadless(['recreate', 'wf-1'], mockDeps);
+        const depsWithNoTrack: HeadlessDeps = {
+          ...mockDeps,
+          noTrack: true,
+        } as HeadlessDeps;
 
-        expect(executeTasksSpy).toHaveBeenCalledTimes(1);
+        await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
+
+        expect(executeTasksSpy).not.toHaveBeenCalled();
         expect((mockDeps.commandService as any).recreateWorkflow).toHaveBeenCalled();
 
+        taskStatus = 'completed';
         executeTasksSpy.mockRestore();
       });
 

--- a/packages/app/src/__tests__/merge-mode.test.ts
+++ b/packages/app/src/__tests__/merge-mode.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { normalizeMergeModeForPersistence } from '../merge-mode.js';
 
 describe('normalizeMergeModeForPersistence', () => {
-  it('maps external_review to external_review', () => {
+  it('maps external review aliases to external_review', () => {
     expect(normalizeMergeModeForPersistence('external_review')).toBe('external_review');
+    expect(normalizeMergeModeForPersistence('github')).toBe('external_review');
   });
 
   it('passes through manual and automatic', () => {
@@ -12,7 +13,6 @@ describe('normalizeMergeModeForPersistence', () => {
   });
 
   it('rejects unknown labels', () => {
-    expect(() => normalizeMergeModeForPersistence('github')).toThrow(/Invalid mergeMode/);
     expect(() => normalizeMergeModeForPersistence('gitlab')).toThrow(/Invalid mergeMode/);
   });
 });

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -787,6 +787,96 @@ tasks:
     const result = parsePlan(yaml);
     expect(result.visualProof).toBeUndefined();
   });
+
+  it('normalizes github mergeMode to external_review and default reviewGate', () => {
+    const yaml = `
+name: GitHub Review Gate
+repoUrl: git@github.com:test/repo.git
+mergeMode: github
+tasks:
+  - id: task-1
+    description: Do something
+    command: echo hello
+`;
+    const result = parsePlan(yaml);
+    expect(result.mergeMode).toBe('external_review');
+    expect(result.reviewProvider).toBe('github');
+    expect(result.reviewGate).toEqual({
+      type: 'pull_requests',
+      authoring: { mode: 'automatic', preferredShape: 'stacked_diffs' },
+      completion: { required: 'all', state: 'merged' },
+    });
+  });
+
+  it('normalizes partial reviewGate blocks to defaults', () => {
+    const yaml = `
+name: Manual Review Gate
+repoUrl: git@github.com:test/repo.git
+mergeMode: external_review
+reviewGate:
+  authoring:
+    mode: manual
+tasks:
+  - id: task-1
+    description: Do something
+    command: echo hello
+`;
+    const result = parsePlan(yaml);
+    expect(result.reviewGate).toEqual({
+      type: 'pull_requests',
+      authoring: { mode: 'manual', preferredShape: 'stacked_diffs' },
+      completion: { required: 'all', state: 'merged' },
+    });
+  });
+
+  it('rejects numeric reviewGate completion counts', () => {
+    const yaml = `
+name: Numeric Review Gate
+repoUrl: git@github.com:test/repo.git
+mergeMode: external_review
+reviewGate:
+  completion:
+    required: 3
+tasks:
+  - id: task-1
+    description: Do something
+    command: echo hello
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow('reviewGate.completion.required');
+  });
+
+  it('rejects fixed reviewGate PR count fields', () => {
+    const yaml = `
+name: Counted Review Gate
+repoUrl: git@github.com:test/repo.git
+mergeMode: external_review
+reviewGate:
+  requiredPullRequests: 3
+tasks:
+  - id: task-1
+    description: Do something
+    command: echo hello
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow('reviewGate.requiredPullRequests');
+  });
+
+  it('rejects unknown reviewGate fields by field name', () => {
+    const yaml = `
+name: Bad Review Gate
+repoUrl: git@github.com:test/repo.git
+mergeMode: external_review
+reviewGate:
+  type: issues
+tasks:
+  - id: task-1
+    description: Do something
+    command: echo hello
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow('reviewGate.type');
+  });
 });
 
 describe('detectDefaultBranch', () => {

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -47,7 +47,7 @@ import {
   PlanConflictError,
   TopologyForkRequired,
 } from '@invoker/workflow-core';
-import type { ExternalGatePolicyUpdate, Orchestrator } from '@invoker/workflow-core';
+import type { ExternalGatePolicyUpdate, Orchestrator, ReviewArtifactInput, ReviewGateExecution } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { ExecutorRegistry } from '@invoker/execution-engine';
 import type {
@@ -72,6 +72,7 @@ export interface ApiMutationFacade {
   provideInput(taskId: string, text: string): void;
   editTaskCommand(taskId: string, newCommand: string): Promise<MutationResult>;
   editTaskPrompt(taskId: string, newPrompt: string): Promise<MutationResult>;
+  editTaskType(taskId: string, runnerKind: string, poolMemberId?: string): Promise<MutationResult>;
   editTaskAgent(taskId: string, agentName: string): Promise<MutationResult>;
   setTaskExternalGatePolicies(
     taskId: string,
@@ -94,6 +95,8 @@ export interface ApiMutationFacade {
   forkWorkflow(workflowId: string): Promise<ForkMutationResult>;
   cancelWorkflow(workflowId: string): Promise<CancelMutationResult>;
   setWorkflowMergeMode(workflowId: string, mergeMode: string): Promise<void>;
+  attachReviewArtifact(workflowId: string, artifact: ReviewArtifactInput): Promise<ReviewGateExecution>;
+  sealReviewGate(workflowId: string): Promise<ReviewGateExecution>;
   setWorkflowMetadata(
     workflowId: string,
     fieldPath: string,
@@ -607,7 +610,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       // POST /api/tasks/:id/edit-type
       const editTypeMatch = path.match(/^\/api\/tasks\/([^/]+)\/edit-type$/);
       if (method === 'POST' && editTypeMatch) {
-        json(res, 410, { error: 'Executor selection is internal. Assign tasks to an execution pool instead.' });
+        json(res, 410, { error: 'Executor selection is internal; use the headless set pool command instead.' });
         return;
       }
 
@@ -716,6 +719,34 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             upstreamWorkflowId,
             action: 'detached',
           });
+        } catch (err) {
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
+        }
+        return;
+      }
+
+      // POST /api/workflows/:id/review-artifacts
+      const wfReviewArtifactsMatch = path.match(/^\/api\/workflows\/([^/]+)\/review-artifacts$/);
+      if (method === 'POST' && wfReviewArtifactsMatch) {
+        const workflowId = decodeURIComponent(wfReviewArtifactsMatch[1]);
+        try {
+          const artifact = JSON.parse(await readBody(req)) as ReviewArtifactInput;
+          const reviewGate = await mutations.attachReviewArtifact(workflowId, artifact);
+          json(res, 200, { ok: true, reviewGate });
+        } catch (err) {
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
+        }
+        return;
+      }
+
+      // POST /api/workflows/:id/review-gate/seal
+      const wfReviewGateSealMatch = path.match(/^\/api\/workflows\/([^/]+)\/review-gate\/seal$/);
+      if (method === 'POST' && wfReviewGateSealMatch) {
+        const workflowId = decodeURIComponent(wfReviewGateSealMatch[1]);
+        try {
+          await readBody(req);
+          const reviewGate = await mutations.sealReviewGate(workflowId);
+          json(res, 200, { ok: true, reviewGate });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }

--- a/packages/app/src/cli-installer.ts
+++ b/packages/app/src/cli-installer.ts
@@ -51,6 +51,12 @@ function searchDirs(context: CliInstallerContext): string[] {
   // one location (used by the hermetic e2e scripts).
   const override = context.env.INVOKER_CLI_INSTALL_DIR;
   if (override) return [override];
+  if (context.candidateInstallDirs) {
+    return [...new Set([
+      ...context.candidateInstallDirs,
+      ...pathDirs(context),
+    ])];
+  }
   const dirs = [
     ...defaultCandidateInstallDirs(context),
     ...pathDirs(context),

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -299,6 +299,7 @@ export function serializeTask(task: TaskState): Record<string, unknown> {
   if (task.execution.reviewUrl != null) execution.reviewUrl = task.execution.reviewUrl;
   if (task.execution.reviewId != null) execution.reviewId = task.execution.reviewId;
   if (task.execution.reviewStatus != null) execution.reviewStatus = task.execution.reviewStatus;
+  if (task.execution.reviewGate != null) execution.reviewGate = task.execution.reviewGate;
   if (task.execution.autoFixAttempts != null) execution.autoFixAttempts = task.execution.autoFixAttempts;
   if (task.execution.agentSessionId != null) execution.agentSessionId = task.execution.agentSessionId;
   if (task.execution.lastAgentSessionId != null) execution.lastAgentSessionId = task.execution.lastAgentSessionId;

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -13,7 +13,7 @@ import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@inv
 import { makeEnvelope } from '@invoker/contracts';
 import type { AgentSessionData } from '@invoker/contracts';
 import { OrchestratorErrorCode } from '@invoker/workflow-core';
-import type { Attempt, Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
+import type { Attempt, Orchestrator, CommandService, ReviewArtifactInput, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { Channels } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
@@ -969,10 +969,9 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
       await headlessEditPrompt(args[1], args.slice(2).join(' '), deps);
       break;
     case 'pool':
-      await headlessEditPool(args[1], args[2], deps);
-      break;
     case 'executor':
-      throw new Error('Executor selection is internal. Use: --headless set pool <taskId> <poolId>');
+      await headlessEditExecutor(args[1], args[2], args[3], deps);
+      break;
     case 'agent':
       await headlessEditAgent(args[1], args[2], deps);
       break;
@@ -997,6 +996,75 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
     default:
       throw new Error(`Unknown set sub-command: "${subCommand}". Use: ${formatHeadlessSetSubcommands(', ')}`);
   }
+}
+
+function parseReviewGateAttachArgs(args: string[]): { workflowId: string; artifact: ReviewArtifactInput } {
+  const workflowId = args[0];
+  const url = args[1];
+  if (!workflowId || !url) {
+    throw new Error('Usage: --headless review-gate attach <workflowId> <url> [--identifier <id>] [--title <title>] [--base <branch>] [--head <branch>]');
+  }
+  const artifact: ReviewArtifactInput = { url };
+  for (let index = 2; index < args.length; index += 1) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!value) throw new Error(`Missing value for ${flag}`);
+    switch (flag) {
+      case '--identifier':
+        artifact.identifier = value;
+        break;
+      case '--title':
+        artifact.title = value;
+        break;
+      case '--base':
+        artifact.baseBranch = value;
+        break;
+      case '--head':
+        artifact.headBranch = value;
+        break;
+      default:
+        throw new Error(`Unknown review-gate attach flag: ${flag}`);
+    }
+    index += 1;
+  }
+  return { workflowId, artifact };
+}
+
+async function headlessReviewGate(args: string[], deps: HeadlessDeps): Promise<void> {
+  const subCommand = args[0];
+  if (!subCommand) {
+    throw new Error('Missing review-gate sub-command. Usage: --headless review-gate <attach|seal|check>');
+  }
+  if (subCommand === 'attach') {
+    const { workflowId, artifact } = parseReviewGateAttachArgs(args.slice(1));
+    const result = await deps.commandService.attachReviewArtifact(
+      makeEnvelope('headless.review-gate.attach', 'headless', 'workflow', { workflowId, artifact }),
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    process.stdout.write(`Attached review artifact to workflow "${workflowId}".\n`);
+    return;
+  }
+  if (subCommand === 'seal') {
+    const workflowId = args[1];
+    if (!workflowId) throw new Error('Usage: --headless review-gate seal <workflowId>');
+    const result = await deps.commandService.sealReviewGate(
+      makeEnvelope('headless.review-gate.seal', 'headless', 'workflow', { workflowId }),
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    process.stdout.write(`Sealed review gate for workflow "${workflowId}".\n`);
+    return;
+  }
+  if (subCommand === 'check') {
+    const workflowId = args[1];
+    if (!workflowId) throw new Error('Usage: --headless review-gate check <workflowId>');
+    const mergeTask = deps.orchestrator.getMergeNode(workflowId);
+    if (!mergeTask) throw new Error(`Workflow "${workflowId}" has no review gate`);
+    const taskExecutor = createHeadlessExecutor(deps);
+    await taskExecutor.checkPrApprovalNow(mergeTask.id);
+    process.stdout.write(`Checked review gate for workflow "${workflowId}".\n`);
+    return;
+  }
+  throw new Error(`Unknown review-gate sub-command: "${subCommand}". Use: attach, seal, check`);
 }
 
 async function headlessMigrateCompatibility(deps: HeadlessDeps): Promise<void> {
@@ -1040,6 +1108,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       break;
     case 'set':
       await headlessSet(args.slice(1), deps);
+      break;
+    case 'review-gate':
+      await headlessReviewGate(args.slice(1), deps);
       break;
     case 'migrate-compat':
       await headlessMigrateCompatibility(deps);
@@ -1187,7 +1258,8 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'edit-executor':
     case 'edit-type':
       warnDeprecated(command, 'set pool');
-      throw new Error('Executor selection is internal. Use: --headless set pool <taskId> <poolId>');
+      await headlessSet(['pool', ...args.slice(1)], deps);
+      break;
     case 'edit-agent':
       warnDeprecated('edit-agent', 'set agent');
       await headlessSet(['agent', ...args.slice(1)], deps);
@@ -1294,7 +1366,7 @@ ${BOLD}Configure:${RESET}
   install-skills [install|update|reinstall]          Install bundled Invoker skills into Codex
   set command <taskId> <cmd>                          Edit task command and re-run
   set prompt <taskId> <text>                          Edit task prompt and re-run
-  set pool <taskId> <poolId>                        Change execution pool and re-run
+  set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)
   set agent <taskId> <agent>                          Change execution agent (claude|codex)
   set merge-mode <workflowId> <mode>                  manual | automatic | external_review
   set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
@@ -1317,7 +1389,7 @@ ${BOLD}Lifecycle:${RESET}
 ${BOLD}Deprecated${RESET} (use new names above):
   list → query workflows       status → query tasks       task-status → query task
   queue → query queue           audit → query audit         session → query session
-  edit → set command
+  edit → set command            edit-executor → set pool
   edit-agent → set agent        set-merge-mode → set merge-mode
   delete-workflow → delete
 
@@ -1949,41 +2021,39 @@ async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps):
   if (!recreateWfResult.ok) throw new Error(recreateWfResult.error.message);
   const started = recreateWfResult.data;
   const runnable = started.filter(isDispatchableLaunch);
-  if (runnable.length > 0) {
-    const te = createHeadlessExecutor(deps);
-    const autoFix = wireHeadlessAutoFix(deps, te);
-    remoteFetchForPool.enabled = false;
-    let topup: TaskState[] = [];
-    try {
-      await te.executeTasks(runnable);
-      topup = await executeGlobalTopup({
-        orchestrator: deps.orchestrator,
-        taskExecutor: te,
-        logger: deps.logger,
-        context: 'headless.recreate-workflow',
-        alreadyDispatched: runnable,
-        mutationTiming: deps.mutationTiming,
-      });
-    } finally {
-      remoteFetchForPool.enabled = true;
-    }
-    if (runnable.length + topup.length === 0) {
-      autoFix.unsubscribe();
-      return;
-    }
-    if (deps.noTrack) {
-      process.stdout.write('[headless] --no-track enabled: recreate accepted; exiting without tracking.\n');
-      autoFix.unsubscribe();
-      return;
-    }
-    await trackHeadlessWorkflow(workflowId, deps, {
-      hasBackgroundWork: autoFix.isBusy,
-      printSummary: false,
-      printTaskOutput: true,
-      setExitCodeOnFailure: false,
-    });
-    autoFix.unsubscribe();
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  remoteFetchForPool.enabled = false;
+  let topup: TaskState[] = [];
+  try {
+    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: te,
+      logger: deps.logger,
+      context: 'headless.recreate-workflow',
+      started,
+      mutationTiming: deps.mutationTiming,
+    }));
+  } finally {
+    remoteFetchForPool.enabled = true;
   }
+  if (runnable.length + topup.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: recreate accepted; exiting without tracking.\n');
+    autoFix.unsubscribe();
+    return;
+  }
+  await trackHeadlessWorkflow(workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
+  autoFix.unsubscribe();
+
   const tasksStarted = runnable.length;
   process.stdout.write(`Recreate workflow "${workflowId}" — ${tasksStarted} task(s) to execute (pool fetch skipped)\n`);
 }
@@ -2376,14 +2446,15 @@ async function headlessEditPrompt(taskId: string, newPrompt: string, deps: Headl
   autoFix.unsubscribe();
 }
 
-async function headlessEditPool(
+async function headlessEditExecutor(
   taskId: string,
-  poolId: string,
+  runnerKind: string,
+  poolMemberId: string | undefined,
   deps: HeadlessDeps,
 ): Promise<void> {
-  if (!taskId || !poolId) {
+  if (!taskId || !runnerKind) {
     throw new Error(
-      'Missing arguments. Usage: --headless set pool <taskId> <poolId>',
+      'Missing arguments. Usage: --headless set pool <taskId> <runnerKind> [poolMemberId]',
     );
   }
   const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'set pool');
@@ -2392,12 +2463,15 @@ async function headlessEditPool(
   const taskExecutor = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
 
-  const envelope = makeEnvelope('edit-task-pool', 'headless', 'task', { taskId, poolId });
-  const result = await deps.commandService.editTaskPool(envelope);
+  const envelope = makeEnvelope('edit-task-type', 'headless', 'task', { taskId, runnerKind, poolMemberId });
+  const result = await deps.commandService.editTaskType(envelope);
   if (!result.ok) throw new Error(result.error.message);
   const runnable = result.data.filter(isDispatchableLaunch);
-  await dispatchHeadlessRunnableTasks(deps, taskExecutor, runnable, 'edit-task-pool');
-  process.stdout.write(`Edited task "${taskId}" pool → "${poolId}"\n`);
+  await dispatchHeadlessRunnableTasks(deps, taskExecutor, runnable, 'edit-task-type');
+  process.stdout.write(
+    `Edited task "${taskId}" executor → "${runnerKind}"` +
+    `${poolMemberId ? ` (poolMemberId=${poolMemberId})` : ''}\n`,
+  );
 
   if (deps.noTrack) {
     process.stdout.write('[headless] --no-track enabled: set pool accepted; exiting without tracking.\n');

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1607,9 +1607,7 @@ function startHeadlessMode(): void {
             return orchestrator.getWorkflowStatus();
           }
           if (kind === 'tasks' || kind === 'task-graph-refresh') {
-            if (kind === 'task-graph-refresh') {
-              orchestrator.syncAllFromDb();
-            }
+            orchestrator.syncAllFromDb();
             return {
               tasks: orchestrator.getAllTasks(),
               workflows: persistence.listWorkflows(),
@@ -2589,6 +2587,8 @@ function createEmbeddedTerminalBackendFromConfig(
         return { channel: 'headless.exec', request: { args: ['set', 'command', String(arg0), String(arg1)] } };
       case 'invoker:edit-task-prompt':
         return { channel: 'headless.exec', request: { args: ['set', 'prompt', String(arg0), String(arg1)] } };
+      case 'invoker:edit-task-type':
+        return { channel: 'headless.exec', request: { args: ['set', 'executor', String(arg0), String(arg1)] } };
       case 'invoker:edit-task-pool':
         return null;
       case 'invoker:edit-task-agent':
@@ -3132,9 +3132,7 @@ function createEmbeddedTerminalBackendFromConfig(
           return orchestrator.getWorkflowStatus();
         }
         if (kind === 'tasks' || kind === 'task-graph-refresh') {
-          if (kind === 'task-graph-refresh') {
-            orchestrator.syncAllFromDb();
-          }
+          orchestrator.syncAllFromDb();
           return {
             tasks: orchestrator.getAllTasks(),
             workflows: persistence.listWorkflows(),
@@ -4293,6 +4291,28 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
+    registerGuiMutationHandler('invoker:edit-task-type', async (taskIdArg: unknown, runnerKindArg: unknown, poolMemberIdArg?: unknown) => {
+      const taskId = String(taskIdArg);
+      const runnerKind = String(runnerKindArg);
+      const poolMemberId = poolMemberIdArg === undefined ? undefined : String(poolMemberIdArg);
+      logger.info(`edit-task-type: "${taskId}" → "${runnerKind}" poolMemberId=${poolMemberId ?? 'none'}`, { module: 'ipc' });
+      try {
+        const envelope = makeEnvelope('edit-task-type', 'ui', 'task', { taskId, runnerKind, poolMemberId });
+        const result = await commandService.editTaskType(envelope);
+        if (!result.ok) throw new Error(result.error.message);
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.edit-task-type',
+          started: result.data,
+          scopedTaskIds: [taskId],
+        });
+      } catch (err) {
+        logger.error(`edit-task-type failed: ${err}`, { module: 'ipc' });
+        throw err;
+      }
+    });
 
     registerGuiMutationHandler('invoker:edit-task-pool', async (taskIdArg: unknown, poolIdArg: unknown) => {
       const taskId = String(taskIdArg);

--- a/packages/app/src/merge-mode.ts
+++ b/packages/app/src/merge-mode.ts
@@ -3,7 +3,7 @@
  */
 export type CanonicalMergeMode = 'manual' | 'automatic' | 'external_review';
 
-const VALID_INPUT = new Set(['manual', 'automatic', 'external_review']);
+const VALID_INPUT = new Set(['manual', 'automatic', 'external_review', 'github']);
 
 /**
  * Normalize user-facing merge mode strings for workflow persistence.
@@ -15,7 +15,7 @@ export function normalizeMergeModeForPersistence(raw: string): CanonicalMergeMod
       `Invalid mergeMode: "${raw}". Expected one of: ${[...VALID_INPUT].join(', ')}`,
     );
   }
-  if (raw === 'external_review') return 'external_review';
+  if (raw === 'external_review' || raw === 'github') return 'external_review';
   if (raw === 'automatic') return 'automatic';
   return 'manual';
 }

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -41,6 +41,20 @@ export interface RawExperimentVariant {
   prompt?: string;
   command?: string;
 }
+export interface RawReviewGate {
+  type?: string;
+  authoring?: {
+    mode?: string;
+    preferredShape?: string;
+  };
+  completion?: {
+    required?: unknown;
+    state?: string;
+  };
+  requiredPullRequests?: unknown;
+  prCount?: unknown;
+}
+
 
 export interface RawPlanTask {
   id?: string;
@@ -72,6 +86,7 @@ export interface RawPlan {
   featureBranch?: string;
   mergeMode?: string;
   reviewProvider?: string;
+  reviewGate?: RawReviewGate;
   repoUrl?: string;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
@@ -212,6 +227,76 @@ function assertNoLegacyRoutingKeys(ownerLabel: string, value: object): void {
     }
   }
 }
+function parseReviewGate(
+  rawReviewGate: RawReviewGate | undefined,
+  mergeMode: PlanDefinition['mergeMode'] | undefined,
+): PlanDefinition['reviewGate'] | undefined {
+  const defaultGate: NonNullable<PlanDefinition['reviewGate']> = {
+    type: 'pull_requests',
+    authoring: { mode: 'automatic', preferredShape: 'stacked_diffs' },
+    completion: { required: 'all', state: 'merged' },
+  };
+  if (rawReviewGate === undefined) {
+    return mergeMode === 'external_review' ? defaultGate : undefined;
+  }
+  if (!rawReviewGate || typeof rawReviewGate !== 'object') {
+    throw new PlanParseError('"reviewGate" must be an object');
+  }
+  const hasOwn = (obj: object, key: string): boolean => Object.prototype.hasOwnProperty.call(obj, key);
+  if (hasOwn(rawReviewGate as object, 'requiredPullRequests')) {
+    throw new PlanParseError('"reviewGate.requiredPullRequests" is not supported; use completion.required: all');
+  }
+  if (hasOwn(rawReviewGate as object, 'prCount')) {
+    throw new PlanParseError('"reviewGate.prCount" is not supported; use completion.required: all');
+  }
+
+  const type = rawReviewGate.type ?? defaultGate.type;
+  if (type !== 'pull_requests') {
+    throw new PlanParseError(`"reviewGate.type" must be "pull_requests". Got: "${String(type)}"`);
+  }
+
+  const rawAuthoring = rawReviewGate.authoring ?? {};
+  if (!rawAuthoring || typeof rawAuthoring !== 'object') {
+    throw new PlanParseError('"reviewGate.authoring" must be an object');
+  }
+  const mode = rawAuthoring.mode ?? defaultGate.authoring.mode;
+  if (mode !== 'automatic' && mode !== 'manual' && mode !== 'external') {
+    throw new PlanParseError(`"reviewGate.authoring.mode" must be one of: automatic, manual, external. Got: "${String(mode)}"`);
+  }
+  const preferredShape = rawAuthoring.preferredShape ?? defaultGate.authoring.preferredShape;
+  if (preferredShape !== 'stacked_diffs' && preferredShape !== 'independent') {
+    throw new PlanParseError(`"reviewGate.authoring.preferredShape" must be one of: stacked_diffs, independent. Got: "${String(preferredShape)}"`);
+  }
+
+  const rawCompletion = rawReviewGate.completion ?? {};
+  if (!rawCompletion || typeof rawCompletion !== 'object') {
+    throw new PlanParseError('"reviewGate.completion" must be an object');
+  }
+  if (hasOwn(rawCompletion as object, 'requiredPullRequests')) {
+    throw new PlanParseError('"reviewGate.completion.requiredPullRequests" is not supported; use completion.required: all');
+  }
+  if (hasOwn(rawCompletion as object, 'prCount')) {
+    throw new PlanParseError('"reviewGate.completion.prCount" is not supported; use completion.required: all');
+  }
+  const required = rawCompletion.required ?? defaultGate.completion.required;
+  if (typeof required === 'number') {
+    throw new PlanParseError('"reviewGate.completion.required" must be "all"; numeric pull request counts are not supported');
+  }
+  if (required !== 'all') {
+    throw new PlanParseError(`"reviewGate.completion.required" must be "all". Got: "${String(required)}"`);
+  }
+  const state = rawCompletion.state ?? defaultGate.completion.state;
+  if (state !== 'merged') {
+    throw new PlanParseError(`"reviewGate.completion.state" must be "merged". Got: "${String(state)}"`);
+  }
+
+  return {
+    type,
+    authoring: { mode, preferredShape },
+    completion: { required, state },
+  };
+}
+
 
 /**
  * Parse a YAML string into a validated PlanDefinition.
@@ -256,8 +341,8 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   }
   const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
 
-  // Validate mergeMode against canonical values only.
-  const validMergeModes = ['manual', 'automatic', 'external_review'] as const;
+  // Validate mergeMode against canonical values and the YAML-only github alias.
+  const validMergeModes = ['manual', 'automatic', 'external_review', 'github'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(
       `"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`,
@@ -270,7 +355,8 @@ export function parsePlan(yamlContent: string): PlanDefinition {
 
   // Default reviewProvider to 'github' for external-review workflows.
   const reviewProvider = raw.reviewProvider
-    ?? (rawMergeMode === 'external_review' ? 'github' : undefined);
+    ?? (mergeMode === 'external_review' ? 'github' : undefined);
+  const reviewGate = parseReviewGate(raw.reviewGate, mergeMode);
 
   // Auto-generate featureBranch from plan name when not explicitly specified
   if (!raw.featureBranch) {
@@ -365,6 +451,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     featureBranch: raw.featureBranch,
     mergeMode,
     reviewProvider,
+    reviewGate,
     repoUrl: raw.repoUrl,
     intermediateRepoUrl: raw.intermediateRepoUrl,
     externalDependencies: topLevelExternalDependencies,

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -627,6 +627,15 @@ export function editTaskPrompt(
   return deps.orchestrator.editTaskPrompt(taskId, newPrompt);
 }
 
+export function editTaskType(
+  taskId: string,
+  runnerKind: string,
+  deps: Pick<ActionDeps, 'orchestrator'>,
+  poolMemberId?: string,
+): TaskState[] {
+  return deps.orchestrator.editTaskType(taskId, runnerKind, poolMemberId);
+}
+
 
 export function editTaskAgent(
   taskId: string,

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -18,7 +18,7 @@
 import type { Logger } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
 import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
-import type { CommandService, Orchestrator, ExternalGatePolicyUpdate, TaskState } from '@invoker/workflow-core';
+import type { CommandService, Orchestrator, ExternalGatePolicyUpdate, TaskState, ReviewArtifactInput, ReviewGateExecution } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
 import {
@@ -33,6 +33,7 @@ import {
   forkWorkflow as sharedForkWorkflow,
   editTaskCommand as sharedEditTaskCommand,
   editTaskPrompt as sharedEditTaskPrompt,
+  editTaskType as sharedEditTaskType,
   editTaskAgent as sharedEditTaskAgent,
   setTaskExternalGatePolicies as sharedSetTaskExternalGatePolicies,
   setWorkflowExternalGatePolicies as sharedSetWorkflowExternalGatePolicies,
@@ -202,6 +203,19 @@ export class WorkflowMutationFacade {
     return this.finalizeWithTopup(started, 'facade.edit-task-prompt', { scopedTaskIds: [taskId] });
   }
 
+  async editTaskType(
+    taskId: string,
+    runnerKind: string,
+    poolMemberId?: string,
+  ): Promise<MutationResult> {
+    const started = sharedEditTaskType(
+      taskId,
+      runnerKind,
+      { orchestrator: this.deps.orchestrator },
+      poolMemberId,
+    );
+    return this.finalizeWithTopup(started, 'facade.edit-task-type', { scopedTaskIds: [taskId] });
+  }
 
   async editTaskAgent(taskId: string, agentName: string): Promise<MutationResult> {
     const started = sharedEditTaskAgent(taskId, agentName, {
@@ -352,6 +366,22 @@ export class WorkflowMutationFacade {
       persistence: this.deps.persistence,
       taskExecutor: this.deps.taskExecutor,
     });
+  }
+
+  async attachReviewArtifact(workflowId: string, artifact: ReviewArtifactInput): Promise<ReviewGateExecution> {
+    const result = await this.deps.commandService.attachReviewArtifact(
+      makeEnvelope('attach-review-artifact', 'surface', 'workflow', { workflowId, artifact }),
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    return result.data;
+  }
+
+  async sealReviewGate(workflowId: string): Promise<ReviewGateExecution> {
+    const result = await this.deps.commandService.sealReviewGate(
+      makeEnvelope('seal-review-gate', 'surface', 'workflow', { workflowId }),
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    return result.data;
   }
 
   async setWorkflowMetadata(

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -61,7 +61,7 @@ describe('invoker-cli', () => {
     const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir]);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('hello-from-invoker-cli');
-  });
+  }, 60_000);
 
   it('--json emits a successful workflow result object', () => {
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-json-db-'));
@@ -70,7 +70,7 @@ describe('invoker-cli', () => {
     const lines = result.stdout.trim().split('\n');
     const json = JSON.parse(lines[lines.length - 1]);
     expect(json.workflow.status).toBe('success');
-  });
+  }, 60_000);
 
   it('invalid YAML exits non-zero with a validation error', () => {
     const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-invalid-'));
@@ -138,7 +138,7 @@ tasks:
     expect(createMessageBus).not.toHaveBeenCalled();
     expect(output.stdout).toContain('hello-from-invoker-cli');
     output.restore();
-  });
+  }, 60_000);
 
   it('auto mode delegates when a GUI owner exists', async () => {
     const output = captureProcessOutput();

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -102,6 +102,42 @@ export type ResponseStatus =
   | 'spawn_experiments'
   | 'select_experiment';
 
+export type ReviewArtifactType = 'pull_request';
+export type ReviewArtifactStatus = 'open' | 'merged' | 'closed' | 'rejected' | 'unknown';
+export type ReviewGateRelationshipKind = 'stacked_diffs' | 'independent' | 'unknown';
+
+export interface ReviewGateArtifact {
+  readonly id: string;
+  readonly provider: string;
+  readonly type: ReviewArtifactType;
+  readonly url: string;
+  readonly identifier: string;
+  readonly title?: string;
+  readonly baseBranch?: string;
+  readonly headBranch?: string;
+  readonly status?: ReviewArtifactStatus;
+  readonly statusText?: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly replacedById?: string;
+}
+
+export interface ReviewGateCompletionPolicy {
+  readonly required: 'all';
+  readonly state: 'merged';
+}
+
+export interface ReviewGateExecution {
+  readonly sealed: boolean;
+  readonly completion: ReviewGateCompletionPolicy;
+  readonly relationship: {
+    readonly kind: ReviewGateRelationshipKind;
+    readonly managedBy: 'external';
+  };
+  readonly artifacts: readonly ReviewGateArtifact[];
+  readonly statusText?: string;
+}
+
 export interface WorkResponseOutputs {
   exitCode?: number;
   error?: string;
@@ -118,6 +154,7 @@ export interface WorkResponseOutputs {
   reviewId?: string;
   /** Human-readable review state produced by merge-gate style actions. */
   reviewStatus?: string;
+  reviewGate?: ReviewGateExecution;
 }
 
 export interface SpawnExperimentsRequest {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -115,6 +115,83 @@ describe('SQLiteAdapter', () => {
       expect(loaded[0].status).toBe('pending');
     });
 
+    it('round-trips reviewGate execution through save and update', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('merge', {
+        execution: {
+          reviewGate: {
+            sealed: true,
+            completion: { required: 'all', state: 'merged' },
+            relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+            artifacts: [
+              {
+                id: 'github:pull_request:12',
+                provider: 'github',
+                type: 'pull_request',
+                url: 'https://github.com/acme/repo/pull/12',
+                identifier: '12',
+                status: 'open',
+              },
+            ],
+            statusText: 'Awaiting review',
+          },
+        },
+      }));
+
+      adapter.updateTask('merge', {
+        execution: {
+          reviewGate: {
+            sealed: true,
+            completion: { required: 'all', state: 'merged' },
+            relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+            artifacts: [
+              {
+                id: 'github:pull_request:12',
+                provider: 'github',
+                type: 'pull_request',
+                url: 'https://github.com/acme/repo/pull/12',
+                identifier: '12',
+                status: 'merged',
+              },
+            ],
+            statusText: 'All review artifacts merged',
+          },
+        },
+      });
+
+      expect(adapter.loadTask('merge')?.execution.reviewGate).toMatchObject({
+        sealed: true,
+        completion: { required: 'all', state: 'merged' },
+        relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+        artifacts: [{ identifier: '12', status: 'merged' }],
+        statusText: 'All review artifacts merged',
+      });
+    });
+
+    it('synthesizes reviewGate from legacy scalar review fields', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('legacy-merge'));
+      (adapter as any).db.run(
+        'UPDATE tasks SET review_url = ?, review_id = ?, review_status = ?, review_gate = NULL WHERE id = ?',
+        ['https://github.com/acme/repo/pull/7', '7', 'Awaiting review', 'legacy-merge'],
+      );
+
+      expect(adapter.loadTask('legacy-merge')?.execution.reviewGate).toEqual({
+        sealed: true,
+        completion: { required: 'all', state: 'merged' },
+        relationship: { kind: 'unknown', managedBy: 'external' },
+        artifacts: [{
+          id: 'github:pull_request:7',
+          provider: 'github',
+          type: 'pull_request',
+          url: 'https://github.com/acme/repo/pull/7',
+          identifier: '7',
+          statusText: 'Awaiting review',
+        }],
+        statusText: 'Awaiting review',
+      });
+    });
+
     it('persists poolMemberId through updateTask and getPoolMemberId', () => {
       adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('ssh-task', {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -5,7 +5,7 @@
  * This allows swapping storage backends (in-memory, SQLite, etc.)
  */
 
-import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-core';
+import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, ReviewGateDefinition } from '@invoker/workflow-core';
 import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 
 // ── Conversation Types ─────────────────────────────────────
@@ -47,6 +47,7 @@ export interface Workflow {
   featureBranch?: string;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
   reviewProvider?: string;
+  reviewGate?: ReviewGateDefinition;
   externalDependencies?: ExternalDependency[];
   externalDependencyChanges?: ExternalDependencyChange[];
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -31,6 +31,7 @@ import type {
   ExternalDependency,
   ExternalDependencyChange,
   DetachedExternalDependency,
+  ReviewGateExecution,
 } from '@invoker/workflow-core';
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
 import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
@@ -694,6 +695,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         feature_branch TEXT,
         merge_mode TEXT,
         review_provider TEXT,
+        review_gate_definition TEXT,
         external_dependencies TEXT,
         external_dependency_changes TEXT,
         detached_external_dependencies TEXT,
@@ -749,6 +751,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
         -- Merge node
         is_merge_node INTEGER DEFAULT 0,
+        review_gate TEXT,
 
         -- Claude session
         claude_session_id TEXT,
@@ -993,6 +996,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE tasks ADD COLUMN review_id TEXT',
       'ALTER TABLE tasks ADD COLUMN review_status TEXT',
       'ALTER TABLE tasks ADD COLUMN review_provider_id TEXT',
+      'ALTER TABLE tasks ADD COLUMN review_gate TEXT',
       'ALTER TABLE tasks ADD COLUMN is_fixing_with_ai INTEGER DEFAULT 0',
       'ALTER TABLE tasks ADD COLUMN execution_generation INTEGER DEFAULT 0',
       'ALTER TABLE tasks ADD COLUMN docker_image TEXT',
@@ -1005,6 +1009,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE tasks ADD COLUMN agent_session_id TEXT',
       'ALTER TABLE attempts ADD COLUMN agent_session_id TEXT',
       'ALTER TABLE workflows ADD COLUMN review_provider TEXT',
+      'ALTER TABLE workflows ADD COLUMN review_gate_definition TEXT',
       'ALTER TABLE workflows ADD COLUMN external_dependencies TEXT',
       'ALTER TABLE workflows ADD COLUMN external_dependency_changes TEXT',
       // detached_external_dependencies: read-only provenance for deps removed by detachWorkflow
@@ -1089,6 +1094,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         feature_branch TEXT,
         merge_mode TEXT,
         review_provider TEXT,
+        review_gate_definition TEXT,
         external_dependencies TEXT,
         external_dependency_changes TEXT,
         generation INTEGER DEFAULT 0,
@@ -1100,13 +1106,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
       INSERT INTO workflows_new (
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
-        review_provider, external_dependencies, external_dependency_changes,
+        review_provider, review_gate_definition, external_dependencies, external_dependency_changes,
         generation, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
-        review_provider, external_dependencies, external_dependency_changes,
+        review_provider, review_gate_definition, external_dependencies, external_dependency_changes,
         generation, created_at, updated_at
       FROM workflows
     `);
@@ -1279,8 +1285,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   saveWorkflow(workflow: Workflow): void {
     this.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, review_gate_definition, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
@@ -1289,6 +1295,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
       workflow.mergeMode ?? null,
       workflow.reviewProvider ?? null,
+      workflow.reviewGate ? JSON.stringify(workflow.reviewGate) : null,
       workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
       workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
       workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
@@ -1297,7 +1304,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     ]);
   }
 
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void {
+  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'reviewGate' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void {
     const setClauses: string[] = [];
     const values: unknown[] = [];
     const columnMap: Record<string, string> = {
@@ -1345,6 +1352,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if ('externalDependencyChanges' in changes) {
       setClauses.push('external_dependency_changes = ?');
       values.push(changes.externalDependencyChanges ? JSON.stringify(changes.externalDependencyChanges) : null);
+    }
+    if ('reviewGate' in changes) {
+      setClauses.push('review_gate_definition = ?');
+      values.push(changes.reviewGate ? JSON.stringify(changes.reviewGate) : null);
     }
     if ('detachedExternalDependencies' in changes) {
       setClauses.push('detached_external_dependencies = ?');
@@ -1521,7 +1532,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         action_request_id, experiments,
         created_at, launch_phase, launch_started_at, launch_completed_at, started_at, completed_at, last_heartbeat_at,
         utilization, pending_fix_error,
-        review_url, review_id, review_status, review_provider_id,
+        review_url, review_id, review_status, review_provider_id, review_gate,
         is_fixing_with_ai,
         execution_generation,
         pool_member_id,
@@ -1543,7 +1554,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ?, ?,
         ?, ?, ?, ?,
         ?, ?,
-        ?, ?, ?, ?,
+        ?, ?, ?, ?, ?,
         ?,
         ?,
         ?,
@@ -1599,6 +1610,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       exec.reviewId ?? null,
       exec.reviewStatus ?? null,
       exec.reviewProviderId ?? null,
+      exec.reviewGate ? JSON.stringify(exec.reviewGate) : null,
       exec.isFixingWithAI ? 1 : 0,
       exec.generation ?? 0,
       (cfg as { poolMemberId?: string }).poolMemberId ?? null,
@@ -1718,6 +1730,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         experiments: 'experiments',
         selectedExperiments: 'selected_experiments',
         experimentResults: 'experiment_results',
+        reviewGate: 'review_gate',
       };
 
       for (const [key, col] of Object.entries(execMap)) {
@@ -2699,12 +2712,41 @@ export class SQLiteAdapter implements PersistenceAdapter {
       featureBranch: row.feature_branch ?? undefined,
       mergeMode: row.merge_mode ?? undefined,
       reviewProvider: row.review_provider ?? undefined,
+      reviewGate: row.review_gate_definition ? JSON.parse(row.review_gate_definition) : undefined,
       externalDependencies: row.external_dependencies ? JSON.parse(row.external_dependencies) : undefined,
       externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
       detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
       generation: row.generation ?? 0,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+    };
+  }
+
+  private reviewGateFromRow(row: any): ReviewGateExecution | undefined {
+    if (row.review_gate) {
+      return JSON.parse(row.review_gate) as ReviewGateExecution;
+    }
+    const reviewUrl = row.review_url ?? undefined;
+    const reviewId = row.review_id ?? undefined;
+    if (!reviewUrl && !reviewId) return undefined;
+    const identifier = String(reviewId ?? reviewUrl);
+    const url = String(reviewUrl ?? '');
+    const statusText = row.review_status ?? undefined;
+    return {
+      sealed: true,
+      completion: { required: 'all', state: 'merged' },
+      relationship: { kind: 'unknown', managedBy: 'external' },
+      artifacts: [
+        {
+          id: `github:pull_request:${identifier}`,
+          provider: 'github',
+          type: 'pull_request',
+          url,
+          identifier,
+          statusText,
+        },
+      ],
+      statusText,
     };
   }
 
@@ -2773,6 +2815,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         reviewId: row.review_id ?? undefined,
         reviewStatus: row.review_status ?? undefined,
         reviewProviderId: row.review_provider_id ?? undefined,
+        reviewGate: this.reviewGateFromRow(row),
         phase: row.launch_phase ?? undefined,
         launchStartedAt: row.launch_started_at ? new Date(row.launch_started_at) : undefined,
         launchCompletedAt: row.launch_completed_at ? new Date(row.launch_completed_at) : undefined,

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -51,14 +51,14 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/Neko-Catpital-Labs/Invoker/pull/42","number":42}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'master',
         featureBranch: 'feature/test',
         title: 'Test PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/Neko-Catpital-Labs/Invoker/pull/42');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/Neko-Catpital-Labs/Invoker/pull/42');
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
         [
@@ -101,15 +101,15 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'origin/main',
         featureBranch: 'feature/test',
         title: 'Test PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/owner/repo/pull/42');
-      expect(result.identifier).toBe('42');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/42');
+      expect(result.artifacts[0]?.identifier).toBe('42');
       expect(spawnMock).toHaveBeenCalledWith(
         'git',
         ['push', '--force', 'origin', 'feature/test:refs/heads/feature/test'],
@@ -169,14 +169,14 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'main',
         featureBranch: 'feature/test',
         title: 'Test PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/owner/repo/pull/42');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/42');
       expect(pushAttempts).toBe(2);
       expect(spawnMock).toHaveBeenCalledWith(
         'git',
@@ -214,14 +214,14 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'main',
         featureBranch: 'feature/test',
         title: 'Test PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/owner/repo/pull/42');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/42');
       expect(pushAttempts).toBe(2);
       expect(spawnMock).toHaveBeenCalledWith(
         'git',
@@ -254,14 +254,14 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'main',
         featureBranch: 'feature/test',
         title: 'Test PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/owner/repo/pull/42');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/42');
       expect(lookupAttempts).toBe(2);
     });
 
@@ -283,7 +283,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'main',
         featureBranch: 'feature/test',
         title: 'Updated PR',
@@ -291,7 +291,7 @@ describe('GitHubMergeGateProvider', () => {
         body: '## Summary',
       });
 
-      expect(result.url).toBe('https://github.com/owner/repo/pull/10');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/10');
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
         [
@@ -323,7 +323,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'main',
         featureBranch: 'feature/test',
         title: 'Updated PR',
@@ -331,9 +331,21 @@ describe('GitHubMergeGateProvider', () => {
         body: '## Summary',
       });
 
-      expect(result).toEqual({
-        url: 'https://github.com/owner/repo/pull/11',
-        identifier: '11',
+      expect(result).toMatchObject({
+        sealed: true,
+        relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+        artifacts: [{
+          id: 'github:pull_request:11',
+          provider: 'github',
+          type: 'pull_request',
+          url: 'https://github.com/owner/repo/pull/11',
+          identifier: '11',
+          title: 'Updated PR',
+          baseBranch: 'main',
+          headBranch: 'feature/test',
+          status: 'open',
+          statusText: 'Awaiting review',
+        }],
       });
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
@@ -376,14 +388,14 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/Neko-Catpital-Labs/Invoker/pull/99","number":99}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'master',
         featureBranch: 'feature/test',
         title: 'Env target PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/Neko-Catpital-Labs/Invoker/pull/99');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/Neko-Catpital-Labs/Invoker/pull/99');
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
         expect.arrayContaining(['api', 'repos/Neko-Catpital-Labs/Invoker/pulls']),
@@ -402,7 +414,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      await expect(provider.createReview({
+      await expect(provider.publishReviewGate({
         baseBranch: 'master',
         featureBranch: 'feature/test',
         title: 'Missing target',
@@ -424,7 +436,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      await expect(provider.createReview({
+      await expect(provider.publishReviewGate({
         baseBranch: 'master',
         featureBranch: 'feature/test',
         title: 'Missing origin',
@@ -444,7 +456,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      await provider.closeReview({ identifier: '42', cwd: '/tmp/repo' });
+      await provider.closeArtifact({ identifier: '42', cwd: '/tmp/repo' });
 
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
@@ -475,7 +487,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.checkApproval({ identifier: '1', cwd: '/tmp/repo' });
+      const result = await provider.checkArtifact({ identifier: '1', cwd: '/tmp/repo' });
 
       expect(result.approved).toBe(true);
       expect(result.rejected).toBe(false);
@@ -498,7 +510,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.checkApproval({ identifier: '2', cwd: '/tmp/repo' });
+      const result = await provider.checkArtifact({ identifier: '2', cwd: '/tmp/repo' });
 
       expect(result.approved).toBe(false);
       expect(result.rejected).toBe(false);
@@ -521,7 +533,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.checkApproval({ identifier: '3', cwd: '/tmp/repo' });
+      const result = await provider.checkArtifact({ identifier: '3', cwd: '/tmp/repo' });
 
       expect(result.approved).toBe(false);
       expect(result.rejected).toBe(false);
@@ -569,7 +581,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.checkApproval({ identifier: '4', cwd: '/tmp/repo' });
+      const result = await provider.checkArtifact({ identifier: '4', cwd: '/tmp/repo' });
 
       expect(result.headSha).toBe('abc123');
       expect(result.headRef).toBe('feature/red-ci');

--- a/packages/execution-engine/src/__tests__/review-provider-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/review-provider-registry.test.ts
@@ -1,12 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { ReviewProviderRegistry } from '../review-provider-registry.js';
-import type { MergeGateProvider } from '../merge-gate-provider.js';
+import type { ReviewGateProvider } from '../merge-gate-provider.js';
 
-function makeFakeProvider(name: string): MergeGateProvider {
+function makeFakeProvider(name: string): ReviewGateProvider {
   return {
     name,
-    createReview: async () => ({ url: `https://example.com/${name}/1`, identifier: `${name}#1` }),
-    checkApproval: async () => ({ approved: false, rejected: false, statusText: 'pending', url: '' }),
+    publishReviewGate: async () => ({
+      sealed: true,
+      relationship: { kind: 'unknown', managedBy: 'external' },
+      artifacts: [{
+        id: `${name}:pull_request:1`,
+        provider: name,
+        type: 'pull_request',
+        url: `https://example.com/${name}/1`,
+        identifier: `${name}#1`,
+      }],
+    }),
+    checkArtifact: async () => ({ approved: false, rejected: false, statusText: 'pending', url: '' }),
   };
 }
 

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -12,6 +12,23 @@ import { EventEmitter } from 'events';
 import { buildCanonicalPrBody, validateCanonicalPrBody } from '../pr-authoring.js';
 import type { PrAuthoringContext } from '../pr-authoring.js';
 
+function reviewGateResult(url: string, identifier: string) {
+  return {
+    sealed: true,
+    relationship: { kind: 'stacked_diffs' as const, managedBy: 'external' as const },
+    artifacts: [{
+      id: `github:pull_request:${identifier}`,
+      provider: 'github',
+      type: 'pull_request' as const,
+      url,
+      identifier,
+      status: 'open' as const,
+      statusText: 'Awaiting review',
+    }],
+  };
+}
+
+
 /**
  * Creates a mock executor that auto-completes on start().
  * For merge nodes (no command/prompt), this simulates the executor's
@@ -1626,7 +1643,7 @@ describe('TaskRunner', () => {
       expect(result.body).toContain('pnpm run build');
     });
 
-    it('external_review propagates authored PR body to createReview, not raw summary', async () => {
+    it('external_review propagates authored PR body to publishReviewGate, not raw summary', async () => {
       const completedTask = makeTask({
         id: 't1',
         status: 'completed',
@@ -1647,10 +1664,7 @@ describe('TaskRunner', () => {
       const allTasks = [mergeTask, completedTask];
 
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/42',
-          identifier: 'owner/repo#42',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/42', 'owner/repo#42')),
       };
 
       const orchestrator = {
@@ -1709,15 +1723,15 @@ describe('TaskRunner', () => {
 
       await executor.publishAfterFix(mergeTask);
 
-      // createReview must receive the authored body, NOT the raw summary
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      // publishReviewGate must receive the authored body, NOT the raw summary
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({
           body: authoredBody,
         }),
       );
       // Verify the raw summary was NOT passed as the body
-      const createReviewCall = mergeGateProvider.createReview.mock.calls[0][0];
-      expect(createReviewCall.body).not.toBe('Raw summary text only');
+      const publishReviewGateCall = mergeGateProvider.publishReviewGate.mock.calls[0][0];
+      expect(publishReviewGateCall.body).not.toBe('Raw summary text only');
     });
 
     it('canonical body retains executed UI verification commands in Test Plan', () => {
@@ -2062,10 +2076,7 @@ describe('TaskRunner', () => {
       };
 
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/99',
-          identifier: 'owner/repo#99',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/99', 'owner/repo#99')),
       };
 
       const gitCalls: { args: string[]; dir: string }[] = [];
@@ -2156,7 +2167,7 @@ describe('TaskRunner', () => {
       }));
 
       // PR created via mergeGateProvider with authored body (not raw summary)
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({
           baseBranch: 'master',
           featureBranch: 'plan/feature',
@@ -2170,9 +2181,7 @@ describe('TaskRunner', () => {
       expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
         execution: expect.objectContaining({
           branch: 'plan/feature',
-          reviewUrl: 'https://github.com/owner/repo/pull/99',
-          reviewId: 'owner/repo#99',
-          reviewStatus: 'Awaiting review',
+          reviewGate: expect.objectContaining({ artifacts: [expect.objectContaining({ identifier: 'owner/repo#99', url: 'https://github.com/owner/repo/pull/99' })] }),
         }),
       }));
 
@@ -4069,7 +4078,7 @@ describe('TaskRunner', () => {
   });
 
   describe('external_review propagation of authored PR body', () => {
-    it('createReview receives the authored body, not the raw workflowSummary', async () => {
+    it('publishReviewGate receives the authored body, not the raw workflowSummary', async () => {
       const allTasks = [
         makeTask({
           id: 't1',
@@ -4098,10 +4107,7 @@ describe('TaskRunner', () => {
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/99',
-          identifier: '99',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/99', '99')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -4136,12 +4142,12 @@ describe('TaskRunner', () => {
 
       await (executor as any).executeMergeNode(mergeTask);
 
-      // The authored body must be passed to createReview, not the raw summary
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      // The authored body must be passed to publishReviewGate, not the raw summary
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({ body: authoredBody }),
       );
       // Raw summary must not leak into the PR body
-      const prBodyArg = mergeGateProvider.createReview.mock.calls[0][0].body;
+      const prBodyArg = mergeGateProvider.publishReviewGate.mock.calls[0][0].body;
       expect(prBodyArg).not.toContain('Raw workflow summary — should not appear in PR body');
     });
 
@@ -4176,7 +4182,7 @@ describe('TaskRunner', () => {
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({ url: 'https://example.com/pr/1', identifier: '1' }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://example.com/pr/1', '1')),
       };
       const authorPrSpy = vi.fn().mockResolvedValue({
         body: '## Summary\n\nOK\n\n## Test Plan\n\n- [x] pnpm test\n\n## Revert Plan\n\n- Safe',

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -13,6 +13,43 @@ import { EventEmitter } from 'events';
 import { buildCanonicalPrBody, validateCanonicalPrBody } from '../pr-authoring.js';
 import type { PrAuthoringContext } from '../pr-authoring.js';
 
+function reviewGateResult(url: string, identifier: string) {
+  return {
+    sealed: true,
+    relationship: { kind: 'stacked_diffs' as const, managedBy: 'external' as const },
+    artifacts: [{
+      id: `github:pull_request:${identifier}`,
+      provider: 'github',
+      type: 'pull_request' as const,
+      url,
+      identifier,
+      status: 'open' as const,
+      statusText: 'Awaiting review',
+    }],
+  };
+}
+
+
+function reviewGateExecution(identifier: string, status: 'open' | 'merged' | 'closed' | 'rejected' | 'unknown' = 'open') {
+  const number = identifier.match(/(\d+)$/)?.[1] ?? identifier;
+  return {
+    sealed: true,
+    completion: { required: 'all' as const, state: 'merged' as const },
+    relationship: { kind: 'stacked_diffs' as const, managedBy: 'external' as const },
+    artifacts: [{
+      id: `github:pull_request:${identifier}`,
+      provider: 'github',
+      type: 'pull_request' as const,
+      url: `https://github.com/owner/repo/pull/${number}`,
+      identifier,
+      status,
+      statusText: status === 'merged' ? 'Merged' : 'Awaiting review',
+    }],
+    statusText: status === 'merged' ? 'Merged' : 'Awaiting review',
+  };
+}
+
+
 /**
  * Creates a mock executor that auto-completes on start().
  * For merge nodes (no command/prompt), this simulates the executor's
@@ -3122,10 +3159,7 @@ describe('TaskRunner', () => {
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/42',
-          identifier: 'owner/repo#42',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/42', 'owner/repo#42')),
       };
       const onComplete = vi.fn();
       const executor = new TaskRunner({
@@ -3184,7 +3218,7 @@ describe('TaskRunner', () => {
       }));
 
       // Should create a PR via mergeGateProvider with authored body
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({
           baseBranch: 'master',
           featureBranch: 'plan/feature',
@@ -3199,9 +3233,7 @@ describe('TaskRunner', () => {
         config: expect.objectContaining({ runnerKind: 'worktree' }),
         execution: expect.objectContaining({
           branch: 'plan/feature',
-          reviewUrl: 'https://github.com/owner/repo/pull/42',
-          reviewId: 'owner/repo#42',
-          reviewStatus: 'Awaiting review',
+          reviewGate: expect.objectContaining({ artifacts: [expect.objectContaining({ identifier: 'owner/repo#42', url: 'https://github.com/owner/repo/pull/42' })] }),
         }),
       }));
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
@@ -3235,10 +3267,7 @@ describe('TaskRunner', () => {
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/42',
-          identifier: 'owner/repo#42',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/42', 'owner/repo#42')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -3392,10 +3421,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/invoker/invoker/pull/276',
-          identifier: 'invoker/invoker#276',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/invoker/invoker/pull/276', 'invoker/invoker#276')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -3431,8 +3457,8 @@ console.log(JSON.stringify(out));
       await (executor as any).executeMergeNode(mergeTask);
 
       expect(gitCalls.some(c => c[0] === 'push')).toBe(true);
-      expect(mergeGateProvider.createReview).toHaveBeenCalledTimes(1);
-      const providerBody = mergeGateProvider.createReview.mock.calls[0][0].body;
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledTimes(1);
+      const providerBody = mergeGateProvider.publishReviewGate.mock.calls[0][0].body;
       expect(providerBody).toContain('## Visual Proof');
       expect(providerBody).toContain('merge-gate-no-inline-approve.png');
       expect(providerBody).toContain('![before](https://img.example.test/before--merge-gate-no-inline-approve.png)');
@@ -3551,10 +3577,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/55',
-          identifier: 'owner/repo#55',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/55', 'owner/repo#55')),
       };
       const onComplete = vi.fn();
       const executor = new TaskRunner({
@@ -3595,7 +3618,7 @@ console.log(JSON.stringify(out));
       expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalled();
 
       // Should create a PR via mergeGateProvider
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({
           baseBranch: 'master',
           featureBranch: 'plan/feature',
@@ -3608,9 +3631,7 @@ console.log(JSON.stringify(out));
         config: expect.objectContaining({ runnerKind: 'worktree' }),
         execution: expect.objectContaining({
           branch: 'plan/feature',
-          reviewUrl: 'https://github.com/owner/repo/pull/55',
-          reviewId: 'owner/repo#55',
-          reviewStatus: 'Awaiting review',
+          reviewGate: expect.objectContaining({ artifacts: [expect.objectContaining({ identifier: 'owner/repo#55', url: 'https://github.com/owner/repo/pull/55' })] }),
         }),
       }));
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
@@ -3640,10 +3661,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/55',
-          identifier: 'owner/repo#55',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/55', 'owner/repo#55')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -3707,10 +3725,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/55',
-          identifier: 'owner/repo#55',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/55', 'owner/repo#55')),
       };
       const onComplete = vi.fn();
       const executor = new TaskRunner({
@@ -3747,7 +3762,7 @@ console.log(JSON.stringify(out));
 
       await (executor as any).executeMergeNode(mergeTask);
 
-      expect(mergeGateProvider.createReview).toHaveBeenCalled();
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalled();
       expect(orchestrator.setTaskReviewReady).toHaveBeenCalled();
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
     });
@@ -3887,10 +3902,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/99',
-          identifier: '99',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/99', '99')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -3928,7 +3940,7 @@ console.log(JSON.stringify(out));
       await (executor as any).executeMergeNode(mergeTask);
 
       expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining('https://github.com/owner/repo/pull/99'),
+        expect.stringContaining('Created review artifacts: 99'),
       );
 
       logSpy.mockRestore();
@@ -3958,10 +3970,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/42',
-          identifier: '42',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/42', '42')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -4152,7 +4161,7 @@ console.log(JSON.stringify(out));
       );
     });
 
-    it('executeMergeNode passes authored body to createReview in external_review mode', async () => {
+    it('executeMergeNode passes authored body to publishReviewGate in external_review mode', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
       ];
@@ -4176,10 +4185,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/42',
-          identifier: '42',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/42', '42')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -4223,8 +4229,8 @@ console.log(JSON.stringify(out));
         }),
       );
 
-      // createReview receives the authored body, not the raw summary
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      // publishReviewGate receives the authored body, not the raw summary
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({ body: '## Summary\n\nAuthored PR body from summary' }),
       );
       expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith(
@@ -4358,7 +4364,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'awaiting_approval',
-          execution: { reviewId: 'owner/repo#42' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#42') },
         })),
         approve: vi.fn(),
       };
@@ -4366,7 +4372,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: false,
           rejected: false,
           statusText: 'Awaiting review',
@@ -4385,12 +4391,12 @@ console.log(JSON.stringify(out));
       await executor.checkPrApprovalNow('task-1');
 
       expect(orchestrator.getTask).toHaveBeenCalledWith('task-1');
-      expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+      expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
         identifier: 'owner/repo#42',
         cwd: '/tmp',
       });
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
-        execution: { reviewStatus: 'Awaiting review' },
+        execution: { reviewGate: expect.objectContaining({ statusText: 'Awaiting review' }) },
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
     });
@@ -4404,7 +4410,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
-          execution: { reviewId: 'owner/repo#42' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#42') },
         })),
         approve: vi.fn().mockResolvedValue([downstream]),
       };
@@ -4412,7 +4418,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: true,
           rejected: false,
           statusText: 'Merged',
@@ -4432,7 +4438,7 @@ console.log(JSON.stringify(out));
       await executor.checkPrApprovalNow('task-1');
 
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
-        execution: { reviewStatus: 'Merged' },
+        execution: { reviewGate: expect.objectContaining({ statusText: 'All review artifacts merged' }) },
       });
       expect(orchestrator.approve).toHaveBeenCalledWith('task-1');
       expect(executeTasks).toHaveBeenCalledWith([downstream]);
@@ -4443,7 +4449,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
-          execution: { reviewId: 'owner/repo#42' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#42') },
         })),
         approve: vi.fn(),
       };
@@ -4451,7 +4457,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: false,
           rejected: false,
           statusText: 'Approved, awaiting merge',
@@ -4470,7 +4476,7 @@ console.log(JSON.stringify(out));
       await executor.checkPrApprovalNow('task-1');
 
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
-        execution: { reviewStatus: 'Approved, awaiting merge' },
+        execution: { reviewGate: expect.objectContaining({ statusText: 'Approved, awaiting merge' }) },
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
     });
@@ -4480,7 +4486,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
-          execution: { reviewId: 'owner/repo#42' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#42') },
         })),
         approve: vi.fn(),
       };
@@ -4488,7 +4494,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: false,
           rejected: true,
           statusText: 'Changes requested',
@@ -4508,7 +4514,7 @@ console.log(JSON.stringify(out));
       await executor.checkPrApprovalNow('task-1');
 
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
-        execution: { reviewStatus: 'Changes requested' },
+        execution: { reviewGate: expect.objectContaining({ statusText: 'Changes requested' }) },
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
       expect(executeTasks).not.toHaveBeenCalled();
@@ -4519,7 +4525,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
-          execution: { reviewId: 'owner/repo#43' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#43') },
         })),
         approve: vi.fn(),
       };
@@ -4527,7 +4533,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: false,
           rejected: false,
           closed: true,
@@ -4549,7 +4555,7 @@ console.log(JSON.stringify(out));
 
       expect(persistence.updateTask).toHaveBeenCalledWith('task-closed', {
         status: 'closed',
-        execution: { reviewStatus: 'Closed' },
+        execution: { reviewStatus: expect.stringContaining('Review artifact closed:') },
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
       expect(executeTasks).not.toHaveBeenCalled();
@@ -4564,7 +4570,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
-          execution: { reviewId: 'owner/repo#42' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#42') },
         })),
         approve: vi.fn().mockResolvedValue([downstream]),
       };
@@ -4572,7 +4578,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: true,
           rejected: false,
           statusText: 'Merged',
@@ -4593,7 +4599,7 @@ console.log(JSON.stringify(out));
       // No active poller is registered — simulates a fresh process after restart
       await executor.checkPrApprovalNow('task-with-no-poller');
 
-      expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+      expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
         identifier: 'owner/repo#42',
         cwd: '/tmp',
       });
@@ -4614,7 +4620,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn(),
+        checkArtifact: vi.fn(),
       };
 
       const executor = new TaskRunner({
@@ -4627,7 +4633,7 @@ console.log(JSON.stringify(out));
 
       await executor.checkPrApprovalNow('task-without-review-id');
 
-      expect(mergeGateProvider.checkApproval).not.toHaveBeenCalled();
+      expect(mergeGateProvider.checkArtifact).not.toHaveBeenCalled();
       expect(persistence.updateTask).not.toHaveBeenCalled();
       expect(orchestrator.approve).not.toHaveBeenCalled();
     });
@@ -4650,14 +4656,14 @@ console.log(JSON.stringify(out));
 
       await executor.checkPrApprovalNow('task-1');
 
-      expect(orchestrator.getTask).not.toHaveBeenCalled();
+      expect(orchestrator.getTask).toHaveBeenCalledWith('task-1');
       expect(persistence.updateTask).not.toHaveBeenCalled();
     });
   });
 
-  // ── merge-gate checkApproval cwd resolution ────────────
+  // ── merge-gate checkArtifact cwd resolution ────────────
 
-  describe('merge-gate checkApproval uses workspacePath as cwd', () => {
+  describe('merge-gate checkArtifact uses workspacePath as cwd', () => {
     describe('checkPrApprovalNow', () => {
       it('uses task workspacePath as cwd when present', async () => {
         const orchestrator = {
@@ -4665,7 +4671,7 @@ console.log(JSON.stringify(out));
             id,
             status: 'review_ready',
             execution: {
-              reviewId: 'owner/repo#99',
+              reviewGate: reviewGateExecution('owner/repo#99'),
               workspacePath: '/workspace/merge-worktree',
             },
           })),
@@ -4673,7 +4679,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             statusText: 'Pending',
@@ -4691,7 +4697,7 @@ console.log(JSON.stringify(out));
 
         await executor.checkPrApprovalNow('task-ws');
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#99',
           cwd: '/workspace/merge-worktree',
         });
@@ -4702,13 +4708,13 @@ console.log(JSON.stringify(out));
           getTask: vi.fn((id: string) => ({
             id,
             status: 'review_ready',
-            execution: { reviewId: 'owner/repo#100' },
+            execution: { reviewGate: reviewGateExecution('owner/repo#100') },
           })),
           approve: vi.fn(),
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             statusText: 'Pending',
@@ -4726,7 +4732,7 @@ console.log(JSON.stringify(out));
 
         await executor.checkPrApprovalNow('task-no-ws');
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#100',
           cwd: '/runner-base-cwd',
         });
@@ -4742,7 +4748,7 @@ console.log(JSON.stringify(out));
             id,
             status: 'review_ready',
             execution: {
-              reviewId: 'owner/repo#101',
+              reviewGate: reviewGateExecution('owner/repo#101'),
               workspacePath: '/workspace/approved-worktree',
             },
           })),
@@ -4750,7 +4756,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: true,
             rejected: false,
             statusText: 'Merged',
@@ -4769,12 +4775,12 @@ console.log(JSON.stringify(out));
 
         await executor.checkPrApprovalNow('task-approved');
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#101',
           cwd: '/workspace/approved-worktree',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('task-approved', {
-          execution: { reviewStatus: 'Merged' },
+          execution: { reviewGate: expect.objectContaining({ statusText: 'All review artifacts merged' }) },
         });
         expect(orchestrator.approve).toHaveBeenCalledWith('task-approved');
         expect(executeTasks).toHaveBeenCalledWith([downstream]);
@@ -4789,7 +4795,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { workflowId: 'wf-close', isMergeNode: true },
             execution: {
-              reviewId: '205',
+              reviewGate: reviewGateExecution('205'),
               workspacePath: '/workspace/close-gate',
             },
           }),
@@ -4798,7 +4804,7 @@ console.log(JSON.stringify(out));
           getAllTasks: () => allTasks,
         };
         const mergeGateProvider = {
-          closeReview: vi.fn().mockResolvedValue(undefined),
+          closeArtifact: vi.fn().mockResolvedValue(undefined),
         };
 
         const executor = new TaskRunner({
@@ -4811,7 +4817,7 @@ console.log(JSON.stringify(out));
 
         await executor.closeWorkflowReview('wf-close');
 
-        expect(mergeGateProvider.closeReview).toHaveBeenCalledWith({
+        expect(mergeGateProvider.closeArtifact).toHaveBeenCalledWith({
           identifier: '205',
           cwd: '/workspace/close-gate',
         });
@@ -4824,7 +4830,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { isMergeNode: true },
             execution: {
-              reviewId: 'owner/repo#200',
+              reviewGate: reviewGateExecution('owner/repo#200'),
               workspacePath: '/workspace/gate-worktree',
             },
           }),
@@ -4836,7 +4842,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             statusText: 'Pending',
@@ -4853,7 +4859,7 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#200',
           cwd: '/workspace/gate-worktree',
         });
@@ -4865,7 +4871,7 @@ console.log(JSON.stringify(out));
             id: 'merge-no-ws',
             status: 'awaiting_approval',
             config: { isMergeNode: true },
-            execution: { reviewId: 'owner/repo#201' },
+            execution: { reviewGate: reviewGateExecution('owner/repo#201') },
           }),
         ];
         const orchestrator = {
@@ -4875,7 +4881,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             statusText: 'Pending',
@@ -4892,7 +4898,7 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#201',
           cwd: '/runner-base-cwd',
         });
@@ -4909,7 +4915,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { isMergeNode: true },
             execution: {
-              reviewId: 'owner/repo#202',
+              reviewGate: reviewGateExecution('owner/repo#202'),
               workspacePath: '/workspace/approved-gate',
             },
           }),
@@ -4921,7 +4927,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: true,
             rejected: false,
             statusText: 'Merged',
@@ -4939,12 +4945,12 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#202',
           cwd: '/workspace/approved-gate',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('merge-approved', {
-          execution: { reviewStatus: 'Merged' },
+          execution: { reviewGate: expect.objectContaining({ statusText: 'All review artifacts merged' }) },
         });
         expect(orchestrator.approve).toHaveBeenCalledWith('merge-approved');
         expect(executeTasks).toHaveBeenCalledWith([downstream]);
@@ -4957,7 +4963,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { isMergeNode: true },
             execution: {
-              reviewId: 'owner/repo#203',
+              reviewGate: reviewGateExecution('owner/repo#203'),
               workspacePath: '/workspace/open-approved-gate',
             },
           }),
@@ -4969,7 +4975,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             statusText: 'Approved, awaiting merge',
@@ -4986,12 +4992,12 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#203',
           cwd: '/workspace/open-approved-gate',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('merge-open-approved', {
-          execution: { reviewStatus: 'Approved, awaiting merge' },
+          execution: { reviewGate: expect.objectContaining({ statusText: 'Approved, awaiting merge' }) },
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
       });
@@ -5003,7 +5009,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { isMergeNode: true },
             execution: {
-              reviewId: 'owner/repo#204',
+              reviewGate: reviewGateExecution('owner/repo#204'),
               workspacePath: '/workspace/rejected-gate',
             },
           }),
@@ -5015,7 +5021,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: true,
             statusText: 'Changes requested',
@@ -5033,12 +5039,12 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#204',
           cwd: '/workspace/rejected-gate',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('merge-rejected', {
-          execution: { reviewStatus: 'Changes requested' },
+          execution: { reviewGate: expect.objectContaining({ statusText: 'Changes requested' }) },
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(executeTasks).not.toHaveBeenCalled();
@@ -5051,7 +5057,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { isMergeNode: true },
             execution: {
-              reviewId: 'owner/repo#205',
+              reviewGate: reviewGateExecution('owner/repo#205'),
               workspacePath: '/workspace/closed-gate',
             },
           }),
@@ -5063,7 +5069,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             closed: true,
@@ -5082,13 +5088,13 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#205',
           cwd: '/workspace/closed-gate',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('merge-closed', {
           status: 'closed',
-          execution: { reviewStatus: 'Closed' },
+          execution: { reviewStatus: expect.stringContaining('Review artifact closed:') },
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(executeTasks).not.toHaveBeenCalled();
@@ -5100,7 +5106,7 @@ console.log(JSON.stringify(out));
           status: 'awaiting_approval',
           config: { isMergeNode: true },
           execution: {
-            reviewId: 'owner/repo#206',
+            reviewGate: reviewGateExecution('owner/repo#206'),
             workspacePath: '/workspace/awaiting-closed-gate',
           },
         });
@@ -5111,7 +5117,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             closed: true,
@@ -5132,7 +5138,7 @@ console.log(JSON.stringify(out));
 
         expect(persistence.updateTask).toHaveBeenCalledWith('merge-awaiting-closed', {
           status: 'closed',
-          execution: { reviewStatus: 'Closed' },
+          execution: { reviewStatus: expect.stringContaining('Review artifact closed:') },
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(executeTasks).not.toHaveBeenCalled();
@@ -5144,7 +5150,7 @@ console.log(JSON.stringify(out));
           status: 'review_ready',
           config: { isMergeNode: true },
           execution: {
-            reviewId: 'owner/repo#207',
+            reviewGate: reviewGateExecution('owner/repo#207'),
             workspacePath: '/workspace/closed-stop-poll',
           },
         });
@@ -5161,7 +5167,7 @@ console.log(JSON.stringify(out));
           }),
         };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             closed: true,
@@ -5179,13 +5185,13 @@ console.log(JSON.stringify(out));
         vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
         await executor.checkMergeGateStatuses();
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledTimes(1);
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledTimes(1);
         expect(task.status).toBe('closed');
 
         await executor.checkMergeGateStatuses();
         // Closed status falls outside the (review_ready || awaiting_approval) polling filter,
         // so no additional provider call should happen on the second refresh pass.
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledTimes(1);
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -1,8 +1,8 @@
 import { spawn } from 'node:child_process';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 import type {
-  MergeGateProvider,
-  MergeGateProviderResult,
+  ReviewGateProvider,
+  ReviewGatePublishResult,
   MergeGateApprovalStatus,
   MergeGateFailedCheck,
 } from './merge-gate-provider.js';
@@ -11,32 +11,33 @@ import { isGitRefLockRace, retryTransientGitHubCli } from './git-utils.js';
 
 type ExistingPullRequest = { url: string; number: number };
 
-export class GitHubMergeGateProvider implements MergeGateProvider {
+export class GitHubMergeGateProvider implements ReviewGateProvider {
   readonly name = 'github';
 
   private static readonly TARGET_REPO_ENV = 'INVOKER_GITHUB_TARGET_REPO';
 
-  async createReview(opts: {
+  async publishReviewGate(opts: {
     baseBranch: string;
     featureBranch: string;
     title: string;
     cwd: string;
     body?: string;
-  }): Promise<MergeGateProviderResult> {
+    preferredShape?: 'stacked_diffs' | 'independent';
+  }): Promise<ReviewGatePublishResult> {
     const { baseBranch, featureBranch, title, cwd, body } = opts;
     console.log(
-      `${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview ` +
+      `${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate ` +
       `baseBranch=${baseBranch} featureBranch=${featureBranch} title=${title} cwd=${cwd} body=${body}`,
     );
     const ghBase = normalizeBranchForGithubCli(baseBranch);
     const ghHead = normalizeBranchForGithubCli(featureBranch);
     const targetRepo = await this.resolveTargetRepo(cwd);
-    console.log(`[merge-gate] createReview: ghBase=${ghBase} apiHead=${ghHead} cwd=${cwd}`);
+    console.log(`[merge-gate] publishReviewGate: ghBase=${ghBase} apiHead=${ghHead} cwd=${cwd}`);
 
     await this.pushFeatureBranch(cwd, featureBranch);
 
     const existing = await this.findExistingOpenPullRequest(cwd, targetRepo, ghHead);
-    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview existing=${existing}`);
+    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate existing=${existing}`);
 
     if (existing.length > 0) {
       const apiArgs = [
@@ -47,9 +48,31 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       ];
       if (body) apiArgs.push('-f', `body=${body}`);
       const ghResult = await retryTransientGitHubCli(() => this.exec('gh', apiArgs, cwd));
-      console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview update existing gh_result=${ghResult}`);
+      console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate update existing gh_result=${ghResult}`);
 
-      return { url: existing[0].url, identifier: String(existing[0].number) };
+      const artifact = {
+        id: `github:pull_request:${existing[0].number}`,
+        provider: 'github',
+        type: 'pull_request' as const,
+        url: existing[0].url,
+        identifier: String(existing[0].number),
+        title,
+        baseBranch,
+        headBranch: featureBranch,
+        status: 'open' as const,
+        statusText: 'Awaiting review',
+      };
+      if (!artifact.url || !artifact.identifier) {
+        throw new Error('Review gate publisher returned no pull request artifacts');
+      }
+      return {
+        sealed: true,
+        relationship: {
+          kind: (opts.preferredShape ?? 'stacked_diffs') === 'stacked_diffs' ? 'stacked_diffs' : 'independent',
+          managedBy: 'external',
+        },
+        artifacts: [artifact],
+      };
     }
 
     const createArgs = [
@@ -59,13 +82,34 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       '-f', `body=${body ?? ''}`,
     ];
     const stdout = await this.exec('gh', createArgs, cwd);
-    const pr = JSON.parse(stdout) as { html_url: string; number: number };
+    const pr = JSON.parse(stdout) as { html_url?: string; number?: number };
 
-    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview creating stdout=${stdout}`);
-    return { url: pr.html_url, identifier: String(pr.number) };
+    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate creating stdout=${stdout}`);
+    if (!pr.html_url || pr.number === undefined || pr.number === null) {
+      throw new Error('Review gate publisher returned no pull request artifacts');
+    }
+    return {
+      sealed: true,
+      relationship: {
+        kind: (opts.preferredShape ?? 'stacked_diffs') === 'stacked_diffs' ? 'stacked_diffs' : 'independent',
+        managedBy: 'external',
+      },
+      artifacts: [{
+        id: `github:pull_request:${pr.number}`,
+        provider: 'github',
+        type: 'pull_request',
+        url: pr.html_url,
+        identifier: String(pr.number),
+        title,
+        baseBranch,
+        headBranch: featureBranch,
+        status: 'open',
+        statusText: 'Awaiting review',
+      }],
+    };
   }
 
-  async closeReview(opts: {
+  async closeArtifact(opts: {
     identifier: string;
     cwd: string;
   }): Promise<void> {
@@ -78,7 +122,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     ], cwd));
   }
 
-  async checkApproval(opts: {
+  async checkArtifact(opts: {
     identifier: string;
     cwd: string;
   }): Promise<MergeGateApprovalStatus> {
@@ -183,7 +227,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
         '--json', 'url,number',
         '--limit', '1',
       ], cwd);
-      console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview listOutput=${listOutput}`);
+      console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate listOutput=${listOutput}`);
       return JSON.parse(listOutput) as ExistingPullRequest[];
     } catch (err) {
       console.warn(
@@ -208,7 +252,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       '-f', `head=${owner}:${ghHead}`,
       '-f', 'per_page=1',
     ], cwd));
-    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview restListOutput=${output}`);
+    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate restListOutput=${output}`);
     const pulls = JSON.parse(output) as Array<{ html_url?: string; url?: string; number: number }>;
     return pulls
       .map((pull) => ({

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -1,24 +1,18 @@
-export interface MergeGateProviderResult {
-  url: string;
-  identifier: string;
-}
+import type { ReviewGateArtifact } from '@invoker/workflow-core';
 
-export interface MergeGateCreateReviewOptions {
+export interface ReviewGatePublishOptions {
   baseBranch: string;
   featureBranch: string;
   title: string;
   cwd: string;
   body?: string;
+  preferredShape: 'stacked_diffs' | 'independent';
 }
 
-export interface MergeGateCheckApprovalOptions {
-  identifier: string;
-  cwd: string;
-}
-
-export interface MergeGateCloseReviewOptions {
-  identifier: string;
-  cwd: string;
+export interface ReviewGatePublishResult {
+  sealed: boolean;
+  relationship: { kind: 'stacked_diffs' | 'independent' | 'unknown'; managedBy: 'external' };
+  artifacts: ReviewGateArtifact[];
 }
 
 export interface MergeGateCheckSummary {
@@ -45,14 +39,14 @@ export interface MergeGateFailedCheck {
   summary?: string;
 }
 
-export interface MergeGateProvider {
+export interface ReviewGateProvider {
   readonly name: string;
 
   // INV-77 selected boundary: execution-engine owns provider IO and exposes
-  // typed review creation, polling, closure, check, and merge-state metadata.
-  createReview(opts: MergeGateCreateReviewOptions): Promise<MergeGateProviderResult>;
+  // typed review publishing, polling, closure, check, and merge-state metadata.
+  publishReviewGate(opts: ReviewGatePublishOptions): Promise<ReviewGatePublishResult>;
 
-  checkApproval(opts: MergeGateCheckApprovalOptions): Promise<MergeGateApprovalStatus>;
+  checkArtifact(opts: { identifier: string; cwd: string }): Promise<MergeGateApprovalStatus>;
 
-  closeReview?(opts: MergeGateCloseReviewOptions): Promise<void>;
+  closeArtifact?(opts: { identifier: string; cwd: string }): Promise<void>;
 }

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -10,12 +10,12 @@ import { normalize, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 
-import type { Orchestrator, TaskState, TaskStateChanges } from '@invoker/workflow-core';
+import type { Orchestrator, ReviewGateExecution, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkResponse } from '@invoker/contracts';
 import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
-import type { MergeGateProvider } from './merge-gate-provider.js';
+import type { ReviewGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 import type { PrAuthoringContext, PrAuthoringTaskEntry } from './pr-authoring.js';
@@ -45,6 +45,31 @@ function canonicalMergeMode(mode: string | undefined): 'manual' | 'automatic' | 
   if (m === 'external_review') return 'external_review';
   if (m === 'automatic') return 'automatic';
   return 'manual';
+}
+
+function reviewGateExecutionFromPublished(
+  result: { sealed: boolean; relationship: ReviewGateExecution['relationship']; artifacts: ReviewGateExecution['artifacts'] },
+): ReviewGateExecution {
+  if (result.sealed && result.artifacts.length === 0) {
+    throw new Error('Review gate publisher returned no pull request artifacts');
+  }
+  return {
+    sealed: result.sealed,
+    completion: { required: 'all', state: 'merged' },
+    relationship: result.relationship,
+    artifacts: result.artifacts,
+    statusText: result.artifacts.length > 0 ? 'Awaiting review' : undefined,
+  };
+}
+
+function waitingReviewGateExecution(preferredShape: 'stacked_diffs' | 'independent'): ReviewGateExecution {
+  return {
+    sealed: false,
+    completion: { required: 'all', state: 'merged' },
+    relationship: { kind: preferredShape, managedBy: 'external' },
+    artifacts: [],
+    statusText: 'Waiting for review artifacts',
+  };
 }
 
 async function resolveBaseCheckoutRef(
@@ -168,7 +193,7 @@ export interface MergeRunnerHost {
   readonly defaultBranch: string | undefined;
   readonly callbacks: TaskRunnerCallbacks;
   readonly cwd: string;
-  readonly mergeGateProvider?: MergeGateProvider;
+  readonly mergeGateProvider?: ReviewGateProvider;
   readonly reviewProviderRegistry?: ReviewProviderRegistry;
 
   execGitReadonly(args: string[], cwd?: string): Promise<string>;
@@ -458,6 +483,7 @@ export async function runMergeGateActionImpl(
       reviewUrl: undefined,
       reviewId: undefined,
       reviewStatus: undefined,
+      reviewGate: undefined,
     },
   });
 
@@ -526,14 +552,44 @@ export async function runMergeGateActionImpl(
         };
       }
       if (mergeMode === 'external_review') {
-        if (!host.mergeGateProvider) {
-          throw new Error('mergeMode is "external_review" but no review provider configured');
-        }
 
         // The PR branch is pushed from the separate consolidation clone above.
         // Fetch it into the persistent gate workspace and check it out before
         // persisting the workspace handoff used by review terminals.
         await syncGateWorkspaceToFeatureBranch(host, gateWorkspacePath, featureBranch);
+
+        const reviewGateDefinition = workflow?.reviewGate;
+        const preferredShape = reviewGateDefinition?.authoring.preferredShape ?? 'stacked_diffs';
+        const authoringMode = reviewGateDefinition?.authoring.mode ?? 'automatic';
+        if (authoringMode === 'manual' || authoringMode === 'external') {
+          const reviewGate = waitingReviewGateExecution(preferredShape);
+          response = {
+            requestId: `merge-${task.id}`,
+            actionId: task.id,
+            executionGeneration: task.execution.generation ?? 0,
+            status: 'review_ready',
+            outputs: {
+              exitCode: 0,
+              summary,
+              branch: featureBranch,
+              reviewGate,
+            },
+          };
+          return {
+            response,
+            taskChanges: {
+              config: { summary },
+              execution: {
+                branch: featureBranch,
+                workspacePath: gateWorkspacePath,
+                reviewGate,
+              },
+            },
+          };
+        }
+        if (!host.mergeGateProvider) {
+          throw new Error('mergeMode is "external_review" but no review provider configured');
+        }
 
         let fullSummary = summary;
         let vpMarkdownCapture: string | undefined;
@@ -563,22 +619,20 @@ export async function runMergeGateActionImpl(
 
         // Create PR via provider (consolidation already done above).
         // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
-        const result = await host.mergeGateProvider.createReview({
+        const result = await host.mergeGateProvider.publishReviewGate({
           baseBranch,
           featureBranch,
           title: workflow?.name ?? 'Workflow',
           cwd: gateWorkspacePath!,
           body: prBody,
+          preferredShape,
         });
-        console.log(`[merge] Created GitHub PR: ${result.url}`);
-
-        reviewUrl = result.url;
-        reviewId = result.identifier;
-        reviewStatus = 'Awaiting review';
+        const reviewGate = reviewGateExecutionFromPublished(result);
+        console.log(`[merge] Created review artifacts: ${reviewGate.artifacts.map((artifact) => artifact.identifier).join(', ')}`);
         mergeTrace('GATE_WS_PATH_EXTERNAL_REVIEW_AWAIT', {
           taskId: task.id,
           gateWorkspacePath: gateWorkspacePath ?? null,
-          reviewUrl: result.url,
+          reviewUrl: reviewGate.artifacts.at(-1)?.url ?? null,
         });
         console.log(
           `[merge-gate-workspace] setTaskReviewReady path=external_review ` +
@@ -593,9 +647,7 @@ export async function runMergeGateActionImpl(
             exitCode: 0,
             summary,
             branch: featureBranch,
-            reviewUrl,
-            reviewId,
-            reviewStatus,
+            reviewGate,
           },
         };
         return {
@@ -605,9 +657,7 @@ export async function runMergeGateActionImpl(
             execution: {
               branch: featureBranch,
               workspacePath: gateWorkspacePath,
-              reviewUrl,
-              reviewId,
-              reviewStatus,
+              reviewGate,
             },
           },
         };
@@ -1068,6 +1118,25 @@ export async function publishAfterFixImpl(
     }
 
     if (mergeMode === 'external_review') {
+      const reviewGateDefinition = workflow?.reviewGate;
+      const preferredShape = reviewGateDefinition?.authoring.preferredShape ?? 'stacked_diffs';
+      const authoringMode = reviewGateDefinition?.authoring.mode ?? 'automatic';
+      if (authoringMode === 'manual' || authoringMode === 'external') {
+        const reviewGate = waitingReviewGateExecution(preferredShape);
+        setMergeGateReviewReady(host, task.id, {
+          config: { runnerKind: 'worktree', summary },
+          execution: {
+            branch: featureBranch,
+            workspacePath: gateWorkspacePath,
+            reviewGate,
+            fixedIntegrationSha: undefined,
+            fixedIntegrationRecordedAt: undefined,
+            fixedIntegrationSource: undefined,
+          },
+        });
+        await startReviewReadyDependents(host);
+        return;
+      }
       if (!host.mergeGateProvider) {
         throw new Error('mergeMode is "external_review" but no review provider configured');
       }
@@ -1087,25 +1156,23 @@ export async function publishAfterFixImpl(
         cwd: consolidateDir,
       });
 
-      const result = await host.mergeGateProvider.createReview({
+      const result = await host.mergeGateProvider.publishReviewGate({
         baseBranch,
         featureBranch,
         title: workflow?.name ?? 'Workflow',
         cwd: consolidateDir,
         body: prBodyReview,
+        preferredShape,
       });
-      console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
-
-
+      const reviewGate = reviewGateExecutionFromPublished(result);
+      console.log(`[merge] Post-fix: created/updated review artifacts: ${reviewGate.artifacts.map((artifact) => artifact.identifier).join(', ')}`);
 
       setMergeGateReviewReady(host, task.id, {
         config: { runnerKind: 'worktree', summary },
         execution: {
           branch: featureBranch,
           workspacePath: gateWorkspacePath,
-          reviewUrl: result.url,
-          reviewId: result.identifier,
-          reviewStatus: 'Awaiting review',
+          reviewGate,
           fixedIntegrationSha: undefined,
           fixedIntegrationRecordedAt: undefined,
           fixedIntegrationSource: undefined,

--- a/packages/execution-engine/src/review-provider-registry.ts
+++ b/packages/execution-engine/src/review-provider-registry.ts
@@ -1,24 +1,24 @@
 /**
  * ReviewProviderRegistry — Registry for pluggable review providers.
  *
- * Maps provider names (e.g. 'github', 'gitlab') to MergeGateProvider instances.
+ * Maps provider names (e.g. 'github', 'gitlab') to ReviewGateProvider instances.
  * Follows the same pattern as AgentRegistry.
  */
 
-import type { MergeGateProvider } from './merge-gate-provider.js';
+import type { ReviewGateProvider } from './merge-gate-provider.js';
 
 export class ReviewProviderRegistry {
-  private providers = new Map<string, MergeGateProvider>();
+  private providers = new Map<string, ReviewGateProvider>();
 
-  register(provider: MergeGateProvider): void {
+  register(provider: ReviewGateProvider): void {
     this.providers.set(provider.name, provider);
   }
 
-  get(name: string): MergeGateProvider | undefined {
+  get(name: string): ReviewGateProvider | undefined {
     return this.providers.get(name);
   }
 
-  getOrThrow(name: string): MergeGateProvider {
+  getOrThrow(name: string): ReviewGateProvider {
     const provider = this.providers.get(name);
     if (!provider) {
       throw new Error(
@@ -28,7 +28,7 @@ export class ReviewProviderRegistry {
     return provider;
   }
 
-  list(): MergeGateProvider[] {
+  list(): ReviewGateProvider[] {
     return [...this.providers.values()];
   }
 }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 
 import { scopePlanTaskId } from '@invoker/workflow-core';
-import type { Orchestrator, TaskState, ExperimentVariant, RunnerKind } from '@invoker/workflow-core';
+import type { Orchestrator, ReviewArtifactStatus, TaskState, ExperimentVariant, RunnerKind } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
@@ -24,7 +24,7 @@ import { createExecutionBench } from './execution-bench.js';
 import { ResourceLimitError, type RepoPoolTiming } from './repo-pool.js';
 import type { ExecutorRegistry } from './registry.js';
 import type { AgentRegistry } from './agent-registry.js';
-import type { MergeGateProvider, MergeGateApprovalStatus } from './merge-gate-provider.js';
+import type { ReviewGateProvider, MergeGateApprovalStatus } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
@@ -274,7 +274,7 @@ export interface TaskRunnerConfig {
   /** Default branch from config (e.g. "master"). Falls back to git heuristic if unset. */
   defaultBranch?: string;
   callbacks?: TaskRunnerCallbacks;
-  mergeGateProvider?: MergeGateProvider;
+  mergeGateProvider?: ReviewGateProvider;
   reviewProviderRegistry?: ReviewProviderRegistry;
   onReviewGateCiFailure?: (trigger: ReviewGateCiFailureTrigger) => Promise<void>;
   /**
@@ -322,7 +322,7 @@ export class TaskRunner {
   private maxWorktreesPerRepo: number;
   /** @internal */ defaultBranch: string | undefined;
   /** @internal */ callbacks: TaskRunnerCallbacks;
-  /** @internal */ mergeGateProvider?: MergeGateProvider;
+  /** @internal */ mergeGateProvider?: ReviewGateProvider;
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
   private onReviewGateCiFailure?: (trigger: ReviewGateCiFailureTrigger) => Promise<void>;
   private reviewGateCiFixInFlight = new Set<string>();
@@ -2394,30 +2394,56 @@ export class TaskRunner {
     }
   }
 
+  private getReviewGateProvider(workflowId?: string): ReviewGateProvider | undefined {
+    const workflow = workflowId ? this.persistence.loadWorkflow?.(workflowId) : undefined;
+    const providerName = workflow?.reviewProvider ?? 'github';
+    return this.reviewProviderRegistry?.get(providerName) ?? this.mergeGateProvider;
+  }
+
   async closeWorkflowReview(workflowId: string): Promise<void> {
-    if (!this.mergeGateProvider?.closeReview) return;
+    const provider = this.getReviewGateProvider(workflowId);
+    if (!provider?.closeArtifact) return;
     const getAllTasks = this.orchestrator.getAllTasks?.bind(this.orchestrator);
     if (!getAllTasks) return;
     const mergeTask = getAllTasks().find((task) =>
       task.config.workflowId === workflowId
       && task.config.isMergeNode
-      && !!task.execution.reviewId
     );
-    if (!mergeTask?.execution.reviewId) return;
+    const reviewGate = mergeTask?.execution.reviewGate;
+    if (!mergeTask || !reviewGate?.sealed) return;
 
-    await this.mergeGateProvider.closeReview({
-      identifier: mergeTask.execution.reviewId,
-      cwd: mergeTask.execution.workspacePath ?? this.cwd,
-    });
+    const artifacts = reviewGate.artifacts.map((artifact) => ({ ...artifact }));
+    let changed = false;
+    for (const artifact of artifacts) {
+      if (artifact.status === 'merged' || artifact.status === 'closed') continue;
+      await provider.closeArtifact({
+        identifier: artifact.identifier,
+        cwd: mergeTask.execution.workspacePath ?? this.cwd,
+      });
+      artifact.status = 'closed';
+      artifact.statusText = 'Closed';
+      changed = true;
+    }
+    if (changed) {
+      this.persistence.updateTask(mergeTask.id, {
+        execution: {
+          reviewGate: {
+            ...reviewGate,
+            artifacts,
+            statusText: 'Review artifacts closed',
+          },
+        },
+      });
+    }
   }
 
   private async handleApprovedMergeGate(
     taskId: string,
-    reviewId: string,
+    completionLabel: string,
     source?: 'refresh' | 'manual check',
   ): Promise<void> {
     const sourceSuffix = source ? ` (${source})` : '';
-    this.logger.info(`[merge-gate] PR ${reviewId} approved${sourceSuffix}, completing merge gate`);
+    this.logger.info(`[merge-gate] ${completionLabel} complete${sourceSuffix}, completing merge gate`);
     const newlyStarted = await this.orchestrator.approve(taskId);
     if (newlyStarted.length > 0) {
       await this.executeTasks(newlyStarted);
@@ -2426,104 +2452,111 @@ export class TaskRunner {
 
   private handleClosedMergeGate(
     taskId: string,
-    reviewId: string,
+    completionLabel: string,
     statusText: string,
     source?: 'refresh' | 'manual check',
   ): void {
     const sourceSuffix = source ? ` (${source})` : '';
-    this.logger.info(`[merge-gate] PR ${reviewId} closed${sourceSuffix}: ${statusText}`);
+    this.logger.info(`[merge-gate] ${completionLabel} closed${sourceSuffix}: ${statusText}`);
     this.persistence.updateTask(taskId, {
       status: 'closed',
       execution: { reviewStatus: statusText },
     });
   }
 
+  private async refreshReviewGateArtifacts(
+    task: TaskState,
+    source: 'refresh' | 'manual check',
+  ): Promise<void> {
+    const reviewGate = task.execution.reviewGate;
+    if (!reviewGate?.sealed || reviewGate.artifacts.length === 0) return;
+    const provider = this.getReviewGateProvider(task.config?.workflowId);
+    if (!provider) return;
+
+    const gateCwd = task.execution.workspacePath ?? this.cwd;
+    const artifacts = await Promise.all(reviewGate.artifacts.map(async (artifact) => {
+      if (artifact.status === 'merged' || artifact.status === 'closed') return artifact;
+      const status = await provider.checkArtifact({
+        identifier: artifact.identifier,
+        cwd: gateCwd,
+      });
+      await this.maybeTriggerReviewGateCiFix(task, status, artifact);
+      const nextStatus: ReviewArtifactStatus = status.approved
+        ? 'merged'
+        : status.closed
+          ? 'closed'
+          : status.rejected
+            ? 'rejected'
+            : (artifact.status ?? 'open');
+      return {
+        ...artifact,
+        status: nextStatus,
+        statusText: status.statusText,
+        headSha: status.headSha ?? artifact.headSha,
+        headRef: status.headRef ?? artifact.headRef,
+      };
+    }));
+
+    const closedArtifact = artifacts.find((artifact) => artifact.status === 'closed');
+    const statusText = closedArtifact
+      ? `Review artifact closed: ${closedArtifact.identifier}`
+      : artifacts.every((artifact) => artifact.status === 'merged')
+        ? 'All review artifacts merged'
+        : artifacts.find((artifact) => artifact.status === 'rejected')?.statusText
+          ?? artifacts.find((artifact) => artifact.statusText)?.statusText
+          ?? reviewGate.statusText
+          ?? 'Awaiting review';
+    const nextGate = { ...reviewGate, artifacts, statusText };
+    this.persistence.updateTask(task.id, { execution: { reviewGate: nextGate } });
+
+    if (closedArtifact) {
+      this.handleClosedMergeGate(task.id, 'review artifact', statusText, source);
+      return;
+    }
+    if (artifacts.every((artifact) => artifact.status === 'merged')) {
+      await this.handleApprovedMergeGate(task.id, 'all review artifacts', source);
+    }
+  }
+
   async checkMergeGateStatuses(): Promise<void> {
-    if (!this.mergeGateProvider) return;
     for (const task of this.orchestrator.getAllTasks()) {
       if (
         task.config.isMergeNode &&
         (task.status === 'review_ready' || task.status === 'awaiting_approval') &&
-        task.execution.reviewId
+        task.execution.reviewGate?.sealed === true
       ) {
         try {
-          const gateCwd = task.execution.workspacePath ?? this.cwd;
-          const status = await this.mergeGateProvider.checkApproval({
-            identifier: task.execution.reviewId,
-            cwd: gateCwd,
-          });
-          if (status.closed) {
-            this.handleClosedMergeGate(task.id, task.execution.reviewId, status.statusText, 'refresh');
-          } else if (status.approved) {
-            this.persistence.updateTask(task.id, {
-              execution: { reviewStatus: status.statusText },
-            });
-            await this.handleApprovedMergeGate(task.id, task.execution.reviewId, 'refresh');
-          } else if (status.rejected) {
-            this.persistence.updateTask(task.id, {
-              execution: { reviewStatus: status.statusText },
-            });
-            this.logger.info(`[merge-gate] PR ${task.execution.reviewId} rejected (refresh): ${status.statusText}`);
-          } else {
-            this.persistence.updateTask(task.id, {
-              execution: { reviewStatus: status.statusText },
-            });
-            await this.maybeTriggerReviewGateCiFix(task, status);
-          }
+          await this.refreshReviewGateArtifacts(task, 'refresh');
         } catch (err) {
-          this.logger.error(`[merge-gate] PR status check error for ${task.id}`, { err });
+          this.logger.error(`[merge-gate] Review artifact status check error for ${task.id}`, { err });
         }
       }
     }
   }
 
   async checkPrApprovalNow(taskId: string): Promise<void> {
-    if (!this.mergeGateProvider) return;
-
     const task = this.orchestrator.getTask(taskId);
-    const reviewId = task?.execution.reviewId;
-    if (!task || !reviewId) return;
-
+    if (!task) return;
     try {
-      const manualCwd = task.execution.workspacePath ?? this.cwd;
-      const status = await this.mergeGateProvider.checkApproval({
-        identifier: reviewId,
-        cwd: manualCwd,
-      });
-
-      if (status.closed) {
-        this.handleClosedMergeGate(taskId, reviewId, status.statusText, 'manual check');
-      } else if (status.approved) {
-        this.persistence.updateTask(taskId, {
-          execution: { reviewStatus: status.statusText },
-        });
-        await this.handleApprovedMergeGate(taskId, reviewId, 'manual check');
-      } else if (status.rejected) {
-        this.persistence.updateTask(taskId, {
-          execution: { reviewStatus: status.statusText },
-        });
-        this.logger.info(`[merge-gate] PR ${reviewId} rejected (manual check): ${status.statusText}`);
-      } else {
-        this.persistence.updateTask(taskId, {
-          execution: { reviewStatus: status.statusText },
-        });
-        await this.maybeTriggerReviewGateCiFix(task, status);
-      }
+      await this.refreshReviewGateArtifacts(task, 'manual check');
     } catch (err) {
-      this.logger.error(`[merge-gate] Manual PR check error for ${taskId}`, { err });
+      this.logger.error(`[merge-gate] Manual review gate check error for ${taskId}`, { err });
     }
   }
 
   private async maybeTriggerReviewGateCiFix(
     task: TaskState,
     status: MergeGateApprovalStatus,
+    artifact?: { identifier: string; url: string; headSha?: string; headRef?: string },
   ): Promise<void> {
     if (!this.onReviewGateCiFailure) return;
-    if (!task.config.workflowId || !task.execution.reviewId) return;
+    const reviewId = artifact?.identifier ?? task.execution.reviewId;
+    if (!task.config?.workflowId || !reviewId) return;
     if (status.checks?.state !== 'failure' || status.checks.failed.length === 0) return;
 
     const key = [
       task.id,
+      reviewId,
       task.execution.selectedAttemptId ?? 'no-attempt',
       task.execution.generation ?? 0,
       status.headSha ?? 'no-head-sha',
@@ -2535,12 +2568,11 @@ export class TaskRunner {
       await this.onReviewGateCiFailure({
         taskId: task.id,
         workflowId: task.config.workflowId,
-        reviewId: task.execution.reviewId,
-        reviewUrl: status.url,
-        headSha: status.headSha,
-        headRef: status.headRef,
-        branch: task.execution.branch,
-        selectedAttemptId: task.execution.selectedAttemptId,
+        reviewId,
+        reviewUrl: artifact?.url ?? status.url,
+        headSha: status.headSha ?? artifact?.headSha,
+        headRef: status.headRef ?? artifact?.headRef,
+        branch: artifact?.headRef ?? task.execution.branch,
         generation: task.execution.generation ?? 0,
         failedChecks: status.checks.failed,
         statusText: status.statusText,

--- a/packages/test-kit/src/test-harness.ts
+++ b/packages/test-kit/src/test-harness.ts
@@ -1,5 +1,5 @@
 import { Orchestrator, type PlanDefinition, type TaskState } from '@invoker/workflow-core';
-import { TaskRunner, ExecutorRegistry, type MergeGateProvider } from '@invoker/execution-engine';
+import { TaskRunner, ExecutorRegistry, type ReviewGateProvider } from '@invoker/execution-engine';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { Executor, ExecutorHandle, PersistedTaskMeta, TerminalSpec } from '@invoker/execution-engine';
 import { InMemoryPersistence } from './in-memory-persistence.js';
@@ -84,7 +84,7 @@ export interface TestHarness {
  */
 export function createTestHarness(opts?: {
   maxConcurrency?: number;
-  mergeGateProvider?: MergeGateProvider;
+  mergeGateProvider?: ReviewGateProvider;
 }): TestHarness {
   const persistence = new InMemoryPersistence();
   const bus = new InMemoryBus();

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -389,6 +389,7 @@ export function App() {
   const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
   const [selectedActionNode, setSelectedActionNode] = useState<ActionGraphNode | null>(null);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+  const [remoteTargets, setRemoteTargets] = useState<string[]>([]);
   const [executionPools, setExecutionPools] = useState<string[]>([]);
   const [executionAgents, setExecutionAgents] = useState<string[]>([]);
   const [statusFilters, setStatusFilters] = useState<Set<WorkflowStatus>>(new Set());
@@ -451,6 +452,7 @@ export function App() {
   }, []);
 
   useEffect(() => {
+    window.invoker?.getRemoteTargets?.().then(setRemoteTargets).catch(() => {});
     window.invoker?.getExecutionPools?.().then(setExecutionPools).catch(() => {});
     window.invoker?.getExecutionAgents?.().then(setExecutionAgents).catch(() => {});
     refreshSystemDiagnostics();
@@ -649,13 +651,23 @@ export function App() {
     return STATUS_KEY_ORDER.filter((key) => key === 'completed' || key === 'running' || key === 'failed' || key === 'pending' || (counts.get(key) ?? 0) > 0);
   }, [tasks]);
 
+  const getWorkflowReviewUrl = useCallback((workflowId: string) => {
+    const workflowTasks = [...tasks.values()].filter((task) => task.config.workflowId === workflowId);
+    const mergeTask = workflowTasks.find((task) => task.config.isMergeNode);
+    const artifacts = mergeTask?.execution.reviewGate?.artifacts;
+    if (artifacts && artifacts.length > 0) {
+      const artifact = [...artifacts].reverse().find((candidate) => candidate.status !== 'closed') ?? artifacts[artifacts.length - 1];
+      return artifact?.url;
+    }
+    return workflowTasks.find((task) => task.execution.reviewUrl)?.execution.reviewUrl;
+  }, [tasks]);
+
   const searchResults = useMemo<SearchResult[]>(() => {
     const query = normalizedSearchText(searchQuery.trim());
     if (!query) return [];
     const results: SearchResult[] = [];
     for (const workflow of workflows.values()) {
-      const workflowTasks = [...tasks.values()].filter((task) => task.config.workflowId === workflow.id);
-      const reviewUrl = workflowTasks.find((task) => task.execution.reviewUrl)?.execution.reviewUrl;
+      const reviewUrl = getWorkflowReviewUrl(workflow.id);
       const haystack = [
         workflow.id,
         workflow.name,
@@ -696,7 +708,7 @@ export function App() {
       }
     }
     return results.slice(0, 12);
-  }, [searchQuery, tasks, workflows]);
+  }, [getWorkflowReviewUrl, searchQuery, tasks, workflows]);
 
   useEffect(() => {
     setSearchActiveIndex(0);
@@ -1343,13 +1355,12 @@ export function App() {
   }, []);
 
   const handleOpenWorkflowPr = useCallback((workflowId: string) => {
-    const workflowTasks = [...tasks.values()].filter((task) => task.config.workflowId === workflowId);
-    const reviewUrl = workflowTasks.find((task) => task.execution.reviewUrl)?.execution.reviewUrl;
+    const reviewUrl = getWorkflowReviewUrl(workflowId);
     if (reviewUrl) {
       window.open(reviewUrl, '_blank', 'noopener,noreferrer');
     }
     setWorkflowContextMenu(null);
-  }, [tasks]);
+  }, [getWorkflowReviewUrl]);
 
   const handleCopyWorkflowId = useCallback((workflowId: string) => {
     navigator.clipboard?.writeText(workflowId).catch(() => {});
@@ -1544,6 +1555,18 @@ export function App() {
     [invoker],
   );
 
+  // ── Edit task executor type ───────────────────────────────
+  const handleEditType = useCallback(
+    async (taskId: string, runnerKind: string, poolMemberId?: string) => {
+      if (!invoker) return;
+      try {
+        await invoker.editTaskType(taskId, runnerKind, poolMemberId);
+      } catch (err) {
+        console.error('Failed to edit task type:', err);
+      }
+    },
+    [invoker],
+  );
 
   // ── Edit task execution pool ─────────────────────────────
   const handleEditPool = useCallback(
@@ -1926,11 +1949,13 @@ export function App() {
               workflow={selectedWorkflow}
               task={selectedTask}
               workflowTasks={miniDagTasks}
+              remoteTargets={remoteTargets}
               executionPools={executionPools}
               executionAgents={executionAgents}
               collapsed={inspectorCollapsed}
               advancedExpanded={advancedMetadataExpanded}
               actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
+              onEditType={handleEditType}
               onEditPool={handleEditPool}
               onEditAgent={handleEditAgent}
               onEditPrompt={handleEditPrompt}

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -55,6 +55,12 @@ function extractWorkspaceSetupFailures(events: readonly TaskAuditEvent[]): strin
   return failures;
 }
 
+function chooseReviewArtifact(task?: TaskState) {
+  const artifacts = task?.execution.reviewGate?.artifacts;
+  if (!artifacts || artifacts.length === 0) return undefined;
+  return [...artifacts].reverse().find((artifact) => artifact.status !== 'closed') ?? artifacts[artifacts.length - 1];
+}
+
 function formatElapsed(dateVal: Date | string | undefined): string {
   if (!dateVal) return '--';
   const d = dateVal instanceof Date ? dateVal : new Date(dateVal);
@@ -101,6 +107,7 @@ interface TaskPanelProps {
   allTasks?: Map<string, TaskState>;
   baseBranch?: string;
   workflowRepoUrl?: string;
+  remoteTargets?: string[];
   executionAgents?: string[];
   onProvideInput: (task: TaskState) => void;
   onApprove: (task: TaskState) => void;
@@ -108,6 +115,7 @@ interface TaskPanelProps {
   onSelectExperiment: (task: TaskState) => void;
   onEditCommand?: (taskId: string, newCommand: string) => void;
   onEditPrompt?: (taskId: string, newPrompt: string) => void;
+  onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
   onEditAgent?: (taskId: string, agentName: string) => void;
   onSetExternalGatePolicies?: (taskId: string, updates: ExternalGatePolicyUpdate[]) => Promise<void>;
   onSetMergeBranch?: (workflowId: string, baseBranch: string) => Promise<void>;
@@ -122,6 +130,18 @@ function formatDate(date?: Date | string): string {
   return d.toLocaleTimeString();
 }
 
+/**
+ * Display value when task.config.runnerKind is unset: matches orchestrator
+ * loadPlan default worktree. SSH tasks encode the remote target ID as
+ * "ssh:<targetId>" for the compound select. Merge nodes hide the selector.
+ */
+function effectiveExecutorSelectValue(task: TaskState): string {
+  if (task.config.runnerKind === 'ssh' && task.config.poolMemberId) {
+    return `ssh:${task.config.poolMemberId}`;
+  }
+  if (task.config.runnerKind) return task.config.runnerKind;
+  return 'worktree';
+}
 
 /**
  * Format a repo URL for display. Handles GitHub HTTPS and SSH patterns,
@@ -209,6 +229,7 @@ export function TaskPanel({
   allTasks,
   baseBranch,
   workflowRepoUrl,
+  remoteTargets,
   executionAgents,
   onProvideInput,
   onApprove,
@@ -216,6 +237,7 @@ export function TaskPanel({
   onSelectExperiment,
   onEditCommand,
   onEditPrompt,
+  onEditType,
   onEditAgent,
   onSetExternalGatePolicies,
   onSetMergeBranch,
@@ -313,6 +335,7 @@ export function TaskPanel({
   const phaseLabel = task.status === 'running'
     ? getRunningPhaseLabel(task.execution.phase)
     : null;
+  const executorSelectValue = effectiveExecutorSelectValue(task);
 
   const mergeGateDisplayTitle = mergeGatePanelHeading(task, mergeMode);
   const isFixApproval = Boolean(task.execution.pendingFixError);
@@ -433,8 +456,30 @@ export function TaskPanel({
         </div>
       )}
 
-      {/* Review link (merge gates only) */}
-      {task.config.isMergeNode && task.execution?.reviewUrl && (
+      {task.config.isMergeNode && task.execution?.reviewGate && task.execution.reviewGate.artifacts.length > 0 && (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-gray-400">Review artifacts</span>
+            <span className="text-xs text-gray-300">PRs: {task.execution.reviewGate.artifacts.length}</span>
+          </div>
+          {task.execution.reviewGate.artifacts.map((artifact) => (
+            <div key={artifact.id} className="flex items-center justify-between gap-2">
+              <a
+                href={artifact.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs font-mono text-blue-400 hover:text-blue-300 underline break-all whitespace-normal max-w-[220px]"
+                title={artifact.url}
+                data-testid="pr-url-link"
+              >
+                {artifact.provider} PR #{artifact.identifier}
+              </a>
+              <span className="text-xs text-gray-300">{artifact.statusText ?? artifact.status ?? 'unknown'}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {task.config.isMergeNode && !task.execution?.reviewGate && task.execution?.reviewUrl && (
         <div className="flex items-center justify-between">
           <span className="text-sm text-gray-400">Review link</span>
           <a
@@ -458,8 +503,7 @@ export function TaskPanel({
         </div>
       )}
 
-      {/* PR target repo (pending merge gates without a review URL yet) */}
-      {task.config.isMergeNode && task.status === 'pending' && !task.execution?.reviewUrl && workflowRepoUrl && (
+      {task.config.isMergeNode && task.status === 'pending' && !task.execution?.reviewUrl && !task.execution?.reviewGate && workflowRepoUrl && (
         <div className="flex items-center justify-between" data-testid="pr-target-repo">
           <span className="text-sm text-gray-400">PR target repo</span>
           <span className="text-xs font-mono text-gray-200 break-all whitespace-normal text-right max-w-[260px]" title={workflowRepoUrl}>
@@ -468,6 +512,34 @@ export function TaskPanel({
         </div>
       )}
 
+      {/* Primary execution controls */}
+      {onEditType && !task.config.isMergeNode && (
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-gray-400">Run on</span>
+          <select
+            value={executorSelectValue}
+            onChange={(e) => {
+              const val = e.target.value;
+              if (val.startsWith('ssh:')) {
+                onEditType(task.id, 'ssh', val.slice(4));
+              } else {
+                onEditType(task.id, val);
+              }
+            }}
+            disabled={task.status === 'running' || task.status === 'fixing_with_ai'}
+            className="bg-gray-700 text-gray-200 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            data-testid="runner-kind-select"
+          >
+            <option value="worktree">Worktree</option>
+            <option value="docker">Docker</option>
+            {remoteTargets?.map((targetId) => (
+              <option key={targetId} value={`ssh:${targetId}`}>
+                SSH: {targetId}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       {task.config.prompt && onEditAgent && (
         <div className="flex items-center justify-between">
@@ -791,13 +863,18 @@ export function TaskPanel({
                   const status = resolveExternalDepStatus(dep, allTasks);
                   const normalizedTaskId = normalizeExternalDepTaskId(dep);
                   const isMergeGate = normalizedTaskId === '__merge__';
-
-                  // Detect mixed policy
                   const group = workflowGroups.get(dep.workflowId) ?? [];
-                  const policies = new Set(group.map(d => d.gatePolicy ?? 'review_ready'));
+                  const policies = new Set(group.map((candidate) => candidate.gatePolicy ?? 'review_ready'));
                   const hasMixedPolicy = policies.size > 1;
+                  let reviewUrl = '';
+                  let reviewCount = 0;
+                  if (isMergeGate && allTasks) {
+                    const mergeNode = allTasks.get(`__merge__${dep.workflowId}`);
+                    const artifact = chooseReviewArtifact(mergeNode);
+                    reviewUrl = artifact?.url ?? mergeNode?.execution?.reviewUrl ?? '';
+                    reviewCount = mergeNode?.execution?.reviewGate?.artifacts.length ?? (reviewUrl ? 1 : 0);
+                  }
 
-                  // Compute impact
                   const steps = status !== 'missing' && !hasMixedPolicy
                     ? computeSteps(status as TaskStatus, draftPolicy as TaskStatus)
                     : Infinity;
@@ -818,13 +895,6 @@ export function TaskPanel({
                     }
                   }
 
-                  // Get reviewUrl from merge node if it's a merge gate
-                  let reviewUrl = '';
-                  if (isMergeGate && allTasks) {
-                    const mergeNode = allTasks.get(`__merge__${dep.workflowId}`);
-                    reviewUrl = mergeNode?.execution?.reviewUrl ?? '';
-                  }
-
                   const dotColor = status !== 'missing' ? getStatusColor(status as TaskStatus).dot : 'bg-slate-500';
 
                   return (
@@ -841,7 +911,7 @@ export function TaskPanel({
                                 rel="noopener noreferrer"
                                 className="ml-2 text-blue-400 hover:text-blue-300"
                               >
-                                PR #{reviewUrl.split('/').pop()} ↗
+                                PRs: {reviewCount || 1} ↗
                               </a>
                             )}
                           </div>
@@ -896,7 +966,6 @@ export function TaskPanel({
               </div>
             )}
 
-            {/* Satisfied gates disclosure */}
             {satisfied.length > 0 && (
               <div className="space-y-1">
                 <button
@@ -916,13 +985,14 @@ export function TaskPanel({
                       const status = resolveExternalDepStatus(dep, allTasks);
                       const normalizedTaskId = normalizeExternalDepTaskId(dep);
                       const isMergeGate = normalizedTaskId === '__merge__';
-
                       let reviewUrl = '';
+                      let reviewCount = 0;
                       if (isMergeGate && allTasks) {
                         const mergeNode = allTasks.get(`__merge__${dep.workflowId}`);
-                        reviewUrl = mergeNode?.execution?.reviewUrl ?? '';
+                        const artifact = chooseReviewArtifact(mergeNode);
+                        reviewUrl = artifact?.url ?? mergeNode?.execution?.reviewUrl ?? '';
+                        reviewCount = mergeNode?.execution?.reviewGate?.artifacts.length ?? (reviewUrl ? 1 : 0);
                       }
-
                       const dotColor = status !== 'missing' ? getStatusColor(status as TaskStatus).dot : 'bg-slate-500';
 
                       return (
@@ -949,7 +1019,7 @@ export function TaskPanel({
                                   rel="noopener noreferrer"
                                   className="ml-1 text-blue-400 hover:text-blue-300"
                                 >
-                                  PR#{reviewUrl.split('/').pop()} ↗
+                                  PRs: {reviewCount || 1} ↗
                                 </a>
                               )}
                             </>
@@ -966,7 +1036,7 @@ export function TaskPanel({
                                   rel="noopener noreferrer"
                                   className="ml-1 text-blue-400 hover:text-blue-300"
                                 >
-                                  PR#{reviewUrl.split('/').pop()}
+                                  PRs: {reviewCount || 1}
                                 </a>
                               )}
                             </>

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -7,11 +7,13 @@ interface WorkflowInspectorProps {
   workflow: WorkflowMeta | null;
   task: TaskState | null;
   workflowTasks?: Map<string, TaskState>;
+  remoteTargets?: string[];
   executionPools?: string[];
   executionAgents?: string[];
   actionNode?: unknown;
   collapsed: boolean;
   advancedExpanded: boolean;
+  onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
   onEditPool?: (taskId: string, poolId: string) => void;
   onEditAgent?: (taskId: string, agentName: string) => void;
   onEditPrompt?: (taskId: string, newPrompt: string) => void;
@@ -36,12 +38,13 @@ function getReviewReadyMergeNodeReviewUrl(
 ): string | undefined {
   if (!tasks) return undefined;
   for (const candidate of tasks.values()) {
-    if (
-      candidate.config.isMergeNode &&
-      candidate.status === 'review_ready' &&
-      candidate.execution.reviewUrl
-    ) {
-      return candidate.execution.reviewUrl;
+    if (candidate.config.isMergeNode && candidate.status === 'review_ready') {
+      const artifacts = candidate.execution.reviewGate?.artifacts;
+      if (artifacts && artifacts.length > 0) {
+        const artifact = [...artifacts].reverse().find((entry) => entry.status !== 'closed') ?? artifacts[artifacts.length - 1];
+        if (artifact?.url) return artifact.url;
+      }
+      if (candidate.execution.reviewUrl) return candidate.execution.reviewUrl;
     }
   }
   return undefined;
@@ -89,7 +92,7 @@ export function WorkflowInspector({
     workflow?.status === 'review_ready'
       ? task
         ? task.config.isMergeNode && task.status === 'review_ready'
-          ? task.execution.reviewUrl
+          ? getReviewReadyMergeNodeReviewUrl(new Map([[task.id, task]]))
           : undefined
         : getReviewReadyMergeNodeReviewUrl(workflowTasks)
       : undefined;

--- a/packages/ui/src/lib/merge-gate.ts
+++ b/packages/ui/src/lib/merge-gate.ts
@@ -48,7 +48,9 @@ function hasKnownMergeGatePrefix(description: string): boolean {
 }
 
 function shouldUseExternalReviewHeading(task: TaskState, mergeMode?: string): boolean {
-  return mergeMode === 'external_review' || Boolean(task.execution?.reviewUrl);
+  return mergeMode === 'external_review'
+    || Boolean(task.execution?.reviewGate?.artifacts.length)
+    || Boolean(task.execution?.reviewUrl);
 }
 
 /**

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -100,6 +100,34 @@ export interface TaskConfig {
 
 // ── Task Execution (runtime fields) ────────────────────────
 
+export type ReviewArtifactType = 'pull_request';
+export type ReviewArtifactStatus = 'open' | 'merged' | 'closed' | 'rejected' | 'unknown';
+export type ReviewGateRelationshipKind = 'stacked_diffs' | 'independent' | 'unknown';
+
+export interface ReviewGateArtifact {
+  readonly id: string;
+  readonly provider: string;
+  readonly type: ReviewArtifactType;
+  readonly url: string;
+  readonly identifier: string;
+  readonly title?: string;
+  readonly baseBranch?: string;
+  readonly headBranch?: string;
+  readonly status?: ReviewArtifactStatus;
+  readonly statusText?: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly replacedById?: string;
+}
+
+export interface ReviewGateExecution {
+  readonly sealed: boolean;
+  readonly completion: { readonly required: 'all'; readonly state: 'merged' };
+  readonly relationship: { readonly kind: ReviewGateRelationshipKind; readonly managedBy: 'external' };
+  readonly artifacts: readonly ReviewGateArtifact[];
+  readonly statusText?: string;
+}
+
 export interface TaskExecution {
   readonly phase?: 'launching' | 'executing';
   readonly generation?: number;
@@ -131,6 +159,7 @@ export interface TaskExecution {
   readonly reviewId?: string;
   readonly reviewStatus?: string;
   readonly reviewProviderId?: string;
+  readonly reviewGate?: ReviewGateExecution;
   readonly mergeConflict?: {
     readonly failedBranch: string;
     readonly conflictFiles: readonly string[];

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -27,14 +27,14 @@ class InMemoryPersistence implements OrchestratorPersistence {
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
   events: Array<{ taskId: string; eventType: string; payload?: unknown }> = [];
-  launchDispatchRows: Array<{
+  launchDispatches: Array<{
     id: number;
     taskId: string;
     attemptId: string;
     workflowId: string;
-    state: 'enqueued';
-    priority: 'high' | 'normal' | 'low';
     generation: number;
+    state: 'enqueued';
+    priority: 'normal';
   }> = [];
   updateWorkflowCalls = new Map<string, number>();
 
@@ -53,8 +53,9 @@ class InMemoryPersistence implements OrchestratorPersistence {
     const now = new Date().toISOString();
     this.workflows.set(workflow.id, {
       ...workflow,
-      // Synthesize a placeholder repoUrl so tests with SSH-routed
-      // plans do not need to spell out a remote URL.
+      // Synthesize a placeholder repoUrl so SSH-validation tests
+      // (Step 5 `editTaskType` → ssh) keep passing without each
+      // plan having to spell out a remote URL.
       repoUrl: workflow.repoUrl ?? 'memory://test-repo',
       baseBranch: workflow.baseBranch,
       featureBranch: workflow.featureBranch,
@@ -212,6 +213,25 @@ class InMemoryPersistence implements OrchestratorPersistence {
     this.events.push({ taskId, eventType, payload });
   }
 
+  enqueueLaunchDispatch(input: {
+    taskId: string;
+    attemptId: string;
+    workflowId: string;
+    generation: number;
+  }): { id: number; state: 'enqueued'; priority: 'normal' } {
+    const row = {
+      id: this.launchDispatches.length + 1,
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+      workflowId: input.workflowId,
+      generation: input.generation,
+      state: 'enqueued' as const,
+      priority: 'normal' as const,
+    };
+    this.launchDispatches.push(row);
+    return row;
+  }
+
   saveAttempt(attempt: Attempt): void {
     const list = this.attempts.get(attempt.nodeId) ?? [];
     list.push(attempt);
@@ -230,7 +250,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
     return undefined;
   }
 
-  updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
+  updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'branch' | 'commit' | 'summary' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void {
     for (const list of this.attempts.values()) {
       const idx = list.findIndex(a => a.id === attemptId);
       if (idx !== -1) {
@@ -238,26 +258,6 @@ class InMemoryPersistence implements OrchestratorPersistence {
         return;
       }
     }
-  }
-
-  enqueueLaunchDispatch(input: {
-    taskId: string;
-    attemptId: string;
-    workflowId: string;
-    priority?: 'high' | 'normal' | 'low';
-    generation: number;
-  }): { id: number; state: 'enqueued'; priority: 'high' | 'normal' | 'low' } {
-    const row = {
-      id: this.launchDispatchRows.length + 1,
-      taskId: input.taskId,
-      attemptId: input.attemptId,
-      workflowId: input.workflowId,
-      state: 'enqueued' as const,
-      priority: input.priority ?? 'normal' as const,
-      generation: input.generation,
-    };
-    this.launchDispatchRows.push(row);
-    return row;
   }
 
   deleteWorkflow(workflowId: string): void {
@@ -877,77 +877,82 @@ describe('Orchestrator', () => {
     });
 
     it('non-merge merge_conflict fix approval relaunches through the launch outbox when launch is deferred', async () => {
-      const localPersistence = new InMemoryPersistence();
-      const localBus = new InMemoryBus();
-      const localOrchestrator = new Orchestrator({
-        persistence: localPersistence,
-        messageBus: localBus,
+      persistence = new InMemoryPersistence();
+      bus = new InMemoryBus();
+      publishedDeltas = [];
+      bus.subscribe('task.delta', (delta) => {
+        publishedDeltas.push(delta as TaskDelta);
+      });
+      orchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
         maxConcurrency: 3,
         logger: consoleLogger,
         deferRunningUntilLaunch: true,
       });
-      const mergeConflictError = JSON.stringify({
-        type: 'merge_conflict',
-        failedBranch: 'experiment/non-merge-branch-abc123',
-        conflictFiles: ['src/non-merge.ts'],
-      });
-
-      localOrchestrator.loadPlan({
+      orchestrator.loadPlan({
         name: 'deferred-fix-test',
         tasks: [
           { id: 'f1', description: 'Root task' },
           { id: 'f2', description: 'Failing task', dependencies: ['f1'] },
         ],
       });
-      const [f1Claim] = localOrchestrator.startExecution();
-      expect(f1Claim?.status).toBe('pending');
-      expect(f1Claim?.execution.phase).toBe('launching');
-      expect(
-        localOrchestrator.markTaskRunningAfterLaunch('f1', f1Claim!.execution.selectedAttemptId!),
-      ).toBe(true);
-      const [f2Claim] = localOrchestrator.handleWorkerResponse(
-        makeResponse({ actionId: 'f1', status: 'completed', outputs: { exitCode: 0 } }),
+      orchestrator.startExecution();
+      const f1 = orchestrator.getTask('f1')!;
+      expect(f1.status).toBe('pending');
+      expect(f1.execution.phase).toBe('launching');
+      orchestrator.markTaskRunningAfterLaunch('f1', f1.execution.selectedAttemptId!);
+      orchestrator.handleWorkerResponse(
+        makeResponse({
+          actionId: 'f1',
+          attemptId: f1.execution.selectedAttemptId!,
+          status: 'completed',
+          outputs: { exitCode: 0 },
+        }),
       );
-      expect(f2Claim?.status).toBe('pending');
-      expect(f2Claim?.execution.phase).toBe('launching');
-      expect(
-        localOrchestrator.markTaskRunningAfterLaunch('f2', f2Claim!.execution.selectedAttemptId!),
-      ).toBe(true);
-      localOrchestrator.handleWorkerResponse(
+      const f2Launch = orchestrator.getTask('f2')!;
+      expect(f2Launch.status).toBe('pending');
+      expect(f2Launch.execution.phase).toBe('launching');
+      orchestrator.markTaskRunningAfterLaunch('f2', f2Launch.execution.selectedAttemptId!);
+
+      const mergeConflictError = JSON.stringify({
+        type: 'merge_conflict',
+        failedBranch: 'experiment/non-merge-branch-abc123',
+        conflictFiles: ['src/non-merge.ts'],
+      });
+      orchestrator.handleWorkerResponse(
         makeResponse({
           actionId: 'f2',
+          attemptId: f2Launch.execution.selectedAttemptId!,
+          executionGeneration: f2Launch.execution.generation,
           status: 'failed',
           outputs: { exitCode: 1, error: mergeConflictError },
         }),
       );
+      const { savedError } = orchestrator.beginConflictResolution('f2');
+      expect(savedError).toBe(mergeConflictError);
+      const fixAttemptId = orchestrator.getTask('f2')!.execution.selectedAttemptId!;
+      orchestrator.setFixAwaitingApproval('f2', mergeConflictError);
+      const dispatchesBeforeApproval = persistence.launchDispatches.length;
 
-      const { savedError } = localOrchestrator.beginConflictResolution('f2');
-      localOrchestrator.setFixAwaitingApproval('f2', savedError);
-      const fixAttemptId = localOrchestrator.getTask('f2')!.execution.selectedAttemptId!;
-      const launchRowsBeforeApprove = localPersistence.launchDispatchRows.length;
+      const started = await orchestrator.resumeTaskAfterFixApproval('f2');
 
-      const [claim] = await localOrchestrator.resumeTaskAfterFixApproval('f2');
-      const task = localOrchestrator.getTask('f2')!;
-
-      expect(claim?.id).toBe(task.id);
-      expect(task.status).toBe('pending');
-      expect(task.execution.phase).toBe('launching');
-      expect(task.execution.pendingFixError).toBeUndefined();
-      expect(task.execution.selectedAttemptId).not.toBe(fixAttemptId);
-      expect(localPersistence.loadAttempt(fixAttemptId)?.status).toBe('superseded');
-      expect(localPersistence.loadAttempt(task.execution.selectedAttemptId!)?.status).toBe('claimed');
-      const newLaunchRows = localPersistence.launchDispatchRows.slice(launchRowsBeforeApprove);
-      expect(newLaunchRows).toHaveLength(1);
-      expect(newLaunchRows[0]).toMatchObject({
-        taskId: task.id,
-        attemptId: task.execution.selectedAttemptId,
-        state: 'enqueued',
-      });
-      expect(
-        localPersistence.events.some(
-          (event) => event.taskId === task.id && event.eventType === 'task.launch_claimed',
-        ),
-      ).toBe(true);
+      expect(started).toHaveLength(1);
+      expect(started[0].status).toBe('pending');
+      expect(started[0].execution.phase).toBe('launching');
+      expect(started[0].execution.selectedAttemptId).not.toBe(fixAttemptId);
+      expect(started[0].execution.pendingFixError).toBeUndefined();
+      expect(persistence.loadAttempt(fixAttemptId)?.status).toBe('superseded');
+      expect(persistence.launchDispatches).toHaveLength(dispatchesBeforeApproval + 1);
+      const dispatch = persistence.launchDispatches.at(-1)!;
+      expect(dispatch.taskId).toBe(started[0].id);
+      expect(dispatch.attemptId).toBe(started[0].execution.selectedAttemptId);
+      expect(persistence.events.some(
+        (event) => event.taskId === started[0].id && event.eventType === 'task.launch_claimed',
+      )).toBe(true);
+      expect(persistence.events.some(
+        (event) => event.taskId === started[0].id && event.eventType === 'task.dispatch_enqueued',
+      )).toBe(true);
     });
 
     it('non-merge plain-text pendingFixError approve transitions failed -> fixing_with_ai -> awaiting_approval -> completed', async () => {

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -7,13 +7,13 @@
 
 import type { CommandEnvelope, CommandResult } from '@invoker/contracts';
 import { OrchestratorError } from './orchestrator.js';
-import type { Orchestrator, ExternalGatePolicyUpdate, TaskReplacementDef } from './orchestrator.js';
+import type { Orchestrator, ExternalGatePolicyUpdate, TaskReplacementDef, ReviewArtifactInput } from './orchestrator.js';
 import {
   applyInvalidation,
   buildOrchestratorOnlyInvalidationDeps,
   type InvalidationDeps,
 } from './invalidation-policy.js';
-import type { TaskState } from '@invoker/workflow-graph';
+import type { ReviewGateExecution, TaskState } from '@invoker/workflow-graph';
 
 // ── Cancel Result ────────────────────────────────────────────
 
@@ -231,6 +231,19 @@ export class CommandService {
     );
   }
 
+    async editTaskType(
+    envelope: CommandEnvelope<{ taskId: string; runnerKind: string; poolMemberId?: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'EDIT_TASK_TYPE_FAILED',
+      () => this.orchestrator.editTaskType(
+        envelope.payload.taskId,
+        envelope.payload.runnerKind,
+        envelope.payload.poolMemberId,
+      ),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
 
     async editTaskPool(
     envelope: CommandEnvelope<{ taskId: string; poolId: string }>,
@@ -257,9 +270,9 @@ export class CommandService {
    * invalidation route per Step 9 of the task-invalidation roadmap
    * (chart Decision Table row "Change merge mode";
    * `MUTATION_POLICIES.mergeMode` → `retryTask` / task scope, scoped
-   * to the merge node). Mirrors the remaining retry-class seams
-   * (`selectExperiment` / `selectExperiments`) rather than the
-   * recreate-class `editTaskCommand` / `editTaskPrompt` /
+   * to the merge node). Mirrors the Step 5/7/8 retry-class seams
+   * (`editTaskType` / `selectExperiment` / `selectExperiments`) rather
+   * than the recreate-class `editTaskCommand` / `editTaskPrompt` /
    * `editTaskAgent` seams: a merge-mode flip changes the merge
    * execution policy but preserves the merge node's branch /
    * workspacePath lineage.
@@ -299,8 +312,8 @@ export class CommandService {
    * invalidation route per Step 10 of the task-invalidation roadmap
    * (chart Decision Table row "Change fix prompt or fix context while
    * `fixing_with_ai`"; `MUTATION_POLICIES.fixContext` → `retryTask` /
-   * task scope, scoped to the failed/fixing task). Mirrors the
-   * remaining retry-class seams (`selectExperiment` /
+   * task scope, scoped to the failed/fixing task). Mirrors the Step
+   * 5/7/8/9 retry-class seams (`editTaskType` / `selectExperiment` /
    * `selectExperiments` / `editTaskMergeMode`) rather than the
    * recreate-class `editTaskCommand` / `editTaskPrompt` /
    * `editTaskAgent` seams: a fix prompt/context edit redirects the
@@ -396,6 +409,29 @@ export class CommandService {
       'CANCEL_TASK_FAILED',
       () => this.orchestrator.cancelTask(envelope.payload.taskId),
       this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
+  async attachReviewArtifact(
+    envelope: CommandEnvelope<{ workflowId: string; artifact: ReviewArtifactInput }>,
+  ): Promise<CommandResult<ReviewGateExecution>> {
+    return this.executeCommand<ReviewGateExecution>(
+      'ATTACH_REVIEW_ARTIFACT_FAILED',
+      () => this.orchestrator.attachReviewArtifact(
+        envelope.payload.workflowId,
+        envelope.payload.artifact,
+      ),
+      envelope.payload.workflowId,
+    );
+  }
+
+  async sealReviewGate(
+    envelope: CommandEnvelope<{ workflowId: string }>,
+  ): Promise<CommandResult<ReviewGateExecution>> {
+    return this.executeCommand<ReviewGateExecution>(
+      'SEAL_REVIEW_GATE_FAILED',
+      () => this.orchestrator.sealReviewGate(envelope.payload.workflowId),
+      envelope.payload.workflowId,
     );
   }
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -19,7 +19,7 @@ import { TaskStateMachine } from './state-machine.js';
 import { ResponseHandler } from './response-handler.js';
 import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
-import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, TaskStatus, TaskHeartbeatSource, ReviewGateArtifact, ReviewGateExecution } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
 import { createTaskState, createAttempt } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
@@ -141,6 +141,7 @@ const RECREATE_RESET_CHANGES: TaskStateChanges = {
     reviewUrl: undefined,
     reviewId: undefined,
     reviewStatus: undefined,
+    reviewGate: undefined,
     reviewProviderId: undefined,
     agentSessionId: undefined,
     containerId: undefined,
@@ -217,11 +218,13 @@ export interface OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    reviewProvider?: string;
+    reviewGate?: ReviewGateDefinition;
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
   }): void;
-  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[] }): void;
+  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review'; reviewProvider?: string; reviewGate?: ReviewGateDefinition; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[] }): void;
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
@@ -269,8 +272,9 @@ export interface OrchestratorPersistence {
     attemptPatch: Partial<Pick<Attempt, 'status' | 'exitCode' | 'error' | 'completedAt'>>
   ): void;
   /**
-   * Load a workflow by ID. Used by same-mode no-op detection in
-   * `editTaskMergeMode` (`mergeMode`).
+   * Load a workflow by ID. Used by:
+   *   - SSH validation in `editTaskType` (`repoUrl`),
+   *   - same-mode no-op detection in `editTaskMergeMode` (`mergeMode`).
    * The interface lists only the fields the orchestrator actually reads;
    * concrete adapters (e.g. `SQLiteAdapter.loadWorkflow`) return more.
    */
@@ -280,6 +284,8 @@ export interface OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    reviewProvider?: string;
+    reviewGate?: ReviewGateDefinition;
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
@@ -332,6 +338,29 @@ export interface DeleteAllWorkflowsOptions {
   publishRemovalDeltas?: boolean;
 }
 
+export interface ReviewGateDefinition {
+  type: 'pull_requests';
+  authoring: {
+    mode: 'automatic' | 'manual' | 'external';
+    preferredShape: 'stacked_diffs' | 'independent';
+  };
+  completion: {
+    required: 'all';
+    state: 'merged';
+  };
+}
+
+export interface ReviewArtifactInput {
+  provider?: 'github';
+  type?: 'pull_request';
+  url: string;
+  identifier?: string;
+  title?: string;
+  baseBranch?: string;
+  headBranch?: string;
+  status?: ReviewGateArtifact['status'];
+}
+
 export interface PlanDefinition {
   name: string;
   description?: string;
@@ -341,6 +370,7 @@ export interface PlanDefinition {
   featureBranch?: string;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
   reviewProvider?: string;
+  reviewGate?: ReviewGateDefinition;
   repoUrl?: string;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
@@ -646,6 +676,7 @@ export class Orchestrator {
       reviewUrl: undefined,
       reviewId: undefined,
       reviewStatus: undefined,
+      reviewGate: undefined,
       reviewProviderId: undefined,
       fixedIntegrationSha: undefined,
       fixedIntegrationRecordedAt: undefined,
@@ -1418,6 +1449,8 @@ export class Orchestrator {
       baseBranch: plan.baseBranch,
       featureBranch: plan.featureBranch,
       mergeMode: plan.mergeMode,
+      reviewProvider: plan.reviewProvider,
+      reviewGate: plan.reviewGate,
       externalDependencies: workflowExternalDependencies.length > 0 ? workflowExternalDependencies : undefined,
       createdAt,
       updatedAt: createdAt,
@@ -1758,6 +1791,100 @@ export class Orchestrator {
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
 
+  private defaultReviewGateForAttachment(): ReviewGateExecution {
+    return {
+      sealed: false,
+      completion: { required: 'all', state: 'merged' },
+      relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+      artifacts: [],
+      statusText: 'Waiting for review artifacts',
+    };
+  }
+
+  private normalizeReviewArtifactInput(input: ReviewArtifactInput): ReviewGateArtifact {
+    const provider = input.provider ?? 'github';
+    const type = input.type ?? 'pull_request';
+    if (provider !== 'github') throw new Error('Review artifact provider must be "github"');
+    if (type !== 'pull_request') throw new Error('Review artifact type must be "pull_request"');
+    const url = input.url?.trim();
+    if (!url) throw new Error('Review artifact URL is required');
+    const parsedIdentifier = provider === 'github'
+      ? url.match(/\/pull\/(\d+)(?:[/?#].*)?$/)?.[1]
+      : undefined;
+    const identifier = input.identifier?.trim() || parsedIdentifier;
+    if (!identifier) throw new Error('Review artifact identifier is required');
+    return {
+      id: `${provider}:${type}:${identifier}`,
+      provider,
+      type,
+      url,
+      identifier,
+      title: input.title,
+      baseBranch: input.baseBranch,
+      headBranch: input.headBranch,
+      status: input.status,
+    };
+  }
+
+  attachReviewArtifact(workflowId: string, input: ReviewArtifactInput): ReviewGateExecution {
+    this.refreshFromDb();
+    const task = this.getMergeNode(workflowId);
+    if (!task) throw new Error(`Workflow "${workflowId}" has no review gate`);
+    if (task.status !== 'review_ready' && task.status !== 'awaiting_approval') {
+      throw new Error('Review artifacts can only be attached while the review gate is review_ready or awaiting_approval');
+    }
+    const artifact = this.normalizeReviewArtifactInput(input);
+    const current = task.execution.reviewGate ?? this.defaultReviewGateForAttachment();
+    const artifacts = [...current.artifacts];
+    const existingIndex = artifacts.findIndex((candidate) => candidate.id === artifact.id);
+    if (existingIndex >= 0) {
+      const existing = artifacts[existingIndex];
+      artifacts[existingIndex] = {
+        ...existing,
+        ...artifact,
+        status: artifact.status ?? existing.status,
+        statusText: existing.statusText,
+        headSha: existing.headSha,
+        headRef: existing.headRef,
+      };
+    } else {
+      artifacts.push({ ...artifact, status: artifact.status ?? 'open' });
+    }
+    const reviewGate: ReviewGateExecution = {
+      ...current,
+      artifacts,
+      statusText: current.sealed ? current.statusText : 'Waiting for review artifacts',
+    };
+    const changes: TaskStateChanges = { execution: { reviewGate } };
+    const updatedReview = this.writeAndSync(task.id, changes);
+    this.persistence.logEvent?.(task.id, 'review_gate.artifact_attached', { artifact });
+    this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updatedReview, changes));
+    return reviewGate;
+  }
+
+  sealReviewGate(workflowId: string): ReviewGateExecution {
+    this.refreshFromDb();
+    const task = this.getMergeNode(workflowId);
+    if (!task) throw new Error(`Workflow "${workflowId}" has no review gate`);
+    if (task.status !== 'review_ready' && task.status !== 'awaiting_approval') {
+      throw new Error('Review gate can only be sealed while it is review_ready or awaiting_approval');
+    }
+    const current = task.execution.reviewGate ?? this.defaultReviewGateForAttachment();
+    if (current.artifacts.length === 0) {
+      throw new Error('Cannot seal review gate without pull request artifacts');
+    }
+    const reviewGate: ReviewGateExecution = {
+      ...current,
+      sealed: true,
+      statusText: current.statusText ?? 'Awaiting review',
+    };
+    const changes: TaskStateChanges = { execution: { reviewGate } };
+    const updatedReview = this.writeAndSync(task.id, changes);
+    this.persistence.logEvent?.(task.id, 'review_gate.sealed', { artifactCount: reviewGate.artifacts.length });
+    this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updatedReview, changes));
+    return reviewGate;
+  }
+
   setBeforeApproveHook(fn: (task: TaskState) => Promise<void>): void {
     this.beforeApproveHook = fn;
   }
@@ -1842,7 +1969,6 @@ export class Orchestrator {
     if (!task || !isApprovalState || task.execution.pendingFixError === undefined) {
       return [];
     }
-    const id = task.id;
 
     if (!task.config.isMergeNode) {
       const prepared = this.prepareTaskForNewAttempt(task.id, 'approved fix relaunch');
@@ -1854,16 +1980,16 @@ export class Orchestrator {
       status: 'running',
       execution: { pendingFixError: undefined, startedAt: now, lastHeartbeatAt: now },
     };
-    const updated = this.writeAndSync(id, changes);
-    this.updateSelectedAttempt(id, {
+    const updated = this.writeAndSync(taskId, changes);
+    this.updateSelectedAttempt(taskId, {
       status: 'running',
       startedAt: now,
       lastHeartbeatAt: now,
     });
     const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
-    this.persistence.logEvent?.(id, 'task.running', changes);
+    this.persistence.logEvent?.(taskId, 'task.running', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
-    return [this.stateGetTask(id)!];
+    return [this.stateGetTask(taskId)!];
   }
 
   /**
@@ -2810,6 +2936,57 @@ export class Orchestrator {
     return this.dispatchPostMutation(MUTATION_POLICIES.prompt.action, taskId);
   }
 
+    editTaskType(taskId: string, runnerKind: string, poolMemberId?: string): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    if (task.config.isMergeNode) throw new Error(`Cannot change executor type of merge node ${taskId}`);
+
+    const effectiveType = normalizeRunnerKind(runnerKind) ?? runnerKind;
+
+    // SSH requires repoUrl on the workflow to clone onto the remote host
+    if (effectiveType === 'ssh' && task.config.workflowId && this.persistence.loadWorkflow) {
+      const wf = this.persistence.loadWorkflow(task.config.workflowId);
+      if (!wf?.repoUrl) {
+        throw new Error(
+          `Cannot switch task "${taskId}" to SSH: workflow has no repoUrl. ` +
+          `Add repoUrl to the plan YAML.`,
+        );
+      }
+    }
+
+    const oldRunnerKind = task.config.runnerKind;
+    const oldPoolMemberId =
+      oldRunnerKind === 'ssh' ? (task.config as { poolMemberId?: string }).poolMemberId : undefined;
+    const newPoolMemberId = effectiveType === 'ssh' ? poolMemberId : undefined;
+    const hostKey = (et: string | undefined, rid: string | undefined): string =>
+      et === 'ssh' ? `ssh:${rid ?? ''}` : 'local';
+    const hostChanged =
+      hostKey(oldRunnerKind, oldPoolMemberId) !==
+      hostKey(effectiveType, newPoolMemberId);
+
+    if (isActiveForInvalidation(task.status)) {
+      this.cancelTask(taskId);
+    }
+
+    const configPatch: Record<string, unknown> = { runnerKind: effectiveType };
+    if (effectiveType === 'ssh') {
+      configPatch.poolMemberId = poolMemberId;
+    } else {
+      configPatch.poolMemberId = undefined;
+    }
+    const typeChanges: TaskStateChanges = { config: configPatch };
+    const typeBefore = this.stateGetTask(taskId)!;
+    const typeUpdated = this.writeAndSync(taskId, typeChanges);
+    const typeDelta: TaskDelta = this.buildUpdateDelta(typeBefore, typeUpdated, typeChanges);
+    this.persistence.logEvent?.(taskId, 'task.updated', typeChanges);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, typeDelta);
+
+    const typeAction = hostChanged
+      ? MUTATION_POLICIES.poolMemberId.action
+      : MUTATION_POLICIES.runnerKind.action;
+    return this.dispatchPostMutation(typeAction, taskId);
+  }
 
     editTaskPool(taskId: string, poolId: string): TaskState[] {
     this.refreshFromDb();
@@ -4115,6 +4292,7 @@ export class Orchestrator {
       reviewUrl?: string;
       reviewId?: string;
       reviewStatus?: string;
+      reviewGate?: ReviewGateExecution;
     } = {
       exitCode: parsed.exitCode,
       completedAt: new Date(),
@@ -4142,6 +4320,9 @@ export class Orchestrator {
     }
     if (parsed.reviewStatus !== undefined) {
       execution.reviewStatus = parsed.reviewStatus;
+    }
+    if (parsed.reviewGate !== undefined) {
+      execution.reviewGate = parsed.reviewGate;
     }
 
     const changes: TaskStateChanges = {
@@ -4295,6 +4476,7 @@ export class Orchestrator {
         reviewUrl: parsed.reviewUrl,
         reviewId: parsed.reviewId,
         reviewStatus: parsed.reviewStatus,
+        reviewGate: parsed.reviewGate,
       },
     };
     this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', changes);

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -15,6 +15,20 @@ export interface RawExperimentVariant {
   prompt?: string;
   command?: string;
 }
+export interface RawReviewGate {
+  type?: string;
+  authoring?: {
+    mode?: string;
+    preferredShape?: string;
+  };
+  completion?: {
+    required?: unknown;
+    state?: string;
+  };
+  requiredPullRequests?: unknown;
+  prCount?: unknown;
+}
+
 
 export interface RawPlanTask {
   id?: string;
@@ -46,6 +60,7 @@ export interface RawPlan {
   featureBranch?: string;
   mergeMode?: string;
   reviewProvider?: string;
+  reviewGate?: RawReviewGate;
   repoUrl?: string;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
@@ -158,6 +173,76 @@ function assertNoLegacyRoutingKeys(ownerLabel: string, value: object): void {
     }
   }
 }
+function parseReviewGate(
+  rawReviewGate: RawReviewGate | undefined,
+  mergeMode: PlanDefinition['mergeMode'] | undefined,
+): PlanDefinition['reviewGate'] | undefined {
+  const defaultGate: NonNullable<PlanDefinition['reviewGate']> = {
+    type: 'pull_requests',
+    authoring: { mode: 'automatic', preferredShape: 'stacked_diffs' },
+    completion: { required: 'all', state: 'merged' },
+  };
+  if (rawReviewGate === undefined) {
+    return mergeMode === 'external_review' ? defaultGate : undefined;
+  }
+  if (!rawReviewGate || typeof rawReviewGate !== 'object') {
+    throw new PlanParseError('"reviewGate" must be an object');
+  }
+  const hasOwn = (obj: object, key: string): boolean => Object.prototype.hasOwnProperty.call(obj, key);
+  if (hasOwn(rawReviewGate as object, 'requiredPullRequests')) {
+    throw new PlanParseError('"reviewGate.requiredPullRequests" is not supported; use completion.required: all');
+  }
+  if (hasOwn(rawReviewGate as object, 'prCount')) {
+    throw new PlanParseError('"reviewGate.prCount" is not supported; use completion.required: all');
+  }
+
+  const type = rawReviewGate.type ?? defaultGate.type;
+  if (type !== 'pull_requests') {
+    throw new PlanParseError(`"reviewGate.type" must be "pull_requests". Got: "${String(type)}"`);
+  }
+
+  const rawAuthoring = rawReviewGate.authoring ?? {};
+  if (!rawAuthoring || typeof rawAuthoring !== 'object') {
+    throw new PlanParseError('"reviewGate.authoring" must be an object');
+  }
+  const mode = rawAuthoring.mode ?? defaultGate.authoring.mode;
+  if (mode !== 'automatic' && mode !== 'manual' && mode !== 'external') {
+    throw new PlanParseError(`"reviewGate.authoring.mode" must be one of: automatic, manual, external. Got: "${String(mode)}"`);
+  }
+  const preferredShape = rawAuthoring.preferredShape ?? defaultGate.authoring.preferredShape;
+  if (preferredShape !== 'stacked_diffs' && preferredShape !== 'independent') {
+    throw new PlanParseError(`"reviewGate.authoring.preferredShape" must be one of: stacked_diffs, independent. Got: "${String(preferredShape)}"`);
+  }
+
+  const rawCompletion = rawReviewGate.completion ?? {};
+  if (!rawCompletion || typeof rawCompletion !== 'object') {
+    throw new PlanParseError('"reviewGate.completion" must be an object');
+  }
+  if (hasOwn(rawCompletion as object, 'requiredPullRequests')) {
+    throw new PlanParseError('"reviewGate.completion.requiredPullRequests" is not supported; use completion.required: all');
+  }
+  if (hasOwn(rawCompletion as object, 'prCount')) {
+    throw new PlanParseError('"reviewGate.completion.prCount" is not supported; use completion.required: all');
+  }
+  const required = rawCompletion.required ?? defaultGate.completion.required;
+  if (typeof required === 'number') {
+    throw new PlanParseError('"reviewGate.completion.required" must be "all"; numeric pull request counts are not supported');
+  }
+  if (required !== 'all') {
+    throw new PlanParseError(`"reviewGate.completion.required" must be "all". Got: "${String(required)}"`);
+  }
+  const state = rawCompletion.state ?? defaultGate.completion.state;
+  if (state !== 'merged') {
+    throw new PlanParseError(`"reviewGate.completion.state" must be "merged". Got: "${String(state)}"`);
+  }
+
+  return {
+    type,
+    authoring: { mode, preferredShape },
+    completion: { required, state },
+  };
+}
+
 
 export function parsePlan(yamlContent: string): PlanDefinition {
   let raw: RawPlan;
@@ -188,12 +273,14 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   }
   const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
 
-  const validMergeModes = ['manual', 'automatic', 'external_review'] as const;
+  const validMergeModes = ['manual', 'automatic', 'external_review', 'github'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(`"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`);
   }
-  const mergeMode = raw.mergeMode as (typeof validMergeModes)[number] | undefined;
-  const reviewProvider = raw.reviewProvider ?? (raw.mergeMode === 'external_review' ? 'github' : undefined);
+  const rawMergeMode = raw.mergeMode as (typeof validMergeModes)[number] | undefined;
+  const mergeMode = rawMergeMode === 'github' ? 'external_review' : rawMergeMode;
+  const reviewProvider = raw.reviewProvider ?? (mergeMode === 'external_review' ? 'github' : undefined);
+  const reviewGate = parseReviewGate(raw.reviewGate, mergeMode);
 
   if (!raw.repoUrl || typeof raw.repoUrl !== 'string') {
     throw new PlanParseError('Plan must have a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git).');
@@ -259,6 +346,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     featureBranch: raw.featureBranch,
     mergeMode,
     reviewProvider,
+    reviewGate,
     repoUrl: raw.repoUrl,
     intermediateRepoUrl: raw.intermediateRepoUrl,
     externalDependencies: topLevelExternalDependencies,

--- a/packages/workflow-core/src/response-handler.ts
+++ b/packages/workflow-core/src/response-handler.ts
@@ -6,7 +6,7 @@
  * the Orchestrator what writes to make.
  */
 
-import type { WorkResponse } from '@invoker/contracts';
+import type { ReviewGateExecution, WorkResponse } from '@invoker/contracts';
 import { validateWorkResponse } from '@invoker/contracts';
 
 /** Plan-local id segment for experiment id prefixing (strip `${workflowId}/` when present). */
@@ -40,6 +40,7 @@ export type ParsedResponse =
       reviewUrl?: string;
       reviewId?: string;
       reviewStatus?: string;
+      reviewGate?: ReviewGateExecution;
     }
   | {
       type: 'review_ready';
@@ -50,6 +51,7 @@ export type ParsedResponse =
       reviewUrl?: string;
       reviewId?: string;
       reviewStatus?: string;
+      reviewGate?: ReviewGateExecution;
     }
   | {
       type: 'failed';
@@ -103,6 +105,7 @@ export class ResponseHandler {
           reviewUrl: outputs.reviewUrl,
           reviewId: outputs.reviewId,
           reviewStatus: outputs.reviewStatus,
+          reviewGate: outputs.reviewGate,
         };
 
       case 'review_ready':
@@ -115,6 +118,7 @@ export class ResponseHandler {
           reviewUrl: outputs.reviewUrl,
           reviewId: outputs.reviewId,
           reviewStatus: outputs.reviewStatus,
+          reviewGate: outputs.reviewGate,
         };
 
       case 'failed':

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -128,6 +128,42 @@ export interface DetachedExternalDependency {
 
 export type TaskRunPhase = 'launching' | 'executing';
 export type TaskHeartbeatSource = 'executor' | 'remote_workload';
+export type ReviewArtifactType = 'pull_request';
+export type ReviewArtifactStatus = 'open' | 'merged' | 'closed' | 'rejected' | 'unknown';
+export type ReviewGateRelationshipKind = 'stacked_diffs' | 'independent' | 'unknown';
+
+export interface ReviewGateArtifact {
+  readonly id: string;
+  readonly provider: string;
+  readonly type: ReviewArtifactType;
+  readonly url: string;
+  readonly identifier: string;
+  readonly title?: string;
+  readonly baseBranch?: string;
+  readonly headBranch?: string;
+  readonly status?: ReviewArtifactStatus;
+  readonly statusText?: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly replacedById?: string;
+}
+
+export interface ReviewGateCompletionPolicy {
+  readonly required: 'all';
+  readonly state: 'merged';
+}
+
+export interface ReviewGateExecution {
+  readonly sealed: boolean;
+  readonly completion: ReviewGateCompletionPolicy;
+  readonly relationship: {
+    readonly kind: ReviewGateRelationshipKind;
+    readonly managedBy: 'external';
+  };
+  readonly artifacts: readonly ReviewGateArtifact[];
+  readonly statusText?: string;
+}
+
 
 export interface TaskExecution {
   readonly generation?: number;
@@ -164,6 +200,7 @@ export interface TaskExecution {
   readonly reviewId?: string;
   readonly reviewStatus?: string;
   readonly reviewProviderId?: string;
+  readonly reviewGate?: ReviewGateExecution;
   readonly phase?: TaskRunPhase;
   readonly launchStartedAt?: Date;
   readonly launchCompletedAt?: Date;


### PR DESCRIPTION
## Summary

This change lets one workflow review gate track a live set of PRs instead of only one PR.

It also gives manual and external review flows a first-class way to fill in those PRs later.

The old single-PR shape blocked stacked review flows and left review state inconsistent across runtime, storage, and the UI.

## Review Claim

One workflow review gate can now publish, store, poll, and show multiple PR artifacts without changing the single-gate-per-workflow model.

## Review Lane

behavior

## Safety Invariant

Each workflow still has one merge gate task. This diff only changes the review payload on that task from one PR to a list of PR artifacts.

## Slice Rationale

The cutover needs one landing point because the parser, persistence, runtime, API, and UI all read the same review-gate shape. A partial landing would leave mixed scalar and plural review state behind.

## Non-goals

- Automatic GitHub publishing still creates one PR today.
- Completion policy still only supports `all` + `merged`.
- This does not add PR-count YAML fields.

## Architecture

### Before

```mermaid
flowchart LR
  Plan[Plan YAML] --> Parser
  Parser --> Workflow[Workflow mergeMode + reviewProvider]
  Workflow --> MergeRunner
  MergeRunner --> Scalar[reviewUrl / reviewId / reviewStatus]
  Scalar --> Store[(SQLite tasks columns)]
  Scalar --> UI[TaskPanel / Open PR]
  Scalar --> Poller[TaskRunner checkApproval]
```

### After

```mermaid
flowchart LR
  Plan[Plan YAML + reviewGate] --> Parser
  Parser --> Workflow[Workflow mergeMode + reviewGate definition]
  Workflow --> MergeRunner
  MergeRunner --> Gate[execution.reviewGate]
  Gate --> Store[(SQLite task review_gate JSON)]
  Gate --> API[attach / seal / check lifecycle]
  Gate --> UI[TaskPanel / Open PR chooser]
  Gate --> Poller[TaskRunner poll all artifacts]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm exec vitest run src/__tests__/plan-parser.test.ts src/__tests__/merge-mode.test.ts` in `packages/app`
- [x] `pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts` in `packages/data-store`
- [x] `pnpm exec vitest run src/__tests__/github-merge-gate-provider.test.ts src/__tests__/task-runner.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts` in `packages/execution-engine`
- [x] `pnpm exec vitest run src/__tests__/task-panel-double-click.test.tsx src/__tests__/workflow-inspector.test.tsx src/__tests__/keyboard-controls.test.tsx` in `packages/ui`
- [x] `pnpm exec vitest run src/__tests__/headless-delegation.test.ts src/__tests__/cli-installer.test.ts` in `packages/app`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`
- [x] `bash skills/plan-to-invoker/scripts/skill-doctor.sh plans/plan-to-invoker-review-gate-positive.yaml`
- [x] `bash scripts/test-suites/required/10-vitest-workspace.sh`
- [x] `bash scripts/test-suites/required/19-task-new-attempt-reset-repro.sh`
- [x] `bash scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh`

## Visual Proof

Static mock of the updated review-artifact list layout in `TaskPanel`.

![Review artifact list proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-093cb0/review-gate-ui-proof.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 517013805`
- Post-revert steps: None
- Data migration? No
