### PR TITLE
[Workflow Status](3) Use backend workflow rollups in the UI

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -29,7 +29,7 @@ import { WorkflowGraph } from './components/WorkflowGraph.js';
 import { FloatingGraphPanel } from './components/FloatingGraphPanel.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
-import { StatusBar } from './components/StatusBar.js';
+import { WorkflowStatusChips } from './components/WorkflowStatusChips.js';
 import { TerminalDrawer, type TerminalDrawerState } from './components/TerminalDrawer.js';
 import {
   isExperimentSpawnPivotTask,
@@ -66,17 +66,17 @@ type SearchResult =
 
 const KEYBOARD_REGION_ORDER: readonly KeyboardRegion[] = ['workflowGraph', 'taskGraph', 'inspector', 'bottomBar'];
 const SIDEBAR_NAV_ITEM_SELECTOR = '[data-sidebar-nav-item]';
-const STATUS_KEY_ORDER: readonly string[] = [
+const STATUS_KEY_ORDER: readonly WorkflowStatus[] = [
   'completed',
   'running',
   'failed',
   'closed',
   'pending',
-  'needs_input',
   'review_ready',
   'awaiting_approval',
   'blocked',
   'fixing_with_ai',
+  'stale',
 ];
 const EDITABLE_SELECTOR = [
   'input',
@@ -695,13 +695,12 @@ export function App() {
   }, []);
 
   const visibleStatusKeys = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const task of tasks.values()) {
-      const key = task.status === 'awaiting_approval' && task.execution.pendingFixError ? 'fix_approval' : task.status;
-      counts.set(key, (counts.get(key) ?? 0) + 1);
+    const counts = new Map<WorkflowStatus, number>();
+    for (const workflow of workflows.values()) {
+      counts.set(workflow.status, (counts.get(workflow.status) ?? 0) + 1);
     }
     return STATUS_KEY_ORDER.filter((key) => key === 'completed' || key === 'running' || key === 'failed' || key === 'pending' || (counts.get(key) ?? 0) > 0);
-  }, [tasks]);
+  }, [workflows]);
 
   const searchResults = useMemo<SearchResult[]>(() => {
     const query = normalizedSearchText(searchQuery.trim());
@@ -1923,7 +1922,6 @@ export function App() {
               ) : (
                 <>
                   <WorkflowGraph
-                    tasks={tasks}
                     workflows={workflows}
                     selectedWorkflowId={selectedWorkflow?.id ?? null}
                     cameraCommand={cameraCommand}
@@ -1977,11 +1975,11 @@ export function App() {
                 data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
                 className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
               >
-                <StatusBar
-                  tasks={tasks}
+                <WorkflowStatusChips
+                  workflows={workflows}
                   activeFilters={statusFilters}
                   keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
-                  onStatusClick={(filterKey, event) => handleStatusClick(filterKey as WorkflowStatus, event)}
+                  onStatusClick={handleStatusClick}
                 />
                 <TerminalDrawer
                   state={terminalDrawerState}

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -211,13 +211,13 @@ export function createMockInvoker(
 
       // Fire created graph events for each task after subscribers attach.
       for (const task of tasks) {
-        graphEventCallback?.({ type: 'delta', delta: { type: 'created', task } });
+        graphEventCallback?.({ type: 'delta', delta: { type: 'created', task }, workflowRollups: [] });
       }
     });
   }
 
   function fireDelta(delta: TaskDelta) {
-    graphEventCallback?.({ type: 'delta', delta });
+    graphEventCallback?.({ type: 'delta', delta, workflowRollups: [] });
   }
   function fireGraphEvent(event: TaskGraphEvent) {
     graphEventCallback?.(event);

--- a/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
+++ b/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
@@ -70,7 +70,7 @@ describe('selected workflow graph metadata-gap regression', () => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
     });
 
-    expect(screen.getByText('Total:')).toHaveTextContent('Total: 2');
+    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('running (1)');
     expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
     expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
     expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
@@ -140,7 +140,7 @@ describe('selected workflow graph metadata-gap regression', () => {
     expect(screen.getByTestId('rf__node-__merge__wf-a')).toBeInTheDocument();
     expect(screen.getByTestId('selected-workflow-mini-dag-refreshing')).toBeInTheDocument();
     expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
-    expect(screen.getByText('Total:')).not.toHaveTextContent('Total: 0');
+    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('running (1)');
 
     await act(async () => {
       mock.fireDelta({ type: 'created', task: alpha });

--- a/packages/ui/src/__tests__/task-graph-event-pipeline.test.ts
+++ b/packages/ui/src/__tests__/task-graph-event-pipeline.test.ts
@@ -23,7 +23,7 @@ describe('task-graph-event-pipeline', () => {
     vi.useFakeTimers();
     const onBatch = vi.fn<(batch: TaskGraphEvent[]) => void>();
     const pipeline = createTaskGraphEventPipeline({ flushMs: 100, onBatch });
-    const deltaEvent: TaskGraphEvent = { type: 'delta', delta: { type: 'created', task: makeTask('t1') } };
+    const deltaEvent: TaskGraphEvent = { type: 'delta', delta: { type: 'created', task: makeTask('t1') }, workflowRollups: [] };
     const snapshotEvent: TaskGraphEvent = {
       type: 'snapshot',
       tasks: [makeTask('t2')],
@@ -47,7 +47,7 @@ describe('task-graph-event-pipeline', () => {
     const onBatch = vi.fn<(batch: TaskGraphEvent[]) => void>();
     const pipeline = createTaskGraphEventPipeline({ flushMs: 100, onBatch });
 
-    pipeline.push({ type: 'delta', delta: { type: 'created', task: makeTask('t1') } });
+    pipeline.push({ type: 'delta', delta: { type: 'created', task: makeTask('t1') }, workflowRollups: [] });
     pipeline.clear();
     vi.advanceTimersByTime(100);
 

--- a/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
@@ -61,7 +61,7 @@ function installInvoker(opts: {
     reportUiPerfMock,
     onTaskGraphEventMock,
     refreshTaskGraphMock,
-    fireDelta: (delta) => handler?.({ type: 'delta', delta }),
+    fireDelta: (delta) => handler?.({ type: 'delta', delta, workflowRollups: [] }),
     fireSnapshot: (snapshot) => handler?.({
       type: 'snapshot',
       tasks: snapshot.tasks,

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -6,6 +6,34 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useTasks } from '../hooks/useTasks.js';
 import { makeUITask } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+
+function makeWorkflowRollup(
+  status: NonNullable<WorkflowMeta['rollup']>['status'],
+  counts: Partial<NonNullable<WorkflowMeta['rollup']>['countsByStatus']> = {},
+): NonNullable<WorkflowMeta['rollup']> {
+  return {
+    status,
+    countsByStatus: {
+      pending: 0,
+      running: 0,
+      fixing_with_ai: 0,
+      completed: 0,
+      failed: 0,
+      closed: 0,
+      needs_input: 0,
+      blocked: 0,
+      review_ready: 0,
+      awaiting_approval: 0,
+      stale: 0,
+      ...counts,
+    },
+    failedTasks: [],
+    fixingTasks: [],
+    waitingTasks: [],
+  };
+}
+
 
 describe('useTasks', () => {
   let workflowsChangedHandler: ((wfList: unknown[]) => void) | undefined;
@@ -105,6 +133,7 @@ describe('useTasks', () => {
           taskStateVersion: 2,
           previousTaskStateVersion: 1,
         },
+        workflowRollups: [],
       });
       await new Promise((resolve) => setTimeout(resolve, 110));
     });
@@ -356,6 +385,7 @@ describe('useTasks', () => {
           type: 'created',
           task: makeUITask({ id: 'wf-2/task-1', workflowId: 'wf-2', status: 'pending' }),
         },
+        workflowRollups: [],
       });
       await new Promise((resolve) => setTimeout(resolve, 130));
     });
@@ -367,17 +397,17 @@ describe('useTasks', () => {
     });
   });
 
-  it('keeps backend-sent workflow status until workflows-changed refreshes metadata', async () => {
-    const taskA = makeUITask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'failed' });
-    const taskB = makeUITask({ id: 'wf-1/task-b', workflowId: 'wf-1', status: 'completed' });
+  it('applies backend rollup patches from task graph deltas', async () => {
+    const task = makeUITask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'failed' });
+    const runningRollup = makeWorkflowRollup('running', { running: 1 });
     (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
-      tasks: [taskA, taskB],
-      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed' }],
+      tasks: [task],
+      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed', rollup: makeWorkflowRollup('failed', { failed: 1 }) }],
     };
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
       getTasks: vi.fn().mockResolvedValue({
-        tasks: [taskA, taskB],
-        workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed' }],
+        tasks: [task],
+        workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed', rollup: makeWorkflowRollup('failed', { failed: 1 }) }],
       }),
       onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
         taskGraphEventHandler = cb;
@@ -398,62 +428,90 @@ describe('useTasks', () => {
         delta: {
           type: 'updated',
           taskId: 'wf-1/task-a',
-          changes: { status: 'pending' },
+          changes: { status: 'running' },
           taskStateVersion: 2,
           previousTaskStateVersion: 1,
         },
-      });
-      taskGraphEventHandler!({
-        type: 'delta',
-        delta: {
-          type: 'updated',
-          taskId: 'wf-1/task-b',
-          changes: { status: 'pending' },
-          taskStateVersion: 2,
-          previousTaskStateVersion: 1,
-        },
+        workflowRollups: [{ workflowId: 'wf-1', status: 'running', rollup: runningRollup }],
       });
       await new Promise((resolve) => setTimeout(resolve, 110));
     });
 
     await waitFor(() => {
-      expect(result.current.tasks.get('wf-1/task-a')?.status).toBe('pending');
-      expect(result.current.tasks.get('wf-1/task-b')?.status).toBe('pending');
+      expect(result.current.tasks.get('wf-1/task-a')?.status).toBe('running');
+      expect(result.current.workflows.get('wf-1')?.status).toBe('running');
+    });
+    expect(result.current.workflows.get('wf-1')?.rollup?.countsByStatus.running).toBe(1);
+    expect(workflowsChangedHandler).toBeDefined();
+  });
+
+  it('does not locally recompute workflow status when rollup patches are empty', async () => {
+    const task = makeUITask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'failed' });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [task],
+      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed', rollup: makeWorkflowRollup('failed', { failed: 1 }) }],
+    };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks: vi.fn().mockResolvedValue({
+        tasks: [task],
+        workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed', rollup: makeWorkflowRollup('failed', { failed: 1 }) }],
+      }),
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn((cb: (wfList: unknown[]) => void) => {
+        workflowsChangedHandler = cb;
+        return () => {};
+      }),
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: 'wf-1/task-a',
+          changes: { status: 'running' },
+          taskStateVersion: 2,
+          previousTaskStateVersion: 1,
+        },
+        workflowRollups: [],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 110));
+    });
+
+    await waitFor(() => {
+      expect(result.current.tasks.get('wf-1/task-a')?.status).toBe('running');
     });
     expect(result.current.workflows.get('wf-1')?.status).toBe('failed');
