### PR TITLE
[Planning Bootstrap](1) Fall back from daemon owner startup

### DIFF
--- a/packages/app/src/__tests__/app-bootstrap.test.ts
+++ b/packages/app/src/__tests__/app-bootstrap.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   configureEarlyElectronApp,
+  formatGuiOwnerBootstrapFallbackMessage,
+  guiOwnerBootstrapTimeoutMs,
   registerGuiLifecycleHandlers,
+  resolveGuiOwnerPreference,
   runElectronReadyBootstrap,
+  shouldRefreshGuiOwnerRoute,
   startGuiModeBootstrap,
   startMainProcessBootstrap,
 } from '../bootstrap/app-bootstrap.js';
@@ -211,6 +215,34 @@ describe('app-bootstrap', () => {
     });
 
     expect(order).toEqual(['headless', 'gui']);
+  });
+
+  it('defaults GUI owner startup to auto discovery instead of daemon bootstrap', () => {
+    expect(resolveGuiOwnerPreference({})).toBe('auto');
+    expect(resolveGuiOwnerPreference({ INVOKER_GUI_OWNER_MODE: 'daemon' })).toBe('daemon');
+    expect(resolveGuiOwnerPreference({ INVOKER_GUI_OWNER_MODE: 'local' })).toBe('gui');
+    expect(resolveGuiOwnerPreference({ INVOKER_GUI_DAEMON_OWNER: '1' })).toBe('daemon');
+  });
+
+  it('refreshes GUI owner routing for daemon-backed GUI clients only', () => {
+    expect(shouldRefreshGuiOwnerRoute('daemon', false)).toBe(true);
+    expect(shouldRefreshGuiOwnerRoute('auto', true)).toBe(true);
+    expect(shouldRefreshGuiOwnerRoute('auto', false)).toBe(false);
+    expect(shouldRefreshGuiOwnerRoute('gui', true)).toBe(false);
+  });
+
+  it('uses a bounded daemon bootstrap timeout and ignores invalid overrides', () => {
+    expect(guiOwnerBootstrapTimeoutMs({ INVOKER_GUI_OWNER_BOOTSTRAP_TIMEOUT_MS: '2500' })).toBe(2500);
+    expect(guiOwnerBootstrapTimeoutMs({ INVOKER_GUI_OWNER_BOOTSTRAP_TIMEOUT_MS: '-1' })).toBe(60000);
+    expect(guiOwnerBootstrapTimeoutMs({ INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS: '1200' })).toBe(1200);
+  });
+
+  it('formats daemon bootstrap failures with a local owner recovery path', () => {
+    const message = formatGuiOwnerBootstrapFallbackMessage('Timed out after 60000ms waiting for daemon owner');
+
+    expect(message).toContain('Daemon owner startup failed');
+    expect(message).toContain('Falling back to local GUI owner mode');
+    expect(message).toContain('INVOKER_GUI_OWNER_MODE=gui');
   });
 
   it('does not acquire a GUI lock or start GUI setup in headless mode', () => {

--- a/packages/app/src/bootstrap/app-bootstrap.ts
+++ b/packages/app/src/bootstrap/app-bootstrap.ts
@@ -1,5 +1,41 @@
 import type { App } from 'electron';
 
+export type GuiOwnerPreference = 'auto' | 'daemon' | 'gui';
+
+export function resolveGuiOwnerPreference(env: NodeJS.ProcessEnv = process.env): GuiOwnerPreference {
+  const raw = (env.INVOKER_GUI_OWNER_MODE ?? '').trim().toLowerCase();
+  if (raw === 'daemon' || raw === 'client' || raw === 'follower') return 'daemon';
+  if (raw === 'auto') return 'auto';
+  if (raw === 'gui' || raw === 'owner' || raw === 'local') return 'gui';
+  if (env.INVOKER_GUI_DAEMON_OWNER === '1') return 'daemon';
+  return 'auto';
+}
+
+export function shouldRefreshGuiOwnerRoute(
+  preference: GuiOwnerPreference,
+  isUsingDaemonOwner: boolean,
+): boolean {
+  return preference === 'daemon' || (preference === 'auto' && isUsingDaemonOwner);
+}
+
+export function guiOwnerBootstrapTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const parsed = Number.parseInt(
+    env.INVOKER_GUI_OWNER_BOOTSTRAP_TIMEOUT_MS
+      ?? env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS
+      ?? '60000',
+    10,
+  );
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60000;
+}
+
+export function formatGuiOwnerBootstrapFallbackMessage(message: string): string {
+  return [
+    `Daemon owner startup failed: ${message}`,
+    'Falling back to local GUI owner mode.',
+    'Set INVOKER_GUI_OWNER_MODE=daemon to retry daemon/client mode, or INVOKER_GUI_OWNER_MODE=gui to force local ownership.',
+  ].join('\n');
+}
+
 export interface EarlyElectronAppOptions {
   app: Pick<App, 'disableHardwareAcceleration' | 'commandLine' | 'name'> & Partial<Pick<App, 'setActivationPolicy' | 'dock'>>;
   platform?: NodeJS.Platform;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -38,8 +38,12 @@ import { mkdirSync } from 'node:fs';
 import { homedir } from 'node:os';
 import {
   configureEarlyElectronApp,
+  formatGuiOwnerBootstrapFallbackMessage,
+  guiOwnerBootstrapTimeoutMs,
   registerGuiLifecycleHandlers,
+  resolveGuiOwnerPreference,
   runElectronReadyBootstrap,
+  shouldRefreshGuiOwnerRoute,
   startGuiModeBootstrap,
   startMainProcessBootstrap,
 } from './bootstrap/app-bootstrap.js';
@@ -333,6 +337,7 @@ let commandService: CommandService;
 // constructed in initServices before TaskRunner exists, so the deps
 // resolve via this getter at cancel-in-flight time.
 let latestTaskExecutor: TaskRunner | null = null;
+let guiUsingDaemonOwner = false;
 
 function buildCommandServiceInvalidationDeps() {
   return buildWorkflowInvalidationDeps({
@@ -401,27 +406,6 @@ interface HeadlessResumeMutationPayload {
 }
 
 type HeadlessOwnerMode = 'standalone' | 'gui';
-type GuiOwnerPreference = 'auto' | 'daemon' | 'gui';
-
-function resolveGuiOwnerPreference(): GuiOwnerPreference {
-  const raw = (process.env.INVOKER_GUI_OWNER_MODE ?? '').trim().toLowerCase();
-  if (raw === 'daemon' || raw === 'client' || raw === 'follower') return 'daemon';
-  if (raw === 'auto') return 'auto';
-  if (raw === 'gui' || raw === 'owner' || raw === 'local') return 'gui';
-  if (process.env.INVOKER_GUI_DAEMON_OWNER === '1') return 'daemon';
-  return 'daemon';
-}
-
-function guiOwnerBootstrapTimeoutMs(): number {
-  const parsed = Number.parseInt(
-    process.env.INVOKER_GUI_OWNER_BOOTSTRAP_TIMEOUT_MS
-      ?? process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS
-      ?? '60000',
-    10,
-  );
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60000;
-}
-
 function headlessExecLogFields(
   payload: HeadlessExecMutationPayload,
   mode: HeadlessOwnerMode,
@@ -552,10 +536,15 @@ async function ensureStandaloneOwnerForGui(): Promise<void> {
 let guiOwnerRouteRefreshPromise: Promise<void> | null = null;
 
 async function refreshGuiMutationOwnerRoute(): Promise<void> {
-  if (resolveGuiOwnerPreference() !== 'daemon') return;
+  const ownerPreference = resolveGuiOwnerPreference();
+  if (!shouldRefreshGuiOwnerRoute(ownerPreference, guiUsingDaemonOwner)) return;
   if (!guiOwnerRouteRefreshPromise) {
     guiOwnerRouteRefreshPromise = (async () => {
-      await ensureStandaloneOwnerForGui();
+      if (ownerPreference === 'daemon') {
+        await ensureStandaloneOwnerForGui();
+      } else if (!await discoverStandaloneOwnerForGui(2_000)) {
+        throw new Error('No mutation owner is available');
+      }
       const previousMessageBus = typeof messageBus === 'undefined' ? null : messageBus;
       const refreshedMessageBus = new IpcBus(undefined, { allowServe: false });
       await refreshedMessageBus.ready();
@@ -908,6 +897,7 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
 const RESET = '\x1b[0m';
 const BOLD = '\x1b[1m';
 const RED = '\x1b[31m';
+const YELLOW = '\x1b[33m';
 
 // ══════════════════════════════════════════════════════════════
 // HEADLESS MODE
@@ -3011,6 +3001,10 @@ function createEmbeddedTerminalBackendFromConfig(
 
   const runGuiReadyBootstrap = async (): Promise<void> => {
     recordStartupMark('app.whenReady');
+    // GUI owner modes:
+    // - daemon: GUI is a client; a background daemon owns workflow writes, and startup failure is serious.
+    // - gui/local: GUI owns workflow writes directly with no daemon.
+    // - auto: GUI uses an existing daemon when one is available, otherwise it runs locally as owner.
     const guiOwnerPreference = resolveGuiOwnerPreference();
     let daemonGuiOwner = false;
     if (guiOwnerPreference === 'daemon') {
@@ -3021,9 +3015,10 @@ function createEmbeddedTerminalBackendFromConfig(
         daemonGuiOwner = true;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
-        app.quit();
-        return;
+        const fallbackMessage = formatGuiOwnerBootstrapFallbackMessage(message);
+        logger.warn(fallbackMessage, { module: 'init' });
+        process.stderr.write(`${YELLOW}Warning:${RESET} ${fallbackMessage}\n`);
+        daemonGuiOwner = false;
       }
     } else if (guiOwnerPreference === 'auto') {
       recordStartupMark('daemonOwner.discover.start');
@@ -3039,6 +3034,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
     if (daemonGuiOwner) {
       ownerMode = false;
+      guiUsingDaemonOwner = true;
       try {
         recordStartupMark('initServices.readOnly.start');
         await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
@@ -3051,6 +3047,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     } else {
       ownerMode = true;
+      guiUsingDaemonOwner = false;
       try {
         recordStartupMark('initServices.start');
         await initServices({ executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
@@ -3065,6 +3062,7 @@ function createEmbeddedTerminalBackendFromConfig(
         recordStartupMark('initServices.readOnly.start');
         await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
         ownerMode = false;
+        guiUsingDaemonOwner = false;
         recordStartupMark('initServices.readOnly.end', { ownerMode: false });
       }
     }


### PR DESCRIPTION
## Summary

GUI startup no longer treats daemon ownership as a hard launch dependency.

If explicit daemon startup fails, the GUI warns and falls back to local ownership instead of exiting.

Daemon-backed GUI clients can refresh their owner route after reconnect without spawning a replacement daemon.

<details>
<summary>Review metadata</summary>

Review Claim: GUI owner bootstrap can recover from daemon startup and reconnect failures without changing workflow mutations.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The change is scoped to GUI owner selection and route refresh helpers, with focused bootstrap tests for failure and reconnect paths.

Slice Rationale: This first stack slice stabilizes owner routing so the follow-up diagnostics and prompt-policy slices do not depend on fragile startup behavior.

Architectural Effect: GUI startup moves from daemon-first ownership to auto discovery with local fallback, and daemon-backed clients can rebuild their owner route after reconnect.

Alternative Considerations: Keeping daemon ownership as the default would preserve the old launch path, but still leaves a failed daemon as a GUI startup blocker.

</details>

## Non-goals

- Do not change headless owner behavior.
- Do not change workflow mutation semantics.
- Do not change bundled skill installation behavior.

## Architecture

### Before

```mermaid
graph TD
    A["GUI startup"] --> B["daemon preference by default"]
    B --> C["daemon startup failure exits"]
    B --> D["refresh only when preference is daemon"]
```

### After

```mermaid
graph TD
    A["GUI startup"] --> B["auto discovery by default"]
    B --> C["daemon failure falls back to local owner"]
    B --> D["daemon-backed clients rediscover and rebuild route"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/app-bootstrap.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert c52524a1`
- Post-revert steps: None
- Data migration? No

Co-authored-by: Codex <noreply@openai.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Daemon GUI owner startup failures now show a warning with clear recovery instructions and retry hints (instead of terminating), and the app continues with local GUI ownership when needed.

* **Refactor**
  * Centralized GUI “owner mode” preference resolution and bootstrap timeout parsing, with GUI route refreshing now driven by whether the daemon-backed owner is actually in use.

* **Tests**
  * Added unit tests covering owner mode resolution, route-refresh conditions, timeout bounds/overrides, and fallback message formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->