### PR TITLE
Document focused plan-to-invoker verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to Invoker will be documented in this file.
 
+## Unreleased
+
+- Make `plan-to-invoker` use focused verification by default instead of mandatory `pnpm test` or `pnpm run test:all` gates.
+
 ## 0.0.4
 
 - Publish complete CLI and desktop release assets for npm launcher packages.

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -51,12 +51,12 @@ for installed in "$CODEX_INSTALLED" "$CLAUDE_INSTALLED"; do
   fi
 done
 
-# SKILL.md — runtime verification + Invoker headless as complementary lane
+# SKILL.md — focused runtime verification + Invoker headless as complementary lane
 must_contain "$SKILL_MD" "## Intended flow (do not skip steps)" "SKILL must document the full flow"
 must_contain "$SKILL_MD" "Runtime verification (Phase 1b)" "SKILL must require runtime behavioral verification"
 must_contain "$SKILL_MD" "Invoker headless" "SKILL must mention Invoker headless as a verification lane"
-must_contain "$SKILL_MD" "pnpm test" "SKILL must mention pnpm test for behavioral proof"
-must_contain "$SKILL_MD" "terminal stack workflows must end with" "SKILL must require the final full-suite regression gate for standalone plans and terminal stack workflows"
+must_contain "$SKILL_MD" "cheapest deterministic command" "SKILL must prefer focused behavioral proof"
+must_contain "$SKILL_MD" "Do not require a terminal" "SKILL must not require a final full-suite regression gate"
 must_contain "$SKILL_MD" "Grep-only checks" "SKILL must separate grep from behavioral verification"
 must_contain "$SKILL_MD" "see playbook" "SKILL Execution must reference the playbook"
 must_contain "$SKILL_MD" "Phase 1b" "SKILL must reference Phase 1b"
@@ -118,12 +118,12 @@ must_output_contain "$DOCTOR_HELP" "  1 = one or more checks failed" "skill-doct
 must_output_contain "$DOCTOR_HELP" "  2 = usage/argument error" "skill-doctor --help must expose usage-error exit code"
 must_output_contain "$DOCTOR_HELP" "Output: JSON summary of all checks with pass/fail status" "skill-doctor --help must expose JSON output contract"
 
-# Playbook — Phase 1a / 1b (three lanes) and anti-patterns
+# Playbook — Phase 1a / 1b focused lanes and anti-patterns
 must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must define Phase 1a"
 must_contain "$PLAYBOOK" "### Phase 1b — Runtime verification" "Playbook must define runtime behavioral verification"
 must_contain "$PLAYBOOK" "Phase 1b-invoker" "Playbook must define Invoker headless verification lane"
-must_contain "$PLAYBOOK" "pnpm test" "Playbook must document pnpm test for behavioral verification"
-must_contain "$PLAYBOOK" "pnpm run test:all" "Playbook must document the final full-suite regression gate"
+must_contain "$PLAYBOOK" "Avoid mandatory" "Playbook must reject mandatory pnpm test gates"
+must_contain "$PLAYBOOK" "Do **not** add a mandatory terminal" "Playbook must reject mandatory final full-suite gates"
 must_contain "$PLAYBOOK" "Invoker is mandatory" "Playbook must warn when Invoker verification is mandatory"
 must_contain "$PLAYBOOK" "coverageItems" "Playbook must document row-level coverage for policy-matrix sources"
 must_contain "$PLAYBOOK" "assume no prior context" "Playbook must require zero-context prompt framing for implementation tasks"

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -57,7 +57,7 @@ For implementation benchmark plans, switch `onFinish` and `mergeMode` only when 
 
 1. Discuss scope/risk with the user.
 2. Phase 1a static analysis.
-3. Runtime verification (Phase 1b): run targeted `pnpm test`, plus Invoker headless when applicable.
+3. Runtime verification (Phase 1b): run the cheapest deterministic command that exercises the behavior, plus Invoker headless when applicable.
 4. Generate implementation YAML from verified facts.
 5. Validate with deterministic scripts.
 6. Present plan and submit on confirmation.
@@ -137,7 +137,7 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
    `bash skills/plan-to-invoker/scripts/validate-plan.sh <plan-file>`
 4. `step-lint-atomicity`
    `bash skills/plan-to-invoker/scripts/lint-task-atomicity.sh <plan-file>`  
