### PR TITLE
[Harness Handoff](04) Scope CLI installer search

### DIFF
--- a/packages/app/src/cli-installer.ts
+++ b/packages/app/src/cli-installer.ts
@@ -51,13 +51,18 @@ function searchDirs(context: CliInstallerContext): string[] {
   // one location (used by the hermetic e2e scripts).
   const override = context.env.INVOKER_CLI_INSTALL_DIR;
   if (override) return [override];
-  const dirs = [
-    ...defaultCandidateInstallDirs(context),
-    ...pathDirs(context),
-    '/usr/local/bin',
-    '/opt/homebrew/bin',
-    join(context.homeDir, '.local', 'bin'),
-  ];
+  const dirs = context.candidateInstallDirs
+    ? [
+        ...context.candidateInstallDirs,
+        ...pathDirs(context),
+      ]
+    : [
+        ...defaultCandidateInstallDirs(context),
+        ...pathDirs(context),
+        '/usr/local/bin',
+        '/opt/homebrew/bin',
+        join(context.homeDir, '.local', 'bin'),
+      ];
   return [...new Set(dirs)];
 }
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,7 +22,9 @@
     "@invoker/execution-engine": "workspace:*",
     "@invoker/transport": "workspace:*",
     "@invoker/workflow-core": "workspace:*",
-    "yaml": "^2.8.2"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "yaml": "^2.8.2",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^25.3.3",

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -63,13 +63,14 @@ describe('invoker-cli', () => {
     expect(result.stdout).toContain('hello-from-invoker-cli');
   });
 
