### PR TITLE
Tighten review-gate stack repair tooling

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -141,14 +141,15 @@ Options:
   --help               Show this help
 
 Stack PR title schema:
-  Stacked PRs must start with a shared idea and one slice index, for example:
+  Stacked PRs must start with a shared idea and one slice index.
+  Replacement slices may add one trailing lowercase letter:
   [Graph Blanking](1) Preserve selected graph while loading
-  [Graph Blanking](2) Follow-up slice
+  [Graph Blanking](3a) Split follow-up slice
 
 Stack flow:
   1. Publish stack branches with \`mergify stack push\`
   2. Switch to the created stack branch if needed
-  3. Run \`node scripts/create-pr.mjs --title "[Graph Blanking](1) <slice title>" --base <branch> --body-file <file> --update-existing\`
+  3. Run \`node scripts/create-pr.mjs --title "[Graph Blanking](3a) <slice title>" --base <branch> --body-file <file> --update-existing\`
 
 PR body schema:
   Required: ## Summary with collapsed Review metadata, ## Non-goals, ## Test Plan, ## Revert Plan
@@ -199,7 +200,7 @@ function parseArgs() {
 }
 
 const TRUNK_BRANCHES = new Set(['main', 'master', 'develop']);
-const STACK_PR_TITLE_PATTERN = /^\[[^\[\]\r\n]{3,80}\]\([1-9]\d*\)(?:\s+\S.*)?$/;
+const STACK_PR_TITLE_PATTERN = /^\[[^\[\]\r\n]{3,80}\]\([1-9]\d*[a-z]?\)(?:\s+\S.*)?$/;
 
 function isStackedPrContext(baseBranch, mergifyState) {
   return mergifyState.managed || !TRUNK_BRANCHES.has(baseBranch);
@@ -212,7 +213,7 @@ function assertValidStackPrTitle(title) {
     [
       'Stack PR titles must start with a shared idea and exactly one slice index.',
       'Use: [Graph Blanking](1) Preserve selected graph while loading',
-      'Use the next slice number for the next PR: [Graph Blanking](2) Follow-up slice',
+      'Use lettered replacements when one published slice must split: [Graph Blanking](3a) Split follow-up slice',
     ].join('\n'),
   );
 }
@@ -236,8 +237,8 @@ async function assertValidPrBody(body, options = {}) {
   );
 }
 
-function printPrBodyWarnings(body) {
-  const warnings = getPrBodyWarnings(body);
+function printPrBodyWarnings(body, changedFiles = []) {
+  const warnings = getPrBodyWarnings(body, { changedFiles });
   if (warnings.length === 0) return;
 
   console.error('PR body validation warnings:');
@@ -664,7 +665,7 @@ async function main() {
   }
 
   await assertValidPrBody(body, { requiresVisualProof: uiImpactingFiles.length > 0, changedFiles });
-  printPrBodyWarnings(body);
+  printPrBodyWarnings(body, changedFiles);
   body = await injectImages(body, args.dryRun);
 
   const currentBranch = getCurrentBranch();

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -131,6 +131,9 @@ const ALLOWED_CHANGE_OPERATIONS = new Set([
 
 const PATH_LIKE = /^(?:packages|scripts|skills|docs|plans|\.github|[A-Za-z0-9_.-]+\/)[^:]+/;
 const APP_SRC_PREFIX = 'packages/app/src/';
+const REVIEW_GATE_PUBLICATION_PATH = 'packages/execution-engine/src/merge-runner.ts';
+const REVIEW_GATE_POLLING_PATH = 'packages/execution-engine/src/task-runner.ts';
+
 
 export function firstMeaningfulLine(value = '') {
   return String(value)
@@ -352,6 +355,22 @@ export function validateReviewUnitChangedFiles({ declaredReviewUnit, changedFile
 
   return [
     `${context} Review Unit "${declaredReviewUnit}" cannot ship with ${formatReviewUnits(forbidden)} files in the same PR. Split this into one Review Unit per PR.`,
+  ];
+}
+
+export function validateKnownReviewBoundaries({ reviewLane = '', changedFiles = [], context }) {
+  if (!['behavior', 'refactor'].includes(reviewLane) || changedFiles.length === 0) return [];
+
+  const changedFileSet = new Set(changedFiles);
+  if (
+    !changedFileSet.has(REVIEW_GATE_PUBLICATION_PATH)
+    || !changedFileSet.has(REVIEW_GATE_POLLING_PATH)
+  ) {
+    return [];
+  }
+
+  return [
+    `${context} Publication and poll/approval runtime behavior must be split into separate PRs. Do not change ${REVIEW_GATE_PUBLICATION_PATH} and ${REVIEW_GATE_POLLING_PATH} in the same PR.`,
   ];
 }
 

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -286,8 +286,8 @@ function baseArgs() {
   return ['--title', 'test title', '--base', 'master', '--body-file', 'pr-body.md'];
 }
 
-function stackTitleArgs(base = 'master') {
-  return ['--title', '[Graph Blanking](1) Preserve graph blanking', '--base', base, '--body-file', 'pr-body.md'];
+function stackTitleArgs(base = 'master', title = '[Graph Blanking](1) Preserve graph blanking') {
+  return ['--title', title, '--base', base, '--body-file', 'pr-body.md'];
 }
 
 function expectNoPush(harness, label) {
@@ -368,6 +368,49 @@ function testMergifyManagedUpdateSkipsPush() {
     assert(Boolean(patchCall), 'managed update should patch the existing PR');
     assert(patchCall.stdin.includes('"title":"[Graph Blanking](1) Preserve graph blanking"'), 'managed update patch should include title');
     assert(patchCall.stdin.includes('## Summary'), 'managed update patch should include PR body');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+function testMergifyManagedUpdateAcceptsLetteredTitle() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    const branch = 'stack/test-lettered-update';
+    createTrackedBranch(work, branch);
+    commitFile(work, 'stack.txt', 'stack\n', 'stack update\n\nChange-Id: Iletter0001');
+    gitQuiet(work, 'push', '-u', 'origin', branch);
+    setManagedBranchConfig(work, branch);
+
+    const result = runCreatePr(work, harness, [
+      ...stackTitleArgs('master', '[Graph Blanking](3a) Split follow-up slice'),
+      '--update-existing',
+    ], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 43,
+          html_url: 'https://example.com/pull/43',
+          head: { ref: branch, repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+      GH_PATCH_RESPONSE: JSON.stringify({ html_url: 'https://example.com/pull/43' }),
+    });
+
+    const ghLog = existsSync(harness.ghLog) ? readFileSync(harness.ghLog, 'utf-8') : '';
+    assert(
+      result.status === 0,
+      `managed stack update should accept a lettered title\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}\ngh log:\n${ghLog}`,
+    );
+    assert(
+      result.stdout.trim() === 'https://example.com/pull/43',
+      `managed stack update should print updated PR URL for lettered titles\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}\ngh log:\n${ghLog}`,
+    );
+    expectNoPush(harness, 'managed lettered update skip push');
+
+    const ghCalls = readGhCalls(harness.ghLog);
+    const patchCall = ghCalls.find((call) => call.route.endsWith('/pulls/43'));
+    assert(Boolean(patchCall), 'managed lettered update should patch the existing PR');
+    assert(patchCall.stdin.includes('"title":"[Graph Blanking](3a) Split follow-up slice"'), 'managed lettered update patch should include lettered title');
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }
@@ -537,6 +580,7 @@ const tests = [
   testStaleBaseDetection,
   testMergifyManagedCreateRefusal,
   testMergifyManagedUpdateSkipsPush,
+  testMergifyManagedUpdateAcceptsLetteredTitle,
   testMergifyManagedUpdateRejectsPlainTitle,
   testMergifyManagedUpdateRejectsNestedTitle,
   testUnpublishedStackCommitsBlockUpdate,

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -656,6 +656,60 @@ assert(
   'routing review unit should reject mixed activation-surface stack slices like old #1755',
 );
 
+const old1756MixedRuntimeBody = `## Summary
+
+Publish review gate artifacts and approve merge tasks from review polling.
+
+<details>
+<summary>Review metadata</summary>
+
+Review Claim:
+
+External review publication and approval polling both use the same review gate state.
+
+Review Lane:
+
+- behavior
+
+Review Unit:
+
+- routing
+
+Safety Invariant:
+
+The merge task still waits for required review gates.
+
+Slice Rationale:
+
+Publication and polling landed together around the same review gate contract.
+
+</details>
+
+## Non-goals
+
+- Do not add docs or policy updates in this slice.
+
+## Test Plan
+
+- [ ] \`pnpm test\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`;
+const old1756BoundaryErrors = await validatePrBody(old1756MixedRuntimeBody, {
+  changedFiles: [
+    'packages/execution-engine/src/merge-runner.ts',
+    'packages/execution-engine/src/task-runner.ts',
+  ],
+});
+assert(
+  old1756BoundaryErrors.some((error) => error.includes('Publication and poll/approval runtime behavior must be split into separate PRs')),
+  'old #1756 mixed runtime slice should fail the publication vs poll/approval boundary guard',
+);
 const validationPolicyBody = `## Summary
 
 Validate stale recovery candidates.

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -8,6 +8,7 @@ import {
   getMarkdownSection,
   normalizeReviewUnit,
   reviewUnitsForChangedFiles,
+  validateKnownReviewBoundaries,
   validateReviewLaneUnitCompatibility,
   validateReviewUnitChangedFiles,
   validateReviewUnitFocus,
@@ -355,6 +356,11 @@ export async function validatePrBody(body, options = {}) {
     errors.push(...validatePrScope({ changedFiles: options.changedFiles, reviewLane, body: trimmed }));
     errors.push(...validateReviewUnitChangedFiles({
       declaredReviewUnit: reviewUnit,
+      changedFiles: options.changedFiles,
+      context: 'PR body',
+    }));
+    errors.push(...validateKnownReviewBoundaries({
+      reviewLane,
       changedFiles: options.changedFiles,
       context: 'PR body',
     }));

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -158,6 +158,20 @@ mergify stack push
 
 Do not generalize this to unrelated repos.
 
+## Stack repair after review
+
+If review says one published stack slice is still too broad:
+
+1. Re-run `skills/review-compression/SKILL.md`.
+2. If one published slice must split, keep the shared idea and create lettered replacement titles such as `(4a)` and `(4b)`.
+3. Run `mergify stack push`.
+4. Switch to each generated stack branch.
+5. Get the real base branch with `gh pr view --json baseRefName --jq .baseRefName`.
+6. Update each PR with `node scripts/create-pr.mjs --title "..." --base <actual-base-branch> --body-file <file> --update-existing`.
+
+Manual `gh pr edit` is a last-resort escape hatch only when `create-pr` itself is broken. The normal path is `create-pr --update-existing`.
+
+
 ## Validation
 
 - ensure the branch is pushed


### PR DESCRIPTION
## Summary

This makes stack repair safer after review.

It fixes two weak spots. `create-pr` now accepts lettered replacement slices like `(3a)`, and the PR validator now stops the old mixed `merge-runner.ts` plus `task-runner.ts` slice before publish.

It also teaches the make-pr skill to restack and re-author repaired slices with `create-pr --update-existing` instead of falling back to manual GitHub edits.

<details>
<summary>Review metadata</summary>

Review Claim:

The PR tooling now supports lettered stack repair slices and blocks the known mixed review-gate runtime boundary before publication.

Review Lane:

- policy

Review Unit:

- tooling-policy

Safety Invariant:

Only PR authoring rules, validation, and their deterministic tests change. Runtime execution code stays untouched.

Slice Rationale:

The stack split needs both the lettered-title repair path and the narrow boundary guard first, so reviewers can trust the next restack.

</details>

## Non-goals

- Do not change review-gate runtime behavior.
- Do not replace the existing review-unit taxonomy.

## Test Plan

- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/test-create-pr-stack-workflow.mjs`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for lettered slice indices (e.g., `[3a]`) in stacked PR titles for replacement scenarios.
  * Introduced validation to prevent mixing publication vs polling runtime behavior changes in the same PR.

* **Documentation**
  * Added "Stack repair after review" guide for re-splitting overly-broad published stacked PR slices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->