### PR TITLE
[Multi PR Review Gate](3a) Discard invalidated review gate state

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -419,6 +419,114 @@ describe('Orchestrator', () => {
       expect(task.execution.reviewId).toBe('owner/repo#1');
       expect(task.execution.reviewStatus).toBe('Awaiting review');
     });
+
+
+    it('discards review gate artifacts and clears scalar review fields on retry', () => {
+      orchestrator.loadPlan({
+        name: 'Review discard retry',
+        mergeMode: 'external_review',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      persistence.updateTask(mergeId, {
+        status: 'review_ready',
+        execution: {
+          generation: 3,
+          reviewId: 'owner/repo#1',
+          reviewUrl: 'https://github.com/owner/repo/pull/1',
+          reviewStatus: 'open',
+          reviewProviderId: 'owner/repo#1',
+          reviewGate: {
+            activeGeneration: 3,
+            completion: { required: 'all', status: 'approved' },
+            artifacts: [
+              {
+                id: 'contracts',
+                providerId: 'owner/repo#1',
+                url: 'https://github.com/owner/repo/pull/1',
+                required: true,
+                status: 'approved',
+                generation: 3,
+              },
+              {
+                id: 'runtime',
+                providerId: 'owner/repo#2',
+                url: 'https://github.com/owner/repo/pull/2',
+                required: true,
+                status: 'open',
+                generation: 3,
+                dependsOn: ['contracts'],
+              },
+            ],
+          },
+        },
+      });
+
+      orchestrator.retryTask(mergeId);
+
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.execution.reviewId).toBeUndefined();
+      expect(task.execution.reviewUrl).toBeUndefined();
+      expect(task.execution.reviewStatus).toBeUndefined();
+      expect(task.execution.reviewProviderId).toBeUndefined();
+      expect(task.execution.reviewGate?.activeGeneration).toBe(4);
+      expect(task.execution.reviewGate?.artifacts).toHaveLength(2);
+      expect(task.execution.reviewGate?.artifacts.every((artifact) => artifact.status === 'discarded')).toBe(true);
+      expect(task.execution.reviewGate?.artifacts.every((artifact) => artifact.discardReason === 'task subgraph reset to pending')).toBe(true);
+      const currentRequired = task.execution.reviewGate!.artifacts.filter((artifact) =>
+        artifact.required
+        && artifact.generation === task.execution.reviewGate!.activeGeneration
+        && artifact.status !== 'discarded'
+      );
+      expect(currentRequired).toEqual([]);
+    });
+
+    it('synthesizes a discarded artifact from scalar review fields on recreate', () => {
+      orchestrator.loadPlan({
+        name: 'Review discard recreate',
+        mergeMode: 'external_review',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      persistence.updateTask(mergeId, {
+        status: 'review_ready',
+        execution: {
+          generation: 5,
+          reviewId: 'owner/repo#scalar',
+          reviewUrl: 'https://github.com/owner/repo/pull/9',
+          reviewStatus: 'open',
+          reviewProviderId: 'owner/repo#scalar',
+        },
+      });
+
+      orchestrator.recreateWorkflow(workflowId);
+
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.execution.reviewId).toBeUndefined();
+      expect(task.execution.reviewUrl).toBeUndefined();
+      expect(task.execution.reviewStatus).toBeUndefined();
+      expect(task.execution.reviewProviderId).toBeUndefined();
+      expect(task.execution.reviewGate).toMatchObject({
+        activeGeneration: 6,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [
+          {
+            id: 'owner/repo#scalar',
+            providerId: 'owner/repo#scalar',
+            url: 'https://github.com/owner/repo/pull/9',
+            required: true,
+            status: 'discarded',
+            generation: 5,
+            discardReason: 'workflow recreation reset',
+          },
+        ],
+      });
+      expect(task.execution.reviewGate?.artifacts[0].discardedAt).toEqual(expect.any(String));
+    });
   });
 
   describe('workflow status transitions during retry paths', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -19,7 +19,7 @@ import { TaskStateMachine } from './state-machine.js';
 import { ResponseHandler } from './response-handler.js';
 import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
-import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, TaskExecution, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
 import { createTaskState, createAttempt } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
@@ -900,7 +900,11 @@ export class Orchestrator {
           continue;
         }
 
-        const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
+        const changesWithGeneration = this.withBumpedExecutionGenerationAndDiscardedReviewGate(
+          current,
+          resetChanges,
+          'task subgraph reset to pending',
+        );
         const updated = this.writeAndSync(id, changesWithGeneration, { skipWorkflowStatusSync: true });
         const priorAttemptId = current.execution.selectedAttemptId;
         this.replaceSelectedAttempt(current, {}, { skipWorkflowStatusSync: true });
@@ -1027,6 +1031,74 @@ export class Orchestrator {
       },
     };
   }
