### PR TITLE
[Harness Handoff](4) Define OMP model task contracts

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -53,8 +53,10 @@ export interface WorkRequestInputs {
   baseBranch?: string;
   /** Already-resolved base commit for baseBranch, used to skip redundant base ref resolution. */
   baseCommit?: string;
-  /** Name of the execution agent to use (e.g. 'claude', 'codex'). Defaults to 'claude'. */
+  /** Name of the execution agent to use (e.g. 'claude', 'codex', 'omp'). Defaults to 'claude'. */
   executionAgent?: string;
+  /** Agent-specific model selector. The selected CLI owns validation. */
+  executionModel?: string;
   /** When true, executors must not reuse existing task worktrees for this run. */
   freshWorkspace?: boolean;
   /**

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -40,8 +40,10 @@ export interface BaseTaskConfig {
   readonly approach?: string;
   readonly testPlan?: string;
   readonly reproCommand?: string;
-  /** Name of the execution agent to use (e.g. 'claude', 'codex'). Defaults to 'claude'. */
+  /** Name of the execution agent to use (e.g. 'claude', 'codex', 'omp'). Defaults to 'claude'. */
   readonly executionAgent?: string;
+  /** Agent-specific model selector passed through without central validation. */
+  readonly executionModel?: string;
   /** Cross-workflow prerequisites for this task. */
   readonly externalDependencies?: readonly ExternalDependency[];
   /** Execution pool identifier for shared queue/drain scheduling across substrates. */


### PR DESCRIPTION
## Summary

Invoker task metadata can now carry `executionModel` in the shared task and work-request types.

Before this, the handoff stack had no common contract for model metadata. Higher layers could talk about OMP models, but the core task shape could not name them.

This slice is contract-only. It does not add execution wiring, editable controls, or plan YAML loading.

<details>
<summary>Review metadata</summary>

Review Claim: The shared Invoker task contracts now name OMP model metadata explicitly.

Review Lane: behavior

Review Unit: contract

Safety Invariant: The change is limited to shared type definitions and does not alter executor behavior by itself.

Slice Rationale: The runtime wiring needs a stable shared field before it can safely thread model metadata through orchestration code.

</details>

## Non-goals

- Adding execution-engine wiring for OMP tasks
- Loading `executionModel` from plan YAML
- Editing model metadata from the UI

## Test Plan

- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 133c7f9be`
- Post-revert steps: None
- Data migration? No