### PR TITLE
[Workflow Status](2) Publish live workflow rollups from the owner

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -222,7 +222,7 @@ const SSH_TERMINAL_RESUME_PLAN = {
 };
 
 function workflowNode(page: Page, workflowId: string) {
-  return page.getByTestId(`workflow-node-${workflowId}`);
+  return page.getByTestId(`rf__node-${workflowId}`).first();
 }
 
 function taskNodeCard(page: Page, taskIdSuffix: string) {
@@ -354,17 +354,31 @@ async function openContextMenu(page: Page, locator: Locator) {
 
 async function selectWorkflowNode(page: Page, workflowId: string): Promise<void> {
   const node = workflowNode(page, workflowId);
-  await node.waitFor({ state: 'attached', timeout: 15000 });
-  await node.scrollIntoViewIfNeeded();
-  try {
-    await node.click({ force: true });
-  } catch {
-    await node.dispatchEvent('click', { bubbles: true });
-  }
   const miniDag = page.getByTestId('selected-workflow-mini-dag');
-  if (!(await miniDag.isVisible({ timeout: 1500 }).catch(() => false))) {
-    await node.dispatchEvent('click', { bubbles: true });
+
+  if (await miniDag.isVisible({ timeout: 500 }).catch(() => false)) {
+    await page.getByTestId('workflow-graph-react-flow').click({ position: { x: 8, y: 8 } });
+    await expect(miniDag).not.toBeVisible({ timeout: 5000 });
   }
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await node.waitFor({ state: 'attached', timeout: 15000 });
+    await node.scrollIntoViewIfNeeded();
+    try {
+      await node.click({ force: true });
+    } catch {
+      await node.dispatchEvent('click', { bubbles: true });
+    }
+    if (!(await miniDag.isVisible({ timeout: 1500 }).catch(() => false))) {
+      await node.dispatchEvent('click', { bubbles: true });
+    }
+    if (await miniDag.isVisible({ timeout: 1500 }).catch(() => false)) {
+      return;
+    }
+    await page.getByRole('button', { name: 'Refresh' }).click();
+    await page.waitForTimeout(300);
+  }
+
   await expect(miniDag).toBeVisible({ timeout: 10000 });
 }
 
@@ -374,14 +388,17 @@ async function loadPlanAndSelectWorkflow(page: Page, plan: unknown): Promise<str
     return workflows.map((workflow: { id: string }) => workflow.id);
   });
   await page.evaluate((yaml) => window.invoker.loadPlan(yaml), yamlStringify(plan));
