### PR TITLE
Hide PR review metadata by default

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -28,9 +28,9 @@
  *
  * PR body validation:
  *   Enforces the canonical PR schema:
- *   ## Summary, ## Review Claim, ## Review Lane, ## Safety Invariant,
- *   ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan,
- *   plus optional ## Architecture and required ## Visual Proof for UI changes.
+ *   ## Summary with collapsed Review metadata, ## Non-goals,
+ *   ## Test Plan, ## Revert Plan, plus optional ## Architecture
+ *   and required ## Visual Proof for UI changes.
  */
 
 import { readFileSync, existsSync } from 'node:fs';
@@ -151,7 +151,7 @@ Stack flow:
   3. Run \`node scripts/create-pr.mjs --title "[Graph Blanking](1) <slice title>" --base <branch> --body-file <file> --update-existing\`
 
 PR body schema:
-  Required: ## Summary, ## Review Claim, ## Review Lane, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
+  Required: ## Summary with collapsed Review metadata, ## Non-goals, ## Test Plan, ## Revert Plan
   Optional: ## Architecture (must include ### Before and ### After when present)
   UI-impacting diffs require ## Visual Proof with screenshot or video proof.
   Template: scripts/pr-body-template.md`);

--- a/scripts/pr-body-template.md
+++ b/scripts/pr-body-template.md
@@ -6,21 +6,20 @@ Write paragraphs, not bullets. Keep each paragraph under 30 words.
 
 Put one idea in each paragraph. If one idea leads to another, split them into separate short paragraphs.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
 
-State the one thing the reviewer is being asked to approve.
+Review Claim: State the one thing the reviewer is being asked to approve.
 
-## Review Lane
+Review Lane: Choose exactly one: `behavior`, `refactor`, `proof`, `cleanup`, `policy`, or `docs`.
 
-Choose exactly one: `behavior`, `refactor`, `proof`, `cleanup`, `policy`, or `docs`.
+Review Unit: Choose the matching review unit, such as `tooling-policy`, `routing`, or `docs`.
 
-## Safety Invariant
+Safety Invariant: Explain why this slice is safe to review locally.
 
-Explain why this slice is safe to review locally.
+Slice Rationale: Explain why this work is split here instead of bundled elsewhere.
 
-## Slice Rationale
-
-Explain why this work is split here instead of bundled elsewhere.
+</details>
 
 ## Non-goals
 

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -266,7 +266,10 @@ export function classifyReviewUnitsForPath(filePath) {
   const basename = path.split('/').pop() ?? '';
 
   if (path.startsWith('scripts/repro/')) return ['proof'];
-  if (path === 'scripts/test-create-pr-visual-proof.mjs') return ['tooling-policy'];
+  if (
+    path === 'scripts/pr-body-template.md'
+    || path === 'scripts/test-create-pr-visual-proof.mjs'
+  ) return ['tooling-policy'];
   if (/(benchmark|performance|visual-proof)/.test(lowerPath)) return ['proof'];
   if (path === 'skills/make-pr/SKILL.md') return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -14,25 +14,30 @@ const VALID_BODY = `## Summary
 
 This branch updates the PR workflow.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
 
 Keep stack publication on the supported path.
 
-## Review Lane
+Review Lane:
 
 - policy
 
-## Review Unit
+Review Unit:
 
 - tooling-policy
 
-## Safety Invariant
+Safety Invariant:
 
 Only PR workflow tooling changes.
 
-## Slice Rationale
+Slice Rationale:
 
 Stack publishing stays separate from unrelated cleanup.
+
+</details>
 
 ## Non-goals
 

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -12,21 +12,30 @@ const validMinimal = `## Summary
 
 Small fix.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
 
 Keep the owner fallback local.
 
-## Review Lane
+Review Lane:
 
 - behavior
 
-## Safety Invariant
+Review Unit:
+
+- routing
+
+Safety Invariant:
 
 Only the refresh path changes.
 
-## Slice Rationale
+Slice Rationale:
 
 Proof and cleanup stay separate.
+
+</details>
 
 ## Non-goals
 
@@ -48,21 +57,30 @@ const validArchitecture = `## Summary
 
 Flow change.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
 
 Route refresh through one helper.
 
-## Review Lane
+Review Lane:
 
 - behavior
 
-## Safety Invariant
+Review Unit:
+
+- routing
+
+Safety Invariant:
 
 The same callers keep the same contract.
 
-## Slice Rationale
+Slice Rationale:
 
 Move behavior without mixing cleanup.
+
+</details>
 
 ## Non-goals
 
@@ -113,6 +131,40 @@ assert(validatePrBody(validMinimal).length === 0, 'valid minimal body should pas
 assert(validatePrBody(validArchitecture).length === 0, 'valid architecture body should pass');
 assert(getPrBodyWarnings(validMinimal).length === 0, 'short summary should produce no warnings');
 
+const visibleMetadataErrors = validatePrBody(`## Summary
+
+Small fix.
+
+## Review Claim
+
+Keep visible metadata out of the main PR body.
+
+## Non-goals
+
+- No docs.
+
+## Test Plan
+
+- [ ] \`pnpm test\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`);
+assert(
+  visibleMetadataErrors.some((error) => error.includes('belongs in the collapsed Review metadata block')),
+  'visible review metadata headings should fail',
+);
+
+const openMetadataErrors = validatePrBody(validMinimal.replace('<details>', '<details open>'));
+assert(
+  openMetadataErrors.some((error) => error.includes('collapsed by default')),
+  'review metadata should stay collapsed by default',
+);
+
 const lightweightErrors = validatePrBody(lightweight);
 assert(lightweightErrors.some((error) => error.includes('Unsupported section: ## Testing')), 'lightweight format should reject ## Testing');
 assert(lightweightErrors.some((error) => error.includes('Unsupported section: ## Notes')), 'lightweight format should reject ## Notes');
