### PR TITLE
Show queued workflow mutations in the UI

### DIFF
--- a/packages/app/src/__tests__/action-graph-diagnostics.test.ts
+++ b/packages/app/src/__tests__/action-graph-diagnostics.test.ts
@@ -71,6 +71,67 @@ describe('buildActionGraphDiagnostics', () => {
     expect(graph.edges).toContainEqual(expect.objectContaining({ source: 'action:wf-1', target: 'intent:7' }));
   });
 
+  it('creates running mutation action nodes with running duration', () => {
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [],
+      attemptsByTaskId: new Map(),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [{
+        id: 8,
+        workflowId: 'wf-1',
+        channel: 'invoker:rebase-recreate',
+        args: ['wf-1'],
+        priority: 'high',
+        status: 'running',
+        createdAt: '2026-05-14T11:54:00.000Z',
+        startedAt: '2026-05-14T11:58:00.000Z',
+      }],
+      mutationLeases: [],
+      eventsByTaskId: new Map(),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    const intent = graph.nodes.find((node) => node.id === 'intent:8');
+    expect(intent?.type).toBe('mutation-intent');
+    expect(intent?.status).toBe('running');
+    expect(intent?.durations?.runningMs).toBe(2 * 60_000);
+  });
+
+  it('creates failed mutation action nodes with backend error and suggested action', () => {
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [],
+      attemptsByTaskId: new Map(),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [{
+        id: 9,
+        workflowId: 'wf-1',
+        channel: 'invoker:rebase-recreate',
+        args: ['wf-1'],
+        priority: 'high',
+        status: 'failed',
+        createdAt: '2026-05-14T11:54:00.000Z',
+        startedAt: '2026-05-14T11:55:00.000Z',
+        completedAt: '2026-05-14T11:56:00.000Z',
+        error: 'boom',
+      }],
+      mutationLeases: [],
+      eventsByTaskId: new Map(),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    const intent = graph.nodes.find((node) => node.id === 'intent:9');
+    expect(intent?.type).toBe('mutation-intent');
+    expect(intent?.status).toBe('failed');
+    expect(intent?.latestError).toBe('boom');
+    expect(intent?.suggestedNextAction).toBe('Open the history expander and inspect the failed mutation error.');
+  });
+
   it('marks expired mutation leases as stalled with heartbeat age', () => {
     const graph = buildActionGraphDiagnostics({
       workflows: [workflow],

--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -136,22 +136,24 @@ describe('ipc-registration', () => {
   it('registers workflow-scoped handlers with the same dispatcher and enqueue shape', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
     const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-    const calls: Array<{
-      workflowId: string | undefined;
-      priority: WorkflowMutationPriority;
-      channel: string;
-      args: unknown[];
-    }> = [];
+    const accepted = {
+      ok: true as const,
+      accepted: true as const,
+      queued: true as const,
+      intentId: 42,
+      workflowId: 'workflow-for-task-1',
+      channel: 'invoker:restart-task',
+      label: 'Retry task',
+      status: 'queued' as const,
+    };
+    const submitWorkflowMutation = vi.fn(() => accepted);
     const context: WorkflowScopedGuiMutationRegistrationContext = {
       ipcMain,
       getOwnerMode: () => true,
       getMessageBus: () => ({ request: vi.fn() }),
       translateGuiMutationToHeadless: vi.fn(),
       workflowMutationDispatcher,
-      runWorkflowMutation: async (workflowId, priority, channel, args, op) => {
-        calls.push({ workflowId, priority, channel, args });
-        return op();
-      },
+      submitWorkflowMutation,
     };
     const handler = vi.fn(async (taskId: unknown) => `done:${String(taskId)}`);
 
@@ -163,24 +165,28 @@ describe('ipc-registration', () => {
       handler,
     );
 
-    await expect(handleHandlers.get('invoker:restart-task')?.({}, 'task-1')).resolves.toBe('done:task-1');
+    await expect(handleHandlers.get('invoker:restart-task')?.({}, 'task-1')).resolves.toBe(accepted);
+    expect(handler).not.toHaveBeenCalled();
+    expect(submitWorkflowMutation).toHaveBeenCalledWith('workflow-for-task-1', 'high', 'invoker:restart-task', ['task-1']);
     expect(workflowMutationDispatcher.has('invoker:restart-task')).toBe(true);
     await expect(workflowMutationDispatcher.get('invoker:restart-task')?.('task-2')).resolves.toBe('done:task-2');
-    expect(calls).toEqual([
-      {
-        workflowId: 'workflow-for-task-1',
-        priority: 'high',
-        channel: 'invoker:restart-task',
-        args: ['task-1'],
-      },
-    ]);
   });
 
   it('creates typed registrars that preserve channel registration outputs', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
     const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
     const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-    const runWorkflowMutation = vi.fn(async (_workflowId, _priority, _channel, _args, op) => op());
+    const accepted = {
+      ok: true as const,
+      accepted: true as const,
+      queued: true as const,
+      intentId: 9,
+      workflowId: 'wf:task-1',
+      channel: 'invoker:scoped',
+      label: 'Scoped',
+      status: 'queued' as const,
+    };
+    const submitWorkflowMutation = vi.fn(() => accepted);
     const guiContext: GuiMutationRegistrationContext = {
       ipcMain,
       getOwnerMode: () => true,
@@ -191,7 +197,7 @@ describe('ipc-registration', () => {
     const workflowContext: WorkflowScopedGuiMutationRegistrationContext = {
       ...guiContext,
       workflowMutationDispatcher,
-      runWorkflowMutation,
+      submitWorkflowMutation,
     };
 
     const {
@@ -208,15 +214,14 @@ describe('ipc-registration', () => {
     );
 
     await expect(handleHandlers.get('invoker:plain')?.({}, 'a')).resolves.toBe('plain:a');
-    await expect(handleHandlers.get('invoker:scoped')?.({}, 'task-1')).resolves.toBe('scoped:task-1');
+    await expect(handleHandlers.get('invoker:scoped')?.({}, 'task-1')).resolves.toBe(accepted);
     expect([...guiMutationHandlers.keys()]).toEqual(['invoker:plain', 'invoker:scoped']);
     expect([...workflowMutationDispatcher.keys()]).toEqual(['invoker:scoped']);
-    expect(runWorkflowMutation).toHaveBeenCalledWith(
+    expect(submitWorkflowMutation).toHaveBeenCalledWith(
       'wf:task-1',
       'normal',
       'invoker:scoped',
       ['task-1'],
-      expect.any(Function),
     );
   });
 

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -3,6 +3,7 @@ import { TransportError, TransportErrorCode } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkflowMutationPriority } from '../workflow-mutation-coordinator.js';
+import type { WorkflowMutationAcceptedResult } from '@invoker/contracts';
 
 export interface GuiMutationPayload {
   channel: string;
@@ -79,13 +80,12 @@ export function registerGuiMutationHandler<TResult = unknown>(
 
 export interface WorkflowScopedGuiMutationRegistrationContext extends GuiMutationRegistrationContext {
   workflowMutationDispatcher: Map<string, (...args: unknown[]) => Promise<unknown>>;
-  runWorkflowMutation: <T>(
+  submitWorkflowMutation: (
     workflowId: string | undefined,
     priority: WorkflowMutationPriority,
     channel: string,
     args: unknown[],
-    op: () => Promise<T>,
-  ) => Promise<T>;
+  ) => WorkflowMutationAcceptedResult;
 }
 
 export function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
@@ -98,7 +98,7 @@ export function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
   context.workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
   registerGuiMutationHandler(context, channel, async (...args: unknown[]) => {
     const workflowId = resolveWorkflowId(...args);
-    return context.runWorkflowMutation(workflowId, priority, channel, args, () => handler(...args));
+    return context.submitWorkflowMutation(workflowId, priority, channel, args);
   });
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -67,13 +67,15 @@ import type {
   TaskStateChanges,
 } from '@invoker/workflow-core';
 import {
+  IpcChannels,
   makeEnvelope,
   CommandError,
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { ActionGraphResponse, WorkflowMeta, WorkResponse } from '@invoker/contracts';
+import type { ActionGraphResponse, WorkflowMeta, WorkResponse, WorkflowMutationAcceptedResult, WorkflowMutationStatusEntry } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
+import type { WorkflowMutationIntent } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
   WorkspaceProbeAdapter,
@@ -445,12 +447,69 @@ function logHeadlessExecReceived(payload: HeadlessExecMutationPayload, mode: Hea
   );
 }
 
+function toWorkflowMutationStatusEntry(intent: WorkflowMutationIntent): WorkflowMutationStatusEntry {
+  return {
+    intentId: intent.id,
+    workflowId: intent.workflowId,
+    channel: intent.channel,
+    label: workflowMutationLabel(intent.channel, intent.args),
+    status: intent.status,
+    priority: intent.priority,
+    ownerId: intent.ownerId,
+    error: intent.error,
+    createdAt: intent.createdAt,
+    startedAt: intent.startedAt,
+    completedAt: intent.completedAt,
+    args: intent.args,
+  };
+}
+function workflowMutationLabel(channel: string, args: unknown[]): string {
+  const labels: Record<string, string> = {
+    'invoker:delete-workflow': 'Delete workflow',
+    'invoker:detach-workflow': 'Detach workflow',
+    'invoker:provide-input': 'Provide input',
+    'invoker:approve': 'Approve task',
+    'invoker:reject': 'Reject task',
+    'invoker:select-experiment': 'Select experiment',
+    'invoker:restart-task': 'Retry task',
+    'invoker:cancel-task': 'Cancel task',
+    'invoker:cancel-workflow': 'Cancel workflow',
+    'invoker:edit-task-command': 'Edit task command',
+    'invoker:edit-task-prompt': 'Edit task prompt',
+    'invoker:edit-task-type': 'Edit task executor',
+    'invoker:edit-task-pool': 'Edit task pool',
+    'invoker:edit-task-agent': 'Edit task agent',
+    'invoker:set-task-external-gate-policies': 'Set gate policy',
+    'invoker:replace-task': 'Replace task',
+    'invoker:recreate-workflow': 'Recreate workflow',
+    'invoker:recreate-task': 'Recreate task',
+    'invoker:recreate-downstream': 'Recreate downstream',
+    'invoker:retry-workflow': 'Retry workflow',
+    'invoker:rebase-retry': 'Rebase and Retry',
+    'invoker:rebase-recreate': 'Rebase and Recreate',
+    'invoker:set-merge-branch': 'Set merge branch',
+    'invoker:set-merge-mode': 'Set merge mode',
+    'invoker:approve-merge': 'Approve merge',
+    'invoker:resolve-conflict': 'Resolve conflict',
+    'invoker:fix-with-agent': 'Fix with agent',
+    'headless.exec': 'CLI command',
+  };
+
+  if (channel === 'headless.exec') {
+    const payload = args[0] as { args?: unknown } | undefined;
+    const cliArgs = Array.isArray(payload?.args) ? payload.args.filter((arg): arg is string => typeof arg === 'string') : [];
+    if (cliArgs.length > 0) return `CLI: ${cliArgs.join(' ')}`;
+  }
+
+  return labels[channel] ?? channel;
+}
+
 function acknowledgeNoTrackHeadlessExec(
   payload: HeadlessExecMutationPayload,
   workflowId: string | undefined,
   priority: WorkflowMutationPriority,
   mode: HeadlessOwnerMode,
-): { ok: true; intentId: number } | undefined {
+): WorkflowMutationAcceptedResult | undefined {
   logger.info(
     `headless.exec decision ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId ?? '<none>'}"`, priority })}`,
     { module: 'ipc-delegate' },
@@ -466,7 +525,7 @@ function acknowledgeNoTrackHeadlessExec(
       `headless.exec accepted ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId}"`, intent: intentId, priority })}`,
       { module: 'ipc-delegate' },
     );
-    return { ok: true, intentId };
+    return { ok: true, accepted: true, queued: true, intentId, workflowId, channel: 'headless.exec', label: workflowMutationLabel('headless.exec', [payload]), status: 'queued' };
   }
 
   const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
@@ -1098,6 +1157,29 @@ function startHeadlessMode(): void {
         return { workflowId, tasks };
       };
 
+      const submitStandaloneGuiMutation = (
+        workflowId: string | undefined,
+        priority: WorkflowMutationPriority,
+        channel: string,
+        args: unknown[],
+        handler: (...handlerArgs: unknown[]) => Promise<unknown>,
+      ): WorkflowMutationAcceptedResult => {
+        if (!workflowId) throw new Error(`Could not resolve workflow for ${channel}`);
+        if (!workflowMutationCoordinator) throw new Error('Workflow mutation coordinator is unavailable');
+        workflowMutationDispatcher.set(channel, handler);
+        const intentId = workflowMutationCoordinator.submit(workflowId, priority, channel, args);
+        return {
+          ok: true,
+          accepted: true,
+          queued: true,
+          intentId,
+          workflowId,
+          channel,
+          label: workflowMutationLabel(channel, args),
+          status: 'queued',
+        };
+      };
+
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
         switch (payload.channel) {
           case 'invoker:clear': {
@@ -1168,33 +1250,40 @@ function startHeadlessMode(): void {
           }
           case 'invoker:set-merge-branch': {
             const workflowId = String(payload.args[0]);
-            const baseBranch = String(payload.args[1]);
-            persistence.updateWorkflow(workflowId, { baseBranch });
-            const tasks = persistence.loadTasks(workflowId);
-            const mergeTask = tasks.find((task) => task.config.isMergeNode);
-            if (!mergeTask) return undefined;
-            const executor = createStandaloneTaskExecutor();
-            const envelope = makeEnvelope('set-merge-branch', 'ui', 'task', { taskId: mergeTask.id });
-            const result = await commandService.retryTask(envelope);
-            if (!result.ok) throw new Error(result.error.message);
-            const started = result.data;
-            await dispatchStartedTasksWithGlobalTopup({
-              orchestrator,
-              taskExecutor: executor,
-              logger,
-              context: 'standalone.set-merge-branch',
-              started,
-              scopedTaskIds: [mergeTask.id],
+            return submitStandaloneGuiMutation(workflowId, 'normal', payload.channel, payload.args, async (workflowIdArg: unknown, baseBranchArg: unknown) => {
+              const queuedWorkflowId = String(workflowIdArg);
+              const baseBranch = String(baseBranchArg);
+              persistence.updateWorkflow(queuedWorkflowId, { baseBranch });
+              const tasks = persistence.loadTasks(queuedWorkflowId);
+              const mergeTask = tasks.find((task) => task.config.isMergeNode);
+              if (!mergeTask) return undefined;
+              const executor = createStandaloneTaskExecutor();
+              const envelope = makeEnvelope('set-merge-branch', 'ui', 'task', { taskId: mergeTask.id });
+              const result = await commandService.retryTask(envelope);
+              if (!result.ok) throw new Error(result.error.message);
+              const started = result.data;
+              await dispatchStartedTasksWithGlobalTopup({
+                orchestrator,
+                taskExecutor: executor,
+                logger,
+                context: 'standalone.set-merge-branch',
+                started,
+                scopedTaskIds: [mergeTask.id],
+              });
+              return undefined;
             });
-            return undefined;
           }
           case 'invoker:replace-task': {
             const taskId = String(payload.args[0]);
-            const replacementTasks = payload.args[1] as TaskReplacementDef[];
-            const envelope = makeEnvelope('replace-task', 'ui', 'task', { taskId, replacementTasks });
-            const result = await commandService.replaceTask(envelope);
-            if (!result.ok) throw new Error(result.error.message);
-            return result.data;
+            const workflowId = resolveHeadlessTargetWorkflowId(taskId, persistence);
+            return submitStandaloneGuiMutation(workflowId, 'high', payload.channel, payload.args, async (taskIdArg: unknown, replacementTasksArg: unknown) => {
+              const queuedTaskId = String(taskIdArg);
+              const replacementTasks = replacementTasksArg as TaskReplacementDef[];
+              const envelope = makeEnvelope('replace-task', 'ui', 'task', { taskId: queuedTaskId, replacementTasks });
+              const result = await commandService.replaceTask(envelope);
+              if (!result.ok) throw new Error(result.error.message);
+              return result.data;
+            });
           }
           case 'invoker:check-pr-statuses': {
             const executor = createStandaloneTaskExecutor();
@@ -1212,25 +1301,33 @@ function startHeadlessMode(): void {
           }
           case 'invoker:select-experiment': {
             const taskId = String(payload.args[0]);
-            const experimentId = payload.args[1] as string | string[];
-            const ids = Array.isArray(experimentId) ? experimentId : [experimentId];
-            const executor = createStandaloneTaskExecutor();
-            if (ids.length === 1) {
-              const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId, experimentId: ids[0] });
-              const result = await commandService.selectExperiment(envelope);
-              if (!result.ok) throw new Error(result.error.message);
+            const workflowId = resolveHeadlessTargetWorkflowId(taskId, persistence);
+            return submitStandaloneGuiMutation(workflowId, 'normal', payload.channel, payload.args, async (taskIdArg: unknown, experimentIdArg: unknown) => {
+              const queuedTaskId = String(taskIdArg);
+              const experimentId = experimentIdArg as string | string[];
+              const ids = Array.isArray(experimentId) ? experimentId : [experimentId];
+              const executor = createStandaloneTaskExecutor();
+              if (ids.length === 1) {
+                const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId: queuedTaskId, experimentId: ids[0] });
+                const result = await commandService.selectExperiment(envelope);
+                if (!result.ok) throw new Error(result.error.message);
+                return undefined;
+              }
+              await sharedSelectExperiments(queuedTaskId, ids, { orchestrator, taskExecutor: executor });
               return undefined;
-            }
-            await sharedSelectExperiments(taskId, ids, { orchestrator, taskExecutor: executor });
-            return undefined;
+            });
           }
           case 'invoker:set-task-external-gate-policies': {
             const taskId = String(payload.args[0]);
-            const updates = payload.args[1] as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }>;
-            const envelope = makeEnvelope('set-gate-policies', 'ui', 'task', { taskId, updates });
-            const result = await commandService.setTaskExternalGatePolicies(envelope);
-            if (!result.ok) throw new Error(result.error.message);
-            return undefined;
+            const workflowId = resolveHeadlessTargetWorkflowId(taskId, persistence);
+            return submitStandaloneGuiMutation(workflowId, 'normal', payload.channel, payload.args, async (taskIdArg: unknown, updatesArg: unknown) => {
+              const queuedTaskId = String(taskIdArg);
+              const updates = updatesArg as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }>;
+              const envelope = makeEnvelope('set-gate-policies', 'ui', 'task', { taskId: queuedTaskId, updates });
+              const result = await commandService.setTaskExternalGatePolicies(envelope);
+              if (!result.ok) throw new Error(result.error.message);
+              return undefined;
+            });
           }
           default:
             throw new Error(`Unsupported internal mutation for standalone owner: ${payload.channel}`);
@@ -1597,7 +1694,7 @@ function startHeadlessMode(): void {
             `headless.run received trace=${traceId ?? '<none>'} planPath="${planPath}" ownerId=${workflowMutationOwnerId} mode=standalone`,
             { module: 'ipc-delegate' },
           );
-          const result = await executeStandaloneHeadlessRun({ planPath });
+          const result = await executeStandaloneHeadlessRun({ planPath, traceId });
           logger.info(
             `headless.run accepted trace=${traceId ?? '<none>'} workflow="${result.workflowId}" tasks=${result.tasks.length} mode=standalone`,
             { module: 'ipc-delegate' },
@@ -1614,7 +1711,7 @@ function startHeadlessMode(): void {
         });
         messageBus.onRequest('headless.query', async (req: unknown) => {
           noteStandaloneOwnerActivity();
-          const { kind, reset } = req as { kind?: string; reset?: boolean };
+          const { kind, reset, workflowId } = req as { kind?: string; reset?: boolean; workflowId?: string };
           if (kind === 'ui-perf') {
             if (reset) {
               headlessDeps.resetUiPerfStats?.();
@@ -1626,6 +1723,10 @@ function startHeadlessMode(): void {
           }
           if (kind === 'queue') {
             return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+          }
+          if (kind === 'workflow-mutation-statuses') {
+            const scopedWorkflowId = typeof workflowId === 'string' && workflowId.length > 0 ? workflowId : undefined;
+            return persistence.listWorkflowMutationStatusIntents(scopedWorkflowId).map(toWorkflowMutationStatusEntry);
           }
           if (kind === 'workflow-status') {
             return orchestrator.getWorkflowStatus();
@@ -2511,6 +2612,30 @@ function createEmbeddedTerminalBackendFromConfig(
     return workflowMutationCoordinator.enqueue<T>(workflowId, priority, channel, args);
   }
 
+  function submitWorkflowMutation(
+    workflowId: string | undefined,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+  ): WorkflowMutationAcceptedResult {
+    if (!workflowId) throw new Error(`Could not resolve workflow for ${channel}`);
+    if (!workflowMutationCoordinator) throw new Error('Workflow mutation coordinator is unavailable');
+    if (!workflowMutationDispatcher.has(channel)) {
+      throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
+    }
+    const intentId = workflowMutationCoordinator.submit(workflowId, priority, channel, args);
+    return {
+      ok: true,
+      accepted: true,
+      queued: true,
+      intentId,
+      workflowId,
+      channel,
+      label: workflowMutationLabel(channel, args),
+      status: 'queued',
+    };
+  }
+
   function translateGuiMutationToHeadless(payload: GuiMutationPayload):
     | { channel: 'headless.gui-mutation'; request: GuiMutationPayload }
     | { channel: 'headless.run'; request: HeadlessRunMutationPayload }
@@ -2657,7 +2782,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const workflowScopedGuiMutationRegistrationContext: WorkflowScopedGuiMutationRegistrationContext = {
     ...guiMutationRegistrationContext,
     workflowMutationDispatcher,
-    runWorkflowMutation,
+    submitWorkflowMutation,
   };
 
   const {
@@ -2667,6 +2792,18 @@ function createEmbeddedTerminalBackendFromConfig(
     guiMutationRegistrationContext,
     workflowScopedGuiMutationRegistrationContext,
   );
+
+  function registerTaskScopedGuiMutationHandler<TResult = unknown>(
+    channel: keyof typeof IpcChannels & string,
+    resolveWorkflowId: (...args: unknown[]) => string | undefined,
+    priority: WorkflowMutationPriority,
+    handler: (...args: unknown[]) => Promise<TResult>,
+  ): void {
+    workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
+    registerGuiMutationHandler(channel, async (...args: unknown[]) => (
+      submitWorkflowMutation(resolveWorkflowId(...args), priority, channel, args)
+    ));
+  }
 
   function createWindow(): void {
     createMainWindow({
@@ -3121,7 +3258,7 @@ function createEmbeddedTerminalBackendFromConfig(
         mode: 'gui',
       }));
       messageBus.onRequest('headless.query', async (req: unknown) => {
-        const { kind, reset } = req as { kind?: string; reset?: boolean };
+        const { kind, reset, workflowId } = req as { kind?: string; reset?: boolean; workflowId?: string };
         if (kind === 'ui-perf') {
           if (reset) {
             resetUiPerfStats();
@@ -3133,6 +3270,10 @@ function createEmbeddedTerminalBackendFromConfig(
         }
         if (kind === 'queue') {
           return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+        }
+        if (kind === 'workflow-mutation-statuses') {
+          const scopedWorkflowId = typeof workflowId === 'string' && workflowId.length > 0 ? workflowId : undefined;
+          return persistence.listWorkflowMutationStatusIntents(scopedWorkflowId).map(toWorkflowMutationStatusEntry);
         }
         if (kind === 'workflow-status') {
           return orchestrator.getWorkflowStatus();
@@ -3561,7 +3702,7 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:provide-input', async (taskIdArg: unknown, inputArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:provide-input', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, inputArg: unknown) => {
       const taskId = String(taskIdArg);
       const input = String(inputArg);
       const envelope = makeEnvelope('provide-input', 'ui', 'task', { taskId, input });
@@ -3590,7 +3731,7 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:reject', async (taskIdArg: unknown, reasonArg?: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:reject', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, reasonArg?: unknown) => {
       const taskId = String(taskIdArg);
       const reason = reasonArg === undefined ? undefined : String(reasonArg);
       const envelope = makeEnvelope('reject', 'ui', 'task', { taskId, reason });
@@ -3598,7 +3739,7 @@ function createEmbeddedTerminalBackendFromConfig(
       if (!result.ok) throw new Error(result.error.message);
     });
 
-    registerGuiMutationHandler('invoker:select-experiment', async (taskIdArg: unknown, experimentIdArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:select-experiment', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, experimentIdArg: unknown) => {
       const taskId = String(taskIdArg);
       const experimentId = experimentIdArg as string | string[];
       const ids = Array.isArray(experimentId) ? experimentId : [experimentId];
@@ -3735,6 +3876,23 @@ function createEmbeddedTerminalBackendFromConfig(
         }
       }
       return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
+    });
+
+    ipcMain.handle('invoker:get-workflow-mutation-statuses', async (_event, workflowIdArg?: unknown) => {
+      const workflowId = typeof workflowIdArg === 'string' && workflowIdArg.length > 0 ? workflowIdArg : undefined;
+      if (!ownerMode) {
+        try {
+          return await messageBus.request('headless.query', { kind: 'workflow-mutation-statuses', workflowId });
+        } catch (err) {
+          logger.warn(
+            `get-workflow-mutation-statuses owner delegation failed; falling back to local read-only snapshot: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            { module: 'ipc' },
+          );
+        }
+      }
+      return persistence.listWorkflowMutationStatusIntents(workflowId).map(toWorkflowMutationStatusEntry);
     });
 
     ipcMain.handle('invoker:report-ui-perf', (_event, metric: string, data?: Record<string, unknown>) => {
@@ -4056,7 +4214,7 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:set-merge-branch', async (workflowIdArg: unknown, baseBranchArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:set-merge-branch', (workflowIdArg: unknown) => String(workflowIdArg), 'normal', async (workflowIdArg: unknown, baseBranchArg: unknown) => {
       const workflowId = String(workflowIdArg);
       const baseBranch = String(baseBranchArg);
       logger.info(`set-merge-branch: workflow="${workflowId}" → "${baseBranch}"`, { module: 'ipc' });
@@ -4085,7 +4243,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:set-merge-mode', async (workflowIdArg: unknown, mergeModeArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:set-merge-mode', (workflowIdArg: unknown) => String(workflowIdArg), 'normal', async (workflowIdArg: unknown, mergeModeArg: unknown) => {
       const workflowId = String(workflowIdArg);
       const mergeMode = String(mergeModeArg);
       logger.info(`set-merge-mode: workflow="${workflowId}" → "${mergeMode}"`, { module: 'ipc' });
@@ -4227,7 +4385,7 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:edit-task-command', async (taskIdArg: unknown, newCommandArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:edit-task-command', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, newCommandArg: unknown) => {
       const taskId = String(taskIdArg);
       const newCommand = String(newCommandArg);
       logger.info(`edit-task-command: "${taskId}" → "${newCommand}"`, { module: 'ipc' });
@@ -4249,7 +4407,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-prompt', async (taskIdArg: unknown, newPromptArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:edit-task-prompt', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, newPromptArg: unknown) => {
       const taskId = String(taskIdArg);
       const newPrompt = String(newPromptArg);
       logger.info(`edit-task-prompt: "${taskId}" → "${newPrompt}"`, { module: 'ipc' });
@@ -4271,7 +4429,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-type', async (taskIdArg: unknown, runnerKindArg: unknown, poolMemberIdArg?: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:edit-task-type', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, runnerKindArg: unknown, poolMemberIdArg?: unknown) => {
       const taskId = String(taskIdArg);
       const runnerKind = String(runnerKindArg);
       const poolMemberId = poolMemberIdArg === undefined ? undefined : String(poolMemberIdArg);
@@ -4294,7 +4452,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-pool', async (taskIdArg: unknown, poolIdArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:edit-task-pool', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, poolIdArg: unknown) => {
       const taskId = String(taskIdArg);
       const poolId = String(poolIdArg);
       logger.info(`edit-task-pool: "${taskId}" → "${poolId}"`, { module: 'ipc' });
@@ -4316,7 +4474,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-agent', async (taskIdArg: unknown, agentNameArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:edit-task-agent', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, agentNameArg: unknown) => {
       const taskId = String(taskIdArg);
       const agentName = String(agentNameArg);
       logger.info(`edit-task-agent: "${taskId}" → "${agentName}"`, { module: 'ipc' });
@@ -4338,8 +4496,10 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler(
+    registerTaskScopedGuiMutationHandler(
       'invoker:set-task-external-gate-policies',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
       async (taskIdArg: unknown, updatesArg: unknown) => {
         const taskId = String(taskIdArg);
         const updates = updatesArg as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }>;
@@ -4394,7 +4554,7 @@ function createEmbeddedTerminalBackendFromConfig(
       return updateInvokerCli(buildCliInstallerContext());
     });
 
-    registerGuiMutationHandler('invoker:replace-task', async (taskIdArg: unknown, replacementTasksArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:replace-task', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'high', async (taskIdArg: unknown, replacementTasksArg: unknown) => {
       const taskId = String(taskIdArg);
       const replacementTasks = replacementTasksArg as unknown[];
       logger.info(`replace-task: "${taskId}" with ${replacementTasks.length} replacement(s)`, { module: 'ipc' });

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -203,6 +203,35 @@ export interface ActionGraphResponse {
   edges: ActionGraphEdge[];
 }
 
+export type WorkflowMutationUiStatus = 'queued' | 'running' | 'completed' | 'failed';
+export type WorkflowMutationUiPriority = 'high' | 'normal';
+
+export interface WorkflowMutationAcceptedResult {
+  ok: true;
+  accepted: true;
+  queued: true;
+  intentId: number;
+  workflowId: string;
+  channel: string;
+  label: string;
+  status: 'queued';
+}
+
+export interface WorkflowMutationStatusEntry {
+  intentId: number;
+  workflowId: string;
+  channel: string;
+  label: string;
+  status: WorkflowMutationUiStatus;
+  priority: WorkflowMutationUiPriority;
+  ownerId?: string;
+  error?: string;
+  createdAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  args: unknown[];
+}
+
 export interface ResumeWorkflowResult {
   workflow: { id: string; name: string; status: string };
   taskCount: number;
@@ -400,11 +429,11 @@ export const IpcChannels = {
   },
   'invoker:delete-workflow': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:detach-workflow': {} as {
     request: [workflowId: string, upstreamWorkflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:load-workflow': {} as {
     request: [workflowId: string];
@@ -444,19 +473,19 @@ export const IpcChannels = {
   // Task Actions
   'invoker:provide-input': {} as {
     request: [taskId: string, input: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:approve': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:reject': {} as {
     request: [taskId: string, reason?: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:select-experiment': {} as {
     request: [taskId: string, experimentId: string | string[]];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   /**
    * @deprecated Step 13 (`docs/architecture/task-invalidation-roadmap.md`):
@@ -473,41 +502,45 @@ export const IpcChannels = {
    */
   'invoker:restart-task': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:cancel-task': {} as {
     request: [taskId: string];
-    response: CancelResult;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:cancel-workflow': {} as {
     request: [workflowId: string];
-    response: CancelResult;
+    response: WorkflowMutationAcceptedResult;
   },
 
   // Task Editing
   'invoker:edit-task-command': {} as {
     request: [taskId: string, newCommand: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
+  },
+  'invoker:edit-task-type': {} as {
+    request: [taskId: string, runnerKind: string, poolMemberId?: string];
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:edit-task-pool': {} as {
     request: [taskId: string, poolId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:edit-task-agent': {} as {
     request: [taskId: string, agentName: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:edit-task-prompt': {} as {
     request: [taskId: string, newPrompt: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:set-task-external-gate-policies': {} as {
     request: [taskId: string, updates: ExternalGatePolicyUpdate[]];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:replace-task': {} as {
     request: [taskId: string, replacementTasks: TaskReplacementDef[]];
-    response: TaskState[];
+    response: WorkflowMutationAcceptedResult;
   },
 
   // Session & Agent Access
@@ -523,39 +556,39 @@ export const IpcChannels = {
   // Workflow Mutation & Merge
   'invoker:recreate-workflow': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:recreate-task': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:recreate-downstream': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:retry-workflow': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:rebase-retry': {} as {
     request: [target: string];
-    response: RebaseAndRetryResult;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:rebase-recreate': {} as {
     request: [target: string];
-    response: RebaseAndRetryResult;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:set-merge-branch': {} as {
     request: [workflowId: string, baseBranch: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:set-merge-mode': {} as {
     request: [workflowId: string, mergeMode: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:approve-merge': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
 
   // PR & Conflict Resolution
@@ -569,11 +602,11 @@ export const IpcChannels = {
   },
   'invoker:resolve-conflict': {} as {
     request: [taskId: string, agentName?: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:fix-with-agent': {} as {
     request: [taskId: string, agentName?: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
 
   // Queue & Configuration
@@ -584,6 +617,10 @@ export const IpcChannels = {
   'invoker:get-action-graph': {} as {
     request: [];
     response: ActionGraphResponse;
+  },
+  'invoker:get-workflow-mutation-statuses': {} as {
+    request: [workflowId?: string];
+    response: WorkflowMutationStatusEntry[];
   },
   'invoker:get-remote-targets': {} as {
     request: [];

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3010,6 +3010,33 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return rows.map((row) => this.rowToWorkflowMutationIntent(row));
   }
 
+  listWorkflowMutationStatusIntents(
+    workflowId?: string,
+    terminalLimit = 50,
+  ): WorkflowMutationIntent[] {
+    const workflowWhere = workflowId ? 'AND workflow_id = ?' : '';
+    const workflowParams = workflowId ? [workflowId] : [];
+    const openRows = this.queryAll(
+      `SELECT * FROM workflow_mutation_intents
+       WHERE status IN ('queued', 'running') ${workflowWhere}
+       ORDER BY CASE priority WHEN 'high' THEN 0 ELSE 1 END ASC, id ASC`,
+      workflowParams,
+    );
+    const limit = Math.max(0, Math.floor(terminalLimit));
+    const terminalRows = limit === 0
+      ? []
+      : this.queryAll(
+        `SELECT * FROM workflow_mutation_intents
+         WHERE status IN ('failed', 'completed') ${workflowWhere}
+         ORDER BY id DESC
+         LIMIT ?`,
+        [...workflowParams, limit],
+      );
+    return [...openRows, ...terminalRows]
+      .map((row) => this.rowToWorkflowMutationIntent(row))
+      .sort((a, b) => b.id - a.id);
+  }
+
   requeueRunningWorkflowMutationIntents(): number {
     const running = this.queryOne(
       `SELECT COUNT(*) AS count FROM workflow_mutation_intents WHERE status = 'running'`,

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,9 +12,10 @@
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
 import yaml from 'js-yaml';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
-import type { ActionGraphNode, TerminalSessionDescriptor } from '@invoker/contracts';
+import type { ActionGraphNode, TerminalSessionDescriptor, WorkflowMutationAcceptedResult, WorkflowMutationStatusEntry } from '@invoker/contracts';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
+import { useWorkflowMutations } from './hooks/useWorkflowMutations.js';
 import { useInvoker } from './hooks/useInvoker.js';
 import { TaskDAG } from './components/TaskDAG.js';
 import { HistoryView } from './components/HistoryView.js';
@@ -383,10 +384,23 @@ export function App() {
   });
   const invoker = useInvoker();
   const queueStatus = useQueueStatus();
+  const { mutationsByWorkflow, recordAcceptedMutation } = useWorkflowMutations();
+  const trackAcceptedMutation = useCallback((result: unknown) => {
+    if (result && typeof result === 'object' && (result as { accepted?: unknown }).accepted === true) {
+      recordAcceptedMutation(result as WorkflowMutationAcceptedResult);
+    }
+  }, [recordAcceptedMutation]);
   const runningTaskIds = useMemo(
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
     [queueStatus],
   );
+  const openMutationsByWorkflow = useMemo(() => {
+    const open = new Map<string, WorkflowMutationStatusEntry | undefined>();
+    for (const [workflowId, rows] of mutationsByWorkflow) {
+      open.set(workflowId, rows.find((row) => row.status === 'queued' || row.status === 'running'));
+    }
+    return open;
+  }, [mutationsByWorkflow]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
@@ -638,6 +652,10 @@ export function App() {
   }, [miniDagTasks, selectedTask, selectedWorkflow, selectedWorkflowId, tasks.size, workflowSelectionDismissed]);
   const isSelectedWorkflowGraphRefreshing = displayedSelectedWorkflowGraph !== null
     && !(selectedWorkflow && miniDagTasks.size > 0);
+  const selectedWorkflowMutations = useMemo(() => {
+    const workflowId = (displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow)?.id;
+    return workflowId ? mutationsByWorkflow.get(workflowId) : undefined;
+  }, [displayedSelectedWorkflowGraph, mutationsByWorkflow, selectedWorkflow]);
   const selectedTaskDagWorkflows = useMemo(() => {
     const workflowForDag = displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow;
     if (!workflowForDag || workflows.has(workflowForDag.id)) {
@@ -1222,11 +1240,11 @@ export function App() {
     if (!invoker) return;
     setContextMenu(null);
     try {
-      await invoker.restartTask(taskId);
+      trackAcceptedMutation(await invoker.restartTask(taskId));
     } catch (err) {
       console.error('Failed to restart task:', err);
     }
-  }, [invoker]);
+  }, [invoker, trackAcceptedMutation]);
 
   const handleOpenTerminal = useCallback(
     (taskId: string) => {
@@ -1266,71 +1284,65 @@ export function App() {
 
   const handleReplaceSubmit = useCallback(async (taskId: string, replacements: TaskReplacementDef[]) => {
     try {
-      await window.invoker?.replaceTask(taskId, replacements);
+      trackAcceptedMutation(await window.invoker?.replaceTask(taskId, replacements));
     } catch (err) {
       console.error('Failed to replace task:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRebaseRetry = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      const result = await window.invoker?.rebaseRetry(workflowId);
-      if (result && !result.success) {
-        console.error('Rebase and Retry failed for some branches:', result.errors);
-      }
+      trackAcceptedMutation(await window.invoker?.rebaseRetry(workflowId));
     } catch (err) {
       console.error('Rebase and Retry failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRebaseRecreate = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      const result = await window.invoker?.rebaseRecreate(workflowId);
-      if (result && !result.success) {
-        console.error('Rebase and Recreate failed for some branches:', result.errors);
-      }
+      trackAcceptedMutation(await window.invoker?.rebaseRecreate(workflowId));
     } catch (err) {
       console.error('Rebase and Recreate failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRetryWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.retryWorkflow(workflowId);
+      trackAcceptedMutation(await window.invoker?.retryWorkflow(workflowId));
     } catch (err) {
       console.error('Retry Workflow failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRecreateWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.recreateWorkflow(workflowId);
+      trackAcceptedMutation(await window.invoker?.recreateWorkflow(workflowId));
     } catch (err) {
       console.error('Recreate Workflow failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRecreateTask = useCallback(async (taskId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.recreateTask(taskId);
+      trackAcceptedMutation(await window.invoker?.recreateTask(taskId));
     } catch (err) {
       console.error('Recreate from Task failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRecreateDownstream = useCallback(async (taskId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.recreateDownstream(taskId);
+      trackAcceptedMutation(await window.invoker?.recreateDownstream(taskId));
     } catch (err) {
       console.error('Recreate Downstream failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleDeleteWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
@@ -1339,7 +1351,7 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await window.invoker?.deleteWorkflow(workflowId);
+      trackAcceptedMutation(await window.invoker?.deleteWorkflow(workflowId));
       setSelectedTaskId(null);
       if (selectedWorkflowId === workflowId) {
         setSelectedWorkflowId(null);
@@ -1348,7 +1360,7 @@ export function App() {
     } catch (err) {
       console.error('Delete Workflow failed:', err);
     }
-  }, [refreshTaskGraph, selectedWorkflowId]);
+  }, [refreshTaskGraph, selectedWorkflowId, trackAcceptedMutation]);
 
   const handleFix = useCallback(async (taskId: string, agentName: string) => {
     setContextMenu(null);
@@ -1364,16 +1376,15 @@ export function App() {
     }
     try {
       const hasMergeConflict = hasMergeConflictExecution(task);
-      if (hasMergeConflict) {
-        await window.invoker?.resolveConflict(taskId, agentName);
-      } else {
-        await window.invoker?.fixWithAgent(taskId, agentName);
-      }
+      const result = hasMergeConflict
+        ? await window.invoker?.resolveConflict(taskId, agentName)
+        : await window.invoker?.fixWithAgent(taskId, agentName);
+      trackAcceptedMutation(result);
       refreshTaskGraph();
     } catch (err) {
       console.error('Fix failed:', err);
     }
-  }, [tasks, refreshTaskGraph]);
+  }, [tasks, refreshTaskGraph, trackAcceptedMutation]);
 
   const handleCancelTask = useCallback(async (taskId: string) => {
     setContextMenu(null);
@@ -1382,11 +1393,11 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await window.invoker?.cancelTask(taskId);
+      trackAcceptedMutation(await window.invoker?.cancelTask(taskId));
     } catch (err) {
       console.error('Failed to cancel task:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleCancelWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
@@ -1395,11 +1406,11 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await window.invoker?.cancelWorkflow(workflowId);
+      trackAcceptedMutation(await window.invoker?.cancelWorkflow(workflowId));
     } catch (err) {
       console.error('Failed to cancel workflow:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleOpenWorkflowPr = useCallback((workflowId: string) => {
     const workflowTasks = [...tasks.values()].filter((task) => task.config.workflowId === workflowId);
@@ -1548,33 +1559,33 @@ export function App() {
   const handleProvideInput = useCallback(
     async (taskId: string, input: string) => {
       if (!invoker) return;
-      await invoker.provideInput(taskId, input);
+      trackAcceptedMutation(await invoker.provideInput(taskId, input));
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleApprove = useCallback(
     async (taskId: string) => {
       if (!invoker) return;
-      await invoker.approve(taskId);
+      trackAcceptedMutation(await invoker.approve(taskId));
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleReject = useCallback(
     async (taskId: string, reason?: string) => {
       if (!invoker) return;
-      await invoker.reject(taskId, reason);
+      trackAcceptedMutation(await invoker.reject(taskId, reason));
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleSelectExperiment = useCallback(
     async (taskId: string, experimentIds: string[]) => {
       if (!invoker) return;
-      await invoker.selectExperiment(taskId, experimentIds.length === 1 ? experimentIds[0] : experimentIds);
+      trackAcceptedMutation(await invoker.selectExperiment(taskId, experimentIds.length === 1 ? experimentIds[0] : experimentIds));
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task command ──────────────────────────────────────
@@ -1582,12 +1593,12 @@ export function App() {
     async (taskId: string, newCommand: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskCommand(taskId, newCommand);
+        trackAcceptedMutation(await invoker.editTaskCommand(taskId, newCommand));
       } catch (err) {
         console.error('Failed to edit task command:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task prompt ───────────────────────────────────────
@@ -1595,12 +1606,12 @@ export function App() {
     async (taskId: string, newPrompt: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskPrompt(taskId, newPrompt);
+        trackAcceptedMutation(await invoker.editTaskPrompt(taskId, newPrompt));
       } catch (err) {
         console.error('Failed to edit task prompt:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task executor type ───────────────────────────────
@@ -1608,12 +1619,12 @@ export function App() {
     async (taskId: string, runnerKind: string, poolMemberId?: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskType(taskId, runnerKind, poolMemberId);
+        trackAcceptedMutation(await invoker.editTaskType(taskId, runnerKind, poolMemberId));
       } catch (err) {
         console.error('Failed to edit task type:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task execution pool ─────────────────────────────
@@ -1621,12 +1632,12 @@ export function App() {
     async (taskId: string, poolId: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskPool(taskId, poolId);
+        trackAcceptedMutation(await invoker.editTaskPool(taskId, poolId));
       } catch (err) {
         console.error('Failed to edit task pool:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task execution agent ────────────────────────────
@@ -1634,50 +1645,50 @@ export function App() {
     async (taskId: string, agentName: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskAgent(taskId, agentName);
+        trackAcceptedMutation(await invoker.editTaskAgent(taskId, agentName));
       } catch (err) {
         console.error('Failed to edit task agent:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleSetExternalGatePolicies = useCallback(
     async (taskId: string, updates: ExternalGatePolicyUpdate[]) => {
       if (!invoker) return;
       try {
-        await invoker.setTaskExternalGatePolicies(taskId, updates);
+        trackAcceptedMutation(await invoker.setTaskExternalGatePolicies(taskId, updates));
       } catch (err) {
         console.error('Failed to set external gate policies:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleSetMergeBranch = useCallback(
     async (workflowId: string, baseBranch: string) => {
       if (!invoker) return;
       try {
-        await invoker.setMergeBranch(workflowId, baseBranch);
+        trackAcceptedMutation(await invoker.setMergeBranch(workflowId, baseBranch));
         refreshTaskGraph();
       } catch (err) {
         console.error('Failed to set merge branch:', err);
       }
     },
-    [invoker, refreshTaskGraph],
+    [invoker, refreshTaskGraph, trackAcceptedMutation],
   );
 
   const handleSetMergeMode = useCallback(
     async (workflowId: string, mergeMode: 'manual' | 'automatic' | 'external_review') => {
       if (!invoker) return;
       try {
-        await invoker.setMergeMode(workflowId, mergeMode);
+        trackAcceptedMutation(await invoker.setMergeMode(workflowId, mergeMode));
         refreshTaskGraph();
       } catch (err) {
         console.error('Failed to set merge mode:', err);
       }
     },
-    [invoker, refreshTaskGraph],
+    [invoker, refreshTaskGraph, trackAcceptedMutation],
   );
 
   // ── Modal triggers ────────────────────────────────────────
@@ -1933,6 +1944,7 @@ export function App() {
                     selectedWorkflowId={selectedWorkflow?.id ?? null}
                     cameraCommand={cameraCommand}
                     statusFilters={statusFilters}
+                    openMutationsByWorkflow={openMutationsByWorkflow}
                     onSelectWorkflow={handleWorkflowClick}
                     onWorkflowContextMenu={handleWorkflowContextMenu}
                     onManualViewport={handleManualViewport}
@@ -2015,6 +2027,7 @@ export function App() {
             <WorkflowInspector
               workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
               task={selectedTask}
+              workflowMutations={selectedWorkflowMutations}
               workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
               remoteTargets={remoteTargets}
               executionPools={executionPools}

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -61,6 +61,7 @@ describe('Context menu (component)', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     mock.cleanup();
   });
 
@@ -259,6 +260,90 @@ describe('Context menu (component)', () => {
     fireEvent.click(await screen.findByText('Rebase and Recreate'));
     await waitFor(() => expect(mock.api.rebaseRecreate).toHaveBeenCalledWith('wf-1'));
     expectOnlyWorkflowApiCalled('rebaseRecreate');
+  });
+
+  it('workflow context menu shows backend accepted queued mutation', async () => {
+    await setup();
+    vi.mocked(mock.api.rebaseRecreate).mockResolvedValueOnce({
+      intentId: 77,
+      workflowId: 'wf-1',
+      channel: 'invoker:rebase-recreate',
+      label: 'Rebase and Recreate',
+      status: 'queued',
+      accepted: true,
+      queued: true,
+      ok: true,
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));
+    fireEvent.click(await screen.findByText('More'));
+    fireEvent.click(await screen.findByText('Rebase and Recreate'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-1-mutation')).toHaveTextContent('Queued: Rebase and Recreate');
+    });
+    fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
+    expect(await screen.findByTestId('workflow-mutation-row-77')).toHaveTextContent('Rebase and Recreate');
+    expect(screen.getByTestId('workflow-mutation-status-77')).toHaveTextContent('QUEUED');
+  });
+
+  it('workflow mutation status poll updates queued to running and failed', async () => {
+    await setup();
+    vi.mocked(mock.api.rebaseRecreate).mockResolvedValueOnce({
+      intentId: 77,
+      workflowId: 'wf-1',
+      channel: 'invoker:rebase-recreate',
+      label: 'Rebase and Recreate',
+      status: 'queued',
+      accepted: true,
+      queued: true,
+      ok: true,
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));
+    fireEvent.click(await screen.findByText('More'));
+    fireEvent.click(await screen.findByText('Rebase and Recreate'));
+    await screen.findByTestId('workflow-mutation-row-77');
+
+    mock.setWorkflowMutationStatuses([{
+      intentId: 77,
+      workflowId: 'wf-1',
+      channel: 'invoker:rebase-recreate',
+      label: 'Rebase and Recreate',
+      status: 'running',
+      priority: 'high',
+      createdAt: '2026-06-22T00:00:00.000Z',
+      startedAt: '2026-06-22T00:00:01.000Z',
+      args: ['wf-1'],
+    }]);
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2100));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-1-mutation')).toHaveTextContent('Running: Rebase and Recreate');
+    });
+
+    mock.setWorkflowMutationStatuses([{
+      intentId: 77,
+      workflowId: 'wf-1',
+      channel: 'invoker:rebase-recreate',
+      label: 'Rebase and Recreate',
+      status: 'failed',
+      priority: 'high',
+      error: 'boom',
+      createdAt: '2026-06-22T00:00:00.000Z',
+      startedAt: '2026-06-22T00:00:01.000Z',
+      completedAt: '2026-06-22T00:00:02.000Z',
+      args: ['wf-1'],
+    }]);
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2100));
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('workflow-node-wf-1-mutation')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('workflow-mutation-status-77')).toHaveTextContent('FAILED');
+    expect(screen.getByTestId('workflow-mutation-row-77')).toHaveTextContent('boom');
   });
 
   it('workflow context menu cancels workflow', async () => {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -16,7 +16,7 @@ import type {
   TaskConfig,
   TaskExecution,
 } from '../../types.js';
-import type { TerminalOutputEvent } from '@invoker/contracts';
+import type { TerminalOutputEvent, WorkflowMutationAcceptedResult, WorkflowMutationStatusEntry } from '@invoker/contracts';
 
 export interface MockInvoker {
   /** The mock InvokerAPI object installed on window.invoker. */
@@ -31,6 +31,8 @@ export interface MockInvoker {
   fireWorkflowsChanged: (workflows: WorkflowMeta[]) => void;
   /** Fire an embedded terminal output event to subscribers. */
   fireTerminalOutput: (event: TerminalOutputEvent) => void;
+  /** Replace the workflow mutation status snapshot. */
+  setWorkflowMutationStatuses: (rows: WorkflowMutationStatusEntry[]) => void;
   /** Install the mock on window.invoker. */
   install: () => void;
   /** Remove window.invoker. */
@@ -43,9 +45,30 @@ export function createMockInvoker(
 ): MockInvoker {
   let taskSnapshot = initialTasks;
   let workflowSnapshot = initialWorkflows;
+  let mutationStatusSnapshot: WorkflowMutationStatusEntry[] = [];
   let graphEventCallback: ((event: TaskGraphEvent) => void) | undefined;
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
+
+  const workflowIdForTask = (taskId: string): string => (
+    taskSnapshot.find((task) => task.id === taskId)?.config.workflowId
+    ?? workflowSnapshot[0]?.id
+    ?? 'wf-1'
+  );
+  const acceptedResult = (
+    channel: string,
+    label: string,
+    workflowId: string,
+  ): WorkflowMutationAcceptedResult => ({
+    ok: true,
+    accepted: true,
+    queued: true,
+    intentId: mutationStatusSnapshot.length + 1,
+    workflowId,
+    channel,
+    label,
+    status: 'queued',
+  });
 
   const api: InvokerAPI = {
     // Defer resolution one microtask so the startup snapshot is read after synchronous setTasks()
@@ -92,15 +115,18 @@ export function createMockInvoker(
     stop: vi.fn(async () => {}),
     clear: vi.fn(async () => {}),
     getStatus: vi.fn(async () => ({ total: 0, completed: 0, failed: 0, closed: 0, running: 0, pending: 0 })),
-    provideInput: vi.fn(async () => {}),
-    approve: vi.fn(async () => {}),
-    reject: vi.fn(async () => {}),
-    selectExperiment: vi.fn(async () => {}),
-    restartTask: vi.fn(async () => {}),
-    editTaskCommand: vi.fn(async () => {}),
-    editTaskPool: vi.fn(async () => {}),
-    editTaskAgent: vi.fn(async () => {}),
-    setTaskExternalGatePolicies: vi.fn(async () => {}),
+    getWorkflowMutationStatuses: vi.fn(async () => mutationStatusSnapshot),
+    provideInput: vi.fn(async (taskId: string) => acceptedResult('invoker:provide-input', 'Provide input', workflowIdForTask(taskId))),
+    approve: vi.fn(async (taskId: string) => acceptedResult('invoker:approve', 'Approve task', workflowIdForTask(taskId))),
+    reject: vi.fn(async (taskId: string) => acceptedResult('invoker:reject', 'Reject task', workflowIdForTask(taskId))),
+    selectExperiment: vi.fn(async (taskId: string) => acceptedResult('invoker:select-experiment', 'Select experiment', workflowIdForTask(taskId))),
+    restartTask: vi.fn(async (taskId: string) => acceptedResult('invoker:restart-task', 'Retry task', workflowIdForTask(taskId))),
+    editTaskPrompt: vi.fn(async (taskId: string) => acceptedResult('invoker:edit-task-prompt', 'Edit task prompt', workflowIdForTask(taskId))),
+    editTaskType: vi.fn(async (taskId: string) => acceptedResult('invoker:edit-task-type', 'Edit task executor', workflowIdForTask(taskId))),
+    editTaskCommand: vi.fn(async (taskId: string) => acceptedResult('invoker:edit-task-command', 'Edit task command', workflowIdForTask(taskId))),
+    editTaskPool: vi.fn(async (taskId: string) => acceptedResult('invoker:edit-task-pool', 'Edit task pool', workflowIdForTask(taskId))),
+    editTaskAgent: vi.fn(async (taskId: string) => acceptedResult('invoker:edit-task-agent', 'Edit task agent', workflowIdForTask(taskId))),
+    setTaskExternalGatePolicies: vi.fn(async (taskId: string) => acceptedResult('invoker:set-task-external-gate-policies', 'Set gate policy', workflowIdForTask(taskId))),
     getRemoteTargets: vi.fn(async () => []),
     getExecutionPools: vi.fn(async () => ['mixed-local-ssh', 'pnpm-ssh']),
     getExecutionAgents: vi.fn(async () => ['claude', 'codex']),
@@ -144,7 +170,7 @@ export function createMockInvoker(
         { id: 'cursor', name: 'Cursor', path: '/tmp/.cursor/skills-cursor', available: true, installed: false, upToDate: false, installedSkillNames: [] },
       ],
     })),
-    replaceTask: vi.fn(async () => []),
+    replaceTask: vi.fn(async (taskId: string) => acceptedResult('invoker:replace-task', 'Replace task', workflowIdForTask(taskId))),
     getActivityLogs: vi.fn(async () => []),
     getEvents: vi.fn(async () => []),
     openTerminal: vi.fn(async (taskId: string) => ({
@@ -172,22 +198,23 @@ export function createMockInvoker(
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),
     deleteAllWorkflows: vi.fn(async () => {}),
     deleteAllWorkflowsBulk: vi.fn(async () => {}),
-    deleteWorkflow: vi.fn(async () => {}),
+    deleteWorkflow: vi.fn(async (workflowId: string) => acceptedResult('invoker:delete-workflow', 'Delete workflow', workflowId)),
+    detachWorkflow: vi.fn(async (workflowId: string) => acceptedResult('invoker:detach-workflow', 'Detach workflow', workflowId)),
     cleanupWorktrees: vi.fn(async () => ({ removed: [], errors: [] })),
-    recreateWorkflow: vi.fn(async () => {}),
-    recreateTask: vi.fn(async () => {}),
-    recreateDownstream: vi.fn(async () => {}),
-    retryWorkflow: vi.fn(async () => {}),
-    rebaseRetry: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
-    rebaseRecreate: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
-    setMergeBranch: vi.fn(async () => {}),
-    approveMerge: vi.fn(async () => {}),
-    resolveConflict: vi.fn(async () => {}),
-    fixWithAgent: vi.fn(async () => {}),
-    setMergeMode: vi.fn(async () => {}),
+    recreateWorkflow: vi.fn(async (workflowId: string) => acceptedResult('invoker:recreate-workflow', 'Recreate workflow', workflowId)),
+    recreateTask: vi.fn(async (taskId: string) => acceptedResult('invoker:recreate-task', 'Recreate task', workflowIdForTask(taskId))),
+    recreateDownstream: vi.fn(async (taskId: string) => acceptedResult('invoker:recreate-downstream', 'Recreate downstream', workflowIdForTask(taskId))),
+    retryWorkflow: vi.fn(async (workflowId: string) => acceptedResult('invoker:retry-workflow', 'Retry workflow', workflowId)),
+    rebaseRetry: vi.fn(async (workflowId: string) => acceptedResult('invoker:rebase-retry', 'Rebase and Retry', workflowId)),
+    rebaseRecreate: vi.fn(async (workflowId: string) => acceptedResult('invoker:rebase-recreate', 'Rebase and Recreate', workflowId)),
+    setMergeBranch: vi.fn(async (workflowId: string) => acceptedResult('invoker:set-merge-branch', 'Set merge branch', workflowId)),
+    approveMerge: vi.fn(async (workflowId: string) => acceptedResult('invoker:approve-merge', 'Approve merge', workflowId)),
+    resolveConflict: vi.fn(async (taskId: string) => acceptedResult('invoker:resolve-conflict', 'Resolve conflict', workflowIdForTask(taskId))),
+    fixWithAgent: vi.fn(async (taskId: string) => acceptedResult('invoker:fix-with-agent', 'Fix with agent', workflowIdForTask(taskId))),
+    setMergeMode: vi.fn(async (workflowId: string) => acceptedResult('invoker:set-merge-mode', 'Set merge mode', workflowId)),
     checkPrStatuses: vi.fn(async () => {}),
-    cancelTask: vi.fn(async () => ({ cancelled: [], runningCancelled: [] })),
-    cancelWorkflow: vi.fn(async () => ({ cancelled: [], runningCancelled: [] })),
+    cancelTask: vi.fn(async (taskId: string) => acceptedResult('invoker:cancel-task', 'Cancel task', workflowIdForTask(taskId))),
+    cancelWorkflow: vi.fn(async (workflowId: string) => acceptedResult('invoker:cancel-workflow', 'Cancel workflow', workflowId)),
     getQueueStatus: vi.fn(async () => ({
       maxConcurrency: 0,
       runningCount: 0,
@@ -214,6 +241,10 @@ export function createMockInvoker(
         graphEventCallback?.({ type: 'delta', delta: { type: 'created', task }, workflowRollups: [] });
       }
     });
+  }
+
+  function setWorkflowMutationStatuses(rows: WorkflowMutationStatusEntry[]) {
+    mutationStatusSnapshot = rows;
   }
 
   function fireDelta(delta: TaskDelta) {
@@ -249,7 +280,7 @@ export function createMockInvoker(
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
   }
 
-  return { api, setTasks, fireDelta, fireGraphEvent, fireWorkflowsChanged, fireTerminalOutput, install, cleanup };
+  return { api, setTasks, setWorkflowMutationStatuses, fireDelta, fireGraphEvent, fireWorkflowsChanged, fireTerminalOutput, install, cleanup };
 }
 
 /** Create a minimal TaskState for testing. */

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
+import type { WorkflowMutationStatusEntry } from '@invoker/contracts';
 import type { WorkflowMeta, WorkflowStatus } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
 import { deriveWorkflowGraph, layoutWorkflowGraph, type WorkflowGraphEdge } from '../lib/workflow-graph.js';
@@ -29,6 +30,7 @@ interface WorkflowGraphProps {
    */
   cameraCommand?: GraphCameraCommand | null;
   statusFilters: Set<WorkflowStatus>;
+  openMutationsByWorkflow?: Map<string, WorkflowMutationStatusEntry | undefined>;
   onSelectWorkflow: (workflowId: string) => void;
   onWorkflowContextMenu: (event: MouseEvent, workflowId: string) => void;
   /** Fired when the user manually pans or zooms the viewport. */
@@ -39,6 +41,7 @@ interface WorkflowNodeData extends Record<string, unknown> {
   workflow: WorkflowMeta;
   selected: boolean;
   dimmed: boolean;
+  openMutation?: WorkflowMutationStatusEntry;
 }
 
 const nodeTypes = {
@@ -91,6 +94,7 @@ function WorkflowFlowNode({ data }: NodeProps<Node<WorkflowNodeData>>): JSX.Elem
         dimmed={data.dimmed}
         onClick={() => {}}
         onContextMenu={() => {}}
+        openMutation={data.openMutation}
       />
       <Handle
         type="source"
@@ -106,6 +110,7 @@ function WorkflowGraphInner({
   workflows,
   selectedWorkflowId,
   cameraCommand,
+  openMutationsByWorkflow,
   statusFilters,
   onSelectWorkflow,
   onWorkflowContextMenu,
@@ -149,12 +154,13 @@ function WorkflowGraphInner({
           workflow: node.workflow,
           selected: selectedWorkflowId === node.id,
           dimmed,
+          openMutation: openMutationsByWorkflow?.get(node.id),
         },
       };
     });
     graphMetricsRef.current.objectsMs = performance.now() - startedAt;
     return nextNodes;
-  }, [graph.nodes, positions, selectedWorkflowId, statusFilters]);
+  }, [graph.nodes, openMutationsByWorkflow, positions, selectedWorkflowId, statusFilters]);
 
   const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => {
     const visual = workflowEdgeVisual(edge.kind);

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { TaskState, WorkflowMeta } from '../types.js';
+import type { WorkflowMutationStatusEntry } from '@invoker/contracts';
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 
@@ -9,6 +10,7 @@ interface WorkflowInspectorProps {
   workflow: WorkflowMeta | null;
   task: TaskState | null;
   workflowTasks?: Map<string, TaskState>;
+  workflowMutations?: WorkflowMutationStatusEntry[];
   remoteTargets?: string[];
   executionPools?: string[];
   executionAgents?: string[];
@@ -60,6 +62,7 @@ export function WorkflowInspector({
   workflow,
   task,
   workflowTasks,
+  workflowMutations,
   executionPools,
   executionAgents,
   collapsed,
@@ -249,6 +252,39 @@ export function WorkflowInspector({
             </div>
           )}
         </section>
+        {workflow && !task && workflowMutations && workflowMutations.length > 0 && (
+          <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+            <h3 className="text-[11px] uppercase tracking-wide text-gray-400">Action history</h3>
+            <div className="mt-2 space-y-2">
+              {workflowMutations.slice(0, 5).map((mutation) => (
+                <div
+                  key={mutation.intentId}
+                  data-testid={`workflow-mutation-row-${mutation.intentId}`}
+                  className="rounded border border-gray-700 bg-gray-900/60 p-2"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 text-xs text-gray-100">{mutation.label}</div>
+                    <div
+                      data-testid={`workflow-mutation-status-${mutation.intentId}`}
+                      className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-gray-300"
+                    >
+                      {mutation.status.toUpperCase()}
+                    </div>
+                  </div>
+                  {mutation.status === 'failed' && mutation.error && (
+                    <div className="mt-1 text-xs text-red-300 break-words">{mutation.error}</div>
+                  )}
+                  {mutation.status === 'queued' && (
+                    <div className="mt-1 text-[11px] text-amber-200">Accepted by backend; waiting for command runner.</div>
+                  )}
+                  {mutation.status === 'running' && (
+                    <div className="mt-1 text-[11px] text-blue-200">Command runner is processing this action.</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
 
         {task && !task.config.isMergeNode && onEditPool && (
           <section className="rounded border border-gray-700 bg-gray-800/70 p-3">

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -1,5 +1,6 @@
 import type { KeyboardEvent, MouseEvent } from 'react';
 import type { WorkflowMeta, WorkflowStatus } from '../types.js';
+import type { WorkflowMutationStatusEntry } from '@invoker/contracts';
 import { isWorkflowStatusActive, workflowStatusVisual } from '../lib/workflow-status.js';
 
 interface WorkflowNodeProps {
@@ -8,6 +9,7 @@ interface WorkflowNodeProps {
   dimmed: boolean;
   onClick: () => void;
   onContextMenu: (event: MouseEvent<HTMLDivElement>) => void;
+  openMutation?: WorkflowMutationStatusEntry;
 }
 
 function statusLabel(status: WorkflowStatus): string {
@@ -24,12 +26,13 @@ export function WorkflowNode({
   dimmed,
   onClick,
   onContextMenu,
+  openMutation,
 }: WorkflowNodeProps): JSX.Element {
   const visual = workflowStatusVisual(workflow.status);
   const detachedDependencyCount = workflow.detachedExternalDependencies?.length ?? 0;
   const runningCount = workflow.rollup?.countsByStatus.running ?? 0;
   const showRunningTaskLine = workflow.status !== 'running' && runningCount > 0;
-
+  const showOpenMutation = openMutation?.status === 'queued' || openMutation?.status === 'running';
   return (
     <div
       data-testid={`workflow-node-${workflow.id}`}
@@ -70,6 +73,22 @@ export function WorkflowNode({
       </div>
       <div className="mt-1 text-[11px] text-gray-400 truncate">{workflow.id}</div>
       <div className={`mt-2 text-[10px] uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
+      {showOpenMutation && (
+        <div
+          data-testid={`workflow-node-${workflow.id}-mutation`}
+          className={[
+            'mt-2 inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium',
+            openMutation.status === 'running'
+              ? 'border-blue-400/50 bg-blue-950/30 text-blue-200'
+              : 'border-amber-400/50 bg-amber-950/30 text-amber-200',
+          ].join(' ')}
+        >
+          {openMutation.status === 'running' && <span className="h-1.5 w-1.5 rounded-full bg-blue-300 animate-pulse" />}
+          <span className="truncate">
+            {openMutation.status === 'running' ? 'Running' : 'Queued'}: {openMutation.label}
+          </span>
+        </div>
+      )}
       {showRunningTaskLine && (
         <div
           data-testid={`workflow-node-${workflow.id}-running-tasks`}

--- a/packages/ui/src/hooks/useWorkflowMutations.ts
+++ b/packages/ui/src/hooks/useWorkflowMutations.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { WorkflowMutationAcceptedResult, WorkflowMutationStatusEntry } from '@invoker/contracts';
+
+const HIGH_PRIORITY_CHANNELS: Record<string, true> = {
+  'invoker:delete-workflow': true,
+  'invoker:detach-workflow': true,
+  'invoker:restart-task': true,
+  'invoker:cancel-task': true,
+  'invoker:cancel-workflow': true,
+  'invoker:replace-task': true,
+  'invoker:recreate-workflow': true,
+  'invoker:recreate-task': true,
+  'invoker:recreate-downstream': true,
+  'invoker:retry-workflow': true,
+  'invoker:rebase-retry': true,
+  'invoker:rebase-recreate': true,
+};
+
+function newestFirst(a: WorkflowMutationStatusEntry, b: WorkflowMutationStatusEntry): number {
+  return b.intentId - a.intentId;
+}
+
+export function useWorkflowMutations(pollMs = 2000): {
+  mutations: WorkflowMutationStatusEntry[];
+  mutationsByWorkflow: Map<string, WorkflowMutationStatusEntry[]>;
+  recordAcceptedMutation: (accepted: WorkflowMutationAcceptedResult | undefined | void) => void;
+  refreshWorkflowMutations: () => Promise<void>;
+} {
+  const [mutations, setMutations] = useState<WorkflowMutationStatusEntry[]>([]);
+
+  const refreshWorkflowMutations = useCallback(async () => {
+    try {
+      const rows = await window.invoker?.getWorkflowMutationStatuses?.();
+      if (rows) {
+        setMutations([...rows].sort(newestFirst));
+      }
+    } catch {
+      // ignore polling errors
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshWorkflowMutations();
+    const interval = window.setInterval(() => {
+      void refreshWorkflowMutations();
+    }, pollMs);
+    return () => window.clearInterval(interval);
+  }, [pollMs, refreshWorkflowMutations]);
+
+  const recordAcceptedMutation = useCallback((accepted: WorkflowMutationAcceptedResult | undefined | void) => {
+    if (!accepted?.accepted) return;
+
+    const entry: WorkflowMutationStatusEntry = {
+      intentId: accepted.intentId,
+      workflowId: accepted.workflowId,
+      channel: accepted.channel,
+      label: accepted.label,
+      status: 'queued',
+      priority: HIGH_PRIORITY_CHANNELS[accepted.channel] ? 'high' : 'normal',
+      createdAt: new Date().toISOString(),
+      args: [],
+    };
+
+    setMutations((current) => {
+      const withoutExisting = current.filter((row) => row.intentId !== entry.intentId);
+      return [entry, ...withoutExisting].sort(newestFirst);
+    });
+  }, []);
+
+  const mutationsByWorkflow = useMemo(() => {
+    const grouped = new Map<string, WorkflowMutationStatusEntry[]>();
+    for (const mutation of mutations) {
+      const rows = grouped.get(mutation.workflowId) ?? [];
+      rows.push(mutation);
+      grouped.set(mutation.workflowId, rows);
+    }
+    for (const rows of grouped.values()) {
+      rows.sort(newestFirst);
+    }
+    return grouped;
+  }, [mutations]);
+
+  return {
+    mutations,
+    mutationsByWorkflow,
+    recordAcceptedMutation,
+    refreshWorkflowMutations,
+  };
+}

--- a/scripts/repro/repro-rebase-recreate-ui-delay.sh
+++ b/scripts/repro/repro-rebase-recreate-ui-delay.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:---expect-fixed}"
+
+case "$mode" in
+  --expect-fixed)
+    pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu-e2e.test.tsx -t "workflow context menu shows backend accepted queued mutation|workflow mutation status poll updates queued to running and failed"
+    ;;
+  --expect-bug)
+    pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu-e2e.test.tsx -t "workflow mutation status poll updates queued to running and failed" && {
+      printf 'Expected old UI-delay bug, but backend-backed mutation status was visible.\n' >&2
+      exit 1
+    }
+    ;;
+  *)
+    printf 'Usage: %s [--expect-fixed|--expect-bug]\n' "$0" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

Workflow actions now show when the backend accepted them, instead of staying quiet while a command promise is still running.

The bug was that Rebase and Recreate could be queued by the backend while the UI looked unchanged.

This change reads persisted mutation intents and shows queued, running, and failed states on the workflow card and inspector history.

<details>
<summary>Review metadata</summary>

Review Claim: Workflow-targeted UI mutations now return accepted queue state and render persisted mutation status.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Existing mutation bodies still run through the persisted coordinator; this only changes when GUI IPC returns and how status is displayed.

Slice Rationale: This keeps the queue, read model, UI, and tests together because they are one visible behavior.
</details>

## Non-goals

This does not change global commands like load, start, stop, clear, or PR status checks because they do not target one workflow card.

## Architecture

### Before

```mermaid
graph TD
    UI["Renderer calls Rebase and Recreate"] --> IPC["GUI IPC waits for command completion"]
    IPC --> Queue["Backend queues mutation intent"]
    Queue --> Runner["Command runner eventually executes"]
    IPC --> UIQuiet["UI stays quiet until promise resolves"]
```

### After

```mermaid
graph TD
    UI["Renderer calls Rebase and Recreate"] --> IPC["GUI IPC submits persisted mutation intent"]
    IPC --> Accepted["Accepted result returns with intent id"]
    Accepted --> Badge["Workflow card shows queued or running"]
    QueueRead["Mutation status IPC reads persisted intents"] --> Badge
    QueueRead --> History["Inspector Action history shows failed backend errors"]
    Runner["Command runner executes intent"] --> QueueRead
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/ipc-registration.test.ts -t "workflow-scoped"`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/action-graph-diagnostics.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu-e2e.test.tsx -t "workflow context menu shows backend accepted queued mutation|workflow mutation status poll updates queued to running and failed"`
- [x] `scripts/repro/repro-rebase-recreate-ui-delay.sh --expect-fixed`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/ui build`

## Visual Proof

Automated UI proof only. The context-menu component test and repro assert the workflow badge, action history row, running update, and failed backend error.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 2d25a1deb209de61ac253f360a99f3f954b900c9`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow actions now display real-time status (queued, running, completed, failed) with visual indicators on the workflow graph
  * Added "Action history" section in the workflow inspector showing recent mutations with status and error details when available
  * Enhanced feedback when actions are submitted, providing immediate confirmation of queued or in-progress status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->