### PR TITLE
[Workflow Mutation Status](6) Add accepted mutation result contract

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -506,14 +506,16 @@ describe('headless-client', () => {
     stdout.mockRestore();
   });
 
-  it('does not silently fall back for query action-graph when no owner endpoint is reachable', async () => {
-    await expect(
-      runHeadlessClientCommand(['query', 'action-graph', '--output', 'json'], {
-        messageBus: new LocalBus(),
-        ensureStandaloneOwner: vi.fn(async () => {}),
-        runElectronHeadless: vi.fn(async () => 0),
-      }),
-    ).rejects.toThrow(/query action-graph requires a running shared owner process/);
+  it('falls back to direct Electron headless for query action-graph when no owner endpoint is reachable', async () => {
+    const runElectronHeadless = vi.fn(async () => 0);
+    const exitCode = await runHeadlessClientCommand(['query', 'action-graph', '--output', 'json'], {
+      messageBus: new LocalBus(),
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runElectronHeadless).toHaveBeenCalledWith(['query', 'action-graph', '--output', 'json']);
   }, 30_000);
 
   it('delegates query queue to a reachable owner endpoint', async () => {

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -112,6 +112,34 @@ describe('headless delegation enforcement', () => {
       ).resolves.toBeUndefined();
     });
 
+    it('prints direct action graph query JSON in read-only mode', async () => {
+      const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      mockDeps.orchestrator.syncAllFromDb = vi.fn();
+      mockDeps.orchestrator.getAllTasks = vi.fn(() => []);
+      mockDeps.orchestrator.getQueueStatus = vi.fn(() => ({
+        maxConcurrency: 1,
+        runningCount: 0,
+        running: [],
+        queued: [],
+      }));
+      mockDeps.persistence.listWorkflows = vi.fn(() => []);
+      mockDeps.persistence.listWorkflowMutationIntents = vi.fn(() => []);
+      mockDeps.persistence.listWorkflowMutationLeases = vi.fn(() => []);
+      mockDeps.persistence.getActivityLogs = vi.fn(() => []);
+      mockDeps.persistence.listLaunchDispatchesByState = vi.fn(() => []);
+
+      await expect(
+        runHeadless(['query', 'action-graph', '--output', 'json'], mockDeps),
+      ).resolves.toBeUndefined();
+
+      const parsed = JSON.parse(stdout.mock.calls[0][0] as string);
+      expect(parsed).toEqual(expect.objectContaining({
+        nodes: [],
+        edges: [],
+      }));
+      stdout.mockRestore();
+    });
+
       it('allows deprecated list command in read-only mode', async () => {
         await expect(
           runHeadless(['list'], mockDeps)

--- a/packages/app/src/action-graph-snapshot.ts
+++ b/packages/app/src/action-graph-snapshot.ts
@@ -1,0 +1,34 @@
+import type { ActionGraphResponse } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { Orchestrator } from '@invoker/workflow-core';
+import type { InvokerConfig } from './config.js';
+import {
+  buildActionGraphDiagnostics,
+  resolveActionDiagnosticsStallThresholdMs,
+} from './action-graph-diagnostics.js';
+
+export function buildCurrentActionGraphSnapshot(args: {
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  invokerConfig: InvokerConfig;
+}): ActionGraphResponse {
+  args.orchestrator.syncAllFromDb();
+  const tasks = args.orchestrator.getAllTasks();
+  const workflows = args.persistence.listWorkflows();
+
+  return buildActionGraphDiagnostics({
+    workflows,
+    tasks,
+    attemptsByTaskId: new Map(tasks.map((task) => [
+      task.id,
+      args.persistence.loadActionGraphAttempts(task.id, task.execution.selectedAttemptId),
+    ])),
+    queueStatus: args.orchestrator.getQueueStatus(),
+    mutationIntents: args.persistence.listWorkflowMutationIntents(undefined, ['queued', 'running', 'failed']),
+    mutationLeases: args.persistence.listWorkflowMutationLeases(),
+    eventsByTaskId: new Map(tasks.map((task) => [task.id, args.persistence.getEvents(task.id, 'desc', 20)])),
+    activityLogs: args.persistence.getActivityLogs(0, 200),
+    stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(args.invokerConfig),
+    launchDispatches: args.persistence.listLaunchDispatchesByState(['enqueued', 'leased']),
+  });
+}

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -161,11 +161,10 @@ async function delegateReadOnlyQuery(
   );
   const ownerResult = await resolver.waitForAny(READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS);
   if (!ownerResult.resolved) {
+    if (isActionGraph) return false;
     throw new Error(isUiPerf
       ? 'query ui-perf requires a running shared owner process'
-      : isActionGraph
-        ? 'query action-graph requires a running shared owner process'
-        : 'query queue requires a running shared owner process');
+      : 'query queue requires a running shared owner process');
   }
 
   let messageBus = ownerResult.bus;
@@ -187,13 +186,27 @@ async function delegateReadOnlyQuery(
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   if (!response) {
+    if (isActionGraph) return false;
     throw new Error(isUiPerf
       ? 'Live owner is present but did not serve ui-perf query'
-      : isActionGraph
-        ? 'Live owner is present but did not serve action-graph query'
-        : 'Live owner is present but did not serve queue query');
+      : 'Live owner is present but did not serve queue query');
   }
-  if (isUiPerf || isActionGraph) {
+  if (isActionGraph) {
+    const outputIndex = args.indexOf('--output');
+    const output = outputIndex >= 0 ? args[outputIndex + 1] : undefined;
+    const nodes = Array.isArray(response.nodes) ? response.nodes as Array<Record<string, unknown>> : [];
+    const edges = Array.isArray(response.edges) ? response.edges as Array<Record<string, unknown>> : [];
+    if (output === 'label') {
+      process.stdout.write(nodes.map((node) => String(node.id ?? '')).filter(Boolean).join('\n') + '\n');
+    } else if (output === 'jsonl') {
+      for (const node of nodes) process.stdout.write(`${JSON.stringify({ kind: 'node', ...node })}\n`);
+      for (const edge of edges) process.stdout.write(`${JSON.stringify({ kind: 'edge', ...edge })}\n`);
+    } else {
+      process.stdout.write(`${JSON.stringify(response)}\n`);
+    }
+    return true;
+  }
+  if (isUiPerf) {
     process.stdout.write(`${JSON.stringify(response)}\n`);
     return true;
   }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -9,9 +9,8 @@
  * This file handles CLI parsing, TaskRunner lifecycle, and output formatting.
  */
 
-import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@invoker/contracts';
+import type { AgentSessionData, BundledSkillsInstallMode, BundledSkillsStatus, Logger, NormalizedCostEvent } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
-import type { AgentSessionData } from '@invoker/contracts';
 import { OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { Attempt, Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -66,6 +65,7 @@ import { resolveHeadlessTargetWorkflowId } from './headless-command-classificati
 import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
+import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import { publishReviewGateCiFailedLifecycleEvent } from './lifecycle-event-bridge.js';
@@ -395,7 +395,7 @@ export function parseQueryFlags(args: string[]): QueryFlags {
 async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|audit|session|cost|cost-events|costs|ui-perf|stats>');
+    throw new Error('Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|action-graph|audit|session|cost|cost-events|costs|ui-perf|stats>');
   }
   const flags = parseQueryFlags(args.slice(1));
 
@@ -455,7 +455,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
         throw new Error(`Workflow "${workflowFilter}" not found.`);
       }
 
-      let allTasks: import('@invoker/workflow-core').TaskState[] = [];
+      let allTasks: TaskState[] = [];
       for (const wf of targetWorkflows) {
         // Query must stay read-only: sync graph from DB without starting/restarting tasks.
         orchestrator.syncFromDb(wf.id);
@@ -519,6 +519,31 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
           break;
         }
         default: process.stdout.write(formatQueueStatus(status) + '\n'); break;
+      }
+      break;
+    }
+    case 'action-graph': {
+      const graph = buildCurrentActionGraphSnapshot({
+        orchestrator: deps.orchestrator,
+        persistence: deps.persistence,
+        invokerConfig: deps.invokerConfig,
+      });
+      switch (flags.output) {
+        case 'label':
+          process.stdout.write(graph.nodes.map((node) => node.id).join('\n') + '\n');
+          break;
+        case 'jsonl':
+          for (const node of graph.nodes) {
+            process.stdout.write(JSON.stringify({ kind: 'node', ...node }) + '\n');
+          }
+          for (const edge of graph.edges) {
+            process.stdout.write(JSON.stringify({ kind: 'edge', ...edge }) + '\n');
+          }
+          break;
+        case 'json':
+        default:
+          process.stdout.write(formatAsJson(graph) + '\n');
+          break;
       }
       break;
     }
@@ -640,7 +665,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
       break;
     }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, cost, cost-events, costs, ui-perf, stats`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, action-graph, audit, session, cost, cost-events, costs, ui-perf, stats`);
   }
 }
 
@@ -721,7 +746,7 @@ function resolveCostAttributionAttempt(
 async function collectCostEvents(
   flags: QueryFlags,
   deps: CostQueryDeps,
-): Promise<import('@invoker/contracts').NormalizedCostEvent[]> {
+): Promise<NormalizedCostEvent[]> {
   const { attributeSessionUsage, buildAttributionContext } = await import('./cost-rollup.js');
 
   const workflowFilter = flags.workflow ?? flags.positional[0];
@@ -736,7 +761,7 @@ async function collectCostEvents(
     throw new Error(`Workflow "${workflowFilter}" not found.`);
   }
 
-  const allEvents: import('@invoker/contracts').NormalizedCostEvent[] = [];
+  const allEvents: NormalizedCostEvent[] = [];
 
   for (const wf of targetWorkflows) {
     deps.orchestrator.syncFromDb(wf.id);
@@ -1280,6 +1305,7 @@ ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
     [--no-merge] [--output F]
   query task <taskId> [--output F]                    Print single task status
   query queue [--output F]                            Show queue status
+  query action-graph [--output F]                     Print action graph source-of-truth snapshot
   query audit <taskId> [--output F]                   Print event history
   query session <taskId>                              Print agent session messages
   query ui-perf [--output F] [--reset]               Print live UI perf stats
@@ -2418,7 +2444,7 @@ export async function resolveAgentSession(
   sessionId: string,
   agentName: string,
   registry?: AgentRegistry,
-  allTasks?: import('@invoker/workflow-core').TaskState[],
+  allTasks?: TaskState[],
 ): Promise<AgentSessionData | null> {
   const driver = registry?.getSessionDriver(agentName);
   if (!driver) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -203,10 +203,7 @@ import {
   parseFixWithAgentMutationArgs,
 } from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
-import {
-  buildActionGraphDiagnostics,
-  resolveActionDiagnosticsStallThresholdMs,
-} from './action-graph-diagnostics.js';
+import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import {
@@ -248,31 +245,6 @@ import {
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
 
-function buildCurrentActionGraphSnapshot(args: {
-  orchestrator: Orchestrator;
-  persistence: SQLiteAdapter;
-  invokerConfig: InvokerConfig;
-}): ActionGraphResponse {
-  args.orchestrator.syncAllFromDb();
-  const tasks = args.orchestrator.getAllTasks();
-  const workflows = args.persistence.listWorkflows();
-
-  return buildActionGraphDiagnostics({
-    workflows,
-    tasks,
-    attemptsByTaskId: new Map(tasks.map((task) => [
-      task.id,
-      args.persistence.loadActionGraphAttempts(task.id, task.execution.selectedAttemptId),
-    ])),
-    queueStatus: args.orchestrator.getQueueStatus(),
-    mutationIntents: args.persistence.listWorkflowMutationIntents(undefined, ['queued', 'running', 'failed']),
-    mutationLeases: args.persistence.listWorkflowMutationLeases(),
-    eventsByTaskId: new Map(tasks.map((task) => [task.id, args.persistence.getEvents(task.id, 'desc', 20)])),
-    activityLogs: args.persistence.getActivityLogs(0, 200),
-    stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(args.invokerConfig),
-    launchDispatches: args.persistence.listLaunchDispatchesByState(['enqueued', 'leased']),
-  });
-}
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -225,6 +225,14 @@ export interface RebaseAndRetryResult {
   errors: string[];
 }
 
+export interface WorkflowMutationAcceptedResult {
+  ok: true;
+  accepted: true;
+  intentId: number;
+  workflowId: string;
+  channel: string;
+}
+
 export interface CancelResult {
   cancelled: string[];
   runningCancelled: string[];
@@ -426,11 +434,11 @@ export const IpcChannels = {
   },
   'invoker:delete-workflow': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:detach-workflow': {} as {
     request: [workflowId: string, upstreamWorkflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:load-workflow': {} as {
     request: [workflowId: string];
@@ -470,19 +478,19 @@ export const IpcChannels = {
   // Task Actions
   'invoker:provide-input': {} as {
     request: [taskId: string, input: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:approve': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:reject': {} as {
     request: [taskId: string, reason?: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:select-experiment': {} as {
     request: [taskId: string, experimentId: string | string[]];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   /**
    * @deprecated Step 13 (`docs/architecture/task-invalidation-roadmap.md`):
@@ -499,41 +507,45 @@ export const IpcChannels = {
    */
   'invoker:restart-task': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:cancel-task': {} as {
     request: [taskId: string];
-    response: CancelResult;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:cancel-workflow': {} as {
     request: [workflowId: string];
-    response: CancelResult;
+    response: WorkflowMutationAcceptedResult;
   },
 
   // Task Editing
   'invoker:edit-task-command': {} as {
     request: [taskId: string, newCommand: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:edit-task-pool': {} as {
     request: [taskId: string, poolId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
+  },
+  'invoker:edit-task-type': {} as {
+    request: [taskId: string, runnerKind: string, poolMemberId?: string];
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:edit-task-agent': {} as {
     request: [taskId: string, agentName: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:edit-task-prompt': {} as {
     request: [taskId: string, newPrompt: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:set-task-external-gate-policies': {} as {
     request: [taskId: string, updates: ExternalGatePolicyUpdate[]];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:replace-task': {} as {
     request: [taskId: string, replacementTasks: TaskReplacementDef[]];
-    response: TaskState[];
+    response: WorkflowMutationAcceptedResult;
   },
 
   // Session & Agent Access
@@ -549,39 +561,39 @@ export const IpcChannels = {
   // Workflow Mutation & Merge
   'invoker:recreate-workflow': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:recreate-task': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:recreate-downstream': {} as {
     request: [taskId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:retry-workflow': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:rebase-retry': {} as {
     request: [target: string];
-    response: RebaseAndRetryResult;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:rebase-recreate': {} as {
     request: [target: string];
-    response: RebaseAndRetryResult;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:set-merge-branch': {} as {
     request: [workflowId: string, baseBranch: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:set-merge-mode': {} as {
     request: [workflowId: string, mergeMode: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:approve-merge': {} as {
     request: [workflowId: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
 
   'invoker:get-review-gate': {} as {
@@ -600,11 +612,11 @@ export const IpcChannels = {
   },
   'invoker:resolve-conflict': {} as {
     request: [taskId: string, agentName?: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
   'invoker:fix-with-agent': {} as {
     request: [taskId: string, agentName?: string];
-    response: void;
+    response: WorkflowMutationAcceptedResult;
   },
 
   // Queue & Configuration


### PR DESCRIPTION
## Summary

This adds one accepted-result contract for queued workflow mutations.

The UI needed a small response that says a mutation was accepted without implying the workflow work already started.

Now app and UI code can share that shape.

<details>
<summary>Review metadata</summary>

Review Claim: Queued workflow-mutation acceptance now has one shared contract.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This slice only changes the contract shape.

Slice Rationale: The contract needs to exist before the app and UI switch to it.

</details>

## Non-goals

This does not change the coordinator runtime path.

This does not change workflow-card copy.

## Test Plan

- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 0bc9bbe28`
- Post-revert steps: Rebuild dependents if needed.
- Data migration? No.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow and task mutation actions now return a consistent, typed “accepted” response, improving reliability for operations such as cancel, retry, recreate, approve, reject, edit, detach, and delete.
  * Workflow conflict resolution and merge-related actions now provide a clearer, standardized success/acceptance result.
  * Task replacement and rebase/retry workflows now use the same standardized accepted response to reduce inconsistencies across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2048