### PR TITLE
[Graph Blank Storm 2] Ignore stale stream snapshots

### DIFF
--- a/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
@@ -18,6 +18,7 @@ function installInvoker(opts: {
   onTaskGraphEventMock: ReturnType<typeof vi.fn>;
   refreshTaskGraphMock: ReturnType<typeof vi.fn>;
   fireDelta: (delta: unknown) => void;
+  fireSnapshot: (snapshot: TaskSnapshot & { reason?: string }) => void;
 } {
   let handler: ((event: unknown) => void) | undefined;
 
@@ -61,6 +62,13 @@ function installInvoker(opts: {
     onTaskGraphEventMock,
     refreshTaskGraphMock,
     fireDelta: (delta) => handler?.({ type: 'delta', delta }),
+    fireSnapshot: (snapshot) => handler?.({
+      type: 'snapshot',
+      tasks: snapshot.tasks,
+      workflows: snapshot.workflows,
+      reason: snapshot.reason ?? 'test-snapshot',
+      streamSequence: snapshot.streamSequence,
+    }),
   };
 }
 
@@ -245,5 +253,43 @@ describe('useTasks stream-sequence gap-detect', () => {
     expect(result.current.tasks.get('t1')?.status).toBe('running');
     expect(getTasksMock).not.toHaveBeenCalled();
     expect(reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected')).toHaveLength(0);
+  });
+
+  it('ignores stale empty snapshots below the current stream watermark', async () => {
+    const t1 = makeUITask({ id: 't1', status: 'running' });
+
+    const {
+      refreshTaskGraphMock,
+      reportUiPerfMock,
+      onTaskGraphEventMock,
+      fireSnapshot,
+    } = installInvoker({
+      bootstrap: { tasks: [t1], streamSequence: 10 },
+      responses: [{ tasks: [t1], workflows: [], streamSequence: 10 }],
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(onTaskGraphEventMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      fireSnapshot({
+        tasks: [],
+        workflows: [],
+        streamSequence: 9,
+        reason: 'stale-empty',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 130));
+    });
+
+    expect(result.current.tasks.has('t1')).toBe(true);
+    expect(refreshTaskGraphMock).not.toHaveBeenCalled();
+    expect(reportUiPerfMock).toHaveBeenCalledWith('ui_task_graph_stale_snapshot_ignored', {
+      current: 10,
+      snapshot: 9,
+      reason: 'stale-empty',
+    });
   });
 });

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -241,7 +241,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
             }
             return wfMap;
           });
-          uiTaskGraphStreamWatermarkRef.current = firstEvent.streamSequence;
+          uiTaskGraphStreamWatermarkRef.current = Math.max(uiTaskGraphStreamWatermarkRef.current, firstEvent.streamSequence);
           isResyncInFlightRef.current = false;
           onTaskGraphSnapshotApplied?.();
           void window.invoker.reportUiPerf?.('useTasks_snapshot_replace', {
@@ -294,6 +294,16 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       invalidateStartupSnapshot();
       deltaPerfRef.current.received += 1;
       if (event.type === 'snapshot') {
+        const snapshotStreamSequence = event.streamSequence;
+        const currentStreamSequence = uiTaskGraphStreamWatermarkRef.current;
+        if (snapshotStreamSequence < currentStreamSequence) {
+          window.invoker.reportUiPerf?.('ui_task_graph_stale_snapshot_ignored', {
+            current: currentStreamSequence,
+            snapshot: snapshotStreamSequence,
+            reason: event.reason,
+          });
+          return;
+        }
         graphEventPipelineRef.current?.push(event);
         return;
       }


### PR DESCRIPTION
## Summary

The task stream now ignores old snapshot events instead of replacing newer data.

A stale empty snapshot can no longer clear the task map after live events advance the stream.

The stream watermark only advances when snapshots are applied.

## Review Claim

Approve the snapshot freshness check before events enter the pipeline.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Only snapshots older than the current watermark are rejected. Current and newer snapshots still apply normally.

## Slice Rationale

This slice keeps snapshot freshness separate from selected graph display fallback.

## Non-goals

This does not change delta batching, selected graph fallback, or graph rendering.

## Architecture

### Before

```mermaid
flowchart LR
  Event[Snapshot event] --> Pipeline[Pipeline]
  Pipeline --> Replace[Replace task and workflow maps]
```

### After

```mermaid
flowchart LR
  Event[Snapshot event] --> Watermark{Older than watermark?}
  Watermark -->|yes| Ignore[Report and ignore]
  Watermark -->|no| Pipeline[Pipeline]
  Pipeline --> Replace[Replace task and workflow maps]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/use-tasks-stream-gap-detect.test.tsx src/__tests__/selected-workflow-graph-disappears-repro.test.tsx`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run the task stream tests.
- Data migration? No