### PR TITLE
[Graph Blank Storm 3] Keep selected mini DAG visible

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -366,6 +366,12 @@ export function hasMergeConflictExecution(task: TaskState | undefined): boolean 
   }
 }
 
+type SelectedWorkflowGraphSnapshot = {
+  workflowId: string;
+  workflow: WorkflowMeta;
+  tasks: Map<string, TaskState>;
+};
+
 export function App() {
   const [graphRefreshSequence, setGraphRefreshSequence] = useState(0);
   const handleTaskGraphSnapshotApplied = useCallback(() => {
@@ -377,6 +383,7 @@ export function App() {
   const invoker = useInvoker();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
+  const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [stickySelectedWorkflow, setStickySelectedWorkflow] = useState<WorkflowMeta | null>(null);
@@ -581,14 +588,59 @@ export function App() {
     }
     return next;
   }, [selectedWorkflow, selectedWorkflowId, tasks]);
+  useEffect(() => {
+    if (selectedWorkflow && miniDagTasks.size > 0) {
+      lastGoodSelectedWorkflowGraphRef.current = {
+        workflowId: selectedWorkflow.id,
+        workflow: selectedWorkflow,
+        tasks: miniDagTasks,
+      };
+      return;
+    }
+
+    if (!selectedWorkflowId || workflowSelectionDismissed || tasks.size === 0) {
+      lastGoodSelectedWorkflowGraphRef.current = null;
+    }
+  }, [miniDagTasks, selectedWorkflow, selectedWorkflowId, tasks.size, workflowSelectionDismissed]);
+
+  const displayedSelectedWorkflowGraph = useMemo<SelectedWorkflowGraphSnapshot | null>(() => {
+    if (selectedWorkflow && miniDagTasks.size > 0) {
+      return {
+        workflowId: selectedWorkflow.id,
+        workflow: selectedWorkflow,
+        tasks: miniDagTasks,
+      };
+    }
+
+    const snapshot = lastGoodSelectedWorkflowGraphRef.current;
+    const selectedTaskWorkflowId = selectedTask?.config.workflowId ?? null;
+    const selectedTaskForcesDifferentWorkflow = selectedTaskWorkflowId !== null
+      && snapshot !== null
+      && selectedTaskWorkflowId !== snapshot.workflowId;
+    if (
+      snapshot
+      && selectedWorkflowId === snapshot.workflowId
+      && snapshot.tasks.size > 0
+      && !workflowSelectionDismissed
+      && !selectedTaskForcesDifferentWorkflow
+      && tasks.size > 0
+    ) {
+      return snapshot;
+    }
+
+    return null;
+  }, [miniDagTasks, selectedTask, selectedWorkflow, selectedWorkflowId, tasks.size, workflowSelectionDismissed]);
+  const isSelectedWorkflowGraphRefreshing = displayedSelectedWorkflowGraph !== null
+    && !(selectedWorkflow && miniDagTasks.size > 0);
   const selectedTaskDagWorkflows = useMemo(() => {
-    if (!selectedWorkflow || workflows.has(selectedWorkflow.id)) {
+    const workflowForDag = displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow;
+    if (!workflowForDag || workflows.has(workflowForDag.id)) {
       return workflows;
     }
     const next = new Map(workflows);
-    next.set(selectedWorkflow.id, selectedWorkflow);
+    next.set(workflowForDag.id, workflowForDag);
     return next;
-  }, [selectedWorkflow, workflows]);
+  }, [displayedSelectedWorkflowGraph, selectedWorkflow, workflows]);
 
   useEffect(() => {
     if (!selectedWorkflowId) {
@@ -1880,12 +1932,12 @@ export function App() {
                     onWorkflowContextMenu={handleWorkflowContextMenu}
                     onManualViewport={handleManualViewport}
                   />
-                  {selectedWorkflow && miniDagTasks.size > 0 && (
+                  {displayedSelectedWorkflowGraph !== null && (
                     <FloatingGraphPanel
-                      key={selectedWorkflow.id}
+                      key={displayedSelectedWorkflowGraph.workflow.id}
                       testId="selected-workflow-mini-dag"
                       dragHandleTestId="selected-workflow-mini-dag-drag-handle"
-                      title={`${selectedWorkflow.name} task DAG`}
+                      title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
                       boundsRef={graphSurfaceRef}
                       contentClassName="h-[250px]"
                     >
@@ -1895,8 +1947,13 @@ export function App() {
                         data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
                         className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
                       >
+                        {isSelectedWorkflowGraphRefreshing && (
+                          <div data-testid="selected-workflow-mini-dag-refreshing" className="px-2 py-1 text-xs text-amber-200">
+                            Refreshing graph…
+                          </div>
+                        )}
                         <TaskDAG
-                          tasks={miniDagTasks}
+                          tasks={displayedSelectedWorkflowGraph.tasks}
                           workflows={selectedTaskDagWorkflows}
                           selectedTaskId={selectedTaskId}
                           cameraCommand={cameraCommand}
@@ -1950,9 +2007,9 @@ export function App() {
             className={`${inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
           >
             <WorkflowInspector
-              workflow={selectedWorkflow}
+              workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
               task={selectedTask}
-              workflowTasks={miniDagTasks}
+              workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
               remoteTargets={remoteTargets}
               executionPools={executionPools}
               executionAgents={executionAgents}

--- a/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
+++ b/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
@@ -76,4 +76,84 @@ describe('selected workflow graph metadata-gap regression', () => {
     expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
     expect(screen.getByTestId('rf__node-task-beta')).toBeInTheDocument();
   });
+
+  it('keeps the selected mini-DAG visible during a merge-node remove/create/update storm', async () => {
+    const alpha = makeUITask({
+      id: 'task-alpha',
+      description: 'Workflow A first task',
+      status: 'pending',
+      workflowId: 'wf-a',
+      taskStateVersion: 1,
+    });
+    const beta = makeUITask({
+      id: 'task-beta',
+      description: 'Workflow A second task',
+      status: 'pending',
+      workflowId: 'wf-a',
+      dependencies: ['task-alpha'],
+      taskStateVersion: 1,
+    });
+    const merge = makeUITask({
+      id: '__merge__wf-a',
+      description: 'Workflow A merge',
+      status: 'pending',
+      workflowId: 'wf-a',
+      isMergeNode: true,
+      dependencies: ['task-beta'],
+      taskStateVersion: 1,
+    });
+    const gamma = makeUITask({
+      id: 'task-gamma',
+      description: 'Workflow B task',
+      status: 'running',
+      workflowId: 'wf-b',
+      taskStateVersion: 1,
+    });
+
+    render(<App />);
+    act(() => mock.setTasks([alpha, beta, merge, gamma], [workflowA, workflowB]));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A task DAG');
+      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
+      expect(screen.getByTestId('rf__node-task-beta')).toBeInTheDocument();
+      expect(screen.getByTestId('rf__node-__merge__wf-a')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      mock.fireDelta({ type: 'removed', taskId: 'task-alpha', previousTaskStateVersion: 1 });
+      mock.fireDelta({ type: 'removed', taskId: 'task-beta', previousTaskStateVersion: 1 });
+      mock.fireDelta({ type: 'removed', taskId: '__merge__wf-a', previousTaskStateVersion: 1 });
+      await new Promise((resolve) => setTimeout(resolve, 130));
+    });
+
+    expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
+    expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
+    expect(screen.getByTestId('rf__node-task-beta')).toBeInTheDocument();
+    expect(screen.getByTestId('rf__node-__merge__wf-a')).toBeInTheDocument();
+    expect(screen.getByTestId('selected-workflow-mini-dag-refreshing')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+    expect(screen.getByText('Total:')).not.toHaveTextContent('Total: 0');
+
+    await act(async () => {
+      mock.fireDelta({ type: 'created', task: alpha });
+      mock.fireDelta({ type: 'created', task: beta });
+      mock.fireDelta({ type: 'created', task: merge });
+      await new Promise((resolve) => setTimeout(resolve, 130));
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('selected-workflow-mini-dag-refreshing')).not.toBeInTheDocument();
+      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
+      expect(screen.getByTestId('rf__node-task-beta')).toBeInTheDocument();
+      expect(screen.getByTestId('rf__node-__merge__wf-a')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
@@ -18,6 +18,7 @@ function installInvoker(opts: {
   onTaskGraphEventMock: ReturnType<typeof vi.fn>;
   refreshTaskGraphMock: ReturnType<typeof vi.fn>;
   fireDelta: (delta: unknown) => void;
+  fireSnapshot: (snapshot: TaskSnapshot & { reason?: string }) => void;
 } {
   let handler: ((event: unknown) => void) | undefined;
 
@@ -61,6 +62,13 @@ function installInvoker(opts: {
     onTaskGraphEventMock,
     refreshTaskGraphMock,
     fireDelta: (delta) => handler?.({ type: 'delta', delta }),
+    fireSnapshot: (snapshot) => handler?.({
+      type: 'snapshot',
+      tasks: snapshot.tasks,
+      workflows: snapshot.workflows,
+      reason: snapshot.reason ?? 'test-snapshot',
+      streamSequence: snapshot.streamSequence,
+    }),
   };
 }
 
@@ -245,5 +253,43 @@ describe('useTasks stream-sequence gap-detect', () => {
     expect(result.current.tasks.get('t1')?.status).toBe('running');
     expect(getTasksMock).not.toHaveBeenCalled();
     expect(reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected')).toHaveLength(0);
+  });
+
+  it('ignores stale empty snapshots below the current stream watermark', async () => {
+    const t1 = makeUITask({ id: 't1', status: 'running' });
+
+    const {
+      refreshTaskGraphMock,
+      reportUiPerfMock,
+      onTaskGraphEventMock,
+      fireSnapshot,
+    } = installInvoker({
+      bootstrap: { tasks: [t1], streamSequence: 10 },
+      responses: [{ tasks: [t1], workflows: [], streamSequence: 10 }],
+    });
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(onTaskGraphEventMock).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      fireSnapshot({
+        tasks: [],
+        workflows: [],
+        streamSequence: 9,
+        reason: 'stale-empty',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 130));
+    });
+
+    expect(result.current.tasks.has('t1')).toBe(true);
+    expect(refreshTaskGraphMock).not.toHaveBeenCalled();
+    expect(reportUiPerfMock).toHaveBeenCalledWith('ui_task_graph_stale_snapshot_ignored', {
+      current: 10,
+      snapshot: 9,
+      reason: 'stale-empty',
+    });
   });
 });

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -241,7 +241,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
             }
             return wfMap;
           });
-          uiTaskGraphStreamWatermarkRef.current = firstEvent.streamSequence;
+          uiTaskGraphStreamWatermarkRef.current = Math.max(uiTaskGraphStreamWatermarkRef.current, firstEvent.streamSequence);
           isResyncInFlightRef.current = false;
           onTaskGraphSnapshotApplied?.();
           void window.invoker.reportUiPerf?.('useTasks_snapshot_replace', {
@@ -294,6 +294,16 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       invalidateStartupSnapshot();
       deltaPerfRef.current.received += 1;
       if (event.type === 'snapshot') {
+        const snapshotStreamSequence = event.streamSequence;
+        const currentStreamSequence = uiTaskGraphStreamWatermarkRef.current;
+        if (snapshotStreamSequence < currentStreamSequence) {
+          window.invoker.reportUiPerf?.('ui_task_graph_stale_snapshot_ignored', {
+            current: currentStreamSequence,
+            snapshot: snapshotStreamSequence,
+            reason: event.reason,
+          });
+          return;
+        }
         graphEventPipelineRef.current?.push(event);
         return;
       }


### PR DESCRIPTION
## Summary

The selected workflow mini-DAG keeps showing its last good graph during short data gaps.

This prevents the side panel and floating graph from blanking while task data refreshes.

The fallback clears when the task map is empty or selection is dismissed.

## Review Claim

Approve the selected graph fallback for temporary task-map gaps.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The fallback is scoped to the selected workflow id and only runs while task data still exists.

## Slice Rationale

This slice is separate from stream freshness so the review can focus on displayed selected graph state.

## Non-goals

This does not change workflow graph layout, task execution, or owner cache behavior.

## Architecture

### Before

```mermaid
flowchart LR
  LiveTasks[Live task map] --> MiniDag[Selected mini-DAG]
  MiniDag -->|empty| Blank[Panel blanks]
```

### After

```mermaid
flowchart LR
  LiveTasks[Live task map] --> MiniDag{Has selected tasks?}
  MiniDag -->|yes| Live[Render live graph]
  MiniDag -->|temporary gap| Snapshot[Render last good graph]
  MiniDag -->|explicit clear| Blank[Panel clears]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/use-tasks-stream-gap-detect.test.tsx src/__tests__/selected-workflow-graph-disappears-repro.test.tsx`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run the selected workflow graph tests.
- Data migration? No

Depends-On: #1684