### PR TITLE
[Action Graph Optimization](2) Add action graph bounded data reads

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
 import type { Workflow, Conversation } from '../adapter.js';
 import { createAttempt } from '@invoker/workflow-core';
-import type { TaskState, TaskStateChanges } from '@invoker/workflow-core';
+import type { Attempt, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 
 describe('SQLiteAdapter', () => {
   let adapter: SQLiteAdapter;
@@ -169,6 +169,12 @@ describe('SQLiteAdapter', () => {
       const result = (adapter as any).db.exec('PRAGMA index_list(tasks)') as Array<{ values: unknown[][] }>;
       const indexNames = (result[0]?.values ?? []).map((row) => String(row[1]));
       expect(indexNames).toContain('idx_tasks_workflow_id');
+    });
+
+    it('creates an index for task event lookups', () => {
+      const result = (adapter as any).db.exec('PRAGMA index_list(events)') as Array<{ values: unknown[][] }>;
+      const indexNames = (result[0]?.values ?? []).map((row) => String(row[1]));
+      expect(indexNames).toContain('idx_events_task_id_id');
     });
   });
 
@@ -1064,6 +1070,63 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  describe('loadActionGraphAttempts', () => {
+    function attemptAt(id: string, status: Attempt['status'], createdAt: string, nodeId = 't1'): Attempt {
+      return {
+        ...createAttempt(nodeId, { status }),
+        id,
+        createdAt: new Date(createdAt),
+      };
+    }
+
+    it('returns active attempts plus the selected terminal attempt', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const selected = attemptAt('selected-superseded', 'superseded', '2026-01-01T00:05:00.000Z');
+      adapter.saveTask('wf-1', makeTask('t1', {
+        execution: { selectedAttemptId: selected.id },
+      }));
+      adapter.saveTask('wf-1', makeTask('t2'));
+      const attempts = [
+        attemptAt('old-superseded', 'superseded', '2026-01-01T00:00:00.000Z'),
+        attemptAt('completed', 'completed', '2026-01-01T00:01:00.000Z'),
+        attemptAt('failed', 'failed', '2026-01-01T00:02:00.000Z'),
+        attemptAt('pending', 'pending', '2026-01-01T00:03:00.000Z'),
+        attemptAt('claimed', 'claimed', '2026-01-01T00:04:00.000Z'),
+        selected,
+        attemptAt('running', 'running', '2026-01-01T00:06:00.000Z'),
+        attemptAt('needs-input', 'needs_input', '2026-01-01T00:07:00.000Z'),
+        attemptAt('unrelated-running', 'running', '2026-01-01T00:08:00.000Z', 't2'),
+      ];
+      for (const attempt of attempts) adapter.saveAttempt(attempt);
+
+      expect(adapter.loadActionGraphAttempts('t1', selected.id).map((attempt) => attempt.id)).toEqual([
+        'pending',
+        'claimed',
+        'selected-superseded',
+        'running',
+        'needs-input',
+      ]);
+    });
+
+    it('returns active attempts plus the newest attempt when no selected attempt is present', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      const attempts = [
+        attemptAt('completed-old', 'completed', '2026-01-01T00:00:00.000Z'),
+        attemptAt('pending-current', 'pending', '2026-01-01T00:01:00.000Z'),
+        attemptAt('running-current', 'running', '2026-01-01T00:02:00.000Z'),
+        attemptAt('failed-newest', 'failed', '2026-01-01T00:03:00.000Z'),
+      ];
+      for (const attempt of attempts) adapter.saveAttempt(attempt);
+
+      expect(adapter.loadActionGraphAttempts('t1').map((attempt) => attempt.id)).toEqual([
+        'pending-current',
+        'running-current',
+        'failed-newest',
+      ]);
+    });
+  });
+
   describe('saveWorkflow + loadWorkflow', () => {
     it('round-trips a workflow', () => {
       adapter.saveWorkflow(testWorkflow);
@@ -1390,6 +1453,37 @@ describe('SQLiteAdapter', () => {
       expect(events[0].eventType).toBe('started');
       expect(events[1].eventType).toBe('completed');
       expect(JSON.parse(events[0].payload!)).toEqual({ attempt: 1 });
+    });
+
+    it('uses the task event lookup index for ordered event reads', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      const planRows = (adapter as any).db
+        .prepare('EXPLAIN QUERY PLAN SELECT * FROM events WHERE task_id = ? ORDER BY id ASC')
+        .all('t1') as Array<{ detail: string }>;
+      const detail = planRows.map((row) => row.detail).join('\n');
+
+      expect(detail).toContain('SEARCH events');
+      expect(detail).toContain('idx_events_task_id_id');
+      expect(detail).not.toContain('SCAN events');
+      expect(detail).not.toContain('USE TEMP B-TREE');
+    });
+
+    it('returns limited task events in the requested order', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      for (let index = 0; index < 30; index += 1) {
+        adapter.logEvent('t1', `event-${index}`, { index });
+      }
+
+      const events = adapter.getEvents('t1', 'desc', 20);
+
+      expect(events).toHaveLength(20);
+      expect(events.map((event) => event.eventType)).toEqual(
+        Array.from({ length: 20 }, (_value, index) => `event-${29 - index}`),
+      );
+      expect(adapter.getEvents('t1', 'desc', 0)).toEqual([]);
     });
   });
 

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -118,6 +118,7 @@ export interface PersistenceAdapter {
   // Events (audit trail)
   logEvent(taskId: string, eventType: string, payload?: unknown): void;
   getEvents(taskId: string): TaskEvent[];
+  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
 
   // Conversations (Slack thread-based)
   saveConversation(conversation: Conversation): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -776,6 +776,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
         FOREIGN KEY (task_id) REFERENCES tasks(id)
       );
 
