### PR TITLE
[Graph Blank Storm 2] Name task stream watermark

### DIFF
--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -76,7 +76,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
   const startupSnapshotGenerationRef = useRef(0);
   const reportedStartupBootstrapRef = useRef(false);
   const reportedStartupSnapshotRef = useRef(false);
-  const lastSeenSequenceRef = useRef<number>(bootstrapState?.streamSequence ?? 0);
+  const uiTaskGraphStreamWatermarkRef = useRef<number>(bootstrapState?.streamSequence ?? 0);
   const isResyncInFlightRef = useRef<boolean>(false);
 
   const invalidateStartupSnapshot = useCallback(() => {
@@ -111,7 +111,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
         return wfMap;
       });
       if (typeof result.streamSequence === 'number') {
-        lastSeenSequenceRef.current = result.streamSequence;
+        uiTaskGraphStreamWatermarkRef.current = result.streamSequence;
       }
       isResyncInFlightRef.current = false;
       const replaceDurationMs = performance.now() - replaceStartedAt;
@@ -241,7 +241,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
             }
             return wfMap;
           });
-          lastSeenSequenceRef.current = firstEvent.streamSequence;
+          uiTaskGraphStreamWatermarkRef.current = firstEvent.streamSequence;
           isResyncInFlightRef.current = false;
           onTaskGraphSnapshotApplied?.();
           void window.invoker.reportUiPerf?.('useTasks_snapshot_replace', {
@@ -317,7 +317,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
 
       const seq = delta.streamSequence;
       if (typeof seq === 'number') {
-        const lastSeen = lastSeenSequenceRef.current;
+        const lastSeen = uiTaskGraphStreamWatermarkRef.current;
         if (seq <= lastSeen) return;
         if (isResyncInFlightRef.current) return;
         if (seq !== lastSeen + 1) {
@@ -332,7 +332,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
           refreshTaskGraph();
           return;
         }
-        lastSeenSequenceRef.current = seq;
+        uiTaskGraphStreamWatermarkRef.current = seq;
       }
 
       graphEventPipelineRef.current?.push(event);


### PR DESCRIPTION
## Summary

The task stream order marker now has a name that says what it stores.

It tracks the highest task graph stream number the UI has safely accepted.

This is only a rename. It does not change stream behavior.

## Review Claim

Approve the clearer task graph stream watermark name.

## Review Lane

refactor

## Review Unit

naming

## Safety Invariant

Only the ref name changes. Reads and writes keep the same values as before.

## Slice Rationale

This slice makes the next freshness check easier to review.

## Non-goals

This does not change event order, snapshot handling, or graph rendering.

## Test Plan

- [x] pnpm --filter @invoker/ui test -- src/__tests__/use-tasks-stream-gap-detect.test.tsx

## Revert Plan

- Safe to revert? Yes

- Revert command: git revert <sha>

- Post-revert steps: Re-run the task stream tests.

- Data migration? No