### PR TITLE
[Review Gates](1) Require resolved review threads

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -3,8 +3,9 @@
 # queued yet. This lets reviewers leave approval-adjacent comments without
 # Mergify landing the PR before small follow-ups are pushed.
 # GitHub rulesets already require PRs, squash merges, and one approval on master.
-# Keep repo-local conditions minimal and let Mergify respect the protected-branch
-# requirements instead of duplicating the full CI matrix here.
+# Require every GitHub review thread to be resolved before queueing or merging.
+# This makes CodeRabbit and human review comments explicit blockers instead of
+# letting an approval send unresolved feedback to Mergify.
 
 queue_rules:
   - name: default
@@ -14,6 +15,7 @@ queue_rules:
       - -draft
       - "#approved-reviews-by >= 1"
       - -label=merge-hold
+      - "#review-threads-unresolved = 0"
     merge_conditions:
       - check-success = build-artifacts
       - check-success = quality / Dependency Cruise
@@ -31,6 +33,7 @@ queue_rules:
       - check-success = ssh / shard-31
       - check-success = optional / Worktree Provisioning
       - check-success = optional / Visual Proof Validate
+      - "#review-threads-unresolved = 0"
 
   - name: admin-bypass
     merge_method: squash
@@ -39,6 +42,7 @@ queue_rules:
       - -draft
       - label=admin-bypass
       - -label=merge-hold
+      - "#review-threads-unresolved = 0"
     merge_conditions:
       - check-success = build-artifacts
       - check-success = quality / Dependency Cruise
@@ -56,6 +60,7 @@ queue_rules:
       - check-success = ssh / shard-31
       - check-success = optional / Worktree Provisioning
       - check-success = optional / Visual Proof Validate
+      - "#review-threads-unresolved = 0"
 
 pull_request_rules:
   - name: autoqueue ready approved PRs to master
@@ -66,6 +71,7 @@ pull_request_rules:
       - label=ready-to-merge
       - -label=admin-bypass
       - -label=merge-hold
+      - "#review-threads-unresolved = 0"
     actions:
       queue:
         name: default
@@ -76,6 +82,7 @@ pull_request_rules:
       - -draft
       - label=admin-bypass
       - -label=merge-hold
+      - "#review-threads-unresolved = 0"
     actions:
       queue:
         name: admin-bypass


### PR DESCRIPTION
## Summary

Mergify now waits for every GitHub review thread to be resolved before queueing or merging a PR.

CodeRabbit review comments use GitHub review threads. This keeps those comments visible until someone resolves or accepts them.

The existing `merge-hold` escape hatch stays in place. This change only adds a review-thread gate.

<details>
<summary>Review metadata</summary>

Review Claim: Mergify cannot queue or merge while review threads remain unresolved.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: The change only tightens Mergify conditions in `.mergify.yml`.

Slice Rationale: This is separate because it changes merge policy, not application behavior.

</details>

## Non-goals

This does not change CodeRabbit settings or application code.

This does not auto-resolve review comments.

## Test Plan

- [x] `node -e "const fs=require('node:fs'); const YAML=require('yaml'); const doc=YAML.parse(fs.readFileSync('.mergify.yml','utf8')); const required='#review-threads-unresolved = 0'; const hold='-label=merge-hold'; for (const rule of doc.queue_rules) { for (const key of ['queue_conditions','merge_conditions']) { if (!Array.isArray(rule[key]) || !rule[key].includes(required)) throw new Error(rule.name+' missing '+key); } if (!rule.queue_conditions.includes(hold)) throw new Error(rule.name+' missing merge-hold queue guard'); } for (const rule of doc.pull_request_rules) { if (!Array.isArray(rule.conditions) || !rule.conditions.includes(required)) throw new Error(rule.name+' missing conditions'); if (!rule.conditions.includes(hold)) throw new Error(rule.name+' missing merge-hold condition'); } console.log('Mergify review-thread gate present in every queue, merge, and autoqueue rule.');"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 9681bf70f`
- Post-revert steps: None
- Data migration? No
