### PR TITLE
[Multi PR Review Gate](3d) Close every current review artifact

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-facade.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-facade.test.ts
@@ -113,6 +113,19 @@ describe('WorkflowMutationFacade', () => {
       expect(result.runnable).toHaveLength(1);
       expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
+
+    it('closes the workflow review before task-scoped invalidation', async () => {
+      (deps.orchestrator.getTask as ReturnType<typeof vi.fn>).mockReturnValue(
+        makeTask({ id: 'task-a', config: { workflowId: 'wf-1' } }),
+      );
+
+      await facade.retryTask('task-a');
+
+      expect(deps.taskExecutor.closeWorkflowReview).toHaveBeenCalledWith('wf-1');
+      expect((deps.taskExecutor.closeWorkflowReview as any).mock.invocationCallOrder[0]).toBeLessThan(
+        (deps.commandService.retryTask as any).mock.invocationCallOrder[0],
+      );
+    });
   });
 
   describe('recreateTask', () => {
@@ -123,6 +136,19 @@ describe('WorkflowMutationFacade', () => {
       expect(result.started).toHaveLength(1);
       expect(result.runnable).toHaveLength(1);
       expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
+    });
+
+    it('closes the workflow review before task-scoped recreate', async () => {
+      (deps.orchestrator.getTask as ReturnType<typeof vi.fn>).mockReturnValue(
+        makeTask({ id: 'task-a', config: { workflowId: 'wf-1' } }),
+      );
+
+      await facade.recreateTask('task-a');
+
+      expect(deps.taskExecutor.closeWorkflowReview).toHaveBeenCalledWith('wf-1');
+      expect((deps.taskExecutor.closeWorkflowReview as any).mock.invocationCallOrder[0]).toBeLessThan(
+        (deps.commandService.recreateTask as any).mock.invocationCallOrder[0],
+      );
     });
   });
 
