### PR TITLE
Register standalone owner handlers before launch-dispatch polling

### DIFF
--- a/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
+++ b/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const MAIN = path.resolve(__dirname, '..', 'main.ts');
+
+/**
+ * Regression guard for INV-192: a standalone owner must register its owner
+ * discovery (headless.owner-ping) and exec handlers before it starts
+ * launch-dispatch polling. If polling starts first, the owner can own the IPC
+ * socket while owner-ping still returns NO_HANDLER, so peer clients connect but
+ * cannot resolve a standalone owner and mutating commands fail closed.
+ */
+describe('standalone owner handler ordering', () => {
+  it('registers owner discovery and exec handlers before starting launch-dispatch polling', () => {
+    const source = readFileSync(MAIN, 'utf8');
+
+    const ownerPingIdx = source.indexOf("messageBus.onRequest('headless.owner-ping'");
+    const execIdx = source.indexOf("messageBus.onRequest('headless.exec'");
+    const dispatcherIdx = source.indexOf('startStandaloneLaunchDispatcher({');
+
+    expect(ownerPingIdx, 'standalone headless.owner-ping handler not found').toBeGreaterThan(-1);
+    expect(execIdx, 'standalone headless.exec handler not found').toBeGreaterThan(-1);
+    expect(dispatcherIdx, 'startStandaloneLaunchDispatcher call not found').toBeGreaterThan(-1);
+
+    expect(
+      ownerPingIdx,
+      'INV-192: startStandaloneLaunchDispatcher must run after headless.owner-ping is registered',
+    ).toBeLessThan(dispatcherIdx);
+    expect(
+      execIdx,
+      'INV-192: startStandaloneLaunchDispatcher must run after headless.exec is registered',
+    ).toBeLessThan(dispatcherIdx);
+  });
+});

--- a/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
+++ b/packages/app/src/__tests__/standalone-owner-handler-ordering.test.ts
@@ -4,13 +4,6 @@ import * as path from 'node:path';
 
 const MAIN = path.resolve(__dirname, '..', 'main.ts');
 
