### PR TITLE
Expose headless auto-fix worker scan

### DIFF
--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -2,7 +2,31 @@ import { describe, expect, it, vi } from 'vitest';
 import { LocalBus } from '@invoker/transport';
 import { Channels } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
-import { wireHeadlessAutoFix } from '../headless.js';
+import { runHeadless, wireHeadlessAutoFix } from '../headless.js';
+import { buildFixWithAgentMutationArgs } from '../auto-fix-intents.js';
+import type { TaskState } from '@invoker/workflow-core';
+import type { WorkflowMutationPriority } from '@invoker/data-store';
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/task-1',
+    description: 'failed task',
+    status: 'failed',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', ...(config ?? {}) },
+    execution: {
+      error: 'boom',
+      autoFixAttempts: 0,
+      generation: 1,
+      selectedAttemptId: 'attempt-1',
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 4,
+    ...rest,
+  };
+}
 
 describe('wireHeadlessAutoFix', () => {
   it('subscribes auto-fix for failed deltas in generic headless execution paths', async () => {
@@ -41,5 +65,42 @@ describe('wireHeadlessAutoFix', () => {
     expect(invokeAutoFix).toHaveBeenCalledTimes(1);
     expect(invokeAutoFix).toHaveBeenCalledWith('wf-1/task-1');
     expect(onError).not.toHaveBeenCalled();
+  });
+});
+
+describe('headless worker autofix', () => {
+  it('runs a one-shot scan and enqueues the normal fix command intent', async () => {
+    const task = makeTask();
+    const enqueueWorkflowMutationIntent = vi.fn((
+      _workflowId: string,
+      _channel: string,
+      _args: unknown[],
+      _priority: WorkflowMutationPriority,
+    ) => 1);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    try {
+      await runHeadless(['worker', 'autofix'], {
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn() },
+        persistence: {
+          listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+          loadTasks: vi.fn(() => [task]),
+          loadTask: vi.fn(() => task),
+          listWorkflowMutationIntents: vi.fn(() => []),
+          logEvent: vi.fn(),
+          enqueueWorkflowMutationIntent,
+        },
+        invokerConfig: { autoFixRetries: 3, autoFixAgent: 'codex' },
+      } as any);
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(enqueueWorkflowMutationIntent).toHaveBeenCalledWith(
+      'wf-1',
+      'invoker:fix-with-agent',
+      buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', { autoFix: true }),
+      'normal',
+    );
   });
 });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -59,7 +59,7 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
-import { RECOVERY_WORKER_KIND } from './workers/auto-fix-recovery.js';
+import { createAutoFixRecoveryTick, RECOVERY_WORKER_KIND } from './workers/auto-fix-recovery.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
@@ -1147,7 +1147,7 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessQuerySelect(args[1], deps);
       break;
     case 'worker':
-      headlessWorker(args[1]);
+      await headlessWorker(args[1], deps);
       break;
 
     // ── Deprecated aliases → query ──
@@ -1206,21 +1206,40 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
 }
 
 /**
- * Worker kinds exposed to the CLI. Each entry is `available: false` until the
- * worker actually performs work; unavailable kinds are reported as such instead
- * of being silently advertised as functional.
+ * Worker kinds exposed to the CLI.
  */
 const HEADLESS_WORKER_KINDS: ReadonlyArray<{ kind: string; available: boolean; note: string }> = [
   {
-    kind: RECOVERY_WORKER_KIND,
-    available: false,
-    note: 'no-op in this slice; auto-fix recovery still runs through its existing owner',
+    kind: 'autofix',
+    available: true,
+    note: 'scans persisted failed tasks and submits normal auto-fix command intents',
   },
 ];
 
-function headlessWorker(subCommand: string | undefined): void {
+async function headlessWorker(subCommand: string | undefined, deps: HeadlessDeps): Promise<void> {
+  if (subCommand === 'autofix') {
+    const tick = createAutoFixRecoveryTick({
+      store: deps.persistence,
+      submitter: {
+        submit: (workflowId, priority, channel, args) => (
+          deps.persistence.enqueueWorkflowMutationIntent(workflowId, channel, args, priority)
+        ),
+      },
+      logger: deps.logger,
+      defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
+      getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
+    });
+    await tick({
+      identity: { kind: RECOVERY_WORKER_KIND, instanceId: 'headless-worker-autofix' },
+      reason: 'manual',
+      tickNumber: 1,
+    });
+    process.stdout.write('Auto-fix worker scan completed.\n');
+    return;
+  }
+
   if (subCommand && subCommand !== 'list' && subCommand !== 'status') {
-    throw new Error(`Unknown worker sub-command: "${subCommand}". Use: list, status`);
+    throw new Error(`Unknown worker sub-command: "${subCommand}". Use: autofix, list, status`);
   }
   process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);
   for (const worker of HEADLESS_WORKER_KINDS) {
@@ -1310,7 +1329,7 @@ ${BOLD}Lifecycle:${RESET}
   delete-all                                          Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
   open-terminal <taskId>                              Open OS terminal for a task
   slack                                               Start Slack bot (long-running)
-  worker [list|status]                                List worker kinds and availability (recovery: unavailable)
+  worker [autofix|list|status]                        Run/list worker kinds (autofix scans failed tasks)
 
 ${BOLD}Deprecated${RESET} (use new names above):
   list → query workflows       status → query tasks       task-status → query task


### PR DESCRIPTION
Review claim: The headless worker command exposes auto-fix recovery as a one-shot scan surface.

Safety invariant: The command only submits the existing invoker:fix-with-agent mutation intent and does not execute fixes directly.

Slice rationale: CLI activation is the last stack diff after ownership, policy, and wakeup behavior are independently reviewable.

Architectural effect: Headless worker dispatch now calls the auto-fix recovery policy through its store and submitter ports.

Alternative considerations: A generic worker registry is deferred until another concrete worker exists.

Depends-On: #1623