### PR TITLE
Fix action graph query timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to Invoker will be documented in this file.
 - Relaunch non-merge fix approvals through the normal launch queue so approved fixes get a fresh executor dispatch.
 - Allow policy review slices to include docs while still blocking behavior and proof files.
 
+## 0.0.6
+
+- Bound Action Graph diagnostics to indexed current task data so large databases return quickly.
+
 ## 0.0.4
 
 - Publish complete CLI and desktop release assets for npm launcher packages.

--- a/packages/app/src/__tests__/action-graph-diagnostics.test.ts
+++ b/packages/app/src/__tests__/action-graph-diagnostics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Attempt, TaskState } from '@invoker/workflow-core';
-import type { TaskLaunchDispatch, Workflow } from '@invoker/data-store';
+import type { TaskEvent, TaskLaunchDispatch, Workflow } from '@invoker/data-store';
 import {
   buildActionGraphDiagnostics,
   resolveActionDiagnosticsStallThresholdMs,
@@ -188,6 +188,66 @@ describe('buildActionGraphDiagnostics', () => {
 
     expect(graph.nodes.find((node) => node.id === 'blocker:launch-failed:error')?.label).toBe('Launch failed');
     expect(graph.nodes.find((node) => node.id === 'blocker:launch-failed:workspace')?.label).toBe('Missing workspace');
+  });
+
+  it('keeps only the latest task events in selected attempt history', () => {
+    const selectedAttempt = attempt({ id: 'attempt-a1', nodeId: 'task-a' });
+    const events: TaskEvent[] = Array.from({ length: 30 }, (_value, index) => ({
+      id: index + 1,
+      taskId: 'task-a',
+      eventType: `event-${index}`,
+      payload: `payload-${index}`,
+      createdAt: new Date(Date.UTC(2026, 4, 14, 11, index)).toISOString(),
+    }));
+
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [task({ id: 'task-a', execution: { selectedAttemptId: selectedAttempt.id } })],
+      attemptsByTaskId: new Map([['task-a', [selectedAttempt]]]),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [],
+      mutationLeases: [],
+      eventsByTaskId: new Map([['task-a', events]]),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    const selected = graph.nodes.find((node) => node.id === 'attempt:attempt-a1');
+    expect(selected?.history?.map((entry) => entry.source)).toEqual(
+      Array.from({ length: 20 }, (_value, index) => `event-${index + 10}`),
+    );
+  });
+
+  it('skips upstream attempt edges whose source attempts are omitted', () => {
+    const upstream = task({ id: 'upstream', status: 'failed' });
+    const downstream = task({ id: 'downstream', status: 'pending', dependencies: ['upstream'] });
+    const downstreamAttempt = attempt({
+      id: 'downstream-a1',
+      nodeId: 'downstream',
+      upstreamAttemptIds: ['old-upstream-a1'],
+    });
+
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [upstream, downstream],
+      attemptsByTaskId: new Map([['downstream', [downstreamAttempt]]]),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [],
+      mutationLeases: [],
+      eventsByTaskId: new Map(),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    expect(graph.edges).not.toContainEqual(expect.objectContaining({
+      source: 'attempt:old-upstream-a1',
+      target: 'attempt:downstream-a1',
+    }));
+    expect(graph.nodes.find((node) => node.id === 'blocker:downstream:dependency:upstream')).toEqual(
+      expect.objectContaining({ type: 'blocker', status: 'waiting' }),
+    );
   });
 });
 

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -477,6 +477,45 @@ describe('headless-client', () => {
     ).rejects.toThrow(/requires a running shared owner process/);
   }, 30_000);
 
