### PR TITLE
Validate auto-fix recovery candidates

### DIFF
--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import type { WorkflowMutationIntent } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 
+import { buildFixWithAgentMutationArgs } from '../auto-fix-intents.js';
 import {
+  collectValidatedAutoFixRecoveryCandidates,
   createRecoveryWorker,
   listAutoFixRecoveryScanCandidates,
   RECOVERY_WORKER_KIND,
@@ -36,6 +39,30 @@ function makeTask(overrides: Partial<TaskState> = {}): TaskState {
     taskStateVersion: 4,
     ...rest,
   };
+}
+
+function makeRecoveryPolicyHarness(task: TaskState = makeTask(), existingIntents: WorkflowMutationIntent[] = []) {
+  const workflows = [{ id: 'wf-1' }];
+  const tasks = new Map<string, TaskState>([[task.id, task]]);
+  const intents: WorkflowMutationIntent[] = [...existingIntents];
+  const logEvent = vi.fn();
+  const options = {
+    store: {
+      listWorkflows: vi.fn(() => workflows),
+      loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
+      loadTask: vi.fn((taskId: string) => tasks.get(taskId)),
+      listWorkflowMutationIntents: vi.fn((workflowId?: string, statuses?: string[]) => intents.filter((intent) => (
+        (!workflowId || intent.workflowId === workflowId)
+        && (!statuses || statuses.includes(intent.status))
+      ))),
+      logEvent,
+    },
+    submitter: { submit: vi.fn() },
+    logger,
+    defaultAutoFixRetries: 3,
+    getAutoFixAgent: () => 'codex',
+  };
+  return { options, logEvent, tasks, intents };
 }
 
 describe('auto-fix recovery worker', () => {
@@ -99,5 +126,99 @@ describe('auto-fix recovery scan candidates', () => {
         source: 'scan',
       },
     ]);
+  });
+});
+
+describe('auto-fix recovery candidate validation', () => {
+  it('accepts eligible scan candidates after reloading current task state', () => {
+    const harness = makeRecoveryPolicyHarness();
+
+    const candidates = collectValidatedAutoFixRecoveryCandidates(harness.options);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      taskId: 'wf-1/task-1',
+      workflowId: 'wf-1',
+      generation: 1,
+      taskStateVersion: 4,
+      source: 'scan',
+      task: expect.objectContaining({ id: 'wf-1/task-1' }),
+    });
+  });
+
+  it.each([
+    {
+      name: 'workflow',
+      task: makeTask({ config: { workflowId: 'wf-2' } }),
+      reason: 'stale-workflow',
+      details: { latestWorkflowId: 'wf-2' },
+    },
+    {
+      name: 'generation',
+      task: makeTask({ execution: { error: 'boom', autoFixAttempts: 0, generation: 2, selectedAttemptId: 'attempt-1' } }),
+      reason: 'stale-generation',
+      details: { latestGeneration: 2 },
+    },
+    {
+      name: 'task-state version',
+      task: makeTask({ taskStateVersion: 5 }),
+      reason: 'stale-task-state-version',
+      details: { latestTaskStateVersion: 5 },
+    },
+    {
+      name: 'attempt',
+      task: makeTask({ execution: { error: 'boom', autoFixAttempts: 0, generation: 1, selectedAttemptId: 'attempt-2' } }),
+      reason: 'stale-attempt',
+      details: { latestAttemptId: 'attempt-2' },
+    },
+  ])('skips stale $name candidates before eligibility checks', ({ task, reason, details }) => {
+    const harness = makeRecoveryPolicyHarness(task);
+
+    const candidates = collectValidatedAutoFixRecoveryCandidates(harness.options, [
+      {
+        taskId: 'wf-1/task-1',
+        workflowId: 'wf-1',
+        generation: 1,
+        taskStateVersion: 4,
+        attemptId: 'attempt-1',
+        source: 'scan',
+      },
+    ]);
+
+    expect(candidates).toHaveLength(0);
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'worker-autofix-skip',
+        reason,
+        ...details,
+      }),
+    );
+  });
+
+  it('skips failed tasks that already have an open fix intent', () => {
+    const existingIntent: WorkflowMutationIntent = {
+      id: 1,
+      workflowId: 'wf-1',
+      priority: 'normal',
+      channel: 'invoker:fix-with-agent',
+      args: buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', { autoFix: true }),
+      status: 'queued',
+      createdAt: new Date().toISOString(),
+    };
+    const harness = makeRecoveryPolicyHarness(makeTask(), [existingIntent]);
+
+    const candidates = collectValidatedAutoFixRecoveryCandidates(harness.options);
+
+    expect(candidates).toHaveLength(0);
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'worker-autofix-skip',
+        reason: 'already-queued-intent',
+      }),
+    );
   });
 });

