### PR TITLE
[Harness Handoff](09) Print helper install targets

### DIFF
--- a/packages/app/src/__tests__/headless-install-skills.test.ts
+++ b/packages/app/src/__tests__/headless-install-skills.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { runHeadless, type HeadlessDeps } from '../headless.js';
+
+function makeStatus() {
+  return {
+    available: true,
+    promptRecommended: false,
+    managedPrefix: 'invoker-',
+    bundledSkillNames: ['plan-to-invoker', 'make-pr'],
+    targets: [
+      { id: 'codex', name: 'Codex', path: '/tmp/.codex/skills', available: true, installed: true, upToDate: true, installedSkillNames: ['invoker-plan-to-invoker'] },
+    ],
+    commandTargets: [
+      { id: 'omp', name: 'OMP', path: '/tmp/.omp/agent/commands', available: true, installed: true, upToDate: true, installedCommandNames: ['invoker-plan-to-invoker'] },
+    ],
+    mcpTargets: [
+      { id: 'omp', name: 'OMP', path: '/tmp/.omp/agent/mcp.json', available: true, installed: true, upToDate: true, serverName: 'invoker' },
+    ],
+  };
+}
+
+
+describe('headless install-skills', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('prints skill, command, and MCP helper install targets', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const installBundledSkills = vi.fn(() => makeStatus());
+
+    await runHeadless(['install-skills', 'reinstall'], {
+      installBundledSkills,
+    } as unknown as HeadlessDeps);
+
+    expect(installBundledSkills).toHaveBeenCalledWith('reinstall');
+    const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+    expect(output).toContain('Installed 2 bundled AI helpers with prefix "invoker-".');
+    expect(output).toContain('Skill target (Codex): /tmp/.codex/skills');
+    expect(output).toContain('Command target (OMP): /tmp/.omp/agent/commands');
+    expect(output).toContain('MCP target (OMP): /tmp/.omp/agent/mcp.json');
+    expect(output).toContain('- invoker-plan-to-invoker');
+    expect(output).toContain('- invoker-make-pr');
+  });
+});

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1012,12 +1012,18 @@ async function headlessInstallSkills(
   deps: Pick<HeadlessDeps, 'installBundledSkills'>,
 ): Promise<void> {
   if (!deps.installBundledSkills) {
-    throw new Error('Bundled skill installation is not available in this runtime.');
+    throw new Error('Bundled AI helper installation is not available in this runtime.');
   }
   const status = deps.installBundledSkills(mode ?? 'install');
-  process.stdout.write(`Installed ${status.bundledSkillNames.length} bundled skills with prefix "${status.managedPrefix}".\n`);
+  process.stdout.write(`Installed ${status.bundledSkillNames.length} bundled AI helpers with prefix "${status.managedPrefix}".\n`);
   for (const target of status.targets) {
-    process.stdout.write(`Target (${target.name}): ${target.path}\n`);
+    process.stdout.write(`Skill target (${target.name}): ${target.path}\n`);
+  }
+  for (const target of status.commandTargets) {
+    process.stdout.write(`Command target (${target.name}): ${target.path}\n`);
+  }
+  for (const target of status.mcpTargets) {
+    process.stdout.write(`MCP target (${target.name}): ${target.path}\n`);
   }
   for (const skillName of status.bundledSkillNames) {
     process.stdout.write(`- ${status.managedPrefix}${skillName}\n`);
@@ -1310,11 +1316,11 @@ ${BOLD}Respond:${RESET}
   select <taskId> <experimentId>                      Select winning experiment
 
 ${BOLD}Configure:${RESET}
-  install-skills [install|update|reinstall]          Install bundled Invoker skills into Codex
+  install-skills [install|update|reinstall]          Install bundled Invoker AI helpers
   set command <taskId> <cmd>                          Edit task command and re-run
   set prompt <taskId> <text>                          Edit task prompt and re-run
   set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)
-  set agent <taskId> <agent>                          Change execution agent (claude|codex)
+  set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)
   set merge-mode <workflowId> <mode>                  manual | automatic | external_review
   set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
   set fix-context <taskId> <text>                     Update fix-session context and retry
@@ -2440,8 +2446,9 @@ async function headlessEditExecutor(
   autoFix.unsubscribe();
 }
 
+
 async function headlessEditAgent(taskId: string, agentName: string, deps: HeadlessDeps): Promise<void> {
-  if (!taskId || !agentName) throw new Error('Missing arguments. Usage: --headless edit-agent <taskId> <claude|codex>');
+  if (!taskId || !agentName) throw new Error('Missing arguments. Usage: --headless set agent <taskId> <claude|codex|omp>');
   const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'set agent');
   if (!restored) return;
   taskId = restored.resolvedTaskId;

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -282,8 +282,8 @@ export interface BundledSkillsStatus {
   lastInstallAt?: string;
   lastInstallError?: string;
   targets: BundledSkillTargetStatus[];
-  commandTargets?: HarnessConfigState[];
-  mcpTargets?: HarnessMcpConfigState[];
+  commandTargets: HarnessConfigState[];
+  mcpTargets: HarnessMcpConfigState[];
 }
 
 export type BundledSkillsInstallMode = 'install' | 'update' | 'reinstall';


### PR DESCRIPTION
## Summary

Headless setup output now prints every installed helper target.

That includes skill folders, prompt folders, and the OMP MCP path.

A focused headless test now checks that all three target groups are printed.


<details><summary>Review metadata</summary>

Review Claim: Headless setup exposes the full helper installation result.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This only changes install output after the installer has already computed status.

Slice Rationale: Output changes land after installer writes so reviewers can check display separately.

</details>

## Non-goals

No installer write behavior changes. No UI changes. No MCP server changes.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-install-skills.test.ts src/__tests__/bundled-skills.test.ts src/__tests__/cli-installer.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 92122669106086016ccf346c3ed7c81190b53e19`
- Post-revert steps: Re-run the app helper checks.
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for the headless `install-skills` command, verifying it reports bundled skill, command, and MCP installer targets and formats output correctly.

* **Documentation**
  * Updated headless help/usage text to include `install-skills` and `set agent`, including expanded agent options.

* **Bug Fixes**
  * Improved wording for errors related to bundled helper installation and `set agent` configuration.
  * Updated installer summary/target labels to use clearer “AI helpers” and “Skill/Command/MCP target” terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->