### PR TITLE
[Workflow Mutation Status](4) Add mutation status repro

### DIFF
--- a/scripts/repro/repro-rebase-recreate-ui-delay.sh
+++ b/scripts/repro/repro-rebase-recreate-ui-delay.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mode="${1:---expect-fixed}"
+
+case "$mode" in
+  --expect-fixed)
+    pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu-e2e.test.tsx -t "workflow context menu shows backend accepted queued mutation|workflow mutation status poll updates queued to running and failed"
+    ;;
+  --expect-bug)
+    pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu-e2e.test.tsx -t "workflow mutation status poll updates queued to running and failed" && {
+      printf 'Expected old UI-delay bug, but backend-backed mutation status was visible.\n' >&2
+      exit 1
+    }
+    ;;
+  *)
+    printf 'Usage: %s [--expect-fixed|--expect-bug]\n' "$0" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Depends-On: #1981

## Summary

This adds a small repro command for the delayed rebase and recreate UI path.

The fixed mode runs the two focused UI tests that prove queued, running, and failed action states stay visible.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the regression proof command for workflow mutation status.

Review Lane: proof

Review Unit: proof

Safety Invariant: This slice only adds a script under scripts/repro.

Slice Rationale: Proof is separate from behavior so it can be reviewed without runtime changes.

</details>

## Non-goals

This does not change product behavior.

This does not change PR tooling.

## Test Plan

- [x] `scripts/repro/repro-rebase-recreate-ui-delay.sh --expect-fixed`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 59028acc4`
- Post-revert steps: None
- Data migration? No
