### PR TITLE
[Workflow Status](1) Add workflow rollup patches to task graph events

### DIFF
--- a/packages/app/src/task-graph-event-publisher.ts
+++ b/packages/app/src/task-graph-event-publisher.ts
@@ -72,6 +72,7 @@ export function createTaskGraphEventPublisher(
       publishEvent({
         type: 'delta',
         delta: options.stampDelta(delta),
+        workflowRollups: [],
       });
     },
     publishSnapshot(reason: string, tasks: TaskState[], workflows: WorkflowMeta[]): void {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -47,10 +47,17 @@ export interface WorkflowMeta {
   createdAt?: string;
   updatedAt?: string;
 }
+export interface WorkflowRollupPatch {
+  workflowId: string;
+  status: WorkflowDerivedStatus;
+  rollup: WorkflowRollup;
+}
+
 export type TaskGraphEvent =
   | {
       type: 'delta';
       delta: TaskDelta;
+      workflowRollups: WorkflowRollupPatch[];
     }
   | {
       type: 'snapshot';


### PR DESCRIPTION
## Summary

Task graph delta events now include workflow rollup patches.

Before this, the shared event type could carry only the task delta itself.

Now the event contract can also carry backend-derived workflow status and rollup data for the affected workflow ids.

<details>
<summary>Review metadata</summary>

Review Claim: The shared task-graph delta contract now carries workflow rollup patches.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This slice changes only the shared event shape.

Slice Rationale: The event type has to grow first so later slices can publish and consume workflow rollup patches.

</details>

## Non-goals

- Publishing rollup patches from the main process.
- Changing UI workflow rendering.
- Removing workflow status from persistence saves.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-rollup-projection.test.ts src/__tests__/delta-merge.test.ts --reporter=verbose`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
