### PR TITLE
[Crabbox SSH](6) docs and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,29 @@ tasks:
 
 Use this when you want Invoker to spread work across machines you already manage. The SSH executor does not provision the hosts for you; it connects to the target you name and runs there.
 
+### Crabbox-backed SSH targets
+
+When you don't have a host ready, a `type: crabbox` target lets Invoker lease one. Invoker warms up a Crabbox box, reads its SSH details, then runs the **same SSH executor** against it — tasks still use `runnerKind: ssh`, never `runnerKind: crabbox`.
+
+```json
+"remoteTargets": {
+  "crab-builder": {
+    "type": "crabbox",
+    "crabboxCommand": "crabbox",
+    "provider": "fly",
+    "class": "performance-4x",
+    "ttl": "30m",
+    "idleTimeout": "10m",
+    "network": "default",
+    "target": "ubuntu-22",
+    "stopAfter": "success",
+    "keepOnFailure": true
+  }
+}
+```
+
+`stopAfter` controls when Invoker stops the lease (`success`/`failure`/`always`/`never`). `keepOnFailure: true` keeps a failed task's box alive so you can debug it — but it does **not** override Crabbox's own `ttl` or `idleTimeout`, so a kept box still goes away on its own. To inspect or clean up a kept lease: `crabbox ssh --id <lease>` and `crabbox stop <lease>`. Full details: [docs/remote-ssh-targets.md](docs/remote-ssh-targets.md#crabbox-backed-targets).
+
 ## Quick start
 
 For a guided first run, use [the first agent workflow tutorial](docs/tutorial-first-agent-workflow.md). It gives you a toy repo and exact UI checkpoints.

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -42,6 +42,20 @@
       "remoteInvokerHome": "~/.invoker",
       "provisionCommand": "pnpm install --frozen-lockfile",
       "remoteHeartbeatIntervalSeconds": 30
+    },
+    "crab-builder": {
+      "comment": "Crabbox-backed target: Invoker leases a box, then runs the normal SSH executor against it. Tasks still use runnerKind: ssh and poolMemberId: crab-builder.",
+      "type": "crabbox",
+      "crabboxCommand": "crabbox",
+      "provider": "fly",
+      "class": "performance-4x",
+      "ttl": "30m",
+      "idleTimeout": "10m",
+      "network": "default",
+      "target": "ubuntu-22",
+      "stopAfter": "success",
+      "keepOnFailure": true,
+      "port": 22
     }
   },
 

--- a/docs/remote-ssh-targets.md
+++ b/docs/remote-ssh-targets.md
@@ -77,6 +77,77 @@ tasks:
 
 This is the supported way to run multiple SSH executors in one workflow: define multiple targets, then attach different tasks to different target IDs.
 
+## Crabbox-backed Targets
+
+Crabbox is a machine supplier. Invoker leases a box from Crabbox first, then runs the **same SSH executor** against it. There is no `runnerKind: crabbox` — tasks still use `runnerKind: ssh`. The only difference is the target config: it has `type: crabbox`, so Invoker warms up a lease and reads its SSH host/user/key before connecting.
+
+Add a Crabbox target under `remoteTargets`:
+
+```json
+{
+  "remoteTargets": {
+    "crab-builder": {
+      "type": "crabbox",
+      "crabboxCommand": "crabbox",
+      "provider": "fly",
+      "class": "performance-4x",
+      "ttl": "30m",
+      "idleTimeout": "10m",
+      "network": "default",
+      "target": "ubuntu-22",
+      "stopAfter": "success",
+      "keepOnFailure": true,
+      "port": 22
+    }
+  }
+}
+```
+
+Tasks reference it exactly like any other SSH target:
+
+```yaml
+tasks:
+  - id: build
+    description: "Build on a leased Crabbox machine"
+    command: "pnpm run build"
+    runnerKind: ssh
+    poolMemberId: crab-builder
+```
+
+### Lifecycle
+
+1. Invoker runs `crabbox warmup ...` to create or find the leased machine.
+2. It reads the lease's SSH host, user, and key from `crabbox status`.
+3. The normal `SshExecutor` connects and runs the task command.
+4. After the task settles, Invoker stops the lease based on `stopAfter` and `keepOnFailure`.
+
+### Cleanup policy
+
+`stopAfter` decides when Invoker stops the lease after a task finishes:
+
+| Value | Stops the lease when |
+|-------|----------------------|
+| `success` | the task succeeded (default — don't leak machines) |
+| `failure` | the task failed |
+| `always` | the task succeeded or failed |
+| `never` | never; you stop it yourself |
+
+`keepOnFailure: true` (default) overrides `stopAfter` on failure: a failed task's machine is kept alive so you can SSH in and debug. With `keepOnFailure: false`, failures follow `stopAfter` like any other outcome.
+
+> **Warning:** `keepOnFailure` only keeps Invoker from stopping the lease. It does **not** defeat Crabbox's own `ttl` (lease time-to-live) or `idleTimeout` cleanup. A kept machine still disappears once its TTL expires or it sits idle past the idle timeout. Debug it promptly, or raise `ttl`/`idleTimeout` for that target.
+
+### Recovery commands
+
+When a lease is kept after a failure, Invoker logs the lease id. To inspect or clean it up manually:
+
+```bash
+# Open an interactive SSH session to the kept lease
+crabbox ssh --id <lease>
+
+# Stop (release) the lease when you're done debugging
+crabbox stop <lease>
+```
+
 ## Usage in Plans
 
 Reference a remote target in a plan YAML task:


### PR DESCRIPTION
## Summary

This adds operator docs and safe examples for using Crabbox as a machine supplier behind Invoker's existing SSH executor.

The docs show a static SSH target and a Crabbox-backed target side by side, so readers see Crabbox is just a source of remote machines, not a new runner kind.

The documented runtime shape stays `runnerKind: ssh`. A Crabbox target only changes where the machine comes from, while Invoker still owns the workflow and the SSH session.

The docs also cover failure recovery. A failed lease is kept so you can reconnect, with the exact `crabbox ssh --id` and `crabbox stop` recovery steps.

They also note leases still expire on TTL or idle timeout.

<details>
<summary>Review metadata</summary>

Review Claim: Approve that the docs describe Crabbox-backed SSH targets correctly and keep `runnerKind: ssh` as the only documented executor shape.

Review Lane: docs

Review Unit: docs

Safety Invariant: Docs and example files only; no runtime or behavior changes, so this slice is safe to review on its own.

Slice Rationale: This step owns only operator-facing docs and examples; the runtime resolver and terminal work ship in earlier steps of the stack.

</details>

## Non-goals

- No runtime code changes; no new executor or runner kind.
- Does not add a Crabbox provider integration in code.
- Does not change SSH pool resolution behavior.

## Test Plan

- [ ] `grep -q '"type": "crabbox"' docs/remote-ssh-targets.md`
- [ ] `grep -q 'runnerKind: ssh' docs/remote-ssh-targets.md`
- [ ] `grep -q 'crabbox ssh --id' docs/remote-ssh-targets.md`
- [ ] `grep -q 'crabbox stop' docs/remote-ssh-targets.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Crabbox-backed SSH remote targets, including configuration fields, lease lifecycle controls, and cleanup procedures
  * Included configuration examples demonstrating `crabbox` type setup with provider, class, TTL, and idle timeout settings
  * Added recovery commands for inspecting and managing leased machines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->