--- a/packages/app/src/workers/auto-fix-recovery.ts
+++ b/packages/app/src/workers/auto-fix-recovery.ts
@@ -6,6 +6,8 @@ import type {
 } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 
+import { listOpenFixIntentsForTask } from '../auto-fix-intents.js';
+import { shouldSkipAutoFixForError } from '../auto-fix-gating.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
 
 /** Public worker kind for the auto-fix recovery worker. */
@@ -53,6 +55,24 @@ export type AutoFixRecoveryCandidate = {
   source: 'scan';
 };
 
+export type ValidatedAutoFixRecoveryCandidate = AutoFixRecoveryCandidate & {
+  task: TaskState;
+};
+
+type AutoFixCandidateSnapshotMismatchReason =
+  | 'stale-workflow'
+  | 'stale-generation'
+  | 'stale-task-state-version'
+  | 'stale-attempt';
+
+type AutoFixCandidateSnapshotComparison =
+  | { ok: true }
+  | {
+    ok: false;
+    reason: AutoFixCandidateSnapshotMismatchReason;
+    details: Record<string, unknown>;
+  };
+
 function workflowIdForTask(task: TaskState): string | undefined {
   return task.config.workflowId ?? task.id.split('/')[0];
 }
@@ -82,6 +102,154 @@ export function listAutoFixRecoveryScanCandidates(
     }
   }
   return candidates;
