### PR TITLE
Persist concrete task failure diagnostics

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -4560,7 +4560,7 @@ function createEmbeddedTerminalBackendFromConfig(
         }
         if (orchestrator) {
           for (const task of orchestrator.getAllTasks()) {
-            if (task.status === 'running' || task.status === 'fixing_with_ai') {
+            if (isTaskInFlightForForcedStop(task)) {
               if (persistence) {
                 persistShutdownDiagnostic(task, persistence, {
                   flushPendingOutput: flushTaskOutput,

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2201,6 +2201,40 @@ describe('SQLiteAdapter', () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+
+    it('surfaces legacy startup diagnostic rows alongside spool stream without duplicating old stream rows', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-output-legacy-diag-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const db = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        db.saveWorkflow(testWorkflow);
+        db.saveTask('wf-1', makeTask('t-legacy-diag-tail'));
+
+        db.appendOutputChunk('t-legacy-diag-tail', 'test output before failure\n');
+        (db as any).db.run(
+          'INSERT INTO task_output (task_id, data) VALUES (?, ?)',
+          ['t-legacy-diag-tail', 'duplicate stream row\n'],
+        );
+        (db as any).db.run(
+          'INSERT INTO task_output (task_id, data) VALUES (?, ?)',
+          [
+            't-legacy-diag-tail',
+            '\n[Startup Failure Diagnostic]\nmessage=concrete startup stderr\n--- end startup failure diagnostic ---\n',
+          ],
+        );
+
+        const output = db.getTaskOutput('t-legacy-diag-tail');
+        expect(output).toContain('test output before failure');
+        expect(output).toContain('[Startup Failure Diagnostic]');
+        expect(output).toContain('concrete startup stderr');
+        expect(output).not.toContain('duplicate stream row');
+
+        db.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('pruneDuplicateTaskOutputRows', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2324,13 +2324,32 @@ export class SQLiteAdapter implements PersistenceAdapter {
     const diagnosticFile = this.readTaskOutputFile(taskId);
     const spoolChunks = this.getOutputChunks(taskId);
     if (spoolChunks.length > 0) {
-      return spoolChunks.map((chunk) => chunk.data).join('') + diagnosticFile;
+      return spoolChunks.map((chunk) => chunk.data).join('')
+        + this.readLegacyDiagnosticTaskOutputRows(taskId)
+        + diagnosticFile;
     }
     const rows = this.queryAll(
       'SELECT data FROM task_output WHERE task_id = ? ORDER BY id ASC',
       [taskId],
     ) as Array<{ data: string }>;
     return rows.map((r) => r.data).join('') + diagnosticFile;
+  }
+
+  private readLegacyDiagnosticTaskOutputRows(taskId: string): string {
+    const rows = this.queryAll(
+      'SELECT data FROM task_output WHERE task_id = ? ORDER BY id ASC',
+      [taskId],
+    ) as Array<{ data: string }>;
+    return rows
+      .map((r) => r.data)
+      .filter((data) => this.isDiagnosticTaskOutput(data))
+      .join('');
+  }
+
+  private isDiagnosticTaskOutput(data: string): boolean {
+    return data.includes('[Shutdown Diagnostic]')
+      || data.includes('[Startup Failure Diagnostic]')
+      || data.includes('Executor startup failed');
   }
 
   /**

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1041,6 +1041,58 @@ describe('TaskRunner', () => {
       );
     });
 
+    it('appends a compact durable diagnostic block for startup stderr/stdout', async () => {
+      const handleWorkerResponse = vi.fn();
+      const orchestrator = {
+        getTask: () => undefined,
+        handleWorkerResponse,
+      };
+      const startupError = Object.assign(new Error('spawn failed before handle'), {
+        stderr: 'remote setup stderr\nmissing dependency\n',
+        stdout: 'remote setup stdout\n',
+      });
+      const throwingExecutor = {
+        type: 'ssh',
+        start: async () => { throw startupError; },
+        onOutput: () => () => {},
+        onComplete: () => () => {},
+      };
+      const registry = {
+        getDefault: () => throwingExecutor,
+        get: () => throwingExecutor,
+        getAll: () => [throwingExecutor],
+      };
+      const appendTaskOutput = vi.fn();
+
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: { appendTaskOutput } as any,
+        executorRegistry: registry as any,
+        cwd: '/tmp',
+      });
+
+      const task = makeTask({ id: 'failing-start', status: 'running', config: { command: 'echo hi' } });
+      await executor.executeTask(task);
+
+      expect(appendTaskOutput).toHaveBeenCalledWith(
+        'failing-start',
+        expect.stringContaining('[Startup Failure Diagnostic]'),
+      );
+      const output = appendTaskOutput.mock.calls[0]?.[1] as string;
+      expect(output).toContain('executor=ssh');
+      expect(output).toContain('message=spawn failed before handle');
+      expect(output).toContain('--- startup stderr ---');
+      expect(output).toContain('missing dependency');
+      expect(output).toContain('--- startup stdout ---');
+      expect(output).toContain('remote setup stdout');
+      expect(handleWorkerResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'failed',
+          outputs: expect.objectContaining({ exitCode: 1 }),
+        }),
+      );
+    });
+
     it('startup error includes stack trace in outputs.error', async () => {
       const handleWorkerResponse = vi.fn();
       const orchestrator = {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -75,6 +75,8 @@ type StartupFailureMetadata = {
   branch?: string;
   agentSessionId?: string;
   containerId?: string;
+  stdout?: unknown;
+  stderr?: unknown;
 };
 
 type ActiveExecutionHandle = ExecutorHandle & { attemptId?: string };
@@ -98,6 +100,8 @@ type ExecutionPoolConfig = {
   maxConcurrentTasksPerMember?: number;
 };
 
+const STARTUP_DIAGNOSTIC_DETAIL_CHARS = 4_000;
+
 type PoolSelection = {
   poolId: string;
   member: ExecutionPoolMember;
@@ -119,6 +123,41 @@ function isRetryableSshStartupTransportError(err: unknown): boolean {
     || lower.includes('banner exchange')
     || lower.includes('kex_exchange_identification')
     || lower.includes('remote session terminated unexpectedly');
+}
+
+function truncateStartupDiagnosticValue(value: string): string {
+  if (value.length <= STARTUP_DIAGNOSTIC_DETAIL_CHARS) return value;
+  return `...${value.slice(value.length - STARTUP_DIAGNOSTIC_DETAIL_CHARS)}`;
+}
+
+function stringifyStartupDiagnosticValue(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  return Buffer.isBuffer(value) ? value.toString('utf8') : String(value);
+}
+
+function formatStartupFailureDiagnostic(
+  task: TaskState,
+  executorType: string,
+  err: unknown,
+): string {
+  const meta = err as StartupFailureMetadata;
+  const message = err instanceof Error ? err.message : String(err);
+  const stderr = stringifyStartupDiagnosticValue(meta.stderr);
+  const stdout = stringifyStartupDiagnosticValue(meta.stdout);
+  const parts = [
+    '\n[Startup Failure Diagnostic]',
+    `status=${task.status}`,
+    `executor=${executorType}`,
+    `message=${message}`,
+  ];
+  if (stderr) {
+    parts.push(`--- startup stderr ---\n${truncateStartupDiagnosticValue(stderr)}`);
+  }
+  if (stdout) {
+    parts.push(`--- startup stdout ---\n${truncateStartupDiagnosticValue(stdout)}`);
+  }
+  parts.push('--- end startup failure diagnostic ---\n');
+  return parts.join('\n');
 }
 
 type FreshBaseCommit = {
@@ -988,7 +1027,10 @@ export class TaskRunner {
         const startupErrorMessage = `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}\n`;
         this.callbacks.onOutput?.(task.id, startupErrorMessage);
         try {
-          this.persistence.appendTaskOutput(task.id, startupErrorMessage);
+          this.persistence.appendTaskOutput(
+            task.id,
+            formatStartupFailureDiagnostic(task, executor.type, err),
+          );
         } catch {
           // Preserve the original startup failure if output persistence also fails.
         }


### PR DESCRIPTION
## Summary

You can reproduce this with a shell command that runs the CLI against a temporary database and a failing provision command.

Task output now keeps concrete startup and shutdown diagnostic details.

The durable output path preserves those details even when the visible terminal state is coarse.

## Review Claim

Durable task output preserves executor startup and shutdown diagnostics without changing task status semantics.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Diagnostics are appended after failure paths and do not alter scheduling, retries, or completion decisions.

## Slice Rationale

This slice contains only the diagnostic routing and retrieval path needed to make post-mortem output reliable.

## Non-goals

- No task status changes.
- No retry policy changes.
- No rendered UI changes.

## Test Plan

- [x] pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts src/__tests__/auto-commit.test.ts
- [x] pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert ec6a0b469`
- Post-revert steps: None
- Data migration? No
