### PR TITLE
[Action Graph Optimization](3) Use current action graph snapshot

### DIFF
--- a/packages/app/src/__tests__/action-graph-diagnostics.test.ts
+++ b/packages/app/src/__tests__/action-graph-diagnostics.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Attempt, TaskState } from '@invoker/workflow-core';
-import type { TaskLaunchDispatch, Workflow } from '@invoker/data-store';
+import type { TaskEvent, TaskLaunchDispatch, Workflow } from '@invoker/data-store';
 import {
   buildActionGraphDiagnostics,
   resolveActionDiagnosticsStallThresholdMs,
@@ -188,6 +188,66 @@ describe('buildActionGraphDiagnostics', () => {
 
     expect(graph.nodes.find((node) => node.id === 'blocker:launch-failed:error')?.label).toBe('Launch failed');
     expect(graph.nodes.find((node) => node.id === 'blocker:launch-failed:workspace')?.label).toBe('Missing workspace');
+  });
+
+  it('keeps only the latest task events in selected attempt history', () => {
+    const selectedAttempt = attempt({ id: 'attempt-a1', nodeId: 'task-a' });
+    const events: TaskEvent[] = Array.from({ length: 30 }, (_value, index) => ({
+      id: index + 1,
+      taskId: 'task-a',
+      eventType: `event-${index}`,
+      payload: `payload-${index}`,
+      createdAt: new Date(Date.UTC(2026, 4, 14, 11, index)).toISOString(),
+    }));
+
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [task({ id: 'task-a', execution: { selectedAttemptId: selectedAttempt.id } })],
+      attemptsByTaskId: new Map([['task-a', [selectedAttempt]]]),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [],
+      mutationLeases: [],
+      eventsByTaskId: new Map([['task-a', events]]),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    const selected = graph.nodes.find((node) => node.id === 'attempt:attempt-a1');
+    expect(selected?.history?.map((entry) => entry.source)).toEqual(
+      Array.from({ length: 20 }, (_value, index) => `event-${index + 10}`),
+    );
+  });
+
+  it('skips upstream attempt edges whose source attempts are omitted', () => {
+    const upstream = task({ id: 'upstream', status: 'failed' });
+    const downstream = task({ id: 'downstream', status: 'pending', dependencies: ['upstream'] });
+    const downstreamAttempt = attempt({
+      id: 'downstream-a1',
+      nodeId: 'downstream',
+      upstreamAttemptIds: ['old-upstream-a1'],
+    });
+
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [upstream, downstream],
+      attemptsByTaskId: new Map([['downstream', [downstreamAttempt]]]),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [],
+      mutationLeases: [],
+      eventsByTaskId: new Map(),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    expect(graph.edges).not.toContainEqual(expect.objectContaining({
+      source: 'attempt:old-upstream-a1',
+      target: 'attempt:downstream-a1',
+    }));
+    expect(graph.nodes.find((node) => node.id === 'blocker:downstream:dependency:upstream')).toEqual(
+      expect.objectContaining({ type: 'blocker', status: 'waiting' }),
+    );
   });
 });
 

--- a/packages/app/src/action-graph-diagnostics.ts
+++ b/packages/app/src/action-graph-diagnostics.ts
@@ -129,6 +129,11 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
   const workflowsById = new Map(input.workflows.map((workflow) => [workflow.id, workflow]));
   const runningQueueIds = new Set(input.queueStatus.running.map((item) => item.taskId));
   const queuedQueueIds = new Set(input.queueStatus.queued.map((item) => item.taskId));
+  const visibleAttemptIds = new Set<string>();
+  for (const attempts of input.attemptsByTaskId.values()) {
+    for (const attempt of attempts) visibleAttemptIds.add(attempt.id);
+  }
+
 
   for (const workflow of input.workflows) {
     const actionId = `action:${workflow.id}`;
@@ -267,6 +272,10 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
     const selectedAttemptId = task.execution.selectedAttemptId ?? attempts.at(-1)?.id ?? task.id;
     const selectedNodeId = `attempt:${selectedAttemptId}`;
     const taskEvents = input.eventsByTaskId.get(task.id) ?? [];
+    if (attempts.length === 0) {
+      visibleAttemptIds.add(selectedAttemptId);
+    }
+
 
     for (const attempt of attempts.length > 0 ? attempts : [{
       id: selectedAttemptId,
@@ -328,12 +337,14 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
       });
 
       for (const upstreamAttemptId of attempt.upstreamAttemptIds) {
-        edges.push({
-          id: edgeId(`attempt:${upstreamAttemptId}`, nodeId, 'upstream'),
-          source: `attempt:${upstreamAttemptId}`,
-          target: nodeId,
-          label: 'upstream',
-        });
+        if (visibleAttemptIds.has(upstreamAttemptId)) {
+          edges.push({
+            id: edgeId(`attempt:${upstreamAttemptId}`, nodeId, 'upstream'),
+            source: `attempt:${upstreamAttemptId}`,
+            target: nodeId,
+            label: 'upstream',
+          });
+        }
       }
     }
 
@@ -414,6 +425,8 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
         selectedNode.durations = { ...selectedNode.durations, waitingMs: ageMs(nowMs, task.createdAt) };
       }
     }
