### PR TITLE
[Graph Blank Storm 1] Drop stale owner deltas

### DIFF
--- a/packages/app/src/__tests__/delta-merge.test.ts
+++ b/packages/app/src/__tests__/delta-merge.test.ts
@@ -96,11 +96,27 @@ describe('applyDelta', () => {
       const result = applyDelta(delta, cache);
 
       expect(result.quarantined).toEqual([]);
+      expect(result.accepted).toBe(true);
       expect(cache.has('t1')).toBe(true);
       const stored = JSON.parse(cache.get('t1')!);
       expect(stored.id).toBe('t1');
       expect(stored.status).toBe('running');
       expect(cache.getEntry('t1')?.taskStateVersion).toBe(2);
+    });
+    it('drops stale created deltas that would downgrade cache state', () => {
+      const cache = new TaskSnapshotCache();
+      cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 5, status: 'running' })));
+
+      const result = applyDelta({
+        type: 'created',
+        task: makeTask('t1', { taskStateVersion: 4, status: 'completed' }),
+      }, cache);
+
+      expect(result.accepted).toBe(false);
+      expect(result.quarantined).toEqual([]);
+      expect(cache.getEntry('t1')?.taskStateVersion).toBe(5);
+      const stored = JSON.parse(cache.get('t1')!);
+      expect(stored.status).toBe('running');
     });
   });
 
@@ -121,6 +137,7 @@ describe('applyDelta', () => {
       const result = applyDelta(delta, cache);
 
       expect(result.quarantined).toEqual([]);
+      expect(result.accepted).toBe(true);
       const stored = JSON.parse(cache.get('t1')!);
       expect(stored.status).toBe('completed');
       expect(stored.execution.exitCode).toBe(0);
@@ -180,6 +197,25 @@ describe('applyDelta', () => {
       expect(stored.status).toBe('running');
       expect(stored.taskStateVersion).toBe(1);
     });
+    it('drops stale updated deltas without quarantining', () => {
+      const cache = new TaskSnapshotCache();
+      cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 5, status: 'running' })));
+
+      const result = applyDelta({
+        type: 'updated',
+        taskId: 't1',
+        changes: { status: 'completed' },
+        taskStateVersion: 4,
+        previousTaskStateVersion: 3,
+      }, cache);
+
+      expect(result.accepted).toBe(false);
+      expect(result.quarantined).toEqual([]);
+      expect(cache.getEntry('t1')?.taskStateVersion).toBe(5);
+      expect(cache.isQuarantined('t1')).toBe(false);
+      const stored = JSON.parse(cache.get('t1')!);
+      expect(stored.status).toBe('running');
+    });
 
     it('quarantines when task is unknown (no prior created)', () => {
       const cache = new TaskSnapshotCache();
@@ -235,9 +271,25 @@ describe('applyDelta', () => {
 
       const delta: TaskDelta = { type: 'removed', taskId: 't1', previousTaskStateVersion: 1 };
 
-      applyDelta(delta, cache);
+      const result = applyDelta(delta, cache);
 
       expect(cache.has('t1')).toBe(false);
+      expect(result.accepted).toBe(true);
+    });
+    it('drops stale removed deltas that would delete newer cache state', () => {
+      const cache = new TaskSnapshotCache();
+      cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 5 })));
+
+      const result = applyDelta({
+        type: 'removed',
+        taskId: 't1',
+        previousTaskStateVersion: 3,
+      }, cache);
+
+      expect(result.accepted).toBe(false);
+      expect(result.quarantined).toEqual([]);
+      expect(cache.has('t1')).toBe(true);
+      expect(cache.getEntry('t1')?.taskStateVersion).toBe(5);
     });
   });
 
