### PR TITLE
[Workflow Mutation Status](1) Add mutation status IPC contracts

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -203,6 +203,35 @@ export interface ActionGraphResponse {
   edges: ActionGraphEdge[];
 }
 
+export type WorkflowMutationUiStatus = 'queued' | 'running' | 'completed' | 'failed';
+export type WorkflowMutationUiPriority = 'high' | 'normal';
+
+export interface WorkflowMutationAcceptedResult {
+  ok: true;
+  accepted: true;
+  queued: true;
+  intentId: number;
+  workflowId: string;
+  channel: string;
+  label: string;
+  status: 'queued';
+}
+
+export interface WorkflowMutationStatusEntry {
+  intentId: number;
+  workflowId: string;
+  channel: string;
+  label: string;
+  status: WorkflowMutationUiStatus;
+  priority: WorkflowMutationUiPriority;
+  ownerId?: string;
+  error?: string;
+  createdAt: string;
+  startedAt?: string;
+  completedAt?: string;
+  args: unknown[];
+}
+
 export interface ResumeWorkflowResult {
   workflow: { id: string; name: string; status: string };
   taskCount: number;
@@ -400,11 +429,11 @@ export const IpcChannels = {
   },
   'invoker:delete-workflow': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:detach-workflow': {} as {
     request: [workflowId: string, upstreamWorkflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:load-workflow': {} as {
     request: [workflowId: string];
@@ -444,19 +473,19 @@ export const IpcChannels = {
   // Task Actions
   'invoker:provide-input': {} as {
     request: [taskId: string, input: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:approve': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:reject': {} as {
     request: [taskId: string, reason?: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:select-experiment': {} as {
     request: [taskId: string, experimentId: string | string[]];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   /**
    * @deprecated Step 13 (`docs/architecture/task-invalidation-roadmap.md`):
@@ -473,41 +502,45 @@ export const IpcChannels = {
    */
   'invoker:restart-task': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:cancel-task': {} as {
     request: [taskId: string];
-    response: CancelResult;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:cancel-workflow': {} as {
     request: [workflowId: string];
-    response: CancelResult;
+    response: WorkflowMutationAcceptedResult;
   },
 
   // Task Editing
   'invoker:edit-task-command': {} as {
     request: [taskId: string, newCommand: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
+  },
+  'invoker:edit-task-type': {} as {
+    request: [taskId: string, runnerKind: string, poolMemberId?: string];
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:edit-task-pool': {} as {
     request: [taskId: string, poolId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:edit-task-agent': {} as {
     request: [taskId: string, agentName: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:edit-task-prompt': {} as {
     request: [taskId: string, newPrompt: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:set-task-external-gate-policies': {} as {
     request: [taskId: string, updates: ExternalGatePolicyUpdate[]];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:replace-task': {} as {
     request: [taskId: string, replacementTasks: TaskReplacementDef[]];
-    response: TaskState[];
+    response: WorkflowMutationAcceptedResult;
   },
 
   // Session & Agent Access
@@ -523,39 +556,39 @@ export const IpcChannels = {
   // Workflow Mutation & Merge
   'invoker:recreate-workflow': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:recreate-task': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:recreate-downstream': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:retry-workflow': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:rebase-retry': {} as {
     request: [target: string];
-    response: RebaseAndRetryResult;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:rebase-recreate': {} as {
     request: [target: string];
-    response: RebaseAndRetryResult;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:set-merge-branch': {} as {
     request: [workflowId: string, baseBranch: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:set-merge-mode': {} as {
     request: [workflowId: string, mergeMode: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:approve-merge': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
 
   // PR & Conflict Resolution
@@ -569,11 +602,11 @@ export const IpcChannels = {
   },
   'invoker:resolve-conflict': {} as {
     request: [taskId: string, agentName?: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:fix-with-agent': {} as {
     request: [taskId: string, agentName?: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
 
   // Queue & Configuration
@@ -584,6 +617,10 @@ export const IpcChannels = {
   'invoker:get-action-graph': {} as {
     request: [];
     response: ActionGraphResponse;
+  },
+  'invoker:get-workflow-mutation-statuses': {} as {
+    request: [workflowId?: string];
+    response: WorkflowMutationStatusEntry[];
   },
   'invoker:get-remote-targets': {} as {
     request: [];


### PR DESCRIPTION
## Summary

This adds the shared types for queued workflow action status.

The renderer and app now agree on accepted action results, status rows, priorities, and the status lookup channel.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the shared workflow mutation status contracts.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This slice only changes the typed IPC contract surface.

Slice Rationale: The later slices need these types before wiring runtime and UI behavior.

</details>

## Non-goals

This does not change runtime behavior.

This does not change the renderer.

## Test Plan

- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes, after reverting dependent stack slices first.
- Revert command: `git revert b852e5327`
- Post-revert steps: None
- Data migration? No