-  const workflowId = await page.evaluate(async (knownIds) => {
+  const workflow = await page.evaluate(async (knownIds) => {
     const workflows = await window.invoker.listWorkflows();
-    const created = workflows.find((workflow: { id: string }) => !knownIds.includes(workflow.id));
-    return created?.id ?? workflows[workflows.length - 1]?.id ?? null;
+    return workflows.find((candidate: { id: string }) => !knownIds.includes(candidate.id))
+      ?? workflows[workflows.length - 1]
+      ?? null;
   }, beforeIds);
-  expect(workflowId).toBeTruthy();
-  await selectWorkflowNode(page, workflowId!);
-  return workflowId!;
+  expect(workflow?.id).toBeTruthy();
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await page.waitForTimeout(300);
+  await selectWorkflowNode(page, workflow!.id);
+  return workflow!.id;
 }
 async function seedActiveLaunchAttempt(dbPath: string, taskId: string, attemptId: string, now: Date): Promise<void> {
   const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -352,6 +352,22 @@ async function openContextMenu(page: Page, locator: Locator) {
   return menu;
 }
 
+async function selectWorkflowNode(page: Page, workflowId: string): Promise<void> {
+  const node = workflowNode(page, workflowId);
+  await node.waitFor({ state: 'attached', timeout: 15000 });
+  await node.scrollIntoViewIfNeeded();
+  try {
+    await node.click({ force: true });
+  } catch {
+    await node.dispatchEvent('click', { bubbles: true });
+  }
+  const miniDag = page.getByTestId('selected-workflow-mini-dag');
+  if (!(await miniDag.isVisible({ timeout: 1500 }).catch(() => false))) {
+    await node.dispatchEvent('click', { bubbles: true });
+  }
+  await expect(miniDag).toBeVisible({ timeout: 10000 });
+}
+
 async function loadPlanAndSelectWorkflow(page: Page, plan: unknown): Promise<string> {
   const beforeIds = await page.evaluate(async () => {
     const workflows = await window.invoker.listWorkflows();
@@ -364,10 +380,7 @@ async function loadPlanAndSelectWorkflow(page: Page, plan: unknown): Promise<str
     return created?.id ?? workflows[workflows.length - 1]?.id ?? null;
   }, beforeIds);
   expect(workflowId).toBeTruthy();
-  const node = workflowNode(page, workflowId!);
-  await node.waitFor({ state: 'attached', timeout: 15000 });
-  await node.dispatchEvent('click', { bubbles: true });
-  await expect(page.getByTestId('selected-workflow-mini-dag')).toBeVisible({ timeout: 10000 });
+  await selectWorkflowNode(page, workflowId!);
   return workflowId!;
 }
 async function seedActiveLaunchAttempt(dbPath: string, taskId: string, attemptId: string, now: Date): Promise<void> {
@@ -764,7 +777,7 @@ test.describe('Visual proof capture', () => {
 
     const reviewUrl = 'https://github.com/Neko-Catpital-Labs/Invoker/pull/626';
 
-    await workflowNode(page, workflowId).dispatchEvent('click', { bubbles: true });
+    await selectWorkflowNode(page, workflowId);
     await expect(page.getByTestId('workflow-inspector-title')).toHaveText('Review ready workflow PR proof');
     await expect(page.getByText('Inspector', { exact: true })).toHaveCount(0);
     await expect(page.getByTestId('workflow-inspector-status-label')).not.toContainText('review ready');
@@ -787,8 +800,10 @@ test.describe('Visual proof capture', () => {
         },
       },
     ]);
+    await page.getByRole('button', { name: 'Refresh' }).click();
+    await page.waitForTimeout(300);
 
-    await workflowNode(page, workflowId).dispatchEvent('click', { bubbles: true });
+    await selectWorkflowNode(page, workflowId);
     await expect(page.getByTestId('workflow-inspector-title')).toHaveText('Review ready workflow PR proof');
     await expect(page.getByText('Inspector', { exact: true })).toHaveCount(0);
     await expect(page.getByTestId('workflow-inspector-status-label')).toContainText('review ready');
@@ -818,8 +833,10 @@ test.describe('Visual proof capture', () => {
         },
       },
     ]);
+    await page.getByRole('button', { name: 'Refresh' }).click();
+    await page.waitForTimeout(300);
 
-    await workflowNode(page, workflowId).dispatchEvent('click', { bubbles: true });
+    await selectWorkflowNode(page, workflowId);
     await expect(page.getByTestId('inspector-pr-link')).toHaveAttribute('href', reviewUrl);
 
     await page.keyboard.press('Tab');
@@ -907,6 +924,8 @@ test.describe('Visual proof capture', () => {
         },
       },
     ]);
