### PR TITLE
[Queue Assigning](3) Show assigning in task DAG

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -383,6 +383,10 @@ export function App() {
   });
   const invoker = useInvoker();
   const queueStatus = useQueueStatus();
+  const runningTaskIds = useMemo(
+    () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
+    [queueStatus],
+  );
   const fileInputRef = useRef<HTMLInputElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
@@ -1965,6 +1969,7 @@ export function App() {
                           onTaskContextMenu={handleTaskContextMenu}
                           onManualViewport={handleManualViewport}
                           statusFilters={new Set()}
+                          runningTaskIds={runningTaskIds}
                         />
                       </div>
                     </FloatingGraphPanel>

--- a/packages/ui/src/__tests__/task-dag.test.tsx
+++ b/packages/ui/src/__tests__/task-dag.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import * as ReactFlowModule from '@xyflow/react';
+import { TaskDAG } from '../components/TaskDAG.js';
+import { makeUITask } from './helpers/mock-invoker.js';
+import type { TaskState, WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  // Vitest hoists mock factories before static helper imports initialize.
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
+const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
+const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
+
+describe('TaskDAG status filters', () => {
+  beforeEach(() => {
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    getZoomMock.mockReset();
+    getZoomMock.mockReturnValue(1);
+  });
+
+  it('keeps queue-assigning tasks visible under the assigning filter', async () => {
+    const assigningTask = makeUITask({
+      id: 'wf-1/assigning-task',
+      workflowId: 'wf-1',
+      status: 'pending',
+      description: 'assigning task',
+      execution: { phase: 'launching', selectedAttemptId: 'wf-1/assigning-task-a1' },
+    });
+    const pendingTask = makeUITask({
+      id: 'wf-1/pending-task',
+      workflowId: 'wf-1',
+      status: 'pending',
+      description: 'pending task',
+      dependencies: ['wf-1/assigning-task'],
+    });
+    const tasks = new Map<string, TaskState>([
+      [assigningTask.id, assigningTask],
+      [pendingTask.id, pendingTask],
+    ]);
+    const workflows = new Map<string, WorkflowMeta>([
+      ['wf-1', { id: 'wf-1', name: 'wf-1', status: 'running' }],
+    ]);
+
+    render(
+      <TaskDAG
+        tasks={tasks}
+        workflows={workflows}
+        statusFilters={new Set(['assigning'])}
+        runningTaskIds={new Set([assigningTask.id])}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId(`rf__node-${assigningTask.id}`)).toBeInTheDocument();
+      expect(screen.getByTestId(`rf__node-${pendingTask.id}`)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('ASSIGNING')).toBeInTheDocument();
+
+    const assigningNode = screen.getByTestId(`rf__node-${assigningTask.id}`).firstElementChild as HTMLElement;
+    const pendingNode = screen.getByTestId(`rf__node-${pendingTask.id}`).firstElementChild as HTMLElement;
+
+    expect(assigningNode.className).not.toContain('opacity-20');
+    expect(pendingNode.className).toContain('opacity-20');
+  });
+});

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -53,6 +53,7 @@ interface TaskDAGProps {
   /** Fired when the user manually pans or zooms the viewport. */
   onManualViewport?: () => void;
   statusFilters?: Set<string>;
+  runningTaskIds?: ReadonlySet<string>;
 }
 
 const nodeTypes = { taskNode: TaskNode, mergeGateNode: MergeGateNode };
@@ -151,7 +152,7 @@ function mergeMeasuredNodeState(prevNodes: Node[], nextNodes: Node[]): Node[] {
   });
 }
 
-function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskClick, onTaskDoubleClick, onTaskContextMenu, onManualViewport, statusFilters }: TaskDAGProps) {
+function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskClick, onTaskDoubleClick, onTaskContextMenu, onManualViewport, statusFilters, runningTaskIds }: TaskDAGProps) {
   const { fitView, setCenter, getZoom } = useReactFlow();
   const graphRootRef = useRef<HTMLDivElement>(null);
   const prevNodeCount = useRef(0);
@@ -223,7 +224,8 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     const dimmedNodeIds = new Set<string>();
     if (statusFilters && statusFilters.size > 0) {
       for (const task of taskArray) {
-        const vs = getEffectiveVisualStatus(task.status, task.execution);
+        const runningLike = runningTaskIds?.has(task.id) === true;
+        const vs = getEffectiveVisualStatus(task.status, task.execution, { runningLike });
         if (!Array.from(statusFilters).some((filterKey) => matchesStatusFilter(filterKey, vs))) {
           dimmedNodeIds.add(task.id);
         }
@@ -241,7 +243,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       fallbackLayout: makeFallbackLayout(taskArray),
       layoutKey: layoutKeyFor(layoutTasks, rawEdges),
     };
-  }, [tasks, statusFilters]);
+  }, [runningTaskIds, tasks, statusFilters]);
 
   useEffect(() => {
     if (rawGraph.taskArray.length === 0) return;
@@ -280,7 +282,8 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       const wfMeta = workflows?.get(wfGroupId);
       const wfMergeMode = (wfMeta?.mergeMode as 'manual' | 'automatic' | 'external_review') ?? 'manual';
       const pos = activeLayout.positions.get(task.id) ?? { x: 0, y: 0 };
-      const visualStatus = getEffectiveVisualStatus(task.status, task.execution);
+      const runningLike = runningTaskIds?.has(task.id) === true;
+      const visualStatus = getEffectiveVisualStatus(task.status, task.execution, { runningLike });
       const dimmed = statusFilters
         && statusFilters.size > 0
         && !Array.from(statusFilters).some((filterKey) => matchesStatusFilter(filterKey, visualStatus));
@@ -324,6 +327,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
             label: task.description,
             dimmed,
             selected: selectedTaskId === task.id,
+            runningLike,
             ...(onTaskDoubleClick ? { onDoubleClick: onTaskDoubleClick } : {}),
           },
         });
