### PR TITLE
[Workflow Status](7) Remove workflow status from save contracts

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -60,13 +60,9 @@ describe('LaunchDispatcher', () => {
 
   describe('complete / fail transitions', () => {
     function seedWorkflowAndTask(selectedAttemptId?: string): void {
-      adapter.saveWorkflow({
-        id: 'wf-1',
-        name: 'wf-1',
-        status: 'running',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
+      adapter.saveWorkflow({ id: 'wf-1',
+      name: 'wf-1', createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(), });
       adapter.saveTask('wf-1', {
         id: 'wf-1/t1',
         description: 'one',
@@ -242,13 +238,9 @@ describe('LaunchDispatcher', () => {
 
   describe('reapers', () => {
     function seed(): void {
-      adapter.saveWorkflow({
-        id: 'wf-r',
-        name: 'wf-r',
-        status: 'running',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
+      adapter.saveWorkflow({ id: 'wf-r',
+      name: 'wf-r', createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(), });
       adapter.saveTask('wf-r', {
         id: 'wf-r/t1',
         description: 't1',
@@ -515,13 +507,9 @@ describe('LaunchDispatcher', () => {
       workflowId = 'wf-a',
       execution: Record<string, unknown> = {},
     ) {
-      adapter.saveWorkflow({
-        id: workflowId,
-        name: workflowId,
-        status: 'running',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
+      adapter.saveWorkflow({ id: workflowId,
+      name: workflowId, createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(), });
       const task = {
         id: taskId,
         description: taskId,

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -15,6 +15,7 @@ import { mkdirSync, rmSync } from 'node:fs';
 import { EventEmitter } from 'node:events';
 
 import {
+  computeWorkflowRollup,
   Orchestrator,
   type Attempt,
   type PlanDefinition,
@@ -65,14 +66,11 @@ class InMemoryPersistence implements OrchestratorPersistence {
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   attempts = new Map<string, Attempt>();
 
-  saveWorkflow(workflow: { id: string; name: string; status: string }): void {
+  saveWorkflow(workflow: { id: string; name: string }): void {
     const now = new Date().toISOString();
-    this.workflows.set(workflow.id, { ...workflow, createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
+    this.workflows.set(workflow.id, { ...workflow, status: 'pending', createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
   }
-  updateWorkflow(workflowId: string, changes: { status?: string }): void {
-    const wf = this.workflows.get(workflowId);
-    if (wf && changes.status) wf.status = changes.status;
-  }
+  updateWorkflow(_workflowId: string, _changes: { updatedAt?: string }): void {}
   saveTask(workflowId: string, task: TaskState): void {
     this.tasks.set(task.id, { workflowId, task });
   }
@@ -81,7 +79,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
     if (entry) entry.task = { ...entry.task, ...changes } as TaskState;
   }
   listWorkflows(): Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string }> {
-    return Array.from(this.workflows.values());
+    return Array.from(this.workflows.values()).map((workflow) => ({ ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status }));
   }
   loadTasks(workflowId: string): TaskState[] {
     return Array.from(this.tasks.values())

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -29,13 +29,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('high-priority queued work runs before queued normal work for the same workflow', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const order: string[] = [];
     const gate = deferred();
@@ -66,13 +62,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('releases a workflow lease after fire-and-forget task launch acceptance', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const startedTask = {
       id: 'task-a',
@@ -118,13 +110,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('evicts older queued workflow intents when a delegated recreate fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -172,13 +160,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('invalidates an older running workflow intent when recreate is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -236,13 +220,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('invalidates an older running workflow intent when internal recreate-task is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -287,13 +267,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('invalidates an older running workflow intent when headless recreate-task is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -340,13 +316,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('evicts older queued workflow intents when internal recreate-task fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -383,13 +355,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('evicts older queued workflow intents when rebase-recreate fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -426,13 +394,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('invalidates an older running workflow intent when rebase-recreate is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -478,13 +442,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('treats headless rebase-recreate as a recreate fence', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -527,13 +487,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('evicts older queued workflow intents when retry-workflow fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -572,20 +528,12 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('coalesces duplicate fire-and-forget headless workflow retries while queued or running', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
-    adapter.saveWorkflow({
-      id: 'wf-2',
-      name: 'wf-2',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
+    adapter.saveWorkflow({ id: 'wf-2',
+    name: 'wf-2', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const runningGate = deferred();
     const order: string[] = [];
@@ -651,13 +599,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('requeues interrupted running workflow mutations on restart and drains persisted queued work', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const firstGate = deferred();
     const owner1Order: string[] = [];
@@ -696,13 +640,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('requeues interrupted fix-with-agent workflow mutations on restart', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const firstGate = deferred();
     const owner1Order: string[] = [];
@@ -739,13 +679,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('does not let another owner steal a live workflow lease', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const owner1Order: string[] = [];
@@ -789,13 +725,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('submit returns immediately while persisted work drains in the background', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -823,13 +755,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     for (let index = 1; index <= 4; index += 1) {
-      adapter.saveWorkflow({
-        id: `wf-${index}`,
-        name: `wf-${index}`,
-        status: 'running',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
+      adapter.saveWorkflow({ id: `wf-${index}`,
+      name: `wf-${index}`, createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(), });
       adapter.enqueueWorkflowMutationIntent(`wf-${index}`, 'mut', [`job-${index}`], 'normal');
     }
 
@@ -869,13 +797,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('does not run two intents for the same workflow concurrently', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const firstGate = deferred();
     const order: string[] = [];
@@ -913,13 +837,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('invalidates an older running workflow intent when internal delete-workflow is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -965,13 +885,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('evicts older queued workflow intents when internal delete-workflow fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -1008,13 +924,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('invalidates an older running workflow intent when delegated headless delete is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -1062,13 +974,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('evicts older queued workflow intents when delegated headless delete fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -1116,13 +1024,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('invalidates an older running workflow intent when internal delete-all-workflows is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -1168,13 +1072,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('evicts older queued workflow intents when internal delete-all-workflows fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -1211,13 +1111,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('invalidates an older running workflow intent when delegated headless delete-all is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -1265,13 +1161,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('evicts older queued workflow intents when delegated headless delete-all fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -1321,13 +1213,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('invalidates an older running workflow intent when internal bulk delete-all-workflows is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -1373,13 +1261,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('evicts older queued workflow intents when internal bulk delete-all-workflows fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     const order: string[] = [];
@@ -1418,13 +1302,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('aborts the dispatch AbortSignal when recreate-task preempts a running fix mutation', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     let capturedContext: WorkflowMutationContext | undefined;
@@ -1468,13 +1348,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('aborts the dispatch AbortSignal when delete-workflow preempts a running fix mutation', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     let capturedContext: WorkflowMutationContext | undefined;
@@ -1515,13 +1391,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('aborts the dispatch AbortSignal when rebase-recreate preempts a running fix mutation', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     let capturedContext: WorkflowMutationContext | undefined;
@@ -1562,13 +1434,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('does not abort the dispatch AbortSignal for non-preempted mutations that complete normally', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     let signalAbortedDuringDispatch = false;
     const coordinator = new PersistedWorkflowMutationCoordinator(
@@ -1594,13 +1462,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('abort signal reason is a WorkflowMutationInvalidatedError when preempted', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     const gate = deferred();
     let capturedContext: WorkflowMutationContext | undefined;
@@ -1641,13 +1505,9 @@ describe('PersistedWorkflowMutationCoordinator', () => {
   it('dispatch handler can observe abort during long-running work and stop early', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(), });
 
     let iterationsBeforeAbort = 0;
     const gate = deferred();

--- a/packages/app/src/__tests__/workflow-mutation-timing.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-timing.test.ts
@@ -15,13 +15,9 @@ describe('createWorkflowMutationTiming', () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     const now = new Date();
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: now.toISOString(),
-      updatedAt: now.toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1',
+    name: 'wf-1', createdAt: now.toISOString(),
+    updatedAt: now.toISOString(), });
     adapter.saveTask('wf-1', {
       id: '__merge__wf-1',
       description: 'merge',

--- a/packages/data-store/src/__tests__/attempt-persistence.test.ts
+++ b/packages/data-store/src/__tests__/attempt-persistence.test.ts
@@ -8,10 +8,7 @@ describe('Attempt persistence', () => {
   beforeEach(async () => {
     adapter = await SQLiteAdapter.create(':memory:');
     // Create a workflow and task so FK constraints pass
-    adapter.saveWorkflow({
-      id: 'wf-1', name: 'Test', status: 'running',
-      createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(),
-    });
+    adapter.saveWorkflow({ id: 'wf-1', name: 'Test', createdAt: new Date().toISOString(), updatedAt: new Date().toISOString(), });
     const task = createTaskState('taskA', 'Task A', [], { workflowId: 'wf-1' });
     adapter.saveTask('wf-1', task);
   });

--- a/packages/data-store/src/__tests__/owner-boundary.test.ts
+++ b/packages/data-store/src/__tests__/owner-boundary.test.ts
@@ -57,7 +57,7 @@ describe('owner boundary enforcement', () => {
       const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
 
       // Verify mutations are blocked
-      expect(() => reader.saveWorkflow({ ...testWorkflow, status: 'completed' }))
+      expect(() => reader.saveWorkflow(testWorkflow))
         .toThrow(/read-only/i);
       expect(() => reader.updateWorkflow('wf-boundary-test', { generation: 1 }))
         .toThrow(/read-only/i);
@@ -190,20 +190,12 @@ describe('owner boundary enforcement', () => {
       const writerA = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
       const writerB = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
 
-      writerA.saveWorkflow({
-        id: 'wf-a',
-        name: 'Workflow A',
-        status: 'running',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
-      writerB.saveWorkflow({
-        id: 'wf-b',
-        name: 'Workflow B',
-        status: 'running',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      });
+      writerA.saveWorkflow({ id: 'wf-a',
+      name: 'Workflow A', createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(), });
+      writerB.saveWorkflow({ id: 'wf-b',
+      name: 'Workflow B', createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(), });
 
       writerB.close();
       writerA.close();

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1153,7 +1153,7 @@ describe('SQLiteAdapter', () => {
     });
 
     it('derives workflow status and rollup details from task rows', () => {
-      adapter.saveWorkflow({ ...testWorkflow, status: 'completed' });
+      adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('t1', {
         status: 'failed',
         execution: { error: 'first failure', exitCode: 10 },
@@ -1176,7 +1176,7 @@ describe('SQLiteAdapter', () => {
     });
 
     it('derives stale workflow states from task rows', () => {
-      adapter.saveWorkflow({ ...testWorkflow, status: 'running' });
+      adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('t1', { status: 'stale' }));
       adapter.saveTask('wf-1', makeTask('t2', { status: 'stale' }));
 
@@ -1193,7 +1193,7 @@ describe('SQLiteAdapter', () => {
     });
 
     it('recomputes workflow status on every read after task state changes', () => {
-      adapter.saveWorkflow({ ...testWorkflow, status: 'completed' });
+      adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('t1', { status: 'pending' }));
       expect(adapter.loadWorkflow('wf-1')!.status).toBe('pending');
 
@@ -1209,7 +1209,7 @@ describe('SQLiteAdapter', () => {
     });
 
     it('derives failed when pending work is blocked by failed dependencies', () => {
-      adapter.saveWorkflow({ ...testWorkflow, status: 'running' });
+      adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('alpha', { status: 'failed' }));
       adapter.saveTask('wf-1', makeTask('beta', { status: 'pending', dependencies: ['alpha'] }));
       adapter.saveTask('wf-1', makeTask('merge', { status: 'pending', dependencies: ['beta'] }));
@@ -1223,7 +1223,7 @@ describe('SQLiteAdapter', () => {
     });
 
     it('derives failed when failed tasks do not block all pending work', () => {
-      adapter.saveWorkflow({ ...testWorkflow, status: 'running' });
+      adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('alpha', { status: 'failed' }));
       adapter.saveTask('wf-1', makeTask('independent', { status: 'pending' }));
 
@@ -1231,12 +1231,11 @@ describe('SQLiteAdapter', () => {
     });
 
     it('derives listWorkflows with one aggregate rollup per workflow', () => {
-      adapter.saveWorkflow({ ...testWorkflow, status: 'running' });
+      adapter.saveWorkflow(testWorkflow);
       adapter.saveWorkflow({
         ...testWorkflow,
         id: 'wf-2',
         name: 'Second Workflow',
-        status: 'running',
       });
       adapter.saveTask('wf-1', makeTask('wf1-a', { status: 'pending' }));
       adapter.saveTask('wf-1', makeTask('wf1-b', { status: 'pending' }));
@@ -1899,20 +1898,12 @@ describe('SQLiteAdapter', () => {
 
   describe('deleteAllWorkflows', () => {
     it('deletes all workflows, tasks, and events', () => {
-      adapter.saveWorkflow({
-        id: 'wf-1',
-        name: 'First',
-        status: 'running',
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-01T00:00:00Z',
-      });
-      adapter.saveWorkflow({
-        id: 'wf-2',
-        name: 'Second',
-        status: 'running',
-        createdAt: '2024-01-02T00:00:00Z',
-        updatedAt: '2024-01-02T00:00:00Z',
-      });
+      adapter.saveWorkflow({ id: 'wf-1',
+      name: 'First', createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z', });
+      adapter.saveWorkflow({ id: 'wf-2',
+      name: 'Second', createdAt: '2024-01-02T00:00:00Z',
+      updatedAt: '2024-01-02T00:00:00Z', });
 
       adapter.saveTask('wf-1', makeTask('t1'));
       adapter.saveTask('wf-2', makeTask('t2'));
@@ -1932,20 +1923,12 @@ describe('SQLiteAdapter', () => {
     });
 
     it('clears output spool rows and in-memory tails for all tasks', () => {
-      adapter.saveWorkflow({
-        id: 'wf-del-all-1',
-        name: 'First',
-        status: 'running',
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-01T00:00:00Z',
-      });
-      adapter.saveWorkflow({
-        id: 'wf-del-all-2',
-        name: 'Second',
-        status: 'running',
-        createdAt: '2024-01-02T00:00:00Z',
-        updatedAt: '2024-01-02T00:00:00Z',
-      });
+      adapter.saveWorkflow({ id: 'wf-del-all-1',
+      name: 'First', createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z', });
+      adapter.saveWorkflow({ id: 'wf-del-all-2',
+      name: 'Second', createdAt: '2024-01-02T00:00:00Z',
+      updatedAt: '2024-01-02T00:00:00Z', });
       adapter.saveTask('wf-del-all-1', makeTask('t-del-all-1'));
       adapter.saveTask('wf-del-all-2', makeTask('t-del-all-2'));
 
@@ -1966,20 +1949,12 @@ describe('SQLiteAdapter', () => {
   describe('deleteWorkflow', () => {
     it('deletes a single workflow and its tasks/events but keeps other workflows', () => {
       // Create two workflows with tasks and events
-      adapter.saveWorkflow({
-        id: 'wf-1',
-        name: 'First',
-        status: 'running',
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-01T00:00:00Z',
-      });
-      adapter.saveWorkflow({
-        id: 'wf-2',
-        name: 'Second',
-        status: 'running',
-        createdAt: '2024-01-02T00:00:00Z',
-        updatedAt: '2024-01-02T00:00:00Z',
-      });
+      adapter.saveWorkflow({ id: 'wf-1',
+      name: 'First', createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z', });
+      adapter.saveWorkflow({ id: 'wf-2',
+      name: 'Second', createdAt: '2024-01-02T00:00:00Z',
+      updatedAt: '2024-01-02T00:00:00Z', });
 
       adapter.saveTask('wf-1', makeTask('t1'));
       adapter.saveTask('wf-1', makeTask('t2'));
@@ -2016,13 +1991,9 @@ describe('SQLiteAdapter', () => {
     });
 
     it('works when workflow has no tasks', () => {
-      adapter.saveWorkflow({
-        id: 'wf-empty',
-        name: 'Empty Workflow',
-        status: 'running',
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-01T00:00:00Z',
-      });
+      adapter.saveWorkflow({ id: 'wf-empty',
+      name: 'Empty Workflow', createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z', });
 
       adapter.deleteWorkflow('wf-empty');
 
@@ -2046,13 +2017,9 @@ describe('SQLiteAdapter', () => {
     });
 
     it('is a no-op for non-existent workflow', () => {
-      adapter.saveWorkflow({
-        id: 'wf-exists',
-        name: 'Existing',
-        status: 'running',
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-01T00:00:00Z',
-      });
+      adapter.saveWorkflow({ id: 'wf-exists',
+      name: 'Existing', createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z', });
       adapter.saveTask('wf-exists', makeTask('t1'));
 
       // Call deleteWorkflow on a non-existent workflow
@@ -2095,20 +2062,12 @@ describe('SQLiteAdapter', () => {
     });
 
     it('removes output spool rows and tail cache only for deleted workflow tasks', () => {
-      adapter.saveWorkflow({
-        id: 'wf-delete-target',
-        name: 'Delete Target',
-        status: 'running',
-        createdAt: '2024-01-01T00:00:00Z',
-        updatedAt: '2024-01-01T00:00:00Z',
-      });
-      adapter.saveWorkflow({
-        id: 'wf-keep',
-        name: 'Keep',
-        status: 'running',
-        createdAt: '2024-01-02T00:00:00Z',
-        updatedAt: '2024-01-02T00:00:00Z',
-      });
+      adapter.saveWorkflow({ id: 'wf-delete-target',
+      name: 'Delete Target', createdAt: '2024-01-01T00:00:00Z',
+      updatedAt: '2024-01-01T00:00:00Z', });
+      adapter.saveWorkflow({ id: 'wf-keep',
+      name: 'Keep', createdAt: '2024-01-02T00:00:00Z',
+      updatedAt: '2024-01-02T00:00:00Z', });
 
       adapter.saveTask('wf-delete-target', makeTask('t-delete-spool'));
       adapter.saveTask('wf-keep', makeTask('t-keep-spool'));
@@ -2544,8 +2503,8 @@ describe('SQLiteAdapter', () => {
 
   describe('loadAllCompletedTasks', () => {
     it('returns completed tasks across multiple workflows with workflowName', () => {
-      adapter.saveWorkflow({ id: 'wf-1', name: 'First Plan', status: 'completed', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' });
-      adapter.saveWorkflow({ id: 'wf-2', name: 'Second Plan', status: 'completed', createdAt: '2024-01-02T00:00:00Z', updatedAt: '2024-01-02T00:00:00Z' });
+      adapter.saveWorkflow({ id: 'wf-1', name: 'First Plan', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' });
+      adapter.saveWorkflow({ id: 'wf-2', name: 'Second Plan', createdAt: '2024-01-02T00:00:00Z', updatedAt: '2024-01-02T00:00:00Z' });
 
       adapter.saveTask('wf-1', makeTask('t1', { status: 'completed', execution: { completedAt: new Date('2024-01-02') } }));
       adapter.saveTask('wf-2', makeTask('t2', { status: 'completed', execution: { completedAt: new Date('2024-01-03') } }));
@@ -2560,7 +2519,7 @@ describe('SQLiteAdapter', () => {
     });
 
     it('excludes non-completed tasks', () => {
-      adapter.saveWorkflow({ id: 'wf-1', name: 'Test', status: 'running', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' });
+      adapter.saveWorkflow({ id: 'wf-1', name: 'Test', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:00:00Z' });
       adapter.saveTask('wf-1', makeTask('t1', { status: 'pending' }));
       adapter.saveTask('wf-1', makeTask('t2', { status: 'running' }));
       adapter.saveTask('wf-1', makeTask('t3', { status: 'failed' }));

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -55,6 +55,8 @@ export interface Workflow {
   createdAt: string;
   updatedAt: string;
 }
+export type WorkflowSaveInput = Omit<Workflow, 'status' | 'rollup'>;
+
 
 export interface TaskEvent {
   id: number;
@@ -96,7 +98,7 @@ export interface ExecutionResourceLeaseReleaseRow {
 
 export interface PersistenceAdapter {
   // Workflows
-  saveWorkflow(workflow: Workflow): void;
+  saveWorkflow(workflow: WorkflowSaveInput): void;
   updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'detachedExternalDependencies' | 'generation' | 'updatedAt'>>): void;
   loadWorkflow(workflowId: string): Workflow | undefined;
   listWorkflows(): Workflow[];

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -44,6 +44,7 @@ import type {
   LaunchDispatchInvalidationRow,
   PersistenceAdapter,
   Workflow,
+  WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
   ActivityLogEntry,
@@ -1283,7 +1284,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   // ── Workflows ─────────────────────────────────────────
 
-  saveWorkflow(workflow: Workflow): void {
+  saveWorkflow(workflow: WorkflowSaveInput): void {
     this.execRun(`
       INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, detached_external_dependencies, generation, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)

--- a/packages/data-store/src/sqlite-task-repository.ts
+++ b/packages/data-store/src/sqlite-task-repository.ts
@@ -25,9 +25,7 @@ export class SqliteTaskRepository implements TaskRepository {
   // ── Workflow writes ──
 
   saveWorkflow(workflow: WorkflowRecord): void {
-    // Port uses broader types (string) than adapter (literal unions).
-    // Safe at runtime because callers always pass valid literals.
-    this.adapter.saveWorkflow(workflow as any);
+    this.adapter.saveWorkflow(workflow);
   }
 
   updateWorkflow(workflowId: string, changes: WorkflowChanges): void {

--- a/packages/test-kit/src/in-memory-persistence.ts
+++ b/packages/test-kit/src/in-memory-persistence.ts
@@ -9,7 +9,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
   workflows = new Map<string, {
     id: string; name: string; status: string;
     createdAt: string; updatedAt: string;
-    onFinish?: string; baseBranch?: string; featureBranch?: string;
+    onFinish?: 'none' | 'merge' | 'pull_request'; baseBranch?: string; featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
@@ -19,9 +19,9 @@ export class InMemoryPersistence implements OrchestratorPersistence {
   private attempts = new Map<string, Attempt[]>();
 
   saveWorkflow(workflow: {
-    id: string; name: string; status: string;
-    createdAt?: string; updatedAt?: string;
-    onFinish?: string; baseBranch?: string; featureBranch?: string;
+    id: string; name: string;
+    createdAt: string; updatedAt: string;
+    onFinish?: 'none' | 'merge' | 'pull_request'; baseBranch?: string; featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
@@ -30,6 +30,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     const now = new Date().toISOString();
     this.workflows.set(workflow.id, {
       ...workflow,
+      status: 'pending',
       createdAt: workflow.createdAt ?? now,
       updatedAt: workflow.updatedAt ?? now,
     });
@@ -111,7 +112,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     return workflow ? this.withDerivedStatus(workflow) as any : undefined;
   }
 
-  private withDerivedStatus<T extends { id: string; status: string }>(workflow: T): T {
+  private withDerivedStatus<T extends { id: string }>(workflow: T): T & { status: string } {
     const tasks = this.loadTasks(workflow.id);
     const rollup = computeWorkflowRollup(tasks);
     return { ...workflow, status: rollup.status, rollup };

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -117,6 +117,24 @@ describe('WorkflowGraph', () => {
     expect(node).toHaveClass('opacity-35');
   });
 
+  it('shows running task count under non-running workflow status', () => {
+    const workflows = new Map([
+      ['wf-a', wf('wf-a', 'failed', { rollup: rollup('failed', 1) })],
+    ]);
+
+    render(
+      <WorkflowGraph
+        workflows={workflows}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('workflow-node-wf-a')).toHaveTextContent('failed');
+    expect(screen.getByTestId('workflow-node-wf-a-running-tasks')).toHaveTextContent('1 running task');
+  });
 
   it('renders the React Flow wrapper for non-empty workflow graphs', () => {
     const workflows = new Map([

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -13,6 +13,10 @@ interface WorkflowNodeProps {
 function statusLabel(status: WorkflowStatus): string {
   return status.replaceAll('_', ' ');
 }
+function runningTaskLabel(count: number): string {
+  return count === 1 ? '1 running task' : `${count} running tasks`;
+}
+
 
 export function WorkflowNode({
   workflow,
@@ -23,6 +27,8 @@ export function WorkflowNode({
 }: WorkflowNodeProps): JSX.Element {
   const visual = workflowStatusVisual(workflow.status);
   const detachedDependencyCount = workflow.detachedExternalDependencies?.length ?? 0;
+  const runningCount = workflow.rollup?.countsByStatus.running ?? 0;
+  const showRunningTaskLine = workflow.status !== 'running' && runningCount > 0;
 
   return (
     <div
@@ -64,6 +70,14 @@ export function WorkflowNode({
       </div>
       <div className="mt-1 text-[11px] text-gray-400 truncate">{workflow.id}</div>
       <div className={`mt-2 text-[10px] uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
+      {showRunningTaskLine && (
+        <div
+          data-testid={`workflow-node-${workflow.id}-running-tasks`}
+          className="mt-1 text-[10px] text-gray-300"
+        >
+          {runningTaskLabel(runningCount)}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/workflow-core/src/__tests__/cancel-first-invariant.test.ts
+++ b/packages/workflow-core/src/__tests__/cancel-first-invariant.test.ts
@@ -12,7 +12,7 @@ import {
   type OrchestratorPersistence,
   type OrchestratorMessageBus,
 } from '../orchestrator.js';
-import type { TaskState, TaskStateChanges, Attempt } from '../task-types.js';
+import { computeWorkflowRollup, type TaskState, type TaskStateChanges, type Attempt } from '../task-types.js';
 
 // ── In-memory fixtures (focused, mirrors orchestrator.test.ts) ──
 
@@ -20,7 +20,6 @@ class InMemoryPersistence implements OrchestratorPersistence {
   workflows = new Map<string, {
     id: string;
     name: string;
-    status: string;
     createdAt: string;
     updatedAt: string;
     repoUrl?: string;
@@ -33,13 +32,13 @@ class InMemoryPersistence implements OrchestratorPersistence {
   saveWorkflow(workflow: {
     id: string;
     name: string;
-    status: string;
     repoUrl?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
   }): void {
     const now = new Date().toISOString();
     this.workflows.set(workflow.id, {
       ...workflow,
+      status: 'pending',
       repoUrl: workflow.repoUrl ?? 'memory://test-repo',
       createdAt: (workflow as { createdAt?: string }).createdAt ?? now,
       updatedAt: (workflow as { updatedAt?: string }).updatedAt ?? now,
@@ -67,7 +66,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
       execution: { ...entry.task.execution, ...changes.execution },
     } as TaskState;
   }
-  listWorkflows() { return Array.from(this.workflows.values()); }
+  listWorkflows() { return Array.from(this.workflows.values()).map((workflow) => ({ ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status })); }
   loadTasks(workflowId: string): TaskState[] {
     return Array.from(this.tasks.values())
       .filter((e) => e.workflowId === workflowId)
@@ -300,7 +299,7 @@ describe('cancel-first invariant — policy-table iteration', () => {
 // ── Sub-suite 2: direct primitive calls bypass applyInvalidation ──
 
 function seedActiveTask(p: InMemoryPersistence, wfId: string, taskId: string): void {
-  p.saveWorkflow({ id: wfId, name: 'fixture', status: 'running' });
+  p.saveWorkflow({ id: wfId, name: 'fixture' });
   p.saveTask(wfId, {
     id: taskId,
     description: 'Active task',

--- a/packages/workflow-core/src/__tests__/cancel-task.test.ts
+++ b/packages/workflow-core/src/__tests__/cancel-task.test.ts
@@ -9,21 +9,18 @@ import type { WorkResponse } from '@invoker/contracts';
 // ── In-Memory Persistence Mock ──────────────────────────────
 
 class InMemoryPersistence implements OrchestratorPersistence {
-  workflows = new Map<string, { id: string; name: string; status: string; createdAt: string; updatedAt: string }>();
+  workflows = new Map<string, { id: string; name: string; createdAt: string; updatedAt: string }>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
   events: Array<{ taskId: string; eventType: string; payload?: unknown }> = [];
 
-  saveWorkflow(workflow: { id: string; name: string; status: string }): void {
+  saveWorkflow(workflow: { id: string; name: string }): void {
     const now = new Date().toISOString();
     this.workflows.set(workflow.id, { ...workflow, createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
   }
 
-  updateWorkflow(workflowId: string, changes: { status?: string; updatedAt?: string }): void {
+  updateWorkflow(workflowId: string, changes: { updatedAt?: string }): void {
     const wf = this.workflows.get(workflowId);
-    if (wf && changes.status) {
-      wf.status = changes.status;
-    }
     if (wf && changes.updatedAt) {
       wf.updatedAt = changes.updatedAt;
     }
@@ -48,9 +45,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
 
   listWorkflows(): Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string }> {
     return Array.from(this.workflows.values()).map((workflow) => {
-      const tasks = this.loadTasks(workflow.id);
-      if (tasks.length === 0) return workflow;
-      const rollup = computeWorkflowRollup(tasks);
+      const rollup = computeWorkflowRollup(this.loadTasks(workflow.id));
       return { ...workflow, status: rollup.status, rollup };
     });
   }

--- a/packages/workflow-core/src/__tests__/experiment-lifecycle.test.ts
+++ b/packages/workflow-core/src/__tests__/experiment-lifecycle.test.ts
@@ -10,7 +10,7 @@ import { reconciliationNeedsInputWorkResponse } from './reconciliation-needs-inp
 import { rid, sid } from './scoped-test-helpers.js';
 import { Orchestrator } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
-import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '../task-types.js';
+import { computeWorkflowRollup, type TaskState, type TaskDelta, type TaskStateChanges, type Attempt } from '../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
 import { MUTATION_POLICIES } from '../invalidation-policy.js';
 
@@ -21,18 +21,15 @@ class InMemoryPersistence implements OrchestratorPersistence {
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
 
-  saveWorkflow(workflow: { id: string; name: string; status: string }): void {
+  saveWorkflow(workflow: { id: string; name: string }): void {
     const now = new Date().toISOString();
-    this.workflows.set(workflow.id, { ...workflow, createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
+    this.workflows.set(workflow.id, { ...workflow, status: 'pending', createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
   }
 
-  updateWorkflow(workflowId: string, changes: { status?: string }): void {
-    const wf = this.workflows.get(workflowId);
-    if (wf && changes.status) wf.status = changes.status;
-  }
+  updateWorkflow(_workflowId: string, _changes: { updatedAt?: string }): void {}
 
   listWorkflows(): Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string }> {
-    return Array.from(this.workflows.values());
+    return Array.from(this.workflows.values()).map((workflow) => ({ ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status }));
   }
 
   saveTask(workflowId: string, task: TaskState): void {

--- a/packages/workflow-core/src/__tests__/graph-mutation.test.ts
+++ b/packages/workflow-core/src/__tests__/graph-mutation.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { sid } from './scoped-test-helpers.js';
 import { Orchestrator } from '../orchestrator.js';
 import type { OrchestratorPersistence, OrchestratorMessageBus, GraphMutation } from '../orchestrator.js';
-import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '../task-types.js';
+import { computeWorkflowRollup, type TaskState, type TaskDelta, type TaskStateChanges, type Attempt } from '../task-types.js';
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -19,18 +19,15 @@ class InMemoryPersistence implements OrchestratorPersistence {
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
 
-  saveWorkflow(workflow: { id: string; name: string; status: string }): void {
+  saveWorkflow(workflow: { id: string; name: string }): void {
     const now = new Date().toISOString();
-    this.workflows.set(workflow.id, { ...workflow, createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
+    this.workflows.set(workflow.id, { ...workflow, status: 'pending', createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
   }
 
-  updateWorkflow(workflowId: string, changes: { status?: string }): void {
-    const wf = this.workflows.get(workflowId);
-    if (wf && changes.status) wf.status = changes.status;
-  }
+  updateWorkflow(_workflowId: string, _changes: { updatedAt?: string }): void {}
 
   listWorkflows(): Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string }> {
-    return Array.from(this.workflows.values());
+    return Array.from(this.workflows.values()).map((workflow) => ({ ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status }));
   }
 
   saveTask(workflowId: string, task: TaskState): void {

--- a/packages/workflow-core/src/__tests__/helpers/cross-workflow-cascade-helpers.ts
+++ b/packages/workflow-core/src/__tests__/helpers/cross-workflow-cascade-helpers.ts
@@ -4,14 +4,13 @@ import {
   type OrchestratorPersistence,
   type OrchestratorMessageBus,
 } from '../../orchestrator.js';
-import type { TaskState, TaskStateChanges, Attempt } from '../../task-types.js';
+import { computeWorkflowRollup, type TaskState, type TaskStateChanges, type Attempt } from '../../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
 
 export class InMemoryPersistence implements OrchestratorPersistence {
   workflows = new Map<string, {
     id: string;
     name: string;
-    status: string;
     createdAt: string;
     updatedAt: string;
     repoUrl?: string;
@@ -26,7 +25,6 @@ export class InMemoryPersistence implements OrchestratorPersistence {
   saveWorkflow(workflow: {
     id: string;
     name: string;
-    status: string;
     repoUrl?: string;
     baseBranch?: string;
     featureBranch?: string;
@@ -35,6 +33,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     const now = new Date().toISOString();
     this.workflows.set(workflow.id, {
       ...workflow,
+      status: 'pending',
       repoUrl: workflow.repoUrl ?? 'memory://test-repo',
       createdAt: (workflow as { createdAt?: string }).createdAt ?? now,
       updatedAt: (workflow as { updatedAt?: string }).updatedAt ?? now,
@@ -64,7 +63,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
       execution: { ...entry.task.execution, ...changes.execution },
     } as TaskState;
   }
-  listWorkflows() { return Array.from(this.workflows.values()); }
+  listWorkflows() { return Array.from(this.workflows.values()).map((workflow) => ({ ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status })); }
   loadTasks(workflowId: string): TaskState[] {
     return Array.from(this.tasks.values())
       .filter((e) => e.workflowId === workflowId)

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -8,7 +8,7 @@ import type {
   OrchestratorPersistence,
   PlanDefinition,
 } from '../orchestrator.js';
-import type { TaskState, TaskStateChanges } from '../task-types.js';
+import { computeWorkflowRollup, type TaskState, type TaskStateChanges } from '../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
 
 interface LoggedEvent {
@@ -44,15 +44,12 @@ class InMemoryPersistence implements OrchestratorPersistence {
   private attempts = new Map<string, Attempt[]>();
   private nextDispatchId = 1;
 
-  saveWorkflow(workflow: { id: string; name: string; status: string }): void {
+  saveWorkflow(workflow: { id: string; name: string }): void {
     const now = new Date().toISOString();
-    this.workflows.set(workflow.id, { ...workflow, createdAt: now, updatedAt: now });
+    this.workflows.set(workflow.id, { ...workflow, status: 'pending', createdAt: now, updatedAt: now });
   }
 
-  updateWorkflow(workflowId: string, changes: { status?: string }): void {
-    const existing = this.workflows.get(workflowId);
-    if (existing && changes.status !== undefined) existing.status = changes.status;
-  }
+  updateWorkflow(_workflowId: string, _changes: { updatedAt?: string }): void {}
 
   saveTask(workflowId: string, task: TaskState): void {
     this.tasks.set(task.id, { workflowId, task });
@@ -71,7 +68,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
   }
 
   listWorkflows(): Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string }> {
-    return Array.from(this.workflows.values());
+    return Array.from(this.workflows.values()).map((workflow) => ({ ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status }));
   }
 
   loadTasks(workflowId: string): TaskState[] {

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -13,7 +13,6 @@ class InMemoryPersistence implements OrchestratorPersistence {
   workflows = new Map<string, {
     id: string;
     name: string;
-    status: string;
     createdAt: string;
     updatedAt: string;
     repoUrl?: string;
@@ -32,7 +31,6 @@ class InMemoryPersistence implements OrchestratorPersistence {
   saveWorkflow(workflow: {
     id: string;
     name: string;
-    status: string;
     repoUrl?: string;
     baseBranch?: string;
     featureBranch?: string;
@@ -58,7 +56,6 @@ class InMemoryPersistence implements OrchestratorPersistence {
   updateWorkflow(
     workflowId: string,
     changes: {
-      status?: string;
       updatedAt?: string;
       baseBranch?: string;
       mergeMode?: 'manual' | 'automatic' | 'external_review';
@@ -69,9 +66,6 @@ class InMemoryPersistence implements OrchestratorPersistence {
   ): void {
     const wf = this.workflows.get(workflowId);
     this.updateWorkflowCalls.set(workflowId, (this.updateWorkflowCalls.get(workflowId) ?? 0) + 1);
-    if (wf && changes.status) {
-      wf.status = changes.status;
-    }
     if (wf && changes.updatedAt) {
       wf.updatedAt = changes.updatedAt;
     }
@@ -174,12 +168,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
       workflowTasks.push(task);
       tasksByWorkflowId.set(workflowId, workflowTasks);
     }
-    const workflows = Array.from(this.workflows.values()).map((workflow) => {
-      const tasks = tasksByWorkflowId.get(workflow.id) ?? [];
-      if (tasks.length === 0) return workflow;
-      const rollup = computeWorkflowRollup(tasks);
-      return { ...workflow, status: rollup.status, rollup };
-    });
+    const workflows = Array.from(this.workflows.values()).map((workflow) => this.withDerivedStatus(workflow, tasksByWorkflowId.get(workflow.id) ?? []));
     return {
       workflows,
       tasks: Array.from(this.tasks.values()).map((entry) => entry.task),
@@ -187,9 +176,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
     };
   }
 
-  private withDerivedStatus<T extends { id: string; status: string }>(workflow: T): T {
-    const tasks = this.loadTasks(workflow.id);
-    if (tasks.length === 0) return workflow;
+  private withDerivedStatus<T extends { id: string }>(workflow: T, tasks = this.loadTasks(workflow.id)): T & { status: string } {
     const rollup = computeWorkflowRollup(tasks);
     return { ...workflow, status: rollup.status, rollup };
   }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -13,7 +13,6 @@ class InMemoryPersistence implements OrchestratorPersistence {
   workflows = new Map<string, {
     id: string;
     name: string;
-    status: string;
     createdAt: string;
     updatedAt: string;
     repoUrl?: string;
@@ -31,7 +30,6 @@ class InMemoryPersistence implements OrchestratorPersistence {
   saveWorkflow(workflow: {
     id: string;
     name: string;
-    status: string;
     repoUrl?: string;
     baseBranch?: string;
     featureBranch?: string;
@@ -55,7 +53,6 @@ class InMemoryPersistence implements OrchestratorPersistence {
   updateWorkflow(
     workflowId: string,
     changes: {
-      status?: string;
       updatedAt?: string;
       baseBranch?: string;
       mergeMode?: 'manual' | 'automatic' | 'external_review';
@@ -65,9 +62,6 @@ class InMemoryPersistence implements OrchestratorPersistence {
   ): void {
     const wf = this.workflows.get(workflowId);
     this.updateWorkflowCalls.set(workflowId, (this.updateWorkflowCalls.get(workflowId) ?? 0) + 1);
-    if (wf && changes.status) {
-      wf.status = changes.status;
-    }
     if (wf && changes.updatedAt) {
       wf.updatedAt = changes.updatedAt;
     }
@@ -167,12 +161,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
       workflowTasks.push(task);
       tasksByWorkflowId.set(workflowId, workflowTasks);
     }
-    const workflows = Array.from(this.workflows.values()).map((workflow) => {
-      const tasks = tasksByWorkflowId.get(workflow.id) ?? [];
-      if (tasks.length === 0) return workflow;
-      const rollup = computeWorkflowRollup(tasks);
-      return { ...workflow, status: rollup.status, rollup };
-    });
+    const workflows = Array.from(this.workflows.values()).map((workflow) => this.withDerivedStatus(workflow, tasksByWorkflowId.get(workflow.id) ?? []));
     return {
       workflows,
       tasks: Array.from(this.tasks.values()).map((entry) => entry.task),
@@ -180,9 +169,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
     };
   }
 
-  private withDerivedStatus<T extends { id: string; status: string }>(workflow: T): T {
-    const tasks = this.loadTasks(workflow.id);
-    if (tasks.length === 0) return workflow;
+  private withDerivedStatus<T extends { id: string }>(workflow: T, tasks = this.loadTasks(workflow.id)): T & { status: string } {
     const rollup = computeWorkflowRollup(tasks);
     return { ...workflow, status: rollup.status, rollup };
   }
@@ -486,7 +473,6 @@ describe('Orchestrator', () => {
         makeResponse({ actionId: taskId, status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
       );
 
-      persistence.workflows.get(workflowId)!.status = 'failed';
 
       const restarted = orchestrator.retryTask(taskId);
 
@@ -514,7 +500,6 @@ describe('Orchestrator', () => {
         makeResponse({ actionId: taskId, status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
       );
 
-      persistence.workflows.get(workflowId)!.status = 'failed';
 
       const restarted = orchestrator.recreateWorkflow(workflowId);
 
@@ -6083,7 +6068,7 @@ describe('Orchestrator', () => {
       const b = new InMemoryBus();
       const wfId = 'wf-retry-status-batch';
 
-      p.saveWorkflow({ id: wfId, name: wfId, status: 'failed' });
+      p.saveWorkflow({ id: wfId, name: wfId });
       p.saveTask(wfId, {
         id: 'root',
         description: 'root',
@@ -6508,7 +6493,6 @@ describe('Orchestrator', () => {
         p.saveWorkflow({
           id: wfId,
           name: 'wf',
-          status: 'running',
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
         } as any);

--- a/packages/workflow-core/src/__tests__/parity.test.ts
+++ b/packages/workflow-core/src/__tests__/parity.test.ts
@@ -15,7 +15,7 @@ import { ResponseHandler } from '../response-handler.js';
 import { TaskScheduler } from '../scheduler.js';
 import { Orchestrator } from '../orchestrator.js';
 import { topologicalSort } from '../dag.js';
-import { createTaskState } from '../task-types.js';
+import { createTaskState, computeWorkflowRollup } from '../task-types.js';
 import type {
   OrchestratorPersistence,
   OrchestratorMessageBus,
@@ -30,18 +30,15 @@ class InMemoryPersistence implements OrchestratorPersistence {
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
 
-  saveWorkflow(workflow: { id: string; name: string; status: string }): void {
+  saveWorkflow(workflow: { id: string; name: string }): void {
     const now = new Date().toISOString();
-    this.workflows.set(workflow.id, { ...workflow, createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
+    this.workflows.set(workflow.id, { ...workflow, status: 'pending', createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
   }
 
-  updateWorkflow(workflowId: string, changes: { status?: string }): void {
-    const wf = this.workflows.get(workflowId);
-    if (wf && changes.status) wf.status = changes.status;
-  }
+  updateWorkflow(_workflowId: string, _changes: { updatedAt?: string }): void {}
 
   listWorkflows(): Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string }> {
-    return Array.from(this.workflows.values());
+    return Array.from(this.workflows.values()).map((workflow) => ({ ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status }));
   }
 
   saveTask(workflowId: string, task: TaskState): void {

--- a/packages/workflow-core/src/__tests__/replace-task.test.ts
+++ b/packages/workflow-core/src/__tests__/replace-task.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { sid } from './scoped-test-helpers.js';
 import { Orchestrator, TopologyForkRequired } from '../orchestrator.js';
 import type { OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
-import type { TaskState, TaskStateChanges, Attempt } from '../task-types.js';
+import { computeWorkflowRollup, type TaskState, type TaskStateChanges, type Attempt } from '../task-types.js';
 import { validateDAG } from '../dag.js';
 
 // ── Mocks ────────────────────────────────────────────────────
@@ -12,18 +12,15 @@ class InMemoryPersistence implements OrchestratorPersistence {
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
 
-  saveWorkflow(workflow: { id: string; name: string; status: string }): void {
+  saveWorkflow(workflow: { id: string; name: string }): void {
     const now = new Date().toISOString();
-    this.workflows.set(workflow.id, { ...workflow, createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
+    this.workflows.set(workflow.id, { ...workflow, status: 'pending', createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
   }
 
-  updateWorkflow(workflowId: string, changes: { status?: string }): void {
-    const wf = this.workflows.get(workflowId);
-    if (wf && changes.status) wf.status = changes.status;
-  }
+  updateWorkflow(_workflowId: string, _changes: { updatedAt?: string }): void {}
 
   listWorkflows(): Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string }> {
-    return Array.from(this.workflows.values());
+    return Array.from(this.workflows.values()).map((workflow) => ({ ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status }));
   }
 
   saveTask(workflowId: string, task: TaskState): void {

--- a/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Orchestrator } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
-import type { TaskState, TaskStateChanges, Attempt, ExternalDependency, ExternalDependencyChange } from '../task-types.js';
+import { computeWorkflowRollup, type TaskState, type TaskStateChanges, type Attempt, type ExternalDependency, type ExternalDependencyChange } from '../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
 import { MUTATION_POLICIES } from '../invalidation-policy.js';
 
@@ -30,24 +30,22 @@ class InMemoryPersistence implements OrchestratorPersistence {
   saveWorkflow(workflow: {
     id: string;
     name: string;
-    status: string;
     externalDependencies?: ExternalDependency[];
     externalDependencyChanges?: ExternalDependencyChange[];
   }): void {
     const now = new Date().toISOString();
-    this.workflows.set(workflow.id, { ...workflow, createdAt: now, updatedAt: now });
+    this.workflows.set(workflow.id, { ...workflow, status: 'pending', createdAt: now, updatedAt: now });
   }
 
   updateWorkflow(
     workflowId: string,
     changes: {
-      status?: string;
       externalDependencies?: ExternalDependency[];
       externalDependencyChanges?: ExternalDependencyChange[];
     },
   ): void {
     const wf = this.workflows.get(workflowId);
-    if (wf && changes.status) wf.status = changes.status;
+    
     if (wf && 'externalDependencies' in changes) wf.externalDependencies = changes.externalDependencies;
     if (wf && 'externalDependencyChanges' in changes) {
       wf.externalDependencyChanges = changes.externalDependencyChanges;
@@ -72,11 +70,12 @@ class InMemoryPersistence implements OrchestratorPersistence {
   }
 
   listWorkflows() {
-    return Array.from(this.workflows.values());
+    return Array.from(this.workflows.values()).map((workflow) => ({ ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status }));
   }
 
   loadWorkflow(workflowId: string) {
-    return this.workflows.get(workflowId);
+    const workflow = this.workflows.get(workflowId);
+    return workflow ? { ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status } : undefined;
   }
 
   loadTasks(workflowId: string): TaskState[] {

--- a/packages/workflow-core/src/__tests__/type-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/type-topology-matrix.test.ts
@@ -9,7 +9,7 @@ import { reconciliationNeedsInputWorkResponse } from './reconciliation-needs-inp
 import { rid, sid } from './scoped-test-helpers.js';
 import { Orchestrator } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
-import type { TaskState, TaskStateChanges , Attempt} from '../task-types.js';
+import { computeWorkflowRollup, type TaskState, type TaskStateChanges , type Attempt} from '../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
 
 // ── In-Memory Persistence Mock ──────────────────────────────
@@ -19,15 +19,12 @@ class InMemoryPersistence implements OrchestratorPersistence {
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
 
-  saveWorkflow(workflow: { id: string; name: string; status: string }): void {
+  saveWorkflow(workflow: { id: string; name: string }): void {
     const now = new Date().toISOString();
-    this.workflows.set(workflow.id, { ...workflow, createdAt: now, updatedAt: now });
+    this.workflows.set(workflow.id, { ...workflow, status: 'pending', createdAt: now, updatedAt: now });
   }
 
-  updateWorkflow(workflowId: string, changes: { status?: string }): void {
-    const wf = this.workflows.get(workflowId);
-    if (wf && changes.status) wf.status = changes.status;
-  }
+  updateWorkflow(_workflowId: string, _changes: { updatedAt?: string }): void {}
 
   saveTask(workflowId: string, task: TaskState): void {
     this.tasks.set(task.id, { workflowId, task });
@@ -47,7 +44,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
   }
 
   listWorkflows() {
-    return Array.from(this.workflows.values());
+    return Array.from(this.workflows.values()).map((workflow) => ({ ...workflow, status: computeWorkflowRollup(this.loadTasks(workflow.id)).status }));
   }
 
   loadTasks(workflowId: string): TaskState[] {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -208,7 +208,6 @@ export interface OrchestratorPersistence {
     name: string;
     description?: string;
     visualProof?: boolean;
-    status: WorkflowDerivedStatus;
     createdAt: string;
     updatedAt: string;
     repoUrl?: string;
@@ -1412,7 +1411,6 @@ export class Orchestrator {
       name: plan.name,
       description: plan.description,
       visualProof: plan.visualProof,
-      status: 'pending',
       repoUrl: plan.repoUrl,
       intermediateRepoUrl: plan.intermediateRepoUrl,
       onFinish: plan.onFinish,
@@ -3312,7 +3310,6 @@ export class Orchestrator {
       name: sourceMeta && (sourceMeta as { name?: string }).name
         ? `${(sourceMeta as { name: string }).name} (fork of ${workflowId})`
         : `Fork of ${workflowId}`,
-      status: 'running',
       createdAt,
       updatedAt: createdAt,
     };

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -10,7 +10,7 @@
  * inside orchestrator.ts.
  */
 
-import type { TaskState, TaskStateChanges, Attempt, WorkflowDerivedStatus, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-graph';
+import type { TaskState, TaskStateChanges, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-graph';
 
 // ── Workflow value types (inline in OrchestratorPersistence today) ────
 
@@ -19,11 +19,11 @@ export interface WorkflowRecord {
   name: string;
   description?: string;
   visualProof?: boolean;
-  status: WorkflowDerivedStatus;
   createdAt: string;
   updatedAt: string;
   repoUrl?: string;
-  onFinish?: string;
+  intermediateRepoUrl?: string;
+  onFinish?: 'none' | 'merge' | 'pull_request';
   baseBranch?: string;
   featureBranch?: string;
   mergeMode?: 'manual' | 'automatic' | 'external_review';


### PR DESCRIPTION
## Summary

Workflow save calls no longer thread derived status through the orchestrator path.

Status was already computed from task rows on reads, but the orchestrator and several test doubles still passed status values through workflow save calls anyway.

Now workflow save calls carry only real metadata, and tests build failed or running workflows by changing tasks instead of stored workflow rows.

<details>
<summary>Review metadata</summary>

Review Claim: Workflow save calls now stop threading derived status through the orchestrator path.

Review Lane: refactor

Review Unit: routing

Safety Invariant: Reads still return workflow status and rollup. This slice only removes derived status fields from workflow save flow and updates fixtures to match.

Slice Rationale: The live rollup behavior already works. Keeping the save-call cleanup separate keeps review focused on one narrow follow-on path.

</details>

## Non-goals

- No behavior change.
- Changing live task-delta publishing or renderer status updates.
- Adding new persistence tables, columns, or migrations.

## Test Plan

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts --reporter=verbose`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts src/__tests__/cancel-task.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts --reporter=verbose`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #1745