### PR TITLE
[Workflow Status](6) Show running task count on cards

### DIFF
--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -117,6 +117,24 @@ describe('WorkflowGraph', () => {
     expect(node).toHaveClass('opacity-35');
   });
 
+  it('shows running task count under non-running workflow status', () => {
+    const workflows = new Map([
+      ['wf-a', wf('wf-a', 'failed', { rollup: rollup('failed', 1) })],
+    ]);
+
+    render(
+      <WorkflowGraph
+        workflows={workflows}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('workflow-node-wf-a')).toHaveTextContent('failed');
+    expect(screen.getByTestId('workflow-node-wf-a-running-tasks')).toHaveTextContent('1 running task');
+  });
 
   it('renders the React Flow wrapper for non-empty workflow graphs', () => {
     const workflows = new Map([

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -13,6 +13,10 @@ interface WorkflowNodeProps {
 function statusLabel(status: WorkflowStatus): string {
   return status.replaceAll('_', ' ');
 }
+function runningTaskLabel(count: number): string {
+  return count === 1 ? '1 running task' : `${count} running tasks`;
+}
+
 
 export function WorkflowNode({
   workflow,
@@ -23,6 +27,8 @@ export function WorkflowNode({
 }: WorkflowNodeProps): JSX.Element {
   const visual = workflowStatusVisual(workflow.status);
   const detachedDependencyCount = workflow.detachedExternalDependencies?.length ?? 0;
+  const runningCount = workflow.rollup?.countsByStatus.running ?? 0;
+  const showRunningTaskLine = workflow.status !== 'running' && runningCount > 0;
 
   return (
     <div
@@ -64,6 +70,14 @@ export function WorkflowNode({
       </div>
       <div className="mt-1 text-[11px] text-gray-400 truncate">{workflow.id}</div>
       <div className={`mt-2 text-[10px] uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
+      {showRunningTaskLine && (
+        <div
+          data-testid={`workflow-node-${workflow.id}-running-tasks`}
+          className="mt-1 text-[10px] text-gray-300"
+        >
+          {runningTaskLabel(runningCount)}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Failed workflow cards now show a second line when work is still running inside that workflow.

Before this, the graph only showed the aggregate failed state, so active work inside the same workflow was easy to miss.

Now cards keep the main aggregate status and add a live running-task count from backend rollups.

<details>
<summary>Review metadata</summary>

Review Claim: Workflow cards now expose active running work without changing the aggregate workflow status.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This is a renderer-only presentation change. It reads existing workflow rollup data and does not change task execution or persistence behavior.

Slice Rationale: Keeping the secondary label separate makes the card copy and screenshot proof reviewable without mixing in the rollup plumbing or persistence contract changes.

</details>

## Non-goals

- Changing how workflow status is derived.
- Changing queue, task DAG, or inspector status labels.
- Adding any new workflow actions or filters.

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-graph.test.tsx --reporter=verbose`
- [x] `CAPTURE_MODE=after pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts --reporter=line`
- [x] `bash scripts/test-suites/optional/70-ui-visual-proof-validate.sh`

## Visual Proof

![Failed workflow with running-task sublabel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260622-60a604/workflow-running-task-secondary-line.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
