### PR TITLE
[Multi PR Review Gate](5) Publish linear review stacks through make-pr

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1206,6 +1206,142 @@ describe('TaskRunner', () => {
       }
     });
 
+    it('publishReviewStackWithMakePrSkill uses preferred agent then falls back to another make-pr agent', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const attempts: string[] = [];
+        const claudeAgent = {
+          name: 'claude',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.claude', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => {
+            attempts.push('claude');
+            return { cmd: 'node', args: ['-e', 'process.stdout.write("not json")'], sessionId: 'sess-claude' };
+          },
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+        const codexAgent = {
+          name: 'codex',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.codex', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => {
+            attempts.push('codex');
+            return {
+              cmd: 'node',
+              args: ['-e', 'process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master"},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"]}]}))'],
+              sessionId: 'sess-codex',
+            };
+          },
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+        const executor = new TaskRunner({
+          orchestrator: {
+            getTask: () => null,
+            getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-1', executionAgent: 'claude' } })],
+          } as any,
+          persistence: {} as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          executionAgentRegistry: {
+            get: (name: string) => (name === 'claude' ? claudeAgent : name === 'codex' ? codexAgent : undefined),
+            getOrThrow: vi.fn(),
+            getSessionDriver: vi.fn().mockReturnValue(undefined),
+            listWithCapability: vi.fn().mockReturnValue([claudeAgent, codexAgent]),
+          } as any,
+          cwd: '/tmp',
+        });
+
+        const result = await (executor as any).publishReviewStackWithMakePrSkill({
+          workflowId: 'wf-1',
+          title: 'Stack',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: 'summary',
+          cwd: '/tmp',
+        });
+
+        expect(attempts).toEqual(['claude', 'codex']);
+        expect(result.agentName).toBe('codex');
+        expect(result.artifacts[1].dependsOn).toEqual(['contracts']);
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
+    it('publishReviewStackWithMakePrSkill throws when make-pr agents cannot publish valid JSON', async () => {
+      const badAgent = {
+        name: 'claude',
+        stdinMode: 'ignore' as const,
+        bundledSkills: ['make-pr'],
+        buildCommand: () => ({ cmd: 'node', args: ['-e', 'process.stdout.write("not json")'], sessionId: 'bad' }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: vi.fn().mockReturnValue(badAgent),
+          getOrThrow: vi.fn(),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([badAgent]),
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await expect((executor as any).publishReviewStackWithMakePrSkill({
+        workflowId: 'wf-1',
+        title: 'Stack',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        workflowSummary: 'summary',
+        cwd: '/tmp',
+      })).rejects.toThrow('make-pr skill is required to publish Invoker review stacks');
+    });
+    it('publishReviewStackWithMakePrSkill throws when make-pr agents publish a branched review stack', async () => {
+      const branchedAgent = {
+        name: 'claude',
+        stdinMode: 'ignore' as const,
+        bundledSkills: ['make-pr'],
+        buildCommand: () => ({
+          cmd: 'node',
+          args: ['-e', 'process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master"},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"]},{id:"ui",title:"UI",url:"https://example.test/pr/3",providerId:"3",branch:"stack/ui",baseBranch:"stack/runtime",dependsOn:["contracts"]}]}))'],
+          sessionId: 'branched',
+        }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: vi.fn().mockReturnValue(branchedAgent),
+          getOrThrow: vi.fn(),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([branchedAgent]),
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await expect((executor as any).publishReviewStackWithMakePrSkill({
+        workflowId: 'wf-1',
+        title: 'Stack',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        workflowSummary: 'summary',
+        cwd: '/tmp',
+      })).rejects.toThrow('make-pr skill is required to publish Invoker review stacks');
+    });
+
     it('authorPrBodyWithSkill falls back to canonical body when authored body is invalid and no other agents available', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;
@@ -2026,6 +2162,7 @@ describe('TaskRunner', () => {
       featureBranch?: string;
       gateWorkspacePath?: string | null;
       taskBranches?: TaskState[];
+      repoUrl?: string;
     }) {
       const mergeTaskId = '__merge__wf-pub';
       const workflowId = 'wf-pub';
@@ -2057,6 +2194,7 @@ describe('TaskRunner', () => {
           baseBranch: 'master',
           featureBranch: opts.featureBranch,
           name: 'Test Workflow',
+          repoUrl: opts.repoUrl,
         }),
         updateTask: vi.fn(),
         getWorkspacePath: () => opts.gateWorkspacePath ?? null,
@@ -2103,6 +2241,84 @@ describe('TaskRunner', () => {
       return { executor, mergeTask, orchestrator, persistence, mergeGateProvider, gitCalls };
     }
 
+
+    it('external_review on Invoker publishes a make-pr review stack instead of direct provider PR', async () => {
+      const contractsTask = makeTask({
+        id: 'contracts',
+        status: 'completed',
+        config: { workflowId: 'wf-pub' },
+        execution: { branch: 'invoker/contracts' },
+        description: 'Contracts',
+      });
+      const runtimeTask = makeTask({
+        id: 'runtime',
+        status: 'completed',
+        config: { workflowId: 'wf-pub' },
+        execution: { branch: 'invoker/runtime' },
+        description: 'Runtime',
+      });
+
+      const { executor, mergeTask, orchestrator, mergeGateProvider } = setupPublishAfterFix({
+        mergeMode: 'external_review',
+        featureBranch: 'plan/feature',
+        gateWorkspacePath: '/tmp/gate-clone',
+        taskBranches: [contractsTask, runtimeTask],
+        repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+      });
+
+      (executor as any).publishReviewStackWithMakePrSkill = vi.fn().mockResolvedValue({
+        artifacts: [
+          {
+            id: 'contracts',
+            title: 'Define contracts',
+            url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/1',
+            providerId: '1',
+            branch: 'stack/contracts',
+            baseBranch: 'master',
+            required: true,
+            status: 'open',
+            generation: 0,
+          },
+          {
+            id: 'runtime',
+            title: 'Wire runtime',
+            url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/2',
+            providerId: '2',
+            branch: 'stack/runtime',
+            baseBranch: 'stack/contracts',
+            dependsOn: ['contracts'],
+            required: true,
+            status: 'open',
+            generation: 0,
+          },
+        ],
+        sessionId: 'sess-stack',
+        agentName: 'codex',
+      });
+
+      await executor.publishAfterFix(mergeTask);
+
+      expect((executor as any).publishReviewStackWithMakePrSkill).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Test Workflow',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        cwd: '/tmp/gate-clone',
+      }));
+      expect(mergeGateProvider.createReview).not.toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
+        execution: expect.objectContaining({
+          reviewUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/1',
+          reviewId: '1',
+          reviewGate: expect.objectContaining({
+            activeGeneration: 0,
+            artifacts: [
+              expect.objectContaining({ id: 'contracts', generation: 0 }),
+              expect.objectContaining({ id: 'runtime', dependsOn: ['contracts'], generation: 0 }),
+            ],
+          }),
+        }),
+      }), expect.objectContaining({ generation: 0 }));
+    });
     it('external_review mode: detaches HEAD, fetches, consolidates, creates PR', async () => {
       const completedTask = makeTask({
         id: 't1',

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -18,8 +18,10 @@ import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 import type { MergeGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
-import type { PrAuthoringContext, PrAuthoringTaskEntry } from './pr-authoring.js';
+import { isInvokerRepoUrl, type PrAuthoringContext, type PrAuthoringTaskEntry } from './pr-authoring.js';
 import { isGitRefLockRace } from './git-utils.js';
+type ReviewGateState = NonNullable<TaskState['execution']['reviewGate']>;
+type ReviewGateArtifact = ReviewGateState['artifacts'][number];
 
 // ── Trace logging ────────────────────────────────────────
 
@@ -207,6 +209,16 @@ export interface MergeRunnerHost {
   removeMergeWorktree(dir: string): Promise<void>;
   execGh(args: string[], cwd?: string): Promise<string>;
   execPr(baseBranch: string, featureBranch: string, title: string, body?: string, cwd?: string): Promise<string>;
+  publishReviewStackWithMakePrSkill?(args: {
+    workflowId?: string;
+    mergeNodeTaskId?: string;
+    title: string;
+    baseBranch: string;
+    featureBranch: string;
+    workflowSummary: string;
+    cwd: string;
+    reviewGate?: ReviewGateState;
+  }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }>;
   authorPrBodyWithSkill?(args: {
     workflowId?: string;
     mergeNodeTaskId?: string;
@@ -556,7 +568,8 @@ export async function runMergeGateActionImpl(
         };
       }
       if (mergeMode === 'external_review') {
-        if (!host.mergeGateProvider) {
+        const invokerReviewStack = isInvokerRepoUrl(workflow?.repoUrl);
+        if (!invokerReviewStack && !host.mergeGateProvider) {
           throw new Error('mergeMode is "external_review" but no review provider configured');
         }
 
@@ -577,49 +590,84 @@ export async function runMergeGateActionImpl(
           }
         }
 
-        // Route through shared PR-authoring helper for consistent PR bodies.
-        const structuredCtx = workflowId
-          ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture)
-          : undefined;
-        const prBody = await authorPrBodyForMerge(host, {
-          workflowId,
-          mergeNodeTaskId: task.id,
-          title: workflow?.name ?? 'Workflow',
-          baseBranch,
-          featureBranch: featureBranch!,
-          workflowSummary: fullSummary ?? '',
-          structuredContext: structuredCtx,
-          cwd: gateWorkspacePath!,
-        });
+        let reviewGate: ReviewGateState;
+        if (invokerReviewStack) {
+          if (!host.publishReviewStackWithMakePrSkill) {
+            throw new Error('make-pr skill is required to publish Invoker review stacks');
+          }
+          const published = await host.publishReviewStackWithMakePrSkill({
+            workflowId,
+            mergeNodeTaskId: task.id,
+            title: workflow?.name ?? 'Workflow',
+            baseBranch,
+            featureBranch: featureBranch!,
+            workflowSummary: fullSummary ?? '',
+            cwd: gateWorkspacePath!,
+          });
+          const artifacts = published.artifacts.map((artifact) => ({
+            ...artifact,
+            baseBranch: artifact.baseBranch ?? baseBranch,
+            required: true,
+            status: 'open' as const,
+            generation: expectedGeneration,
+          }));
+          reviewGate = {
+            activeGeneration: expectedGeneration,
+            completion: { required: 'all', status: 'approved' },
+            artifacts,
+          };
+          const firstArtifact = artifacts[0];
+          reviewUrl = firstArtifact?.url;
+          reviewId = firstArtifact?.providerId;
+          reviewStatus = 'Awaiting review';
+          console.log(
+            `[merge] Published Invoker review stack via ${published.agentName} skill`,
+          );
+        } else {
+          // Route through shared PR-authoring helper for consistent PR bodies.
+          const structuredCtx = workflowId
+            ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture)
+            : undefined;
+          const prBody = await authorPrBodyForMerge(host, {
+            workflowId,
+            mergeNodeTaskId: task.id,
+            title: workflow?.name ?? 'Workflow',
+            baseBranch,
+            featureBranch: featureBranch!,
+            workflowSummary: fullSummary ?? '',
+            structuredContext: structuredCtx,
+            cwd: gateWorkspacePath!,
+          });
 
-        // Create PR via provider (consolidation already done above).
-        // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
-        const result = await host.mergeGateProvider.createReview({
-          baseBranch,
-          featureBranch,
-          title: workflow?.name ?? 'Workflow',
-          cwd: gateWorkspacePath!,
-          body: prBody,
-        });
-        console.log(`[merge] Created GitHub PR: ${result.url}`);
+          // Create PR via provider (consolidation already done above).
+          // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
+          const result = await host.mergeGateProvider!.createReview({
+            baseBranch,
+            featureBranch,
+            title: workflow?.name ?? 'Workflow',
+            cwd: gateWorkspacePath!,
+            body: prBody,
+          });
+          console.log(`[merge] Created GitHub PR: ${result.url}`);
 
-        reviewUrl = result.url;
-        reviewId = result.identifier;
-        reviewStatus = 'Awaiting review';
-        const reviewGate = buildSingleArtifactReviewGate({
-          expectedGeneration,
-          title: workflow?.name ?? 'Workflow',
-          url: result.url,
-          providerId: result.identifier,
-          provider: host.mergeGateProvider.name,
-          branch: featureBranch,
-          baseBranch,
-          nowIso: new Date().toISOString(),
-        });
+          reviewUrl = result.url;
+          reviewId = result.identifier;
+          reviewStatus = 'Awaiting review';
+          reviewGate = buildSingleArtifactReviewGate({
+            expectedGeneration,
+            title: workflow?.name ?? 'Workflow',
+            url: result.url,
+            providerId: result.identifier,
+            provider: host.mergeGateProvider!.name,
+            branch: featureBranch,
+            baseBranch,
+            nowIso: new Date().toISOString(),
+          });
+        }
         mergeTrace('GATE_WS_PATH_EXTERNAL_REVIEW_AWAIT', {
           taskId: task.id,
           gateWorkspacePath: gateWorkspacePath ?? null,
-          reviewUrl: result.url,
+          reviewUrl,
         });
         console.log(
           `[merge-gate-workspace] setTaskReviewReady path=external_review ` +
@@ -1117,53 +1165,91 @@ export async function publishAfterFixImpl(
     }
 
     if (mergeMode === 'external_review') {
-      if (!host.mergeGateProvider) {
+      const invokerReviewStack = isInvokerRepoUrl(workflow?.repoUrl);
+      if (!invokerReviewStack && !host.mergeGateProvider) {
         throw new Error('mergeMode is "external_review" but no review provider configured');
       }
 
-      // Route through shared PR-authoring helper for consistent PR bodies.
-      const structuredCtxReview = workflowId
-        ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture2)
-        : undefined;
-      const prBodyReview = await authorPrBodyForMerge(host, {
-        workflowId,
-        mergeNodeTaskId: task.id,
-        title: workflow?.name ?? 'Workflow',
-        baseBranch,
-        featureBranch,
-        workflowSummary: fullSummary ?? '',
-        structuredContext: structuredCtxReview,
-        cwd: consolidateDir,
-      });
-
-      const result = await host.mergeGateProvider.createReview({
-        baseBranch,
-        featureBranch,
-        title: workflow?.name ?? 'Workflow',
-        cwd: consolidateDir,
-        body: prBodyReview,
-      });
-      console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
-
       const expectedGeneration = task.execution.generation ?? 0;
-      const reviewGate = buildSingleArtifactReviewGate({
-        expectedGeneration,
-        title: workflow?.name ?? 'Workflow',
-        url: result.url,
-        providerId: result.identifier,
-        provider: host.mergeGateProvider.name,
-        branch: featureBranch,
-        baseBranch,
-        nowIso: new Date().toISOString(),
-      });
+      let reviewUrl: string | undefined;
+      let reviewId: string | undefined;
+      let reviewGate: ReviewGateState;
+      if (invokerReviewStack) {
+        if (!host.publishReviewStackWithMakePrSkill) {
+          throw new Error('make-pr skill is required to publish Invoker review stacks');
+        }
+        const published = await host.publishReviewStackWithMakePrSkill({
+          workflowId,
+          mergeNodeTaskId: task.id,
+          title: workflow?.name ?? 'Workflow',
+          baseBranch,
+          featureBranch,
+          workflowSummary: fullSummary ?? '',
+          cwd: consolidateDir,
+        });
+        const artifacts = published.artifacts.map((artifact) => ({
+          ...artifact,
+          baseBranch: artifact.baseBranch ?? baseBranch,
+          required: true,
+          status: 'open' as const,
+          generation: expectedGeneration,
+        }));
+        reviewGate = {
+          activeGeneration: expectedGeneration,
+          completion: { required: 'all', status: 'approved' },
+          artifacts,
+        };
+        reviewUrl = artifacts[0]?.url;
+        reviewId = artifacts[0]?.providerId;
+        console.log(
+          `[merge] Post-fix: published Invoker review stack via ${published.agentName} skill`,
+        );
+      } else {
+        // Route through shared PR-authoring helper for consistent PR bodies.
+        const structuredCtxReview = workflowId
+          ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture2)
+          : undefined;
+        const prBodyReview = await authorPrBodyForMerge(host, {
+          workflowId,
+          mergeNodeTaskId: task.id,
+          title: workflow?.name ?? 'Workflow',
+          baseBranch,
+          featureBranch,
+          workflowSummary: fullSummary ?? '',
+          structuredContext: structuredCtxReview,
+          cwd: consolidateDir,
+        });
+
+        const result = await host.mergeGateProvider!.createReview({
+          baseBranch,
+          featureBranch,
+          title: workflow?.name ?? 'Workflow',
+          cwd: consolidateDir,
+          body: prBodyReview,
+        });
+        console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
+
+        reviewUrl = result.url;
+        reviewId = result.identifier;
+        reviewGate = buildSingleArtifactReviewGate({
+          expectedGeneration,
+          title: workflow?.name ?? 'Workflow',
+          url: result.url,
+          providerId: result.identifier,
+          provider: host.mergeGateProvider!.name,
+          branch: featureBranch,
+          baseBranch,
+          nowIso: new Date().toISOString(),
+        });
+      }
 
       setMergeGateReviewReady(host, task.id, {
         config: { runnerKind: 'worktree', summary },
         execution: {
           branch: featureBranch,
           workspacePath: gateWorkspacePath,
-          reviewUrl: result.url,
-          reviewId: result.identifier,
+          reviewUrl,
+          reviewId,
           reviewStatus: 'Awaiting review',
           reviewGate,
           fixedIntegrationSha: undefined,

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -8,6 +8,16 @@ import type { ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
 import { cleanElectronEnv, resolveExecutableOnCurrentPath } from './process-utils.js';
 
+export interface MakePrStackArtifactOutput {
+  readonly id: string;
+  readonly title?: string;
+  readonly url: string;
+  readonly providerId?: string;
+  readonly branch?: string;
+  readonly baseBranch?: string;
+  readonly dependsOn?: readonly string[];
+}
+
 // ── Structured PR-authoring context ──────────────────────
 
 /** Per-task evidence carried through PR authoring. */
@@ -150,6 +160,148 @@ export function resolveSkillPathViaAgent(agent: ExecutionAgent, skillName: strin
     if (existsSync(join(skillDir, 'SKILL.md'))) return skillDir;
   }
   return resolveInstalledSkillPathForAgent(agent.name, skillName);
+}
+
+const INVOKER_REPO_OWNER_RE = /^(neko-catpital-labs|edbertchan)$/i;
+
+export function isInvokerRepoUrl(repoUrl: string | undefined): boolean {
+  if (!repoUrl) return false;
+  const trimmed = repoUrl.trim();
+  const httpsMatch = /^https:\/\/github\.com\/([^/]+)\/([^/.]+)(?:\.git)?\/?$/i.exec(trimmed);
+  const sshMatch = /^(?:git@github\.com:|ssh:\/\/git@github\.com\/)([^/]+)\/([^/.]+)(?:\.git)?\/?$/i.exec(trimmed);
+  const match = httpsMatch ?? sshMatch;
+  if (!match) return false;
+  const [, owner, repo] = match;
+  return INVOKER_REPO_OWNER_RE.test(owner) && repo.toLowerCase() === 'invoker';
+}
+
+export function buildMakePrStackPublishPrompt(args: {
+  skillPath: string;
+  title: string;
+  baseBranch: string;
+  featureBranch: string;
+  workflowSummary: string;
+  cwd: string;
+  reviewGate?: unknown;
+}): string {
+  const lines = [
+    `Publish the Invoker-on-Invoker review PR stack for branch "${args.featureBranch}" targeting "${args.baseBranch}".`,
+    '',
+    `Use the installed skill "invoker-make-pr" at: ${args.skillPath}`,
+    'Read invoker-make-pr/SKILL.md first and follow the repo-local PR workflow exactly.',
+    'Use Mergify stack publication for this Invoker stack.',
+    '',
+    'Requirements:',
+    `- PR title prefix/base title: "${args.title}"`,
+    `- Repository working directory: ${args.cwd}`,
+    '- Use the repo-local PR workflow and validation tools from the skill.',
+    '- Output only JSON. Do not include markdown, commentary, explanations, or code fences.',
+    '- The JSON shape must be exactly:',
+    '{"artifacts":[{"id":"string","title":"string","url":"string","providerId":"string","branch":"string","baseBranch":"string","dependsOn":["string"]}]}',
+    '- artifacts are already listed in stack order.',
+    '- artifacts[0].dependsOn must be omitted or [].',
+    '- For every i > 0, artifacts[i].dependsOn must be exactly [artifacts[i - 1].id].',
+    '- Do not emit branches, merges, skipped predecessors, or multiple dependencies.',
+    '- Do not add fixed PR-count fields.',
+    '- Do not add Mergify-specific fields to the JSON.',
+    '',
+    'Workflow summary:',
+    '```md',
+    args.workflowSummary.trim(),
+    '```',
+  ];
+  if (args.reviewGate) {
+    lines.push('', 'Existing review-gate intent:', '```json', JSON.stringify(args.reviewGate, null, 2), '```');
+  }
+  return lines.join('\n');
+}
+
+export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactOutput[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.trim());
+  } catch {
+    throw new Error('make-pr stack publisher must output JSON');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('make-pr stack publisher output must be a JSON object');
+  }
+  const artifacts = (parsed as { artifacts?: unknown }).artifacts;
+  if (!Array.isArray(artifacts)) {
+    throw new Error('make-pr stack publisher output must include artifacts array');
+  }
+
+  if (artifacts.length === 0) {
+    throw new Error('make-pr stack publisher output must include at least one artifact');
+  }
+  const ids = new Set<string>();
+  const records: MakePrStackArtifactOutput[] = [];
+  for (let i = 0; i < artifacts.length; i += 1) {
+    const artifact = artifacts[i];
+    if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
+      throw new Error(`artifacts[${i}] must be an object`);
+    }
+    const record = artifact as Record<string, unknown>;
+    if (typeof record.id !== 'string' || record.id.trim().length === 0) {
+      throw new Error(`artifacts[${i}].id must be a non-empty string`);
+    }
+    const id = record.id.trim();
+    if (ids.has(id)) {
+      throw new Error(`artifacts[${i}].id duplicates artifact "${id}"`);
+    }
+    if (typeof record.url !== 'string' || record.url.trim().length === 0) {
+      throw new Error(`artifacts[${i}].url must be a non-empty string`);
+    }
+    const url = record.url.trim();
+    const dependsOn = record.dependsOn === undefined ? undefined : record.dependsOn;
+    if (dependsOn !== undefined && !Array.isArray(dependsOn)) {
+      throw new Error(`artifacts[${i}].dependsOn must be an array`);
+    }
+    const normalizedDependsOn = dependsOn === undefined
+      ? undefined
+      : dependsOn.map((dependency) => {
+        if (typeof dependency !== 'string' || dependency.trim().length === 0) {
+          throw new Error(`artifacts[${i}].dependsOn must contain non-empty artifact ids`);
+        }
+        return dependency.trim();
+      });
+    ids.add(id);
+    records.push({
+      id,
+      title: typeof record.title === 'string' ? record.title : undefined,
+      url,
+      providerId: typeof record.providerId === 'string' ? record.providerId : undefined,
+      branch: typeof record.branch === 'string' ? record.branch : undefined,
+      baseBranch: typeof record.baseBranch === 'string' ? record.baseBranch : undefined,
+      dependsOn: normalizedDependsOn,
+    });
+  }
+
+  for (let i = 0; i < records.length; i += 1) {
+    const artifact = records[i];
+    for (const dependency of artifact.dependsOn ?? []) {
+      if (!ids.has(dependency)) {
+        throw new Error(`artifacts[${i}].dependsOn references unknown artifact "${dependency}"`);
+      }
+      if (dependency === artifact.id) {
+        throw new Error(`artifacts[${i}].dependsOn must not reference itself`);
+      }
+    }
+  }
+
+  if ((records[0]?.dependsOn?.length ?? 0) > 0) {
+    throw new Error('artifacts[0].dependsOn must be omitted or [] to start the review stack');
+  }
+  for (let i = 1; i < records.length; i += 1) {
+    const expectedDependency = records[i - 1]?.id;
+    const dependencies = records[i]?.dependsOn;
+    if (dependencies?.length !== 1 || dependencies[0] !== expectedDependency) {
+      throw new Error(`artifacts[${i}].dependsOn must be ["${expectedDependency}"] to keep the review stack linear`);
+    }
+  }
+
+  return records;
 }
 
 /**

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -53,7 +53,9 @@ import {
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import {
   buildCanonicalPrBody,
+  buildMakePrStackPublishPrompt,
   buildMakePrPrompt,
+  parseMakePrStackPublishResult,
   resolveSkillPathViaAgent,
   spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
@@ -2755,6 +2757,68 @@ export class TaskRunner {
       structuredContext: args.structuredContext,
     });
     return { body: canonicalBody, sessionId: 'canonical-fallback', agentName: 'canonical' };
+  }
+
+  async publishReviewStackWithMakePrSkill(args: {
+    workflowId?: string;
+    mergeNodeTaskId?: string;
+    title: string;
+    baseBranch: string;
+    featureBranch: string;
+    workflowSummary: string;
+    cwd: string;
+    reviewGate?: ReviewGateState;
+  }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }> {
+    if (!this.executionAgentRegistry) {
+      throw new Error('make-pr skill is required to publish Invoker review stacks');
+    }
+
+    const preferredName = this.resolvePrAuthoringAgentName(args.workflowId, args.mergeNodeTaskId);
+    const prCapableAgents = this.executionAgentRegistry.listWithCapability('make-pr');
+    const orderedAgents = this.buildAgentFallbackOrder(preferredName, prCapableAgents);
+    const errors: string[] = [];
+
+    for (const agent of orderedAgents) {
+      const skillPath = resolveSkillPathViaAgent(agent, 'make-pr');
+      if (!skillPath) {
+        errors.push(`${agent.name}: skill "invoker-make-pr" not installed`);
+        continue;
+      }
+
+      const driver = this.executionAgentRegistry.getSessionDriver(agent.name);
+      const prompt = buildMakePrStackPublishPrompt({
+        skillPath,
+        title: args.title,
+        baseBranch: args.baseBranch,
+        featureBranch: args.featureBranch,
+        workflowSummary: args.workflowSummary,
+        cwd: args.cwd,
+        reviewGate: args.reviewGate,
+      });
+
+      try {
+        const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
+        const parsedArtifacts = parseMakePrStackPublishResult(result.body);
+        const nowIso = new Date().toISOString();
+        const generation = args.reviewGate?.activeGeneration ?? 0;
+        const artifacts: ReviewGateArtifact[] = parsedArtifacts.map((artifact) => ({
+          ...artifact,
+          provider: 'github',
+          baseBranch: artifact.baseBranch ?? args.baseBranch,
+          required: true,
+          status: 'open',
+          generation,
+          createdAt: nowIso,
+        }));
+        return { artifacts, sessionId: result.sessionId, agentName: agent.name };
+      } catch (err) {
+        errors.push(`${agent.name}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    throw new Error(
+      `make-pr skill is required to publish Invoker review stacks${errors.length > 0 ? `: ${errors.join(' | ')}` : ''}`,
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

This keeps Invoker review-stack publishing to one straight PR chain.

The old make-pr prompt and parser still accepted branched `dependsOn` data, so a publisher could emit stack shapes the rest of review-gate should not describe.

The prompt now tells agents to emit adjacent links only, and the publish path rejects skipped, merged, or branched predecessors.

<details>
<summary>Review metadata</summary>

Review Claim: Invoker publishes a linear make-pr review stack where each PR depends only on the PR directly before it.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: Only Invoker-on-Invoker make-pr publication is narrowed; the persisted artifact shape and non-Invoker review publishing stay the same.

Slice Rationale: The publish path must reject branched stacks before the query, UI, and plan-policy slices can safely assume one linear order.

Architectural Effect: `publishReviewStackWithMakePrSkill` still persists `ReviewGateArtifact[]`, but its make-pr result path now accepts only one ordered chain.

Alternative Considerations: We could have normalized branched output after parsing, but rejecting it at the publisher boundary avoids silently rewriting agent output.
</details>

## Non-goals

This does not remove `dependsOn` from persisted review-gate artifacts.

This does not change direct external-review publishing for non-Invoker repositories.

## Architecture

### Before

```mermaid
graph TD
  A["make-pr publisher output"] --> B["arbitrary dependsOn arrays"]
  B --> C["persisted reviewGate artifacts"]
```

### After

```mermaid
graph TD
  A["make-pr publisher output"] --> B["linear-chain publish guard"]
  B --> C["persisted reviewGate artifacts"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "publishReviewStackWithMakePrSkill"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert ecb7403b2`
- Post-revert steps: None
- Data migration? No

Depends-On: #1865


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for publishing Invoker repository review stacks using integrated “make-pr” skills with strict JSON-only artifact output and linear `dependsOn` validation.
  * Enhanced the `external_review` and publish-after-fix flows for Invoker repositories to build a multi-artifact review gate (with generated review URL/ID and required/open status wiring).

* **Bug Fixes**
  * Made the missing merge-gate provider error apply only to non-Invoker workflows.

* **Tests**
  * Added/extended coverage for preferred PR agent fallback, invalid/non-JSON handling, “no valid agent” failure, and Invoker regression scenarios (including optional repo URL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->