### PR TITLE
Update queue running proof for aligned UI

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1411,13 +1411,25 @@ test.describe('Visual proof capture', () => {
       },
     ]);
     await page.waitForTimeout(2200);
-    await expect(page.getByTestId('status-bar-pill-running')).toContainText('Running: 0');
-    await expect(page.getByTestId('status-bar-pill-pending')).toContainText('Pending: 1');
+    const captureBefore = process.env.CAPTURE_MODE === 'before';
+
+    if (captureBefore) {
+      await expect(page.getByTestId('status-bar-pill-running')).toContainText('Running: 0');
+      await expect(page.getByTestId('status-bar-pill-pending')).toContainText('Pending: 1');
+    } else {
+      await expect(page.getByTestId('status-bar-pill-running')).toContainText('Running: 1');
+      await expect(page.getByTestId('status-bar-pill-pending')).toContainText('Pending: 0');
+      await expect(page.getByText('Running includes launching and AI-fix work.')).toBeVisible();
+    }
     await captureScreenshot(page, 'running-launching-statusbar');
 
     await page.getByTestId('rail-queue').click();
     const queueRow = page.locator('[data-row-id$=\"launching-task\"]');
     await expect(queueRow).toBeVisible();
+    if (!captureBefore) {
+      await expect(queueRow.getByText('Running', { exact: true })).toBeVisible();
+      await expect(queueRow.getByText('phase: Launching')).toBeVisible();
+    }
     await captureScreenshot(page, 'running-launching-queue');
   });
 


### PR DESCRIPTION
## Summary

This updates the proof case to match the aligned `Running` behavior.

After the queue and DAG changes land, the same seeded launching task should show `Running` in the bottom bar, queue row, and mini DAG.

The Playwright proof now checks the final aligned UI while still capturing the same screenshots.

## Review Claim

Approve updating the queue-running proof case to assert the final aligned UI behavior.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This does not change product behavior. It only updates the proof case after the behavior slices underneath it land.

## Slice Rationale

The validator does not allow proof files inside behavior PRs. This keeps the behavior slices smaller, then updates the proof case at the top of the stack.

## Non-goals

- No queue logic changes.
- No bottom bar count changes.
- No DAG logic changes.

## Test Plan

- [x] `cd packages/app && pnpm exec playwright test e2e/visual-proof.spec.ts -g "queue running launching state"`

## Visual Proof

Bottom bar before:

![Bottom bar before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-ff4d94/running-launching-statusbar-before.png)

Bottom bar after:

![Bottom bar after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-ff4d94/running-launching-statusbar-after.png)

Queue row before:

![Queue row before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-ff4d94/running-launching-queue-before.png)

Queue row after:

![Queue row after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-ff4d94/running-launching-queue-after.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f1a5ae470`
- Post-revert steps: None
- Data migration? No
