### PR TITLE
[Harness Handoff](07) Add helper state contract

### DIFF
--- a/packages/contracts/src/__tests__/bundled-skills-status.test.ts
+++ b/packages/contracts/src/__tests__/bundled-skills-status.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import type { BundledSkillsStatus, SystemDiagnostics } from '../ipc-channels.js';
+
+describe('BundledSkillsStatus contract', () => {
+  it('requires harness command and MCP config state arrays on diagnostics fixtures', () => {
+    const bundledSkills = {
+      available: true,
+      promptRecommended: true,
+      managedPrefix: 'invoker-',
+      bundledSkillNames: ['plan-to-invoker'],
+      targets: [
+        { id: 'codex', name: 'Codex', path: '/tmp/.codex/skills', available: true, installed: true, upToDate: true, installedSkillNames: ['invoker-plan-to-invoker'] },
+      ],
+      commandTargets: [
+        { id: 'omp', name: 'OMP', path: '/tmp/.omp/agent/commands', available: true, installed: true, upToDate: true, installedCommandNames: ['invoker-plan-to-invoker'] },
+      ],
+      mcpTargets: [
+        { id: 'omp', name: 'OMP', path: '/tmp/.omp/agent/mcp.json', available: true, installed: true, upToDate: true, serverName: 'invoker' },
+      ],
+    } satisfies BundledSkillsStatus;
+
+    const diagnostics = {
+      platform: 'darwin',
+      arch: 'arm64',
+      appVersion: '0.0.5',
+      isPackaged: true,
+      tools: [],
+      bundledSkills,
+    } satisfies SystemDiagnostics;
+
+    expect(diagnostics.bundledSkills.commandTargets[0]?.installedCommandNames).toEqual(['invoker-plan-to-invoker']);
+    expect(diagnostics.bundledSkills.mcpTargets[0]?.serverName).toBe('invoker');
+  });
+});

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -253,6 +253,26 @@ export interface BundledSkillTargetStatus {
   installedSkillNames: string[];
 }
 
+export interface HarnessConfigState {
+  id: string;
+  name: string;
+  path: string;
+  available: boolean;
+  installed: boolean;
+  upToDate: boolean;
+  installedCommandNames: string[];
+}
+
+export interface HarnessMcpConfigState {
+  id: string;
+  name: string;
+  path: string;
+  available: boolean;
+  installed: boolean;
+  upToDate: boolean;
+  serverName: string;
+}
+
 export interface BundledSkillsStatus {
   available: boolean;
   promptRecommended: boolean;
@@ -262,6 +282,8 @@ export interface BundledSkillsStatus {
   lastInstallAt?: string;
   lastInstallError?: string;
   targets: BundledSkillTargetStatus[];
+  commandTargets?: HarnessConfigState[];
+  mcpTargets?: HarnessMcpConfigState[];
 }
 
 export type BundledSkillsInstallMode = 'install' | 'update' | 'reinstall';

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -120,6 +120,8 @@ export function createMockInvoker(
           { id: 'claude', name: 'Claude', path: '/tmp/.claude/skills', available: true, installed: false, upToDate: false, installedSkillNames: [] },
           { id: 'cursor', name: 'Cursor', path: '/tmp/.cursor/skills-cursor', available: true, installed: false, upToDate: false, installedSkillNames: [] },
         ],
+        commandTargets: [],
+        mcpTargets: [],
       },
     })),
     getBundledSkillsStatus: vi.fn(async () => ({
@@ -132,6 +134,8 @@ export function createMockInvoker(
         { id: 'claude', name: 'Claude', path: '/tmp/.claude/skills', available: true, installed: false, upToDate: false, installedSkillNames: [] },
         { id: 'cursor', name: 'Cursor', path: '/tmp/.cursor/skills-cursor', available: true, installed: false, upToDate: false, installedSkillNames: [] },
       ],
+      commandTargets: [],
+      mcpTargets: [],
     })),
     installBundledSkills: vi.fn(async () => ({
       available: false,
@@ -143,6 +147,8 @@ export function createMockInvoker(
         { id: 'claude', name: 'Claude', path: '/tmp/.claude/skills', available: true, installed: false, upToDate: false, installedSkillNames: [] },
         { id: 'cursor', name: 'Cursor', path: '/tmp/.cursor/skills-cursor', available: true, installed: false, upToDate: false, installedSkillNames: [] },
       ],
+      commandTargets: [],
+      mcpTargets: [],
     })),
     replaceTask: vi.fn(async () => []),
     getActivityLogs: vi.fn(async () => []),


### PR DESCRIPTION
## Summary

Bundled helper state now has typed fields for harness config state and MCP config state.

UI test helpers return those fields too, so callers can depend on one complete state shape.

The names use harness language because these are host surfaces, not model names.

<details><summary>Review metadata</summary>

Review Claim: The helper state contract can represent skills, harness config state, and MCP config state.

Review Lane: behavior

Review Unit: contract

Safety Invariant: The new fields are additive and existing skill status fields keep their names.

Slice Rationale: The contract lands before installer behavior so later slices do not hide a type change.

Architectural Effect: The shared contract now separates skill targets from `HarnessConfigState` and `HarnessMcpConfigState`.

Alternative considerations: `BundledCommandTargetStatus` and `BundledMcpTargetStatus` were rejected because they sound like bundled objects, not observed harness state.

</details>

## Non-goals

No file copying. No config writes. No visible setup copy changes.

## Test Plan

- [x] `pnpm --filter @invoker/contracts test -- src/__tests__/bundled-skills-status.test.ts`
- [x] `pnpm --filter @invoker/app test bundled-skills.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 8d2512cf9f7bcd72441e82a3fefc8e7fd579b481`
- Post-revert steps: Re-run type and app helper checks.
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended bundled skills status to include command target details and MCP server target details.

* **Tests**
  * Added a new test suite validating the bundled skills status fixture structure and key expected values.
  * Updated mock invoker API responses to include the new command target and MCP server target fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->