### PR TITLE
[Planning Bootstrap](2) Show managed skill install diagnostics

### DIFF
--- a/packages/app/src/__tests__/bundled-skills.test.ts
+++ b/packages/app/src/__tests__/bundled-skills.test.ts
@@ -64,6 +64,10 @@ describe('bundled-skills', () => {
       expect(status.promptRecommended).toBe(true);
       expect(status.bundledSkillNames).toEqual(['make-pr', 'plan-to-invoker']);
       expect(status.targets[0]?.installed).toBe(false);
+      expect(status.targets[0]?.missingSkillNames).toEqual(['invoker-make-pr', 'invoker-plan-to-invoker']);
+      expect(status.targets[0]?.staleReason).toBe('not-installed');
+      expect(status.targets[0]?.diagnostic).toContain('prefix "invoker-"');
+      expect(status.targets[0]?.diagnostic).toContain('invoker-plan-to-invoker');
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;
@@ -240,6 +244,46 @@ describe('bundled-skills', () => {
         invokerHomeRoot,
       })).toThrow(`Invalid OMP MCP config at ${mcpPath}: expected a JSON object`);
       expect(readFileSync(mcpPath, 'utf-8')).toBe('{"mcpServers":');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('reports stale installed skills when the bundled source hash changes', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+      });
+
+      writeFileSync(join(resourcesRoot, 'skills', 'plan-to-invoker', 'SKILL.md'), '# plan-to-invoker\n\nUpdated bundled content.\n');
+
+      const status = resolveBundledSkillsStatus({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+      });
+
+      expect(status.targets.every((target) => target.installed)).toBe(true);
+      expect(status.targets.every((target) => !target.upToDate)).toBe(true);
+      expect(status.targets[0]?.staleReason).toBe('bundle-updated');
+      expect(status.targets[0]?.diagnostic).toContain('bundled source changed');
+      expect(status.targets[0]?.diagnostic).toContain('prefix "invoker-"');
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/packages/app/src/bundled-skills.ts
+++ b/packages/app/src/bundled-skills.ts
@@ -36,6 +36,7 @@ interface BundledSkillsContext {
 }
 
 type JsonRecord = Record<string, unknown>;
