### PR TITLE
[Recovery Lifecycle 2e][D1] CLI installer PATH search

### DIFF
--- a/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
+++ b/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
@@ -5,7 +5,10 @@ import {
   isWorkflowLifecycleEvent,
   type WorkflowLifecycleEvent,
 } from '../lifecycle-events.js';
-import { startLifecycleEventBridge } from '../lifecycle-event-bridge.js';
+import {
+  publishReviewGateCiFailedLifecycleEvent,
+  startLifecycleEventBridge,
+} from '../lifecycle-event-bridge.js';
 
 const CREATED_AT = '2026-06-04T00:00:00.000Z';
 
@@ -201,6 +204,63 @@ describe('lifecycle event bridge', () => {
     expect(recoverySurface.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
     expect(recoverySurface.launchExternalRecovery).not.toHaveBeenCalled();
     expect(recoverySurface.resolveConflict).not.toHaveBeenCalled();
+  });
+
+  it('publishes review-gate CI failure wakeups with persisted task context', () => {
+    const bus = new LocalBus();
+    const events = collectLifecycleEvents(bus);
+    const task = makeTask({
+      id: 'wf-1/merge',
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        generation: 7,
+        selectedAttemptId: 'attempt-merge',
+        reviewId: '123',
+        branch: 'feature/ci-red',
+      },
+      taskStateVersion: 12,
+    });
+
+    const event = publishReviewGateCiFailedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      headRef: 'feature/ci-red',
+      branch: 'feature/ci-red',
+      selectedAttemptId: 'attempt-merge',
+      generation: 7,
+      failedChecks: [
+        { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
+      ],
+      statusText: 'CI failed',
+    }, {
+      messageBus: bus,
+      getTask: () => task,
+      now: () => CREATED_AT,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toBe(event);
+    expect(events[0]).toMatchObject({
+      eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge|generation:7|attempt:attempt-merge|task-state:12|review:123:abc123',
+      kind: 'review_gate.ci_failed',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      taskStateVersion: 12,
+      generation: 7,
+      attemptId: 'attempt-merge',
+      createdAt: CREATED_AT,
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      statusText: 'CI failed',
+    });
+    expectRecoveryWakeup(events[0], { reason: 'review_gate_failure' });
+    expect(isWorkflowLifecycleEvent(events[0])).toBe(true);
   });
 
   it('unsubscribes cleanly', () => {

--- a/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
+++ b/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
@@ -263,6 +263,49 @@ describe('lifecycle event bridge', () => {
     expect(isWorkflowLifecycleEvent(events[0])).toBe(true);
   });
 
+  it('fills review-gate CI failure attempt context from persisted task state', () => {
+    const bus = new LocalBus();
+    const events = collectLifecycleEvents(bus);
+    const task = makeTask({
+      id: 'wf-1/merge',
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        generation: 7,
+        selectedAttemptId: 'attempt-persisted',
+        reviewId: '123',
+        branch: 'feature/ci-red',
+      },
+      taskStateVersion: 12,
+    });
+
+    publishReviewGateCiFailedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      headRef: 'feature/ci-red',
+      branch: 'feature/ci-red',
+      generation: 7,
+      failedChecks: [
+        { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
+      ],
+      statusText: 'CI failed',
+    }, {
+      messageBus: bus,
+      getTask: () => task,
+      now: () => CREATED_AT,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge|generation:7|attempt:attempt-persisted|task-state:12|review:123:abc123',
+      attemptId: 'attempt-persisted',
+    });
+    expectRecoveryWakeup(events[0], { reason: 'review_gate_failure' });
+  });
+
   it('unsubscribes cleanly', () => {
     const bus = new LocalBus();
     const events = collectLifecycleEvents(bus);

--- a/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
+++ b/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
@@ -29,6 +29,21 @@ function collectLifecycleEvents(bus: MessageBus): WorkflowLifecycleEvent[] {
   return events;
 }
 
+function expectRecoveryWakeup(event: any, expected: Record<string, unknown>): void {
+  expect(event.recoveryWakeup).toEqual({
+    eventKey: event.eventKey,
+    eventKind: event.kind,
+    workflowId: event.workflowId,
+    ...(event.taskId ? { taskId: event.taskId } : {}),
+    ...(event.taskStateVersion != null ? { taskStateVersion: event.taskStateVersion } : {}),
+    generation: event.generation,
+    ...(event.attemptId ? { attemptId: event.attemptId } : {}),
+    createdAt: event.createdAt,
+    authoritative: false,
+    ...expected,
+  });
+}
+
 describe('lifecycle event bridge', () => {
   it('publishes task.created lifecycle events from created deltas', () => {
     const bus = new LocalBus();
@@ -50,6 +65,7 @@ describe('lifecycle event bridge', () => {
       createdAt: CREATED_AT,
     });
     expect(isWorkflowLifecycleEvent(events[0])).toBe(true);
+    expectRecoveryWakeup(events[0], { reason: 'task_lifecycle' });
   });
 
   it.each([
@@ -88,6 +104,9 @@ describe('lifecycle event bridge', () => {
       attemptId: 'attempt-2',
       createdAt: CREATED_AT,
     });
+    expectRecoveryWakeup(events[0], {
+      reason: kind === 'task.failed' ? 'task_failure' : 'task_lifecycle',
+    });
   });
 
   it('publishes task.updated for non-status updates using cached task status', () => {
@@ -120,6 +139,7 @@ describe('lifecycle event bridge', () => {
       attemptId: 'attempt-1',
       createdAt: CREATED_AT,
     });
+    expectRecoveryWakeup(events[0], { reason: 'task_lifecycle' });
   });
 
   it('publishes task.removed lifecycle events from removed deltas', () => {
@@ -150,6 +170,7 @@ describe('lifecycle event bridge', () => {
       attemptId: 'attempt-1',
       createdAt: CREATED_AT,
     });
+    expectRecoveryWakeup(events[0], { reason: 'task_lifecycle' });
   });
 
   it('does not call recovery or TaskRunner methods while publishing wakeups', () => {

--- a/packages/app/src/__tests__/lifecycle-events.test.ts
+++ b/packages/app/src/__tests__/lifecycle-events.test.ts
@@ -27,6 +27,21 @@ function makeTask(overrides: Partial<TaskState> = {}): TaskState {
   } as TaskState;
 }
 
+function expectRecoveryWakeup(event: any, expected: Record<string, unknown>): void {
+  expect(event.recoveryWakeup).toEqual({
+    eventKey: event.eventKey,
+    eventKind: event.kind,
+    workflowId: event.workflowId,
+    ...(event.taskId ? { taskId: event.taskId } : {}),
+    ...(event.taskStateVersion != null ? { taskStateVersion: event.taskStateVersion } : {}),
+    generation: event.generation,
+    ...(event.attemptId ? { attemptId: event.attemptId } : {}),
+    createdAt: event.createdAt,
+    authoritative: false,
+    ...expected,
+  });
+}
+
 describe('worker lifecycle channel', () => {
   it('adds workflow lifecycle without changing existing task channels', () => {
     expect(Channels.TASK_DELTA).toBe('task.delta');
@@ -54,6 +69,7 @@ describe('lifecycle event helpers', () => {
       createdAt: CREATED_AT,
     });
     expect(isTaskLifecycleEvent(event)).toBe(true);
+    expectRecoveryWakeup(event, { reason: 'task_lifecycle' });
   });
 
   it('builds task.updated from non-terminal status updates', () => {
@@ -83,6 +99,7 @@ describe('lifecycle event helpers', () => {
       attemptId: 'attempt-2',
       createdAt: CREATED_AT,
     });
+    expectRecoveryWakeup(event, { reason: 'task_lifecycle' });
   });
 
   it('maps completed and failed status updates to worker lifecycle kinds', () => {
@@ -114,6 +131,8 @@ describe('lifecycle event helpers', () => {
     expect(failed.kind).toBe('task.failed');
     expect(completed.eventKey).toBe('task.completed|workflow:wf-1|task:wf-1/task-a|generation:4|attempt:attempt-2|task-state:3');
     expect(failed.eventKey).toBe('task.failed|workflow:wf-1|task:wf-1/task-b|generation:1|attempt:attempt-3|task-state:4');
+    expectRecoveryWakeup(completed, { reason: 'task_lifecycle' });
+    expectRecoveryWakeup(failed, { reason: 'task_failure' });
   });
 
   it('maps review readiness status updates to worker lifecycle kinds', () => {
@@ -144,6 +163,7 @@ describe('lifecycle event helpers', () => {
     expect(lifecycleEventKindForTaskStatus('needs_input')).toBe('task.needs_input');
     expect(needsInput.kind).toBe('task.needs_input');
     expect(isWorkflowLifecycleEvent(needsInput)).toBe(true);
+    expectRecoveryWakeup(needsInput, { reason: 'task_lifecycle' });
   });
 
   it('builds task.removed from removed deltas', () => {
@@ -169,6 +189,7 @@ describe('lifecycle event helpers', () => {
       attemptId: 'attempt-9',
       createdAt: CREATED_AT,
     });
+    expectRecoveryWakeup(event, { reason: 'task_lifecycle' });
   });
 
   it('builds review_gate.ci_failed lifecycle wakeups', () => {
@@ -210,6 +231,7 @@ describe('lifecycle event helpers', () => {
       { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
     ]);
     expect(isWorkflowLifecycleEvent(event)).toBe(true);
+    expectRecoveryWakeup(event, { reason: 'review_gate_failure' });
   });
 
   it('builds workflow.wakeup events for persisted-state reconciliation', () => {
@@ -228,9 +250,40 @@ describe('lifecycle event helpers', () => {
       status: 'running',
       generation: 8,
       createdAt: CREATED_AT,
+      recoveryWakeup: {
+        eventKey: 'workflow.wakeup|workflow:wf-1|generation:8|reason:stalled_workflow_recovery',
+        eventKind: 'workflow.wakeup',
+        workflowId: 'wf-1',
+        generation: 8,
+        createdAt: CREATED_AT,
+        reason: 'workflow_reconcile',
+        authoritative: false,
+      },
       reason: 'stalled_workflow_recovery',
     });
     expect(isWorkflowLifecycleEvent(event)).toBe(true);
+  });
+
+  it('marks recovery wakeup data as non-authoritative optimization hints', () => {
+    const event = buildTaskUpdatedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      status: 'failed',
+      previousStatus: 'running',
+      taskStateVersion: 10,
+      generation: 5,
+      attemptId: 'attempt-stale',
+      createdAt: CREATED_AT,
+    });
+
+    expect(event.recoveryWakeup).toMatchObject({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      generation: 5,
+      attemptId: 'attempt-stale',
+      taskStateVersion: 10,
+      authoritative: false,
+    });
   });
 
   it('rejects malformed lifecycle events', () => {
@@ -241,5 +294,16 @@ describe('lifecycle event helpers', () => {
       reason: 'manual_reconcile',
       createdAt: CREATED_AT,
     }), generation: '1' })).toBe(false);
+    expect(isWorkflowLifecycleEvent({
+      ...buildTaskUpdatedLifecycleEvent({
+        workflowId: 'wf-1',
+        taskId: 'wf-1/task-a',
+        status: 'failed',
+        taskStateVersion: 1,
+        generation: 1,
+        createdAt: CREATED_AT,
+      }),
+      recoveryWakeup: { authoritative: true },
+    })).toBe(false);
   });
 });

--- a/packages/app/src/__tests__/lifecycle-events.test.ts
+++ b/packages/app/src/__tests__/lifecycle-events.test.ts
@@ -8,6 +8,7 @@ import {
   buildWorkflowWakeupLifecycleEvent,
   isTaskLifecycleEvent,
   isWorkflowLifecycleEvent,
+  lifecycleEventMatchesPersistedTask,
   lifecycleEventKindForTaskStatus,
 } from '../lifecycle-events.js';
 
@@ -284,6 +285,40 @@ describe('lifecycle event helpers', () => {
       taskStateVersion: 10,
       authoritative: false,
     });
+  });
+
+  it('requires persisted task generation, attempt, and state version checks for wakeups', () => {
+    const event = buildTaskUpdatedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      status: 'failed',
+      previousStatus: 'running',
+      taskStateVersion: 10,
+      generation: 5,
+      attemptId: 'attempt-current',
+      createdAt: CREATED_AT,
+    });
+
+    expect(lifecycleEventMatchesPersistedTask(event, makeTask({
+      status: 'failed',
+      taskStateVersion: 10,
+      execution: { generation: 5, selectedAttemptId: 'attempt-current' },
+    }))).toBe(true);
+    expect(lifecycleEventMatchesPersistedTask(event, makeTask({
+      status: 'failed',
+      taskStateVersion: 10,
+      execution: { generation: 6, selectedAttemptId: 'attempt-current' },
+    }))).toBe(false);
+    expect(lifecycleEventMatchesPersistedTask(event, makeTask({
+      status: 'failed',
+      taskStateVersion: 10,
+      execution: { generation: 5, selectedAttemptId: 'attempt-next' },
+    }))).toBe(false);
+    expect(lifecycleEventMatchesPersistedTask(event, makeTask({
+      status: 'failed',
+      taskStateVersion: 11,
+      execution: { generation: 5, selectedAttemptId: 'attempt-current' },
+    }))).toBe(false);
   });
 
   it('rejects malformed lifecycle events', () => {

--- a/packages/app/src/cli-installer.ts
+++ b/packages/app/src/cli-installer.ts
@@ -51,6 +51,12 @@ function searchDirs(context: CliInstallerContext): string[] {
   // one location (used by the hermetic e2e scripts).
   const override = context.env.INVOKER_CLI_INSTALL_DIR;
   if (override) return [override];
+  if (context.candidateInstallDirs) {
+    return [...new Set([
+      ...context.candidateInstallDirs,
+      ...pathDirs(context),
+    ])];
+  }
   const dirs = [
     ...defaultCandidateInstallDirs(context),
     ...pathDirs(context),

--- a/packages/app/src/lifecycle-event-bridge.ts
+++ b/packages/app/src/lifecycle-event-bridge.ts
@@ -80,6 +80,7 @@ export function publishReviewGateCiFailedLifecycleEvent(
   const currentTask = options.getTask?.(input.taskId);
   const status = input.status ?? currentTask?.status;
   const taskStateVersion = input.taskStateVersion ?? currentTask?.taskStateVersion;
+  const attemptId = input.selectedAttemptId ?? currentTask?.execution.selectedAttemptId;
   if (!status || taskStateVersion == null) return undefined;
 
   const event = buildReviewGateCiFailedLifecycleEvent({
@@ -95,7 +96,7 @@ export function publishReviewGateCiFailedLifecycleEvent(
     failedChecks: input.failedChecks,
     statusText: input.statusText,
     generation: input.generation,
-    attemptId: input.selectedAttemptId,
+    attemptId,
     createdAt: options.now?.(),
   });
   options.messageBus.publish(Channels.WORKFLOW_LIFECYCLE, event);

--- a/packages/app/src/lifecycle-event-bridge.ts
+++ b/packages/app/src/lifecycle-event-bridge.ts
@@ -1,9 +1,11 @@
 import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
 import type { TaskDelta, TaskState, TaskStatus } from '@invoker/workflow-core';
 import {
+  buildReviewGateCiFailedLifecycleEvent,
   buildTaskCreatedLifecycleEvent,
   buildTaskRemovedLifecycleEvent,
   buildTaskUpdatedLifecycleEvent,
+  type ReviewGateFailedCheck,
   type WorkflowLifecycleEvent,
 } from './lifecycle-events.js';
 
@@ -27,6 +29,22 @@ export interface LifecycleEventBridgeOptions {
 
 export interface LifecycleEventBridge {
   readonly stop: Unsubscribe;
+}
+
+export interface ReviewGateCiFailedWakeupInput {
+  readonly workflowId: string;
+  readonly taskId: string;
+  readonly status?: TaskStatus;
+  readonly taskStateVersion?: number;
+  readonly reviewId: string;
+  readonly reviewUrl: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly branch?: string;
+  readonly selectedAttemptId?: string;
+  readonly generation: number;
+  readonly failedChecks: readonly ReviewGateFailedCheck[];
+  readonly statusText: string;
 }
 
 export function startLifecycleEventBridge(options: LifecycleEventBridgeOptions): LifecycleEventBridge {
@@ -53,6 +71,35 @@ export function startLifecycleEventBridge(options: LifecycleEventBridgeOptions):
   });
 
   return { stop };
+}
+
+export function publishReviewGateCiFailedLifecycleEvent(
+  input: ReviewGateCiFailedWakeupInput,
+  options: Pick<LifecycleEventBridgeOptions, 'messageBus' | 'getTask' | 'now'>,
+): WorkflowLifecycleEvent | undefined {
+  const currentTask = options.getTask?.(input.taskId);
+  const status = input.status ?? currentTask?.status;
+  const taskStateVersion = input.taskStateVersion ?? currentTask?.taskStateVersion;
+  if (!status || taskStateVersion == null) return undefined;
+
+  const event = buildReviewGateCiFailedLifecycleEvent({
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    status,
+    taskStateVersion,
+    reviewId: input.reviewId,
+    reviewUrl: input.reviewUrl,
+    headSha: input.headSha,
+    headRef: input.headRef,
+    branch: input.branch,
+    failedChecks: input.failedChecks,
+    statusText: input.statusText,
+    generation: input.generation,
+    attemptId: input.selectedAttemptId,
+    createdAt: options.now?.(),
+  });
+  options.messageBus.publish(Channels.WORKFLOW_LIFECYCLE, event);
+  return event;
 }
 
 function buildEventForTaskDelta(

--- a/packages/app/src/lifecycle-events.ts
+++ b/packages/app/src/lifecycle-events.ts
@@ -32,7 +32,27 @@ export interface WorkflowLifecycleEventBase {
   readonly generation: number;
   readonly attemptId?: string;
   readonly createdAt: string;
+  readonly recoveryWakeup: RecoveryWorkerWakeupHint;
 }
+
+export interface RecoveryWorkerWakeupHint {
+  readonly eventKey: string;
+  readonly eventKind: WorkflowLifecycleEventKind;
+  readonly workflowId: string;
+  readonly taskId?: string;
+  readonly taskStateVersion?: number;
+  readonly generation: number;
+  readonly attemptId?: string;
+  readonly createdAt: string;
+  readonly reason: RecoveryWorkerWakeupReason;
+  readonly authoritative: false;
+}
+
+export type RecoveryWorkerWakeupReason =
+  | 'task_lifecycle'
+  | 'task_failure'
+  | 'review_gate_failure'
+  | 'workflow_reconcile';
 
 export interface TaskLifecycleEvent extends WorkflowLifecycleEventBase {
   readonly kind:
@@ -232,12 +252,14 @@ export function buildTaskRemovedLifecycleEvent(input: TaskRemovedLifecycleEventI
 export function buildReviewGateCiFailedLifecycleEvent(
   input: ReviewGateCiFailedLifecycleEventInput,
 ): ReviewGateCiFailedLifecycleEvent {
+  const generation = input.generation ?? 0;
+  const createdAt = normalizeCreatedAt(input.createdAt);
   const eventKey = buildLifecycleEventKey({
     kind: 'review_gate.ci_failed',
     workflowId: input.workflowId,
     taskId: input.taskId,
     taskStateVersion: input.taskStateVersion,
-    generation: input.generation,
+    generation,
     attemptId: input.attemptId,
     discriminator: `review:${input.reviewId}:${input.headSha ?? 'no-head-sha'}`,
   });
@@ -249,10 +271,21 @@ export function buildReviewGateCiFailedLifecycleEvent(
     taskId: input.taskId,
     status: input.status,
     taskStateVersion: input.taskStateVersion,
-    generation: input.generation ?? 0,
+    generation,
     ...(input.previousStatus ? { previousStatus: input.previousStatus } : {}),
     ...(input.attemptId ? { attemptId: input.attemptId } : {}),
-    createdAt: normalizeCreatedAt(input.createdAt),
+    createdAt,
+    recoveryWakeup: buildRecoveryWorkerWakeupHint({
+      eventKey,
+      eventKind: 'review_gate.ci_failed',
+      workflowId: input.workflowId,
+      taskId: input.taskId,
+      taskStateVersion: input.taskStateVersion,
+      generation,
+      attemptId: input.attemptId,
+      createdAt,
+      reason: 'review_gate_failure',
+    }),
     reviewId: input.reviewId,
     reviewUrl: input.reviewUrl,
     ...(input.headSha ? { headSha: input.headSha } : {}),
@@ -267,18 +300,28 @@ export function buildWorkflowWakeupLifecycleEvent(
   input: WorkflowWakeupLifecycleEventInput,
 ): WorkflowWakeupLifecycleEvent {
   const generation = input.generation ?? 0;
+  const createdAt = normalizeCreatedAt(input.createdAt);
+  const eventKey = buildLifecycleEventKey({
+    kind: 'workflow.wakeup',
+    workflowId: input.workflowId,
+    generation,
+    discriminator: `reason:${input.reason}`,
+  });
   return {
-    eventKey: buildLifecycleEventKey({
-      kind: 'workflow.wakeup',
-      workflowId: input.workflowId,
-      generation,
-      discriminator: `reason:${input.reason}`,
-    }),
+    eventKey,
     kind: 'workflow.wakeup',
     workflowId: input.workflowId,
     ...(input.status ? { status: input.status } : {}),
     generation,
-    createdAt: normalizeCreatedAt(input.createdAt),
+    createdAt,
+    recoveryWakeup: buildRecoveryWorkerWakeupHint({
+      eventKey,
+      eventKind: 'workflow.wakeup',
+      workflowId: input.workflowId,
+      generation,
+      createdAt,
+      reason: 'workflow_reconcile',
+    }),
     reason: input.reason,
   };
 }
@@ -333,6 +376,7 @@ export function isWorkflowLifecycleEvent(value: unknown): value is WorkflowLifec
   if (value.previousStatus != null && !isTaskStatus(value.previousStatus)) return false;
   if (value.taskStateVersion != null && typeof value.taskStateVersion !== 'number') return false;
   if (value.attemptId != null && typeof value.attemptId !== 'string') return false;
+  if (!isRecoveryWorkerWakeupHint(value.recoveryWakeup, value)) return false;
 
   switch (value.kind) {
     case 'task.created':
@@ -363,6 +407,19 @@ export function isTaskLifecycleEvent(value: unknown): value is TaskLifecycleEven
   return isWorkflowLifecycleEvent(value) && value.kind.startsWith('task.');
 }
 
+export function lifecycleEventMatchesPersistedTask(
+  event: WorkflowLifecycleEvent,
+  task: TaskState | undefined,
+): boolean {
+  if (!event.taskId || !task) return false;
+  if (event.workflowId !== task.config.workflowId) return false;
+  if (event.taskId !== task.id) return false;
+  if (event.taskStateVersion !== task.taskStateVersion) return false;
+  if (event.generation !== (task.execution.generation ?? 0)) return false;
+  if (event.attemptId !== task.execution.selectedAttemptId) return false;
+  return true;
+}
+
 function buildTaskLifecycleEvent(input: {
   readonly kind: TaskLifecycleEvent['kind'];
   readonly workflowId: string;
@@ -374,8 +431,10 @@ function buildTaskLifecycleEvent(input: {
   readonly attemptId?: string;
   readonly createdAt?: string | Date;
 }): TaskLifecycleEvent {
+  const createdAt = normalizeCreatedAt(input.createdAt);
+  const eventKey = buildLifecycleEventKey(input);
   return {
-    eventKey: buildLifecycleEventKey(input),
+    eventKey,
     kind: input.kind,
     workflowId: input.workflowId,
     taskId: input.taskId,
@@ -384,7 +443,43 @@ function buildTaskLifecycleEvent(input: {
     taskStateVersion: input.taskStateVersion,
     generation: input.generation,
     ...(input.attemptId ? { attemptId: input.attemptId } : {}),
-    createdAt: normalizeCreatedAt(input.createdAt),
+    createdAt,
+    recoveryWakeup: buildRecoveryWorkerWakeupHint({
+      eventKey,
+      eventKind: input.kind,
+      workflowId: input.workflowId,
+      taskId: input.taskId,
+      taskStateVersion: input.taskStateVersion,
+      generation: input.generation,
+      attemptId: input.attemptId,
+      createdAt,
+      reason: input.kind === 'task.failed' ? 'task_failure' : 'task_lifecycle',
+    }),
+  };
+}
+
+function buildRecoveryWorkerWakeupHint(input: {
+  readonly eventKey: string;
+  readonly eventKind: WorkflowLifecycleEventKind;
+  readonly workflowId: string;
+  readonly taskId?: string;
+  readonly taskStateVersion?: number;
+  readonly generation: number;
+  readonly attemptId?: string;
+  readonly createdAt: string;
+  readonly reason: RecoveryWorkerWakeupReason;
+}): RecoveryWorkerWakeupHint {
+  return {
+    eventKey: input.eventKey,
+    eventKind: input.eventKind,
+    workflowId: input.workflowId,
+    ...(input.taskId ? { taskId: input.taskId } : {}),
+    ...(input.taskStateVersion != null ? { taskStateVersion: input.taskStateVersion } : {}),
+    generation: input.generation,
+    ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+    createdAt: input.createdAt,
+    reason: input.reason,
+    authoritative: false,
   };
 }
 
@@ -409,6 +504,35 @@ function isWorkflowLifecycleStatus(value: unknown): value is WorkflowLifecycleSt
 
 function isTaskStatus(value: unknown): value is TaskStatus {
   return isWorkflowLifecycleStatus(value);
+}
+
+function isRecoveryWorkerWakeupHint(
+  value: unknown,
+  event: {
+    readonly eventKey?: unknown;
+    readonly kind?: unknown;
+    readonly workflowId?: unknown;
+    readonly taskId?: unknown;
+    readonly taskStateVersion?: unknown;
+    readonly generation?: unknown;
+    readonly attemptId?: unknown;
+    readonly createdAt?: unknown;
+  },
+): value is RecoveryWorkerWakeupHint {
+  if (!isRecord(value)) return false;
+  if (value.eventKey !== event.eventKey) return false;
+  if (value.eventKind !== event.kind) return false;
+  if (value.workflowId !== event.workflowId) return false;
+  if (value.taskId !== event.taskId) return false;
+  if (value.taskStateVersion !== event.taskStateVersion) return false;
+  if (value.generation !== event.generation) return false;
+  if (value.attemptId !== event.attemptId) return false;
+  if (value.createdAt !== event.createdAt) return false;
+  if (value.authoritative !== false) return false;
+  return value.reason === 'task_lifecycle'
+    || value.reason === 'task_failure'
+    || value.reason === 'review_gate_failure'
+    || value.reason === 'workflow_reconcile';
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

The CLI installer now checks explicit test/install candidates and PATH together. Existing installs are no longer skipped when callers provide candidate directories.

The install-dir override still scopes installation to one directory. The broader search only applies after that check.

## Architecture

### Before

```mermaid
graph TD
    Detect[installer detection] --> Candidates[candidate dirs]
    Candidates --> Choice[choose install path]
    Candidates --> NoPATH[PATH skipped]
```

### After

```mermaid
graph TD
    Detect[installer detection] --> InstallDir[explicit install-dir override]
    InstallDir --> Choice[choose install path]
    Detect --> Candidates[candidate dirs]
    Detect --> PATH[PATH search]
    Candidates --> Choice
    PATH --> Choice
```

## Test Plan

- [x] `cd packages/app && pnpm test -- src/__tests__/cli-installer.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 053351f6a56f815df34d6eac5eb9342c8b5456b0`
- Post-revert steps: None
- Data migration? No