-  Optional: append `--warn-delegation` to print additional advisory hints. For authored stacks, append `--stack-manifest <file>` so non-terminal workflows may end with focused verification while the highest-order workflow still requires `pnpm run test:all`. Atomicity lint always runs `--strict-delegation` inside `skill-doctor` and, for implementation plans (`onFinish != none`), hard-fails missing/invalid `Layer:` and `Feature state:` metadata, missing required review-compression/rationale headings in `description` on any task (`Review claim`, `Review lane`, `Safety invariant`, `Slice rationale`, `Architectural effect`, `Goal`, `Motivation`, `Alternative considerations`/`Alternatives`, `Implementation details`/`Implementation`), missing required rationale headings in `prompt` for prompt tasks, prompt tasks without `Files:`/`Change types:`/`Acceptance criteria:` description blocks, prompts missing zero-context execution framing, prompts missing deterministic pass/fail expectations, invalid cross-layer dependency direction without `Layer exception: allowed`, missing one-conceptual-unit enforcement, and missing experiment-artifact handoff/cleanup contract when experiment tasks are present.
+  Optional: append `--warn-delegation` to print additional advisory hints. For authored stacks, append `--stack-manifest <file>` so stack slices are validated with stack context. Atomicity lint always runs `--strict-delegation` inside `skill-doctor` and, for implementation plans (`onFinish != none`), hard-fails missing/invalid `Layer:` and `Feature state:` metadata, missing required review-compression/rationale headings in `description` on any task (`Review claim`, `Review lane`, `Safety invariant`, `Slice rationale`, `Architectural effect`, `Goal`, `Motivation`, `Alternative considerations`/`Alternatives`, `Implementation details`/`Implementation`), missing required rationale headings directly in prompt text, and cross-layer dependency-direction violations.
 5. `step-parse-verify-results`
    `bash skills/plan-to-invoker/scripts/parse-results.sh < /tmp/invoker-verify.txt`
 
@@ -170,12 +170,12 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
 
 ## Runtime verification (Phase 1b)
 
-- Unit/package lane: `cd packages/<pkg> && pnpm test`
+- Focused command lane: run the smallest deterministic command that proves the behavior or assumption. Prefer direct scripts, parser checks, focused builds, or repo-specific repro commands over package-wide test suites.
 - Invoker headless lane: run `./submit-plan.sh plans/verify-<slug>.yaml` when flow involves orchestrator/executor/persistence/headless behavior
 - Visual proof lane when UI changes apply
-- Implementation-plan full-suite gate: standalone implementation plans and terminal stack workflows must end with `pnpm run test:all` from the repo root and depend on every earlier task. Non-terminal stack workflows should end with focused verification; validate them with `skill-doctor --stack-manifest <file>` so the stack position is explicit.
+- Implementation-plan verification: include focused proof tasks that exercise the changed behavior. Do not require a terminal `pnpm run test:all` gate unless the user explicitly asks for a full-suite gate or the risk calls for it.
 
-When Invoker config enables heavyweight command routing, keep `pnpm ...` commands in the plan as normal command tasks unless a specific remote target must be declared explicitly. Runtime config may auto-route those commands to SSH.
+When Invoker config enables heavyweight command routing, keep commands in the plan as normal command tasks unless a specific remote target must be declared explicitly. Runtime config may auto-route those commands to SSH.
 
 Authoring YAML is not verification; execution is verification.
 

--- a/skills/plan-to-invoker/fixtures/README.md
+++ b/skills/plan-to-invoker/fixtures/README.md
@@ -31,13 +31,13 @@ fixtures/
 Positive fixtures demonstrate valid plan patterns:
 
 - **01-minimal-verification.yaml** - Verification-only plan with `onFinish: none`
-- **02-feature-implementation.yaml** - Standard implement → test → verify pattern
+- **02-feature-implementation.yaml** - Standard implement → focused proof → verify pattern
 - **03-multi-step-refactor-worktrees.yaml** - Multi-step refactor using worktrees
 - **04-large-refactor-pull-request.yaml** - Complex plan with diamond dependencies and `onFinish: pull_request`
