### PR TITLE
[Multi PR Review Gate](1) Define review gate artifact contracts

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -102,6 +102,42 @@ export type ResponseStatus =
   | 'spawn_experiments'
   | 'select_experiment';
 
+export type ReviewArtifactType = 'pull_request';
+export type ReviewArtifactStatus = 'open' | 'merged' | 'closed' | 'rejected' | 'unknown';
+export type ReviewGateRelationshipKind = 'stacked_diffs' | 'independent' | 'unknown';
+
+export interface ReviewGateArtifact {
+  readonly id: string;
+  readonly provider: string;
+  readonly type: ReviewArtifactType;
+  readonly url: string;
+  readonly identifier: string;
+  readonly title?: string;
+  readonly baseBranch?: string;
+  readonly headBranch?: string;
+  readonly status?: ReviewArtifactStatus;
+  readonly statusText?: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly replacedById?: string;
+}
+
+export interface ReviewGateCompletionPolicy {
+  readonly required: 'all';
+  readonly state: 'merged';
+}
+
+export interface ReviewGateExecution {
+  readonly sealed: boolean;
+  readonly completion: ReviewGateCompletionPolicy;
+  readonly relationship: {
+    readonly kind: ReviewGateRelationshipKind;
+    readonly managedBy: 'external';
+  };
+  readonly artifacts: readonly ReviewGateArtifact[];
+  readonly statusText?: string;
+}
+
 export interface WorkResponseOutputs {
   exitCode?: number;
   error?: string;
@@ -118,6 +154,7 @@ export interface WorkResponseOutputs {
   reviewId?: string;
   /** Human-readable review state produced by merge-gate style actions. */
   reviewStatus?: string;
+  reviewGate?: ReviewGateExecution;
 }
 
 export interface SpawnExperimentsRequest {

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -128,6 +128,42 @@ export interface DetachedExternalDependency {
 
 export type TaskRunPhase = 'launching' | 'executing';
 export type TaskHeartbeatSource = 'executor' | 'remote_workload';
+export type ReviewArtifactType = 'pull_request';
+export type ReviewArtifactStatus = 'open' | 'merged' | 'closed' | 'rejected' | 'unknown';
+export type ReviewGateRelationshipKind = 'stacked_diffs' | 'independent' | 'unknown';
+
+export interface ReviewGateArtifact {
+  readonly id: string;
+  readonly provider: string;
+  readonly type: ReviewArtifactType;
+  readonly url: string;
+  readonly identifier: string;
+  readonly title?: string;
+  readonly baseBranch?: string;
+  readonly headBranch?: string;
+  readonly status?: ReviewArtifactStatus;
+  readonly statusText?: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly replacedById?: string;
+}
+
+export interface ReviewGateCompletionPolicy {
+  readonly required: 'all';
+  readonly state: 'merged';
+}
+
+export interface ReviewGateExecution {
+  readonly sealed: boolean;
+  readonly completion: ReviewGateCompletionPolicy;
+  readonly relationship: {
+    readonly kind: ReviewGateRelationshipKind;
+    readonly managedBy: 'external';
+  };
+  readonly artifacts: readonly ReviewGateArtifact[];
+  readonly statusText?: string;
+}
+
 
 export interface TaskExecution {
   readonly generation?: number;
@@ -164,6 +200,7 @@ export interface TaskExecution {
   readonly reviewId?: string;
   readonly reviewStatus?: string;
   readonly reviewProviderId?: string;
+  readonly reviewGate?: ReviewGateExecution;
   readonly phase?: TaskRunPhase;
   readonly launchStartedAt?: Date;
   readonly launchCompletedAt?: Date;


### PR DESCRIPTION
## Summary

This adds the shared contract for review-gate pull request artifacts.

The contract can describe one or many pull requests without changing task status names.

## Architecture

This is the target shape for the full stack. This PR only lands the shared names at the bottom, so later PRs can wire runtime, storage, API, UI, and policy one layer at a time.

### Before

```mermaid
graph TD
    Plan["Plan merge gate"] --> Core["Workflow core"]
    Core --> Runner["Execution engine"]
    Runner --> GitHub["One GitHub PR"]
    GitHub --> State["Task state stores one PR URL"]
    State --> UI["UI shows one review link"]
    GitHub --> Gate["Merge gate waits for one PR merge"]
```

### After

```mermaid
graph TD
    Plan["Plan reviewGate.artifacts[]"] --> C1["(1) Contracts\nReviewGateArtifact + task review state"]
    C1 --> C2["(2) Core\nvalidates and tracks artifact state"]
    C2 --> C3["(3) Store\npersists artifact state"]
    C2 --> C4["(4) Engine\npublishes and polls review PRs"]
    C3 --> C5["(5) API\nattaches review artifacts"]
    C4 --> C5
    C5 --> C6["(6) UI\nshows the review PR list"]
    PlanPolicy["(7) Plan policy\nallows multi-PR review gates"] -.-> Plan
    C6 --> Reviewer["Reviewer sees every required PR"]
    C4 --> GitHub["GitHub PR artifacts"]
    GitHub --> Gate["Merge gate waits for every required PR merge"]
    C8["(8) Changelog"] -.-> Reviewer
```

## Review Claim

The shared contract now represents review-gate pull request artifacts.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This only adds optional fields and shared types. Existing single-PR fields remain untouched.

## Slice Rationale

This lands first so later slices can use the same contract instead of redefining it.

## Non-goals

- No storage changes.
- No execution changes.
- No UI changes.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/plan-parser.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/github-merge-gate-provider.test.ts src/__tests__/task-runner.test.ts`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No
