### PR TITLE
Push HEAD when branch ref is missing

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -2091,10 +2091,13 @@ describe('BaseExecutor.pushBranchToRemote', () => {
     expect(remoteBranches).toContain('invoker/task-push');
   });
 
-  it('returns an error message when branch does not exist on remote', async () => {
-    const err = await executor.testPushBranchToRemote(cloneDir, 'nonexistent-branch');
-    expect(err).toBeDefined();
-    expect(typeof err).toBe('string');
+  it('pushes current HEAD when the requested local branch ref is missing', async () => {
+    const err = await executor.testPushBranchToRemote(cloneDir, 'invoker/head-fallback');
+    expect(err).toBeUndefined();
+
+    const remoteHead = execSync('git rev-parse invoker/head-fallback', { cwd: originDir }).toString().trim();
+    const localHead = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+    expect(remoteHead).toBe(localHead);
   });
 
   it('returns an error message when remote is unreachable', async () => {

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -853,6 +853,12 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     branchRepoUrlOverride?: string,
   ): Promise<string | undefined> {
     try {
+      let sourceRef = branch;
+      try {
+        await this.execGitSimple(['rev-parse', '--verify', `refs/heads/${branch}`], cwd);
+      } catch {
+        sourceRef = 'HEAD';
+      }
       const requestBranchRepoUrl = branchRepoUrlOverride ?? (executionId
         ? this.entries.get(executionId)?.request.inputs.branchRepoUrl
         : undefined);
@@ -865,11 +871,11 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
           context: { caller: `${this.type}.pushBranchToRemote`, detail: branch },
         });
         await this.execGitSimpleWithNetworkTimeout(
-          ['push', '--force-with-lease', BaseExecutor.BRANCH_REMOTE_NAME, `${branch}:refs/heads/${branch}`],
+          ['push', '--force-with-lease', BaseExecutor.BRANCH_REMOTE_NAME, `${sourceRef}:refs/heads/${branch}`],
           cwd,
         );
       } else {
-        await this.execGitSimpleWithNetworkTimeout(['push', '--force-with-lease', 'origin', `${branch}:refs/heads/${branch}`], cwd);
+        await this.execGitSimpleWithNetworkTimeout(['push', '--force-with-lease', 'origin', `${sourceRef}:refs/heads/${branch}`], cwd);
       }
       return undefined;
     } catch (err) {


### PR DESCRIPTION
## Summary

You can reproduce this with a shell command that creates a temporary git repository and runs the branch-push fallback test.

Branch publication now falls back to the current checkout when the named local branch ref is absent.

The existing branch-ref path remains unchanged when that ref exists.

## Review Claim

BaseExecutor can publish the current checkout when the requested local branch ref is missing.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The fallback only runs after `refs/heads/<branch>` fails verification.

Existing branch publication still uses the named branch ref.

## Slice Rationale

This slice is separate from the diagnostic work because it only changes the source ref used for remote branch publication.

## Non-goals

- No remote selection changes.
- No force-with-lease changes.
- No PR creation changes.

## Test Plan

- [x] pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts src/__tests__/auto-commit.test.ts

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 5238a51ed`
- Post-revert steps: None
- Data migration? No