+
+
   }
 
   const uniqueEdges = new Map(edges.map((edge) => [edge.id, edge]));

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -72,7 +72,7 @@ import {
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { WorkflowMeta, WorkResponse } from '@invoker/contracts';
+import type { ActionGraphResponse, WorkflowMeta, WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
@@ -237,6 +237,32 @@ import {
 } from './window/window-lifecycle.js';
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
+
+function buildCurrentActionGraphSnapshot(args: {
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  invokerConfig: InvokerConfig;
+}): ActionGraphResponse {
+  args.orchestrator.syncAllFromDb();
+  const tasks = args.orchestrator.getAllTasks();
+  const workflows = args.persistence.listWorkflows();
+
+  return buildActionGraphDiagnostics({
+    workflows,
+    tasks,
+    attemptsByTaskId: new Map(tasks.map((task) => [
+      task.id,
+      args.persistence.loadActionGraphAttempts(task.id, task.execution.selectedAttemptId),
+    ])),
+    queueStatus: args.orchestrator.getQueueStatus(),
+    mutationIntents: args.persistence.listWorkflowMutationIntents(undefined, ['queued', 'running', 'failed']),
+    mutationLeases: args.persistence.listWorkflowMutationLeases(),
+    eventsByTaskId: new Map(tasks.map((task) => [task.id, args.persistence.getEvents(task.id, 'desc', 20)])),
+    activityLogs: args.persistence.getActivityLogs(0, 200),
+    stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(args.invokerConfig),
+    launchDispatches: args.persistence.listLaunchDispatchesByState(['enqueued', 'leased']),
+  });
+}
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -1618,21 +1644,7 @@ function startHeadlessMode(): void {
             };
           }
           if (kind === 'action-graph') {
-            orchestrator.syncAllFromDb();
-            const tasks = orchestrator.getAllTasks();
-            const workflows = persistence.listWorkflows();
-            return buildActionGraphDiagnostics({
-              workflows,
-              tasks,
-              attemptsByTaskId: new Map(tasks.map((task) => [task.id, persistence.loadAttempts(task.id)])),
-              queueStatus: orchestrator.getQueueStatus(),
-              mutationIntents: persistence.listWorkflowMutationIntents(),
-              mutationLeases: persistence.listWorkflowMutationLeases(),
-              eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
-              activityLogs: persistence.getActivityLogs(0, 200),
-              stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
-              launchDispatches: persistence.listLaunchDispatchesByState(['enqueued', 'leased', 'abandoned']),
-            });
+            return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
           }
           throw new Error(`Unsupported headless query: ${String(kind)}`);
         });
@@ -3145,21 +3157,7 @@ function createEmbeddedTerminalBackendFromConfig(
           };
         }
         if (kind === 'action-graph') {
-          orchestrator.syncAllFromDb();
-          const tasks = orchestrator.getAllTasks();
-          const workflows = persistence.listWorkflows();
-          return buildActionGraphDiagnostics({
-            workflows,
-            tasks,
-            attemptsByTaskId: new Map(tasks.map((task) => [task.id, persistence.loadAttempts(task.id)])),
-            queueStatus: orchestrator.getQueueStatus(),
-            mutationIntents: persistence.listWorkflowMutationIntents(),
-            mutationLeases: persistence.listWorkflowMutationLeases(),
-            eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
-            activityLogs: persistence.getActivityLogs(0, 200),
-            stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
-            launchDispatches: persistence.listLaunchDispatchesByState(['enqueued', 'leased', 'abandoned']),
-          });
+          return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
         }
         throw new Error(`Unsupported headless query: ${String(kind)}`);
       });
@@ -3744,21 +3742,7 @@ function createEmbeddedTerminalBackendFromConfig(
           );
         }
       }
-      orchestrator.syncAllFromDb();
-      const tasks = orchestrator.getAllTasks();
-      const workflows = persistence.listWorkflows();
-      return buildActionGraphDiagnostics({
-        workflows,
-        tasks,
-        attemptsByTaskId: new Map(tasks.map((task) => [task.id, persistence.loadAttempts(task.id)])),
-        queueStatus: orchestrator.getQueueStatus(),
-        mutationIntents: persistence.listWorkflowMutationIntents(),
-        mutationLeases: persistence.listWorkflowMutationLeases(),
-        eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
-        activityLogs: persistence.getActivityLogs(0, 200),
-        stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
-        launchDispatches: persistence.listLaunchDispatchesByState(['enqueued', 'leased', 'abandoned']),
-      });
+      return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
     });
 
     ipcMain.handle('invoker:report-ui-perf', (_event, metric: string, data?: Record<string, unknown>) => {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1125,6 +1125,21 @@ describe('SQLiteAdapter', () => {
         'failed-newest',
       ]);
     });
