### PR TITLE
[Multi PR Review Gate](3) Discard invalidated review gate PRs

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-facade.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-facade.test.ts
@@ -113,6 +113,19 @@ describe('WorkflowMutationFacade', () => {
       expect(result.runnable).toHaveLength(1);
       expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
+
+    it('closes the workflow review before task-scoped invalidation', async () => {
+      (deps.orchestrator.getTask as ReturnType<typeof vi.fn>).mockReturnValue(
+        makeTask({ id: 'task-a', config: { workflowId: 'wf-1' } }),
+      );
+
+      await facade.retryTask('task-a');
+
+      expect(deps.taskExecutor.closeWorkflowReview).toHaveBeenCalledWith('wf-1');
+      expect((deps.taskExecutor.closeWorkflowReview as any).mock.invocationCallOrder[0]).toBeLessThan(
+        (deps.commandService.retryTask as any).mock.invocationCallOrder[0],
+      );
+    });
   });
 
   describe('recreateTask', () => {
@@ -123,6 +136,19 @@ describe('WorkflowMutationFacade', () => {
       expect(result.started).toHaveLength(1);
       expect(result.runnable).toHaveLength(1);
       expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
+    });
+
+    it('closes the workflow review before task-scoped recreate', async () => {
+      (deps.orchestrator.getTask as ReturnType<typeof vi.fn>).mockReturnValue(
+        makeTask({ id: 'task-a', config: { workflowId: 'wf-1' } }),
+      );
+
+      await facade.recreateTask('task-a');
+
+      expect(deps.taskExecutor.closeWorkflowReview).toHaveBeenCalledWith('wf-1');
+      expect((deps.taskExecutor.closeWorkflowReview as any).mock.invocationCallOrder[0]).toBeLessThan(
+        (deps.commandService.recreateTask as any).mock.invocationCallOrder[0],
+      );
     });
   });
 
