### PR TITLE
[Rebase Feedback](1) Show pending status for rebase recreate

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -64,6 +64,11 @@ type WorkflowContextMenuState = { x: number; y: number; workflowId: string; retu
 type SearchResult =
   | { kind: 'workflow'; id: string; title: string; subtitle: string }
   | { kind: 'task'; id: string; workflowId: string | null; title: string; subtitle: string };
+type WorkflowActionNotice = {
+  id: number;
+  workflowId: string;
+  label: string;
+};
 
 const KEYBOARD_REGION_ORDER: readonly KeyboardRegion[] = ['workflowGraph', 'taskGraph', 'inspector', 'bottomBar'];
 const SIDEBAR_NAV_ITEM_SELECTOR = '[data-sidebar-nav-item]';
@@ -419,6 +424,8 @@ export function App() {
   const [terminalSessions, setTerminalSessions] = useState<TerminalSessionDescriptor[]>([]);
   const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null);
   const [workflowContextMenu, setWorkflowContextMenu] = useState<WorkflowContextMenuState | null>(null);
+  const workflowActionNoticeIdRef = useRef(0);
+  const [workflowActionNotice, setWorkflowActionNotice] = useState<WorkflowActionNotice | null>(null);
   const [keyboardRegion, setKeyboardRegion] = useState<KeyboardRegion>('workflowGraph');
   const [previousGraphRegion, setPreviousGraphRegion] = useState<KeyboardRegion>('workflowGraph');
   // Typed graph camera state. The graph viewport is user-owned after the
@@ -583,6 +590,11 @@ export function App() {
     }
     return null;
   }, [selectedWorkflowId, selectedTask, workflows, stickySelectedWorkflow, selectedWorkflowTaskCount]);
+  const workflowActionNoticeTarget = useMemo(() => {
+    if (!workflowActionNotice) return null;
+    const workflow = workflows.get(workflowActionNotice.workflowId);
+    return workflow?.name || workflowActionNotice.workflowId;
+  }, [workflowActionNotice, workflows]);
   const miniDagTasks = useMemo(() => {
     const activeWorkflowId = selectedWorkflow?.id ?? selectedWorkflowId;
     if (!activeWorkflowId) return new Map<string, TaskState>();
@@ -1272,8 +1284,20 @@ export function App() {
     }
   }, []);
 
+  const beginWorkflowActionNotice = useCallback((workflowId: string, label: string) => {
+    const id = workflowActionNoticeIdRef.current + 1;
+    workflowActionNoticeIdRef.current = id;
+    setWorkflowActionNotice({ id, workflowId, label });
+    return id;
+  }, []);
+
+  const clearWorkflowActionNotice = useCallback((id: number) => {
+    setWorkflowActionNotice((current) => (current?.id === id ? null : current));
+  }, []);
+
   const handleRebaseRetry = useCallback(async (workflowId: string) => {
     setContextMenu(null);
+    const noticeId = beginWorkflowActionNotice(workflowId, 'Rebase and Retry');
     try {
       const result = await window.invoker?.rebaseRetry(workflowId);
       if (result && !result.success) {
@@ -1281,11 +1305,14 @@ export function App() {
       }
     } catch (err) {
       console.error('Rebase and Retry failed:', err);
+    } finally {
+      clearWorkflowActionNotice(noticeId);
     }
-  }, []);
+  }, [beginWorkflowActionNotice, clearWorkflowActionNotice]);
 
   const handleRebaseRecreate = useCallback(async (workflowId: string) => {
     setContextMenu(null);
+    const noticeId = beginWorkflowActionNotice(workflowId, 'Rebase and Recreate');
     try {
       const result = await window.invoker?.rebaseRecreate(workflowId);
       if (result && !result.success) {
@@ -1293,8 +1320,10 @@ export function App() {
       }
     } catch (err) {
       console.error('Rebase and Recreate failed:', err);
+    } finally {
+      clearWorkflowActionNotice(noticeId);
     }
-  }, []);
+  }, [beginWorkflowActionNotice, clearWorkflowActionNotice]);
 
   const handleRetryWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