+  it('delegates query action-graph to a reachable owner endpoint', async () => {
+    const bus = new LocalBus();
+    const graph = {
+      generatedAt: '2026-05-14T12:00:00.000Z',
+      stallThresholdMs: 60_000,
+      nodes: [],
+      edges: [],
+    };
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.query', async (payload) => {
+      expect(payload).toEqual({ kind: 'action-graph' });
+      return graph;
+    });
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const runElectronHeadless = vi.fn(async () => 0);
+
+    const exitCode = await runHeadlessClientCommand(['query', 'action-graph', '--output', 'json'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+    expect(stdout).toHaveBeenCalledWith(`${JSON.stringify(graph)}\n`);
+    stdout.mockRestore();
+  });
+
+  it('does not silently fall back for query action-graph when no owner endpoint is reachable', async () => {
+    await expect(
+      runHeadlessClientCommand(['query', 'action-graph', '--output', 'json'], {
+        messageBus: new LocalBus(),
+        ensureStandaloneOwner: vi.fn(async () => {}),
+        runElectronHeadless: vi.fn(async () => 0),
+      }),
+    ).rejects.toThrow(/query action-graph requires a running shared owner process/);
+  }, 30_000);
+
   it('delegates query queue to a reachable owner endpoint', async () => {
     const bus = new LocalBus();
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));

--- a/packages/app/src/action-graph-diagnostics.ts
+++ b/packages/app/src/action-graph-diagnostics.ts
@@ -129,6 +129,11 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
   const workflowsById = new Map(input.workflows.map((workflow) => [workflow.id, workflow]));
   const runningQueueIds = new Set(input.queueStatus.running.map((item) => item.taskId));
   const queuedQueueIds = new Set(input.queueStatus.queued.map((item) => item.taskId));
+  const visibleAttemptIds = new Set<string>();
+  for (const attempts of input.attemptsByTaskId.values()) {
+    for (const attempt of attempts) visibleAttemptIds.add(attempt.id);
+  }
+
 
   for (const workflow of input.workflows) {
     const actionId = `action:${workflow.id}`;
@@ -267,6 +272,10 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
     const selectedAttemptId = task.execution.selectedAttemptId ?? attempts.at(-1)?.id ?? task.id;
     const selectedNodeId = `attempt:${selectedAttemptId}`;
     const taskEvents = input.eventsByTaskId.get(task.id) ?? [];
+    if (attempts.length === 0) {
+      visibleAttemptIds.add(selectedAttemptId);
+    }
+
 
     for (const attempt of attempts.length > 0 ? attempts : [{
       id: selectedAttemptId,
@@ -328,12 +337,14 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
       });
 
       for (const upstreamAttemptId of attempt.upstreamAttemptIds) {
-        edges.push({
-          id: edgeId(`attempt:${upstreamAttemptId}`, nodeId, 'upstream'),
-          source: `attempt:${upstreamAttemptId}`,
-          target: nodeId,
-          label: 'upstream',
-        });
+        if (visibleAttemptIds.has(upstreamAttemptId)) {
+          edges.push({
+            id: edgeId(`attempt:${upstreamAttemptId}`, nodeId, 'upstream'),
+            source: `attempt:${upstreamAttemptId}`,
+            target: nodeId,
+            label: 'upstream',
+          });
+        }
       }
     }
 
@@ -414,6 +425,8 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
         selectedNode.durations = { ...selectedNode.durations, waitingMs: ageMs(nowMs, task.createdAt) };
       }
     }
+
+
   }
 
   const uniqueEdges = new Map(edges.map((edge) => [edge.id, edge]));

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -72,7 +72,7 @@ import {
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { WorkflowMeta, WorkResponse } from '@invoker/contracts';
+import type { ActionGraphResponse, WorkflowMeta, WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
@@ -237,6 +237,32 @@ import {
 } from './window/window-lifecycle.js';
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
+
+function buildCurrentActionGraphSnapshot(args: {
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  invokerConfig: InvokerConfig;
+}): ActionGraphResponse {
+  args.orchestrator.syncAllFromDb();
+  const tasks = args.orchestrator.getAllTasks();
+  const workflows = args.persistence.listWorkflows();
+
+  return buildActionGraphDiagnostics({
+    workflows,
+    tasks,
+    attemptsByTaskId: new Map(tasks.map((task) => [
+      task.id,
+      args.persistence.loadActionGraphAttempts(task.id, task.execution.selectedAttemptId),
+    ])),
+    queueStatus: args.orchestrator.getQueueStatus(),
+    mutationIntents: args.persistence.listWorkflowMutationIntents(undefined, ['queued', 'running', 'failed']),
+    mutationLeases: args.persistence.listWorkflowMutationLeases(),
+    eventsByTaskId: new Map(tasks.map((task) => [task.id, args.persistence.getRecentEvents(task.id, 20)])),
+    activityLogs: args.persistence.getActivityLogs(0, 200),
+    stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(args.invokerConfig),
+    launchDispatches: args.persistence.listLaunchDispatchesByState(['enqueued', 'leased']),
+  });
+}
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -1616,21 +1642,7 @@ function startHeadlessMode(): void {
             };
           }
           if (kind === 'action-graph') {
-            orchestrator.syncAllFromDb();
-            const tasks = orchestrator.getAllTasks();
-            const workflows = persistence.listWorkflows();
-            return buildActionGraphDiagnostics({
-              workflows,
-              tasks,
-              attemptsByTaskId: new Map(tasks.map((task) => [task.id, persistence.loadAttempts(task.id)])),
-              queueStatus: orchestrator.getQueueStatus(),
-              mutationIntents: persistence.listWorkflowMutationIntents(),
-              mutationLeases: persistence.listWorkflowMutationLeases(),
-              eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
-              activityLogs: persistence.getActivityLogs(0, 200),
-              stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
-              launchDispatches: persistence.listLaunchDispatchesByState(['enqueued', 'leased', 'abandoned']),
-            });
+            return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
           }
           throw new Error(`Unsupported headless query: ${String(kind)}`);
         });
