### PR TITLE
[Multi PR Review Gate](3) Persist review gate state

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -115,6 +115,83 @@ describe('SQLiteAdapter', () => {
       expect(loaded[0].status).toBe('pending');
     });
 
+    it('round-trips reviewGate execution through save and update', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('merge', {
+        execution: {
+          reviewGate: {
+            sealed: true,
+            completion: { required: 'all', state: 'merged' },
+            relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+            artifacts: [
+              {
+                id: 'github:pull_request:12',
+                provider: 'github',
+                type: 'pull_request',
+                url: 'https://github.com/acme/repo/pull/12',
+                identifier: '12',
+                status: 'open',
+              },
+            ],
+            statusText: 'Awaiting review',
+          },
+        },
+      }));
+
+      adapter.updateTask('merge', {
+        execution: {
+          reviewGate: {
+            sealed: true,
+            completion: { required: 'all', state: 'merged' },
+            relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+            artifacts: [
+              {
+                id: 'github:pull_request:12',
+                provider: 'github',
+                type: 'pull_request',
+                url: 'https://github.com/acme/repo/pull/12',
+                identifier: '12',
+                status: 'merged',
+              },
+            ],
+            statusText: 'All review artifacts merged',
+          },
+        },
+      });
+
+      expect(adapter.loadTask('merge')?.execution.reviewGate).toMatchObject({
+        sealed: true,
+        completion: { required: 'all', state: 'merged' },
+        relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+        artifacts: [{ identifier: '12', status: 'merged' }],
+        statusText: 'All review artifacts merged',
+      });
+    });
+
+    it('synthesizes reviewGate from legacy scalar review fields', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('legacy-merge'));
+      (adapter as any).db.run(
+        'UPDATE tasks SET review_url = ?, review_id = ?, review_status = ?, review_gate = NULL WHERE id = ?',
+        ['https://github.com/acme/repo/pull/7', '7', 'Awaiting review', 'legacy-merge'],
+      );
+
+      expect(adapter.loadTask('legacy-merge')?.execution.reviewGate).toEqual({
+        sealed: true,
+        completion: { required: 'all', state: 'merged' },
+        relationship: { kind: 'unknown', managedBy: 'external' },
+        artifacts: [{
+          id: 'github:pull_request:7',
+          provider: 'github',
+          type: 'pull_request',
+          url: 'https://github.com/acme/repo/pull/7',
+          identifier: '7',
+          statusText: 'Awaiting review',
+        }],
+        statusText: 'Awaiting review',
+      });
+    });
+
     it('persists poolMemberId through updateTask and getPoolMemberId', () => {
       adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('ssh-task', {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -5,7 +5,7 @@
  * This allows swapping storage backends (in-memory, SQLite, etc.)
  */
 
-import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-core';
+import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, ReviewGateDefinition } from '@invoker/workflow-core';
 import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 
 // ── Conversation Types ─────────────────────────────────────
@@ -47,6 +47,7 @@ export interface Workflow {
   featureBranch?: string;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
   reviewProvider?: string;
+  reviewGate?: ReviewGateDefinition;
   externalDependencies?: ExternalDependency[];
   externalDependencyChanges?: ExternalDependencyChange[];
   /** Read-only provenance for dependencies removed by `detachWorkflow`. Never re-read by scheduling. */

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -31,6 +31,7 @@ import type {
   ExternalDependency,
   ExternalDependencyChange,
   DetachedExternalDependency,
+  ReviewGateExecution,
 } from '@invoker/workflow-core';
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
 import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
@@ -694,6 +695,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         feature_branch TEXT,
         merge_mode TEXT,
         review_provider TEXT,
+        review_gate_definition TEXT,
         external_dependencies TEXT,
         external_dependency_changes TEXT,
         detached_external_dependencies TEXT,
@@ -749,6 +751,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
         -- Merge node
         is_merge_node INTEGER DEFAULT 0,
+        review_gate TEXT,
 
         -- Claude session
         claude_session_id TEXT,
@@ -993,6 +996,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE tasks ADD COLUMN review_id TEXT',
       'ALTER TABLE tasks ADD COLUMN review_status TEXT',
       'ALTER TABLE tasks ADD COLUMN review_provider_id TEXT',
+      'ALTER TABLE tasks ADD COLUMN review_gate TEXT',
       'ALTER TABLE tasks ADD COLUMN is_fixing_with_ai INTEGER DEFAULT 0',
       'ALTER TABLE tasks ADD COLUMN execution_generation INTEGER DEFAULT 0',
       'ALTER TABLE tasks ADD COLUMN docker_image TEXT',
@@ -1005,6 +1009,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE tasks ADD COLUMN agent_session_id TEXT',
       'ALTER TABLE attempts ADD COLUMN agent_session_id TEXT',
       'ALTER TABLE workflows ADD COLUMN review_provider TEXT',
+      'ALTER TABLE workflows ADD COLUMN review_gate_definition TEXT',
       'ALTER TABLE workflows ADD COLUMN external_dependencies TEXT',
       'ALTER TABLE workflows ADD COLUMN external_dependency_changes TEXT',
       // detached_external_dependencies: read-only provenance for deps removed by detachWorkflow
@@ -1089,6 +1094,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         feature_branch TEXT,
         merge_mode TEXT,
         review_provider TEXT,
+        review_gate_definition TEXT,
         external_dependencies TEXT,
         external_dependency_changes TEXT,
         generation INTEGER DEFAULT 0,
@@ -1100,13 +1106,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
       INSERT INTO workflows_new (
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
-        review_provider, external_dependencies, external_dependency_changes,
+        review_provider, review_gate_definition, external_dependencies, external_dependency_changes,
         generation, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
-        review_provider, external_dependencies, external_dependency_changes,
+        review_provider, review_gate_definition, external_dependencies, external_dependency_changes,
         generation, created_at, updated_at
       FROM workflows
     `);
@@ -1279,8 +1285,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   saveWorkflow(workflow: Workflow): void {
     this.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, review_gate_definition, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
@@ -1289,6 +1295,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
       workflow.mergeMode ?? null,
       workflow.reviewProvider ?? null,
+      workflow.reviewGate ? JSON.stringify(workflow.reviewGate) : null,
       workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
       workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
       workflow.detachedExternalDependencies ? JSON.stringify(workflow.detachedExternalDependencies) : null,
@@ -1297,7 +1304,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     ]);
   }
 
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void {
+  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'reviewGate' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void {
     const setClauses: string[] = [];
     const values: unknown[] = [];
     const columnMap: Record<string, string> = {
@@ -1345,6 +1352,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if ('externalDependencyChanges' in changes) {
       setClauses.push('external_dependency_changes = ?');
       values.push(changes.externalDependencyChanges ? JSON.stringify(changes.externalDependencyChanges) : null);
+    }
+    if ('reviewGate' in changes) {
+      setClauses.push('review_gate_definition = ?');
+      values.push(changes.reviewGate ? JSON.stringify(changes.reviewGate) : null);
     }
     if ('detachedExternalDependencies' in changes) {
       setClauses.push('detached_external_dependencies = ?');
@@ -1521,7 +1532,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         action_request_id, experiments,
         created_at, launch_phase, launch_started_at, launch_completed_at, started_at, completed_at, last_heartbeat_at,
         utilization, pending_fix_error,
-        review_url, review_id, review_status, review_provider_id,
+        review_url, review_id, review_status, review_provider_id, review_gate,
         is_fixing_with_ai,
         execution_generation,
         pool_member_id,
@@ -1543,7 +1554,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ?, ?,
         ?, ?, ?, ?,
         ?, ?,
-        ?, ?, ?, ?,
+        ?, ?, ?, ?, ?,
         ?,
         ?,
         ?,
@@ -1599,6 +1610,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       exec.reviewId ?? null,
       exec.reviewStatus ?? null,
       exec.reviewProviderId ?? null,
+      exec.reviewGate ? JSON.stringify(exec.reviewGate) : null,
       exec.isFixingWithAI ? 1 : 0,
       exec.generation ?? 0,
       (cfg as { poolMemberId?: string }).poolMemberId ?? null,
@@ -1718,6 +1730,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         experiments: 'experiments',
         selectedExperiments: 'selected_experiments',
         experimentResults: 'experiment_results',
+        reviewGate: 'review_gate',
       };
 
       for (const [key, col] of Object.entries(execMap)) {
@@ -2699,12 +2712,41 @@ export class SQLiteAdapter implements PersistenceAdapter {
       featureBranch: row.feature_branch ?? undefined,
       mergeMode: row.merge_mode ?? undefined,
       reviewProvider: row.review_provider ?? undefined,
+      reviewGate: row.review_gate_definition ? JSON.parse(row.review_gate_definition) : undefined,
       externalDependencies: row.external_dependencies ? JSON.parse(row.external_dependencies) : undefined,
       externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
       detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
       generation: row.generation ?? 0,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+    };
+  }
+
+  private reviewGateFromRow(row: any): ReviewGateExecution | undefined {
+    if (row.review_gate) {
+      return JSON.parse(row.review_gate) as ReviewGateExecution;
+    }
+    const reviewUrl = row.review_url ?? undefined;
+    const reviewId = row.review_id ?? undefined;
+    if (!reviewUrl && !reviewId) return undefined;
+    const identifier = String(reviewId ?? reviewUrl);
+    const url = String(reviewUrl ?? '');
+    const statusText = row.review_status ?? undefined;
+    return {
+      sealed: true,
+      completion: { required: 'all', state: 'merged' },
+      relationship: { kind: 'unknown', managedBy: 'external' },
+      artifacts: [
+        {
+          id: `github:pull_request:${identifier}`,
+          provider: 'github',
+          type: 'pull_request',
+          url,
+          identifier,
+          statusText,
+        },
+      ],
+      statusText,
     };
   }
 
@@ -2773,6 +2815,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         reviewId: row.review_id ?? undefined,
         reviewStatus: row.review_status ?? undefined,
         reviewProviderId: row.review_provider_id ?? undefined,
+        reviewGate: this.reviewGateFromRow(row),
         phase: row.launch_phase ?? undefined,
         launchStartedAt: row.launch_started_at ? new Date(row.launch_started_at) : undefined,
         launchCompletedAt: row.launch_completed_at ? new Date(row.launch_completed_at) : undefined,


### PR DESCRIPTION
## Summary

This saves review-gate artifact state in SQLite.

Loaded tasks now keep the full gate state instead of losing it between process restarts.

## Review Claim

SQLite persistence now round-trips review-gate artifact state.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

The value is stored as optional JSON. Rows without review-gate state still load normally.

## Slice Rationale

This follows core state support so the new state survives reloads before execution uses it.

## Non-goals

- No GitHub provider changes.
- No API changes.
- No UI changes.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/plan-parser.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/github-merge-gate-provider.test.ts src/__tests__/task-runner.test.ts`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

Depends-On: #1697