### PR TITLE
[Harness Handoff](5) Add OMP model task routing

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -53,8 +53,10 @@ export interface WorkRequestInputs {
   baseBranch?: string;
   /** Already-resolved base commit for baseBranch, used to skip redundant base ref resolution. */
   baseCommit?: string;
-  /** Name of the execution agent to use (e.g. 'claude', 'codex'). Defaults to 'claude'. */
+  /** Name of the execution agent to use (e.g. 'claude', 'codex', 'omp'). Defaults to 'claude'. */
   executionAgent?: string;
+  /** Agent-specific model selector. The selected CLI owns validation. */
+  executionModel?: string;
   /** When true, executors must not reuse existing task worktrees for this run. */
   freshWorkspace?: boolean;
   /**

--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { AgentRegistry } from '../agent-registry.js';
+import { registerBuiltinAgents } from '../agents/index.js';
 import type { ExecutionAgent } from '../agent.js';
 
 function makeExecutionAgent(name: string, opts?: {
@@ -16,6 +17,13 @@ function makeExecutionAgent(name: string, opts?: {
     ...(opts?.bundledSkills !== undefined && { bundledSkills: opts.bundledSkills }),
   };
 }
+
+describe('registerBuiltinAgents', () => {
+  it('registers claude, codex, and omp execution agents', () => {
+    const names = registerBuiltinAgents().listExecution().map((agent) => agent.name);
+    expect(names).toEqual(expect.arrayContaining(['claude', 'codex', 'omp']));
+  });
+});
 
 describe('AgentRegistry', () => {
   let registry: AgentRegistry;

--- a/packages/execution-engine/src/__tests__/omp-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/omp-execution-agent.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { OmpExecutionAgent } from '../agents/omp-execution-agent.js';
+
+describe('OmpExecutionAgent', () => {
+  it('builds print command with auto approve and model selector', () => {
+    const agent = new OmpExecutionAgent({ command: 'omp-test' });
+    const spec = agent.buildCommand('prompt text', { executionModel: 'openai/gpt-5.2' });
+
+    expect(spec.cmd).toBe('omp-test');
+    expect(spec.args).toEqual([
+      '--no-title',
+      '--auto-approve',
+      '--model',
+      'openai/gpt-5.2',
+      '-p',
+      'prompt text',
+    ]);
+    expect(spec.sessionId).toBeDefined();
+    expect(spec.fullPrompt).toBe('prompt text');
+  });
+
+  it('omits model args when executionModel is absent', () => {
+    const agent = new OmpExecutionAgent({ command: 'omp-test' });
+    expect(agent.buildCommand('prompt text').args).toEqual([
+      '--no-title',
+      '--auto-approve',
+      '-p',
+      'prompt text',
+    ]);
+  });
+
+  it('uses cwd-local continue for resume', () => {
+    const agent = new OmpExecutionAgent({ command: 'omp-test' });
+    expect(agent.buildResumeArgs('ignored-session')).toEqual({ cmd: 'omp-test', args: ['--continue'] });
+  });
+
+  it('mounts host OMP agent config into containers', () => {
+    const agent = new OmpExecutionAgent({ configDir: '/host/.omp/agent', containerHomePath: '/home/invoker' });
+    expect(agent.getContainerRequirements()).toEqual({
+      mounts: [{ hostPath: '/host/.omp/agent', containerPath: '/home/invoker/.omp/agent' }],
+      env: {},
+    });
+  });
+});

--- a/packages/execution-engine/src/__tests__/omp-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/omp-session-driver.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { OmpSessionDriver } from '../omp-session-driver.js';
+
+const originalDbDir = process.env.INVOKER_DB_DIR;
+
+afterEach(() => {
+  process.env.INVOKER_DB_DIR = originalDbDir;
+});
+
+describe('OmpSessionDriver', () => {
+  it('stores raw stdout and returns it as readable text', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'omp-session-driver-'));
+    process.env.INVOKER_DB_DIR = dir;
+    try {
+      const driver = new OmpSessionDriver();
+      const raw = 'OMP answer text';
+
+      expect(driver.processOutput('session-1', raw)).toBe(raw);
+      expect(driver.loadSession('session-1')).toBe(raw);
+      expect(driver.parseSession(raw)).toEqual([{ role: 'assistant', content: raw, timestamp: '' }]);
+      expect(driver.inspectSession(raw)).toEqual({ state: 'finished' });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reports empty output as an error state', () => {
+    const driver = new OmpSessionDriver();
+    expect(driver.parseSession('')).toEqual([]);
+    expect(driver.inspectSession('')).toEqual({ state: 'error', reason: 'Empty OMP session output' });
+  });
+});

--- a/packages/execution-engine/src/agent.ts
+++ b/packages/execution-engine/src/agent.ts
@@ -15,6 +15,10 @@ export interface AgentCommandSpec {
   fullPrompt?: string;
 }
 
+export interface AgentCommandBuildOptions {
+  executionModel?: string;
+}
+
 export const DEFAULT_EXECUTION_AGENT = 'claude';
 
 export interface ExecutionAgent {
@@ -37,10 +41,10 @@ export interface ExecutionAgent {
    */
   readonly bundledSkills?: readonly string[];
 
-  buildCommand(fullPrompt: string): AgentCommandSpec;
+  buildCommand(fullPrompt: string, options?: AgentCommandBuildOptions): AgentCommandSpec;
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] };
   /** Build a command spec for a fix/conflict-resolution prompt. */
