### PR TITLE
Align UI running status with queue semantics

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -14,6 +14,7 @@ import yaml from 'js-yaml';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { ActionGraphNode, TerminalSessionDescriptor } from '@invoker/contracts';
 import { useTasks } from './hooks/useTasks.js';
+import { useQueueStatus } from './hooks/useQueueStatus.js';
 import { useInvoker } from './hooks/useInvoker.js';
 import { TaskDAG } from './components/TaskDAG.js';
 import { HistoryView } from './components/HistoryView.js';
@@ -375,6 +376,11 @@ export function App() {
     onTaskGraphSnapshotApplied: handleTaskGraphSnapshotApplied,
   });
   const invoker = useInvoker();
+  const queueStatus = useQueueStatus();
+  const runningTaskIds = useMemo(
+    () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
+    [queueStatus],
+  );
   const fileInputRef = useRef<HTMLInputElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
@@ -1847,6 +1853,7 @@ export function App() {
               {viewMode === 'queue' ? (
                 <QueueView
                   tasks={tasks}
+                  queueStatus={queueStatus}
                   onTaskClick={handleTaskClick}
                   onCancel={handleCancelTask}
                   selectedTaskId={selectedTaskId}
@@ -1901,6 +1908,7 @@ export function App() {
                           onTaskContextMenu={handleTaskContextMenu}
                           onManualViewport={handleManualViewport}
                           statusFilters={new Set()}
+                          runningTaskIds={runningTaskIds}
                         />
                       </div>
                     </FloatingGraphPanel>
@@ -1918,6 +1926,7 @@ export function App() {
               >
                 <StatusBar
                   tasks={tasks}
+                  queueStatus={queueStatus}
                   activeFilters={statusFilters}
                   keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
                   onStatusClick={(filterKey, event) => handleStatusClick(filterKey as WorkflowStatus, event)}

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -1,12 +1,30 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { QueueView } from '../components/QueueView.js';
 import { makeUITask } from './helpers/mock-invoker.js';
-import type { TaskState } from '../types.js';
+import type { QueueStatus, TaskState } from '../types.js';
 
 describe('QueueView', () => {
   const onTaskClick = vi.fn();
   const onCancel = vi.fn();
+  const EMPTY_QUEUE_STATUS: QueueStatus = {
+    maxConcurrency: 0,
+    runningCount: 0,
+    running: [],
+    queued: [],
+  };
+
+  function renderQueueView(tasks: Map<string, TaskState>, queueStatus: QueueStatus, selectedTaskId: string | null = null) {
+    render(
+      <QueueView
+        tasks={tasks}
+        queueStatus={queueStatus}
+        onTaskClick={onTaskClick}
+        onCancel={onCancel}
+        selectedTaskId={selectedTaskId}
+      />,
+    );
+  }
 
   beforeEach(() => {
     onTaskClick.mockReset();
@@ -18,7 +36,7 @@ describe('QueueView', () => {
     vi.unstubAllGlobals();
   });
 
-  it('renders action queue in running-then-queued order and separates backlog', async () => {
+  it('renders action queue in running-then-queued order and separates backlog', () => {
     const runningTask = makeUITask({
       id: 'wf-1/running-task',
       status: 'running',
@@ -41,40 +59,54 @@ describe('QueueView', () => {
       [queuedTask.id, queuedTask],
       [blockedTask.id, blockedTask],
     ]);
-
-    const getQueueStatus = vi.fn(async () => ({
+    const queueStatus: QueueStatus = {
       maxConcurrency: 6,
       runningCount: 1,
       running: [{ taskId: runningTask.id, description: runningTask.description }],
       queued: [{ taskId: queuedTask.id, priority: 0, description: queuedTask.description }],
-    }));
-    (window as unknown as { invoker: unknown }).invoker = { getQueueStatus };
+    };
 
-    render(
-      <QueueView
-        tasks={tasks}
-        onTaskClick={onTaskClick}
-        onCancel={onCancel}
-        selectedTaskId={null}
-      />,
-    );
+    renderQueueView(tasks, queueStatus);
 
-    await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
     expect(screen.getByText('Action Queue (2)')).toBeInTheDocument();
     expect(screen.getByText('Backlog (1)')).toBeInTheDocument();
     expect(screen.getByText('#1')).toBeInTheDocument();
     expect(screen.getByText('#2')).toBeInTheDocument();
-    // Canonical status labels instead of raw "running"/"queued"
     expect(screen.getByText('Running')).toBeInTheDocument();
     expect(screen.getByText('Pending')).toBeInTheDocument();
     expect(screen.getByText('phase: Executing')).toBeInTheDocument();
     expect(screen.getByText('priority: 0')).toBeInTheDocument();
     expect(screen.getByText('deps: running-task')).toBeInTheDocument();
-    // Backlog rows now show canonical status badge
     expect(screen.getByText('Blocked')).toBeInTheDocument();
   });
 
-  it('supports click-through and cancel actions in queue rows', async () => {
+  it('renders queue-running launching tasks as Running with launching phase copy', () => {
+    const launchingTask = makeUITask({
+      id: 'wf-1/launching-task',
+      status: 'pending',
+      description: 'launching task',
+      execution: { phase: 'launching', selectedAttemptId: 'wf-1/launching-task-a1' },
+    });
+    const tasks = new Map<string, TaskState>([[launchingTask.id, launchingTask]]);
+    const queueStatus: QueueStatus = {
+      maxConcurrency: 6,
+      runningCount: 1,
+      running: [{ taskId: launchingTask.id, description: launchingTask.description }],
+      queued: [],
+    };
+
+    renderQueueView(tasks, queueStatus);
+
+    expect(screen.getByText('Running 1 / 6')).toBeInTheDocument();
+    expect(screen.getByText('Running includes launching and AI-fix work.')).toBeInTheDocument();
+    expect(screen.getByText('Running')).toBeInTheDocument();
+    expect(screen.getByText('phase: Launching')).toBeInTheDocument();
+    const row = screen.getByText('launching-task').closest('[data-row-id]');
+    expect(row).not.toBeNull();
+    expect(row).not.toHaveTextContent('Pending');
+  });
+
+  it('supports click-through and cancel actions in queue rows', () => {
     const runningTask = makeUITask({
       id: 'wf-1/run-all-fixture-tests',
       status: 'running',
@@ -90,74 +122,40 @@ describe('QueueView', () => {
       [runningTask.id, runningTask],
       [queuedTask.id, queuedTask],
     ]);
-
-    const getQueueStatus = vi.fn(async () => ({
+    const queueStatus: QueueStatus = {
       maxConcurrency: 6,
       runningCount: 1,
       running: [{ taskId: runningTask.id, description: runningTask.description }],
       queued: [{ taskId: queuedTask.id, priority: 1, description: queuedTask.description }],
-    }));
-    (window as unknown as { invoker: unknown }).invoker = { getQueueStatus };
+    };
 
-    render(
-      <QueueView
-        tasks={tasks}
-        onTaskClick={onTaskClick}
-        onCancel={onCancel}
-        selectedTaskId={null}
-      />,
-    );
-
-    await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
+    renderQueueView(tasks, queueStatus);
 
     fireEvent.click(screen.getByText('run-all-fixture-tests'));
     expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: runningTask.id }));
 
     fireEvent.click(screen.getAllByText('Terminate')[0]);
     expect(onCancel).toHaveBeenCalledWith(runningTask.id);
-    // Confirm dialog uses display-friendly task ID, not raw ID
-    expect(window.confirm).toHaveBeenCalledWith(
-      expect.stringContaining('run-all-fixture-tests'),
-    );
-    expect(window.confirm).not.toHaveBeenCalledWith(
-      expect.stringContaining('wf-1/'),
-    );
+    expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('run-all-fixture-tests'));
+    expect(window.confirm).not.toHaveBeenCalledWith(expect.stringContaining('wf-1/'));
   });
 
-  it('renders merge gate ids with a stable label', async () => {
+  it('renders merge gate ids with a stable label', () => {
     const mergeGateTask = makeUITask({
       id: '__merge__wf-123',
       status: 'blocked',
       description: 'Workflow gate for queued merge',
       dependencies: ['wf-1/build'],
     });
-    const tasks = new Map<string, TaskState>([
-      [mergeGateTask.id, mergeGateTask],
-    ]);
+    const tasks = new Map<string, TaskState>([[mergeGateTask.id, mergeGateTask]]);
 
-    const getQueueStatus = vi.fn(async () => ({
-      maxConcurrency: 6,
-      runningCount: 0,
-      running: [],
-      queued: [],
-    }));
-    (window as unknown as { invoker: unknown }).invoker = { getQueueStatus };
+    renderQueueView(tasks, EMPTY_QUEUE_STATUS);
 
-    render(
-      <QueueView
-        tasks={tasks}
-        onTaskClick={onTaskClick}
-        onCancel={onCancel}
-        selectedTaskId={null}
-      />,
-    );
-
-    await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
     expect(screen.getByText('merge gate')).toBeInTheDocument();
     expect(screen.queryByText('__merge__wf-123')).not.toBeInTheDocument();
   });
 
-  it('places manual-action tasks in Action Queue with canonical labels', async () => {
+  it('places manual-action tasks in Action Queue with canonical labels', () => {
     const fixingTask = makeUITask({
       id: 'wf-1/fixing-task',
       status: 'fixing_with_ai',
@@ -192,67 +190,33 @@ describe('QueueView', () => {
       [blockedTask.id, blockedTask],
     ]);
 
-    const getQueueStatus = vi.fn(async () => ({
-      maxConcurrency: 6,
-      runningCount: 0,
-      running: [],
-      queued: [],
-    }));
-    (window as unknown as { invoker: unknown }).invoker = { getQueueStatus };
+    renderQueueView(tasks, EMPTY_QUEUE_STATUS);
 
-    render(
-      <QueueView
-        tasks={tasks}
-        onTaskClick={onTaskClick}
-        onCancel={onCancel}
-        selectedTaskId={null}
-      />,
-    );
-
-    await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
-
-    // All manual-action tasks land in Action Queue
     expect(screen.getByText('Action Queue (4)')).toBeInTheDocument();
     expect(screen.getByText('Backlog (1)')).toBeInTheDocument();
-
-    // Canonical status labels
     expect(screen.getByText('Fixing With AI')).toBeInTheDocument();
     expect(screen.getByText('Needs Input')).toBeInTheDocument();
     expect(screen.getByText('Review Ready')).toBeInTheDocument();
     expect(screen.getByText('Awaiting Approval')).toBeInTheDocument();
-
-    // Blocked task stays in backlog
     expect(screen.getByText('blocked by something')).toBeInTheDocument();
   });
 
-  it('shows pending tasks in Action Queue when scheduler-queued with canonical Pending label', async () => {
+  it('shows pending tasks in Action Queue when scheduler-queued with canonical Pending label', () => {
     const pendingTask = makeUITask({
       id: 'wf-1/pending-task',
       status: 'pending',
       description: 'waiting to run',
     });
-    const tasks = new Map<string, TaskState>([
-      [pendingTask.id, pendingTask],
-    ]);
-
-    const getQueueStatus = vi.fn(async () => ({
+    const tasks = new Map<string, TaskState>([[pendingTask.id, pendingTask]]);
+    const queueStatus: QueueStatus = {
       maxConcurrency: 6,
       runningCount: 0,
       running: [],
       queued: [{ taskId: pendingTask.id, priority: 5, description: pendingTask.description }],
-    }));
-    (window as unknown as { invoker: unknown }).invoker = { getQueueStatus };
+    };
 
-    render(
-      <QueueView
-        tasks={tasks}
-        onTaskClick={onTaskClick}
-        onCancel={onCancel}
-        selectedTaskId={null}
-      />,
-    );
+    renderQueueView(tasks, queueStatus);
 
-    await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
     expect(screen.getByText('Action Queue (1)')).toBeInTheDocument();
     expect(screen.getByText('Backlog (0)')).toBeInTheDocument();
     expect(screen.getByText('Pending')).toBeInTheDocument();
@@ -261,8 +225,6 @@ describe('QueueView', () => {
 
   describe('relationship expander', () => {
     function setupRelationshipScenario() {
-      // A -> B -> C chain: A has no deps, B depends on A, C depends on B.
-      // This gives A downstream=[B], B upstream=[A] downstream=[C], C upstream=[B].
       const taskA = makeUITask({
         id: 'wf-1/task-a',
         status: 'running',
@@ -286,175 +248,99 @@ describe('QueueView', () => {
         [taskB.id, taskB],
         [taskC.id, taskC],
       ]);
-
-      const getQueueStatus = vi.fn(async () => ({
+      const queueStatus: QueueStatus = {
         maxConcurrency: 6,
         runningCount: 1,
         running: [{ taskId: taskA.id, description: taskA.description }],
         queued: [],
-      }));
-      (window as unknown as { invoker: unknown }).invoker = { getQueueStatus };
+      };
 
-      return { tasks, taskA, taskB, taskC, getQueueStatus };
+      return { tasks, taskA, taskB, taskC, queueStatus };
     }
 
-    it('relationships are collapsed by default', async () => {
-      const { tasks, getQueueStatus } = setupRelationshipScenario();
+    it('relationships are collapsed by default', () => {
+      const { tasks, queueStatus } = setupRelationshipScenario();
 
-      render(
-        <QueueView
-          tasks={tasks}
-          onTaskClick={onTaskClick}
-          onCancel={onCancel}
-          selectedTaskId={null}
-        />,
-      );
+      renderQueueView(tasks, queueStatus);
 
-      await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
-
-      // The rels toggle buttons should be present (tasks have relationships).
-      // task-a is in Action Queue; task-b and task-c are in Backlog.
       expect(screen.getByTestId('queue-rels-toggle-action-wf-1/task-a')).toBeInTheDocument();
       expect(screen.getByTestId('queue-rels-toggle-backlog-wf-1/task-b')).toBeInTheDocument();
       expect(screen.getByTestId('queue-rels-toggle-backlog-wf-1/task-c')).toBeInTheDocument();
-
-      // But no upstream/downstream labels should be visible (collapsed)
       expect(screen.queryByText('upstream:')).not.toBeInTheDocument();
       expect(screen.queryByText('downstream:')).not.toBeInTheDocument();
     });
 
-    it('clicking expander toggles relationship section per row', async () => {
-      const { tasks, getQueueStatus } = setupRelationshipScenario();
+    it('clicking expander toggles relationship section per row', () => {
+      const { tasks, queueStatus } = setupRelationshipScenario();
 
-      render(
-        <QueueView
-          tasks={tasks}
-          onTaskClick={onTaskClick}
-          onCancel={onCancel}
-          selectedTaskId={null}
-        />,
-      );
+      renderQueueView(tasks, queueStatus);
 
-      await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
-
-      // task-a is in Action Queue; it has downstream only (task-b depends on it).
-      // Expand task-a's relationships.
       const expandButtons = screen.getAllByLabelText('Expand relationships');
-      // Click the first one (task-a in Action Queue)
       fireEvent.click(expandButtons[0]);
 
-      // Now the relationship section for task-a should appear
       const relsSection = screen.getByTestId('rels-wf-1/task-a');
       expect(relsSection).toBeInTheDocument();
       expect(relsSection.textContent).toContain('downstream:');
       expect(relsSection.textContent).toContain('task-b');
 
-      // Click again to collapse
       const collapseButton = screen.getByLabelText('Collapse relationships');
       fireEvent.click(collapseButton);
       expect(screen.queryByTestId('rels-wf-1/task-a')).not.toBeInTheDocument();
     });
 
-    it('shows both upstream and downstream in expanded row', async () => {
-      const { tasks, getQueueStatus } = setupRelationshipScenario();
+    it('shows both upstream and downstream in expanded row', () => {
+      const { tasks, queueStatus } = setupRelationshipScenario();
 
-      render(
-        <QueueView
-          tasks={tasks}
-          onTaskClick={onTaskClick}
-          onCancel={onCancel}
-          selectedTaskId={null}
-        />,
-      );
+      renderQueueView(tasks, queueStatus);
 
-      await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
-
-      // task-b is in Backlog (blocked), has upstream=[task-a] and downstream=[task-c].
-      // Find the rels button for task-b in backlog.
-      // The backlog has task-b and task-c. task-b has both directions.
       const expandButtons = screen.getAllByLabelText('Expand relationships');
-      // There should be buttons for task-a (action queue), task-b (backlog), task-c (backlog).
-      // task-a has only downstream, task-b has both, task-c has only upstream.
-      // Expand task-b (second expand button, index 1)
       fireEvent.click(expandButtons[1]);
 
       expect(screen.getByText('upstream:')).toBeInTheDocument();
       expect(screen.getByText('downstream:')).toBeInTheDocument();
-      // upstream chip shows task-a
       expect(screen.getByTestId('rels-wf-1/task-b')).toBeInTheDocument();
     });
 
-    it('clicking a related task chip selects and navigates to that task', async () => {
-      const { tasks, getQueueStatus } = setupRelationshipScenario();
+    it('clicking a related task chip selects and navigates to that task', () => {
+      const { tasks, queueStatus } = setupRelationshipScenario();
 
-      render(
-        <QueueView
-          tasks={tasks}
-          onTaskClick={onTaskClick}
-          onCancel={onCancel}
-          selectedTaskId={null}
-        />,
-      );
+      renderQueueView(tasks, queueStatus);
 
-      await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
-
-      // Expand task-a to see downstream task-b chip
       const expandButtons = screen.getAllByLabelText('Expand relationships');
       fireEvent.click(expandButtons[0]);
 
-      // The downstream chip for task-b is inside the rels section
       const relsSection = screen.getByTestId('rels-wf-1/task-a');
       const taskBChip = relsSection.querySelector('button');
       expect(taskBChip).not.toBeNull();
       fireEvent.click(taskBChip!);
 
-      // onTaskClick should have been called with task-b's state
-      expect(onTaskClick).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'wf-1/task-b' }),
-      );
+      expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: 'wf-1/task-b' }));
     });
 
-    it('does not show rels button for tasks with no relationships', async () => {
+    it('does not show rels button for tasks with no relationships', () => {
       const loneTask = makeUITask({
         id: 'wf-1/lone-task',
         status: 'pending',
         description: 'no deps',
         dependencies: [],
       });
-      const tasks = new Map<string, TaskState>([
-        [loneTask.id, loneTask],
-      ]);
-
-      const getQueueStatus = vi.fn(async () => ({
+      const tasks = new Map<string, TaskState>([[loneTask.id, loneTask]]);
+      const queueStatus: QueueStatus = {
         maxConcurrency: 6,
         runningCount: 0,
         running: [],
         queued: [{ taskId: loneTask.id, priority: 0, description: loneTask.description }],
-      }));
-      (window as unknown as { invoker: unknown }).invoker = { getQueueStatus };
+      };
 
-      render(
-        <QueueView
-          tasks={tasks}
-          onTaskClick={onTaskClick}
-          onCancel={onCancel}
-          selectedTaskId={null}
-        />,
-      );
+      renderQueueView(tasks, queueStatus);
 
-      await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
       expect(screen.queryByTestId('queue-rels-toggle-action-wf-1/lone-task')).not.toBeInTheDocument();
       expect(screen.queryByTestId('queue-rels-toggle-backlog-wf-1/lone-task')).not.toBeInTheDocument();
     });
   });
 
   describe('integrated queue hardening', () => {
-    it('canonical labels, expanded rels, and Terminate coexist in a composed queue', async () => {
-      // Scenario: running task with a downstream blocked dep, plus a manual-action task.
-      // Exercises all three prior-workflow features together:
-      // 1. Canonical status labels (Running, Fixing With AI, Blocked)
-      // 2. Relationship expanders (upstream/downstream chips)
-      // 3. Task-level Terminate wording on action buttons
+    it('canonical labels, expanded rels, and Terminate coexist in a composed queue', () => {
       const runningTask = makeUITask({
         id: 'wf-1/build',
         status: 'running',
@@ -480,27 +366,15 @@ describe('QueueView', () => {
         [fixingTask.id, fixingTask],
         [blockedTask.id, blockedTask],
       ]);
-
-      const getQueueStatus = vi.fn(async () => ({
+      const queueStatus: QueueStatus = {
         maxConcurrency: 4,
         runningCount: 1,
         running: [{ taskId: runningTask.id, description: runningTask.description }],
         queued: [],
-      }));
-      (window as unknown as { invoker: unknown }).invoker = { getQueueStatus };
+      };
 
-      render(
-        <QueueView
-          tasks={tasks}
-          onTaskClick={onTaskClick}
-          onCancel={onCancel}
-          selectedTaskId={null}
-        />,
-      );
+      renderQueueView(tasks, queueStatus);
 
-      await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
-
-      // 1. Canonical status labels present in both sections
       expect(screen.getByText('Action Queue (2)')).toBeInTheDocument();
       expect(screen.getByText('Backlog (1)')).toBeInTheDocument();
       expect(screen.getByText('Running')).toBeInTheDocument();
@@ -508,43 +382,33 @@ describe('QueueView', () => {
       expect(screen.getByText('Blocked')).toBeInTheDocument();
       expect(screen.getByText('phase: Executing')).toBeInTheDocument();
 
-      // 2. Relationship expanders visible on tasks with deps
       const expandButtons = screen.getAllByLabelText('Expand relationships');
-      expect(expandButtons.length).toBe(2); // build (downstream) and deploy (upstream)
+      expect(expandButtons.length).toBe(2);
 
-      // Expand the running task (build) to see downstream
       fireEvent.click(expandButtons[0]);
       const buildRels = screen.getByTestId('rels-wf-1/build');
       expect(buildRels.textContent).toContain('downstream:');
       expect(buildRels.textContent).toContain('deploy');
 
-      // Expand the blocked task (deploy) to see upstream
       fireEvent.click(expandButtons[1]);
       const deployRels = screen.getByTestId('rels-wf-1/deploy');
       expect(deployRels.textContent).toContain('upstream:');
       expect(deployRels.textContent).toContain('build');
 
-      // 3. Task-level Terminate buttons present on all action rows
       const terminateButtons = screen.getAllByText('Terminate');
-      expect(terminateButtons.length).toBe(3); // 2 action + 1 backlog
+      expect(terminateButtons.length).toBe(3);
 
-      // Click Terminate on the running task — confirm uses display-friendly ID
       fireEvent.click(terminateButtons[0]);
-      expect(window.confirm).toHaveBeenCalledWith(
-        expect.stringContaining('build'),
-      );
+      expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('build'));
       expect(onCancel).toHaveBeenCalledWith(runningTask.id);
 
-      // Navigate via relationship chip: click "deploy" chip in build's rels
       const deployChip = buildRels.querySelector('button');
       expect(deployChip).not.toBeNull();
       fireEvent.click(deployChip!);
-      expect(onTaskClick).toHaveBeenCalledWith(
-        expect.objectContaining({ id: 'wf-1/deploy' }),
-      );
+      expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: 'wf-1/deploy' }));
     });
 
-    it('selection highlight persists on expanded rows', async () => {
+    it('selection highlight persists on expanded rows', () => {
       const taskA = makeUITask({
         id: 'wf-1/task-a',
         status: 'running',
@@ -561,36 +425,21 @@ describe('QueueView', () => {
         [taskA.id, taskA],
         [taskB.id, taskB],
       ]);
-
-      const getQueueStatus = vi.fn(async () => ({
+      const queueStatus: QueueStatus = {
         maxConcurrency: 4,
         runningCount: 1,
         running: [{ taskId: taskA.id, description: taskA.description }],
         queued: [],
-      }));
-      (window as unknown as { invoker: unknown }).invoker = { getQueueStatus };
+      };
 
-      // Render with task-a selected
-      render(
-        <QueueView
-          tasks={tasks}
-          onTaskClick={onTaskClick}
-          onCancel={onCancel}
-          selectedTaskId="wf-1/task-a"
-        />,
-      );
+      renderQueueView(tasks, queueStatus, 'wf-1/task-a');
 
-      await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
-
-      // The selected row should have bg-gray-600 highlight
       const selectedRow = screen.getByText('task-a').closest('[data-row-id]');
       expect(selectedRow?.className).toContain('bg-gray-600');
 
-      // Expand relationships on the selected row
       const expandButtons = screen.getAllByLabelText('Expand relationships');
       fireEvent.click(expandButtons[0]);
 
-      // Selection highlight still applies after expansion
       expect(selectedRow?.className).toContain('bg-gray-600');
       expect(screen.getByTestId('rels-wf-1/task-a')).toBeInTheDocument();
     });

--- a/packages/ui/src/__tests__/status-bar-click.test.tsx
+++ b/packages/ui/src/__tests__/status-bar-click.test.tsx
@@ -178,6 +178,44 @@ describe('StatusBar click behavior', () => {
       expect(mockOnStatusClick).toHaveBeenCalledWith('blocked', expect.any(Object));
     });
   });
+  describe('queue running counts', () => {
+    it('uses queue-running semantics for counts and keeps the running pill clickable', () => {
+      const task: TaskState = {
+        id: 'wf-1/launching-task',
+        description: 'Launching task',
+        status: 'pending',
+        dependencies: [],
+        createdAt: new Date(),
+        config: {},
+        execution: {
+          phase: 'launching',
+          selectedAttemptId: 'wf-1/launching-task-a1',
+        },
+      } as TaskState;
+      const tasks = new Map<string, TaskState>([[task.id, task]]);
+
+      render(
+        <StatusBar
+          tasks={tasks}
+          queueStatus={{
+            maxConcurrency: 6,
+            runningCount: 1,
+            running: [{ taskId: task.id, description: task.description }],
+            queued: [],
+          }}
+          onStatusClick={mockOnStatusClick}
+        />,
+      );
+
+      expect(screen.getByTestId('status-bar-pill-running')).toHaveTextContent('Running: 1');
+      expect(screen.getByTestId('status-bar-pill-pending')).toHaveTextContent('Pending: 0');
+      expect(screen.getByText('Running includes launching and AI-fix work.')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('status-bar-pill-running'));
+      expect(mockOnStatusClick).toHaveBeenCalledWith('running', expect.any(Object));
+    });
+  });
+
 
   describe('Edge cases', () => {
     it('does not crash when onStatusClick is undefined', () => {

--- a/packages/ui/src/__tests__/task-dag.test.tsx
+++ b/packages/ui/src/__tests__/task-dag.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import * as ReactFlowModule from '@xyflow/react';
+import { TaskDAG } from '../components/TaskDAG.js';
+import { makeUITask } from './helpers/mock-invoker.js';
+import type { TaskState, WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  // Vitest hoists mock factories before static helper imports initialize.
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
+const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
+const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
+
+describe('TaskDAG running filters', () => {
+  beforeEach(() => {
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    getZoomMock.mockReset();
+    getZoomMock.mockReturnValue(1);
+  });
+
+  it('keeps queue-running launching tasks visible under the running filter', async () => {
+    const launchingTask = makeUITask({
+      id: 'wf-1/launching-task',
+      workflowId: 'wf-1',
+      status: 'pending',
+      description: 'launching task',
+      execution: { phase: 'launching', selectedAttemptId: 'wf-1/launching-task-a1' },
+    });
+    const pendingTask = makeUITask({
+      id: 'wf-1/pending-task',
+      workflowId: 'wf-1',
+      status: 'pending',
+      description: 'pending task',
+      dependencies: ['wf-1/launching-task'],
+    });
+    const tasks = new Map<string, TaskState>([
+      [launchingTask.id, launchingTask],
+      [pendingTask.id, pendingTask],
+    ]);
+    const workflows = new Map<string, WorkflowMeta>([
+      ['wf-1', { id: 'wf-1', name: 'wf-1', status: 'running' }],
+    ]);
+
+    render(
+      <TaskDAG
+        tasks={tasks}
+        workflows={workflows}
+        statusFilters={new Set(['running'])}
+        runningTaskIds={new Set([launchingTask.id])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`rf__node-${launchingTask.id}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`rf__node-${pendingTask.id}`)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('RUNNING · LAUNCHING')).toBeInTheDocument();
+
+    const launchingNode = screen.getByTestId(`rf__node-${launchingTask.id}`).firstElementChild as HTMLElement;
+    const pendingNode = screen.getByTestId(`rf__node-${pendingTask.id}`).firstElementChild as HTMLElement;
+
+    expect(launchingNode.className).not.toContain('opacity-20');
+    expect(pendingNode.className).toContain('opacity-20');
+  });
+});

--- a/packages/ui/src/components/QueueView.tsx
+++ b/packages/ui/src/components/QueueView.tsx
@@ -9,8 +9,8 @@
  * Backlog shows blocked or otherwise non-actionable tasks.
  */
 
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import type { TaskState } from '../types.js';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import type { QueueStatus, TaskState } from '../types.js';
 import {
   getRunningPhaseLabel,
   getStatusColor,
@@ -20,16 +20,10 @@ import {
 
 interface QueueViewProps {
   tasks: Map<string, TaskState>;
+  queueStatus: QueueStatus | null;
   onTaskClick: (task: TaskState) => void;
   onCancel: (taskId: string) => void;
   selectedTaskId: string | null;
-}
-
-interface QueueStatus {
-  maxConcurrency: number;
-  runningCount: number;
-  running: Array<{ taskId: string; description: string; attemptId?: string }>;
-  queued: Array<{ taskId: string; priority: number; description: string }>;
 }
 
 function displayTaskId(taskId: string): string {
@@ -49,9 +43,18 @@ const MANUAL_ACTION_STATUSES = new Set([
   'review_ready',
   'awaiting_approval',
 ]);
+type QueueRowSource = 'running' | 'queued' | 'manual';
 
-export function QueueView({ tasks, onTaskClick, onCancel, selectedTaskId }: QueueViewProps) {
-  const [queueStatus, setQueueStatus] = useState<QueueStatus | null>(null);
+type QueueRow = {
+  taskId: string;
+  description: string;
+  order: number;
+  source: QueueRowSource;
+  attemptId?: string;
+  priority?: number;
+};
+
+export function QueueView({ tasks, queueStatus, onTaskClick, onCancel, selectedTaskId }: QueueViewProps) {
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
@@ -93,25 +96,6 @@ export function QueueView({ tasks, onTaskClick, onCancel, selectedTaskId }: Queu
     [tasks, onTaskClick],
   );
 
-  useEffect(() => {
-    let cancelled = false;
-
-    const poll = async () => {
-      try {
-        const status = await window.invoker?.getQueueStatus();
-        if (!cancelled && status) setQueueStatus(status);
-      } catch {
-        // ignore polling errors
-      }
-    };
-
-    poll();
-    const interval = setInterval(poll, 2000);
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
-  }, []);
 
   const handleCancel = useCallback(
     (taskId: string) => {
@@ -121,26 +105,38 @@ export function QueueView({ tasks, onTaskClick, onCancel, selectedTaskId }: Queu
     [onCancel],
   );
 
-  const actionRows = useMemo(() => {
+  const actionRows = useMemo<QueueRow[]>(() => {
     const schedulerTaskIds = new Set<string>();
 
-    const running = (queueStatus?.running ?? []).map((job, idx) => {
+    const running: QueueRow[] = (queueStatus?.running ?? []).map((job, idx) => {
       schedulerTaskIds.add(job.taskId);
-      return { ...job, order: idx + 1 };
+      return {
+        taskId: job.taskId,
+        description: job.description,
+        attemptId: job.attemptId,
+        order: idx + 1,
+        source: 'running',
+      };
     });
 
-    const queued = (queueStatus?.queued ?? []).map((job, idx) => {
+    const queued: QueueRow[] = (queueStatus?.queued ?? []).map((job, idx) => {
       schedulerTaskIds.add(job.taskId);
-      return { taskId: job.taskId, description: job.description, priority: job.priority, order: running.length + idx + 1 };
+      return {
+        taskId: job.taskId,
+        description: job.description,
+        priority: job.priority,
+        order: running.length + idx + 1,
+        source: 'queued',
+      };
     });
 
-    // Manual-action tasks not already in the scheduler queue
-    const manualAction = Array.from(tasks.values())
+    const manualAction: QueueRow[] = Array.from(tasks.values())
       .filter((t) => MANUAL_ACTION_STATUSES.has(t.status) && !schedulerTaskIds.has(t.id))
       .map((t, idx) => ({
         taskId: t.id,
         description: t.description,
         order: running.length + queued.length + idx + 1,
+        source: 'manual',
       }));
 
     return [...running, ...queued, ...manualAction];
@@ -168,22 +164,32 @@ export function QueueView({ tasks, onTaskClick, onCancel, selectedTaskId }: Queu
           Action Queue ({actionRows.length})
         </h3>
         <div className="text-xs text-gray-400 mb-2">
-          Running and scheduled actions, plus tasks awaiting manual action.
+          Running, scheduled, and manual-action work.
         </div>
         {queueStatus && (
-          <div className="text-xs text-gray-400 mb-2">
-            Running {queueStatus.runningCount} / {queueStatus.maxConcurrency}
-          </div>
+          <>
+            <div className="text-xs text-gray-400 mb-2">
+              Running {queueStatus.runningCount} / {queueStatus.maxConcurrency}
+            </div>
+            <div className="text-xs text-gray-400 mb-2">
+              Running includes launching and AI-fix work.
+            </div>
+          </>
         )}
 
         {actionRows.map((job) => {
           const task = tasks.get(job.taskId);
+          const runningLike = job.source === 'running';
           const visualStatus = task
-            ? getEffectiveVisualStatus(task.status, task.execution)
+            ? getEffectiveVisualStatus(task.status, task.execution, { runningLike })
             : 'pending';
-          const statusLabel = task ? formatStatusLabel(task.status) : 'Pending';
+          const statusLabel = runningLike ? 'Running' : task ? formatStatusLabel(task.status) : 'Pending';
           const colors = getStatusColor(visualStatus);
-          const phaseLabel = task?.status === 'running' ? getRunningPhaseLabel(task.execution.phase) : null;
+          const phaseLabel = runningLike
+            ? getRunningPhaseLabel(task?.execution.phase)
+            : task?.status === 'running'
+              ? getRunningPhaseLabel(task.execution.phase)
+              : null;
           const isExpanded = expandedRows.has(job.taskId);
           const upstream = task?.dependencies ?? [];
           const downstream = dependentsMap.get(job.taskId) ?? [];
@@ -224,8 +230,8 @@ export function QueueView({ tasks, onTaskClick, onCancel, selectedTaskId }: Queu
                   {phaseLabel && (
                     <span className="text-xs text-amber-300 truncate block">phase: {phaseLabel}</span>
                   )}
-                  {'priority' in job && typeof (job as Record<string, unknown>).priority === 'number' && (
-                    <span className="text-xs text-cyan-300 truncate block">priority: {(job as Record<string, unknown>).priority as number}</span>
+                  {typeof job.priority === 'number' && (
+                    <span className="text-xs text-cyan-300 truncate block">priority: {job.priority}</span>
                   )}
                 </div>
                 <button

--- a/packages/ui/src/components/StatusBar.tsx
+++ b/packages/ui/src/components/StatusBar.tsx
@@ -6,19 +6,20 @@
  * Status labels are clickable to filter DAG nodes by status.
  */
 
-import type { TaskState } from '../types.js';
+import type { QueueStatus, TaskState } from '../types.js';
 import { getStatusVisual } from '../lib/status-colors.js';
 
 interface StatusBarProps {
   tasks: Map<string, TaskState>;
+  queueStatus?: QueueStatus | null;
   activeFilters?: Set<string>;
   keyboardActiveKey?: string | null;
   onStatusClick?: (filterKey: string, event: React.MouseEvent) => void;
 }
 
-export function StatusBar({ tasks, activeFilters, keyboardActiveKey, onStatusClick }: StatusBarProps) {
+export function StatusBar({ tasks, queueStatus, activeFilters, keyboardActiveKey, onStatusClick }: StatusBarProps) {
   let completed = 0;
-  let running = 0;
+  let running = queueStatus?.runningCount ?? 0;
   let failed = 0;
   let closed = 0;
   let pending = 0;
@@ -28,6 +29,7 @@ export function StatusBar({ tasks, activeFilters, keyboardActiveKey, onStatusCli
   let blocked = 0;
   let fixing = 0;
   let fixApproval = 0;
+  const runningTaskIds = new Set((queueStatus?.running ?? []).map((entry) => entry.taskId));
 
   for (const task of tasks.values()) {
     switch (task.status) {
@@ -37,7 +39,7 @@ export function StatusBar({ tasks, activeFilters, keyboardActiveKey, onStatusCli
       case 'running':
         if (task.execution.isFixingWithAI) {
           fixing++;
-        } else {
+        } else if (!queueStatus) {
           running++;
         }
         break;
@@ -51,7 +53,9 @@ export function StatusBar({ tasks, activeFilters, keyboardActiveKey, onStatusCli
         closed++;
         break;
       case 'pending':
-        pending++;
+        if (!runningTaskIds.has(task.id)) {
+          pending++;
+        }
         break;
       case 'needs_input':
         needsInput++;
@@ -185,6 +189,11 @@ export function StatusBar({ tasks, activeFilters, keyboardActiveKey, onStatusCli
           onClick={(e) => onStatusClick?.('fixing_with_ai', e)}
         >
           Fixing: <span className="font-medium">{fixing}</span>
+        </span>
+      )}
+      {queueStatus && (
+        <span className="text-xs text-gray-400">
+          Running includes launching and AI-fix work.
         </span>
       )}
       {fixApproval > 0 && (

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -53,6 +53,7 @@ interface TaskDAGProps {
   /** Fired when the user manually pans or zooms the viewport. */
   onManualViewport?: () => void;
   statusFilters?: Set<string>;
+  runningTaskIds?: ReadonlySet<string>;
 }
 
 const nodeTypes = { taskNode: TaskNode, mergeGateNode: MergeGateNode };
@@ -151,7 +152,7 @@ function mergeMeasuredNodeState(prevNodes: Node[], nextNodes: Node[]): Node[] {
   });
 }
 
-function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskClick, onTaskDoubleClick, onTaskContextMenu, onManualViewport, statusFilters }: TaskDAGProps) {
+function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskClick, onTaskDoubleClick, onTaskContextMenu, onManualViewport, statusFilters, runningTaskIds }: TaskDAGProps) {
   const { fitView, setCenter, getZoom } = useReactFlow();
   const prevNodeCount = useRef(0);
   const lastNodeClickRef = useRef<{ id: string; at: number } | null>(null);
@@ -222,7 +223,8 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     const dimmedNodeIds = new Set<string>();
     if (statusFilters && statusFilters.size > 0) {
       for (const task of taskArray) {
-        const vs = getEffectiveVisualStatus(task.status, task.execution);
+        const runningLike = runningTaskIds?.has(task.id) === true;
+        const vs = getEffectiveVisualStatus(task.status, task.execution, { runningLike });
         if (!Array.from(statusFilters).some((filterKey) => matchesStatusFilter(filterKey, vs))) {
           dimmedNodeIds.add(task.id);
         }
@@ -240,7 +242,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       fallbackLayout: makeFallbackLayout(taskArray),
       layoutKey: layoutKeyFor(layoutTasks, rawEdges),
     };
-  }, [tasks, statusFilters]);
+  }, [runningTaskIds, tasks, statusFilters]);
 
   useEffect(() => {
     if (rawGraph.taskArray.length === 0) return;
@@ -279,7 +281,8 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       const wfMeta = workflows?.get(wfGroupId);
       const wfMergeMode = (wfMeta?.mergeMode as 'manual' | 'automatic' | 'external_review') ?? 'manual';
       const pos = activeLayout.positions.get(task.id) ?? { x: 0, y: 0 };
-      const visualStatus = getEffectiveVisualStatus(task.status, task.execution);
+      const runningLike = runningTaskIds?.has(task.id) === true;
+      const visualStatus = getEffectiveVisualStatus(task.status, task.execution, { runningLike });
       const dimmed = statusFilters
         && statusFilters.size > 0
         && !Array.from(statusFilters).some((filterKey) => matchesStatusFilter(filterKey, visualStatus));
@@ -323,6 +326,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
             label: task.description,
             dimmed,
             selected: selectedTaskId === task.id,
+            runningLike,
             ...(onTaskDoubleClick ? { onDoubleClick: onTaskDoubleClick } : {}),
           },
         });
@@ -405,7 +409,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     });
 
     return { nodes: allNodes, edges: newEdges };
-  }, [activeLayout.positions, onTaskDoubleClick, rawGraph, routedEdgePoints, selectedTaskId, statusFilters, tasks, workflows]);
+  }, [activeLayout.positions, onTaskDoubleClick, rawGraph, routedEdgePoints, runningTaskIds, selectedTaskId, statusFilters, tasks, workflows]);
 
   // Merge task-derived nodes with React Flow's internal dimension state.
   // Without this, each task-delta re-render creates new node objects that discard

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -13,13 +13,14 @@
 import { Handle, Position } from '@xyflow/react';
 import type { MouseEvent } from 'react';
 import type { TaskState } from '../types.js';
-import { getStatusColor, getEffectiveVisualStatus, getRunningPhaseLabel } from '../lib/colors.js';
+import { getStatusColor, getEffectiveVisualStatus } from '../lib/colors.js';
 
 interface TaskNodeData {
   task: TaskState;
   label?: string;
   dimmed?: boolean;
   selected?: boolean;
+  runningLike?: boolean;
   onDoubleClick?: (task: TaskState) => void;
   [key: string]: unknown;
 }
@@ -32,10 +33,11 @@ export function TaskNode({ data }: TaskNodeProps) {
   const { task } = data;
   const dimmed = data.dimmed ?? false;
   const selected = data.selected ?? false;
-  const visualStatus = getEffectiveVisualStatus(task.status, task.execution);
+  const visualStatus = getEffectiveVisualStatus(task.status, task.execution, { runningLike: data.runningLike });
   const colors = getStatusColor(visualStatus);
 
   const isAnimated =
+    data.runningLike === true ||
     task.status === 'running' ||
     task.status === 'needs_input' ||
     task.status === 'awaiting_approval';
@@ -45,13 +47,17 @@ export function TaskNode({ data }: TaskNodeProps) {
       ? 'FIXING WITH AI'
       : visualStatus === 'fix_approval'
         ? 'APPROVE FIX'
-        : task.status === 'running' && task.execution.phase
-          ? `RUNNING · ${(getRunningPhaseLabel(task.execution.phase) ?? task.execution.phase).toUpperCase()}`
-        : task.status === 'awaiting_approval'
-          ? 'APPROVE'
-          : task.config.isReconciliation && task.status === 'needs_input'
-            ? 'SELECT'
-            : task.status.toUpperCase();
+        : visualStatus === 'running_launching'
+          ? 'RUNNING · LAUNCHING'
+          : visualStatus === 'running_executing'
+            ? 'RUNNING · EXECUTING'
+            : visualStatus === 'running'
+              ? 'RUNNING'
+              : task.status === 'awaiting_approval'
+                ? 'APPROVE'
+                : task.config.isReconciliation && task.status === 'needs_input'
+                  ? 'SELECT'
+                  : task.status.toUpperCase();
 
   const isStale = task.status === 'stale';
   const dotClass = `${colors.dot} ${isAnimated ? 'pulse-strong' : ''}`;

--- a/packages/ui/src/hooks/useQueueStatus.ts
+++ b/packages/ui/src/hooks/useQueueStatus.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import type { QueueStatus } from '../types.js';
+
+export function useQueueStatus(pollMs = 2000): QueueStatus | null {
+  const [queueStatus, setQueueStatus] = useState<QueueStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const status = await window.invoker?.getQueueStatus();
+        if (!cancelled && status) {
+          setQueueStatus(status);
+        }
+      } catch {
+        // ignore polling errors
+      }
+    };
+
+    void poll();
+    const interval = window.setInterval(() => {
+      void poll();
+    }, pollMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [pollMs]);
+
+  return queueStatus;
+}

--- a/packages/ui/src/lib/colors.ts
+++ b/packages/ui/src/lib/colors.ts
@@ -47,12 +47,16 @@ export function getStatusInlineColors(status: string): {
 export function getEffectiveVisualStatus(
   status: string,
   execution?: { isFixingWithAI?: boolean; pendingFixError?: string; phase?: string },
+  opts?: { runningLike?: boolean },
 ): string {
   if (status === 'fixing_with_ai') return 'fixing_with_ai';
   if (status === 'running' && execution?.isFixingWithAI) return 'fixing_with_ai';
+  if (opts?.runningLike === true && execution?.phase === 'launching') return 'running_launching';
+  if (opts?.runningLike === true && execution?.phase === 'executing') return 'running_executing';
+  if (opts?.runningLike === true) return 'running';
+  if (status === 'awaiting_approval' && execution?.pendingFixError) return 'fix_approval';
   if (status === 'running' && execution?.phase === 'launching') return 'running_launching';
   if (status === 'running' && execution?.phase === 'executing') return 'running_executing';
-  if (status === 'awaiting_approval' && execution?.pendingFixError) return 'fix_approval';
   return status;
 }
 

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -217,6 +217,13 @@ export interface WorkflowMeta {
   createdAt?: string;
   updatedAt?: string;
 }
+export interface QueueStatus {
+  maxConcurrency: number;
+  runningCount: number;
+  running: Array<{ taskId: string; description: string; attemptId?: string }>;
+  queued: Array<{ taskId: string; priority: number; description: string }>;
+}
+
 export type TaskGraphEvent =
   | {
       readonly type: 'delta';


### PR DESCRIPTION
## Summary

This makes one renderer rule explicit: any task in `queueStatus.running` is `Running` in the queue, bottom bar, and DAG filter.

Before this, the queue read live scheduler state but other renderer surfaces read saved task status. A launching task could look running in one place and pending in another.

The UI now shares one queue snapshot for renderer running state and keeps `Fixing` as a separate overlap count.

## Review Claim

Approve using `queueStatus.running` as the renderer-wide source of truth for `Running`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Backend queue semantics do not change. This only changes renderer classification for tasks already present in `queueStatus.running`.

## Slice Rationale

The proof case lands in the parent PR. This slice only applies that proved rule to renderer counts, queue rows, and DAG filtering.

## Non-goals

- No backend or CLI naming changes.
- No task panel or workflow inspector status rewrites.
- No new queue mutation API or renderer-only queue mock.

## Architecture

### Before

```mermaid
graph TD
    Q[QueueView local poll] --> QV[Queue running labels]
    T[Persisted task status only] --> SB[StatusBar counts]
    T --> DAG[TaskDAG filter and node labels]
```

### After

```mermaid
graph TD
    QS[Shared queue status poll in App] --> RT[Renderer running set]
    RT --> QV[QueueView labels]
    RT --> SB[StatusBar counts]
    RT --> DAG[TaskDAG filter and node labels]
    T[Persisted task status] --> QV
    T --> SB
    T --> DAG
```

## Test Plan

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/queue-view.test.tsx src/__tests__/status-bar-click.test.tsx src/__tests__/task-dag.test.tsx`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Visual Proof

Bottom bar before:

![Bottom bar before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-1a22f5/running-launching-statusbar.png)

Bottom bar after:

![Bottom bar after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-1a22f5/running-launching-statusbar.png)

Queue row before:

![Queue row before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-1a22f5/running-launching-queue.png)

Queue row after:

![Queue row after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-1a22f5/running-launching-queue.png)

Queue summary still says `Running 1 / 6`:

![Queue summary after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-1a22f5/queue-view-concurrency.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 04f1cde10`
- Post-revert steps: None
- Data migration? No