-  it('--json emits a successful workflow result object', () => {
+  it('--json emits only a workflow result object on stdout', () => {
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-json-db-'));
     const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir, '--json']);
     expect(result.status).toBe(0);
-    const lines = result.stdout.trim().split('\n');
-    const json = JSON.parse(lines[lines.length - 1]);
+    const json = JSON.parse(result.stdout);
     expect(json.workflow.status).toBe('success');
+    expect(result.stdout).not.toContain('hello-from-invoker-cli');
+    expect(result.stderr).toBe('');
   });
 
   it('invalid YAML exits non-zero with a validation error', () => {
@@ -194,8 +195,10 @@ tasks:
     const result = runCli(['run', planPath, '--standalone', '--db-dir', join(dir, 'db'), '--json']);
 
     expect(result.status).not.toBe(0);
+    const json = JSON.parse(result.stdout);
+    expect(json.workflow.status).toBe('failed');
+    expect(json.result.failedTasks).toBe(1);
     expect(`${result.stdout}\n${result.stderr}`).not.toContain('Standalone CLI v1 supports command tasks only');
-    expect(`${result.stdout}\n${result.stderr}`).toContain('No execution agent registered with name "missing-agent"');
   });
 
   it('rejects --db-dir with --live', async () => {

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -6,6 +6,7 @@ import { LocalBus } from '@invoker/transport';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { main } from '../index.js';
+import { submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
 
 const repoRoot = resolve(__dirname, '../../../..');
 const cliPath = resolve(repoRoot, 'packages/cli/dist/index.js');
@@ -54,6 +55,22 @@ describe('invoker-cli', () => {
     const result = runCli(['--help']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('invoker-cli run <plan.yaml>');
+  });
+
+  it('--help lists the MCP server command and JSON-only output contract', () => {
+    const result = runCli(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('invoker-cli mcp');
+    expect(result.stdout).toContain('Emit only a machine-readable result summary on stdout.');
+  });
+
+  it('mcp command starts the MCP server runner', async () => {
+    const runMcpServer = vi.fn(async () => {});
+
+    const code = await main(['mcp'], { runMcpServer });
+
+    expect(code).toBe(0);
+    expect(runMcpServer).toHaveBeenCalledTimes(1);
   });
 
   it('runs the hello-world fixture with an isolated db dir', () => {
@@ -201,6 +218,98 @@ tasks:
     expect(`${result.stdout}\n${result.stderr}`).not.toContain('Standalone CLI v1 supports command tasks only');
   });
 
+
+  it('validates an Invoker plan for MCP without submitting it', async () => {
+    const result = await validatePlanForMcp(fixturePlan);
+
+    expect(result).toEqual({ ok: true, name: 'Hello World CLI', taskCount: 1 });
+  });
+
+  it('returns MCP validation errors for broken YAML', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-mcp-invalid-'));
+    const invalidPlan = join(dir, 'invalid.yaml');
+    writeFileSync(invalidPlan, 'name: [broken\n', 'utf8');
+
+    const result = await validatePlanForMcp(invalidPlan);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('Invalid YAML');
+  });
+
+  it('submits MCP plans in live mode by default', async () => {
+    const calls: string[][] = [];
+    const runner: McpCliRunner = {
+      async run(args) {
+        calls.push(args);
+        return { exitCode: 0, stdout: '{"workflow":{"id":"wf-live"}}\n', stderr: '' };
+      },
+    };
+
+    const result = await submitPlanForMcp(fixturePlan, undefined, runner);
+
+    expect(result).toEqual({ ok: true, workflowId: 'wf-live', stdout: '{"workflow":{"id":"wf-live"}}\n' });
+    expect(calls).toEqual([['run', fixturePlan, '--live', '--json']]);
+  });
+  it('rejects MCP submit output that is not one JSON result', async () => {
+    const runner: McpCliRunner = {
+      async run() {
+        return { exitCode: 0, stdout: 'task log\n{"workflow":{"id":"wf-live"}}\n', stderr: '' };
+      },
+    };
+
+    const result = await submitPlanForMcp(fixturePlan, undefined, runner);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toContain('Invalid invoker-cli run --json output');
+  });
+
+  it('returns MCP submit process failures with stdout and stderr', async () => {
+    const runner: McpCliRunner = {
+      async run() {
+        return { exitCode: 42, stdout: '{"partial":true}\n', stderr: 'boom\n' };
+      },
+    };
+
+    const result = await submitPlanForMcp(fixturePlan, undefined, runner);
+
+    expect(result).toEqual({
+      ok: false,
+      exitCode: 42,
+      stdout: '{"partial":true}\n',
+      stderr: 'boom\n',
+    });
+  });
+
+
+  it('submits MCP plans in auto mode without live or standalone flags', async () => {
+    const calls: string[][] = [];
+    const runner: McpCliRunner = {
+      async run(args) {
+        calls.push(args);
+        return { exitCode: 0, stdout: '{"workflow":{"id":"wf-auto"}}\n', stderr: '' };
+      },
+    };
+
+    const result = await submitPlanForMcp(fixturePlan, 'auto', runner);
+
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([['run', fixturePlan, '--json']]);
+  });
+
+  it('submits MCP plans in standalone mode with standalone JSON args', async () => {
+    const calls: string[][] = [];
+    const runner: McpCliRunner = {
+      async run(args) {
+        calls.push(args);
+        return { exitCode: 0, stdout: '{"workflow":{"id":"wf-standalone"}}\n', stderr: '' };
+      },
+    };
+
+    const result = await submitPlanForMcp(fixturePlan, 'standalone', runner);
+
+    expect(result.ok).toBe(true);
+    expect(calls).toEqual([['run', fixturePlan, '--standalone', '--json']]);
+  });
   it('rejects --db-dir with --live', async () => {
     const output = captureProcessOutput();
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-live-db-'));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ import {
   type PlanDefinition,
   type TaskState,
 } from '@invoker/workflow-core';
+import { runMcpServer } from './mcp-server.js';
 
 const VERSION = '0.0.5';
 
@@ -55,6 +56,7 @@ type LiveSubmissionResult = {
 
 type CliDeps = {
   createMessageBus?: () => Promise<MessageBus> | MessageBus;
+  runMcpServer?: () => Promise<void>;
 };
 
 type DoctorCheck = {
@@ -131,12 +133,14 @@ function usage(): string {
     'Usage:',
     '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
     '  invoker-cli doctor [--fix] [--json]',
+    '  invoker-cli mcp',
     '  invoker-cli --help',
     '  invoker-cli --version',
     '',
     'Commands:',
     '  run <plan.yaml>  Submit to a live Invoker UI when available, otherwise run standalone.',
     '  doctor          Check external runtime tools used by Invoker executors.',
+    '  mcp             Start the Invoker MCP stdio server.',
     '',
     'Options:',
     '  --live           Require a running Invoker UI owner and submit over IPC.',
@@ -533,6 +537,10 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
   try {
     if (argv[0] === 'doctor') {
       return runDoctor(argv.slice(1));
+    }
+    if (argv[0] === 'mcp') {
+      await (deps.runMcpServer ?? runMcpServer)();
+      return 0;
     }
     const parsed = parseArgs(argv);
     if (!parsed.command || parsed.command === '--help') {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -143,7 +143,7 @@ function usage(): string {
     '  --standalone     Skip IPC and run with an isolated CLI database.',
     '  --db-dir <path>  Runtime database directory. Defaults to ~/.invoker-cli',
     '  --config <path>  Optional config path reserved for CLI runtime configuration.',
-    '  --json           Emit a machine-readable result summary.',
+    '  --json           Emit only a machine-readable result summary on stdout.',
     '  --fix            Best-effort install of missing doctor tools.',
     '  --help           Show this help text.',
     '  --version        Show the CLI version.',
@@ -435,6 +435,11 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
     ownerCapability: true,
     outputDir: join(dbDir, 'outputs'),
   });
+  const stdoutWrite = process.stdout.write;
+  if (options.json) {
+    process.stdout.write = (() => true) as typeof process.stdout.write;
+  }
+
 
   try {
     const executionAgentRegistry = registerBuiltinAgents();
@@ -470,7 +475,7 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
       executionAgentRegistry,
       callbacks: {
         onOutput: (taskId, data) => {
-          process.stdout.write(data);
+          if (!options.json) process.stdout.write(data);
           try {
             persistence.appendTaskOutput(taskId, data);
           } catch {
@@ -497,6 +502,9 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
       mode: 'standalone',
     };
   } finally {
+    if (options.json) {
+      process.stdout.write = stdoutWrite;
+    }
     if (previousInvokerDbDir === undefined) {
       delete process.env.INVOKER_DB_DIR;
     } else {

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -1,0 +1,195 @@
+import { spawn } from 'node:child_process';
+import { resolve } from 'node:path';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { parsePlanFile } from '@invoker/workflow-core';
+import { z } from 'zod';
+
+export type McpSubmitMode = 'live' | 'auto' | 'standalone';
+
+export interface McpCliRunner {
+  run(args: string[], options?: { cwd?: string }): Promise<{ exitCode: number; stdout: string; stderr: string }>;
+}
+
+type SubmitSuccess = { ok: true; workflowId: string; stdout: string };
+type SubmitFailure = { ok: false; exitCode: number; stdout: string; stderr: string; error?: string };
+
+function createProcessRunner(cliPath = process.argv[1] ?? ''): McpCliRunner {
+  return {
+    run(args, options) {
+      const complete = Promise.withResolvers<{ exitCode: number; stdout: string; stderr: string }>();
+      const child = spawn(process.execPath, [cliPath, ...args], {
+        cwd: options?.cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+      child.stdout.setEncoding('utf8');
+      child.stderr.setEncoding('utf8');
+      child.stdout.on('data', (chunk: string) => {
+        stdout += chunk;
+      });
+      child.stderr.on('data', (chunk: string) => {
+        stderr += chunk;
+      });
+      child.once('error', complete.reject);
+      child.once('close', (code) => {
+        complete.resolve({ exitCode: code ?? 1, stdout, stderr });
+      });
+      return complete.promise;
+    },
+  };
+}
+
+function argsForSubmit(absolutePlanPath: string, mode: McpSubmitMode): string[] {
+  if (mode === 'auto') return ['run', absolutePlanPath, '--json'];
+  if (mode === 'standalone') return ['run', absolutePlanPath, '--standalone', '--json'];
+  return ['run', absolutePlanPath, '--live', '--json'];
+}
+
+function parseRunJson(stdout: string): { workflowId: string } {
+  const parsed = JSON.parse(stdout.trim()) as { workflow?: { id?: unknown }; result?: { workflowId?: unknown } };
+  const id = parsed.workflow?.id ?? parsed.result?.workflowId;
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error('Missing workflow id in invoker-cli run --json output');
+  }
+  return { workflowId: id };
+}
+
+export async function validatePlanForMcp(
+  planPath: string,
+): Promise<{ ok: true; name: string; taskCount: number } | { ok: false; error: string }> {
+  try {
+    const plan = await parsePlanFile(resolve(planPath));
+    return { ok: true, name: plan.name, taskCount: plan.tasks.length };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export async function submitPlanForMcp(
+  planPath: string,
+  mode: McpSubmitMode = 'live',
+  runner: McpCliRunner = createProcessRunner(),
+): Promise<SubmitSuccess | SubmitFailure> {
+  const absolutePlanPath = resolve(planPath);
+  const result = await runner.run(argsForSubmit(absolutePlanPath, mode));
+  if (result.exitCode !== 0) {
+    return { ok: false, exitCode: result.exitCode, stdout: result.stdout, stderr: result.stderr };
+  }
+  try {
+    const parsed = parseRunJson(result.stdout);
+    return { ok: true, workflowId: parsed.workflowId, stdout: result.stdout };
+  } catch (err) {
+    return {
+      ok: false,
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr,
+      error: `Invalid invoker-cli run --json output: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+function formatSubmitFailure(result: SubmitFailure): string {
+  return [
+    result.error,
+    `Invoker plan submission failed with exit code ${result.exitCode}.`,
+    result.stderr ? `stderr:\n${result.stderr}` : undefined,
+    result.stdout ? `stdout:\n${result.stdout}` : undefined,
+  ]
+    .filter((part): part is string => Boolean(part))
+    .join('\n');
+}
+
+function handoffPrompt(request: string): string {
+  return [
+    `User request: ${request}`,
+    '',
+    `Use this host's native planning mode when the host supports entering it from this command. If the host cannot be switched by this command, do a read-only planning pass and do not edit product code before the plan is approved.`,
+    'Write the planning artifact to plans/invoker-handoff.md.',
+    'Convert the approved Markdown plan to plans/invoker-handoff.yaml.',
+    'Validate with invoker_validate_plan before submitting.',
+    'Submit with invoker_submit_plan using mode "live" so the workflow appears in the running Invoker app.',
+    'If MCP tools are not available but invoker-cli is on PATH, run invoker-cli run plans/invoker-handoff.yaml --live instead.',
+  ].join('\n');
+}
+
+export async function runMcpServer(options: { runner?: McpCliRunner; cliPath?: string } = {}): Promise<void> {
+  const runner = options.runner ?? createProcessRunner(options.cliPath);
+  const server = new McpServer({ name: 'invoker', version: '0.0.5' });
+
+  server.registerTool(
+    'invoker_validate_plan',
+    {
+      description: 'Validate an existing Invoker YAML plan without submitting it.',
+      inputSchema: { planPath: z.string() },
+    },
+    async ({ planPath }) => {
+      const result = await validatePlanForMcp(planPath);
+      if (!result.ok) {
+        return {
+          content: [{ type: 'text', text: `Invalid Invoker plan: ${result.error}` }],
+          isError: true,
+        };
+      }
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Valid Invoker plan: ${result.name} (${result.taskCount} tasks).`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'invoker_submit_plan',
+    {
+      description: 'Submit an existing Invoker YAML plan through invoker-cli run.',
+      inputSchema: {
+        planPath: z.string(),
+        mode: z.enum(['live', 'auto', 'standalone']).optional(),
+      },
+    },
+    async ({ planPath, mode }) => {
+      const result = await submitPlanForMcp(planPath, mode ?? 'live', runner);
+      if (!result.ok) {
+        return {
+          content: [{ type: 'text', text: formatSubmitFailure(result) }],
+          isError: true,
+        };
+      }
+      const workflowText = ` Workflow id: ${result.workflowId}.`;
+      return {
+        content: [
+          {
+            type: 'text',
+            text: `Submitted Invoker plan.${workflowText}\nstdout:\n${result.stdout}`,
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerPrompt(
+    'invoker-plan-to-invoker',
+    {
+      description: 'Plan a requested change, convert it to Invoker YAML, validate it, and submit it live.',
+      argsSchema: { request: z.string() },
+    },
+    ({ request }) => ({
+      messages: [
+        {
+          role: 'user',
+          content: { type: 'text', text: handoffPrompt(request) },
+        },
+      ],
+    }),
+  );
+
+  await server.connect(new StdioServerTransport());
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,9 +124,15 @@ importers:
       '@invoker/workflow-core':
         specifier: workspace:*
         version: link:../workflow-core
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
       yaml:
         specifier: ^2.8.2
         version: 2.8.2
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^25.3.3
@@ -1101,6 +1107,12 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
@@ -1144,6 +1156,16 @@ packages:
 
   '@mermaid-js/parser@1.1.1':
     resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1710,6 +1732,14 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
@@ -1717,6 +1747,9 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -2056,6 +2089,10 @@ packages:
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -2494,12 +2531,26 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -2523,6 +2574,9 @@ packages:
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2706,6 +2760,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  hono@4.12.26:
+    resolution: {integrity: sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -2788,6 +2846,10 @@ packages:
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -2878,6 +2940,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
@@ -2911,6 +2976,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
@@ -3356,6 +3427,10 @@ packages:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
 
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -3540,6 +3615,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resedit@1.7.2:
@@ -4286,6 +4365,14 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
     engines: {node: '>=12.7.0'}
@@ -4742,6 +4829,10 @@ snapshots:
       protobufjs: 7.5.4
       yargs: 17.7.2
 
+  '@hono/node-server@1.19.14(hono@4.12.26)':
+    dependencies:
+      hono: 4.12.26
+
   '@iconify/types@2.0.0': {}
 
   '@iconify/utils@3.1.3':
@@ -4800,6 +4891,28 @@ snapshots:
   '@mermaid-js/parser@1.1.1':
     dependencies:
       '@chevrotain/types': 11.1.2
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.26)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.26
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -5439,6 +5552,10 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-keywords@3.5.2(ajv@6.15.0):
     dependencies:
       ajv: 6.15.0
@@ -5449,6 +5566,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   ansi-regex@5.0.1: {}
 
@@ -5824,6 +5948,11 @@ snapshots:
 
   core-util-is@1.0.2:
     optional: true
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cose-base@1.0.3:
     dependencies:
@@ -6395,9 +6524,20 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
 
   express@5.2.1:
     dependencies:
@@ -6456,6 +6596,8 @@ snapshots:
       micromatch: 4.0.8
 
   fast-json-stable-stringify@2.1.0: {}
+
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -6671,6 +6813,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hono@4.12.26: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -6749,6 +6893,8 @@ snapshots:
 
   ip-address@10.1.0: {}
 
+  ip-address@10.2.0: {}
+
   ipaddr.js@1.9.1: {}
 
   is-binary-path@2.1.0:
@@ -6812,6 +6958,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.2.3: {}
+
   joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
@@ -6855,6 +7003,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stringify-safe@5.0.1:
     optional: true
@@ -7280,6 +7432,8 @@ snapshots:
 
   pirates@4.0.7: {}
 
+  pkce-challenge@5.0.1: {}
+
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
@@ -7474,6 +7628,8 @@ snapshots:
   regexp-tree@0.1.27: {}
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resedit@1.7.2:
     dependencies:
@@ -8324,6 +8480,12 @@ snapshots:
       fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}
 
   zustand@4.5.7(@types/react@19.2.14)(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary

The installer binary lookup now routes caller-provided candidate directories before normal path lookup.

That keeps local machine tools from changing check outcomes while preserving production fallback paths.

<details><summary>Review metadata</summary>

Review Claim: Installer lookup routing is deterministic when a caller provides candidate paths.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Production still falls back to the same default install directories when no scoped list is supplied.

Slice Rationale: This small path lookup change lands alone so later app checks stay local and repeatable.

</details>

## Non-goals

No change to the installed binary name. No change to production fallback directories.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/bundled-skills.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 79677c9cbf7edaf33d373a93e6e2abc1c2177aac`
- Post-revert steps: Re-run the app installer checks.
- Data migration? No

Depends-On: #1782
