### PR TITLE
[Multi PR Review Gate](4b) Poll required review gate artifacts

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -4998,6 +4998,147 @@ console.log(JSON.stringify(out));
           cwd: '/runner-base-cwd',
         });
       });
+      it('polls all current reviewGate artifacts and approves only after every required artifact is approved', async () => {
+        const downstream = makeTask({ id: 'downstream-after-stack', status: 'running' });
+        const reviewGate = {
+          activeGeneration: 4,
+          completion: { required: 'all' as const, status: 'approved' as const },
+          artifacts: [
+            { id: 'contracts', providerId: 'pr-1', required: true, status: 'open' as const, generation: 4 },
+            { id: 'runtime', providerId: 'pr-2', required: true, status: 'open' as const, generation: 4, dependsOn: ['contracts'] },
+          ],
+        };
+        const task = makeTask({
+          id: 'merge-stack',
+          status: 'review_ready',
+          config: { isMergeNode: true },
+          execution: {
+            generation: 4,
+            selectedAttemptId: 'attempt-1',
+            reviewGate,
+            workspacePath: '/workspace/stack-gate',
+          },
+        });
+        const orchestrator = {
+          getTask: (id: string) => (id === task.id ? task : undefined),
+          getAllTasks: () => [task],
+          approve: vi.fn().mockResolvedValue([downstream]),
+        };
+        const persistence = {
+          updateTask: vi.fn((id: string, changes: any) => {
+            if (id === task.id && changes.execution?.reviewGate) {
+              (task as any).execution = { ...task.execution, ...changes.execution };
+            }
+          }),
+        };
+        const mergeGateProvider = {
+          checkApproval: vi.fn()
+            .mockResolvedValueOnce({ approved: true, rejected: false, statusText: 'Approved one' })
+            .mockResolvedValueOnce({ approved: false, rejected: false, statusText: 'Pending second' })
+            .mockResolvedValueOnce({ approved: true, rejected: false, statusText: 'Still approved' })
+            .mockResolvedValueOnce({ approved: true, rejected: false, statusText: 'Approved both' }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: persistence as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/runner-base-cwd',
+          mergeGateProvider: mergeGateProvider as any,
+        });
+        const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
+
+        await executor.checkMergeGateStatuses();
+
+        expect(mergeGateProvider.checkApproval).toHaveBeenNthCalledWith(1, {
+          identifier: 'pr-1',
+          cwd: '/workspace/stack-gate',
+        });
+        expect(mergeGateProvider.checkApproval).toHaveBeenNthCalledWith(2, {
+          identifier: 'pr-2',
+          cwd: '/workspace/stack-gate',
+        });
+        expect(orchestrator.approve).not.toHaveBeenCalled();
+        expect(task.execution.reviewGate?.artifacts).toEqual([
+          expect.objectContaining({ id: 'contracts', status: 'approved' }),
+          expect.objectContaining({ id: 'runtime', status: 'open', rawStatus: 'Pending second' }),
+        ]);
+
+        await executor.checkMergeGateStatuses();
+
+        expect(orchestrator.approve).toHaveBeenCalledTimes(1);
+        expect(orchestrator.approve).toHaveBeenCalledWith('merge-stack');
+        expect(executeTasks).toHaveBeenCalledWith([downstream]);
+        expect(task.execution.reviewGate?.artifacts).toEqual([
+          expect.objectContaining({ id: 'contracts', status: 'approved' }),
+          expect.objectContaining({ id: 'runtime', status: 'approved' }),
+        ]);
+      });
+
+      it('skips stale reviewGate poll results when the task generation changes before applying them', async () => {
+        const initialTask = makeTask({
+          id: 'merge-stale-stack',
+          status: 'review_ready',
+          config: { isMergeNode: true },
+          execution: {
+            generation: 4,
+            selectedAttemptId: 'attempt-1',
+            reviewGate: {
+              activeGeneration: 4,
+              completion: { required: 'all' as const, status: 'approved' as const },
+              artifacts: [
+                { id: 'contracts', providerId: 'pr-1', required: true, status: 'open' as const, generation: 4 },
+              ],
+            },
+          },
+        });
+        const newerTask = makeTask({
+          id: 'merge-stale-stack',
+          status: 'review_ready',
+          config: { isMergeNode: true },
+          execution: {
+            ...initialTask.execution,
+            generation: 5,
+            reviewGate: {
+              activeGeneration: 5,
+              completion: { required: 'all' as const, status: 'approved' as const },
+              artifacts: [
+                { id: 'contracts-v2', providerId: 'pr-2', required: true, status: 'open' as const, generation: 5 },
+              ],
+            },
+          },
+        });
+        const orchestrator = {
+          getTask: vi.fn(() => newerTask),
+          getAllTasks: () => [initialTask],
+          approve: vi.fn(),
+        };
+        const persistence = { updateTask: vi.fn() };
+        const mergeGateProvider = {
+          checkApproval: vi.fn().mockResolvedValue({
+            approved: true,
+            rejected: false,
+            statusText: 'Approved stale',
+          }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: persistence as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/runner-base-cwd',
+          mergeGateProvider: mergeGateProvider as any,
+        });
+
+        await executor.checkMergeGateStatuses();
+
+        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+          identifier: 'pr-1',
+          cwd: '/runner-base-cwd',
+        });
+        expect(persistence.updateTask).not.toHaveBeenCalled();
+        expect(orchestrator.approve).not.toHaveBeenCalled();
+      });
 
 
       it('merged status with workspacePath triggers orchestrator.approve', async () => {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -32,6 +32,7 @@ import { MergeGateExecutor } from './merge-gate-executor.js';
 import { isInvokerManagedPoolBranch } from './plan-base-remote.js';
 import { formatLifecycleTag, extractAttemptSuffix } from './branch-utils.js';
 import { SshExecutor } from './ssh-executor.js';
+
 import {
   executeMergeNodeImpl,
   approveMergeImpl,
@@ -2426,6 +2427,7 @@ export class TaskRunner {
       && !artifact.discardedAt;
   }
 
+
   private getCurrentReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
     const gate = task.execution.reviewGate;
     if (!gate) {
@@ -2466,6 +2468,9 @@ export class TaskRunner {
     providerId: string,
   ): boolean {
     if (!current) return false;
+    // Stale-write guard: a late poll must not write after the task already left
+    // the approval state (e.g. completed/closed/retried by another poll).
+    if (current.status !== 'review_ready' && current.status !== 'awaiting_approval') return false;
     if (current.execution.selectedAttemptId !== before.execution.selectedAttemptId) return false;
     if ((current.execution.generation ?? 0) !== (before.execution.generation ?? 0)) return false;
 
@@ -2536,18 +2541,61 @@ export class TaskRunner {
     }
   }
 
-  private handleClosedMergeGate(
-    taskId: string,
-    reviewId: string,
-    statusText: string,
-    source?: 'refresh' | 'manual check',
-  ): void {
-    const sourceSuffix = source ? ` (${source})` : '';
-    this.logger.info(`[merge-gate] PR ${reviewId} closed${sourceSuffix}: ${statusText}`);
-    this.persistence.updateTask(taskId, {
-      status: 'closed',
-      execution: { reviewStatus: statusText },
-    });
+  private async pollMergeGateTask(
+    task: TaskState,
+    source: 'refresh' | 'manual check',
+  ): Promise<void> {
+    const artifacts = this.getCurrentRequiredReviewArtifacts(task);
+    if (artifacts.length === 0) return;
+
+    let latestGate = task.execution.reviewGate;
+    let approvedGate = false;
+    for (const artifact of artifacts) {
+      const providerId = artifact.providerId;
+      if (!providerId) continue;
+      const gateCwd = task.execution.workspacePath ?? this.cwd;
+      const status = await this.mergeGateProvider!.checkApproval({
+        identifier: providerId,
+        cwd: gateCwd,
+      });
+
+      const current = this.orchestrator.getTask(task.id);
+      if (!this.reviewPollStillMatches(task, current, providerId)) {
+        continue;
+      }
+
+      // Rebase each provider update on the freshest persisted gate so concurrent
+      // polls don't clobber each other's artifact statuses with a stale snapshot.
+      const currentGate = current!.execution.reviewGate ?? latestGate;
+      if (currentGate) {
+        latestGate = this.updateReviewGateArtifact(currentGate, providerId, status);
+        this.persistence.updateTask(task.id, {
+          execution: { reviewGate: latestGate, reviewStatus: status.statusText },
+        });
+        if (!approvedGate && this.reviewGateIsApproved(latestGate)) {
+          approvedGate = true;
+          await this.handleApprovedMergeGate(task.id, providerId, source);
+        } else if (status.rejected) {
+          this.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
+        } else if (!status.closed && !status.approved) {
+          await this.maybeTriggerReviewGateCiFix(current!, status, providerId);
+        }
+        continue;
+      }
+
+      this.persistence.updateTask(task.id, {
+        ...(status.closed ? { status: 'closed' as const } : {}),
+        execution: { reviewStatus: status.statusText },
+      });
+      if (!approvedGate && status.approved) {
+        approvedGate = true;
+        await this.handleApprovedMergeGate(task.id, providerId, source);
+      } else if (status.rejected) {
+        this.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
+      } else if (!status.closed) {
+        await this.maybeTriggerReviewGateCiFix(current!, status, providerId);
+      }
+    }
   }
 
   async checkMergeGateStatuses(): Promise<void> {
@@ -2556,32 +2604,10 @@ export class TaskRunner {
       if (
         task.config.isMergeNode &&
         (task.status === 'review_ready' || task.status === 'awaiting_approval') &&
-        task.execution.reviewId
+        this.getCurrentRequiredReviewArtifacts(task).length > 0
       ) {
         try {
-          const gateCwd = task.execution.workspacePath ?? this.cwd;
-          const status = await this.mergeGateProvider.checkApproval({
-            identifier: task.execution.reviewId,
-            cwd: gateCwd,
-          });
-          if (status.closed) {
-            this.handleClosedMergeGate(task.id, task.execution.reviewId, status.statusText, 'refresh');
-          } else if (status.approved) {
-            this.persistence.updateTask(task.id, {
-              execution: { reviewStatus: status.statusText },
-            });
-            await this.handleApprovedMergeGate(task.id, task.execution.reviewId, 'refresh');
-          } else if (status.rejected) {
-            this.persistence.updateTask(task.id, {
-              execution: { reviewStatus: status.statusText },
-            });
-            this.logger.info(`[merge-gate] PR ${task.execution.reviewId} rejected (refresh): ${status.statusText}`);
-          } else {
-            this.persistence.updateTask(task.id, {
-              execution: { reviewStatus: status.statusText },
-            });
-            await this.maybeTriggerReviewGateCiFix(task, status);
-          }
+          await this.pollMergeGateTask(task, 'refresh');
         } catch (err) {
           this.logger.error(`[merge-gate] PR status check error for ${task.id}`, { err });
         }
@@ -2593,34 +2619,10 @@ export class TaskRunner {
     if (!this.mergeGateProvider) return;
 
     const task = this.orchestrator.getTask(taskId);
-    const reviewId = task?.execution.reviewId;
-    if (!task || !reviewId) return;
+    if (!task) return;
 
     try {
-      const manualCwd = task.execution.workspacePath ?? this.cwd;
-      const status = await this.mergeGateProvider.checkApproval({
-        identifier: reviewId,
-        cwd: manualCwd,
-      });
-
-      if (status.closed) {
-        this.handleClosedMergeGate(taskId, reviewId, status.statusText, 'manual check');
-      } else if (status.approved) {
-        this.persistence.updateTask(taskId, {
-          execution: { reviewStatus: status.statusText },
-        });
-        await this.handleApprovedMergeGate(taskId, reviewId, 'manual check');
-      } else if (status.rejected) {
-        this.persistence.updateTask(taskId, {
-          execution: { reviewStatus: status.statusText },
-        });
-        this.logger.info(`[merge-gate] PR ${reviewId} rejected (manual check): ${status.statusText}`);
-      } else {
-        this.persistence.updateTask(taskId, {
-          execution: { reviewStatus: status.statusText },
-        });
-        await this.maybeTriggerReviewGateCiFix(task, status);
-      }
+      await this.pollMergeGateTask(task, 'manual check');
     } catch (err) {
       this.logger.error(`[merge-gate] Manual PR check error for ${taskId}`, { err });
     }
@@ -2629,9 +2631,10 @@ export class TaskRunner {
   private async maybeTriggerReviewGateCiFix(
     task: TaskState,
     status: MergeGateApprovalStatus,
+    reviewId: string = task.execution.reviewId ?? '',
   ): Promise<void> {
     if (!this.onReviewGateCiFailure) return;
-    if (!task.config.workflowId || !task.execution.reviewId) return;
+    if (!task.config.workflowId || !reviewId) return;
     if (status.checks?.state !== 'failure' || status.checks.failed.length === 0) return;
 
     const key = [
@@ -2647,7 +2650,7 @@ export class TaskRunner {
       await this.onReviewGateCiFailure({
         taskId: task.id,
         workflowId: task.config.workflowId,
-        reviewId: task.execution.reviewId,
+        reviewId,
         reviewUrl: status.url,
         headSha: status.headSha,
         headRef: status.headRef,


### PR DESCRIPTION
## Summary

This polls merge-gate approval from the current required review-gate artifacts.

Manual refresh and scheduled polling now read the same current artifact set, ignore out-of-date provider results, and approve the merge task only after every required current artifact is approved.

<details>
<summary>Review metadata</summary>

Review Claim:

Polling and manual refresh approve merge gates from the current required review-gate artifacts.

Review Lane:

- behavior

Review Unit:

- routing

Safety Invariant:

The poller still falls back to the scalar review id when no review-gate artifact state exists, so older single-PR gates still refresh correctly.

Slice Rationale:

Publication already writes the artifact state in the lower slice. This slice only teaches approval polling to read and update that state.

</details>

## Non-goals

This does not publish review-gate artifacts.

This does not change review invalidation, discard, or close-before-invalidation behavior.

## Architecture

### Before

```mermaid
graph TD
  A[poll or manual refresh] --> B[one scalar reviewId]
  B --> C[approve on one PR result]
```

### After

```mermaid
graph TD
  A[poll or manual refresh] --> B[current required reviewGate artifacts]
  B --> C[skip stale provider results]
  C --> D[approve only when all current artifacts are approved]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts -t "polls all current reviewGate artifacts and approves only after every required artifact is approved|skips stale reviewGate poll results when the task generation changes before applying them"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 74f9ba440`
- Post-revert steps: None
- Data migration? No
Depends-On: #1864


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved merge-gate review handling to correctly evaluate multiple required artifacts and approve only when all are approved.
  * Prevented stale merge-gate polling updates from being applied if the task’s generation/review state changes mid-check.
  * Unified the merge-gate approval workflow so manual “check now” and periodic refresh use consistent logic.

* **Tests**
  * Added coverage for multi-artifact merge-gate approval behavior.
  * Added coverage to ensure generation-lineage guards ignore outdated poll results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->