### PR TITLE
[Harness Handoff](1) Add Invoker CLI MCP bridge

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,9 @@
     "@invoker/execution-engine": "workspace:*",
     "@invoker/transport": "workspace:*",
     "@invoker/workflow-core": "workspace:*",
-    "yaml": "^2.8.2"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "yaml": "^2.8.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^25.3.3",

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -6,6 +6,7 @@ import { LocalBus } from '@invoker/transport';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { main } from '../index.js';
+import { submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
 
 const repoRoot = resolve(__dirname, '../../../..');
 const cliPath = resolve(repoRoot, 'packages/cli/dist/index.js');
@@ -54,6 +55,12 @@ describe('invoker-cli', () => {
     const result = runCli(['--help']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('invoker-cli run <plan.yaml>');
+  });
+
+  it('--help lists the MCP server command', () => {
+    const result = runCli(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('invoker-cli mcp');
   });
 
   it('runs the hello-world fixture with an isolated db dir', () => {
@@ -198,6 +205,68 @@ tasks:
     expect(`${result.stdout}\n${result.stderr}`).toContain('No execution agent registered with name "missing-agent"');
   });
 
+
+  it('validates an Invoker plan for MCP without submitting it', async () => {
+    const result = await validatePlanForMcp(fixturePlan);
+
+    expect(result).toEqual({ ok: true, name: 'Hello World CLI', taskCount: 1 });
+  });
+
+  it('returns MCP validation errors for broken YAML', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-mcp-invalid-'));
+    const invalidPlan = join(dir, 'invalid.yaml');
+    writeFileSync(invalidPlan, 'name: [broken\n', 'utf8');
+
+    const result = await validatePlanForMcp(invalidPlan);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('Invalid YAML');
+  });
+
+  it('submits MCP plans in live mode by default', async () => {
+    const calls: string[][] = [];
+    const runner: McpCliRunner = {
+      async run(args) {
+        calls.push(args);
+        return { exitCode: 0, stdout: '{"workflow":{"id":"wf-live"}}\n', stderr: '' };
+      },
+    };
+
+    const result = await submitPlanForMcp(fixturePlan, undefined, runner);
+
+    expect(result).toEqual({ ok: true, workflowId: 'wf-live', stdout: '{"workflow":{"id":"wf-live"}}\n' });
+    expect(calls).toEqual([['run', fixturePlan, '--live', '--json']]);
+  });
+
+  it('submits MCP plans in auto mode without live or standalone flags', async () => {
+    const calls: string[][] = [];
+    const runner: McpCliRunner = {
+      async run(args) {
+        calls.push(args);
+        return { exitCode: 0, stdout: '{"workflow":{"id":"wf-auto"}}\n', stderr: '' };
+      },
+    };
+
+    const result = await submitPlanForMcp(fixturePlan, 'auto', runner);
+
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([['run', fixturePlan, '--json']]);
+  });
+
+  it('submits MCP plans in standalone mode with standalone JSON args', async () => {
+    const calls: string[][] = [];
+    const runner: McpCliRunner = {
+      async run(args) {
+        calls.push(args);
+        return { exitCode: 0, stdout: '{"workflow":{"id":"wf-standalone"}}\n', stderr: '' };
+      },
+    };
+
+    const result = await submitPlanForMcp(fixturePlan, 'standalone', runner);
+
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([['run', fixturePlan, '--standalone', '--json']]);
+  });
   it('rejects --db-dir with --live', async () => {
     const output = captureProcessOutput();
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-live-db-'));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ import {
   type PlanDefinition,
   type TaskState,
 } from '@invoker/workflow-core';
+import { runMcpServer } from './mcp-server.js';
 
 const VERSION = '0.0.5';
 
@@ -131,12 +132,14 @@ function usage(): string {
     'Usage:',
     '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
     '  invoker-cli doctor [--fix] [--json]',
+    '  invoker-cli mcp',
     '  invoker-cli --help',
     '  invoker-cli --version',
     '',
     'Commands:',
     '  run <plan.yaml>  Submit to a live Invoker UI when available, otherwise run standalone.',
     '  doctor          Check external runtime tools used by Invoker executors.',
+    '  mcp             Start the Invoker MCP stdio server.',
     '',
     'Options:',
     '  --live           Require a running Invoker UI owner and submit over IPC.',
@@ -525,6 +528,10 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
   try {
     if (argv[0] === 'doctor') {
       return runDoctor(argv.slice(1));
+    }
+    if (argv[0] === 'mcp') {
+      await runMcpServer();
+      return 0;
     }
     const parsed = parseArgs(argv);
     if (!parsed.command || parsed.command === '--help') {

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -1,0 +1,188 @@
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { parsePlanFile } from '@invoker/workflow-core';
+import { z } from 'zod';
+
+export type McpSubmitMode = 'live' | 'auto' | 'standalone';
+
+export interface McpCliRunner {
+  run(args: string[], options?: { cwd?: string }): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+}
+
+type SubmitSuccess = { ok: true; workflowId?: string; stdout: string };
+type SubmitFailure = { ok: false; exitCode: number; stdout: string; stderr: string };
+
+function createProcessRunner(cliPath = process.argv[1] ?? ''): McpCliRunner {
+  return {
+    run(args, options) {
+      const complete = Promise.withResolvers<{ exitCode: number; stdout: string; stderr: string }>();
+      const child = spawn(process.execPath, [cliPath, ...args], {
+        cwd: options?.cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.on('data', (chunk: string) => {
+        stderr += chunk;
+      });
+      child.once('error', complete.reject);
+      child.once('close', (code) => {
+        complete.resolve({ exitCode: code ?? 1, stdout, stderr });
+      });
+      return complete.promise;
+    },
+  };
+}
+
+function argsForSubmit(absolutePlanPath: string, mode: McpSubmitMode): string[] {
+  if (mode === 'auto') return ['run', absolutePlanPath, '--json'];
+  if (mode === 'standalone') return ['run', absolutePlanPath, '--standalone', '--json'];
+  return ['run', absolutePlanPath, '--live', '--json'];
+}
+
+function extractWorkflowId(stdout: string): string | undefined {
+  const lines = stdout.trim().split('\n').reverse();
+  for (const line of lines) {
+    try {
+      const parsed = JSON.parse(line) as { workflow?: { id?: unknown }; result?: { workflowId?: unknown } };
+      const id = parsed.workflow?.id ?? parsed.result?.workflowId;
+      if (typeof id === 'string') return id;
+    } catch {
+      // Keep scanning: command output can precede the final JSON line.
+    }
+  }
+  return undefined;
+}
+
+export async function validatePlanForMcp(
+  planPath: string,
+): Promise<{ ok: true; name: string; taskCount: number } | { ok: false; error: string }> {
+  try {
+    const plan = await parsePlanFile(resolve(planPath));
+    return { ok: true, name: plan.name, taskCount: plan.tasks.length };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function submitPlanForMcp(
+  planPath: string,
+  mode: McpSubmitMode = 'live',
+  runner: McpCliRunner = createProcessRunner(),
+): Promise<SubmitSuccess | SubmitFailure> {
+  const absolutePlanPath = resolve(planPath);
+  const result = await runner.run(argsForSubmit(absolutePlanPath, mode));
+  if (result.exitCode !== 0) {
+    return { ok: false, exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr };
+  }
+  return { ok: true, workflowId: extractWorkflowId(result.stdout), stdout: result.stdout };
+}
+
+function formatSubmitFailure(result: SubmitFailure): string {
+  return [
+    `Invoker plan submission failed with exit code ${result.exitCode}.`,
+    result.stderr ? `stderr:\n${result.stderr}` : undefined,
+    result.stdout ? `stdout:\n${result.stdout}` : undefined,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join('\n');
+}
+
+function handoffPrompt(request: string): string {
+  return [
+    `User request: ${request}`,
+    '',
+    `Use this host's native planning mode when the host supports entering it from this command. If the host cannot be switched by this command, do a read-only planning pass and do not edit product code before the plan is approved.`,
+    'Write the planning artifact to plans/invoker-handoff.md.',
+    'Convert the approved Markdown plan to plans/invoker-handoff.yaml.',
+    'Validate with invoker_validate_plan before submitting.',
+    'Submit with invoker_submit_plan using mode "live" so the workflow appears in the running Invoker app.',
+    'If MCP tools are not available but invoker-cli is on PATH, run invoker-cli run plans/invoker-handoff.yaml --live instead.',
+  ].join('\n');
+}
+
+export async function runMcpServer(options: { runner?: McpCliRunner; cliPath?: string } = {}): Promise<void> {
+  const runner = options.runner ?? createProcessRunner(options.cliPath);
+  const server = new McpServer({ name: 'invoker', version: '0.0.5' });
+
+  server.registerTool(
+    'invoker_validate_plan',
+    {
+      description: 'Validate an existing Invoker YAML plan without submitting it.',
+      inputSchema: { planPath: z.string() },
+    },
+    async ({ planPath }) => {
+      const result = await validatePlanForMcp(planPath);
+      if (!result.ok) {
+        return {
+          content: [{ type: 'text', text: `Invalid Invoker plan: ${result.error}` }],
+          isError: true,
+        };
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Valid Invoker plan: ${result.name} (${result.taskCount} tasks).`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'invoker_submit_plan',
+    {
+      description: 'Submit an existing Invoker YAML plan through invoker-cli run.',
+      inputSchema: {
+        planPath: z.string(),
+        mode: z.enum(['live', 'auto', 'standalone']).optional(),
+      },
+    },
+    async ({ planPath, mode }) => {
+      const result = await submitPlanForMcp(planPath, mode ?? 'live', runner);
+      if (!result.ok) {
+        return {
+          content: [{ type: 'text', text: formatSubmitFailure(result) }],
+          isError: true,
+        };
+      }
+      const workflowText = result.workflowId ? ` Workflow id: ${result.workflowId}.` : '';
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Submitted Invoker plan.${workflowText}\nstdout:\n${result.stdout}`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerPrompt(
+    'invoker-plan-to-invoker',
+    {
+      description: 'Plan a requested change, convert it to Invoker YAML, validate it, and submit it live.',
+      argsSchema: { request: z.string() },
+    },
+    ({ request }) => ({
+      messages: [
+        {
+          role: 'user',
+          content: { type: 'text', text: handoffPrompt(request) },
+        },
+      ],
+    }),
+  );
+
+  await server.connect(new StdioServerTransport());
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,9 +118,15 @@ importers:
       '@invoker/workflow-core':
         specifier: workspace:*
         version: link:../workflow-core
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       yaml:
         specifier: ^2.8.2
         version: 2.8.2
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^25.3.3
@@ -1086,6 +1092,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1120,6 +1132,16 @@ packages:
   '@malept/flatpak-bundler@0.4.0':
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1602,6 +1624,14 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
@@ -1609,6 +1639,9 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1941,6 +1974,10 @@ packages:
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   cpu-features@0.0.10:
     resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
     engines: {node: '>=10.0.0'}
@@ -2242,12 +2279,26 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -2271,6 +2322,9 @@ packages:
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2451,6 +2505,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hono@4.12.26:
+    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -2523,6 +2581,10 @@ packages:
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2613,6 +2675,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -2646,6 +2711,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -3061,6 +3132,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -3239,6 +3314,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resedit@1.7.2:
@@ -3961,6 +4040,14 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
     engines: {node: '>=12.7.0'}
@@ -4408,6 +4495,10 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
+  '@hono/node-server@1.19.14(hono@4.12.26)':
+    dependencies:
+      hono: 4.12.26
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -4452,6 +4543,28 @@ snapshots:
       fs-extra: 9.1.0
       lodash: 4.18.1
       tmp-promise: 3.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.26)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.26
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -4987,6 +5100,10 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-keywords@3.5.2(ajv@6.15.0):
     dependencies:
       ajv: 6.15.0
@@ -4997,6 +5114,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -5368,6 +5492,11 @@ snapshots:
 
   core-util-is@1.0.2:
     optional: true
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cpu-features@0.0.10:
     dependencies:
@@ -5771,9 +5900,20 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -5832,6 +5972,8 @@ snapshots:
       micromatch: 4.0.8
 
   fast-json-stable-stringify@2.1.0: {}
+
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -6045,6 +6187,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hono@4.12.26: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -6117,6 +6261,8 @@ snapshots:
 
   ip-address@10.1.0: {}
 
+  ip-address@10.2.0: {}
+
   ipaddr.js@1.9.1: {}
 
   is-binary-path@2.1.0:
@@ -6180,6 +6326,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.3: {}
+
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
@@ -6223,6 +6371,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stringify-safe@5.0.1:
     optional: true
@@ -6606,6 +6758,8 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pkce-challenge@5.0.1: {}
+
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -6793,6 +6947,8 @@ snapshots:
   regexp-tree@0.1.27: {}
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resedit@1.7.2:
     dependencies:
@@ -7624,6 +7780,12 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}
 
   zustand@4.5.7(@types/react@19.2.14)(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary

`invoker-cli mcp` now starts a stdio MCP server for existing Invoker YAML plans.

The server reuses the workflow parser for plan checks. Runs still go through `invoker-cli run`, so workflow output cannot corrupt MCP traffic.

<details><summary>Review metadata</summary>

Review Claim: `invoker-cli` exposes a host-facing MCP bridge without creating a second execution path.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: MCP calls never mutate Invoker state directly; they delegate to `invoker-cli run`.

Slice Rationale: The protocol surface lands first so harness commands can call one stable tool.

</details>

## Non-goals

No desktop setup changes. No host command installation. No new execution engine.

## Test Plan

- [x] `pnpm --filter @invoker/cli test`
- [x] `pnpm run check:all`
- [x] `pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Run `pnpm --filter @invoker/cli test`.
- Data migration? No