@@ -121,21 +173,30 @@ const missingTestPlanErrors = validatePrBody(`## Summary
 
 Only summary.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
 
 One claim.
 
-## Review Lane
+Review Lane:
 
 - behavior
 
-## Safety Invariant
+Review Unit:
+
+- validation-policy
+
+Safety Invariant:
 
 Local only.
 
-## Slice Rationale
+Slice Rationale:
 
 Small slice.
+
+</details>
 
 ## Non-goals
 
@@ -154,21 +215,30 @@ const malformedArchitectureErrors = validatePrBody(`## Summary
 
 Flow change.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
 
 One claim.
 
-## Review Lane
+Review Lane:
 
 - behavior
 
-## Safety Invariant
+Review Unit:
+
+- routing
+
+Safety Invariant:
 
 Local only.
 
-## Slice Rationale
+Slice Rationale:
 
 Small slice.
+
+</details>
 
 ## Non-goals
 
@@ -200,17 +270,26 @@ const missingReviewLaneErrors = validatePrBody(`## Summary
 
 Small fix.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
 
 One claim.
 
-## Safety Invariant
+Review Unit:
+
+- routing
+
+Safety Invariant:
 
 Local only.
 
-## Slice Rationale
+Slice Rationale:
 
 Small slice.
+
+</details>
 
 ## Non-goals
 
@@ -227,7 +306,7 @@ Small slice.
 - Post-revert steps: None
 - Data migration? No
 `);
-assert(missingReviewLaneErrors.some((error) => error.includes('Missing required section: ## Review Lane')), 'missing review lane should fail');
+assert(missingReviewLaneErrors.some((error) => error.includes('Review metadata is missing required field: Review Lane:')), 'missing review lane should fail');
 
 const invalidReviewLaneErrors = validatePrBody(validMinimal.replace('- behavior', '- impossible'));
 assert(invalidReviewLaneErrors.some((error) => error.includes('Invalid review lane: impossible')), 'invalid review lane should fail');
@@ -238,21 +317,30 @@ This adds the dormant auto-fix recovery policy.
 
 It scans persisted failed tasks, validates retry and stale-state eligibility, suppresses duplicate open fix intents, and submits fix-with-agent mutation intents.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
 
 Auto-fix recovery can scan persisted failed tasks and enqueue the normal fix intent without a CLI surface.
 
-## Review Lane
+Review Lane:
 
 - behavior
 
-## Safety Invariant
+Review Unit:
+
+- validation-policy
+
+Safety Invariant:
 
 The policy only submits through the existing mutation route and skips stale or already queued candidates.
 
-## Slice Rationale
+Slice Rationale:
 
 Durable-state scan behavior is reviewable separately from lifecycle wakeup routing and CLI activation.
+
+</details>
 
 ## Non-goals
 
@@ -281,21 +369,30 @@ This moves the recovery worker out of the generic runtime.
 
 It scans persisted failed tasks, validates candidates, submits fix intents, routes lifecycle wakeups, and exposes the headless worker command.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
 
 The recovery worker owns auto-fix recovery end to end.
 
-## Review Lane
+Review Lane:
 
 - behavior
 
-## Safety Invariant
+Review Unit:
+
+- validation-policy
+
+Safety Invariant:
 
 Every submitted fix still goes through the existing mutation route.
 
-## Slice Rationale
+Slice Rationale:
 
 The complete auto-fix recovery path lands together for one rollout.
+
+</details>
 
 ## Non-goals
 
@@ -322,21 +419,30 @@ const longSummary = `## Summary
 
 This summary paragraph uses too many words because it tries to explain several related implementation details at the same time instead of giving a tired reviewer one clear idea they can understand immediately.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
 
 One claim.
 
-## Review Lane
+Review Lane:
 
 - behavior
 
-## Safety Invariant
+Review Unit:
+
+- routing
+
+Safety Invariant:
 
 Local only.
 
-## Slice Rationale
+Slice Rationale:
 
 Small slice.
+
+</details>
 
 ## Non-goals
 
@@ -388,6 +494,15 @@ assert(
   'warning-only visual proof should not satisfy UI proof requirement',
 );
 
+const prAuthoringPolicyErrors = validatePrBody(validMinimal.replace('- behavior', '- policy').replace('- routing', '- tooling-policy'), {
+  changedFiles: [
+    'skills/make-pr/SKILL.md',
+    'scripts/pr-body-template.md',
+    'scripts/create-pr.mjs',
+  ],
+});
+assert(prAuthoringPolicyErrors.length === 0, 'PR authoring docs and template files should stay in tooling-policy');
+
 const behaviorScopeErrors = validatePrBody(validMinimal, {
   changedFiles: [
     'packages/app/src/main.ts',
@@ -436,23 +551,32 @@ assert(
 
 const refactorBody = `## Summary
 
-Extract a helper first.
+Route code first.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
 
-Move refresh logic into a helper module.
+Review Claim:
 
-## Review Lane
+Move refresh routing without changing behavior.
+
+Review Lane:
 
 - refactor
 
-## Safety Invariant
+Review Unit:
+
+- routing
+
+Safety Invariant:
 
 Behavior stays unchanged.
 
-## Slice Rationale
+Slice Rationale:
 
 Field additions land in a later behavior PR.
+
+</details>
 
 ## Non-goals
 
@@ -487,21 +611,30 @@ const validationPolicyBody = `## Summary
 
 Validate stale recovery candidates.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
 
 Reject stale auto-fix recovery candidates before submission.
 
-## Review Lane
+Review Lane:
 
 - behavior
 
-## Safety Invariant
+Review Unit:
+
+- validation-policy
+
+Safety Invariant:
 
 The slice returns validated candidates only.
 
-## Slice Rationale
+Slice Rationale:
 
 Validation policy stays separate from command submission.
+
+</details>
 
 ## Non-goals
 

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -3,6 +3,7 @@
 import { readFileSync } from 'node:fs';
 import {
   formatReviewUnits,
+  getLabelSection,
   getMarkdownSection,
   normalizeReviewUnit,
   reviewUnitsForChangedFiles,
@@ -14,14 +15,23 @@ import {
 
 const REQUIRED_SECTIONS = [
   '## Summary',
+  '## Non-goals',
+  '## Test Plan',
+  '## Revert Plan',
+];
+const VISIBLE_METADATA_SECTIONS = [
   '## Review Claim',
   '## Review Lane',
   '## Review Unit',
   '## Safety Invariant',
   '## Slice Rationale',
-  '## Non-goals',
-  '## Test Plan',
-  '## Revert Plan',
+];
+const REQUIRED_METADATA_LABELS = [
+  'Review Claim',
+  'Review Lane',
+  'Review Unit',
+  'Safety Invariant',
+  'Slice Rationale',
 ];
 const DISCOURAGED_HEADINGS = ['## Testing', '## Notes'];
 const SUMMARY_WORD_LIMIT = 30;
@@ -49,6 +59,21 @@ function hasVisualProofMedia(body) {
 
 function normalizeSectionValue(sectionBody) {
   return normalizeReviewUnit(sectionBody);
+}
+
+function getReviewMetadataBlock(body) {
+  const summary = getSectionBody(body, '## Summary');
+  const match = summary.match(/<details\b([^>]*)>\s*<summary>\s*Review metadata\s*<\/summary>([\s\S]*?)<\/details>/i);
+  if (!match) return { body: '', openAttributes: '' };
+  return { body: match[2].trim(), openAttributes: match[1] };
+}
+
+function getReviewMetadataValue(metadata, label) {
+  return getLabelSection(metadata, label);
+}
+
+function stripDetailsBlocks(text) {
+  return String(text).replace(/<details\b[^>]*>[\s\S]*?<\/details>/gi, '').trim();
 }
 
 function classifyScopeKind(filePath) {
@@ -130,7 +155,8 @@ export function getPrBodyWarnings(body, options = {}) {
   const warnings = [];
   const summary = getSectionBody(body, '## Summary');
   if (summary) {
-    const paragraphs = summary.split(/\n\s*\n/).map((paragraph) => paragraph.trim()).filter(Boolean);
+    const visibleSummary = stripDetailsBlocks(summary);
+    const paragraphs = visibleSummary.split(/\n\s*\n/).map((paragraph) => paragraph.trim()).filter(Boolean);
     paragraphs.forEach((paragraph, index) => {
       const wordCount = countWords(paragraph);
       if (wordCount > SUMMARY_WORD_LIMIT) {
@@ -160,13 +186,18 @@ export function validatePrBody(body, options = {}) {
 
   if (!trimmed) {
     return [
-      'PR body is empty. Use the canonical schema: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, and ## Revert Plan.',
+      'PR body is empty. Use the canonical schema: ## Summary with a collapsed Review metadata block, ## Non-goals, ## Test Plan, and ## Revert Plan.',
     ];
   }
 
   for (const heading of REQUIRED_SECTIONS) {
     if (!trimmed.includes(heading)) {
       errors.push(`Missing required section: ${heading}`);
+    }
+  }
+  for (const heading of VISIBLE_METADATA_SECTIONS) {
+    if (trimmed.includes(heading)) {
+      errors.push(`${heading} belongs in the collapsed Review metadata block inside ## Summary, not as a visible top-level section.`);
     }
   }
 
