### PR TITLE
[Workflow Mutation Status](2) Queue GUI workflow mutations

### DIFF
--- a/packages/app/src/__tests__/action-graph-diagnostics.test.ts
+++ b/packages/app/src/__tests__/action-graph-diagnostics.test.ts
@@ -71,6 +71,67 @@ describe('buildActionGraphDiagnostics', () => {
     expect(graph.edges).toContainEqual(expect.objectContaining({ source: 'action:wf-1', target: 'intent:7' }));
   });
 
+  it('creates running mutation action nodes with running duration', () => {
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [],
+      attemptsByTaskId: new Map(),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [{
+        id: 8,
+        workflowId: 'wf-1',
+        channel: 'invoker:rebase-recreate',
+        args: ['wf-1'],
+        priority: 'high',
+        status: 'running',
+        createdAt: '2026-05-14T11:54:00.000Z',
+        startedAt: '2026-05-14T11:58:00.000Z',
+      }],
+      mutationLeases: [],
+      eventsByTaskId: new Map(),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    const intent = graph.nodes.find((node) => node.id === 'intent:8');
+    expect(intent?.type).toBe('mutation-intent');
+    expect(intent?.status).toBe('running');
+    expect(intent?.durations?.runningMs).toBe(2 * 60_000);
+  });
+
+  it('creates failed mutation action nodes with backend error and suggested action', () => {
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [],
+      attemptsByTaskId: new Map(),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [{
+        id: 9,
+        workflowId: 'wf-1',
+        channel: 'invoker:rebase-recreate',
+        args: ['wf-1'],
+        priority: 'high',
+        status: 'failed',
+        createdAt: '2026-05-14T11:54:00.000Z',
+        startedAt: '2026-05-14T11:55:00.000Z',
+        completedAt: '2026-05-14T11:56:00.000Z',
+        error: 'boom',
+      }],
+      mutationLeases: [],
+      eventsByTaskId: new Map(),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    const intent = graph.nodes.find((node) => node.id === 'intent:9');
+    expect(intent?.type).toBe('mutation-intent');
+    expect(intent?.status).toBe('failed');
+    expect(intent?.latestError).toBe('boom');
+    expect(intent?.suggestedNextAction).toBe('Open the history expander and inspect the failed mutation error.');
+  });
+
   it('marks expired mutation leases as stalled with heartbeat age', () => {
     const graph = buildActionGraphDiagnostics({
       workflows: [workflow],

--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -136,22 +136,24 @@ describe('ipc-registration', () => {
   it('registers workflow-scoped handlers with the same dispatcher and enqueue shape', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
     const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-    const calls: Array<{
-      workflowId: string | undefined;
-      priority: WorkflowMutationPriority;
-      channel: string;
-      args: unknown[];
-    }> = [];
+    const accepted = {
+      ok: true as const,
+      accepted: true as const,
+      queued: true as const,
+      intentId: 42,
+      workflowId: 'workflow-for-task-1',
+      channel: 'invoker:restart-task',
+      label: 'Retry task',
+      status: 'queued' as const,
+    };
+    const submitWorkflowMutation = vi.fn(() => accepted);
     const context: WorkflowScopedGuiMutationRegistrationContext = {
       ipcMain,
       getOwnerMode: () => true,
       getMessageBus: () => ({ request: vi.fn() }),
       translateGuiMutationToHeadless: vi.fn(),
       workflowMutationDispatcher,
-      runWorkflowMutation: async (workflowId, priority, channel, args, op) => {
-        calls.push({ workflowId, priority, channel, args });
-        return op();
-      },
+      submitWorkflowMutation,
     };
     const handler = vi.fn(async (taskId: unknown) => `done:${String(taskId)}`);
 
@@ -163,24 +165,28 @@ describe('ipc-registration', () => {
       handler,
     );
 
-    await expect(handleHandlers.get('invoker:restart-task')?.({}, 'task-1')).resolves.toBe('done:task-1');
+    await expect(handleHandlers.get('invoker:restart-task')?.({}, 'task-1')).resolves.toBe(accepted);
+    expect(handler).not.toHaveBeenCalled();
+    expect(submitWorkflowMutation).toHaveBeenCalledWith('workflow-for-task-1', 'high', 'invoker:restart-task', ['task-1']);
     expect(workflowMutationDispatcher.has('invoker:restart-task')).toBe(true);
     await expect(workflowMutationDispatcher.get('invoker:restart-task')?.('task-2')).resolves.toBe('done:task-2');
-    expect(calls).toEqual([
-      {
-        workflowId: 'workflow-for-task-1',
-        priority: 'high',
-        channel: 'invoker:restart-task',
-        args: ['task-1'],
-      },
-    ]);
   });
 
   it('creates typed registrars that preserve channel registration outputs', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
     const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
     const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-    const runWorkflowMutation = vi.fn(async (_workflowId, _priority, _channel, _args, op) => op());
+    const accepted = {
+      ok: true as const,
+      accepted: true as const,
+      queued: true as const,
+      intentId: 9,
+      workflowId: 'wf:task-1',
+      channel: 'invoker:scoped',
+      label: 'Scoped',
+      status: 'queued' as const,
+    };
+    const submitWorkflowMutation = vi.fn(() => accepted);
     const guiContext: GuiMutationRegistrationContext = {
       ipcMain,
       getOwnerMode: () => true,
@@ -191,7 +197,7 @@ describe('ipc-registration', () => {
     const workflowContext: WorkflowScopedGuiMutationRegistrationContext = {
       ...guiContext,
       workflowMutationDispatcher,
-      runWorkflowMutation,
+      submitWorkflowMutation,
     };
 
     const {
@@ -208,15 +214,14 @@ describe('ipc-registration', () => {
     );
 
     await expect(handleHandlers.get('invoker:plain')?.({}, 'a')).resolves.toBe('plain:a');
-    await expect(handleHandlers.get('invoker:scoped')?.({}, 'task-1')).resolves.toBe('scoped:task-1');
+    await expect(handleHandlers.get('invoker:scoped')?.({}, 'task-1')).resolves.toBe(accepted);
     expect([...guiMutationHandlers.keys()]).toEqual(['invoker:plain', 'invoker:scoped']);
     expect([...workflowMutationDispatcher.keys()]).toEqual(['invoker:scoped']);
-    expect(runWorkflowMutation).toHaveBeenCalledWith(
+    expect(submitWorkflowMutation).toHaveBeenCalledWith(
       'wf:task-1',
       'normal',
       'invoker:scoped',
       ['task-1'],
-      expect.any(Function),
     );
   });
 

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -3,6 +3,7 @@ import { TransportError, TransportErrorCode } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkflowMutationPriority } from '../workflow-mutation-coordinator.js';
+import type { WorkflowMutationAcceptedResult } from '@invoker/contracts';
 
 export interface GuiMutationPayload {
   channel: string;
@@ -79,13 +80,12 @@ export function registerGuiMutationHandler<TResult = unknown>(
 
 export interface WorkflowScopedGuiMutationRegistrationContext extends GuiMutationRegistrationContext {
   workflowMutationDispatcher: Map<string, (...args: unknown[]) => Promise<unknown>>;
-  runWorkflowMutation: <T>(
+  submitWorkflowMutation: (
     workflowId: string | undefined,
     priority: WorkflowMutationPriority,
     channel: string,
     args: unknown[],
-    op: () => Promise<T>,
-  ) => Promise<T>;
+  ) => WorkflowMutationAcceptedResult;
 }
 
 export function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
@@ -98,7 +98,7 @@ export function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
   context.workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
   registerGuiMutationHandler(context, channel, async (...args: unknown[]) => {
     const workflowId = resolveWorkflowId(...args);
-    return context.runWorkflowMutation(workflowId, priority, channel, args, () => handler(...args));
+    return context.submitWorkflowMutation(workflowId, priority, channel, args);
   });
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -67,13 +67,15 @@ import type {
   TaskStateChanges,
 } from '@invoker/workflow-core';
 import {
+  IpcChannels,
   makeEnvelope,
   CommandError,
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { ActionGraphResponse, WorkflowMeta, WorkResponse } from '@invoker/contracts';
+import type { ActionGraphResponse, WorkflowMeta, WorkResponse, WorkflowMutationAcceptedResult, WorkflowMutationStatusEntry } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
+import type { WorkflowMutationIntent } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
   WorkspaceProbeAdapter,
@@ -445,12 +447,69 @@ function logHeadlessExecReceived(payload: HeadlessExecMutationPayload, mode: Hea
   );
 }
 
+function toWorkflowMutationStatusEntry(intent: WorkflowMutationIntent): WorkflowMutationStatusEntry {
+  return {
+    intentId: intent.id,
+    workflowId: intent.workflowId,
+    channel: intent.channel,
+    label: workflowMutationLabel(intent.channel, intent.args),
+    status: intent.status,
+    priority: intent.priority,
+    ownerId: intent.ownerId,
+    error: intent.error,
+    createdAt: intent.createdAt,
+    startedAt: intent.startedAt,
+    completedAt: intent.completedAt,
+    args: intent.args,
+  };
+}
+function workflowMutationLabel(channel: string, args: unknown[]): string {
+  const labels: Record<string, string> = {
+    'invoker:delete-workflow': 'Delete workflow',
+    'invoker:detach-workflow': 'Detach workflow',
+    'invoker:provide-input': 'Provide input',
+    'invoker:approve': 'Approve task',
+    'invoker:reject': 'Reject task',
+    'invoker:select-experiment': 'Select experiment',
+    'invoker:restart-task': 'Retry task',
+    'invoker:cancel-task': 'Cancel task',
+    'invoker:cancel-workflow': 'Cancel workflow',
+    'invoker:edit-task-command': 'Edit task command',
+    'invoker:edit-task-prompt': 'Edit task prompt',
+    'invoker:edit-task-type': 'Edit task executor',
+    'invoker:edit-task-pool': 'Edit task pool',
+    'invoker:edit-task-agent': 'Edit task agent',
+    'invoker:set-task-external-gate-policies': 'Set gate policy',
+    'invoker:replace-task': 'Replace task',
+    'invoker:recreate-workflow': 'Recreate workflow',
+    'invoker:recreate-task': 'Recreate task',
+    'invoker:recreate-downstream': 'Recreate downstream',
+    'invoker:retry-workflow': 'Retry workflow',
+    'invoker:rebase-retry': 'Rebase and Retry',
+    'invoker:rebase-recreate': 'Rebase and Recreate',
+    'invoker:set-merge-branch': 'Set merge branch',
+    'invoker:set-merge-mode': 'Set merge mode',
+    'invoker:approve-merge': 'Approve merge',
+    'invoker:resolve-conflict': 'Resolve conflict',
+    'invoker:fix-with-agent': 'Fix with agent',
+    'headless.exec': 'CLI command',
+  };
+
+  if (channel === 'headless.exec') {
+    const payload = args[0] as { args?: unknown } | undefined;
+    const cliArgs = Array.isArray(payload?.args) ? payload.args.filter((arg): arg is string => typeof arg === 'string') : [];
+    if (cliArgs.length > 0) return `CLI: ${cliArgs.join(' ')}`;
+  }
+
+  return labels[channel] ?? channel;
+}
+
 function acknowledgeNoTrackHeadlessExec(
   payload: HeadlessExecMutationPayload,
   workflowId: string | undefined,
   priority: WorkflowMutationPriority,
   mode: HeadlessOwnerMode,
-): { ok: true; intentId: number } | undefined {
+): WorkflowMutationAcceptedResult | undefined {
   logger.info(
     `headless.exec decision ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId ?? '<none>'}"`, priority })}`,
     { module: 'ipc-delegate' },
@@ -466,7 +525,7 @@ function acknowledgeNoTrackHeadlessExec(
       `headless.exec accepted ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId}"`, intent: intentId, priority })}`,
       { module: 'ipc-delegate' },
     );
-    return { ok: true, intentId };
+    return { ok: true, accepted: true, queued: true, intentId, workflowId, channel: 'headless.exec', label: workflowMutationLabel('headless.exec', [payload]), status: 'queued' };
   }
 
   const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
@@ -1098,6 +1157,29 @@ function startHeadlessMode(): void {
         return { workflowId, tasks };
       };
 
+      const submitStandaloneGuiMutation = (
+        workflowId: string | undefined,
+        priority: WorkflowMutationPriority,
+        channel: string,
+        args: unknown[],
+        handler: (...handlerArgs: unknown[]) => Promise<unknown>,
+      ): WorkflowMutationAcceptedResult => {
+        if (!workflowId) throw new Error(`Could not resolve workflow for ${channel}`);
+        if (!workflowMutationCoordinator) throw new Error('Workflow mutation coordinator is unavailable');
+        workflowMutationDispatcher.set(channel, handler);
+        const intentId = workflowMutationCoordinator.submit(workflowId, priority, channel, args);
+        return {
+          ok: true,
+          accepted: true,
+          queued: true,
+          intentId,
+          workflowId,
+          channel,
+          label: workflowMutationLabel(channel, args),
+          status: 'queued',
+        };
+      };
+
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
         switch (payload.channel) {
           case 'invoker:clear': {
@@ -1168,33 +1250,40 @@ function startHeadlessMode(): void {
           }
           case 'invoker:set-merge-branch': {
             const workflowId = String(payload.args[0]);
-            const baseBranch = String(payload.args[1]);
-            persistence.updateWorkflow(workflowId, { baseBranch });
-            const tasks = persistence.loadTasks(workflowId);
-            const mergeTask = tasks.find((task) => task.config.isMergeNode);
-            if (!mergeTask) return undefined;
-            const executor = createStandaloneTaskExecutor();
-            const envelope = makeEnvelope('set-merge-branch', 'ui', 'task', { taskId: mergeTask.id });
-            const result = await commandService.retryTask(envelope);
-            if (!result.ok) throw new Error(result.error.message);
-            const started = result.data;
-            await dispatchStartedTasksWithGlobalTopup({
-              orchestrator,
-              taskExecutor: executor,
-              logger,
-              context: 'standalone.set-merge-branch',
-              started,
-              scopedTaskIds: [mergeTask.id],
+            return submitStandaloneGuiMutation(workflowId, 'normal', payload.channel, payload.args, async (workflowIdArg: unknown, baseBranchArg: unknown) => {
+              const queuedWorkflowId = String(workflowIdArg);
+              const baseBranch = String(baseBranchArg);
+              persistence.updateWorkflow(queuedWorkflowId, { baseBranch });
+              const tasks = persistence.loadTasks(queuedWorkflowId);
+              const mergeTask = tasks.find((task) => task.config.isMergeNode);
+              if (!mergeTask) return undefined;
+              const executor = createStandaloneTaskExecutor();
+              const envelope = makeEnvelope('set-merge-branch', 'ui', 'task', { taskId: mergeTask.id });
+              const result = await commandService.retryTask(envelope);
+              if (!result.ok) throw new Error(result.error.message);
+              const started = result.data;
+              await dispatchStartedTasksWithGlobalTopup({
+                orchestrator,
+                taskExecutor: executor,
+                logger,
+                context: 'standalone.set-merge-branch',
+                started,
+                scopedTaskIds: [mergeTask.id],
+              });
+              return undefined;
             });
-            return undefined;
           }
           case 'invoker:replace-task': {
             const taskId = String(payload.args[0]);
-            const replacementTasks = payload.args[1] as TaskReplacementDef[];
-            const envelope = makeEnvelope('replace-task', 'ui', 'task', { taskId, replacementTasks });
-            const result = await commandService.replaceTask(envelope);
-            if (!result.ok) throw new Error(result.error.message);
-            return result.data;
+            const workflowId = resolveHeadlessTargetWorkflowId(taskId, persistence);
+            return submitStandaloneGuiMutation(workflowId, 'high', payload.channel, payload.args, async (taskIdArg: unknown, replacementTasksArg: unknown) => {
+              const queuedTaskId = String(taskIdArg);
+              const replacementTasks = replacementTasksArg as TaskReplacementDef[];
+              const envelope = makeEnvelope('replace-task', 'ui', 'task', { taskId: queuedTaskId, replacementTasks });
+              const result = await commandService.replaceTask(envelope);
+              if (!result.ok) throw new Error(result.error.message);
+              return result.data;
+            });
           }
           case 'invoker:check-pr-statuses': {
             const executor = createStandaloneTaskExecutor();
@@ -1212,25 +1301,33 @@ function startHeadlessMode(): void {
           }
           case 'invoker:select-experiment': {
             const taskId = String(payload.args[0]);
-            const experimentId = payload.args[1] as string | string[];
-            const ids = Array.isArray(experimentId) ? experimentId : [experimentId];
-            const executor = createStandaloneTaskExecutor();
-            if (ids.length === 1) {
-              const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId, experimentId: ids[0] });
-              const result = await commandService.selectExperiment(envelope);
-              if (!result.ok) throw new Error(result.error.message);
+            const workflowId = resolveHeadlessTargetWorkflowId(taskId, persistence);
+            return submitStandaloneGuiMutation(workflowId, 'normal', payload.channel, payload.args, async (taskIdArg: unknown, experimentIdArg: unknown) => {
+              const queuedTaskId = String(taskIdArg);
+              const experimentId = experimentIdArg as string | string[];
+              const ids = Array.isArray(experimentId) ? experimentId : [experimentId];
+              const executor = createStandaloneTaskExecutor();
+              if (ids.length === 1) {
+                const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId: queuedTaskId, experimentId: ids[0] });
+                const result = await commandService.selectExperiment(envelope);
+                if (!result.ok) throw new Error(result.error.message);
+                return undefined;
+              }
+              await sharedSelectExperiments(queuedTaskId, ids, { orchestrator, taskExecutor: executor });
               return undefined;
-            }
-            await sharedSelectExperiments(taskId, ids, { orchestrator, taskExecutor: executor });
-            return undefined;
+            });
           }
           case 'invoker:set-task-external-gate-policies': {
             const taskId = String(payload.args[0]);
-            const updates = payload.args[1] as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }>;
-            const envelope = makeEnvelope('set-gate-policies', 'ui', 'task', { taskId, updates });
-            const result = await commandService.setTaskExternalGatePolicies(envelope);
-            if (!result.ok) throw new Error(result.error.message);
-            return undefined;
+            const workflowId = resolveHeadlessTargetWorkflowId(taskId, persistence);
+            return submitStandaloneGuiMutation(workflowId, 'normal', payload.channel, payload.args, async (taskIdArg: unknown, updatesArg: unknown) => {
+              const queuedTaskId = String(taskIdArg);
+              const updates = updatesArg as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }>;
+              const envelope = makeEnvelope('set-gate-policies', 'ui', 'task', { taskId: queuedTaskId, updates });
+              const result = await commandService.setTaskExternalGatePolicies(envelope);
+              if (!result.ok) throw new Error(result.error.message);
+              return undefined;
+            });
           }
           default:
             throw new Error(`Unsupported internal mutation for standalone owner: ${payload.channel}`);
@@ -1597,7 +1694,7 @@ function startHeadlessMode(): void {
             `headless.run received trace=${traceId ?? '<none>'} planPath="${planPath}" ownerId=${workflowMutationOwnerId} mode=standalone`,
             { module: 'ipc-delegate' },
           );
-          const result = await executeStandaloneHeadlessRun({ planPath });
+          const result = await executeStandaloneHeadlessRun({ planPath, traceId });
           logger.info(
             `headless.run accepted trace=${traceId ?? '<none>'} workflow="${result.workflowId}" tasks=${result.tasks.length} mode=standalone`,
             { module: 'ipc-delegate' },
@@ -1614,7 +1711,7 @@ function startHeadlessMode(): void {
         });
         messageBus.onRequest('headless.query', async (req: unknown) => {
           noteStandaloneOwnerActivity();
-          const { kind, reset } = req as { kind?: string; reset?: boolean };
+          const { kind, reset, workflowId } = req as { kind?: string; reset?: boolean; workflowId?: string };
           if (kind === 'ui-perf') {
             if (reset) {
               headlessDeps.resetUiPerfStats?.();
@@ -1626,6 +1723,10 @@ function startHeadlessMode(): void {
           }
           if (kind === 'queue') {
             return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+          }
+          if (kind === 'workflow-mutation-statuses') {
+            const scopedWorkflowId = typeof workflowId === 'string' && workflowId.length > 0 ? workflowId : undefined;
+            return persistence.listWorkflowMutationStatusIntents(scopedWorkflowId).map(toWorkflowMutationStatusEntry);
           }
           if (kind === 'workflow-status') {
             return orchestrator.getWorkflowStatus();
@@ -2511,6 +2612,30 @@ function createEmbeddedTerminalBackendFromConfig(
     return workflowMutationCoordinator.enqueue<T>(workflowId, priority, channel, args);
   }
 
+  function submitWorkflowMutation(
+    workflowId: string | undefined,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+  ): WorkflowMutationAcceptedResult {
+    if (!workflowId) throw new Error(`Could not resolve workflow for ${channel}`);
+    if (!workflowMutationCoordinator) throw new Error('Workflow mutation coordinator is unavailable');
+    if (!workflowMutationDispatcher.has(channel)) {
+      throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
+    }
+    const intentId = workflowMutationCoordinator.submit(workflowId, priority, channel, args);
+    return {
+      ok: true,
+      accepted: true,
+      queued: true,
+      intentId,
+      workflowId,
+      channel,
+      label: workflowMutationLabel(channel, args),
+      status: 'queued',
+    };
+  }
+
   function translateGuiMutationToHeadless(payload: GuiMutationPayload):
     | { channel: 'headless.gui-mutation'; request: GuiMutationPayload }
     | { channel: 'headless.run'; request: HeadlessRunMutationPayload }
@@ -2657,7 +2782,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const workflowScopedGuiMutationRegistrationContext: WorkflowScopedGuiMutationRegistrationContext = {
     ...guiMutationRegistrationContext,
     workflowMutationDispatcher,
-    runWorkflowMutation,
+    submitWorkflowMutation,
   };
 
   const {
@@ -2667,6 +2792,18 @@ function createEmbeddedTerminalBackendFromConfig(
     guiMutationRegistrationContext,
     workflowScopedGuiMutationRegistrationContext,
   );
+
+  function registerTaskScopedGuiMutationHandler<TResult = unknown>(
+    channel: keyof typeof IpcChannels & string,
+    resolveWorkflowId: (...args: unknown[]) => string | undefined,
+    priority: WorkflowMutationPriority,
+    handler: (...args: unknown[]) => Promise<TResult>,
+  ): void {
+    workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
+    registerGuiMutationHandler(channel, async (...args: unknown[]) => (
+      submitWorkflowMutation(resolveWorkflowId(...args), priority, channel, args)
+    ));
+  }
 
   function createWindow(): void {
     createMainWindow({
@@ -3121,7 +3258,7 @@ function createEmbeddedTerminalBackendFromConfig(
         mode: 'gui',
       }));
       messageBus.onRequest('headless.query', async (req: unknown) => {
-        const { kind, reset } = req as { kind?: string; reset?: boolean };
+        const { kind, reset, workflowId } = req as { kind?: string; reset?: boolean; workflowId?: string };
         if (kind === 'ui-perf') {
           if (reset) {
             resetUiPerfStats();
@@ -3133,6 +3270,10 @@ function createEmbeddedTerminalBackendFromConfig(
         }
         if (kind === 'queue') {
           return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+        }
+        if (kind === 'workflow-mutation-statuses') {
+          const scopedWorkflowId = typeof workflowId === 'string' && workflowId.length > 0 ? workflowId : undefined;
+          return persistence.listWorkflowMutationStatusIntents(scopedWorkflowId).map(toWorkflowMutationStatusEntry);
         }
         if (kind === 'workflow-status') {
           return orchestrator.getWorkflowStatus();
@@ -3561,7 +3702,7 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:provide-input', async (taskIdArg: unknown, inputArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:provide-input', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, inputArg: unknown) => {
       const taskId = String(taskIdArg);
       const input = String(inputArg);
       const envelope = makeEnvelope('provide-input', 'ui', 'task', { taskId, input });
@@ -3590,7 +3731,7 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:reject', async (taskIdArg: unknown, reasonArg?: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:reject', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, reasonArg?: unknown) => {
       const taskId = String(taskIdArg);
       const reason = reasonArg === undefined ? undefined : String(reasonArg);
       const envelope = makeEnvelope('reject', 'ui', 'task', { taskId, reason });
@@ -3598,7 +3739,7 @@ function createEmbeddedTerminalBackendFromConfig(
       if (!result.ok) throw new Error(result.error.message);
     });
 
-    registerGuiMutationHandler('invoker:select-experiment', async (taskIdArg: unknown, experimentIdArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:select-experiment', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, experimentIdArg: unknown) => {
       const taskId = String(taskIdArg);
       const experimentId = experimentIdArg as string | string[];
       const ids = Array.isArray(experimentId) ? experimentId : [experimentId];
@@ -3735,6 +3876,23 @@ function createEmbeddedTerminalBackendFromConfig(
         }
       }
       return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
+    });
+
+    ipcMain.handle('invoker:get-workflow-mutation-statuses', async (_event, workflowIdArg?: unknown) => {
+      const workflowId = typeof workflowIdArg === 'string' && workflowIdArg.length > 0 ? workflowIdArg : undefined;
+      if (!ownerMode) {
+        try {
+          return await messageBus.request('headless.query', { kind: 'workflow-mutation-statuses', workflowId });
+        } catch (err) {
+          logger.warn(
+            `get-workflow-mutation-statuses owner delegation failed; falling back to local read-only snapshot: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            { module: 'ipc' },
+          );
+        }
+      }
+      return persistence.listWorkflowMutationStatusIntents(workflowId).map(toWorkflowMutationStatusEntry);
     });
 
     ipcMain.handle('invoker:report-ui-perf', (_event, metric: string, data?: Record<string, unknown>) => {
@@ -4056,7 +4214,7 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:set-merge-branch', async (workflowIdArg: unknown, baseBranchArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:set-merge-branch', (workflowIdArg: unknown) => String(workflowIdArg), 'normal', async (workflowIdArg: unknown, baseBranchArg: unknown) => {
       const workflowId = String(workflowIdArg);
       const baseBranch = String(baseBranchArg);
       logger.info(`set-merge-branch: workflow="${workflowId}" → "${baseBranch}"`, { module: 'ipc' });
@@ -4085,7 +4243,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:set-merge-mode', async (workflowIdArg: unknown, mergeModeArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:set-merge-mode', (workflowIdArg: unknown) => String(workflowIdArg), 'normal', async (workflowIdArg: unknown, mergeModeArg: unknown) => {
       const workflowId = String(workflowIdArg);
       const mergeMode = String(mergeModeArg);
       logger.info(`set-merge-mode: workflow="${workflowId}" → "${mergeMode}"`, { module: 'ipc' });
@@ -4227,7 +4385,7 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:edit-task-command', async (taskIdArg: unknown, newCommandArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:edit-task-command', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, newCommandArg: unknown) => {
       const taskId = String(taskIdArg);
       const newCommand = String(newCommandArg);
       logger.info(`edit-task-command: "${taskId}" → "${newCommand}"`, { module: 'ipc' });
@@ -4249,7 +4407,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-prompt', async (taskIdArg: unknown, newPromptArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:edit-task-prompt', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, newPromptArg: unknown) => {
       const taskId = String(taskIdArg);
       const newPrompt = String(newPromptArg);
       logger.info(`edit-task-prompt: "${taskId}" → "${newPrompt}"`, { module: 'ipc' });
@@ -4271,7 +4429,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-type', async (taskIdArg: unknown, runnerKindArg: unknown, poolMemberIdArg?: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:edit-task-type', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, runnerKindArg: unknown, poolMemberIdArg?: unknown) => {
       const taskId = String(taskIdArg);
       const runnerKind = String(runnerKindArg);
       const poolMemberId = poolMemberIdArg === undefined ? undefined : String(poolMemberIdArg);
@@ -4294,7 +4452,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-pool', async (taskIdArg: unknown, poolIdArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:edit-task-pool', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, poolIdArg: unknown) => {
       const taskId = String(taskIdArg);
       const poolId = String(poolIdArg);
       logger.info(`edit-task-pool: "${taskId}" → "${poolId}"`, { module: 'ipc' });
@@ -4316,7 +4474,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-agent', async (taskIdArg: unknown, agentNameArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:edit-task-agent', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'normal', async (taskIdArg: unknown, agentNameArg: unknown) => {
       const taskId = String(taskIdArg);
       const agentName = String(agentNameArg);
       logger.info(`edit-task-agent: "${taskId}" → "${agentName}"`, { module: 'ipc' });
@@ -4338,8 +4496,10 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler(
+    registerTaskScopedGuiMutationHandler(
       'invoker:set-task-external-gate-policies',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
       async (taskIdArg: unknown, updatesArg: unknown) => {
         const taskId = String(taskIdArg);
         const updates = updatesArg as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }>;
@@ -4394,7 +4554,7 @@ function createEmbeddedTerminalBackendFromConfig(
       return updateInvokerCli(buildCliInstallerContext());
     });
 
-    registerGuiMutationHandler('invoker:replace-task', async (taskIdArg: unknown, replacementTasksArg: unknown) => {
+    registerTaskScopedGuiMutationHandler('invoker:replace-task', (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg), 'high', async (taskIdArg: unknown, replacementTasksArg: unknown) => {
       const taskId = String(taskIdArg);
       const replacementTasks = replacementTasksArg as unknown[];
       logger.info(`replace-task: "${taskId}" with ${replacementTasks.length} replacement(s)`, { module: 'ipc' });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3010,6 +3010,33 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return rows.map((row) => this.rowToWorkflowMutationIntent(row));
   }
 
+  listWorkflowMutationStatusIntents(
+    workflowId?: string,
+    terminalLimit = 50,
+  ): WorkflowMutationIntent[] {
+    const workflowWhere = workflowId ? 'AND workflow_id = ?' : '';
+    const workflowParams = workflowId ? [workflowId] : [];
+    const openRows = this.queryAll(
+      `SELECT * FROM workflow_mutation_intents
+       WHERE status IN ('queued', 'running') ${workflowWhere}
+       ORDER BY CASE priority WHEN 'high' THEN 0 ELSE 1 END ASC, id ASC`,
+      workflowParams,
+    );
+    const limit = Math.max(0, Math.floor(terminalLimit));
+    const terminalRows = limit === 0
+      ? []
+      : this.queryAll(
+        `SELECT * FROM workflow_mutation_intents
+         WHERE status IN ('failed', 'completed') ${workflowWhere}
+         ORDER BY id DESC
+         LIMIT ?`,
+        [...workflowParams, limit],
+      );
+    return [...openRows, ...terminalRows]
+      .map((row) => this.rowToWorkflowMutationIntent(row))
+      .sort((a, b) => b.id - a.id);
+  }
+
   requeueRunningWorkflowMutationIntents(): number {
     const running = this.queryOne(
       `SELECT COUNT(*) AS count FROM workflow_mutation_intents WHERE status = 'running'`,


### PR DESCRIPTION
Depends-On: #1979

## Summary

GUI workflow actions now return an accepted status immediately.

The background worker still performs the real work. Failed and running actions stay visible through the existing action graph path.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the runtime handoff for GUI workflow actions.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The existing worker still runs each action; this slice only changes when the GUI gets its response.

Slice Rationale: This is separate from the contract and renderer slices so the runtime handoff can be reviewed locally.

</details>

## Non-goals

This does not change the renderer display.

This does not add a repro script.

## Architecture

### Before

```mermaid
graph TD
    A["GUI workflow action"] --> B["IPC handler waits"]
    B --> C["Worker finishes"]
    C --> D["GUI response"]
```

### After

```mermaid
graph TD
    A["GUI workflow action"] --> B["IPC handler returns accepted status"]
    B --> C["Worker continues action"]
    C --> D["Action graph reports running or failed status"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/ipc-registration.test.ts -t "workflow-scoped"`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/action-graph-diagnostics.test.ts`
- [x] `pnpm run check:types`

## Visual Proof

![Workflow mutation status UI](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260622-48c8e9/workflow-mutation-status-ui.png)

## Revert Plan

- Safe to revert? Yes, after reverting dependent stack slices first.
- Revert command: `git revert 46f8076e5`
- Post-revert steps: None
- Data migration? No