@@ -3141,21 +3153,7 @@ function createEmbeddedTerminalBackendFromConfig(
           };
         }
         if (kind === 'action-graph') {
-          orchestrator.syncAllFromDb();
-          const tasks = orchestrator.getAllTasks();
-          const workflows = persistence.listWorkflows();
-          return buildActionGraphDiagnostics({
-            workflows,
-            tasks,
-            attemptsByTaskId: new Map(tasks.map((task) => [task.id, persistence.loadAttempts(task.id)])),
-            queueStatus: orchestrator.getQueueStatus(),
-            mutationIntents: persistence.listWorkflowMutationIntents(),
-            mutationLeases: persistence.listWorkflowMutationLeases(),
-            eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
-            activityLogs: persistence.getActivityLogs(0, 200),
-            stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
-            launchDispatches: persistence.listLaunchDispatchesByState(['enqueued', 'leased', 'abandoned']),
-          });
+          return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
         }
         throw new Error(`Unsupported headless query: ${String(kind)}`);
       });
@@ -3740,21 +3738,7 @@ function createEmbeddedTerminalBackendFromConfig(
           );
         }
       }
-      orchestrator.syncAllFromDb();
-      const tasks = orchestrator.getAllTasks();
-      const workflows = persistence.listWorkflows();
-      return buildActionGraphDiagnostics({
-        workflows,
-        tasks,
-        attemptsByTaskId: new Map(tasks.map((task) => [task.id, persistence.loadAttempts(task.id)])),
-        queueStatus: orchestrator.getQueueStatus(),
-        mutationIntents: persistence.listWorkflowMutationIntents(),
-        mutationLeases: persistence.listWorkflowMutationLeases(),
-        eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
-        activityLogs: persistence.getActivityLogs(0, 200),
-        stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
-        launchDispatches: persistence.listLaunchDispatchesByState(['enqueued', 'leased', 'abandoned']),
-      });
+      return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
     });
 
     ipcMain.handle('invoker:report-ui-perf', (_event, metric: string, data?: Record<string, unknown>) => {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import type { Workflow, Conversation } from '../adapter.js';
 import { createAttempt } from '@invoker/workflow-core';
-import type { TaskState, TaskStateChanges } from '@invoker/workflow-core';
+import type { Attempt, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 
 describe('SQLiteAdapter', () => {
   let adapter: SQLiteAdapter;
@@ -246,6 +246,12 @@ describe('SQLiteAdapter', () => {
       const result = (adapter as any).db.exec('PRAGMA index_list(tasks)') as Array<{ values: unknown[][] }>;
       const indexNames = (result[0]?.values ?? []).map((row) => String(row[1]));
       expect(indexNames).toContain('idx_tasks_workflow_id');
+    });
+
+    it('creates an index for task event lookups', () => {
+      const result = (adapter as any).db.exec('PRAGMA index_list(events)') as Array<{ values: unknown[][] }>;
+      const indexNames = (result[0]?.values ?? []).map((row) => String(row[1]));
+      expect(indexNames).toContain('idx_events_task_id_id');
     });
   });
 
@@ -1141,6 +1147,63 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  describe('loadActionGraphAttempts', () => {
+    function attemptAt(id: string, status: Attempt['status'], createdAt: string, nodeId = 't1'): Attempt {
+      return {
+        ...createAttempt(nodeId, { status }),
+        id,
+        createdAt: new Date(createdAt),
+      };
+    }
+
+    it('returns active attempts plus the selected terminal attempt', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const selected = attemptAt('selected-superseded', 'superseded', '2026-01-01T00:05:00.000Z');
+      adapter.saveTask('wf-1', makeTask('t1', {
+        execution: { selectedAttemptId: selected.id },
+      }));
+      adapter.saveTask('wf-1', makeTask('t2'));
+      const attempts = [
+        attemptAt('old-superseded', 'superseded', '2026-01-01T00:00:00.000Z'),
+        attemptAt('completed', 'completed', '2026-01-01T00:01:00.000Z'),
+        attemptAt('failed', 'failed', '2026-01-01T00:02:00.000Z'),
+        attemptAt('pending', 'pending', '2026-01-01T00:03:00.000Z'),
+        attemptAt('claimed', 'claimed', '2026-01-01T00:04:00.000Z'),
+        selected,
+        attemptAt('running', 'running', '2026-01-01T00:06:00.000Z'),
+        attemptAt('needs-input', 'needs_input', '2026-01-01T00:07:00.000Z'),
+        attemptAt('unrelated-running', 'running', '2026-01-01T00:08:00.000Z', 't2'),
+      ];
+      for (const attempt of attempts) adapter.saveAttempt(attempt);
+
+      expect(adapter.loadActionGraphAttempts('t1', selected.id).map((attempt) => attempt.id)).toEqual([
+        'pending',
+        'claimed',
+        'selected-superseded',
+        'running',
+        'needs-input',
+      ]);
+    });
+
+    it('returns active attempts plus the newest attempt when no selected attempt is present', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      const attempts = [
+        attemptAt('completed-old', 'completed', '2026-01-01T00:00:00.000Z'),
+        attemptAt('pending-current', 'pending', '2026-01-01T00:01:00.000Z'),
+        attemptAt('running-current', 'running', '2026-01-01T00:02:00.000Z'),
+        attemptAt('failed-newest', 'failed', '2026-01-01T00:03:00.000Z'),
+      ];
+      for (const attempt of attempts) adapter.saveAttempt(attempt);
+
+      expect(adapter.loadActionGraphAttempts('t1').map((attempt) => attempt.id)).toEqual([
+        'pending-current',
+        'running-current',
+        'failed-newest',
+      ]);
+    });
+  });
+
   describe('saveWorkflow + loadWorkflow', () => {
     it('round-trips a workflow', () => {
       adapter.saveWorkflow(testWorkflow);
@@ -1467,6 +1530,37 @@ describe('SQLiteAdapter', () => {
       expect(events[0].eventType).toBe('started');
       expect(events[1].eventType).toBe('completed');
       expect(JSON.parse(events[0].payload!)).toEqual({ attempt: 1 });
+    });
+
+    it('uses the task event lookup index for ordered event reads', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      const planRows = (adapter as any).db
+        .prepare('EXPLAIN QUERY PLAN SELECT * FROM events WHERE task_id = ? ORDER BY id ASC')
+        .all('t1') as Array<{ detail: string }>;
+      const detail = planRows.map((row) => row.detail).join('\n');
+
+      expect(detail).toContain('SEARCH events');
+      expect(detail).toContain('idx_events_task_id_id');
+      expect(detail).not.toContain('SCAN events');
+      expect(detail).not.toContain('USE TEMP B-TREE');
+    });
+
+    it('returns recent task events oldest-to-newest', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      for (let index = 0; index < 30; index += 1) {
+        adapter.logEvent('t1', `event-${index}`, { index });
+      }
+
+      const events = adapter.getRecentEvents('t1', 20);
+
+      expect(events).toHaveLength(20);
+      expect(events.map((event) => event.eventType)).toEqual(
+        Array.from({ length: 20 }, (_value, index) => `event-${index + 10}`),
+      );
+      expect(adapter.getRecentEvents('t1', 0)).toEqual([]);
     });
   });
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -779,6 +779,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
         FOREIGN KEY (task_id) REFERENCES tasks(id)
       );
 