-  buildFixCommand?(prompt: string): AgentCommandSpec;
+  buildFixCommand?(prompt: string, options?: AgentCommandBuildOptions): AgentCommandSpec;
   getContainerRequirements?(): {
     mounts: Array<{ hostPath: string; containerPath: string; readonly?: boolean }>;
     env: Record<string, string>;

--- a/packages/execution-engine/src/agents/index.ts
+++ b/packages/execution-engine/src/agents/index.ts
@@ -4,14 +4,17 @@
 
 export { ClaudeExecutionAgent, type ClaudeExecutionAgentConfig } from './claude-execution-agent.js';
 export { CodexExecutionAgent, type CodexExecutionAgentConfig } from './codex-execution-agent.js';
+export { OmpExecutionAgent, type OmpExecutionAgentConfig } from './omp-execution-agent.js';
 export { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
 
 import { AgentRegistry } from '../agent-registry.js';
 import { ClaudeExecutionAgent, type ClaudeExecutionAgentConfig } from './claude-execution-agent.js';
 import { CodexExecutionAgent, type CodexExecutionAgentConfig } from './codex-execution-agent.js';
+import { OmpExecutionAgent, type OmpExecutionAgentConfig } from './omp-execution-agent.js';
 import { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
 import { CodexSessionDriver } from '../codex-session-driver.js';
 import { ClaudeSessionDriver } from '../claude-session-driver.js';
+import { OmpSessionDriver } from '../omp-session-driver.js';
 
 /**
  * Create an AgentRegistry pre-populated with builtin agents.
@@ -19,11 +22,13 @@ import { ClaudeSessionDriver } from '../claude-session-driver.js';
 export function registerBuiltinAgents(opts?: {
   claude?: ClaudeExecutionAgentConfig;
   codex?: CodexExecutionAgentConfig;
+  omp?: OmpExecutionAgentConfig;
   cursor?: CursorPlanningAgentConfig;
 }): AgentRegistry {
   const registry = new AgentRegistry();
   registry.registerExecution(new ClaudeExecutionAgent(opts?.claude), new ClaudeSessionDriver());
   registry.registerExecution(new CodexExecutionAgent(opts?.codex), new CodexSessionDriver());
+  registry.registerExecution(new OmpExecutionAgent(opts?.omp), new OmpSessionDriver());
   registry.registerPlanning(new CursorPlanningAgent(opts?.cursor));
   return registry;
 }

--- a/packages/execution-engine/src/agents/omp-execution-agent.ts
+++ b/packages/execution-engine/src/agents/omp-execution-agent.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import type { AgentCommandBuildOptions, AgentCommandSpec, ExecutionAgent } from '../agent.js';
+
+export interface OmpExecutionAgentConfig {
+  command?: string;
+  configDir?: string;
+  containerHomePath?: string;
+}
+
+export class OmpExecutionAgent implements ExecutionAgent {
+  readonly name = 'omp';
+  readonly stdinMode = 'ignore' as const;
+  readonly linuxTerminalTail = 'exec_bash' as const;
+  readonly bundledSkillRoot: string;
+  readonly bundledSkills = ['make-pr'] as const;
+
+  private readonly command: string;
+  private readonly configDir: string;
+  private readonly containerHomePath: string;
+
+  constructor(config: OmpExecutionAgentConfig = {}) {
+    this.command = config.command ?? process.env.INVOKER_OMP_COMMAND ?? 'omp';
+    this.configDir = config.configDir ?? join(homedir(), '.omp', 'agent');
+    this.containerHomePath = config.containerHomePath ?? '/home/invoker';
+    this.bundledSkillRoot = join(this.configDir, 'skills');
+  }
+
+  buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
+    const sessionId = randomUUID();
+    return {
+      cmd: this.command,
+      args: this.buildArgs(fullPrompt, options.executionModel),
+      sessionId,
+      fullPrompt,
+    };
+  }
+
+  buildFixCommand(prompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
+    const sessionId = randomUUID();
+    return {
+      cmd: this.command,
+      args: this.buildArgs(prompt, options.executionModel),
+      sessionId,
+    };
+  }
+
+  buildResumeArgs(_sessionId: string): { cmd: string; args: string[] } {
+    return { cmd: this.command, args: ['--continue'] };
+  }
+
+  getContainerRequirements(): {
+    mounts: Array<{ hostPath: string; containerPath: string; readonly?: boolean }>;
+    env: Record<string, string>;
+  } {
+    return {
+      mounts: [
+        {
+          hostPath: this.configDir,
+          containerPath: join(this.containerHomePath, '.omp', 'agent'),
+        },
+      ],
+      env: {},
+    };
+  }
+
+  private buildArgs(prompt: string, executionModel?: string): string[] {
+    return [
+      '--no-title',
+      '--auto-approve',
+      ...(executionModel ? ['--model', executionModel] : []),
+      '-p',
+      prompt,
+    ];
+  }
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -31,3 +31,4 @@ export * from './codex-session.js';
 export * from './session-driver.js';
 export * from './codex-session-driver.js';
 export * from './claude-session-driver.js';
+export * from './omp-session-driver.js';

--- a/packages/execution-engine/src/omp-session-driver.ts
+++ b/packages/execution-engine/src/omp-session-driver.ts
@@ -1,0 +1,35 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import type { AgentMessage } from './codex-session.js';
+import type { AgentSessionInspection, SessionDriver } from './session-driver.js';
+
+export class OmpSessionDriver implements SessionDriver {
+  processOutput(sessionId: string, rawStdout: string): string {
+    const dir = this.getStorageDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${sessionId}.omp.txt`), rawStdout);
+    return rawStdout;
+  }
+
+  loadSession(sessionId: string): string | null {
+    const filePath = join(this.getStorageDir(), `${sessionId}.omp.txt`);
+    if (!existsSync(filePath)) return null;
+    return readFileSync(filePath, 'utf-8');
+  }
+
+  parseSession(raw: string): AgentMessage[] {
+    return raw.length > 0 ? [{ role: 'assistant', content: raw, timestamp: '' }] : [];
+  }
+
+  inspectSession(raw: string): AgentSessionInspection {
+    return raw.length > 0
+      ? { state: 'finished' }
+      : { state: 'error', reason: 'Empty OMP session output' };
+  }
+
+  private getStorageDir(): string {
+    const base = process.env.INVOKER_DB_DIR || join(homedir(), '.invoker');
+    return join(base, 'agent-sessions');
+  }
+}

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -265,6 +265,16 @@ export class CommandService {
     );
   }
 
+  async editTaskModel(
+    envelope: CommandEnvelope<{ taskId: string; executionModel: string | null }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'EDIT_TASK_MODEL_FAILED',
+      () => this.orchestrator.editTaskModel(envelope.payload.taskId, envelope.payload.executionModel),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
   /**
    * Edit the merge mode of a workflow's merge node — **retry-class**
    * invalidation route per Step 9 of the task-invalidation roadmap

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -31,6 +31,7 @@ export type MutationKey =
   | 'command'
   | 'prompt'
   | 'executionAgent'
+  | 'executionModel'
   | 'runnerKind'
   | 'poolMemberId'
   | 'selectedExperiment'
@@ -47,6 +48,7 @@ export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>
   command:               { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   prompt:                { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   executionAgent:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
+  executionModel:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   runnerKind:          { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
   poolMemberId:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   selectedExperiment:    { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -369,6 +369,7 @@ export interface PlanDefinition {
     dockerImage?: string;
     poolId?: string;
     executionAgent?: string;
+    executionModel?: string;
   }>;
 }
 
@@ -480,6 +481,7 @@ export interface TaskReplacementDef {
   dependencies?: string[];
   runnerKind?: RunnerKind;
   executionAgent?: string;
+  executionModel?: string;
 }
 
 export interface ExternalGatePolicyUpdate {
@@ -1426,6 +1428,7 @@ export class Orchestrator {
         requiresManualApproval: taskDef.requiresManualApproval,
         featureBranch: taskDef.featureBranch,
         executionAgent: taskDef.executionAgent,
+        executionModel: taskDef.executionModel,
         poolId: effectivePoolId,
       } as const;
       let taskConfig: TaskConfig;
@@ -2967,7 +2970,29 @@ export class Orchestrator {
     return this.dispatchPostMutation(MUTATION_POLICIES.poolMemberId.action, taskId);
   }
 
-    editTaskAgent(taskId: string, agentName: string): TaskState[] {
+    editTaskModel(taskId: string, executionModel: string | null): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    if (task.config.isMergeNode) throw new Error(`Cannot change execution model of merge node ${taskId}`);
+
+    if (isActiveForInvalidation(task.status)) {
+      this.cancelTask(taskId);
+    }
+
+    const modelChanges: TaskStateChanges = {
+      config: { executionModel: executionModel?.trim() || undefined },
+    };
+    const modelBefore = this.stateGetTask(taskId)!;
+    const modelUpdated = this.writeAndSync(taskId, modelChanges);
+    const modelDelta: TaskDelta = this.buildUpdateDelta(modelBefore, modelUpdated, modelChanges);
+    this.persistence.logEvent?.(taskId, 'task.updated', modelChanges);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, modelDelta);
+
+    return this.dispatchPostMutation(MUTATION_POLICIES.executionModel.action, taskId);
+  }
+
+  editTaskAgent(taskId: string, agentName: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
@@ -3594,6 +3619,7 @@ export class Orchestrator {
         command: rt.command,
         prompt: rt.prompt,
         executionAgent: rt.executionAgent ?? task.config.executionAgent,
+        executionModel: rt.executionModel ?? task.config.executionModel,
         poolId: task.config.poolId,
       } as const;
       // Replacement tasks inherit executor config from the parent task.

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -40,8 +40,10 @@ export interface BaseTaskConfig {
   readonly approach?: string;
   readonly testPlan?: string;
   readonly reproCommand?: string;
-  /** Name of the execution agent to use (e.g. 'claude', 'codex'). Defaults to 'claude'. */
+  /** Name of the execution agent to use (e.g. 'claude', 'codex', 'omp'). Defaults to 'claude'. */
   readonly executionAgent?: string;
+  /** Agent-specific model selector passed through without central validation. */
+  readonly executionModel?: string;
   /** Cross-workflow prerequisites for this task. */
   readonly externalDependencies?: readonly ExternalDependency[];
   /** Execution pool identifier for shared queue/drain scheduling across substrates. */


### PR DESCRIPTION
## Summary

Invoker now has the runtime wiring for OMP model-aware task execution.

This slice adds the OMP execution agent, the OMP session driver, registry wiring, and the orchestrator/service-layer path for model-based task recreation.

This slice stays inside runtime flow. It does not load `executionModel` from YAML or thread model flags through existing Claude/Codex builders.

<details>
<summary>Review metadata</summary>

Review Claim: The runtime can now route OMP-specific model metadata through task invalidation and execution-agent wiring.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The change stays inside orchestration/runtime wiring and OMP-only execution code, with direct unit coverage for the new paths.

Slice Rationale: The shared contracts landed first; this slice threads those contracts through the runtime without mixing in higher-level changes.

</details>

## Non-goals

- Loading `executionModel` from plan YAML
- Editing model metadata from the UI
- Passing model flags through Claude or Codex builders

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm exec vitest run src/__tests__/agent-registry.test.ts src/__tests__/omp-execution-agent.test.ts src/__tests__/omp-session-driver.test.ts`
- [x] `pnpm exec vitest run src/__tests__/orchestrator.test.ts src/__tests__/invalidation-policy.test.ts src/__tests__/command-service.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert b2223a811`
- Post-revert steps: None
- Data migration? No

Depends-On: #1792