### PR TITLE
[Planning Bootstrap](3) Guide ambiguous planning requests

### DIFF
--- a/packages/app/src/__tests__/bundled-skills.test.ts
+++ b/packages/app/src/__tests__/bundled-skills.test.ts
@@ -64,6 +64,10 @@ describe('bundled-skills', () => {
       expect(status.promptRecommended).toBe(true);
       expect(status.bundledSkillNames).toEqual(['make-pr', 'plan-to-invoker']);
       expect(status.targets[0]?.installed).toBe(false);
+      expect(status.targets[0]?.missingSkillNames).toEqual(['invoker-make-pr', 'invoker-plan-to-invoker']);
+      expect(status.targets[0]?.staleReason).toBe('not-installed');
+      expect(status.targets[0]?.diagnostic).toContain('prefix "invoker-"');
+      expect(status.targets[0]?.diagnostic).toContain('invoker-plan-to-invoker');
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;
@@ -240,6 +244,46 @@ describe('bundled-skills', () => {
         invokerHomeRoot,
       })).toThrow(`Invalid OMP MCP config at ${mcpPath}: expected a JSON object`);
       expect(readFileSync(mcpPath, 'utf-8')).toBe('{"mcpServers":');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('reports stale installed skills when the bundled source hash changes', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const codexHome = makeTempRoot('invoker-codex-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = codexHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+      });
+
+      writeFileSync(join(resourcesRoot, 'skills', 'plan-to-invoker', 'SKILL.md'), '# plan-to-invoker\n\nUpdated bundled content.\n');
+
+      const status = resolveBundledSkillsStatus({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+      });
+
+      expect(status.targets.every((target) => target.installed)).toBe(true);
+      expect(status.targets.every((target) => !target.upToDate)).toBe(true);
+      expect(status.targets[0]?.staleReason).toBe('bundle-updated');
+      expect(status.targets[0]?.diagnostic).toContain('bundled source changed');
+      expect(status.targets[0]?.diagnostic).toContain('prefix "invoker-"');
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/packages/app/src/bundled-skills.ts
+++ b/packages/app/src/bundled-skills.ts
@@ -36,6 +36,7 @@ interface BundledSkillsContext {
 }
 
 type JsonRecord = Record<string, unknown>;
+type BundledSkillStaleReason = NonNullable<BundledSkillTargetStatus['staleReason']>;
 
 function resolveBundledSkillsSourceRoot(context: BundledSkillsContext): string | null {
   if (context.isPackaged) {
@@ -193,6 +194,59 @@ function writeManifest(invokerHomeRoot: string, manifest: BundledSkillsManifest)
   writeFileSync(resolveManifestPath(invokerHomeRoot), JSON.stringify(manifest, null, 2));
 }
 
+function resolveStaleReason(
+  target: BundledSkillTargetStatus,
+  installed: boolean,
+  upToDate: boolean,
+  manifest: BundledSkillsManifest | null,
+  bundledHash: string,
+): BundledSkillStaleReason | undefined {
+  if (!installed) return 'not-installed';
+  if (upToDate) return undefined;
+  if (!manifest) return 'manifest-missing';
+  const manifestTarget = manifest.targets[target.id];
+  if (!manifestTarget) return 'manifest-target-missing';
+  if (manifestTarget.path !== target.path) return 'target-path-changed';
+  if (manifest.bundledHash !== bundledHash) return 'bundle-updated';
+  return 'manifest-skill-list-changed';
+}
+
+function staleDiagnostic(
+  staleReason: BundledSkillStaleReason,
+  target: BundledSkillTargetStatus,
+  missingSkillNames: string[],
+  manifestTarget: BundledSkillsManifest['targets'][string] | undefined,
+): string {
+  switch (staleReason) {
+    case 'not-installed':
+      return missingSkillNames.length > 0
+        ? `Missing managed skills with prefix "${MANAGED_PREFIX}": ${missingSkillNames.join(', ')}`
+        : `Managed skills with prefix "${MANAGED_PREFIX}" are not installed.`;
+    case 'manifest-missing':
+      return `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but Invoker has no install manifest. Reinstall to verify the bundle version.`;
+    case 'manifest-target-missing':
+      return `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but the install manifest has no ${target.name} target entry. Reinstall to refresh diagnostics.`;
+    case 'target-path-changed':
+      return `Installed managed skills with prefix "${MANAGED_PREFIX}" are recorded for ${manifestTarget?.path}, not ${target.path}. Reinstall to update this target.`;
+    case 'bundle-updated':
+      return `Installed managed skills with prefix "${MANAGED_PREFIX}" are stale because the bundled source changed. Update skills to refresh them.`;
+    case 'manifest-skill-list-changed':
+      return `Installed managed skills with prefix "${MANAGED_PREFIX}" differ from the bundled skill manifest. Reinstall to restore the managed set.`;
+  }
+}
+
+function buildTargetDiagnostic(
+  staleReason: BundledSkillStaleReason | undefined,
+  target: BundledSkillTargetStatus,
+  missingSkillNames: string[],
+  manifestTarget: BundledSkillsManifest['targets'][string] | undefined,
+): string {
+  if (!staleReason) {
+    return `Installed managed skills with prefix "${MANAGED_PREFIX}" are up to date.`;
+  }
+  return staleDiagnostic(staleReason, target, missingSkillNames, manifestTarget);
+}
+
 function buildTargetStatus(
   target: BundledSkillTargetStatus,
   expectedInstalledNames: string[],
@@ -207,32 +261,8 @@ function buildTargetStatus(
     && manifest?.bundledHash === bundledHash
     && manifestTarget?.path === target.path
     && expectedInstalledNames.every((name) => manifestTarget.installedSkillNames.includes(name));
-  let staleReason: BundledSkillTargetStatus['staleReason'] | undefined;
-  let diagnostic: string;
-
-  if (!installed) {
-    staleReason = 'not-installed';
-    diagnostic = missingSkillNames.length > 0
-      ? `Missing managed skills with prefix "${MANAGED_PREFIX}": ${missingSkillNames.join(', ')}`
-      : `Managed skills with prefix "${MANAGED_PREFIX}" are not installed.`;
-  } else if (upToDate) {
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are up to date.`;
-  } else if (!manifest) {
-    staleReason = 'manifest-missing';
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but Invoker has no install manifest. Reinstall to verify the bundle version.`;
-  } else if (!manifestTarget) {
-    staleReason = 'manifest-target-missing';
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but the install manifest has no ${target.name} target entry. Reinstall to refresh diagnostics.`;
-  } else if (manifestTarget.path !== target.path) {
-    staleReason = 'target-path-changed';
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are recorded for ${manifestTarget.path}, not ${target.path}. Reinstall to update this target.`;
-  } else if (manifest.bundledHash !== bundledHash) {
-    staleReason = 'bundle-updated';
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are stale because the bundled source changed. Update skills to refresh them.`;
-  } else {
-    staleReason = 'manifest-skill-list-changed';
-    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" differ from the bundled skill manifest. Reinstall to restore the managed set.`;
-  }
+  const staleReason = resolveStaleReason(target, installed, upToDate, manifest, bundledHash);
+  const diagnostic = buildTargetDiagnostic(staleReason, target, missingSkillNames, manifestTarget);
 
   return {
     ...target,

--- a/packages/app/src/bundled-skills.ts
+++ b/packages/app/src/bundled-skills.ts
@@ -200,18 +200,48 @@ function buildTargetStatus(
   manifest: BundledSkillsManifest | null,
 ): BundledSkillTargetStatus {
   const installedSkillNames = expectedInstalledNames.filter((name) => existsSync(path.join(target.path, name, 'SKILL.md')));
+  const missingSkillNames = expectedInstalledNames.filter((name) => !installedSkillNames.includes(name));
   const installed = installedSkillNames.length === expectedInstalledNames.length;
   const manifestTarget = manifest?.targets[target.id];
   const upToDate = installed
     && manifest?.bundledHash === bundledHash
     && manifestTarget?.path === target.path
     && expectedInstalledNames.every((name) => manifestTarget.installedSkillNames.includes(name));
+  let staleReason: BundledSkillTargetStatus['staleReason'] | undefined;
+  let diagnostic: string;
+
+  if (!installed) {
+    staleReason = 'not-installed';
+    diagnostic = missingSkillNames.length > 0
+      ? `Missing managed skills with prefix "${MANAGED_PREFIX}": ${missingSkillNames.join(', ')}`
+      : `Managed skills with prefix "${MANAGED_PREFIX}" are not installed.`;
+  } else if (upToDate) {
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are up to date.`;
+  } else if (!manifest) {
+    staleReason = 'manifest-missing';
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but Invoker has no install manifest. Reinstall to verify the bundle version.`;
+  } else if (!manifestTarget) {
+    staleReason = 'manifest-target-missing';
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" exist, but the install manifest has no ${target.name} target entry. Reinstall to refresh diagnostics.`;
+  } else if (manifestTarget.path !== target.path) {
+    staleReason = 'target-path-changed';
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are recorded for ${manifestTarget.path}, not ${target.path}. Reinstall to update this target.`;
+  } else if (manifest.bundledHash !== bundledHash) {
+    staleReason = 'bundle-updated';
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" are stale because the bundled source changed. Update skills to refresh them.`;
+  } else {
+    staleReason = 'manifest-skill-list-changed';
+    diagnostic = `Installed managed skills with prefix "${MANAGED_PREFIX}" differ from the bundled skill manifest. Reinstall to restore the managed set.`;
+  }
 
   return {
     ...target,
     installed,
     upToDate,
     installedSkillNames,
+    missingSkillNames,
+    staleReason,
+    diagnostic,
   };
 }
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -252,6 +252,9 @@ export interface BundledSkillTargetStatus {
   installed: boolean;
   upToDate: boolean;
   installedSkillNames: string[];
+  missingSkillNames?: string[];
+  staleReason?: 'not-installed' | 'manifest-missing' | 'manifest-target-missing' | 'target-path-changed' | 'bundle-updated' | 'manifest-skill-list-changed';
+  diagnostic?: string;
 }
 
 export interface HarnessConfigState {

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -429,6 +429,17 @@ describe('PlanConversation', () => {
     expect(prompt).toContain('Use the package manager and test runner the target repo already uses');
   });
 
+  it('instructs ambiguous implementation requests to include assumptions before YAML', async () => {
+    mockCursorResponse('Hi');
+    await conversation.sendMessage('quick nit: turn lint warnings into pre-commit errors');
+    const prompt = mockSpawn.mock.calls[0][1][1] as string;
+
+    expect(prompt).toContain('For ambiguous implementation requests, tiny nits');
+    expect(prompt).toContain('State concise assumptions');
+    expect(prompt).toContain('Show a short plan preview');
+    expect(prompt).not.toContain('generate the YAML plan directly');
+  });
+
   it('submittedPlanText is null before confirmation', async () => {
     expect(conversation.submittedPlanText).toBeNull();
     mockCursorResponse(VALID_YAML_PLAN);
@@ -576,6 +587,16 @@ describe('PlanConversation prompt construction', () => {
     (conv as any).messages.push({ role: 'user', content: 'Hello' });
     const prompt = conv.buildCursorPrompt();
     expect(prompt).toContain('repoUrl: "git@github.com:user/repo.git"');
+  });
+
+  it('system prompt requires discovered verification commands for target repos', () => {
+    const conv = new PlanConversation({});
+    (conv as any).messages.push({ role: 'user', content: 'Add a small pre-commit lint gate' });
+    const prompt = conv.buildCursorPrompt();
+
+    expect(prompt).toContain('Inspect repo manifests and existing docs/scripts before choosing commands');
+    expect(prompt).toContain('do not impose Invoker-specific commands on external repos');
+    expect(prompt).toContain('reserve broad/full-suite commands for the final gate only when the target repo documents such a command');
   });
 });
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -105,8 +105,11 @@ tasks:
 
 Rules:
 1. Explore the codebase first (list directories, read key files). Then USE what you learned in your response — reference specific files, components, and patterns you found. Do NOT give generic responses that ignore the code you read.
-2. After exploring, generate the YAML plan directly. Do NOT ask clarifying questions unless absolutely necessary — prefer making reasonable assumptions based on the code you read.
-3. Keep plans focused — 3-8 tasks maximum.
+2. For ambiguous implementation requests, tiny nits, or broad "make this better" requests, do a brief scoping pass before YAML:
+   - State concise assumptions based on the repository evidence you found.
+   - Show a short plan preview with the likely review slice(s) and verification commands.
+   - Ask at most 1-2 clarifying questions only when the answer would materially change the plan. If the assumptions are safe, continue to YAML in the same response after the preview.
+3. Keep plans focused — 3-8 tasks maximum. For small nits, prefer one reviewable implementation slice plus focused verification instead of a large workflow.
 4. File-count guidance is a soft heuristic, not a hard validator gate. Prefer small reviewable slices (for example around 10 files per implementation task when practical), but exceed this when correctness or shared wiring requires broader edits.
 5. Each task should have either a \`command\` or a \`prompt\`, not both.
 6. Every step MUST be testable. Every implementation task MUST have a corresponding test task that verifies it works using a concrete, executable \`command\` discovered from the target repo (e.g. that repo's package scripts, build commands, or focused checks such as \`git diff --name-only\`). The test command must produce a clear pass/fail exit code. Do NOT skip tests for any step. Do NOT use prompts for test tasks — use commands only.

--- a/packages/ui/src/components/SystemSetupModal.tsx
+++ b/packages/ui/src/components/SystemSetupModal.tsx
@@ -95,9 +95,14 @@ export function SystemSetupModal({
                             <td className="px-4 py-3 text-gray-100">{target.name}</td>
                             <td className="px-4 py-3 text-gray-400 font-mono text-xs break-all">{target.path}</td>
                             <td className="px-4 py-3">
-                              <span className={target.upToDate ? 'text-green-400' : target.installed ? 'text-yellow-300' : 'text-amber-300'}>
+                              <div className={target.upToDate ? 'text-green-400' : target.installed ? 'text-yellow-300' : 'text-amber-300'}>
                                 {target.upToDate ? 'Installed and up to date' : target.installed ? 'Installed, update available' : 'Not installed'}
-                              </span>
+                              </div>
+                              {target.diagnostic && (
+                                <div className="mt-1 text-xs text-gray-400">
+                                  {target.diagnostic}
+                                </div>
+                              )}
                             </td>
                           </tr>
                         ))}


### PR DESCRIPTION
## Summary

Planning prompts now stop ambiguous nits before they become premature YAML.

The planner first states assumptions, previews the change, and discovers target-repo verification.

<details>
<summary>Review metadata</summary>

Review Claim: Ambiguous planning requests get assumptions, preview, and target-repo verification discovery before final YAML.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: The change is prompt-only and covered by prompt construction tests.

Slice Rationale: This final stack slice changes planning policy after startup recovery and setup diagnostics are isolated.

Architectural Effect: Only planner instructions change; plan parsing and workflow execution stay unchanged.

Alternative Considerations: Generating YAML immediately is faster for precise requests, but vague tasks need an assumptions pass before execution planning.

</details>

## Non-goals

- Do not change plan parsing.
- Do not change workflow execution.
- Do not change bundled skill installation diagnostics.

## Test Plan

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-conversation.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f4a4c9d6`
- Post-revert steps: None
- Data migration? No

Co-authored-by: Codex <noreply@openai.com>

Depends-On: #1823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Plan generation for ambiguous requests now includes a brief scoping phase with explicit assumptions and a short preview (including likely review slice(s) and verification commands) before producing the full output.
  * Enhanced system guidance to inspect existing repo manifests and docs/scripts to select appropriate verification/command routines, while avoiding inappropriate invoker-specific actions and reserving broad full-suite commands for the final gate only when documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->