+
+    it('keeps a recent cancelled attempt next to the active replacement', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      const attempts = [
+        attemptAt('old-cancelled', 'superseded', '2026-01-01T00:00:00.000Z'),
+        attemptAt('pending-current', 'pending', '2026-01-01T00:01:00.000Z'),
+      ];
+      for (const attempt of attempts) adapter.saveAttempt(attempt);
+
+      expect(adapter.loadActionGraphAttempts('t1').map((attempt) => attempt.id)).toEqual([
+        'old-cancelled',
+        'pending-current',
+      ]);
+    });
   });
 
   describe('saveWorkflow + loadWorkflow', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -60,6 +60,8 @@ function loadNativeSqlite(): Promise<NativeSqlite> {
   nativeSqlite ??= import(nativeSqliteSpecifier) as Promise<NativeSqlite>;
   return nativeSqlite;
 }
+const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
+
 
 /**
  * Rewrite `pnpm test packages/<pkg>/...` (incorrect root-level invocation)
@@ -2508,25 +2510,28 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return rows.map(this.rowToAttempt);
   }
 
-  loadActionGraphAttempts(nodeId: string, selectedAttemptId?: string): Attempt[] {
-    const rows = selectedAttemptId
-      ? this.queryAll(
-        `SELECT * FROM attempts
-        WHERE node_id = ?
-          AND (status IN ('pending', 'claimed', 'running', 'needs_input') OR id = ?)
-        ORDER BY created_at ASC`,
-        [nodeId, selectedAttemptId],
-      )
-      : this.queryAll(
-        `SELECT * FROM attempts
-        WHERE node_id = ?
-          AND (
-            status IN ('pending', 'claimed', 'running', 'needs_input')
-            OR id = (SELECT id FROM attempts WHERE node_id = ? ORDER BY created_at DESC LIMIT 1)
+  loadActionGraphAttempts(
+    nodeId: string,
+    selectedAttemptId?: string,
+    recentAttemptLimit = ACTION_GRAPH_RECENT_ATTEMPT_LIMIT,
+  ): Attempt[] {
+    const limit = Math.max(0, Math.trunc(recentAttemptLimit));
+    const rows = this.queryAll(
+      `SELECT * FROM attempts
+      WHERE node_id = ?
+        AND (
+          status IN ('pending', 'claimed', 'running', 'needs_input')
+          OR id = ?
+          OR id IN (
+            SELECT id FROM attempts
+            WHERE node_id = ?
+            ORDER BY created_at DESC
+            LIMIT ?
           )
-        ORDER BY created_at ASC`,
-        [nodeId, nodeId],
-      );
+        )
+      ORDER BY created_at ASC`,
+      [nodeId, selectedAttemptId ?? null, nodeId, limit],
+    );
     return rows.map(this.rowToAttempt);
   }
 


### PR DESCRIPTION
## Summary

Every Action Graph entrypoint now uses one shared current snapshot builder.

The graph keeps active attempts, selected attempts, recent cancelled attempts, and recent task events through bounded reads.

It also keeps active dispatch data and avoids edges to hidden upstream attempts.

<details>
<summary>Review metadata</summary>

Review Claim: Approve routing all Action Graph entrypoints through the shared current snapshot builder.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The graph still shows current failures and blockers. Full task history remains stored outside this diagnostic snapshot.

Slice Rationale: This slice wires the data-store reads into the app after the database support exists. It keeps proof scripting and changelog edits separate.

</details>

## Non-goals

This does not change task execution, retry behavior, or stored event rows.

This does not add a full-history Action Graph mode.

## Architecture

### Before

```mermaid
graph TD
    UI[UI/client] --> A[Action Graph loader A]
    UI --> B[Action Graph loader B]
    UI --> C[Action Graph loader C]
    A --> Full[Full per-task history]
    B --> Full
    C --> Full
```

### After

```mermaid
graph TD
    UI[UI/client] --> Snapshot[Shared Action Graph snapshot]
    Snapshot --> Current[Current attempts and recent events]
    Snapshot --> Graph[Bounded diagnostics graph]
```

## Test Plan

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/action-graph-diagnostics.test.ts`
- [x] `cd packages/data-store && pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm run check:types`

## Visual Proof

No visual layout changed. This screenshot records the live Action Graph query result after this stack returned within the owner timeout.

![Live Action Graph query proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-c7df0a/action-graph-live-query-proof.png)

## Revert Plan

- Safe to revert? Yes, if the dependent changelog slice is reverted first.
- Revert command: `git revert 576d8e88d`
- Post-revert steps: Restart any running shared owner.
- Data migration? No.
