### PR TITLE
[Workflow Mutation Status](8) Return accepted GUI mutation responses

### DIFF
--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -133,54 +133,46 @@ describe('ipc-registration', () => {
     expect(request).toHaveBeenCalledTimes(2);
   });
 
-  it('registers workflow-scoped handlers with the same dispatcher and enqueue shape', async () => {
+  it('registers workflow-scoped handlers with the same dispatcher and accepted intent result', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
     const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-    const calls: Array<{
-      workflowId: string | undefined;
-      priority: WorkflowMutationPriority;
-      channel: string;
-      args: unknown[];
-    }> = [];
+    const accepted = { ok: true as const, accepted: true as const, intentId: 123, workflowId: 'wf-1', channel: 'invoker:rebase-recreate' };
+    const submitWorkflowMutation = vi.fn(() => accepted);
     const context: WorkflowScopedGuiMutationRegistrationContext = {
       ipcMain,
       getOwnerMode: () => true,
       getMessageBus: () => ({ request: vi.fn() }),
       translateGuiMutationToHeadless: vi.fn(),
       workflowMutationDispatcher,
-      runWorkflowMutation: async (workflowId, priority, channel, args, op) => {
-        calls.push({ workflowId, priority, channel, args });
-        return op();
-      },
+      submitWorkflowMutation,
     };
     const handler = vi.fn(async (taskId: unknown) => `done:${String(taskId)}`);
 
     registerWorkflowScopedGuiMutationHandler(
       context,
-      'invoker:restart-task',
-      (taskId) => `workflow-for-${String(taskId)}`,
+      'invoker:rebase-recreate',
+      () => 'wf-1',
       'high',
       handler,
     );
 
-    await expect(handleHandlers.get('invoker:restart-task')?.({}, 'task-1')).resolves.toBe('done:task-1');
-    expect(workflowMutationDispatcher.has('invoker:restart-task')).toBe(true);
-    await expect(workflowMutationDispatcher.get('invoker:restart-task')?.('task-2')).resolves.toBe('done:task-2');
-    expect(calls).toEqual([
-      {
-        workflowId: 'workflow-for-task-1',
-        priority: 'high',
-        channel: 'invoker:restart-task',
-        args: ['task-1'],
-      },
-    ]);
+    await expect(handleHandlers.get('invoker:rebase-recreate')?.({}, 'wf-1')).resolves.toBe(accepted);
+    expect(handler).not.toHaveBeenCalled();
+    expect(workflowMutationDispatcher.has('invoker:rebase-recreate')).toBe(true);
+    await expect(workflowMutationDispatcher.get('invoker:rebase-recreate')?.('task-2')).resolves.toBe('done:task-2');
+    expect(submitWorkflowMutation).toHaveBeenCalledWith(
+      'wf-1',
+      'high',
+      'invoker:rebase-recreate',
+      ['wf-1'],
+    );
   });
 
   it('creates typed registrars that preserve channel registration outputs', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
     const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
     const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-    const runWorkflowMutation = vi.fn(async (_workflowId, _priority, _channel, _args, op) => op());
+    const submitWorkflowMutation = vi.fn(() => ({ ok: true as const, accepted: true as const, intentId: 456, workflowId: 'wf:task-1', channel: 'invoker:scoped' }));
     const guiContext: GuiMutationRegistrationContext = {
       ipcMain,
       getOwnerMode: () => true,
@@ -191,7 +183,7 @@ describe('ipc-registration', () => {
     const workflowContext: WorkflowScopedGuiMutationRegistrationContext = {
       ...guiContext,
       workflowMutationDispatcher,
-      runWorkflowMutation,
+      submitWorkflowMutation,
     };
 
     const {
@@ -208,15 +200,14 @@ describe('ipc-registration', () => {
     );
 
     await expect(handleHandlers.get('invoker:plain')?.({}, 'a')).resolves.toBe('plain:a');
-    await expect(handleHandlers.get('invoker:scoped')?.({}, 'task-1')).resolves.toBe('scoped:task-1');
+    await expect(handleHandlers.get('invoker:scoped')?.({}, 'task-1')).resolves.toEqual({ ok: true, accepted: true, intentId: 456, workflowId: 'wf:task-1', channel: 'invoker:scoped' });
     expect([...guiMutationHandlers.keys()]).toEqual(['invoker:plain', 'invoker:scoped']);
     expect([...workflowMutationDispatcher.keys()]).toEqual(['invoker:scoped']);
-    expect(runWorkflowMutation).toHaveBeenCalledWith(
+    expect(submitWorkflowMutation).toHaveBeenCalledWith(
       'wf:task-1',
       'normal',
       'invoker:scoped',
       ['task-1'],
-      expect.any(Function),
     );
   });
 

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -521,6 +521,19 @@ describe('headless→owner delegation', () => {
       expect(outcome.kind).toBe('delegated');
     });
 
+    it('accepts an accepted-acknowledgement that carries a workflowId (no tasks)', async () => {
+      messageBus.onRequest('headless.exec', async () => ({
+        ok: true,
+        accepted: true,
+        intentId: 1,
+        workflowId: 'wf-test',
+        channel: 'headless.exec',
+      }));
+
+      const outcome = await tryDelegateExec(['retry', 'wf-test', '--no-track'], messageBus);
+      expect(outcome.kind).toBe('delegated');
+    });
+
     it('accepts valid workflow response as delegated', async () => {
       messageBus.onRequest('headless.run', async () => ({
         workflowId: 'wf-valid',

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -268,9 +268,10 @@ async function tryDelegate(
   }
 
   // ── Response-shape validation ──────────────────────────────────────────
-  // Owner handlers return one of two shapes:
+  // Owner handlers return one of these shapes:
   //   1. { workflowId: string; tasks: TaskState[] }  — workflow-creating commands
-  //   2. { ok: true, ... }                           — mutation commands
+  //   2. { ok: true, ... }                           — mutation commands / accepted
+  //      acknowledgements (a fire-and-forget submit also carries workflowId/intentId)
   // Anything else is a protocol violation.
   if (raw == null || typeof raw !== 'object') {
     const msg = `expected object response, got ${raw === null ? 'null' : typeof raw}`;
@@ -283,17 +284,19 @@ async function tryDelegate(
   const hasWorkflowId = 'workflowId' in response && typeof response.workflowId === 'string';
   const hasOk = 'ok' in response && response.ok === true;
 
-  if (hasWorkflowId) {
-    if (!Array.isArray(response.tasks)) {
-      const msg = `response has workflowId but tasks is ${typeof response.tasks}, expected array`;
+  if (!hasOk) {
+    if (hasWorkflowId) {
+      if (!Array.isArray(response.tasks)) {
+        const msg = `response has workflowId but tasks is ${typeof response.tasks}, expected array`;
+        delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
+        return { kind: 'protocol-error', message: msg };
+      }
+    } else {
+      const keys = Object.keys(response).join(', ');
+      const msg = `response has neither workflowId (string) nor ok (true); keys: [${keys}]`;
       delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
       return { kind: 'protocol-error', message: msg };
     }
-  } else if (!hasOk) {
-    const keys = Object.keys(response).join(', ');
-    const msg = `response has neither workflowId (string) nor ok (true); keys: [${keys}]`;
-    delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
-    return { kind: 'protocol-error', message: msg };
   }
 
   if (hasWorkflowId) {
@@ -303,7 +306,7 @@ async function tryDelegate(
     process.stdout.write('Delegated to owner\n');
   }
 
-  const outcome: DelegationOutcome = hasWorkflowId
+  const outcome: DelegationOutcome = hasWorkflowId && Array.isArray(response.tasks)
     ? { kind: 'delegated', workflowId: response.workflowId as string, tasks: response.tasks as TaskState[] }
     : { kind: 'delegated' };
 

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -2,6 +2,7 @@ import type { IpcMain } from 'electron';
 import { TransportError, TransportErrorCode } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import type { TaskState } from '@invoker/workflow-core';
+import type { WorkflowMutationAcceptedResult } from '@invoker/contracts';
 import type { WorkflowMutationPriority } from '../workflow-mutation-coordinator.js';
 
 export interface GuiMutationPayload {
@@ -79,13 +80,12 @@ export function registerGuiMutationHandler<TResult = unknown>(
 
 export interface WorkflowScopedGuiMutationRegistrationContext extends GuiMutationRegistrationContext {
   workflowMutationDispatcher: Map<string, (...args: unknown[]) => Promise<unknown>>;
-  runWorkflowMutation: <T>(
+  submitWorkflowMutation: (
     workflowId: string | undefined,
     priority: WorkflowMutationPriority,
     channel: string,
     args: unknown[],
-    op: () => Promise<T>,
-  ) => Promise<T>;
+  ) => WorkflowMutationAcceptedResult;
 }
 
 export function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
@@ -98,7 +98,7 @@ export function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
   context.workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
   registerGuiMutationHandler(context, channel, async (...args: unknown[]) => {
     const workflowId = resolveWorkflowId(...args);
-    return context.runWorkflowMutation(workflowId, priority, channel, args, () => handler(...args));
+    return context.submitWorkflowMutation(workflowId, priority, channel, args);
   });
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -73,10 +73,11 @@ import type {
 import {
   makeEnvelope,
   CommandError,
+  IpcChannels,
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { ActionGraphResponse, WorkflowMeta, WorkResponse } from '@invoker/contracts';
+import type { ActionGraphResponse, BundledSkillsInstallMode, Logger, WorkflowMeta, WorkflowMutationAcceptedResult, WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
@@ -97,8 +98,8 @@ import {
   registerBuiltinAgents,
   RepoPool,
   DEFAULT_EXECUTION_AGENT,
+  type AgentRegistry,
 } from '@invoker/execution-engine';
-import type { Logger } from '@invoker/contracts';
 import { FileAndDbLogger } from './logger.js';
 import type { TaskOutputData } from './types.js';
 import {
@@ -186,6 +187,7 @@ import { WorkflowRollupProjection } from './workflow-rollup-projection.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
+import type { WorkflowMutationContext } from './persisted-workflow-mutation-coordinator.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
 import {
@@ -367,7 +369,7 @@ const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promi
  * cleared afterward. Allows fix-with-agent and conflict-resolution
  * handlers to read the AbortSignal without changing every handler signature.
  */
-let activeMutationContext: import('./persisted-workflow-mutation-coordinator.js').WorkflowMutationContext | undefined;
+let activeMutationContext: WorkflowMutationContext | undefined;
 let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
 let writerLock: DbWriterLockResult | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
@@ -414,7 +416,7 @@ function acknowledgeNoTrackHeadlessExec(
   workflowId: string | undefined,
   priority: WorkflowMutationPriority,
   mode: HeadlessOwnerMode,
-): { ok: true; intentId: number } | undefined {
+): WorkflowMutationAcceptedResult | undefined {
   logger.info(
     `headless.exec decision ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId ?? '<none>'}"`, priority })}`,
     { module: 'ipc-delegate' },
@@ -430,7 +432,7 @@ function acknowledgeNoTrackHeadlessExec(
       `headless.exec accepted ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId}"`, intent: intentId, priority })}`,
       { module: 'ipc-delegate' },
     );
-    return { ok: true, intentId };
+    return { ok: true, accepted: true, intentId, workflowId, channel: 'headless.exec' };
   }
 
   const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
@@ -576,7 +578,7 @@ function assertDeleteAllEnabled(): void {
 
 interface InitServicesOptions {
   readOnly?: boolean;
-  executionAgentRegistry?: import('@invoker/execution-engine').AgentRegistry;
+  executionAgentRegistry?: AgentRegistry;
   startupSyncMode?: 'all' | 'none';
 }
 
@@ -592,7 +594,7 @@ function getBundledSkillsStatus() {
   return resolveBundledSkillsStatus(buildBundledSkillsContext());
 }
 
-function installPackagedSkills(mode: import('@invoker/contracts').BundledSkillsInstallMode = 'install') {
+function installPackagedSkills(mode: BundledSkillsInstallMode = 'install') {
   return installBundledSkills(buildBundledSkillsContext(), mode);
 }
 
@@ -2591,6 +2593,33 @@ function createEmbeddedTerminalBackendFromConfig(
     return workflowMutationCoordinator.enqueue<T>(workflowId, priority, channel, args);
   }
 
+  function submitWorkflowMutation(
+    workflowId: string | undefined,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+  ): WorkflowMutationAcceptedResult {
+    if (!workflowId) throw new Error(`Could not resolve workflow for ${channel}`);
+    if (!workflowMutationCoordinator) throw new Error('Workflow mutation coordinator is unavailable');
+    if (!workflowMutationDispatcher.has(channel)) {
+      throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
+    }
+    const intentId = workflowMutationCoordinator.submit(workflowId, priority, channel, args);
+    return { ok: true, accepted: true, intentId, workflowId, channel };
+  }
+
+  function registerTaskScopedGuiMutationHandler<TResult = unknown>(
+    channel: keyof typeof IpcChannels & string,
+    resolveWorkflowId: (...args: unknown[]) => string | undefined,
+    priority: WorkflowMutationPriority,
+    handler: (...args: unknown[]) => Promise<TResult>,
+  ): void {
+    workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
+    registerGuiMutationHandler(channel, async (...args: unknown[]) => (
+      submitWorkflowMutation(resolveWorkflowId(...args), priority, channel, args)
+    ));
+  }
+
   function translateGuiMutationToHeadless(payload: GuiMutationPayload):
     | { channel: 'headless.gui-mutation'; request: GuiMutationPayload }
     | { channel: 'headless.run'; request: HeadlessRunMutationPayload }
@@ -2618,20 +2647,20 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'invoker:delete-all-workflows-bulk':
         return { channel: 'headless.exec', request: { args: ['delete-all'] } };
       case 'invoker:delete-workflow':
-        return { channel: 'headless.exec', request: { args: ['delete', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['delete', String(arg0)], noTrack: true } };
       case 'invoker:detach-workflow':
-        return { channel: 'headless.exec', request: { args: ['detach-workflow', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['detach-workflow', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:provide-input':
-        return { channel: 'headless.exec', request: { args: ['input', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['input', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:approve':
-        return { channel: 'headless.exec', request: { args: ['approve', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['approve', String(arg0)], noTrack: true } };
       case 'invoker:reject':
         return arg1 === undefined
-          ? { channel: 'headless.exec', request: { args: ['reject', String(arg0)] } }
-          : { channel: 'headless.exec', request: { args: ['reject', String(arg0), String(arg1)] } };
+          ? { channel: 'headless.exec', request: { args: ['reject', String(arg0)], noTrack: true } }
+          : { channel: 'headless.exec', request: { args: ['reject', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:select-experiment':
         if (Array.isArray(arg1)) return null;
-        return { channel: 'headless.exec', request: { args: ['select', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['select', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:restart-task':
         return { channel: 'headless.exec', request: { args: ['retry-task', String(arg0)], noTrack: true } };
       case 'invoker:cancel-task':
@@ -2653,12 +2682,12 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'invoker:set-merge-branch':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:set-merge-mode':
-        return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:approve-merge': {
         const workflowId = String(arg0);
         const mergeTask = persistence.loadTasks(workflowId).find((task) => task.config.isMergeNode);
         if (!mergeTask) return null;
-        return { channel: 'headless.exec', request: { args: ['approve', mergeTask.id] } };
+        return { channel: 'headless.exec', request: { args: ['approve', mergeTask.id], noTrack: true } };
       }
       case 'invoker:check-pr-statuses':
         return { channel: 'headless.gui-mutation', request: payload };
@@ -2666,22 +2695,22 @@ function createEmbeddedTerminalBackendFromConfig(
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resolve-conflict':
         return arg1 === undefined
-          ? { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0)] } }
-          : { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0), String(arg1)] } };
+          ? { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0)], noTrack: true } }
+          : { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:fix-with-agent': {
         const { taskId, agentName, context } = parseFixWithAgentMutationArgs(payload.args);
-        return { channel: 'headless.exec', request: { args: buildHeadlessFixArgs(taskId, agentName, context) } };
+        return { channel: 'headless.exec', request: { args: buildHeadlessFixArgs(taskId, agentName, context), noTrack: true } };
       }
       case 'invoker:edit-task-command':
-        return { channel: 'headless.exec', request: { args: ['set', 'command', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['set', 'command', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:edit-task-prompt':
-        return { channel: 'headless.exec', request: { args: ['set', 'prompt', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['set', 'prompt', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:edit-task-type':
-        return { channel: 'headless.exec', request: { args: ['set', 'executor', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['set', 'executor', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:edit-task-pool':
         return null;
       case 'invoker:edit-task-agent':
-        return { channel: 'headless.exec', request: { args: ['set', 'agent', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['set', 'agent', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:set-task-external-gate-policies': {
         const taskId = String(arg0);
         const updates = Array.isArray(arg1) ? arg1 as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }> : [];
@@ -2691,12 +2720,12 @@ function createEmbeddedTerminalBackendFromConfig(
         const args = ['set', 'gate-policy', taskId, update.workflowId];
         if (update.taskId) args.push(update.taskId);
         args.push(update.gatePolicy);
-        return { channel: 'headless.exec', request: { args } };
+        return { channel: 'headless.exec', request: { args, noTrack: true } };
       }
       case 'invoker:replace-task':
         return {
           channel: 'headless.exec',
-          request: { args: ['replace-task', String(arg0), JSON.stringify(Array.isArray(arg1) ? arg1 : [])] },
+          request: { args: ['replace-task', String(arg0), JSON.stringify(Array.isArray(arg1) ? arg1 : [])], noTrack: true },
         };
       default:
         return null;
@@ -3664,7 +3693,11 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:provide-input', async (taskIdArg: unknown, inputArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:provide-input',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, inputArg: unknown) => {
       const taskId = String(taskIdArg);
       const input = String(inputArg);
       const envelope = makeEnvelope('provide-input', 'ui', 'task', { taskId, input });
@@ -3693,7 +3726,11 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:reject', async (taskIdArg: unknown, reasonArg?: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:reject',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, reasonArg?: unknown) => {
       const taskId = String(taskIdArg);
       const reason = reasonArg === undefined ? undefined : String(reasonArg);
       const envelope = makeEnvelope('reject', 'ui', 'task', { taskId, reason });
@@ -3701,7 +3738,11 @@ function createEmbeddedTerminalBackendFromConfig(
       if (!result.ok) throw new Error(result.error.message);
     });
 
-    registerGuiMutationHandler('invoker:select-experiment', async (taskIdArg: unknown, experimentIdArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:select-experiment',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, experimentIdArg: unknown) => {
       const taskId = String(taskIdArg);
       const experimentId = experimentIdArg as string | string[];
       const ids = Array.isArray(experimentId) ? experimentId : [experimentId];
@@ -4159,7 +4200,11 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:set-merge-branch', async (workflowIdArg: unknown, baseBranchArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:set-merge-branch',
+      (workflowIdArg: unknown) => String(workflowIdArg),
+      'normal',
+      async (workflowIdArg: unknown, baseBranchArg: unknown) => {
       const workflowId = String(workflowIdArg);
       const baseBranch = String(baseBranchArg);
       logger.info(`set-merge-branch: workflow="${workflowId}" → "${baseBranch}"`, { module: 'ipc' });
@@ -4188,7 +4233,11 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:set-merge-mode', async (workflowIdArg: unknown, mergeModeArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:set-merge-mode',
+      (workflowIdArg: unknown) => String(workflowIdArg),
+      'normal',
+      async (workflowIdArg: unknown, mergeModeArg: unknown) => {
       const workflowId = String(workflowIdArg);
       const mergeMode = String(mergeModeArg);
       logger.info(`set-merge-mode: workflow="${workflowId}" → "${mergeMode}"`, { module: 'ipc' });
@@ -4330,7 +4379,11 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:edit-task-command', async (taskIdArg: unknown, newCommandArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:edit-task-command',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, newCommandArg: unknown) => {
       const taskId = String(taskIdArg);
       const newCommand = String(newCommandArg);
       logger.info(`edit-task-command: "${taskId}" → "${newCommand}"`, { module: 'ipc' });
@@ -4352,7 +4405,11 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-prompt', async (taskIdArg: unknown, newPromptArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:edit-task-prompt',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, newPromptArg: unknown) => {
       const taskId = String(taskIdArg);
       const newPrompt = String(newPromptArg);
       logger.info(`edit-task-prompt: "${taskId}" → "${newPrompt}"`, { module: 'ipc' });
@@ -4374,7 +4431,11 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-type', async (taskIdArg: unknown, runnerKindArg: unknown, poolMemberIdArg?: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:edit-task-type',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, runnerKindArg: unknown, poolMemberIdArg?: unknown) => {
       const taskId = String(taskIdArg);
       const runnerKind = String(runnerKindArg);
       const poolMemberId = poolMemberIdArg === undefined ? undefined : String(poolMemberIdArg);
@@ -4397,7 +4458,11 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-pool', async (taskIdArg: unknown, poolIdArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:edit-task-pool',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, poolIdArg: unknown) => {
       const taskId = String(taskIdArg);
       const poolId = String(poolIdArg);
       logger.info(`edit-task-pool: "${taskId}" → "${poolId}"`, { module: 'ipc' });
@@ -4419,7 +4484,11 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-agent', async (taskIdArg: unknown, agentNameArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:edit-task-agent',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, agentNameArg: unknown) => {
       const taskId = String(taskIdArg);
       const agentName = String(agentNameArg);
       logger.info(`edit-task-agent: "${taskId}" → "${agentName}"`, { module: 'ipc' });
@@ -4441,8 +4510,10 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler(
+    registerTaskScopedGuiMutationHandler(
       'invoker:set-task-external-gate-policies',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
       async (taskIdArg: unknown, updatesArg: unknown) => {
         const taskId = String(taskIdArg);
         const updates = updatesArg as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }>;
@@ -4497,7 +4568,11 @@ function createEmbeddedTerminalBackendFromConfig(
       return updateInvokerCli(buildCliInstallerContext());
     });
 
-    registerGuiMutationHandler('invoker:replace-task', async (taskIdArg: unknown, replacementTasksArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:replace-task',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'high',
+      async (taskIdArg: unknown, replacementTasksArg: unknown) => {
       const taskId = String(taskIdArg);
       const replacementTasks = replacementTasksArg as unknown[];
       logger.info(`replace-task: "${taskId}" with ${replacementTasks.length} replacement(s)`, { module: 'ipc' });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2766,7 +2766,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const workflowScopedGuiMutationRegistrationContext: WorkflowScopedGuiMutationRegistrationContext = {
     ...guiMutationRegistrationContext,
     workflowMutationDispatcher,
-    runWorkflowMutation,
+    submitWorkflowMutation,
   };
 
   const {


### PR DESCRIPTION
## Summary

This changes the GUI IPC wrapper to return accepted mutation results.

The renderer only needs to know that the mutation was queued, then it can refresh real state.

Now the handler stays on the dispatcher path, and the IPC call returns acceptance data.

<details>
<summary>Review metadata</summary>

Review Claim: The GUI IPC wrapper now returns accepted mutation metadata instead of completion-shaped results.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice only changes the IPC surface and its focused test.

Slice Rationale: The renderer can only stop trusting inline mutation results after this wrapper returns explicit acceptance data.

</details>

## Non-goals

This does not change coordinator routing.

This does not change workflow-card copy.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/ipc-registration.test.ts`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 271e28e63`
- Post-revert steps: Rebuild `@invoker/app`.
- Data migration? No.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow-scoped actions now consistently return an “accepted” result containing `intentId`, `workflowId`, and `channel`.
  * Workflow-scoped GUI mutation routing now follows the unified submission flow, matching the accepted-payload shape and dispatcher wiring.
* **Tests**
  * Updated workflow-scoped IPC registration and typed registrar tests to validate the new accepted result object and the updated submission call signature (`workflowId`, `priority`, `channel`, `args`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2050