+
+  private buildDiscardReviewGatePatch(
+    task: TaskState,
+    reason: string,
+    nextGeneration: number,
+    now: Date = new Date(),
+  ): Partial<TaskExecution> {
+    const reviewGate = task.execution.reviewGate;
+    if (!reviewGate && !task.execution.reviewId && !task.execution.reviewUrl) return {};
+
+    const discardedAt = now.toISOString();
+    const oldArtifacts = reviewGate?.artifacts ?? [{
+      id: task.execution.reviewId ?? 'review',
+      ...(task.execution.reviewId ? { providerId: task.execution.reviewId } : {}),
+      ...(task.execution.reviewUrl ? { url: task.execution.reviewUrl } : {}),
+      required: true,
+      status: 'discarded' as const,
+      generation: task.execution.generation ?? 0,
+      discardedAt,
+      discardReason: reason,
+    }];
+
+    return {
+      reviewUrl: undefined,
+      reviewId: undefined,
+      reviewStatus: undefined,
+      reviewProviderId: undefined,
+      reviewGate: {
+        activeGeneration: nextGeneration,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: oldArtifacts.map((artifact) =>
+          artifact.discardedAt || artifact.status === 'discarded'
+            ? artifact
+            : {
+                ...artifact,
+                status: 'discarded',
+                discardedAt,
+                discardReason: reason,
+              },
+        ),
+      },
+    };
+  }
+
+  private withBumpedExecutionGenerationAndDiscardedReviewGate(
+    task: TaskState,
+    changes: TaskStateChanges,
+    discardReason: string,
+  ): TaskStateChanges {
+    const bumpedChanges = this.withBumpedExecutionGeneration(task, changes);
+    if (!task.config.isMergeNode) {
+      return bumpedChanges;
+    }
+
+    const discardPatch = this.buildDiscardReviewGatePatch(
+      task,
+      discardReason,
+      bumpedChanges.execution?.generation ?? this.getExecutionGeneration(task) + 1,
+    );
+    return {
+      ...bumpedChanges,
+      execution: {
+        ...bumpedChanges.execution,
+        ...discardPatch,
+      },
+    };
+  }
+
 
   private getSelectedAttempt(task: TaskState | undefined): Attempt | undefined {
     const attemptId = task?.execution.selectedAttemptId;
@@ -2316,7 +2388,11 @@ export class Orchestrator {
     for (const id of toResetIds) {
       const current = this.stateGetTask(id);
       if (!current) continue;
-      const changesWithGeneration = this.withBumpedExecutionGeneration(current, RECREATE_RESET_CHANGES);
+      const changesWithGeneration = this.withBumpedExecutionGenerationAndDiscardedReviewGate(
+        current,
+        RECREATE_RESET_CHANGES,
+        artifactReason,
+      );
       const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
       const priorAttemptId = current.execution.selectedAttemptId;
       this.replaceSelectedAttempt(current);
@@ -2439,7 +2515,11 @@ export class Orchestrator {
         agentSessionId: prevSess ?? 'null',
         containerId: prevCt ?? 'null',
       });
-      const changesWithGeneration = this.withBumpedExecutionGeneration(task, resetChanges);
+      const changesWithGeneration = this.withBumpedExecutionGenerationAndDiscardedReviewGate(
+        task,
+        resetChanges,
+        'workflow recreation reset',
+      );
       const after = this.writeAndSync(task.id, changesWithGeneration);
       const priorAttemptId = task.execution.selectedAttemptId;
       this.replaceSelectedAttempt(task);


### PR DESCRIPTION


Depends-On: #1988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of review gate states during workflow retries and recreation. When workflows with active reviews are retried, review information is now properly cleared. When workflows are recreated, review artifacts are correctly converted and marked with appropriate discard status to maintain accurate state tracking throughout the workflow lifecycle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->