### PR TITLE
[Multi PR Review Gate](7) Show linear review gate stack in side panel

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -788,6 +788,54 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'closed-status-merge-gate');
   });
 
+  test('review gate stack side panel shows a linear PR chain', async ({ page }) => {
+    await loadPlanAndSelectWorkflow(page, MERGE_GATE_TEXT_VISUAL_PLAN);
+    await page.locator('.react-flow__node[data-testid$="mg-visual-work"]').first().waitFor({ state: 'visible', timeout: 15000 });
+
+    const mergeGateTaskId = await page.evaluate(async () => {
+      const result = await window.invoker.getTasks();
+      const tasks = Array.isArray(result) ? result : result.tasks;
+      const mergeTask = tasks.find((task: { id: string }) => task.id.includes('__merge__'));
+      return mergeTask?.id ?? null;
+    });
+    expect(mergeGateTaskId).toBeTruthy();
+
+    await injectTaskStates(page, [
+      {
+        taskId: mergeGateTaskId!,
+        changes: {
+          status: 'review_ready',
+          execution: {
+            reviewGate: {
+              activeGeneration: 0,
+              completion: { required: 'all', status: 'approved' },
+              artifacts: [
+                { id: 'contracts', title: 'Contracts PR', url: 'https://example.test/contracts', required: true, status: 'open', generation: 0 },
+                { id: 'runtime', title: 'Runtime PR', url: 'https://example.test/runtime', required: true, status: 'open', generation: 0, dependsOn: ['contracts'] },
+                { id: 'ui', title: 'UI PR', url: 'https://example.test/ui', required: true, status: 'open', generation: 0, dependsOn: ['runtime'] },
+              ],
+            },
+          },
+        },
+      },
+    ]);
+
+    const mergeGateNode = page
+      .locator(`.react-flow__node[data-testid="${mergeGateTaskId}"], .react-flow__node[data-testid$="${mergeGateTaskId}"]`)
+      .first();
+    await mergeGateNode.click();
+    const stackSection = page.locator('section').filter({ hasText: 'Pull Request Stack' }).first();
+    await expect(stackSection.getByText('Pull Request Stack')).toBeVisible();
+    await expect(stackSection.getByText('Contracts PR')).toBeVisible();
+    await expect(stackSection.getByText('Runtime PR')).toBeVisible();
+    await expect(stackSection.getByText('UI PR')).toBeVisible();
+    await expect(stackSection.getByTestId('review-gate-connector').first()).toBeVisible();
+    await expect(stackSection.getByText(/depends on/i)).toHaveCount(0);
+
+    await captureScreenshot(page, 'review-gate-stack-side-panel');
+    await assertPageScreenshot(page, 'review-gate-stack-side-panel');
+  });
+
   test('workflow inspector captures review-ready and not-review-ready pull request states', async ({ page }) => {
     const workflowId = await loadPlanAndSelectWorkflow(page, REVIEW_READY_WORKFLOW_PR_PLAN);
     await page.locator('.react-flow__node[data-testid$="rr-work"]').first().waitFor({ state: 'visible', timeout: 15000 });

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -371,6 +371,110 @@ describe('GET /api/workflows', () => {
   });
 });
 