@@ -1973,6 +2002,18 @@ export function App() {
                     </FloatingGraphPanel>
                   )}
                 </>
+              )}
+              {workflowActionNotice && workflowActionNoticeTarget && (
+                <div
+                  data-testid="workflow-action-notice"
+                  role="status"
+                  className="pointer-events-none absolute right-4 top-4 z-20 max-w-md rounded border border-blue-400/40 bg-blue-950/90 px-3 py-2 text-xs text-blue-100 shadow-lg"
+                >
+                  <div className="font-medium">{workflowActionNotice.label} started</div>
+                  <div className="mt-1 text-blue-200">
+                    {workflowActionNoticeTarget} will update when this finishes.
+                  </div>
+                </div>
               )}
             </div>
 

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -261,6 +261,29 @@ describe('Context menu (component)', () => {
     expectOnlyWorkflowApiCalled('rebaseRecreate');
   });
 
+  it('shows immediate feedback while rebase recreate is still running', async () => {
+    let finishRebase!: (value: { success: true; rebasedBranches: string[]; errors: string[] }) => void;
+    const pendingRebase = new Promise<{ success: true; rebasedBranches: string[]; errors: string[] }>((resolve) => {
+      finishRebase = resolve;
+    });
+    vi.mocked(mock.api.rebaseRecreate).mockImplementation(() => pendingRebase);
+
+    await setup();
+    fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));
+    fireEvent.click(await screen.findByText('More'));
+    fireEvent.click(await screen.findByText('Rebase and Recreate'));
+
+    expect(await screen.findByTestId('workflow-action-notice')).toHaveTextContent('Rebase and Recreate started');
+    expect(screen.getByTestId('workflow-action-notice')).toHaveTextContent('Test Workflow will update when this finishes.');
+    expect(mock.api.rebaseRecreate).toHaveBeenCalledWith('wf-1');
+
+    await act(async () => {
+      finishRebase({ success: true, rebasedBranches: [], errors: [] });
+      await pendingRebase;
+    });
+    await waitFor(() => expect(screen.queryByTestId('workflow-action-notice')).not.toBeInTheDocument());
+  });
+
   it('workflow context menu cancels workflow', async () => {
     await setup();
     fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));


### PR DESCRIPTION
## Summary

Rebase and Recreate now shows an immediate status message while the rebase is still running.

Before this, the menu closed and the app waited for the slow rebase call. That made a valid click look ignored.

The fix adds temporary UI state for workflow rebase actions. It clears when the action returns.

<details>
<summary>Review metadata</summary>

Review Claim: A workflow rebase action now gives immediate feedback during the pending wait.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The change only wraps existing workflow rebase calls with local pending UI state.

Slice Rationale: This is the user-visible feedback fix. Repro script proof is in the next stack slice.

</details>

## Non-goals

This does not change rebase logic, branch selection, task graph updates, or retry behavior.

## Architecture

### Before

```mermaid
graph TD
    A["User clicks Rebase and Recreate"] --> B["Close context menu"]
    B --> C["Await slow rebase IPC"]
    C --> D["Graph updates later"]
```

### After

```mermaid
graph TD
    A["User clicks Rebase and Recreate"] --> B["Close context menu"]
    B --> C["Show pending status message"]
    C --> D["Await slow rebase IPC"]
    D --> E["Clear pending status message"]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu-e2e.test.tsx -t "shows immediate feedback"`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/ui build`

## Visual Proof

![Rebase and Recreate pending feedback](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260622-85d67a/rebase-recreate-feedback.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a9cb6c182`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rebase operations now display a real-time status notification banner when initiated, clearly indicating which workflow is being rebased and providing feedback that the operation has started. The notification automatically dismisses when the operation completes or encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->