### PR TITLE
[Graph Blank Storm 4] Scope React Flow watchdogs

### DIFF
--- a/packages/ui/src/__tests__/task-dag-stability.test.ts
+++ b/packages/ui/src/__tests__/task-dag-stability.test.ts
@@ -252,13 +252,13 @@ describe('TaskDAG stability', () => {
   // ── Watchdog detection logic ──────────────────────────────
   describe('watchdog detection logic', () => {
     function shouldTrigger(
-      domNodeCount: number,
-      hiddenCount: number,
+      renderedNodeElementCount: number,
+      missingRenderedNodeCount: number,
       propsNodeCount: number,
     ): boolean {
       return (
-        (domNodeCount === 0 && propsNodeCount > 0) ||
-        (hiddenCount > 0 && hiddenCount === domNodeCount)
+        (renderedNodeElementCount === 0 && propsNodeCount > 0) ||
+        (missingRenderedNodeCount > 0 && missingRenderedNodeCount === renderedNodeElementCount)
       );
     }
 
@@ -310,6 +310,13 @@ describe('TaskDAG stability', () => {
       expect(source).toContain('const WATCHDOG_RECOVERY_MISS_COUNT = 3;');
       expect(source).toContain('setFlowInstanceKey((key) => key + 1)');
       expect(reactFlowBlock).toContain('key={flowInstanceKey}');
+    });
+
+    it('scopes watchdog DOM queries to the graph root', () => {
+      expect(source).toContain('graphRootRef');
+      expect(source).toContain('graphRootRef.current');
+      expect(source).toContain('root.querySelectorAll');
+      expect(source).not.toContain('document.querySelectorAll');
     });
   });
 

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -1,5 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { WorkflowGraph } from '../components/WorkflowGraph.js';
 import { createGraphCameraCommandIssuer } from '../lib/graph-camera.js';
 import type { TaskState, WorkflowMeta, WorkflowStatus } from '../types.js';
@@ -13,6 +15,11 @@ vi.mock('@xyflow/react', async () => {
 const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
 const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
 const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
+
+const source = readFileSync(
+  resolve(__dirname, '..', 'components', 'WorkflowGraph.tsx'),
+  'utf-8',
+);
 
 function wf(id: string, status: WorkflowStatus, overrides: Partial<WorkflowMeta> = {}): WorkflowMeta {
   return { id, name: id, status, ...overrides };
@@ -482,5 +489,18 @@ describe('WorkflowGraph', () => {
     // A manual move must never autofocus the graph.
     expect(setCenterMock).not.toHaveBeenCalled();
     expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it('uses a scoped bounded watchdog for React Flow recovery', () => {
+    const reactFlowBlock = source.slice(
+      source.indexOf('<ReactFlow'),
+      source.indexOf('</ReactFlow>'),
+    );
+    expect(source).toContain('const WATCHDOG_RECOVERY_MISS_COUNT = 3;');
+    expect(source).toContain('setFlowInstanceKey((key) => key + 1)');
+    expect(reactFlowBlock).toContain('key={flowInstanceKey}');
+    expect(source).toContain('graphRootRef');
+    expect(source).toContain('graphRootRef.current');
+    expect(source).toContain('root.querySelectorAll');
   });
 });

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -153,6 +153,7 @@ function mergeMeasuredNodeState(prevNodes: Node[], nextNodes: Node[]): Node[] {
 
 function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskClick, onTaskDoubleClick, onTaskContextMenu, onManualViewport, statusFilters }: TaskDAGProps) {
   const { fitView, setCenter, getZoom } = useReactFlow();
+  const graphRootRef = useRef<HTMLDivElement>(null);
   const prevNodeCount = useRef(0);
   const lastNodeClickRef = useRef<{ id: string; at: number } | null>(null);
   const reportedGraphVisibleRef = useRef(false);
@@ -497,14 +498,16 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   useEffect(() => {
     if (nodes.length === 0) return;
     const interval = setInterval(() => {
-      const domNodes = document.querySelectorAll('.react-flow__node');
-      const hiddenNodes = document.querySelectorAll(
+      const root = graphRootRef.current;
+      if (!root) return;
+      const renderedNodeElements = root.querySelectorAll('.react-flow__node');
+      const missingRenderedNodes = root.querySelectorAll(
         '.react-flow__node[style*="visibility: hidden"]',
       );
 
       if (
-        (domNodes.length === 0 && nodes.length > 0) ||
-        (hiddenNodes.length > 0 && hiddenNodes.length === domNodes.length)
+        (renderedNodeElements.length === 0 && nodes.length > 0) ||
+        (missingRenderedNodes.length > 0 && missingRenderedNodes.length === renderedNodeElements.length)
       ) {
         watchdogMissCountRef.current += 1;
         const shouldRecover =
@@ -517,8 +520,8 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
             : '[DAG-watchdog] Nodes hidden or missing, forcing fitView',
           {
             propsNodeCount: nodes.length,
-            domNodeCount: domNodes.length,
-            hiddenCount: hiddenNodes.length,
+            renderedNodeElementCount: renderedNodeElements.length,
+            missingRenderedNodeCount: missingRenderedNodes.length,
             missCount: watchdogMissCountRef.current,
             recoveryAttempted: watchdogRecoveryAttemptedRef.current,
             recoveryTriggered: shouldRecover,
@@ -589,7 +592,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   }
 
   return (
-    <div className="h-full w-full" style={{ minHeight: '300px' }}>
+    <div ref={graphRootRef} className="h-full w-full" style={{ minHeight: '300px' }}>
       <ReactFlow
         key={flowInstanceKey}
         nodes={rfNodes}

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
 import type { TaskState, WorkflowMeta, WorkflowStatus } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
@@ -45,6 +45,8 @@ interface WorkflowNodeData extends Record<string, unknown> {
 const nodeTypes = {
   workflowNode: WorkflowFlowNode,
 };
+const WATCHDOG_RECOVERY_MISS_COUNT = 3;
+
 
 function workflowEdgeVisual(kind: WorkflowGraphEdge['kind']): {
   stroke: string;
@@ -112,9 +114,13 @@ function WorkflowGraphInner({
   onManualViewport,
 }: WorkflowGraphProps): JSX.Element {
   const { fitView, setCenter, getZoom } = useReactFlow();
+  const graphRootRef = useRef<HTMLDivElement>(null);
   const reportedVisibleRef = useRef(false);
   const lastHandledCameraSeqRef = useRef(0);
   const initFitFrameRef = useRef(0);
+  const watchdogMissCountRef = useRef(0);
+  const watchdogRecoveryAttemptedRef = useRef(false);
+  const [flowInstanceKey, setFlowInstanceKey] = useState(0);
   const graphMetricsRef = useRef({ deriveMs: 0, layoutMs: 0, objectsMs: 0 });
   const graph = useMemo(() => {
     const startedAt = performance.now();
@@ -188,6 +194,13 @@ function WorkflowGraphInner({
   // Cancel a pending first-fit frame on unmount so it never fires against a
   // torn-down graph after the component has gone away.
   useEffect(() => () => cancelAnimationFrame(initFitFrameRef.current), []);
+  useEffect(() => {
+    if (nodes.length > 0) {
+      watchdogMissCountRef.current = 0;
+      watchdogRecoveryAttemptedRef.current = false;
+    }
+  }, [nodes.length]);
+
 
   // Manual pan/zoom from the user. React Flow passes a non-null DOM event for
   // user-driven moves and null for programmatic setCenter/fitView, so this only
@@ -264,15 +277,27 @@ function WorkflowGraphInner({
   useEffect(() => {
     if (nodes.length === 0) return;
     const interval = setInterval(() => {
-      const domNodes = document.querySelectorAll('[data-testid^="workflow-node-"]');
-      const hiddenNodes = document.querySelectorAll(
+      const root = graphRootRef.current;
+      if (!root) return;
+      const renderedNodeElements = root.querySelectorAll('[data-testid^="workflow-node-"]');
+      const missingRenderedNodes = root.querySelectorAll(
         '.react-flow__node[style*="visibility: hidden"] [data-testid^="workflow-node-"]',
       );
       if (
-        (domNodes.length === 0 && nodes.length > 0) ||
-        (hiddenNodes.length > 0 && hiddenNodes.length === domNodes.length)
+        (renderedNodeElements.length === 0 && nodes.length > 0) ||
+        (missingRenderedNodes.length > 0 && missingRenderedNodes.length === renderedNodeElements.length)
       ) {
+        watchdogMissCountRef.current += 1;
+        const shouldRecover =
+          watchdogMissCountRef.current >= WATCHDOG_RECOVERY_MISS_COUNT &&
+          !watchdogRecoveryAttemptedRef.current;
         fitView({ padding: 0.2 });
+        if (shouldRecover) {
+          watchdogRecoveryAttemptedRef.current = true;
+          setFlowInstanceKey((key) => key + 1);
+        }
+      } else {
+        watchdogMissCountRef.current = 0;
       }
     }, 2000);
     return () => clearInterval(interval);
@@ -292,8 +317,9 @@ function WorkflowGraphInner({
       className="h-full w-full overflow-hidden"
       style={{ minHeight: '300px' }}
     >
-      <div data-testid="workflow-graph-react-flow" className="h-full w-full">
+      <div ref={graphRootRef} data-testid="workflow-graph-react-flow" className="h-full w-full">
         <ReactFlow
+          key={flowInstanceKey}
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}


### PR DESCRIPTION
## Summary

React Flow watchdogs now check only the graph they own.

The workflow graph also gets bounded remount recovery after repeated missing-node checks, matching the task DAG behavior.

This avoids global DOM false positives while still recovering a blank graph mount.

## Review Claim

Approve scoped graph-root watchdog checks and one bounded workflow graph remount.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The watchdog only reads inside its graph root. Remount recovery is limited to one attempt after repeated misses.

## Slice Rationale

This slice is separate because it changes React Flow DOM recovery, not task stream state.

## Non-goals

This does not change graph layout, node data, task state, or workflow status logic.

## Architecture

### Before

```mermaid
flowchart LR
  Watchdog[Watchdog] --> Document[Whole document]
  Document --> Fit[fitView only]
```

### After

```mermaid
flowchart LR
  Watchdog[Watchdog] --> Root[Graph root]
  Root --> Fit[fitView]
  Fit -->|three misses| Remount[Remount React Flow once]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/task-dag-stability.test.ts src/__tests__/workflow-graph.test.tsx`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run the graph watchdog tests.
- Data migration? No