### PR TITLE
Use queue running state in task DAG

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -377,6 +377,10 @@ export function App() {
   });
   const invoker = useInvoker();
   const queueStatus = useQueueStatus();
+  const runningTaskIds = useMemo(
+    () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
+    [queueStatus],
+  );
   const fileInputRef = useRef<HTMLInputElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
@@ -1904,6 +1908,7 @@ export function App() {
                           onTaskContextMenu={handleTaskContextMenu}
                           onManualViewport={handleManualViewport}
                           statusFilters={new Set()}
+                          runningTaskIds={runningTaskIds}
                         />
                       </div>
                     </FloatingGraphPanel>

--- a/packages/ui/src/__tests__/task-dag.test.tsx
+++ b/packages/ui/src/__tests__/task-dag.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import * as ReactFlowModule from '@xyflow/react';
+import { TaskDAG } from '../components/TaskDAG.js';
+import { makeUITask } from './helpers/mock-invoker.js';
+import type { TaskState, WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  // Vitest hoists mock factories before static helper imports initialize.
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
+const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
+const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
+
+describe('TaskDAG running filters', () => {
+  beforeEach(() => {
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    getZoomMock.mockReset();
+    getZoomMock.mockReturnValue(1);
+  });
+
+  it('keeps queue-running launching tasks visible under the running filter', async () => {
+    const launchingTask = makeUITask({
+      id: 'wf-1/launching-task',
+      workflowId: 'wf-1',
+      status: 'pending',
+      description: 'launching task',
+      execution: { phase: 'launching', selectedAttemptId: 'wf-1/launching-task-a1' },
+    });
+    const pendingTask = makeUITask({
+      id: 'wf-1/pending-task',
+      workflowId: 'wf-1',
+      status: 'pending',
+      description: 'pending task',
+      dependencies: ['wf-1/launching-task'],
+    });
+    const tasks = new Map<string, TaskState>([
+      [launchingTask.id, launchingTask],
+      [pendingTask.id, pendingTask],
+    ]);
+    const workflows = new Map<string, WorkflowMeta>([
+      ['wf-1', { id: 'wf-1', name: 'wf-1', status: 'running' }],
+    ]);
+
+    render(
+      <TaskDAG
+        tasks={tasks}
+        workflows={workflows}
+        statusFilters={new Set(['running'])}
+        runningTaskIds={new Set([launchingTask.id])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`rf__node-${launchingTask.id}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`rf__node-${pendingTask.id}`)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('RUNNING · LAUNCHING')).toBeInTheDocument();
+
+    const launchingNode = screen.getByTestId(`rf__node-${launchingTask.id}`).firstElementChild as HTMLElement;
+    const pendingNode = screen.getByTestId(`rf__node-${pendingTask.id}`).firstElementChild as HTMLElement;
+
+    expect(launchingNode.className).not.toContain('opacity-20');
+    expect(pendingNode.className).toContain('opacity-20');
+  });
+});

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -53,6 +53,7 @@ interface TaskDAGProps {
   /** Fired when the user manually pans or zooms the viewport. */
   onManualViewport?: () => void;
   statusFilters?: Set<string>;
+  runningTaskIds?: ReadonlySet<string>;
 }
 
 const nodeTypes = { taskNode: TaskNode, mergeGateNode: MergeGateNode };
@@ -151,7 +152,7 @@ function mergeMeasuredNodeState(prevNodes: Node[], nextNodes: Node[]): Node[] {
   });
 }
 
-function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskClick, onTaskDoubleClick, onTaskContextMenu, onManualViewport, statusFilters }: TaskDAGProps) {
+function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskClick, onTaskDoubleClick, onTaskContextMenu, onManualViewport, statusFilters, runningTaskIds }: TaskDAGProps) {
   const { fitView, setCenter, getZoom } = useReactFlow();
   const prevNodeCount = useRef(0);
   const lastNodeClickRef = useRef<{ id: string; at: number } | null>(null);
@@ -222,7 +223,8 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     const dimmedNodeIds = new Set<string>();
     if (statusFilters && statusFilters.size > 0) {
       for (const task of taskArray) {
-        const vs = getEffectiveVisualStatus(task.status, task.execution);
+        const runningLike = runningTaskIds?.has(task.id) === true;
+        const vs = getEffectiveVisualStatus(task.status, task.execution, { runningLike });
         if (!Array.from(statusFilters).some((filterKey) => matchesStatusFilter(filterKey, vs))) {
           dimmedNodeIds.add(task.id);
         }
@@ -240,7 +242,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       fallbackLayout: makeFallbackLayout(taskArray),
       layoutKey: layoutKeyFor(layoutTasks, rawEdges),
     };
-  }, [tasks, statusFilters]);
+  }, [runningTaskIds, tasks, statusFilters]);
 
   useEffect(() => {
     if (rawGraph.taskArray.length === 0) return;
@@ -279,7 +281,8 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       const wfMeta = workflows?.get(wfGroupId);
       const wfMergeMode = (wfMeta?.mergeMode as 'manual' | 'automatic' | 'external_review') ?? 'manual';
       const pos = activeLayout.positions.get(task.id) ?? { x: 0, y: 0 };
-      const visualStatus = getEffectiveVisualStatus(task.status, task.execution);
+      const runningLike = runningTaskIds?.has(task.id) === true;
+      const visualStatus = getEffectiveVisualStatus(task.status, task.execution, { runningLike });
       const dimmed = statusFilters
         && statusFilters.size > 0
         && !Array.from(statusFilters).some((filterKey) => matchesStatusFilter(filterKey, visualStatus));
@@ -323,6 +326,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
             label: task.description,
             dimmed,
             selected: selectedTaskId === task.id,
+            runningLike,
             ...(onTaskDoubleClick ? { onDoubleClick: onTaskDoubleClick } : {}),
           },
         });
@@ -405,7 +409,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     });
 
     return { nodes: allNodes, edges: newEdges };
-  }, [activeLayout.positions, onTaskDoubleClick, rawGraph, routedEdgePoints, selectedTaskId, statusFilters, tasks, workflows]);
+  }, [activeLayout.positions, onTaskDoubleClick, rawGraph, routedEdgePoints, runningTaskIds, selectedTaskId, statusFilters, tasks, workflows]);
 
   // Merge task-derived nodes with React Flow's internal dimension state.
   // Without this, each task-delta re-render creates new node objects that discard

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -13,13 +13,14 @@
 import { Handle, Position } from '@xyflow/react';
 import type { MouseEvent } from 'react';
 import type { TaskState } from '../types.js';
-import { getStatusColor, getEffectiveVisualStatus, getRunningPhaseLabel } from '../lib/colors.js';
+import { getStatusColor, getEffectiveVisualStatus } from '../lib/colors.js';
 
 interface TaskNodeData {
   task: TaskState;
   label?: string;
   dimmed?: boolean;
   selected?: boolean;
+  runningLike?: boolean;
   onDoubleClick?: (task: TaskState) => void;
   [key: string]: unknown;
 }
@@ -32,10 +33,11 @@ export function TaskNode({ data }: TaskNodeProps) {
   const { task } = data;
   const dimmed = data.dimmed ?? false;
   const selected = data.selected ?? false;
-  const visualStatus = getEffectiveVisualStatus(task.status, task.execution);
+  const visualStatus = getEffectiveVisualStatus(task.status, task.execution, { runningLike: data.runningLike });
   const colors = getStatusColor(visualStatus);
 
   const isAnimated =
+    data.runningLike === true ||
     task.status === 'running' ||
     task.status === 'needs_input' ||
     task.status === 'awaiting_approval';
@@ -45,13 +47,17 @@ export function TaskNode({ data }: TaskNodeProps) {
       ? 'FIXING WITH AI'
       : visualStatus === 'fix_approval'
         ? 'APPROVE FIX'
-        : task.status === 'running' && task.execution.phase
-          ? `RUNNING · ${(getRunningPhaseLabel(task.execution.phase) ?? task.execution.phase).toUpperCase()}`
-        : task.status === 'awaiting_approval'
-          ? 'APPROVE'
-          : task.config.isReconciliation && task.status === 'needs_input'
-            ? 'SELECT'
-            : task.status.toUpperCase();
+        : visualStatus === 'running_launching'
+          ? 'RUNNING · LAUNCHING'
+          : visualStatus === 'running_executing'
+            ? 'RUNNING · EXECUTING'
+            : visualStatus === 'running'
+              ? 'RUNNING'
+              : task.status === 'awaiting_approval'
+                ? 'APPROVE'
+                : task.config.isReconciliation && task.status === 'needs_input'
+                  ? 'SELECT'
+                  : task.status.toUpperCase();
 
   const isStale = task.status === 'stale';
   const dotClass = `${colors.dot} ${isAnimated ? 'pulse-strong' : ''}`;


### PR DESCRIPTION
## Summary

This makes the task DAG use the same queue-running set as the queue and bottom bar.

Before this, a launching task could count as running in the queue but still look pending in the filtered DAG.

The DAG now gets queue-running task ids from `App` and uses them for node labels and running-filter dimming.

## Review Claim

Approve using queue-running task ids as the task DAG source of truth for `Running` labels and filtering.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only changes DAG presentation. Queue and bottom-bar behavior already landed in the parent PR.

## Slice Rationale

This stays separate because it activates a second UI surface. The queue and bottom bar can be reviewed without also reviewing DAG filter behavior.

## Non-goals

- No queue row changes.
- No bottom bar count changes.
- No backend or CLI naming changes.

## Architecture

### Before

```mermaid
graph TD
    T[Persisted task status] --> DAG[TaskDAG labels and filters]
```

### After

```mermaid
graph TD
    QS[Queue running task ids from App] --> DAG[TaskDAG labels and filters]
    T[Persisted task status] --> DAG
```

## Test Plan

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/task-dag.test.tsx`

## Visual Proof

Before, the mini DAG still showed the launching task as pending:

![DAG before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-9c684f/running-launching-statusbar-before.png)

After, the mini DAG shows `RUNNING · LAUNCHING` while the queue and bottom bar stay aligned:

![DAG after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-9c684f/running-launching-statusbar-after.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 99086267b`
- Post-revert steps: None
- Data migration? No
