### PR TITLE
[Harness Handoff](14) Trigger PR skills from skill handoff mode

### DIFF
--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -30,6 +30,14 @@ must_contain() {
   fi
 }
 
+must_not_exist() {
+  local path="$1"
+  local hint="$2"
+  if [[ -e "$path" ]]; then
+    fail "$hint — unexpected file exists: $path"
+  fi
+}
+
 
 must_output_contain() {
   local output="$1"
@@ -40,6 +48,8 @@ must_output_contain() {
   fi
 }
 [[ -f "$CANONICAL_COMMAND" ]] || fail "expected canonical command source"
+must_not_exist "$REPO_ROOT/.claude/commands/plan-to-invoker.md" "legacy Claude handoff command copy must not drift from canonical source"
+must_not_exist "$REPO_ROOT/.cursor/commands/plan-to-invoker.md" "legacy Cursor handoff command copy must not drift from canonical source"
 [[ -f "$README" ]] || fail "expected $README"
 [[ -f "$TUTORIAL" ]] || fail "expected $TUTORIAL"
 must_contain "$CANONICAL_COMMAND" "invoker_submit_plan" "Invoker handoff command must submit through MCP"
@@ -92,8 +102,12 @@ must_contain "$SKILL_MD" "\"/invoker-plan-to-invoker\"" "SKILL frontmatter must 
 must_contain "$SKILL_MD" "## Harness handoff mode" "SKILL must document harness handoff mode"
 must_contain "$SKILL_MD" "Use this mode when invoked by the installed command or MCP prompt." "SKILL must define when handoff mode applies"
 must_contain "$SKILL_MD" "First produce a Markdown planning artifact at \`plans/invoker-handoff.md\`." "SKILL handoff mode must require a Markdown plan"
+must_contain "$SKILL_MD" "In an Invoker source checkout, still run \`bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>\` before submission." "SKILL handoff mode must keep checkout-local skill-doctor validation"
+must_contain "$SKILL_MD" "Outside an Invoker source checkout, \`invoker_validate_plan\` is the deterministic validation gate." "SKILL handoff mode must keep outside-checkout MCP validation"
 must_contain "$SKILL_MD" "Convert the approved Markdown plan to \`plans/invoker-handoff.yaml\`." "SKILL handoff mode must require YAML conversion"
 must_contain "$SKILL_MD" "Prefer the MCP tools \`invoker_validate_plan\` and \`invoker_submit_plan\` when available." "SKILL handoff mode must prefer MCP validation and submit"
+must_contain "$SKILL_MD" "skills/make-pr/SKILL.md" "SKILL handoff mode must trigger the PR skill for PR work"
+must_contain "$SKILL_MD" "skills/review-compression/SKILL.md" "SKILL handoff mode must trigger review compression for stack work"
 must_contain "$SKILL_MD" "never version or metadata wrappers" "SKILL frontmatter must reject legacy benchmark YAML wrappers"
 must_contain "$SKILL_MD" "## Benchmark/direct-output mode" "SKILL must document benchmark/direct-output mode"
 must_contain "$SKILL_MD" "Treat the literal absolute output path" "SKILL must require literal output path handling"

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -64,6 +64,9 @@ Use this mode when invoked by the installed command or MCP prompt.
 - In an Invoker source checkout, still run `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` before submission.
 - Outside an Invoker source checkout, `invoker_validate_plan` is the deterministic validation gate.
 
+- If the request involves creating, updating, publishing, or splitting pull requests or PR stacks, first read and follow `skills/make-pr/SKILL.md` (or `skill://make-pr/SKILL.md` when available) before PR authoring or publication.
+- If the request involves multiple review slices, first read and follow `skills/review-compression/SKILL.md` (or `skill://review-compression/SKILL.md` when available) before writing workflow YAML.
+
 ## Intended flow (do not skip steps)
 
 1. Discuss scope/risk with the user.


### PR DESCRIPTION
## Summary

The plan-to-invoker skill handoff mode now names the PR skills before publication work.

That covers hosts that enter the flow through the installed skill text instead of the slash command text.

The skill check now fails if this PR-skill trigger disappears again.

<details><summary>Review metadata</summary>

Review Claim: Skill handoff mode tells agents to load PR skills before PR stack work.

Review Lane: docs

Review Unit: docs

Safety Invariant: This changes instruction text and a focused skill assertion only; it does not submit or run workflows.

Slice Rationale: Skill-mode guidance is separate from the MCP prompt guidance so each entry path is reviewable alone.

</details>

## Non-goals

No MCP server changes. No installer changes. No command asset rewrites.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 8317a89473b479612ef934c6f52750db272d0cdf`
- Post-revert steps: Re-run `bash scripts/test-plan-to-invoker-skill.sh`.
- Data migration? No




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated plan-to-invoker “Handoff mode” instructions with new prerequisites for PR creation/updating/publishing and multi-slice review workflows, including cross-references to related skills.

* **Tests**
  * Enhanced plan-to-invoker contract validations to ensure legacy handoff command copies are absent from the repo root.
  * Added additional handoff-mode checks covering invoker validation/submit behavior, required plan transformation, MCP-preferred validation flow, and required trigger handling for PR/review-compression workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->