### PR TITLE
[Recovery Lifecycle 2e][D3] Headless client worker owner

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -444,6 +444,51 @@ describe('headless-client', () => {
     expect(runElectronHeadless).toHaveBeenCalledWith(['query', 'workflows']);
   });
 
+  it('starts autofix worker only through the explicit worker command after resolving an owner', async () => {
+    const bus = new LocalBus();
+    const ensureStandaloneOwner = vi.fn(async () => {
+      bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-worker', mode: 'standalone' }));
+    });
+    const runElectronHeadless = vi.fn(async () => 0);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    const exitCode = await runHeadlessClientCommand(['worker', 'autofix', '--count', '1'], {
+      messageBus: bus,
+      ensureStandaloneOwner,
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('[worker:autofix] owner ready: owner-worker'));
+    expect(stdout).toHaveBeenCalledWith(expect.stringContaining('[worker:autofix] tick completed:'));
+    stdout.mockRestore();
+  });
+
+  it('does not start worker loops as a side effect of run delegation', async () => {
+    const bus = new LocalBus();
+    const runHandler = vi.fn(async () => ({ ok: true }));
+    const execHandler = vi.fn(async () => ({ ok: true }));
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const runElectronHeadless = vi.fn(async () => 0);
+    bus.onRequest('headless.run', runHandler);
+    bus.onRequest('headless.exec', execHandler);
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-run', mode: 'standalone' }));
+
+    const exitCode = await runHeadlessClientCommand(['run', '/tmp/plan.yaml', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner,
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runHandler).toHaveBeenCalledTimes(1);
+    expect(execHandler).not.toHaveBeenCalled();
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+  });
+
   it('delegates query ui-perf to a reachable owner endpoint', async () => {
     const bus = new LocalBus();
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -26,6 +26,7 @@ import {
   isStandaloneCapable,
 } from './owner-endpoint.js';
 import { createOwnerResolver, type ResolvedOwner } from './owner-resolver.js';
+import { createRecoveryWorker } from './worker-runtime.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -94,6 +95,14 @@ const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 8_000;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
 const DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS = 60_000;
+
+const workerLogger = {
+  debug() {},
+  info(message: string) { process.stderr.write(`${message}\n`); },
+  warn(message: string) { process.stderr.write(`${message}\n`); },
+  error(message: string) { process.stderr.write(`${message}\n`); },
+  child() { return workerLogger; },
+};
 
 function standaloneOwnerBootstrapTimeoutMs(): number {
   const raw = process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS;
@@ -279,6 +288,92 @@ function shouldUseSharedMutationOwner(args: string[], standaloneMode: boolean, i
   return isHeadlessMutatingCommand(args) && !standaloneMode && !internalOwnerServe;
 }
 
+function isAutofixWorkerCommand(args: string[]): boolean {
+  return args[0] === 'worker' && args[1] === 'autofix';
+}
+
+function parseAutofixWorkerOptions(args: string[]): { count: number | undefined; intervalMs: number | undefined } {
+  let count: number | undefined;
+  let intervalMs: number | undefined;
+  for (let index = 2; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === '--count') {
+      const value = args[index + 1];
+      if (!value) throw new Error('Missing value for --count');
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new Error(`Invalid --count value: ${value}`);
+      }
+      count = parsed;
+      index += 1;
+    } else if (arg === '--interval-ms') {
+      const value = args[index + 1];
+      if (!value) throw new Error('Missing value for --interval-ms');
+      const parsed = Number(value);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new Error(`Invalid --interval-ms value: ${value}`);
+      }
+      intervalMs = parsed;
+      index += 1;
+    } else {
+      throw new Error(`Unknown worker autofix option: ${arg}`);
+    }
+  }
+  return { count, intervalMs };
+}
+
+async function resolveOwnerForAutofixWorker(deps: HeadlessClientDeps): Promise<ResolvedOwner> {
+  const resolver = createOwnerResolver(
+    {
+      messageBus: deps.messageBus,
+      refreshMessageBus: deps.refreshMessageBus,
+      ensureStandaloneOwner: deps.ensureStandaloneOwner,
+      isRetryableBootstrapError: isSharedMutationOwnerTimeoutError,
+    },
+    {
+      discoveryTimeoutMs: 3_000,
+      refreshDiscoveryTimeoutMs: 1_000,
+      postBootstrapReadyTimeoutMs: POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS,
+      maxBootstrapAttempts: POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS,
+    },
+  );
+  return resolver.resolve(true);
+}
+
+async function runAutofixWorkerCommand(args: string[], deps: HeadlessClientDeps): Promise<number> {
+  const options = parseAutofixWorkerOptions(args);
+  const resolved = await resolveOwnerForAutofixWorker(deps);
+  process.stdout.write(`[worker:autofix] owner ready: ${resolved.owner.ownerId}\n`);
+
+  const worker = createRecoveryWorker({
+    logger: workerLogger,
+    intervalMs: options.intervalMs,
+    installSignalHandlers: options.count === undefined,
+    tickOnStart: false,
+  });
+
+  if (options.count !== undefined) {
+    for (let tick = 0; tick < options.count; tick += 1) {
+      await worker.tick('manual');
+    }
+    await worker.stop();
+    process.stdout.write(options.count === 1
+      ? `[worker:autofix] tick completed: ${worker.identity.instanceId}\n`
+      : `[worker:autofix] ticks completed: ${options.count}: ${worker.identity.instanceId}\n`);
+    return 0;
+  }
+
+  worker.start();
+  process.stdout.write(`[worker:autofix] started: ${worker.identity.instanceId}\n`);
+  await new Promise<void>((resolveStop) => {
+    const finish = (): void => resolveStop();
+    process.once('SIGINT', finish);
+    process.once('SIGTERM', finish);
+  });
+  await worker.stop();
+  return 0;
+}
+
 /**
  * Resolve a writable owner endpoint using the resolver, then delegate.
  *
@@ -369,6 +464,10 @@ export async function runHeadlessClientCommand(
   const { args, waitForApproval, noTrack } = parseArgs(argv);
   const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
   const internalOwnerServe = args[0] === 'owner-serve';
+
+  if (isAutofixWorkerCommand(args)) {
+    return runAutofixWorkerCommand(args, deps);
+  }
 
   if (!standaloneMode && !internalOwnerServe && await delegateReadOnlyQuery(args, deps.messageBus, deps.refreshMessageBus)) {
     const exitCode = process.exitCode;

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -322,7 +322,7 @@ function parseAutofixWorkerOptions(args: string[]): { count: number | undefined;
   return { count, intervalMs };
 }
 
-async function resolveOwnerForAutofixWorker(deps: HeadlessClientDeps): Promise<ResolvedOwner> {
+async function resolveOwnerForAutofixWorker(deps: HeadlessClientDeps): Promise<ResolvedOwner | null> {
   const resolver = createOwnerResolver(
     {
       messageBus: deps.messageBus,
@@ -337,18 +337,31 @@ async function resolveOwnerForAutofixWorker(deps: HeadlessClientDeps): Promise<R
       maxBootstrapAttempts: POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS,
     },
   );
-  return resolver.resolve(true);
+  try {
+    return await resolver.resolve(true);
+  } catch (err) {
+    if (err instanceof Error && /Could not resolve a standalone-capable owner/.test(err.message)) {
+      return null;
+    }
+    throw err;
+  }
 }
 
 async function runAutofixWorkerCommand(args: string[], deps: HeadlessClientDeps): Promise<number> {
   const options = parseAutofixWorkerOptions(args);
   const resolved = await resolveOwnerForAutofixWorker(deps);
+  if (resolved === null) {
+    process.stderr.write(
+      `${RED}Error:${RESET} Autofix worker could not reach a standalone shared owner after bootstrap.\n`,
+    );
+    return 1;
+  }
   process.stdout.write(`[worker:autofix] owner ready: ${resolved.owner.ownerId}\n`);
 
   const worker = createRecoveryWorker({
     logger: workerLogger,
     intervalMs: options.intervalMs,
-    installSignalHandlers: options.count === undefined,
+    installSignalHandlers: false,
     tickOnStart: false,
   });
 


### PR DESCRIPTION
## Summary

The app headless client now resolves the shared owner before starting the worker. Worker startup stays behind the same mutation boundary as the rest of the app.

The worker path no longer looks like a normal fallback command. It resolves or bootstraps the owner first, then starts the worker with bounded runs still using `--count N`.

## Architecture

### Before

```mermaid
graph TD
    ClientWorker[headless-client worker autofix] --> Fallback[fallback host execution path]
    Fallback --> Host[runElectronHeadless]

    ClientRun[headless-client run] --> Delegation[headless.run delegation]
```

### After

```mermaid
graph TD
    ClientWorker[headless-client worker autofix --count N] --> Resolver[owner resolver/bootstrap]
    Resolver --> Owner[shared mutation owner]
    ClientWorker --> Runtime[recovery worker]
    Runtime --> Owner

    ClientRun[headless-client run] --> Delegation[headless.run delegation]
    Delegation --> NoWorker[no recovery worker loop]
```

## Test Plan

- [x] `cd packages/app && pnpm test -- src/__tests__/headless-client.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f313872024e2b904926e38d968f0c6cf4350f29e`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for worker autofix command with configurable execution modes and shutdown handling.

* **Tests**
  * Added behavioral tests for worker autofix command execution and owner delegation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->