+    await page.getByRole('button', { name: 'Refresh' }).click();
+    await page.waitForTimeout(300);
 
     const workflowId = await page.evaluate(async () => {
       const workflows = await window.invoker.listWorkflows();
@@ -915,7 +934,7 @@ test.describe('Visual proof capture', () => {
     expect(workflowId).toBeTruthy();
 
     // Re-select the workflow so the inspector reflects the derived workflow status.
-    await workflowNode(page, workflowId!).dispatchEvent('click', { bubbles: true });
+    await selectWorkflowNode(page, workflowId!);
 
     // Workflow-level surface: sidebar workflow node displays the workflow-status hue.
     await expect(workflowNode(page, workflowId!).getByText('review ready')).toBeVisible();
@@ -1024,6 +1043,8 @@ test.describe('Visual proof capture', () => {
         })),
       ],
     );
+    await page.getByRole('button', { name: 'Refresh' }).click();
+    await page.waitForTimeout(300);
 
     await hideSelectedWorkflowMiniDagIfVisible(page);
     await minimizeInspectorIfVisible(page);

--- a/packages/app/src/__tests__/workflow-rollup-projection.test.ts
+++ b/packages/app/src/__tests__/workflow-rollup-projection.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
+import type { TaskState } from '@invoker/workflow-core';
+
+function makeTask(
+  id: string,
+  workflowId: string | undefined,
+  status: TaskState['status'] = 'pending',
+  overrides: Partial<TaskState> = {},
+): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id,
+    description: `Task ${id}`,
+    status,
+    dependencies: [],
+    createdAt: new Date('2025-01-01T00:00:00Z'),
+    config: { workflowId, command: `echo ${id}`, runnerKind: 'worktree', ...config },
+    execution: { ...execution },
+    taskStateVersion: 1,
+    ...rest,
+  } as TaskState;
+}
+
+describe('WorkflowRollupProjection', () => {
+  it('replaces the index and ignores tasks without workflow ids', () => {
+    const projection = new WorkflowRollupProjection();
+    projection.replaceAll([
+      makeTask('wf-1/task-a', 'wf-1', 'running'),
+      makeTask('standalone', undefined, 'failed'),
+    ]);
+
+    const patch = projection.patchFor('wf-1');
+
+    expect(patch.workflowId).toBe('wf-1');
+    expect(patch.status).toBe('running');
+    expect(patch.rollup.countsByStatus.running).toBe(1);
+    expect(projection.patchFor('standalone').status).toBe('pending');
+  });
+
+  it('returns one patch for a created task workflow', () => {
+    const projection = new WorkflowRollupProjection();
+
+    const patches = projection.applyDelta({
+      type: 'created',
+      task: makeTask('wf-1/task-a', 'wf-1', 'running'),
+    });
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'running' });
+  });
+
+  it('returns no created patch when the task has no workflow id', () => {
+    const projection = new WorkflowRollupProjection();
+
+    const patches = projection.applyDelta({
+      type: 'created',
+      task: makeTask('task-a', undefined, 'running'),
+    });
+
+    expect(patches).toEqual([]);
+  });
+
+  it('merges accepted updates and publishes status from live tasks', () => {
+    const projection = new WorkflowRollupProjection();
+    projection.replaceAll([makeTask('wf-1/task-a', 'wf-1', 'failed')]);
+
+    const patches = projection.applyDelta({
+      type: 'updated',
+      taskId: 'wf-1/task-a',
+      changes: {
+        status: 'running',
+        config: { command: 'echo changed' },
+        execution: { branch: 'feature/live-rollup' },
+      },
+      previousTaskStateVersion: 1,
+      taskStateVersion: 2,
+    });
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'running' });
+    expect(patches[0]?.rollup.countsByStatus.running).toBe(1);
+  });
+
+  it('does not patch unknown updated tasks', () => {
+    const projection = new WorkflowRollupProjection();
+
+    const patches = projection.applyDelta({
+      type: 'updated',
+      taskId: 'wf-1/missing',
+      changes: { status: 'running' },
+      previousTaskStateVersion: 1,
+      taskStateVersion: 2,
+    });
+
+    expect(patches).toEqual([]);
+  });
+
+  it('patches old and new workflow ids after a workflow move', () => {
+    const projection = new WorkflowRollupProjection();
+    projection.replaceAll([makeTask('task-a', 'wf-1', 'running')]);
+
+    const patches = projection.applyDelta({
+      type: 'updated',
+      taskId: 'task-a',
+      changes: { config: { workflowId: 'wf-2' } },
+      previousTaskStateVersion: 1,
+      taskStateVersion: 2,
+    });
+
+    expect(patches.map((patch) => [patch.workflowId, patch.status])).toEqual([
+      ['wf-1', 'pending'],
+      ['wf-2', 'running'],
+    ]);
+  });
+
+  it('returns a pending patch when the last workflow task is removed', () => {
+    const projection = new WorkflowRollupProjection();
+    projection.replaceAll([makeTask('wf-1/task-a', 'wf-1', 'running')]);
+
+    const patches = projection.applyDelta({
+      type: 'removed',
+      taskId: 'wf-1/task-a',
+      previousTaskStateVersion: 1,
+    });
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'pending' });
+    expect(patches[0]?.rollup.countsByStatus.running).toBe(0);
+  });
+
+  it('does not patch unknown removed tasks', () => {
+    const projection = new WorkflowRollupProjection();
+
+    const patches = projection.applyDelta({
+      type: 'removed',
+      taskId: 'wf-1/missing',
+      previousTaskStateVersion: 1,
+    });
+
+    expect(patches).toEqual([]);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -174,10 +174,8 @@ import { buildAppMenuTemplate } from './app-menu.js';
 import { createRequire } from 'node:module';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
 import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from './delta-merge.js';
-import {
-  CoalescedWorkflowMetadataPublisher,
-  WorkflowMetadataInvalidator,
-} from './workflow-metadata-invalidation.js';
+import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
+import { WorkflowRollupProjection } from './workflow-rollup-projection.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -1831,6 +1829,7 @@ function createEmbeddedTerminalBackendFromConfig(
   let activityPollInterval: ReturnType<typeof setInterval> | null = null;
   let uiPerfLogInterval: ReturnType<typeof setInterval> | null = null;
   const lastKnownTaskStates = new TaskSnapshotCache();
+  const workflowRollupProjection = new WorkflowRollupProjection();
   const deferredWorkflowLaunches = new Map<string, {
     timer: ReturnType<typeof setTimeout>;
     taskIds: string[];
@@ -1848,7 +1847,6 @@ function createEmbeddedTerminalBackendFromConfig(
   };
   const pendingOutputBuffers = new Map<string, string[]>();
   const outputFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
-  let workflowMetadataInvalidator: WorkflowMetadataInvalidator | null = null;
   let workflowMetadataPublisher: CoalescedWorkflowMetadataPublisher | null = null;
   let lastKnownWorkflowCount = 0;
   let lastActivityLogId = 0;
@@ -1990,9 +1988,6 @@ function createEmbeddedTerminalBackendFromConfig(
   const taskDeltaStream = createTaskDeltaStreamSequence();
   const getTaskDeltaStreamSequence = (): number => taskDeltaStream.current();
 
-  const markWorkflowMetadataFromTaskDelta = (delta: TaskDelta): void => {
-    workflowMetadataInvalidator?.markFromTaskDelta(delta);
-  };
 
   const taskGraphEventPublisher = createTaskGraphEventPublisher({
     getMainWindow: () => mainWindow,
@@ -2008,9 +2003,9 @@ function createEmbeddedTerminalBackendFromConfig(
     },
   });
 
-  const sendTaskDeltaToRenderer = (delta: TaskDelta): void => {
-    markWorkflowMetadataFromTaskDelta(delta);
-    taskGraphEventPublisher.publishDelta(delta);
+  const publishTaskDeltaToRenderer = (delta: TaskDelta): void => {
+    const workflowRollups = workflowRollupProjection.applyDelta(delta);
+    taskGraphEventPublisher.publishDelta(delta, workflowRollups);
   };
 
   const applyTaskDeltaToOwnerCacheOrRecover = (delta: TaskDelta): TaskDelta[] => {
@@ -2689,8 +2684,10 @@ function createEmbeddedTerminalBackendFromConfig(
 
   function seedUiSnapshotCache(): void {
     lastKnownWorkflowCount = persistence.listWorkflows().length;
+    const tasks = orchestrator.getAllTasks();
     lastKnownTaskStates.clear();
-    for (const task of orchestrator.getAllTasks()) {
+    workflowRollupProjection.replaceAll(tasks);
+    for (const task of tasks) {
       lastKnownTaskStates.set(task.id, JSON.stringify(task));
     }
   }
@@ -2716,12 +2713,6 @@ function createEmbeddedTerminalBackendFromConfig(
       }
       mainWindow.webContents.send('invoker:workflows-changed', workflows);
     },
-  });
-  workflowMetadataInvalidator = new WorkflowMetadataInvalidator({
-    getCachedTaskSnapshot: (taskId) => lastKnownTaskStates.get(taskId),
-    loadTask: loadTaskByIdFromPersistence,
-    listWorkflows: () => [],
-    publish: () => requestWorkflowMetadataPublish('task-delta'),
   });
 
   function listWorkflowsByStartupRecency() {
@@ -2797,18 +2788,19 @@ function createEmbeddedTerminalBackendFromConfig(
     const tasks = orchestrator.getAllTasks();
     const previousTaskIds = new Set(lastKnownTaskStates.keys());
     lastKnownTaskStates.clear();
+    workflowRollupProjection.replaceAll(tasks);
     for (const task of tasks) {
       const snapshot = JSON.stringify(task);
       previousTaskIds.delete(task.id);
       lastKnownTaskStates.set(task.id, snapshot);
       if (mainWindow && !mainWindow.isDestroyed()) {
-        sendTaskDeltaToRenderer({ type: 'created', task });
+        publishTaskDeltaToRenderer({ type: 'created', task });
       }
     }
     lastKnownWorkflowCount = workflows.length;
     if (mainWindow && !mainWindow.isDestroyed()) {
       for (const removedTaskId of previousTaskIds) {
-        sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
+        publishTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
       }
       requestWorkflowMetadataPublish('orchestrator-snapshot');
     }
@@ -2965,7 +2957,7 @@ function createEmbeddedTerminalBackendFromConfig(
                   }
                   lastKnownTaskStates.set(task.id, snapshot);
                   uiPerfStats.dbPollCreated += 1;
-                  sendTaskDeltaToRenderer({ type: 'created', task });
+                  publishTaskDeltaToRenderer({ type: 'created', task });
                 } else if (prev !== snapshot) {
                   if (traceDbPollPerTask) {
                     const msg = `Task updated: ${task.id} (${task.status})`;
@@ -2974,7 +2966,7 @@ function createEmbeddedTerminalBackendFromConfig(
                   }
                   lastKnownTaskStates.set(task.id, snapshot);
                   uiPerfStats.dbPollUpdatedAsCreated += 1;
-                  sendTaskDeltaToRenderer({ type: 'created', task });
+                  publishTaskDeltaToRenderer({ type: 'created', task });
                 }
               }
             }
@@ -3273,7 +3265,6 @@ function createEmbeddedTerminalBackendFromConfig(
       if (traceUiDeltaFlow) {
         logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
       }
-      markWorkflowMetadataFromTaskDelta(d);
 
       const deltaTaskId = d.type === 'updated' || d.type === 'removed'
         ? d.taskId
@@ -3292,7 +3283,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
 
       for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(d)) {
-        taskGraphEventPublisher.publishDelta(rendererDelta);
+        publishTaskDeltaToRenderer(rendererDelta);
       }
     });
 
@@ -3357,9 +3348,6 @@ function createEmbeddedTerminalBackendFromConfig(
           } satisfies TaskDelta);
         }
         orchestrator.syncAllFromDb();
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          requestWorkflowMetadataPublish('gap-detect');
-        }
       };
       ipcMain.handle(
         'invoker:inject-task-states',
@@ -3398,10 +3386,11 @@ function createEmbeddedTerminalBackendFromConfig(
 
       const allStarted = orchestrator.startExecution();
       const tasks = orchestrator.getAllTasks();
+      workflowRollupProjection.replaceAll(tasks);
       for (const task of tasks) {
         lastKnownTaskStates.set(task.id, JSON.stringify(task));
         if (mainWindow && !mainWindow.isDestroyed()) {
-          sendTaskDeltaToRenderer({ type: 'created', task });
+          publishTaskDeltaToRenderer({ type: 'created', task });
         }
       }
       logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
@@ -3468,6 +3457,7 @@ function createEmbeddedTerminalBackendFromConfig(
       rebuildTaskRunner();
       taskHandles.clear();
       lastKnownTaskStates.clear();
+      workflowRollupProjection.clear();
       lastKnownWorkflowCount = 0;
       requestWorkflowMetadataPublish('clear');
     });
@@ -3515,6 +3505,7 @@ function createEmbeddedTerminalBackendFromConfig(
       await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
       lastKnownTaskStates.clear();
+      workflowRollupProjection.clear();
       lastKnownWorkflowCount = 0;
       requestWorkflowMetadataPublish('delete-all-workflows');
     });
