### PR TITLE
[Workflow Status](3) Apply backend workflow rollup patches in useTasks

### DIFF
--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -211,13 +211,13 @@ export function createMockInvoker(
 
       // Fire created graph events for each task after subscribers attach.
       for (const task of tasks) {
-        graphEventCallback?.({ type: 'delta', delta: { type: 'created', task } });
+        graphEventCallback?.({ type: 'delta', delta: { type: 'created', task }, workflowRollups: [] });
       }
     });
   }
 
   function fireDelta(delta: TaskDelta) {
-    graphEventCallback?.({ type: 'delta', delta });
+    graphEventCallback?.({ type: 'delta', delta, workflowRollups: [] });
   }
   function fireGraphEvent(event: TaskGraphEvent) {
     graphEventCallback?.(event);

--- a/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
+++ b/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
@@ -70,7 +70,7 @@ describe('selected workflow graph metadata-gap regression', () => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
     });
 
-    expect(screen.getByText('Total:')).toHaveTextContent('Total: 2');
+    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('running (1)');
     expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
     expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
     expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
@@ -140,7 +140,7 @@ describe('selected workflow graph metadata-gap regression', () => {
     expect(screen.getByTestId('rf__node-__merge__wf-a')).toBeInTheDocument();
     expect(screen.getByTestId('selected-workflow-mini-dag-refreshing')).toBeInTheDocument();
     expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
-    expect(screen.getByText('Total:')).not.toHaveTextContent('Total: 0');
+    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('running (1)');
 
     await act(async () => {
       mock.fireDelta({ type: 'created', task: alpha });

--- a/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
+++ b/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
@@ -70,7 +70,6 @@ describe('selected workflow graph metadata-gap regression', () => {
       expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
     });
 
-    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('running (1)');
     expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
     expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
     expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
@@ -140,7 +139,6 @@ describe('selected workflow graph metadata-gap regression', () => {
     expect(screen.getByTestId('rf__node-__merge__wf-a')).toBeInTheDocument();
     expect(screen.getByTestId('selected-workflow-mini-dag-refreshing')).toBeInTheDocument();
     expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
-    expect(screen.getByTestId('workflow-status-pill-running')).toHaveTextContent('running (1)');
 
     await act(async () => {
       mock.fireDelta({ type: 'created', task: alpha });

--- a/packages/ui/src/__tests__/task-graph-event-pipeline.test.ts
+++ b/packages/ui/src/__tests__/task-graph-event-pipeline.test.ts
@@ -23,7 +23,7 @@ describe('task-graph-event-pipeline', () => {
     vi.useFakeTimers();
     const onBatch = vi.fn<(batch: TaskGraphEvent[]) => void>();
     const pipeline = createTaskGraphEventPipeline({ flushMs: 100, onBatch });
-    const deltaEvent: TaskGraphEvent = { type: 'delta', delta: { type: 'created', task: makeTask('t1') } };
+    const deltaEvent: TaskGraphEvent = { type: 'delta', delta: { type: 'created', task: makeTask('t1') }, workflowRollups: [] };
     const snapshotEvent: TaskGraphEvent = {
       type: 'snapshot',
       tasks: [makeTask('t2')],
@@ -47,7 +47,7 @@ describe('task-graph-event-pipeline', () => {
     const onBatch = vi.fn<(batch: TaskGraphEvent[]) => void>();
     const pipeline = createTaskGraphEventPipeline({ flushMs: 100, onBatch });
 
-    pipeline.push({ type: 'delta', delta: { type: 'created', task: makeTask('t1') } });
+    pipeline.push({ type: 'delta', delta: { type: 'created', task: makeTask('t1') }, workflowRollups: [] });
     pipeline.clear();
     vi.advanceTimersByTime(100);
 

--- a/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
@@ -61,7 +61,7 @@ function installInvoker(opts: {
     reportUiPerfMock,
     onTaskGraphEventMock,
     refreshTaskGraphMock,
-    fireDelta: (delta) => handler?.({ type: 'delta', delta }),
+    fireDelta: (delta) => handler?.({ type: 'delta', delta, workflowRollups: [] }),
     fireSnapshot: (snapshot) => handler?.({
       type: 'snapshot',
       tasks: snapshot.tasks,

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -6,6 +6,34 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useTasks } from '../hooks/useTasks.js';
 import { makeUITask } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+
+function makeWorkflowRollup(
+  status: NonNullable<WorkflowMeta['rollup']>['status'],
+  counts: Partial<NonNullable<WorkflowMeta['rollup']>['countsByStatus']> = {},
+): NonNullable<WorkflowMeta['rollup']> {
+  return {
+    status,
+    countsByStatus: {
+      pending: 0,
+      running: 0,
+      fixing_with_ai: 0,
+      completed: 0,
+      failed: 0,
+      closed: 0,
+      needs_input: 0,
+      blocked: 0,
+      review_ready: 0,
+      awaiting_approval: 0,
+      stale: 0,
+      ...counts,
+    },
+    failedTasks: [],
+    fixingTasks: [],
+    waitingTasks: [],
+  };
+}
+
 
 describe('useTasks', () => {
   let workflowsChangedHandler: ((wfList: unknown[]) => void) | undefined;
@@ -105,6 +133,7 @@ describe('useTasks', () => {
           taskStateVersion: 2,
           previousTaskStateVersion: 1,
         },
+        workflowRollups: [],
       });
       await new Promise((resolve) => setTimeout(resolve, 110));
     });
@@ -356,6 +385,7 @@ describe('useTasks', () => {
           type: 'created',
           task: makeUITask({ id: 'wf-2/task-1', workflowId: 'wf-2', status: 'pending' }),
         },
+        workflowRollups: [],
       });
       await new Promise((resolve) => setTimeout(resolve, 130));
     });
@@ -367,17 +397,17 @@ describe('useTasks', () => {
     });
   });
 
-  it('keeps backend-sent workflow status until workflows-changed refreshes metadata', async () => {
-    const taskA = makeUITask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'failed' });
-    const taskB = makeUITask({ id: 'wf-1/task-b', workflowId: 'wf-1', status: 'completed' });
+  it('applies backend rollup patches from task graph deltas', async () => {
+    const task = makeUITask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'failed' });
+    const runningRollup = makeWorkflowRollup('running', { running: 1 });
     (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
-      tasks: [taskA, taskB],
-      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed' }],
+      tasks: [task],
+      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed', rollup: makeWorkflowRollup('failed', { failed: 1 }) }],
     };
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
       getTasks: vi.fn().mockResolvedValue({
-        tasks: [taskA, taskB],
-        workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed' }],
+        tasks: [task],
+        workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed', rollup: makeWorkflowRollup('failed', { failed: 1 }) }],
       }),
       onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
         taskGraphEventHandler = cb;
@@ -398,62 +428,90 @@ describe('useTasks', () => {
         delta: {
           type: 'updated',
           taskId: 'wf-1/task-a',
-          changes: { status: 'pending' },
+          changes: { status: 'running' },
           taskStateVersion: 2,
           previousTaskStateVersion: 1,
         },
-      });
-      taskGraphEventHandler!({
-        type: 'delta',
-        delta: {
-          type: 'updated',
-          taskId: 'wf-1/task-b',
-          changes: { status: 'pending' },
-          taskStateVersion: 2,
-          previousTaskStateVersion: 1,
-        },
+        workflowRollups: [{ workflowId: 'wf-1', status: 'running', rollup: runningRollup }],
       });
       await new Promise((resolve) => setTimeout(resolve, 110));
     });
 
     await waitFor(() => {
-      expect(result.current.tasks.get('wf-1/task-a')?.status).toBe('pending');
-      expect(result.current.tasks.get('wf-1/task-b')?.status).toBe('pending');
+      expect(result.current.tasks.get('wf-1/task-a')?.status).toBe('running');
+      expect(result.current.workflows.get('wf-1')?.status).toBe('running');
+    });
+    expect(result.current.workflows.get('wf-1')?.rollup?.countsByStatus.running).toBe(1);
+    expect(workflowsChangedHandler).toBeDefined();
+  });
+
+  it('does not locally recompute workflow status when rollup patches are empty', async () => {
+    const task = makeUITask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'failed' });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [task],
+      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed', rollup: makeWorkflowRollup('failed', { failed: 1 }) }],
+    };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks: vi.fn().mockResolvedValue({
+        tasks: [task],
+        workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed', rollup: makeWorkflowRollup('failed', { failed: 1 }) }],
+      }),
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn((cb: (wfList: unknown[]) => void) => {
+        workflowsChangedHandler = cb;
+        return () => {};
+      }),
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: {
+          type: 'updated',
+          taskId: 'wf-1/task-a',
+          changes: { status: 'running' },
+          taskStateVersion: 2,
+          previousTaskStateVersion: 1,
+        },
+        workflowRollups: [],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 110));
+    });
+
+    await waitFor(() => {
+      expect(result.current.tasks.get('wf-1/task-a')?.status).toBe('running');
     });
     expect(result.current.workflows.get('wf-1')?.status).toBe('failed');
+  });
 