+type BundledSkillStaleReason = NonNullable<BundledSkillTargetStatus['staleReason']>;
 
 function resolveBundledSkillsSourceRoot(context: BundledSkillsContext): string | null {
   if (context.isPackaged) {
@@ -193,6 +194,59 @@ function writeManifest(invokerHomeRoot: string, manifest: BundledSkillsManifest)
   writeFileSync(resolveManifestPath(invokerHomeRoot), JSON.stringify(manifest, null, 2));
 }
 
+function resolveStaleReason(
+  target: BundledSkillTargetStatus,
+  installed: boolean,
+  upToDate: boolean,
+  manifest: BundledSkillsManifest | null,
+  bundledHash: string,
+): BundledSkillStaleReason | undefined {
+  if (!installed) return 'not-installed';
+  if (upToDate) return undefined;
+  if (!manifest) return 'manifest-missing';
+  const manifestTarget = manifest.targets[target.id];
+  if (!manifestTarget) return 'manifest-target-missing';
+  if (manifestTarget.path !== target.path) return 'target-path-changed';
+  if (manifest.bundledHash !== bundledHash) return 'bundle-updated';
+  return 'manifest-skill-list-changed';
+}
+
+function staleDiagnostic(
+  staleReason: BundledSkillStaleReason,
+  target: BundledSkillTargetStatus,
+  missingSkillNames: string[],
+  manifestTarget: BundledSkillsManifest['targets'][string] | undefined,
+): string {
+  switch (staleReason) {
+    case 'not-installed':
+      return missingSkillNames.length > 0
+        ? `Missing managed skills with prefix "${MANAGED_PREFIX}": ${missingSkillNames.join(', ')}`
+        : `Managed skills with prefix "${MANAGED_PREFIX}" are not installed.`;
+    case 'manifest-missing':
+      return `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but Invoker has no install manifest. Reinstall to verify the bundle version.`;
+    case 'manifest-target-missing':
+      return `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but the install manifest has no ${target.name} target entry. Reinstall to refresh diagnostics.`;
+    case 'target-path-changed':
+      return `Installed managed skills with prefix "${MANAGED_PREFIX}" are recorded for ${manifestTarget?.path}, not ${target.path}. Reinstall to update this target.`;
+    case 'bundle-updated':
+      return `Installed managed skills with prefix "${MANAGED_PREFIX}" are stale because the bundled source changed. Update skills to refresh them.`;
+    case 'manifest-skill-list-changed':
+      return `Installed managed skills with prefix "${MANAGED_PREFIX}" differ from the bundled skill manifest. Reinstall to restore the managed set.`;
+  }
+}
+
+function buildTargetDiagnostic(
+  staleReason: BundledSkillStaleReason | undefined,
+  target: BundledSkillTargetStatus,
+  missingSkillNames: string[],
+  manifestTarget: BundledSkillsManifest['targets'][string] | undefined,
+): string {
+  if (!staleReason) {
+    return `Installed managed skills with prefix "${MANAGED_PREFIX}" are up to date.`;
+  }
+  return staleDiagnostic(staleReason, target, missingSkillNames, manifestTarget);
+}
+
 function buildTargetStatus(
   target: BundledSkillTargetStatus,
   expectedInstalledNames: string[],
@@ -207,32 +261,8 @@ function buildTargetStatus(
     && manifest?.bundledHash === bundledHash
     && manifestTarget?.path === target.path
     && expectedInstalledNames.every((name) => manifestTarget.installedSkillNames.includes(name));
-  let staleReason: BundledSkillTargetStatus['staleReason'] | undefined;
-  let diagnostic: string;
-
-  if (!installed) {
-    staleReason = 'not-installed';
-    diagnostic = missingSkillNames.length > 0
-      ? `Missing managed skills with prefix "${MANAGED_PREFIX}": ${missingSkillNames.join(', ')}`
-      : `Managed skills with prefix "${MANAGED_PREFIX}" are not installed.`;
-  } else if (upToDate) {
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are up to date.`;
-  } else if (!manifest) {
-    staleReason = 'manifest-missing';
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but Invoker has no install manifest. Reinstall to verify the bundle version.`;
-  } else if (!manifestTarget) {
-    staleReason = 'manifest-target-missing';
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but the install manifest has no ${target.name} target entry. Reinstall to refresh diagnostics.`;
-  } else if (manifestTarget.path !== target.path) {
-    staleReason = 'target-path-changed';
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are recorded for ${manifestTarget.path}, not ${target.path}. Reinstall to update this target.`;
-  } else if (manifest.bundledHash !== bundledHash) {
-    staleReason = 'bundle-updated';
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are stale because the bundled source changed. Update skills to refresh them.`;
-  } else {
-    staleReason = 'manifest-skill-list-changed';
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" differ from the bundled skill manifest. Reinstall to restore the managed set.`;
-  }
+  const staleReason = resolveStaleReason(target, installed, upToDate, manifest, bundledHash);
+  const diagnostic = buildTargetDiagnostic(staleReason, target, missingSkillNames, manifestTarget);
 
   return {
     ...target,

--- a/packages/app/src/bundled-skills.ts
+++ b/packages/app/src/bundled-skills.ts
@@ -200,18 +200,48 @@ function buildTargetStatus(
   manifest: BundledSkillsManifest | null,
 ): BundledSkillTargetStatus {
   const installedSkillNames = expectedInstalledNames.filter((name) => existsSync(path.join(target.path, name, 'SKILL.md')));
+  const missingSkillNames = expectedInstalledNames.filter((name) => !installedSkillNames.includes(name));
   const installed = installedSkillNames.length === expectedInstalledNames.length;
   const manifestTarget = manifest?.targets[target.id];
   const upToDate = installed
     && manifest?.bundledHash === bundledHash
     && manifestTarget?.path === target.path
     && expectedInstalledNames.every((name) => manifestTarget.installedSkillNames.includes(name));
+  let staleReason: BundledSkillTargetStatus['staleReason'] | undefined;
+  let diagnostic: string;
+
+  if (!installed) {
+    staleReason = 'not-installed';
+    diagnostic = missingSkillNames.length > 0
+      ? `Missing managed skills with prefix "${MANAGED_PREFIX}": ${missingSkillNames.join(', ')}`
+      : `Managed skills with prefix "${MANAGED_PREFIX}" are not installed.`;
+  } else if (upToDate) {
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are up to date.`;
+  } else if (!manifest) {
+    staleReason = 'manifest-missing';
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but Invoker has no install manifest. Reinstall to verify the bundle version.`;
+  } else if (!manifestTarget) {
+    staleReason = 'manifest-target-missing';
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but the install manifest has no ${target.name} target entry. Reinstall to refresh diagnostics.`;
+  } else if (manifestTarget.path !== target.path) {
+    staleReason = 'target-path-changed';
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are recorded for ${manifestTarget.path}, not ${target.path}. Reinstall to update this target.`;
+  } else if (manifest.bundledHash !== bundledHash) {
+    staleReason = 'bundle-updated';
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are stale because the bundled source changed. Update skills to refresh them.`;
+  } else {
+    staleReason = 'manifest-skill-list-changed';
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" differ from the bundled skill manifest. Reinstall to restore the managed set.`;
+  }
 
   return {
     ...target,
     installed,
     upToDate,
     installedSkillNames,
+    missingSkillNames,
+    staleReason,
+    diagnostic,
   };
 }
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -252,6 +252,9 @@ export interface BundledSkillTargetStatus {
   installed: boolean;
   upToDate: boolean;
   installedSkillNames: string[];
+  missingSkillNames?: string[];
+  staleReason?: 'not-installed' | 'manifest-missing' | 'manifest-target-missing' | 'target-path-changed' | 'bundle-updated' | 'manifest-skill-list-changed';
+  diagnostic?: string;
 }
 
 export interface HarnessConfigState {

--- a/packages/ui/src/components/SystemSetupModal.tsx
+++ b/packages/ui/src/components/SystemSetupModal.tsx
@@ -95,9 +95,14 @@ export function SystemSetupModal({
                             <td className="px-4 py-3 text-gray-100">{target.name}</td>
                             <td className="px-4 py-3 text-gray-400 font-mono text-xs break-all">{target.path}</td>
                             <td className="px-4 py-3">
-                              <span className={target.upToDate ? 'text-green-400' : target.installed ? 'text-yellow-300' : 'text-amber-300'}>
+                              <div className={target.upToDate ? 'text-green-400' : target.installed ? 'text-yellow-300' : 'text-amber-300'}>
                                 {target.upToDate ? 'Installed and up to date' : target.installed ? 'Installed, update available' : 'Not installed'}
-                              </span>
+                              </div>
+                              {target.diagnostic && (
+                                <div className="mt-1 text-xs text-gray-400">
+                                  {target.diagnostic}
+                                </div>
+                              )}
                             </td>
                           </tr>
                         ))}


### PR DESCRIPTION
## Summary

Bundled skill setup now explains why each managed target is missing, outdated, or current.

The existing setup modal shows that diagnostic beside the install state, so users can repair skills without guessing.

<details>
<summary>Review metadata</summary>

Review Claim: The setup surface can explain managed skill target status without changing installation behavior.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The fields are additive on the existing IPC status shape, and `installed` plus `upToDate` remain authoritative.

Slice Rationale: This second stack slice exposes diagnostics after owner startup is recoverable and before prompt-policy changes.

Architectural Effect: The bundled-skill read path adds diagnostic fields to the IPC status contract, and the setup modal renders them read-only.

Alternative Considerations: Reusing only `installed` and `upToDate` keeps the contract smaller, but it leaves outdated and missing managed targets indistinguishable in the UI.

</details>

## Non-goals

- Do not change which skills are installed.
- Do not change install paths or managed skill prefixes.
- Do not change planning prompt behavior.

## Architecture

### Before

```mermaid
graph TD
    A["Bundled skill status"] --> B["installed and upToDate booleans"]
    B --> C["setup modal shows a coarse state"]
```

### After

```mermaid
graph TD
    A["Bundled skill status"] --> B["additive diagnostic fields"]
    B --> C["setup modal shows the reason beside the state"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/bundled-skills.test.ts`
- [x] `pnpm run check:types`

## Visual Proof

UI impact is limited to secondary diagnostic text inside the existing System Setup table.

The DOM visual-proof CI job passed: [System Setup proof](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/27933397392/job/82649950466).

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 9a294320 4b9c6786`
- Post-revert steps: None
- Data migration? No

Co-authored-by: Codex <noreply@openai.com>

Depends-On: #1822

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bundled skills now surface richer status details, including specific staleness reasons and human-readable diagnostics (for example: not installed, or bundled content changes).

* **Improvements**
  * The System Setup Modal now shows these bundled-skill diagnostic messages under the status label for clearer troubleshooting.

* **Tests**
  * Expanded coverage to verify the new bundled-skill staleness diagnostics and behavior after bundled source updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->