### PR TITLE
INV-198 Enforce headless set registry invariant

### DIFF
--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  HEADLESS_SET_SUBCOMMANDS,
+  formatHeadlessSetSubcommands,
+} from '../headless-command-registry.js';
 import {
   isHeadlessMutatingCommand,
   isHeadlessReadOnlyCommand,
@@ -6,8 +10,13 @@ import {
   resolveHeadlessTargetWorkflowId,
   type HeadlessTargetLookup,
 } from '../headless-command-classification.js';
+import { runHeadless } from '../headless.js';
 
 describe('headless-command-classification', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   const targetLookup: HeadlessTargetLookup = {
     loadWorkflow: (workflowId) => workflowId === 'wf-1' ? { id: workflowId } as any : undefined,
     listWorkflows: () => [{ id: 'wf-1' } as any, { id: 'wf-2' } as any],
@@ -44,6 +53,36 @@ describe('headless-command-classification', () => {
     expect(isHeadlessMutatingCommand(['set', 'agent'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'fix-context'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'xyz'])).toBe(false);
+  });
+
+  it('classifies every registered set subcommand as mutating', () => {
+    for (const subcommand of HEADLESS_SET_SUBCOMMANDS) {
+      expect(isHeadlessMutatingCommand(['set', subcommand])).toBe(true);
+    }
+
+    expect(isHeadlessMutatingCommand(['set', 'xyz'])).toBe(false);
+    expect(isHeadlessMutatingCommand(['set'])).toBe(false);
+  });
+
+  it('derives set subcommand errors from the registry', async () => {
+    await expect(runHeadless(['set'], {} as any)).rejects.toThrow(
+      `Missing set sub-command. Usage: --headless set <${formatHeadlessSetSubcommands('|')}>`,
+    );
+    await expect(runHeadless(['set', 'xyz'], {} as any)).rejects.toThrow(
+      `Unknown set sub-command: "xyz". Use: ${formatHeadlessSetSubcommands(', ')}`,
+    );
+  });
+
+  it('documents registered public set subcommands in help output', async () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['--help'], {} as any);
+
+    const help = write.mock.calls.map(([chunk]) => String(chunk)).join('');
+    for (const subcommand of HEADLESS_SET_SUBCOMMANDS) {
+      if (subcommand === 'executor') continue;
+      expect(help).toContain(`set ${subcommand}`);
+    }
   });
 
   it('resolves workflow and task targets via lookup', () => {

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -9,6 +9,7 @@ export interface HeadlessCommandDefinition {
 export const HEADLESS_SET_SUBCOMMANDS = [
   'command',
   'prompt',
+  'pool',
   'executor',
   'agent',
   'merge-mode',
@@ -18,6 +19,10 @@ export const HEADLESS_SET_SUBCOMMANDS = [
   'workflow',
   'task',
 ] as const;
+
+export function formatHeadlessSetSubcommands(separator: string): string {
+  return HEADLESS_SET_SUBCOMMANDS.join(separator);
+}
 
 export const HEADLESS_COMMANDS = [
   { name: 'owner-serve', kind: 'special' },

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -61,6 +61,7 @@ import {
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import { RECOVERY_WORKER_KIND } from './worker-runtime.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
+import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
@@ -957,7 +958,7 @@ async function headlessCostEvents(
 async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing set sub-command. Usage: --headless set <command|prompt|pool|agent|merge-mode|gate-policy|workflow|task>');
+    throw new Error(`Missing set sub-command. Usage: --headless set <${formatHeadlessSetSubcommands('|')}>`);
   }
 
   switch (subCommand) {
@@ -994,7 +995,7 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
       await headlessSetTaskMetadata(args[1], args[2], args.slice(3).join(' '), deps);
       break;
     default:
-      throw new Error(`Unknown set sub-command: "${subCommand}". Use: command, prompt, executor, agent, merge-mode, fix-prompt, fix-context, gate-policy, workflow, task`);
+      throw new Error(`Unknown set sub-command: "${subCommand}". Use: ${formatHeadlessSetSubcommands(', ')}`);
   }
 }
 


### PR DESCRIPTION
Fixes https://linear.app/invokerorchestrator/issue/INV-198/enforce-headless-set-subcommand-registry-invariant

Tests:
- pnpm --filter @invoker/app exec vitest run src/__tests__/headless-command-classification.test.ts
- pnpm run check:types
- pnpm run check:all