+      CREATE INDEX IF NOT EXISTS idx_events_task_id_id
+        ON events(task_id, id);
+
       CREATE TABLE IF NOT EXISTS activity_log (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         timestamp TEXT NOT NULL DEFAULT (datetime('now')),
@@ -1052,6 +1055,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     // Replace old attempt_number index with created_at index
     this.db.run('DROP INDEX IF EXISTS idx_attempts_node');
     this.db.run('CREATE INDEX IF NOT EXISTS idx_attempts_node_created ON attempts(node_id, created_at)');
+    this.db.run('CREATE INDEX IF NOT EXISTS idx_events_task_id_id ON events(task_id, id)');
     this.db.run('CREATE INDEX IF NOT EXISTS idx_tasks_workflow_id ON tasks(workflow_id)');
     this.db.run('DROP INDEX IF EXISTS idx_task_launch_dispatch_active_attempt');
     this.db.run(`
@@ -2098,6 +2102,23 @@ export class SQLiteAdapter implements PersistenceAdapter {
     }));
   }
 
+  getRecentEvents(taskId: string, limit = 20): TaskEvent[] {
+    if (limit <= 0) return [];
+    const rows = this.queryAll(
+      `SELECT * FROM (
+        SELECT * FROM events WHERE task_id = ? ORDER BY id DESC LIMIT ?
+      ) ORDER BY id ASC`,
+      [taskId, Math.floor(limit)],
+    );
+    return rows.map((row: any) => ({
+      id: row.id,
+      taskId: row.task_id,
+      eventType: row.event_type,
+      payload: row.payload ?? undefined,
+      createdAt: row.created_at,
+    }));
+  }
+
   // ── Queries ─────────────────────────────────────────
 
   getSelectedExperiment(taskId: string): string | null {
@@ -2504,6 +2525,28 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'SELECT * FROM attempts WHERE node_id = ? ORDER BY created_at ASC',
       [nodeId],
     );
+    return rows.map(this.rowToAttempt);
+  }
+
+  loadActionGraphAttempts(nodeId: string, selectedAttemptId?: string): Attempt[] {
+    const rows = selectedAttemptId
+      ? this.queryAll(
+        `SELECT * FROM attempts
+        WHERE node_id = ?
+          AND (status IN ('pending', 'claimed', 'running', 'needs_input') OR id = ?)
+        ORDER BY created_at ASC`,
+        [nodeId, selectedAttemptId],
+      )
+      : this.queryAll(
+        `SELECT * FROM attempts
+        WHERE node_id = ?
+          AND (
+            status IN ('pending', 'claimed', 'running', 'needs_input')
+            OR id = (SELECT id FROM attempts WHERE node_id = ? ORDER BY created_at DESC LIMIT 1)
+          )
+        ORDER BY created_at ASC`,
+        [nodeId, nodeId],
+      );
     return rows.map(this.rowToAttempt);
   }
 

--- a/scripts/repro/repro-action-graph-query-timeout.sh
+++ b/scripts/repro/repro-action-graph-query-timeout.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/headless-lib.sh"
+
+EXPECTATION="fixed"
+KEEP_TEMP=false
+EVENT_COUNT=200000
+
+usage() {
+  echo "usage: $0 [--expect-bug|--expect-fixed] [--keep-temp] [--event-count <n>]" >&2
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect-bug)
+      EXPECTATION="bug"
+      shift
+      ;;
+    --expect-fixed)
+      EXPECTATION="fixed"
+      shift
+      ;;
+    --keep-temp)
+      KEEP_TEMP=true
+      shift
+      ;;
+    --event-count)
+      if [[ $# -lt 2 || ! "$2" =~ ^[0-9]+$ ]]; then
+        usage
+        exit 2
+      fi
+      EVENT_COUNT="$2"
+      shift 2
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/iag.XXXXXX")"
+HOME_DIR="$TMP_ROOT/home"
+DB_DIR="$TMP_ROOT/db"
+SOCKET_PATH="$TMP_ROOT/i.sock"
+CONFIG_PATH="$TMP_ROOT/config.json"
+PLAN_PATH="$TMP_ROOT/repro-plan.yaml"
+REPO_FIXTURE_DIR="$TMP_ROOT/repo"
+OWNER_LOG="$TMP_ROOT/owner.log"
+SUBMIT_OUT="$TMP_ROOT/submit.out"
+SUBMIT_ERR="$TMP_ROOT/submit.err"
+TASKS_JSON="$TMP_ROOT/tasks.json"
+QUERY_OUT="$TMP_ROOT/action-graph.out"
+QUERY_ERR="$TMP_ROOT/action-graph.err"
+QUERY_PLAN="$TMP_ROOT/query-plan.txt"
+OWNER_PID=""
+
+cleanup() {
+  if [[ -n "$OWNER_PID" ]]; then
+    local children
+    children="$(pgrep -P "$OWNER_PID" 2>/dev/null || true)"
+    if [[ -n "$children" ]]; then
+      # shellcheck disable=SC2086
+      kill $children 2>/dev/null || true
+    fi
+    kill "$OWNER_PID" 2>/dev/null || true
+    wait "$OWNER_PID" 2>/dev/null || true
+  fi
+  if [[ "$KEEP_TEMP" == true ]]; then
+    echo "temp root: $TMP_ROOT"
+  else
+    rm -rf "$TMP_ROOT" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+wait_for_log() {
+  local file="$1"
+  local needle="$2"
+  local deadline=$((SECONDS + 45))
+  while (( SECONDS < deadline )); do
+    if [[ -f "$file" ]] && grep -Fq "$needle" "$file"; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for '$needle' in $file" >&2
+  [[ -f "$file" ]] && tail -80 "$file" >&2
+  return 1
+}
+
+require_node_sqlite() {
+  if ! node -e "import('node:sqlite').catch(() => process.exit(1))" >/dev/null 2>&1; then
+    echo "node:sqlite is required for this repro" >&2
+    exit 1
+  fi
+}
+
+build_if_missing() {
+  pushd "$ROOT_DIR" >/dev/null
+  if [[ ! -f packages/data-store/dist/index.js ]]; then
+    pnpm --filter @invoker/data-store build
+  fi
+  if [[ ! -f packages/app/dist/main.js || ! -f packages/app/dist/headless-client.js ]]; then
+    pnpm --filter @invoker/app build
+  fi
+  popd >/dev/null
+}
+
+start_owner() {
+  INVOKER_DB_DIR="$DB_DIR" \
+    INVOKER_IPC_SOCKET="$SOCKET_PATH" \
+    INVOKER_REPO_CONFIG_PATH="$CONFIG_PATH" \
+    INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS=600000 \
+    INVOKER_HEADLESS_STANDALONE=1 \
+    HOME="$HOME_DIR" \
+    "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless owner-serve >"$OWNER_LOG" 2>&1 &
+  OWNER_PID="$!"
+  wait_for_log "$OWNER_LOG" "standalone owner ready"
+}
+
+headless_client() {
+  INVOKER_DB_DIR="$DB_DIR" \
+    INVOKER_IPC_SOCKET="$SOCKET_PATH" \
+    INVOKER_REPO_CONFIG_PATH="$CONFIG_PATH" \
+    HOME="$HOME_DIR" \
+    node "$ROOT_DIR/packages/app/dist/headless-client.js" "$@"
+}
+
+wait_for_tasks_json() {
+  local deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    if headless_client query tasks --output json >"$TASKS_JSON" 2>/dev/null; then
+      if node - "$TASKS_JSON" <<'NODE'
+const fs = require('node:fs');
+const tasks = JSON.parse(fs.readFileSync(process.argv[2], 'utf8'));
+process.exit(Array.isArray(tasks) && tasks.length >= 3 ? 0 : 1);
+NODE
+      then
+        return 0
+      fi
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for submitted tasks" >&2
+  [[ -f "$TASKS_JSON" ]] && cat "$TASKS_JSON" >&2
+  return 1
+}
+
+seed_events_and_plan() {
+  node - "$DB_DIR/invoker.db" "$TASKS_JSON" "$EVENT_COUNT" "$QUERY_PLAN" <<'NODE'
+import fs from 'node:fs';
+const [dbPath, tasksPath, countRaw, planPath] = process.argv.slice(2);
+const count = Number(countRaw);
+const tasks = JSON.parse(fs.readFileSync(tasksPath, 'utf8'));
+const taskIds = tasks.map((task) => task.id).filter((id) => typeof id === 'string' && id.length > 0);
+if (taskIds.length === 0) throw new Error('no task ids found');
+const { DatabaseSync } = await import('node:sqlite');
+const db = new DatabaseSync(dbPath);
+try {
+  db.exec('PRAGMA foreign_keys = ON');
+  const insert = db.prepare('INSERT INTO events (task_id, event_type, payload) VALUES (?, ?, ?)');
+  db.exec('BEGIN');
+  try {
+    for (let seq = 0; seq < count; seq += 1) {
+      insert.run(taskIds[seq % taskIds.length], 'repro.event', JSON.stringify({ seq }));
+    }
+    db.exec('COMMIT');
+  } catch (error) {
+    db.exec('ROLLBACK');
+    throw error;
+  }
+  const planRows = db.prepare('EXPLAIN QUERY PLAN SELECT * FROM events WHERE task_id = ? ORDER BY id ASC').all(taskIds[0]);
+  const details = planRows.map((row) => row.detail).join('\n');
+  fs.writeFileSync(planPath, details, 'utf8');
+} finally {
+  db.close();
+}
+NODE
+}
+
+assert_fixed_action_graph() {
+  node - "$QUERY_OUT" <<'NODE'
+const fs = require('node:fs');
+const raw = fs.readFileSync(process.argv[2], 'utf8');
+const graph = JSON.parse(raw);
+if (!Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
+  throw new Error('action graph JSON must include nodes and edges arrays');
+}
+let largestHistory = 0;
+for (const node of graph.nodes) {
+  if (node.kind === 'task-attempt' && Array.isArray(node.history)) {
+    largestHistory = Math.max(largestHistory, node.history.length);
+  }
+}
+if (largestHistory > 30) {
+  throw new Error(`largest task-attempt history length ${largestHistory} exceeds 30`);
+}
+NODE
+}
+
+mkdir -p "$HOME_DIR" "$DB_DIR" "$REPO_FIXTURE_DIR"
+require_node_sqlite
+build_if_missing
+
+cat > "$CONFIG_PATH" <<'JSON'
+{
+  "allowGraphMutation": true,
+  "disableAutoRunOnStartup": true
+}
+JSON
+
+git -C "$REPO_FIXTURE_DIR" init -b main >/dev/null 2>&1
+git -C "$REPO_FIXTURE_DIR" config user.name "Invoker Repro"
+git -C "$REPO_FIXTURE_DIR" config user.email "repro@example.com"
+printf 'action graph query timeout repro fixture\n' > "$REPO_FIXTURE_DIR/README.md"
+git -C "$REPO_FIXTURE_DIR" add README.md
+git -C "$REPO_FIXTURE_DIR" commit -m "Initial fixture" >/dev/null 2>&1
+
+cat > "$PLAN_PATH" <<EOF
+name: Action Graph Query Timeout Repro
+repoUrl: $REPO_FIXTURE_DIR
+onFinish: none
+mergeMode: manual
+baseBranch: HEAD
+tasks:
+  - id: repro-one
+    description: First no-op task
+    command: "true"
+    dependencies: []
+  - id: repro-two
+    description: Second no-op task
+    command: "true"
+    dependencies: []
+  - id: repro-three
+    description: Third no-op task
+    command: "true"
+    dependencies: []
+EOF
+
+start_owner
+
+if ! headless_client --no-track run "$PLAN_PATH" >"$SUBMIT_OUT" 2>"$SUBMIT_ERR"; then
+  echo "failed to submit repro workflow" >&2
+  cat "$SUBMIT_OUT" >&2 || true
+  cat "$SUBMIT_ERR" >&2 || true
+  exit 1
+fi
+
+wait_for_tasks_json
+seed_events_and_plan
+PLAN_DETAIL="$(cat "$QUERY_PLAN")"
+printf 'query plan: %s\n' "$PLAN_DETAIL"
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  if [[ "$PLAN_DETAIL" == *"SCAN events"* ]]; then
+    echo "PASS: event lookup scans events table"
+    echo "PASS: action graph query timeout repro matched bug"
+    exit 0
+  fi
+fi
+
+set +e
+headless_client query action-graph --output json >"$QUERY_OUT" 2>"$QUERY_ERR"
+QUERY_STATUS=$?
+set -e
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  if [[ "$QUERY_STATUS" -ne 0 ]] && grep -Fq "Live owner is present but did not serve action-graph query" "$QUERY_ERR"; then
+    echo "PASS: action graph query timeout repro matched bug"
+    exit 0
+  fi
+  echo "FAIL: expected action graph delegated query timeout" >&2
+  cat "$QUERY_OUT" >&2 || true
+  cat "$QUERY_ERR" >&2 || true
+  exit 1
+fi
+
+if [[ "$PLAN_DETAIL" != *"SEARCH events"* || "$PLAN_DETAIL" != *"idx_events_task_id_id"* ]]; then
+  echo "FAIL: expected indexed SEARCH events plan using idx_events_task_id_id" >&2
+  cat "$QUERY_PLAN" >&2
+  exit 1
+fi
+if [[ "$PLAN_DETAIL" == *"SCAN events"* || "$PLAN_DETAIL" == *"USE TEMP B-TREE"* ]]; then
+  echo "FAIL: expected no scan or temp sort in event lookup plan" >&2
+  cat "$QUERY_PLAN" >&2
+  exit 1
+fi
+if [[ "$QUERY_STATUS" -ne 0 ]]; then
+  echo "FAIL: action graph query failed" >&2
+  cat "$QUERY_OUT" >&2 || true
+  cat "$QUERY_ERR" >&2 || true
+  exit 1
+fi
+assert_fixed_action_graph
+
+echo "PASS: action graph query timeout repro matched fixed"


### PR DESCRIPTION
## Summary

Action Graph now reads a small current-diagnostics graph instead of old event history.

Large databases made the owner scan task events and time out before the client got data.

This adds an event lookup index, bounded graph reads, and a repro that proves the old scan and the fixed response.

## Review Claim

Approve the bounded Action Graph read path for large databases.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Full task history remains in events and logs. This only changes the Action Graph diagnostic snapshot.

## Slice Rationale

The timeout fix needs the index, bounded reads, graph edge guard, and repro together to prove the read path.

## Non-goals

This does not add a full-history Action Graph mode.

This does not change task execution, retry behavior, or stored event rows.

## Architecture

### Before

```mermaid
graph TD
    UI[UI/client] --> Loader[Action Graph loader]
    Loader --> Attempts[Per-task full attempts]
    Loader --> Events[Per-task full getEvents scan]
    Events --> Timeout[Owner query timeout]
```

### After

```mermaid
graph TD
    UI[UI/client] --> Snapshot[Shared Action Graph snapshot]
    Snapshot --> Attempts[Current attempts only]
    Snapshot --> Events[Indexed recent events]
    Events --> Graph[Bounded diagnostics graph]
```

## Test Plan

- [x] `bash scripts/repro/repro-action-graph-query-timeout.sh --expect-bug --event-count 200000`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/action-graph-diagnostics.test.ts src/__tests__/headless-client.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/data-store build && pnpm --filter @invoker/app build`
- [x] `bash scripts/repro/repro-action-graph-query-timeout.sh --expect-fixed --event-count 200000`
- [x] `owner_log="${TMPDIR:-/tmp}/iag-live-owner.log"; INVOKER_HEADLESS_STANDALONE=1 INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS=60000 ./run.sh --headless owner-serve >"$owner_log" 2>&1 & owner_pid=$!; sleep 3; /usr/bin/time -p ./run.sh --headless query action-graph | node -e "let s=''; process.stdin.on('data', c => s += c); process.stdin.on('end', () => { const g = JSON.parse(s); console.log(JSON.stringify({ nodes: g.nodes.length, edges: g.edges.length, failed: g.nodes.filter(n => n.status === 'failed').length })); });"; status=$?; /bin/kill "$owner_pid" >/dev/null 2>&1 || true; wait "$owner_pid" >/dev/null 2>&1 || true; exit "$status"`

## Visual Proof

Not visual. The UI still renders the same Action Graph; the proof is the live query result in the test plan.

## Revert Plan

- Safe to revert? No, if production databases rely on the new index for UI responsiveness.
- Revert command: `git revert e3e460987`
- Post-revert steps: Restart any running shared owner.
- Data migration? No, the added index is idempotent and can be dropped by revert if needed.
