### PR TITLE
[Review Gate Mode](1) Restore merge mode selector

### DIFF
--- a/packages/app/e2e/pending-review-gate-target-repo.proof.spec.ts
+++ b/packages/app/e2e/pending-review-gate-target-repo.proof.spec.ts
@@ -48,3 +48,27 @@ test('pending review gate target repo row', async ({ page }) => {
 
   await captureScreenshot(page, 'pending-review-gate-target-repo');
 });
+
+test('pending review gate merge mode selector', async ({ page }) => {
+  await page.evaluate((yaml) => window.invoker.loadPlan(yaml), yamlStringify(REVIEW_GATE_PROOF_PLAN));
+  await page.locator('.react-flow__node[data-testid$="review-gate-proof-task"]').first().waitFor({ state: 'visible', timeout: 15000 });
+
+  const mergeGateTaskId = await page.evaluate(async () => {
+    const result = await window.invoker.getTasks();
+    const tasks = Array.isArray(result) ? result : result.tasks;
+    const mergeTask = tasks.find((task: { id: string }) => task.id.includes('__merge__'));
+    return mergeTask?.id ?? null;
+  });
+  expect(mergeGateTaskId).toBeTruthy();
+
+  const mergeGateNode = page.locator(`.react-flow__node[data-testid="${mergeGateTaskId}"], .react-flow__node[data-testid$="${mergeGateTaskId}"]`).first();
+  await expect(mergeGateNode).toBeVisible({ timeout: 15000 });
+  await mergeGateNode.click();
+
+  await expect(page.getByTestId('workflow-inspector-title')).toBeVisible();
+  await expect(page.getByText('Merge mode')).toBeVisible();
+  await expect(page.getByTestId('merge-mode-select')).toHaveValue('external_review');
+  await expect(page.getByRole('option', { name: 'External review (GitHub)' })).toBeAttached();
+
+  await captureScreenshot(page, 'pending-review-gate-merge-mode-selector');
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1610,6 +1610,19 @@ export function App() {
     [invoker, refreshTaskGraph],
   );
 
+  const handleSetMergeMode = useCallback(
+    async (workflowId: string, mergeMode: 'manual' | 'automatic' | 'external_review') => {
+      if (!invoker) return;
+      try {
+        await invoker.setMergeMode(workflowId, mergeMode);
+        refreshTaskGraph();
+      } catch (err) {
+        console.error('Failed to set merge mode:', err);
+      }
+    },
+    [invoker, refreshTaskGraph],
+  );
+
   // ── Modal triggers ────────────────────────────────────────
   const openInputModal = useCallback((task: TaskState) => {
     setModal({ type: 'input', task });
@@ -1954,6 +1967,7 @@ export function App() {
               onApprove={openApprovalModal}
               onReject={openRejectModal}
               onSetMergeBranch={handleSetMergeBranch}
+              onSetMergeMode={handleSetMergeMode}
               onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
               onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}
             />

--- a/packages/ui/src/__tests__/merge-gate-approval-flow.test.tsx
+++ b/packages/ui/src/__tests__/merge-gate-approval-flow.test.tsx
@@ -106,4 +106,51 @@ describe('Merge gate approval flow (integration)', () => {
     fireEvent.click(screen.getAllByRole('button', { name: 'Approve Fix' }).at(-1)!);
     await waitFor(() => expect(mock.api.approve).toHaveBeenCalledWith('fix-task'));
   });
+
+  it('changes merge mode from the selected merge gate inspector', async () => {
+    const completedTask = makeUITask({
+      id: 'merge-work',
+      description: 'Work before review',
+      status: 'completed',
+      workflowId: 'wf-merge',
+      command: 'echo ready',
+    });
+    const reviewGate = makeUITask({
+      id: '__merge__wf-merge',
+      description: 'Review gate for test plan',
+      status: 'review_ready',
+      workflowId: 'wf-merge',
+      isMergeNode: true,
+      dependencies: ['merge-work'],
+    });
+    const reviewWorkflow: WorkflowMeta = {
+      id: 'wf-merge',
+      name: 'Merge Workflow',
+      status: 'review_ready',
+      baseBranch: 'main',
+      onFinish: 'pull_request',
+      mergeMode: 'manual',
+    };
+
+    render(<App />);
+    act(() => mock.setTasks([completedTask, reviewGate], [reviewWorkflow]));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-merge')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-merge'));
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-__merge__wf-merge')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rf__node-__merge__wf-merge'));
+    await waitFor(() => {
+      expect(screen.getByTestId('merge-mode-select')).toHaveValue('manual');
+    });
+
+    fireEvent.change(screen.getByTestId('merge-mode-select'), { target: { value: 'external_review' } });
+    await waitFor(() => expect(mock.api.setMergeMode).toHaveBeenCalledWith('wf-merge', 'external_review'));
+    await waitFor(() => expect(mock.api.refreshTaskGraph).toHaveBeenCalled());
+  });
 });

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -105,6 +105,56 @@ describe('WorkflowInspector', () => {
     expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/34');
   });
 