@@ -3525,6 +3516,7 @@ function createEmbeddedTerminalBackendFromConfig(
       await sharedDeleteAllWorkflowsBulk({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
       lastKnownTaskStates.clear();
+      workflowRollupProjection.clear();
       lastKnownWorkflowCount = 0;
       requestWorkflowMetadataPublish('delete-all-workflows-bulk');
     });

--- a/packages/app/src/task-graph-event-publisher.ts
+++ b/packages/app/src/task-graph-event-publisher.ts
@@ -72,12 +72,7 @@ export function createTaskGraphEventPublisher(
       publishEvent({
         type: 'delta',
         delta: options.stampDelta(delta),
-<<<<<<< HEAD
-        workflowRollups: [],
-||||||| parent of d4890c1ac (Publish live workflow rollups from the owner)
-=======
         workflowRollups: [...workflowRollups],
->>>>>>> d4890c1ac (Publish live workflow rollups from the owner)
       });
     },
     publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[]): void {

--- a/packages/app/src/task-graph-event-publisher.ts
+++ b/packages/app/src/task-graph-event-publisher.ts
@@ -1,5 +1,5 @@
 import type { BrowserWindow } from 'electron';
-import type { TaskGraphEvent, WorkflowMeta } from '@invoker/contracts';
+import type { TaskGraphEvent, WorkflowMeta, WorkflowRollupPatch } from '@invoker/contracts';
 import type { TaskDelta, TaskState } from '@invoker/workflow-core';
 
 const UI_TASK_GRAPH_FLUSH_DELAY_MS = 25;
@@ -9,7 +9,7 @@ const UI_TASK_GRAPH_LARGE_BATCH_THRESHOLD = 200;
 type SnapshotTaskStates = Extract<TaskGraphEvent, { type: 'snapshot' }>['tasks'];
 
 export interface TaskGraphEventPublisher {
-  publishDelta(delta: TaskDelta): void;
+  publishDelta(delta: TaskDelta, workflowRollups: readonly WorkflowRollupPatch[]): void;
   publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[]): void;
 }
 
