### PR TITLE
Enforce stack PR title prefixes

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -140,10 +140,15 @@ Options:
   --dry-run            Print actions without executing
   --help               Show this help
 
+Stack PR title schema:
+  Stacked PRs must start with a shared idea and one slice index, for example:
+  [Graph Blanking](1) Preserve selected graph while loading
+  [Graph Blanking](2) Follow-up slice
+
 Stack flow:
   1. Publish stack branches with \`mergify stack push\`
   2. Switch to the created stack branch if needed
-  3. Run \`node scripts/create-pr.mjs --title "..." --base <branch> --body-file <file> --update-existing\`
+  3. Run \`node scripts/create-pr.mjs --title "[Graph Blanking](1) <slice title>" --base <branch> --body-file <file> --update-existing\`
 
 PR body schema:
   Required: ## Summary, ## Review Claim, ## Review Lane, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
@@ -191,6 +196,25 @@ function parseArgs() {
   }
 
   return parsed;
+}
+
+const TRUNK_BRANCHES = new Set(['main', 'master', 'develop']);
+const STACK_PR_TITLE_PATTERN = /^\[[^\[\]\r\n]{3,80}\]\([1-9]\d*\)(?:\s+\S.*)?$/;
+
+function isStackedPrContext(baseBranch, mergifyState) {
+  return mergifyState.managed || !TRUNK_BRANCHES.has(baseBranch);
+}
+
+function assertValidStackPrTitle(title) {
+  if (STACK_PR_TITLE_PATTERN.test(title.trim())) return;
+
+  throw new Error(
+    [
+      'Stack PR titles must start with a shared idea and exactly one slice index.',
+      'Use: [Graph Blanking](1) Preserve selected graph while loading',
+      'Use the next slice number for the next PR: [Graph Blanking](2) Follow-up slice',
+    ].join('\n'),
+  );
 }
 
 function assertValidPrBody(body, options = {}) {
@@ -659,6 +683,10 @@ async function main() {
 
   if (mergifyState.managed && requestedUpdatePath) {
     assertPublishedMergifyBranch(currentBranch, mergifyState.trackedBaseRef);
+  }
+
+  if (isStackedPrContext(args.base, mergifyState)) {
+    assertValidStackPrTitle(args.title);
   }
 
   const nwo = args.dryRun ? 'OWNER/REPO' : getRepoNwo();

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -268,6 +268,7 @@ export function classifyReviewUnitsForPath(filePath) {
   if (path.startsWith('scripts/repro/')) return ['proof'];
   if (path === 'scripts/test-create-pr-visual-proof.mjs') return ['tooling-policy'];
   if (/(benchmark|performance|visual-proof)/.test(lowerPath)) return ['proof'];
+  if (path === 'skills/make-pr/SKILL.md') return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];
   if (path.startsWith('.github/')) return ['tooling-policy'];
   if (

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -20,7 +20,11 @@ Keep stack publication on the supported path.
 
 ## Review Lane
 
-- behavior
+- policy
+
+## Review Unit
+
+- tooling-policy
 
 ## Safety Invariant
 
@@ -231,6 +235,10 @@ function baseArgs() {
   return ['--title', 'test title', '--base', 'master', '--body-file', 'pr-body.md'];
 }
 
+function stackTitleArgs(base = 'master') {
+  return ['--title', '[Graph Blanking](1) Preserve graph blanking', '--base', base, '--body-file', 'pr-body.md'];
+}
+
 function expectNoPush(harness, label) {
   assert(readLogLines(harness.pushLog).length === 0, `${label}: expected no git push attempt`);
 }
@@ -262,8 +270,8 @@ function testMergifyManagedCreateRefusal() {
     setManagedBranchConfig(work, 'pr/stack-create');
 
     const result = runCreatePr(work, harness, baseArgs());
-    assert(result.status === 1, 'managed stack create should fail');
-    assert(result.stderr.includes('This branch is managed by Mergify stacks.'), 'managed stack create should explain branch state');
+    assert(result.status === 1, `managed stack create should fail\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('This branch is managed by Mergify stacks.'), `managed stack create should explain branch state\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
     assert(result.stderr.includes('mergify stack push'), 'managed stack create should require mergify stack push');
     expectNoPush(harness, 'managed create refusal');
   } finally {
@@ -281,7 +289,7 @@ function testMergifyManagedUpdateSkipsPush() {
     gitQuiet(work, 'push', '-u', 'origin', branch);
     setManagedBranchConfig(work, branch);
 
-    const result = runCreatePr(work, harness, [...baseArgs(), '--update-existing'], {
+    const result = runCreatePr(work, harness, [...stackTitleArgs(), '--update-existing'], {
       GH_API_PULLS_JSON: JSON.stringify([
         {
           number: 42,
@@ -307,8 +315,58 @@ function testMergifyManagedUpdateSkipsPush() {
     assert(ghCalls.some((call) => call.route.includes('/pulls?')), 'managed update should look up current branch PR');
     const patchCall = ghCalls.find((call) => call.route.endsWith('/pulls/42'));
     assert(Boolean(patchCall), 'managed update should patch the existing PR');
-    assert(patchCall.stdin.includes('"title":"test title"'), 'managed update patch should include title');
+    assert(patchCall.stdin.includes('"title":"[Graph Blanking](1) Preserve graph blanking"'), 'managed update patch should include title');
     assert(patchCall.stdin.includes('## Summary'), 'managed update patch should include PR body');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testMergifyManagedUpdateRejectsPlainTitle() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-title-reject';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Ititle0001');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [...baseArgs(), '--update-existing']);
+
+    assert(result.status === 1, 'managed stack update should reject a plain title');
+    assert(result.stderr.includes('Stack PR titles must start with a shared idea'), 'stack title error should explain format');
+    expectNoPush(harness, 'managed title rejection');
+    assert(readGhCalls(harness.ghLog).length === 0, 'managed title rejection should fail before GitHub calls');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testMergifyManagedUpdateRejectsNestedTitle() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-nested-title-reject';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Inested0001');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [
+      '--title',
+      '[Graph Blanking](1)(2) Follow-up slice',
+      '--base',
+      'master',
+      '--body-file',
+      'pr-body.md',
+      '--update-existing',
+    ]);
+
+    assert(result.status === 1, 'managed stack update should reject a nested title');
+    assert(result.stderr.includes('exactly one slice index'), 'nested stack title error should explain format');
+    expectNoPush(harness, 'managed nested title rejection');
+    assert(readGhCalls(harness.ghLog).length === 0, 'managed nested title rejection should fail before GitHub calls');
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }
@@ -345,7 +403,7 @@ function testCurrentBranchPrLookupFailure() {
     gitQuiet(work, 'push', '-u', 'origin', branch);
     setManagedBranchConfig(work, branch);
 
-    const result = runCreatePr(work, harness, [...baseArgs(), '--update-existing'], {
+    const result = runCreatePr(work, harness, [...stackTitleArgs(), '--update-existing'], {
       GH_API_PULLS_JSON: '[]',
     });
 
@@ -353,6 +411,26 @@ function testCurrentBranchPrLookupFailure() {
     assert(result.stderr.includes(`No PR exists for current branch "${branch}" in owner/repo.`), 'missing PR lookup should name the current branch');
     assert(result.stderr.includes('Run `mergify stack push` first for stack branches'), 'missing PR lookup should explain next step');
     expectNoPush(harness, 'missing current-branch PR');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testStackedDiffTitleRequiredForNonTrunkBase() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    gitQuiet(work, 'branch', 'pr/previous', 'origin/master');
+    gitQuiet(work, 'push', 'origin', 'pr/previous');
+    createTrackedBranch(work, 'pr/stacked-diff', 'origin/pr/previous');
+    commitFile(work, 'stacked.txt', 'stacked\n', 'stacked diff');
+
+    const result = runCreatePr(work, harness, ['--title', 'plain title', '--base', 'pr/previous', '--body-file', 'pr-body.md']);
+
+    assert(result.status === 1, 'stacked diff PR should reject a plain title');
+    assert(result.stderr.includes('Stack PR titles must start with a shared idea'), 'stacked diff title error should explain format');
+    expectNoPush(harness, 'stacked diff title rejection');
+    assert(readGhCalls(harness.ghLog).length === 0, 'stacked diff title rejection should fail before GitHub calls');
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }
@@ -374,8 +452,11 @@ const tests = [
   testStaleBaseDetection,
   testMergifyManagedCreateRefusal,
   testMergifyManagedUpdateSkipsPush,
+  testMergifyManagedUpdateRejectsPlainTitle,
+  testMergifyManagedUpdateRejectsNestedTitle,
   testUnpublishedStackCommitsBlockUpdate,
   testCurrentBranchPrLookupFailure,
+  testStackedDiffTitleRequiredForNonTrunkBase,
   testHelpMentionsStackUpdateFlow,
 ];
 

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -125,6 +125,20 @@ node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-p
 
 This script handles local image path upload/injection when configured. It also rejects UI-impacting diffs unless the body includes visual proof media.
 
+## Stack PR title schema
+
+For Mergify stacks and manual stacks of diffs, every PR title must start with the same short stack idea and exactly one slice index:
+
+```text
+[Graph Blanking](1) Preserve selected graph while loading
+[Graph Blanking](2) Reconcile graph refresh after task updates
+```
+
+Use the bracketed idea as the shared stack name. Use the parenthesized number as that PR's slice number. Do not chain numbers like `(1)(2)`. `scripts/create-pr.mjs` rejects stacked PR titles that do not start this way.
+
+For single, unstacked PRs against `master`, use a normal clear title.
+
+
 ## Upstream-first workflow
 
 Use the canonical repository as the PR target and an explicit publish remote (typically `origin`) for branch publication.
@@ -150,6 +164,12 @@ If the target repo is Invoker itself (`EdbertChan/Invoker` or `Neko-Catpital-Lab
 mergify stack push
 ```
 
+- after `mergify stack push`, repair PR titles or bodies by rerunning `create-pr` in update mode on the created stack branch; stacked titles must use `[Stack Idea](N)` prefixes
+
+```bash
+node scripts/create-pr.mjs --title "[Graph Blanking](1) Preserve selected graph while loading" --base <base> --body-file /tmp/my-pr.md --update-existing
+```
+
 Do not generalize this to unrelated repos.
 
 ## Validation
@@ -160,6 +180,7 @@ Before creating a PR:
 - ensure the body sections are present and concrete
 - ensure test commands are real commands that were actually run when possible
 - ensure revert guidance is honest
+- ensure stacked PR titles start with `[Stack Idea](N)`, not `[Stack Idea](N)(M)`
 - validate the body with `node scripts/validate-pr-body.mjs --body-file <file>`
 - for UI-impacting diffs, include `## Visual Proof` with screenshot or video proof before `node scripts/create-pr.mjs`
 


### PR DESCRIPTION
## Summary

Stacked PR titles now have one shared idea and one slice number.

This stops titles like `[Graph Blanking](1)(2)` and keeps later slices as `[Graph Blanking](2)`.

## Review Claim

Approve the stack title rule in `create-pr` and the make-pr skill guidance.

## Review Lane

- policy

## Review Unit

- tooling-policy

## Safety Invariant

This only changes PR authoring checks and docs. Runtime app behavior is unchanged.

## Slice Rationale

The validation, skill text, and stack workflow test cover one PR authoring rule together.

## Non-goals

- Do not change Mergify stack publishing.
- Do not change runtime workflow behavior.

## Test Plan

- [x] `node scripts/test-create-pr-stack-workflow.mjs`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
