### PR TITLE
Split recovery worker from runtime

### DIFF
--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createRecoveryWorker,
+  RECOVERY_WORKER_KIND,
+} from '../workers/auto-fix-recovery.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+describe('auto-fix recovery worker', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('exposes the recovery identity', () => {
+    const runtime = createRecoveryWorker({ logger, instanceId: 'rec-1', installSignalHandlers: false });
+    expect(runtime.identity).toEqual({ kind: RECOVERY_WORKER_KIND, instanceId: 'rec-1' });
+  });
+
+  it('is behavior-neutral: its default tick does nothing and does not throw', async () => {
+    const runtime = createRecoveryWorker({ logger, instanceId: 'rec-2', installSignalHandlers: false });
+    await expect(runtime.tick()).resolves.toBeUndefined();
+    expect(logger.error).not.toHaveBeenCalled();
+    await runtime.stop();
+  });
+
+  it('does not auto-run a tick on start', async () => {
+    vi.useFakeTimers();
+    const onTick = vi.fn();
+    const runtime = createRecoveryWorker({
+      logger,
+      instanceId: 'rec-3',
+      intervalMs: 1000,
+      onTick,
+      installSignalHandlers: false,
+    });
+    runtime.start();
+    await Promise.resolve();
+    // tickOnStart defaults to false for the recovery worker.
+    expect(onTick).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(onTick).toHaveBeenCalledTimes(1);
+    await runtime.stop();
+  });
+});

--- a/packages/app/src/__tests__/worker-runtime.test.ts
+++ b/packages/app/src/__tests__/worker-runtime.test.ts
@@ -1,9 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
-  createRecoveryWorker,
   createWorkerRuntime,
-  RECOVERY_WORKER_KIND,
   type WorkerTickContext,
 } from '../worker-runtime.js';
 
@@ -361,39 +359,6 @@ describe('worker runtime', () => {
       expect(process.listenerCount('SIGINT')).toBe(before + 1);
       await runtime.stop();
       expect(process.listenerCount('SIGINT')).toBe(before);
-    });
-  });
-
-  describe('recovery worker', () => {
-    it('exposes the recovery identity', () => {
-      const runtime = createRecoveryWorker({ logger, instanceId: 'rec-1', installSignalHandlers: false });
-      expect(runtime.identity).toEqual({ kind: RECOVERY_WORKER_KIND, instanceId: 'rec-1' });
-    });
-
-    it('is behavior-neutral: its default tick does nothing and does not throw', async () => {
-      const runtime = createRecoveryWorker({ logger, instanceId: 'rec-2', installSignalHandlers: false });
-      await expect(runtime.tick()).resolves.toBeUndefined();
-      expect(logger.error).not.toHaveBeenCalled();
-      await runtime.stop();
-    });
-
-    it('does not auto-run a tick on start', async () => {
-      vi.useFakeTimers();
-      const onTick = vi.fn();
-      const runtime = createRecoveryWorker({
-        logger,
-        instanceId: 'rec-3',
-        intervalMs: 1000,
-        onTick,
-        installSignalHandlers: false,
-      });
-      runtime.start();
-      await Promise.resolve();
-      // tickOnStart defaults to false for the recovery worker.
-      expect(onTick).not.toHaveBeenCalled();
-      await vi.advanceTimersByTimeAsync(1000);
-      expect(onTick).toHaveBeenCalledTimes(1);
-      await runtime.stop();
     });
   });
 });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -59,7 +59,7 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
-import { RECOVERY_WORKER_KIND } from './worker-runtime.js';
+import { RECOVERY_WORKER_KIND } from './workers/auto-fix-recovery.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';

--- a/packages/app/src/worker-runtime.ts
+++ b/packages/app/src/worker-runtime.ts
@@ -10,11 +10,6 @@
  *   - shutdown   — `stop()` is deterministic and idempotent: it clears the
  *                  timer, drops SIGINT/SIGTERM handlers, and awaits the
  *                  in-flight tick before resolving
- *
- * This slice only establishes the contract. The recovery worker built on top
- * of it is intentionally behavior-neutral (its tick is a no-op by default), so
- * existing auto-fix paths keep running exactly as before — nothing is routed
- * through this runtime yet.
  */
 
 import type { Logger } from '@invoker/contracts';
@@ -207,42 +202,4 @@ export function createWorkerRuntime(options: WorkerRuntimeOptions): WorkerRuntim
   const isRunning = (): boolean => started && !stopped;
 
   return { identity, start, wake, tick, stop, isRunning };
-}
-
-// ── Recovery worker ──────────────────────────────────────────
-
-/** Public worker kind for the auto-fix recovery worker. */
-export const RECOVERY_WORKER_KIND = 'recovery';
-
-const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
-
-export interface RecoveryWorkerOptions {
-  logger: Logger;
-  instanceId?: string;
-  intervalMs?: number;
-  installSignalHandlers?: boolean;
-  tickOnStart?: boolean;
-  /**
-   * Behavior-neutral override for the tick. Defaults to a no-op for this slice:
-   * the recovery worker does not submit recovery commands yet, and existing
-   * auto-fix paths continue to run through their current owner.
-   */
-  onTick?: WorkerTick;
-}
-
-/**
- * Create the recovery worker runtime. By default its tick is a no-op so that
- * standing up the worker is behavior-neutral — no recovery commands are
- * submitted and no existing auto-fix path is rerouted in this slice.
- */
-export function createRecoveryWorker(options: RecoveryWorkerOptions): WorkerRuntime {
-  return createWorkerRuntime({
-    kind: RECOVERY_WORKER_KIND,
-    instanceId: options.instanceId,
-    logger: options.logger,
-    intervalMs: options.intervalMs ?? DEFAULT_RECOVERY_POLL_INTERVAL_MS,
-    tickOnStart: options.tickOnStart ?? false,
-    installSignalHandlers: options.installSignalHandlers,
-    onTick: options.onTick ?? (() => {}),
-  });
 }

--- a/packages/app/src/workers/auto-fix-recovery.ts
+++ b/packages/app/src/workers/auto-fix-recovery.ts
@@ -1,0 +1,39 @@
+import type { Logger } from '@invoker/contracts';
+
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+/** Public worker kind for the auto-fix recovery worker. */
+export const RECOVERY_WORKER_KIND = 'recovery';
+
+const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
+
+export interface RecoveryWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  /**
+   * Behavior-neutral override for the tick. Defaults to a no-op for this slice:
+   * the recovery worker does not submit recovery commands yet, and existing
+   * auto-fix paths continue to run through their current owner.
+   */
+  onTick?: WorkerTick;
+}
+
+/**
+ * Create the recovery worker runtime. By default its tick is a no-op so that
+ * standing up the worker is behavior-neutral: no recovery commands are
+ * submitted and no existing auto-fix path is rerouted in this slice.
+ */
+export function createRecoveryWorker(options: RecoveryWorkerOptions): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: RECOVERY_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_RECOVERY_POLL_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: options.onTick ?? (() => {}),
+  });
+}


### PR DESCRIPTION
Review claim: The recovery worker wrapper has its own module while worker-runtime stays generic lifecycle infrastructure.

Safety invariant: The moved recovery worker remains behavior-neutral and defaults to a no-op tick.

Slice rationale: Module ownership is separated before adding auto-fix policy behavior.

Architectural effect: Concrete recovery worker ownership moves from generic runtime infrastructure to packages/app/src/workers/.

Alternative considerations: Keeping the wrapper in worker-runtime was rejected because future concrete workers would keep accumulating in the runtime module.