### PR TITLE
[Workflow Mutation Status](5) Expose action graph query surfaces

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -506,14 +506,16 @@ describe('headless-client', () => {
     stdout.mockRestore();
   });
 
-  it('does not silently fall back for query action-graph when no owner endpoint is reachable', async () => {
-    await expect(
-      runHeadlessClientCommand(['query', 'action-graph', '--output', 'json'], {
-        messageBus: new LocalBus(),
-        ensureStandaloneOwner: vi.fn(async () => {}),
-        runElectronHeadless: vi.fn(async () => 0),
-      }),
-    ).rejects.toThrow(/query action-graph requires a running shared owner process/);
+  it('falls back to direct Electron headless for query action-graph when no owner endpoint is reachable', async () => {
+    const runElectronHeadless = vi.fn(async () => 0);
+    const exitCode = await runHeadlessClientCommand(['query', 'action-graph', '--output', 'json'], {
+      messageBus: new LocalBus(),
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runElectronHeadless).toHaveBeenCalledWith(['query', 'action-graph', '--output', 'json']);
   }, 30_000);
 
   it('delegates query queue to a reachable owner endpoint', async () => {

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -112,6 +112,34 @@ describe('headless delegation enforcement', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('prints direct action graph query JSON in read-only mode', async () => {
+      const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      mockDeps.orchestrator.syncAllFromDb = vi.fn();
+      mockDeps.orchestrator.getAllTasks = vi.fn(() => []);
+      mockDeps.orchestrator.getQueueStatus = vi.fn(() => ({
+        maxConcurrency: 1,
+        runningCount: 0,
+        running: [],
+        queued: [],
+      }));
+      mockDeps.persistence.listWorkflows = vi.fn(() => []);
+      mockDeps.persistence.listWorkflowMutationIntents = vi.fn(() => []);
+      mockDeps.persistence.listWorkflowMutationLeases = vi.fn(() => []);
+      mockDeps.persistence.getActivityLogs = vi.fn(() => []);
+      mockDeps.persistence.listLaunchDispatchesByState = vi.fn(() => []);
+
+      await expect(
+        runHeadless(['query', 'action-graph', '--output', 'json'], mockDeps),
+      ).resolves.toBeUndefined();
+
+      const parsed = JSON.parse(stdout.mock.calls[0][0] as string);
+      expect(parsed).toEqual(expect.objectContaining({
+        nodes: [],
+        edges: [],
+      }));
+      stdout.mockRestore();
+    });
+
       it('allows deprecated list command in read-only mode', async () => {
         await expect(
           runHeadless(['list'], mockDeps)

--- a/packages/app/src/action-graph-snapshot.ts
+++ b/packages/app/src/action-graph-snapshot.ts
@@ -1,0 +1,34 @@
+import type { ActionGraphResponse } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { Orchestrator } from '@invoker/workflow-core';
+import type { InvokerConfig } from './config.js';
+import {
+  buildActionGraphDiagnostics,
+  resolveActionDiagnosticsStallThresholdMs,
+} from './action-graph-diagnostics.js';
+
+export function buildCurrentActionGraphSnapshot(args: {
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  invokerConfig: InvokerConfig;
+}): ActionGraphResponse {
+  args.orchestrator.syncAllFromDb();
+  const tasks = args.orchestrator.getAllTasks();
+  const workflows = args.persistence.listWorkflows();
+
+  return buildActionGraphDiagnostics({
+    workflows,
+    tasks,
+    attemptsByTaskId: new Map(tasks.map((task) => [
+      task.id,
+      args.persistence.loadActionGraphAttempts(task.id, task.execution.selectedAttemptId),
+    ])),
+    queueStatus: args.orchestrator.getQueueStatus(),
+    mutationIntents: args.persistence.listWorkflowMutationIntents(undefined, ['queued', 'running', 'failed']),
+    mutationLeases: args.persistence.listWorkflowMutationLeases(),
+    eventsByTaskId: new Map(tasks.map((task) => [task.id, args.persistence.getEvents(task.id, 'desc', 20)])),
+    activityLogs: args.persistence.getActivityLogs(0, 200),
+    stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(args.invokerConfig),
+    launchDispatches: args.persistence.listLaunchDispatchesByState(['enqueued', 'leased']),
+  });
+}

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -161,11 +161,10 @@ async function delegateReadOnlyQuery(
   );
   const ownerResult = await resolver.waitForAny(READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS);
   if (!ownerResult.resolved) {
+    if (isActionGraph) return false;
     throw new Error(isUiPerf
       ? 'query ui-perf requires a running shared owner process'
-      : isActionGraph
-        ? 'query action-graph requires a running shared owner process'
-        : 'query queue requires a running shared owner process');
+      : 'query queue requires a running shared owner process');
   }
 
   let messageBus = ownerResult.bus;
@@ -187,13 +186,27 @@ async function delegateReadOnlyQuery(
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   if (!response) {
+    if (isActionGraph) return false;
     throw new Error(isUiPerf
       ? 'Live owner is present but did not serve ui-perf query'
-      : isActionGraph
-        ? 'Live owner is present but did not serve action-graph query'
-        : 'Live owner is present but did not serve queue query');
+      : 'Live owner is present but did not serve queue query');
   }
-  if (isUiPerf || isActionGraph) {
+  if (isActionGraph) {
+    const outputIndex = args.indexOf('--output');
+    const output = outputIndex >= 0 ? args[outputIndex + 1] : undefined;
+    const nodes = Array.isArray(response.nodes) ? response.nodes as Array<Record<string, unknown>> : [];
+    const edges = Array.isArray(response.edges) ? response.edges as Array<Record<string, unknown>> : [];
+    if (output === 'label') {
+      process.stdout.write(nodes.map((node) => String(node.id ?? '')).filter(Boolean).join('\n') + '\n');
+    } else if (output === 'jsonl') {
+      for (const node of nodes) process.stdout.write(`${JSON.stringify({ kind: 'node', ...node })}\n`);
+      for (const edge of edges) process.stdout.write(`${JSON.stringify({ kind: 'edge', ...edge })}\n`);
+    } else {
+      process.stdout.write(`${JSON.stringify(response)}\n`);
+    }
+    return true;
+  }
+  if (isUiPerf) {
     process.stdout.write(`${JSON.stringify(response)}\n`);
     return true;
   }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -9,9 +9,8 @@
  * This file handles CLI parsing, TaskRunner lifecycle, and output formatting.
  */
 
-import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@invoker/contracts';
+import type { AgentSessionData, BundledSkillsInstallMode, BundledSkillsStatus, Logger, NormalizedCostEvent } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
-import type { AgentSessionData } from '@invoker/contracts';
 import { OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { Attempt, Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -66,6 +65,7 @@ import { resolveHeadlessTargetWorkflowId } from './headless-command-classificati
 import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
+import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import { publishReviewGateCiFailedLifecycleEvent } from './lifecycle-event-bridge.js';
@@ -395,7 +395,7 @@ export function parseQueryFlags(args: string[]): QueryFlags {
 async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|audit|session|cost|cost-events|costs|ui-perf|stats>');
+    throw new Error('Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|action-graph|audit|session|cost|cost-events|costs|ui-perf|stats>');
   }
   const flags = parseQueryFlags(args.slice(1));
 
@@ -455,7 +455,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
         throw new Error(`Workflow "${workflowFilter}" not found.`);
       }
 
-      let allTasks: import('@invoker/workflow-core').TaskState[] = [];
+      let allTasks: TaskState[] = [];
       for (const wf of targetWorkflows) {
         // Query must stay read-only: sync graph from DB without starting/restarting tasks.
         orchestrator.syncFromDb(wf.id);
@@ -519,6 +519,31 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
           break;
         }
         default: process.stdout.write(formatQueueStatus(status) + '\n'); break;
+      }
+      break;
+    }
+    case 'action-graph': {
+      const graph = buildCurrentActionGraphSnapshot({
+        orchestrator: deps.orchestrator,
+        persistence: deps.persistence,
+        invokerConfig: deps.invokerConfig,
+      });
+      switch (flags.output) {
+        case 'label':
+          process.stdout.write(graph.nodes.map((node) => node.id).join('\n') + '\n');
+          break;
+        case 'jsonl':
+          for (const node of graph.nodes) {
+            process.stdout.write(JSON.stringify({ kind: 'node', ...node }) + '\n');
+          }
+          for (const edge of graph.edges) {
+            process.stdout.write(JSON.stringify({ kind: 'edge', ...edge }) + '\n');
+          }
+          break;
+        case 'json':
+        default:
+          process.stdout.write(formatAsJson(graph) + '\n');
+          break;
       }
       break;
     }
@@ -640,7 +665,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
       break;
     }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, cost, cost-events, costs, ui-perf, stats`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, action-graph, audit, session, cost, cost-events, costs, ui-perf, stats`);
   }
 }
 
@@ -721,7 +746,7 @@ function resolveCostAttributionAttempt(
 async function collectCostEvents(
   flags: QueryFlags,
   deps: CostQueryDeps,
-): Promise<import('@invoker/contracts').NormalizedCostEvent[]> {
+): Promise<NormalizedCostEvent[]> {
   const { attributeSessionUsage, buildAttributionContext } = await import('./cost-rollup.js');
 
   const workflowFilter = flags.workflow ?? flags.positional[0];
@@ -736,7 +761,7 @@ async function collectCostEvents(
     throw new Error(`Workflow "${workflowFilter}" not found.`);
   }
 
-  const allEvents: import('@invoker/contracts').NormalizedCostEvent[] = [];
+  const allEvents: NormalizedCostEvent[] = [];
 
   for (const wf of targetWorkflows) {
     deps.orchestrator.syncFromDb(wf.id);
@@ -1280,6 +1305,7 @@ ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
     [--no-merge] [--output F]
   query task <taskId> [--output F]                    Print single task status
   query queue [--output F]                            Show queue status
+  query action-graph [--output F]                     Print action graph source-of-truth snapshot
   query audit <taskId> [--output F]                   Print event history
   query session <taskId>                              Print agent session messages
   query ui-perf [--output F] [--reset]               Print live UI perf stats
@@ -2418,7 +2444,7 @@ export async function resolveAgentSession(
   sessionId: string,
   agentName: string,
   registry?: AgentRegistry,
-  allTasks?: import('@invoker/workflow-core').TaskState[],
+  allTasks?: TaskState[],
 ): Promise<AgentSessionData | null> {
   const driver = registry?.getSessionDriver(agentName);
   if (!driver) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -203,10 +203,7 @@ import {
   parseFixWithAgentMutationArgs,
 } from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
-import {
-  buildActionGraphDiagnostics,
-  resolveActionDiagnosticsStallThresholdMs,
-} from './action-graph-diagnostics.js';
+import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import {
@@ -248,31 +245,6 @@ import {
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
 
-function buildCurrentActionGraphSnapshot(args: {
-  orchestrator: Orchestrator;
-  persistence: SQLiteAdapter;
-  invokerConfig: InvokerConfig;
-}): ActionGraphResponse {
-  args.orchestrator.syncAllFromDb();
-  const tasks = args.orchestrator.getAllTasks();
-  const workflows = args.persistence.listWorkflows();
-
-  return buildActionGraphDiagnostics({
-    workflows,
-    tasks,
-    attemptsByTaskId: new Map(tasks.map((task) => [
-      task.id,
-      args.persistence.loadActionGraphAttempts(task.id, task.execution.selectedAttemptId),
-    ])),
-    queueStatus: args.orchestrator.getQueueStatus(),
-    mutationIntents: args.persistence.listWorkflowMutationIntents(undefined, ['queued', 'running', 'failed']),
-    mutationLeases: args.persistence.listWorkflowMutationLeases(),
-    eventsByTaskId: new Map(tasks.map((task) => [task.id, args.persistence.getEvents(task.id, 'desc', 20)])),
-    activityLogs: args.persistence.getActivityLogs(0, 200),
-    stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(args.invokerConfig),
-    launchDispatches: args.persistence.listLaunchDispatchesByState(['enqueued', 'leased']),
-  });
-}
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'


### PR DESCRIPTION
## Summary

This adds `query action-graph` to the command line read path.

Before this, the graph was tied to the live owner path, and the no-owner fallback had no matching query.

Now the command line can print the same snapshot in json, label, or jsonl form.

<details>
<summary>Review metadata</summary>

Review Claim: The command line now serves action-graph reads with the same direct fallback used for other reads.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice only changes the read surface and its focused tests.

Slice Rationale: The repro and UI need one callable action-graph surface outside the live owner path.

</details>

## Non-goals

This does not change workflow-card rendering.

This does not change GUI mutation submission.

## Architecture

### Before

```mermaid
flowchart LR
  Owner["live owner read"] --> Graph["action graph"]
  Direct["direct fallback"] --> Gap["no matching query"]
```

### After

```mermaid
flowchart LR
  Owner["live owner read"] --> Snapshot["shared snapshot builder"]
  Direct["direct fallback"] --> Snapshot
  Snapshot --> Graph["action graph"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-client.test.ts src/__tests__/headless-delegation.test.ts`
- [x] `./run.sh --headless query action-graph --output json`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 0b6719c68`
- Post-revert steps: Rebuild `@invoker/app`.
- Data migration? No.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `action-graph` headless query with `label`, `json`, and `jsonl` output formats.
  * Updated help text and command validation so `action-graph` appears alongside other query options.

* **Bug Fixes**
  * Improved fallback behavior when a shared owner is unavailable, allowing `action-graph` to run directly in headless mode.
  * Ensured empty action graphs are returned cleanly as JSON with empty nodes and edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2047