@@ -362,7 +414,10 @@ function simulateMainProcessDeltaHandler(
 ): { rendererDeltas: TaskDelta[] } {
   const rendererDeltas: TaskDelta[] = [];
 
-  const { quarantined } = applyDelta(delta, cache);
+  const { quarantined, accepted } = applyDelta(delta, cache);
+  if (quarantined.length === 0 && accepted) {
+    rendererDeltas.push(delta);
+  }
   for (const taskId of quarantined) {
     const { rendererDelta } = recoverQuarantinedTask(cache, taskId, {
       loadTask: persistence.loadTask,
@@ -688,7 +743,8 @@ describe('regression: out-of-order updates never merge from orchestrator memory'
       previousTaskStateVersion: 2,
     }, cache);
 
-    expect(result.quarantined).toEqual(['t1']);
+    expect(result.accepted).toBe(false);
+    expect(result.quarantined).toEqual([]);
     // Cache still shows taskStateVersion 5, not downgraded
     const stored = JSON.parse(cache.get('t1')!);
     expect(stored.status).toBe('completed');

--- a/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
+++ b/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
@@ -87,7 +87,10 @@ function runRecovery(
   loaders: RecoveryLoaders,
 ): { rendererDeltas: TaskDelta[] } {
   const rendererDeltas: TaskDelta[] = [];
-  const { quarantined } = applyDelta(delta, cache);
+  const { quarantined, accepted } = applyDelta(delta, cache);
+  if (quarantined.length === 0 && accepted) {
+    rendererDeltas.push(delta);
+  }
   for (const taskId of quarantined) {
     const { rendererDelta } = recoverQuarantinedTask(cache, taskId, loaders);
     if (rendererDelta) {
@@ -175,38 +178,46 @@ describe('synthetic __merge__ quarantine-loop repro (graph-blank root cause)', (
     expect((rendererDeltas[0] as { type: 'removed'; taskId: string }).taskId).toBe(SYNTHETIC_ID);
   });
 
-  it('(c) burst of stale out-of-order synthetic deltas each get a recovery delta (no silent loop)', () => {
-    // Models the live-log signature: three `[gap-detect]` events for
-    // `__merge__wf-X` in <1s. Each iteration sends an `updated` delta whose
-    // `previousTaskStateVersion` does not match the (post-recovery) cache,
-    // mirroring the realistic case where the orchestrator races ahead and
-    // multiple stale deltas land in quick succession. Every quarantine MUST
-    // produce exactly one recovery delta — no silent loops.
+  it('(c) burst of stale out-of-order synthetic deltas quarantines once, then drops stale deltas', () => {
+    // First delta is a real forward gap: cache is at v2, the delta expects v3,
+    // and recovery loads the authoritative merge node at v10. Later deltas are
+    // older than that recovered snapshot, so they must be dropped instead of
+    // re-quarantining and re-sending created deltas in a loop.
     const cache = seedCacheWithMergeNode(2);
-    // Orchestrator advances faster than the deltas arriving on the bus.
-    let authoritativeVersion = 10;
     const loaders: RecoveryLoaders = {
       loadTask: loadTaskNeverReturnsSynthetic,
       getMergeNode: (workflowId) =>
-        workflowId === WORKFLOW_ID ? makeMergeNode(WORKFLOW_ID, authoritativeVersion) : undefined,
+        workflowId === WORKFLOW_ID ? makeMergeNode(WORKFLOW_ID, 10) : undefined,
     };
 
     const allRendererDeltas: TaskDelta[] = [];
     let totalQuarantined = 0;
 
-    for (const orchestratorVersion of [10, 11, 12]) {
-      authoritativeVersion = orchestratorVersion;
-      // Each delta is stale (prev=3) relative to whatever the cache holds
-      // after the previous recovery (v=10, then v=11, then v=12) — so all
-      // three deltas hit the gap branch in applyDelta.
-      const delta: TaskDelta = {
+    const deltas: TaskDelta[] = [
+      {
         type: 'updated',
         taskId: SYNTHETIC_ID,
         changes: { status: 'running' },
         taskStateVersion: 4,
         previousTaskStateVersion: 3,
-      };
+      },
+      {
+        type: 'updated',
+        taskId: SYNTHETIC_ID,
+        changes: { status: 'completed' },
+        taskStateVersion: 5,
+        previousTaskStateVersion: 4,
+      },
+      {
+        type: 'updated',
+        taskId: SYNTHETIC_ID,
+        changes: { status: 'failed' },
+        taskStateVersion: 10,
+        previousTaskStateVersion: 9,
+      },
+    ];
 
+    for (const delta of deltas) {
       const beforeQuarantineState = applyDelta(delta, copyCache(cache));
       totalQuarantined += beforeQuarantineState.quarantined.length;
 
@@ -214,10 +225,10 @@ describe('synthetic __merge__ quarantine-loop repro (graph-blank root cause)', (
       allRendererDeltas.push(...rendererDeltas);
     }
 
-    expect(totalQuarantined).toBe(3);
-    expect(allRendererDeltas).toHaveLength(3);
-    expect(allRendererDeltas.every((d) => d.type === 'created')).toBe(true);
-    expect(cache.getEntry(SYNTHETIC_ID)?.taskStateVersion).toBe(12);
+    expect(totalQuarantined).toBe(1);
+    expect(allRendererDeltas).toHaveLength(1);
+    expect(allRendererDeltas[0].type).toBe('created');
+    expect(cache.getEntry(SYNTHETIC_ID)?.taskStateVersion).toBe(10);
   });
 
   it('(d) no implicit drops: non-synthetic ghost task emits removed delta', () => {

--- a/packages/app/src/delta-merge.ts
+++ b/packages/app/src/delta-merge.ts
@@ -88,36 +88,51 @@ export class TaskSnapshotCache {
 export interface ApplyDeltaResult {
   /** Task IDs that need authoritative reload from persistence. */
   quarantined: string[];
+  /** True when the original delta is current and safe to forward to the renderer. */
+  accepted: boolean;
 }
 
 /**
  * Apply a single TaskDelta to the snapshot cache.
  *
  * Task-state-version-aware semantics:
- * - `created`: unconditionally stores the task snapshot and taskStateVersion.
+ * - `created`: stores new task snapshots, but rejects stale snapshots that
+ *   would downgrade an existing cache entry.
  * - `updated` with matching `previousTaskStateVersion`: merges changes, bumps
  *   the cached taskStateVersion to `delta.taskStateVersion`.
- * - `updated` with a taskStateVersion gap or unknown task: quarantines the task
- *   and returns its id in `result.quarantined`.
- * - `removed`: deletes the cache entry.
+ * - `updated` with a forward taskStateVersion gap or unknown task: quarantines
+ *   the task and returns its id in `result.quarantined`.
+ * - `updated` at or behind the cached taskStateVersion is stale and ignored.
+ * - `removed`: deletes the cache entry unless the remove is stale.
  * - Deltas targeting a quarantined task are silently ignored.
  *
- * @returns IDs of tasks that were quarantined and need authoritative reload.
+ * @returns IDs of tasks that were quarantined and whether the original delta was accepted.
  */
 export function applyDelta(
   delta: TaskDelta,
   cache: TaskSnapshotCache,
 ): ApplyDeltaResult {
-  const result: ApplyDeltaResult = { quarantined: [] };
+  const result: ApplyDeltaResult = { quarantined: [], accepted: false };
 
   if (delta.type === 'created') {
+    const entry = cache.getEntry(delta.task.id);
+    const nextVersion = delta.task.taskStateVersion ?? 1;
+    if (entry && nextVersion < entry.taskStateVersion) {
+      return result;
+    }
+
     cache.set(delta.task.id, JSON.stringify(delta.task));
-    return result;
+    return { quarantined: [], accepted: true };
   }
 
   if (delta.type === 'removed') {
+    const entry = cache.getEntry(delta.taskId);
+    if (entry && delta.previousTaskStateVersion < entry.taskStateVersion) {
+      return result;
+    }
+
     cache.delete(delta.taskId);
-    return result;
+    return { quarantined: [], accepted: true };
   }
 
   // delta.type === 'updated'
@@ -128,13 +143,22 @@ export function applyDelta(
     return result;
   }
 
-  // Unknown task or taskStateVersion gap → quarantine.
-  if (!entry || entry.taskStateVersion !== delta.previousTaskStateVersion) {
-    // Mark as quarantined.  If the entry exists, keep its snapshot but
-    // flag it; if it doesn't, create a placeholder entry.
-    if (entry) {
-      entry.quarantined = true;
-    }
+  // Unknown task → quarantine so persistence can tell the renderer to create
+  // or remove the task authoritatively.
+  if (!entry) {
+    result.quarantined.push(delta.taskId);
+    return result;
+  }
+
+  // Stale/backward delta → drop without quarantining or mutating cache.
+  if (delta.taskStateVersion <= entry.taskStateVersion) {
+    return result;
+  }
+
+  // Forward gap → quarantine. Keep the cached snapshot but block later deltas
+  // until recovery replaces or removes it.
+  if (entry.taskStateVersion !== delta.previousTaskStateVersion) {
+    entry.quarantined = true;
     result.quarantined.push(delta.taskId);
     return result;
   }
@@ -154,7 +178,7 @@ export function applyDelta(
   entry.snapshot = snapshot;
   entry.taskStateVersion = delta.taskStateVersion;
 
-  return result;
+  return { quarantined: [], accepted: true };
 }
 
 /**

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2002,9 +2002,9 @@ function createEmbeddedTerminalBackendFromConfig(
   };
 
   const applyTaskDeltaToOwnerCacheOrRecover = (delta: TaskDelta): TaskDelta[] => {
-    const { quarantined } = applyDelta(delta, lastKnownTaskStates);
+    const { quarantined, accepted } = applyDelta(delta, lastKnownTaskStates);
     if (quarantined.length === 0) {
-      return [delta];
+      return accepted ? [delta] : [];
     }
 
     const rendererDeltas: TaskDelta[] = [];


### PR DESCRIPTION
## Summary

Owner cache deltas now say whether the original event is safe to forward.

The trigger was a merge-node delta storm: logs showed gap detection quarantining `__merge__` tasks while the app still had 152 tasks and 34 workflows.

Repro proof lives in `packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts`; it recreates stale `__merge__` updates and proves they collapse to one quarantine and recovery.

Stale created, removed, and updated events no longer downgrade or delete newer cache state.

Real forward gaps still recover from the authoritative task snapshot.

## Review Claim

Approve the stale-delta validation rule in the owner cache.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Rejected deltas leave the owner cache unchanged. Forward gaps still use the existing recovery path.

## Slice Rationale

This slice fixes freshness before renderer fallbacks depend on owner stream correctness.

## Non-goals

This does not change persistence loading, renderer rendering, or publisher buffering.

## Architecture

### Before

```mermaid
flowchart LR
  Delta[Task delta] --> Cache[Owner cache]
  Cache --> Renderer[Renderer]
  Cache --> Recovery[Recovery]
  Recovery --> Renderer
```

### After

```mermaid
flowchart LR
  Delta[Task delta] --> Cache[Owner cache freshness check]
  Cache -->|accepted| Renderer[Renderer]
  Cache -->|stale| Drop[Drop original]
  Cache -->|forward gap| Recovery[Authoritative recovery]
  Recovery --> Renderer
```

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/delta-merge.test.ts src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run the app delta tests.
- Data migration? No