### PR TITLE
Make worktree provisioning configurable

### DIFF
--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -38,6 +38,8 @@ export interface WorktreeExecutorConfig {
   claudeCommand?: string;
   /** Agent registry for pluggable AI agents. When set, overrides claudeCommand. */
   agentRegistry?: import('./agent-registry.js').AgentRegistry;
+  /** Shell command used to provision each worktree before task execution. */
+  provisionCommand?: string;
   /** Heartbeat interval in milliseconds. Default: 30000. */
   heartbeatIntervalMs?: number;
   /** Maximum task duration in milliseconds. Default: 4 hours. */
@@ -85,12 +87,14 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
   private readonly worktreeBaseDir: string;
   private readonly claudeCommand: string;
   private readonly agentRegistry?: import('./agent-registry.js').AgentRegistry;
+  private readonly provisionCommand: string;
   private pool: RepoPool;
 
   constructor(config: WorktreeExecutorConfig) {
     super(config.heartbeatIntervalMs, config.maxDurationMs);
     this.claudeCommand = config.claudeCommand ?? 'claude';
     this.agentRegistry = config.agentRegistry;
+    this.provisionCommand = config.provisionCommand ?? DEFAULT_WORKTREE_PROVISION_COMMAND;
     this.worktreeBaseDir =
       config.worktreeBaseDir ?? resolve(homedir(), '.invoker', 'worktrees');
     this.pool = new RepoPool({
@@ -707,7 +711,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
   private provisionWorktree(dir: string, executionId?: string): { child: ChildProcess; completion: Promise<void> } {
     traceExecution(`[WorktreeExecutor] provisionWorktree begin dir=${dir}`);
     const t0 = Date.now();
-    const cmd = `set -euo pipefail; ${DEFAULT_WORKTREE_PROVISION_COMMAND}`;
+    const cmd = `set -euo pipefail; ${this.provisionCommand}`;
     const child = spawn('/bin/bash', ['-c', cmd], {
       cwd: dir,
       env: cleanElectronEnv(),


### PR DESCRIPTION
## Summary

You can reproduce this with a shell command that runs the provisioning test against a temporary database and config file.

WorktreeExecutor now stores an optional provision override and uses it during local worktree setup.

The default setup path stays the same when no override is supplied.

## Review Claim

WorktreeExecutor accepts optional provisioning input while preserving the existing default behavior.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The executor falls back to `DEFAULT_WORKTREE_PROVISION_COMMAND` whenever runtime input omits `provisionCommand`.

## Slice Rationale

This slice changes only how WorktreeExecutor selects the shell snippet used during local worktree setup.

## Non-goals

- No CLI config parsing changes.
- No SSH provisioning changes.
- No plan syntax changes.

## Test Plan

- [x] pnpm --filter @invoker/cli exec vitest run src/__tests__/cli.test.ts

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert c8ec31f36`
- Post-revert steps: None
- Data migration? No
