### PR TITLE
[Multi PR Review Gate](2) Add core review gate state

### DIFF
--- a/packages/app/src/__tests__/merge-mode.test.ts
+++ b/packages/app/src/__tests__/merge-mode.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { normalizeMergeModeForPersistence } from '../merge-mode.js';
 
 describe('normalizeMergeModeForPersistence', () => {
-  it('maps external_review to external_review', () => {
+  it('maps external review aliases to external_review', () => {
     expect(normalizeMergeModeForPersistence('external_review')).toBe('external_review');
+    expect(normalizeMergeModeForPersistence('github')).toBe('external_review');
   });
 
   it('passes through manual and automatic', () => {
@@ -12,7 +13,6 @@ describe('normalizeMergeModeForPersistence', () => {
   });
 
   it('rejects unknown labels', () => {
-    expect(() => normalizeMergeModeForPersistence('github')).toThrow(/Invalid mergeMode/);
     expect(() => normalizeMergeModeForPersistence('gitlab')).toThrow(/Invalid mergeMode/);
   });
 });

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -787,6 +787,96 @@ tasks:
     const result = parsePlan(yaml);
     expect(result.visualProof).toBeUndefined();
   });
+
+  it('normalizes github mergeMode to external_review and default reviewGate', () => {
+    const yaml = `
+name: GitHub Review Gate
+repoUrl: git@github.com:test/repo.git
+mergeMode: github
+tasks:
+  - id: task-1
+    description: Do something
+    command: echo hello
+`;
+    const result = parsePlan(yaml);
+    expect(result.mergeMode).toBe('external_review');
+    expect(result.reviewProvider).toBe('github');
+    expect(result.reviewGate).toEqual({
+      type: 'pull_requests',
+      authoring: { mode: 'automatic', preferredShape: 'stacked_diffs' },
+      completion: { required: 'all', state: 'merged' },
+    });
+  });
+
+  it('normalizes partial reviewGate blocks to defaults', () => {
+    const yaml = `
+name: Manual Review Gate
+repoUrl: git@github.com:test/repo.git
+mergeMode: external_review
+reviewGate:
+  authoring:
+    mode: manual
+tasks:
+  - id: task-1
+    description: Do something
+    command: echo hello
+`;
+    const result = parsePlan(yaml);
+    expect(result.reviewGate).toEqual({
+      type: 'pull_requests',
+      authoring: { mode: 'manual', preferredShape: 'stacked_diffs' },
+      completion: { required: 'all', state: 'merged' },
+    });
+  });
+
+  it('rejects numeric reviewGate completion counts', () => {
+    const yaml = `
+name: Numeric Review Gate
+repoUrl: git@github.com:test/repo.git
+mergeMode: external_review
+reviewGate:
+  completion:
+    required: 3
+tasks:
+  - id: task-1
+    description: Do something
+    command: echo hello
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow('reviewGate.completion.required');
+  });
+
+  it('rejects fixed reviewGate PR count fields', () => {
+    const yaml = `
+name: Counted Review Gate
+repoUrl: git@github.com:test/repo.git
+mergeMode: external_review
+reviewGate:
+  requiredPullRequests: 3
+tasks:
+  - id: task-1
+    description: Do something
+    command: echo hello
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow('reviewGate.requiredPullRequests');
+  });
+
+  it('rejects unknown reviewGate fields by field name', () => {
+    const yaml = `
+name: Bad Review Gate
+repoUrl: git@github.com:test/repo.git
+mergeMode: external_review
+reviewGate:
+  type: issues
+tasks:
+  - id: task-1
+    description: Do something
+    command: echo hello
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow('reviewGate.type');
+  });
 });
 
 describe('detectDefaultBranch', () => {

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -299,6 +299,7 @@ export function serializeTask(task: TaskState): Record<string, unknown> {
   if (task.execution.reviewUrl != null) execution.reviewUrl = task.execution.reviewUrl;
   if (task.execution.reviewId != null) execution.reviewId = task.execution.reviewId;
   if (task.execution.reviewStatus != null) execution.reviewStatus = task.execution.reviewStatus;
+  if (task.execution.reviewGate != null) execution.reviewGate = task.execution.reviewGate;
   if (task.execution.autoFixAttempts != null) execution.autoFixAttempts = task.execution.autoFixAttempts;
   if (task.execution.agentSessionId != null) execution.agentSessionId = task.execution.agentSessionId;
   if (task.execution.lastAgentSessionId != null) execution.lastAgentSessionId = task.execution.lastAgentSessionId;

--- a/packages/app/src/merge-mode.ts
+++ b/packages/app/src/merge-mode.ts
@@ -3,7 +3,7 @@
  */
 export type CanonicalMergeMode = 'manual' | 'automatic' | 'external_review';
 
-const VALID_INPUT = new Set(['manual', 'automatic', 'external_review']);
+const VALID_INPUT = new Set(['manual', 'automatic', 'external_review', 'github']);
 
 /**
  * Normalize user-facing merge mode strings for workflow persistence.
@@ -15,7 +15,7 @@ export function normalizeMergeModeForPersistence(raw: string): CanonicalMergeMod
       `Invalid mergeMode: "${raw}". Expected one of: ${[...VALID_INPUT].join(', ')}`,
     );
   }
-  if (raw === 'external_review') return 'external_review';
+  if (raw === 'external_review' || raw === 'github') return 'external_review';
   if (raw === 'automatic') return 'automatic';
   return 'manual';
 }

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -41,6 +41,20 @@ export interface RawExperimentVariant {
   prompt?: string;
   command?: string;
 }
+export interface RawReviewGate {
+  type?: string;
+  authoring?: {
+    mode?: string;
+    preferredShape?: string;
+  };
+  completion?: {
+    required?: unknown;
+    state?: string;
+  };
+  requiredPullRequests?: unknown;
+  prCount?: unknown;
+}
+
 
 export interface RawPlanTask {
   id?: string;
@@ -72,6 +86,7 @@ export interface RawPlan {
   featureBranch?: string;
   mergeMode?: string;
   reviewProvider?: string;
+  reviewGate?: RawReviewGate;
   repoUrl?: string;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
@@ -212,6 +227,76 @@ function assertNoLegacyRoutingKeys(ownerLabel: string, value: object): void {
     }
   }
 }
+function parseReviewGate(
+  rawReviewGate: RawReviewGate | undefined,
+  mergeMode: PlanDefinition['mergeMode'] | undefined,
+): PlanDefinition['reviewGate'] | undefined {
+  const defaultGate: NonNullable<PlanDefinition['reviewGate']> = {
+    type: 'pull_requests',
+    authoring: { mode: 'automatic', preferredShape: 'stacked_diffs' },
+    completion: { required: 'all', state: 'merged' },
+  };
+  if (rawReviewGate === undefined) {
+    return mergeMode === 'external_review' ? defaultGate : undefined;
+  }
+  if (!rawReviewGate || typeof rawReviewGate !== 'object') {
+    throw new PlanParseError('"reviewGate" must be an object');
+  }
+  const hasOwn = (obj: object, key: string): boolean => Object.prototype.hasOwnProperty.call(obj, key);
+  if (hasOwn(rawReviewGate as object, 'requiredPullRequests')) {
+    throw new PlanParseError('"reviewGate.requiredPullRequests" is not supported; use completion.required: all');
+  }
+  if (hasOwn(rawReviewGate as object, 'prCount')) {
+    throw new PlanParseError('"reviewGate.prCount" is not supported; use completion.required: all');
+  }
+
+  const type = rawReviewGate.type ?? defaultGate.type;
+  if (type !== 'pull_requests') {
+    throw new PlanParseError(`"reviewGate.type" must be "pull_requests". Got: "${String(type)}"`);
+  }
+
+  const rawAuthoring = rawReviewGate.authoring ?? {};
+  if (!rawAuthoring || typeof rawAuthoring !== 'object') {
+    throw new PlanParseError('"reviewGate.authoring" must be an object');
+  }
+  const mode = rawAuthoring.mode ?? defaultGate.authoring.mode;
+  if (mode !== 'automatic' && mode !== 'manual' && mode !== 'external') {
+    throw new PlanParseError(`"reviewGate.authoring.mode" must be one of: automatic, manual, external. Got: "${String(mode)}"`);
+  }
+  const preferredShape = rawAuthoring.preferredShape ?? defaultGate.authoring.preferredShape;
+  if (preferredShape !== 'stacked_diffs' && preferredShape !== 'independent') {
+    throw new PlanParseError(`"reviewGate.authoring.preferredShape" must be one of: stacked_diffs, independent. Got: "${String(preferredShape)}"`);
+  }
+
+  const rawCompletion = rawReviewGate.completion ?? {};
+  if (!rawCompletion || typeof rawCompletion !== 'object') {
+    throw new PlanParseError('"reviewGate.completion" must be an object');
+  }
+  if (hasOwn(rawCompletion as object, 'requiredPullRequests')) {
+    throw new PlanParseError('"reviewGate.completion.requiredPullRequests" is not supported; use completion.required: all');
+  }
+  if (hasOwn(rawCompletion as object, 'prCount')) {
+    throw new PlanParseError('"reviewGate.completion.prCount" is not supported; use completion.required: all');
+  }
+  const required = rawCompletion.required ?? defaultGate.completion.required;
+  if (typeof required === 'number') {
+    throw new PlanParseError('"reviewGate.completion.required" must be "all"; numeric pull request counts are not supported');
+  }
+  if (required !== 'all') {
+    throw new PlanParseError(`"reviewGate.completion.required" must be "all". Got: "${String(required)}"`);
+  }
+  const state = rawCompletion.state ?? defaultGate.completion.state;
+  if (state !== 'merged') {
+    throw new PlanParseError(`"reviewGate.completion.state" must be "merged". Got: "${String(state)}"`);
+  }
+
+  return {
+    type,
+    authoring: { mode, preferredShape },
+    completion: { required, state },
+  };
+}
+
 
 /**
  * Parse a YAML string into a validated PlanDefinition.
@@ -256,8 +341,8 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   }
   const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
 
-  // Validate mergeMode against canonical values only.
-  const validMergeModes = ['manual', 'automatic', 'external_review'] as const;
+  // Validate mergeMode against canonical values and the YAML-only github alias.
+  const validMergeModes = ['manual', 'automatic', 'external_review', 'github'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(
       `"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`,
@@ -270,7 +355,8 @@ export function parsePlan(yamlContent: string): PlanDefinition {
 
   // Default reviewProvider to 'github' for external-review workflows.
   const reviewProvider = raw.reviewProvider
-    ?? (rawMergeMode === 'external_review' ? 'github' : undefined);
+    ?? (mergeMode === 'external_review' ? 'github' : undefined);
+  const reviewGate = parseReviewGate(raw.reviewGate, mergeMode);
 
   // Auto-generate featureBranch from plan name when not explicitly specified
   if (!raw.featureBranch) {
@@ -365,6 +451,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     featureBranch: raw.featureBranch,
     mergeMode,
     reviewProvider,
+    reviewGate,
     repoUrl: raw.repoUrl,
     intermediateRepoUrl: raw.intermediateRepoUrl,
     externalDependencies: topLevelExternalDependencies,

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -61,7 +61,7 @@ describe('invoker-cli', () => {
     const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir]);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('hello-from-invoker-cli');
-  });
+  }, 60_000);
 
   it('--json emits a successful workflow result object', () => {
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-json-db-'));
@@ -70,7 +70,7 @@ describe('invoker-cli', () => {
     const lines = result.stdout.trim().split('\n');
     const json = JSON.parse(lines[lines.length - 1]);
     expect(json.workflow.status).toBe('success');
-  });
+  }, 60_000);
 
   it('invalid YAML exits non-zero with a validation error', () => {
     const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-invalid-'));
@@ -138,7 +138,7 @@ tasks:
     expect(createMessageBus).not.toHaveBeenCalled();
     expect(output.stdout).toContain('hello-from-invoker-cli');
     output.restore();
-  });
+  }, 60_000);
 
   it('auto mode delegates when a GUI owner exists', async () => {
     const output = captureProcessOutput();

--- a/packages/test-kit/src/test-harness.ts
+++ b/packages/test-kit/src/test-harness.ts
@@ -1,5 +1,5 @@
 import { Orchestrator, type PlanDefinition, type TaskState } from '@invoker/workflow-core';
-import { TaskRunner, ExecutorRegistry, type MergeGateProvider } from '@invoker/execution-engine';
+import { TaskRunner, ExecutorRegistry, type ReviewGateProvider } from '@invoker/execution-engine';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { Executor, ExecutorHandle, PersistedTaskMeta, TerminalSpec } from '@invoker/execution-engine';
 import { InMemoryPersistence } from './in-memory-persistence.js';
@@ -84,7 +84,7 @@ export interface TestHarness {
  */
 export function createTestHarness(opts?: {
   maxConcurrency?: number;
-  mergeGateProvider?: MergeGateProvider;
+  mergeGateProvider?: ReviewGateProvider;
 }): TestHarness {
   const persistence = new InMemoryPersistence();
   const bus = new InMemoryBus();

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -27,6 +27,15 @@ class InMemoryPersistence implements OrchestratorPersistence {
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
   events: Array<{ taskId: string; eventType: string; payload?: unknown }> = [];
+  launchDispatches: Array<{
+    id: number;
+    taskId: string;
+    attemptId: string;
+    workflowId: string;
+    generation: number;
+    state: 'enqueued';
+    priority: 'normal';
+  }> = [];
   updateWorkflowCalls = new Map<string, number>();
 
   saveWorkflow(workflow: {
@@ -202,6 +211,25 @@ class InMemoryPersistence implements OrchestratorPersistence {
 
   logEvent(taskId: string, eventType: string, payload?: unknown): void {
     this.events.push({ taskId, eventType, payload });
+  }
+
+  enqueueLaunchDispatch(input: {
+    taskId: string;
+    attemptId: string;
+    workflowId: string;
+    generation: number;
+  }): { id: number; state: 'enqueued'; priority: 'normal' } {
+    const row = {
+      id: this.launchDispatches.length + 1,
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+      workflowId: input.workflowId,
+      generation: input.generation,
+      state: 'enqueued' as const,
+      priority: 'normal' as const,
+    };
+    this.launchDispatches.push(row);
+    return row;
   }
 
   saveAttempt(attempt: Attempt): void {
@@ -818,7 +846,7 @@ describe('Orchestrator', () => {
       expect(task.execution.error).toBe('test failed: expected 1 to be 2');
     });
 
-    it('non-merge merge_conflict JSON pendingFixError resume transitions failed -> fixing_with_ai -> awaiting_approval -> running and clears pendingFixError', async () => {
+    it('non-merge merge_conflict JSON pendingFixError resume relaunches with a fresh attempt', async () => {
       const mergeConflictError = JSON.stringify({
         type: 'merge_conflict',
         failedBranch: 'experiment/non-merge-branch-abc123',
@@ -843,7 +871,88 @@ describe('Orchestrator', () => {
       expect(task.status).toBe('running');
       expect(task.status).not.toBe('completed');
       expect(task.execution.pendingFixError).toBeUndefined();
-      expect(persistence.loadAttempt(fixAttemptId!)?.status).toBe('running');
+      expect(task.execution.selectedAttemptId).not.toBe(fixAttemptId);
+      expect(persistence.loadAttempt(fixAttemptId!)?.status).toBe('superseded');
+      expect(persistence.loadAttempt(task.execution.selectedAttemptId!)?.status).toBe('running');
+    });
+
+    it('non-merge merge_conflict fix approval relaunches through the launch outbox when launch is deferred', async () => {
+      persistence = new InMemoryPersistence();
+      bus = new InMemoryBus();
+      publishedDeltas = [];
+      bus.subscribe('task.delta', (delta) => {
+        publishedDeltas.push(delta as TaskDelta);
+      });
+      orchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        maxConcurrency: 3,
+        logger: consoleLogger,
+        deferRunningUntilLaunch: true,
+      });
+      orchestrator.loadPlan({
+        name: 'deferred-fix-test',
+        tasks: [
+          { id: 'f1', description: 'Root task' },
+          { id: 'f2', description: 'Failing task', dependencies: ['f1'] },
+        ],
+      });
+      orchestrator.startExecution();
+      const f1 = orchestrator.getTask('f1')!;
+      expect(f1.status).toBe('pending');
+      expect(f1.execution.phase).toBe('launching');
+      orchestrator.markTaskRunningAfterLaunch('f1', f1.execution.selectedAttemptId!);
+      orchestrator.handleWorkerResponse(
+        makeResponse({
+          actionId: 'f1',
+          attemptId: f1.execution.selectedAttemptId!,
+          status: 'completed',
+          outputs: { exitCode: 0 },
+        }),
+      );
+      const f2Launch = orchestrator.getTask('f2')!;
+      expect(f2Launch.status).toBe('pending');
+      expect(f2Launch.execution.phase).toBe('launching');
+      orchestrator.markTaskRunningAfterLaunch('f2', f2Launch.execution.selectedAttemptId!);
+
+      const mergeConflictError = JSON.stringify({
+        type: 'merge_conflict',
+        failedBranch: 'experiment/non-merge-branch-abc123',
+        conflictFiles: ['src/non-merge.ts'],
+      });
+      orchestrator.handleWorkerResponse(
+        makeResponse({
+          actionId: 'f2',
+          attemptId: f2Launch.execution.selectedAttemptId!,
+          executionGeneration: f2Launch.execution.generation,
+          status: 'failed',
+          outputs: { exitCode: 1, error: mergeConflictError },
+        }),
+      );
+      const { savedError } = orchestrator.beginConflictResolution('f2');
+      expect(savedError).toBe(mergeConflictError);
+      const fixAttemptId = orchestrator.getTask('f2')!.execution.selectedAttemptId!;
+      orchestrator.setFixAwaitingApproval('f2', mergeConflictError);
+      const dispatchesBeforeApproval = persistence.launchDispatches.length;
+
+      const started = await orchestrator.resumeTaskAfterFixApproval('f2');
+
+      expect(started).toHaveLength(1);
+      expect(started[0].status).toBe('pending');
+      expect(started[0].execution.phase).toBe('launching');
+      expect(started[0].execution.selectedAttemptId).not.toBe(fixAttemptId);
+      expect(started[0].execution.pendingFixError).toBeUndefined();
+      expect(persistence.loadAttempt(fixAttemptId)?.status).toBe('superseded');
+      expect(persistence.launchDispatches).toHaveLength(dispatchesBeforeApproval + 1);
+      const dispatch = persistence.launchDispatches.at(-1)!;
+      expect(dispatch.taskId).toBe(started[0].id);
+      expect(dispatch.attemptId).toBe(started[0].execution.selectedAttemptId);
+      expect(persistence.events.some(
+        (event) => event.taskId === started[0].id && event.eventType === 'task.launch_claimed',
+      )).toBe(true);
+      expect(persistence.events.some(
+        (event) => event.taskId === started[0].id && event.eventType === 'task.dispatch_enqueued',
+      )).toBe(true);
     });
 
     it('non-merge plain-text pendingFixError approve transitions failed -> fixing_with_ai -> awaiting_approval -> completed', async () => {

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -7,13 +7,13 @@
 
 import type { CommandEnvelope, CommandResult } from '@invoker/contracts';
 import { OrchestratorError } from './orchestrator.js';
-import type { Orchestrator, ExternalGatePolicyUpdate, TaskReplacementDef } from './orchestrator.js';
+import type { Orchestrator, ExternalGatePolicyUpdate, TaskReplacementDef, ReviewArtifactInput } from './orchestrator.js';
 import {
   applyInvalidation,
   buildOrchestratorOnlyInvalidationDeps,
   type InvalidationDeps,
 } from './invalidation-policy.js';
-import type { TaskState } from '@invoker/workflow-graph';
+import type { ReviewGateExecution, TaskState } from '@invoker/workflow-graph';
 
 // ── Cancel Result ────────────────────────────────────────────
 
@@ -409,6 +409,29 @@ export class CommandService {
       'CANCEL_TASK_FAILED',
       () => this.orchestrator.cancelTask(envelope.payload.taskId),
       this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
+  async attachReviewArtifact(
+    envelope: CommandEnvelope<{ workflowId: string; artifact: ReviewArtifactInput }>,
+  ): Promise<CommandResult<ReviewGateExecution>> {
+    return this.executeCommand<ReviewGateExecution>(
+      'ATTACH_REVIEW_ARTIFACT_FAILED',
+      () => this.orchestrator.attachReviewArtifact(
+        envelope.payload.workflowId,
+        envelope.payload.artifact,
+      ),
+      envelope.payload.workflowId,
+    );
+  }
+
+  async sealReviewGate(
+    envelope: CommandEnvelope<{ workflowId: string }>,
+  ): Promise<CommandResult<ReviewGateExecution>> {
+    return this.executeCommand<ReviewGateExecution>(
+      'SEAL_REVIEW_GATE_FAILED',
+      () => this.orchestrator.sealReviewGate(envelope.payload.workflowId),
+      envelope.payload.workflowId,
     );
   }
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -19,7 +19,7 @@ import { TaskStateMachine } from './state-machine.js';
 import { ResponseHandler } from './response-handler.js';
 import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
-import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, TaskStatus, TaskHeartbeatSource, ReviewGateArtifact, ReviewGateExecution } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
 import { createTaskState, createAttempt } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
@@ -141,6 +141,7 @@ const RECREATE_RESET_CHANGES: TaskStateChanges = {
     reviewUrl: undefined,
     reviewId: undefined,
     reviewStatus: undefined,
+    reviewGate: undefined,
     reviewProviderId: undefined,
     agentSessionId: undefined,
     containerId: undefined,
@@ -217,11 +218,13 @@ export interface OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    reviewProvider?: string;
+    reviewGate?: ReviewGateDefinition;
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
   }): void;
-  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[] }): void;
+  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review'; reviewProvider?: string; reviewGate?: ReviewGateDefinition; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[]; detachedExternalDependencies?: DetachedExternalDependency[] }): void;
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
@@ -281,6 +284,8 @@ export interface OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    reviewProvider?: string;
+    reviewGate?: ReviewGateDefinition;
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
     detachedExternalDependencies?: DetachedExternalDependency[];
@@ -333,6 +338,29 @@ export interface DeleteAllWorkflowsOptions {
   publishRemovalDeltas?: boolean;
 }
 
+export interface ReviewGateDefinition {
+  type: 'pull_requests';
+  authoring: {
+    mode: 'automatic' | 'manual' | 'external';
+    preferredShape: 'stacked_diffs' | 'independent';
+  };
+  completion: {
+    required: 'all';
+    state: 'merged';
+  };
+}
+
+export interface ReviewArtifactInput {
+  provider?: 'github';
+  type?: 'pull_request';
+  url: string;
+  identifier?: string;
+  title?: string;
+  baseBranch?: string;
+  headBranch?: string;
+  status?: ReviewGateArtifact['status'];
+}
+
 export interface PlanDefinition {
   name: string;
   description?: string;
@@ -342,6 +370,7 @@ export interface PlanDefinition {
   featureBranch?: string;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
   reviewProvider?: string;
+  reviewGate?: ReviewGateDefinition;
   repoUrl?: string;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
@@ -647,6 +676,7 @@ export class Orchestrator {
       reviewUrl: undefined,
       reviewId: undefined,
       reviewStatus: undefined,
+      reviewGate: undefined,
       reviewProviderId: undefined,
       fixedIntegrationSha: undefined,
       fixedIntegrationRecordedAt: undefined,
@@ -1419,6 +1449,8 @@ export class Orchestrator {
       baseBranch: plan.baseBranch,
       featureBranch: plan.featureBranch,
       mergeMode: plan.mergeMode,
+      reviewProvider: plan.reviewProvider,
+      reviewGate: plan.reviewGate,
       externalDependencies: workflowExternalDependencies.length > 0 ? workflowExternalDependencies : undefined,
       createdAt,
       updatedAt: createdAt,
@@ -1759,6 +1791,100 @@ export class Orchestrator {
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
 
+  private defaultReviewGateForAttachment(): ReviewGateExecution {
+    return {
+      sealed: false,
+      completion: { required: 'all', state: 'merged' },
+      relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+      artifacts: [],
+      statusText: 'Waiting for review artifacts',
+    };
+  }
+
+  private normalizeReviewArtifactInput(input: ReviewArtifactInput): ReviewGateArtifact {
+    const provider = input.provider ?? 'github';
+    const type = input.type ?? 'pull_request';
+    if (provider !== 'github') throw new Error('Review artifact provider must be "github"');
+    if (type !== 'pull_request') throw new Error('Review artifact type must be "pull_request"');
+    const url = input.url?.trim();
+    if (!url) throw new Error('Review artifact URL is required');
+    const parsedIdentifier = provider === 'github'
+      ? url.match(/\/pull\/(\d+)(?:[/?#].*)?$/)?.[1]
+      : undefined;
+    const identifier = input.identifier?.trim() || parsedIdentifier;
+    if (!identifier) throw new Error('Review artifact identifier is required');
+    return {
+      id: `${provider}:${type}:${identifier}`,
+      provider,
+      type,
+      url,
+      identifier,
+      title: input.title,
+      baseBranch: input.baseBranch,
+      headBranch: input.headBranch,
+      status: input.status,
+    };
+  }
+
+  attachReviewArtifact(workflowId: string, input: ReviewArtifactInput): ReviewGateExecution {
+    this.refreshFromDb();
+    const task = this.getMergeNode(workflowId);
+    if (!task) throw new Error(`Workflow "${workflowId}" has no review gate`);
+    if (task.status !== 'review_ready' && task.status !== 'awaiting_approval') {
+      throw new Error('Review artifacts can only be attached while the review gate is review_ready or awaiting_approval');
+    }
+    const artifact = this.normalizeReviewArtifactInput(input);
+    const current = task.execution.reviewGate ?? this.defaultReviewGateForAttachment();
+    const artifacts = [...current.artifacts];
+    const existingIndex = artifacts.findIndex((candidate) => candidate.id === artifact.id);
+    if (existingIndex >= 0) {
+      const existing = artifacts[existingIndex];
+      artifacts[existingIndex] = {
+        ...existing,
+        ...artifact,
+        status: artifact.status ?? existing.status,
+        statusText: existing.statusText,
+        headSha: existing.headSha,
+        headRef: existing.headRef,
+      };
+    } else {
+      artifacts.push({ ...artifact, status: artifact.status ?? 'open' });
+    }
+    const reviewGate: ReviewGateExecution = {
+      ...current,
+      artifacts,
+      statusText: current.sealed ? current.statusText : 'Waiting for review artifacts',
+    };
+    const changes: TaskStateChanges = { execution: { reviewGate } };
+    const updatedReview = this.writeAndSync(task.id, changes);
+    this.persistence.logEvent?.(task.id, 'review_gate.artifact_attached', { artifact });
+    this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updatedReview, changes));
+    return reviewGate;
+  }
+
+  sealReviewGate(workflowId: string): ReviewGateExecution {
+    this.refreshFromDb();
+    const task = this.getMergeNode(workflowId);
+    if (!task) throw new Error(`Workflow "${workflowId}" has no review gate`);
+    if (task.status !== 'review_ready' && task.status !== 'awaiting_approval') {
+      throw new Error('Review gate can only be sealed while it is review_ready or awaiting_approval');
+    }
+    const current = task.execution.reviewGate ?? this.defaultReviewGateForAttachment();
+    if (current.artifacts.length === 0) {
+      throw new Error('Cannot seal review gate without pull request artifacts');
+    }
+    const reviewGate: ReviewGateExecution = {
+      ...current,
+      sealed: true,
+      statusText: current.statusText ?? 'Awaiting review',
+    };
+    const changes: TaskStateChanges = { execution: { reviewGate } };
+    const updatedReview = this.writeAndSync(task.id, changes);
+    this.persistence.logEvent?.(task.id, 'review_gate.sealed', { artifactCount: reviewGate.artifacts.length });
+    this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updatedReview, changes));
+    return reviewGate;
+  }
+
   setBeforeApproveHook(fn: (task: TaskState) => Promise<void>): void {
     this.beforeApproveHook = fn;
   }
@@ -1842,6 +1968,11 @@ export class Orchestrator {
     const isApprovalState = task?.status === 'awaiting_approval' || task?.status === 'review_ready';
     if (!task || !isApprovalState || task.execution.pendingFixError === undefined) {
       return [];
+    }
+
+    if (!task.config.isMergeNode) {
+      const prepared = this.prepareTaskForNewAttempt(task.id, 'approved fix relaunch');
+      return this.autoStartReadyTasks([prepared.id], Orchestrator.EXPEDITED_PRIORITY);
     }
 
     const now = new Date();
@@ -4161,6 +4292,7 @@ export class Orchestrator {
       reviewUrl?: string;
       reviewId?: string;
       reviewStatus?: string;
+      reviewGate?: ReviewGateExecution;
     } = {
       exitCode: parsed.exitCode,
       completedAt: new Date(),
@@ -4188,6 +4320,9 @@ export class Orchestrator {
     }
     if (parsed.reviewStatus !== undefined) {
       execution.reviewStatus = parsed.reviewStatus;
+    }
+    if (parsed.reviewGate !== undefined) {
+      execution.reviewGate = parsed.reviewGate;
     }
 
     const changes: TaskStateChanges = {
@@ -4341,6 +4476,7 @@ export class Orchestrator {
         reviewUrl: parsed.reviewUrl,
         reviewId: parsed.reviewId,
         reviewStatus: parsed.reviewStatus,
+        reviewGate: parsed.reviewGate,
       },
     };
     this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', changes);

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -15,6 +15,20 @@ export interface RawExperimentVariant {
   prompt?: string;
   command?: string;
 }
+export interface RawReviewGate {
+  type?: string;
+  authoring?: {
+    mode?: string;
+    preferredShape?: string;
+  };
+  completion?: {
+    required?: unknown;
+    state?: string;
+  };
+  requiredPullRequests?: unknown;
+  prCount?: unknown;
+}
+
 
 export interface RawPlanTask {
   id?: string;
@@ -46,6 +60,7 @@ export interface RawPlan {
   featureBranch?: string;
   mergeMode?: string;
   reviewProvider?: string;
+  reviewGate?: RawReviewGate;
   repoUrl?: string;
   intermediateRepoUrl?: string;
   externalDependencies?: Array<{
@@ -158,6 +173,76 @@ function assertNoLegacyRoutingKeys(ownerLabel: string, value: object): void {
     }
   }
 }
+function parseReviewGate(
+  rawReviewGate: RawReviewGate | undefined,
+  mergeMode: PlanDefinition['mergeMode'] | undefined,
+): PlanDefinition['reviewGate'] | undefined {
+  const defaultGate: NonNullable<PlanDefinition['reviewGate']> = {
+    type: 'pull_requests',
+    authoring: { mode: 'automatic', preferredShape: 'stacked_diffs' },
+    completion: { required: 'all', state: 'merged' },
+  };
+  if (rawReviewGate === undefined) {
+    return mergeMode === 'external_review' ? defaultGate : undefined;
+  }
+  if (!rawReviewGate || typeof rawReviewGate !== 'object') {
+    throw new PlanParseError('"reviewGate" must be an object');
+  }
+  const hasOwn = (obj: object, key: string): boolean => Object.prototype.hasOwnProperty.call(obj, key);
+  if (hasOwn(rawReviewGate as object, 'requiredPullRequests')) {
+    throw new PlanParseError('"reviewGate.requiredPullRequests" is not supported; use completion.required: all');
+  }
+  if (hasOwn(rawReviewGate as object, 'prCount')) {
+    throw new PlanParseError('"reviewGate.prCount" is not supported; use completion.required: all');
+  }
+
+  const type = rawReviewGate.type ?? defaultGate.type;
+  if (type !== 'pull_requests') {
+    throw new PlanParseError(`"reviewGate.type" must be "pull_requests". Got: "${String(type)}"`);
+  }
+
+  const rawAuthoring = rawReviewGate.authoring ?? {};
+  if (!rawAuthoring || typeof rawAuthoring !== 'object') {
+    throw new PlanParseError('"reviewGate.authoring" must be an object');
+  }
+  const mode = rawAuthoring.mode ?? defaultGate.authoring.mode;
+  if (mode !== 'automatic' && mode !== 'manual' && mode !== 'external') {
+    throw new PlanParseError(`"reviewGate.authoring.mode" must be one of: automatic, manual, external. Got: "${String(mode)}"`);
+  }
+  const preferredShape = rawAuthoring.preferredShape ?? defaultGate.authoring.preferredShape;
+  if (preferredShape !== 'stacked_diffs' && preferredShape !== 'independent') {
+    throw new PlanParseError(`"reviewGate.authoring.preferredShape" must be one of: stacked_diffs, independent. Got: "${String(preferredShape)}"`);
+  }
+
+  const rawCompletion = rawReviewGate.completion ?? {};
+  if (!rawCompletion || typeof rawCompletion !== 'object') {
+    throw new PlanParseError('"reviewGate.completion" must be an object');
+  }
+  if (hasOwn(rawCompletion as object, 'requiredPullRequests')) {
+    throw new PlanParseError('"reviewGate.completion.requiredPullRequests" is not supported; use completion.required: all');
+  }
+  if (hasOwn(rawCompletion as object, 'prCount')) {
+    throw new PlanParseError('"reviewGate.completion.prCount" is not supported; use completion.required: all');
+  }
+  const required = rawCompletion.required ?? defaultGate.completion.required;
+  if (typeof required === 'number') {
+    throw new PlanParseError('"reviewGate.completion.required" must be "all"; numeric pull request counts are not supported');
+  }
+  if (required !== 'all') {
+    throw new PlanParseError(`"reviewGate.completion.required" must be "all". Got: "${String(required)}"`);
+  }
+  const state = rawCompletion.state ?? defaultGate.completion.state;
+  if (state !== 'merged') {
+    throw new PlanParseError(`"reviewGate.completion.state" must be "merged". Got: "${String(state)}"`);
+  }
+
+  return {
+    type,
+    authoring: { mode, preferredShape },
+    completion: { required, state },
+  };
+}
+
 
 export function parsePlan(yamlContent: string): PlanDefinition {
   let raw: RawPlan;
@@ -188,12 +273,14 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   }
   const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
 
-  const validMergeModes = ['manual', 'automatic', 'external_review'] as const;
+  const validMergeModes = ['manual', 'automatic', 'external_review', 'github'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(`"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`);
   }
-  const mergeMode = raw.mergeMode as (typeof validMergeModes)[number] | undefined;
-  const reviewProvider = raw.reviewProvider ?? (raw.mergeMode === 'external_review' ? 'github' : undefined);
+  const rawMergeMode = raw.mergeMode as (typeof validMergeModes)[number] | undefined;
+  const mergeMode = rawMergeMode === 'github' ? 'external_review' : rawMergeMode;
+  const reviewProvider = raw.reviewProvider ?? (mergeMode === 'external_review' ? 'github' : undefined);
+  const reviewGate = parseReviewGate(raw.reviewGate, mergeMode);
 
   if (!raw.repoUrl || typeof raw.repoUrl !== 'string') {
     throw new PlanParseError('Plan must have a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git).');
@@ -259,6 +346,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     featureBranch: raw.featureBranch,
     mergeMode,
     reviewProvider,
+    reviewGate,
     repoUrl: raw.repoUrl,
     intermediateRepoUrl: raw.intermediateRepoUrl,
     externalDependencies: topLevelExternalDependencies,

--- a/packages/workflow-core/src/response-handler.ts
+++ b/packages/workflow-core/src/response-handler.ts
@@ -6,7 +6,7 @@
  * the Orchestrator what writes to make.
  */
 
-import type { WorkResponse } from '@invoker/contracts';
+import type { ReviewGateExecution, WorkResponse } from '@invoker/contracts';
 import { validateWorkResponse } from '@invoker/contracts';
 
 /** Plan-local id segment for experiment id prefixing (strip `${workflowId}/` when present). */
@@ -40,6 +40,7 @@ export type ParsedResponse =
       reviewUrl?: string;
       reviewId?: string;
       reviewStatus?: string;
+      reviewGate?: ReviewGateExecution;
     }
   | {
       type: 'review_ready';
@@ -50,6 +51,7 @@ export type ParsedResponse =
       reviewUrl?: string;
       reviewId?: string;
       reviewStatus?: string;
+      reviewGate?: ReviewGateExecution;
     }
   | {
       type: 'failed';
@@ -103,6 +105,7 @@ export class ResponseHandler {
           reviewUrl: outputs.reviewUrl,
           reviewId: outputs.reviewId,
           reviewStatus: outputs.reviewStatus,
+          reviewGate: outputs.reviewGate,
         };
 
       case 'review_ready':
@@ -115,6 +118,7 @@ export class ResponseHandler {
           reviewUrl: outputs.reviewUrl,
           reviewId: outputs.reviewId,
           reviewStatus: outputs.reviewStatus,
+          reviewGate: outputs.reviewGate,
         };
 
       case 'failed':


### PR DESCRIPTION
## Summary

This lets workflow core carry review-gate artifact state from plans and worker responses.

Core can attach artifacts manually and seal a gate when artifacts are ready.

## Review Claim

Workflow core now owns review-gate artifact state handling.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new state is optional. Existing single-PR review fields still reset and relay as before.

## Slice Rationale

This follows the artifact shape slice so core can pass gate state through the workflow.

## Non-goals

- No database serialization changes.
- No GitHub provider changes.
- No UI changes.

## Architecture

### Before

```mermaid
flowchart LR
  Worker[Worker response] --> Core[Workflow core]
  Core --> Fields[Single PR fields]
```

### After

```mermaid
flowchart LR
  Worker[Worker response] --> Core[Workflow core]
  Core --> Gate[Review gate artifacts]
  Core --> Fields[Single PR fields]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/plan-parser.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/github-merge-gate-provider.test.ts src/__tests__/task-runner.test.ts`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

Depends-On: #1696