### PR TITLE
[Harness Handoff](08) Generate bundled handoff commands

### DIFF
--- a/packages/app/src/__tests__/bundled-skills.test.ts
+++ b/packages/app/src/__tests__/bundled-skills.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, lstatSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -20,6 +20,12 @@ function writeSkill(sourceRoot: string, name: string): void {
   writeFileSync(join(skillDir, 'scripts', 'check.sh'), '#!/usr/bin/env bash\necho ok\n');
 }
 
+function writePlanToInvokerCommands(sourceRoot: string): void {
+  const commandDir = join(sourceRoot, 'skills', 'plan-to-invoker', 'commands');
+  mkdirSync(commandDir, { recursive: true });
+  writeFileSync(join(commandDir, 'invoker-plan-to-invoker.md'), 'Submit with invoker_submit_plan\n');
+}
+
 afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true });
@@ -37,6 +43,7 @@ describe('bundled-skills', () => {
 
     try {
       writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
       writeSkill(resourcesRoot, 'make-pr');
 
       const status = resolveBundledSkillsStatus({
@@ -70,6 +77,7 @@ describe('bundled-skills', () => {
     try {
       writeSkill(resourcesRoot, 'plan-to-invoker');
       writeSkill(resourcesRoot, 'make-pr');
+      writePlanToInvokerCommands(resourcesRoot);
 
       const installed = installBundledSkills({
         isPackaged: true,
@@ -89,10 +97,32 @@ describe('bundled-skills', () => {
         expect(existsSync(join(targetRoot, 'invoker-make-pr', 'scripts', 'check.sh'))).toBe(true);
         expect(readFileSync(join(targetRoot, 'invoker-plan-to-invoker', 'SKILL.md'), 'utf-8')).toContain('plan-to-invoker');
       }
+      const expectedCommandTargets = [
+        join(codexHome, '.codex', 'commands'),
+        join(codexHome, '.claude', 'commands'),
+        join(codexHome, '.cursor', 'commands'),
+        join(codexHome, '.omp', 'agent', 'commands'),
+      ];
+
+      for (const targetRoot of expectedCommandTargets) {
+        const installedCommand = join(targetRoot, 'invoker-plan-to-invoker.md');
+        expect(existsSync(installedCommand)).toBe(true);
+        expect(lstatSync(installedCommand).isSymbolicLink()).toBe(false);
+        expect(readFileSync(installedCommand, 'utf-8')).toBe('Submit with invoker_submit_plan\n');
+      }
+
+      const mcpConfig = JSON.parse(readFileSync(join(codexHome, '.omp', 'agent', 'mcp.json'), 'utf-8'));
+      expect(mcpConfig.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
 
       expect(installed.targets).toHaveLength(3);
+      expect(installed.commandTargets).toHaveLength(4);
+      expect(installed.mcpTargets).toHaveLength(1);
       expect(installed.targets.every((target) => target.installed)).toBe(true);
       expect(installed.targets.every((target) => target.upToDate)).toBe(true);
+      expect(installed.commandTargets.every((target) => target.installed)).toBe(true);
+      expect(installed.commandTargets.every((target) => target.upToDate)).toBe(true);
+      expect(installed.mcpTargets.every((target) => target.installed)).toBe(true);
+      expect(installed.mcpTargets.every((target) => target.upToDate)).toBe(true);
       expect(installed.promptRecommended).toBe(false);
 
       const status = resolveBundledSkillsStatus({
@@ -102,7 +132,74 @@ describe('bundled-skills', () => {
         invokerHomeRoot,
       });
       expect(status.targets.every((target) => target.upToDate)).toBe(true);
+      expect(status.commandTargets.every((target) => target.upToDate)).toBe(true);
+      expect(status.mcpTargets.every((target) => target.upToDate)).toBe(true);
       expect(status.promptRecommended).toBe(false);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('preserves existing OMP MCP servers while adding Invoker', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const fakeHome = makeTempRoot('invoker-omp-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
+      const mcpPath = join(fakeHome, '.omp', 'agent', 'mcp.json');
+      mkdirSync(join(fakeHome, '.omp', 'agent'), { recursive: true });
+      writeFileSync(mcpPath, JSON.stringify({ mcpServers: { filesystem: { command: 'npx', args: ['server'] } } }, null, 2));
+
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+      });
+
+      const config = JSON.parse(readFileSync(mcpPath, 'utf-8'));
+      expect(config.mcpServers.filesystem).toEqual({ command: 'npx', args: ['server'] });
+      expect(config.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('rejects invalid OMP MCP JSON without rewriting it', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const fakeHome = makeTempRoot('invoker-omp-invalid-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
+      const mcpPath = join(fakeHome, '.omp', 'agent', 'mcp.json');
+      mkdirSync(join(fakeHome, '.omp', 'agent'), { recursive: true });
+      writeFileSync(mcpPath, '[]');
+
+      expect(() => installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+      })).toThrow(`Invalid OMP MCP config at ${mcpPath}: expected a JSON object`);
+      expect(readFileSync(mcpPath, 'utf-8')).toBe('[]');
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/packages/app/src/bundled-skills.ts
+++ b/packages/app/src/bundled-skills.ts
@@ -1,14 +1,22 @@
-import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { homedir } from 'node:os';
 import * as path from 'node:path';
 
-import type { BundledSkillsInstallMode, BundledSkillsStatus, BundledSkillTargetStatus } from '@invoker/contracts';
+import type {
+  HarnessConfigState,
+  HarnessMcpConfigState,
+  BundledSkillsInstallMode,
+  BundledSkillsStatus,
+  BundledSkillTargetStatus,
+} from '@invoker/contracts';
 
 import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 
 const MANAGED_PREFIX = 'invoker-';
 const MANIFEST_FILE = 'bundled-skills.json';
+const OMP_MCP_SCHEMA_URL = 'https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json';
+const INVOKER_MCP_SERVER = { type: 'stdio', command: 'invoker-cli', args: ['mcp'] } as const;
 
 interface BundledSkillsManifest {
   bundledHash: string;
@@ -16,6 +24,8 @@ interface BundledSkillsManifest {
   installedAt: string;
   lastInstallError?: string;
   targets: Record<string, { path: string; installedSkillNames: string[] }>;
+  commandTargets?: Record<string, { path: string; installedCommandNames: string[] }>;
+  mcpTargets?: Record<string, { path: string; serverName: string }>;
 }
 
 interface BundledSkillsContext {
@@ -24,6 +34,8 @@ interface BundledSkillsContext {
   resourcesPath?: string;
   invokerHomeRoot?: string;
 }
+
+type JsonRecord = Record<string, unknown>;
 
 function resolveBundledSkillsSourceRoot(context: BundledSkillsContext): string | null {
   if (context.isPackaged) {
@@ -106,6 +118,61 @@ function resolveManagedTargets(): BundledSkillTargetStatus[] {
   return [resolveCodexTarget(), resolveClaudeTarget(), resolveCursorTarget()];
 }
 
+function resolveManagedCommandTargets(): HarnessConfigState[] {
+  return [
+    {
+      id: 'codex',
+      name: 'Codex',
+      path: path.join(homedir(), '.codex', 'commands'),
+      available: true,
+      installed: false,
+      upToDate: false,
+      installedCommandNames: [],
+    },
+    {
+      id: 'claude',
+      name: 'Claude',
+      path: path.join(homedir(), '.claude', 'commands'),
+      available: true,
+      installed: false,
+      upToDate: false,
+      installedCommandNames: [],
+    },
+    {
+      id: 'cursor',
+      name: 'Cursor',
+      path: path.join(homedir(), '.cursor', 'commands'),
+      available: true,
+      installed: false,
+      upToDate: false,
+      installedCommandNames: [],
+    },
+    {
+      id: 'omp',
+      name: 'OMP',
+      path: path.join(homedir(), '.omp', 'agent', 'commands'),
+      available: true,
+      installed: false,
+      upToDate: false,
+      installedCommandNames: [],
+    },
+  ];
+}
+
+function resolveManagedMcpTargets(): HarnessMcpConfigState[] {
+  return [
+    {
+      id: 'omp',
+      name: 'OMP',
+      path: path.join(homedir(), '.omp', 'agent', 'mcp.json'),
+      available: true,
+      installed: false,
+      upToDate: false,
+      serverName: 'invoker',
+    },
+  ];
+}
+
 function resolveManifestPath(invokerHomeRoot: string): string {
   return path.join(invokerHomeRoot, MANIFEST_FILE);
 }
@@ -156,6 +223,117 @@ function prefixedSkillNames(skillNames: string[]): string[] {
   return skillNames.map(managedSkillName);
 }
 
+function commandSourceDir(sourceRoot: string): string {
+  return path.join(sourceRoot, 'plan-to-invoker', 'commands');
+}
+
+function listCommandNames(sourceRoot: string): string[] {
+  const sourceDir = commandSourceDir(sourceRoot);
+  if (!existsSync(sourceDir)) return [];
+  return readdirSync(sourceDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function commandDisplayName(fileName: string): string {
+  return fileName.endsWith('.md') ? fileName.slice(0, -3) : fileName;
+}
+
+function buildCommandConfigState(
+  target: HarnessConfigState,
+  expectedCommandFiles: string[],
+  bundledHash: string,
+  manifest: BundledSkillsManifest | null,
+): HarnessConfigState {
+  const installedFiles = expectedCommandFiles.filter((fileName) => existsSync(path.join(target.path, fileName)));
+  const installedCommandNames = installedFiles.map(commandDisplayName);
+  const expectedCommandNames = expectedCommandFiles.map(commandDisplayName);
+  const installed = installedFiles.length === expectedCommandFiles.length;
+  const manifestTarget = manifest?.commandTargets?.[target.id];
+  const upToDate = installed
+    && manifest?.bundledHash === bundledHash
+    && manifestTarget?.path === target.path
+    && expectedCommandNames.every((name) => manifestTarget.installedCommandNames.includes(name));
+
+  return {
+    ...target,
+    installed,
+    upToDate,
+    installedCommandNames,
+  };
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readJsonRecordIfPresent(filePath: string): JsonRecord | null {
+  if (!existsSync(filePath)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf-8')) as unknown;
+    return isJsonRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function isInvokerMcpServer(value: unknown): boolean {
+  if (!isJsonRecord(value)) return false;
+  return value.type === 'stdio'
+    && value.command === 'invoker-cli'
+    && Array.isArray(value.args)
+    && value.args.length === 1
+    && value.args[0] === 'mcp';
+}
+
+function buildMcpConfigState(
+  target: HarnessMcpConfigState,
+  bundledHash: string,
+  manifest: BundledSkillsManifest | null,
+): HarnessMcpConfigState {
+  const config = readJsonRecordIfPresent(target.path);
+  const servers = isJsonRecord(config?.mcpServers) ? config.mcpServers : undefined;
+  const installed = isInvokerMcpServer(servers?.[target.serverName]);
+  const manifestTarget = manifest?.mcpTargets?.[target.id];
+  const upToDate = installed
+    && manifest?.bundledHash === bundledHash
+    && manifestTarget?.path === target.path
+    && manifestTarget.serverName === target.serverName;
+
+  return {
+    ...target,
+    installed,
+    upToDate,
+  };
+}
+
+function readMutableMcpConfig(filePath: string): { config: JsonRecord; created: boolean } {
+  if (!existsSync(filePath)) {
+    return { config: { $schema: OMP_MCP_SCHEMA_URL }, created: true };
+  }
+
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf-8')) as unknown;
+    if (isJsonRecord(parsed)) return { config: parsed, created: false };
+  } catch {
+    // Throw the same public error for invalid JSON and non-object JSON.
+  }
+
+  throw new Error(`Invalid OMP MCP config at ${filePath}: expected a JSON object`);
+}
+
+function installOmpMcpTarget(target: HarnessMcpConfigState): void {
+  const { config } = readMutableMcpConfig(target.path);
+  const existingServers = isJsonRecord(config.mcpServers) ? config.mcpServers : {};
+  config.mcpServers = {
+    ...existingServers,
+    [target.serverName]: INVOKER_MCP_SERVER,
+  };
+  mkdirSync(path.dirname(target.path), { recursive: true });
+  writeFileSync(target.path, `${JSON.stringify(config, null, 2)}\n`);
+}
+
 export function resolveBundledSkillsStatus(context: BundledSkillsContext): BundledSkillsStatus {
   const invokerHomeRoot = context.invokerHomeRoot ?? resolveInvokerHomeRoot();
   const sourceRoot = resolveBundledSkillsSourceRoot(context);
@@ -166,6 +344,8 @@ export function resolveBundledSkillsStatus(context: BundledSkillsContext): Bundl
       managedPrefix: MANAGED_PREFIX,
       bundledSkillNames: [],
       targets: resolveManagedTargets(),
+      commandTargets: resolveManagedCommandTargets(),
+      mcpTargets: resolveManagedMcpTargets(),
     };
   }
 
@@ -176,16 +356,29 @@ export function resolveBundledSkillsStatus(context: BundledSkillsContext): Bundl
   const targets = resolveManagedTargets().map((target) =>
     buildTargetStatus(target, installedNames, bundledHash, manifest),
   );
+  const commandFiles = listCommandNames(sourceRoot);
+  const commandTargets = resolveManagedCommandTargets().map((target) =>
+    buildCommandConfigState(target, commandFiles, bundledHash, manifest),
+  );
+  const mcpTargets = resolveManagedMcpTargets().map((target) =>
+    buildMcpConfigState(target, bundledHash, manifest),
+  );
 
   return {
     available: true,
-    promptRecommended: context.isPackaged && targets.some((target) => !target.upToDate),
+    promptRecommended: context.isPackaged && (
+      targets.some((target) => !target.upToDate)
+      || commandTargets.some((target) => !target.upToDate)
+      || mcpTargets.some((target) => !target.upToDate)
+    ),
     sourcePath: sourceRoot,
     managedPrefix: MANAGED_PREFIX,
     bundledSkillNames,
     lastInstallAt: manifest?.installedAt,
     lastInstallError: manifest?.lastInstallError,
     targets,
+    commandTargets,
+    mcpTargets,
   };
 }
 
@@ -203,7 +396,11 @@ export function installBundledSkills(
   const bundledHash = hashDirectory(sourceRoot);
   const installedNames = prefixedSkillNames(bundledSkillNames);
   const targets = resolveManagedTargets();
+  const commandTargets = resolveManagedCommandTargets();
+  const mcpTargets = resolveManagedMcpTargets();
   const manifestTargets: BundledSkillsManifest['targets'] = {};
+  const manifestCommandTargets: NonNullable<BundledSkillsManifest['commandTargets']> = {};
+  const manifestMcpTargets: NonNullable<BundledSkillsManifest['mcpTargets']> = {};
 
   for (const target of targets) {
     mkdirSync(target.path, { recursive: true });
@@ -219,11 +416,34 @@ export function installBundledSkills(
     };
   }
 
+  const commandSourceRoot = commandSourceDir(sourceRoot);
+  const commandFiles = listCommandNames(sourceRoot);
+  for (const target of commandTargets) {
+    mkdirSync(target.path, { recursive: true });
+    for (const fileName of commandFiles) {
+      copyFileSync(path.join(commandSourceRoot, fileName), path.join(target.path, fileName));
+    }
+    manifestCommandTargets[target.id] = {
+      path: target.path,
+      installedCommandNames: commandFiles.map(commandDisplayName),
+    };
+  }
+
+  for (const target of mcpTargets) {
+    installOmpMcpTarget(target);
+    manifestMcpTargets[target.id] = {
+      path: target.path,
+      serverName: target.serverName,
+    };
+  }
+
   const manifest: BundledSkillsManifest = {
     bundledHash,
     bundledSkillNames,
     installedAt: new Date().toISOString(),
     targets: manifestTargets,
+    commandTargets: manifestCommandTargets,
+    mcpTargets: manifestMcpTargets,
   };
 
   writeManifest(invokerHomeRoot, manifest);

--- a/packages/contracts/src/__tests__/bundled-skills-status.test.ts
+++ b/packages/contracts/src/__tests__/bundled-skills-status.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import type { BundledSkillsStatus, SystemDiagnostics } from '../ipc-channels.js';
+
+describe('BundledSkillsStatus contract', () => {
+  it('requires harness command and MCP config state arrays on diagnostics fixtures', () => {
+    const bundledSkills = {
+      available: true,
+      promptRecommended: true,
+      managedPrefix: 'invoker-',
+      bundledSkillNames: ['plan-to-invoker'],
+      targets: [
+        { id: 'codex', name: 'Codex', path: '/tmp/.codex/skills', available: true, installed: true, upToDate: true, installedSkillNames: ['invoker-plan-to-invoker'] },
+      ],
+      commandTargets: [
+        { id: 'omp', name: 'OMP', path: '/tmp/.omp/agent/commands', available: true, installed: true, upToDate: true, installedCommandNames: ['invoker-plan-to-invoker'] },
+      ],
+      mcpTargets: [
+        { id: 'omp', name: 'OMP', path: '/tmp/.omp/agent/mcp.json', available: true, installed: true, upToDate: true, serverName: 'invoker' },
+      ],
+    } satisfies BundledSkillsStatus;
+
+    const diagnostics = {
+      platform: 'darwin',
+      arch: 'arm64',
+      appVersion: '0.0.5',
+      isPackaged: true,
+      tools: [],
+      bundledSkills,
+    } satisfies SystemDiagnostics;
+
+    expect(diagnostics.bundledSkills.commandTargets[0]?.installedCommandNames).toEqual(['invoker-plan-to-invoker']);
+    expect(diagnostics.bundledSkills.mcpTargets[0]?.serverName).toBe('invoker');
+  });
+});

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -253,6 +253,26 @@ export interface BundledSkillTargetStatus {
   installedSkillNames: string[];
 }
 
+export interface HarnessConfigState {
+  id: string;
+  name: string;
+  path: string;
+  available: boolean;
+  installed: boolean;
+  upToDate: boolean;
+  installedCommandNames: string[];
+}
+
+export interface HarnessMcpConfigState {
+  id: string;
+  name: string;
+  path: string;
+  available: boolean;
+  installed: boolean;
+  upToDate: boolean;
+  serverName: string;
+}
+
 export interface BundledSkillsStatus {
   available: boolean;
   promptRecommended: boolean;
@@ -262,6 +282,8 @@ export interface BundledSkillsStatus {
   lastInstallAt?: string;
   lastInstallError?: string;
   targets: BundledSkillTargetStatus[];
+  commandTargets?: HarnessConfigState[];
+  mcpTargets?: HarnessMcpConfigState[];
 }
 
 export type BundledSkillsInstallMode = 'install' | 'update' | 'reinstall';

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -120,6 +120,8 @@ export function createMockInvoker(
           { id: 'claude', name: 'Claude', path: '/tmp/.claude/skills', available: true, installed: false, upToDate: false, installedSkillNames: [] },
           { id: 'cursor', name: 'Cursor', path: '/tmp/.cursor/skills-cursor', available: true, installed: false, upToDate: false, installedSkillNames: [] },
         ],
+        commandTargets: [],
+        mcpTargets: [],
       },
     })),
     getBundledSkillsStatus: vi.fn(async () => ({
@@ -132,6 +134,8 @@ export function createMockInvoker(
         { id: 'claude', name: 'Claude', path: '/tmp/.claude/skills', available: true, installed: false, upToDate: false, installedSkillNames: [] },
         { id: 'cursor', name: 'Cursor', path: '/tmp/.cursor/skills-cursor', available: true, installed: false, upToDate: false, installedSkillNames: [] },
       ],
+      commandTargets: [],
+      mcpTargets: [],
     })),
     installBundledSkills: vi.fn(async () => ({
       available: false,
@@ -143,6 +147,8 @@ export function createMockInvoker(
         { id: 'claude', name: 'Claude', path: '/tmp/.claude/skills', available: true, installed: false, upToDate: false, installedSkillNames: [] },
         { id: 'cursor', name: 'Cursor', path: '/tmp/.cursor/skills-cursor', available: true, installed: false, upToDate: false, installedSkillNames: [] },
       ],
+      commandTargets: [],
+      mcpTargets: [],
     })),
     replaceTask: vi.fn(async () => []),
     getActivityLogs: vi.fn(async () => []),


### PR DESCRIPTION
## Summary

Bundled helper installation now generates each host command file from the canonical handoff source.

The installed files are real Markdown files, not symlinks. Existing OMP MCP servers are preserved, and malformed top-level data is rejected without rewriting the file.

<details><summary>Review metadata</summary>

Review Claim: Helper installation fans one canonical command source out to each supported host safely.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Installation only touches managed helper files, generated command files, and the `invoker` MCP server.

Slice Rationale: Installer behavior lands after assets and the status shape, before output and UI exposure.

Architectural Effect: Command discovery no longer depends on host-specific repo files or symlink support.

Alternative considerations: Host symlinks were rejected because not every harness contract promises link following. Runtime generation scales by adding command targets in one installer list.

</details>

## Non-goals

No user-facing copy changes. No non-OMP MCP edits. No new workflow execution path.

## Architecture

### Before

```mermaid
graph TD
    Installer[Helper installer] --> Skills[Skill targets]
```

### After

```mermaid
graph TD
    Source[canonical command Markdown]
    Installer[Helper installer] --> Skills[Skill targets]
    Installer --> Source
    Source --> Prompts[real host prompt files]
    Installer --> OMP[OMP MCP target]
```

## Test Plan

- [x] `pnpm --filter @invoker/app test bundled-skills.test.ts`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 56bef27032cb14c1c46ae5a1217001324f8eb00b`
- Post-revert steps: Re-run `pnpm --filter @invoker/app test bundled-skills.test.ts`.
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Installation workflow now manages bundled IDE command markdown files and updates OMP MCP server configuration alongside bundled skills
  * Status checks now include command and MCP target up-to-date detection, and recommendations reflect any non-up-to-date targets
  * Added safeguards to preserve existing MCP configuration while applying the required Invoker MCP update

* **Tests**
  * Extended installation and status test coverage for command and MCP targets
  * Added scenarios validating MCP JSON parsing/validation and ensuring invalid MCP configs aren’t overwritten
  * Added filesystem assertions for installed command artifacts and related target integrity
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #1786