-- **05-ui-change-with-visual-proof.yaml** - UI workflow that pairs visual proof with a final full-suite regression gate
-- **06-invoker-dogfood-mergify-stack.yaml** - Invoker-on-Invoker PR publication example with a final full-suite regression gate
+- **05-ui-change-with-visual-proof.yaml** - UI workflow that pairs visual proof with focused verification
+- **06-invoker-dogfood-mergify-stack.yaml** - Invoker-on-Invoker PR publication example with focused skill verification
 - **07-prompt-edit-layered-split-with-dormant.yaml** - Dependency-first layer split for prompt-edit bridge work, including a dormant activation slice
-- Standalone implementation fixtures with `onFinish != none` end with a final `pnpm run test:all` task. In authored stacks, only the terminal workflow requires that full-suite gate; non-terminal workflows must be validated with a stack manifest.
+- Implementation fixtures use focused verification by default. Full-suite gates are optional and risk-based, not a validator requirement.
 
 All positive fixtures are extracted from `references/examples.md` sections 1-4.
 
@@ -47,15 +47,14 @@ Negative fixtures demonstrate anti-patterns and validation errors:
 
 ### Anti-Patterns (from examples.md Section 5)
 
-- **anti-pattern-a-npx-vitest.yaml** - Using `npx vitest run` instead of `pnpm test` (banned_pattern)
-- **anti-pattern-b-tests-from-root.yaml** - Running tests from repo root instead of cd-ing into package
+- **anti-pattern-a-npx-vitest.yaml** - Using `npx vitest run` instead of a repo-supported script or explicit package-local command (banned_pattern)
+- **anti-pattern-b-tests-from-root.yaml** - Running package-scoped tests from repo root instead of the package directory
 - **anti-pattern-c-both-command-and-prompt.yaml** - Task with both command and prompt (command_prompt_exclusive)
 - **anti-pattern-d-missing-dependencies.yaml** - Task missing dependencies field (missing_required_field)
 - **anti-pattern-e-no-verification.yaml** - Implementation without verification (policy violation)
 - **anti-pattern-f-dangerous-commands.yaml** - Dangerous commands (rm -rf, force push, etc.)
 - **anti-pattern-g-monolithic-prompt-edit-bridge.yaml** - Monolithic `wf-1777929074509-8`-shaped workflow missing required layer/state decomposition metadata (**fails `skill-doctor` lint, not YAML schema**)
 - **anti-pattern-h-layer-order-violation.yaml** - Lower architectural layer depends on a higher layer without `Layer exception: allowed` (**fails `skill-doctor` lint, not YAML schema**)
-- **anti-pattern-i-final-regression-not-test-all.yaml** - Standalone implementation workflow missing the terminal `pnpm run test:all` regression gate (**fails `skill-doctor` lint, not YAML schema**)
 - **anti-pattern-j-zero-context-missing-metadata.yaml** - Prompt task omits strict zero-context handoff metadata (**fails `skill-doctor` lint, not YAML schema**)
 - **anti-pattern-k-missing-review-compression.yaml** - Implementation task omits review-compression metadata (**fails `skill-doctor` lint, not YAML schema**)
 - **anti-pattern-n-broad-autofix-policy-review-unit.yaml** - #1574-shaped auto-fix policy task combines scan, validation, duplicate suppression, and submit work (**fails `skill-doctor` review-unit lint**)

--- a/skills/plan-to-invoker/fixtures/negative/anti-pattern-a-npx-vitest.yaml
+++ b/skills/plan-to-invoker/fixtures/negative/anti-pattern-a-npx-vitest.yaml
@@ -4,7 +4,7 @@
 #
 # WRONG: npx vitest run may not resolve correctly in worktrees
 # Running `npx vitest run` may fail in worktrees where `node_modules/.bin` isn't in PATH.
-# Always use `pnpm test`, which resolves vitest through the package.json `test` script reliably.
+# Use repo-supported scripts or explicit package-local commands instead.
 
 name: "Anti-pattern: npx vitest run"
 repoUrl: git@github.com:example-org/acme-repo.git

--- a/skills/plan-to-invoker/playbooks/verify-then-build.md
+++ b/skills/plan-to-invoker/playbooks/verify-then-build.md
@@ -66,17 +66,17 @@ bash skills/plan-to-invoker/scripts/skill-doctor.sh \
 
 For policy-matrix inputs, `skill-doctor` now fails if the coverage map or stack manifest is missing.
 
-### Phase 1b — Runtime verification (three lanes)
+### Phase 1b — Runtime verification (focused lanes)
 