+}
+
+function retryBudgetForTask(task: TaskState, options: AutoFixRecoveryPolicyOptions): number {
+  const raw = options.getRetryBudget?.(task) ?? options.defaultAutoFixRetries ?? 0;
+  if (!Number.isFinite(raw)) return 0;
+  return Math.min(Math.max(0, Math.floor(raw)), 10);
+}
+
+function isRuntimeAutoFixEligibleTask(task: TaskState, options: AutoFixRecoveryPolicyOptions): boolean {
+  if (task.status !== 'failed') return false;
+  if (task.config.isReconciliation) return false;
+  if (task.config.parentTask) return false;
+  if (shouldSkipAutoFixForError(task.execution.error)) return false;
+  const max = retryBudgetForTask(task, options);
+  if (max <= 0) return false;
+  return (task.execution.autoFixAttempts ?? 0) < max;
+}
+
+function loadLatestTask(
+  candidate: AutoFixRecoveryCandidate,
+  options: AutoFixRecoveryPolicyOptions,
+): TaskState | undefined {
+  const direct = options.store.loadTask?.(candidate.taskId);
+  if (direct) return direct;
+  return options.store.loadTasks(candidate.workflowId).find((task) => task.id === candidate.taskId);
+}
+
+function logAutoFixWorkerEvent(
+  options: AutoFixRecoveryPolicyOptions,
+  taskId: string,
+  phase: string,
+  details: Record<string, unknown>,
+): void {
+  const payload = { phase, worker: RECOVERY_WORKER_KIND, ...details };
+  options.store.logEvent?.(taskId, 'debug.auto-fix', payload);
+  options.logger.debug?.(`[worker:${RECOVERY_WORKER_KIND}] ${phase}`, {
+    module: 'auto-fix-recovery',
+    taskId,
+    ...details,
+  });
+}
+
+function skipAutoFixCandidate(
+  options: AutoFixRecoveryPolicyOptions,
+  candidate: AutoFixRecoveryCandidate,
+  reason: string,
+  details: Record<string, unknown> = {},
+): void {
+  logAutoFixWorkerEvent(options, candidate.taskId, 'worker-autofix-skip', {
+    reason,
+    source: candidate.source,
+    workflowId: candidate.workflowId,
+    generation: candidate.generation,
+    taskStateVersion: candidate.taskStateVersion,
+    attemptId: candidate.attemptId ?? null,
+    ...details,
+  });
+}
+
+function compareAutoFixCandidateSnapshot(
+  candidate: AutoFixRecoveryCandidate,
+  latest: TaskState,
+): AutoFixCandidateSnapshotComparison {
+  const latestWorkflowId = workflowIdForTask(latest);
+  if (latestWorkflowId !== candidate.workflowId) {
+    return {
+      ok: false,
+      reason: 'stale-workflow',
+      details: { latestWorkflowId: latestWorkflowId ?? null },
+    };
+  }
+
+  const latestGeneration = latest.execution.generation ?? 0;
+  if (latestGeneration !== candidate.generation) {
+    return {
+      ok: false,
+      reason: 'stale-generation',
+      details: { latestGeneration },
+    };
+  }
+
+  if (latest.taskStateVersion !== candidate.taskStateVersion) {
+    return {
+      ok: false,
+      reason: 'stale-task-state-version',
+      details: { latestTaskStateVersion: latest.taskStateVersion },
+    };
+  }
+
+  const latestAttemptId = latest.execution.selectedAttemptId ?? null;
+  if (latestAttemptId !== (candidate.attemptId ?? null)) {
+    return {
+      ok: false,
+      reason: 'stale-attempt',
+      details: { latestAttemptId },
+    };
+  }
+
+  return { ok: true };
+}
+
+function validateAutoFixCandidate(
+  candidate: AutoFixRecoveryCandidate,
+  options: AutoFixRecoveryPolicyOptions,
+): ValidatedAutoFixRecoveryCandidate | undefined {
+  const latest = loadLatestTask(candidate, options);
+  if (!latest) {
+    skipAutoFixCandidate(options, candidate, 'task-not-found');
+    return undefined;
+  }
+
+  const snapshotComparison = compareAutoFixCandidateSnapshot(candidate, latest);
+  if (!snapshotComparison.ok) {
+    skipAutoFixCandidate(options, candidate, snapshotComparison.reason, snapshotComparison.details);
+    return undefined;
+  }
+
+  if (!isRuntimeAutoFixEligibleTask(latest, options)) {
+    skipAutoFixCandidate(options, candidate, 'not-eligible', {
+      status: latest.status,
+      autoFixAttempts: latest.execution.autoFixAttempts ?? 0,
+      maxRetries: retryBudgetForTask(latest, options),
+      isReconciliation: Boolean(latest.config.isReconciliation),
+      hasParentTask: Boolean(latest.config.parentTask),
+      skippedForError: shouldSkipAutoFixForError(latest.execution.error),
+    });
+    return undefined;
+  }
+
+  const openIntents = options.store.listWorkflowMutationIntents(candidate.workflowId, ['queued', 'running']);
+  const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, candidate.taskId);
+  if (openTaskFixIntents.length > 0) {
+    skipAutoFixCandidate(options, candidate, 'already-queued-intent', {
+      existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
+    });
+    return undefined;
+  }
+
+  return { ...candidate, task: latest };
+}
+
+export function collectValidatedAutoFixRecoveryCandidates(
+  options: AutoFixRecoveryPolicyOptions,
+  candidates: AutoFixRecoveryCandidate[] = listAutoFixRecoveryScanCandidates(options),
+): ValidatedAutoFixRecoveryCandidate[] {
+  return candidates
+    .map((candidate) => validateAutoFixCandidate(candidate, options))
+    .filter((candidate): candidate is ValidatedAutoFixRecoveryCandidate => Boolean(candidate));
 }
 
 export interface RecoveryWorkerOptions {


### PR DESCRIPTION
Review claim: Auto-fix recovery can reject stale, ineligible, or already queued scan candidates before submission.

Safety invariant: This slice still returns validated candidates only and does not submit mutation intents.

Slice rationale: Eligibility and stale-state policy are reviewable independently from candidate discovery and command submission.

Architectural effect: The recovery module owns retry/error/open-intent validation for auto-fix candidates.

Alternative considerations: Pushing these checks into the submit loop would obscure why a candidate is skipped.

Depends-On: #1620