-/**
- * Regression guard for INV-192: a standalone owner must register its owner
- * discovery (headless.owner-ping) and exec handlers before it starts
- * launch-dispatch polling. If polling starts first, the owner can own the IPC
- * socket while owner-ping still returns NO_HANDLER, so peer clients connect but
- * cannot resolve a standalone owner and mutating commands fail closed.
- */
 describe('standalone owner handler ordering', () => {
   it('registers owner discovery and exec handlers before starting launch-dispatch polling', () => {
     const source = readFileSync(MAIN, 'utf8');

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1229,14 +1229,6 @@ function startHeadlessMode(): void {
 
       // In standalone owner mode, serve delegated requests from peer headless processes.
       if (standaloneMode && messageBus) {
-        if (!readOnlyMode) {
-          standaloneLaunchDispatcherController = startStandaloneLaunchDispatcher({
-            headlessDeps,
-            ownerId: workflowMutationOwnerId,
-            createTaskExecutor: createStandaloneTaskExecutor,
-            setLatestTaskExecutor: (executor) => { latestTaskExecutor = executor; },
-          });
-        }
         const standaloneOwnerIdleTimeoutMs = Number.parseInt(
           process.env.INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '0',
           10,
@@ -1695,6 +1687,19 @@ function startHeadlessMode(): void {
           getTaskExecutor: createStandaloneTaskExecutor,
           logger,
         });
+
+        // Start launch-dispatch polling only after the owner discovery (headless.owner-ping)
+        // and exec handlers above are registered. Otherwise the owner can own the IPC socket
+        // and begin dispatching while owner-ping still returns NO_HANDLER, so peer clients
+        // connect but cannot resolve a standalone owner and mutating commands fail closed (INV-192).
+        if (!readOnlyMode) {
+          standaloneLaunchDispatcherController = startStandaloneLaunchDispatcher({
+            headlessDeps,
+            ownerId: workflowMutationOwnerId,
+            createTaskExecutor: createStandaloneTaskExecutor,
+            setLatestTaskExecutor: (executor) => { latestTaskExecutor = executor; },
+          });
+        }
       }
 
       await runHeadless(cliArgs, headlessDeps);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1688,10 +1688,7 @@ function startHeadlessMode(): void {
           logger,
         });
 
-        // Start launch-dispatch polling only after the owner discovery (headless.owner-ping)
-        // and exec handlers above are registered. Otherwise the owner can own the IPC socket
-        // and begin dispatching while owner-ping still returns NO_HANDLER, so peer clients
-        // connect but cannot resolve a standalone owner and mutating commands fail closed (INV-192).
+        // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
           standaloneLaunchDispatcherController = startStandaloneLaunchDispatcher({
             headlessDeps,

--- a/scripts/repro/repro-standalone-owner-ping-before-dispatch.sh
+++ b/scripts/repro/repro-standalone-owner-ping-before-dispatch.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/invoker-owner-ping-before-dispatch.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+SOCKET_PATH="$TMP_ROOT/ipc.sock"
+
+if [[ ! -f "$ROOT_DIR/packages/transport/dist/index.js" ]]; then
+  (cd "$ROOT_DIR" && pnpm --filter @invoker/transport build)
+fi
+
+echo "==> reproduce standalone owner-ping race window with real IPC transport"
+(
+  cd "$ROOT_DIR"
+  REPRO_SOCKET="$SOCKET_PATH" node \
+    --import 'data:text/javascript,import { register } from "node:module"; import { pathToFileURL } from "node:url"; register("./scripts/repro/compiled-workspace-loader.mjs", pathToFileURL("./"));' \
+    --input-type=module <<'NODE'
+import { IpcBus, TransportErrorCode } from './packages/transport/dist/index.js';
+
+const socketPath = process.env.REPRO_SOCKET;
+const owner = new IpcBus(socketPath, { allowServe: true, requestDeadlineMs: 500 });
+let client;
+
+try {
+  await owner.ready();
+  client = new IpcBus(socketPath, { allowServe: false, requestDeadlineMs: 500 });
+  await client.ready();
+
+  let dispatchPollRan = false;
+  const runLaunchDispatchPoll = async () => {
+    dispatchPollRan = true;
+  };
+
+  await runLaunchDispatchPoll();
+
+  try {
+    await client.request('headless.owner-ping', {});
+    throw new Error('expected owner-ping to fail before the owner handler is registered');
+  } catch (err) {
+    if (err?.code !== TransportErrorCode.NO_HANDLER) {
+      throw err;
+    }
+  }
+
+  if (!dispatchPollRan) {
+    throw new Error('dispatch poll did not run before owner-ping was checked');
+  }
+
+  owner.onRequest('headless.owner-ping', async () => ({
+    ok: true,
+    ownerId: 'owner-race-repro',
+    mode: 'standalone',
+  }));
+
+  const response = await client.request('headless.owner-ping', {});
+  if (response?.ok !== true || response?.mode !== 'standalone') {
+    throw new Error(`unexpected owner-ping response after registration: ${JSON.stringify(response)}`);
+  }
+
+  console.log('PASS: IPC can be reachable while owner-ping returns NO_HANDLER before registration');
+  console.log('PASS: owner-ping succeeds after registration, so dispatch polling must start after handlers');
+} finally {
+  client?.disconnect();
+  owner.disconnect();
+}
+NODE
+)
+
+echo
+echo "==> verify production standalone owner registers handlers before dispatch polling"
+(
+  cd "$ROOT_DIR"
+  pnpm --filter @invoker/app exec vitest run \
+    src/__tests__/standalone-owner-handler-ordering.test.ts
+)

--- a/scripts/repro/repro-standalone-owner-ping-before-dispatch.sh
+++ b/scripts/repro/repro-standalone-owner-ping-before-dispatch.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/invoker-owner-ping-before-dispatch.XXXXXX")"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/inv-ping.XXXXXX")"
 
 cleanup() {
   rm -rf "$TMP_ROOT"


### PR DESCRIPTION
## Summary

Closes INV-192.

A standalone owner could make IPC reachable before registering its owner identity handler.

This patch starts launch-dispatch polling after the owner identity, exec, and GUI mutation handlers are registered.

The repro script demonstrates the bad race window with the real IPC transport: IPC can be reachable while `headless.owner-ping` still returns `NO_HANDLER` before registration.

The current production check is a source-order guard. The deeper boot-level check is tracked separately in INV-222.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the narrow startup-order patch that prevents dispatch polling from preceding owner handler registration.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The change only reorders standalone owner startup within the same block; read-only mode still skips launch dispatch.

Slice Rationale: This patch closes the observed handler-registration gap while the broader runtime proof is tracked independently.

</details>

## Non-goals

- Does not change delegated routing semantics.
- Does not change launch-dispatch polling behavior once started.
- Does not add the boot-level owner handler check; that follow-up is tracked in INV-222.

## Architecture

### Before

```mermaid
graph TD
    A["standalone owner starts"] --> B["launch-dispatch polling can start"]
    B --> C["owner handlers registered later"]
```

### After

```mermaid
graph TD
    A["standalone owner starts"] --> B["owner and exec handlers registered"]
    B --> C["launch-dispatch polling starts"]
```

## Test Plan

- [x] `scripts/repro/repro-standalone-owner-ping-before-dispatch.sh`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/standalone-owner-handler-ordering.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved standalone headless startup sequencing so the standalone owner registers its IPC request handlers before the dispatcher begins polling, reducing the risk of “no handler” connection failures during startup.

* **Tests**
  * Added a regression test that verifies the ordering of the standalone owner IPC handler setup relative to dispatcher startup to prevent future reordering issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->