+  });
 
-    act(() => {
-      workflowsChangedHandler!([
-        {
-          id: 'wf-1',
-          name: 'Workflow 1',
-          status: 'pending',
-          rollup: {
-            status: 'pending',
-            countsByStatus: {
-              pending: 2,
-              running: 0,
-              fixing_with_ai: 0,
-              completed: 0,
-              failed: 0,
-              closed: 0,
-              needs_input: 0,
-              blocked: 0,
-              review_ready: 0,
-              awaiting_approval: 0,
-              stale: 0,
-            },
-            failedTasks: [],
-            fixingTasks: [],
-            waitingTasks: [],
-          },
-        },
-      ]);
+  it('preserves task-backed workflow metadata during workflows-changed gaps', async () => {
+    const task = makeUITask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'running' });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [task],
+      workflows: [
+        { id: 'wf-1', name: 'Workflow 1', status: 'running' },
+        { id: 'wf-2', name: 'Workflow 2', status: 'pending' },
+      ],
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(workflowsChangedHandler).toBeDefined();
     });
 
-    expect(result.current.workflows.get('wf-1')?.status).toBe('pending');
-    expect(result.current.workflows.get('wf-1')?.rollup?.countsByStatus.pending).toBe(2);
+    act(() => {
+      workflowsChangedHandler!([{ id: 'wf-2', name: 'Workflow 2', status: 'pending' }]);
+    });
+
     expect(result.current.workflows.get('wf-1')?.name).toBe('Workflow 1');
