### PR TITLE
[Workflow Mutation Status](3) Show pending mutations in UI

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,9 +12,10 @@
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
 import yaml from 'js-yaml';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
-import type { ActionGraphNode, TerminalSessionDescriptor } from '@invoker/contracts';
+import type { ActionGraphNode, TerminalSessionDescriptor, WorkflowMutationAcceptedResult, WorkflowMutationStatusEntry } from '@invoker/contracts';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
+import { useWorkflowMutations } from './hooks/useWorkflowMutations.js';
 import { useInvoker } from './hooks/useInvoker.js';
 import { TaskDAG } from './components/TaskDAG.js';
 import { HistoryView } from './components/HistoryView.js';
@@ -383,10 +384,23 @@ export function App() {
   });
   const invoker = useInvoker();
   const queueStatus = useQueueStatus();
+  const { mutationsByWorkflow, recordAcceptedMutation } = useWorkflowMutations();
+  const trackAcceptedMutation = useCallback((result: unknown) => {
+    if (result && typeof result === 'object' && (result as { accepted?: unknown }).accepted === true) {
+      recordAcceptedMutation(result as WorkflowMutationAcceptedResult);
+    }
+  }, [recordAcceptedMutation]);
   const runningTaskIds = useMemo(
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
     [queueStatus],
   );
+  const openMutationsByWorkflow = useMemo(() => {
+    const open = new Map<string, WorkflowMutationStatusEntry | undefined>();
+    for (const [workflowId, rows] of mutationsByWorkflow) {
+      open.set(workflowId, rows.find((row) => row.status === 'queued' || row.status === 'running'));
+    }
+    return open;
+  }, [mutationsByWorkflow]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
@@ -638,6 +652,10 @@ export function App() {
   }, [miniDagTasks, selectedTask, selectedWorkflow, selectedWorkflowId, tasks.size, workflowSelectionDismissed]);
   const isSelectedWorkflowGraphRefreshing = displayedSelectedWorkflowGraph !== null
     && !(selectedWorkflow && miniDagTasks.size > 0);
