### PR TITLE
[Harness Handoff](3) Explain one-step Invoker handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,13 +112,21 @@ Tagged releases are configured to publish:
 - desktop `.dmg`, `.zip`, `.deb`, and `.AppImage`
 - `SHA256SUMS` covering release assets
 
-Packaged installs bundle the first-party Invoker skills inside the app. On first GUI launch, Invoker prompts you to install those skills into the supported global skill directories for Codex, Claude, and Cursor using `invoker-`-prefixed names so they do not overwrite existing skills. Npm launcher users can install the same bundled skills explicitly with:
+Packaged installs bundle the first-party Invoker AI helpers inside the app. Install helpers from System Setup or:
 
 ```bash
 invoker-ui --install-skills
 ```
 
-Source checkouts can install the repo skills with `bash scripts/setup-agent-skills.sh`.
+Then, in Codex, Claude, Cursor, or OMP, run:
+
+```text
+/invoker-plan-to-invoker "help me plan <change>"
+```
+
+The command plans first, writes `plans/invoker-handoff.md`, converts it to YAML, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
+
+Source checkouts can install the repo helpers with `bash scripts/setup-agent-skills.sh`.
 
 ## First tutorial
 
@@ -259,9 +267,9 @@ tasks:
     dependencies: [api, ui]
 ```
 
-If you need to turn a product or implementation plan into an Invoker workflow, use the `invoker-plan-to-invoker` skill. If you need to operate existing workflows or tasks, use the `invoker-ops` skill.
+If you need to turn a product or implementation plan into an Invoker workflow, install helpers from System Setup or `invoker-ui --install-skills`, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to YAML, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
 
-Source checkouts can install prefixed skill copies with `bash scripts/setup-agent-skills.sh`. Packaged installs can install bundled skills from the first-run System Setup prompt or, for npm launcher installs, with `invoker-ui --install-skills`.
+If you need to operate existing workflows or tasks, use the `invoker-ops` skill.
 
 Use `--output text|label|json|jsonl` on headless `query` commands. Use `./run.sh --headless retry-tasks --status pending|failed --parallel 8` for bulk safe retries. Only **one** process should **write** the workflow database at a time; see [docs/persistence-architecture-single-writer.md](docs/persistence-architecture-single-writer.md).
 

--- a/docs/tutorial-first-agent-workflow.md
+++ b/docs/tutorial-first-agent-workflow.md
@@ -29,6 +29,8 @@ bash scripts/setup-agent-skills.sh
 pnpm run build
 ```
 