+  it('shows and changes merge mode for a review-ready merge gate', () => {
+    const onSetMergeMode = vi.fn();
+
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready', mergeMode: 'manual' }}
+        task={makeTask({
+          id: '__merge__wf-1',
+          description: 'Review gate',
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onSetMergeMode={onSetMergeMode}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Merge mode')).toBeInTheDocument();
+    const select = screen.getByTestId('merge-mode-select');
+    expect(select).toHaveValue('manual');
+    expect(screen.getByRole('option', { name: 'External review (GitHub)' })).toBeInTheDocument();
+
+    fireEvent.change(select, { target: { value: 'external_review' } });
+    expect(onSetMergeMode).toHaveBeenCalledWith('wf-1', 'external_review');
+  });
+
+  it('disables merge mode while a merge gate is running', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'running', mergeMode: 'manual' }}
+        task={makeTask({
+          id: '__merge__wf-1',
+          description: 'Review gate',
+          status: 'running',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onSetMergeMode={() => Promise.resolve()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('merge-mode-select')).toBeDisabled();
+  });
+
   it('resolves the review-ready merge node PR URL for workflow-only selection when the workflow is review_ready', () => {
     const mergeTask = makeTask({
       id: '__merge__wf-1',

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -3,6 +3,8 @@ import type { TaskState, WorkflowMeta } from '../types.js';
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 
+type MergeMode = 'manual' | 'automatic' | 'external_review';
+
 interface WorkflowInspectorProps {
   workflow: WorkflowMeta | null;
   task: TaskState | null;
@@ -21,6 +23,7 @@ interface WorkflowInspectorProps {
   onApprove?: (task: TaskState) => void;
   onReject?: (task: TaskState) => void;
   onSetMergeBranch?: (workflowId: string, baseBranch: string) => Promise<void>;
+  onSetMergeMode?: (workflowId: string, mergeMode: MergeMode) => Promise<void>;
   onToggleCollapsed: () => void;
   onToggleAdvanced: () => void;
 }
@@ -31,6 +34,10 @@ function formatStatus(value: string | undefined): string {
 
 function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function mergeModeValue(value: string | undefined): MergeMode {
+  return value === 'automatic' || value === 'external_review' ? value : 'manual';
 }
 
 function getReviewReadyMergeNodeReviewUrl(
@@ -64,6 +71,7 @@ export function WorkflowInspector({
   onApprove,
   onReject,
   onSetMergeBranch,
+  onSetMergeMode,
   onToggleCollapsed,
   onToggleAdvanced,
 }: WorkflowInspectorProps): JSX.Element {
@@ -283,26 +291,44 @@ export function WorkflowInspector({
           </section>
         )}
 
-        {isMergeNode && onSetMergeBranch && (
+        {isMergeNode && (onSetMergeBranch || onSetMergeMode) && (
           <section className="rounded border border-gray-700 bg-gray-800/70 p-3 space-y-3">
-            <label className="flex items-center justify-between gap-3">
-              <span className="text-xs uppercase tracking-wide text-gray-400">Target Branch</span>
-              <input
-                data-testid="target-branch-input"
-                value={branchValue}
-                onChange={(event) => setBranchValue(event.target.value)}
-                onBlur={saveBranch}
-                onKeyDown={(event) => {
-                  if (event.key === 'Enter') {
-                    (event.target as HTMLInputElement).blur();
-                  }
-                  if (event.key === 'Escape') {
-                    setBranchValue(workflow?.baseBranch ?? '');
-                  }
-                }}
-                className="min-w-0 max-w-[190px] rounded border border-gray-600 bg-gray-700 px-2 py-1 text-right font-mono text-xs text-gray-100 focus:border-blue-500 focus:outline-none"
-              />
-            </label>
+            {onSetMergeBranch && (
+              <label className="flex items-center justify-between gap-3">
+                <span className="text-xs uppercase tracking-wide text-gray-400">Target Branch</span>
+                <input
+                  data-testid="target-branch-input"
+                  value={branchValue}
+                  onChange={(event) => setBranchValue(event.target.value)}
+                  onBlur={saveBranch}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter') {
+                      (event.target as HTMLInputElement).blur();
+                    }
+                    if (event.key === 'Escape') {
+                      setBranchValue(workflow?.baseBranch ?? '');
+                    }
+                  }}
+                  className="min-w-0 max-w-[190px] rounded border border-gray-600 bg-gray-700 px-2 py-1 text-right font-mono text-xs text-gray-100 focus:border-blue-500 focus:outline-none"
+                />
+              </label>
+            )}
+            {onSetMergeMode && workflow?.id && (
+              <label className="flex items-center justify-between gap-3">
+                <span className="text-xs uppercase tracking-wide text-gray-400">Merge mode</span>
+                <select
+                  value={mergeModeValue(workflow.mergeMode)}
+                  onChange={(event) => void onSetMergeMode(workflow.id, event.target.value as MergeMode)}
+                  disabled={isTaskBusy}
+                  className="min-w-0 max-w-[190px] rounded border border-gray-600 bg-gray-700 px-2 py-1 text-xs text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                  data-testid="merge-mode-select"
+                >
+                  <option value="manual">Manual</option>
+                  <option value="automatic">Automatic</option>
+                  <option value="external_review">External review (GitHub)</option>
+                </select>
+              </label>
+            )}
             {workflow?.repoUrl && (
               <div className="flex items-start justify-between gap-3">
                 <span className="text-xs uppercase tracking-wide text-gray-400">PR target repo</span>


### PR DESCRIPTION
## Summary

The review gate side panel now shows the missing merge mode picker again.

GitHub review state was hard to see from the active side panel. The picker lived only in the unused `TaskPanel`.

The fix exposes the existing `setMergeMode` action in `WorkflowInspector` and adds screenshot proof for both the picker and the GitHub URL.

## Review Claim

Review gates can be changed to External review (GitHub) from the active right side panel, and review-ready GitHub PR links are visible there.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only merge gate side panel UI changes. The existing backend merge mode mutation path and review URL rendering path are reused unchanged.

## Slice Rationale

This is one local activation-surface regression fix: restore the missing control, wire it, and prove the GitHub URL state in UI screenshots.

## Non-goals

This does not change merge mode backend behavior, review gate execution, or GitHub PR creation logic.

## Architecture

### Before

```mermaid
graph TD
    A[App] --> B[WorkflowInspector]
    C[TaskPanel unused] --> D[Merge mode select]
    B --> E[Target branch and PR URL only when already review ready]
```

### After

```mermaid
graph TD
    A[App] --> B[WorkflowInspector]
    B --> C[Merge mode select]
    C --> D[invoker.setMergeMode]
    D --> E[Existing merge mode mutation]
    B --> F[Existing review-ready PR URL]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui test --run src/__tests__/workflow-inspector.test.tsx src/__tests__/merge-gate-approval-flow.test.tsx`
- [x] `pnpm run check:types`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec pending-review-gate-target-repo.proof.spec.ts`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec visual-proof.spec.ts`

## Visual Proof

External review mode selected in the side panel:

![Review gate GitHub mode side panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-995e1e/pending-review-gate-merge-mode-selector.png)

Review-ready GitHub pull request URL visible in the same side panel:

![Review-ready GitHub URL in side panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-995e1e/review-ready-workflow-pr-sidebar.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 17ef9b396`
- Post-revert steps: None
- Data migration? No