@@ -406,7 +410,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     });
 
     return { nodes: allNodes, edges: newEdges };
-  }, [activeLayout.positions, onTaskDoubleClick, rawGraph, routedEdgePoints, selectedTaskId, statusFilters, tasks, workflows]);
+  }, [activeLayout.positions, onTaskDoubleClick, rawGraph, routedEdgePoints, runningTaskIds, selectedTaskId, statusFilters, tasks, workflows]);
 
   // Merge task-derived nodes with React Flow's internal dimension state.
   // Without this, each task-delta re-render creates new node objects that discard

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -13,13 +13,14 @@
 import { Handle, Position } from '@xyflow/react';
 import type { MouseEvent } from 'react';
 import type { TaskState } from '../types.js';
-import { getStatusColor, getEffectiveVisualStatus, getRunningPhaseLabel } from '../lib/colors.js';
+import { getStatusColor, getEffectiveVisualStatus } from '../lib/colors.js';
 
 interface TaskNodeData {
   task: TaskState;
   label?: string;
   dimmed?: boolean;
   selected?: boolean;
+  runningLike?: boolean;
   onDoubleClick?: (task: TaskState) => void;
   [key: string]: unknown;
 }
@@ -28,30 +29,34 @@ interface TaskNodeProps {
   data: TaskNodeData;
 }
 
+const TASK_NODE_STATUS_LABELS: Record<string, string> = {
+  assigning: 'ASSIGNING',
+  awaiting_approval: 'APPROVE',
+  fix_approval: 'APPROVE FIX',
+  fixing_with_ai: 'FIXING WITH AI',
+  running: 'RUNNING',
+  running_executing: 'RUNNING · EXECUTING',
+};
+
+function getTaskNodeStatusLabel(task: TaskState, visualStatus: string): string {
+  if (task.config.isReconciliation && task.status === 'needs_input') return 'SELECT';
+  return TASK_NODE_STATUS_LABELS[visualStatus] ?? task.status.toUpperCase();
+}
+
 export function TaskNode({ data }: TaskNodeProps) {
   const { task } = data;
   const dimmed = data.dimmed ?? false;
   const selected = data.selected ?? false;
-  const visualStatus = getEffectiveVisualStatus(task.status, task.execution);
+  const visualStatus = getEffectiveVisualStatus(task.status, task.execution, { runningLike: data.runningLike });
   const colors = getStatusColor(visualStatus);
 
   const isAnimated =
+    data.runningLike === true ||
     task.status === 'running' ||
     task.status === 'needs_input' ||
     task.status === 'awaiting_approval';
 
-  const statusLabel =
-    visualStatus === 'fixing_with_ai'
-      ? 'FIXING WITH AI'
-      : visualStatus === 'fix_approval'
-        ? 'APPROVE FIX'
-        : task.status === 'running' && task.execution.phase
-          ? `RUNNING · ${(getRunningPhaseLabel(task.execution.phase) ?? task.execution.phase).toUpperCase()}`
-        : task.status === 'awaiting_approval'
-          ? 'APPROVE'
-          : task.config.isReconciliation && task.status === 'needs_input'
-            ? 'SELECT'
-            : task.status.toUpperCase();
+  const statusLabel = getTaskNodeStatusLabel(task, visualStatus);
 
   const isStale = task.status === 'stale';
   const dotClass = `${colors.dot} ${isAnimated ? 'pulse-strong' : ''}`;


### PR DESCRIPTION
## Summary

This makes the task DAG use the same `Assigning` state as the queue and bottom bar.

Before this, a claimed launch-phase task could be shown as `Running · Launching` and match the running filter.

The DAG now labels queue launch-phase work as `ASSIGNING` and keeps it under the Assigning filter.

<details>
<summary>Review metadata</summary>

Review Claim: Approve using queue launch-phase task ids as the DAG source of truth for `Assigning` labels and filtering.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This only changes DAG presentation. Queue and bottom-bar behavior already landed in the parent PR.

Slice Rationale: The task graph depends on the shared status vocabulary added by the parent slice.

</details>

## Non-goals

This does not change queue capacity, executor assignment, status persistence, or changelog text.

## Test Plan

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/colors.test.ts src/__tests__/queue-view.test.tsx src/__tests__/status-bar-click.test.tsx src/__tests__/task-dag.test.tsx`
- [x] `cd packages/app && pnpm exec playwright test e2e/visual-proof.spec.ts -g "queue view concurrency display|queue assigning state"`

## Visual Proof

Before, the task graph proof did not isolate assigning work as its own task state.

![Before task graph](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-91dec1/before-status-filter-dimmed-dag.png)

After, assigning work is separate from running work in the task graph proof.

![After task graph](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-91dec1/after-status-filter-dimmed-dag.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e50c2d43ad9b3d3ce0ccf0302cae22b39be04fcc`
- Post-revert steps: Revert dependent PRs first if they have landed.
- Data migration? No

Depends-On: #1634
