### PR TITLE
[Multi PR Review Gate](4) Publish and poll review artifacts

### DIFF
--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -51,14 +51,14 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/Neko-Catpital-Labs/Invoker/pull/42","number":42}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'master',
         featureBranch: 'feature/test',
         title: 'Test PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/Neko-Catpital-Labs/Invoker/pull/42');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/Neko-Catpital-Labs/Invoker/pull/42');
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
         [
@@ -101,15 +101,15 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'origin/main',
         featureBranch: 'feature/test',
         title: 'Test PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/owner/repo/pull/42');
-      expect(result.identifier).toBe('42');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/42');
+      expect(result.artifacts[0]?.identifier).toBe('42');
       expect(spawnMock).toHaveBeenCalledWith(
         'git',
         ['push', '--force', 'origin', 'feature/test:refs/heads/feature/test'],
@@ -169,14 +169,14 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'main',
         featureBranch: 'feature/test',
         title: 'Test PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/owner/repo/pull/42');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/42');
       expect(pushAttempts).toBe(2);
       expect(spawnMock).toHaveBeenCalledWith(
         'git',
@@ -214,14 +214,14 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'main',
         featureBranch: 'feature/test',
         title: 'Test PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/owner/repo/pull/42');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/42');
       expect(pushAttempts).toBe(2);
       expect(spawnMock).toHaveBeenCalledWith(
         'git',
@@ -254,14 +254,14 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'main',
         featureBranch: 'feature/test',
         title: 'Test PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/owner/repo/pull/42');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/42');
       expect(lookupAttempts).toBe(2);
     });
 
@@ -283,7 +283,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'main',
         featureBranch: 'feature/test',
         title: 'Updated PR',
@@ -291,7 +291,7 @@ describe('GitHubMergeGateProvider', () => {
         body: '## Summary',
       });
 
-      expect(result.url).toBe('https://github.com/owner/repo/pull/10');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/10');
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
         [
@@ -323,7 +323,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'main',
         featureBranch: 'feature/test',
         title: 'Updated PR',
@@ -331,9 +331,21 @@ describe('GitHubMergeGateProvider', () => {
         body: '## Summary',
       });
 
-      expect(result).toEqual({
-        url: 'https://github.com/owner/repo/pull/11',
-        identifier: '11',
+      expect(result).toMatchObject({
+        sealed: true,
+        relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+        artifacts: [{
+          id: 'github:pull_request:11',
+          provider: 'github',
+          type: 'pull_request',
+          url: 'https://github.com/owner/repo/pull/11',
+          identifier: '11',
+          title: 'Updated PR',
+          baseBranch: 'main',
+          headBranch: 'feature/test',
+          status: 'open',
+          statusText: 'Awaiting review',
+        }],
       });
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
@@ -376,14 +388,14 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('{"html_url":"https://github.com/Neko-Catpital-Labs/Invoker/pull/99","number":99}', 0);
       }) as any);
 