@@ -309,6 +335,15 @@ describe('WorkflowMutationFacade', () => {
       expect(deps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
       expect(result.started).toHaveLength(1);
     });
+
+    it('closes the workflow review before workflow-scoped recreate', async () => {
+      await facade.recreateWorkflow('wf-1');
+
+      expect(deps.taskExecutor.closeWorkflowReview).toHaveBeenCalledWith('wf-1');
+      expect((deps.taskExecutor.closeWorkflowReview as any).mock.invocationCallOrder[0]).toBeLessThan(
+        (deps.commandService.recreateWorkflow as any).mock.invocationCallOrder[0],
+      );
+    });
   });
 
   describe('retryWorkflow', () => {
@@ -336,6 +371,15 @@ describe('WorkflowMutationFacade', () => {
       expect(result.started).toHaveLength(1);
       expect(result.runnable).toHaveLength(1);
       expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
+    });
+
+    it('closes the workflow review before workflow-scoped invalidation', async () => {
+      await facade.retryWorkflow('wf-1');
+
+      expect(deps.taskExecutor.closeWorkflowReview).toHaveBeenCalledWith('wf-1');
+      expect((deps.taskExecutor.closeWorkflowReview as any).mock.invocationCallOrder[0]).toBeLessThan(
+        (deps.commandService.retryWorkflow as any).mock.invocationCallOrder[0],
+      );
     });
   });
 

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -151,6 +151,7 @@ export class WorkflowMutationFacade {
   }
 
   async retryTask(taskId: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = await this.runViaCommandService(
       (cs) => cs.retryTask(makeEnvelope('facade.retry-task', 'surface', 'task', { taskId })),
     );
@@ -158,6 +159,7 @@ export class WorkflowMutationFacade {
   }
 
   async recreateTask(taskId: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = await this.runViaCommandService(
       (cs) => cs.recreateTask(makeEnvelope('facade.recreate-task', 'surface', 'task', { taskId })),
     );
@@ -165,6 +167,7 @@ export class WorkflowMutationFacade {
   }
 
   async recreateDownstream(taskId: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = await this.runViaCommandService(
       (cs) => cs.recreateDownstream(makeEnvelope('facade.recreate-downstream', 'surface', 'task', { taskId })),
     );
@@ -175,6 +178,7 @@ export class WorkflowMutationFacade {
   }
 
   async selectExperiment(taskId: string, experimentId: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = sharedSelectExperiment(taskId, experimentId, {
       orchestrator: this.deps.orchestrator,
     });
@@ -182,6 +186,7 @@ export class WorkflowMutationFacade {
   }
 
   async selectExperiments(taskId: string, experimentIds: string[]): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = await sharedSelectExperiments(taskId, experimentIds, {
       orchestrator: this.deps.orchestrator,
       taskExecutor: this.deps.taskExecutor,
@@ -190,6 +195,7 @@ export class WorkflowMutationFacade {
   }
 
   async editTaskCommand(taskId: string, newCommand: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = sharedEditTaskCommand(taskId, newCommand, {
       orchestrator: this.deps.orchestrator,
     });
@@ -197,6 +203,7 @@ export class WorkflowMutationFacade {
   }
 
   async editTaskPrompt(taskId: string, newPrompt: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = sharedEditTaskPrompt(taskId, newPrompt, {
       orchestrator: this.deps.orchestrator,
     });
@@ -208,6 +215,7 @@ export class WorkflowMutationFacade {
     runnerKind: string,
     poolMemberId?: string,
   ): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = sharedEditTaskType(
       taskId,
       runnerKind,
@@ -218,6 +226,7 @@ export class WorkflowMutationFacade {
   }
 
   async editTaskAgent(taskId: string, agentName: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = sharedEditTaskAgent(taskId, agentName, {
       orchestrator: this.deps.orchestrator,
     });
@@ -272,6 +281,7 @@ export class WorkflowMutationFacade {
   // ── Workflow-scoped mutations ────────────────────────────
 
   async retryWorkflow(workflowId: string): Promise<MutationResult> {
+    await this.closeReviewForWorkflow(workflowId);
     const started = await this.runViaCommandService(
       (cs) => cs.retryWorkflow(makeEnvelope('facade.retry-workflow', 'surface', 'workflow', { workflowId })),
     );
@@ -279,6 +289,7 @@ export class WorkflowMutationFacade {
   }
 
   async recreateWorkflow(workflowId: string): Promise<MutationResult> {
+    await this.closeReviewForWorkflow(workflowId);
     const started = await this.runViaCommandService(
       (cs) => cs.recreateWorkflow(makeEnvelope('facade.recreate-workflow', 'surface', 'workflow', { workflowId })),
     );
@@ -286,18 +297,21 @@ export class WorkflowMutationFacade {
   }
 
   async recreateWorkflowFromFreshBase(workflowId: string): Promise<MutationResult> {
+    await this.closeReviewForWorkflow(workflowId);
     const started = await sharedRecreateWorkflowFromFreshBase(workflowId, this.actionDeps());
     return this.finalizeWithTopup(started, 'facade.recreate-from-fresh-base', { scopedWorkflowId: workflowId });
   }
 
   async rebaseRetry(target: string): Promise<MutationResult> {
     const workflowId = resolveWorkflowIdForRebaseTarget(target, this.actionDeps());
+    await this.closeReviewForWorkflow(workflowId);
     const started = await sharedRebaseRetry(target, this.actionDeps());
     return this.finalizeWithTopup(started, 'facade.rebase-retry', { scopedWorkflowId: workflowId });
   }
 
   async rebaseRecreate(target: string): Promise<MutationResult> {
     const workflowId = resolveWorkflowIdForRebaseTarget(target, this.actionDeps());
+    await this.closeReviewForWorkflow(workflowId);
     const started = await sharedRebaseRecreate(target, this.actionDeps());
     return this.finalizeWithTopup(started, 'facade.rebase-recreate', { scopedWorkflowId: workflowId });
   }
@@ -518,5 +532,14 @@ export class WorkflowMutationFacade {
       context,
       dispatchMode: this.deps.dispatchMode,
     });
+  }
+
+  private async closeReviewForWorkflow(workflowId: string | undefined): Promise<void> {
+    if (workflowId) await this.deps.taskExecutor.closeWorkflowReview?.(workflowId);
+  }
+
+  private async closeReviewForTask(taskId: string): Promise<void> {
+    const workflowId = this.deps.orchestrator.getTask(taskId)?.config.workflowId;
+    await this.closeReviewForWorkflow(workflowId);
   }
 }

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -113,6 +113,74 @@ afterEach(() => {
 });
 
 describe('TaskRunner', () => {
+  it('closes every current review gate artifact and continues after one close failure', async () => {
+    const logger = createMockLogger();
+    const closeReview = vi.fn()
+      .mockRejectedValueOnce(new Error('first close failed'))
+      .mockResolvedValue(undefined);
+    const tasks = [
+      makeTask({
+        id: '__merge__wf-1',
+        status: 'review_ready',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: {
+          workspacePath: '/tmp/review-workspace',
+          reviewGate: {
+            activeGeneration: 4,
+            completion: { required: 'all', status: 'approved' },
+            artifacts: [
+              { id: 'contracts', providerId: 'pr-1', required: true, status: 'open', generation: 4 },
+              { id: 'runtime', providerId: 'pr-2', required: true, status: 'approved', generation: 4 },
+              { id: 'old', providerId: 'pr-old', required: true, status: 'open', generation: 3 },
+              { id: 'discarded', providerId: 'pr-discarded', required: true, status: 'discarded', generation: 4 },
+              { id: 'local', required: true, status: 'open', generation: 4 },
+            ],
+          },
+        },
+      }),
+    ];
+    const runner = new TaskRunner({
+      orchestrator: { getAllTasks: () => tasks } as any,
+      persistence: {} as any,
+      executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+      mergeGateProvider: { closeReview } as any,
+      logger,
+      cwd: '/tmp/fallback',
+    });
+
+    await runner.closeWorkflowReview('wf-1');
+
+    expect(closeReview).toHaveBeenCalledTimes(2);
+    expect(closeReview).toHaveBeenNthCalledWith(1, { identifier: 'pr-1', cwd: '/tmp/review-workspace' });
+    expect(closeReview).toHaveBeenNthCalledWith(2, { identifier: 'pr-2', cwd: '/tmp/review-workspace' });
+    expect(logger.error).toHaveBeenCalledWith('[merge-gate] Failed to close review pr-1', { err: expect.any(Error) });
+  });
+
+  it('falls back to scalar review id when no review gate exists', async () => {
+    const closeReview = vi.fn().mockResolvedValue(undefined);
+    const tasks = [
+      makeTask({
+        id: '__merge__wf-1',
+        status: 'review_ready',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: {
+          reviewId: 'scalar-pr',
+          workspacePath: '/tmp/review-workspace',
+        },
+      }),
+    ];
+    const runner = new TaskRunner({
+      orchestrator: { getAllTasks: () => tasks } as any,
+      persistence: {} as any,
+      executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+      mergeGateProvider: { closeReview } as any,
+      cwd: '/tmp/fallback',
+    });
+
+    await runner.closeWorkflowReview('wf-1');
+
+    expect(closeReview).toHaveBeenCalledWith({ identifier: 'scalar-pr', cwd: '/tmp/review-workspace' });
+  });
   it('sends attemptId and executionGeneration in work requests and preserves them in responses', async () => {
     const handleWorkerResponse = vi.fn();
     let seenRequest: any;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -2395,20 +2395,37 @@ export class TaskRunner {
   }
 
   async closeWorkflowReview(workflowId: string): Promise<void> {
-    if (!this.mergeGateProvider?.closeReview) return;
+    const closeReview = this.mergeGateProvider?.closeReview?.bind(this.mergeGateProvider);
+    if (!closeReview) return;
     const getAllTasks = this.orchestrator.getAllTasks?.bind(this.orchestrator);
     if (!getAllTasks) return;
     const mergeTask = getAllTasks().find((task) =>
       task.config.workflowId === workflowId
       && task.config.isMergeNode
-      && !!task.execution.reviewId
+      && (!!task.execution.reviewGate || !!task.execution.reviewId)
     );
-    if (!mergeTask?.execution.reviewId) return;
+    if (!mergeTask) return;
 
-    await this.mergeGateProvider.closeReview({
-      identifier: mergeTask.execution.reviewId,
-      cwd: mergeTask.execution.workspacePath ?? this.cwd,
-    });
+    const gate = mergeTask.execution.reviewGate;
+    const identifiers = gate
+      ? gate.artifacts
+          .filter((artifact) =>
+            artifact.generation === gate.activeGeneration
+            && artifact.status !== 'discarded'
+            && !!artifact.providerId,
+          )
+          .map((artifact) => artifact.providerId!)
+      : mergeTask.execution.reviewId
+        ? [mergeTask.execution.reviewId]
+        : [];
+    const cwd = mergeTask.execution.workspacePath ?? this.cwd;
+    for (const identifier of identifiers) {
+      try {
+        await closeReview({ identifier, cwd });
+      } catch (err) {
+        this.logger.error(`[merge-gate] Failed to close review ${identifier}`, { err });
+      }
+    }
   }
 
   private async handleApprovedMergeGate(

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -432,6 +432,138 @@ describe('Orchestrator', () => {
       expect(task.execution.reviewId).toBe('owner/repo#1');
       expect(task.execution.reviewStatus).toBe('Awaiting review');
     });
+
+    it('ignores setTaskReviewReady for a stale execution generation', () => {
+      orchestrator.loadPlan({
+        name: 'Review ready lineage',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      persistence.updateTask(mergeId, {
+        status: 'running',
+        execution: { generation: 2, selectedAttemptId: 'attempt-current' },
+      });
+
+      orchestrator.setTaskReviewReady(
+        mergeId,
+        { execution: { reviewId: 'owner/repo#stale', reviewUrl: 'https://example.test/stale' } },
+        { taskId: mergeId, selectedAttemptId: 'attempt-current', generation: 1 },
+      );
+
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.status).toBe('running');
+      expect(task.execution.reviewId).toBeUndefined();
+      expect(task.execution.reviewUrl).toBeUndefined();
+    });
+
+    it('discards review gate artifacts and clears scalar review fields on retry', () => {
+      orchestrator.loadPlan({
+        name: 'Review discard retry',
+        mergeMode: 'external_review',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      persistence.updateTask(mergeId, {
+        status: 'review_ready',
+        execution: {
+          generation: 3,
+          reviewId: 'owner/repo#1',
+          reviewUrl: 'https://github.com/owner/repo/pull/1',
+          reviewStatus: 'open',
+          reviewProviderId: 'owner/repo#1',
+          reviewGate: {
+            activeGeneration: 3,
+            completion: { required: 'all', status: 'approved' },
+            artifacts: [
+              {
+                id: 'contracts',
+                providerId: 'owner/repo#1',
+                url: 'https://github.com/owner/repo/pull/1',
+                required: true,
+                status: 'approved',
+                generation: 3,
+              },
+              {
+                id: 'runtime',
+                providerId: 'owner/repo#2',
+                url: 'https://github.com/owner/repo/pull/2',
+                required: true,
+                status: 'open',
+                generation: 3,
+                dependsOn: ['contracts'],
+              },
+            ],
+          },
+        },
+      });
+
+      orchestrator.retryTask(mergeId);
+
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.execution.reviewId).toBeUndefined();
+      expect(task.execution.reviewUrl).toBeUndefined();
+      expect(task.execution.reviewStatus).toBeUndefined();
+      expect(task.execution.reviewProviderId).toBeUndefined();
+      expect(task.execution.reviewGate?.activeGeneration).toBe(4);
+      expect(task.execution.reviewGate?.artifacts).toHaveLength(2);
+      expect(task.execution.reviewGate?.artifacts.every((artifact) => artifact.status === 'discarded')).toBe(true);
+      expect(task.execution.reviewGate?.artifacts.every((artifact) => artifact.discardReason === 'task subgraph reset to pending')).toBe(true);
+      const currentRequired = task.execution.reviewGate!.artifacts.filter((artifact) =>
+        artifact.required
+        && artifact.generation === task.execution.reviewGate!.activeGeneration
+        && artifact.status !== 'discarded'
+      );
+      expect(currentRequired).toEqual([]);
+    });
+
+    it('synthesizes a discarded artifact from scalar review fields on recreate', () => {
+      orchestrator.loadPlan({
+        name: 'Review discard recreate',
+        mergeMode: 'external_review',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      persistence.updateTask(mergeId, {
+        status: 'review_ready',
+        execution: {
+          generation: 5,
+          reviewId: 'owner/repo#scalar',
+          reviewUrl: 'https://github.com/owner/repo/pull/9',
+          reviewStatus: 'open',
+          reviewProviderId: 'owner/repo#scalar',
+        },
+      });
+
+      orchestrator.recreateWorkflow(workflowId);
+
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.execution.reviewId).toBeUndefined();
+      expect(task.execution.reviewUrl).toBeUndefined();
+      expect(task.execution.reviewStatus).toBeUndefined();
+      expect(task.execution.reviewProviderId).toBeUndefined();
+      expect(task.execution.reviewGate).toMatchObject({
+        activeGeneration: 6,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [
+          {
+            id: 'owner/repo#scalar',
+            providerId: 'owner/repo#scalar',
+            url: 'https://github.com/owner/repo/pull/9',
+            required: true,
+            status: 'discarded',
+            generation: 5,
+            discardReason: 'workflow recreation reset',
+          },
+        ],
+      });
+      expect(task.execution.reviewGate?.artifacts[0].discardedAt).toEqual(expect.any(String));
+    });
   });
 
   describe('workflow status transitions during retry paths', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -19,7 +19,7 @@ import { TaskStateMachine } from './state-machine.js';
 import { ResponseHandler } from './response-handler.js';
 import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
-import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, TaskExecution, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
 import { createTaskState, createAttempt } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
@@ -901,7 +901,21 @@ export class Orchestrator {
           continue;
         }
 
-        const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
+        const bumpedChanges = this.withBumpedExecutionGeneration(current, resetChanges);
+        const discardPatch = current.config.isMergeNode
+          ? this.buildDiscardReviewGatePatch(
+              current,
+              'task subgraph reset to pending',
+              bumpedChanges.execution?.generation ?? this.getExecutionGeneration(current) + 1,
+            )
+          : {};
+        const changesWithGeneration: TaskStateChanges = {
+          ...bumpedChanges,
+          execution: {
+            ...bumpedChanges.execution,
+            ...discardPatch,
+          },
+        };
         const updated = this.writeAndSync(id, changesWithGeneration, { skipWorkflowStatusSync: true });
         const priorAttemptId = current.execution.selectedAttemptId;
         this.replaceSelectedAttempt(current, {}, { skipWorkflowStatusSync: true });
@@ -1025,6 +1039,49 @@ export class Orchestrator {
       execution: {
         ...changes.execution,
         generation: this.getExecutionGeneration(task) + 1,
+      },
+    };
+  }
+
+  private buildDiscardReviewGatePatch(
+    task: TaskState,
+    reason: string,
+    nextGeneration: number,
+    now: Date = new Date(),
+  ): Partial<TaskExecution> {
+    const reviewGate = task.execution.reviewGate;
+    if (!reviewGate && !task.execution.reviewId && !task.execution.reviewUrl) return {};
+
+    const discardedAt = now.toISOString();
+    const oldArtifacts = reviewGate?.artifacts ?? [{
+      id: task.execution.reviewId ?? 'review',
+      ...(task.execution.reviewId ? { providerId: task.execution.reviewId } : {}),
+      ...(task.execution.reviewUrl ? { url: task.execution.reviewUrl } : {}),
+      required: true,
+      status: 'discarded' as const,
+      generation: task.execution.generation ?? 0,
+      discardedAt,
+      discardReason: reason,
+    }];
+
+    return {
+      reviewUrl: undefined,
+      reviewId: undefined,
+      reviewStatus: undefined,
+      reviewProviderId: undefined,
+      reviewGate: {
+        activeGeneration: nextGeneration,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: oldArtifacts.map((artifact) =>
+          artifact.discardedAt || artifact.status === 'discarded'
+            ? artifact
+            : {
+                ...artifact,
+                status: 'discarded',
+                discardedAt,
+                discardReason: reason,
+              },
+        ),
       },
     };
   }
@@ -1629,10 +1686,12 @@ export class Orchestrator {
     status: 'awaiting_approval' | 'review_ready',
     eventName: 'task.awaiting_approval' | 'task.review_ready',
     additionalChanges?: TaskStateChanges,
+    expectedLineage?: TaskLineageExpectation,
   ): void {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) return;
+    if (!this.taskMatchesLineageExpectation(task, expectedLineage)) return;
     const id = task.id;
 
     const additionalExecution = additionalChanges?.execution;
@@ -1701,8 +1760,12 @@ export class Orchestrator {
    * Transition a running merge gate directly to review_ready.
    * Used by merge-gate execution when output is ready for human review.
    */
-  setTaskReviewReady(taskId: string, additionalChanges?: TaskStateChanges): void {
-    this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', additionalChanges);
+  setTaskReviewReady(
+    taskId: string,
+    additionalChanges?: TaskStateChanges,
+    expectedLineage?: TaskLineageExpectation,
+  ): void {
+    this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', additionalChanges, expectedLineage);
   }
 
   setFixAwaitingApproval(
@@ -2318,7 +2381,21 @@ export class Orchestrator {
     for (const id of toResetIds) {
       const current = this.stateGetTask(id);
       if (!current) continue;
-      const changesWithGeneration = this.withBumpedExecutionGeneration(current, RECREATE_RESET_CHANGES);
+      const bumpedChanges = this.withBumpedExecutionGeneration(current, RECREATE_RESET_CHANGES);
+      const discardPatch = current.config.isMergeNode
+        ? this.buildDiscardReviewGatePatch(
+            current,
+            artifactReason,
+            bumpedChanges.execution?.generation ?? this.getExecutionGeneration(current) + 1,
+          )
+        : {};
+      const changesWithGeneration: TaskStateChanges = {
+        ...bumpedChanges,
+        execution: {
+          ...bumpedChanges.execution,
+          ...discardPatch,
+        },
+      };
       const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
       const priorAttemptId = current.execution.selectedAttemptId;
       this.replaceSelectedAttempt(current);
@@ -2441,7 +2518,21 @@ export class Orchestrator {
         agentSessionId: prevSess ?? 'null',
         containerId: prevCt ?? 'null',
       });
-      const changesWithGeneration = this.withBumpedExecutionGeneration(task, resetChanges);
+      const bumpedChanges = this.withBumpedExecutionGeneration(task, resetChanges);
+      const discardPatch = task.config.isMergeNode
+        ? this.buildDiscardReviewGatePatch(
+            task,
+            'workflow recreation reset',
+            bumpedChanges.execution?.generation ?? this.getExecutionGeneration(task) + 1,
+          )
+        : {};
+      const changesWithGeneration: TaskStateChanges = {
+        ...bumpedChanges,
+        execution: {
+          ...bumpedChanges.execution,
+          ...discardPatch,
+        },
+      };
       const after = this.writeAndSync(task.id, changesWithGeneration);
       const priorAttemptId = task.execution.selectedAttemptId;
       this.replaceSelectedAttempt(task);
@@ -4341,6 +4432,7 @@ export class Orchestrator {
         reviewUrl: parsed.reviewUrl,
         reviewId: parsed.reviewId,
         reviewStatus: parsed.reviewStatus,
+        reviewGate: parsed.reviewGate,
       },
     };
     this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', changes);


### PR DESCRIPTION
## Summary

This closes and discards stale review-gate PR artifacts when merge output is invalidated.

It also adds lineage guards so old review-ready writes stop at the task boundary.

<details>
<summary>Review metadata</summary>

Review Claim: Invalidated merge gates close and discard the PR artifacts they relied on.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: Discarded artifacts stay stored for audit, but current gate checks stop counting them.

Slice Rationale: Invalidation behavior must land before multi-artifact polling, or old PRs would stay live and ambiguous.

Architectural Effect: Review artifacts now follow the same invalidation boundary as execution output.

Alternative Considerations: We could have deleted stale artifacts outright, but keeping them preserves history and queryability.
</details>

## Non-goals

This does not change how new review PRs are created.

This does not change approval rules for current gates.

## Architecture

### Before

```mermaid
graph TD
  A[Retry recreate reset] --> B[clear scalar review fields]
```

### After

```mermaid
graph TD
  A[Retry recreate reset] --> B[close provider reviews]
  A --> C[discard current reviewGate artifacts]
  A --> D[lineage guard stale seal writes]
```

## Test Plan

- [x] `pnpm exec vitest run src/__tests__/orchestrator.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `pnpm exec vitest run src/__tests__/workflow-mutation-facade.test.ts`
- [x] `pnpm exec vitest run src/__tests__/task-runner.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 2fd7cf146`
- Post-revert steps: None
- Data migration? No

Depends-On: #1754