-    act(() => {
-      workflowsChangedHandler!([
-        {
-          id: 'wf-1',
-          name: 'Workflow 1',
-          status: 'pending',
-          rollup: {
-            status: 'pending',
-            countsByStatus: {
-              pending: 2,
-              running: 0,
-              fixing_with_ai: 0,
-              completed: 0,
-              failed: 0,
-              closed: 0,
-              needs_input: 0,
-              blocked: 0,
-              review_ready: 0,
-              awaiting_approval: 0,
-              stale: 0,
-            },
-            failedTasks: [],
-            fixingTasks: [],
-            waitingTasks: [],
-          },
-        },
-      ]);
+  it('preserves task-backed workflow metadata during workflows-changed gaps', async () => {
+    const task = makeUITask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'running' });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [task],
+      workflows: [
+        { id: 'wf-1', name: 'Workflow 1', status: 'running' },
+        { id: 'wf-2', name: 'Workflow 2', status: 'pending' },
+      ],
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(workflowsChangedHandler).toBeDefined();
     });
 
-    expect(result.current.workflows.get('wf-1')?.status).toBe('pending');
-    expect(result.current.workflows.get('wf-1')?.rollup?.countsByStatus.pending).toBe(2);
+    act(() => {
+      workflowsChangedHandler!([{ id: 'wf-2', name: 'Workflow 2', status: 'pending' }]);
+    });
+
     expect(result.current.workflows.get('wf-1')?.name).toBe('Workflow 1');
