### PR TITLE
[Workflow Mutation Status](1) Add build support for status proof

### DIFF
--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -5,7 +5,7 @@ import { cpSync } from 'node:fs';
 const gitSha = execSync('git rev-parse --short HEAD').toString().trim();
 
 export default defineConfig({
-  entry: ['src/main.ts', 'src/preload.ts', 'src/headless-client.ts'],
+  entry: ['src/main.ts', 'src/preload.ts', 'src/headless-client.ts', 'src/action-graph-diagnostics.ts'],
   format: ['cjs'],
   outDir: 'dist',
   external: ['electron', 'node:sqlite', 'sql.js', 'dockerode', 'node-pty', '@invoker/surfaces', '@slack/bolt', 'dotenv'],

--- a/packages/data-store/package.json
+++ b/packages/data-store/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
+    "build": "tsup",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/data-store/tsup.config.ts
+++ b/packages/data-store/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: true,
+  tsconfig: 'tsconfig.build.json',
+  noExternal: ['@invoker/contracts', '@invoker/workflow-core', '@invoker/workflow-graph'],
+  external: ['yaml'],
+});


### PR DESCRIPTION
## Summary

This makes the proof buildable.

The repro needed app, data-store, and UI outputs that were not all emitted before.

Now those package builds produce the files the proof script and selector check read.

<details>
<summary>Review metadata</summary>

Review Claim: The package builds now produce the files the workflow-status proof reads.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This slice only changes build wiring.

Slice Rationale: The proof needs stable build outputs before the repro and selector checks can run.

</details>

## Non-goals

This does not change workflow status logic.

This does not change GUI mutation behavior.

## Test Plan

- [x] `pnpm --filter @invoker/data-store build`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/ui build`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert c8cd58316`
- Post-revert steps: Rebuild the affected packages if needed.
- Data migration? No.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building an additional diagnostics component in the app.

* **Chores**
  * Simplified data store build settings for a more consistent build process.
  * Updated build configuration for the data store to better support TypeScript declarations and module output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->