-**Required** when the investigation claims something about **executed** behavior (not just “this string appears in a file”). **Phase 1b has three parts; use all that apply.**
+**Required** when the investigation claims something about **executed** behavior (not just “this string appears in a file”). Use the smallest lane that proves the claim.
 
-#### Phase 1b-unit — Package tests (agent shell)
+#### Phase 1b-command — Focused command (agent shell)
 
-- Run **`cd packages/<pkg> && pnpm test`**, optionally scoped to a test file that encodes the hypothesis.
-- **Alternative:** `node scripts/verify-<slug>.mjs` (or `tsx`) that imports production modules and asserts output — must follow repo environment rules.
+- Run the cheapest deterministic command that exercises the behavior. Prefer direct parser checks, focused builds, repo-specific repro scripts, or tiny `node`/`tsx` assertions over package-wide test suites.
+- Avoid mandatory `pnpm test` gates during planning. They are allowed only when they are the smallest real proof for the claim.
 - **Record** pass/fail and what each result proves.
 
-**When:** Always appropriate for logic that can be expressed in Vitest (components, pure functions, parsers).
+**When:** Logic or config behavior can be proven without submitting an Invoker workflow.
 
 #### Phase 1b-invoker — Headless Invoker (`submit-plan.sh`)
 
@@ -87,7 +87,7 @@ For policy-matrix inputs, `skill-doctor` now fails if the coverage map or stack 
 
 **When Invoker is mandatory (not optional):** The assumption or bug involves **any of**: `loadPlan` / plan defaults, **Orchestrator** mutations, **TaskRunner** + **Executor** selection, **SQLite** task rows, **headless** commands (`--headless edit-type`, etc.), **Electron** main process, or **integration** across app + persistence + executor. If in doubt, run Phase 1b-invoker.
 
-**Note:** `./submit-plan.sh` output includes executor/git noise; that is normal. For **renderer-only** UI bugs, Vitest (1b-unit) may suffice **without** Invoker — but if the reported bug reproduces **only** through IPC or persisted state, use 1b-invoker.
+**Note:** `./submit-plan.sh` output includes executor/git noise; that is normal. For **renderer-only** UI bugs, a focused command may suffice **without** Invoker — but if the reported bug reproduces **only** through IPC or persisted state, use 1b-invoker.
 
 #### Phase 1b-visual — Visual proof baseline (capture script)
 
@@ -99,7 +99,7 @@ For policy-matrix inputs, `skill-doctor` now fails if the coverage map or stack 
 
 #### Combine Phase 1a + 1b in YAML
 
-Submit **one** verification plan YAML that includes **static** tasks (Phase 1a) **and** **runtime** tasks: at least `pnpm test` **and/or** commands that only run when the verify plan is **submitted** via `submit-plan.sh` (e.g. SQLite assertions after a minimal task). **Anti-pattern:** verify plan with **only** `rg`/`test -f` and **no** `pnpm test` and **no** path that exercises Invoker when Phase 1b-invoker applies.
+Submit **one** verification plan YAML that includes **static** tasks (Phase 1a) **and**, when behavior is claimed, focused runtime tasks or commands that only run when the verify plan is **submitted** via `submit-plan.sh` (e.g. SQLite assertions after a minimal task). **Anti-pattern:** verify plan with **only** `rg`/`test -f` when Phase 1b-invoker applies.
 
 #### Validate YAML shape (not behavior)
 
@@ -156,22 +156,20 @@ For prompt tasks in implementation plans, write instructions as if the remote ex
 For each failed verification:
 
 - Missing file → add a task to create it before tasks that reference it
-- Failed test → add a task to fix the test or adjust the implementation approach
+- Failed verification → add a task to fix the behavior or adjust the implementation approach
 - Missing function/symbol → adjust prompts to create rather than modify
 
-### Final verification task (required)
+### Final verification task (focused by default)
 
-The implementation plan **must** end with a final **`command`** task that runs:
+The implementation plan should end with the smallest command task that proves the changed behavior, or with Invoker headless / visual proof when those lanes apply.
 
-- `pnpm run test:all`
+Do **not** add a mandatory terminal `pnpm run test:all` task by default. Use a full-suite gate only when the user asks for it or when the change risk makes it the smallest honest proof.
 
-Use earlier tasks to re-run the focused repro from Phase 1b (`cd packages/<pkg> && pnpm test -- <repro>`, `./submit-plan.sh plans/verify-<slug>.yaml`, or both). The terminal gate for standalone implementation plans and terminal stack workflows is the full repo suite; non-terminal stack workflows use focused verification.
+**Dependencies:** A terminal verification task should depend on every task whose output it verifies.
 
