### PR TITLE
[Multi PR Review Gate](1) Define review gate artifact contracts

### DIFF
--- a/packages/contracts/src/__tests__/validation.test.ts
+++ b/packages/contracts/src/__tests__/validation.test.ts
@@ -50,6 +50,27 @@ describe('validateWorkResponse', () => {
     status: 'completed',
     outputs: { exitCode: 0 },
   };
+  const validReviewGate = {
+    activeGeneration: 1,
+    completion: { required: 'all', status: 'approved' },
+    artifacts: [
+      {
+        id: 'contracts',
+        title: 'Define contracts',
+        required: true,
+        status: 'approved',
+        generation: 1,
+      },
+      {
+        id: 'runtime',
+        title: 'Wire runtime',
+        required: true,
+        status: 'open',
+        generation: 1,
+        dependsOn: ['contracts'],
+      },
+    ],
+  } as const;
 
   it('accepts a valid completed response', () => {
     const result = validateWorkResponse(baseResponse);
@@ -74,6 +95,97 @@ describe('validateWorkResponse', () => {
       },
     });
     expect(result.valid).toBe(true);
+  });
+
+  it('accepts a valid two-artifact reviewGate stack', () => {
+    const result = validateWorkResponse({
+      ...baseResponse,
+      outputs: {
+        exitCode: 0,
+        reviewGate: validReviewGate,
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects reviewGate duplicate artifact ids', () => {
+    const result = validateWorkResponse({
+      ...baseResponse,
+      outputs: {
+        reviewGate: {
+          ...validReviewGate,
+          artifacts: [
+            validReviewGate.artifacts[0],
+            {
+              ...validReviewGate.artifacts[1],
+              id: 'contracts',
+            },
+          ],
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('outputs.reviewGate.artifacts[1].id duplicates artifact "contracts"');
+  });
+
+  it('rejects reviewGate unknown dependencies', () => {
+    const result = validateWorkResponse({
+      ...baseResponse,
+      outputs: {
+        reviewGate: {
+          ...validReviewGate,
+          artifacts: [
+            validReviewGate.artifacts[0],
+            {
+              ...validReviewGate.artifacts[1],
+              dependsOn: ['missing'],
+            },
+          ],
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('outputs.reviewGate.artifacts[1].dependsOn references unknown artifact "missing"');
+  });
+
+  it('rejects reviewGate self-dependencies', () => {
+    const result = validateWorkResponse({
+      ...baseResponse,
+      outputs: {
+        reviewGate: {
+          ...validReviewGate,
+          artifacts: [
+            {
+              ...validReviewGate.artifacts[0],
+              dependsOn: ['contracts'],
+            },
+            validReviewGate.artifacts[1],
+          ],
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('outputs.reviewGate.artifacts[0].dependsOn must not reference itself');
+  });
+
+  it('rejects reviewGate dependency cycles', () => {
+    const result = validateWorkResponse({
+      ...baseResponse,
+      outputs: {
+        reviewGate: {
+          ...validReviewGate,
+          artifacts: [
+            {
+              ...validReviewGate.artifacts[0],
+              dependsOn: ['runtime'],
+            },
+            validReviewGate.artifacts[1],
+          ],
+        },
+      },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('outputs.reviewGate.artifacts dependency graph has a cycle');
   });
 
   it('accepts a valid spawn_experiments response with dagMutation', () => {
@@ -242,4 +354,5 @@ describe('validateWorkResponse', () => {
       expect(result.error).toBe('select_experiment status requires dagMutation.selectExperiment');
     });
   });
+
 });

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -5,6 +5,7 @@
  * Orchestrator writes a WorkRequest; executor runs the action;
  * executor returns a WorkResponse (via callback or IPC).
  */
+import type { ReviewGateState } from '@invoker/workflow-graph';
 
 // ── Action Types ────────────────────────────────────────────
 
@@ -118,6 +119,8 @@ export interface WorkResponseOutputs {
   reviewId?: string;
   /** Human-readable review state produced by merge-gate style actions. */
   reviewStatus?: string;
+  /** Typed review-gate artifact state produced by merge-gate style actions. */
+  reviewGate?: ReviewGateState;
 }
 
 export interface SpawnExperimentsRequest {

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -49,6 +49,163 @@ export function validateWorkRequest(req: unknown): ValidationResult {
   return { valid: true };
 }
 
+const validReviewGateArtifactStatuses = [
+  'pending',
+  'open',
+  'approved',
+  'changes_requested',
+  'merged',
+  'closed',
+  'discarded',
+  'unknown',
+] as const;
+
+function checkForCycle(dependencies: ReadonlyMap<string, readonly string[]>, ids: Iterable<string>): string | undefined {
+  const visitState = new Map<string, 'visiting' | 'visited'>();
+
+  const visit = (id: string): string | undefined => {
+    const state = visitState.get(id);
+    if (state === 'visiting') {
+      return id;
+    }
+    if (state === 'visited') {
+      return undefined;
+    }
+
+    visitState.set(id, 'visiting');
+    for (const dependency of dependencies.get(id) ?? []) {
+      const cycleAt = visit(dependency);
+      if (cycleAt) {
+        return cycleAt;
+      }
+    }
+    visitState.set(id, 'visited');
+    return undefined;
+  };
+
+  for (const id of ids) {
+    const cycleAt = visit(id);
+    if (cycleAt) {
+      return cycleAt;
+    }
+  }
+
+  return undefined;
+}
+
+type ReviewGateArtifactsValidationResult =
+  | ValidationResult & { valid: false }
+  | {
+      valid: true;
+      ids: Set<string>;
+      artifactRecords: Array<Record<string, unknown>>;
+    };
+
+function validateReviewGateArtifacts(args: {
+  artifacts: readonly unknown[];
+  prefix: string;
+}): ReviewGateArtifactsValidationResult {
+  const ids = new Set<string>();
+  const artifactRecords: Array<Record<string, unknown>> = [];
+
+  for (let i = 0; i < args.artifacts.length; i += 1) {
+    const artifact = args.artifacts[i];
+    const artifactPrefix = `${args.prefix}.artifacts[${i}]`;
+    if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
+      return { valid: false, error: `${artifactPrefix} must be an object` };
+    }
+
+    const record = artifact as Record<string, unknown>;
+    artifactRecords.push(record);
+    if (typeof record.id !== 'string' || record.id.length === 0) {
+      return { valid: false, error: `${artifactPrefix}.id must be a non-empty string` };
+    }
+    if (ids.has(record.id)) {
+      return { valid: false, error: `${artifactPrefix}.id duplicates artifact "${record.id}"` };
+    }
+    ids.add(record.id);
+
+    if (typeof record.required !== 'boolean') {
+      return { valid: false, error: `${artifactPrefix}.required must be a boolean` };
+    }
+    if (!validReviewGateArtifactStatuses.includes(record.status as (typeof validReviewGateArtifactStatuses)[number])) {
+      return { valid: false, error: `${artifactPrefix}.status must be one of: ${validReviewGateArtifactStatuses.join(', ')}` };
+    }
+    if (!Number.isInteger(record.generation) || (record.generation as number) < 0) {
+      return { valid: false, error: `${artifactPrefix}.generation must be a non-negative integer` };
+    }
+    if (record.dependsOn !== undefined && !Array.isArray(record.dependsOn)) {
+      return { valid: false, error: `${artifactPrefix}.dependsOn must be an array` };
+    }
+  }
+
+  return { valid: true, ids, artifactRecords };
+}
+
+
+
+function validateReviewGate(reviewGate: unknown): ValidationResult {
+  const prefix = 'outputs.reviewGate';
+  if (!reviewGate || typeof reviewGate !== 'object' || Array.isArray(reviewGate)) {
+    return { valid: false, error: `${prefix} must be an object` };
+  }
+
+  const gate = reviewGate as Record<string, unknown>;
+  if (!Number.isInteger(gate.activeGeneration) || (gate.activeGeneration as number) < 0) {
+    return { valid: false, error: `${prefix}.activeGeneration must be a non-negative integer` };
+  }
+
+  if (!gate.completion || typeof gate.completion !== 'object' || Array.isArray(gate.completion)) {
+    return { valid: false, error: `${prefix}.completion must be an object` };
+  }
+  const completion = gate.completion as Record<string, unknown>;
+  if (completion.required !== 'all') {
+    return { valid: false, error: `${prefix}.completion.required must be "all"` };
+  }
+  if (completion.status !== 'approved') {
+    return { valid: false, error: `${prefix}.completion.status must be "approved"` };
+  }
+
+  if (!Array.isArray(gate.artifacts)) {
+    return { valid: false, error: `${prefix}.artifacts must be an array` };
+  }
+
+  const validatedArtifacts = validateReviewGateArtifacts({ artifacts: gate.artifacts, prefix });
+  if (!validatedArtifacts.valid) {
+    return validatedArtifacts;
+  }
+  const { ids, artifactRecords } = validatedArtifacts;
+
+  const dependencies = new Map<string, string[]>();
+  for (let i = 0; i < artifactRecords.length; i += 1) {
+    const record = artifactRecords[i];
+    const artifactPrefix = `${prefix}.artifacts[${i}]`;
+    const id = record.id as string;
+    const dependsOn = (record.dependsOn ?? []) as unknown[];
+    const artifactDependencies: string[] = [];
+    for (const dependency of dependsOn) {
+      if (typeof dependency !== 'string' || dependency.length === 0) {
+        return { valid: false, error: `${artifactPrefix}.dependsOn must contain non-empty artifact ids` };
+      }
+      if (!ids.has(dependency)) {
+        return { valid: false, error: `${artifactPrefix}.dependsOn references unknown artifact "${dependency}"` };
+      }
+      if (dependency === id) {
+        return { valid: false, error: `${artifactPrefix}.dependsOn must not reference itself` };
+      }
+      artifactDependencies.push(dependency);
+    }
+    dependencies.set(id, artifactDependencies);
+  }
+
+  const cycleAt = checkForCycle(dependencies, ids);
+  if (cycleAt) {
+    return { valid: false, error: `${prefix}.artifacts dependency graph has a cycle involving "${cycleAt}"` };
+  }
+
+  return { valid: true };
+}
+
 export function validateWorkResponse(res: unknown): ValidationResult {
   if (!res || typeof res !== 'object' || Array.isArray(res)) {
     return { valid: false, error: 'WorkResponse must be an object' };
@@ -94,6 +251,14 @@ export function validateWorkResponse(res: unknown): ValidationResult {
     const dm = r.dagMutation as Record<string, unknown> | undefined;
     if (!dm?.selectExperiment) {
       return { valid: false, error: 'select_experiment status requires dagMutation.selectExperiment' };
+    }
+  }
+
+  const outputs = r.outputs as Record<string, unknown>;
+  if (outputs.reviewGate !== undefined) {
+    const reviewGateValidation = validateReviewGate(outputs.reviewGate);
+    if (!reviewGateValidation.valid) {
+      return reviewGateValidation;
     }
   }
 

--- a/packages/workflow-core/src/__tests__/response-handler.test.ts
+++ b/packages/workflow-core/src/__tests__/response-handler.test.ts
@@ -82,6 +82,43 @@ describe('ResponseHandler (pure parser)', () => {
         reviewStatus: 'Awaiting review',
       });
     });
+
+    it('passes reviewGate through review_ready responses', () => {
+      const reviewGate = {
+        activeGeneration: 1,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [
+          {
+            id: 'contracts',
+            title: 'Define contracts',
+            required: true,
+            status: 'approved',
+            generation: 1,
+          },
+          {
+            id: 'runtime',
+            title: 'Wire runtime',
+            required: true,
+            status: 'open',
+            generation: 1,
+            dependsOn: ['contracts'],
+          },
+        ],
+      } as const;
+      const result = handler.parseResponse(
+        makeResponse({
+          status: 'review_ready',
+          outputs: {
+            exitCode: 0,
+            reviewGate,
+          },
+        }),
+      );
+      expect('type' in result).toBe(true);
+      if (!('type' in result)) return;
+      expect(result.type).toBe('review_ready');
+      expect(result.reviewGate).toEqual(reviewGate);
+    });
   });
 
   // ── failed ─────────────────────────────────────────────

--- a/packages/workflow-core/src/response-handler.ts
+++ b/packages/workflow-core/src/response-handler.ts
@@ -8,6 +8,7 @@
 
 import type { WorkResponse } from '@invoker/contracts';
 import { validateWorkResponse } from '@invoker/contracts';
+import type { ReviewGateState } from '@invoker/workflow-graph';
 
 /** Plan-local id segment for experiment id prefixing (strip `${workflowId}/` when present). */
 function planLocalFromActionId(actionId: string): string {
@@ -40,6 +41,7 @@ export type ParsedResponse =
       reviewUrl?: string;
       reviewId?: string;
       reviewStatus?: string;
+      reviewGate?: ReviewGateState;
     }
   | {
       type: 'review_ready';
@@ -50,6 +52,7 @@ export type ParsedResponse =
       reviewUrl?: string;
       reviewId?: string;
       reviewStatus?: string;
+      reviewGate?: ReviewGateState;
     }
   | {
       type: 'failed';
@@ -103,6 +106,7 @@ export class ResponseHandler {
           reviewUrl: outputs.reviewUrl,
           reviewId: outputs.reviewId,
           reviewStatus: outputs.reviewStatus,
+          reviewGate: outputs.reviewGate,
         };
 
       case 'review_ready':
@@ -115,6 +119,7 @@ export class ResponseHandler {
           reviewUrl: outputs.reviewUrl,
           reviewId: outputs.reviewId,
           reviewStatus: outputs.reviewStatus,
+          reviewGate: outputs.reviewGate,
         };
 
       case 'failed':

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -129,6 +129,44 @@ export interface DetachedExternalDependency {
 export type TaskRunPhase = 'launching' | 'executing';
 export type TaskHeartbeatSource = 'executor' | 'remote_workload';
 
+export type ReviewGateArtifactStatus =
+  | 'pending'
+  | 'open'
+  | 'approved'
+  | 'changes_requested'
+  | 'merged'
+  | 'closed'
+  | 'discarded'
+  | 'unknown';
+
+export interface ReviewGateArtifact {
+  readonly id: string;
+  readonly title?: string;
+  readonly url?: string;
+  readonly providerId?: string;
+  readonly provider?: string;
+  readonly branch?: string;
+  readonly baseBranch?: string;
+  readonly required: boolean;
+  readonly status: ReviewGateArtifactStatus;
+  readonly rawStatus?: string;
+  readonly dependsOn?: readonly string[];
+  readonly generation: number;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+  readonly discardedAt?: string;
+  readonly discardReason?: string;
+}
+
+export interface ReviewGateState {
+  readonly activeGeneration: number;
+  readonly completion: {
+    readonly required: 'all';
+    readonly status: 'approved';
+  };
+  readonly artifacts: readonly ReviewGateArtifact[];
+}
+
 export interface TaskExecution {
   readonly generation?: number;
   readonly blockedBy?: string;
@@ -164,6 +202,7 @@ export interface TaskExecution {
   readonly reviewId?: string;
   readonly reviewStatus?: string;
   readonly reviewProviderId?: string;
+  readonly reviewGate?: ReviewGateState;
   readonly phase?: TaskRunPhase;
   readonly launchStartedAt?: Date;
   readonly launchCompletedAt?: Date;


### PR DESCRIPTION
## Summary

This adds a typed review-gate artifact model for stacked PR state.

It keeps the old scalar review fields, so old callers still keep working.

<details>
<summary>Review metadata</summary>

Review Claim: Shared runtime contracts can represent review-gate PR artifacts and optional dependency order.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This slice only adds optional fields and validation, so no runtime gate behavior changes yet.

Slice Rationale: The type contract lands first so later persistence, polling, and UI slices can share one shape.

Architectural Effect: Review-gate state moves from one scalar PR link to a typed artifact list.

Alternative Considerations: We could have kept provider-specific fields, but one neutral artifact model keeps later slices simpler.
</details>

## Non-goals

This does not persist review-gate artifacts yet.

This does not poll or render stacked PRs yet.

## Architecture

### Before

```mermaid
graph TD
  A["TaskExecution"] --> B["reviewUrl / reviewId / reviewStatus"]
```

### After

```mermaid
graph TD
  A["TaskExecution"] --> B["reviewUrl / reviewId / reviewStatus"]
  A --> C["reviewGate.artifacts"]
  C --> D["dependsOn metadata"]
```

## Test Plan

- [x] `pnpm --filter @invoker/contracts test -- src/__tests__/validation.test.ts`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/response-handler.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f4fb88d15`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added review gate support for managing artifact states and approval workflows across your system.
  * Integrated comprehensive dependency validation that prevents duplicate artifact IDs, detects circular dependency chains, blocks self-referencing artifacts, and ensures data integrity throughout workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->