### PR TITLE
Stop generated verify plans from running package tests

### DIFF
--- a/skills/plan-to-invoker/scripts/generate-verify-plan.sh
+++ b/skills/plan-to-invoker/scripts/generate-verify-plan.sh
@@ -61,7 +61,7 @@ EOF
   done
 fi
 
-# Generate package test checks
+# Generate package existence checks without running package test suites.
 if command -v jq &>/dev/null; then
   pkgs=$(echo "$assumptions" | jq -r '.packages[]' 2>/dev/null || true)
 else
@@ -70,12 +70,11 @@ fi
 
 while IFS= read -r pkg; do
   [[ -z "$pkg" ]] && continue
-  # Only generate test task if packages/<pkg> directory exists reference
-  task_id="verify-tests-${pkg}"
+  task_id="verify-package-${pkg}"
   cat <<EOF
   - id: ${task_id}
-    description: "Verify tests pass for package: ${pkg}"
-    command: "cd packages/${pkg} && pnpm test"
+    description: "Verify package directory exists: ${pkg}"
+    command: "test -d packages/${pkg}"
     dependencies: []
 
 EOF

--- a/skills/plan-to-invoker/scripts/skill-doctor.sh
+++ b/skills/plan-to-invoker/scripts/skill-doctor.sh
@@ -339,7 +339,7 @@ fi
 MOCK_RESULTS=$(cat <<'MOCK_EOF'
 [verify-file-test] completed
 task "verify-pattern-foo" completed
-PASS verify-tests-pkg
+PASS verify-package-pkg
 MOCK_EOF
 )
 run_check \


### PR DESCRIPTION
## Summary

Generated verify plans stop running package tests for package assumptions.

They now check that the package directory exists. That keeps assumption checks fast and avoids broad pnpm work during planning.

Skill-doctor mock output now names the package check instead of a test run.

## Review Claim

Approve changing generated package-assumption verification from package tests to package existence checks.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The slice only changes the verify-plan generator and its doctor smoke fixture. It does not change submitted workflow execution.

## Slice Rationale

This follows the linter relaxation. It removes the generator path that still created pnpm test work.

## Non-goals

This does not change the written skill guidance or the linter rule from the previous slice.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh` at `696902a78`
- [x] `printf '%s\n' '{"files":[],"patterns":[],"packages":["core"]}' | bash skills/plan-to-invoker/scripts/generate-verify-plan.sh "Package Smoke"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 696902a78`
- Post-revert steps: None
- Data migration? No