### PR TITLE
[Multi PR Review Gate](6) Show review gate artifact lists

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -651,13 +651,23 @@ export function App() {
     return STATUS_KEY_ORDER.filter((key) => key === 'completed' || key === 'running' || key === 'failed' || key === 'pending' || (counts.get(key) ?? 0) > 0);
   }, [tasks]);
 
+  const getWorkflowReviewUrl = useCallback((workflowId: string) => {
+    const workflowTasks = [...tasks.values()].filter((task) => task.config.workflowId === workflowId);
+    const mergeTask = workflowTasks.find((task) => task.config.isMergeNode);
+    const artifacts = mergeTask?.execution.reviewGate?.artifacts;
+    if (artifacts && artifacts.length > 0) {
+      const artifact = [...artifacts].reverse().find((candidate) => candidate.status !== 'closed') ?? artifacts[artifacts.length - 1];
+      return artifact?.url;
+    }
+    return workflowTasks.find((task) => task.execution.reviewUrl)?.execution.reviewUrl;
+  }, [tasks]);
+
   const searchResults = useMemo<SearchResult[]>(() => {
     const query = normalizedSearchText(searchQuery.trim());
     if (!query) return [];
     const results: SearchResult[] = [];
     for (const workflow of workflows.values()) {
-      const workflowTasks = [...tasks.values()].filter((task) => task.config.workflowId === workflow.id);
-      const reviewUrl = workflowTasks.find((task) => task.execution.reviewUrl)?.execution.reviewUrl;
+      const reviewUrl = getWorkflowReviewUrl(workflow.id);
       const haystack = [
         workflow.id,
         workflow.name,
@@ -698,7 +708,7 @@ export function App() {
       }
     }
     return results.slice(0, 12);
-  }, [searchQuery, tasks, workflows]);
+  }, [getWorkflowReviewUrl, searchQuery, tasks, workflows]);
 
   useEffect(() => {
     setSearchActiveIndex(0);
@@ -1345,13 +1355,12 @@ export function App() {
   }, []);
 
   const handleOpenWorkflowPr = useCallback((workflowId: string) => {
-    const workflowTasks = [...tasks.values()].filter((task) => task.config.workflowId === workflowId);
-    const reviewUrl = workflowTasks.find((task) => task.execution.reviewUrl)?.execution.reviewUrl;
+    const reviewUrl = getWorkflowReviewUrl(workflowId);
     if (reviewUrl) {
       window.open(reviewUrl, '_blank', 'noopener,noreferrer');
     }
     setWorkflowContextMenu(null);
-  }, [tasks]);
+  }, [getWorkflowReviewUrl]);
 
   const handleCopyWorkflowId = useCallback((workflowId: string) => {
     navigator.clipboard?.writeText(workflowId).catch(() => {});

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -55,6 +55,12 @@ function extractWorkspaceSetupFailures(events: readonly TaskAuditEvent[]): strin
   return failures;
 }
 
+function chooseReviewArtifact(task?: TaskState) {
+  const artifacts = task?.execution.reviewGate?.artifacts;
+  if (!artifacts || artifacts.length === 0) return undefined;
+  return [...artifacts].reverse().find((artifact) => artifact.status !== 'closed') ?? artifacts[artifacts.length - 1];
+}
+
 function formatElapsed(dateVal: Date | string | undefined): string {
   if (!dateVal) return '--';
   const d = dateVal instanceof Date ? dateVal : new Date(dateVal);
@@ -450,8 +456,30 @@ export function TaskPanel({
         </div>
       )}
 
-      {/* Review link (merge gates only) */}
-      {task.config.isMergeNode && task.execution?.reviewUrl && (
+      {task.config.isMergeNode && task.execution?.reviewGate && task.execution.reviewGate.artifacts.length > 0 && (
+        <div className="space-y-1">
+          <div className="flex items-center justify-between">
+            <span className="text-sm text-gray-400">Review artifacts</span>
+            <span className="text-xs text-gray-300">PRs: {task.execution.reviewGate.artifacts.length}</span>
+          </div>
+          {task.execution.reviewGate.artifacts.map((artifact) => (
+            <div key={artifact.id} className="flex items-center justify-between gap-2">
+              <a
+                href={artifact.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs font-mono text-blue-400 hover:text-blue-300 underline break-all whitespace-normal max-w-[220px]"
+                title={artifact.url}
+                data-testid="pr-url-link"
+              >
+                {artifact.provider} PR #{artifact.identifier}
+              </a>
+              <span className="text-xs text-gray-300">{artifact.statusText ?? artifact.status ?? 'unknown'}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {task.config.isMergeNode && !task.execution?.reviewGate && task.execution?.reviewUrl && (
         <div className="flex items-center justify-between">
           <span className="text-sm text-gray-400">Review link</span>
           <a
@@ -475,8 +503,7 @@ export function TaskPanel({
         </div>
       )}
 
-      {/* PR target repo (pending merge gates without a review URL yet) */}
-      {task.config.isMergeNode && task.status === 'pending' && !task.execution?.reviewUrl && workflowRepoUrl && (
+      {task.config.isMergeNode && task.status === 'pending' && !task.execution?.reviewUrl && !task.execution?.reviewGate && workflowRepoUrl && (
         <div className="flex items-center justify-between" data-testid="pr-target-repo">
           <span className="text-sm text-gray-400">PR target repo</span>
           <span className="text-xs font-mono text-gray-200 break-all whitespace-normal text-right max-w-[260px]" title={workflowRepoUrl}>
@@ -836,13 +863,18 @@ export function TaskPanel({
                   const status = resolveExternalDepStatus(dep, allTasks);
                   const normalizedTaskId = normalizeExternalDepTaskId(dep);
                   const isMergeGate = normalizedTaskId === '__merge__';
-
-                  // Detect mixed policy
                   const group = workflowGroups.get(dep.workflowId) ?? [];
-                  const policies = new Set(group.map(d => d.gatePolicy ?? 'review_ready'));
+                  const policies = new Set(group.map((candidate) => candidate.gatePolicy ?? 'review_ready'));
                   const hasMixedPolicy = policies.size > 1;
+                  let reviewUrl = '';
+                  let reviewCount = 0;
+                  if (isMergeGate && allTasks) {
+                    const mergeNode = allTasks.get(`__merge__${dep.workflowId}`);
+                    const artifact = chooseReviewArtifact(mergeNode);
+                    reviewUrl = artifact?.url ?? mergeNode?.execution?.reviewUrl ?? '';
+                    reviewCount = mergeNode?.execution?.reviewGate?.artifacts.length ?? (reviewUrl ? 1 : 0);
+                  }
 
-                  // Compute impact
                   const steps = status !== 'missing' && !hasMixedPolicy
                     ? computeSteps(status as TaskStatus, draftPolicy as TaskStatus)
                     : Infinity;
@@ -863,13 +895,6 @@ export function TaskPanel({
                     }
                   }
 
-                  // Get reviewUrl from merge node if it's a merge gate
-                  let reviewUrl = '';
-                  if (isMergeGate && allTasks) {
-                    const mergeNode = allTasks.get(`__merge__${dep.workflowId}`);
-                    reviewUrl = mergeNode?.execution?.reviewUrl ?? '';
-                  }
-
                   const dotColor = status !== 'missing' ? getStatusColor(status as TaskStatus).dot : 'bg-slate-500';
 
                   return (
@@ -886,7 +911,7 @@ export function TaskPanel({
                                 rel="noopener noreferrer"
                                 className="ml-2 text-blue-400 hover:text-blue-300"
                               >
-                                PR #{reviewUrl.split('/').pop()} ↗
+                                PRs: {reviewCount || 1} ↗
                               </a>
                             )}
                           </div>
@@ -941,7 +966,6 @@ export function TaskPanel({
               </div>
             )}
 
-            {/* Satisfied gates disclosure */}
             {satisfied.length > 0 && (
               <div className="space-y-1">
                 <button
@@ -961,13 +985,14 @@ export function TaskPanel({
                       const status = resolveExternalDepStatus(dep, allTasks);
                       const normalizedTaskId = normalizeExternalDepTaskId(dep);
                       const isMergeGate = normalizedTaskId === '__merge__';
-
                       let reviewUrl = '';
+                      let reviewCount = 0;
                       if (isMergeGate && allTasks) {
                         const mergeNode = allTasks.get(`__merge__${dep.workflowId}`);
-                        reviewUrl = mergeNode?.execution?.reviewUrl ?? '';
+                        const artifact = chooseReviewArtifact(mergeNode);
+                        reviewUrl = artifact?.url ?? mergeNode?.execution?.reviewUrl ?? '';
+                        reviewCount = mergeNode?.execution?.reviewGate?.artifacts.length ?? (reviewUrl ? 1 : 0);
                       }
-
                       const dotColor = status !== 'missing' ? getStatusColor(status as TaskStatus).dot : 'bg-slate-500';
 
                       return (
@@ -994,7 +1019,7 @@ export function TaskPanel({
                                   rel="noopener noreferrer"
                                   className="ml-1 text-blue-400 hover:text-blue-300"
                                 >
-                                  PR#{reviewUrl.split('/').pop()} ↗
+                                  PRs: {reviewCount || 1} ↗
                                 </a>
                               )}
                             </>
@@ -1011,7 +1036,7 @@ export function TaskPanel({
                                   rel="noopener noreferrer"
                                   className="ml-1 text-blue-400 hover:text-blue-300"
                                 >
-                                  PR#{reviewUrl.split('/').pop()}
+                                  PRs: {reviewCount || 1}
                                 </a>
                               )}
                             </>

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -38,12 +38,13 @@ function getReviewReadyMergeNodeReviewUrl(
 ): string | undefined {
   if (!tasks) return undefined;
   for (const candidate of tasks.values()) {
-    if (
-      candidate.config.isMergeNode &&
-      candidate.status === 'review_ready' &&
-      candidate.execution.reviewUrl
-    ) {
-      return candidate.execution.reviewUrl;
+    if (candidate.config.isMergeNode && candidate.status === 'review_ready') {
+      const artifacts = candidate.execution.reviewGate?.artifacts;
+      if (artifacts && artifacts.length > 0) {
+        const artifact = [...artifacts].reverse().find((entry) => entry.status !== 'closed') ?? artifacts[artifacts.length - 1];
+        if (artifact?.url) return artifact.url;
+      }
+      if (candidate.execution.reviewUrl) return candidate.execution.reviewUrl;
     }
   }
   return undefined;
@@ -91,7 +92,7 @@ export function WorkflowInspector({
     workflow?.status === 'review_ready'
       ? task
         ? task.config.isMergeNode && task.status === 'review_ready'
-          ? task.execution.reviewUrl
+          ? getReviewReadyMergeNodeReviewUrl(new Map([[task.id, task]]))
           : undefined
         : getReviewReadyMergeNodeReviewUrl(workflowTasks)
       : undefined;

--- a/packages/ui/src/lib/merge-gate.ts
+++ b/packages/ui/src/lib/merge-gate.ts
@@ -48,7 +48,9 @@ function hasKnownMergeGatePrefix(description: string): boolean {
 }
 
 function shouldUseExternalReviewHeading(task: TaskState, mergeMode?: string): boolean {
-  return mergeMode === 'external_review' || Boolean(task.execution?.reviewUrl);
+  return mergeMode === 'external_review'
+    || Boolean(task.execution?.reviewGate?.artifacts.length)
+    || Boolean(task.execution?.reviewUrl);
 }
 
 /**

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -100,6 +100,34 @@ export interface TaskConfig {
 
 // ── Task Execution (runtime fields) ────────────────────────
 
+export type ReviewArtifactType = 'pull_request';
+export type ReviewArtifactStatus = 'open' | 'merged' | 'closed' | 'rejected' | 'unknown';
+export type ReviewGateRelationshipKind = 'stacked_diffs' | 'independent' | 'unknown';
+
+export interface ReviewGateArtifact {
+  readonly id: string;
+  readonly provider: string;
+  readonly type: ReviewArtifactType;
+  readonly url: string;
+  readonly identifier: string;
+  readonly title?: string;
+  readonly baseBranch?: string;
+  readonly headBranch?: string;
+  readonly status?: ReviewArtifactStatus;
+  readonly statusText?: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly replacedById?: string;
+}
+
+export interface ReviewGateExecution {
+  readonly sealed: boolean;
+  readonly completion: { readonly required: 'all'; readonly state: 'merged' };
+  readonly relationship: { readonly kind: ReviewGateRelationshipKind; readonly managedBy: 'external' };
+  readonly artifacts: readonly ReviewGateArtifact[];
+  readonly statusText?: string;
+}
+
 export interface TaskExecution {
   readonly phase?: 'launching' | 'executing';
   readonly generation?: number;
@@ -131,6 +159,7 @@ export interface TaskExecution {
   readonly reviewId?: string;
   readonly reviewStatus?: string;
   readonly reviewProviderId?: string;
+  readonly reviewGate?: ReviewGateExecution;
   readonly mergeConflict?: {
     readonly failedBranch: string;
     readonly conflictFiles: readonly string[];


### PR DESCRIPTION
## Summary

This shows review-gate pull request artifacts in the task panel.

Users can open each tracked PR instead of seeing only one review link.

## Review Claim

The UI now displays all tracked review-gate artifacts for a task.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The UI only reads task state. It does not mutate review-gate artifacts.

## Slice Rationale

This follows the API slice so the UI renders the state that callers can now attach.

## Non-goals

- No new polling behavior.
- No new artifact attachment form.
- No planning policy changes.

## Architecture

### Before

```mermaid
flowchart LR
  TaskState[Task state] --> Link[One review link]
```

### After

```mermaid
flowchart LR
  TaskState[Task state] --> Artifacts[Review artifact list]
  Artifacts --> Links[One link per PR]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/plan-parser.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/github-merge-gate-provider.test.ts src/__tests__/task-runner.test.ts`
- [x] `pnpm --filter @invoker/data-store test -- src/__tests__/sqlite-adapter.test.ts`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Visual Proof

![Review artifact list proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-093cb0/review-gate-ui-proof.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <this-pr-merge-commit>`
- Post-revert steps: None
- Data migration? No

Depends-On: #1700