-**Dependencies:** When present, the final `pnpm run test:all` task **must depend on every earlier task** so it runs last as the terminal regression gate.
+**Naming:** `verify-<behavior>`, `regression-<bug>`, `capture-visual-proof`, etc.
 
-**Naming:** `final-regression`, `regression-test-all`, `final-test-suite`, etc.
-
-**Anti-pattern:** Standalone implementation plan or terminal stack workflow with **no** final `pnpm run test:all` task — you cannot show the submitted workflow or stack passed the full suite end-to-end.
+**Anti-pattern:** Expensive full-suite gates that do not prove anything more specific than the focused command already proves.
 
 ### Visual proof capture task (when `visualProof: true`)
 
@@ -195,8 +193,8 @@ Generate the implementation plan, validate with `scripts/validate-plan.sh`, pres
 - **Skipping verification for plans that reference 3+ specific files** — these are exactly the plans most likely to have stale assumptions.
 - **Static-only verification for behavioral claims** — `rg`/`test -f` prove presence of text, not runtime behavior.
 - **Treating `validate-plan.sh` as proof** — it only validates YAML structure.
-- **Stopping at `pnpm test` when Phase 1b-invoker is mandatory** — Invoker path unverified.
+- **Skipping Invoker when Phase 1b-invoker is mandatory** — Invoker path unverified.
 - **Not cleaning up verification workflow** — Invoker may still have the verify plan running. Use `delete-all` before submitting implementation when needed.
 - **Trusting file paths from a plan without checking** — plans can reference moved, renamed, or deleted files. Verify first.
 - **Proceeding after verification failures without adjusting** — the whole point of Phase 1 is to inform Phase 2.
-- **Standalone plan or terminal stack workflow without a final `pnpm run test:all` task** — cannot confirm the submitted workflow or stack passed the full suite.
+- **Defaulting to a full-suite gate** — it slows planning and often proves less than a focused command tied to the changed behavior.

