### PR TITLE
[Multi PR Review Gate](6) Expose linear review gate stack links

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -371,6 +371,110 @@ describe('GET /api/workflows', () => {
   });
 });
 
+describe('GET /api/workflows/:id/review-gate', () => {
+  it('returns 404 when workflow is missing', async () => {
+    mocks.persistence.loadWorkflow.mockReturnValue(undefined);
+    const res = await request(port, 'GET', '/api/workflows/missing/review-gate');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Workflow not found' });
+  });
+
+  it('returns an empty response when no merge node exists', async () => {
+    mocks.persistence.loadTasks.mockReturnValue([makeTask({ id: 'task-1' })]);
+    const res = await request(port, 'GET', '/api/workflows/wf-1/review-gate');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      workflowId: 'wf-1',
+      mergeTaskId: null,
+      status: null,
+      ready: false,
+      artifacts: [],
+      discardedArtifacts: [],
+      edges: [],
+    });
+  });
+
+  it('returns current artifacts, linear stack links, and discarded artifacts separately', async () => {
+    mocks.persistence.loadTasks.mockReturnValue([
+      makeTask({
+        id: '__merge__wf-1',
+        status: 'review_ready',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: {
+          reviewGate: {
+            activeGeneration: 2,
+            completion: { required: 'all', status: 'approved' },
+            artifacts: [
+              { id: 'contracts', required: true, status: 'approved', generation: 2 },
+              { id: 'runtime', required: true, status: 'open', generation: 2, dependsOn: ['contracts'] },
+              { id: 'ui', required: true, status: 'open', generation: 2, dependsOn: ['contracts'] },
+              { id: 'old', required: true, status: 'discarded', generation: 1, discardedAt: '2024-01-01T00:00:00Z' },
+            ],
+          },
+        },
+      }),
+    ]);
+
+    const res = await request(port, 'GET', '/api/workflows/wf-1/review-gate');
+    expect(res.status).toBe(200);
+    expect(res.body.artifacts.map((artifact: { id: string }) => artifact.id)).toEqual(['contracts', 'runtime', 'ui']);
+    expect(res.body.discardedArtifacts.map((artifact: { id: string }) => artifact.id)).toEqual(['old']);
+    expect(res.body.edges).toEqual([
+      { from: 'contracts', to: 'runtime' },
+      { from: 'runtime', to: 'ui' },
+    ]);
+    expect(res.body.ready).toBe(false);
+  });
+
+  it('returns ready only when all required current artifacts are approved', async () => {
+    mocks.persistence.loadTasks.mockReturnValue([
+      makeTask({
+        id: '__merge__wf-1',
+        status: 'review_ready',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: {
+          reviewGate: {
+            activeGeneration: 0,
+            completion: { required: 'all', status: 'approved' },
+            artifacts: [
+              { id: 'contracts', required: true, status: 'approved', generation: 0 },
+              { id: 'runtime', required: true, status: 'approved', generation: 0 },
+            ],
+          },
+        },
+      }),
+    ]);
+
+    const res = await request(port, 'GET', '/api/workflows/wf-1/review-gate');
+    expect(res.status).toBe(200);
+    expect(res.body.ready).toBe(true);
+  });
+
+  it('synthesizes a scalar fallback artifact', async () => {
+    mocks.persistence.loadTasks.mockReturnValue([
+      makeTask({
+        id: '__merge__wf-1',
+        status: 'review_ready',
+        config: { workflowId: 'wf-1', isMergeNode: true, summary: 'Review PR' },
+        execution: {
+          reviewId: '42',
+          reviewUrl: 'https://example.test/pr/42',
+          reviewStatus: 'Awaiting review',
+          reviewProviderId: '42',
+          generation: 3,
+        },
+      }),
+    ]);
+
+    const res = await request(port, 'GET', '/api/workflows/wf-1/review-gate');
+    expect(res.status).toBe(200);
+    expect(res.body.activeGeneration).toBe(3);
+    expect(res.body.artifacts).toEqual([
+      expect.objectContaining({ id: '42', url: 'https://example.test/pr/42', providerId: '42' }),
+    ]);
+  });
+});
+
 describe('GET /api/queue', () => {
   it('returns queue status', async () => {
     const res = await request(port, 'GET', '/api/queue');

--- a/packages/app/src/__tests__/formatter.test.ts
+++ b/packages/app/src/__tests__/formatter.test.ts
@@ -257,6 +257,12 @@ describe('serializeTask', () => {
         branch: 'feature/test',
         commit: 'abc123',
         exitCode: 0,
+        reviewProviderId: '42',
+        reviewGate: {
+          activeGeneration: 0,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [{ id: 'contracts', required: true, status: 'open', generation: 0 }],
+        },
         error: undefined,
       } as TaskState['execution'],
     });
@@ -265,6 +271,12 @@ describe('serializeTask', () => {
     expect(execution.branch).toBe('feature/test');
     expect(execution.commit).toBe('abc123');
     expect(execution.exitCode).toBe(0);
+    expect(execution.reviewProviderId).toBe('42');
+    expect(execution.reviewGate).toEqual({
+      activeGeneration: 0,
+      completion: { required: 'all', status: 'approved' },
+      artifacts: [{ id: 'contracts', required: true, status: 'open', generation: 0 }],
+    });
     expect(execution).not.toHaveProperty('error');
   });
 

--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -67,6 +67,59 @@ describe('registerReadOnlyIpcHandlers', () => {
       streamSequence: 42,
     });
   });
+
+  it('get-review-gate returns the shared review gate shape', async () => {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler);
+      }),
+    };
+    const mergeTask = {
+      ...makeTask('__merge__wf-1'),
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        reviewGate: {
+          activeGeneration: 0,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [
+            { id: 'contracts', required: true, status: 'approved', generation: 0 },
+            { id: 'runtime', required: true, status: 'open', generation: 0, dependsOn: ['contracts'] },
+            { id: 'ui', required: true, status: 'open', generation: 0, dependsOn: ['runtime'] },
+          ],
+        },
+      },
+    };
+
+    registerReadOnlyIpcHandlers({
+      ipcMain: ipcMain as never,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+      persistence: {
+        listWorkflows: vi.fn(() => []),
+        loadWorkflow: vi.fn(() => ({ id: 'wf-1' })),
+        loadTasks: vi.fn(() => [mergeTask]),
+      } as never,
+      getOrchestrator: () => ({ getAllTasks: () => [mergeTask], getWorkflowStatus: () => ({}) }) as never,
+      agentRegistry: {} as never,
+      loadTaskByIdFromPersistence: () => undefined,
+      resolveAgentSession: vi.fn(async () => null),
+      recordStartupDuration: vi.fn(),
+      getTaskDeltaStreamSequence: () => 1,
+    });
+
+    const result = await handlers.get('invoker:get-review-gate')?.({}, 'wf-1');
+
+    expect(result).toMatchObject({
+      workflowId: 'wf-1',
+      mergeTaskId: '__merge__wf-1',
+      edges: [
+        { from: 'contracts', to: 'runtime' },
+        { from: 'runtime', to: 'ui' },
+      ],
+      ready: false,
+    });
+  });
   it('does not expose renderer write tools to read handlers', () => {
     expectReadContextWriteToolsAreAbsent();
   });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -60,6 +60,7 @@ import type {
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { parseMetadataPatchBody, type MetadataSetResult } from './metadata-setter.js';
+import { buildReviewGateQueryResponse } from './review-gate-query.js';
 
 export interface ApiMutationFacade {
   cancelTask(taskId: string): Promise<CancelMutationResult>;
@@ -381,6 +382,20 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       }
 
       // GET /api/workflows
+      // GET /api/workflows/:id/review-gate
+      const reviewGateMatch = path.match(/^\/api\/workflows\/([^/]+)\/review-gate$/);
+      if (method === 'GET' && reviewGateMatch) {
+        const workflowId = decodeURIComponent(reviewGateMatch[1]);
+        const workflow = persistence.loadWorkflow(workflowId);
+        if (!workflow) {
+          json(res, 404, { error: 'Workflow not found' });
+          return;
+        }
+        const tasks = persistence.loadTasks(workflowId);
+        json(res, 200, buildReviewGateQueryResponse({ workflowId, workflow, tasks }));
+        return;
+      }
+
       if (method === 'GET' && path === '/api/workflows') {
         const workflows = persistence.listWorkflows();
         json(res, 200, workflows);

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -299,6 +299,8 @@ export function serializeTask(task: TaskState): Record<string, unknown> {
   if (task.execution.reviewUrl != null) execution.reviewUrl = task.execution.reviewUrl;
   if (task.execution.reviewId != null) execution.reviewId = task.execution.reviewId;
   if (task.execution.reviewStatus != null) execution.reviewStatus = task.execution.reviewStatus;
+  if (task.execution.reviewProviderId != null) execution.reviewProviderId = task.execution.reviewProviderId;
+  if (task.execution.reviewGate != null) execution.reviewGate = task.execution.reviewGate;
   if (task.execution.autoFixAttempts != null) execution.autoFixAttempts = task.execution.autoFixAttempts;
   if (task.execution.agentSessionId != null) execution.agentSessionId = task.execution.agentSessionId;
   if (task.execution.lastAgentSessionId != null) execution.lastAgentSessionId = task.execution.lastAgentSessionId;

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -6,6 +6,7 @@ import type { AgentRegistry } from '@invoker/execution-engine';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { MessageBus } from '@invoker/transport';
 import { loadConfig } from './config.js';
+import { buildReviewGateQueryResponse } from './review-gate-query.js';
 
 export interface RegisterReadOnlyIpcHandlersContext {
   ipcMain: IpcMain;
@@ -88,6 +89,13 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     const workflow = persistence.loadWorkflow(workflowId);
     logger.info(`load-workflow: found ${tasks.length} tasks for "${workflow?.name ?? workflowId}"`, { module: 'ipc' });
     return { workflow, tasks };
+  });
+
+  ipcMain.handle('invoker:get-review-gate', (_event, workflowId: string) => {
+    const workflow = persistence.loadWorkflow(workflowId);
+    if (!workflow) return null;
+    const tasks = persistence.loadTasks(workflowId);
+    return buildReviewGateQueryResponse({ workflowId, workflow, tasks });
   });
 
   ipcMain.handle('invoker:get-tasks', async () => {

--- a/packages/app/src/review-gate-query.ts
+++ b/packages/app/src/review-gate-query.ts
@@ -1,0 +1,83 @@
+import type { ReviewGateQueryResponse } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
+
+type ReviewGateArtifact = NonNullable<NonNullable<TaskState['execution']['reviewGate']>['artifacts']>[number];
+
+const completion = { required: 'all' as const, status: 'approved' as const };
+
+function scalarArtifact(task: TaskState): ReviewGateArtifact | null {
+  if (!task.execution.reviewId && !task.execution.reviewUrl) return null;
+  return {
+    id: task.execution.reviewId ?? 'review',
+    title: task.config.summary,
+    url: task.execution.reviewUrl,
+    providerId: task.execution.reviewId,
+    provider: task.execution.reviewProviderId,
+    required: true,
+    status: task.execution.reviewStatus === 'Approved' ? 'approved' : 'open',
+    rawStatus: task.execution.reviewStatus,
+    generation: task.execution.generation ?? 0,
+  };
+}
+
+export function buildReviewGateQueryResponse(args: {
+  workflowId: string;
+  workflow: unknown | undefined;
+  tasks: readonly TaskState[];
+}): ReviewGateQueryResponse {
+  const mergeTask = args.tasks.find((task) => task.config.isMergeNode === true && task.config.workflowId === args.workflowId);
+  if (!mergeTask) {
+    return {
+      workflowId: args.workflowId,
+      mergeTaskId: null,
+      status: null,
+      activeGeneration: null,
+      completion,
+      ready: false,
+      artifacts: [],
+      discardedArtifacts: [],
+      edges: [],
+    };
+  }
+
+  const reviewGate = mergeTask.execution.reviewGate;
+  let activeGeneration: number | null = null;
+  let artifacts: ReviewGateArtifact[] = [];
+  let discardedArtifacts: ReviewGateArtifact[] = [];
+
+  if (reviewGate) {
+    activeGeneration = reviewGate.activeGeneration;
+    for (const artifact of reviewGate.artifacts) {
+      const discarded = Boolean(artifact.discardedAt) || artifact.status === 'discarded' || artifact.generation !== reviewGate.activeGeneration;
+      if (discarded) discardedArtifacts.push(artifact);
+      else artifacts.push(artifact);
+    }
+  } else {
+    const fallback = scalarArtifact(mergeTask);
+    if (fallback) {
+      activeGeneration = fallback.generation;
+      artifacts = [fallback];
+    }
+  }
+
+  const requiredArtifacts = artifacts.filter((artifact) => artifact.required);
+  const ready = requiredArtifacts.length > 0 && requiredArtifacts.every((artifact) => artifact.status === 'approved');
+  const edges = artifacts.length < 2
+    ? []
+    : artifacts.slice(0, -1).map((artifact, index) => ({
+      from: artifact.id,
+      to: artifacts[index + 1]!.id,
+    }));
+
+  return {
+    workflowId: args.workflowId,
+    mergeTaskId: mergeTask.id,
+    status: mergeTask.status,
+    activeGeneration,
+    completion,
+    ready,
+    artifacts,
+    discardedArtifacts,
+    edges,
+  };
+}

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -18,6 +18,7 @@ import type {
 } from '@invoker/workflow-graph';
 
 export type { WorkflowDerivedStatus, WorkflowRollup } from '@invoker/workflow-graph';
+import type { ReviewGateQueryResponse } from './types.js';
 
 // ── Types used by IPC channels ──────────────────────────────
 // These were previously in packages/app/src/types.ts.
@@ -578,6 +579,11 @@ export const IpcChannels = {
   'invoker:approve-merge': {} as {
     request: [workflowId: string];
     response: void;
+  },
+
+  'invoker:get-review-gate': {} as {
+    request: [workflowId: string];
+    response: ReviewGateQueryResponse | null;
   },
 
   // PR & Conflict Resolution

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -5,7 +5,7 @@
  * Orchestrator writes a WorkRequest; executor runs the action;
  * executor returns a WorkResponse (via callback or IPC).
  */
-import type { ReviewGateState } from '@invoker/workflow-graph';
+import type { ReviewGateArtifact, ReviewGateState, TaskStatus } from '@invoker/workflow-graph';
 
 // ── Action Types ────────────────────────────────────────────
 
@@ -123,6 +123,18 @@ export interface WorkResponseOutputs {
   reviewStatus?: string;
   /** Typed review-gate artifact state produced by merge-gate style actions. */
   reviewGate?: ReviewGateState;
+}
+
+export interface ReviewGateQueryResponse {
+  workflowId: string;
+  mergeTaskId: string | null;
+  status: TaskStatus | null;
+  activeGeneration: number | null;
+  completion: { required: 'all'; status: 'approved' };
+  ready: boolean;
+  artifacts: ReviewGateArtifact[];
+  discardedArtifacts: ReviewGateArtifact[];
+  edges: Array<{ from: string; to: string }>;
 }
 
 export interface SpawnExperimentsRequest {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1206,6 +1206,142 @@ describe('TaskRunner', () => {
       }
     });
 
+    it('publishReviewStackWithMakePrSkill uses preferred agent then falls back to another make-pr agent', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const attempts: string[] = [];
+        const claudeAgent = {
+          name: 'claude',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.claude', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => {
+            attempts.push('claude');
+            return { cmd: 'node', args: ['-e', 'process.stdout.write("not json")'], sessionId: 'sess-claude' };
+          },
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+        const codexAgent = {
+          name: 'codex',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.codex', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => {
+            attempts.push('codex');
+            return {
+              cmd: 'node',
+              args: ['-e', 'process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master"},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"]}]}))'],
+              sessionId: 'sess-codex',
+            };
+          },
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+        const executor = new TaskRunner({
+          orchestrator: {
+            getTask: () => null,
+            getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-1', executionAgent: 'claude' } })],
+          } as any,
+          persistence: {} as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          executionAgentRegistry: {
+            get: (name: string) => (name === 'claude' ? claudeAgent : name === 'codex' ? codexAgent : undefined),
+            getOrThrow: vi.fn(),
+            getSessionDriver: vi.fn().mockReturnValue(undefined),
+            listWithCapability: vi.fn().mockReturnValue([claudeAgent, codexAgent]),
+          } as any,
+          cwd: '/tmp',
+        });
+
+        const result = await (executor as any).publishReviewStackWithMakePrSkill({
+          workflowId: 'wf-1',
+          title: 'Stack',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: 'summary',
+          cwd: '/tmp',
+        });
+
+        expect(attempts).toEqual(['claude', 'codex']);
+        expect(result.agentName).toBe('codex');
+        expect(result.artifacts[1].dependsOn).toEqual(['contracts']);
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
+    it('publishReviewStackWithMakePrSkill throws when make-pr agents cannot publish valid JSON', async () => {
+      const badAgent = {
+        name: 'claude',
+        stdinMode: 'ignore' as const,
+        bundledSkills: ['make-pr'],
+        buildCommand: () => ({ cmd: 'node', args: ['-e', 'process.stdout.write("not json")'], sessionId: 'bad' }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: vi.fn().mockReturnValue(badAgent),
+          getOrThrow: vi.fn(),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([badAgent]),
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await expect((executor as any).publishReviewStackWithMakePrSkill({
+        workflowId: 'wf-1',
+        title: 'Stack',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        workflowSummary: 'summary',
+        cwd: '/tmp',
+      })).rejects.toThrow('make-pr skill is required to publish Invoker review stacks');
+    });
+    it('publishReviewStackWithMakePrSkill throws when make-pr agents publish a branched review stack', async () => {
+      const branchedAgent = {
+        name: 'claude',
+        stdinMode: 'ignore' as const,
+        bundledSkills: ['make-pr'],
+        buildCommand: () => ({
+          cmd: 'node',
+          args: ['-e', 'process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master"},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"]},{id:"ui",title:"UI",url:"https://example.test/pr/3",providerId:"3",branch:"stack/ui",baseBranch:"stack/runtime",dependsOn:["contracts"]}]}))'],
+          sessionId: 'branched',
+        }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: vi.fn().mockReturnValue(branchedAgent),
+          getOrThrow: vi.fn(),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([branchedAgent]),
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await expect((executor as any).publishReviewStackWithMakePrSkill({
+        workflowId: 'wf-1',
+        title: 'Stack',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        workflowSummary: 'summary',
+        cwd: '/tmp',
+      })).rejects.toThrow('make-pr skill is required to publish Invoker review stacks');
+    });
+
     it('authorPrBodyWithSkill falls back to canonical body when authored body is invalid and no other agents available', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;
@@ -2026,6 +2162,7 @@ describe('TaskRunner', () => {
       featureBranch?: string;
       gateWorkspacePath?: string | null;
       taskBranches?: TaskState[];
+      repoUrl?: string;
     }) {
       const mergeTaskId = '__merge__wf-pub';
       const workflowId = 'wf-pub';
@@ -2057,6 +2194,7 @@ describe('TaskRunner', () => {
           baseBranch: 'master',
           featureBranch: opts.featureBranch,
           name: 'Test Workflow',
+          repoUrl: opts.repoUrl,
         }),
         updateTask: vi.fn(),
         getWorkspacePath: () => opts.gateWorkspacePath ?? null,
@@ -2103,6 +2241,84 @@ describe('TaskRunner', () => {
       return { executor, mergeTask, orchestrator, persistence, mergeGateProvider, gitCalls };
     }
 
+
+    it('external_review on Invoker publishes a make-pr review stack instead of direct provider PR', async () => {
+      const contractsTask = makeTask({
+        id: 'contracts',
+        status: 'completed',
+        config: { workflowId: 'wf-pub' },
+        execution: { branch: 'invoker/contracts' },
+        description: 'Contracts',
+      });
+      const runtimeTask = makeTask({
+        id: 'runtime',
+        status: 'completed',
+        config: { workflowId: 'wf-pub' },
+        execution: { branch: 'invoker/runtime' },
+        description: 'Runtime',
+      });
+
+      const { executor, mergeTask, orchestrator, mergeGateProvider } = setupPublishAfterFix({
+        mergeMode: 'external_review',
+        featureBranch: 'plan/feature',
+        gateWorkspacePath: '/tmp/gate-clone',
+        taskBranches: [contractsTask, runtimeTask],
+        repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+      });
+
+      (executor as any).publishReviewStackWithMakePrSkill = vi.fn().mockResolvedValue({
+        artifacts: [
+          {
+            id: 'contracts',
+            title: 'Define contracts',
+            url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/1',
+            providerId: '1',
+            branch: 'stack/contracts',
+            baseBranch: 'master',
+            required: true,
+            status: 'open',
+            generation: 0,
+          },
+          {
+            id: 'runtime',
+            title: 'Wire runtime',
+            url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/2',
+            providerId: '2',
+            branch: 'stack/runtime',
+            baseBranch: 'stack/contracts',
+            dependsOn: ['contracts'],
+            required: true,
+            status: 'open',
+            generation: 0,
+          },
+        ],
+        sessionId: 'sess-stack',
+        agentName: 'codex',
+      });
+
+      await executor.publishAfterFix(mergeTask);
+
+      expect((executor as any).publishReviewStackWithMakePrSkill).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Test Workflow',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        cwd: '/tmp/gate-clone',
+      }));
+      expect(mergeGateProvider.createReview).not.toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
+        execution: expect.objectContaining({
+          reviewUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/1',
+          reviewId: '1',
+          reviewGate: expect.objectContaining({
+            activeGeneration: 0,
+            artifacts: [
+              expect.objectContaining({ id: 'contracts', generation: 0 }),
+              expect.objectContaining({ id: 'runtime', dependsOn: ['contracts'], generation: 0 }),
+            ],
+          }),
+        }),
+      }), expect.objectContaining({ generation: 0 }));
+    });
     it('external_review mode: detaches HEAD, fetches, consolidates, creates PR', async () => {
       const completedTask = makeTask({
         id: 't1',

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -18,8 +18,10 @@ import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 import type { MergeGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
-import type { PrAuthoringContext, PrAuthoringTaskEntry } from './pr-authoring.js';
+import { isInvokerRepoUrl, type PrAuthoringContext, type PrAuthoringTaskEntry } from './pr-authoring.js';
 import { isGitRefLockRace } from './git-utils.js';
+type ReviewGateState = NonNullable<TaskState['execution']['reviewGate']>;
+type ReviewGateArtifact = ReviewGateState['artifacts'][number];
 
 // ── Trace logging ────────────────────────────────────────
 
@@ -207,6 +209,16 @@ export interface MergeRunnerHost {
   removeMergeWorktree(dir: string): Promise<void>;
   execGh(args: string[], cwd?: string): Promise<string>;
   execPr(baseBranch: string, featureBranch: string, title: string, body?: string, cwd?: string): Promise<string>;
+  publishReviewStackWithMakePrSkill?(args: {
+    workflowId?: string;
+    mergeNodeTaskId?: string;
+    title: string;
+    baseBranch: string;
+    featureBranch: string;
+    workflowSummary: string;
+    cwd: string;
+    reviewGate?: ReviewGateState;
+  }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }>;
   authorPrBodyWithSkill?(args: {
     workflowId?: string;
     mergeNodeTaskId?: string;
@@ -556,7 +568,8 @@ export async function runMergeGateActionImpl(
         };
       }
       if (mergeMode === 'external_review') {
-        if (!host.mergeGateProvider) {
+        const invokerReviewStack = isInvokerRepoUrl(workflow?.repoUrl);
+        if (!invokerReviewStack && !host.mergeGateProvider) {
           throw new Error('mergeMode is "external_review" but no review provider configured');
         }
 
@@ -577,49 +590,84 @@ export async function runMergeGateActionImpl(
           }
         }
 
-        // Route through shared PR-authoring helper for consistent PR bodies.
-        const structuredCtx = workflowId
-          ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture)
-          : undefined;
-        const prBody = await authorPrBodyForMerge(host, {
-          workflowId,
-          mergeNodeTaskId: task.id,
-          title: workflow?.name ?? 'Workflow',
-          baseBranch,
-          featureBranch: featureBranch!,
-          workflowSummary: fullSummary ?? '',
-          structuredContext: structuredCtx,
-          cwd: gateWorkspacePath!,
-        });
+        let reviewGate: ReviewGateState;
+        if (invokerReviewStack) {
+          if (!host.publishReviewStackWithMakePrSkill) {
+            throw new Error('make-pr skill is required to publish Invoker review stacks');
+          }
+          const published = await host.publishReviewStackWithMakePrSkill({
+            workflowId,
+            mergeNodeTaskId: task.id,
+            title: workflow?.name ?? 'Workflow',
+            baseBranch,
+            featureBranch: featureBranch!,
+            workflowSummary: fullSummary ?? '',
+            cwd: gateWorkspacePath!,
+          });
+          const artifacts = published.artifacts.map((artifact) => ({
+            ...artifact,
+            baseBranch: artifact.baseBranch ?? baseBranch,
+            required: true,
+            status: 'open' as const,
+            generation: expectedGeneration,
+          }));
+          reviewGate = {
+            activeGeneration: expectedGeneration,
+            completion: { required: 'all', status: 'approved' },
+            artifacts,
+          };
+          const firstArtifact = artifacts[0];
+          reviewUrl = firstArtifact?.url;
+          reviewId = firstArtifact?.providerId;
+          reviewStatus = 'Awaiting review';
+          console.log(
+            `[merge] Published Invoker review stack via ${published.agentName} skill`,
+          );
+        } else {
+          // Route through shared PR-authoring helper for consistent PR bodies.
+          const structuredCtx = workflowId
+            ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture)
+            : undefined;
+          const prBody = await authorPrBodyForMerge(host, {
+            workflowId,
+            mergeNodeTaskId: task.id,
+            title: workflow?.name ?? 'Workflow',
+            baseBranch,
+            featureBranch: featureBranch!,
+            workflowSummary: fullSummary ?? '',
+            structuredContext: structuredCtx,
+            cwd: gateWorkspacePath!,
+          });
 
-        // Create PR via provider (consolidation already done above).
-        // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
-        const result = await host.mergeGateProvider.createReview({
-          baseBranch,
-          featureBranch,
-          title: workflow?.name ?? 'Workflow',
-          cwd: gateWorkspacePath!,
-          body: prBody,
-        });
-        console.log(`[merge] Created GitHub PR: ${result.url}`);
+          // Create PR via provider (consolidation already done above).
+          // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
+          const result = await host.mergeGateProvider!.createReview({
+            baseBranch,
+            featureBranch,
+            title: workflow?.name ?? 'Workflow',
+            cwd: gateWorkspacePath!,
+            body: prBody,
+          });
+          console.log(`[merge] Created GitHub PR: ${result.url}`);
 
-        reviewUrl = result.url;
-        reviewId = result.identifier;
-        reviewStatus = 'Awaiting review';
-        const reviewGate = buildSingleArtifactReviewGate({
-          expectedGeneration,
-          title: workflow?.name ?? 'Workflow',
-          url: result.url,
-          providerId: result.identifier,
-          provider: host.mergeGateProvider.name,
-          branch: featureBranch,
-          baseBranch,
-          nowIso: new Date().toISOString(),
-        });
+          reviewUrl = result.url;
+          reviewId = result.identifier;
+          reviewStatus = 'Awaiting review';
+          reviewGate = buildSingleArtifactReviewGate({
+            expectedGeneration,
+            title: workflow?.name ?? 'Workflow',
+            url: result.url,
+            providerId: result.identifier,
+            provider: host.mergeGateProvider!.name,
+            branch: featureBranch,
+            baseBranch,
+            nowIso: new Date().toISOString(),
+          });
+        }
         mergeTrace('GATE_WS_PATH_EXTERNAL_REVIEW_AWAIT', {
           taskId: task.id,
           gateWorkspacePath: gateWorkspacePath ?? null,
-          reviewUrl: result.url,
+          reviewUrl,
         });
         console.log(
           `[merge-gate-workspace] setTaskReviewReady path=external_review ` +
@@ -1117,53 +1165,91 @@ export async function publishAfterFixImpl(
     }
 
     if (mergeMode === 'external_review') {
-      if (!host.mergeGateProvider) {
+      const invokerReviewStack = isInvokerRepoUrl(workflow?.repoUrl);
+      if (!invokerReviewStack && !host.mergeGateProvider) {
         throw new Error('mergeMode is "external_review" but no review provider configured');
       }
 
-      // Route through shared PR-authoring helper for consistent PR bodies.
-      const structuredCtxReview = workflowId
-        ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture2)
-        : undefined;
-      const prBodyReview = await authorPrBodyForMerge(host, {
-        workflowId,
-        mergeNodeTaskId: task.id,
-        title: workflow?.name ?? 'Workflow',
-        baseBranch,
-        featureBranch,
-        workflowSummary: fullSummary ?? '',
-        structuredContext: structuredCtxReview,
-        cwd: consolidateDir,
-      });
-
-      const result = await host.mergeGateProvider.createReview({
-        baseBranch,
-        featureBranch,
-        title: workflow?.name ?? 'Workflow',
-        cwd: consolidateDir,
-        body: prBodyReview,
-      });
-      console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
-
       const expectedGeneration = task.execution.generation ?? 0;
-      const reviewGate = buildSingleArtifactReviewGate({
-        expectedGeneration,
-        title: workflow?.name ?? 'Workflow',
-        url: result.url,
-        providerId: result.identifier,
-        provider: host.mergeGateProvider.name,
-        branch: featureBranch,
-        baseBranch,
-        nowIso: new Date().toISOString(),
-      });
+      let reviewUrl: string | undefined;
+      let reviewId: string | undefined;
+      let reviewGate: ReviewGateState;
+      if (invokerReviewStack) {
+        if (!host.publishReviewStackWithMakePrSkill) {
+          throw new Error('make-pr skill is required to publish Invoker review stacks');
+        }
+        const published = await host.publishReviewStackWithMakePrSkill({
+          workflowId,
+          mergeNodeTaskId: task.id,
+          title: workflow?.name ?? 'Workflow',
+          baseBranch,
+          featureBranch,
+          workflowSummary: fullSummary ?? '',
+          cwd: consolidateDir,
+        });
+        const artifacts = published.artifacts.map((artifact) => ({
+          ...artifact,
+          baseBranch: artifact.baseBranch ?? baseBranch,
+          required: true,
+          status: 'open' as const,
+          generation: expectedGeneration,
+        }));
+        reviewGate = {
+          activeGeneration: expectedGeneration,
+          completion: { required: 'all', status: 'approved' },
+          artifacts,
+        };
+        reviewUrl = artifacts[0]?.url;
+        reviewId = artifacts[0]?.providerId;
+        console.log(
+          `[merge] Post-fix: published Invoker review stack via ${published.agentName} skill`,
+        );
+      } else {
+        // Route through shared PR-authoring helper for consistent PR bodies.
+        const structuredCtxReview = workflowId
+          ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture2)
+          : undefined;
+        const prBodyReview = await authorPrBodyForMerge(host, {
+          workflowId,
+          mergeNodeTaskId: task.id,
+          title: workflow?.name ?? 'Workflow',
+          baseBranch,
+          featureBranch,
+          workflowSummary: fullSummary ?? '',
+          structuredContext: structuredCtxReview,
+          cwd: consolidateDir,
+        });
+
+        const result = await host.mergeGateProvider!.createReview({
+          baseBranch,
+          featureBranch,
+          title: workflow?.name ?? 'Workflow',
+          cwd: consolidateDir,
+          body: prBodyReview,
+        });
+        console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
+
+        reviewUrl = result.url;
+        reviewId = result.identifier;
+        reviewGate = buildSingleArtifactReviewGate({
+          expectedGeneration,
+          title: workflow?.name ?? 'Workflow',
+          url: result.url,
+          providerId: result.identifier,
+          provider: host.mergeGateProvider!.name,
+          branch: featureBranch,
+          baseBranch,
+          nowIso: new Date().toISOString(),
+        });
+      }
 
       setMergeGateReviewReady(host, task.id, {
         config: { runnerKind: 'worktree', summary },
         execution: {
           branch: featureBranch,
           workspacePath: gateWorkspacePath,
-          reviewUrl: result.url,
-          reviewId: result.identifier,
+          reviewUrl,
+          reviewId,
           reviewStatus: 'Awaiting review',
           reviewGate,
           fixedIntegrationSha: undefined,

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -8,6 +8,16 @@ import type { ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
 import { cleanElectronEnv, resolveExecutableOnCurrentPath } from './process-utils.js';
 
+export interface MakePrStackArtifactOutput {
+  readonly id: string;
+  readonly title?: string;
+  readonly url: string;
+  readonly providerId?: string;
+  readonly branch?: string;
+  readonly baseBranch?: string;
+  readonly dependsOn?: readonly string[];
+}
+
 // ── Structured PR-authoring context ──────────────────────
 
 /** Per-task evidence carried through PR authoring. */
@@ -150,6 +160,148 @@ export function resolveSkillPathViaAgent(agent: ExecutionAgent, skillName: strin
     if (existsSync(join(skillDir, 'SKILL.md'))) return skillDir;
   }
   return resolveInstalledSkillPathForAgent(agent.name, skillName);
+}
+
+const INVOKER_REPO_OWNER_RE = /^(neko-catpital-labs|edbertchan)$/i;
+
+export function isInvokerRepoUrl(repoUrl: string | undefined): boolean {
+  if (!repoUrl) return false;
+  const trimmed = repoUrl.trim();
+  const httpsMatch = /^https:\/\/github\.com\/([^/]+)\/([^/.]+)(?:\.git)?\/?$/i.exec(trimmed);
+  const sshMatch = /^(?:git@github\.com:|ssh:\/\/git@github\.com\/)([^/]+)\/([^/.]+)(?:\.git)?\/?$/i.exec(trimmed);
+  const match = httpsMatch ?? sshMatch;
+  if (!match) return false;
+  const [, owner, repo] = match;
+  return INVOKER_REPO_OWNER_RE.test(owner) && repo.toLowerCase() === 'invoker';
+}
+
+export function buildMakePrStackPublishPrompt(args: {
+  skillPath: string;
+  title: string;
+  baseBranch: string;
+  featureBranch: string;
+  workflowSummary: string;
+  cwd: string;
+  reviewGate?: unknown;
+}): string {
+  const lines = [
+    `Publish the Invoker-on-Invoker review PR stack for branch "${args.featureBranch}" targeting "${args.baseBranch}".`,
+    '',
+    `Use the installed skill "invoker-make-pr" at: ${args.skillPath}`,
+    'Read invoker-make-pr/SKILL.md first and follow the repo-local PR workflow exactly.',
+    'Use Mergify stack publication for this Invoker stack.',
+    '',
+    'Requirements:',
+    `- PR title prefix/base title: "${args.title}"`,
+    `- Repository working directory: ${args.cwd}`,
+    '- Use the repo-local PR workflow and validation tools from the skill.',
+    '- Output only JSON. Do not include markdown, commentary, explanations, or code fences.',
+    '- The JSON shape must be exactly:',
+    '{"artifacts":[{"id":"string","title":"string","url":"string","providerId":"string","branch":"string","baseBranch":"string","dependsOn":["string"]}]}',
+    '- artifacts are already listed in stack order.',
+    '- artifacts[0].dependsOn must be omitted or [].',
+    '- For every i > 0, artifacts[i].dependsOn must be exactly [artifacts[i - 1].id].',
+    '- Do not emit branches, merges, skipped predecessors, or multiple dependencies.',
+    '- Do not add fixed PR-count fields.',
+    '- Do not add Mergify-specific fields to the JSON.',
+    '',
+    'Workflow summary:',
+    '```md',
+    args.workflowSummary.trim(),
+    '```',
+  ];
+  if (args.reviewGate) {
+    lines.push('', 'Existing review-gate intent:', '```json', JSON.stringify(args.reviewGate, null, 2), '```');
+  }
+  return lines.join('\n');
+}
+
+export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactOutput[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.trim());
+  } catch {
+    throw new Error('make-pr stack publisher must output JSON');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('make-pr stack publisher output must be a JSON object');
+  }
+  const artifacts = (parsed as { artifacts?: unknown }).artifacts;
+  if (!Array.isArray(artifacts)) {
+    throw new Error('make-pr stack publisher output must include artifacts array');
+  }
+
+  if (artifacts.length === 0) {
+    throw new Error('make-pr stack publisher output must include at least one artifact');
+  }
+  const ids = new Set<string>();
+  const records: MakePrStackArtifactOutput[] = [];
+  for (let i = 0; i < artifacts.length; i += 1) {
+    const artifact = artifacts[i];
+    if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
+      throw new Error(`artifacts[${i}] must be an object`);
+    }
+    const record = artifact as Record<string, unknown>;
+    if (typeof record.id !== 'string' || record.id.trim().length === 0) {
+      throw new Error(`artifacts[${i}].id must be a non-empty string`);
+    }
+    const id = record.id.trim();
+    if (ids.has(id)) {
+      throw new Error(`artifacts[${i}].id duplicates artifact "${id}"`);
+    }
+    if (typeof record.url !== 'string' || record.url.trim().length === 0) {
+      throw new Error(`artifacts[${i}].url must be a non-empty string`);
+    }
+    const url = record.url.trim();
+    const dependsOn = record.dependsOn === undefined ? undefined : record.dependsOn;
+    if (dependsOn !== undefined && !Array.isArray(dependsOn)) {
+      throw new Error(`artifacts[${i}].dependsOn must be an array`);
+    }
+    const normalizedDependsOn = dependsOn === undefined
+      ? undefined
+      : dependsOn.map((dependency) => {
+        if (typeof dependency !== 'string' || dependency.trim().length === 0) {
+          throw new Error(`artifacts[${i}].dependsOn must contain non-empty artifact ids`);
+        }
+        return dependency.trim();
+      });
+    ids.add(id);
+    records.push({
+      id,
+      title: typeof record.title === 'string' ? record.title : undefined,
+      url,
+      providerId: typeof record.providerId === 'string' ? record.providerId : undefined,
+      branch: typeof record.branch === 'string' ? record.branch : undefined,
+      baseBranch: typeof record.baseBranch === 'string' ? record.baseBranch : undefined,
+      dependsOn: normalizedDependsOn,
+    });
+  }
+
+  for (let i = 0; i < records.length; i += 1) {
+    const artifact = records[i];
+    for (const dependency of artifact.dependsOn ?? []) {
+      if (!ids.has(dependency)) {
+        throw new Error(`artifacts[${i}].dependsOn references unknown artifact "${dependency}"`);
+      }
+      if (dependency === artifact.id) {
+        throw new Error(`artifacts[${i}].dependsOn must not reference itself`);
+      }
+    }
+  }
+
+  if ((records[0]?.dependsOn?.length ?? 0) > 0) {
+    throw new Error('artifacts[0].dependsOn must be omitted or [] to start the review stack');
+  }
+  for (let i = 1; i < records.length; i += 1) {
+    const expectedDependency = records[i - 1]?.id;
+    const dependencies = records[i]?.dependsOn;
+    if (dependencies?.length !== 1 || dependencies[0] !== expectedDependency) {
+      throw new Error(`artifacts[${i}].dependsOn must be ["${expectedDependency}"] to keep the review stack linear`);
+    }
+  }
+
+  return records;
 }
 
 /**

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -53,7 +53,9 @@ import {
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import {
   buildCanonicalPrBody,
+  buildMakePrStackPublishPrompt,
   buildMakePrPrompt,
+  parseMakePrStackPublishResult,
   resolveSkillPathViaAgent,
   spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
@@ -2755,6 +2757,68 @@ export class TaskRunner {
       structuredContext: args.structuredContext,
     });
     return { body: canonicalBody, sessionId: 'canonical-fallback', agentName: 'canonical' };
+  }
+
+  async publishReviewStackWithMakePrSkill(args: {
+    workflowId?: string;
+    mergeNodeTaskId?: string;
+    title: string;
+    baseBranch: string;
+    featureBranch: string;
+    workflowSummary: string;
+    cwd: string;
+    reviewGate?: ReviewGateState;
+  }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }> {
+    if (!this.executionAgentRegistry) {
+      throw new Error('make-pr skill is required to publish Invoker review stacks');
+    }
+
+    const preferredName = this.resolvePrAuthoringAgentName(args.workflowId, args.mergeNodeTaskId);
+    const prCapableAgents = this.executionAgentRegistry.listWithCapability('make-pr');
+    const orderedAgents = this.buildAgentFallbackOrder(preferredName, prCapableAgents);
+    const errors: string[] = [];
+
+    for (const agent of orderedAgents) {
+      const skillPath = resolveSkillPathViaAgent(agent, 'make-pr');
+      if (!skillPath) {
+        errors.push(`${agent.name}: skill "invoker-make-pr" not installed`);
+        continue;
+      }
+
+      const driver = this.executionAgentRegistry.getSessionDriver(agent.name);
+      const prompt = buildMakePrStackPublishPrompt({
+        skillPath,
+        title: args.title,
+        baseBranch: args.baseBranch,
+        featureBranch: args.featureBranch,
+        workflowSummary: args.workflowSummary,
+        cwd: args.cwd,
+        reviewGate: args.reviewGate,
+      });
+
+      try {
+        const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
+        const parsedArtifacts = parseMakePrStackPublishResult(result.body);
+        const nowIso = new Date().toISOString();
+        const generation = args.reviewGate?.activeGeneration ?? 0;
+        const artifacts: ReviewGateArtifact[] = parsedArtifacts.map((artifact) => ({
+          ...artifact,
+          provider: 'github',
+          baseBranch: artifact.baseBranch ?? args.baseBranch,
+          required: true,
+          status: 'open',
+          generation,
+          createdAt: nowIso,
+        }));
+        return { artifacts, sessionId: result.sessionId, agentName: agent.name };
+      } catch (err) {
+        errors.push(`${agent.name}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    throw new Error(
+      `make-pr skill is required to publish Invoker review stacks${errors.length > 0 ? `: ${errors.join(' | ')}` : ''}`,
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

This makes the review-gate query return one straight set of stack links.

The old helper mirrored every stored `dependsOn` edge, so older branched artifacts still looked like a graph even after the write path narrowed.

The read path now keeps the stored artifacts as-is and synthesizes adjacent links from the current artifact order for HTTP and IPC.

<details>
<summary>Review metadata</summary>

Review Claim: Review-gate query surfaces expose adjacent linear stack links from the current artifact order.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice is read-only; it does not mutate persisted artifacts or change review readiness.

Slice Rationale: The shared query helper must become line-shaped before the UI can stop thinking in graph edges.

Architectural Effect: `buildReviewGateQueryResponse(...)` now derives `edges` from adjacent current artifacts instead of flattening stored `dependsOn` arrays.

Alternative Considerations: We could have rejected older branched artifacts on read, but tolerant reads keep historical data viewable while the public surface stays linear.
</details>

## Non-goals

This does not remove `dependsOn` from the response artifacts.

This does not change merge-gate scheduling or approval rules.

## Architecture

### Before

```mermaid
graph TD
  A["HTTP route"] --> C["buildReviewGateQueryResponse"]
  B["IPC read handler"] --> C
  C --> D["stored dependency edges"]
```

### After

```mermaid
graph TD
  A["HTTP route"] --> C["buildReviewGateQueryResponse"]
  B["IPC read handler"] --> C
  C --> D["adjacent linear stack links"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/api-server.test.ts src/__tests__/ipc-read-handlers.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert d3daa63f3`
- Post-revert steps: None
- Data migration? No

Depends-On: #1757


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `GET /api/workflows/:id/review-gate` to return a review-gate summary with merge task info, approved vs discarded artifacts, dependency edges, and an overall `ready` status.
  * Added a matching read-only IPC handler (`invoker:get-review-gate`) that returns the same payload shape (or `null` when missing).

* **Bug Fixes**
  * Updated task serialization to include `reviewProviderId` and `reviewGate` in the execution payload when available.

* **Tests**
  * Added/expanded coverage for missing workflows, artifact splitting, edge chaining, scalar fallback, and readiness computation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->