+For your own changes, install helpers from System Setup or `invoker-ui --install-skills`, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to YAML, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
+
 Make sure at least one supported agent CLI is installed and authenticated:
 
 ```bash

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1736,9 +1736,9 @@ export function App() {
             {missingRequiredTool
               ? `${missingRequiredTool.name} is missing. Invoker needs it for local workflows.`
               : needsBundledSkillsPrompt
-                ? 'Bundled Invoker skills are ready to install into Codex. Install them before using packaged skill-driven flows.'
+                ? 'Invoker AI helpers are ready to install for Codex, Claude, Cursor, and OMP. Install them before using one-command plan handoff.'
               : installedAgentCount === 0
-                ? 'No Claude or Codex CLI detected yet. Install one before running agent-backed tasks.'
+                ? 'No Claude or Codex CLI detected yet. Install one before running agent-backed execution tasks.'
                 : 'Review local prerequisites before running packaged workflows.'}
           </div>
           <div className="flex items-center gap-2 shrink-0">

--- a/packages/ui/src/__tests__/system-setup-cli.test.tsx
+++ b/packages/ui/src/__tests__/system-setup-cli.test.tsx
@@ -8,11 +8,11 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import type { SystemDiagnostics, CliInstallerStatus } from '@invoker/contracts';
+import type { SystemDiagnostics, CliInstallerStatus, BundledSkillsStatus } from '@invoker/contracts';
 
 import { SystemSetupModal } from '../components/SystemSetupModal.js';
 
-function makeDiagnostics(cliInstaller: CliInstallerStatus | undefined): SystemDiagnostics {
+function makeDiagnostics(cliInstaller: CliInstallerStatus | undefined, bundledSkills?: BundledSkillsStatus): SystemDiagnostics {
   return {
     platform: 'darwin',
     arch: 'arm64',
@@ -20,6 +20,7 @@ function makeDiagnostics(cliInstaller: CliInstallerStatus | undefined): SystemDi
     isPackaged: true,
     tools: [],
     cliInstaller,
+    bundledSkills,
   };
 }
 
@@ -84,6 +85,35 @@ describe('SystemSetupModal — Invoker CLI section', () => {
     expect(screen.queryByRole('button', { name: /invoker-cli/ })).not.toBeInTheDocument();
   });
 
+
+  it('shows installed AI helper command and MCP targets', () => {
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics(undefined, {
+          available: true,
+          promptRecommended: true,
+          managedPrefix: 'invoker-',
+          bundledSkillNames: ['plan-to-invoker'],
+          targets: [
+            { id: 'codex', name: 'Codex', path: '/tmp/.codex/skills', available: true, installed: false, upToDate: false, installedSkillNames: [] },
+          ],
+          commandTargets: [
+            { id: 'omp', name: 'OMP', path: '/tmp/.omp/agent/commands', available: true, installed: false, upToDate: false, installedCommandNames: [] },
+          ],
+          mcpTargets: [
+            { id: 'omp', name: 'OMP', path: '/tmp/.omp/agent/mcp.json', available: true, installed: false, upToDate: false, serverName: 'invoker' },
+          ],
+        })}
+        onInstallBundledSkills={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Invoker AI helpers')).toBeInTheDocument();
+    expect(screen.getByText('/invoker-plan-to-invoker "help me plan <change>"')).toBeInTheDocument();
+    expect(screen.getByText('/tmp/.omp/agent/commands')).toBeInTheDocument();
+    expect(screen.getByText('/tmp/.omp/agent/mcp.json')).toBeInTheDocument();
+  });
   it('hides the section entirely when unsupported (dev mode)', () => {
     render(
       <SystemSetupModal

--- a/packages/ui/src/components/SystemSetupModal.tsx
+++ b/packages/ui/src/components/SystemSetupModal.tsx
@@ -25,11 +25,14 @@ export function SystemSetupModal({
   const bundledSkills = diagnostics?.bundledSkills;
   const cliInstaller = diagnostics?.cliInstaller;
   const canInstallBundledSkills = Boolean(bundledSkills?.available && onInstallBundledSkills);
-  const installActionLabel = bundledSkills?.targets.some((target) => target.installed && !target.upToDate)
-    ? 'Update Skills'
-    : bundledSkills?.targets.some((target) => target.installed)
-      ? 'Reinstall Skills'
-      : 'Install Skills';
+  const helperTargets = bundledSkills
+    ? [...bundledSkills.targets, ...bundledSkills.commandTargets, ...bundledSkills.mcpTargets]
+    : [];
+  const installActionLabel = helperTargets.some((target) => target.installed && !target.upToDate)
+    ? 'Update Helpers'
+    : helperTargets.some((target) => target.installed)
+      ? 'Reinstall Helpers'
+      : 'Install Helpers';
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
@@ -53,11 +56,14 @@ export function SystemSetupModal({
           {bundledSkills?.available && (
             <div className="rounded border border-indigo-700/60 bg-indigo-950/30 px-4 py-4 space-y-3">
               <div>
-                <div className="text-sm font-medium text-indigo-100">Bundled Invoker Skills</div>
+                <div className="text-sm font-medium text-indigo-100">Invoker AI helpers</div>
                 <div className="text-sm text-indigo-200/80 mt-1">
-                  Packaged installs can copy first-party Invoker skills into your Codex skill directory using the
-                  `invoker-` prefix so they do not overwrite existing skills.
+                  Install first-party skills, slash commands, and the OMP MCP entry. Then use /invoker-plan-to-invoker in your harness to plan first, generate Invoker YAML, and submit it to the running Invoker app.
                 </div>
+              </div>
+
+              <div className="rounded bg-gray-950/60 border border-gray-700 px-3 py-2 text-sm text-gray-100 font-mono">
+                <code>/invoker-plan-to-invoker &quot;help me plan &lt;change&gt;&quot;</code>
               </div>
 
               <div className="text-sm text-gray-300">
@@ -67,32 +73,94 @@ export function SystemSetupModal({
               </div>
 
               {bundledSkills.targets.length > 0 && (
-                <div className="rounded border border-gray-700 overflow-hidden">
-                  <table className="w-full text-sm">
-                    <thead className="bg-gray-900 text-gray-300">
-                      <tr>
-                        <th className="text-left px-4 py-2 font-medium">Target</th>
-                        <th className="text-left px-4 py-2 font-medium">Path</th>
-                        <th className="text-left px-4 py-2 font-medium">Status</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {bundledSkills.targets.map((target) => (
-                        <tr key={target.id} className="border-t border-gray-700">
-                          <td className="px-4 py-3 text-gray-100">{target.name}</td>
-                          <td className="px-4 py-3 text-gray-400 font-mono text-xs break-all">{target.path}</td>
-                          <td className="px-4 py-3">
-                            <span className={target.upToDate ? 'text-green-400' : target.installed ? 'text-yellow-300' : 'text-amber-300'}>
-                              {target.upToDate ? 'Installed and up to date' : target.installed ? 'Installed, update available' : 'Not installed'}
-                            </span>
-                          </td>
+                <div className="space-y-2">
+                  <div className="text-xs uppercase tracking-wide text-gray-400">Skills</div>
+                  <div className="rounded border border-gray-700 overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead className="bg-gray-900 text-gray-300">
+                        <tr>
+                          <th className="text-left px-4 py-2 font-medium">Target</th>
+                          <th className="text-left px-4 py-2 font-medium">Path</th>
+                          <th className="text-left px-4 py-2 font-medium">Status</th>
                         </tr>
-                      ))}
-                    </tbody>
-                  </table>
+                      </thead>
+                      <tbody>
+                        {bundledSkills.targets.map((target) => (
+                          <tr key={target.id} className="border-t border-gray-700">
+                            <td className="px-4 py-3 text-gray-100">{target.name}</td>
+                            <td className="px-4 py-3 text-gray-400 font-mono text-xs break-all">{target.path}</td>
+                            <td className="px-4 py-3">
+                              <span className={target.upToDate ? 'text-green-400' : target.installed ? 'text-yellow-300' : 'text-amber-300'}>
+                                {target.upToDate ? 'Installed and up to date' : target.installed ? 'Installed, update available' : 'Not installed'}
+                              </span>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               )}
 
+              {bundledSkills.commandTargets.length > 0 && (
+                <div className="space-y-2">
+                  <div className="text-xs uppercase tracking-wide text-gray-400">Commands</div>
+                  <div className="rounded border border-gray-700 overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead className="bg-gray-900 text-gray-300">
+                        <tr>
+                          <th className="text-left px-4 py-2 font-medium">Target</th>
+                          <th className="text-left px-4 py-2 font-medium">Path</th>
+                          <th className="text-left px-4 py-2 font-medium">Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {bundledSkills.commandTargets.map((target) => (
+                          <tr key={target.id} className="border-t border-gray-700">
+                            <td className="px-4 py-3 text-gray-100">{target.name}</td>
+                            <td className="px-4 py-3 text-gray-400 font-mono text-xs break-all">{target.path}</td>
+                            <td className="px-4 py-3">
+                              <span className={target.upToDate ? 'text-green-400' : target.installed ? 'text-yellow-300' : 'text-amber-300'}>
+                                {target.upToDate ? 'Installed and up to date' : target.installed ? 'Installed, update available' : 'Not installed'}
+                              </span>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              {bundledSkills.mcpTargets.length > 0 && (
+                <div className="space-y-2">
+                  <div className="text-xs uppercase tracking-wide text-gray-400">MCP</div>
+                  <div className="rounded border border-gray-700 overflow-hidden">
+                    <table className="w-full text-sm">
+                      <thead className="bg-gray-900 text-gray-300">
+                        <tr>
+                          <th className="text-left px-4 py-2 font-medium">Target</th>
+                          <th className="text-left px-4 py-2 font-medium">Path</th>
+                          <th className="text-left px-4 py-2 font-medium">Status</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {bundledSkills.mcpTargets.map((target) => (
+                          <tr key={target.id} className="border-t border-gray-700">
+                            <td className="px-4 py-3 text-gray-100">{target.name}</td>
+                            <td className="px-4 py-3 text-gray-400 font-mono text-xs break-all">{target.path}</td>
+                            <td className="px-4 py-3">
+                              <span className={target.upToDate ? 'text-green-400' : target.installed ? 'text-yellow-300' : 'text-amber-300'}>
+                                {target.upToDate ? 'Installed and up to date' : target.installed ? 'Installed, update available' : 'Not installed'}
+                              </span>
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
               {bundledSkills.lastInstallError && (
                 <div className="rounded border border-red-700/50 bg-red-950/30 px-3 py-2 text-sm text-red-200">
                   Last install error: {bundledSkills.lastInstallError}
@@ -108,19 +176,19 @@ export function SystemSetupModal({
               {canInstallBundledSkills && (
                 <div className="flex items-center gap-2">
                   <button
-                    onClick={() => onInstallBundledSkills?.(bundledSkills.targets.some((target) => target.installed) ? 'update' : 'install')}
+                    onClick={() => onInstallBundledSkills?.(helperTargets.some((target) => target.installed) ? 'update' : 'install')}
                     disabled={installPending}
                     className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 disabled:bg-indigo-900 disabled:text-indigo-200 text-white rounded text-sm font-medium transition-colors"
                   >
                     {installPending ? 'Installing…' : installActionLabel}
                   </button>
-                  {bundledSkills.targets.some((target) => target.installed) && (
+                  {helperTargets.some((target) => target.installed) && (
                     <button
                       onClick={() => onInstallBundledSkills?.('reinstall')}
                       disabled={installPending}
                       className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-800 disabled:text-gray-500 text-white rounded text-sm font-medium transition-colors"
                     >
-                      Reinstall Skills
+                      Reinstall Helpers
                     </button>
                   )}
                 </div>

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -2,10 +2,11 @@
 name: plan-to-invoker
 description: >
   Convert a plan into an Invoker YAML plan file. Trigger: "convert to invoker",
-  "submit to invoker", "create invoker plan", "/plan-to-invoker", or turning
-  a plan file into Invoker tasks. For benchmark/direct-output prompts with
-  "Required output path", write a complete YAML document directly to that
-  literal path; it must start with top-level name, onFinish, mergeMode,
+  "submit to invoker", "create invoker plan", "invoker-plan-to-invoker",
+  "/invoker-plan-to-invoker", "/plan-to-invoker", or turning a plan file into
+  Invoker tasks. For benchmark/direct-output prompts with "Required output path",
+  write a complete YAML document directly to that literal path; it must start
+  with top-level name, onFinish, mergeMode,
   repoUrl, and tasks, never version or metadata wrappers, and must not scan,
   validate, submit, or discover env vars.
 ---
@@ -52,6 +53,16 @@ tasks:
 ```
 
 For implementation benchmark plans, switch `onFinish` and `mergeMode` only when the prompt clearly requires a PR/submission workflow, and include task metadata from the prompt itself rather than discovering local references.