+describe('GET /api/workflows/:id/review-gate', () => {
+  it('returns 404 when workflow is missing', async () => {
+    mocks.persistence.loadWorkflow.mockReturnValue(undefined);
+    const res = await request(port, 'GET', '/api/workflows/missing/review-gate');
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'Workflow not found' });
+  });
+
+  it('returns an empty response when no merge node exists', async () => {
+    mocks.persistence.loadTasks.mockReturnValue([makeTask({ id: 'task-1' })]);
+    const res = await request(port, 'GET', '/api/workflows/wf-1/review-gate');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      workflowId: 'wf-1',
+      mergeTaskId: null,
+      status: null,
+      ready: false,
+      artifacts: [],
+      discardedArtifacts: [],
+      edges: [],
+    });
+  });
+
+  it('returns current artifacts, linear stack links, and discarded artifacts separately', async () => {
+    mocks.persistence.loadTasks.mockReturnValue([
+      makeTask({
+        id: '__merge__wf-1',
+        status: 'review_ready',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: {
+          reviewGate: {
+            activeGeneration: 2,
+            completion: { required: 'all', status: 'approved' },
+            artifacts: [
+              { id: 'contracts', required: true, status: 'approved', generation: 2 },
+              { id: 'runtime', required: true, status: 'open', generation: 2, dependsOn: ['contracts'] },
+              { id: 'ui', required: true, status: 'open', generation: 2, dependsOn: ['contracts'] },
+              { id: 'old', required: true, status: 'discarded', generation: 1, discardedAt: '2024-01-01T00:00:00Z' },
+            ],
+          },
+        },
+      }),
+    ]);
+
+    const res = await request(port, 'GET', '/api/workflows/wf-1/review-gate');
+    expect(res.status).toBe(200);
+    expect(res.body.artifacts.map((artifact: { id: string }) => artifact.id)).toEqual(['contracts', 'runtime', 'ui']);
+    expect(res.body.discardedArtifacts.map((artifact: { id: string }) => artifact.id)).toEqual(['old']);
+    expect(res.body.edges).toEqual([
+      { from: 'contracts', to: 'runtime' },
+      { from: 'runtime', to: 'ui' },
+    ]);
+    expect(res.body.ready).toBe(false);
+  });
+
+  it('returns ready only when all required current artifacts are approved', async () => {
+    mocks.persistence.loadTasks.mockReturnValue([
+      makeTask({
+        id: '__merge__wf-1',
+        status: 'review_ready',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: {
+          reviewGate: {
+            activeGeneration: 0,
+            completion: { required: 'all', status: 'approved' },
+            artifacts: [
+              { id: 'contracts', required: true, status: 'approved', generation: 0 },
+              { id: 'runtime', required: true, status: 'approved', generation: 0 },
+            ],
+          },
+        },
+      }),
+    ]);
+
+    const res = await request(port, 'GET', '/api/workflows/wf-1/review-gate');
+    expect(res.status).toBe(200);
+    expect(res.body.ready).toBe(true);
+  });
+
+  it('synthesizes a scalar fallback artifact', async () => {
+    mocks.persistence.loadTasks.mockReturnValue([
+      makeTask({
+        id: '__merge__wf-1',
+        status: 'review_ready',
+        config: { workflowId: 'wf-1', isMergeNode: true, summary: 'Review PR' },
+        execution: {
+          reviewId: '42',
+          reviewUrl: 'https://example.test/pr/42',
+          reviewStatus: 'Awaiting review',
+          reviewProviderId: '42',
+          generation: 3,
+        },
+      }),
+    ]);
+
+    const res = await request(port, 'GET', '/api/workflows/wf-1/review-gate');
+    expect(res.status).toBe(200);
+    expect(res.body.activeGeneration).toBe(3);
+    expect(res.body.artifacts).toEqual([
+      expect.objectContaining({ id: '42', url: 'https://example.test/pr/42', providerId: '42' }),
+    ]);
+  });
+});
+
 describe('GET /api/queue', () => {
   it('returns queue status', async () => {
     const res = await request(port, 'GET', '/api/queue');

--- a/packages/app/src/__tests__/formatter.test.ts
+++ b/packages/app/src/__tests__/formatter.test.ts
@@ -257,6 +257,12 @@ describe('serializeTask', () => {
         branch: 'feature/test',
         commit: 'abc123',
         exitCode: 0,
+        reviewProviderId: '42',
+        reviewGate: {
+          activeGeneration: 0,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [{ id: 'contracts', required: true, status: 'open', generation: 0 }],
+        },
         error: undefined,
       } as TaskState['execution'],
     });
@@ -265,6 +271,12 @@ describe('serializeTask', () => {
     expect(execution.branch).toBe('feature/test');
     expect(execution.commit).toBe('abc123');
     expect(execution.exitCode).toBe(0);
+    expect(execution.reviewProviderId).toBe('42');
+    expect(execution.reviewGate).toEqual({
+      activeGeneration: 0,
+      completion: { required: 'all', status: 'approved' },
+      artifacts: [{ id: 'contracts', required: true, status: 'open', generation: 0 }],
+    });
     expect(execution).not.toHaveProperty('error');
   });
 

--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -67,6 +67,59 @@ describe('registerReadOnlyIpcHandlers', () => {
       streamSequence: 42,
     });
   });
+
+  it('get-review-gate returns the shared review gate shape', async () => {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler);
+      }),
+    };
+    const mergeTask = {
+      ...makeTask('__merge__wf-1'),
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        reviewGate: {
+          activeGeneration: 0,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [
+            { id: 'contracts', required: true, status: 'approved', generation: 0 },
+            { id: 'runtime', required: true, status: 'open', generation: 0, dependsOn: ['contracts'] },
+            { id: 'ui', required: true, status: 'open', generation: 0, dependsOn: ['runtime'] },
+          ],
+        },
+      },
+    };
+
+    registerReadOnlyIpcHandlers({
+      ipcMain: ipcMain as never,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+      persistence: {
+        listWorkflows: vi.fn(() => []),
+        loadWorkflow: vi.fn(() => ({ id: 'wf-1' })),
+        loadTasks: vi.fn(() => [mergeTask]),
+      } as never,
+      getOrchestrator: () => ({ getAllTasks: () => [mergeTask], getWorkflowStatus: () => ({}) }) as never,
+      agentRegistry: {} as never,
+      loadTaskByIdFromPersistence: () => undefined,
+      resolveAgentSession: vi.fn(async () => null),
+      recordStartupDuration: vi.fn(),
+      getTaskDeltaStreamSequence: () => 1,
+    });
+
+    const result = await handlers.get('invoker:get-review-gate')?.({}, 'wf-1');
+
+    expect(result).toMatchObject({
+      workflowId: 'wf-1',
+      mergeTaskId: '__merge__wf-1',
+      edges: [
+        { from: 'contracts', to: 'runtime' },
+        { from: 'runtime', to: 'ui' },
+      ],
+      ready: false,
+    });
+  });
   it('does not expose renderer write tools to read handlers', () => {
     expectReadContextWriteToolsAreAbsent();
   });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -60,6 +60,7 @@ import type {
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { parseMetadataPatchBody, type MetadataSetResult } from './metadata-setter.js';
+import { buildReviewGateQueryResponse } from './review-gate-query.js';
 
 export interface ApiMutationFacade {
   cancelTask(taskId: string): Promise<CancelMutationResult>;
@@ -381,6 +382,20 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       }
 
       // GET /api/workflows
+      // GET /api/workflows/:id/review-gate
+      const reviewGateMatch = path.match(/^\/api\/workflows\/([^/]+)\/review-gate$/);
+      if (method === 'GET' && reviewGateMatch) {
+        const workflowId = decodeURIComponent(reviewGateMatch[1]);
+        const workflow = persistence.loadWorkflow(workflowId);
+        if (!workflow) {
+          json(res, 404, { error: 'Workflow not found' });
+          return;
+        }
+        const tasks = persistence.loadTasks(workflowId);
+        json(res, 200, buildReviewGateQueryResponse({ workflowId, workflow, tasks }));
+        return;
+      }
+
       if (method === 'GET' && path === '/api/workflows') {
         const workflows = persistence.listWorkflows();
         json(res, 200, workflows);

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -299,6 +299,8 @@ export function serializeTask(task: TaskState): Record<string, unknown> {
   if (task.execution.reviewUrl != null) execution.reviewUrl = task.execution.reviewUrl;
   if (task.execution.reviewId != null) execution.reviewId = task.execution.reviewId;
   if (task.execution.reviewStatus != null) execution.reviewStatus = task.execution.reviewStatus;
+  if (task.execution.reviewProviderId != null) execution.reviewProviderId = task.execution.reviewProviderId;
+  if (task.execution.reviewGate != null) execution.reviewGate = task.execution.reviewGate;
   if (task.execution.autoFixAttempts != null) execution.autoFixAttempts = task.execution.autoFixAttempts;
   if (task.execution.agentSessionId != null) execution.agentSessionId = task.execution.agentSessionId;
   if (task.execution.lastAgentSessionId != null) execution.lastAgentSessionId = task.execution.lastAgentSessionId;

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -6,6 +6,7 @@ import type { AgentRegistry } from '@invoker/execution-engine';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { MessageBus } from '@invoker/transport';
 import { loadConfig } from './config.js';
+import { buildReviewGateQueryResponse } from './review-gate-query.js';
 
 export interface RegisterReadOnlyIpcHandlersContext {
   ipcMain: IpcMain;
@@ -88,6 +89,13 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     const workflow = persistence.loadWorkflow(workflowId);
     logger.info(`load-workflow: found ${tasks.length} tasks for "${workflow?.name ?? workflowId}"`, { module: 'ipc' });
     return { workflow, tasks };
+  });
+
+  ipcMain.handle('invoker:get-review-gate', (_event, workflowId: string) => {
+    const workflow = persistence.loadWorkflow(workflowId);
+    if (!workflow) return null;
+    const tasks = persistence.loadTasks(workflowId);
+    return buildReviewGateQueryResponse({ workflowId, workflow, tasks });
   });
 
   ipcMain.handle('invoker:get-tasks', async () => {

--- a/packages/app/src/review-gate-query.ts
+++ b/packages/app/src/review-gate-query.ts
@@ -1,0 +1,83 @@
+import type { ReviewGateQueryResponse } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
+
+type ReviewGateArtifact = NonNullable<NonNullable<TaskState['execution']['reviewGate']>['artifacts']>[number];
+
+const completion = { required: 'all' as const, status: 'approved' as const };
+
+function scalarArtifact(task: TaskState): ReviewGateArtifact | null {
+  if (!task.execution.reviewId && !task.execution.reviewUrl) return null;
+  return {
+    id: task.execution.reviewId ?? 'review',
+    title: task.config.summary,
+    url: task.execution.reviewUrl,
+    providerId: task.execution.reviewId,
+    provider: task.execution.reviewProviderId,
+    required: true,
+    status: task.execution.reviewStatus === 'Approved' ? 'approved' : 'open',
+    rawStatus: task.execution.reviewStatus,
+    generation: task.execution.generation ?? 0,
+  };
+}
+
+export function buildReviewGateQueryResponse(args: {
+  workflowId: string;
+  workflow: unknown | undefined;
+  tasks: readonly TaskState[];
+}): ReviewGateQueryResponse {
+  const mergeTask = args.tasks.find((task) => task.config.isMergeNode === true && task.config.workflowId === args.workflowId);
+  if (!mergeTask) {
+    return {
+      workflowId: args.workflowId,
+      mergeTaskId: null,
+      status: null,
+      activeGeneration: null,
+      completion,
+      ready: false,
+      artifacts: [],
+      discardedArtifacts: [],
+      edges: [],
+    };
+  }
+
+  const reviewGate = mergeTask.execution.reviewGate;
+  let activeGeneration: number | null = null;
+  let artifacts: ReviewGateArtifact[] = [];
+  let discardedArtifacts: ReviewGateArtifact[] = [];
+
+  if (reviewGate) {
+    activeGeneration = reviewGate.activeGeneration;
+    for (const artifact of reviewGate.artifacts) {
+      const discarded = Boolean(artifact.discardedAt) || artifact.status === 'discarded' || artifact.generation !== reviewGate.activeGeneration;
+      if (discarded) discardedArtifacts.push(artifact);
+      else artifacts.push(artifact);
+    }
+  } else {
+    const fallback = scalarArtifact(mergeTask);
+    if (fallback) {
+      activeGeneration = fallback.generation;
+      artifacts = [fallback];
+    }
+  }
+
+  const requiredArtifacts = artifacts.filter((artifact) => artifact.required);
+  const ready = requiredArtifacts.length > 0 && requiredArtifacts.every((artifact) => artifact.status === 'approved');
+  const edges = artifacts.length < 2
+    ? []
+    : artifacts.slice(0, -1).map((artifact, index) => ({
+      from: artifact.id,
+      to: artifacts[index + 1]!.id,
+    }));
+
+  return {
+    workflowId: args.workflowId,
+    mergeTaskId: mergeTask.id,
+    status: mergeTask.status,
+    activeGeneration,
+    completion,
+    ready,
+    artifacts,
+    discardedArtifacts,
+    edges,
+  };
+}

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -18,6 +18,7 @@ import type {
 } from '@invoker/workflow-graph';
 
 export type { WorkflowDerivedStatus, WorkflowRollup } from '@invoker/workflow-graph';
+import type { ReviewGateQueryResponse } from './types.js';
 
 // ── Types used by IPC channels ──────────────────────────────
 // These were previously in packages/app/src/types.ts.
@@ -578,6 +579,11 @@ export const IpcChannels = {
   'invoker:approve-merge': {} as {
     request: [workflowId: string];
     response: void;
+  },
+
+  'invoker:get-review-gate': {} as {
+    request: [workflowId: string];
+    response: ReviewGateQueryResponse | null;
   },
 
   // PR & Conflict Resolution

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -5,7 +5,7 @@
  * Orchestrator writes a WorkRequest; executor runs the action;
  * executor returns a WorkResponse (via callback or IPC).
  */
-import type { ReviewGateState } from '@invoker/workflow-graph';
+import type { ReviewGateArtifact, ReviewGateState, TaskStatus } from '@invoker/workflow-graph';
 
 // ── Action Types ────────────────────────────────────────────
 
@@ -123,6 +123,18 @@ export interface WorkResponseOutputs {
   reviewStatus?: string;
   /** Typed review-gate artifact state produced by merge-gate style actions. */
   reviewGate?: ReviewGateState;
+}
+
+export interface ReviewGateQueryResponse {
+  workflowId: string;
+  mergeTaskId: string | null;
+  status: TaskStatus | null;
+  activeGeneration: number | null;
+  completion: { required: 'all'; status: 'approved' };
+  ready: boolean;
+  artifacts: ReviewGateArtifact[];
+  discardedArtifacts: ReviewGateArtifact[];
+  edges: Array<{ from: string; to: string }>;
 }
 
 export interface SpawnExperimentsRequest {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1206,6 +1206,142 @@ describe('TaskRunner', () => {
       }
     });
 
+    it('publishReviewStackWithMakePrSkill uses preferred agent then falls back to another make-pr agent', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const attempts: string[] = [];
+        const claudeAgent = {
+          name: 'claude',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.claude', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => {
+            attempts.push('claude');
+            return { cmd: 'node', args: ['-e', 'process.stdout.write("not json")'], sessionId: 'sess-claude' };
+          },
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+        const codexAgent = {
+          name: 'codex',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.codex', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => {
+            attempts.push('codex');
+            return {
+              cmd: 'node',
+              args: ['-e', 'process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master"},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"]}]}))'],
+              sessionId: 'sess-codex',
+            };
+          },
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+        const executor = new TaskRunner({
+          orchestrator: {
+            getTask: () => null,
+            getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-1', executionAgent: 'claude' } })],
+          } as any,
+          persistence: {} as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          executionAgentRegistry: {
+            get: (name: string) => (name === 'claude' ? claudeAgent : name === 'codex' ? codexAgent : undefined),
+            getOrThrow: vi.fn(),
+            getSessionDriver: vi.fn().mockReturnValue(undefined),
+            listWithCapability: vi.fn().mockReturnValue([claudeAgent, codexAgent]),
+          } as any,
+          cwd: '/tmp',
+        });
+
+        const result = await (executor as any).publishReviewStackWithMakePrSkill({
+          workflowId: 'wf-1',
+          title: 'Stack',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: 'summary',
+          cwd: '/tmp',
+        });
+
+        expect(attempts).toEqual(['claude', 'codex']);
+        expect(result.agentName).toBe('codex');
+        expect(result.artifacts[1].dependsOn).toEqual(['contracts']);
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
+    it('publishReviewStackWithMakePrSkill throws when make-pr agents cannot publish valid JSON', async () => {
+      const badAgent = {
+        name: 'claude',
+        stdinMode: 'ignore' as const,
+        bundledSkills: ['make-pr'],
+        buildCommand: () => ({ cmd: 'node', args: ['-e', 'process.stdout.write("not json")'], sessionId: 'bad' }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: vi.fn().mockReturnValue(badAgent),
+          getOrThrow: vi.fn(),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([badAgent]),
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await expect((executor as any).publishReviewStackWithMakePrSkill({
+        workflowId: 'wf-1',
+        title: 'Stack',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        workflowSummary: 'summary',
+        cwd: '/tmp',
+      })).rejects.toThrow('make-pr skill is required to publish Invoker review stacks');
+    });
+    it('publishReviewStackWithMakePrSkill throws when make-pr agents publish a branched review stack', async () => {
+      const branchedAgent = {
+        name: 'claude',
+        stdinMode: 'ignore' as const,
+        bundledSkills: ['make-pr'],
+        buildCommand: () => ({
+          cmd: 'node',
+          args: ['-e', 'process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master"},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"]},{id:"ui",title:"UI",url:"https://example.test/pr/3",providerId:"3",branch:"stack/ui",baseBranch:"stack/runtime",dependsOn:["contracts"]}]}))'],
+          sessionId: 'branched',
+        }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: vi.fn().mockReturnValue(branchedAgent),
+          getOrThrow: vi.fn(),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([branchedAgent]),
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await expect((executor as any).publishReviewStackWithMakePrSkill({
+        workflowId: 'wf-1',
+        title: 'Stack',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        workflowSummary: 'summary',
+        cwd: '/tmp',
+      })).rejects.toThrow('make-pr skill is required to publish Invoker review stacks');
+    });
+
     it('authorPrBodyWithSkill falls back to canonical body when authored body is invalid and no other agents available', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;
@@ -2026,6 +2162,7 @@ describe('TaskRunner', () => {
       featureBranch?: string;
       gateWorkspacePath?: string | null;
       taskBranches?: TaskState[];
+      repoUrl?: string;
     }) {
       const mergeTaskId = '__merge__wf-pub';
       const workflowId = 'wf-pub';
@@ -2057,6 +2194,7 @@ describe('TaskRunner', () => {
           baseBranch: 'master',
           featureBranch: opts.featureBranch,
           name: 'Test Workflow',
+          repoUrl: opts.repoUrl,
         }),
         updateTask: vi.fn(),
         getWorkspacePath: () => opts.gateWorkspacePath ?? null,
@@ -2103,6 +2241,84 @@ describe('TaskRunner', () => {
       return { executor, mergeTask, orchestrator, persistence, mergeGateProvider, gitCalls };
     }
 
+
+    it('external_review on Invoker publishes a make-pr review stack instead of direct provider PR', async () => {
+      const contractsTask = makeTask({
+        id: 'contracts',
+        status: 'completed',
+        config: { workflowId: 'wf-pub' },
+        execution: { branch: 'invoker/contracts' },
+        description: 'Contracts',
+      });
+      const runtimeTask = makeTask({
+        id: 'runtime',
+        status: 'completed',
+        config: { workflowId: 'wf-pub' },
+        execution: { branch: 'invoker/runtime' },
+        description: 'Runtime',
+      });
+
+      const { executor, mergeTask, orchestrator, mergeGateProvider } = setupPublishAfterFix({
+        mergeMode: 'external_review',
+        featureBranch: 'plan/feature',
+        gateWorkspacePath: '/tmp/gate-clone',
+        taskBranches: [contractsTask, runtimeTask],
+        repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+      });
+
+      (executor as any).publishReviewStackWithMakePrSkill = vi.fn().mockResolvedValue({
+        artifacts: [
+          {
+            id: 'contracts',
+            title: 'Define contracts',
+            url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/1',
+            providerId: '1',
+            branch: 'stack/contracts',
+            baseBranch: 'master',
+            required: true,
+            status: 'open',
+            generation: 0,
+          },
+          {
+            id: 'runtime',
+            title: 'Wire runtime',
+            url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/2',
+            providerId: '2',
+            branch: 'stack/runtime',
+            baseBranch: 'stack/contracts',
+            dependsOn: ['contracts'],
+            required: true,
+            status: 'open',
+            generation: 0,
+          },
+        ],
+        sessionId: 'sess-stack',
+        agentName: 'codex',
+      });
+
+      await executor.publishAfterFix(mergeTask);
+
+      expect((executor as any).publishReviewStackWithMakePrSkill).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Test Workflow',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        cwd: '/tmp/gate-clone',
+      }));
+      expect(mergeGateProvider.createReview).not.toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
+        execution: expect.objectContaining({
+          reviewUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/1',
+          reviewId: '1',
+          reviewGate: expect.objectContaining({
+            activeGeneration: 0,
+            artifacts: [
+              expect.objectContaining({ id: 'contracts', generation: 0 }),
+              expect.objectContaining({ id: 'runtime', dependsOn: ['contracts'], generation: 0 }),
+            ],
+          }),
+        }),
+      }), expect.objectContaining({ generation: 0 }));
+    });
     it('external_review mode: detaches HEAD, fetches, consolidates, creates PR', async () => {
       const completedTask = makeTask({
         id: 't1',

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -18,8 +18,10 @@ import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 import type { MergeGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
-import type { PrAuthoringContext, PrAuthoringTaskEntry } from './pr-authoring.js';
+import { isInvokerRepoUrl, type PrAuthoringContext, type PrAuthoringTaskEntry } from './pr-authoring.js';
 import { isGitRefLockRace } from './git-utils.js';
+type ReviewGateState = NonNullable<TaskState['execution']['reviewGate']>;
+type ReviewGateArtifact = ReviewGateState['artifacts'][number];
 
 // ── Trace logging ────────────────────────────────────────
 
@@ -207,6 +209,16 @@ export interface MergeRunnerHost {
   removeMergeWorktree(dir: string): Promise<void>;
   execGh(args: string[], cwd?: string): Promise<string>;
   execPr(baseBranch: string, featureBranch: string, title: string, body?: string, cwd?: string): Promise<string>;
+  publishReviewStackWithMakePrSkill?(args: {
+    workflowId?: string;
+    mergeNodeTaskId?: string;
+    title: string;
+    baseBranch: string;
+    featureBranch: string;
+    workflowSummary: string;
+    cwd: string;
+    reviewGate?: ReviewGateState;
+  }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }>;
   authorPrBodyWithSkill?(args: {
     workflowId?: string;
     mergeNodeTaskId?: string;
@@ -556,7 +568,8 @@ export async function runMergeGateActionImpl(
         };
       }
       if (mergeMode === 'external_review') {
-        if (!host.mergeGateProvider) {
+        const invokerReviewStack = isInvokerRepoUrl(workflow?.repoUrl);
+        if (!invokerReviewStack && !host.mergeGateProvider) {
           throw new Error('mergeMode is "external_review" but no review provider configured');
         }
 
@@ -577,49 +590,84 @@ export async function runMergeGateActionImpl(
           }
         }
 
-        // Route through shared PR-authoring helper for consistent PR bodies.
-        const structuredCtx = workflowId
-          ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture)
-          : undefined;
-        const prBody = await authorPrBodyForMerge(host, {
-          workflowId,
-          mergeNodeTaskId: task.id,
-          title: workflow?.name ?? 'Workflow',
-          baseBranch,
-          featureBranch: featureBranch!,
-          workflowSummary: fullSummary ?? '',
-          structuredContext: structuredCtx,
-          cwd: gateWorkspacePath!,
-        });
+        let reviewGate: ReviewGateState;
+        if (invokerReviewStack) {
+          if (!host.publishReviewStackWithMakePrSkill) {
+            throw new Error('make-pr skill is required to publish Invoker review stacks');
+          }
+          const published = await host.publishReviewStackWithMakePrSkill({
+            workflowId,
+            mergeNodeTaskId: task.id,
+            title: workflow?.name ?? 'Workflow',
+            baseBranch,
+            featureBranch: featureBranch!,
+            workflowSummary: fullSummary ?? '',
+            cwd: gateWorkspacePath!,
+          });
+          const artifacts = published.artifacts.map((artifact) => ({
+            ...artifact,
+            baseBranch: artifact.baseBranch ?? baseBranch,
+            required: true,
+            status: 'open' as const,
+            generation: expectedGeneration,
+          }));
+          reviewGate = {
+            activeGeneration: expectedGeneration,
+            completion: { required: 'all', status: 'approved' },
+            artifacts,
+          };
+          const firstArtifact = artifacts[0];
+          reviewUrl = firstArtifact?.url;
+          reviewId = firstArtifact?.providerId;
+          reviewStatus = 'Awaiting review';
+          console.log(
+            `[merge] Published Invoker review stack via ${published.agentName} skill`,
+          );
+        } else {
+          // Route through shared PR-authoring helper for consistent PR bodies.
+          const structuredCtx = workflowId
+            ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture)
+            : undefined;
+          const prBody = await authorPrBodyForMerge(host, {
+            workflowId,
+            mergeNodeTaskId: task.id,
+            title: workflow?.name ?? 'Workflow',
+            baseBranch,
+            featureBranch: featureBranch!,
+            workflowSummary: fullSummary ?? '',
+            structuredContext: structuredCtx,
+            cwd: gateWorkspacePath!,
+          });
 
-        // Create PR via provider (consolidation already done above).
-        // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
-        const result = await host.mergeGateProvider.createReview({
-          baseBranch,
-          featureBranch,
-          title: workflow?.name ?? 'Workflow',
-          cwd: gateWorkspacePath!,
-          body: prBody,
-        });
-        console.log(`[merge] Created GitHub PR: ${result.url}`);
+          // Create PR via provider (consolidation already done above).
+          // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
+          const result = await host.mergeGateProvider!.createReview({
+            baseBranch,
+            featureBranch,
+            title: workflow?.name ?? 'Workflow',
+            cwd: gateWorkspacePath!,
+            body: prBody,
+          });
+          console.log(`[merge] Created GitHub PR: ${result.url}`);
 
-        reviewUrl = result.url;
-        reviewId = result.identifier;
-        reviewStatus = 'Awaiting review';
-        const reviewGate = buildSingleArtifactReviewGate({
-          expectedGeneration,
-          title: workflow?.name ?? 'Workflow',
-          url: result.url,
-          providerId: result.identifier,
-          provider: host.mergeGateProvider.name,
-          branch: featureBranch,
-          baseBranch,
-          nowIso: new Date().toISOString(),
-        });
+          reviewUrl = result.url;
+          reviewId = result.identifier;
+          reviewStatus = 'Awaiting review';
+          reviewGate = buildSingleArtifactReviewGate({
+            expectedGeneration,
+            title: workflow?.name ?? 'Workflow',
+            url: result.url,
+            providerId: result.identifier,
+            provider: host.mergeGateProvider!.name,
+            branch: featureBranch,
+            baseBranch,
+            nowIso: new Date().toISOString(),
+          });
+        }
         mergeTrace('GATE_WS_PATH_EXTERNAL_REVIEW_AWAIT', {
           taskId: task.id,
           gateWorkspacePath: gateWorkspacePath ?? null,
-          reviewUrl: result.url,
+          reviewUrl,
         });
         console.log(
           `[merge-gate-workspace] setTaskReviewReady path=external_review ` +
@@ -1117,53 +1165,91 @@ export async function publishAfterFixImpl(
     }
 
     if (mergeMode === 'external_review') {
-      if (!host.mergeGateProvider) {
+      const invokerReviewStack = isInvokerRepoUrl(workflow?.repoUrl);
+      if (!invokerReviewStack && !host.mergeGateProvider) {
         throw new Error('mergeMode is "external_review" but no review provider configured');
       }
 
-      // Route through shared PR-authoring helper for consistent PR bodies.
-      const structuredCtxReview = workflowId
-        ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture2)
-        : undefined;
-      const prBodyReview = await authorPrBodyForMerge(host, {
-        workflowId,
-        mergeNodeTaskId: task.id,
-        title: workflow?.name ?? 'Workflow',
-        baseBranch,
-        featureBranch,
-        workflowSummary: fullSummary ?? '',
-        structuredContext: structuredCtxReview,
-        cwd: consolidateDir,
-      });
-
-      const result = await host.mergeGateProvider.createReview({
-        baseBranch,
-        featureBranch,
-        title: workflow?.name ?? 'Workflow',
-        cwd: consolidateDir,
-        body: prBodyReview,
-      });
-      console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
-
       const expectedGeneration = task.execution.generation ?? 0;
-      const reviewGate = buildSingleArtifactReviewGate({
-        expectedGeneration,
-        title: workflow?.name ?? 'Workflow',
-        url: result.url,
-        providerId: result.identifier,
-        provider: host.mergeGateProvider.name,
-        branch: featureBranch,
-        baseBranch,
-        nowIso: new Date().toISOString(),
-      });
+      let reviewUrl: string | undefined;
+      let reviewId: string | undefined;
+      let reviewGate: ReviewGateState;
+      if (invokerReviewStack) {
+        if (!host.publishReviewStackWithMakePrSkill) {
+          throw new Error('make-pr skill is required to publish Invoker review stacks');
+        }
+        const published = await host.publishReviewStackWithMakePrSkill({
+          workflowId,
+          mergeNodeTaskId: task.id,
+          title: workflow?.name ?? 'Workflow',
+          baseBranch,
+          featureBranch,
+          workflowSummary: fullSummary ?? '',
+          cwd: consolidateDir,
+        });
+        const artifacts = published.artifacts.map((artifact) => ({
+          ...artifact,
+          baseBranch: artifact.baseBranch ?? baseBranch,
+          required: true,
+          status: 'open' as const,
+          generation: expectedGeneration,
+        }));
+        reviewGate = {
+          activeGeneration: expectedGeneration,
+          completion: { required: 'all', status: 'approved' },
+          artifacts,
+        };
+        reviewUrl = artifacts[0]?.url;
+        reviewId = artifacts[0]?.providerId;
+        console.log(
+          `[merge] Post-fix: published Invoker review stack via ${published.agentName} skill`,
+        );
+      } else {
+        // Route through shared PR-authoring helper for consistent PR bodies.
+        const structuredCtxReview = workflowId
+          ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture2)
+          : undefined;
+        const prBodyReview = await authorPrBodyForMerge(host, {
+          workflowId,
+          mergeNodeTaskId: task.id,
+          title: workflow?.name ?? 'Workflow',
+          baseBranch,
+          featureBranch,
+          workflowSummary: fullSummary ?? '',
+          structuredContext: structuredCtxReview,
+          cwd: consolidateDir,
+        });
+
+        const result = await host.mergeGateProvider!.createReview({
+          baseBranch,
+          featureBranch,
+          title: workflow?.name ?? 'Workflow',
+          cwd: consolidateDir,
+          body: prBodyReview,
+        });
+        console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
+
+        reviewUrl = result.url;
+        reviewId = result.identifier;
+        reviewGate = buildSingleArtifactReviewGate({
+          expectedGeneration,
+          title: workflow?.name ?? 'Workflow',
+          url: result.url,
+          providerId: result.identifier,
+          provider: host.mergeGateProvider!.name,
+          branch: featureBranch,
+          baseBranch,
+          nowIso: new Date().toISOString(),
+        });
+      }
 
       setMergeGateReviewReady(host, task.id, {
         config: { runnerKind: 'worktree', summary },
         execution: {
           branch: featureBranch,
           workspacePath: gateWorkspacePath,
-          reviewUrl: result.url,
-          reviewId: result.identifier,
+          reviewUrl,
+          reviewId,
           reviewStatus: 'Awaiting review',
           reviewGate,
           fixedIntegrationSha: undefined,

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -8,6 +8,16 @@ import type { ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
 import { cleanElectronEnv, resolveExecutableOnCurrentPath } from './process-utils.js';
 
+export interface MakePrStackArtifactOutput {
+  readonly id: string;
+  readonly title?: string;
+  readonly url: string;
+  readonly providerId?: string;
+  readonly branch?: string;
+  readonly baseBranch?: string;
+  readonly dependsOn?: readonly string[];
+}
+
 // ── Structured PR-authoring context ──────────────────────
 
 /** Per-task evidence carried through PR authoring. */
@@ -150,6 +160,148 @@ export function resolveSkillPathViaAgent(agent: ExecutionAgent, skillName: strin
     if (existsSync(join(skillDir, 'SKILL.md'))) return skillDir;
   }
   return resolveInstalledSkillPathForAgent(agent.name, skillName);
+}
+
+const INVOKER_REPO_OWNER_RE = /^(neko-catpital-labs|edbertchan)$/i;
+
+export function isInvokerRepoUrl(repoUrl: string | undefined): boolean {
+  if (!repoUrl) return false;
+  const trimmed = repoUrl.trim();
+  const httpsMatch = /^https:\/\/github\.com\/([^/]+)\/([^/.]+)(?:\.git)?\/?$/i.exec(trimmed);
+  const sshMatch = /^(?:git@github\.com:|ssh:\/\/git@github\.com\/)([^/]+)\/([^/.]+)(?:\.git)?\/?$/i.exec(trimmed);
+  const match = httpsMatch ?? sshMatch;
+  if (!match) return false;
+  const [, owner, repo] = match;
+  return INVOKER_REPO_OWNER_RE.test(owner) && repo.toLowerCase() === 'invoker';
+}
+
+export function buildMakePrStackPublishPrompt(args: {
+  skillPath: string;
+  title: string;
+  baseBranch: string;
+  featureBranch: string;
+  workflowSummary: string;
+  cwd: string;
+  reviewGate?: unknown;
+}): string {
+  const lines = [
+    `Publish the Invoker-on-Invoker review PR stack for branch "${args.featureBranch}" targeting "${args.baseBranch}".`,
+    '',
+    `Use the installed skill "invoker-make-pr" at: ${args.skillPath}`,
+    'Read invoker-make-pr/SKILL.md first and follow the repo-local PR workflow exactly.',
+    'Use Mergify stack publication for this Invoker stack.',
+    '',
+    'Requirements:',
+    `- PR title prefix/base title: "${args.title}"`,
+    `- Repository working directory: ${args.cwd}`,
+    '- Use the repo-local PR workflow and validation tools from the skill.',
+    '- Output only JSON. Do not include markdown, commentary, explanations, or code fences.',
+    '- The JSON shape must be exactly:',
+    '{"artifacts":[{"id":"string","title":"string","url":"string","providerId":"string","branch":"string","baseBranch":"string","dependsOn":["string"]}]}',
+    '- artifacts are already listed in stack order.',
+    '- artifacts[0].dependsOn must be omitted or [].',
+    '- For every i > 0, artifacts[i].dependsOn must be exactly [artifacts[i - 1].id].',
+    '- Do not emit branches, merges, skipped predecessors, or multiple dependencies.',
+    '- Do not add fixed PR-count fields.',
+    '- Do not add Mergify-specific fields to the JSON.',
+    '',
+    'Workflow summary:',
+    '```md',
+    args.workflowSummary.trim(),
+    '```',
+  ];
+  if (args.reviewGate) {
+    lines.push('', 'Existing review-gate intent:', '```json', JSON.stringify(args.reviewGate, null, 2), '```');
+  }
+  return lines.join('\n');
+}
+
+export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactOutput[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw.trim());
+  } catch {
+    throw new Error('make-pr stack publisher must output JSON');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('make-pr stack publisher output must be a JSON object');
+  }
+  const artifacts = (parsed as { artifacts?: unknown }).artifacts;
+  if (!Array.isArray(artifacts)) {
+    throw new Error('make-pr stack publisher output must include artifacts array');
+  }
+
+  if (artifacts.length === 0) {
+    throw new Error('make-pr stack publisher output must include at least one artifact');
+  }
+  const ids = new Set<string>();
+  const records: MakePrStackArtifactOutput[] = [];
+  for (let i = 0; i < artifacts.length; i += 1) {
+    const artifact = artifacts[i];
+    if (!artifact || typeof artifact !== 'object' || Array.isArray(artifact)) {
+      throw new Error(`artifacts[${i}] must be an object`);
+    }
+    const record = artifact as Record<string, unknown>;
+    if (typeof record.id !== 'string' || record.id.trim().length === 0) {
+      throw new Error(`artifacts[${i}].id must be a non-empty string`);
+    }
+    const id = record.id.trim();
+    if (ids.has(id)) {
+      throw new Error(`artifacts[${i}].id duplicates artifact "${id}"`);
+    }
+    if (typeof record.url !== 'string' || record.url.trim().length === 0) {
+      throw new Error(`artifacts[${i}].url must be a non-empty string`);
+    }
+    const url = record.url.trim();
+    const dependsOn = record.dependsOn === undefined ? undefined : record.dependsOn;
+    if (dependsOn !== undefined && !Array.isArray(dependsOn)) {
+      throw new Error(`artifacts[${i}].dependsOn must be an array`);
+    }
+    const normalizedDependsOn = dependsOn === undefined
+      ? undefined
+      : dependsOn.map((dependency) => {
+        if (typeof dependency !== 'string' || dependency.trim().length === 0) {
+          throw new Error(`artifacts[${i}].dependsOn must contain non-empty artifact ids`);
+        }
+        return dependency.trim();
+      });
+    ids.add(id);
+    records.push({
+      id,
+      title: typeof record.title === 'string' ? record.title : undefined,
+      url,
+      providerId: typeof record.providerId === 'string' ? record.providerId : undefined,
+      branch: typeof record.branch === 'string' ? record.branch : undefined,
+      baseBranch: typeof record.baseBranch === 'string' ? record.baseBranch : undefined,
+      dependsOn: normalizedDependsOn,
+    });
+  }
+
+  for (let i = 0; i < records.length; i += 1) {
+    const artifact = records[i];
+    for (const dependency of artifact.dependsOn ?? []) {
+      if (!ids.has(dependency)) {
+        throw new Error(`artifacts[${i}].dependsOn references unknown artifact "${dependency}"`);
+      }
+      if (dependency === artifact.id) {
+        throw new Error(`artifacts[${i}].dependsOn must not reference itself`);
+      }
+    }
+  }
+
+  if ((records[0]?.dependsOn?.length ?? 0) > 0) {
+    throw new Error('artifacts[0].dependsOn must be omitted or [] to start the review stack');
+  }
+  for (let i = 1; i < records.length; i += 1) {
+    const expectedDependency = records[i - 1]?.id;
+    const dependencies = records[i]?.dependsOn;
+    if (dependencies?.length !== 1 || dependencies[0] !== expectedDependency) {
+      throw new Error(`artifacts[${i}].dependsOn must be ["${expectedDependency}"] to keep the review stack linear`);
+    }
+  }
+
+  return records;
 }
 
 /**

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -53,7 +53,9 @@ import {
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import {
   buildCanonicalPrBody,
+  buildMakePrStackPublishPrompt,
   buildMakePrPrompt,
+  parseMakePrStackPublishResult,
   resolveSkillPathViaAgent,
   spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
@@ -2755,6 +2757,68 @@ export class TaskRunner {
       structuredContext: args.structuredContext,
     });
     return { body: canonicalBody, sessionId: 'canonical-fallback', agentName: 'canonical' };
+  }
+
+  async publishReviewStackWithMakePrSkill(args: {
+    workflowId?: string;
+    mergeNodeTaskId?: string;
+    title: string;
+    baseBranch: string;
+    featureBranch: string;
+    workflowSummary: string;
+    cwd: string;
+    reviewGate?: ReviewGateState;
+  }): Promise<{ artifacts: ReviewGateArtifact[]; sessionId: string; agentName: string }> {
+    if (!this.executionAgentRegistry) {
+      throw new Error('make-pr skill is required to publish Invoker review stacks');
+    }
+
+    const preferredName = this.resolvePrAuthoringAgentName(args.workflowId, args.mergeNodeTaskId);
+    const prCapableAgents = this.executionAgentRegistry.listWithCapability('make-pr');
+    const orderedAgents = this.buildAgentFallbackOrder(preferredName, prCapableAgents);
+    const errors: string[] = [];
+
+    for (const agent of orderedAgents) {
+      const skillPath = resolveSkillPathViaAgent(agent, 'make-pr');
+      if (!skillPath) {
+        errors.push(`${agent.name}: skill "invoker-make-pr" not installed`);
+        continue;
+      }
+
+      const driver = this.executionAgentRegistry.getSessionDriver(agent.name);
+      const prompt = buildMakePrStackPublishPrompt({
+        skillPath,
+        title: args.title,
+        baseBranch: args.baseBranch,
+        featureBranch: args.featureBranch,
+        workflowSummary: args.workflowSummary,
+        cwd: args.cwd,
+        reviewGate: args.reviewGate,
+      });
+
+      try {
+        const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
+        const parsedArtifacts = parseMakePrStackPublishResult(result.body);
+        const nowIso = new Date().toISOString();
+        const generation = args.reviewGate?.activeGeneration ?? 0;
+        const artifacts: ReviewGateArtifact[] = parsedArtifacts.map((artifact) => ({
+          ...artifact,
+          provider: 'github',
+          baseBranch: artifact.baseBranch ?? args.baseBranch,
+          required: true,
+          status: 'open',
+          generation,
+          createdAt: nowIso,
+        }));
+        return { artifacts, sessionId: result.sessionId, agentName: agent.name };
+      } catch (err) {
+        errors.push(`${agent.name}: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    throw new Error(
+      `make-pr skill is required to publish Invoker review stacks${errors.length > 0 ? `: ${errors.join(' | ')}` : ''}`,
+    );
   }
 
   /**

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,8 +11,8 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
 import yaml from 'js-yaml';
+import type { ActionGraphNode, ReviewGateQueryResponse, TerminalSessionDescriptor } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
-import type { ActionGraphNode, TerminalSessionDescriptor } from '@invoker/contracts';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
 import { useInvoker } from './hooks/useInvoker.js';
@@ -393,6 +393,7 @@ export function App() {
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
+  const [reviewGateByWorkflowId, setReviewGateByWorkflowId] = useState<Record<string, ReviewGateQueryResponse | null>>({});
   const [stickySelectedWorkflow, setStickySelectedWorkflow] = useState<WorkflowMeta | null>(null);
   const [workflowSelectionDismissed, setWorkflowSelectionDismissed] = useState(false);
   const [modal, setModal] = useState<ModalState>({ type: 'none' });
@@ -669,6 +670,29 @@ export function App() {
     next.set(workflowForDag.id, workflowForDag);
     return next;
   }, [displayedSelectedWorkflowGraph, selectedWorkflow, workflows]);
+
+  useEffect(() => {
+    const workflowId = selectedWorkflow?.id;
+    if (!workflowId) return;
+    const getReviewGate = window.invoker?.getReviewGate;
+    if (!getReviewGate) {
+      setReviewGateByWorkflowId((prev) => ({ ...prev, [workflowId]: null }));
+      return;
+    }
+    let cancelled = false;
+    void getReviewGate(workflowId)
+      .then((reviewGate) => {
+        if (cancelled) return;
+        setReviewGateByWorkflowId((prev) => ({ ...prev, [workflowId]: reviewGate }));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setReviewGateByWorkflowId((prev) => ({ ...prev, [workflowId]: null }));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedWorkflow?.id, tasks]);
 
   useEffect(() => {
     if (!selectedWorkflowId) {
@@ -2038,6 +2062,7 @@ export function App() {
               workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
               task={selectedTask}
               workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
+              reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
               remoteTargets={remoteTargets}
               executionPools={executionPools}
               executionAgents={executionAgents}

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -176,6 +176,7 @@ export function createMockInvoker(
     resumeWorkflow: vi.fn(async () => null),
     listWorkflows: vi.fn(async () => workflowSnapshot),
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),
+    getReviewGate: vi.fn(async () => null),
     deleteAllWorkflows: vi.fn(async () => {}),
     deleteAllWorkflowsBulk: vi.fn(async () => {}),
     deleteWorkflow: vi.fn(async () => {}),

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -188,6 +188,132 @@ describe('WorkflowInspector', () => {
     expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/34');
   });
 
+  it('shows an empty pull request stack when review gate metadata has no current artifacts', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready' }}
+        task={null}
+        reviewGate={{
+          workflowId: 'wf-1',
+          mergeTaskId: '__merge__wf-1',
+          status: 'review_ready',
+          activeGeneration: 0,
+          completion: { required: 'all', status: 'approved' },
+          ready: false,
+          artifacts: [],
+          discardedArtifacts: [],
+          edges: [],
+        }}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Pull Request Stack')).toBeInTheDocument();
+    expect(screen.getByText('No pull requests yet')).toBeInTheDocument();
+  });
+
+  it('renders a flat pull request stack in artifact order', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready' }}
+        task={null}
+        reviewGate={{
+          workflowId: 'wf-1',
+          mergeTaskId: '__merge__wf-1',
+          status: 'review_ready',
+          activeGeneration: 0,
+          completion: { required: 'all', status: 'approved' },
+          ready: false,
+          artifacts: [
+            { id: 'contracts', title: 'Define contracts', url: 'https://example.test/contracts', required: true, status: 'open', generation: 0 },
+            { id: 'runtime', title: 'Wire runtime', url: 'https://example.test/runtime', required: true, status: 'open', generation: 0 },
+          ],
+          discardedArtifacts: [],
+          edges: [],
+        }}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByTestId('inspector-pr-link').map((link) => link.textContent)).toEqual([
+      'Define contracts',
+      'Wire runtime',
+    ]);
+  });
+
+  it('renders a linear pull request stack with connectors', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready' }}
+        task={null}
+        reviewGate={{
+          workflowId: 'wf-1',
+          mergeTaskId: '__merge__wf-1',
+          status: 'review_ready',
+          activeGeneration: 0,
+          completion: { required: 'all', status: 'approved' },
+          ready: false,
+          artifacts: [
+            { id: 'contracts', title: 'Contracts', url: 'https://example.test/contracts', required: true, status: 'approved', generation: 0 },
+            { id: 'runtime', title: 'Runtime', url: 'https://example.test/runtime', required: true, status: 'open', generation: 0, dependsOn: ['contracts'] },
+            { id: 'ui', title: 'UI', url: 'https://example.test/ui', required: true, status: 'open', generation: 0, dependsOn: ['runtime'] },
+          ],
+          discardedArtifacts: [],
+          edges: [{ from: 'contracts', to: 'runtime' }, { from: 'runtime', to: 'ui' }],
+        }}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getAllByTestId('review-gate-connector')).toHaveLength(3);
+    expect(screen.queryByText(/depends on/i)).not.toBeInTheDocument();
+    expect(screen.getAllByTestId('inspector-pr-link').map((link) => link.textContent)).toEqual([
+      'Contracts',
+      'Runtime',
+      'UI',
+    ]);
+  });
+
+  it('hides discarded artifacts from the main pull request stack', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready' }}
+        task={null}
+        reviewGate={{
+          workflowId: 'wf-1',
+          mergeTaskId: '__merge__wf-1',
+          status: 'review_ready',
+          activeGeneration: 1,
+          completion: { required: 'all', status: 'approved' },
+          ready: false,
+          artifacts: [
+            { id: 'runtime', title: 'Runtime', url: 'https://example.test/runtime', required: true, status: 'open', generation: 1 },
+          ],
+          discardedArtifacts: [
+            { id: 'contracts', title: 'Discarded contracts', required: true, status: 'discarded', generation: 0, discardedAt: '2024-01-01T00:00:00Z' },
+          ],
+          edges: [],
+        }}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Runtime')).toBeInTheDocument();
+    expect(screen.queryByText('Discarded contracts')).not.toBeInTheDocument();
+  });
+
   it('can be collapsed and restored', () => {
     const { rerender } = render(
       <WorkflowInspector

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { TaskState, WorkflowMeta } from '../types.js';
+import type { ReviewGateArtifact, ReviewGateQueryResponse, TaskState, WorkflowMeta } from '../types.js';
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 
@@ -9,6 +9,7 @@ interface WorkflowInspectorProps {
   workflow: WorkflowMeta | null;
   task: TaskState | null;
   workflowTasks?: Map<string, TaskState>;
+  reviewGate?: ReviewGateQueryResponse | null;
   remoteTargets?: string[];
   executionPools?: string[];
   executionAgents?: string[];
@@ -56,10 +57,61 @@ function getReviewReadyMergeNodeReviewUrl(
   return undefined;
 }
 
+
+function artifactLabel(artifact: ReviewGateArtifact): string {
+  return artifact.title || artifact.url || (artifact.providerId ? `#${artifact.providerId}` : artifact.id);
+}
+
+function ReviewGateStackSection({ reviewGate }: { reviewGate: ReviewGateQueryResponse }): JSX.Element {
+  const artifacts = reviewGate.artifacts;
+  const hasConnectors = artifacts.length > 1;
+  return (
+    <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+      <div className="text-[11px] uppercase tracking-wide text-gray-400">Pull Request Stack</div>
+      {artifacts.length === 0 ? (
+        <div className="mt-2 text-xs text-gray-500">No pull requests yet</div>
+      ) : (
+        <ol className="mt-2 space-y-2">
+          {artifacts.map((artifact, index) => (
+            <li key={artifact.id} className="relative pl-5 text-xs">
+              {hasConnectors && (
+                <span
+                  aria-hidden="true"
+                  data-testid="review-gate-connector"
+                  className="absolute left-1 top-0 h-full border-l border-gray-600 before:absolute before:left-0 before:top-3 before:w-3 before:border-t before:border-gray-600"
+                />
+              )}
+              <div className="rounded border border-gray-700 bg-gray-950/80 px-2 py-1">
+                {artifact.url ? (
+                  <a
+                    href={artifact.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    data-testid="inspector-pr-link"
+                    data-sidebar-nav-item
+                    data-sidebar-nav-order={String(30 + index)}
+                    className="text-blue-300 underline break-words"
+                  >
+                    {artifactLabel(artifact)}
+                  </a>
+                ) : (
+                  <div className="text-gray-200">{artifactLabel(artifact)}</div>
+                )}
+                <div className="mt-1 text-[11px] text-gray-400">{formatStatus(artifact.status)}</div>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}
+
 export function WorkflowInspector({
   workflow,
   task,
   workflowTasks,
+  reviewGate,
   executionPools,
   executionAgents,
   collapsed,
@@ -408,7 +460,9 @@ export function WorkflowInspector({
           </section>
         )}
 
-        {reviewUrl && (
+        {reviewGate ? (
+          <ReviewGateStackSection reviewGate={reviewGate} />
+        ) : reviewUrl && (
           <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
             <div className="text-[11px] uppercase tracking-wide text-gray-400">Pull Request</div>
             <a

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -314,10 +314,10 @@ export interface TaskReplacementDef {
 // ── IPC Bridge API ──────────────────────────────────────────
 // InvokerAPI is derived from the IPC channel registry in @invoker/contracts.
 
-export type { InvokerAPI, ClaudeMessage, AgentSessionData } from '@invoker/contracts';
+export type { ReviewGateArtifact, ReviewGateState } from '@invoker/workflow-graph';
+export type { InvokerAPI, ClaudeMessage, AgentSessionData, ReviewGateQueryResponse } from '@invoker/contracts';
 
 import type { InvokerAPI, TerminalOutputEvent } from '@invoker/contracts';
-
 // ── Augment global Window ───────────────────────────────────
 
 declare global {


### PR DESCRIPTION
## Summary

This makes the side panel show the review PR stack as one straight list.

The old inspector still sorted artifacts like a graph and printed `depends on` labels, which kept branched language alive after the stack model narrowed.

The inspector now renders the returned order directly, keeps the simple connector rail, and refreshes the stacked screenshot to match.

<details>
<summary>Review metadata</summary>

Review Claim: The side panel shows a linear review PR chain with no graph wording.

Review Lane: behavior

Review Unit: read-path

Safety Invariant: This only changes how the inspector renders already-fetched review-gate data, and it keeps the single-PR fallback unchanged.

Slice Rationale: The UI should stop sorting or labeling graph edges only after lower slices already guarantee one linear order.

Architectural Effect: `WorkflowInspector` now renders `reviewGate.artifacts` in returned order and treats the connector as a simple stack rail.

Alternative Considerations: We could have kept a defensive dependency sorter in the UI, but that would preserve graph behavior the lower slices no longer support.
</details>

## Non-goals

This does not show discarded artifacts in the main stack.

This does not change keyboard routing or review-ready approval state.

## Architecture

### Before

```mermaid
graph TD
  A["App review-gate data"] --> B["WorkflowInspector"]
  B --> C["dependency sort and labels"]
```

### After

```mermaid
graph TD
  A["App review-gate data"] --> B["WorkflowInspector"]
  B --> C["ordered PR list and connector rail"]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-inspector.test.tsx`
- [x] `pnpm exec playwright test e2e/visual-proof.spec.ts --grep "review gate stack side panel|workflow inspector captures review-ready and not-review-ready pull request states"`
- [x] `CAPTURE_MODE=after pnpm exec playwright test e2e/visual-proof.spec.ts --grep "review gate stack side panel"`

## Visual Proof

Focused Playwright capture for the linear review-gate side panel.

![Linear review gate side panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260622-f6baca/review-gate-stack-side-panel.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 2da3bbe7c`
- Post-revert steps: None
- Data migration? No

Depends-On: #1758


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the workflow inspector with a “Pull Request Stack” powered by the selected workflow’s review gate, including empty, ordered (flat), and linearly chained views with connector visuals. Falls back to the prior single review-link section when no review gate is available.
  * The app now fetches and maintains per-workflow review gate data for the currently selected workflow.
* **Tests**
  * Added a visual E2E proof for the review-gate stack side panel (with screenshot baselining).
  * Expanded inspector UI tests for ordering/connector behavior, hiding dependency text, discarded-artifact omission; updated mocks for review-gate retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->