### PR TITLE
[Handoff Coverage](3) Assert handoff guardrails

### DIFF
--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -30,6 +30,18 @@ must_contain() {
   fi
 }
 
+must_contain_count() {
+  local file="$1"
+  local needle="$2"
+  local expected="$3"
+  local hint="$4"
+  local actual
+  actual="$( (grep -oF -- "$needle" "$file" || true) | wc -l | tr -d '[:space:]')"
+  if [[ "$actual" -ne "$expected" ]]; then
+    fail "$hint — expected $expected occurrences in $file but found $actual: $needle"
+  fi
+}
+
 must_not_exist() {
   local path="$1"
   local hint="$2"
@@ -52,17 +64,36 @@ must_not_exist "$REPO_ROOT/.claude/commands/plan-to-invoker.md" "legacy Claude h
 must_not_exist "$REPO_ROOT/.cursor/commands/plan-to-invoker.md" "legacy Cursor handoff command copy must not drift from canonical source"
 [[ -f "$README" ]] || fail "expected $README"
 [[ -f "$TUTORIAL" ]] || fail "expected $TUTORIAL"
+must_contain "$CANONICAL_COMMAND" "description: Plan a change and submit it through Invoker" "Invoker handoff command must keep host command description frontmatter"
+must_contain "$CANONICAL_COMMAND" 'argument-hint: "help me plan <change>"' "Invoker handoff command must keep host argument hint frontmatter"
+must_contain "$CANONICAL_COMMAND" "invoker_validate_plan" "Invoker handoff command must validate through MCP"
 must_contain "$CANONICAL_COMMAND" "invoker_submit_plan" "Invoker handoff command must submit through MCP"
+must_contain "$CANONICAL_COMMAND" "mode \`live\`" "Invoker handoff command must submit in live mode"
+must_contain "$CANONICAL_COMMAND" "invoker-cli run plans/invoker-handoff.yaml --live" "Invoker handoff command must document CLI live fallback"
 must_contain "$CANONICAL_COMMAND" "plans/invoker-handoff.md" "Invoker handoff command must write Markdown plan"
 must_contain "$CANONICAL_COMMAND" "plans/invoker-handoff.yaml" "Invoker handoff command must write YAML plan"
 must_contain "$CANONICAL_COMMAND" "skill://make-pr/SKILL.md" "Invoker handoff command must trigger the PR skill for PR work"
+must_contain "$CANONICAL_COMMAND" "creating, updating, publishing, or splitting pull requests or PR stacks" "Invoker handoff command must define PR skill trigger scope"
+must_contain "$CANONICAL_COMMAND" "before PR authoring or publication" "Invoker handoff command must require PR skill before publication work"
 must_contain "$CANONICAL_COMMAND" "skill://review-compression/SKILL.md" "Invoker handoff command must trigger review compression for stack work"
+must_contain "$CANONICAL_COMMAND" "multiple review slices" "Invoker handoff command must define review-compression trigger scope"
+must_contain "$CANONICAL_COMMAND" "before writing workflow YAML" "Invoker handoff command must require review compression before workflow YAML"
+must_contain "$README" "Install helpers from System Setup or:" "README must document System Setup helper installation"
+must_contain "$README" "invoker-ui --install-skills" "README must document headless helper installation"
+must_contain "$README" "Codex, Claude, Cursor, or OMP" "README must document supported handoff hosts"
 must_contain "$README" '/invoker-plan-to-invoker "help me plan <change>"' "README must document the installed handoff command"
 must_contain "$README" "plans/invoker-handoff.md" "README must document the handoff Markdown plan path"
+must_contain "$README" "plans/invoker-handoff.yaml" "README must document the handoff YAML plan path"
+must_contain "$README" "converts it to \`plans/invoker-handoff.yaml\`, validates" "README must document YAML conversion and validation"
 must_contain "$README" "invoker-cli run --live" "README must document the CLI handoff submit path"
 must_contain "$README" "Invoker MCP tool" "README must document the MCP handoff submit path"
+must_contain_count "$README" '/invoker-plan-to-invoker "help me plan <change>"' 2 "README must document the handoff command in install and usage sections"
+must_contain "$TUTORIAL" "System Setup or \`invoker-ui --install-skills\`" "Tutorial must document helper installation"
+must_contain "$TUTORIAL" "Codex, Claude, Cursor, or OMP" "Tutorial must document supported handoff hosts"
 must_contain "$TUTORIAL" '/invoker-plan-to-invoker "help me plan <change>"' "Tutorial must document the installed handoff command"
 must_contain "$TUTORIAL" "plans/invoker-handoff.md" "Tutorial must document the handoff Markdown plan path"
+must_contain "$TUTORIAL" "plans/invoker-handoff.yaml" "Tutorial must document the handoff YAML plan path"
+must_contain "$TUTORIAL" "converts it to \`plans/invoker-handoff.yaml\`, validates" "Tutorial must document YAML conversion and validation"
 must_contain "$TUTORIAL" "invoker-cli run --live" "Tutorial must document the CLI handoff submit path"
 must_contain "$TUTORIAL" "Invoker MCP tool" "Tutorial must document the MCP handoff submit path"
 
@@ -106,8 +137,14 @@ must_contain "$SKILL_MD" "In an Invoker source checkout, still run \`bash skills
 must_contain "$SKILL_MD" "Outside an Invoker source checkout, \`invoker_validate_plan\` is the deterministic validation gate." "SKILL handoff mode must keep outside-checkout MCP validation"
 must_contain "$SKILL_MD" "Convert the approved Markdown plan to \`plans/invoker-handoff.yaml\`." "SKILL handoff mode must require YAML conversion"
 must_contain "$SKILL_MD" "Prefer the MCP tools \`invoker_validate_plan\` and \`invoker_submit_plan\` when available." "SKILL handoff mode must prefer MCP validation and submit"
+must_contain "$SKILL_MD" "creating, updating, publishing, or splitting pull requests or PR stacks" "SKILL handoff mode must define PR skill trigger scope"
 must_contain "$SKILL_MD" "skills/make-pr/SKILL.md" "SKILL handoff mode must trigger the PR skill for PR work"
+must_contain "$SKILL_MD" "skill://make-pr/SKILL.md" "SKILL handoff mode must include skill URI fallback for PR work"
+must_contain "$SKILL_MD" "before PR authoring or publication" "SKILL handoff mode must require PR skill before publication work"
+must_contain "$SKILL_MD" "multiple review slices" "SKILL handoff mode must define review-compression trigger scope"
 must_contain "$SKILL_MD" "skills/review-compression/SKILL.md" "SKILL handoff mode must trigger review compression for stack work"
+must_contain "$SKILL_MD" "skill://review-compression/SKILL.md" "SKILL handoff mode must include skill URI fallback for review compression"
+must_contain "$SKILL_MD" "before writing workflow YAML" "SKILL handoff mode must require review compression before workflow YAML"
 must_contain "$SKILL_MD" "never version or metadata wrappers" "SKILL frontmatter must reject legacy benchmark YAML wrappers"
 must_contain "$SKILL_MD" "## Benchmark/direct-output mode" "SKILL must document benchmark/direct-output mode"
 must_contain "$SKILL_MD" "Treat the literal absolute output path" "SKILL must require literal output path handling"


### PR DESCRIPTION
## Summary

The plan-to-invoker shell check now covers the handoff text added by this stack.

It asserts frontmatter, PR-skill wording, host names, file paths, and fallback text.

<details>
<summary>Review metadata</summary>

Review Claim: The skill shell check fails when handoff guardrail text disappears.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This changes a shell check only; runtime behavior is unchanged.

Slice Rationale: This script guard follows the text slice so it can assert the final wording.

</details>

## Non-goals

No runtime changes. No docs text changes. No MCP server changes.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit>`
- Post-revert steps: Re-run `bash scripts/test-plan-to-invoker-skill.sh`.
- Data migration? No

Depends-On: #1884


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for handoff documentation requirements, adding assertions for validation and submission tool specifications, live-mode behavior, CLI live fallback options, PR trigger scope and ordering, and review-compression trigger scope/skill-URI fallback—also verifying review compression occurs before workflow YAML generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->