--- a/skills/plan-to-invoker/references/examples.md
+++ b/skills/plan-to-invoker/references/examples.md
@@ -16,11 +16,11 @@ Verification-only plan with command tasks. Uses `onFinish: none` (nothing to mer
 
 ## 2. Feature Implementation
 
-Standard pattern: **implement → test → verify**. Uses `onFinish: merge` to auto-merge after completion.
+Standard pattern: **implement → focused proof → verify**. Uses `onFinish: merge` to auto-merge after completion.
 
 **See**: `fixtures/positive/02-feature-implementation.yaml`
 
-**Pattern**: Every prompt task MUST have a corresponding command task to verify. Standalone implementation plans and terminal stack workflows end with a final `pnpm run test:all` gate; non-terminal stack workflows end with focused verification.
+**Pattern**: Every prompt task MUST have a corresponding command task to verify the changed behavior. Use focused proof by default; do not add a full-suite gate unless it is the smallest honest proof.
 
 ---
 
@@ -47,15 +47,14 @@ Complex plan with diamond dependencies. Uses `onFinish: pull_request` for manual
 ## 5. Common Anti-Patterns
 
 **See negative fixtures** for invalid plans caught by validation:
-- `fixtures/negative/anti-pattern-a-npx-vitest.yaml` — Use `pnpm test` not `npx vitest run`
-- `fixtures/negative/anti-pattern-b-tests-from-root.yaml` — cd into package before running tests
+- `fixtures/negative/anti-pattern-a-npx-vitest.yaml` — Avoid `npx vitest run`; use repo-supported scripts or explicit package-local commands
+- `fixtures/negative/anti-pattern-b-tests-from-root.yaml` — Do not run package-scoped tests from the repo root
 - `fixtures/negative/anti-pattern-c-both-command-and-prompt.yaml` — Task must have command OR prompt, not both
 - `fixtures/negative/anti-pattern-d-missing-dependencies.yaml` — Dependencies field is required
 - `fixtures/negative/anti-pattern-e-no-verification.yaml` — Implementation tasks need verification
 - `fixtures/negative/anti-pattern-f-dangerous-commands.yaml` — Avoid destructive commands (`rm -rf`, force push)
 - `fixtures/negative/anti-pattern-g-monolithic-prompt-edit-bridge.yaml` — Monolithic `wf-1777929074509-8`-style workflow missing dependency-first layered decomposition metadata
 - `fixtures/negative/anti-pattern-h-layer-order-violation.yaml` — Lower layer depends on higher layer without `Layer exception: allowed`
-- `fixtures/negative/anti-pattern-i-final-regression-not-test-all.yaml` — Standalone implementation plan ends without a terminal `pnpm run test:all` gate
 - `fixtures/negative/anti-pattern-j-zero-context-missing-metadata.yaml` — Prompt task omits strict zero-context handoff metadata required for implementation plans
 - `fixtures/negative/anti-pattern-k-missing-review-compression.yaml` — Implementation task omits review claim, safety invariant, slice rationale, and architectural effect metadata
 
@@ -71,7 +70,7 @@ All anti-patterns are validated by `scripts/test-fixtures.sh` with deterministic
 description: |
   Implement foo. Files: packages/foo/src/bar.ts (may add tests). Change types:
   - packages/foo/src/bar.ts — modify
-  Acceptance criteria: cd packages/foo && pnpm test exits 0.
+  Acceptance criteria: focused verification command exits 0.
 ```
 
 `Files:`, `Change types:`, and `Acceptance criteria:` are strict gates for implementation-plan prompt tasks under `skill-doctor`. Verify-only plans (`onFinish: none`) keep these headings advisory.
@@ -135,7 +134,7 @@ Use this pattern when a change is too large for a single reviewable workflow. Fo
 
 **Positive patterns**:
 - Verification-only → `onFinish: none`, command tasks
-- Feature implementation → implement → test → verify, `onFinish: merge`
+- Feature implementation → implement → focused proof → verify, `onFinish: merge`
 - Multi-step refactors → omit routing fields for default worktree execution, chained dependencies
 - Large refactors → `onFinish: pull_request`, diamond DAGs
 - Invoker-on-Invoker PR publication → keep `mergeMode: github`, then use `mergify stack push` as the repo-specific publication step
@@ -143,9 +142,9 @@ Use this pattern when a change is too large for a single reviewable workflow. Fo
 - Dependency-first layered decomposition → enforce `Layer:` + `Feature state:` metadata, preserve dependency direction, allow explicit dormant tasks
 
 **Validation enforces**:
-- Every prompt task must have verification command task
-- Standalone implementation plans and terminal stack workflows must end with `pnpm run test:all` as the final regression gate
-- Use `pnpm test`, never `npx vitest run`
+- Every prompt task must have a verification command task or proof lane
+- Focused proof is the default; full-suite gates are optional and risk-based
+- Avoid `npx vitest run`; use repo-supported scripts or explicit package-local commands
 - Dependencies field required (even if empty)
 - No dangerous commands without manual approval
 - For implementation plans: `Layer:` + `Feature state:` headings, allowed values, and layer-consistent dependency direction

--- a/skills/plan-to-invoker/references/schema.md
+++ b/skills/plan-to-invoker/references/schema.md
@@ -51,14 +51,14 @@ Source of truth: `packages/app/src/plan-parser.ts` (interfaces + validation, lin
 
 ## Implementation plans (convention)
 
-`plan-parser.ts` does not require a special field for this, but **standalone implementation** YAML (not one-off verify-only plans) must reserve the **last** task for the terminal regression gate: a `command` task that runs `pnpm run test:all`. In authored stacks, reserve that full-suite task for the highest-order workflow in the stack manifest; non-terminal stack workflows should end with focused package/headless repro verification. When a final `pnpm run test:all` task is present, it must depend on every earlier task so it runs last. See `references/task-patterns.md` and `playbooks/verify-then-build.md` Phase 2.
+`plan-parser.ts` does not require a special field for implementation verification. Implementation YAML should include command tasks that prove changed behavior with the smallest deterministic command. A full-suite gate such as `pnpm run test:all` is optional, not required; when present, it should depend on every task whose output it verifies. See `references/task-patterns.md` and `playbooks/verify-then-build.md` Phase 2.
 
 ## Banned Patterns
 
 These will cause validation failures:
 
-- **`npx vitest run`** — parser rejects it (ABI mismatch). Use `cd packages/<pkg> && pnpm test`.
-- **`pnpm test <path>` from repo root** — runs `pnpm -r test` across all packages. Always `cd` into the package first.
+- **`npx vitest run`** — parser rejects it (ABI mismatch). Use a repo-supported script or explicit package-local command.
+- **`pnpm test <path>` from repo root** — runs `pnpm -r test` across all packages. If you choose package tests, run them from that package directory.
 - **Invented test filenames** — verify they exist before referencing them in commands.
 - **`command` + `prompt` on same task** — pick one. Shell logic → `command`. Reasoning → `prompt`.
 - **`runnerKind`** — obsolete routing field. Omit it for default worktree execution, use `poolId` for configured pools, or use `dockerImage` for Docker tasks.

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -6,9 +6,9 @@ Source of truth: `packages/surfaces/src/slack/plan-conversation.ts:100-116`
 
 | What you see in the plan | Task type | Template |
 |--------------------------|-----------|----------|
-| "Run tests" / "verify" / "check" | `command` | `cd packages/<pkg> && pnpm test` |
-| "Run specific test file" | `command` | `cd packages/<pkg> && pnpm test -- src/__tests__/file.test.ts` |
-| "Run final regression suite" | `command` | `pnpm run test:all` |
+| "Run tests" / "verify" / "check" | `command` | Smallest deterministic command that proves the behavior |
+| "Run specific test file" | `command` | Package-local command only when that test is the smallest proof |
+| "Run final regression suite" | `command` | Optional full-suite command only when explicitly requested or risk-justified |
 | "Refactor X" / "Add feature Y" | `prompt` | Detailed instructions with file paths, line numbers, acceptance criteria |
 | "Build/compile" | `command` | `pnpm --filter @invoker/<pkg> build` |
 | "Build all" / "verify compilation" | `command` | `pnpm build` |
@@ -17,7 +17,7 @@ Source of truth: `packages/surfaces/src/slack/plan-conversation.ts:100-116`
 | "Lint / type-check" | `command` | `pnpm --filter @invoker/<pkg> lint` or `pnpm --filter @invoker/<pkg> typecheck` |
 | "Check file exists" | `command` | `test -f <path>` |
 | "Check pattern in file" | `command` | `grep -q '<pattern>' <path>` |
-| **Post-fix / regression** (standalone or terminal stack gate) | `command` | `pnpm run test:all` — keep focused repro commands earlier in the plan, and reserve the full-suite gate for standalone plans or the terminal stack workflow |
+| **Post-fix / regression** | `command` | Focused repro or proof command tied to the changed behavior; full-suite gates are optional |
 | "Modify UI component" / "Fix layout" / "Change Electron window UI" | `prompt` + `visualProof: true` | Set `visualProof: true` at plan level; include `description` |
 | **Add visual proof E2E test case** | `prompt` | Add a test to `packages/app/e2e/visual-proof.spec.ts` that sets up the exact UI state being changed and calls `captureScreenshot(page, '<plan-slug>-<state>')`. See `skills/visual-proof/SKILL.md`. |
 | **Capture visual proof (after)** | `command` | `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after` — depends on **all** implementation tasks |
@@ -48,16 +48,16 @@ not split.
 
 ### Must be sequential (add dependency)
 - **Same file modified by two tasks** → one depends on the other. Order by logical sequence.
-- **Test task** → depends on the implementation task it verifies.
+- **Verification task** → depends on the implementation task it verifies.
 - **Build/compile check** → depends on all implementation tasks that change source.
-- **Integration test** → depends on all unit-level tasks it integrates.
-- **Final full-suite regression task** → for standalone plans and terminal stack workflows, depends on **every earlier task** and runs **last** as `pnpm run test:all`; non-terminal stack workflows end with focused verification instead.
+- **Integration check** → depends on all lower-level tasks it integrates.
+- **Terminal verification task** → depends on every task whose output it verifies; use the smallest honest command by default.
 - **Visual proof capture task** → depends on **all** implementation tasks and the E2E test case task (it must run after code changes AND the new Playwright test exist).
 
 ### Can be parallel (no dependency needed)
 - **Independent packages** → tasks touching different packages with no cross-package imports.
 - **Independent files** → tasks creating/modifying unrelated files.
-- **All verification tasks** → file-existence and grep checks are read-only, run them all in parallel — **except** the final regression task, which must depend on every earlier task (see above).
+- **Independent verification tasks** → file-existence and grep checks are read-only; run them in parallel when they do not verify a prior implementation task.
 
 ## Layered decomposition contract (hard requirement for implementation plans)
 
@@ -227,7 +227,7 @@ See `SKILL.md` (bugfix repro blurb) and this repo’s `scripts/repro-*.sh` examp
 
 When writing `command` fields:
 
-1. **Package tests must `cd` first**: `cd packages/<pkg> && pnpm test`; reserve root-level `pnpm run test:all` for standalone plans or the final workflow in an authored stack.
+1. **Use focused proof by default**: choose the smallest deterministic command that proves the behavior; package tests and full-suite gates are optional, not required.
 2. **Use `&&` for sequential steps**: ensures early failure stops execution
 3. **Exit codes matter**: the command succeeds (exit 0) or fails (non-zero). Design accordingly.
 4. **No interactive commands**: everything must run non-interactively
@@ -268,25 +268,17 @@ tasks:
     description: "Fix modal CSS"
     prompt: "..."
     dependencies: []
-  - id: run-unit-tests
-    description: "Run UI unit tests"
-    command: "cd packages/ui && pnpm test"
-    dependencies: [fix-layout]
   - id: capture-visual-proof
     description: "Build and capture after-state screenshots"
     command: "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after"
     dependencies: [fix-layout, add-visual-proof-test]
-  - id: regression
-    description: "Final regression — run the full repository test suite"
-    command: "pnpm run test:all"
-    dependencies: [add-visual-proof-test, fix-layout, run-unit-tests, capture-visual-proof]
 ```
 
 ## Anti-Patterns
 
 - **God task**: one `prompt` task that says "implement the whole feature" — split it up.
-- **Test-free plan**: every implementation task needs a corresponding verification. No exceptions.
-- **No final full-suite task**: standalone implementation plans and terminal stack workflows must end with a **command** task that runs `pnpm run test:all`. Non-terminal stack workflows must be validated with a stack manifest and focused verification.
+- **Test-free plan**: every implementation task needs a corresponding verification command or proof lane. No exceptions.
+- **Default full-suite gate**: do not add one unless the user asks or it is risk-justified; prefer focused proof tied to the changed behavior.
 - **Circular dependencies**: task A depends on B, B depends on A — validator catches this but don't generate it.
 - **Phantom files**: referencing files that don't exist without a task to create them first.
 - **UI plan without visual proof tasks**: `visualProof: true` without the E2E test case task and capture task means no plan-specific screenshots are captured.

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -390,7 +390,7 @@ function validatePlan(yamlContent) {
         errorType: 'banned_pattern',
         field: 'command',
         taskId,
-        message: `Task "${taskId}" uses 'npx vitest run' which may not resolve correctly. Use 'pnpm test' instead.`,
+        message: `Task "${taskId}" uses 'npx vitest run' which may not resolve correctly. Use a repo-supported script or explicit package-local command instead.`,
         value: task.command,
       });
     }

