### PR TITLE
[Multi PR Review Gate](5) Expose review gate attachment APIs

### DIFF
--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestHarness, type TestHarness, InMemoryBus, InMemoryPersistence, MockGit } from '@invoker/test-kit';
 import { Orchestrator, type PlanDefinition, type TaskState } from '@invoker/workflow-core';
-import { TaskRunner, ExecutorRegistry, type MergeGateProvider } from '@invoker/execution-engine';
+import { TaskRunner, ExecutorRegistry, type ReviewGateProvider } from '@invoker/execution-engine';
 import { setWorkflowMergeMode } from '../workflow-actions.js';
 import { executeGlobalTopup } from '../global-topup.js';
 
@@ -1157,13 +1157,20 @@ const MANUAL_MERGE_ONFINISH_NONE_PLAN: PlanDefinition = {
 // ── Flow 9c: UI external_review merge mode ───────────────────
 
 describe('Flow 9c: set-merge-mode external_review', () => {
-  const mockMergeGate: MergeGateProvider = {
+  const mockMergeGate: ReviewGateProvider = {
     name: 'mock',
-    createReview: async () => ({
-      url: 'https://github.com/owner/repo/pull/99',
-      identifier: 'owner/repo#99',
+    publishReviewGate: async () => ({
+      sealed: true,
+      relationship: { kind: 'unknown', managedBy: 'external' },
+      artifacts: [{
+        id: 'github:pull_request:99',
+        provider: 'github',
+        type: 'pull_request',
+        url: 'https://github.com/owner/repo/pull/99',
+        identifier: 'owner/repo#99',
+      }],
     }),
-    checkApproval: async () => ({
+    checkArtifact: async () => ({
       approved: false,
       rejected: false,
       statusText: 'Open',
@@ -1189,7 +1196,7 @@ describe('Flow 9c: set-merge-mode external_review', () => {
 
     expect(h.persistence.loadWorkflow(wfId)!.mergeMode).toBe('external_review');
     expect(h.getTask(mergeId)!.status).toBe('review_ready');
-    expect(h.getTask(mergeId)!.execution.reviewUrl).toBe('https://github.com/owner/repo/pull/99');
+    expect(h.getTask(mergeId)!.execution.reviewGate?.artifacts[0]?.url).toBe('https://github.com/owner/repo/pull/99');
   });
 });
 

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -321,6 +321,44 @@ describe('headless delegation enforcement', () => {
         await runHeadless(['approve', 'wf-1/task-1'], mockDeps);
         expect(mockDeps.commandService.approve).toHaveBeenCalled();
       });
+
+      it('routes review-gate attach, seal, and check through the new headless commands', async () => {
+        mockDeps.commandService.attachReviewArtifact = vi.fn(async () => ({
+          ok: true as const,
+          data: {
+            sealed: false,
+            completion: { required: 'all', state: 'merged' },
+            relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+            artifacts: [{ id: 'github:pull_request:41', provider: 'github', type: 'pull_request', url: 'https://github.com/acme/repo/pull/41', identifier: '41' }],
+            statusText: 'Waiting for review artifacts',
+          },
+        }));
+        mockDeps.commandService.sealReviewGate = vi.fn(async () => ({
+          ok: true as const,
+          data: {
+            sealed: true,
+            completion: { required: 'all', state: 'merged' },
+            relationship: { kind: 'stacked_diffs', managedBy: 'external' },
+            artifacts: [{ id: 'github:pull_request:41', provider: 'github', type: 'pull_request', url: 'https://github.com/acme/repo/pull/41', identifier: '41' }],
+            statusText: 'Awaiting review',
+          },
+        }));
+        const checkPrApprovalNow = vi.fn(async () => {});
+        mockDeps.ownerTaskRunnerProvider = () => ({ checkPrApprovalNow } as unknown as TaskRunner);
+        mockDeps.orchestrator.getMergeNode = vi.fn(() => ({
+          id: '__merge__wf-1',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+        } as any));
+
+        await runHeadless(['review-gate', 'attach', 'wf-1', 'https://github.com/acme/repo/pull/41'], mockDeps);
+        await runHeadless(['review-gate', 'seal', 'wf-1'], mockDeps);
+        await runHeadless(['review-gate', 'check', 'wf-1'], mockDeps);
+
+        expect(mockDeps.commandService.attachReviewArtifact).toHaveBeenCalled();
+        expect(mockDeps.commandService.sealReviewGate).toHaveBeenCalled();
+        expect(mockDeps.orchestrator.getMergeNode).toHaveBeenCalledWith('wf-1');
+        expect(checkPrApprovalNow).toHaveBeenCalledWith('__merge__wf-1');
+      });
     });
 
     /**
@@ -1045,7 +1083,7 @@ describe('headless delegation enforcement', () => {
         expect(mockDeps.commandService.recreateWorkflow).toHaveBeenCalled();
       });
 
-      it('headless recreate dispatches runnable tasks before waiting for completion', async () => {
+      it('headless recreate hands runnable tasks to the launch outbox instead of waiting for completion', async () => {
         let taskStatus: 'running' | 'completed' = 'running';
         (mockDeps.commandService as any).recreateWorkflow = vi.fn(async () => ({
           ok: true as const,
@@ -1054,7 +1092,7 @@ describe('headless delegation enforcement', () => {
               id: 'wf-1/task-1',
               status: 'running',
               config: { workflowId: 'wf-1' },
-              execution: {},
+              execution: { selectedAttemptId: 'attempt-1' },
             } as any,
           ],
         }));
@@ -1072,27 +1110,29 @@ describe('headless delegation enforcement', () => {
           id: 'wf-1/task-1',
           status: taskStatus,
           config: { workflowId: 'wf-1' },
-          execution: {},
+          execution: { selectedAttemptId: 'attempt-1' },
         } as any]);
         mockDeps.orchestrator.getAllTasks = vi.fn(() => [{
           id: 'wf-1/task-1',
           status: taskStatus,
           config: { workflowId: 'wf-1' },
-          execution: {},
+          execution: { selectedAttemptId: 'attempt-1' },
         } as any]);
         mockDeps.orchestrator.getReadyTasks = vi.fn(() => []);
 
-        const executeTasksSpy = vi
-          .spyOn(TaskRunner.prototype, 'executeTasks')
-          .mockImplementation(async () => {
-            taskStatus = 'completed';
-          });
+        const executeTasksSpy = vi.spyOn(TaskRunner.prototype, 'executeTasks');
 
-        await runHeadless(['recreate', 'wf-1'], mockDeps);
+        const depsWithNoTrack: HeadlessDeps = {
+          ...mockDeps,
+          noTrack: true,
+        } as HeadlessDeps;
 
-        expect(executeTasksSpy).toHaveBeenCalledTimes(1);
+        await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
+
+        expect(executeTasksSpy).not.toHaveBeenCalled();
         expect((mockDeps.commandService as any).recreateWorkflow).toHaveBeenCalled();
 
+        taskStatus = 'completed';
         executeTasksSpy.mockRestore();
       });
 

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -47,7 +47,7 @@ import {
   PlanConflictError,
   TopologyForkRequired,
 } from '@invoker/workflow-core';
-import type { ExternalGatePolicyUpdate, Orchestrator } from '@invoker/workflow-core';
+import type { ExternalGatePolicyUpdate, Orchestrator, ReviewArtifactInput, ReviewGateExecution } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { ExecutorRegistry } from '@invoker/execution-engine';
 import type {
@@ -95,6 +95,8 @@ export interface ApiMutationFacade {
   forkWorkflow(workflowId: string): Promise<ForkMutationResult>;
   cancelWorkflow(workflowId: string): Promise<CancelMutationResult>;
   setWorkflowMergeMode(workflowId: string, mergeMode: string): Promise<void>;
+  attachReviewArtifact(workflowId: string, artifact: ReviewArtifactInput): Promise<ReviewGateExecution>;
+  sealReviewGate(workflowId: string): Promise<ReviewGateExecution>;
   setWorkflowMetadata(
     workflowId: string,
     fieldPath: string,
@@ -717,6 +719,34 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             upstreamWorkflowId,
             action: 'detached',
           });
+        } catch (err) {
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
+        }
+        return;
+      }
+
+      // POST /api/workflows/:id/review-artifacts
+      const wfReviewArtifactsMatch = path.match(/^\/api\/workflows\/([^/]+)\/review-artifacts$/);
+      if (method === 'POST' && wfReviewArtifactsMatch) {
+        const workflowId = decodeURIComponent(wfReviewArtifactsMatch[1]);
+        try {
+          const artifact = JSON.parse(await readBody(req)) as ReviewArtifactInput;
+          const reviewGate = await mutations.attachReviewArtifact(workflowId, artifact);
+          json(res, 200, { ok: true, reviewGate });
+        } catch (err) {
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
+        }
+        return;
+      }
+
+      // POST /api/workflows/:id/review-gate/seal
+      const wfReviewGateSealMatch = path.match(/^\/api\/workflows\/([^/]+)\/review-gate\/seal$/);
+      if (method === 'POST' && wfReviewGateSealMatch) {
+        const workflowId = decodeURIComponent(wfReviewGateSealMatch[1]);
+        try {
+          await readBody(req);
+          const reviewGate = await mutations.sealReviewGate(workflowId);
+          json(res, 200, { ok: true, reviewGate });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }

--- a/packages/app/src/cli-installer.ts
+++ b/packages/app/src/cli-installer.ts
@@ -51,6 +51,12 @@ function searchDirs(context: CliInstallerContext): string[] {
   // one location (used by the hermetic e2e scripts).
   const override = context.env.INVOKER_CLI_INSTALL_DIR;
   if (override) return [override];
+  if (context.candidateInstallDirs) {
+    return [...new Set([
+      ...context.candidateInstallDirs,
+      ...pathDirs(context),
+    ])];
+  }
   const dirs = [
     ...defaultCandidateInstallDirs(context),
     ...pathDirs(context),

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -13,7 +13,7 @@ import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@inv
 import { makeEnvelope } from '@invoker/contracts';
 import type { AgentSessionData } from '@invoker/contracts';
 import { OrchestratorErrorCode } from '@invoker/workflow-core';
-import type { Attempt, Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
+import type { Attempt, Orchestrator, CommandService, ReviewArtifactInput, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { Channels } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
@@ -998,6 +998,75 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
   }
 }
 
+function parseReviewGateAttachArgs(args: string[]): { workflowId: string; artifact: ReviewArtifactInput } {
+  const workflowId = args[0];
+  const url = args[1];
+  if (!workflowId || !url) {
+    throw new Error('Usage: --headless review-gate attach <workflowId> <url> [--identifier <id>] [--title <title>] [--base <branch>] [--head <branch>]');
+  }
+  const artifact: ReviewArtifactInput = { url };
+  for (let index = 2; index < args.length; index += 1) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!value) throw new Error(`Missing value for ${flag}`);
+    switch (flag) {
+      case '--identifier':
+        artifact.identifier = value;
+        break;
+      case '--title':
+        artifact.title = value;
+        break;
+      case '--base':
+        artifact.baseBranch = value;
+        break;
+      case '--head':
+        artifact.headBranch = value;
+        break;
+      default:
+        throw new Error(`Unknown review-gate attach flag: ${flag}`);
+    }
+    index += 1;
+  }
+  return { workflowId, artifact };
+}
+
+async function headlessReviewGate(args: string[], deps: HeadlessDeps): Promise<void> {
+  const subCommand = args[0];
+  if (!subCommand) {
+    throw new Error('Missing review-gate sub-command. Usage: --headless review-gate <attach|seal|check>');
+  }
+  if (subCommand === 'attach') {
+    const { workflowId, artifact } = parseReviewGateAttachArgs(args.slice(1));
+    const result = await deps.commandService.attachReviewArtifact(
+      makeEnvelope('headless.review-gate.attach', 'headless', 'workflow', { workflowId, artifact }),
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    process.stdout.write(`Attached review artifact to workflow "${workflowId}".\n`);
+    return;
+  }
+  if (subCommand === 'seal') {
+    const workflowId = args[1];
+    if (!workflowId) throw new Error('Usage: --headless review-gate seal <workflowId>');
+    const result = await deps.commandService.sealReviewGate(
+      makeEnvelope('headless.review-gate.seal', 'headless', 'workflow', { workflowId }),
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    process.stdout.write(`Sealed review gate for workflow "${workflowId}".\n`);
+    return;
+  }
+  if (subCommand === 'check') {
+    const workflowId = args[1];
+    if (!workflowId) throw new Error('Usage: --headless review-gate check <workflowId>');
+    const mergeTask = deps.orchestrator.getMergeNode(workflowId);
+    if (!mergeTask) throw new Error(`Workflow "${workflowId}" has no review gate`);
+    const taskExecutor = createHeadlessExecutor(deps);
+    await taskExecutor.checkPrApprovalNow(mergeTask.id);
+    process.stdout.write(`Checked review gate for workflow "${workflowId}".\n`);
+    return;
+  }
+  throw new Error(`Unknown review-gate sub-command: "${subCommand}". Use: attach, seal, check`);
+}
+
 async function headlessMigrateCompatibility(deps: HeadlessDeps): Promise<void> {
   const report = deps.persistence.runCompatibilityMigration();
   process.stdout.write(`${BOLD}Compatibility migration complete.${RESET}\n`);
@@ -1039,6 +1108,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       break;
     case 'set':
       await headlessSet(args.slice(1), deps);
+      break;
+    case 'review-gate':
+      await headlessReviewGate(args.slice(1), deps);
       break;
     case 'migrate-compat':
       await headlessMigrateCompatibility(deps);
@@ -1949,41 +2021,39 @@ async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps):
   if (!recreateWfResult.ok) throw new Error(recreateWfResult.error.message);
   const started = recreateWfResult.data;
   const runnable = started.filter(isDispatchableLaunch);
-  if (runnable.length > 0) {
-    const te = createHeadlessExecutor(deps);
-    const autoFix = wireHeadlessAutoFix(deps, te);
-    remoteFetchForPool.enabled = false;
-    let topup: TaskState[] = [];
-    try {
-      await te.executeTasks(runnable);
-      topup = await executeGlobalTopup({
-        orchestrator: deps.orchestrator,
-        taskExecutor: te,
-        logger: deps.logger,
-        context: 'headless.recreate-workflow',
-        alreadyDispatched: runnable,
-        mutationTiming: deps.mutationTiming,
-      });
-    } finally {
-      remoteFetchForPool.enabled = true;
-    }
-    if (runnable.length + topup.length === 0) {
-      autoFix.unsubscribe();
-      return;
-    }
-    if (deps.noTrack) {
-      process.stdout.write('[headless] --no-track enabled: recreate accepted; exiting without tracking.\n');
-      autoFix.unsubscribe();
-      return;
-    }
-    await trackHeadlessWorkflow(workflowId, deps, {
-      hasBackgroundWork: autoFix.isBusy,
-      printSummary: false,
-      printTaskOutput: true,
-      setExitCodeOnFailure: false,
-    });
-    autoFix.unsubscribe();
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  remoteFetchForPool.enabled = false;
+  let topup: TaskState[] = [];
+  try {
+    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: te,
+      logger: deps.logger,
+      context: 'headless.recreate-workflow',
+      started,
+      mutationTiming: deps.mutationTiming,
+    }));
+  } finally {
+    remoteFetchForPool.enabled = true;
   }
+  if (runnable.length + topup.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: recreate accepted; exiting without tracking.\n');
+    autoFix.unsubscribe();
+    return;
+  }
+  await trackHeadlessWorkflow(workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
+  autoFix.unsubscribe();
+
   const tasksStarted = runnable.length;
   process.stdout.write(`Recreate workflow "${workflowId}" — ${tasksStarted} task(s) to execute (pool fetch skipped)\n`);
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1607,9 +1607,7 @@ function startHeadlessMode(): void {
             return orchestrator.getWorkflowStatus();
           }
           if (kind === 'tasks' || kind === 'task-graph-refresh') {
-            if (kind === 'task-graph-refresh') {
-              orchestrator.syncAllFromDb();
-            }
+            orchestrator.syncAllFromDb();
             return {
               tasks: orchestrator.getAllTasks(),
               workflows: persistence.listWorkflows(),
@@ -3134,9 +3132,7 @@ function createEmbeddedTerminalBackendFromConfig(
           return orchestrator.getWorkflowStatus();
         }
         if (kind === 'tasks' || kind === 'task-graph-refresh') {
-          if (kind === 'task-graph-refresh') {
-            orchestrator.syncAllFromDb();
-          }
+          orchestrator.syncAllFromDb();
           return {
             tasks: orchestrator.getAllTasks(),
             workflows: persistence.listWorkflows(),

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -18,7 +18,7 @@
 import type { Logger } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
 import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
-import type { CommandService, Orchestrator, ExternalGatePolicyUpdate, TaskState } from '@invoker/workflow-core';
+import type { CommandService, Orchestrator, ExternalGatePolicyUpdate, TaskState, ReviewArtifactInput, ReviewGateExecution } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
 import {
@@ -366,6 +366,22 @@ export class WorkflowMutationFacade {
       persistence: this.deps.persistence,
       taskExecutor: this.deps.taskExecutor,
     });
+  }
+
+  async attachReviewArtifact(workflowId: string, artifact: ReviewArtifactInput): Promise<ReviewGateExecution> {
+    const result = await this.deps.commandService.attachReviewArtifact(
+      makeEnvelope('attach-review-artifact', 'surface', 'workflow', { workflowId, artifact }),
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    return result.data;
+  }
+
+  async sealReviewGate(workflowId: string): Promise<ReviewGateExecution> {
+    const result = await this.deps.commandService.sealReviewGate(
+      makeEnvelope('seal-review-gate', 'surface', 'workflow', { workflowId }),
+    );
+    if (!result.ok) throw new Error(result.error.message);
+    return result.data;
   }
 
   async setWorkflowMetadata(


### PR DESCRIPTION
## Summary

This exposes APIs for adding review artifacts to a workflow gate.

Headless and desktop callers can attach pull requests and seal the gate after the stack exists.

## Review Claim

Invoker callers can attach and seal review-gate artifacts through the app API.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new calls delegate to workflow core. They do not change automatic task execution by themselves.

## Slice Rationale

This follows execution support so external stack publishers can hand PRs back to Invoker.

## Non-goals

- No UI list rendering.
- No planning policy changes.
- No new GitHub publication mode.

## Architecture

### Before

```mermaid
flowchart LR
  External[External stack publisher] --> Manual[No gate artifact API]
```

### After

```mermaid
flowchart LR
  External[External stack publisher] --> API[Attach artifact API]
  API --> Core[Workflow core]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/plan-parser.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/github-merge-gate-provider.test.ts src/__tests__/task-runner.test.ts`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

Depends-On: #1699