@@ -186,12 +217,25 @@ export function validatePrBody(body, options = {}) {
     }
   }
 
-  const reviewLane = normalizeSectionValue(getSectionBody(trimmed, '## Review Lane'));
+  const reviewMetadata = getReviewMetadataBlock(trimmed);
+  if (!reviewMetadata.body) {
+    errors.push('## Summary must include a collapsed <details> block with <summary>Review metadata</summary>.');
+  } else if (/\bopen\b/i.test(reviewMetadata.openAttributes)) {
+    errors.push('Review metadata details must be collapsed by default; remove the open attribute.');
+  }
+
+  for (const label of REQUIRED_METADATA_LABELS) {
+    if (!getReviewMetadataValue(reviewMetadata.body, label)) {
+      errors.push(`Review metadata is missing required field: ${label}:`);
+    }
+  }
+
+  const reviewLane = normalizeSectionValue(getReviewMetadataValue(reviewMetadata.body, 'Review Lane'));
   if (reviewLane && !VALID_REVIEW_LANES.has(reviewLane)) {
     errors.push(`Invalid review lane: ${reviewLane}. Expected one of ${Array.from(VALID_REVIEW_LANES).join(', ')}.`);
   }
 
-  const reviewUnit = normalizeReviewUnit(getSectionBody(trimmed, '## Review Unit'));
+  const reviewUnit = normalizeReviewUnit(getReviewMetadataValue(reviewMetadata.body, 'Review Unit'));
   errors.push(...validateReviewUnitValue(reviewUnit, 'PR body'));
   errors.push(...validateReviewLaneUnitCompatibility({
     reviewLane,
@@ -199,17 +243,17 @@ export function validatePrBody(body, options = {}) {
     context: 'PR body',
   }));
 
-  const reviewClaim = getSectionBody(trimmed, '## Review Claim');
+  const reviewClaim = getReviewMetadataValue(reviewMetadata.body, 'Review Claim');
   if (reviewClaim && !reviewClaim.trim()) {
-    errors.push('## Review Claim must not be empty.');
+    errors.push('Review metadata field Review Claim must not be empty.');
   }
   errors.push(...validateReviewUnitFocus({
     declaredReviewUnit: reviewUnit,
     context: 'PR body',
     texts: [
-      getSectionBody(trimmed, '## Summary'),
+      stripDetailsBlocks(getSectionBody(trimmed, '## Summary')),
       reviewClaim,
-      getSectionBody(trimmed, '## Slice Rationale'),
+      getReviewMetadataValue(reviewMetadata.body, 'Slice Rationale'),
     ],
   }));
 
@@ -235,7 +279,7 @@ function usage() {
   console.error(`Usage: node scripts/validate-pr-body.mjs (--body-file <file> | --body <markdown>) [--require-visual-proof]
 
 Validates the canonical PR schema:
-  Required: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
+  Required: ## Summary with a collapsed Review metadata block, ## Non-goals, ## Test Plan, ## Revert Plan
   Optional: ## Architecture (must include ### Before and ### After when present)
   UI changes: pass --require-visual-proof to require screenshot or video proof.`);
   process.exit(1);

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -37,21 +37,20 @@ Put one idea in each paragraph. If one idea leads to another, split them into se
 
 Avoid implementation jargon unless it is necessary for understanding the change.
 
-## Review Claim
+<details>
+<summary>Review metadata</summary>
 
-State the one thing the reviewer is being asked to approve.
+Review Claim: State the one thing the reviewer is being asked to approve.
 
-## Review Lane
+Review Lane: Choose exactly one: `behavior`, `refactor`, `proof`, `cleanup`, `policy`, or `docs`.
 
-Choose exactly one: `behavior`, `refactor`, `proof`, `cleanup`, `policy`, or `docs`.
+Review Unit: Choose the matching review unit, such as `tooling-policy`, `routing`, or `docs`.
 
-## Safety Invariant
+Safety Invariant: Explain why this slice is safe to review locally.
 
-Explain why this slice is safe to review locally.
+Slice Rationale: Explain why this work is split here instead of bundled elsewhere.
 
-## Slice Rationale
-
-Explain why this work is split here instead of bundled elsewhere.
+</details>
 
 ## Non-goals
 
@@ -94,7 +93,7 @@ If the change is small and has no architectural impact, omit `## Architecture` r
 
 If the change touches UI-impacting files, use `skills/visual-proof/SKILL.md` first and include its screenshot/video markdown in `## Visual Proof`. UI-impacting files include `packages/ui/**`, Electron window lifecycle files, preload, main process window wiring, and app menu changes.
 
-Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Review Claim / ## Review Lane / ## Safety Invariant / ## Slice Rationale / ## Non-goals / ## Test Plan / ## Revert Plan` as the floor, add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.
+Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary` with a collapsed `<details><summary>Review metadata</summary>` block, then `## Non-goals / ## Test Plan / ## Revert Plan` as the floor. Add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.
 
 ## Command surface
 


### PR DESCRIPTION
## Summary

PR review metadata now lives inside a collapsed block in the summary.

This keeps audit fields available without making the main PR body harder to read.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the PR body schema change that hides review metadata by default.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This only changes PR authoring validation, templates, skill text, and tests.

Slice Rationale: The skill guidance and validator need to land together so generated PR bodies stay accepted.

</details>

## Non-goals

- Do not change runtime app behavior.
- Do not change Mergify queue behavior.

## Test Plan

- [x] `node scripts/test-create-pr-stack-workflow.mjs && node scripts/test-pr-body-validator.mjs && node scripts/test-create-pr-visual-proof.mjs`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