+  const selectedWorkflowMutations = useMemo(() => {
+    const workflowId = (displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow)?.id;
+    return workflowId ? mutationsByWorkflow.get(workflowId) : undefined;
+  }, [displayedSelectedWorkflowGraph, mutationsByWorkflow, selectedWorkflow]);
   const selectedTaskDagWorkflows = useMemo(() => {
     const workflowForDag = displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow;
     if (!workflowForDag || workflows.has(workflowForDag.id)) {
@@ -1222,11 +1240,11 @@ export function App() {
     if (!invoker) return;
     setContextMenu(null);
     try {
-      await invoker.restartTask(taskId);
+      trackAcceptedMutation(await invoker.restartTask(taskId));
     } catch (err) {
       console.error('Failed to restart task:', err);
     }
-  }, [invoker]);
+  }, [invoker, trackAcceptedMutation]);
 
   const handleOpenTerminal = useCallback(
     (taskId: string) => {
@@ -1266,71 +1284,65 @@ export function App() {
 
   const handleReplaceSubmit = useCallback(async (taskId: string, replacements: TaskReplacementDef[]) => {
     try {
-      await window.invoker?.replaceTask(taskId, replacements);
+      trackAcceptedMutation(await window.invoker?.replaceTask(taskId, replacements));
     } catch (err) {
       console.error('Failed to replace task:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRebaseRetry = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      const result = await window.invoker?.rebaseRetry(workflowId);
-      if (result && !result.success) {
-        console.error('Rebase and Retry failed for some branches:', result.errors);
-      }
+      trackAcceptedMutation(await window.invoker?.rebaseRetry(workflowId));
     } catch (err) {
       console.error('Rebase and Retry failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRebaseRecreate = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      const result = await window.invoker?.rebaseRecreate(workflowId);
-      if (result && !result.success) {
-        console.error('Rebase and Recreate failed for some branches:', result.errors);
-      }
+      trackAcceptedMutation(await window.invoker?.rebaseRecreate(workflowId));
     } catch (err) {
       console.error('Rebase and Recreate failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRetryWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.retryWorkflow(workflowId);
+      trackAcceptedMutation(await window.invoker?.retryWorkflow(workflowId));
     } catch (err) {
       console.error('Retry Workflow failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRecreateWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.recreateWorkflow(workflowId);
+      trackAcceptedMutation(await window.invoker?.recreateWorkflow(workflowId));
     } catch (err) {
       console.error('Recreate Workflow failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRecreateTask = useCallback(async (taskId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.recreateTask(taskId);
+      trackAcceptedMutation(await window.invoker?.recreateTask(taskId));
     } catch (err) {
       console.error('Recreate from Task failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRecreateDownstream = useCallback(async (taskId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.recreateDownstream(taskId);
+      trackAcceptedMutation(await window.invoker?.recreateDownstream(taskId));
     } catch (err) {
       console.error('Recreate Downstream failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleDeleteWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
@@ -1339,7 +1351,7 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await window.invoker?.deleteWorkflow(workflowId);
+      trackAcceptedMutation(await window.invoker?.deleteWorkflow(workflowId));
       setSelectedTaskId(null);
       if (selectedWorkflowId === workflowId) {
         setSelectedWorkflowId(null);
@@ -1348,7 +1360,7 @@ export function App() {
     } catch (err) {
       console.error('Delete Workflow failed:', err);
     }
-  }, [refreshTaskGraph, selectedWorkflowId]);
+  }, [refreshTaskGraph, selectedWorkflowId, trackAcceptedMutation]);
 
   const handleFix = useCallback(async (taskId: string, agentName: string) => {
     setContextMenu(null);
@@ -1364,16 +1376,15 @@ export function App() {
     }
     try {
       const hasMergeConflict = hasMergeConflictExecution(task);
-      if (hasMergeConflict) {
-        await window.invoker?.resolveConflict(taskId, agentName);
-      } else {
-        await window.invoker?.fixWithAgent(taskId, agentName);
-      }
+      const result = hasMergeConflict
+        ? await window.invoker?.resolveConflict(taskId, agentName)
+        : await window.invoker?.fixWithAgent(taskId, agentName);
+      trackAcceptedMutation(result);
       refreshTaskGraph();
     } catch (err) {
       console.error('Fix failed:', err);
     }
-  }, [tasks, refreshTaskGraph]);
+  }, [tasks, refreshTaskGraph, trackAcceptedMutation]);
 
   const handleCancelTask = useCallback(async (taskId: string) => {
     setContextMenu(null);
@@ -1382,11 +1393,11 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await window.invoker?.cancelTask(taskId);
+      trackAcceptedMutation(await window.invoker?.cancelTask(taskId));
     } catch (err) {
       console.error('Failed to cancel task:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleCancelWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
@@ -1395,11 +1406,11 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await window.invoker?.cancelWorkflow(workflowId);
+      trackAcceptedMutation(await window.invoker?.cancelWorkflow(workflowId));
     } catch (err) {
       console.error('Failed to cancel workflow:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleOpenWorkflowPr = useCallback((workflowId: string) => {
     const workflowTasks = [...tasks.values()].filter((task) => task.config.workflowId === workflowId);
@@ -1548,33 +1559,33 @@ export function App() {
   const handleProvideInput = useCallback(
     async (taskId: string, input: string) => {
       if (!invoker) return;
-      await invoker.provideInput(taskId, input);
+      trackAcceptedMutation(await invoker.provideInput(taskId, input));
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleApprove = useCallback(
     async (taskId: string) => {
       if (!invoker) return;
-      await invoker.approve(taskId);
+      trackAcceptedMutation(await invoker.approve(taskId));
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleReject = useCallback(
     async (taskId: string, reason?: string) => {
       if (!invoker) return;
-      await invoker.reject(taskId, reason);
+      trackAcceptedMutation(await invoker.reject(taskId, reason));
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleSelectExperiment = useCallback(
     async (taskId: string, experimentIds: string[]) => {
       if (!invoker) return;
-      await invoker.selectExperiment(taskId, experimentIds.length === 1 ? experimentIds[0] : experimentIds);
+      trackAcceptedMutation(await invoker.selectExperiment(taskId, experimentIds.length === 1 ? experimentIds[0] : experimentIds));
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task command ──────────────────────────────────────
@@ -1582,12 +1593,12 @@ export function App() {
     async (taskId: string, newCommand: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskCommand(taskId, newCommand);
+        trackAcceptedMutation(await invoker.editTaskCommand(taskId, newCommand));
       } catch (err) {
         console.error('Failed to edit task command:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task prompt ───────────────────────────────────────
@@ -1595,12 +1606,12 @@ export function App() {
     async (taskId: string, newPrompt: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskPrompt(taskId, newPrompt);
+        trackAcceptedMutation(await invoker.editTaskPrompt(taskId, newPrompt));
       } catch (err) {
         console.error('Failed to edit task prompt:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task executor type ───────────────────────────────
@@ -1608,12 +1619,12 @@ export function App() {
     async (taskId: string, runnerKind: string, poolMemberId?: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskType(taskId, runnerKind, poolMemberId);
+        trackAcceptedMutation(await invoker.editTaskType(taskId, runnerKind, poolMemberId));
       } catch (err) {
         console.error('Failed to edit task type:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task execution pool ─────────────────────────────
@@ -1621,12 +1632,12 @@ export function App() {
     async (taskId: string, poolId: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskPool(taskId, poolId);
+        trackAcceptedMutation(await invoker.editTaskPool(taskId, poolId));
       } catch (err) {
         console.error('Failed to edit task pool:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task execution agent ────────────────────────────
@@ -1634,50 +1645,50 @@ export function App() {
     async (taskId: string, agentName: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskAgent(taskId, agentName);
+        trackAcceptedMutation(await invoker.editTaskAgent(taskId, agentName));
       } catch (err) {
         console.error('Failed to edit task agent:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleSetExternalGatePolicies = useCallback(
     async (taskId: string, updates: ExternalGatePolicyUpdate[]) => {
       if (!invoker) return;
       try {
-        await invoker.setTaskExternalGatePolicies(taskId, updates);
+        trackAcceptedMutation(await invoker.setTaskExternalGatePolicies(taskId, updates));
       } catch (err) {
         console.error('Failed to set external gate policies:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleSetMergeBranch = useCallback(
     async (workflowId: string, baseBranch: string) => {
       if (!invoker) return;
       try {
-        await invoker.setMergeBranch(workflowId, baseBranch);
+        trackAcceptedMutation(await invoker.setMergeBranch(workflowId, baseBranch));
         refreshTaskGraph();
       } catch (err) {
         console.error('Failed to set merge branch:', err);
       }
     },
-    [invoker, refreshTaskGraph],
+    [invoker, refreshTaskGraph, trackAcceptedMutation],
   );
 
   const handleSetMergeMode = useCallback(
     async (workflowId: string, mergeMode: 'manual' | 'automatic' | 'external_review') => {
       if (!invoker) return;
       try {
-        await invoker.setMergeMode(workflowId, mergeMode);
+        trackAcceptedMutation(await invoker.setMergeMode(workflowId, mergeMode));
         refreshTaskGraph();
       } catch (err) {
         console.error('Failed to set merge mode:', err);
       }
     },
-    [invoker, refreshTaskGraph],
+    [invoker, refreshTaskGraph, trackAcceptedMutation],
   );
 
   // ── Modal triggers ────────────────────────────────────────
@@ -1933,6 +1944,7 @@ export function App() {
                     selectedWorkflowId={selectedWorkflow?.id ?? null}
                     cameraCommand={cameraCommand}
                     statusFilters={statusFilters}
+                    openMutationsByWorkflow={openMutationsByWorkflow}
                     onSelectWorkflow={handleWorkflowClick}
                     onWorkflowContextMenu={handleWorkflowContextMenu}
                     onManualViewport={handleManualViewport}
@@ -2015,6 +2027,7 @@ export function App() {
             <WorkflowInspector
               workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
               task={selectedTask}
+              workflowMutations={selectedWorkflowMutations}
               workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
               remoteTargets={remoteTargets}
               executionPools={executionPools}

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -61,6 +61,7 @@ describe('Context menu (component)', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.useRealTimers();
     mock.cleanup();
   });
 
@@ -259,6 +260,90 @@ describe('Context menu (component)', () => {
     fireEvent.click(await screen.findByText('Rebase and Recreate'));
     await waitFor(() => expect(mock.api.rebaseRecreate).toHaveBeenCalledWith('wf-1'));
     expectOnlyWorkflowApiCalled('rebaseRecreate');
+  });
+
+  it('workflow context menu shows backend accepted queued mutation', async () => {
+    await setup();
+    vi.mocked(mock.api.rebaseRecreate).mockResolvedValueOnce({
+      intentId: 77,
+      workflowId: 'wf-1',
+      channel: 'invoker:rebase-recreate',
+      label: 'Rebase and Recreate',
+      status: 'queued',
+      accepted: true,
+      queued: true,
+      ok: true,
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));
+    fireEvent.click(await screen.findByText('More'));
+    fireEvent.click(await screen.findByText('Rebase and Recreate'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-1-mutation')).toHaveTextContent('Queued: Rebase and Recreate');
+    });
+    fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
+    expect(await screen.findByTestId('workflow-mutation-row-77')).toHaveTextContent('Rebase and Recreate');
+    expect(screen.getByTestId('workflow-mutation-status-77')).toHaveTextContent('QUEUED');
+  });
+
+  it('workflow mutation status poll updates queued to running and failed', async () => {
+    await setup();
+    vi.mocked(mock.api.rebaseRecreate).mockResolvedValueOnce({
+      intentId: 77,
+      workflowId: 'wf-1',
+      channel: 'invoker:rebase-recreate',
+      label: 'Rebase and Recreate',
+      status: 'queued',
+      accepted: true,
+      queued: true,
+      ok: true,
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));
+    fireEvent.click(await screen.findByText('More'));
+    fireEvent.click(await screen.findByText('Rebase and Recreate'));
+    await screen.findByTestId('workflow-mutation-row-77');
+
+    mock.setWorkflowMutationStatuses([{
+      intentId: 77,
+      workflowId: 'wf-1',
+      channel: 'invoker:rebase-recreate',
+      label: 'Rebase and Recreate',
+      status: 'running',
+      priority: 'high',
+      createdAt: '2026-06-22T00:00:00.000Z',
+      startedAt: '2026-06-22T00:00:01.000Z',
+      args: ['wf-1'],
+    }]);
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2100));
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-1-mutation')).toHaveTextContent('Running: Rebase and Recreate');
+    });
+
+    mock.setWorkflowMutationStatuses([{
+      intentId: 77,
+      workflowId: 'wf-1',
+      channel: 'invoker:rebase-recreate',
+      label: 'Rebase and Recreate',
+      status: 'failed',
+      priority: 'high',
+      error: 'boom',
+      createdAt: '2026-06-22T00:00:00.000Z',
+      startedAt: '2026-06-22T00:00:01.000Z',
+      completedAt: '2026-06-22T00:00:02.000Z',
+      args: ['wf-1'],
+    }]);
+    await act(async () => {
+      await new Promise((resolve) => window.setTimeout(resolve, 2100));
+    });
+    await waitFor(() => {
+      expect(screen.queryByTestId('workflow-node-wf-1-mutation')).not.toBeInTheDocument();
+    });
+    expect(screen.getByTestId('workflow-mutation-status-77')).toHaveTextContent('FAILED');
+    expect(screen.getByTestId('workflow-mutation-row-77')).toHaveTextContent('boom');
   });
 
   it('workflow context menu cancels workflow', async () => {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -16,7 +16,7 @@ import type {
   TaskConfig,
   TaskExecution,
 } from '../../types.js';
-import type { TerminalOutputEvent } from '@invoker/contracts';
+import type { TerminalOutputEvent, WorkflowMutationAcceptedResult, WorkflowMutationStatusEntry } from '@invoker/contracts';
 
 export interface MockInvoker {
   /** The mock InvokerAPI object installed on window.invoker. */
@@ -31,6 +31,8 @@ export interface MockInvoker {
   fireWorkflowsChanged: (workflows: WorkflowMeta[]) => void;
   /** Fire an embedded terminal output event to subscribers. */
   fireTerminalOutput: (event: TerminalOutputEvent) => void;
+  /** Replace the workflow mutation status snapshot. */
+  setWorkflowMutationStatuses: (rows: WorkflowMutationStatusEntry[]) => void;
   /** Install the mock on window.invoker. */
   install: () => void;
   /** Remove window.invoker. */
@@ -43,9 +45,30 @@ export function createMockInvoker(
 ): MockInvoker {
   let taskSnapshot = initialTasks;
   let workflowSnapshot = initialWorkflows;
+  let mutationStatusSnapshot: WorkflowMutationStatusEntry[] = [];
   let graphEventCallback: ((event: TaskGraphEvent) => void) | undefined;
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
+
+  const workflowIdForTask = (taskId: string): string => (
+    taskSnapshot.find((task) => task.id === taskId)?.config.workflowId
+    ?? workflowSnapshot[0]?.id
+    ?? 'wf-1'
+  );
+  const acceptedResult = (
+    channel: string,
+    label: string,
+    workflowId: string,
+  ): WorkflowMutationAcceptedResult => ({
+    ok: true,
+    accepted: true,
+    queued: true,
+    intentId: mutationStatusSnapshot.length + 1,
+    workflowId,
+    channel,
+    label,
+    status: 'queued',
+  });
 
   const api: InvokerAPI = {
     // Defer resolution one microtask so the startup snapshot is read after synchronous setTasks()
@@ -92,15 +115,18 @@ export function createMockInvoker(
     stop: vi.fn(async () => {}),
     clear: vi.fn(async () => {}),
     getStatus: vi.fn(async () => ({ total: 0, completed: 0, failed: 0, closed: 0, running: 0, pending: 0 })),
-    provideInput: vi.fn(async () => {}),
-    approve: vi.fn(async () => {}),
-    reject: vi.fn(async () => {}),
-    selectExperiment: vi.fn(async () => {}),
-    restartTask: vi.fn(async () => {}),
-    editTaskCommand: vi.fn(async () => {}),
-    editTaskPool: vi.fn(async () => {}),
-    editTaskAgent: vi.fn(async () => {}),
-    setTaskExternalGatePolicies: vi.fn(async () => {}),
+    getWorkflowMutationStatuses: vi.fn(async () => mutationStatusSnapshot),
+    provideInput: vi.fn(async (taskId: string) => acceptedResult('invoker:provide-input', 'Provide input', workflowIdForTask(taskId))),
+    approve: vi.fn(async (taskId: string) => acceptedResult('invoker:approve', 'Approve task', workflowIdForTask(taskId))),
+    reject: vi.fn(async (taskId: string) => acceptedResult('invoker:reject', 'Reject task', workflowIdForTask(taskId))),
+    selectExperiment: vi.fn(async (taskId: string) => acceptedResult('invoker:select-experiment', 'Select experiment', workflowIdForTask(taskId))),
+    restartTask: vi.fn(async (taskId: string) => acceptedResult('invoker:restart-task', 'Retry task', workflowIdForTask(taskId))),
+    editTaskPrompt: vi.fn(async (taskId: string) => acceptedResult('invoker:edit-task-prompt', 'Edit task prompt', workflowIdForTask(taskId))),
+    editTaskType: vi.fn(async (taskId: string) => acceptedResult('invoker:edit-task-type', 'Edit task executor', workflowIdForTask(taskId))),
+    editTaskCommand: vi.fn(async (taskId: string) => acceptedResult('invoker:edit-task-command', 'Edit task command', workflowIdForTask(taskId))),
+    editTaskPool: vi.fn(async (taskId: string) => acceptedResult('invoker:edit-task-pool', 'Edit task pool', workflowIdForTask(taskId))),
+    editTaskAgent: vi.fn(async (taskId: string) => acceptedResult('invoker:edit-task-agent', 'Edit task agent', workflowIdForTask(taskId))),
+    setTaskExternalGatePolicies: vi.fn(async (taskId: string) => acceptedResult('invoker:set-task-external-gate-policies', 'Set gate policy', workflowIdForTask(taskId))),
     getRemoteTargets: vi.fn(async () => []),
     getExecutionPools: vi.fn(async () => ['mixed-local-ssh', 'pnpm-ssh']),
     getExecutionAgents: vi.fn(async () => ['claude', 'codex']),
@@ -144,7 +170,7 @@ export function createMockInvoker(
         { id: 'cursor', name: 'Cursor', path: '/tmp/.cursor/skills-cursor', available: true, installed: false, upToDate: false, installedSkillNames: [] },
       ],
     })),
-    replaceTask: vi.fn(async () => []),
+    replaceTask: vi.fn(async (taskId: string) => acceptedResult('invoker:replace-task', 'Replace task', workflowIdForTask(taskId))),
     getActivityLogs: vi.fn(async () => []),
     getEvents: vi.fn(async () => []),
     openTerminal: vi.fn(async (taskId: string) => ({
@@ -172,22 +198,23 @@ export function createMockInvoker(
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),
     deleteAllWorkflows: vi.fn(async () => {}),
     deleteAllWorkflowsBulk: vi.fn(async () => {}),
-    deleteWorkflow: vi.fn(async () => {}),
+    deleteWorkflow: vi.fn(async (workflowId: string) => acceptedResult('invoker:delete-workflow', 'Delete workflow', workflowId)),
+    detachWorkflow: vi.fn(async (workflowId: string) => acceptedResult('invoker:detach-workflow', 'Detach workflow', workflowId)),
     cleanupWorktrees: vi.fn(async () => ({ removed: [], errors: [] })),
-    recreateWorkflow: vi.fn(async () => {}),
-    recreateTask: vi.fn(async () => {}),
-    recreateDownstream: vi.fn(async () => {}),
-    retryWorkflow: vi.fn(async () => {}),
-    rebaseRetry: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
-    rebaseRecreate: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
-    setMergeBranch: vi.fn(async () => {}),
-    approveMerge: vi.fn(async () => {}),
-    resolveConflict: vi.fn(async () => {}),
-    fixWithAgent: vi.fn(async () => {}),
-    setMergeMode: vi.fn(async () => {}),
+    recreateWorkflow: vi.fn(async (workflowId: string) => acceptedResult('invoker:recreate-workflow', 'Recreate workflow', workflowId)),
+    recreateTask: vi.fn(async (taskId: string) => acceptedResult('invoker:recreate-task', 'Recreate task', workflowIdForTask(taskId))),
+    recreateDownstream: vi.fn(async (taskId: string) => acceptedResult('invoker:recreate-downstream', 'Recreate downstream', workflowIdForTask(taskId))),
+    retryWorkflow: vi.fn(async (workflowId: string) => acceptedResult('invoker:retry-workflow', 'Retry workflow', workflowId)),
+    rebaseRetry: vi.fn(async (workflowId: string) => acceptedResult('invoker:rebase-retry', 'Rebase and Retry', workflowId)),
+    rebaseRecreate: vi.fn(async (workflowId: string) => acceptedResult('invoker:rebase-recreate', 'Rebase and Recreate', workflowId)),
+    setMergeBranch: vi.fn(async (workflowId: string) => acceptedResult('invoker:set-merge-branch', 'Set merge branch', workflowId)),
+    approveMerge: vi.fn(async (workflowId: string) => acceptedResult('invoker:approve-merge', 'Approve merge', workflowId)),
+    resolveConflict: vi.fn(async (taskId: string) => acceptedResult('invoker:resolve-conflict', 'Resolve conflict', workflowIdForTask(taskId))),
+    fixWithAgent: vi.fn(async (taskId: string) => acceptedResult('invoker:fix-with-agent', 'Fix with agent', workflowIdForTask(taskId))),
+    setMergeMode: vi.fn(async (workflowId: string) => acceptedResult('invoker:set-merge-mode', 'Set merge mode', workflowId)),
     checkPrStatuses: vi.fn(async () => {}),
-    cancelTask: vi.fn(async () => ({ cancelled: [], runningCancelled: [] })),
-    cancelWorkflow: vi.fn(async () => ({ cancelled: [], runningCancelled: [] })),
+    cancelTask: vi.fn(async (taskId: string) => acceptedResult('invoker:cancel-task', 'Cancel task', workflowIdForTask(taskId))),
+    cancelWorkflow: vi.fn(async (workflowId: string) => acceptedResult('invoker:cancel-workflow', 'Cancel workflow', workflowId)),
     getQueueStatus: vi.fn(async () => ({
       maxConcurrency: 0,
       runningCount: 0,
@@ -214,6 +241,10 @@ export function createMockInvoker(
         graphEventCallback?.({ type: 'delta', delta: { type: 'created', task }, workflowRollups: [] });
       }
     });
+  }
+
+  function setWorkflowMutationStatuses(rows: WorkflowMutationStatusEntry[]) {
+    mutationStatusSnapshot = rows;
   }
 
   function fireDelta(delta: TaskDelta) {
@@ -249,7 +280,7 @@ export function createMockInvoker(
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
   }
 
-  return { api, setTasks, fireDelta, fireGraphEvent, fireWorkflowsChanged, fireTerminalOutput, install, cleanup };
+  return { api, setTasks, setWorkflowMutationStatuses, fireDelta, fireGraphEvent, fireWorkflowsChanged, fireTerminalOutput, install, cleanup };
 }
 
 /** Create a minimal TaskState for testing. */

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
+import type { WorkflowMutationStatusEntry } from '@invoker/contracts';
 import type { WorkflowMeta, WorkflowStatus } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
 import { deriveWorkflowGraph, layoutWorkflowGraph, type WorkflowGraphEdge } from '../lib/workflow-graph.js';
@@ -29,6 +30,7 @@ interface WorkflowGraphProps {
    */
   cameraCommand?: GraphCameraCommand | null;
   statusFilters: Set<WorkflowStatus>;
+  openMutationsByWorkflow?: Map<string, WorkflowMutationStatusEntry | undefined>;
   onSelectWorkflow: (workflowId: string) => void;
   onWorkflowContextMenu: (event: MouseEvent, workflowId: string) => void;
   /** Fired when the user manually pans or zooms the viewport. */
@@ -39,6 +41,7 @@ interface WorkflowNodeData extends Record<string, unknown> {
   workflow: WorkflowMeta;
   selected: boolean;
   dimmed: boolean;
+  openMutation?: WorkflowMutationStatusEntry;
 }
 
 const nodeTypes = {
@@ -91,6 +94,7 @@ function WorkflowFlowNode({ data }: NodeProps<Node<WorkflowNodeData>>): JSX.Elem
         dimmed={data.dimmed}
         onClick={() => {}}
         onContextMenu={() => {}}
+        openMutation={data.openMutation}
       />
       <Handle
         type="source"
@@ -106,6 +110,7 @@ function WorkflowGraphInner({
   workflows,
   selectedWorkflowId,
   cameraCommand,
+  openMutationsByWorkflow,
   statusFilters,
   onSelectWorkflow,
   onWorkflowContextMenu,
@@ -149,12 +154,13 @@ function WorkflowGraphInner({
           workflow: node.workflow,
           selected: selectedWorkflowId === node.id,
           dimmed,
+          openMutation: openMutationsByWorkflow?.get(node.id),
         },
       };
     });
     graphMetricsRef.current.objectsMs = performance.now() - startedAt;
     return nextNodes;
-  }, [graph.nodes, positions, selectedWorkflowId, statusFilters]);
+  }, [graph.nodes, openMutationsByWorkflow, positions, selectedWorkflowId, statusFilters]);
 
   const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => {
     const visual = workflowEdgeVisual(edge.kind);

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { TaskState, WorkflowMeta } from '../types.js';
+import type { WorkflowMutationStatusEntry } from '@invoker/contracts';
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 
@@ -9,6 +10,7 @@ interface WorkflowInspectorProps {
   workflow: WorkflowMeta | null;
   task: TaskState | null;
   workflowTasks?: Map<string, TaskState>;
+  workflowMutations?: WorkflowMutationStatusEntry[];
   remoteTargets?: string[];
   executionPools?: string[];
   executionAgents?: string[];
@@ -60,6 +62,7 @@ export function WorkflowInspector({
   workflow,
   task,
   workflowTasks,
+  workflowMutations,
   executionPools,
   executionAgents,
   collapsed,
@@ -249,6 +252,39 @@ export function WorkflowInspector({
             </div>
           )}
         </section>
+        {workflow && !task && workflowMutations && workflowMutations.length > 0 && (
+          <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+            <h3 className="text-[11px] uppercase tracking-wide text-gray-400">Action history</h3>
+            <div className="mt-2 space-y-2">
+              {workflowMutations.slice(0, 5).map((mutation) => (
+                <div
+                  key={mutation.intentId}
+                  data-testid={`workflow-mutation-row-${mutation.intentId}`}
+                  className="rounded border border-gray-700 bg-gray-900/60 p-2"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 text-xs text-gray-100">{mutation.label}</div>
+                    <div
+                      data-testid={`workflow-mutation-status-${mutation.intentId}`}
+                      className="shrink-0 text-[10px] font-semibold uppercase tracking-wide text-gray-300"
+                    >
+                      {mutation.status.toUpperCase()}
+                    </div>
+                  </div>
+                  {mutation.status === 'failed' && mutation.error && (
+                    <div className="mt-1 text-xs text-red-300 break-words">{mutation.error}</div>
+                  )}
+                  {mutation.status === 'queued' && (
+                    <div className="mt-1 text-[11px] text-amber-200">Accepted by backend; waiting for command runner.</div>
+                  )}
+                  {mutation.status === 'running' && (
+                    <div className="mt-1 text-[11px] text-blue-200">Command runner is processing this action.</div>
+                  )}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
 
         {task && !task.config.isMergeNode && onEditPool && (
           <section className="rounded border border-gray-700 bg-gray-800/70 p-3">

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -1,5 +1,6 @@
 import type { KeyboardEvent, MouseEvent } from 'react';
 import type { WorkflowMeta, WorkflowStatus } from '../types.js';
+import type { WorkflowMutationStatusEntry } from '@invoker/contracts';
 import { isWorkflowStatusActive, workflowStatusVisual } from '../lib/workflow-status.js';
 
 interface WorkflowNodeProps {
@@ -8,6 +9,7 @@ interface WorkflowNodeProps {
   dimmed: boolean;
   onClick: () => void;
   onContextMenu: (event: MouseEvent<HTMLDivElement>) => void;
+  openMutation?: WorkflowMutationStatusEntry;
 }
 
 function statusLabel(status: WorkflowStatus): string {
@@ -24,12 +26,13 @@ export function WorkflowNode({
   dimmed,
   onClick,
   onContextMenu,
+  openMutation,
 }: WorkflowNodeProps): JSX.Element {
   const visual = workflowStatusVisual(workflow.status);
   const detachedDependencyCount = workflow.detachedExternalDependencies?.length ?? 0;
   const runningCount = workflow.rollup?.countsByStatus.running ?? 0;
   const showRunningTaskLine = workflow.status !== 'running' && runningCount > 0;
-
+  const showOpenMutation = openMutation?.status === 'queued' || openMutation?.status === 'running';
   return (
     <div
       data-testid={`workflow-node-${workflow.id}`}
@@ -70,6 +73,22 @@ export function WorkflowNode({
       </div>
       <div className="mt-1 text-[11px] text-gray-400 truncate">{workflow.id}</div>
       <div className={`mt-2 text-[10px] uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
+      {showOpenMutation && (
+        <div
+          data-testid={`workflow-node-${workflow.id}-mutation`}
+          className={[
+            'mt-2 inline-flex max-w-full items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium',
+            openMutation.status === 'running'
+              ? 'border-blue-400/50 bg-blue-950/30 text-blue-200'
+              : 'border-amber-400/50 bg-amber-950/30 text-amber-200',
+          ].join(' ')}
+        >
+          {openMutation.status === 'running' && <span className="h-1.5 w-1.5 rounded-full bg-blue-300 animate-pulse" />}
+          <span className="truncate">
+            {openMutation.status === 'running' ? 'Running' : 'Queued'}: {openMutation.label}
+          </span>
+        </div>
+      )}
       {showRunningTaskLine && (
         <div
           data-testid={`workflow-node-${workflow.id}-running-tasks`}

--- a/packages/ui/src/hooks/useWorkflowMutations.ts
+++ b/packages/ui/src/hooks/useWorkflowMutations.ts
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { WorkflowMutationAcceptedResult, WorkflowMutationStatusEntry } from '@invoker/contracts';
+
+const HIGH_PRIORITY_CHANNELS: Record<string, true> = {
+  'invoker:delete-workflow': true,
+  'invoker:detach-workflow': true,
+  'invoker:restart-task': true,
+  'invoker:cancel-task': true,
+  'invoker:cancel-workflow': true,
+  'invoker:replace-task': true,
+  'invoker:recreate-workflow': true,
+  'invoker:recreate-task': true,
+  'invoker:recreate-downstream': true,
+  'invoker:retry-workflow': true,
+  'invoker:rebase-retry': true,
+  'invoker:rebase-recreate': true,
+};
+
+function newestFirst(a: WorkflowMutationStatusEntry, b: WorkflowMutationStatusEntry): number {
+  return b.intentId - a.intentId;
+}
+
+export function useWorkflowMutations(pollMs = 2000): {
+  mutations: WorkflowMutationStatusEntry[];
+  mutationsByWorkflow: Map<string, WorkflowMutationStatusEntry[]>;
+  recordAcceptedMutation: (accepted: WorkflowMutationAcceptedResult | undefined | void) => void;
+  refreshWorkflowMutations: () => Promise<void>;
+} {
+  const [mutations, setMutations] = useState<WorkflowMutationStatusEntry[]>([]);
+
+  const refreshWorkflowMutations = useCallback(async () => {
+    try {
+      const rows = await window.invoker?.getWorkflowMutationStatuses?.();
+      if (rows) {
+        setMutations([...rows].sort(newestFirst));
+      }
+    } catch {
+      // ignore polling errors
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshWorkflowMutations();
+    const interval = window.setInterval(() => {
+      void refreshWorkflowMutations();
+    }, pollMs);
+    return () => window.clearInterval(interval);
+  }, [pollMs, refreshWorkflowMutations]);
+
+  const recordAcceptedMutation = useCallback((accepted: WorkflowMutationAcceptedResult | undefined | void) => {
+    if (!accepted?.accepted) return;
+
+    const entry: WorkflowMutationStatusEntry = {
+      intentId: accepted.intentId,
+      workflowId: accepted.workflowId,
+      channel: accepted.channel,
+      label: accepted.label,
+      status: 'queued',
+      priority: HIGH_PRIORITY_CHANNELS[accepted.channel] ? 'high' : 'normal',
+      createdAt: new Date().toISOString(),
+      args: [],
+    };
+
+    setMutations((current) => {
+      const withoutExisting = current.filter((row) => row.intentId !== entry.intentId);
+      return [entry, ...withoutExisting].sort(newestFirst);
+    });
+  }, []);
+
+  const mutationsByWorkflow = useMemo(() => {
+    const grouped = new Map<string, WorkflowMutationStatusEntry[]>();
+    for (const mutation of mutations) {
+      const rows = grouped.get(mutation.workflowId) ?? [];
+      rows.push(mutation);
+      grouped.set(mutation.workflowId, rows);
+    }
+    for (const rows of grouped.values()) {
+      rows.sort(newestFirst);
+    }
+    return grouped;
+  }, [mutations]);
+
+  return {
+    mutations,
+    mutationsByWorkflow,
+    recordAcceptedMutation,
+    refreshWorkflowMutations,
+  };
+}


### PR DESCRIPTION
Depends-On: #1980

## Summary

The workflow card now shows a badge while a requested action is still pending or running.

The inspector also shows action history, including failed actions and their error text.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the visible workflow action status surface.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The UI reads status rows and renders them; it does not run the action itself.

Slice Rationale: This is separate from the runtime slice so reviewers can focus on what the user sees.

</details>

## Non-goals

This does not change command runner behavior.

This does not change the shared contracts.

## Architecture

### Before

```mermaid
graph TD
    A["User clicks workflow action"] --> B["No pending badge"]
    A --> C["No inspector action history"]
```

### After

```mermaid
graph TD
    A["User clicks workflow action"] --> B["Workflow badge shows open action"]
    A --> C["Inspector shows action history"]
    D["Status polling"] --> B
    D --> C
```

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu-e2e.test.tsx -t "workflow context menu shows backend accepted queued mutation|workflow mutation status poll updates queued to running and failed"`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm run check:types`

## Visual Proof

![Workflow mutation status UI](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260622-48c8e9/workflow-mutation-status-ui.png)

## Revert Plan

- Safe to revert? Yes, after reverting dependent stack slices first.
- Revert command: `git revert 47365568f`
- Post-revert steps: None
- Data migration? No