-      const result = await provider.createReview({
+      const result = await provider.publishReviewGate({
         baseBranch: 'master',
         featureBranch: 'feature/test',
         title: 'Env target PR',
         cwd: '/tmp/repo',
       });
 
-      expect(result.url).toBe('https://github.com/Neko-Catpital-Labs/Invoker/pull/99');
+      expect(result.artifacts[0]?.url).toBe('https://github.com/Neko-Catpital-Labs/Invoker/pull/99');
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
         expect.arrayContaining(['api', 'repos/Neko-Catpital-Labs/Invoker/pulls']),
@@ -402,7 +414,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      await expect(provider.createReview({
+      await expect(provider.publishReviewGate({
         baseBranch: 'master',
         featureBranch: 'feature/test',
         title: 'Missing target',
@@ -424,7 +436,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      await expect(provider.createReview({
+      await expect(provider.publishReviewGate({
         baseBranch: 'master',
         featureBranch: 'feature/test',
         title: 'Missing origin',
@@ -444,7 +456,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      await provider.closeReview({ identifier: '42', cwd: '/tmp/repo' });
+      await provider.closeArtifact({ identifier: '42', cwd: '/tmp/repo' });
 
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
@@ -475,7 +487,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.checkApproval({ identifier: '1', cwd: '/tmp/repo' });
+      const result = await provider.checkArtifact({ identifier: '1', cwd: '/tmp/repo' });
 
       expect(result.approved).toBe(true);
       expect(result.rejected).toBe(false);
@@ -498,7 +510,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.checkApproval({ identifier: '2', cwd: '/tmp/repo' });
+      const result = await provider.checkArtifact({ identifier: '2', cwd: '/tmp/repo' });
 
       expect(result.approved).toBe(false);
       expect(result.rejected).toBe(false);
@@ -521,7 +533,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.checkApproval({ identifier: '3', cwd: '/tmp/repo' });
+      const result = await provider.checkArtifact({ identifier: '3', cwd: '/tmp/repo' });
 
       expect(result.approved).toBe(false);
       expect(result.rejected).toBe(false);
@@ -569,7 +581,7 @@ describe('GitHubMergeGateProvider', () => {
         return mockSpawnResult('', 0);
       }) as any);
 
-      const result = await provider.checkApproval({ identifier: '4', cwd: '/tmp/repo' });
+      const result = await provider.checkArtifact({ identifier: '4', cwd: '/tmp/repo' });
 
       expect(result.headSha).toBe('abc123');
       expect(result.headRef).toBe('feature/red-ci');

--- a/packages/execution-engine/src/__tests__/review-provider-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/review-provider-registry.test.ts
@@ -1,12 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { ReviewProviderRegistry } from '../review-provider-registry.js';
-import type { MergeGateProvider } from '../merge-gate-provider.js';
+import type { ReviewGateProvider } from '../merge-gate-provider.js';
 
-function makeFakeProvider(name: string): MergeGateProvider {
+function makeFakeProvider(name: string): ReviewGateProvider {
   return {
     name,
-    createReview: async () => ({ url: `https://example.com/${name}/1`, identifier: `${name}#1` }),
-    checkApproval: async () => ({ approved: false, rejected: false, statusText: 'pending', url: '' }),
+    publishReviewGate: async () => ({
+      sealed: true,
+      relationship: { kind: 'unknown', managedBy: 'external' },
+      artifacts: [{
+        id: `${name}:pull_request:1`,
+        provider: name,
+        type: 'pull_request',
+        url: `https://example.com/${name}/1`,
+        identifier: `${name}#1`,
+      }],
+    }),
+    checkArtifact: async () => ({ approved: false, rejected: false, statusText: 'pending', url: '' }),
   };
 }
 

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -12,6 +12,23 @@ import { EventEmitter } from 'events';
 import { buildCanonicalPrBody, validateCanonicalPrBody } from '../pr-authoring.js';
 import type { PrAuthoringContext } from '../pr-authoring.js';
 
+function reviewGateResult(url: string, identifier: string) {
+  return {
+    sealed: true,
+    relationship: { kind: 'stacked_diffs' as const, managedBy: 'external' as const },
+    artifacts: [{
+      id: `github:pull_request:${identifier}`,
+      provider: 'github',
+      type: 'pull_request' as const,
+      url,
+      identifier,
+      status: 'open' as const,
+      statusText: 'Awaiting review',
+    }],
+  };
+}
+
+
 /**
  * Creates a mock executor that auto-completes on start().
  * For merge nodes (no command/prompt), this simulates the executor's
@@ -1626,7 +1643,7 @@ describe('TaskRunner', () => {
       expect(result.body).toContain('pnpm run build');
     });
 
-    it('external_review propagates authored PR body to createReview, not raw summary', async () => {
+    it('external_review propagates authored PR body to publishReviewGate, not raw summary', async () => {
       const completedTask = makeTask({
         id: 't1',
         status: 'completed',
@@ -1647,10 +1664,7 @@ describe('TaskRunner', () => {
       const allTasks = [mergeTask, completedTask];
 
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/42',
-          identifier: 'owner/repo#42',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/42', 'owner/repo#42')),
       };
 
       const orchestrator = {
@@ -1709,15 +1723,15 @@ describe('TaskRunner', () => {
 
       await executor.publishAfterFix(mergeTask);
 
-      // createReview must receive the authored body, NOT the raw summary
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      // publishReviewGate must receive the authored body, NOT the raw summary
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({
           body: authoredBody,
         }),
       );
       // Verify the raw summary was NOT passed as the body
-      const createReviewCall = mergeGateProvider.createReview.mock.calls[0][0];
-      expect(createReviewCall.body).not.toBe('Raw summary text only');
+      const publishReviewGateCall = mergeGateProvider.publishReviewGate.mock.calls[0][0];
+      expect(publishReviewGateCall.body).not.toBe('Raw summary text only');
     });
 
     it('canonical body retains executed UI verification commands in Test Plan', () => {
@@ -2062,10 +2076,7 @@ describe('TaskRunner', () => {
       };
 
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/99',
-          identifier: 'owner/repo#99',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/99', 'owner/repo#99')),
       };
 
       const gitCalls: { args: string[]; dir: string }[] = [];
@@ -2156,7 +2167,7 @@ describe('TaskRunner', () => {
       }));
 
       // PR created via mergeGateProvider with authored body (not raw summary)
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({
           baseBranch: 'master',
           featureBranch: 'plan/feature',
@@ -2170,9 +2181,7 @@ describe('TaskRunner', () => {
       expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
         execution: expect.objectContaining({
           branch: 'plan/feature',
-          reviewUrl: 'https://github.com/owner/repo/pull/99',
-          reviewId: 'owner/repo#99',
-          reviewStatus: 'Awaiting review',
+          reviewGate: expect.objectContaining({ artifacts: [expect.objectContaining({ identifier: 'owner/repo#99', url: 'https://github.com/owner/repo/pull/99' })] }),
         }),
       }));
 
@@ -4069,7 +4078,7 @@ describe('TaskRunner', () => {
   });
 
   describe('external_review propagation of authored PR body', () => {
-    it('createReview receives the authored body, not the raw workflowSummary', async () => {
+    it('publishReviewGate receives the authored body, not the raw workflowSummary', async () => {
       const allTasks = [
         makeTask({
           id: 't1',
@@ -4098,10 +4107,7 @@ describe('TaskRunner', () => {
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/99',
-          identifier: '99',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/99', '99')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -4136,12 +4142,12 @@ describe('TaskRunner', () => {
 
       await (executor as any).executeMergeNode(mergeTask);
 
-      // The authored body must be passed to createReview, not the raw summary
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      // The authored body must be passed to publishReviewGate, not the raw summary
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({ body: authoredBody }),
       );
       // Raw summary must not leak into the PR body
-      const prBodyArg = mergeGateProvider.createReview.mock.calls[0][0].body;
+      const prBodyArg = mergeGateProvider.publishReviewGate.mock.calls[0][0].body;
       expect(prBodyArg).not.toContain('Raw workflow summary — should not appear in PR body');
     });
 
@@ -4176,7 +4182,7 @@ describe('TaskRunner', () => {
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({ url: 'https://example.com/pr/1', identifier: '1' }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://example.com/pr/1', '1')),
       };
       const authorPrSpy = vi.fn().mockResolvedValue({
         body: '## Summary\n\nOK\n\n## Test Plan\n\n- [x] pnpm test\n\n## Revert Plan\n\n- Safe',

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -13,6 +13,43 @@ import { EventEmitter } from 'events';
 import { buildCanonicalPrBody, validateCanonicalPrBody } from '../pr-authoring.js';
 import type { PrAuthoringContext } from '../pr-authoring.js';
 
+function reviewGateResult(url: string, identifier: string) {
+  return {
+    sealed: true,
+    relationship: { kind: 'stacked_diffs' as const, managedBy: 'external' as const },
+    artifacts: [{
+      id: `github:pull_request:${identifier}`,
+      provider: 'github',
+      type: 'pull_request' as const,
+      url,
+      identifier,
+      status: 'open' as const,
+      statusText: 'Awaiting review',
+    }],
+  };
+}
+
+
+function reviewGateExecution(identifier: string, status: 'open' | 'merged' | 'closed' | 'rejected' | 'unknown' = 'open') {
+  const number = identifier.match(/(\d+)$/)?.[1] ?? identifier;
+  return {
+    sealed: true,
+    completion: { required: 'all' as const, state: 'merged' as const },
+    relationship: { kind: 'stacked_diffs' as const, managedBy: 'external' as const },
+    artifacts: [{
+      id: `github:pull_request:${identifier}`,
+      provider: 'github',
+      type: 'pull_request' as const,
+      url: `https://github.com/owner/repo/pull/${number}`,
+      identifier,
+      status,
+      statusText: status === 'merged' ? 'Merged' : 'Awaiting review',
+    }],
+    statusText: status === 'merged' ? 'Merged' : 'Awaiting review',
+  };
+}
+
+
 /**
  * Creates a mock executor that auto-completes on start().
  * For merge nodes (no command/prompt), this simulates the executor's
@@ -3122,10 +3159,7 @@ describe('TaskRunner', () => {
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/42',
-          identifier: 'owner/repo#42',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/42', 'owner/repo#42')),
       };
       const onComplete = vi.fn();
       const executor = new TaskRunner({
@@ -3184,7 +3218,7 @@ describe('TaskRunner', () => {
       }));
 
       // Should create a PR via mergeGateProvider with authored body
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({
           baseBranch: 'master',
           featureBranch: 'plan/feature',
@@ -3199,9 +3233,7 @@ describe('TaskRunner', () => {
         config: expect.objectContaining({ runnerKind: 'worktree' }),
         execution: expect.objectContaining({
           branch: 'plan/feature',
-          reviewUrl: 'https://github.com/owner/repo/pull/42',
-          reviewId: 'owner/repo#42',
-          reviewStatus: 'Awaiting review',
+          reviewGate: expect.objectContaining({ artifacts: [expect.objectContaining({ identifier: 'owner/repo#42', url: 'https://github.com/owner/repo/pull/42' })] }),
         }),
       }));
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
@@ -3235,10 +3267,7 @@ describe('TaskRunner', () => {
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/42',
-          identifier: 'owner/repo#42',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/42', 'owner/repo#42')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -3392,10 +3421,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/invoker/invoker/pull/276',
-          identifier: 'invoker/invoker#276',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/invoker/invoker/pull/276', 'invoker/invoker#276')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -3431,8 +3457,8 @@ console.log(JSON.stringify(out));
       await (executor as any).executeMergeNode(mergeTask);
 
       expect(gitCalls.some(c => c[0] === 'push')).toBe(true);
-      expect(mergeGateProvider.createReview).toHaveBeenCalledTimes(1);
-      const providerBody = mergeGateProvider.createReview.mock.calls[0][0].body;
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledTimes(1);
+      const providerBody = mergeGateProvider.publishReviewGate.mock.calls[0][0].body;
       expect(providerBody).toContain('## Visual Proof');
       expect(providerBody).toContain('merge-gate-no-inline-approve.png');
       expect(providerBody).toContain('![before](https://img.example.test/before--merge-gate-no-inline-approve.png)');
@@ -3551,10 +3577,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/55',
-          identifier: 'owner/repo#55',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/55', 'owner/repo#55')),
       };
       const onComplete = vi.fn();
       const executor = new TaskRunner({
@@ -3595,7 +3618,7 @@ console.log(JSON.stringify(out));
       expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalled();
 
       // Should create a PR via mergeGateProvider
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({
           baseBranch: 'master',
           featureBranch: 'plan/feature',
@@ -3608,9 +3631,7 @@ console.log(JSON.stringify(out));
         config: expect.objectContaining({ runnerKind: 'worktree' }),
         execution: expect.objectContaining({
           branch: 'plan/feature',
-          reviewUrl: 'https://github.com/owner/repo/pull/55',
-          reviewId: 'owner/repo#55',
-          reviewStatus: 'Awaiting review',
+          reviewGate: expect.objectContaining({ artifacts: [expect.objectContaining({ identifier: 'owner/repo#55', url: 'https://github.com/owner/repo/pull/55' })] }),
         }),
       }));
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
@@ -3640,10 +3661,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/55',
-          identifier: 'owner/repo#55',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/55', 'owner/repo#55')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -3707,10 +3725,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/55',
-          identifier: 'owner/repo#55',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/55', 'owner/repo#55')),
       };
       const onComplete = vi.fn();
       const executor = new TaskRunner({
@@ -3747,7 +3762,7 @@ console.log(JSON.stringify(out));
 
       await (executor as any).executeMergeNode(mergeTask);
 
-      expect(mergeGateProvider.createReview).toHaveBeenCalled();
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalled();
       expect(orchestrator.setTaskReviewReady).toHaveBeenCalled();
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
     });
@@ -3887,10 +3902,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/99',
-          identifier: '99',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/99', '99')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -3928,7 +3940,7 @@ console.log(JSON.stringify(out));
       await (executor as any).executeMergeNode(mergeTask);
 
       expect(logSpy).toHaveBeenCalledWith(
-        expect.stringContaining('https://github.com/owner/repo/pull/99'),
+        expect.stringContaining('Created review artifacts: 99'),
       );
 
       logSpy.mockRestore();
@@ -3958,10 +3970,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/42',
-          identifier: '42',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/42', '42')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -4152,7 +4161,7 @@ console.log(JSON.stringify(out));
       );
     });
 
-    it('executeMergeNode passes authored body to createReview in external_review mode', async () => {
+    it('executeMergeNode passes authored body to publishReviewGate in external_review mode', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
       ];
@@ -4176,10 +4185,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        createReview: vi.fn().mockResolvedValue({
-          url: 'https://github.com/owner/repo/pull/42',
-          identifier: '42',
-        }),
+        publishReviewGate: vi.fn().mockResolvedValue(reviewGateResult('https://github.com/owner/repo/pull/42', '42')),
       };
       const executor = new TaskRunner({
         orchestrator: orchestrator as any,
@@ -4223,8 +4229,8 @@ console.log(JSON.stringify(out));
         }),
       );
 
-      // createReview receives the authored body, not the raw summary
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+      // publishReviewGate receives the authored body, not the raw summary
+      expect(mergeGateProvider.publishReviewGate).toHaveBeenCalledWith(
         expect.objectContaining({ body: '## Summary\n\nAuthored PR body from summary' }),
       );
       expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith(
@@ -4358,7 +4364,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'awaiting_approval',
-          execution: { reviewId: 'owner/repo#42' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#42') },
         })),
         approve: vi.fn(),
       };
@@ -4366,7 +4372,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: false,
           rejected: false,
           statusText: 'Awaiting review',
@@ -4385,12 +4391,12 @@ console.log(JSON.stringify(out));
       await executor.checkPrApprovalNow('task-1');
 
       expect(orchestrator.getTask).toHaveBeenCalledWith('task-1');
-      expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+      expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
         identifier: 'owner/repo#42',
         cwd: '/tmp',
       });
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
-        execution: { reviewStatus: 'Awaiting review' },
+        execution: { reviewGate: expect.objectContaining({ statusText: 'Awaiting review' }) },
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
     });
@@ -4404,7 +4410,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
-          execution: { reviewId: 'owner/repo#42' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#42') },
         })),
         approve: vi.fn().mockResolvedValue([downstream]),
       };
@@ -4412,7 +4418,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: true,
           rejected: false,
           statusText: 'Merged',
@@ -4432,7 +4438,7 @@ console.log(JSON.stringify(out));
       await executor.checkPrApprovalNow('task-1');
 
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
-        execution: { reviewStatus: 'Merged' },
+        execution: { reviewGate: expect.objectContaining({ statusText: 'All review artifacts merged' }) },
       });
       expect(orchestrator.approve).toHaveBeenCalledWith('task-1');
       expect(executeTasks).toHaveBeenCalledWith([downstream]);
@@ -4443,7 +4449,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
-          execution: { reviewId: 'owner/repo#42' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#42') },
         })),
         approve: vi.fn(),
       };
@@ -4451,7 +4457,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: false,
           rejected: false,
           statusText: 'Approved, awaiting merge',
@@ -4470,7 +4476,7 @@ console.log(JSON.stringify(out));
       await executor.checkPrApprovalNow('task-1');
 
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
-        execution: { reviewStatus: 'Approved, awaiting merge' },
+        execution: { reviewGate: expect.objectContaining({ statusText: 'Approved, awaiting merge' }) },
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
     });
@@ -4480,7 +4486,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
-          execution: { reviewId: 'owner/repo#42' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#42') },
         })),
         approve: vi.fn(),
       };
@@ -4488,7 +4494,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: false,
           rejected: true,
           statusText: 'Changes requested',
@@ -4508,7 +4514,7 @@ console.log(JSON.stringify(out));
       await executor.checkPrApprovalNow('task-1');
 
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
-        execution: { reviewStatus: 'Changes requested' },
+        execution: { reviewGate: expect.objectContaining({ statusText: 'Changes requested' }) },
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
       expect(executeTasks).not.toHaveBeenCalled();
@@ -4519,7 +4525,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
-          execution: { reviewId: 'owner/repo#43' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#43') },
         })),
         approve: vi.fn(),
       };
@@ -4527,7 +4533,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: false,
           rejected: false,
           closed: true,
@@ -4549,7 +4555,7 @@ console.log(JSON.stringify(out));
 
       expect(persistence.updateTask).toHaveBeenCalledWith('task-closed', {
         status: 'closed',
-        execution: { reviewStatus: 'Closed' },
+        execution: { reviewStatus: expect.stringContaining('Review artifact closed:') },
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
       expect(executeTasks).not.toHaveBeenCalled();
@@ -4564,7 +4570,7 @@ console.log(JSON.stringify(out));
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
-          execution: { reviewId: 'owner/repo#42' },
+          execution: { reviewGate: reviewGateExecution('owner/repo#42') },
         })),
         approve: vi.fn().mockResolvedValue([downstream]),
       };
@@ -4572,7 +4578,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn().mockResolvedValue({
+        checkArtifact: vi.fn().mockResolvedValue({
           approved: true,
           rejected: false,
           statusText: 'Merged',
@@ -4593,7 +4599,7 @@ console.log(JSON.stringify(out));
       // No active poller is registered — simulates a fresh process after restart
       await executor.checkPrApprovalNow('task-with-no-poller');
 
-      expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+      expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
         identifier: 'owner/repo#42',
         cwd: '/tmp',
       });
@@ -4614,7 +4620,7 @@ console.log(JSON.stringify(out));
         updateTask: vi.fn(),
       };
       const mergeGateProvider = {
-        checkApproval: vi.fn(),
+        checkArtifact: vi.fn(),
       };
 
       const executor = new TaskRunner({
@@ -4627,7 +4633,7 @@ console.log(JSON.stringify(out));
 
       await executor.checkPrApprovalNow('task-without-review-id');
 
-      expect(mergeGateProvider.checkApproval).not.toHaveBeenCalled();
+      expect(mergeGateProvider.checkArtifact).not.toHaveBeenCalled();
       expect(persistence.updateTask).not.toHaveBeenCalled();
       expect(orchestrator.approve).not.toHaveBeenCalled();
     });
@@ -4650,14 +4656,14 @@ console.log(JSON.stringify(out));
 
       await executor.checkPrApprovalNow('task-1');
 
-      expect(orchestrator.getTask).not.toHaveBeenCalled();
+      expect(orchestrator.getTask).toHaveBeenCalledWith('task-1');
       expect(persistence.updateTask).not.toHaveBeenCalled();
     });
   });
 
-  // ── merge-gate checkApproval cwd resolution ────────────
+  // ── merge-gate checkArtifact cwd resolution ────────────
 
-  describe('merge-gate checkApproval uses workspacePath as cwd', () => {
+  describe('merge-gate checkArtifact uses workspacePath as cwd', () => {
     describe('checkPrApprovalNow', () => {
       it('uses task workspacePath as cwd when present', async () => {
         const orchestrator = {
@@ -4665,7 +4671,7 @@ console.log(JSON.stringify(out));
             id,
             status: 'review_ready',
             execution: {
-              reviewId: 'owner/repo#99',
+              reviewGate: reviewGateExecution('owner/repo#99'),
               workspacePath: '/workspace/merge-worktree',
             },
           })),
@@ -4673,7 +4679,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             statusText: 'Pending',
@@ -4691,7 +4697,7 @@ console.log(JSON.stringify(out));
 
         await executor.checkPrApprovalNow('task-ws');
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#99',
           cwd: '/workspace/merge-worktree',
         });
@@ -4702,13 +4708,13 @@ console.log(JSON.stringify(out));
           getTask: vi.fn((id: string) => ({
             id,
             status: 'review_ready',
-            execution: { reviewId: 'owner/repo#100' },
+            execution: { reviewGate: reviewGateExecution('owner/repo#100') },
           })),
           approve: vi.fn(),
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             statusText: 'Pending',
@@ -4726,7 +4732,7 @@ console.log(JSON.stringify(out));
 
         await executor.checkPrApprovalNow('task-no-ws');
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#100',
           cwd: '/runner-base-cwd',
         });
@@ -4742,7 +4748,7 @@ console.log(JSON.stringify(out));
             id,
             status: 'review_ready',
             execution: {
-              reviewId: 'owner/repo#101',
+              reviewGate: reviewGateExecution('owner/repo#101'),
               workspacePath: '/workspace/approved-worktree',
             },
           })),
@@ -4750,7 +4756,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: true,
             rejected: false,
             statusText: 'Merged',
@@ -4769,12 +4775,12 @@ console.log(JSON.stringify(out));
 
         await executor.checkPrApprovalNow('task-approved');
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#101',
           cwd: '/workspace/approved-worktree',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('task-approved', {
-          execution: { reviewStatus: 'Merged' },
+          execution: { reviewGate: expect.objectContaining({ statusText: 'All review artifacts merged' }) },
         });
         expect(orchestrator.approve).toHaveBeenCalledWith('task-approved');
         expect(executeTasks).toHaveBeenCalledWith([downstream]);
@@ -4789,7 +4795,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { workflowId: 'wf-close', isMergeNode: true },
             execution: {
-              reviewId: '205',
+              reviewGate: reviewGateExecution('205'),
               workspacePath: '/workspace/close-gate',
             },
           }),
@@ -4798,7 +4804,7 @@ console.log(JSON.stringify(out));
           getAllTasks: () => allTasks,
         };
         const mergeGateProvider = {
-          closeReview: vi.fn().mockResolvedValue(undefined),
+          closeArtifact: vi.fn().mockResolvedValue(undefined),
         };
 
         const executor = new TaskRunner({
@@ -4811,7 +4817,7 @@ console.log(JSON.stringify(out));
 
         await executor.closeWorkflowReview('wf-close');
 
-        expect(mergeGateProvider.closeReview).toHaveBeenCalledWith({
+        expect(mergeGateProvider.closeArtifact).toHaveBeenCalledWith({
           identifier: '205',
           cwd: '/workspace/close-gate',
         });
@@ -4824,7 +4830,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { isMergeNode: true },
             execution: {
-              reviewId: 'owner/repo#200',
+              reviewGate: reviewGateExecution('owner/repo#200'),
               workspacePath: '/workspace/gate-worktree',
             },
           }),
@@ -4836,7 +4842,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             statusText: 'Pending',
@@ -4853,7 +4859,7 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#200',
           cwd: '/workspace/gate-worktree',
         });
@@ -4865,7 +4871,7 @@ console.log(JSON.stringify(out));
             id: 'merge-no-ws',
             status: 'awaiting_approval',
             config: { isMergeNode: true },
-            execution: { reviewId: 'owner/repo#201' },
+            execution: { reviewGate: reviewGateExecution('owner/repo#201') },
           }),
         ];
         const orchestrator = {
@@ -4875,7 +4881,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             statusText: 'Pending',
@@ -4892,7 +4898,7 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#201',
           cwd: '/runner-base-cwd',
         });
@@ -4909,7 +4915,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { isMergeNode: true },
             execution: {
-              reviewId: 'owner/repo#202',
+              reviewGate: reviewGateExecution('owner/repo#202'),
               workspacePath: '/workspace/approved-gate',
             },
           }),
@@ -4921,7 +4927,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: true,
             rejected: false,
             statusText: 'Merged',
@@ -4939,12 +4945,12 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#202',
           cwd: '/workspace/approved-gate',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('merge-approved', {
-          execution: { reviewStatus: 'Merged' },
+          execution: { reviewGate: expect.objectContaining({ statusText: 'All review artifacts merged' }) },
         });
         expect(orchestrator.approve).toHaveBeenCalledWith('merge-approved');
         expect(executeTasks).toHaveBeenCalledWith([downstream]);
@@ -4957,7 +4963,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { isMergeNode: true },
             execution: {
-              reviewId: 'owner/repo#203',
+              reviewGate: reviewGateExecution('owner/repo#203'),
               workspacePath: '/workspace/open-approved-gate',
             },
           }),
@@ -4969,7 +4975,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             statusText: 'Approved, awaiting merge',
@@ -4986,12 +4992,12 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#203',
           cwd: '/workspace/open-approved-gate',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('merge-open-approved', {
-          execution: { reviewStatus: 'Approved, awaiting merge' },
+          execution: { reviewGate: expect.objectContaining({ statusText: 'Approved, awaiting merge' }) },
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
       });
@@ -5003,7 +5009,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { isMergeNode: true },
             execution: {
-              reviewId: 'owner/repo#204',
+              reviewGate: reviewGateExecution('owner/repo#204'),
               workspacePath: '/workspace/rejected-gate',
             },
           }),
@@ -5015,7 +5021,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: true,
             statusText: 'Changes requested',
@@ -5033,12 +5039,12 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#204',
           cwd: '/workspace/rejected-gate',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('merge-rejected', {
-          execution: { reviewStatus: 'Changes requested' },
+          execution: { reviewGate: expect.objectContaining({ statusText: 'Changes requested' }) },
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(executeTasks).not.toHaveBeenCalled();
@@ -5051,7 +5057,7 @@ console.log(JSON.stringify(out));
             status: 'review_ready',
             config: { isMergeNode: true },
             execution: {
-              reviewId: 'owner/repo#205',
+              reviewGate: reviewGateExecution('owner/repo#205'),
               workspacePath: '/workspace/closed-gate',
             },
           }),
@@ -5063,7 +5069,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             closed: true,
@@ -5082,13 +5088,13 @@ console.log(JSON.stringify(out));
 
         await executor.checkMergeGateStatuses();
 
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledWith({
           identifier: 'owner/repo#205',
           cwd: '/workspace/closed-gate',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('merge-closed', {
           status: 'closed',
-          execution: { reviewStatus: 'Closed' },
+          execution: { reviewStatus: expect.stringContaining('Review artifact closed:') },
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(executeTasks).not.toHaveBeenCalled();
@@ -5100,7 +5106,7 @@ console.log(JSON.stringify(out));
           status: 'awaiting_approval',
           config: { isMergeNode: true },
           execution: {
-            reviewId: 'owner/repo#206',
+            reviewGate: reviewGateExecution('owner/repo#206'),
             workspacePath: '/workspace/awaiting-closed-gate',
           },
         });
@@ -5111,7 +5117,7 @@ console.log(JSON.stringify(out));
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             closed: true,
@@ -5132,7 +5138,7 @@ console.log(JSON.stringify(out));
 
         expect(persistence.updateTask).toHaveBeenCalledWith('merge-awaiting-closed', {
           status: 'closed',
-          execution: { reviewStatus: 'Closed' },
+          execution: { reviewStatus: expect.stringContaining('Review artifact closed:') },
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(executeTasks).not.toHaveBeenCalled();
@@ -5144,7 +5150,7 @@ console.log(JSON.stringify(out));
           status: 'review_ready',
           config: { isMergeNode: true },
           execution: {
-            reviewId: 'owner/repo#207',
+            reviewGate: reviewGateExecution('owner/repo#207'),
             workspacePath: '/workspace/closed-stop-poll',
           },
         });
@@ -5161,7 +5167,7 @@ console.log(JSON.stringify(out));
           }),
         };
         const mergeGateProvider = {
-          checkApproval: vi.fn().mockResolvedValue({
+          checkArtifact: vi.fn().mockResolvedValue({
             approved: false,
             rejected: false,
             closed: true,
@@ -5179,13 +5185,13 @@ console.log(JSON.stringify(out));
         vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
         await executor.checkMergeGateStatuses();
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledTimes(1);
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledTimes(1);
         expect(task.status).toBe('closed');
 
         await executor.checkMergeGateStatuses();
         // Closed status falls outside the (review_ready || awaiting_approval) polling filter,
         // so no additional provider call should happen on the second refresh pass.
-        expect(mergeGateProvider.checkApproval).toHaveBeenCalledTimes(1);
+        expect(mergeGateProvider.checkArtifact).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -1,8 +1,8 @@
 import { spawn } from 'node:child_process';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 import type {
-  MergeGateProvider,
-  MergeGateProviderResult,
+  ReviewGateProvider,
+  ReviewGatePublishResult,
   MergeGateApprovalStatus,
   MergeGateFailedCheck,
 } from './merge-gate-provider.js';
@@ -11,32 +11,33 @@ import { isGitRefLockRace, retryTransientGitHubCli } from './git-utils.js';
 
 type ExistingPullRequest = { url: string; number: number };
 
-export class GitHubMergeGateProvider implements MergeGateProvider {
+export class GitHubMergeGateProvider implements ReviewGateProvider {
   readonly name = 'github';
 
   private static readonly TARGET_REPO_ENV = 'INVOKER_GITHUB_TARGET_REPO';
 
-  async createReview(opts: {
+  async publishReviewGate(opts: {
     baseBranch: string;
     featureBranch: string;
     title: string;
     cwd: string;
     body?: string;
-  }): Promise<MergeGateProviderResult> {
+    preferredShape?: 'stacked_diffs' | 'independent';
+  }): Promise<ReviewGatePublishResult> {
     const { baseBranch, featureBranch, title, cwd, body } = opts;
     console.log(
-      `${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview ` +
+      `${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate ` +
       `baseBranch=${baseBranch} featureBranch=${featureBranch} title=${title} cwd=${cwd} body=${body}`,
     );
     const ghBase = normalizeBranchForGithubCli(baseBranch);
     const ghHead = normalizeBranchForGithubCli(featureBranch);
     const targetRepo = await this.resolveTargetRepo(cwd);
-    console.log(`[merge-gate] createReview: ghBase=${ghBase} apiHead=${ghHead} cwd=${cwd}`);
+    console.log(`[merge-gate] publishReviewGate: ghBase=${ghBase} apiHead=${ghHead} cwd=${cwd}`);
 
     await this.pushFeatureBranch(cwd, featureBranch);
 
     const existing = await this.findExistingOpenPullRequest(cwd, targetRepo, ghHead);
-    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview existing=${existing}`);
+    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate existing=${existing}`);
 
     if (existing.length > 0) {
       const apiArgs = [
@@ -47,9 +48,31 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       ];
       if (body) apiArgs.push('-f', `body=${body}`);
       const ghResult = await retryTransientGitHubCli(() => this.exec('gh', apiArgs, cwd));
-      console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview update existing gh_result=${ghResult}`);
+      console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate update existing gh_result=${ghResult}`);
 
-      return { url: existing[0].url, identifier: String(existing[0].number) };
+      const artifact = {
+        id: `github:pull_request:${existing[0].number}`,
+        provider: 'github',
+        type: 'pull_request' as const,
+        url: existing[0].url,
+        identifier: String(existing[0].number),
+        title,
+        baseBranch,
+        headBranch: featureBranch,
+        status: 'open' as const,
+        statusText: 'Awaiting review',
+      };
+      if (!artifact.url || !artifact.identifier) {
+        throw new Error('Review gate publisher returned no pull request artifacts');
+      }
+      return {
+        sealed: true,
+        relationship: {
+          kind: (opts.preferredShape ?? 'stacked_diffs') === 'stacked_diffs' ? 'stacked_diffs' : 'independent',
+          managedBy: 'external',
+        },
+        artifacts: [artifact],
+      };
     }
 
     const createArgs = [
@@ -59,13 +82,34 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       '-f', `body=${body ?? ''}`,
     ];
     const stdout = await this.exec('gh', createArgs, cwd);
-    const pr = JSON.parse(stdout) as { html_url: string; number: number };
+    const pr = JSON.parse(stdout) as { html_url?: string; number?: number };
 
-    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview creating stdout=${stdout}`);
-    return { url: pr.html_url, identifier: String(pr.number) };
+    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate creating stdout=${stdout}`);
+    if (!pr.html_url || pr.number === undefined || pr.number === null) {
+      throw new Error('Review gate publisher returned no pull request artifacts');
+    }
+    return {
+      sealed: true,
+      relationship: {
+        kind: (opts.preferredShape ?? 'stacked_diffs') === 'stacked_diffs' ? 'stacked_diffs' : 'independent',
+        managedBy: 'external',
+      },
+      artifacts: [{
+        id: `github:pull_request:${pr.number}`,
+        provider: 'github',
+        type: 'pull_request',
+        url: pr.html_url,
+        identifier: String(pr.number),
+        title,
+        baseBranch,
+        headBranch: featureBranch,
+        status: 'open',
+        statusText: 'Awaiting review',
+      }],
+    };
   }
 
-  async closeReview(opts: {
+  async closeArtifact(opts: {
     identifier: string;
     cwd: string;
   }): Promise<void> {
@@ -78,7 +122,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     ], cwd));
   }
 
-  async checkApproval(opts: {
+  async checkArtifact(opts: {
     identifier: string;
     cwd: string;
   }): Promise<MergeGateApprovalStatus> {
@@ -183,7 +227,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
         '--json', 'url,number',
         '--limit', '1',
       ], cwd);
-      console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview listOutput=${listOutput}`);
+      console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate listOutput=${listOutput}`);
       return JSON.parse(listOutput) as ExistingPullRequest[];
     } catch (err) {
       console.warn(
@@ -208,7 +252,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       '-f', `head=${owner}:${ghHead}`,
       '-f', 'per_page=1',
     ], cwd));
-    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.createReview restListOutput=${output}`);
+    console.log(`${RESTART_TO_BRANCH_TRACE} GitHubMergeGateProvider.publishReviewGate restListOutput=${output}`);
     const pulls = JSON.parse(output) as Array<{ html_url?: string; url?: string; number: number }>;
     return pulls
       .map((pull) => ({

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -1,24 +1,18 @@
-export interface MergeGateProviderResult {
-  url: string;
-  identifier: string;
-}
+import type { ReviewGateArtifact } from '@invoker/workflow-core';
 
-export interface MergeGateCreateReviewOptions {
+export interface ReviewGatePublishOptions {
   baseBranch: string;
   featureBranch: string;
   title: string;
   cwd: string;
   body?: string;
+  preferredShape: 'stacked_diffs' | 'independent';
 }
 
-export interface MergeGateCheckApprovalOptions {
-  identifier: string;
-  cwd: string;
-}
-
-export interface MergeGateCloseReviewOptions {
-  identifier: string;
-  cwd: string;
+export interface ReviewGatePublishResult {
+  sealed: boolean;
+  relationship: { kind: 'stacked_diffs' | 'independent' | 'unknown'; managedBy: 'external' };
+  artifacts: ReviewGateArtifact[];
 }
 
 export interface MergeGateCheckSummary {
@@ -45,14 +39,14 @@ export interface MergeGateFailedCheck {
   summary?: string;
 }
 
-export interface MergeGateProvider {
+export interface ReviewGateProvider {
   readonly name: string;
 
   // INV-77 selected boundary: execution-engine owns provider IO and exposes
-  // typed review creation, polling, closure, check, and merge-state metadata.
-  createReview(opts: MergeGateCreateReviewOptions): Promise<MergeGateProviderResult>;
+  // typed review publishing, polling, closure, check, and merge-state metadata.
+  publishReviewGate(opts: ReviewGatePublishOptions): Promise<ReviewGatePublishResult>;
 
-  checkApproval(opts: MergeGateCheckApprovalOptions): Promise<MergeGateApprovalStatus>;
+  checkArtifact(opts: { identifier: string; cwd: string }): Promise<MergeGateApprovalStatus>;
 
-  closeReview?(opts: MergeGateCloseReviewOptions): Promise<void>;
+  closeArtifact?(opts: { identifier: string; cwd: string }): Promise<void>;
 }

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -10,12 +10,12 @@ import { normalize, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 
-import type { Orchestrator, TaskState, TaskStateChanges } from '@invoker/workflow-core';
+import type { Orchestrator, ReviewGateExecution, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkResponse } from '@invoker/contracts';
 import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
-import type { MergeGateProvider } from './merge-gate-provider.js';
+import type { ReviewGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 import type { PrAuthoringContext, PrAuthoringTaskEntry } from './pr-authoring.js';
@@ -45,6 +45,31 @@ function canonicalMergeMode(mode: string | undefined): 'manual' | 'automatic' | 
   if (m === 'external_review') return 'external_review';
   if (m === 'automatic') return 'automatic';
   return 'manual';
+}
+
+function reviewGateExecutionFromPublished(
+  result: { sealed: boolean; relationship: ReviewGateExecution['relationship']; artifacts: ReviewGateExecution['artifacts'] },
+): ReviewGateExecution {
+  if (result.sealed && result.artifacts.length === 0) {
+    throw new Error('Review gate publisher returned no pull request artifacts');
+  }
+  return {
+    sealed: result.sealed,
+    completion: { required: 'all', state: 'merged' },
+    relationship: result.relationship,
+    artifacts: result.artifacts,
+    statusText: result.artifacts.length > 0 ? 'Awaiting review' : undefined,
+  };
+}
+
+function waitingReviewGateExecution(preferredShape: 'stacked_diffs' | 'independent'): ReviewGateExecution {
+  return {
+    sealed: false,
+    completion: { required: 'all', state: 'merged' },
+    relationship: { kind: preferredShape, managedBy: 'external' },
+    artifacts: [],
+    statusText: 'Waiting for review artifacts',
+  };
 }
 
 async function resolveBaseCheckoutRef(
@@ -168,7 +193,7 @@ export interface MergeRunnerHost {
   readonly defaultBranch: string | undefined;
   readonly callbacks: TaskRunnerCallbacks;
   readonly cwd: string;
-  readonly mergeGateProvider?: MergeGateProvider;
+  readonly mergeGateProvider?: ReviewGateProvider;
   readonly reviewProviderRegistry?: ReviewProviderRegistry;
 
   execGitReadonly(args: string[], cwd?: string): Promise<string>;
@@ -458,6 +483,7 @@ export async function runMergeGateActionImpl(
       reviewUrl: undefined,
       reviewId: undefined,
       reviewStatus: undefined,
+      reviewGate: undefined,
     },
   });
 
@@ -526,14 +552,44 @@ export async function runMergeGateActionImpl(
         };
       }
       if (mergeMode === 'external_review') {
-        if (!host.mergeGateProvider) {
-          throw new Error('mergeMode is "external_review" but no review provider configured');
-        }
 
         // The PR branch is pushed from the separate consolidation clone above.
         // Fetch it into the persistent gate workspace and check it out before
         // persisting the workspace handoff used by review terminals.
         await syncGateWorkspaceToFeatureBranch(host, gateWorkspacePath, featureBranch);
+
+        const reviewGateDefinition = workflow?.reviewGate;
+        const preferredShape = reviewGateDefinition?.authoring.preferredShape ?? 'stacked_diffs';
+        const authoringMode = reviewGateDefinition?.authoring.mode ?? 'automatic';
+        if (authoringMode === 'manual' || authoringMode === 'external') {
+          const reviewGate = waitingReviewGateExecution(preferredShape);
+          response = {
+            requestId: `merge-${task.id}`,
+            actionId: task.id,
+            executionGeneration: task.execution.generation ?? 0,
+            status: 'review_ready',
+            outputs: {
+              exitCode: 0,
+              summary,
+              branch: featureBranch,
+              reviewGate,
+            },
+          };
+          return {
+            response,
+            taskChanges: {
+              config: { summary },
+              execution: {
+                branch: featureBranch,
+                workspacePath: gateWorkspacePath,
+                reviewGate,
+              },
+            },
+          };
+        }
+        if (!host.mergeGateProvider) {
+          throw new Error('mergeMode is "external_review" but no review provider configured');
+        }
 
         let fullSummary = summary;
         let vpMarkdownCapture: string | undefined;
@@ -563,22 +619,20 @@ export async function runMergeGateActionImpl(
 
         // Create PR via provider (consolidation already done above).
         // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
-        const result = await host.mergeGateProvider.createReview({
+        const result = await host.mergeGateProvider.publishReviewGate({
           baseBranch,
           featureBranch,
           title: workflow?.name ?? 'Workflow',
           cwd: gateWorkspacePath!,
           body: prBody,
+          preferredShape,
         });
-        console.log(`[merge] Created GitHub PR: ${result.url}`);
-
-        reviewUrl = result.url;
-        reviewId = result.identifier;
-        reviewStatus = 'Awaiting review';
+        const reviewGate = reviewGateExecutionFromPublished(result);
+        console.log(`[merge] Created review artifacts: ${reviewGate.artifacts.map((artifact) => artifact.identifier).join(', ')}`);
         mergeTrace('GATE_WS_PATH_EXTERNAL_REVIEW_AWAIT', {
           taskId: task.id,
           gateWorkspacePath: gateWorkspacePath ?? null,
-          reviewUrl: result.url,
+          reviewUrl: reviewGate.artifacts.at(-1)?.url ?? null,
         });
         console.log(
           `[merge-gate-workspace] setTaskReviewReady path=external_review ` +
@@ -593,9 +647,7 @@ export async function runMergeGateActionImpl(
             exitCode: 0,
             summary,
             branch: featureBranch,
-            reviewUrl,
-            reviewId,
-            reviewStatus,
+            reviewGate,
           },
         };
         return {
@@ -605,9 +657,7 @@ export async function runMergeGateActionImpl(
             execution: {
               branch: featureBranch,
               workspacePath: gateWorkspacePath,
-              reviewUrl,
-              reviewId,
-              reviewStatus,
+              reviewGate,
             },
           },
         };
@@ -1068,6 +1118,25 @@ export async function publishAfterFixImpl(
     }
 
     if (mergeMode === 'external_review') {
+      const reviewGateDefinition = workflow?.reviewGate;
+      const preferredShape = reviewGateDefinition?.authoring.preferredShape ?? 'stacked_diffs';
+      const authoringMode = reviewGateDefinition?.authoring.mode ?? 'automatic';
+      if (authoringMode === 'manual' || authoringMode === 'external') {
+        const reviewGate = waitingReviewGateExecution(preferredShape);
+        setMergeGateReviewReady(host, task.id, {
+          config: { runnerKind: 'worktree', summary },
+          execution: {
+            branch: featureBranch,
+            workspacePath: gateWorkspacePath,
+            reviewGate,
+            fixedIntegrationSha: undefined,
+            fixedIntegrationRecordedAt: undefined,
+            fixedIntegrationSource: undefined,
+          },
+        });
+        await startReviewReadyDependents(host);
+        return;
+      }
       if (!host.mergeGateProvider) {
         throw new Error('mergeMode is "external_review" but no review provider configured');
       }
@@ -1087,25 +1156,23 @@ export async function publishAfterFixImpl(
         cwd: consolidateDir,
       });
 
-      const result = await host.mergeGateProvider.createReview({
+      const result = await host.mergeGateProvider.publishReviewGate({
         baseBranch,
         featureBranch,
         title: workflow?.name ?? 'Workflow',
         cwd: consolidateDir,
         body: prBodyReview,
+        preferredShape,
       });
-      console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
-
-
+      const reviewGate = reviewGateExecutionFromPublished(result);
+      console.log(`[merge] Post-fix: created/updated review artifacts: ${reviewGate.artifacts.map((artifact) => artifact.identifier).join(', ')}`);
 
       setMergeGateReviewReady(host, task.id, {
         config: { runnerKind: 'worktree', summary },
         execution: {
           branch: featureBranch,
           workspacePath: gateWorkspacePath,
-          reviewUrl: result.url,
-          reviewId: result.identifier,
-          reviewStatus: 'Awaiting review',
+          reviewGate,
           fixedIntegrationSha: undefined,
           fixedIntegrationRecordedAt: undefined,
           fixedIntegrationSource: undefined,

--- a/packages/execution-engine/src/review-provider-registry.ts
+++ b/packages/execution-engine/src/review-provider-registry.ts
@@ -1,24 +1,24 @@
 /**
  * ReviewProviderRegistry — Registry for pluggable review providers.
  *
- * Maps provider names (e.g. 'github', 'gitlab') to MergeGateProvider instances.
+ * Maps provider names (e.g. 'github', 'gitlab') to ReviewGateProvider instances.
  * Follows the same pattern as AgentRegistry.
  */
 
-import type { MergeGateProvider } from './merge-gate-provider.js';
+import type { ReviewGateProvider } from './merge-gate-provider.js';
 
 export class ReviewProviderRegistry {
-  private providers = new Map<string, MergeGateProvider>();
+  private providers = new Map<string, ReviewGateProvider>();
 
-  register(provider: MergeGateProvider): void {
+  register(provider: ReviewGateProvider): void {
     this.providers.set(provider.name, provider);
   }
 
-  get(name: string): MergeGateProvider | undefined {
+  get(name: string): ReviewGateProvider | undefined {
     return this.providers.get(name);
   }
 
-  getOrThrow(name: string): MergeGateProvider {
+  getOrThrow(name: string): ReviewGateProvider {
     const provider = this.providers.get(name);
     if (!provider) {
       throw new Error(
@@ -28,7 +28,7 @@ export class ReviewProviderRegistry {
     return provider;
   }
 
-  list(): MergeGateProvider[] {
+  list(): ReviewGateProvider[] {
     return [...this.providers.values()];
   }
 }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 
 import { scopePlanTaskId } from '@invoker/workflow-core';
-import type { Orchestrator, TaskState, ExperimentVariant, RunnerKind } from '@invoker/workflow-core';
+import type { Orchestrator, ReviewArtifactStatus, TaskState, ExperimentVariant, RunnerKind } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
@@ -24,7 +24,7 @@ import { createExecutionBench } from './execution-bench.js';
 import { ResourceLimitError, type RepoPoolTiming } from './repo-pool.js';
 import type { ExecutorRegistry } from './registry.js';
 import type { AgentRegistry } from './agent-registry.js';
-import type { MergeGateProvider, MergeGateApprovalStatus } from './merge-gate-provider.js';
+import type { ReviewGateProvider, MergeGateApprovalStatus } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
@@ -274,7 +274,7 @@ export interface TaskRunnerConfig {
   /** Default branch from config (e.g. "master"). Falls back to git heuristic if unset. */
   defaultBranch?: string;
   callbacks?: TaskRunnerCallbacks;
-  mergeGateProvider?: MergeGateProvider;
+  mergeGateProvider?: ReviewGateProvider;
   reviewProviderRegistry?: ReviewProviderRegistry;
   onReviewGateCiFailure?: (trigger: ReviewGateCiFailureTrigger) => Promise<void>;
   /**
@@ -322,7 +322,7 @@ export class TaskRunner {
   private maxWorktreesPerRepo: number;
   /** @internal */ defaultBranch: string | undefined;
   /** @internal */ callbacks: TaskRunnerCallbacks;
-  /** @internal */ mergeGateProvider?: MergeGateProvider;
+  /** @internal */ mergeGateProvider?: ReviewGateProvider;
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
   private onReviewGateCiFailure?: (trigger: ReviewGateCiFailureTrigger) => Promise<void>;
   private reviewGateCiFixInFlight = new Set<string>();
@@ -2394,30 +2394,56 @@ export class TaskRunner {
     }
   }
 
+  private getReviewGateProvider(workflowId?: string): ReviewGateProvider | undefined {
+    const workflow = workflowId ? this.persistence.loadWorkflow?.(workflowId) : undefined;
+    const providerName = workflow?.reviewProvider ?? 'github';
+    return this.reviewProviderRegistry?.get(providerName) ?? this.mergeGateProvider;
+  }
+
   async closeWorkflowReview(workflowId: string): Promise<void> {
-    if (!this.mergeGateProvider?.closeReview) return;
+    const provider = this.getReviewGateProvider(workflowId);
+    if (!provider?.closeArtifact) return;
     const getAllTasks = this.orchestrator.getAllTasks?.bind(this.orchestrator);
     if (!getAllTasks) return;
     const mergeTask = getAllTasks().find((task) =>
       task.config.workflowId === workflowId
       && task.config.isMergeNode
-      && !!task.execution.reviewId
     );
-    if (!mergeTask?.execution.reviewId) return;
+    const reviewGate = mergeTask?.execution.reviewGate;
+    if (!mergeTask || !reviewGate?.sealed) return;
 
-    await this.mergeGateProvider.closeReview({
-      identifier: mergeTask.execution.reviewId,
-      cwd: mergeTask.execution.workspacePath ?? this.cwd,
-    });
+    const artifacts = reviewGate.artifacts.map((artifact) => ({ ...artifact }));
+    let changed = false;
+    for (const artifact of artifacts) {
+      if (artifact.status === 'merged' || artifact.status === 'closed') continue;
+      await provider.closeArtifact({
+        identifier: artifact.identifier,
+        cwd: mergeTask.execution.workspacePath ?? this.cwd,
+      });
+      artifact.status = 'closed';
+      artifact.statusText = 'Closed';
+      changed = true;
+    }
+    if (changed) {
+      this.persistence.updateTask(mergeTask.id, {
+        execution: {
+          reviewGate: {
+            ...reviewGate,
+            artifacts,
+            statusText: 'Review artifacts closed',
+          },
+        },
+      });
+    }
   }
 
   private async handleApprovedMergeGate(
     taskId: string,
-    reviewId: string,
+    completionLabel: string,
     source?: 'refresh' | 'manual check',
   ): Promise<void> {
     const sourceSuffix = source ? ` (${source})` : '';
-    this.logger.info(`[merge-gate] PR ${reviewId} approved${sourceSuffix}, completing merge gate`);
+    this.logger.info(`[merge-gate] ${completionLabel} complete${sourceSuffix}, completing merge gate`);
     const newlyStarted = await this.orchestrator.approve(taskId);
     if (newlyStarted.length > 0) {
       await this.executeTasks(newlyStarted);
@@ -2426,104 +2452,111 @@ export class TaskRunner {
 
   private handleClosedMergeGate(
     taskId: string,
-    reviewId: string,
+    completionLabel: string,
     statusText: string,
     source?: 'refresh' | 'manual check',
   ): void {
     const sourceSuffix = source ? ` (${source})` : '';
-    this.logger.info(`[merge-gate] PR ${reviewId} closed${sourceSuffix}: ${statusText}`);
+    this.logger.info(`[merge-gate] ${completionLabel} closed${sourceSuffix}: ${statusText}`);
     this.persistence.updateTask(taskId, {
       status: 'closed',
       execution: { reviewStatus: statusText },
     });
   }
 
+  private async refreshReviewGateArtifacts(
+    task: TaskState,
+    source: 'refresh' | 'manual check',
+  ): Promise<void> {
+    const reviewGate = task.execution.reviewGate;
+    if (!reviewGate?.sealed || reviewGate.artifacts.length === 0) return;
+    const provider = this.getReviewGateProvider(task.config?.workflowId);
+    if (!provider) return;
+
+    const gateCwd = task.execution.workspacePath ?? this.cwd;
+    const artifacts = await Promise.all(reviewGate.artifacts.map(async (artifact) => {
+      if (artifact.status === 'merged' || artifact.status === 'closed') return artifact;
+      const status = await provider.checkArtifact({
+        identifier: artifact.identifier,
+        cwd: gateCwd,
+      });
+      await this.maybeTriggerReviewGateCiFix(task, status, artifact);
+      const nextStatus: ReviewArtifactStatus = status.approved
+        ? 'merged'
+        : status.closed
+          ? 'closed'
+          : status.rejected
+            ? 'rejected'
+            : (artifact.status ?? 'open');
+      return {
+        ...artifact,
+        status: nextStatus,
+        statusText: status.statusText,
+        headSha: status.headSha ?? artifact.headSha,
+        headRef: status.headRef ?? artifact.headRef,
+      };
+    }));
+
+    const closedArtifact = artifacts.find((artifact) => artifact.status === 'closed');
+    const statusText = closedArtifact
+      ? `Review artifact closed: ${closedArtifact.identifier}`
+      : artifacts.every((artifact) => artifact.status === 'merged')
+        ? 'All review artifacts merged'
+        : artifacts.find((artifact) => artifact.status === 'rejected')?.statusText
+          ?? artifacts.find((artifact) => artifact.statusText)?.statusText
+          ?? reviewGate.statusText
+          ?? 'Awaiting review';
+    const nextGate = { ...reviewGate, artifacts, statusText };
+    this.persistence.updateTask(task.id, { execution: { reviewGate: nextGate } });
+
+    if (closedArtifact) {
+      this.handleClosedMergeGate(task.id, 'review artifact', statusText, source);
+      return;
+    }
+    if (artifacts.every((artifact) => artifact.status === 'merged')) {
+      await this.handleApprovedMergeGate(task.id, 'all review artifacts', source);
+    }
+  }
+
   async checkMergeGateStatuses(): Promise<void> {
-    if (!this.mergeGateProvider) return;
     for (const task of this.orchestrator.getAllTasks()) {
       if (
         task.config.isMergeNode &&
         (task.status === 'review_ready' || task.status === 'awaiting_approval') &&
-        task.execution.reviewId
+        task.execution.reviewGate?.sealed === true
       ) {
         try {
-          const gateCwd = task.execution.workspacePath ?? this.cwd;
-          const status = await this.mergeGateProvider.checkApproval({
-            identifier: task.execution.reviewId,
-            cwd: gateCwd,
-          });
-          if (status.closed) {
-            this.handleClosedMergeGate(task.id, task.execution.reviewId, status.statusText, 'refresh');
-          } else if (status.approved) {
-            this.persistence.updateTask(task.id, {
-              execution: { reviewStatus: status.statusText },
-            });
-            await this.handleApprovedMergeGate(task.id, task.execution.reviewId, 'refresh');
-          } else if (status.rejected) {
-            this.persistence.updateTask(task.id, {
-              execution: { reviewStatus: status.statusText },
-            });
-            this.logger.info(`[merge-gate] PR ${task.execution.reviewId} rejected (refresh): ${status.statusText}`);
-          } else {
-            this.persistence.updateTask(task.id, {
-              execution: { reviewStatus: status.statusText },
-            });
-            await this.maybeTriggerReviewGateCiFix(task, status);
-          }
+          await this.refreshReviewGateArtifacts(task, 'refresh');
         } catch (err) {
-          this.logger.error(`[merge-gate] PR status check error for ${task.id}`, { err });
+          this.logger.error(`[merge-gate] Review artifact status check error for ${task.id}`, { err });
         }
       }
     }
   }
 
   async checkPrApprovalNow(taskId: string): Promise<void> {
-    if (!this.mergeGateProvider) return;
-
     const task = this.orchestrator.getTask(taskId);
-    const reviewId = task?.execution.reviewId;
-    if (!task || !reviewId) return;
-
+    if (!task) return;
     try {
-      const manualCwd = task.execution.workspacePath ?? this.cwd;
-      const status = await this.mergeGateProvider.checkApproval({
-        identifier: reviewId,
-        cwd: manualCwd,
-      });
-
-      if (status.closed) {
-        this.handleClosedMergeGate(taskId, reviewId, status.statusText, 'manual check');
-      } else if (status.approved) {
-        this.persistence.updateTask(taskId, {
-          execution: { reviewStatus: status.statusText },
-        });
-        await this.handleApprovedMergeGate(taskId, reviewId, 'manual check');
-      } else if (status.rejected) {
-        this.persistence.updateTask(taskId, {
-          execution: { reviewStatus: status.statusText },
-        });
-        this.logger.info(`[merge-gate] PR ${reviewId} rejected (manual check): ${status.statusText}`);
-      } else {
-        this.persistence.updateTask(taskId, {
-          execution: { reviewStatus: status.statusText },
-        });
-        await this.maybeTriggerReviewGateCiFix(task, status);
-      }
+      await this.refreshReviewGateArtifacts(task, 'manual check');
     } catch (err) {
-      this.logger.error(`[merge-gate] Manual PR check error for ${taskId}`, { err });
+      this.logger.error(`[merge-gate] Manual review gate check error for ${taskId}`, { err });
     }
   }
 
   private async maybeTriggerReviewGateCiFix(
     task: TaskState,
     status: MergeGateApprovalStatus,
+    artifact?: { identifier: string; url: string; headSha?: string; headRef?: string },
   ): Promise<void> {
     if (!this.onReviewGateCiFailure) return;
-    if (!task.config.workflowId || !task.execution.reviewId) return;
+    const reviewId = artifact?.identifier ?? task.execution.reviewId;
+    if (!task.config?.workflowId || !reviewId) return;
     if (status.checks?.state !== 'failure' || status.checks.failed.length === 0) return;
 
     const key = [
       task.id,
+      reviewId,
       task.execution.selectedAttemptId ?? 'no-attempt',
       task.execution.generation ?? 0,
       status.headSha ?? 'no-head-sha',
@@ -2535,12 +2568,11 @@ export class TaskRunner {
       await this.onReviewGateCiFailure({
         taskId: task.id,
         workflowId: task.config.workflowId,
-        reviewId: task.execution.reviewId,
-        reviewUrl: status.url,
-        headSha: status.headSha,
-        headRef: status.headRef,
-        branch: task.execution.branch,
-        selectedAttemptId: task.execution.selectedAttemptId,
+        reviewId,
+        reviewUrl: artifact?.url ?? status.url,
+        headSha: status.headSha ?? artifact?.headSha,
+        headRef: status.headRef ?? artifact?.headRef,
+        branch: artifact?.headRef ?? task.execution.branch,
         generation: task.execution.generation ?? 0,
         failedChecks: status.checks.failed,
         statusText: status.statusText,


### PR DESCRIPTION
## Summary

This changes review publishing and polling to use gate artifacts.

The GitHub publisher still creates one PR today. The poller can wait for every tracked artifact.

## Review Claim

Execution now publishes and polls review-gate artifacts.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

A single-artifact gate behaves the same as before. Multi-artifact gates only complete when all artifacts are merged.

## Slice Rationale

This follows persistence so execution can save and refresh artifact state safely.

## Non-goals

- No manual attachment API.
- No UI changes.
- No planning policy changes.

## Architecture

### Before

```mermaid
flowchart LR
  Publisher[GitHub publisher] --> Scalar[reviewUrl and reviewId]
  Poller[Review poller] --> PR[One PR]
```

### After

```mermaid
flowchart LR
  Publisher[GitHub publisher] --> Artifact[Review artifact]
  Poller[Review poller] --> Artifacts[All gate artifacts]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/plan-parser.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/github-merge-gate-provider.test.ts src/__tests__/task-runner.test.ts`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

Depends-On: #1698