### PR TITLE
[Workflow Mutation Status](4) Share action graph snapshot builder

### DIFF
--- a/packages/app/src/action-graph-snapshot.ts
+++ b/packages/app/src/action-graph-snapshot.ts
@@ -1,0 +1,34 @@
+import type { ActionGraphResponse } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { Orchestrator } from '@invoker/workflow-core';
+import type { InvokerConfig } from './config.js';
+import {
+  buildActionGraphDiagnostics,
+  resolveActionDiagnosticsStallThresholdMs,
+} from './action-graph-diagnostics.js';
+
+export function buildCurrentActionGraphSnapshot(args: {
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  invokerConfig: InvokerConfig;
+}): ActionGraphResponse {
+  args.orchestrator.syncAllFromDb();
+  const tasks = args.orchestrator.getAllTasks();
+  const workflows = args.persistence.listWorkflows();
+
+  return buildActionGraphDiagnostics({
+    workflows,
+    tasks,
+    attemptsByTaskId: new Map(tasks.map((task) => [
+      task.id,
+      args.persistence.loadActionGraphAttempts(task.id, task.execution.selectedAttemptId),
+    ])),
+    queueStatus: args.orchestrator.getQueueStatus(),
+    mutationIntents: args.persistence.listWorkflowMutationIntents(undefined, ['queued', 'running', 'failed']),
+    mutationLeases: args.persistence.listWorkflowMutationLeases(),
+    eventsByTaskId: new Map(tasks.map((task) => [task.id, args.persistence.getEvents(task.id, 'desc', 20)])),
+    activityLogs: args.persistence.getActivityLogs(0, 200),
+    stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(args.invokerConfig),
+    launchDispatches: args.persistence.listLaunchDispatchesByState(['enqueued', 'leased']),
+  });
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -203,10 +203,7 @@ import {
   parseFixWithAgentMutationArgs,
 } from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
-import {
-  buildActionGraphDiagnostics,
-  resolveActionDiagnosticsStallThresholdMs,
-} from './action-graph-diagnostics.js';
+import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import {
@@ -248,31 +245,6 @@ import {
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
 
-function buildCurrentActionGraphSnapshot(args: {
-  orchestrator: Orchestrator;
-  persistence: SQLiteAdapter;
-  invokerConfig: InvokerConfig;
-}): ActionGraphResponse {
-  args.orchestrator.syncAllFromDb();
-  const tasks = args.orchestrator.getAllTasks();
-  const workflows = args.persistence.listWorkflows();
-
-  return buildActionGraphDiagnostics({
-    workflows,
-    tasks,
-    attemptsByTaskId: new Map(tasks.map((task) => [
-      task.id,
-      args.persistence.loadActionGraphAttempts(task.id, task.execution.selectedAttemptId),
-    ])),
-    queueStatus: args.orchestrator.getQueueStatus(),
-    mutationIntents: args.persistence.listWorkflowMutationIntents(undefined, ['queued', 'running', 'failed']),
-    mutationLeases: args.persistence.listWorkflowMutationLeases(),
-    eventsByTaskId: new Map(tasks.map((task) => [task.id, args.persistence.getEvents(task.id, 'desc', 20)])),
-    activityLogs: args.persistence.getActivityLogs(0, 200),
-    stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(args.invokerConfig),
-    launchDispatches: args.persistence.listLaunchDispatchesByState(['enqueued', 'leased']),
-  });
-}
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'


### PR DESCRIPTION
## Summary

This pulls the action-graph snapshot builder into one shared module.

The same snapshot work was sitting inside `main.ts`, which made the later read paths harder to share.

Now owner reads and direct reads can call the same builder.

<details>
<summary>Review metadata</summary>

Review Claim: The current action-graph snapshot builder now lives in one shared routing module.

Review Lane: refactor

Review Unit: routing

Safety Invariant: This slice only relocates snapshot assembly inside the main-process path.

Slice Rationale: The shared builder needs to exist before the later read paths reuse it.

</details>

## Non-goals

No behavior change.

This does not add new query paths by itself.

## Architecture

### Before

```mermaid
flowchart LR
  Main["main.ts"] --> Inline["inline snapshot builder"]
```

### After

```mermaid
flowchart LR
  Main["main.ts"] --> Snapshot["action-graph-snapshot.ts"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 75c8bb54e`
- Post-revert steps: Rebuild `@invoker/app`.
- Data migration? No.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a more comprehensive action-graph snapshot for better visibility into current workflows, tasks, queue status, and recent activity.

* **Refactor**
  * Moved snapshot-building logic into a dedicated area, improving maintainability without changing the user-facing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->