+
+## Harness handoff mode
+
+Use this mode when invoked by the installed command or MCP prompt.
+
+- First produce a Markdown planning artifact at `plans/invoker-handoff.md`.
+- Convert the approved Markdown plan to `plans/invoker-handoff.yaml`.
+- Prefer the MCP tools `invoker_validate_plan` and `invoker_submit_plan` when available.
+- In an Invoker source checkout, still run `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` before submission.
+- Outside an Invoker source checkout, `invoker_validate_plan` is the deterministic validation gate.
 
 ## Intended flow (do not skip steps)
 


### PR DESCRIPTION
## Summary

System Setup now explains the one-step handoff path and shows the exact slash phrase users can copy.

The skill and docs tell users to plan first, save Markdown, make YAML, check it, and send it to the live app.

<details><summary>Review metadata</summary>

Review Claim: Invoker explains the installed handoff path in setup, skill guidance, and onboarding docs.

Review Lane: docs

Review Unit: docs

Safety Invariant: This slice changes wording and display only; execution behavior is unchanged.

Slice Rationale: User-facing guidance lands after the bridge and installer assets exist.

</details>

## Non-goals

No installer behavior changes. No MCP protocol changes. No new workflow execution path.

## Visual Proof

- [x] Captured after screenshots and walkthrough video with `bash scripts/ui-visual-proof.sh capture-after`.
- [Walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260621-8f58b8/walkthrough.webm)

## Test Plan

- [x] `pnpm --filter @invoker/ui test -- system-setup-cli.test.tsx app-launch.test.tsx`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`
- [x] `bash scripts/ui-visual-proof.sh capture-after`
- [x] `pnpm run check:all`
- [x] `pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run `pnpm --filter @invoker/ui test -- system-setup-cli.test.tsx app-launch.test.tsx`.
- Data migration? No

Depends-On: #1766