### PR TITLE
Workflow task graph divergence repro

### DIFF
--- a/packages/ui/src/__tests__/workflow-task-graph-status-divergence-repro.test.tsx
+++ b/packages/ui/src/__tests__/workflow-task-graph-status-divergence-repro.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Repro: a workflow label can show a failed WorkflowMeta.status while its
+ * selected task-graph node still shows a RUNNING TaskState.status.
+ *
+ * The two come from separate renderer channels:
+ *   - Workflow node labels read WorkflowMeta.status.
+ *   - Selected mini-DAG task nodes read TaskState.status.
+ *   - workflow-rollup returns 'failed' as soon as any task is failed, even when
+ *     another task is still running.
+ *   - Workflow metadata (onWorkflowsChanged) can arrive after the task deltas
+ *     that move a task back to running, so the label lags the task graph.
+ *
+ * This test preserves the divergence — it does not assert any product fix.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act, waitFor, fireEvent, within } from '@testing-library/react';
+import { computeWorkflowRollupFromSummaries } from '@invoker/workflow-graph';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { TaskState, WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+/** Build WorkflowMeta whose status/rollup come from the real workflow rollup. */
+function workflowMetaFromTasks(
+  tasks: TaskState[],
+  name = 'Divergence Proof Workflow',
+): WorkflowMeta {
+  const rollup = computeWorkflowRollupFromSummaries(
+    tasks.map((task) => ({
+      id: task.id,
+      description: task.description,
+      status: task.status,
+      dependencies: task.dependencies,
+      execution: task.execution,
+    })),
+  );
+
+  return {
+    id: 'wf-diverge',
+    name,
+    status: rollup.status,
+    rollup,
+    baseBranch: 'main',
+  };
+}
+
+/** Render App, push a snapshot, select the workflow, return its mini-DAG. */
+async function renderWorkflow(
+  mock: MockInvoker,
+  tasks: TaskState[],
+  workflows: WorkflowMeta[],
+): Promise<HTMLElement> {
+  render(<App />);
+  act(() => mock.setTasks(tasks, workflows));
+
+  await waitFor(() => {
+    expect(screen.getByTestId('workflow-node-wf-diverge')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByTestId('workflow-node-wf-diverge'));
+
+  return screen.findByTestId('selected-workflow-mini-dag');
+}
+
+describe('workflow / task-graph status divergence', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('shows a failed workflow beside a running task when the real rollup has both statuses', async () => {
+    const runningTask = makeUITask({
+      id: 'wf-diverge/running-task',
+      description: 'Still running task',
+      status: 'running',
+      workflowId: 'wf-diverge',
+      execution: { phase: 'executing' },
+      taskStateVersion: 1,
+    });
+    const failedTask = makeUITask({
+      id: 'wf-diverge/failed-task',
+      description: 'Already failed task',
+      status: 'failed',
+      workflowId: 'wf-diverge',
+      taskStateVersion: 1,
+    });
+
+    const workflow = workflowMetaFromTasks([runningTask, failedTask]);
+    expect(workflow.status).toBe('failed');
+
+    const miniDag = await renderWorkflow(mock, [runningTask, failedTask], [workflow]);
+
+    expect(screen.getByTestId('workflow-node-wf-diverge')).toHaveTextContent('failed');
+
+    await waitFor(() => {
+      expect(miniDag).toHaveTextContent('Still running task');
+      expect(miniDag).toHaveTextContent('RUNNING · EXECUTING');
+      expect(miniDag).toHaveTextContent('Already failed task');
+      expect(miniDag).toHaveTextContent('FAILED');
+    });
+  });
+
+  it('keeps the workflow label on older metadata until the workflow metadata channel catches up', async () => {
+    const failedTask = makeUITask({
+      id: 'wf-diverge/task-a',
+      description: 'Task that restarts',
+      status: 'failed',
+      workflowId: 'wf-diverge',
+      taskStateVersion: 1,
+    });
+
+    const failedWorkflow = workflowMetaFromTasks([failedTask]);
+    const miniDag = await renderWorkflow(mock, [failedTask], [failedWorkflow]);
+
+    expect(screen.getByTestId('workflow-node-wf-diverge')).toHaveTextContent('failed');
+    await waitFor(() => {
+      expect(miniDag).toHaveTextContent('FAILED');
+    });
+
+    // Task delta restarts the task — the task graph updates ahead of metadata.
+    act(() =>
+      mock.fireDelta({
+        type: 'updated',
+        taskId: 'wf-diverge/task-a',
+        changes: { status: 'running', execution: { phase: 'executing' } },
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
+        streamSequence: 1,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(miniDag).toHaveTextContent('RUNNING · EXECUTING');
+    });
+
+    // Label still reads the older failed metadata: separate renderer channels.
+    expect(screen.getByTestId('workflow-node-wf-diverge')).toHaveTextContent('failed');
+
+    const runningTask: TaskState = {
+      ...failedTask,
+      status: 'running',
+      execution: { phase: 'executing' },
+      taskStateVersion: 2,
+    };
+    const runningWorkflow = workflowMetaFromTasks([runningTask]);
+    expect(runningWorkflow.status).toBe('running');
+
+    act(() => mock.fireWorkflowsChanged([runningWorkflow]));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-diverge')).toHaveTextContent('running');
+    });
+  });
+});

--- a/proof/workflow-task-graph-divergence-report.md
+++ b/proof/workflow-task-graph-divergence-report.md
@@ -1,0 +1,30 @@
+# Workflow / task-graph status divergence — proof report
+
+## What this proves
+
+A workflow label can read `failed` while the same workflow's selected
+task-graph node still reads `RUNNING`. The reproduction lives in
+`packages/ui/src/__tests__/workflow-task-graph-status-divergence-repro.test.tsx`.
+
+This is a scaffold. Later workflow command tasks run the proof (the focused
+UI test) and record the result here. No production source is changed.
+
+## Expected cause: split renderer state
+
+The two statuses come from separate renderer paths that can disagree:
+
+- **Workflow labels read `WorkflowMeta.status`.** `WorkflowNode` renders the
+  workflow metadata status.
+- **Task-graph nodes read `TaskState.status`.** The selected mini-DAG renders
+  each task's own status (and running phase).
+- **Workflow rollups return `failed` before `running`.**
+  `computeWorkflowRollupFromSummaries` reports `failed` as soon as any task has
+  failed, even while another task is still running.
+- **Workflow metadata can arrive after task deltas.** `useTasks` updates tasks
+  and workflows through separate channels, so a task delta that moves a task
+  back to `running` can land before the matching workflow-metadata update — the
+  label lags the task graph until the workflow channel catches up.
+
+## Expected pass condition
+
+The later command tasks that run the focused test exit with code `0`.

--- a/proof/workflow-task-graph-divergence-report.md
+++ b/proof/workflow-task-graph-divergence-report.md
@@ -1,30 +1,6 @@
-# Workflow / task-graph status divergence — proof report
+# Workflow/task graph divergence proof
 
-## What this proves
+Primary repro passed in task run-primary-divergence-repro.
+Adjacent state checks passed in task run-adjacent-state-checks.
 
-A workflow label can read `failed` while the same workflow's selected
-task-graph node still reads `RUNNING`. The reproduction lives in
-`packages/ui/src/__tests__/workflow-task-graph-status-divergence-repro.test.tsx`.
-
-This is a scaffold. Later workflow command tasks run the proof (the focused
-UI test) and record the result here. No production source is changed.
-
-## Expected cause: split renderer state
-
-The two statuses come from separate renderer paths that can disagree:
-
-- **Workflow labels read `WorkflowMeta.status`.** `WorkflowNode` renders the
-  workflow metadata status.
-- **Task-graph nodes read `TaskState.status`.** The selected mini-DAG renders
-  each task's own status (and running phase).
-- **Workflow rollups return `failed` before `running`.**
-  `computeWorkflowRollupFromSummaries` reports `failed` as soon as any task has
-  failed, even while another task is still running.
-- **Workflow metadata can arrive after task deltas.** `useTasks` updates tasks
-  and workflows through separate channels, so a task delta that moves a task
-  back to `running` can land before the matching workflow-metadata update — the
-  label lags the task graph until the workflow channel catches up.
-
-## Expected pass condition
-
-The later command tasks that run the focused test exit with code `0`.
+Cause: workflow labels read WorkflowMeta.status while task graph nodes read TaskState.status. WorkflowMeta.status is an aggregate rollup, and workflow-rollup returns failed before running. Task deltas and workflow metadata also arrive on separate renderer channels, so the task graph can update before the workflow label catches up.


### PR DESCRIPTION
PR body validation passed. Here is the final PR body:

## Summary

This adds a failing-mode repro that pins down a known display divergence: a workflow can read "failed" while one of its tasks in the same graph still reads "running".

The two numbers come from different places. The workflow label reads an aggregate `WorkflowMeta.status` rollup, while each task-graph node reads its own live `TaskState.status`.

The rollup flips to "failed" the moment any one task fails, even while a sibling task keeps running. So the headline disagrees with the node beneath it.

Task updates and workflow metadata also land on separate renderer channels, so the task graph can move ahead before the workflow label catches up.

Nothing here changes product code. It is a repro test plus a written proof report that locks the cause in place for the follow-up fix.

<details>
<summary>Review metadata</summary>

Review Claim: Approve a repro test and proof report that demonstrate the workflow-vs-task status divergence without changing product behavior.

Review Lane: proof

Review Unit: proof

Safety Invariant: The diff only touches a new `__tests__` repro and a `proof/` report, so it cannot alter runtime behavior; reviewing it is reading a test and a markdown note.

Slice Rationale: This is the reproduce-and-prove slice; the product fix is intentionally split into a later PR so the divergence is documented and pinned before any code moves.

</details>

## Non-goals

- Does not fix the divergence or change any product behavior.
- Does not modify the workflow rollup, renderer channels, or task graph components.
- Does not add or alter documentation outside the proof report.

## Test Plan

- [ ] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-task-graph-status-divergence-repro.test.tsx --reporter=verbose`
- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/refresh-task-graph.test.ts --reporter=verbose && pnpm --filter @invoker/ui exec vitest run src/__tests__/selected-workflow-graph-disappears-repro.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx --reporter=verbose`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No