### PR TITLE
Add Mergify merge hold label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,7 @@
 # Mergify merge queue for the default branch.
+# Add the `merge-hold` label when a PR is approved in spirit but must not be
+# queued yet. This lets reviewers leave approval-adjacent comments without
+# Mergify landing the PR before small follow-ups are pushed.
 # GitHub rulesets already require PRs, squash merges, and one approval on master.
 # Keep repo-local conditions minimal and let Mergify respect the protected-branch
 # requirements instead of duplicating the full CI matrix here.
@@ -10,6 +13,7 @@ queue_rules:
       - base=master
       - -draft
       - "#approved-reviews-by >= 1"
+      - -label=merge-hold
     merge_conditions:
       - check-success = build-artifacts
       - check-success = quality / Dependency Cruise
@@ -34,6 +38,7 @@ queue_rules:
       - base=master
       - -draft
       - label=admin-bypass
+      - -label=merge-hold
     merge_conditions:
       - check-success = build-artifacts
       - check-success = quality / Dependency Cruise
@@ -59,6 +64,7 @@ pull_request_rules:
       - -draft
       - "#approved-reviews-by >= 1"
       - -label=admin-bypass
+      - -label=merge-hold
     actions:
       queue:
         name: default
@@ -68,6 +74,7 @@ pull_request_rules:
       - base=master
       - -draft
       - label=admin-bypass
+      - -label=merge-hold
     actions:
       queue:
         name: admin-bypass


### PR DESCRIPTION
## Summary

Approved PRs can now be held out of Mergify with one label.

The new `merge-hold` label blocks both normal approved autoqueue and `admin-bypass` autoqueue until the label is removed.

<details>
<summary>Review metadata</summary>

Review Claim: Mergify will not queue PRs that carry the `merge-hold` label.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This only changes Mergify queue conditions; product code and tests are untouched.

Slice Rationale: This is a small repo-policy change that should land alone so reviewers can check the automation rule directly.

</details>

## Non-goals

This does not create or rename GitHub labels.

This does not change required checks or merge methods.

## Test Plan

- [x] `python3 - <<'PY'
from pathlib import Path
import yaml
with Path('.mergify.yml').open() as f:
    data = yaml.safe_load(f)
assert any('-label=merge-hold' in rule.get('queue_conditions', []) for rule in data['queue_rules'])
assert all('-label=merge-hold' in rule.get('conditions', []) for rule in data['pull_request_rules'])
print('ok .mergify.yml parses and merge-hold blocks queue rules')
PY`
- [x] `mergify config validate`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 6a04ddf46`
- Post-revert steps: None
- Data migration? No
