### PR TITLE
[Mergify Stack](1) Harden create-pr for Mergify stack branches

### DIFF
--- a/scripts/create-clean-pr-branch.sh
+++ b/scripts/create-clean-pr-branch.sh
@@ -84,9 +84,12 @@ if [[ $# -gt 0 ]]; then
 fi
 
 echo ""
+echo ""
 echo "Branch ready: ${BRANCH_NAME}"
 echo "Next:"
 echo "  git push -u ${PUBLISH_REMOTE} ${BRANCH_NAME}"
+echo "  # If this branch is part of a Mergify stack, restore its target before stack push:"
+echo "  git branch --set-upstream-to=${BASE_REMOTE}/${BASE_REF} ${BRANCH_NAME}"
 echo "  cp scripts/pr-body-template.md /tmp/my-pr.md"
 echo "  \$EDITOR /tmp/my-pr.md"
 echo "  node scripts/validate-pr-body.mjs --body-file /tmp/my-pr.md"

--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -7,13 +7,19 @@
  *   node scripts/create-pr.mjs --title "..." --base <branch> [options]
  *
  * Options:
- *   --title <t>        PR title (required)
- *   --base <b>         Base branch (required)
- *   --body-file <f>    Read PR body from file
- *   --body <text>      Inline PR body
- *   --update <num>     Update existing PR instead of creating new
- *   --dry-run          Print what would happen, skip push and API calls
- *   --help             Show this help
+ *   --title <t>          PR title (required)
+ *   --base <b>           Base branch (required)
+ *   --body-file <f>      Read PR body from file
+ *   --body <text>        Inline PR body
+ *   --update <num>       Update existing PR instead of creating new
+ *   --update-existing    Update the PR already attached to the current branch
+ *   --dry-run            Print what would happen, skip push and API calls
+ *   --help               Show this help
+ *
+ * Stack flow:
+ *   1. Publish stack branches with `mergify stack push`
+ *   2. Switch to the created stack branch if needed
+ *   3. Run `node scripts/create-pr.mjs --title "..." --base <branch> --body-file <file> --update-existing`
  *
  * Image injection:
  *   Scans the body for markdown image/link patterns where the URL is a local
@@ -22,18 +28,23 @@
  *
  * PR body validation:
  *   Enforces the canonical PR schema:
- *   ## Summary, ## Test Plan, ## Revert Plan, plus optional ## Architecture.
+ *   ## Summary, ## Review Claim, ## Review Lane, ## Safety Invariant,
+ *   ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan,
+ *   plus optional ## Architecture and required ## Visual Proof for UI changes.
  */
 
 import { readFileSync, existsSync } from 'node:fs';
 import { basename, extname, join } from 'node:path';
 import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
-import { execFileSync, execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import aws4 from 'aws4';
 import { getPrBodyWarnings, validatePrBody } from './validate-pr-body.mjs';
 
-const DEFAULT_PARENT_REMOTE = process.env.INVOKER_PARENT_REMOTE || 'upstream';
+const DEFAULT_BASE_REMOTE = process.env.INVOKER_PARENT_REMOTE || 'origin';
+const HAS_EXPLICIT_NON_ORIGIN_BASE_REMOTE = Boolean(
+  process.env.INVOKER_PARENT_REMOTE && process.env.INVOKER_PARENT_REMOTE !== 'origin',
+);
 
 // ── R2 upload (duplicated from upload-pr-images.mjs for standalone use) ─────
 
@@ -67,7 +78,13 @@ function loadR2Config() {
   }
   const { R2_ACCOUNT_ID, R2_BUCKET_NAME, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_PUBLIC_URL_BASE } = process.env;
   if (R2_ACCOUNT_ID && R2_BUCKET_NAME && R2_ACCESS_KEY_ID && R2_SECRET_ACCESS_KEY && R2_PUBLIC_URL_BASE) {
-    return { accountId: R2_ACCOUNT_ID, bucketName: R2_BUCKET_NAME, accessKeyId: R2_ACCESS_KEY_ID, secretAccessKey: R2_SECRET_ACCESS_KEY, publicUrlBase: R2_PUBLIC_URL_BASE };
+    return {
+      accountId: R2_ACCOUNT_ID,
+      bucketName: R2_BUCKET_NAME,
+      accessKeyId: R2_ACCESS_KEY_ID,
+      secretAccessKey: R2_SECRET_ACCESS_KEY,
+      publicUrlBase: R2_PUBLIC_URL_BASE,
+    };
   }
   return null;
 }
@@ -86,13 +103,19 @@ async function uploadToR2(filePath, key, config) {
   const path = `/${config.bucketName}/${key}`;
 
   const opts = aws4.sign({
-    host, path, method: 'PUT', body,
+    host,
+    path,
+    method: 'PUT',
+    body,
     headers: { 'Content-Type': contentType, 'Content-Length': body.length },
-    service: 's3', region: 'auto',
+    service: 's3',
+    region: 'auto',
   }, { accessKeyId: config.accessKeyId, secretAccessKey: config.secretAccessKey });
 
   const response = await fetch(`https://${host}${path}`, {
-    method: 'PUT', headers: opts.headers, body,
+    method: 'PUT',
+    headers: opts.headers,
+    body,
   });
   if (!response.ok) {
     const text = await response.text();
@@ -108,13 +131,19 @@ function usage() {
   console.error(`Usage: node scripts/create-pr.mjs --title "..." --base <branch> [options]
 
 Options:
-  --title <t>        PR title (required)
-  --base <b>         Base branch (required)
-  --body-file <f>    Read PR body from file
-  --body <text>      Inline PR body
-  --update <num>     Update existing PR number instead of creating new
-  --dry-run          Print actions without executing
-  --help             Show this help
+  --title <t>          PR title (required)
+  --base <b>           Base branch (required)
+  --body-file <f>      Read PR body from file
+  --body <text>        Inline PR body
+  --update <num>       Update existing PR number instead of creating new
+  --update-existing    Update the PR already attached to the current branch
+  --dry-run            Print actions without executing
+  --help               Show this help
+
+Stack flow:
+  1. Publish stack branches with \`mergify stack push\`
+  2. Switch to the created stack branch if needed
+  3. Run \`node scripts/create-pr.mjs --title "..." --base <branch> --body-file <file> --update-existing\`
 
 PR body schema:
   Required: ## Summary, ## Review Claim, ## Review Lane, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
@@ -126,7 +155,15 @@ PR body schema:
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const parsed = { title: '', base: '', body: '', bodyFile: '', update: '', dryRun: false };
+  const parsed = {
+    title: '',
+    base: '',
+    body: '',
+    bodyFile: '',
+    update: '',
+    updateExisting: false,
+    dryRun: false,
+  };
 
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
@@ -137,10 +174,15 @@ function parseArgs() {
       case '--body': parsed.body = args[++i] || ''; break;
       case '--body-file': parsed.bodyFile = args[++i] || ''; break;
       case '--update': parsed.update = args[++i] || ''; break;
+      case '--update-existing': parsed.updateExisting = true; break;
       default:
         console.error(`Unknown option: ${args[i]}`);
         usage();
     }
+  }
+
+  if (parsed.update && parsed.updateExisting) {
+    throw new Error('Use either --update <num> or --update-existing, not both.');
   }
 
   if (!parsed.title || !parsed.base) {
@@ -170,8 +212,8 @@ function assertValidPrBody(body, options = {}) {
   );
 }
 
-function printPrBodyWarnings(body, options = {}) {
-  const warnings = getPrBodyWarnings(body, options);
+function printPrBodyWarnings(body) {
+  const warnings = getPrBodyWarnings(body);
   if (warnings.length === 0) return;
 
   console.error('PR body validation warnings:');
@@ -187,11 +229,9 @@ function printPrBodyWarnings(body, options = {}) {
  * Matches: ![alt](path) and [text](path) where path is not http(s).
  */
 async function injectImages(body, dryRun) {
-  // Match ![...](<path>) or [...](<path>) where path doesn't start with http
   const pattern = /(!?\[[^\]]*\])\(([^)]+)\)/g;
   const localFiles = [];
 
-  // Collect local file paths
   let match;
   while ((match = pattern.exec(body)) !== null) {
     const url = match[2];
@@ -231,7 +271,6 @@ async function injectImages(body, dryRun) {
     }
   }
 
-  // Replace local paths with public URLs
   return body.replace(pattern, (full, bracket, url) => {
     const replacement = urlMap.get(url);
     return replacement ? `${bracket}(${replacement})` : full;
@@ -240,16 +279,44 @@ async function injectImages(body, dryRun) {
 
 // ── Git + GitHub helpers ────────────────────────────────────────────────────
 
-function getRepoNwo() {
-  // Prefer parent remote (fork workflow: PRs target parent, not the fork)
+function runGit(args, options = {}) {
+  return execFileSync('git', args, {
+    encoding: 'utf-8',
+    ...options,
+  });
+}
+
+function runGh(args, options = {}) {
+  return execFileSync('gh', args, {
+    encoding: 'utf-8',
+    ...options,
+  });
+}
+
+function gitText(args, options = {}) {
+  return runGit(args, options).trim();
+}
+
+function gitTextOrEmpty(args, options = {}) {
   try {
-    const url = execSync(`git remote get-url ${DEFAULT_PARENT_REMOTE}`, { encoding: 'utf-8' }).trim();
+    return gitText(args, {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      ...options,
+    });
+  } catch {
+    return '';
+  }
+}
+
+function getRepoNwo() {
+  try {
+    const url = gitText(['remote', 'get-url', DEFAULT_BASE_REMOTE]);
     const match = url.match(/github\.com[:/]([^/]+\/[^/.]+)/);
     if (match) return match[1];
   } catch {
-    // No parent remote; fall back to gh default
+    // No usable base remote; fall back to gh default
   }
-  return execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { encoding: 'utf-8' }).trim();
+  return runGh(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner']);
 }
 
 function gitPush(dryRun) {
@@ -258,16 +325,16 @@ function gitPush(dryRun) {
     return;
   }
   console.error('Pushing branch...');
-  execSync('git push -u origin HEAD', { stdio: 'inherit' });
+  execFileSync('git', ['push', '-u', 'origin', 'HEAD'], { stdio: 'inherit' });
 }
 
 function getCurrentBranch() {
-  return execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
+  return gitText(['branch', '--show-current']);
 }
 
 function hasRemote(name) {
   try {
-    execSync(`git remote get-url ${name}`, { stdio: ['ignore', 'pipe', 'ignore'] });
+    runGit(['remote', 'get-url', name], { stdio: ['ignore', 'pipe', 'ignore'] });
     return true;
   } catch {
     return false;
@@ -275,20 +342,20 @@ function hasRemote(name) {
 }
 
 function revList(range) {
-  try {
-    const out = execSync(`git rev-list ${range}`, { encoding: 'utf-8' }).trim();
-    return out ? out.split('\n').filter(Boolean) : [];
-  } catch {
-    return [];
-  }
+  const out = gitTextOrEmpty(['rev-list', range]);
+  return out ? out.split('\n').filter(Boolean) : [];
 }
 
 function shortOneLine(sha) {
-  try {
-    return execSync(`git show --no-patch --oneline --no-abbrev-commit ${sha}`, { encoding: 'utf-8' }).trim();
-  } catch {
-    return sha;
-  }
+  return gitTextOrEmpty(['show', '--no-patch', '--oneline', '--no-abbrev-commit', sha]) || sha;
+}
+
+function resolveRev(ref) {
+  return gitText(['rev-parse', ref]);
+}
+
+function fetchBranch(remote, branch) {
+  runGit(['fetch', '--quiet', remote, branch], { stdio: 'ignore' });
 }
 
 export function isUiImpactingPath(filePath) {
@@ -305,74 +372,66 @@ export function getUiImpactingFiles(files) {
   return files.filter(isUiImpactingPath);
 }
 
-export function parsePorcelainChangedFiles(statusText) {
-  return statusText
-    .split(/\r?\n/)
-    .map((line) => line.trimEnd())
-    .filter(Boolean)
-    .map((line) => line.slice(3).replace(/^"|"$/g, ''))
-    .filter(Boolean);
-}
-
 function changedFilesSinceBase(baseBranch) {
   try {
-    const output = execFileSync(
-      'git',
-      ['diff', '--name-only', `${DEFAULT_PARENT_REMOTE}/${baseBranch}...HEAD`],
-      { encoding: 'utf-8' },
-    ).trim();
+    const output = runGit(['diff', '--name-only', `${DEFAULT_BASE_REMOTE}/${baseBranch}...HEAD`]).trim();
     return output ? output.split('\n').filter(Boolean) : [];
   } catch {
     return [];
   }
 }
 
-function uncommittedFiles() {
-  try {
-    const output = execFileSync(
-      'git',
-      ['status', '--porcelain', '--untracked-files=all'],
-      { encoding: 'utf-8' },
-    );
-    return parsePorcelainChangedFiles(output);
-  } catch {
-    return [];
-  }
-}
-
-function assertNoUncommittedFiles() {
-  const files = uncommittedFiles();
-  if (files.length === 0) return;
-
-  throw new Error(
-    [
-      'Refusing to create/update PR with uncommitted changes.',
-      'Commit, split, or stash these files first; uncommitted files are not included in review-lane validation.',
-      ...files.map((file) => `  - ${file}`),
-    ].join('\n'),
-  );
-}
-
-
 function assertCleanPrBase(baseBranch) {
-  if (!hasRemote(DEFAULT_PARENT_REMOTE)) {
+  if (!hasRemote(DEFAULT_BASE_REMOTE)) {
     throw new Error(
       [
-        `Missing git parent remote "${DEFAULT_PARENT_REMOTE}".`,
-        `Expected ${DEFAULT_PARENT_REMOTE} to point to the parent repository.`,
-        `Run: git remote add ${DEFAULT_PARENT_REMOTE} <parent-repo-url>`,
+        `Missing git base remote "${DEFAULT_BASE_REMOTE}".`,
+        `Expected ${DEFAULT_BASE_REMOTE} to point to the base repository.`,
+        `Run: git remote add ${DEFAULT_BASE_REMOTE} <base-repo-url>`,
       ].join('\n'),
     );
   }
 
-  // Keep the check deterministic against latest refs.
-  execSync(`git fetch --quiet ${DEFAULT_PARENT_REMOTE} ${baseBranch}`, { stdio: 'ignore' });
-  execSync(`git fetch --quiet origin ${baseBranch}`, { stdio: 'ignore' });
+  if (!hasRemote('origin')) {
+    throw new Error(
+      [
+        'Missing git base remote "origin".',
+        'Expected origin to point to the GitHub repository used for PR publication.',
+        'Run: git remote add origin <github-repo-url>',
+      ].join('\n'),
+    );
+  }
 
-  const originOnly = new Set(revList(`${DEFAULT_PARENT_REMOTE}/${baseBranch}..origin/${baseBranch}`));
+  fetchBranch('origin', baseBranch);
+  const originRef = `origin/${baseBranch}`;
+  const originTip = resolveRev(originRef);
+  const mergeBase = gitText(['merge-base', 'HEAD', originRef]);
+  if (mergeBase !== originTip) {
+    const currentBranch = getCurrentBranch();
+    throw new Error(
+      [
+        `Refusing to create/update PR: current branch is not based on the latest ${originRef}.`,
+        `Rebuild it from ${originRef} and cherry-pick only the intended commits.`,
+        '',
+        'Recovery:',
+        `  git switch -c pr/<name> ${originRef}`,
+        '  git cherry-pick <commit> [<commit> ...]',
+        '  git push -u origin pr/<name>',
+        '',
+        `Current branch: ${currentBranch}`,
+      ].join('\n'),
+    );
+  }
+
+  if (!HAS_EXPLICIT_NON_ORIGIN_BASE_REMOTE || DEFAULT_BASE_REMOTE === 'origin') {
+    return;
+  }
+
+  fetchBranch(DEFAULT_BASE_REMOTE, baseBranch);
+  const originOnly = new Set(revList(`${DEFAULT_BASE_REMOTE}/${baseBranch}..origin/${baseBranch}`));
   if (originOnly.size === 0) return;
 
-  const headOnly = revList(`${DEFAULT_PARENT_REMOTE}/${baseBranch}..HEAD`);
+  const headOnly = revList(`${DEFAULT_BASE_REMOTE}/${baseBranch}..HEAD`);
   const polluted = headOnly.filter((sha) => originOnly.has(sha));
   if (polluted.length === 0) return;
 
@@ -382,22 +441,151 @@ function assertCleanPrBase(baseBranch) {
   throw new Error(
     [
       `Refusing to create/update PR: current branch contains commits unique to origin/${baseBranch}.`,
-      'This would pollute the PR with fork-only history.',
+      'This would pollute the PR with origin-only history.',
       '',
       'Detected commits:',
       ...lines,
       more,
       '',
-      `Fix by creating a clean PR branch from ${DEFAULT_PARENT_REMOTE}/${baseBranch}, then cherry-picking intended commits:`,
-      `  git switch -c pr/<name> ${DEFAULT_PARENT_REMOTE}/${baseBranch}`,
-      `  git cherry-pick <commit> [<commit> ...]`,
-      `  git push -u origin pr/<name>`,
+      `Fix by creating a clean PR branch from ${DEFAULT_BASE_REMOTE}/${baseBranch}, then cherry-picking intended commits:`,
+      `  git switch -c pr/<name> ${DEFAULT_BASE_REMOTE}/${baseBranch}`,
+      '  git cherry-pick <commit> [<commit> ...]',
+      '  git push -u origin pr/<name>',
       '',
       `Current branch: ${currentBranch}`,
     ].join('\n'),
   );
 }
 
+function getBranchMergeRef(branch) {
+  return gitTextOrEmpty(['config', '--get', `branch.${branch}.merge`]);
+}
+
+function getBranchRemote(branch) {
+  return gitTextOrEmpty(['config', '--get', `branch.${branch}.remote`]);
+}
+
+function resolveTrackedBaseRef(branch) {
+  const mergeRef = getBranchMergeRef(branch);
+  if (!mergeRef) return '';
+  const baseBranch = mergeRef.replace(/^refs\/heads\//, '');
+  const remote = getBranchRemote(branch);
+  if (remote) {
+    const remoteRef = `${remote}/${baseBranch}`;
+    if (gitTextOrEmpty(['rev-parse', '--verify', remoteRef])) {
+      return remoteRef;
+    }
+  }
+  if (gitTextOrEmpty(['rev-parse', '--verify', baseBranch])) {
+    return baseBranch;
+  }
+  return baseBranch;
+}
+
+function branchHasChangeId(baseRef) {
+  if (!baseRef) return false;
+  try {
+    const log = runGit(['log', '--format=%B', `${baseRef}..HEAD`]);
+    return /^Change-Id:/m.test(log);
+  } catch {
+    return false;
+  }
+}
+
+
+function getMergifyBranchState(branch = getCurrentBranch()) {
+  if (!branch || ['main', 'master', 'develop'].includes(branch)) {
+    return { managed: false, branch, trackedBaseRef: '' };
+  }
+
+  const trackedBaseRef = resolveTrackedBaseRef(branch);
+  if (branch.startsWith('stack/')) {
+    return { managed: true, branch, trackedBaseRef };
+  }
+
+  const mergeRef = getBranchMergeRef(branch);
+  if (!mergeRef) {
+    return { managed: false, branch, trackedBaseRef: '' };
+  }
+
+  if (!branchHasChangeId(trackedBaseRef)) {
+    return { managed: false, branch, trackedBaseRef };
+  }
+
+  return { managed: true, branch, trackedBaseRef };
+}
+
+function getCurrentUpstream() {
+  return gitTextOrEmpty(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{upstream}']);
+}
+
+function assertPublishedMergifyBranch(branch, trackedBaseRef) {
+  let publishedRef = getCurrentUpstream();
+  const originBranchRef = `origin/${branch}`;
+  if ((!publishedRef || publishedRef === trackedBaseRef) && gitTextOrEmpty(['rev-parse', '--verify', originBranchRef])) {
+    publishedRef = originBranchRef;
+  }
+
+  if (!publishedRef) {
+    throw new Error(
+      [
+        `Current branch "${branch}" has no published remote branch.`,
+        'Run `mergify stack push` first, then rerun this command to update the PR title/body.',
+      ].join('\n'),
+    );
+  }
+
+  const unpublished = revList(`${publishedRef}..HEAD`);
+  if (unpublished.length === 0) return;
+
+  throw new Error(
+    [
+      `Current branch "${branch}" has unpublished local commits ahead of ${publishedRef}.`,
+      'Run `mergify stack push` first, then rerun this command to update the PR title/body.',
+    ].join('\n'),
+  );
+}
+
+function listPullRequestsForHead(nwo, branch) {
+  const [owner] = nwo.split('/');
+  const query = new URLSearchParams({
+    state: 'all',
+    head: `${owner}:${branch}`,
+  }).toString();
+  const raw = runGh(['api', `repos/${nwo}/pulls?${query}`]);
+  const prs = JSON.parse(raw);
+  return prs.filter((pr) => pr?.head?.ref === branch && pr?.head?.repo?.full_name === nwo);
+}
+
+function resolveExistingPrNumber(nwo, branch, dryRun) {
+  if (dryRun) {
+    console.error(`[dry-run] Would resolve PR for current branch: ${branch}`);
+    return '0';
+  }
+
+  const prs = listPullRequestsForHead(nwo, branch);
+  if (prs.length === 1) {
+    return String(prs[0].number);
+  }
+
+  if (prs.length === 0) {
+    throw new Error(
+      [
+        `No PR exists for current branch "${branch}" in ${nwo}.`,
+        'Run `mergify stack push` first for stack branches, or create the PR normally for non-stack branches.',
+      ].join('\n'),
+    );
+  }
+
+  const choices = prs.map((pr) => `  - #${pr.number}: ${pr.html_url}`).join('\n');
+  throw new Error(
+    [
+      `Found multiple PRs for current branch "${branch}" in ${nwo}.`,
+      'Refusing to guess. Resolve the duplicate PRs first.',
+      choices,
+    ].join('\n'),
+  );
+}
 
 async function createPr(nwo, title, base, body, dryRun) {
   const head = getCurrentBranch();
@@ -409,10 +597,9 @@ async function createPr(nwo, title, base, body, dryRun) {
   }
 
   const payload = JSON.stringify({ title, body, head, base });
-  const result = execSync(
-    `gh api repos/${nwo}/pulls --method POST --input -`,
-    { input: payload, encoding: 'utf-8' },
-  );
+  const result = runGh(['api', `repos/${nwo}/pulls`, '--method', 'POST', '--input', '-'], {
+    input: payload,
+  });
   const pr = JSON.parse(result);
   return pr.html_url;
 }
@@ -425,10 +612,9 @@ async function updatePr(nwo, prNum, title, body, dryRun) {
   }
 
   const payload = JSON.stringify({ title, body });
-  const result = execSync(
-    `gh api repos/${nwo}/pulls/${prNum} --method PATCH --input -`,
-    { input: payload, encoding: 'utf-8' },
-  );
+  const result = runGh(['api', `repos/${nwo}/pulls/${prNum}`, '--method', 'PATCH', '--input', '-'], {
+    input: payload,
+  });
   const pr = JSON.parse(result);
   return pr.html_url;
 }
@@ -439,9 +625,7 @@ async function main() {
   const args = parseArgs();
 
   assertCleanPrBase(args.base);
-  assertNoUncommittedFiles();
 
-  // Read body
   let body = '';
   if (args.bodyFile) {
     body = readFileSync(args.bodyFile, 'utf-8');
@@ -456,25 +640,41 @@ async function main() {
   }
 
   assertValidPrBody(body, { requiresVisualProof: uiImpactingFiles.length > 0, changedFiles });
-  printPrBodyWarnings(body, { changedFiles });
-
-  // Inject images
+  printPrBodyWarnings(body);
   body = await injectImages(body, args.dryRun);
 
-  // Push
-  gitPush(args.dryRun);
-
-  // Create or update PR
-  const nwo = args.dryRun ? 'OWNER/REPO' : getRepoNwo();
-  let prUrl;
-
-  if (args.update) {
-    prUrl = await updatePr(nwo, args.update, args.title, body, args.dryRun);
-  } else {
-    prUrl = await createPr(nwo, args.title, args.base, body, args.dryRun);
+  const currentBranch = getCurrentBranch();
+  const mergifyState = getMergifyBranchState(currentBranch);
+  const requestedUpdatePath = Boolean(args.update || args.updateExisting);
+  if (mergifyState.managed && !requestedUpdatePath) {
+    throw new Error(
+      [
+        'This branch is managed by Mergify stacks.',
+        'Use `mergify stack push` instead of `git push`.',
+        '',
+        'After the stack branch is published, rerun `create-pr` in update mode on that branch to repair the PR title/body.',
+      ].join('\n'),
+    );
   }
 
-  // Print PR URL to stdout (only useful output to stdout)
+  if (mergifyState.managed && requestedUpdatePath) {
+    assertPublishedMergifyBranch(currentBranch, mergifyState.trackedBaseRef);
+  }
+
+  const nwo = args.dryRun ? 'OWNER/REPO' : getRepoNwo();
+  let updatePrNumber = args.update;
+  if (args.updateExisting) {
+    updatePrNumber = resolveExistingPrNumber(nwo, currentBranch, args.dryRun);
+  }
+
+  if (!(mergifyState.managed && requestedUpdatePath)) {
+    gitPush(args.dryRun);
+  }
+
+  const prUrl = updatePrNumber
+    ? await updatePr(nwo, updatePrNumber, args.title, body, args.dryRun)
+    : await createPr(nwo, args.title, args.base, body, args.dryRun);
+
   console.log(prUrl);
 }
 

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync, appendFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const CREATE_PR = join(ROOT, 'scripts', 'create-pr.mjs');
+const TMP_PREFIX = join(tmpdir(), 'create-pr-stack-workflow-');
+
+const VALID_BODY = `## Summary
+
+This branch updates the PR workflow.
+
+## Review Claim
+
+Keep stack publication on the supported path.
+
+## Review Lane
+
+- behavior
+
+## Safety Invariant
+
+Only PR workflow tooling changes.
+
+## Slice Rationale
+
+Stack publishing stays separate from unrelated cleanup.
+
+## Non-goals
+
+- Do not change app behavior.
+
+## Test Plan
+
+- [ ] \`node scripts/test-create-pr-stack-workflow.mjs\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`;
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    encoding: 'utf-8',
+    ...options,
+  });
+}
+
+function git(cwd, ...args) {
+  return run('git', ['-C', cwd, ...args]);
+}
+
+function gitQuiet(cwd, ...args) {
+  return execFileSync('git', ['-C', cwd, ...args], { stdio: 'ignore' });
+}
+
+function writeExecutable(path, content) {
+  writeFileSync(path, content, { mode: 0o755 });
+}
+
+function readLogLines(path) {
+  if (!existsSync(path)) return [];
+  return readFileSync(path, 'utf-8').split('\n').filter(Boolean);
+}
+
+function readGhCalls(path) {
+  return readLogLines(path).map((line) => {
+    const [route, stdin = ''] = line.split('\t');
+    return { route, stdin };
+  });
+}
+
+function createHarness() {
+  const root = mkdtempSync(TMP_PREFIX);
+  const binDir = join(root, 'bin');
+  mkdirSync(binDir);
+
+  const pushLog = join(root, 'push.log');
+  const ghLog = join(root, 'gh.log');
+  const realGit = run('which', ['git']).trim();
+
+  writeExecutable(join(binDir, 'git'), `#!/bin/sh
+if [ "$1" = "push" ]; then
+  printf '%s\n' "$*" >> "$TEST_PUSH_LOG"
+  exit 0
+fi
+exec "$REAL_GIT" "$@"
+`);
+
+  writeExecutable(join(binDir, 'gh'), `#!/bin/sh
+if [ "$1" = "repo" ] && [ "$2" = "view" ]; then
+  printf 'repo view\t\n' >> "$GH_CALL_LOG"
+  if [ -n "$GH_REPO_VIEW_OUTPUT" ]; then
+    printf '%s' "$GH_REPO_VIEW_OUTPUT"
+  else
+    printf '%s' 'owner/repo'
+  fi
+  exit 0
+fi
+
+if [ "$1" = "api" ]; then
+  route="$2"
+  stdin=''
+  if [ "$5" = "--input" ] && [ "$6" = "-" ]; then
+    stdin="$(cat)"
+  fi
+  printf '%s\t%s\n' "$route" "$stdin" >> "$GH_CALL_LOG"
+
+  case "$route" in
+    *"/pulls?"*)
+      if [ -n "$GH_API_PULLS_JSON" ]; then
+        printf '%s' "$GH_API_PULLS_JSON"
+      else
+        printf '%s' '[]'
+      fi
+      exit 0
+      ;;
+    */pulls/[0-9]*)
+      if [ -n "$GH_PATCH_RESPONSE" ]; then
+        printf '%s' "$GH_PATCH_RESPONSE"
+      else
+        printf '%s' '{"html_url":"https://example.com/pull/0"}'
+      fi
+      exit 0
+      ;;
+    */pulls)
+      if [ -n "$GH_POST_RESPONSE" ]; then
+        printf '%s' "$GH_POST_RESPONSE"
+      else
+        printf '%s' '{"html_url":"https://example.com/pull/0"}'
+      fi
+      exit 0
+      ;;
+  esac
+fi
+
+printf 'Unexpected gh invocation: %s\n' "$*" >&2
+exit 2
+`);
+
+  return {
+    root,
+    pushLog,
+    ghLog,
+    env: {
+      ...process.env,
+      PATH: `${binDir}:${process.env.PATH}`,
+      REAL_GIT: realGit,
+      TEST_PUSH_LOG: pushLog,
+      GH_CALL_LOG: ghLog,
+      GH_REPO_VIEW_OUTPUT: 'owner/repo',
+    },
+  };
+}
+
+function createRepo(harness) {
+  const originBare = join(harness.root, 'origin.git');
+  const seed = join(harness.root, 'seed');
+  const work = join(harness.root, 'work');
+
+  gitQuiet(harness.root, 'init', '--bare', '--initial-branch=master', originBare);
+  gitQuiet(harness.root, 'clone', originBare, seed);
+  git(seed, 'config', 'user.email', 'test@example.com');
+  git(seed, 'config', 'user.name', 'test-user');
+  writeFileSync(join(seed, 'README.md'), 'seed\n');
+  git(seed, 'add', 'README.md');
+  gitQuiet(seed, 'commit', '-m', 'seed');
+  gitQuiet(seed, 'push', 'origin', 'HEAD:master');
+  rmSync(seed, { recursive: true, force: true });
+
+  gitQuiet(harness.root, 'clone', originBare, work);
+  git(work, 'config', 'user.email', 'test@example.com');
+  git(work, 'config', 'user.name', 'test-user');
+  writeFileSync(join(work, 'pr-body.md'), VALID_BODY);
+
+  return { originBare, work };
+}
+
+function commitFile(work, fileName, content, message) {
+  writeFileSync(join(work, fileName), content);
+  git(work, 'add', fileName);
+  gitQuiet(work, 'commit', '-m', message);
+}
+
+function createTrackedBranch(work, branch, startPoint = 'origin/master') {
+  gitQuiet(work, 'switch', '-c', branch, '--track', startPoint);
+}
+
+function setManagedBranchConfig(work, branch, baseBranch = 'master') {
+  git(work, 'config', `branch.${branch}.remote`, 'origin');
+  git(work, 'config', `branch.${branch}.merge`, `refs/heads/${baseBranch}`);
+}
+
+function advanceOriginMaster(harness, originBare) {
+  const advance = join(harness.root, `advance-${Date.now()}`);
+  gitQuiet(harness.root, 'clone', originBare, advance);
+  git(advance, 'config', 'user.email', 'test@example.com');
+  git(advance, 'config', 'user.name', 'test-user');
+  appendFileSync(join(advance, 'README.md'), 'advance\n');
+  git(advance, 'add', 'README.md');
+  gitQuiet(advance, 'commit', '-m', 'advance origin master');
+  gitQuiet(advance, 'push', 'origin', 'HEAD:master');
+  rmSync(advance, { recursive: true, force: true });
+}
+
+function runCreatePr(work, harness, args, envOverrides = {}) {
+  return spawnSync(process.execPath, [CREATE_PR, ...args], {
+    cwd: work,
+    env: {
+      ...harness.env,
+      ...envOverrides,
+    },
+    encoding: 'utf-8',
+  });
+}
+
+function baseArgs() {
+  return ['--title', 'test title', '--base', 'master', '--body-file', 'pr-body.md'];
+}
+
+function expectNoPush(harness, label) {
+  assert(readLogLines(harness.pushLog).length === 0, `${label}: expected no git push attempt`);
+}
+
+function testStaleBaseDetection() {
+  const harness = createHarness();
+  try {
+    const { originBare, work } = createRepo(harness);
+    createTrackedBranch(work, 'feature/stale');
+    commitFile(work, 'feature.txt', 'feature\n', 'feature change');
+    advanceOriginMaster(harness, originBare);
+
+    const result = runCreatePr(work, harness, baseArgs());
+    assert(result.status === 1, 'stale base detection should fail');
+    assert(result.stderr.includes('not based on the latest origin/master'), 'stale base error should name origin/master');
+    assert(result.stderr.includes('git cherry-pick <commit> [<commit> ...]'), 'stale base error should include cherry-pick recovery');
+    expectNoPush(harness, 'stale base detection');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testMergifyManagedCreateRefusal() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    createTrackedBranch(work, 'pr/stack-create');
+    commitFile(work, 'stack.txt', 'stack\n', 'stack create\n\nChange-Id: Icreate0001');
+    setManagedBranchConfig(work, 'pr/stack-create');
+
+    const result = runCreatePr(work, harness, baseArgs());
+    assert(result.status === 1, 'managed stack create should fail');
+    assert(result.stderr.includes('This branch is managed by Mergify stacks.'), 'managed stack create should explain branch state');
+    assert(result.stderr.includes('mergify stack push'), 'managed stack create should require mergify stack push');
+    expectNoPush(harness, 'managed create refusal');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testMergifyManagedUpdateSkipsPush() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-managed-update';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Iupdate0001');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [...baseArgs(), '--update-existing'], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 42,
+          html_url: 'https://example.com/pull/42',
+          head: { ref: branch, repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+      GH_PATCH_RESPONSE: JSON.stringify({ html_url: 'https://example.com/pull/42' }),
+    });
+
+    const ghLog = existsSync(harness.ghLog) ? readFileSync(harness.ghLog, 'utf-8') : '';
+    assert(
+      result.status === 0,
+      `managed stack update should succeed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}\ngh log:\n${ghLog}`,
+    );
+    assert(
+      result.stdout.trim() === 'https://example.com/pull/42',
+      `managed stack update should print updated PR URL\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}\ngh log:\n${ghLog}`,
+    );
+    expectNoPush(harness, 'managed update skip push');
+
+    const ghCalls = readGhCalls(harness.ghLog);
+    assert(ghCalls.some((call) => call.route.includes('/pulls?')), 'managed update should look up current branch PR');
+    const patchCall = ghCalls.find((call) => call.route.endsWith('/pulls/42'));
+    assert(Boolean(patchCall), 'managed update should patch the existing PR');
+    assert(patchCall.stdin.includes('"title":"test title"'), 'managed update patch should include title');
+    assert(patchCall.stdin.includes('## Summary'), 'managed update patch should include PR body');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testUnpublishedStackCommitsBlockUpdate() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'pr/stack-ahead';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack base\n\nChange-Id: Iahead0001');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+    commitFile(work, 'stack.txt', 'stack\nahead\n', 'stack ahead\n\nChange-Id: Iahead0002');
+
+    const result = runCreatePr(work, harness, [...baseArgs(), '--update-existing']);
+    assert(result.status === 1, 'managed stack update should fail when local commits are unpublished');
+    assert(result.stderr.includes('Run `mergify stack push` first'), 'managed stack update should require mergify stack push first');
+    expectNoPush(harness, 'unpublished stack commits');
+    assert(readGhCalls(harness.ghLog).length === 0, 'unpublished stack commits should fail before GitHub calls');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testCurrentBranchPrLookupFailure() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'pr/stack-missing';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack missing\n\nChange-Id: Imissing0001');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [...baseArgs(), '--update-existing'], {
+      GH_API_PULLS_JSON: '[]',
+    });
+
+    assert(result.status === 1, 'missing PR lookup should fail');
+    assert(result.stderr.includes(`No PR exists for current branch "${branch}" in owner/repo.`), 'missing PR lookup should name the current branch');
+    assert(result.stderr.includes('Run `mergify stack push` first for stack branches'), 'missing PR lookup should explain next step');
+    expectNoPush(harness, 'missing current-branch PR');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testHelpMentionsStackUpdateFlow() {
+  const harness = createHarness();
+  try {
+    const result = runCreatePr(harness.root, harness, ['--help']);
+    assert(result.status === 1, 'help should exit with status 1');
+    assert(result.stderr.includes('--update-existing'), 'help should mention --update-existing');
+    assert(result.stderr.includes('mergify stack push'), 'help should mention mergify stack push');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+const tests = [
+  testStaleBaseDetection,
+  testMergifyManagedCreateRefusal,
+  testMergifyManagedUpdateSkipsPush,
+  testUnpublishedStackCommitsBlockUpdate,
+  testCurrentBranchPrLookupFailure,
+  testHelpMentionsStackUpdateFlow,
+];
+
+for (const test of tests) {
+  test();
+}
+
+console.log('OK: create-pr stack workflow checks passed');

--- a/scripts/test-create-pr-visual-proof.mjs
+++ b/scripts/test-create-pr-visual-proof.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { getUiImpactingFiles, isUiImpactingPath, parsePorcelainChangedFiles } from './create-pr.mjs';
+import { getUiImpactingFiles, isUiImpactingPath } from './create-pr.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -25,18 +25,4 @@ assert(uiFiles.length === 2, 'only UI-impacting files should be returned');
 assert(uiFiles.includes('packages/ui/src/components/TaskPanel.tsx'), 'UI component file should be returned');
 assert(uiFiles.includes('packages/app/src/window/window-lifecycle.ts'), 'window file should be returned');
 
-
-const porcelainFiles = parsePorcelainChangedFiles(` M scripts/validate-pr-body.mjs
-A  scripts/test-pr-body-validator.mjs
-?? packages/app/src/local-refactor.ts
-`);
-const expectedPorcelainFiles = [
-  'scripts/validate-pr-body.mjs',
-  'scripts/test-pr-body-validator.mjs',
-  'packages/app/src/local-refactor.ts',
-];
-assert(
-  JSON.stringify(porcelainFiles) === JSON.stringify(expectedPorcelainFiles),
-  'porcelain parser should return exact changed file paths',
-);
 console.log('OK: create-pr visual proof checks passed');

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -8,22 +8,17 @@ function assert(condition, message) {
   }
 }
 
-function bodyWith({ lane = 'behavior', unit = 'routing', claim = 'Route one owner fallback.', summary = 'Small fix.', slice = 'Small slice.', nonGoals = '- Do not add repro scripts or docs in this slice.' } = {}) {
-  return `## Summary
+const validMinimal = `## Summary
 
-${summary}
+Small fix.
 
 ## Review Claim
 
-${claim}
+Keep the owner fallback local.
 
 ## Review Lane
 
-- ${lane}
-
-## Review Unit
-
-- ${unit}
+- behavior
 
 ## Safety Invariant
 
@@ -31,11 +26,11 @@ Only the refresh path changes.
 
 ## Slice Rationale
 
-${slice}
+Proof and cleanup stay separate.
 
 ## Non-goals
 
-${nonGoals}
+- Do not add repro scripts or docs in this slice.
 
 ## Test Plan
 
@@ -48,9 +43,6 @@ ${nonGoals}
 - Post-revert steps: None
 - Data migration? No
 `;
-}
-
-const validMinimal = bodyWith();
 
 const validArchitecture = `## Summary
 
@@ -63,10 +55,6 @@ Route refresh through one helper.
 ## Review Lane
 
 - behavior
-
-## Review Unit
-
-- routing
 
 ## Safety Invariant
 
@@ -141,10 +129,6 @@ One claim.
 
 - behavior
 
-## Review Unit
-
-- routing
-
 ## Safety Invariant
 
 Local only.
@@ -172,15 +156,11 @@ Flow change.
 
 ## Review Claim
 
-Route one path.
+One claim.
 
 ## Review Lane
 
 - behavior
-
-## Review Unit
-
-- routing
 
 ## Safety Invariant
 
@@ -224,10 +204,6 @@ Small fix.
 
 One claim.
 
-## Review Unit
-
-- routing
-
 ## Safety Invariant
 
 Local only.
@@ -256,38 +232,127 @@ assert(missingReviewLaneErrors.some((error) => error.includes('Missing required 
 const invalidReviewLaneErrors = validatePrBody(validMinimal.replace('- behavior', '- impossible'));
 assert(invalidReviewLaneErrors.some((error) => error.includes('Invalid review lane: impossible')), 'invalid review lane should fail');
 
-const missingReviewUnitErrors = validatePrBody(validMinimal.replace('## Review Unit\n\n- routing\n\n', ''));
-assert(missingReviewUnitErrors.some((error) => error.includes('Missing required section: ## Review Unit')), 'missing review unit should fail');
+const broad1574Body = `## Summary
 
-const broad1574Body = bodyWith({
-  unit: 'validation-policy',
-  summary: 'This adds the dormant auto-fix recovery policy.\n\nIt scans persisted failed tasks, validates retry and stale-state eligibility, suppresses duplicate open fix intents, and submits fix-with-agent mutation intents.',
-  claim: 'Auto-fix recovery can scan persisted failed tasks and enqueue the normal fix intent without a CLI surface.',
-  slice: 'Durable-state scan behavior is reviewable separately from lifecycle wakeup routing and CLI activation.',
-  nonGoals: '- No lifecycle wakeup routing, CLI exposure, or worker registry.',
-});
+This adds the dormant auto-fix recovery policy.
+
+It scans persisted failed tasks, validates retry and stale-state eligibility, suppresses duplicate open fix intents, and submits fix-with-agent mutation intents.
+
+## Review Claim
+
+Auto-fix recovery can scan persisted failed tasks and enqueue the normal fix intent without a CLI surface.
+
+## Review Lane
+
+- behavior
+
+## Safety Invariant
+
+The policy only submits through the existing mutation route and skips stale or already queued candidates.
+
+## Slice Rationale
+
+Durable-state scan behavior is reviewable separately from lifecycle wakeup routing and CLI activation.
+
+## Non-goals
+
+- No lifecycle wakeup routing, CLI exposure, or worker registry.
+
+## Test Plan
+
+- [ ] \`pnpm test\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`;
 const broad1574Errors = validatePrBody(broad1574Body);
 assert(
   broad1574Errors.some((error) => error.includes('mentions multiple review units')),
   'broad #1574-shaped PR body should fail review-unit focus',
 );
 
-const originalAllInOneBody = bodyWith({
-  unit: 'read-path',
-  summary: 'This moves the recovery worker out of the generic runtime.\n\nIt scans persisted failed tasks, validates candidates, submits fix intents, routes lifecycle wakeups, and exposes the headless worker command.',
-  claim: 'The recovery worker owns auto-fix recovery end to end.',
-  slice: 'The complete auto-fix recovery path lands together for one rollout.',
-  nonGoals: '- No worker registry.',
-});
+const originalAllInOneBody = `## Summary
+
+This moves the recovery worker out of the generic runtime.
+
+It scans persisted failed tasks, validates candidates, submits fix intents, routes lifecycle wakeups, and exposes the headless worker command.
+
+## Review Claim
+
+The recovery worker owns auto-fix recovery end to end.
+
+## Review Lane
+
+- behavior
+
+## Safety Invariant
+
+Every submitted fix still goes through the existing mutation route.
+
+## Slice Rationale
+
+The complete auto-fix recovery path lands together for one rollout.
+
+## Non-goals
+
+- No worker registry.
+
+## Test Plan
+
+- [ ] \`pnpm test\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`;
 const originalAllInOneErrors = validatePrBody(originalAllInOneBody);
 assert(
   originalAllInOneErrors.some((error) => error.includes('mentions multiple review units')),
   'original all-in-one auto-fix PR body should fail review-unit focus',
 );
 
-const longSummary = bodyWith({
-  summary: 'This summary paragraph uses too many words because it tries to explain several related implementation details at the same time instead of giving a tired reviewer one clear idea they can understand immediately.',
-});
+const longSummary = `## Summary
+
+This summary paragraph uses too many words because it tries to explain several related implementation details at the same time instead of giving a tired reviewer one clear idea they can understand immediately.
+
+## Review Claim
+
+One claim.
+
+## Review Lane
+
+- behavior
+
+## Safety Invariant
+
+Local only.
+
+## Slice Rationale
+
+Small slice.
+
+## Non-goals
+
+- No docs.
+
+## Test Plan
+
+- [ ] \`pnpm test\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`;
 
 const longSummaryWarnings = getPrBodyWarnings(longSummary);
 assert(validatePrBody(longSummary).length === 0, 'summary readability warnings should not fail validation');
@@ -335,7 +400,7 @@ assert(
   'behavior lane should reject repro/benchmark files in the same PR',
 );
 
-const policyScopeErrors = validatePrBody(bodyWith({ lane: 'policy', unit: 'tooling-policy', claim: 'Keep PR tooling policy local.' }), {
+const policyScopeErrors = validatePrBody(validMinimal.replace('- behavior', '- policy'), {
   changedFiles: [
     'scripts/create-pr.mjs',
     'scripts/validate-pr-body.mjs',
@@ -347,7 +412,7 @@ assert(
   'policy lane should reject product files in the same PR',
 );
 
-const proofScopeErrors = validatePrBody(bodyWith({ lane: 'proof', unit: 'proof', claim: 'Keep regression proof separate.' }), {
+const proofScopeErrors = validatePrBody(validMinimal.replace('- behavior', '- proof'), {
   changedFiles: [
     'packages/app/e2e/ui-graph-drag-performance.spec.ts',
     'packages/app/src/launch-dispatcher.ts',
@@ -358,7 +423,7 @@ assert(
   'proof lane should reject runtime behavior changes in the same PR',
 );
 
-const docsScopeErrors = validatePrBody(bodyWith({ lane: 'docs', unit: 'docs', claim: 'Update docs only.' }), {
+const docsScopeErrors = validatePrBody(validMinimal.replace('- behavior', '- docs'), {
   changedFiles: [
     'skills/make-pr/SKILL.md',
     'scripts/create-pr.mjs',
@@ -369,109 +434,42 @@ assert(
   'docs lane should reject policy/tooling files in the same PR',
 );
 
-const launchOutboxAlwaysActiveFiles = [
-  'docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md',
-  'packages/app/src/config.ts',
-  'packages/app/src/global-topup.ts',
-  'packages/app/src/headless.ts',
-  'packages/app/src/launch-dispatcher.ts',
-  'packages/app/src/main.ts',
-  'packages/cli/src/index.ts',
-  'packages/workflow-core/src/orchestrator.ts',
-  'scripts/repro/repro-launch-outbox-active-only.sh',
-];
-const launchOutboxErrors = validatePrBody(validMinimal, { changedFiles: launchOutboxAlwaysActiveFiles });
-assert(
-  launchOutboxErrors.some((error) => error.includes('Review Unit "routing" cannot ship with')),
-  'launch outbox fixture should fail review-unit changed-file validation',
-);
-for (const unit of ['docs', 'validation-policy', 'activation-surface', 'proof']) {
-  assert(launchOutboxErrors.some((error) => error.includes(unit)), `launch outbox fixture should mention ${unit}`);
-}
+const refactorBody = `## Summary
 
-const releaseInstallerFiles = [
-  '.github/workflows/ci.yml',
-  '.github/workflows/release.yml',
-  'package.json',
-  'packages/app/src/app-menu.ts',
-  'packages/app/src/cli-installer.ts',
-  'packages/app/src/main.ts',
-  'packages/cli/src/index.ts',
-  'packages/contracts/src/ipc-channels.ts',
-  'packages/npm-ui/bin/invoker-cli.js',
-  'packages/ui/src/components/SystemSetupModal.tsx',
-  'scripts/e2e-dmg-cli-install.sh',
-  'scripts/e2e-npm-cli-install.sh',
-];
-const releaseInstallerErrors = validatePrBody(bodyWith({ lane: 'policy', unit: 'tooling-policy', claim: 'Keep PR tooling policy local.' }), {
-  changedFiles: releaseInstallerFiles,
-});
-assert(
-  releaseInstallerErrors.some((error) => error.includes('Review Unit "tooling-policy" cannot ship with')),
-  'release installer fixture should fail review-unit changed-file validation',
-);
-for (const unit of ['activation-surface', 'contract', 'routing']) {
-  assert(releaseInstallerErrors.some((error) => error.includes(unit)), `release installer fixture should mention ${unit}`);
-}
+Extract a helper first.
 
-const headlessAutoFixSurfaceFiles = [
-  'packages/app/src/headless.ts',
-  'packages/app/src/__tests__/headless-autofix.test.ts',
-];
-assert(
-  validatePrBody(bodyWith({ unit: 'activation-surface', claim: 'Expose one headless command.' }), { changedFiles: headlessAutoFixSurfaceFiles }).length === 0,
-  'headless command exposure plus its direct test should pass as one activation-surface unit',
-);
+## Review Claim
 
-const surfaceRuntimeMixedFiles = [
-  'packages/app/src/headless.ts',
-  'packages/app/src/auto-fix-recovery.ts',
-  'packages/app/src/__tests__/headless-autofix.test.ts',
-];
-const surfaceRuntimeMixedErrors = validatePrBody(bodyWith({ unit: 'activation-surface', claim: 'Expose one headless command.' }), {
-  changedFiles: surfaceRuntimeMixedFiles,
-});
-assert(
-  surfaceRuntimeMixedErrors.some((error) => error.includes('read-path')),
-  'surface plus recovery policy should fail as mixed review units',
-);
+Move refresh logic into a helper module.
 
-const uiDocsFixtureDriftFiles = [
-  'packages/ui/src/components/TaskPanel.tsx',
-  'skills/plan-to-invoker/SKILL.md',
-  'skills/plan-to-invoker/fixtures/positive/05-ui-change-with-visual-proof.yaml',
-  'skills/plan-to-invoker/scripts/validate-plan.mjs',
-];
-const uiDocsFixtureDriftErrors = validatePrBody(bodyWith({ unit: 'activation-surface', claim: 'Expose one UI surface.' }), {
-  changedFiles: uiDocsFixtureDriftFiles,
-});
-assert(
-  uiDocsFixtureDriftErrors.some((error) => error.includes('docs')),
-  'skill fixtures and helpers should review as docs/skill changes',
-);
+## Review Lane
 
-const elevenFileWarnings = getPrBodyWarnings(validMinimal, {
-  changedFiles: Array.from({ length: 11 }, (_, index) => `scripts/generated-${index}.mjs`),
-});
-assert(
-  elevenFileWarnings.some((warning) => warning.includes('PR changes 11 files')),
-  'large changed-file count should warn without blocking',
-);
+- refactor
 
-const multiUnitWarnings = getPrBodyWarnings(validMinimal, { changedFiles: launchOutboxAlwaysActiveFiles });
-assert(
-  multiUnitWarnings.some((warning) => warning.includes('PR spans') && warning.includes('review units')),
-  'multi-review-unit changed-file shape should warn',
-);
+## Safety Invariant
 
-const refactorBody = bodyWith({
-  lane: 'refactor',
-  unit: 'routing',
-  claim: 'Route refresh logic through a helper module.',
-  summary: 'Route a helper first.',
-  slice: 'Field additions land in a later behavior PR.',
-  nonGoals: '- No behavior change.\n- No new fields in this slice.',
-});
+Behavior stays unchanged.
+
+## Slice Rationale
+
+Field additions land in a later behavior PR.
+
+## Non-goals
+
+- No behavior change.
+- No new fields in this slice.
+
+## Test Plan
+
+- [ ] \`pnpm test\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`;
 assert(
   validatePrBody(refactorBody, { changedFiles: ['packages/app/src/main.ts', 'packages/app/src/refresh-task-graph.ts'] }).length === 0,
   'refactor lane with explicit no-behavior non-goals should pass for product-only files',
@@ -485,13 +483,41 @@ assert(
   'refactor lane should require an explicit unchanged-behavior non-goal',
 );
 
-const validationPolicyBody = bodyWith({
-  unit: 'validation-policy',
-  summary: 'Validate stale recovery candidates.',
-  claim: 'Reject stale auto-fix recovery candidates before submission.',
-  slice: 'Validation policy stays separate from command submission.',
-  nonGoals: '- Does not submit mutation intents.',
-});
+const validationPolicyBody = `## Summary
+
+Validate stale recovery candidates.
+
+## Review Claim
+
+Reject stale auto-fix recovery candidates before submission.
+
+## Review Lane
+
+- behavior
+
+## Safety Invariant
+
+The slice returns validated candidates only.
+
+## Slice Rationale
+
+Validation policy stays separate from command submission.
+
+## Non-goals
+
+- Does not submit mutation intents.
+
+## Test Plan
+
+- [ ] \`pnpm test\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`;
 assert(validatePrBody(validationPolicyBody).length === 0, 'validation policy non-goal mentioning submit should pass');
 
 const directScopeErrors = validatePrScope({


### PR DESCRIPTION
## Summary

This hardens Invoker PR tooling for stacked branches. `create-pr` now defaults to `origin`, blocks stale-base branches, and updates published stack PRs without pushing again.

The old tooling let bad ancestry through and treated stack repair like a manual lookup step. It now fails early and keeps the update path on the current published branch.

## Review Claim

Invoker PR tooling now handles origin-based stacked branch publication and repair safely.

## Review Lane

- behavior

## Safety Invariant

Only PR tooling scripts and their regression tests change. Workflow execution and product runtime code stay untouched.

## Slice Rationale

Tooling behavior and tooling regressions stay together so this slice proves the new stack path before any docs depend on it.

## Non-goals

- Do not change workflow execution or merge queue behavior.
- Do not add landing automation.

## Test Plan

- [x] `node scripts/test-create-pr-stack-workflow.mjs`
- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/test-create-pr-visual-proof.mjs`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