@@ -68,11 +68,16 @@ export function createTaskGraphEventPublisher(
   };
 
   return {
-    publishDelta(delta: TaskDelta): void {
+    publishDelta(delta: TaskDelta, workflowRollups: readonly WorkflowRollupPatch[]): void {
       publishEvent({
         type: 'delta',
         delta: options.stampDelta(delta),
+<<<<<<< HEAD
         workflowRollups: [],
+||||||| parent of d4890c1ac (Publish live workflow rollups from the owner)
+=======
+        workflowRollups: [...workflowRollups],
+>>>>>>> d4890c1ac (Publish live workflow rollups from the owner)
       });
     },
     publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[]): void {

--- a/packages/app/src/workflow-rollup-projection.ts
+++ b/packages/app/src/workflow-rollup-projection.ts
@@ -1,0 +1,140 @@
+import { computeWorkflowRollup, type TaskDelta, type TaskState } from '@invoker/workflow-core';
+import type { WorkflowRollupPatch } from '@invoker/contracts';
+type UpdatedTaskDelta = Extract<TaskDelta, { type: 'updated' }>;
+
+
+export class WorkflowRollupProjection {
+  private readonly tasksById = new Map<string, TaskState>();
+  private readonly taskIdsByWorkflowId = new Map<string, Set<string>>();
+
+  replaceAll(tasks: readonly TaskState[]): void {
+    this.clear();
+    for (const task of tasks) {
+      this.updateTaskIndexes(task);
+    }
+  }
+
+  clear(): void {
+    this.tasksById.clear();
+    this.taskIdsByWorkflowId.clear();
+  }
+
+  applyDelta(delta: TaskDelta): WorkflowRollupPatch[] {
+    switch (delta.type) {
+      case 'created':
+        return this.applyCreatedTask(delta.task);
+      case 'updated':
+        return this.applyUpdatedTask(delta);
+      case 'removed':
+        return this.applyRemovedTask(delta.taskId);
+    }
+  }
+
+  private applyCreatedTask(task: TaskState): WorkflowRollupPatch[] {
+    this.updateTaskIndexes(task);
+    return this.patchWorkflowById(task.config.workflowId);
+  }
+
+  private applyUpdatedTask(delta: UpdatedTaskDelta): WorkflowRollupPatch[] {
+    const previousTask = this.tasksById.get(delta.taskId);
+    if (!previousTask) {
+      return [];
+    }
+
+    const nextTask = this.mergeUpdatedTask(previousTask, delta);
+    this.updateTaskIndexes(nextTask);
+    return this.patchWorkflowById(previousTask.config.workflowId, nextTask.config.workflowId);
+  }
+
+  private applyRemovedTask(taskId: string): WorkflowRollupPatch[] {
+    const previousTask = this.tasksById.get(taskId);
+    if (!previousTask) {
+      return [];
+    }
+
+    this.tasksById.delete(taskId);
+    const workflowId = previousTask.config.workflowId;
+    if (!workflowId) {
+      return [];
+    }
+
+    this.removeTaskFromWorkflow(taskId, workflowId);
+    return this.patchWorkflowById(workflowId);
+  }
+
+  private mergeUpdatedTask(previousTask: TaskState, delta: UpdatedTaskDelta): TaskState {
+    const {
+      config: configChanges,
+      execution: executionChanges,
+      ...topLevelChanges
+    } = delta.changes;
+    return {
+      ...previousTask,
+      ...topLevelChanges,
+      taskStateVersion: delta.taskStateVersion,
+      config: { ...previousTask.config, ...configChanges } as TaskState['config'],
+      execution: { ...previousTask.execution, ...executionChanges } as TaskState['execution'],
+    } as TaskState;
+  }
+
+  private patchWorkflowById(...workflowIds: Array<string | undefined>): WorkflowRollupPatch[] {
+    const seenWorkflowIds = new Set<string>();
+    const patches: WorkflowRollupPatch[] = [];
+    for (const workflowId of workflowIds) {
+      if (!workflowId || seenWorkflowIds.has(workflowId)) {
+        continue;
+      }
+      seenWorkflowIds.add(workflowId);
+      patches.push(this.patchFor(workflowId));
+    }
+    return patches;
+  }
+
+  patchFor(workflowId: string): WorkflowRollupPatch {
+    const taskIds = this.taskIdsByWorkflowId.get(workflowId);
+    const tasks: TaskState[] = [];
+    if (taskIds) {
+      for (const taskId of taskIds) {
+        const task = this.tasksById.get(taskId);
+        if (task) {
+          tasks.push(task);
+        }
+      }
+    }
+    const rollup = computeWorkflowRollup(tasks);
+    return { workflowId, status: rollup.status, rollup };
+  }
+
+  private updateTaskIndexes(task: TaskState): void {
+    const previous = this.tasksById.get(task.id);
+    const previousWorkflowId = previous?.config.workflowId;
+    if (previousWorkflowId && previousWorkflowId !== task.config.workflowId) {
+      this.removeTaskFromWorkflow(task.id, previousWorkflowId);
+    }
+    this.tasksById.set(task.id, task);
+    const workflowId = task.config.workflowId;
+    if (workflowId) {
+      this.addTaskToWorkflow(task.id, workflowId);
+    }
+  }
+
+  private addTaskToWorkflow(taskId: string, workflowId: string): void {
+    let taskIds = this.taskIdsByWorkflowId.get(workflowId);
+    if (!taskIds) {
+      taskIds = new Set<string>();
+      this.taskIdsByWorkflowId.set(workflowId, taskIds);
+    }
+    taskIds.add(taskId);
+  }
+
+  private removeTaskFromWorkflow(taskId: string, workflowId: string): void {
+    const taskIds = this.taskIdsByWorkflowId.get(workflowId);
+    if (!taskIds) {
+      return;
+    }
+    taskIds.delete(taskId);
+    if (taskIds.size === 0) {
+      this.taskIdsByWorkflowId.delete(workflowId);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The main process now keeps a live workflow rollup projection and publishes workflow patches with accepted task deltas.

Before this, task updates could change workflow status only after a broader workflow refresh.

Now accepted deltas update an in-memory per-workflow rollup first, then publish the changed workflow status and counts directly to the renderer.

<details>
<summary>Review metadata</summary>

Review Claim: The owner now derives and publishes live workflow rollups from accepted task deltas without re-reading workflows from SQLite.

Review Lane: behavior

Review Unit: routing

Safety Invariant: This slice stays in the main process and only changes task-delta handling and publish flow.

Slice Rationale: Owner-side rollup publishing is the narrow step between the shared event shape and the renderer adoption.

</details>

## Non-goals

- Changing renderer workflow merge rules.
- Adding a database workflow status column.
- Changing persistence save inputs.

## Architecture

### Before

```mermaid
graph TD
    Delta[Accepted task delta] --> Renderer[Renderer task map]
    Renderer --> Refresh[Workflow refresh for status]
```

### After

```mermaid
graph TD
    Delta[Accepted task delta] --> Projection[Owner workflow rollup projection]
    Projection --> Patch[workflowRollups patch]
    Patch --> Renderer[Renderer workflow patch stream]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-rollup-projection.test.ts src/__tests__/delta-merge.test.ts --reporter=verbose`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && CAPTURE_MODE=after pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts -g "workflow-live-rollup-update|workflow-running-task-secondary-line"`

## Visual Proof

![Live workflow rollup update](packages/app/e2e/visual-proof/after/workflow-live-rollup-update.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No