### PR TITLE
Tighten make-pr stack review-unit guardrails

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -303,6 +303,7 @@ export function classifyReviewUnitsForPath(filePath) {
     || /^packages\/app\/src\/headless-[^/]+\.ts$/.test(path)
     || path === 'packages/app/src/api-server.ts'
     || path === 'packages/app/src/workflow-actions.ts'
+    || path === 'packages/app/src/workflow-mutation-facade.ts'
     || path.startsWith('packages/app/src/ipc/')
   ) {
     return ['activation-surface'];

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -55,6 +55,51 @@ Stack publishing stays separate from unrelated cleanup.
 - Data migration? No
 `;
 
+const ROUTING_BODY = `## Summary
+
+This branch only changes invalidation routing.
+
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
+
+Keep invalidation routing local.
+
+Review Lane:
+
+- behavior
+
+Review Unit:
+
+- routing
+
+Safety Invariant:
+
+Only invalidation routing changes.
+
+Slice Rationale:
+
+Keep app exposure separate from core runtime behavior.
+
+</details>
+
+## Non-goals
+
+- Do not add docs or proof changes in this slice.
+
+## Test Plan
+
+- [ ] \`node scripts/test-create-pr-stack-workflow.mjs\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`;
+
 function assert(condition, message) {
   if (!condition) {
     throw new Error(message);
@@ -199,6 +244,7 @@ function createRepo(harness) {
 }
 
 function commitFile(work, fileName, content, message) {
+  mkdirSync(dirname(join(work, fileName)), { recursive: true });
   writeFileSync(join(work, fileName), content);
   git(work, 'add', fileName);
   gitQuiet(work, 'commit', '-m', message);
@@ -416,6 +462,40 @@ function testCurrentBranchPrLookupFailure() {
     assert(result.stderr.includes(`No PR exists for current branch "${branch}" in owner/repo.`), 'missing PR lookup should name the current branch');
     assert(result.stderr.includes('Run `mergify stack push` first for stack branches'), 'missing PR lookup should explain next step');
     expectNoPush(harness, 'missing current-branch PR');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+{
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    createTrackedBranch(work, 'stack/example/3-routing');
+    setManagedBranchConfig(work, 'stack/example/3-routing');
+    writeFileSync(join(work, 'pr-body-routing.md'), ROUTING_BODY);
+    commitFile(work, 'packages/workflow-core/src/orchestrator.ts', 'export const orchestrator = true;\n', 'routing core');
+    commitFile(work, 'packages/execution-engine/src/task-runner.ts', 'export const runner = true;\n', 'routing engine');
+    commitFile(work, 'packages/app/src/workflow-mutation-facade.ts', 'export const facade = true;\n', 'activation surface');
+
+    const result = runCreatePr(work, harness, [
+      '--title', '[Example](3) Routing slice',
+      '--base', 'master',
+      '--body-file', 'pr-body-routing.md',
+      '--update-existing',
+    ], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 42,
+          title: '[Example](3) Routing slice',
+          headRefName: 'stack/example/3-routing',
+          baseRefName: 'stack/example/2-previous',
+        },
+      ]),
+    });
+
+    assert(result.status === 1, 'managed stack update should reject mixed routing and activation-surface slice');
+    assert(result.stderr.includes('Review Unit "routing" cannot ship with activation-surface files'), 'stack update should explain mixed review units');
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -644,6 +644,18 @@ assert(
   'refactor lane should require an explicit unchanged-behavior non-goal',
 );
 
+const mixedStackSliceErrors = await validatePrBody(validMinimal, {
+  changedFiles: [
+    'packages/workflow-core/src/orchestrator.ts',
+    'packages/execution-engine/src/task-runner.ts',
+    'packages/app/src/workflow-mutation-facade.ts',
+  ],
+});
+assert(
+  mixedStackSliceErrors.some((error) => error.includes('Review Unit "routing" cannot ship with activation-surface files')),
+  'routing review unit should reject mixed activation-surface stack slices like old #1755',
+);
+
 const validationPolicyBody = `## Summary
 
 Validate stale recovery candidates.

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -11,6 +11,8 @@ description: >
 
 Use this skill when the work is already done and the user wants a PR created, updated, or rewritten.
 
+For stacked PRs, apply `skills/review-compression/SKILL.md` before you write titles or PR bodies. If one branch mixes more than one local review claim, split the stack first.
+
 ## What this skill covers
 
 - PR title/body authoring for Invoker
@@ -125,6 +127,8 @@ Update an existing PR with:
 node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-pr.md --update <pr-number>
 ```
 
+For Mergify-managed stack PRs, this update path is REQUIRED after `mergify stack push`. Do not use `gh pr edit` for stack PR body/title updates, because it bypasses the changed-file scope checks in `create-pr.mjs`.
+
 This script handles local image path upload/injection when configured. It also rejects UI-impacting diffs unless the body includes visual proof media.
 
 ## Upstream-first workflow
@@ -156,13 +160,12 @@ Do not generalize this to unrelated repos.
 
 ## Validation
 
-Before creating a PR:
-
 - ensure the branch is pushed
 - ensure the body sections are present and concrete
 - ensure test commands are real commands that were actually run when possible
 - ensure revert guidance is honest
 - validate the body with `node scripts/validate-pr-body.mjs --body-file <file>`
+- for stacked PRs, update title/body through `node scripts/create-pr.mjs --update-existing ...`, not `gh pr edit`
 - for UI-impacting diffs, include `## Visual Proof` with screenshot or video proof before `node scripts/create-pr.mjs`
 
 If you include `## Architecture`, keep the diagrams renderable by GitHub Mermaid.


### PR DESCRIPTION
## Summary

This tightens the make-pr path so stacked PR updates are less likely to bundle multiple local claims.

It specifically catches the old `#1755` shape, where app-facing work was mixed with core runtime behavior in one slice.

<details>
<summary>Review metadata</summary>

Review Claim:

Make stack PR authoring reject mixed conceptual slices earlier.

Review Lane:

- policy

Review Unit:

- tooling-policy

Safety Invariant:

This only changes PR authoring guidance and deterministic checks. Runtime workflow behavior stays untouched.

Slice Rationale:

The make-pr skill missed a coarse stack slice because its safe update path was not explicit enough and one app-facing file was grouped too loosely in the local review checks.

Architectural Effect:

Stack PR validation now classifies the workflow mutation facade as app-facing surface work, and the make-pr skill now requires the `create-pr --update-existing` path for stack PR updates.

Alternative Considerations:

Only adding docs would still let the same mixed slice pass local tooling. Tightening the classifier and testing the real stack update path closes the gap.
</details>

## Non-goals

- Do not change runtime review-gate behavior.
- Do not rewrite the existing split stack again.

## Test Plan

- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/test-create-pr-stack-workflow.mjs`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 69a1e5344`
- Post-revert steps: None
- Data migration? No
