### PR TITLE
[Workflow Mutation Status](2) Expose action graph through CLI

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -506,14 +506,16 @@ describe('headless-client', () => {
     stdout.mockRestore();
   });
 
-  it('does not silently fall back for query action-graph when no owner endpoint is reachable', async () => {
-    await expect(
-      runHeadlessClientCommand(['query', 'action-graph', '--output', 'json'], {
-        messageBus: new LocalBus(),
-        ensureStandaloneOwner: vi.fn(async () => {}),
-        runElectronHeadless: vi.fn(async () => 0),
-      }),
-    ).rejects.toThrow(/query action-graph requires a running shared owner process/);
+  it('falls back to direct Electron headless for query action-graph when no owner endpoint is reachable', async () => {
+    const runElectronHeadless = vi.fn(async () => 0);
+    const exitCode = await runHeadlessClientCommand(['query', 'action-graph', '--output', 'json'], {
+      messageBus: new LocalBus(),
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runElectronHeadless).toHaveBeenCalledWith(['query', 'action-graph', '--output', 'json']);
   }, 30_000);
 
   it('delegates query queue to a reachable owner endpoint', async () => {

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -112,6 +112,34 @@ describe('headless delegation enforcement', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('prints direct action graph query JSON in read-only mode', async () => {
+      const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      mockDeps.orchestrator.syncAllFromDb = vi.fn();
+      mockDeps.orchestrator.getAllTasks = vi.fn(() => []);
+      mockDeps.orchestrator.getQueueStatus = vi.fn(() => ({
+        maxConcurrency: 1,
+        runningCount: 0,
+        running: [],
+        queued: [],
+      }));
+      mockDeps.persistence.listWorkflows = vi.fn(() => []);
+      mockDeps.persistence.listWorkflowMutationIntents = vi.fn(() => []);
+      mockDeps.persistence.listWorkflowMutationLeases = vi.fn(() => []);
+      mockDeps.persistence.getActivityLogs = vi.fn(() => []);
+      mockDeps.persistence.listLaunchDispatchesByState = vi.fn(() => []);
+
+      await expect(
+        runHeadless(['query', 'action-graph', '--output', 'json'], mockDeps),
+      ).resolves.toBeUndefined();
+
+      const parsed = JSON.parse(stdout.mock.calls[0][0] as string);
+      expect(parsed).toEqual(expect.objectContaining({
+        nodes: [],
+        edges: [],
+      }));
+      stdout.mockRestore();
+    });
+
       it('allows deprecated list command in read-only mode', async () => {
         await expect(
           runHeadless(['list'], mockDeps)

--- a/packages/app/src/action-graph-snapshot.ts
+++ b/packages/app/src/action-graph-snapshot.ts
@@ -1,0 +1,34 @@
+import type { ActionGraphResponse } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { Orchestrator } from '@invoker/workflow-core';
+import type { InvokerConfig } from './config.js';
+import {
+  buildActionGraphDiagnostics,
+  resolveActionDiagnosticsStallThresholdMs,
+} from './action-graph-diagnostics.js';
+
+export function buildCurrentActionGraphSnapshot(args: {
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  invokerConfig: InvokerConfig;
+}): ActionGraphResponse {
+  args.orchestrator.syncAllFromDb();
+  const tasks = args.orchestrator.getAllTasks();
+  const workflows = args.persistence.listWorkflows();
+
+  return buildActionGraphDiagnostics({
+    workflows,
+    tasks,
+    attemptsByTaskId: new Map(tasks.map((task) => [
+      task.id,
+      args.persistence.loadActionGraphAttempts(task.id, task.execution.selectedAttemptId),
+    ])),
+    queueStatus: args.orchestrator.getQueueStatus(),
+    mutationIntents: args.persistence.listWorkflowMutationIntents(undefined, ['queued', 'running', 'failed']),
+    mutationLeases: args.persistence.listWorkflowMutationLeases(),
+    eventsByTaskId: new Map(tasks.map((task) => [task.id, args.persistence.getEvents(task.id, 'desc', 20)])),
+    activityLogs: args.persistence.getActivityLogs(0, 200),
+    stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(args.invokerConfig),
+    launchDispatches: args.persistence.listLaunchDispatchesByState(['enqueued', 'leased']),
+  });
+}

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -161,11 +161,10 @@ async function delegateReadOnlyQuery(
   );
   const ownerResult = await resolver.waitForAny(READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS);
   if (!ownerResult.resolved) {
+    if (isActionGraph) return false;
     throw new Error(isUiPerf
       ? 'query ui-perf requires a running shared owner process'
-      : isActionGraph
-        ? 'query action-graph requires a running shared owner process'
-        : 'query queue requires a running shared owner process');
+      : 'query queue requires a running shared owner process');
   }
 
   let messageBus = ownerResult.bus;
@@ -187,13 +186,27 @@ async function delegateReadOnlyQuery(
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   if (!response) {
+    if (isActionGraph) return false;
     throw new Error(isUiPerf
       ? 'Live owner is present but did not serve ui-perf query'
-      : isActionGraph
-        ? 'Live owner is present but did not serve action-graph query'
-        : 'Live owner is present but did not serve queue query');
+      : 'Live owner is present but did not serve queue query');
   }
-  if (isUiPerf || isActionGraph) {
+  if (isActionGraph) {
+    const outputIndex = args.indexOf('--output');
+    const output = outputIndex >= 0 ? args[outputIndex + 1] : undefined;
+    const nodes = Array.isArray(response.nodes) ? response.nodes as Array<Record<string, unknown>> : [];
+    const edges = Array.isArray(response.edges) ? response.edges as Array<Record<string, unknown>> : [];
+    if (output === 'label') {
+      process.stdout.write(nodes.map((node) => String(node.id ?? '')).filter(Boolean).join('\n') + '\n');
+    } else if (output === 'jsonl') {
+      for (const node of nodes) process.stdout.write(`${JSON.stringify({ kind: 'node', ...node })}\n`);
+      for (const edge of edges) process.stdout.write(`${JSON.stringify({ kind: 'edge', ...edge })}\n`);
+    } else {
+      process.stdout.write(`${JSON.stringify(response)}\n`);
+    }
+    return true;
+  }
+  if (isUiPerf) {
     process.stdout.write(`${JSON.stringify(response)}\n`);
     return true;
   }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -9,9 +9,8 @@
  * This file handles CLI parsing, TaskRunner lifecycle, and output formatting.
  */
 
-import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@invoker/contracts';
+import type { AgentSessionData, BundledSkillsInstallMode, BundledSkillsStatus, Logger, NormalizedCostEvent } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
-import type { AgentSessionData } from '@invoker/contracts';
 import { OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { Attempt, Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -64,6 +63,7 @@ import { resolveHeadlessTargetWorkflowId } from './headless-command-classificati
 import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
+import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
 
@@ -469,7 +469,7 @@ export function parseQueryFlags(args: string[]): QueryFlags {
 async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|audit|session|cost|cost-events|costs|ui-perf|stats>');
+    throw new Error('Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|action-graph|audit|session|cost|cost-events|costs|ui-perf|stats>');
   }
   const flags = parseQueryFlags(args.slice(1));
 
@@ -529,7 +529,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
         throw new Error(`Workflow "${workflowFilter}" not found.`);
       }
 
-      let allTasks: import('@invoker/workflow-core').TaskState[] = [];
+      let allTasks: TaskState[] = [];
       for (const wf of targetWorkflows) {
         // Query must stay read-only: sync graph from DB without starting/restarting tasks.
         orchestrator.syncFromDb(wf.id);
@@ -593,6 +593,31 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
           break;
         }
         default: process.stdout.write(formatQueueStatus(status) + '\n'); break;
+      }
+      break;
+    }
+    case 'action-graph': {
+      const graph = buildCurrentActionGraphSnapshot({
+        orchestrator: deps.orchestrator,
+        persistence: deps.persistence,
+        invokerConfig: deps.invokerConfig,
+      });
+      switch (flags.output) {
+        case 'label':
+          process.stdout.write(graph.nodes.map((node) => node.id).join('\n') + '\n');
+          break;
+        case 'jsonl':
+          for (const node of graph.nodes) {
+            process.stdout.write(JSON.stringify({ kind: 'node', ...node }) + '\n');
+          }
+          for (const edge of graph.edges) {
+            process.stdout.write(JSON.stringify({ kind: 'edge', ...edge }) + '\n');
+          }
+          break;
+        case 'json':
+        default:
+          process.stdout.write(formatAsJson(graph) + '\n');
+          break;
       }
       break;
     }
@@ -714,7 +739,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
       break;
     }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, cost, cost-events, costs, ui-perf, stats`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, action-graph, audit, session, cost, cost-events, costs, ui-perf, stats`);
   }
 }
 
@@ -795,7 +820,7 @@ function resolveCostAttributionAttempt(
 async function collectCostEvents(
   flags: QueryFlags,
   deps: CostQueryDeps,
-): Promise<import('@invoker/contracts').NormalizedCostEvent[]> {
+): Promise<NormalizedCostEvent[]> {
   const { attributeSessionUsage, buildAttributionContext } = await import('./cost-rollup.js');
 
   const workflowFilter = flags.workflow ?? flags.positional[0];
@@ -810,7 +835,7 @@ async function collectCostEvents(
     throw new Error(`Workflow "${workflowFilter}" not found.`);
   }
 
-  const allEvents: import('@invoker/contracts').NormalizedCostEvent[] = [];
+  const allEvents: NormalizedCostEvent[] = [];
 
   for (const wf of targetWorkflows) {
     deps.orchestrator.syncFromDb(wf.id);
@@ -1282,6 +1307,7 @@ ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
     [--no-merge] [--output F]
   query task <taskId> [--output F]                    Print single task status
   query queue [--output F]                            Show queue status
+  query action-graph [--output F]                     Print action graph source-of-truth snapshot
   query audit <taskId> [--output F]                   Print event history
   query session <taskId>                              Print agent session messages
   query ui-perf [--output F] [--reset]               Print live UI perf stats
@@ -2492,7 +2518,7 @@ export async function resolveAgentSession(
   sessionId: string,
   agentName: string,
   registry?: AgentRegistry,
-  allTasks?: import('@invoker/workflow-core').TaskState[],
+  allTasks?: TaskState[],
 ): Promise<AgentSessionData | null> {
   const driver = registry?.getSessionDriver(agentName);
   if (!driver) {


### PR DESCRIPTION


Depends-On: #2031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--headless query action-graph` command to query action graphs in read-only mode with multiple output formats: `label` (node IDs), `jsonl` (serialized nodes/edges), and `json` (full graph).
  * Improved fallback behavior for action-graph queries when the shared owner service is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->