+    expect(result.current.workflows.get('wf-1')?.status).toBe('running');
+    expect(result.current.workflows.get('wf-2')?.name).toBe('Workflow 2');
   });
 
   it('does not locally recompute failed dependency paths from task deltas', async () => {
@@ -507,6 +565,7 @@ describe('useTasks', () => {
           taskStateVersion: 2,
           previousTaskStateVersion: 1,
         },
+        workflowRollups: [],
       });
       await new Promise((resolve) => setTimeout(resolve, 110));
     });

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { WorkflowGraph } from '../components/WorkflowGraph.js';
 import { createGraphCameraCommandIssuer } from '../lib/graph-camera.js';
-import type { TaskState, WorkflowMeta, WorkflowStatus } from '../types.js';
+import type { WorkflowMeta, WorkflowStatus } from '../types.js';
 import * as ReactFlowModule from '@xyflow/react';
 
 vi.mock('@xyflow/react', async () => {
@@ -24,18 +24,32 @@ const source = readFileSync(
 function wf(id: string, status: WorkflowStatus, overrides: Partial<WorkflowMeta> = {}): WorkflowMeta {
   return { id, name: id, status, ...overrides };
 }
-
-function task(id: string, workflowId: string): TaskState {
+function rollup(
+  status: NonNullable<WorkflowMeta['rollup']>['status'],
+  running: number,
+): NonNullable<WorkflowMeta['rollup']> {
   return {
-    id,
-    description: id,
-    status: 'pending',
-    dependencies: [],
-    config: { workflowId },
-    execution: {},
-    taskStateVersion: 1,
+    status,
+    countsByStatus: {
+      pending: 0,
+      running,
+      fixing_with_ai: 0,
+      completed: 0,
+      failed: 0,
+      closed: 0,
+      needs_input: 0,
+      blocked: 0,
+      review_ready: 0,
+      awaiting_approval: 0,
+      stale: 0,
+    },
+    failedTasks: [],
+    fixingTasks: [],
+    waitingTasks: [],
   };
 }
+
+
 
 /** Render a one-workflow graph and wait for the initial first-render fit to
  * settle, then clear the viewport spies so a test can assert on the calls that
@@ -63,13 +77,9 @@ describe('WorkflowGraph', () => {
     const workflows = new Map([
       ['wf-a', wf('wf-a', 'running')],
     ]);
-    const tasks = new Map([
-      ['t1', task('t1', 'wf-a')],
-    ]);
 
     render(
       <WorkflowGraph
-        tasks={tasks}
         workflows={workflows}
         selectedWorkflowId={null}
         statusFilters={new Set()}
@@ -91,13 +101,9 @@ describe('WorkflowGraph', () => {
     const workflows = new Map([
       ['wf-a', wf('wf-a', 'running')],
     ]);
-    const tasks = new Map([
-      ['t1', task('t1', 'wf-a')],
-    ]);
 
     render(
       <WorkflowGraph
-        tasks={tasks}
         workflows={workflows}
         selectedWorkflowId={null}
         statusFilters={new Set<WorkflowStatus>(['failed'])}
@@ -111,17 +117,14 @@ describe('WorkflowGraph', () => {
     expect(node).toHaveClass('opacity-35');
   });
 
+
   it('renders the React Flow wrapper for non-empty workflow graphs', () => {
     const workflows = new Map([
       ['wf-a', wf('wf-a', 'running')],
     ]);
-    const tasks = new Map([
-      ['t1', task('t1', 'wf-a')],
-    ]);
 
     render(
       <WorkflowGraph
-        tasks={tasks}
         workflows={workflows}
         selectedWorkflowId={null}
         statusFilters={new Set()}
@@ -154,7 +157,6 @@ describe('WorkflowGraph', () => {
 
     render(
       <WorkflowGraph
-        tasks={new Map()}
         workflows={workflows}
         selectedWorkflowId={null}
         statusFilters={new Set()}
@@ -194,7 +196,6 @@ describe('WorkflowGraph', () => {
 
     render(
       <WorkflowGraph
-        tasks={new Map()}
         workflows={workflows}
         selectedWorkflowId={null}
         statusFilters={new Set()}
@@ -229,7 +230,6 @@ describe('WorkflowGraph', () => {
 
     render(
       <WorkflowGraph
-        tasks={new Map()}
         workflows={workflows}
         selectedWorkflowId={null}
         statusFilters={new Set()}
@@ -253,11 +253,9 @@ describe('WorkflowGraph', () => {
 
   it('fits the viewport exactly once on the first non-empty render', async () => {
     const workflows = new Map([['wf-a', wf('wf-a', 'running')]]);
-    const tasks = new Map([['t1', task('t1', 'wf-a')]]);
 
     render(
       <WorkflowGraph
-        tasks={tasks}
         workflows={workflows}
         selectedWorkflowId={null}
         statusFilters={new Set()}
@@ -276,12 +274,8 @@ describe('WorkflowGraph', () => {
     const workflows = new Map([
       ['wf-a', wf('wf-a', 'running')],
     ]);
-    const tasks = new Map([
-      ['t1', task('t1', 'wf-a')],
-    ]);
 
     const { rerender } = await renderAndSettleInitialFit({
-      tasks,
       workflows,
       selectedWorkflowId: null,
       statusFilters: new Set(),
@@ -293,14 +287,9 @@ describe('WorkflowGraph', () => {
       ['wf-a', wf('wf-a', 'running')],
       ['wf-b', wf('wf-b', 'pending')],
     ]);
-    const refreshedTasks = new Map([
-      ['t1', task('t1', 'wf-a')],
-      ['t2', task('t2', 'wf-b')],
-    ]);
 
     rerender(
       <WorkflowGraph
-        tasks={refreshedTasks}
         workflows={refreshedWorkflows}
         selectedWorkflowId={null}
         statusFilters={new Set()}
@@ -317,10 +306,8 @@ describe('WorkflowGraph', () => {
   });
 
   it('does not move the camera on a status-only update', async () => {
-    const tasks = new Map([['t1', task('t1', 'wf-a')]]);
 
     const { rerender } = await renderAndSettleInitialFit({
-      tasks,
       workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
       selectedWorkflowId: 'wf-a',
       statusFilters: new Set(),
@@ -331,7 +318,6 @@ describe('WorkflowGraph', () => {
     // Same topology, only the workflow status changes.
     rerender(
       <WorkflowGraph
-        tasks={tasks}
         workflows={new Map([['wf-a', wf('wf-a', 'completed')]])}
         selectedWorkflowId="wf-a"
         statusFilters={new Set()}
@@ -351,7 +337,6 @@ describe('WorkflowGraph', () => {
     getZoomMock.mockReturnValue(1.75);
 
     const { rerender } = await renderAndSettleInitialFit({
-      tasks: new Map([['t1', task('t1', 'wf-a')]]),
       workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
       selectedWorkflowId: 'wf-a',
       statusFilters: new Set(),
@@ -361,7 +346,6 @@ describe('WorkflowGraph', () => {
 
     rerender(
       <WorkflowGraph
-        tasks={new Map([['t1', task('t1', 'wf-a')]])}
         workflows={new Map([['wf-a', wf('wf-a', 'running')]])}
         selectedWorkflowId="wf-a"
         cameraCommand={issuer.centerSelection('workflow', 'wf-a')}
@@ -383,7 +367,6 @@ describe('WorkflowGraph', () => {
     const issuer = createGraphCameraCommandIssuer();
 
     const { rerender } = await renderAndSettleInitialFit({
-      tasks: new Map([['t1', task('t1', 'wf-a')]]),
       workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
       selectedWorkflowId: 'wf-a',
       statusFilters: new Set(),
@@ -393,7 +376,6 @@ describe('WorkflowGraph', () => {
 
     rerender(
       <WorkflowGraph
-        tasks={new Map([['t1', task('t1', 'wf-a')]])}
         workflows={new Map([['wf-a', wf('wf-a', 'running')]])}
         selectedWorkflowId="wf-a"
         cameraCommand={issuer.fitInitial('workflow')}
@@ -411,7 +393,6 @@ describe('WorkflowGraph', () => {
     const issuer = createGraphCameraCommandIssuer();
 
     const { rerender } = await renderAndSettleInitialFit({
-      tasks: new Map([['t1', task('t1', 'wf-a')]]),
       workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
       selectedWorkflowId: 'wf-a',
       statusFilters: new Set(),
@@ -421,7 +402,6 @@ describe('WorkflowGraph', () => {
 
     rerender(
       <WorkflowGraph
-        tasks={new Map([['t1', task('t1', 'wf-a')]])}
         workflows={new Map([['wf-a', wf('wf-a', 'running')]])}
         selectedWorkflowId="wf-a"
         cameraCommand={issuer.centerSelection('task', 't1')}
@@ -441,7 +421,6 @@ describe('WorkflowGraph', () => {
     const command = issuer.centerSelection('workflow', 'wf-a');
 
     const { rerender } = await renderAndSettleInitialFit({
-      tasks: new Map([['t1', task('t1', 'wf-a')]]),
       workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
       selectedWorkflowId: 'wf-a',
       statusFilters: new Set(),
@@ -450,7 +429,6 @@ describe('WorkflowGraph', () => {
     });
 
     const props = {
-      tasks: new Map([['t1', task('t1', 'wf-a')]]),
       workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
       selectedWorkflowId: 'wf-a' as const,
       cameraCommand: command,
@@ -472,7 +450,6 @@ describe('WorkflowGraph', () => {
     const onManualViewport = vi.fn();
 
     await renderAndSettleInitialFit({
-      tasks: new Map([['t1', task('t1', 'wf-a')]]),
       workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
       selectedWorkflowId: 'wf-a',
       statusFilters: new Set(),

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
-import type { TaskState, WorkflowMeta, WorkflowStatus } from '../types.js';
+import type { WorkflowMeta, WorkflowStatus } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
 import { deriveWorkflowGraph, layoutWorkflowGraph, type WorkflowGraphEdge } from '../lib/workflow-graph.js';
 import { WorkflowNode } from './WorkflowNode.js';
@@ -20,7 +20,6 @@ import {
 import '@xyflow/react/dist/style.css';
 
 interface WorkflowGraphProps {
-  tasks: Map<string, TaskState>;
   workflows: Map<string, WorkflowMeta>;
   selectedWorkflowId: string | null;
   /**
@@ -104,7 +103,6 @@ function WorkflowFlowNode({ data }: NodeProps<Node<WorkflowNodeData>>): JSX.Elem
 }
 
 function WorkflowGraphInner({
-  tasks,
   workflows,
   selectedWorkflowId,
   cameraCommand,
@@ -124,10 +122,10 @@ function WorkflowGraphInner({
   const graphMetricsRef = useRef({ deriveMs: 0, layoutMs: 0, objectsMs: 0 });
   const graph = useMemo(() => {
     const startedAt = performance.now();
-    const nextGraph = deriveWorkflowGraph(workflows, tasks);
+    const nextGraph = deriveWorkflowGraph(workflows);
     graphMetricsRef.current.deriveMs = performance.now() - startedAt;
     return nextGraph;
-  }, [workflows, tasks]);
+  }, [workflows]);
   const positions = useMemo(() => {
     const startedAt = performance.now();
     const nextPositions = layoutWorkflowGraph(graph);

--- a/packages/ui/src/components/WorkflowStatusChips.tsx
+++ b/packages/ui/src/components/WorkflowStatusChips.tsx
@@ -6,6 +6,7 @@ interface WorkflowStatusChipsProps {
   workflows: Map<string, WorkflowMeta>;
   activeFilters: Set<WorkflowStatus>;
   onStatusClick: (status: WorkflowStatus, event: MouseEvent<HTMLButtonElement>) => void;
+  keyboardActiveKey?: WorkflowStatus | null;
 }
 
 const DISPLAY_ORDER: WorkflowStatus[] = [
@@ -13,6 +14,7 @@ const DISPLAY_ORDER: WorkflowStatus[] = [
   'failed',
   'closed',
   'blocked',
+  'fixing_with_ai',
   'awaiting_approval',
   'review_ready',
   'pending',
@@ -24,6 +26,7 @@ export function WorkflowStatusChips({
   workflows,
   activeFilters,
   onStatusClick,
+  keyboardActiveKey = null,
 }: WorkflowStatusChipsProps): JSX.Element {
   const counts = new Map<WorkflowStatus, number>();
   for (const status of DISPLAY_ORDER) counts.set(status, 0);
@@ -47,6 +50,7 @@ export function WorkflowStatusChips({
               visual.borderClass,
               visual.textClass,
               active ? 'bg-gray-800' : 'bg-gray-900/70 hover:bg-gray-800/80',
+              keyboardActiveKey === status ? 'ring-2 ring-blue-300/90 ring-offset-1 ring-offset-gray-800' : '',
             ].join(' ')}
           >
             {status.replaceAll('_', ' ')} ({count})

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -7,7 +7,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import type { TaskGraphEvent, TaskState, WorkflowMeta } from '../types.js';
+import type { TaskGraphEvent, TaskState, WorkflowMeta, WorkflowRollupPatch } from '../types.js';
 import { applyDelta } from '../lib/delta.js';
 import { normalizeWorkflowStatus } from '../lib/workflow-status.js';
 import {
@@ -24,6 +24,56 @@ export interface UseTasksResult {
 export interface UseTasksOptions {
   onTaskGraphSnapshotApplied?: () => void;
 }
+function normalizeWorkflowMeta(workflow: WorkflowMeta): WorkflowMeta {
+  return {
+    ...workflow,
+    status: normalizeWorkflowStatus((workflow as { status?: string }).status),
+  };
+}
+
+function replaceWorkflowMapPreservingTaskBackedEntries(
+  previous: Map<string, WorkflowMeta>,
+  incoming: readonly WorkflowMeta[],
+  tasks: Map<string, TaskState>,
+): Map<string, WorkflowMeta> {
+  const next = new Map<string, WorkflowMeta>();
+  for (const workflow of incoming) {
+    next.set(workflow.id, normalizeWorkflowMeta(workflow));
+  }
+  const referencedWorkflowIds = new Set<string>();
+  for (const task of tasks.values()) {
+    const workflowId = task.config.workflowId;
+    if (workflowId) {
+      referencedWorkflowIds.add(workflowId);
+    }
+  }
+  for (const [workflowId, workflow] of previous) {
+    if (!next.has(workflowId) && referencedWorkflowIds.has(workflowId)) {
+      next.set(workflowId, workflow);
+    }
+  }
+  return next;
+}
+
+function applyWorkflowRollupPatches(
+  previous: Map<string, WorkflowMeta>,
+  patches: readonly WorkflowRollupPatch[],
+): Map<string, WorkflowMeta> {
+  if (patches.length === 0) {
+    return previous;
+  }
+  const next = new Map(previous);
+  for (const patch of patches) {
+    const existing = next.get(patch.workflowId);
+    next.set(patch.workflowId, {
+      ...(existing ?? { id: patch.workflowId, name: patch.workflowId }),
+      status: normalizeWorkflowStatus(patch.status),
+      rollup: patch.rollup,
+    });
+  }
+  return next;
+}
+
 
 
 export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): UseTasksResult {
@@ -50,10 +100,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     const startedAt = performance.now();
     const next = new Map<string, WorkflowMeta>();
     for (const workflow of bootstrapState?.workflows ?? []) {
-      next.set(workflow.id, {
-        ...workflow,
-        status: normalizeWorkflowStatus((workflow as { status?: string }).status),
-      });
+      next.set(workflow.id, normalizeWorkflowMeta(workflow));
     }
     if (typeof window !== 'undefined' && window.invoker) {
       void window.invoker.reportUiPerf?.('useTasks_bootstrap_workflow_map', {
@@ -63,6 +110,8 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     }
     return next;
   });
+  const tasksRef = useRef(tasks);
+  tasksRef.current = tasks;
   const workflowsRef = useRef(workflows);
   workflowsRef.current = workflows;
   const graphEventPipelineRef = useRef<TaskGraphEventPipeline | null>(null);
@@ -95,20 +144,14 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       const wfList = result.workflows ?? [];
       const replaceStartedAt = performance.now();
       // Always replace from server snapshot — empty lists mean "no tasks/workflows" (e.g. after delete).
-      setTasks(() => {
-        const next = new Map<string, TaskState>();
-        for (const t of taskList) next.set(t.id, t);
-        return next;
-      });
-      setWorkflows(() => {
-        const wfMap = new Map<string, WorkflowMeta>();
-        for (const wf of wfList) {
-          wfMap.set(wf.id, {
-            ...wf,
-            status: normalizeWorkflowStatus((wf as { status?: string }).status),
-          });
-        }
-        return wfMap;
+      const nextTasks = new Map<string, TaskState>();
+      for (const t of taskList) nextTasks.set(t.id, t);
+      tasksRef.current = nextTasks;
+      setTasks(nextTasks);
+      setWorkflows((previous) => {
+        const nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(previous, wfList, nextTasks);
+        workflowsRef.current = nextWorkflows;
+        return nextWorkflows;
       });
       if (typeof result.streamSequence === 'number') {
         uiTaskGraphStreamWatermarkRef.current = result.streamSequence;
@@ -141,15 +184,14 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
     const requestedAt = performance.now();
     const request = window.invoker.listWorkflows().then((wfList) => {
-      setWorkflows(() => {
-        const wfMap = new Map<string, WorkflowMeta>();
-        for (const wf of wfList) {
-          wfMap.set(wf.id, {
-            ...wf,
-            status: normalizeWorkflowStatus((wf as { status?: string }).status),
-          });
-        }
-        return wfMap;
+      setWorkflows((previous) => {
+        const nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(
+          previous,
+          wfList,
+          tasksRef.current,
+        );
+        workflowsRef.current = nextWorkflows;
+        return nextWorkflows;
       });
       void window.invoker.reportUiPerf?.('useTasks_workflow_metadata_refresh', {
         workflowCount: wfList.length,
@@ -223,24 +265,19 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
         const firstEvent = effectiveBatch[0];
         const deltaEvents = firstEvent?.type === 'snapshot' ? effectiveBatch.slice(1) : effectiveBatch;
         let shouldRefreshWorkflows = false;
+        let nextTasks = tasksRef.current;
+        let nextWorkflows = workflowsRef.current;
+        const replaceStartedAt = performance.now();
+        const t0 = performance.now();
 
         if (firstEvent?.type === 'snapshot') {
-          setTasks(() => {
-            const next = new Map<string, TaskState>();
-            for (const task of firstEvent.tasks) next.set(task.id, task);
-            return next;
-          });
-          const replaceStartedAt = performance.now();
-          setWorkflows(() => {
-            const wfMap = new Map<string, WorkflowMeta>();
-            for (const wf of firstEvent.workflows) {
-              wfMap.set(wf.id, {
-                ...wf,
-                status: normalizeWorkflowStatus((wf as { status?: string }).status),
-              });
-            }
-            return wfMap;
-          });
+          nextTasks = new Map<string, TaskState>();
+          for (const task of firstEvent.tasks) nextTasks.set(task.id, task);
+          nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(
+            nextWorkflows,
+            firstEvent.workflows,
+            nextTasks,
+          );
           uiTaskGraphStreamWatermarkRef.current = Math.max(uiTaskGraphStreamWatermarkRef.current, firstEvent.streamSequence);
           isResyncInFlightRef.current = false;
           onTaskGraphSnapshotApplied?.();
@@ -254,36 +291,35 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
           });
         }
 
-        setTasks((prev) => {
-          const t0 = performance.now();
-          let next = prev;
-
-          for (const event of deltaEvents) {
-            if (event.type !== 'delta') continue;
-            const delta = event.delta;
-            if (delta.type === 'updated' && !next.has(delta.taskId)) {
-              if (traceTaskDeltas) {
-                console.warn(
-                  `[useTasks:task-delta] updated for taskId=${delta.taskId} not in local map before merge (stale snapshot?)`,
-                );
-              }
-            }
-            next = applyDelta(next, delta);
-            if (
-              delta.type === 'created' &&
-              delta.task?.config.workflowId &&
-              !workflowsRef.current.has(delta.task.config.workflowId)
-            ) {
-              shouldRefreshWorkflows = true;
+        for (const event of deltaEvents) {
+          if (event.type !== 'delta') continue;
+          const delta = event.delta;
+          if (delta.type === 'updated' && !nextTasks.has(delta.taskId)) {
+            if (traceTaskDeltas) {
+              console.warn(
+                `[useTasks:task-delta] updated for taskId=${delta.taskId} not in local map before merge (stale snapshot?)`,
+              );
             }
           }
+          if (
+            delta.type === 'created' &&
+            delta.task?.config.workflowId &&
+            !nextWorkflows.has(delta.task.config.workflowId)
+          ) {
+            shouldRefreshWorkflows = true;
+          }
+          nextTasks = applyDelta(nextTasks, delta);
+          nextWorkflows = applyWorkflowRollupPatches(nextWorkflows, event.workflowRollups);
+        }
 
-          const dt = performance.now() - t0;
-          deltaPerfRef.current.applyCount += effectiveBatch.length;
-          deltaPerfRef.current.applyTotalMs += dt;
-          deltaPerfRef.current.applyMaxMs = Math.max(deltaPerfRef.current.applyMaxMs, dt);
-          return next;
-        });
+        const dt = performance.now() - t0;
+        deltaPerfRef.current.applyCount += effectiveBatch.length;
+        deltaPerfRef.current.applyTotalMs += dt;
+        deltaPerfRef.current.applyMaxMs = Math.max(deltaPerfRef.current.applyMaxMs, dt);
+        tasksRef.current = nextTasks;
+        workflowsRef.current = nextWorkflows;
+        setTasks(nextTasks);
+        setWorkflows(nextWorkflows);
         if (shouldRefreshWorkflows) {
           void refreshWorkflowMetadata();
         }
@@ -353,15 +389,14 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     const unsubWf = window.invoker.onWorkflowsChanged?.((wfList: any[]) => {
       invalidateStartupSnapshot();
       if (Array.isArray(wfList)) {
-        setWorkflows(() => {
-          const wfMap = new Map<string, WorkflowMeta>();
-          for (const wf of wfList) {
-            wfMap.set(wf.id, {
-              ...wf,
-              status: normalizeWorkflowStatus((wf as { status?: string }).status),
-            });
-          }
-          return wfMap;
+        setWorkflows((previous) => {
+          const nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(
+            previous,
+            wfList,
+            tasksRef.current,
+          );
+          workflowsRef.current = nextWorkflows;
+          return nextWorkflows;
         });
       }
     });

--- a/packages/ui/src/lib/workflow-graph.test.ts
+++ b/packages/ui/src/lib/workflow-graph.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { TaskState, WorkflowMeta } from '../types.js';
+import type { WorkflowMeta } from '../types.js';
 import { deriveWorkflowGraph, layoutWorkflowGraph, type WorkflowGraph } from './workflow-graph.js';
 
 function makeWorkflow(
@@ -21,17 +21,6 @@ function makeWorkflow(
   };
 }
 
-function makeTask(id: string, workflowId: string): TaskState {
-  return {
-    id,
-    description: id,
-    status: 'pending',
-    dependencies: [],
-    config: { workflowId },
-    execution: {},
-    taskStateVersion: 1,
-  };
-}
 
 describe('deriveWorkflowGraph', () => {
   it('derives linear stack edges', () => {
@@ -40,12 +29,8 @@ describe('deriveWorkflowGraph', () => {
       ['B', makeWorkflow('B', 'running', undefined, [{ workflowId: 'A' }])],
       ['C', makeWorkflow('C', 'running', undefined, [{ workflowId: 'B' }])],
     ]);
-    const tasks = new Map<string, TaskState>([
-      ['b1', makeTask('b1', 'B')],
-      ['c1', makeTask('c1', 'C')],
-    ]);
 
-    const graph = deriveWorkflowGraph(workflows, tasks);
+    const graph = deriveWorkflowGraph(workflows);
     expect(graph.edges).toEqual([
       { source: 'A', target: 'B', kind: 'active' },
       { source: 'B', target: 'C', kind: 'active' },
@@ -59,13 +44,8 @@ describe('deriveWorkflowGraph', () => {
       ['C', makeWorkflow('C', 'running', undefined, [{ workflowId: 'A' }])],
       ['D', makeWorkflow('D', 'running', undefined, [{ workflowId: 'B' }, { workflowId: 'C' }])],
     ]);
-    const tasks = new Map<string, TaskState>([
-      ['b1', makeTask('b1', 'B')],
-      ['c1', makeTask('c1', 'C')],
-      ['d1', makeTask('d1', 'D')],
-    ]);
 
-    const graph = deriveWorkflowGraph(workflows, tasks);
+    const graph = deriveWorkflowGraph(workflows);
     expect(graph.edges).toEqual([
       { source: 'A', target: 'B', kind: 'active' },
       { source: 'A', target: 'C', kind: 'active' },
@@ -78,11 +58,8 @@ describe('deriveWorkflowGraph', () => {
     const workflows = new Map([
       ['B', makeWorkflow('B', 'running', undefined, [{ workflowId: 'missing' }])],
     ]);
-    const tasks = new Map<string, TaskState>([
-      ['b1', makeTask('b1', 'B')],
-    ]);
 
-    const graph = deriveWorkflowGraph(workflows, tasks);
+    const graph = deriveWorkflowGraph(workflows);
     expect(graph.edges).toEqual([]);
     expect(graph.missingDependencies).toEqual(['missing->B']);
   });
@@ -93,21 +70,14 @@ describe('deriveWorkflowGraph', () => {
       ['B', makeWorkflow('B')],
     ]);
 
-    const graph = deriveWorkflowGraph(workflows, new Map());
+    const graph = deriveWorkflowGraph(workflows);
     expect(graph.nodes.map((node) => node.id)).toEqual(['A', 'B']);
     expect(graph.edges).toEqual([]);
   });
 
-  it('keeps workflow nodes visible from tasks when metadata is temporarily missing', () => {
-    const tasks = new Map<string, TaskState>([
-      ['wf-a/task-a', makeTask('wf-a/task-a', 'wf-a')],
-      ['wf-a/task-b', { ...makeTask('wf-a/task-b', 'wf-a'), status: 'failed' }],
-    ]);
-
-    const graph = deriveWorkflowGraph(new Map(), tasks);
-    expect(graph.nodes).toHaveLength(1);
-    expect(graph.nodes[0].id).toBe('wf-a');
-    expect(graph.nodes[0].workflow.status).toBe('failed');
+  it('does not create fallback workflow nodes from task-only state', () => {
+    const graph = deriveWorkflowGraph(new Map());
+    expect(graph.nodes).toEqual([]);
     expect(graph.edges).toEqual([]);
   });
 
@@ -130,7 +100,7 @@ describe('deriveWorkflowGraph', () => {
       ],
     ]);
 
-    const graph = deriveWorkflowGraph(workflows, new Map());
+    const graph = deriveWorkflowGraph(workflows);
 
     expect(graph.edges).toEqual([
       { source: 'A', target: 'B', kind: 'historical' },
@@ -154,7 +124,7 @@ describe('deriveWorkflowGraph', () => {
       ],
     ]);
 
-    const graph = deriveWorkflowGraph(workflows, new Map());
+    const graph = deriveWorkflowGraph(workflows);
 
     expect(graph.edges).toEqual([
       { source: 'A', target: 'B', kind: 'detached' },
@@ -181,7 +151,7 @@ describe('deriveWorkflowGraph', () => {
       ],
     ]);
 
-    const graph = deriveWorkflowGraph(workflows, new Map());
+    const graph = deriveWorkflowGraph(workflows);
 
     expect(graph.edges).toEqual([
       { source: 'A', target: 'B', kind: 'active' },
@@ -213,7 +183,7 @@ describe('deriveWorkflowGraph', () => {
       ],
     ]);
 
-    const graph = deriveWorkflowGraph(workflows, new Map());
+    const graph = deriveWorkflowGraph(workflows);
 
     expect(graph.edges).toEqual([
       { source: 'A', target: 'B', kind: 'detached' },
@@ -240,7 +210,7 @@ describe('deriveWorkflowGraph', () => {
       ],
     ]);
 
-    const graph = deriveWorkflowGraph(workflows, new Map());
+    const graph = deriveWorkflowGraph(workflows);
 
     expect(graph.edges).toEqual([
       { source: 'A', target: 'B', kind: 'active' },
@@ -266,7 +236,7 @@ describe('deriveWorkflowGraph', () => {
       ['C', makeWorkflow('C')],
     ]);
 
-    const graph = deriveWorkflowGraph(workflows, new Map());
+    const graph = deriveWorkflowGraph(workflows);
 
     expect(graph.edges).toEqual([
       { source: 'A', target: 'B', kind: 'historical' },

--- a/packages/ui/src/lib/workflow-graph.ts
+++ b/packages/ui/src/lib/workflow-graph.ts
@@ -1,5 +1,4 @@
-import { computeWorkflowRollupFromSummaries } from '@invoker/workflow-graph';
-import type { TaskState, WorkflowMeta } from '../types.js';
+import type { WorkflowMeta } from '../types.js';
 
 export interface WorkflowGraphNode {
   id: string;
@@ -26,39 +25,8 @@ export interface WorkflowPosition {
 
 export function deriveWorkflowGraph(
   workflows: Map<string, WorkflowMeta>,
-  tasks: Map<string, TaskState>,
 ): WorkflowGraph {
-  const workflowNodes = new Map(workflows);
-  const fallbackTasksByWorkflow = new Map<string, TaskState[]>();
-
-  for (const task of tasks.values()) {
-    const workflowId = task.config.workflowId;
-    if (!workflowId || workflowNodes.has(workflowId)) continue;
-    const workflowTasks = fallbackTasksByWorkflow.get(workflowId);
-    if (workflowTasks) {
-      workflowTasks.push(task);
-    } else {
-      fallbackTasksByWorkflow.set(workflowId, [task]);
-    }
-  }
-
-  for (const [workflowId, workflowTasks] of fallbackTasksByWorkflow) {
-    const rollup = computeWorkflowRollupFromSummaries(workflowTasks.map((task) => ({
-      id: task.id,
-      description: task.description,
-      status: task.status,
-      dependencies: task.dependencies,
-      execution: task.execution,
-    })));
-    workflowNodes.set(workflowId, {
-      id: workflowId,
-      name: workflowId,
-      status: rollup.status,
-      rollup,
-    });
-  }
-
-  const nodes: WorkflowGraphNode[] = [...workflowNodes.values()].map((workflow) => ({
+  const nodes: WorkflowGraphNode[] = [...workflows.values()].map((workflow) => ({
     id: workflow.id,
     name: workflow.name,
     workflow,
@@ -68,11 +36,11 @@ export function deriveWorkflowGraph(
   const edges: WorkflowGraphEdge[] = [];
   const missingDependencies = new Set<string>();
 
-  for (const workflow of workflowNodes.values()) {
+  for (const workflow of workflows.values()) {
     const targetWorkflowId = workflow.id;
     for (const dep of workflow.externalDependencies ?? []) {
       const sourceWorkflowId = dep.workflowId;
-      if (!workflowNodes.has(sourceWorkflowId)) {
+      if (!workflows.has(sourceWorkflowId)) {
         missingDependencies.add(`${sourceWorkflowId}->${targetWorkflowId}`);
         continue;
       }
@@ -93,7 +61,7 @@ export function deriveWorkflowGraph(
       for (const dependency of [change.before, change.after]) {
         if (!dependency) continue;
         const sourceWorkflowId = dependency.workflowId;
-        if (!workflowNodes.has(sourceWorkflowId)) {
+        if (!workflows.has(sourceWorkflowId)) {
           missingDependencies.add(`${sourceWorkflowId}->${targetWorkflowId}`);
           continue;
         }

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -188,10 +188,17 @@ export interface WorkflowMeta {
   createdAt?: string;
   updatedAt?: string;
 }
+export interface WorkflowRollupPatch {
+  readonly workflowId: string;
+  readonly status: WorkflowStatus;
+  readonly rollup: WorkflowRollup;
+}
+
 export type TaskGraphEvent =
   | {
       readonly type: 'delta';
       readonly delta: TaskDelta;
+      readonly workflowRollups: readonly WorkflowRollupPatch[];
     }
   | {
       readonly type: 'snapshot';


### PR DESCRIPTION
## Summary

The UI now treats backend workflow rollup patches as the source of truth for workflow status.

Before this, the renderer rebuilt workflow status from local task maps and could synthesize fallback workflow nodes during metadata gaps.

Now workflow cards, filters, and graph state all read the backend-published workflow status and preserve existing metadata when task-backed workflows briefly disappear from metadata refreshes.

<details>
<summary>Review metadata</summary>

Review Claim: Renderer workflow state now follows backend rollup patches instead of local workflow-status recomputation.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice stays in the renderer. It does not change owner publishing logic or persistence writes.

Slice Rationale: Once the owner publishes workflow patches, the renderer adoption is the next isolated user-facing slice before the extra running-task label.

</details>

## Non-goals

- Adding the running-task secondary line to workflow cards.
- Changing task execution or persistence behavior.
- Adding new workflow actions.

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/workflow-graph.test.tsx src/__tests__/selected-workflow-graph-disappears-repro.test.tsx --reporter=verbose`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && CAPTURE_MODE=after pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts -g "workflow-live-rollup-update|workflow-running-task-secondary-line"`

## Visual Proof

![Live workflow rollup update](packages/app/e2e/visual-proof/after/workflow-live-rollup-update.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #1744