### PR TITLE
[Handoff Coverage](2) Align handoff docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Then, in Codex, Claude, Cursor, or OMP, run:
 /invoker-plan-to-invoker "help me plan <change>"
 ```
 
-The command plans first, writes `plans/invoker-handoff.md`, converts it to YAML, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
+The command plans first, writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
 
 Source checkouts can install the repo helpers with `bash scripts/setup-agent-skills.sh`.
 
@@ -267,7 +267,7 @@ tasks:
     dependencies: [api, ui]
 ```
 
-If you need to turn a product or implementation plan into an Invoker workflow, install helpers from System Setup or `invoker-ui --install-skills`, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to YAML, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
+If you need to turn a product or implementation plan into an Invoker workflow, install helpers from System Setup or `invoker-ui --install-skills`, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
 
 If you need to operate existing workflows or tasks, use the `invoker-ops` skill.
 

--- a/docs/tutorial-first-agent-workflow.md
+++ b/docs/tutorial-first-agent-workflow.md
@@ -29,7 +29,7 @@ bash scripts/setup-agent-skills.sh
 pnpm run build
 ```
 
-For your own changes, install helpers from System Setup or `invoker-ui --install-skills`, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to YAML, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
+For your own changes, install helpers from System Setup or `invoker-ui --install-skills`, then run `/invoker-plan-to-invoker "help me plan <change>"` in Codex, Claude, Cursor, or OMP. The command plans first, writes `plans/invoker-handoff.md`, converts it to `plans/invoker-handoff.yaml`, validates, and submits with `invoker-cli run --live` or the Invoker MCP tool.
 
 Make sure at least one supported agent CLI is installed and authenticated:
 

--- a/packages/app/src/__tests__/bundled-skills.test.ts
+++ b/packages/app/src/__tests__/bundled-skills.test.ts
@@ -53,6 +53,13 @@ describe('bundled-skills', () => {
         invokerHomeRoot,
       });
 
+      expect(status.commandTargets).toHaveLength(4);
+      expect(status.commandTargets.every((target) => !target.installed)).toBe(true);
+      expect(status.commandTargets.every((target) => !target.upToDate)).toBe(true);
+      expect(status.mcpTargets).toHaveLength(1);
+      expect(status.mcpTargets[0]?.installed).toBe(false);
+      expect(status.mcpTargets[0]?.upToDate).toBe(false);
+
       expect(status.available).toBe(true);
       expect(status.promptRecommended).toBe(true);
       expect(status.bundledSkillNames).toEqual(['make-pr', 'plan-to-invoker']);
@@ -63,6 +70,7 @@ describe('bundled-skills', () => {
       } else {
         process.env.HOME = originalHome;
       }
+
     }
   });
 
@@ -112,6 +120,7 @@ describe('bundled-skills', () => {
       }
 
       const mcpConfig = JSON.parse(readFileSync(join(codexHome, '.omp', 'agent', 'mcp.json'), 'utf-8'));
+      expect(mcpConfig.$schema).toBe('https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json');
       expect(mcpConfig.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
 
       expect(installed.targets).toHaveLength(3);
@@ -200,6 +209,37 @@ describe('bundled-skills', () => {
         invokerHomeRoot,
       })).toThrow(`Invalid OMP MCP config at ${mcpPath}: expected a JSON object`);
       expect(readFileSync(mcpPath, 'utf-8')).toBe('[]');
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('rejects malformed OMP MCP JSON without rewriting it', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const fakeHome = makeTempRoot('invoker-omp-malformed-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = fakeHome;
+
+    try {
+      writeSkill(resourcesRoot, 'plan-to-invoker');
+      writePlanToInvokerCommands(resourcesRoot);
+      const mcpPath = join(fakeHome, '.omp', 'agent', 'mcp.json');
+      mkdirSync(join(fakeHome, '.omp', 'agent'), { recursive: true });
+      writeFileSync(mcpPath, '{"mcpServers":');
+
+      expect(() => installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+      })).toThrow(`Invalid OMP MCP config at ${mcpPath}: expected a JSON object`);
+      expect(readFileSync(mcpPath, 'utf-8')).toBe('{"mcpServers":');
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/packages/app/src/__tests__/cli-installer.test.ts
+++ b/packages/app/src/__tests__/cli-installer.test.ts
@@ -4,12 +4,12 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  findInstalledCli,
   maybeAutoInstallCli,
   resolveCliInstallerStatus,
   updateInvokerCli,
   type CliInstallerContext,
 } from '../cli-installer.js';
-
 const APP_VERSION = '0.0.3';
 
 function writeFakeCli(filePath: string, version: string): void {
@@ -79,6 +79,26 @@ describe('cli-installer', () => {
     expect(result.installedTo).toBe(existing);
     expect(readFileSync(existing, 'utf8')).toContain(APP_VERSION);
     expect(result.status.upToDate).toBe(true);
+  });
+
+  it('checks candidate install dirs before PATH when both contain a CLI', () => {
+    const candidateDir = path.join(scratchDir, 'candidate-bin');
+    const pathDir = path.join(scratchDir, 'on-path-bin');
+    mkdirSync(candidateDir);
+    mkdirSync(pathDir);
+    const candidateCli = path.join(candidateDir, 'invoker-cli');
+    const pathCli = path.join(pathDir, 'invoker-cli');
+    writeFakeCli(candidateCli, '0.0.2');
+    writeFakeCli(pathCli, APP_VERSION);
+    const context = makeContext({
+      env: { PATH: `${pathDir}:/usr/bin:/bin` },
+      candidateInstallDirs: [candidateDir],
+    });
+
+    const installed = findInstalledCli(context);
+
+    expect(installed?.path).toBe(candidateCli);
+    expect(installed?.version).toBe('0.0.2');
   });
 
   it('is a no-op when the installed version matches the app version', () => {

--- a/packages/app/src/__tests__/headless-install-skills.test.ts
+++ b/packages/app/src/__tests__/headless-install-skills.test.ts
@@ -42,4 +42,20 @@ describe('headless install-skills', () => {
     expect(output).toContain('- invoker-plan-to-invoker');
     expect(output).toContain('- invoker-make-pr');
   });
+
+  it('throws a clear error when helper installation is unavailable', async () => {
+    await expect(runHeadless(['install-skills'], {} as HeadlessDeps)).rejects.toThrow(
+      'Bundled AI helper installation is not available in this runtime.',
+    );
+  });
+
+  it('documents helper installation and OMP agent selection in help output', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await runHeadless(['--help'], {} as HeadlessDeps);
+
+    const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+    expect(output).toContain('install-skills [install|update|reinstall]          Install bundled Invoker AI helpers');
+    expect(output).toContain('set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)');
+  });
 });

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,12 +1,12 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { LocalBus } from '@invoker/transport';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { main } from '../index.js';
-import { handoffPrompt, submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
+import { HANDOFF_PROMPT_DESCRIPTION, handoffPrompt, submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
 
 const repoRoot = resolve(__dirname, '../../../..');
 const cliPath = resolve(repoRoot, 'packages/cli/dist/index.js');
@@ -49,6 +49,21 @@ function captureProcessOutput() {
 describe('invoker-cli', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('declares MCP runtime dependencies in the CLI manifest and lockfile', () => {
+    const manifest = JSON.parse(readFileSync(resolve(repoRoot, 'packages/cli/package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>;
+    };
+    const lockfile = readFileSync(resolve(repoRoot, 'pnpm-lock.yaml'), 'utf8');
+
+    expect(manifest.dependencies?.['@modelcontextprotocol/sdk']).toBe('^1.29.0');
+    expect(manifest.dependencies?.zod).toBe('^4.4.3');
+    expect(lockfile).toContain('  packages/cli:\n');
+    expect(lockfile).toContain("      '@modelcontextprotocol/sdk':\n        specifier: ^1.29.0\n");
+    expect(lockfile).toContain('      zod:\n        specifier: ^4.4.3\n');
+    expect(lockfile).toContain("'@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':");
+    expect(lockfile).toContain('  zod@4.4.3:');
   });
 
   it('--help exits 0', () => {
@@ -223,9 +238,16 @@ tasks:
   it('tells MCP handoff users to trigger PR skills before publication work', () => {
     const prompt = handoffPrompt('publish this as a PR stack');
 
+    expect(prompt).toContain('creating, updating, publishing, or splitting pull requests or PR stacks');
     expect(prompt).toContain('skill://make-pr/SKILL.md');
+    expect(prompt).toContain('before PR authoring or publication');
+    expect(prompt).toContain('multiple review slices');
     expect(prompt).toContain('skill://review-compression/SKILL.md');
-    expect(prompt).toContain('pull requests or PR stacks');
+    expect(prompt).toContain('before writing workflow YAML');
+  });
+
+  it('describes PR skill triggers in the MCP prompt metadata', () => {
+    expect(HANDOFF_PROMPT_DESCRIPTION).toContain('trigger PR skills for PR/stack work');
   });
   it('validates an Invoker plan for MCP without submitting it', async () => {
     const result = await validatePlanForMcp(fixturePlan);

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -12,6 +12,8 @@ export interface McpCliRunner {
   run(args: string[], options?: { cwd?: string }): Promise<{ exitCode: number; stdout: string; stderr: string }>;
 }
 
+export const HANDOFF_PROMPT_DESCRIPTION = 'Plan a requested change, trigger PR skills for PR/stack work, convert it to Invoker YAML, validate it, and submit it live.';
+
 type SubmitSuccess = { ok: true; workflowId: string; stdout: string };
 type SubmitFailure = { ok: false; exitCode: number; stdout: string; stderr: string; error?: string };
 
@@ -180,7 +182,7 @@ export async function runMcpServer(options: { runner?: McpCliRunner; cliPath?: s
   server.registerPrompt(
     'invoker-plan-to-invoker',
     {
-      description: 'Plan a requested change, trigger PR skills for PR/stack work, convert it to Invoker YAML, validate it, and submit it live.',
+      description: HANDOFF_PROMPT_DESCRIPTION,
       argsSchema: { request: z.string() },
     },
     ({ request }) => ({

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -12,11 +12,12 @@ import { vi } from 'vitest';
 import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
 
 vi.mock('@xyflow/react', async () => {
+  // Dynamic import is required because Vitest hoists mock factories before test imports.
   const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
   return createReactFlowMock();
 });
 
-// Lazy import App after mocking @xyflow/react
+// Dynamic import is required so App sees the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
 
 describe('App launch (component)', () => {
@@ -53,6 +54,32 @@ describe('App launch (component)', () => {
     render(<App />);
     expect(screen.getByTestId('workflow-status-pill-running')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
+  });
+
+  it('warns when no Claude or Codex CLI is installed', async () => {
+    mock.api.getSystemDiagnostics = vi.fn(async () => ({
+      platform: 'darwin',
+      arch: 'arm64',
+      appVersion: '0.0.5',
+      isPackaged: true,
+      tools: [
+        { id: 'claude', name: 'Claude', required: false, installed: false, installHint: 'Install Claude CLI' },
+        { id: 'codex', name: 'Codex', required: false, installed: false, installHint: 'Install Codex CLI' },
+      ],
+      bundledSkills: {
+        available: true,
+        promptRecommended: false,
+        managedPrefix: 'invoker-',
+        bundledSkillNames: ['plan-to-invoker'],
+        targets: [],
+        commandTargets: [],
+        mcpTargets: [],
+      },
+    }));
+
+    render(<App />);
+
+    expect(await screen.findByText('No Claude or Codex CLI detected yet. Install one before running agent-backed execution tasks.')).toBeInTheDocument();
   });
 
   it('opens system setup from left rail settings', async () => {

--- a/packages/ui/src/__tests__/system-setup-cli.test.tsx
+++ b/packages/ui/src/__tests__/system-setup-cli.test.tsx
@@ -144,6 +144,32 @@ describe('SystemSetupModal — Invoker CLI section', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Update Helpers' }));
     expect(onInstallBundledSkills).toHaveBeenCalledWith('update');
   });
+
+  it('reinstalls helpers when installed helper targets are already up to date', () => {
+    const onInstallBundledSkills = vi.fn();
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics(undefined, {
+          available: true,
+          promptRecommended: false,
+          managedPrefix: 'invoker-',
+          bundledSkillNames: ['plan-to-invoker'],
+          targets: [
+            { id: 'codex', name: 'Codex', path: '/tmp/.codex/skills', available: true, installed: true, upToDate: true, installedSkillNames: ['invoker-plan-to-invoker'] },
+          ],
+          commandTargets: [],
+          mcpTargets: [],
+        })}
+        onInstallBundledSkills={onInstallBundledSkills}
+        onClose={() => {}}
+      />,
+    );
+
+    const buttons = screen.getAllByRole('button', { name: 'Reinstall Helpers' });
+    expect(buttons).toHaveLength(2);
+    fireEvent.click(buttons[0]);
+    expect(onInstallBundledSkills).toHaveBeenCalledWith('reinstall');
+  });
   it('hides the section entirely when unsupported (dev mode)', () => {
     render(
       <SystemSetupModal

--- a/packages/ui/src/components/SystemSetupModal.tsx
+++ b/packages/ui/src/components/SystemSetupModal.tsx
@@ -28,9 +28,14 @@ export function SystemSetupModal({
   const helperTargets = bundledSkills
     ? [...bundledSkills.targets, ...bundledSkills.commandTargets, ...bundledSkills.mcpTargets]
     : [];
-  const installActionLabel = helperTargets.some((target) => target.installed && !target.upToDate)
-    ? 'Update Helpers'
+  const installActionMode = helperTargets.some((target) => target.installed && !target.upToDate)
+    ? 'update'
     : helperTargets.some((target) => target.installed)
+      ? 'reinstall'
+      : 'install';
+  const installActionLabel = installActionMode === 'update'
+    ? 'Update Helpers'
+    : installActionMode === 'reinstall'
       ? 'Reinstall Helpers'
       : 'Install Helpers';
 
@@ -176,7 +181,7 @@ export function SystemSetupModal({
               {canInstallBundledSkills && (
                 <div className="flex items-center gap-2">
                   <button
-                    onClick={() => onInstallBundledSkills?.(helperTargets.some((target) => target.installed) ? 'update' : 'install')}
+                    onClick={() => onInstallBundledSkills?.(installActionMode)}
                     disabled={installPending}
                     className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 disabled:bg-indigo-900 disabled:text-indigo-200 text-white rounded text-sm font-medium transition-colors"
                   >

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -30,6 +30,14 @@ must_contain() {
   fi
 }
 
+must_not_exist() {
+  local path="$1"
+  local hint="$2"
+  if [[ -e "$path" ]]; then
+    fail "$hint — unexpected file exists: $path"
+  fi
+}
+
 
 must_output_contain() {
   local output="$1"
@@ -40,6 +48,8 @@ must_output_contain() {
   fi
 }
 [[ -f "$CANONICAL_COMMAND" ]] || fail "expected canonical command source"
+must_not_exist "$REPO_ROOT/.claude/commands/plan-to-invoker.md" "legacy Claude handoff command copy must not drift from canonical source"
+must_not_exist "$REPO_ROOT/.cursor/commands/plan-to-invoker.md" "legacy Cursor handoff command copy must not drift from canonical source"
 [[ -f "$README" ]] || fail "expected $README"
 [[ -f "$TUTORIAL" ]] || fail "expected $TUTORIAL"
 must_contain "$CANONICAL_COMMAND" "invoker_submit_plan" "Invoker handoff command must submit through MCP"
@@ -92,8 +102,12 @@ must_contain "$SKILL_MD" "\"/invoker-plan-to-invoker\"" "SKILL frontmatter must 
 must_contain "$SKILL_MD" "## Harness handoff mode" "SKILL must document harness handoff mode"
 must_contain "$SKILL_MD" "Use this mode when invoked by the installed command or MCP prompt." "SKILL must define when handoff mode applies"
 must_contain "$SKILL_MD" "First produce a Markdown planning artifact at \`plans/invoker-handoff.md\`." "SKILL handoff mode must require a Markdown plan"
+must_contain "$SKILL_MD" "In an Invoker source checkout, still run \`bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>\` before submission." "SKILL handoff mode must keep checkout-local skill-doctor validation"
+must_contain "$SKILL_MD" "Outside an Invoker source checkout, \`invoker_validate_plan\` is the deterministic validation gate." "SKILL handoff mode must keep outside-checkout MCP validation"
 must_contain "$SKILL_MD" "Convert the approved Markdown plan to \`plans/invoker-handoff.yaml\`." "SKILL handoff mode must require YAML conversion"
 must_contain "$SKILL_MD" "Prefer the MCP tools \`invoker_validate_plan\` and \`invoker_submit_plan\` when available." "SKILL handoff mode must prefer MCP validation and submit"
+must_contain "$SKILL_MD" "skills/make-pr/SKILL.md" "SKILL handoff mode must trigger the PR skill for PR work"
+must_contain "$SKILL_MD" "skills/review-compression/SKILL.md" "SKILL handoff mode must trigger review compression for stack work"
 must_contain "$SKILL_MD" "never version or metadata wrappers" "SKILL frontmatter must reject legacy benchmark YAML wrappers"
 must_contain "$SKILL_MD" "## Benchmark/direct-output mode" "SKILL must document benchmark/direct-output mode"
 must_contain "$SKILL_MD" "Treat the literal absolute output path" "SKILL must require literal output path handling"

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -64,6 +64,9 @@ Use this mode when invoked by the installed command or MCP prompt.
 - In an Invoker source checkout, still run `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` before submission.
 - Outside an Invoker source checkout, `invoker_validate_plan` is the deterministic validation gate.
 
+- If the request involves creating, updating, publishing, or splitting pull requests or PR stacks, first read and follow `skills/make-pr/SKILL.md` (or `skill://make-pr/SKILL.md` when available) before PR authoring or publication.
+- If the request involves multiple review slices, first read and follow `skills/review-compression/SKILL.md` (or `skill://review-compression/SKILL.md` when available) before writing workflow YAML.
+
 ## Intended flow (do not skip steps)
 
 1. Discuss scope/risk with the user.


### PR DESCRIPTION
## Summary

The README and first-workflow tutorial now describe the same handoff path.

Both pages name the expected files and tools for that path.

<details>
<summary>Review metadata</summary>

Review Claim: The handoff docs now match each other.

Review Lane: docs

Review Unit: docs

Safety Invariant: This changes README and tutorial text only; runtime behavior is unchanged.

Slice Rationale: This slice keeps user-facing text separate from code and script guardrails.

</details>

## Non-goals

No runtime changes. No script policy changes. No installer changes.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit>`
- Post-revert steps: Re-run `bash scripts/test-plan-to-invoker-skill.sh`.
- Data migration? No

Depends-On: #1883


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow instructions for converting product plans into Invoker workflows with explicit steps for generating handoff files, converting to YAML format, validation, and submission via invoker-cli or Invoker MCP tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->