@@ -309,6 +335,15 @@ describe('WorkflowMutationFacade', () => {
       expect(deps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
       expect(result.started).toHaveLength(1);
     });
+
+    it('closes the workflow review before workflow-scoped recreate', async () => {
+      await facade.recreateWorkflow('wf-1');
+
+      expect(deps.taskExecutor.closeWorkflowReview).toHaveBeenCalledWith('wf-1');
+      expect((deps.taskExecutor.closeWorkflowReview as any).mock.invocationCallOrder[0]).toBeLessThan(
+        (deps.commandService.recreateWorkflow as any).mock.invocationCallOrder[0],
+      );
+    });
   });
 
   describe('retryWorkflow', () => {
@@ -336,6 +371,15 @@ describe('WorkflowMutationFacade', () => {
       expect(result.started).toHaveLength(1);
       expect(result.runnable).toHaveLength(1);
       expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
+    });
+
+    it('closes the workflow review before workflow-scoped invalidation', async () => {
+      await facade.retryWorkflow('wf-1');
+
+      expect(deps.taskExecutor.closeWorkflowReview).toHaveBeenCalledWith('wf-1');
+      expect((deps.taskExecutor.closeWorkflowReview as any).mock.invocationCallOrder[0]).toBeLessThan(
+        (deps.commandService.retryWorkflow as any).mock.invocationCallOrder[0],
+      );
     });
   });
 

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -151,6 +151,7 @@ export class WorkflowMutationFacade {
   }
 
   async retryTask(taskId: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = await this.runViaCommandService(
       (cs) => cs.retryTask(makeEnvelope('facade.retry-task', 'surface', 'task', { taskId })),
     );
@@ -158,6 +159,7 @@ export class WorkflowMutationFacade {
   }
 
   async recreateTask(taskId: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = await this.runViaCommandService(
       (cs) => cs.recreateTask(makeEnvelope('facade.recreate-task', 'surface', 'task', { taskId })),
     );
@@ -165,6 +167,7 @@ export class WorkflowMutationFacade {
   }
 
   async recreateDownstream(taskId: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = await this.runViaCommandService(
       (cs) => cs.recreateDownstream(makeEnvelope('facade.recreate-downstream', 'surface', 'task', { taskId })),
     );
@@ -175,6 +178,7 @@ export class WorkflowMutationFacade {
   }
 
   async selectExperiment(taskId: string, experimentId: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = sharedSelectExperiment(taskId, experimentId, {
       orchestrator: this.deps.orchestrator,
     });
@@ -182,6 +186,7 @@ export class WorkflowMutationFacade {
   }
 
   async selectExperiments(taskId: string, experimentIds: string[]): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = await sharedSelectExperiments(taskId, experimentIds, {
       orchestrator: this.deps.orchestrator,
       taskExecutor: this.deps.taskExecutor,
@@ -190,6 +195,7 @@ export class WorkflowMutationFacade {
   }
 
   async editTaskCommand(taskId: string, newCommand: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = sharedEditTaskCommand(taskId, newCommand, {
       orchestrator: this.deps.orchestrator,
     });
@@ -197,6 +203,7 @@ export class WorkflowMutationFacade {
   }
 
   async editTaskPrompt(taskId: string, newPrompt: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = sharedEditTaskPrompt(taskId, newPrompt, {
       orchestrator: this.deps.orchestrator,
     });
@@ -208,6 +215,7 @@ export class WorkflowMutationFacade {
     runnerKind: string,
     poolMemberId?: string,
   ): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = sharedEditTaskType(
       taskId,
       runnerKind,
@@ -218,6 +226,7 @@ export class WorkflowMutationFacade {
   }
 
   async editTaskAgent(taskId: string, agentName: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
     const started = sharedEditTaskAgent(taskId, agentName, {
       orchestrator: this.deps.orchestrator,
     });
@@ -272,6 +281,7 @@ export class WorkflowMutationFacade {
   // ── Workflow-scoped mutations ────────────────────────────
 
   async retryWorkflow(workflowId: string): Promise<MutationResult> {
+    await this.closeReviewForWorkflow(workflowId);
     const started = await this.runViaCommandService(
       (cs) => cs.retryWorkflow(makeEnvelope('facade.retry-workflow', 'surface', 'workflow', { workflowId })),
     );
@@ -279,6 +289,7 @@ export class WorkflowMutationFacade {
   }
 
   async recreateWorkflow(workflowId: string): Promise<MutationResult> {
+    await this.closeReviewForWorkflow(workflowId);
     const started = await this.runViaCommandService(
       (cs) => cs.recreateWorkflow(makeEnvelope('facade.recreate-workflow', 'surface', 'workflow', { workflowId })),
     );
@@ -286,18 +297,21 @@ export class WorkflowMutationFacade {
   }
 
   async recreateWorkflowFromFreshBase(workflowId: string): Promise<MutationResult> {
+    await this.closeReviewForWorkflow(workflowId);
     const started = await sharedRecreateWorkflowFromFreshBase(workflowId, this.actionDeps());
     return this.finalizeWithTopup(started, 'facade.recreate-from-fresh-base', { scopedWorkflowId: workflowId });
   }
 
   async rebaseRetry(target: string): Promise<MutationResult> {
     const workflowId = resolveWorkflowIdForRebaseTarget(target, this.actionDeps());
+    await this.closeReviewForWorkflow(workflowId);
     const started = await sharedRebaseRetry(target, this.actionDeps());
     return this.finalizeWithTopup(started, 'facade.rebase-retry', { scopedWorkflowId: workflowId });
   }
 
   async rebaseRecreate(target: string): Promise<MutationResult> {
     const workflowId = resolveWorkflowIdForRebaseTarget(target, this.actionDeps());
+    await this.closeReviewForWorkflow(workflowId);
     const started = await sharedRebaseRecreate(target, this.actionDeps());
     return this.finalizeWithTopup(started, 'facade.rebase-recreate', { scopedWorkflowId: workflowId });
   }
@@ -518,5 +532,14 @@ export class WorkflowMutationFacade {
       context,
       dispatchMode: this.deps.dispatchMode,
     });
+  }
+
+  private async closeReviewForWorkflow(workflowId: string | undefined): Promise<void> {
+    if (workflowId) await this.deps.taskExecutor.closeWorkflowReview?.(workflowId);
+  }
+
+  private async closeReviewForTask(taskId: string): Promise<void> {
+    const workflowId = this.deps.orchestrator.getTask(taskId)?.config.workflowId;
+    await this.closeReviewForWorkflow(workflowId);
   }
 }

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -113,6 +113,74 @@ afterEach(() => {
 });
 
 describe('TaskRunner', () => {
+  it('closes every current review gate artifact and continues after one close failure', async () => {
+    const logger = createMockLogger();
+    const closeReview = vi.fn()
+      .mockRejectedValueOnce(new Error('first close failed'))
+      .mockResolvedValue(undefined);
+    const tasks = [
+      makeTask({
+        id: '__merge__wf-1',
+        status: 'review_ready',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: {
+          workspacePath: '/tmp/review-workspace',
+          reviewGate: {
+            activeGeneration: 4,
+            completion: { required: 'all', status: 'approved' },
+            artifacts: [
+              { id: 'contracts', providerId: 'pr-1', required: true, status: 'open', generation: 4 },
+              { id: 'runtime', providerId: 'pr-2', required: true, status: 'approved', generation: 4 },
+              { id: 'old', providerId: 'pr-old', required: true, status: 'open', generation: 3 },
+              { id: 'discarded', providerId: 'pr-discarded', required: true, status: 'discarded', generation: 4 },
+              { id: 'local', required: true, status: 'open', generation: 4 },
+            ],
+          },
+        },
+      }),
+    ];
+    const runner = new TaskRunner({
+      orchestrator: { getAllTasks: () => tasks } as any,
+      persistence: {} as any,
+      executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+      mergeGateProvider: { closeReview } as any,
+      logger,
+      cwd: '/tmp/fallback',
+    });
+
+    await runner.closeWorkflowReview('wf-1');
+
+    expect(closeReview).toHaveBeenCalledTimes(2);
+    expect(closeReview).toHaveBeenNthCalledWith(1, { identifier: 'pr-1', cwd: '/tmp/review-workspace' });
+    expect(closeReview).toHaveBeenNthCalledWith(2, { identifier: 'pr-2', cwd: '/tmp/review-workspace' });
+    expect(logger.error).toHaveBeenCalledWith('[merge-gate] Failed to close review pr-1', { err: expect.any(Error) });
+  });
+
+  it('falls back to scalar review id when no review gate exists', async () => {
+    const closeReview = vi.fn().mockResolvedValue(undefined);
+    const tasks = [
+      makeTask({
+        id: '__merge__wf-1',
+        status: 'review_ready',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: {
+          reviewId: 'scalar-pr',
+          workspacePath: '/tmp/review-workspace',
+        },
+      }),
+    ];
+    const runner = new TaskRunner({
+      orchestrator: { getAllTasks: () => tasks } as any,
+      persistence: {} as any,
+      executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+      mergeGateProvider: { closeReview } as any,
+      cwd: '/tmp/fallback',
+    });
+
+    await runner.closeWorkflowReview('wf-1');
+
+    expect(closeReview).toHaveBeenCalledWith({ identifier: 'scalar-pr', cwd: '/tmp/review-workspace' });
+  });
   it('sends attemptId and executionGeneration in work requests and preserves them in responses', async () => {
     const handleWorkerResponse = vi.fn();
     let seenRequest: any;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -63,6 +63,10 @@ import { killProcessGroup, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 import { retryTransientGitHubCli } from './git-utils.js';
 
 export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-callbacks.js';
+type ReviewGateState = NonNullable<TaskState['execution']['reviewGate']>;
+type ReviewGateArtifact = ReviewGateState['artifacts'][number];
+type ReviewGateArtifactStatus = ReviewGateArtifact['status'];
+
 
 /** Keeps launch metadata fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). */
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -2395,21 +2399,129 @@ export class TaskRunner {
   }
 
   async closeWorkflowReview(workflowId: string): Promise<void> {
-    if (!this.mergeGateProvider?.closeReview) return;
+    const closeReview = this.mergeGateProvider?.closeReview?.bind(this.mergeGateProvider);
+    if (!closeReview) return;
     const getAllTasks = this.orchestrator.getAllTasks?.bind(this.orchestrator);
     if (!getAllTasks) return;
     const mergeTask = getAllTasks().find((task) =>
       task.config.workflowId === workflowId
       && task.config.isMergeNode
-      && !!task.execution.reviewId
+      && (!!task.execution.reviewGate || !!task.execution.reviewId)
     );
-    if (!mergeTask?.execution.reviewId) return;
+    if (!mergeTask) return;
 
-    await this.mergeGateProvider.closeReview({
-      identifier: mergeTask.execution.reviewId,
-      cwd: mergeTask.execution.workspacePath ?? this.cwd,
-    });
+    const identifiers = this.getCurrentClosableReviewIdentifiers(mergeTask);
+    const cwd = mergeTask.execution.workspacePath ?? this.cwd;
+    for (const identifier of identifiers) {
+      try {
+        await closeReview({ identifier, cwd });
+      } catch (err) {
+        this.logger.error(`[merge-gate] Failed to close review ${identifier}`, { err });
+      }
+    }
   }
+  private isCurrentReviewGateArtifact(gate: ReviewGateState, artifact: ReviewGateArtifact): boolean {
+    return artifact.generation === gate.activeGeneration
+      && artifact.status !== 'discarded'
+      && !artifact.discardedAt;
+  }
+
+  private getCurrentReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
+    const gate = task.execution.reviewGate;
+    if (!gate) {
+      if (!task.execution.reviewId) {
+        return [];
+      }
+      return [{
+        id: task.execution.reviewId,
+        providerId: task.execution.reviewId,
+        required: true,
+        status: 'open',
+        generation: task.execution.generation ?? 0,
+      }];
+    }
+
+    return gate.artifacts.filter((artifact) => this.isCurrentReviewGateArtifact(gate, artifact));
+  }
+
+  private getCurrentRequiredReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
+    return this.getCurrentReviewArtifacts(task).filter((artifact) => artifact.required && !!artifact.providerId);
+  }
+
+  private getCurrentClosableReviewIdentifiers(task: TaskState): string[] {
+    return this.getCurrentReviewArtifacts(task)
+      .flatMap((artifact) => (artifact.providerId ? [artifact.providerId] : []));
+  }
+
+  private mapReviewGateArtifactStatus(status: MergeGateApprovalStatus): ReviewGateArtifactStatus {
+    if (status.closed) return 'closed';
+    if (status.approved) return 'approved';
+    if (status.rejected) return 'changes_requested';
+    return 'open';
+  }
+
+  private reviewPollStillMatches(
+    before: TaskState,
+    current: TaskState | undefined,
+    providerId: string,
+  ): boolean {
+    if (!current) return false;
+    if (current.execution.selectedAttemptId !== before.execution.selectedAttemptId) return false;
+    if ((current.execution.generation ?? 0) !== (before.execution.generation ?? 0)) return false;
+
+    const beforeGate = before.execution.reviewGate;
+    if (!beforeGate) {
+      return !current.execution.reviewGate && current.execution.reviewId === providerId;
+    }
+
+    const currentGate = current.execution.reviewGate;
+    if (!currentGate || currentGate.activeGeneration !== beforeGate.activeGeneration) {
+      return false;
+    }
+    return currentGate.artifacts.some((artifact) =>
+      this.isCurrentReviewGateArtifact(currentGate, artifact)
+      && artifact.required
+      && artifact.providerId === providerId,
+    );
+  }
+
+  private updateReviewGateArtifact(
+    gate: ReviewGateState,
+    providerId: string,
+    status: MergeGateApprovalStatus,
+  ): ReviewGateState {
+    const mappedStatus = this.mapReviewGateArtifactStatus(status);
+    return {
+      ...gate,
+      artifacts: gate.artifacts.map((artifact) => {
+        if (
+          !this.isCurrentReviewGateArtifact(gate, artifact)
+          || artifact.providerId !== providerId
+        ) {
+          return artifact;
+        }
+        const next: ReviewGateArtifact = {
+          ...artifact,
+          status: mappedStatus,
+          updatedAt: new Date().toISOString(),
+        };
+        if (mappedStatus === 'open') {
+          return { ...next, rawStatus: status.statusText };
+        }
+        return next;
+      }),
+    };
+  }
+
+  private reviewGateIsApproved(gate: ReviewGateState): boolean {
+    const currentRequired = gate.artifacts.filter((artifact) =>
+      this.isCurrentReviewGateArtifact(gate, artifact) && artifact.required,
+    );
+    return currentRequired.length > 0
+      && currentRequired.every((artifact) => artifact.status === 'approved');
+  }
+
+
 
   private async handleApprovedMergeGate(
     taskId: string,

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -421,6 +421,59 @@ describe('Orchestrator', () => {
     });
 
 
+    it('ignores setTaskReviewReady for a stale execution generation', () => {
+      orchestrator.loadPlan({
+        name: 'Review ready lineage',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      persistence.updateTask(mergeId, {
+        status: 'running',
+        execution: { generation: 2, selectedAttemptId: 'attempt-current' },
+      });
+
+      orchestrator.setTaskReviewReady(
+        mergeId,
+        { execution: { reviewId: 'owner/repo#stale', reviewUrl: 'https://example.test/stale' } },
+        { taskId: mergeId, selectedAttemptId: 'attempt-current', generation: 1 },
+      );
+
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.status).toBe('running');
+      expect(task.execution.reviewId).toBeUndefined();
+      expect(task.execution.reviewUrl).toBeUndefined();
+    });
+
+    it('ignores setTaskReviewReady for a non-executable task with matching lineage', () => {
+      orchestrator.loadPlan({
+        name: 'Review ready non-executable',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      // Task failed on the same attempt: lineage (attempt + generation) is
+      // preserved, so the lineage guard alone would let a late review-ready
+      // write resurrect it.
+      persistence.updateTask(mergeId, {
+        status: 'failed',
+        execution: { generation: 1, selectedAttemptId: 'attempt-current' },
+      });
+
+      orchestrator.setTaskReviewReady(
+        mergeId,
+        { execution: { reviewId: 'owner/repo#late', reviewUrl: 'https://example.test/late' } },
+        { taskId: mergeId, selectedAttemptId: 'attempt-current', generation: 1 },
+      );
+
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.status).toBe('failed');
+      expect(task.execution.reviewId).toBeUndefined();
+      expect(task.execution.reviewUrl).toBeUndefined();
+    });
+
     it('discards review gate artifacts and clears scalar review fields on retry', () => {
       orchestrator.loadPlan({
         name: 'Review discard retry',

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1702,10 +1702,17 @@ export class Orchestrator {
     status: 'awaiting_approval' | 'review_ready',
     eventName: 'task.awaiting_approval' | 'task.review_ready',
     additionalChanges?: TaskStateChanges,
+    expectedLineage?: TaskLineageExpectation,
   ): void {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) return;
+    if (!this.taskMatchesLineageExpectation(task, expectedLineage)) return;
+    // Stale-write guard: lineage (id/attempt/generation) is preserved across a
+    // same-attempt cancellation, so a late approval transition could resurrect a
+    // cancelled/failed task. Only apply the transition while the task is still
+    // executable.
+    if (!this.isExecutableResponseTask(task)) return;
     const id = task.id;
 
     const additionalExecution = additionalChanges?.execution;
@@ -1774,8 +1781,12 @@ export class Orchestrator {
    * Transition a running merge gate directly to review_ready.
    * Used by merge-gate execution when output is ready for human review.
    */
-  setTaskReviewReady(taskId: string, additionalChanges?: TaskStateChanges): void {
-    this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', additionalChanges);
+  setTaskReviewReady(
+    taskId: string,
+    additionalChanges?: TaskStateChanges,
+    expectedLineage?: TaskLineageExpectation,
+  ): void {
+    this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', additionalChanges, expectedLineage);
   }
 
   setFixAwaitingApproval(
@@ -4444,6 +4455,7 @@ export class Orchestrator {
         reviewUrl: parsed.reviewUrl,
         reviewId: parsed.reviewId,
         reviewStatus: parsed.reviewStatus,
+        reviewGate: parsed.reviewGate,
       },
     };
     this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', changes);


### PR DESCRIPTION
## Summary

This makes review closing iterate every current review artifact instead of only one scalar review id.

It best-effort closes each current provider review and keeps going if one close call fails.

<details>
<summary>Review metadata</summary>

Review Claim:

Close every current review artifact when a workflow review is invalidated.

Review Lane:

- behavior

Review Unit:

- routing

Safety Invariant:

This only changes the executor-side close loop. Local discard and app invalidation hooks are already handled in earlier slices.

Slice Rationale:

Provider close behavior is its own runtime concern. Splitting it keeps remote side effects separate from orchestration and app entrypoint changes.

Architectural Effect:

The task runner now derives closable provider ids from current review-gate artifacts instead of one scalar review id.

Alternative Considerations:

Stopping after the first close failure would leave later stale PRs open. Best-effort iteration is safer.
</details>

## Non-goals

- Do not change local invalidation state here.
- Do not change stale-lineage handling here.
- Do not change app mutation entrypoints here.

## Test Plan

- [x] `pnpm exec vitest run src/__tests__/task-runner.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 36fd6d4`
- Post-revert steps: None
- Data migration? No

Depends-On: #1810

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for workflow review closure across multiple merge-gate artifacts, including continued processing after individual close failures and error logging.
  * Added a fallback scenario for workflows using a scalar review identifier.

* **Refactor**
  * Improved workflow review closure to close all currently closable merge-gate reviews for the workflow’s merge-node tasks.
  * Enhanced fallback and resilience: each close is attempted independently, without aborting the overall closure flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->