### PR TITLE
[Queue Assigning](1) Add mismatch proof

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -17,12 +17,14 @@ import {
   injectTaskStates,
   captureScreenshot,
   assertPageScreenshot,
+  getTasks,
   E2E_REPO_URL,
 } from './fixtures/electron-app.js';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { stringify as yamlStringify } from 'yaml';
 import type { Locator, Page } from '@playwright/test';
+import { SQLiteAdapter } from '@invoker/data-store';
 
 /** Plan for queue-semantics visual proof: enough tasks to fill Action Queue and Backlog. */
 const QUEUE_SEMANTICS_PLAN = {
@@ -37,6 +39,14 @@ const QUEUE_SEMANTICS_PLAN = {
     { id: 'qs-approval', description: 'Awaiting approval task', command: 'echo approve', dependencies: [] },
     { id: 'qs-queued', description: 'Queued pending task', command: 'echo queued', dependencies: [] },
     { id: 'qs-blocked', description: 'Blocked by running task', command: 'echo blocked', dependencies: ['qs-running'] },
+  ],
+};
+const QUEUE_ASSIGNING_PLAN = {
+  name: 'Queue assigning proof',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    { id: 'assigning-task', description: 'Assigning queue task', command: 'echo assign', dependencies: [] },
   ],
 };
 
@@ -359,6 +369,24 @@ async function loadPlanAndSelectWorkflow(page: Page, plan: unknown): Promise<str
   await node.dispatchEvent('click', { bubbles: true });
   await expect(page.getByTestId('selected-workflow-mini-dag')).toBeVisible({ timeout: 10000 });
   return workflowId!;
+}
+async function seedActiveLaunchAttempt(dbPath: string, taskId: string, attemptId: string, now: Date): Promise<void> {
+  const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+  try {
+    adapter.saveAttempt({
+      id: attemptId,
+      nodeId: taskId,
+      queuePriority: 0,
+      upstreamAttemptIds: [],
+      status: 'claimed',
+      claimedAt: now,
+      lastHeartbeatAt: now,
+      leaseExpiresAt: new Date(now.getTime() + 60_000),
+      createdAt: now,
+    });
+  } finally {
+    adapter.close();
+  }
 }
 
 test.describe('Visual proof capture', () => {
@@ -1346,6 +1374,51 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByRole('heading', { name: 'Backlog (3)' })).toBeVisible();
     await captureScreenshot(page, 'queue-view-concurrency');
     await assertPageScreenshot(page, 'queue-view-concurrency');
+  });
+  test('queue assigning state', async ({ page, testDir }) => {
+    await loadPlan(page, QUEUE_ASSIGNING_PLAN);
+    const tasks = await getTasks(page);
+    const task = tasks.find((entry: { id: string }) => entry.id.endsWith('/assigning-task') || entry.id === 'assigning-task');
+    const mergeTask = tasks.find((entry: { id: string }) => entry.id.startsWith('__merge__'));
+    expect(task).toBeTruthy();
+    expect(mergeTask).toBeTruthy();
+    const dbPath = path.join(testDir, 'invoker.db');
+    const now = new Date();
+    const attemptId = `${task!.id}-assigning-attempt`;
+    await seedActiveLaunchAttempt(dbPath, task!.id, attemptId, now);
+    await injectTaskStates(page, [
+      {
+        taskId: task!.id,
+        changes: {
+          status: 'pending',
+          execution: {
+            phase: 'launching',
+            selectedAttemptId: attemptId,
+            launchStartedAt: now,
+            lastHeartbeatAt: now,
+          },
+        },
+      },
+      {
+        taskId: mergeTask!.id,
+        changes: {
+          status: 'completed',
+          execution: {
+            startedAt: now,
+            completedAt: now,
+          },
+        },
+      },
+    ]);
+    await page.waitForTimeout(2200);
+    await expect(page.getByTestId('status-bar-pill-running')).toContainText('Running: 0');
+    await expect(page.getByTestId('status-bar-pill-pending')).toContainText('Pending: 1');
+    await captureScreenshot(page, 'queue-assigning-statusbar');
+
+    await page.getByTestId('rail-queue').click();
+    const queueRow = page.locator('[data-row-id$=\"assigning-task\"]');
+    await expect(queueRow).toBeVisible();
+    await captureScreenshot(page, 'queue-assigning-row');
   });
 
   test('queue-semantics — action queue with canonical task states', async ({ page }) => {


### PR DESCRIPTION
## Summary

This adds a durable proof case for the new `Assigning` UI state.

Before the fix, a claimed launch-phase task can be active in the queue while the bottom bar still shows it as pending.

The new Playwright case seeds the real launch attempt row and captures that mismatch without changing renderer behavior.

## Review Claim

Approve adding a real repro case for the queue-assigning versus bottom-bar mismatch.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This does not change backend or renderer behavior. It only adds a seeded proof case in `visual-proof.spec.ts`.

## Slice Rationale

This lands first so the later UI changes can point at one stable mismatch case instead of a one-off manual repro.

## Non-goals

- No queue semantics changes.
- No bottom bar count changes.
- No DAG label or filter changes.

## Test Plan

- [x] `cd packages/app && pnpm exec playwright test e2e/visual-proof.spec.ts -g "queue assigning state"`

## Visual Proof

This is the proof branch behavior. The seeded launch-phase task is already active, but the UI still has no `Assigning` pill and counts it as pending.

![Proof branch shows queue assigning mismatch](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-91dec1/before-queue-assigning-statusbar.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0dc82eace`
- Post-revert steps: None
- Data migration? No
