### PR TITLE
Require ready-to-merge label for Mergify autoqueue

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -53,11 +53,12 @@ queue_rules:
       - check-success = optional / Visual Proof Validate
 
 pull_request_rules:
-  - name: autoqueue approved PRs to master
+  - name: autoqueue ready approved PRs to master
     conditions:
       - base=master
       - -draft
       - "#approved-reviews-by >= 1"
+      - label=ready-to-merge
       - -label=admin-bypass
     actions:
       queue:


### PR DESCRIPTION
## Summary

Mergify no longer treats every approval as permission to merge.

Approved PRs now autoqueue only after someone adds `ready-to-merge`. Reviewers can approve with comments without accidentally starting the merge path.

Manual squash merge remains available after the normal GitHub approval rule passes.

<details>
<summary>Review metadata</summary>

Review Claim: Mergify autoqueue now requires explicit merge intent through `ready-to-merge`.

Review Lane: policy
Review Unit: tooling-policy

Safety Invariant: The default queue checks and admin-bypass path are unchanged; only the autoqueue trigger gains one label condition.

Slice Rationale: This is a single policy change with one observable behavior: approval alone no longer queues a PR.

</details>

## Non-goals

This does not change required checks, merge methods, admin-bypass behavior, or GitHub branch rules.

## Test Plan

- [ ] `node -e "const fs=require('fs'); const YAML=require('yaml'); const cfg=YAML.parse(fs.readFileSync('.mergify.yml','utf8')); const rule=cfg.pull_request_rules.find((entry)=>entry.name==='autoqueue ready approved PRs to master'); if (!rule) throw new Error('missing renamed autoqueue rule'); if (!rule.conditions.includes('label=ready-to-merge')) throw new Error('missing ready-to-merge condition'); const queue=cfg.queue_rules.find((entry)=>entry.name==='default'); if (queue.queue_conditions.includes('label=ready-to-merge')) throw new Error('manual queue would require ready-to-merge'); console.log('ok');"`
- [ ] `gh label list --repo Neko-Catpital-Labs/Invoker --search ready-to-merge --json name,description,color --jq '.[] | select(.name == "ready-to-merge")'`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Remove the `ready-to-merge` GitHub label only if the old approval-means-autoqueue policy is intentionally restored.
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated merge automation configuration to require additional label verification before auto-queuing approved pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->