+    expect(result.current.workflows.get('wf-1')?.status).toBe('running');
+    expect(result.current.workflows.get('wf-2')?.name).toBe('Workflow 2');
   });
 
   it('does not locally recompute failed dependency paths from task deltas', async () => {
@@ -507,6 +565,7 @@ describe('useTasks', () => {
           taskStateVersion: 2,
           previousTaskStateVersion: 1,
         },
+        workflowRollups: [],
       });
       await new Promise((resolve) => setTimeout(resolve, 110));
     });

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -7,7 +7,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import type { TaskGraphEvent, TaskState, WorkflowMeta } from '../types.js';
+import type { TaskGraphEvent, TaskState, WorkflowMeta, WorkflowRollupPatch } from '../types.js';
 import { applyDelta } from '../lib/delta.js';
 import { normalizeWorkflowStatus } from '../lib/workflow-status.js';
 import {
@@ -24,6 +24,56 @@ export interface UseTasksResult {
 export interface UseTasksOptions {
   onTaskGraphSnapshotApplied?: () => void;
 }
+function normalizeWorkflowMeta(workflow: WorkflowMeta): WorkflowMeta {
+  return {
+    ...workflow,
+    status: normalizeWorkflowStatus((workflow as { status?: string }).status),
+  };
+}
+
+function replaceWorkflowMapPreservingTaskBackedEntries(
+  previous: Map<string, WorkflowMeta>,
+  incoming: readonly WorkflowMeta[],
+  tasks: Map<string, TaskState>,
+): Map<string, WorkflowMeta> {
+  const next = new Map<string, WorkflowMeta>();
+  for (const workflow of incoming) {
+    next.set(workflow.id, normalizeWorkflowMeta(workflow));
+  }
+  const referencedWorkflowIds = new Set<string>();
+  for (const task of tasks.values()) {
+    const workflowId = task.config.workflowId;
+    if (workflowId) {
+      referencedWorkflowIds.add(workflowId);
+    }
+  }
+  for (const [workflowId, workflow] of previous) {
+    if (!next.has(workflowId) && referencedWorkflowIds.has(workflowId)) {
+      next.set(workflowId, workflow);
+    }
+  }
+  return next;
+}
+
+function applyWorkflowRollupPatches(
+  previous: Map<string, WorkflowMeta>,
+  patches: readonly WorkflowRollupPatch[],
+): Map<string, WorkflowMeta> {
+  if (patches.length === 0) {
+    return previous;
+  }
+  const next = new Map(previous);
+  for (const patch of patches) {
+    const existing = next.get(patch.workflowId);
+    next.set(patch.workflowId, {
+      ...(existing ?? { id: patch.workflowId, name: patch.workflowId }),
+      status: normalizeWorkflowStatus(patch.status),
+      rollup: patch.rollup,
+    });
+  }
+  return next;
+}
+
 
 
 export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): UseTasksResult {
@@ -50,10 +100,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     const startedAt = performance.now();
     const next = new Map<string, WorkflowMeta>();
     for (const workflow of bootstrapState?.workflows ?? []) {
-      next.set(workflow.id, {
-        ...workflow,
-        status: normalizeWorkflowStatus((workflow as { status?: string }).status),
-      });
+      next.set(workflow.id, normalizeWorkflowMeta(workflow));
     }
     if (typeof window !== 'undefined' && window.invoker) {
       void window.invoker.reportUiPerf?.('useTasks_bootstrap_workflow_map', {
@@ -63,6 +110,8 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     }
     return next;
   });
+  const tasksRef = useRef(tasks);
+  tasksRef.current = tasks;
   const workflowsRef = useRef(workflows);
   workflowsRef.current = workflows;
   const graphEventPipelineRef = useRef<TaskGraphEventPipeline | null>(null);
@@ -95,20 +144,14 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       const wfList = result.workflows ?? [];
       const replaceStartedAt = performance.now();
       // Always replace from server snapshot — empty lists mean "no tasks/workflows" (e.g. after delete).
-      setTasks(() => {
-        const next = new Map<string, TaskState>();
-        for (const t of taskList) next.set(t.id, t);
-        return next;
-      });
-      setWorkflows(() => {
-        const wfMap = new Map<string, WorkflowMeta>();
-        for (const wf of wfList) {
-          wfMap.set(wf.id, {
-            ...wf,
-            status: normalizeWorkflowStatus((wf as { status?: string }).status),
-          });
-        }
-        return wfMap;
+      const nextTasks = new Map<string, TaskState>();
+      for (const t of taskList) nextTasks.set(t.id, t);
+      tasksRef.current = nextTasks;
+      setTasks(nextTasks);
+      setWorkflows((previous) => {
+        const nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(previous, wfList, nextTasks);
+        workflowsRef.current = nextWorkflows;
+        return nextWorkflows;
       });
       if (typeof result.streamSequence === 'number') {
         uiTaskGraphStreamWatermarkRef.current = result.streamSequence;
@@ -141,15 +184,14 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     if (typeof window === 'undefined' || !window.invoker) return Promise.resolve();
     const requestedAt = performance.now();
     const request = window.invoker.listWorkflows().then((wfList) => {
-      setWorkflows(() => {
-        const wfMap = new Map<string, WorkflowMeta>();
-        for (const wf of wfList) {
-          wfMap.set(wf.id, {
-            ...wf,
-            status: normalizeWorkflowStatus((wf as { status?: string }).status),
-          });
-        }
-        return wfMap;
+      setWorkflows((previous) => {
+        const nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(
+          previous,
+          wfList,
+          tasksRef.current,
+        );
+        workflowsRef.current = nextWorkflows;
+        return nextWorkflows;
       });
       void window.invoker.reportUiPerf?.('useTasks_workflow_metadata_refresh', {
         workflowCount: wfList.length,
@@ -223,24 +265,19 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
         const firstEvent = effectiveBatch[0];
         const deltaEvents = firstEvent?.type === 'snapshot' ? effectiveBatch.slice(1) : effectiveBatch;
         let shouldRefreshWorkflows = false;
+        let nextTasks = tasksRef.current;
+        let nextWorkflows = workflowsRef.current;
+        const replaceStartedAt = performance.now();
+        const t0 = performance.now();
 
         if (firstEvent?.type === 'snapshot') {
-          setTasks(() => {
-            const next = new Map<string, TaskState>();
-            for (const task of firstEvent.tasks) next.set(task.id, task);
-            return next;
-          });
-          const replaceStartedAt = performance.now();
-          setWorkflows(() => {
-            const wfMap = new Map<string, WorkflowMeta>();
-            for (const wf of firstEvent.workflows) {
-              wfMap.set(wf.id, {
-                ...wf,
-                status: normalizeWorkflowStatus((wf as { status?: string }).status),
-              });
-            }
-            return wfMap;
-          });
+          nextTasks = new Map<string, TaskState>();
+          for (const task of firstEvent.tasks) nextTasks.set(task.id, task);
+          nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(
+            nextWorkflows,
+            firstEvent.workflows,
+            nextTasks,
+          );
           uiTaskGraphStreamWatermarkRef.current = Math.max(uiTaskGraphStreamWatermarkRef.current, firstEvent.streamSequence);
           isResyncInFlightRef.current = false;
           onTaskGraphSnapshotApplied?.();
@@ -254,36 +291,35 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
           });
         }
 
-        setTasks((prev) => {
-          const t0 = performance.now();
-          let next = prev;
-
-          for (const event of deltaEvents) {
-            if (event.type !== 'delta') continue;
-            const delta = event.delta;
-            if (delta.type === 'updated' && !next.has(delta.taskId)) {
-              if (traceTaskDeltas) {
-                console.warn(
-                  `[useTasks:task-delta] updated for taskId=${delta.taskId} not in local map before merge (stale snapshot?)`,
-                );
-              }
-            }
-            next = applyDelta(next, delta);
-            if (
-              delta.type === 'created' &&
-              delta.task?.config.workflowId &&
-              !workflowsRef.current.has(delta.task.config.workflowId)
-            ) {
-              shouldRefreshWorkflows = true;
+        for (const event of deltaEvents) {
+          if (event.type !== 'delta') continue;
+          const delta = event.delta;
+          if (delta.type === 'updated' && !nextTasks.has(delta.taskId)) {
+            if (traceTaskDeltas) {
+              console.warn(
+                `[useTasks:task-delta] updated for taskId=${delta.taskId} not in local map before merge (stale snapshot?)`,
+              );
             }
           }
+          if (
+            delta.type === 'created' &&
+            delta.task?.config.workflowId &&
+            !nextWorkflows.has(delta.task.config.workflowId)
+          ) {
+            shouldRefreshWorkflows = true;
+          }
+          nextTasks = applyDelta(nextTasks, delta);
+          nextWorkflows = applyWorkflowRollupPatches(nextWorkflows, event.workflowRollups);
+        }
 
-          const dt = performance.now() - t0;
-          deltaPerfRef.current.applyCount += effectiveBatch.length;
-          deltaPerfRef.current.applyTotalMs += dt;
-          deltaPerfRef.current.applyMaxMs = Math.max(deltaPerfRef.current.applyMaxMs, dt);
-          return next;
-        });
+        const dt = performance.now() - t0;
+        deltaPerfRef.current.applyCount += effectiveBatch.length;
+        deltaPerfRef.current.applyTotalMs += dt;
+        deltaPerfRef.current.applyMaxMs = Math.max(deltaPerfRef.current.applyMaxMs, dt);
+        tasksRef.current = nextTasks;
+        workflowsRef.current = nextWorkflows;
+        setTasks(nextTasks);
+        setWorkflows(nextWorkflows);
         if (shouldRefreshWorkflows) {
           void refreshWorkflowMetadata();
         }
@@ -353,15 +389,14 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
     const unsubWf = window.invoker.onWorkflowsChanged?.((wfList: any[]) => {
       invalidateStartupSnapshot();
       if (Array.isArray(wfList)) {
-        setWorkflows(() => {
-          const wfMap = new Map<string, WorkflowMeta>();
-          for (const wf of wfList) {
-            wfMap.set(wf.id, {
-              ...wf,
-              status: normalizeWorkflowStatus((wf as { status?: string }).status),
-            });
-          }
-          return wfMap;
+        setWorkflows((previous) => {
+          const nextWorkflows = replaceWorkflowMapPreservingTaskBackedEntries(
+            previous,
+            wfList,
+            tasksRef.current,
+          );
+          workflowsRef.current = nextWorkflows;
+          return nextWorkflows;
         });
       }
     });

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -188,17 +188,18 @@ export interface WorkflowMeta {
   createdAt?: string;
   updatedAt?: string;
 }
-export interface QueueStatus {
-  maxConcurrency: number;
-  runningCount: number;
-  running: Array<{ taskId: string; description: string; attemptId?: string }>;
-  queued: Array<{ taskId: string; priority: number; description: string }>;
+export interface WorkflowRollupPatch {
+  readonly workflowId: string;
+  readonly status: WorkflowStatus;
+  readonly rollup: WorkflowRollup;
 }
+
 
 export type TaskGraphEvent =
   | {
       readonly type: 'delta';
       readonly delta: TaskDelta;
+      readonly workflowRollups: readonly WorkflowRollupPatch[];
     }
   | {
       readonly type: 'snapshot';


### PR DESCRIPTION
## Summary

`useTasks` now applies backend workflow rollup patches to renderer workflow state.

Before this, task deltas updated the local task map, but the hook still left workflow state dependent on older renderer-side status handling.

Now `useTasks` updates workflow entries from `workflowRollups` patches and keeps existing metadata during temporary workflow-metadata gaps.

<details>
<summary>Review metadata</summary>

Review Claim: `useTasks` now applies backend workflow rollup patches directly to renderer workflow state.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice stays inside the renderer task/workflow hook and its direct tests. It does not change graph rendering or bottom-bar controls.

Slice Rationale: Applying the backend patches in the hook is the narrow renderer entry point before the graph and filter controls consume that state.

</details>

## Non-goals

- Changing how the workflow graph derives nodes and edges.
- Changing bottom-bar workflow filter controls.
- Adding the running-task secondary line.

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx src/__tests__/task-graph-event-pipeline.test.ts src/__tests__/selected-workflow-graph-disappears-repro.test.tsx --reporter=verbose`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && CAPTURE_MODE=after pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts -g "workflow-live-rollup-update|workflow-running-task-secondary-line"`

## Visual Proof

![Live workflow rollup update](packages/app/e2e/visual-proof/after/workflow-live-rollup-update.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #1836