### PR TITLE
[Action Graph Optimization](4) Document action graph timeout fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Invoker will be documented in this file.
 ## Unreleased
 
 - Make `plan-to-invoker` use focused verification by default instead of mandatory `pnpm test` or `pnpm run test:all` gates.
+- Bound Action Graph diagnostics to indexed current task data so large databases return quickly.
 
 ## 0.0.4
 


### PR DESCRIPTION
## Summary

The Unreleased changelog now records the Action Graph timeout fix.

The full stack proof shows the same 200,000-event repro switching from an events table scan to the indexed lookup.

![Action Graph timeout before and after proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-e647ad/action-graph-before-after-proof.png)

<details>
<summary>Review metadata</summary>

Review Claim: Approve the Unreleased changelog entry for the Action Graph timeout fix.

Review Lane: docs

Review Unit: docs

Safety Invariant: This only changes release notes. Runtime code is untouched.

Slice Rationale: The changelog is separate so the behavior and proof PRs stay focused.

</details>

## Non-goals

This does not change code, tests, or scripts.

## Test Plan

- [x] `pnpm --filter @invoker/data-store build && pnpm --filter @invoker/app build && bash scripts/repro/repro-action-graph-query-timeout.sh --expect-fixed --event-count 200000`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 337e381ca`
- Post-revert steps: None.
- Data migration? No.