--- a/skills/plan-to-invoker/scripts/validate-plan.ts
+++ b/skills/plan-to-invoker/scripts/validate-plan.ts
@@ -383,7 +383,7 @@ function validatePlan(yamlContent: string): ValidationError[] {
         errorType: 'banned_pattern',
         field: 'command',
         taskId,
-        message: `Task "${taskId}" uses 'npx vitest run' which may not resolve correctly. Use 'pnpm test' instead.`,
+        message: `Task "${taskId}" uses 'npx vitest run' which may not resolve correctly. Use a repo-supported script or explicit package-local command instead.`,
         value: task.command,
       });
     }


### PR DESCRIPTION
## Summary

Plan-to-invoker guidance now says to use focused proof by default.

The docs keep heavier proof lanes when they fit the work. Full-suite gates stay optional for user requests or real risk.

The skill documentation check now looks for the new wording.

## Review Claim

Approve the written plan-to-invoker guidance for focused verification.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

The slice changes documentation, fixture descriptions, validator wording, and the related documentation check. Runtime behavior came in earlier stack entries.

## Slice Rationale

This lands after earlier slices so the guidance matches the tool behavior it describes.

## Non-goals

This does not change the linter relaxation or generated verify-plan behavior from earlier slices.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh` at `ac77d53d3`
- [x] `printf '%s\n' '{"files":[],"patterns":[],"packages":["core"]}' | bash skills/plan-to-invoker/scripts/generate-verify-plan.sh "Package Smoke"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert ac77d53d3`
- Post-revert steps: None
- Data migration? No