### PR TITLE
[Recovery Lifecycle][Auto-fix Worker Policy][D3.5] Derive auto-fix recovery task references from tasks

### DIFF
--- a/packages/app/src/workers/auto-fix-recovery.ts
+++ b/packages/app/src/workers/auto-fix-recovery.ts
@@ -53,11 +53,13 @@ export type AutoFixRecoveryCandidate = {
   source: 'scan';
 };
 
+type AutoFixRecoveryTaskRef = Omit<AutoFixRecoveryCandidate, 'source'>;
+
 function workflowIdForTask(task: TaskState): string | undefined {
   return task.config.workflowId ?? task.id.split('/')[0];
 }
 
-function candidateFromTask(task: TaskState): AutoFixRecoveryCandidate | undefined {
+function taskRefFromTask(task: TaskState): AutoFixRecoveryTaskRef | undefined {
   const workflowId = workflowIdForTask(task);
   if (!workflowId) return undefined;
   return {
@@ -66,6 +68,14 @@ function candidateFromTask(task: TaskState): AutoFixRecoveryCandidate | undefine
     generation: task.execution.generation ?? 0,
     taskStateVersion: task.taskStateVersion,
     attemptId: task.execution.selectedAttemptId,
+  };
+}
+
+function candidateFromTask(task: TaskState): AutoFixRecoveryCandidate | undefined {
+  const ref = taskRefFromTask(task);
+  if (!ref) return undefined;
+  return {
+    ...ref,
     source: 'scan',
   };
 }


### PR DESCRIPTION
Review claim: Auto-fix recovery candidate references are derived from TaskState in one place.

Safety invariant: This is a behavior-neutral refactor of scan candidate construction.

Slice rationale: The workflow/task identity invariant should be reviewable before validation starts rejecting stale candidates.

Architectural effect: The recovery policy names the task-derived reference that later validation can canonicalize.

Alternative considerations: Dropping workflowId from raw candidates was deferred because scan fallback loading and wakeup payloads still use it.