+      CREATE INDEX IF NOT EXISTS idx_events_task_id_id
+        ON events(task_id, id);
+
       CREATE TABLE IF NOT EXISTS activity_log (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         timestamp TEXT NOT NULL DEFAULT (datetime('now')),
@@ -1047,6 +1050,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     // Replace old attempt_number index with created_at index
     this.db.run('DROP INDEX IF EXISTS idx_attempts_node');
     this.db.run('CREATE INDEX IF NOT EXISTS idx_attempts_node_created ON attempts(node_id, created_at)');
+    this.db.run('CREATE INDEX IF NOT EXISTS idx_events_task_id_id ON events(task_id, id)');
     this.db.run('CREATE INDEX IF NOT EXISTS idx_tasks_workflow_id ON tasks(workflow_id)');
     this.db.run('DROP INDEX IF EXISTS idx_task_launch_dispatch_active_attempt');
     this.db.run(`
@@ -2071,11 +2075,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
     `, [taskId, eventType, payload ? JSON.stringify(payload) : null]);
   }
 
-  getEvents(taskId: string): TaskEvent[] {
-    const rows = this.queryAll(
-      'SELECT * FROM events WHERE task_id = ? ORDER BY id ASC',
-      [taskId],
-    );
+  getEvents(taskId: string): TaskEvent[];
+  getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
+  getEvents(taskId: string, sortBy: 'asc' | 'desc' = 'asc', limit?: number): TaskEvent[] {
+    const orderBy = sortBy === 'desc' ? 'DESC' : 'ASC';
+    const rows = limit === undefined
+      ? this.queryAll(
+        `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy}`,
+        [taskId],
+      )
+      : limit <= 0
+        ? []
+        : this.queryAll(
+          `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy} LIMIT ?`,
+          [taskId, Math.floor(limit)],
+        );
     return rows.map((row: any) => ({
       id: row.id,
       taskId: row.task_id,
@@ -2491,6 +2505,28 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'SELECT * FROM attempts WHERE node_id = ? ORDER BY created_at ASC',
       [nodeId],
     );
+    return rows.map(this.rowToAttempt);
+  }
+
+  loadActionGraphAttempts(nodeId: string, selectedAttemptId?: string): Attempt[] {
+    const rows = selectedAttemptId
+      ? this.queryAll(
+        `SELECT * FROM attempts
+        WHERE node_id = ?
+          AND (status IN ('pending', 'claimed', 'running', 'needs_input') OR id = ?)
+        ORDER BY created_at ASC`,
+        [nodeId, selectedAttemptId],
+      )
+      : this.queryAll(
+        `SELECT * FROM attempts
+        WHERE node_id = ?
+          AND (
+            status IN ('pending', 'claimed', 'running', 'needs_input')
+            OR id = (SELECT id FROM attempts WHERE node_id = ? ORDER BY created_at DESC LIMIT 1)
+          )
+        ORDER BY created_at ASC`,
+        [nodeId, nodeId],
+      );
     return rows.map(this.rowToAttempt);
   }
 


### PR DESCRIPTION
## Summary

Action Graph was timing out because the events log can grow very large.

The old read path needed recent events for one task. The events table did not have an index for that lookup.

SQLite could scan too much history before returning the small slice the UI needed.

This adds a task-and-event-id index, a bounded `getEvents()` overload, and a current-attempt helper. It keeps the full event log, but lets Action Graph read the newest relevant rows directly.

## Review Claim

Approve the bounded Action Graph data access path and event lookup index.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

Default `getEvents(taskId)` full-history behavior is unchanged. The new `getEvents(taskId, sortBy, limit)` overload and attempt helper are covered by SQLite tests.

## Slice Rationale

This is the storage fix after the repro slice. The app can switch to it in the next slice without mixing SQL review with app routing.

## Non-goals

This does not change any Action Graph caller yet.

This does not delete full event or attempt history.

## Architecture

### Before

```mermaid
graph TD
    App[Action Graph caller] --> Events[getEvents full task history]
    App --> Attempts[loadAttempts full task history]
```

### After

```mermaid
graph TD
    App --> Events["getEvents(taskId, sortBy, limit)"]
    App --> Attempts[loadActionGraphAttempts current attempts]
    Events --> Index[idx_events_task_id_id]
```

## Test Plan

- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`

## Revert Plan

- Safe to revert? Yes, before dependent Action Graph app slices land.
- Revert command: `git revert 52ff79297`
- Post-revert steps: None.
- Data migration? No, the index is idempotent and can be dropped by revert if needed.
