### PR TITLE
[Workflow Mutation Status](9) Show core workflow activity

### DIFF
--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -133,54 +133,46 @@ describe('ipc-registration', () => {
     expect(request).toHaveBeenCalledTimes(2);
   });
 
-  it('registers workflow-scoped handlers with the same dispatcher and enqueue shape', async () => {
+  it('registers workflow-scoped handlers with the same dispatcher and accepted intent result', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
     const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-    const calls: Array<{
-      workflowId: string | undefined;
-      priority: WorkflowMutationPriority;
-      channel: string;
-      args: unknown[];
-    }> = [];
+    const accepted = { ok: true as const, accepted: true as const, intentId: 123, workflowId: 'wf-1', channel: 'invoker:rebase-recreate' };
+    const submitWorkflowMutation = vi.fn(() => accepted);
     const context: WorkflowScopedGuiMutationRegistrationContext = {
       ipcMain,
       getOwnerMode: () => true,
       getMessageBus: () => ({ request: vi.fn() }),
       translateGuiMutationToHeadless: vi.fn(),
       workflowMutationDispatcher,
-      runWorkflowMutation: async (workflowId, priority, channel, args, op) => {
-        calls.push({ workflowId, priority, channel, args });
-        return op();
-      },
+      submitWorkflowMutation,
     };
     const handler = vi.fn(async (taskId: unknown) => `done:${String(taskId)}`);
 
     registerWorkflowScopedGuiMutationHandler(
       context,
-      'invoker:restart-task',
-      (taskId) => `workflow-for-${String(taskId)}`,
+      'invoker:rebase-recreate',
+      () => 'wf-1',
       'high',
       handler,
     );
 
-    await expect(handleHandlers.get('invoker:restart-task')?.({}, 'task-1')).resolves.toBe('done:task-1');
-    expect(workflowMutationDispatcher.has('invoker:restart-task')).toBe(true);
-    await expect(workflowMutationDispatcher.get('invoker:restart-task')?.('task-2')).resolves.toBe('done:task-2');
-    expect(calls).toEqual([
-      {
-        workflowId: 'workflow-for-task-1',
-        priority: 'high',
-        channel: 'invoker:restart-task',
-        args: ['task-1'],
-      },
-    ]);
+    await expect(handleHandlers.get('invoker:rebase-recreate')?.({}, 'wf-1')).resolves.toBe(accepted);
+    expect(handler).not.toHaveBeenCalled();
+    expect(workflowMutationDispatcher.has('invoker:rebase-recreate')).toBe(true);
+    await expect(workflowMutationDispatcher.get('invoker:rebase-recreate')?.('task-2')).resolves.toBe('done:task-2');
+    expect(submitWorkflowMutation).toHaveBeenCalledWith(
+      'wf-1',
+      'high',
+      'invoker:rebase-recreate',
+      ['wf-1'],
+    );
   });
 
   it('creates typed registrars that preserve channel registration outputs', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
     const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
     const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-    const runWorkflowMutation = vi.fn(async (_workflowId, _priority, _channel, _args, op) => op());
+    const submitWorkflowMutation = vi.fn(() => ({ ok: true as const, accepted: true as const, intentId: 456, workflowId: 'wf:task-1', channel: 'invoker:scoped' }));
     const guiContext: GuiMutationRegistrationContext = {
       ipcMain,
       getOwnerMode: () => true,
@@ -191,7 +183,7 @@ describe('ipc-registration', () => {
     const workflowContext: WorkflowScopedGuiMutationRegistrationContext = {
       ...guiContext,
       workflowMutationDispatcher,
-      runWorkflowMutation,
+      submitWorkflowMutation,
     };
 
     const {
@@ -208,15 +200,14 @@ describe('ipc-registration', () => {
     );
 
     await expect(handleHandlers.get('invoker:plain')?.({}, 'a')).resolves.toBe('plain:a');
-    await expect(handleHandlers.get('invoker:scoped')?.({}, 'task-1')).resolves.toBe('scoped:task-1');
+    await expect(handleHandlers.get('invoker:scoped')?.({}, 'task-1')).resolves.toEqual({ ok: true, accepted: true, intentId: 456, workflowId: 'wf:task-1', channel: 'invoker:scoped' });
     expect([...guiMutationHandlers.keys()]).toEqual(['invoker:plain', 'invoker:scoped']);
     expect([...workflowMutationDispatcher.keys()]).toEqual(['invoker:scoped']);
-    expect(runWorkflowMutation).toHaveBeenCalledWith(
+    expect(submitWorkflowMutation).toHaveBeenCalledWith(
       'wf:task-1',
       'normal',
       'invoker:scoped',
       ['task-1'],
-      expect.any(Function),
     );
   });
 

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -521,6 +521,19 @@ describe('headless→owner delegation', () => {
       expect(outcome.kind).toBe('delegated');
     });
 
+    it('accepts an accepted-acknowledgement that carries a workflowId (no tasks)', async () => {
+      messageBus.onRequest('headless.exec', async () => ({
+        ok: true,
+        accepted: true,
+        intentId: 1,
+        workflowId: 'wf-test',
+        channel: 'headless.exec',
+      }));
+
+      const outcome = await tryDelegateExec(['retry', 'wf-test', '--no-track'], messageBus);
+      expect(outcome.kind).toBe('delegated');
+    });
+
     it('accepts valid workflow response as delegated', async () => {
       messageBus.onRequest('headless.run', async () => ({
         workflowId: 'wf-valid',

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -268,9 +268,10 @@ async function tryDelegate(
   }
 
   // ── Response-shape validation ──────────────────────────────────────────
-  // Owner handlers return one of two shapes:
+  // Owner handlers return one of these shapes:
   //   1. { workflowId: string; tasks: TaskState[] }  — workflow-creating commands
-  //   2. { ok: true, ... }                           — mutation commands
+  //   2. { ok: true, ... }                           — mutation commands / accepted
+  //      acknowledgements (a fire-and-forget submit also carries workflowId/intentId)
   // Anything else is a protocol violation.
   if (raw == null || typeof raw !== 'object') {
     const msg = `expected object response, got ${raw === null ? 'null' : typeof raw}`;
@@ -283,17 +284,19 @@ async function tryDelegate(
   const hasWorkflowId = 'workflowId' in response && typeof response.workflowId === 'string';
   const hasOk = 'ok' in response && response.ok === true;
 
-  if (hasWorkflowId) {
-    if (!Array.isArray(response.tasks)) {
-      const msg = `response has workflowId but tasks is ${typeof response.tasks}, expected array`;
+  if (!hasOk) {
+    if (hasWorkflowId) {
+      if (!Array.isArray(response.tasks)) {
+        const msg = `response has workflowId but tasks is ${typeof response.tasks}, expected array`;
+        delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
+        return { kind: 'protocol-error', message: msg };
+      }
+    } else {
+      const keys = Object.keys(response).join(', ');
+      const msg = `response has neither workflowId (string) nor ok (true); keys: [${keys}]`;
       delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
       return { kind: 'protocol-error', message: msg };
     }
-  } else if (!hasOk) {
-    const keys = Object.keys(response).join(', ');
-    const msg = `response has neither workflowId (string) nor ok (true); keys: [${keys}]`;
-    delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
-    return { kind: 'protocol-error', message: msg };
   }
 
   if (hasWorkflowId) {
@@ -303,7 +306,7 @@ async function tryDelegate(
     process.stdout.write('Delegated to owner\n');
   }
 
-  const outcome: DelegationOutcome = hasWorkflowId
+  const outcome: DelegationOutcome = hasWorkflowId && Array.isArray(response.tasks)
     ? { kind: 'delegated', workflowId: response.workflowId as string, tasks: response.tasks as TaskState[] }
     : { kind: 'delegated' };
 

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -2,6 +2,7 @@ import type { IpcMain } from 'electron';
 import { TransportError, TransportErrorCode } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import type { TaskState } from '@invoker/workflow-core';
+import type { WorkflowMutationAcceptedResult } from '@invoker/contracts';
 import type { WorkflowMutationPriority } from '../workflow-mutation-coordinator.js';
 
 export interface GuiMutationPayload {
@@ -79,13 +80,12 @@ export function registerGuiMutationHandler<TResult = unknown>(
 
 export interface WorkflowScopedGuiMutationRegistrationContext extends GuiMutationRegistrationContext {
   workflowMutationDispatcher: Map<string, (...args: unknown[]) => Promise<unknown>>;
-  runWorkflowMutation: <T>(
+  submitWorkflowMutation: (
     workflowId: string | undefined,
     priority: WorkflowMutationPriority,
     channel: string,
     args: unknown[],
-    op: () => Promise<T>,
-  ) => Promise<T>;
+  ) => WorkflowMutationAcceptedResult;
 }
 
 export function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
@@ -98,7 +98,7 @@ export function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
   context.workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
   registerGuiMutationHandler(context, channel, async (...args: unknown[]) => {
     const workflowId = resolveWorkflowId(...args);
-    return context.runWorkflowMutation(workflowId, priority, channel, args, () => handler(...args));
+    return context.submitWorkflowMutation(workflowId, priority, channel, args);
   });
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -73,10 +73,11 @@ import type {
 import {
   makeEnvelope,
   CommandError,
+  IpcChannels,
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { ActionGraphResponse, WorkflowMeta, WorkResponse } from '@invoker/contracts';
+import type { ActionGraphResponse, BundledSkillsInstallMode, Logger, WorkflowMeta, WorkflowMutationAcceptedResult, WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
@@ -97,8 +98,8 @@ import {
   registerBuiltinAgents,
   RepoPool,
   DEFAULT_EXECUTION_AGENT,
+  type AgentRegistry,
 } from '@invoker/execution-engine';
-import type { Logger } from '@invoker/contracts';
 import { FileAndDbLogger } from './logger.js';
 import type { TaskOutputData } from './types.js';
 import {
@@ -186,6 +187,7 @@ import { WorkflowRollupProjection } from './workflow-rollup-projection.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
+import type { WorkflowMutationContext } from './persisted-workflow-mutation-coordinator.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
 import {
@@ -367,7 +369,7 @@ const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promi
  * cleared afterward. Allows fix-with-agent and conflict-resolution
  * handlers to read the AbortSignal without changing every handler signature.
  */
-let activeMutationContext: import('./persisted-workflow-mutation-coordinator.js').WorkflowMutationContext | undefined;
+let activeMutationContext: WorkflowMutationContext | undefined;
 let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
 let writerLock: DbWriterLockResult | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
@@ -414,7 +416,7 @@ function acknowledgeNoTrackHeadlessExec(
   workflowId: string | undefined,
   priority: WorkflowMutationPriority,
   mode: HeadlessOwnerMode,
-): { ok: true; intentId: number } | undefined {
+): WorkflowMutationAcceptedResult | undefined {
   logger.info(
     `headless.exec decision ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId ?? '<none>'}"`, priority })}`,
     { module: 'ipc-delegate' },
@@ -430,7 +432,7 @@ function acknowledgeNoTrackHeadlessExec(
       `headless.exec accepted ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId}"`, intent: intentId, priority })}`,
       { module: 'ipc-delegate' },
     );
-    return { ok: true, intentId };
+    return { ok: true, accepted: true, intentId, workflowId, channel: 'headless.exec' };
   }
 
   const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
@@ -576,7 +578,7 @@ function assertDeleteAllEnabled(): void {
 
 interface InitServicesOptions {
   readOnly?: boolean;
-  executionAgentRegistry?: import('@invoker/execution-engine').AgentRegistry;
+  executionAgentRegistry?: AgentRegistry;
   startupSyncMode?: 'all' | 'none';
 }
 
@@ -592,7 +594,7 @@ function getBundledSkillsStatus() {
   return resolveBundledSkillsStatus(buildBundledSkillsContext());
 }
 
-function installPackagedSkills(mode: import('@invoker/contracts').BundledSkillsInstallMode = 'install') {
+function installPackagedSkills(mode: BundledSkillsInstallMode = 'install') {
   return installBundledSkills(buildBundledSkillsContext(), mode);
 }
 
@@ -2591,6 +2593,33 @@ function createEmbeddedTerminalBackendFromConfig(
     return workflowMutationCoordinator.enqueue<T>(workflowId, priority, channel, args);
   }
 
+  function submitWorkflowMutation(
+    workflowId: string | undefined,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+  ): WorkflowMutationAcceptedResult {
+    if (!workflowId) throw new Error(`Could not resolve workflow for ${channel}`);
+    if (!workflowMutationCoordinator) throw new Error('Workflow mutation coordinator is unavailable');
+    if (!workflowMutationDispatcher.has(channel)) {
+      throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
+    }
+    const intentId = workflowMutationCoordinator.submit(workflowId, priority, channel, args);
+    return { ok: true, accepted: true, intentId, workflowId, channel };
+  }
+
+  function registerTaskScopedGuiMutationHandler<TResult = unknown>(
+    channel: keyof typeof IpcChannels & string,
+    resolveWorkflowId: (...args: unknown[]) => string | undefined,
+    priority: WorkflowMutationPriority,
+    handler: (...args: unknown[]) => Promise<TResult>,
+  ): void {
+    workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
+    registerGuiMutationHandler(channel, async (...args: unknown[]) => (
+      submitWorkflowMutation(resolveWorkflowId(...args), priority, channel, args)
+    ));
+  }
+
   function translateGuiMutationToHeadless(payload: GuiMutationPayload):
     | { channel: 'headless.gui-mutation'; request: GuiMutationPayload }
     | { channel: 'headless.run'; request: HeadlessRunMutationPayload }
@@ -2618,20 +2647,20 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'invoker:delete-all-workflows-bulk':
         return { channel: 'headless.exec', request: { args: ['delete-all'] } };
       case 'invoker:delete-workflow':
-        return { channel: 'headless.exec', request: { args: ['delete', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['delete', String(arg0)], noTrack: true } };
       case 'invoker:detach-workflow':
-        return { channel: 'headless.exec', request: { args: ['detach-workflow', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['detach-workflow', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:provide-input':
-        return { channel: 'headless.exec', request: { args: ['input', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['input', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:approve':
-        return { channel: 'headless.exec', request: { args: ['approve', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['approve', String(arg0)], noTrack: true } };
       case 'invoker:reject':
         return arg1 === undefined
-          ? { channel: 'headless.exec', request: { args: ['reject', String(arg0)] } }
-          : { channel: 'headless.exec', request: { args: ['reject', String(arg0), String(arg1)] } };
+          ? { channel: 'headless.exec', request: { args: ['reject', String(arg0)], noTrack: true } }
+          : { channel: 'headless.exec', request: { args: ['reject', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:select-experiment':
         if (Array.isArray(arg1)) return null;
-        return { channel: 'headless.exec', request: { args: ['select', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['select', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:restart-task':
         return { channel: 'headless.exec', request: { args: ['retry-task', String(arg0)], noTrack: true } };
       case 'invoker:cancel-task':
@@ -2653,12 +2682,12 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'invoker:set-merge-branch':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:set-merge-mode':
-        return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:approve-merge': {
         const workflowId = String(arg0);
         const mergeTask = persistence.loadTasks(workflowId).find((task) => task.config.isMergeNode);
         if (!mergeTask) return null;
-        return { channel: 'headless.exec', request: { args: ['approve', mergeTask.id] } };
+        return { channel: 'headless.exec', request: { args: ['approve', mergeTask.id], noTrack: true } };
       }
       case 'invoker:check-pr-statuses':
         return { channel: 'headless.gui-mutation', request: payload };
@@ -2666,22 +2695,22 @@ function createEmbeddedTerminalBackendFromConfig(
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resolve-conflict':
         return arg1 === undefined
-          ? { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0)] } }
-          : { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0), String(arg1)] } };
+          ? { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0)], noTrack: true } }
+          : { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:fix-with-agent': {
         const { taskId, agentName, context } = parseFixWithAgentMutationArgs(payload.args);
-        return { channel: 'headless.exec', request: { args: buildHeadlessFixArgs(taskId, agentName, context) } };
+        return { channel: 'headless.exec', request: { args: buildHeadlessFixArgs(taskId, agentName, context), noTrack: true } };
       }
       case 'invoker:edit-task-command':
-        return { channel: 'headless.exec', request: { args: ['set', 'command', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['set', 'command', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:edit-task-prompt':
-        return { channel: 'headless.exec', request: { args: ['set', 'prompt', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['set', 'prompt', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:edit-task-type':
-        return { channel: 'headless.exec', request: { args: ['set', 'executor', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['set', 'executor', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:edit-task-pool':
         return null;
       case 'invoker:edit-task-agent':
-        return { channel: 'headless.exec', request: { args: ['set', 'agent', String(arg0), String(arg1)] } };
+        return { channel: 'headless.exec', request: { args: ['set', 'agent', String(arg0), String(arg1)], noTrack: true } };
       case 'invoker:set-task-external-gate-policies': {
         const taskId = String(arg0);
         const updates = Array.isArray(arg1) ? arg1 as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }> : [];
@@ -2691,12 +2720,12 @@ function createEmbeddedTerminalBackendFromConfig(
         const args = ['set', 'gate-policy', taskId, update.workflowId];
         if (update.taskId) args.push(update.taskId);
         args.push(update.gatePolicy);
-        return { channel: 'headless.exec', request: { args } };
+        return { channel: 'headless.exec', request: { args, noTrack: true } };
       }
       case 'invoker:replace-task':
         return {
           channel: 'headless.exec',
-          request: { args: ['replace-task', String(arg0), JSON.stringify(Array.isArray(arg1) ? arg1 : [])] },
+          request: { args: ['replace-task', String(arg0), JSON.stringify(Array.isArray(arg1) ? arg1 : [])], noTrack: true },
         };
       default:
         return null;
@@ -3664,7 +3693,11 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:provide-input', async (taskIdArg: unknown, inputArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:provide-input',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, inputArg: unknown) => {
       const taskId = String(taskIdArg);
       const input = String(inputArg);
       const envelope = makeEnvelope('provide-input', 'ui', 'task', { taskId, input });
@@ -3693,7 +3726,11 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:reject', async (taskIdArg: unknown, reasonArg?: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:reject',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, reasonArg?: unknown) => {
       const taskId = String(taskIdArg);
       const reason = reasonArg === undefined ? undefined : String(reasonArg);
       const envelope = makeEnvelope('reject', 'ui', 'task', { taskId, reason });
@@ -3701,7 +3738,11 @@ function createEmbeddedTerminalBackendFromConfig(
       if (!result.ok) throw new Error(result.error.message);
     });
 
-    registerGuiMutationHandler('invoker:select-experiment', async (taskIdArg: unknown, experimentIdArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:select-experiment',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, experimentIdArg: unknown) => {
       const taskId = String(taskIdArg);
       const experimentId = experimentIdArg as string | string[];
       const ids = Array.isArray(experimentId) ? experimentId : [experimentId];
@@ -4159,7 +4200,11 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:set-merge-branch', async (workflowIdArg: unknown, baseBranchArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:set-merge-branch',
+      (workflowIdArg: unknown) => String(workflowIdArg),
+      'normal',
+      async (workflowIdArg: unknown, baseBranchArg: unknown) => {
       const workflowId = String(workflowIdArg);
       const baseBranch = String(baseBranchArg);
       logger.info(`set-merge-branch: workflow="${workflowId}" → "${baseBranch}"`, { module: 'ipc' });
@@ -4188,7 +4233,11 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:set-merge-mode', async (workflowIdArg: unknown, mergeModeArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:set-merge-mode',
+      (workflowIdArg: unknown) => String(workflowIdArg),
+      'normal',
+      async (workflowIdArg: unknown, mergeModeArg: unknown) => {
       const workflowId = String(workflowIdArg);
       const mergeMode = String(mergeModeArg);
       logger.info(`set-merge-mode: workflow="${workflowId}" → "${mergeMode}"`, { module: 'ipc' });
@@ -4330,7 +4379,11 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
-    registerGuiMutationHandler('invoker:edit-task-command', async (taskIdArg: unknown, newCommandArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:edit-task-command',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, newCommandArg: unknown) => {
       const taskId = String(taskIdArg);
       const newCommand = String(newCommandArg);
       logger.info(`edit-task-command: "${taskId}" → "${newCommand}"`, { module: 'ipc' });
@@ -4352,7 +4405,11 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-prompt', async (taskIdArg: unknown, newPromptArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:edit-task-prompt',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, newPromptArg: unknown) => {
       const taskId = String(taskIdArg);
       const newPrompt = String(newPromptArg);
       logger.info(`edit-task-prompt: "${taskId}" → "${newPrompt}"`, { module: 'ipc' });
@@ -4374,7 +4431,11 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-type', async (taskIdArg: unknown, runnerKindArg: unknown, poolMemberIdArg?: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:edit-task-type',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, runnerKindArg: unknown, poolMemberIdArg?: unknown) => {
       const taskId = String(taskIdArg);
       const runnerKind = String(runnerKindArg);
       const poolMemberId = poolMemberIdArg === undefined ? undefined : String(poolMemberIdArg);
@@ -4397,7 +4458,11 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-pool', async (taskIdArg: unknown, poolIdArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:edit-task-pool',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, poolIdArg: unknown) => {
       const taskId = String(taskIdArg);
       const poolId = String(poolIdArg);
       logger.info(`edit-task-pool: "${taskId}" → "${poolId}"`, { module: 'ipc' });
@@ -4419,7 +4484,11 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler('invoker:edit-task-agent', async (taskIdArg: unknown, agentNameArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:edit-task-agent',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, agentNameArg: unknown) => {
       const taskId = String(taskIdArg);
       const agentName = String(agentNameArg);
       logger.info(`edit-task-agent: "${taskId}" → "${agentName}"`, { module: 'ipc' });
@@ -4441,8 +4510,10 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
-    registerGuiMutationHandler(
+    registerTaskScopedGuiMutationHandler(
       'invoker:set-task-external-gate-policies',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
       async (taskIdArg: unknown, updatesArg: unknown) => {
         const taskId = String(taskIdArg);
         const updates = updatesArg as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }>;
@@ -4497,7 +4568,11 @@ function createEmbeddedTerminalBackendFromConfig(
       return updateInvokerCli(buildCliInstallerContext());
     });
 
-    registerGuiMutationHandler('invoker:replace-task', async (taskIdArg: unknown, replacementTasksArg: unknown) => {
+    registerTaskScopedGuiMutationHandler(
+      'invoker:replace-task',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'high',
+      async (taskIdArg: unknown, replacementTasksArg: unknown) => {
       const taskId = String(taskIdArg);
       const replacementTasks = replacementTasksArg as unknown[];
       logger.info(`replace-task: "${taskId}" with ${replacementTasks.length} replacement(s)`, { module: 'ipc' });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2766,7 +2766,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const workflowScopedGuiMutationRegistrationContext: WorkflowScopedGuiMutationRegistrationContext = {
     ...guiMutationRegistrationContext,
     workflowMutationDispatcher,
-    runWorkflowMutation,
+    submitWorkflowMutation,
   };
 
   const {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "NODE_OPTIONS='--max-old-space-size=512' vite build",
+    "build": "NODE_OPTIONS='--max-old-space-size=512' vite build && tsup src/lib/workflow-core-activity.ts --format esm --out-dir dist/lib --clean false",
     "test": "vitest run"
   },
   "dependencies": {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -15,6 +15,7 @@ import type { ActionGraphNode, ReviewGateQueryResponse, TerminalSessionDescripto
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
+import { useActionGraphSnapshot } from './hooks/useActionGraphSnapshot.js';
 import { useInvoker } from './hooks/useInvoker.js';
 import { TaskDAG } from './components/TaskDAG.js';
 import { HistoryView } from './components/HistoryView.js';
@@ -29,6 +30,7 @@ import { SystemSetupModal } from './components/SystemSetupModal.js';
 import { WorkflowGraph } from './components/WorkflowGraph.js';
 import { FloatingGraphPanel } from './components/FloatingGraphPanel.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
+import { groupWorkflowCoreActivity } from './lib/workflow-core-activity.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
 import { WorkflowStatusChips } from './components/WorkflowStatusChips.js';
 import { TerminalDrawer, type TerminalDrawerState } from './components/TerminalDrawer.js';
@@ -390,6 +392,21 @@ export function App() {
   const { tasks, workflows, clearTasks, refreshTaskGraph } = useTasks({
     onTaskGraphSnapshotApplied: handleTaskGraphSnapshotApplied,
   });
+  const {
+    graph: actionGraph,
+    error: actionGraphError,
+    refreshActionGraph,
+  } = useActionGraphSnapshot();
+  const trackAcceptedMutation = useCallback((result: unknown) => {
+    if (result && typeof result === 'object' && (result as { accepted?: unknown }).accepted === true) {
+      void refreshActionGraph();
+      void refreshTaskGraph();
+    }
+  }, [refreshActionGraph, refreshTaskGraph]);
+  const coreActivityByWorkflow = useMemo(
+    () => groupWorkflowCoreActivity(actionGraph?.nodes ?? []),
+    [actionGraph],
+  );
   const invoker = useInvoker();
   const queueStatus = useQueueStatus();
   const runningTaskIds = useMemo(
@@ -408,9 +425,12 @@ export function App() {
   const [hasLoadedPlan, setHasLoadedPlan] = useState(false);
   const [hasStarted, setHasStarted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
-  const [onFinish, setOnFinish] = useState<'none' | 'merge' | 'pull_request'>('merge');
+  const [selectedActionNodeId, setSelectedActionNodeId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
-  const [selectedActionNode, setSelectedActionNode] = useState<ActionGraphNode | null>(null);
+  const selectedActionNode = useMemo(
+    () => actionGraph?.nodes.find((node) => node.id === selectedActionNodeId) ?? null,
+    [actionGraph, selectedActionNodeId],
+  );
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [remoteTargets, setRemoteTargets] = useState<string[]>([]);
   const [executionPools, setExecutionPools] = useState<string[]>([]);
@@ -1278,11 +1298,12 @@ export function App() {
     if (!invoker) return;
     setContextMenu(null);
     try {
-      await invoker.restartTask(taskId);
+      const result = await invoker.restartTask(taskId);
+      trackAcceptedMutation(result);
     } catch (err) {
       console.error('Failed to restart task:', err);
     }
-  }, [invoker]);
+  }, [invoker, trackAcceptedMutation]);
 
   const handleOpenTerminal = useCallback(
     (taskId: string) => {
@@ -1322,71 +1343,72 @@ export function App() {
 
   const handleReplaceSubmit = useCallback(async (taskId: string, replacements: TaskReplacementDef[]) => {
     try {
-      await window.invoker?.replaceTask(taskId, replacements);
+      const result = await window.invoker?.replaceTask(taskId, replacements);
+      trackAcceptedMutation(result);
     } catch (err) {
       console.error('Failed to replace task:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRebaseRetry = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
       const result = await window.invoker?.rebaseRetry(workflowId);
-      if (result && !result.success) {
-        console.error('Rebase and Retry failed for some branches:', result.errors);
-      }
+      trackAcceptedMutation(result);
     } catch (err) {
       console.error('Rebase and Retry failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRebaseRecreate = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
       const result = await window.invoker?.rebaseRecreate(workflowId);
-      if (result && !result.success) {
-        console.error('Rebase and Recreate failed for some branches:', result.errors);
-      }
+      trackAcceptedMutation(result);
     } catch (err) {
       console.error('Rebase and Recreate failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRetryWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.retryWorkflow(workflowId);
+      const result = await window.invoker?.retryWorkflow(workflowId);
+      trackAcceptedMutation(result);
     } catch (err) {
       console.error('Retry Workflow failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRecreateWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.recreateWorkflow(workflowId);
+      const result = await window.invoker?.recreateWorkflow(workflowId);
+      trackAcceptedMutation(result);
     } catch (err) {
       console.error('Recreate Workflow failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRecreateTask = useCallback(async (taskId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.recreateTask(taskId);
+      const result = await window.invoker?.recreateTask(taskId);
+      trackAcceptedMutation(result);
     } catch (err) {
       console.error('Recreate from Task failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleRecreateDownstream = useCallback(async (taskId: string) => {
     setContextMenu(null);
     try {
-      await window.invoker?.recreateDownstream(taskId);
+      const result = await window.invoker?.recreateDownstream(taskId);
+      trackAcceptedMutation(result);
     } catch (err) {
       console.error('Recreate Downstream failed:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleDeleteWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
@@ -1395,7 +1417,8 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await window.invoker?.deleteWorkflow(workflowId);
+      const result = await window.invoker?.deleteWorkflow(workflowId);
+      trackAcceptedMutation(result);
       setSelectedTaskId(null);
       if (selectedWorkflowId === workflowId) {
         setSelectedWorkflowId(null);
@@ -1404,7 +1427,7 @@ export function App() {
     } catch (err) {
       console.error('Delete Workflow failed:', err);
     }
-  }, [refreshTaskGraph, selectedWorkflowId]);
+  }, [refreshTaskGraph, selectedWorkflowId, trackAcceptedMutation]);
 
   const handleDetachWorkflow = useCallback(async (workflowId: string) => {
     setWorkflowContextMenu(null);
@@ -1453,16 +1476,15 @@ export function App() {
     }
     try {
       const hasMergeConflict = hasMergeConflictExecution(task);
-      if (hasMergeConflict) {
-        await window.invoker?.resolveConflict(taskId, agentName);
-      } else {
-        await window.invoker?.fixWithAgent(taskId, agentName);
-      }
+      const result = hasMergeConflict
+        ? await window.invoker?.resolveConflict(taskId, agentName)
+        : await window.invoker?.fixWithAgent(taskId, agentName);
+      trackAcceptedMutation(result);
       refreshTaskGraph();
     } catch (err) {
       console.error('Fix failed:', err);
     }
-  }, [tasks, refreshTaskGraph]);
+  }, [tasks, trackAcceptedMutation]);
 
   const handleCancelTask = useCallback(async (taskId: string) => {
     setContextMenu(null);
@@ -1471,11 +1493,12 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await window.invoker?.cancelTask(taskId);
+      const result = await window.invoker?.cancelTask(taskId);
+      trackAcceptedMutation(result);
     } catch (err) {
       console.error('Failed to cancel task:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleCancelWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
@@ -1484,11 +1507,12 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await window.invoker?.cancelWorkflow(workflowId);
+      const result = await window.invoker?.cancelWorkflow(workflowId);
+      trackAcceptedMutation(result);
     } catch (err) {
       console.error('Failed to cancel workflow:', err);
     }
-  }, []);
+  }, [trackAcceptedMutation]);
 
   const handleOpenWorkflowPr = useCallback((workflowId: string) => {
     const workflowTasks = [...tasks.values()].filter((task) => task.config.workflowId === workflowId);
@@ -1637,33 +1661,37 @@ export function App() {
   const handleProvideInput = useCallback(
     async (taskId: string, input: string) => {
       if (!invoker) return;
-      await invoker.provideInput(taskId, input);
+      const result = await invoker.provideInput(taskId, input);
+      trackAcceptedMutation(result);
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleApprove = useCallback(
     async (taskId: string) => {
       if (!invoker) return;
-      await invoker.approve(taskId);
+      const result = await invoker.approve(taskId);
+      trackAcceptedMutation(result);
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleReject = useCallback(
     async (taskId: string, reason?: string) => {
       if (!invoker) return;
-      await invoker.reject(taskId, reason);
+      const result = await invoker.reject(taskId, reason);
+      trackAcceptedMutation(result);
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleSelectExperiment = useCallback(
     async (taskId: string, experimentIds: string[]) => {
       if (!invoker) return;
-      await invoker.selectExperiment(taskId, experimentIds.length === 1 ? experimentIds[0] : experimentIds);
+      const result = await invoker.selectExperiment(taskId, experimentIds.length === 1 ? experimentIds[0] : experimentIds);
+      trackAcceptedMutation(result);
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task command ──────────────────────────────────────
@@ -1671,12 +1699,13 @@ export function App() {
     async (taskId: string, newCommand: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskCommand(taskId, newCommand);
+        const result = await invoker.editTaskCommand(taskId, newCommand);
+        trackAcceptedMutation(result);
       } catch (err) {
         console.error('Failed to edit task command:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task prompt ───────────────────────────────────────
@@ -1684,12 +1713,13 @@ export function App() {
     async (taskId: string, newPrompt: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskPrompt(taskId, newPrompt);
+        const result = await invoker.editTaskPrompt(taskId, newPrompt);
+        trackAcceptedMutation(result);
       } catch (err) {
         console.error('Failed to edit task prompt:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task executor type ───────────────────────────────
@@ -1697,12 +1727,13 @@ export function App() {
     async (taskId: string, runnerKind: string, poolMemberId?: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskType(taskId, runnerKind, poolMemberId);
+        const result = await invoker.editTaskType(taskId, runnerKind, poolMemberId);
+        trackAcceptedMutation(result);
       } catch (err) {
         console.error('Failed to edit task type:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task execution pool ─────────────────────────────
@@ -1710,12 +1741,13 @@ export function App() {
     async (taskId: string, poolId: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskPool(taskId, poolId);
+        const result = await invoker.editTaskPool(taskId, poolId);
+        trackAcceptedMutation(result);
       } catch (err) {
         console.error('Failed to edit task pool:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Edit task execution agent ────────────────────────────
@@ -1723,50 +1755,52 @@ export function App() {
     async (taskId: string, agentName: string) => {
       if (!invoker) return;
       try {
-        await invoker.editTaskAgent(taskId, agentName);
+        const result = await invoker.editTaskAgent(taskId, agentName);
+        trackAcceptedMutation(result);
       } catch (err) {
         console.error('Failed to edit task agent:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleSetExternalGatePolicies = useCallback(
     async (taskId: string, updates: ExternalGatePolicyUpdate[]) => {
       if (!invoker) return;
       try {
-        await invoker.setTaskExternalGatePolicies(taskId, updates);
+        const result = await invoker.setTaskExternalGatePolicies(taskId, updates);
+        trackAcceptedMutation(result);
       } catch (err) {
         console.error('Failed to set external gate policies:', err);
       }
     },
-    [invoker],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleSetMergeBranch = useCallback(
     async (workflowId: string, baseBranch: string) => {
       if (!invoker) return;
       try {
-        await invoker.setMergeBranch(workflowId, baseBranch);
-        refreshTaskGraph();
+        const result = await invoker.setMergeBranch(workflowId, baseBranch);
+        trackAcceptedMutation(result);
       } catch (err) {
         console.error('Failed to set merge branch:', err);
       }
     },
-    [invoker, refreshTaskGraph],
+    [invoker, trackAcceptedMutation],
   );
 
   const handleSetMergeMode = useCallback(
     async (workflowId: string, mergeMode: 'manual' | 'automatic' | 'external_review') => {
       if (!invoker) return;
       try {
-        await invoker.setMergeMode(workflowId, mergeMode);
-        refreshTaskGraph();
+        const result = await invoker.setMergeMode(workflowId, mergeMode);
+        trackAcceptedMutation(result);
       } catch (err) {
         console.error('Failed to set merge mode:', err);
       }
     },
-    [invoker, refreshTaskGraph],
+    [invoker, trackAcceptedMutation],
   );
 
   // ── Modal triggers ────────────────────────────────────────
@@ -2008,9 +2042,11 @@ export function App() {
                 <TimelineView tasks={tasks} onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
               ) : viewMode === 'actionGraph' ? (
                 <ActionGraphView
-                  selectedNodeId={selectedActionNode?.id ?? null}
+                  graph={actionGraph}
+                  error={actionGraphError}
+                  selectedNodeId={selectedActionNodeId}
                   onSelectNode={(node) => {
-                    setSelectedActionNode(node);
+                    setSelectedActionNodeId(node?.id ?? null);
                     if (node?.taskId) setSelectedTaskId(node.taskId);
                     if (node?.workflowId) setSelectedWorkflowId(node.workflowId);
                   }}
@@ -2022,6 +2058,7 @@ export function App() {
                     selectedWorkflowId={selectedWorkflow?.id ?? null}
                     cameraCommand={cameraCommand}
                     statusFilters={statusFilters}
+                    coreActivityByWorkflow={coreActivityByWorkflow}
                     onSelectWorkflow={handleWorkflowClick}
                     onWorkflowContextMenu={handleWorkflowContextMenu}
                     onManualViewport={handleManualViewport}

--- a/packages/ui/src/__tests__/action-graph-view.test.tsx
+++ b/packages/ui/src/__tests__/action-graph-view.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import type { ActionGraphResponse } from '@invoker/contracts';
 import { ActionGraphView } from '../components/ActionGraphView.js';
 
@@ -35,17 +35,10 @@ const graph: ActionGraphResponse = {
 };
 
 describe('ActionGraphView', () => {
-  beforeEach(() => {
-    vi.useRealTimers();
-    window.invoker = {
-      getActionGraph: vi.fn().mockResolvedValue(graph),
-    } as any;
-  });
+  it('renders action graph nodes with duration badges', () => {
+    render(<ActionGraphView graph={graph} error={null} selectedNodeId={null} onSelectNode={() => {}} />);
 
-  it('renders action graph nodes with duration badges', async () => {
-    render(<ActionGraphView selectedNodeId={null} onSelectNode={() => {}} />);
-
-    expect(await screen.findByTestId('action-graph-view')).toBeInTheDocument();
+    expect(screen.getByTestId('action-graph-view')).toBeInTheDocument();
     expect(screen.getByText('invoker:retry-workflow')).toBeInTheDocument();
     expect(screen.getByText('queued 14m')).toBeInTheDocument();
     expect(screen.getByText('heartbeat 8s ago')).toBeInTheDocument();
@@ -55,9 +48,9 @@ describe('ActionGraphView', () => {
 
   it('selecting a node notifies the inspector owner', async () => {
     const onSelectNode = vi.fn();
-    render(<ActionGraphView selectedNodeId={null} onSelectNode={onSelectNode} />);
+    render(<ActionGraphView graph={graph} error={null} selectedNodeId={null} onSelectNode={onSelectNode} />);
 
-    await waitFor(() => expect(screen.getByTestId('rf__node-intent:1')).toBeInTheDocument());
+    expect(screen.getByTestId('rf__node-intent:1')).toBeInTheDocument();
     fireEvent.click(screen.getByTestId('rf__node-intent:1'));
 
     expect(onSelectNode).toHaveBeenCalledWith(expect.objectContaining({ id: 'intent:1' }));

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -261,6 +261,47 @@ describe('Context menu (component)', () => {
     expectOnlyWorkflowApiCalled('rebaseRecreate');
   });
 
+  it('workflow context menu shows core pending launch status', async () => {
+    mock.setActionGraph({
+      generatedAt: '2026-06-22T10:00:12.000Z',
+      stallThresholdMs: 60_000,
+      nodes: [
+        {
+          id: 'intent:77',
+          type: 'mutation-intent',
+          label: 'invoker:rebase-recreate',
+          status: 'running',
+          workflowId: 'wf-1',
+          intentId: 77,
+          durations: { runningMs: 12000 },
+        },
+        {
+          id: 'launch-dispatch:1',
+          type: 'launch-dispatch',
+          label: 'Launch task-alpha',
+          status: 'queued',
+          workflowId: 'wf-1',
+          taskId: 'task-alpha',
+          attemptId: 'task-alpha-attempt-1',
+          durations: { queuedMs: 5000 },
+        },
+      ],
+      edges: [],
+    });
+    await setup();
+    fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));
+    fireEvent.click(await screen.findByText('More'));
+    fireEvent.click(await screen.findByText('Rebase and Recreate'));
+
+    const workflowNode = screen.getByTestId('workflow-node-wf-1');
+    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-1-core-activity')).toHaveTextContent('Pending: queued for launch'));
+    expect(workflowNode).not.toHaveTextContent(/Rebase|Recreate|invoker:rebase-recreate/);
+
+    fireEvent.click(screen.getByText('Action Graph'));
+    fireEvent.click(await screen.findByTestId('rf__node-intent:77'));
+    expect(await screen.findByTestId('workflow-inspector-action-node')).toHaveTextContent('invoker:rebase-recreate');
+  });
+
   it('workflow context menu cancels workflow', async () => {
     await setup();
     fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -16,7 +16,7 @@ import type {
   TaskConfig,
   TaskExecution,
 } from '../../types.js';
-import type { TerminalOutputEvent } from '@invoker/contracts';
+import type { ActionGraphResponse, TerminalOutputEvent, WorkflowMutationAcceptedResult } from '@invoker/contracts';
 
 export interface MockInvoker {
   /** The mock InvokerAPI object installed on window.invoker. */
@@ -31,6 +31,8 @@ export interface MockInvoker {
   fireWorkflowsChanged: (workflows: WorkflowMeta[]) => void;
   /** Fire an embedded terminal output event to subscribers. */
   fireTerminalOutput: (event: TerminalOutputEvent) => void;
+  /** Replace the action graph snapshot returned by getActionGraph. */
+  setActionGraph: (response: ActionGraphResponse) => void;
   /** Install the mock on window.invoker. */
   install: () => void;
   /** Remove window.invoker. */
@@ -46,6 +48,20 @@ export function createMockInvoker(
   let graphEventCallback: ((event: TaskGraphEvent) => void) | undefined;
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
+  let actionGraphSnapshot: ActionGraphResponse = {
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    stallThresholdMs: 60_000,
+    nodes: [],
+    edges: [],
+  };
+
+  const accepted = (channel: string, workflowId = 'wf-1'): WorkflowMutationAcceptedResult => ({
+    ok: true,
+    accepted: true,
+    intentId: 1,
+    workflowId,
+    channel,
+  });
 
   const api: InvokerAPI = {
     // Defer resolution one microtask so the startup snapshot is read after synchronous setTasks()
@@ -92,15 +108,16 @@ export function createMockInvoker(
     stop: vi.fn(async () => {}),
     clear: vi.fn(async () => {}),
     getStatus: vi.fn(async () => ({ total: 0, completed: 0, failed: 0, closed: 0, running: 0, pending: 0 })),
-    provideInput: vi.fn(async () => {}),
-    approve: vi.fn(async () => {}),
-    reject: vi.fn(async () => {}),
-    selectExperiment: vi.fn(async () => {}),
-    restartTask: vi.fn(async () => {}),
-    editTaskCommand: vi.fn(async () => {}),
-    editTaskPool: vi.fn(async () => {}),
-    editTaskAgent: vi.fn(async () => {}),
-    setTaskExternalGatePolicies: vi.fn(async () => {}),
+    provideInput: vi.fn(async () => accepted('invoker:provide-input')),
+    approve: vi.fn(async () => accepted('invoker:approve')),
+    reject: vi.fn(async () => accepted('invoker:reject')),
+    selectExperiment: vi.fn(async () => accepted('invoker:select-experiment')),
+    restartTask: vi.fn(async () => accepted('invoker:restart-task')),
+    editTaskCommand: vi.fn(async () => accepted('invoker:edit-task-command')),
+    editTaskPrompt: vi.fn(async () => accepted('invoker:edit-task-prompt')),
+    editTaskPool: vi.fn(async () => accepted('invoker:edit-task-pool')),
+    editTaskAgent: vi.fn(async () => accepted('invoker:edit-task-agent')),
+    setTaskExternalGatePolicies: vi.fn(async () => accepted('invoker:set-task-external-gate-policies')),
     getRemoteTargets: vi.fn(async () => []),
     getExecutionPools: vi.fn(async () => ['mixed-local-ssh', 'pnpm-ssh']),
     getExecutionAgents: vi.fn(async () => ['claude', 'codex']),
@@ -150,7 +167,7 @@ export function createMockInvoker(
       commandTargets: [],
       mcpTargets: [],
     })),
-    replaceTask: vi.fn(async () => []),
+    replaceTask: vi.fn(async () => accepted('invoker:replace-task')),
     getActivityLogs: vi.fn(async () => []),
     getEvents: vi.fn(async () => []),
     openTerminal: vi.fn(async (taskId: string) => ({
@@ -179,29 +196,30 @@ export function createMockInvoker(
     getReviewGate: vi.fn(async () => null),
     deleteAllWorkflows: vi.fn(async () => {}),
     deleteAllWorkflowsBulk: vi.fn(async () => {}),
-    deleteWorkflow: vi.fn(async () => {}),
+    deleteWorkflow: vi.fn(async () => accepted('invoker:delete-workflow')),
     detachWorkflow: vi.fn(async () => {}),
     cleanupWorktrees: vi.fn(async () => ({ removed: [], errors: [] })),
-    recreateWorkflow: vi.fn(async () => {}),
-    recreateTask: vi.fn(async () => {}),
-    recreateDownstream: vi.fn(async () => {}),
-    retryWorkflow: vi.fn(async () => {}),
-    rebaseRetry: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
-    rebaseRecreate: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
-    setMergeBranch: vi.fn(async () => {}),
-    approveMerge: vi.fn(async () => {}),
-    resolveConflict: vi.fn(async () => {}),
-    fixWithAgent: vi.fn(async () => {}),
-    setMergeMode: vi.fn(async () => {}),
+    recreateWorkflow: vi.fn(async () => accepted('invoker:recreate-workflow')),
+    recreateTask: vi.fn(async () => accepted('invoker:recreate-task')),
+    recreateDownstream: vi.fn(async () => accepted('invoker:recreate-downstream')),
+    retryWorkflow: vi.fn(async () => accepted('invoker:retry-workflow')),
+    rebaseRetry: vi.fn(async () => accepted('invoker:rebase-retry')),
+    rebaseRecreate: vi.fn(async () => accepted('invoker:rebase-recreate')),
+    setMergeBranch: vi.fn(async () => accepted('invoker:set-merge-branch')),
+    approveMerge: vi.fn(async () => accepted('invoker:approve-merge')),
+    resolveConflict: vi.fn(async () => accepted('invoker:resolve-conflict')),
+    fixWithAgent: vi.fn(async () => accepted('invoker:fix-with-agent')),
+    setMergeMode: vi.fn(async () => accepted('invoker:set-merge-mode')),
     checkPrStatuses: vi.fn(async () => {}),
-    cancelTask: vi.fn(async () => ({ cancelled: [], runningCancelled: [] })),
-    cancelWorkflow: vi.fn(async () => ({ cancelled: [], runningCancelled: [] })),
+    cancelTask: vi.fn(async () => accepted('invoker:cancel-task')),
+    cancelWorkflow: vi.fn(async () => accepted('invoker:cancel-workflow')),
     getQueueStatus: vi.fn(async () => ({
       maxConcurrency: 0,
       runningCount: 0,
       running: [],
       queued: [],
     })),
+    getActionGraph: vi.fn(async () => actionGraphSnapshot),
     getClaudeSession: vi.fn(async () => null),
     getAgentSession: vi.fn(async () => null),
   };
@@ -222,6 +240,10 @@ export function createMockInvoker(
         graphEventCallback?.({ type: 'delta', delta: { type: 'created', task }, workflowRollups: [] });
       }
     });
+  }
+
+  function setActionGraph(response: ActionGraphResponse) {
+    actionGraphSnapshot = response;
   }
 
   function fireDelta(delta: TaskDelta) {
@@ -252,12 +274,22 @@ export function createMockInvoker(
   }
 
   function cleanup() {
-    terminalOutputCallbacks.clear();
-    delete (window as unknown as { invoker?: unknown }).invoker;
+    delete (window as unknown as { invoker?: InvokerAPI }).invoker;
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
+    terminalOutputCallbacks.clear();
   }
 
-  return { api, setTasks, fireDelta, fireGraphEvent, fireWorkflowsChanged, fireTerminalOutput, install, cleanup };
+  return {
+    api,
+    setTasks,
+    setActionGraph,
+    fireDelta,
+    fireGraphEvent,
+    fireWorkflowsChanged,
+    fireTerminalOutput,
+    install,
+    cleanup,
+  };
 }
 
 /** Create a minimal TaskState for testing. */

--- a/packages/ui/src/__tests__/workflow-core-activity.test.ts
+++ b/packages/ui/src/__tests__/workflow-core-activity.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { ActionGraphNode } from '@invoker/contracts';
+import { selectWorkflowCoreActivity } from '../lib/workflow-core-activity.js';
+
+const workflowId = 'wf-1';
+
+function node(overrides: Partial<ActionGraphNode> & Pick<ActionGraphNode, 'id' | 'type' | 'status'>): ActionGraphNode {
+  return {
+    label: overrides.id,
+    workflowId,
+    ...overrides,
+  } as ActionGraphNode;
+}
+
+describe('selectWorkflowCoreActivity', () => {
+  it('uses queued launch state instead of running mutation intent labels', () => {
+    const selected = selectWorkflowCoreActivity([
+      node({ id: 'intent:77', type: 'mutation-intent', status: 'running', label: 'invoker:rebase-recreate' }),
+      node({ id: 'launch-dispatch:1', type: 'launch-dispatch', status: 'queued' }),
+    ], workflowId);
+
+    expect(selected?.label).toBe('Pending: queued for launch');
+  });
+
+  it('ignores running mutation intent when no core activity exists', () => {
+    const selected = selectWorkflowCoreActivity([
+      node({ id: 'intent:77', type: 'mutation-intent', status: 'running', label: 'invoker:rebase-recreate' }),
+    ], workflowId);
+
+    expect(selected).toBeUndefined();
+  });
+
+  it('maps leased launch dispatches to accepted pending launch state', () => {
+    const selected = selectWorkflowCoreActivity([
+      node({ id: 'launch-dispatch:2', type: 'launch-dispatch', status: 'running' }),
+    ], workflowId);
+
+    expect(selected?.label).toBe('Pending: launch accepted');
+  });
+
+  it('lets a running task attempt outrank queued launch dispatches', () => {
+    const selected = selectWorkflowCoreActivity([
+      node({ id: 'launch-dispatch:1', type: 'launch-dispatch', status: 'queued' }),
+      node({ id: 'attempt:1', type: 'task-attempt', status: 'running' }),
+    ], workflowId);
+
+    expect(selected?.label).toBe('Running: task executing');
+  });
+
+  it('lets failed blockers outrank running task attempts', () => {
+    const selected = selectWorkflowCoreActivity([
+      node({ id: 'attempt:1', type: 'task-attempt', status: 'running' }),
+      node({ id: 'blocker:1', type: 'blocker', status: 'failed' }),
+    ], workflowId);
+
+    expect(selected?.label).toBe('Failed: see details');
+  });
+
+  it('uses newest startedAt or createdAt for same-rank candidates', () => {
+    const selected = selectWorkflowCoreActivity([
+      node({ id: 'launch-dispatch:old', type: 'launch-dispatch', status: 'queued', createdAt: '2026-06-22T09:00:00.000Z' }),
+      node({ id: 'launch-dispatch:new', type: 'launch-dispatch', status: 'queued', startedAt: '2026-06-22T10:00:00.000Z' }),
+    ], workflowId);
+
+    expect(selected?.nodeId).toBe('launch-dispatch:new');
+  });
+});

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -136,6 +136,35 @@ describe('WorkflowGraph', () => {
     expect(screen.getByTestId('workflow-node-wf-a-running-tasks')).toHaveTextContent('1 running task');
   });
 
+  it('renders core activity without mutation command labels', () => {
+    const workflows = new Map([
+      ['wf-1', wf('wf-1', 'running')],
+    ]);
+
+    render(
+      <WorkflowGraph
+        workflows={workflows}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        coreActivityByWorkflow={new Map([
+          ['wf-1', {
+            workflowId: 'wf-1',
+            status: 'pending',
+            label: 'Pending: queued for launch',
+            nodeId: 'launch-dispatch:1',
+            nodeType: 'launch-dispatch',
+          }],
+        ])}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    const activity = screen.getByTestId('workflow-node-wf-1-core-activity');
+    expect(activity).toHaveTextContent('Pending: queued for launch');
+    expect(screen.getByTestId('workflow-node-wf-1')).not.toHaveTextContent(/rebase|invoker:rebase-recreate/i);
+  });
+
   it('renders the React Flow wrapper for non-empty workflow graphs', () => {
     const workflows = new Map([
       ['wf-a', wf('wf-a', 'running')],

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -608,4 +608,30 @@ describe('WorkflowInspector', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Reject Fix' }));
     expect(onReject).toHaveBeenCalledWith(task);
   });
+  it('shows selected action graph node details', () => {
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={null}
+        actionNode={{
+          id: 'intent:77',
+          type: 'mutation-intent',
+          label: 'invoker:rebase-recreate',
+          status: 'running',
+          workflowId: 'wf-1',
+          intentId: 77,
+          durations: { runningMs: 12000 },
+        }}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('workflow-inspector-action-node')).toHaveTextContent('invoker:rebase-recreate');
+    expect(screen.getByTestId('workflow-inspector-action-node-status')).toHaveTextContent('RUNNING');
+    expect(screen.getByTestId('workflow-inspector-action-node')).toHaveTextContent('runningMs');
+    expect(screen.getByTestId('workflow-inspector-action-node')).toHaveTextContent('12000');
+  });
 });

--- a/packages/ui/src/components/ActionGraphView.tsx
+++ b/packages/ui/src/components/ActionGraphView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import {
   Background,
   Controls,
@@ -15,6 +15,8 @@ import type { ActionGraphNode, ActionGraphResponse } from '@invoker/contracts';
 import { BundledEdge } from './BundledEdge.js';
 
 interface ActionGraphViewProps {
+  graph: ActionGraphResponse | null;
+  error: string | null;
   selectedNodeId: string | null;
   onSelectNode: (node: ActionGraphNode | null) => void;
 }
@@ -176,31 +178,7 @@ function layoutGraph(graph: ActionGraphResponse | null, selectedNodeId: string |
   return { nodes, edges };
 }
 
-function ActionGraphInner({ selectedNodeId, onSelectNode }: ActionGraphViewProps): JSX.Element {
-  const [graph, setGraph] = useState<ActionGraphResponse | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    let alive = true;
-    const load = () => {
-      window.invoker?.getActionGraph?.()
-        .then((response) => {
-          if (!alive) return;
-          setGraph(response);
-          setError(null);
-        })
-        .catch((err) => {
-          if (!alive) return;
-          setError(err instanceof Error ? err.message : String(err));
-        });
-    };
-    load();
-    const interval = setInterval(load, 5_000);
-    return () => {
-      alive = false;
-      clearInterval(interval);
-    };
-  }, []);
+function ActionGraphInner({ graph, error, selectedNodeId, onSelectNode }: ActionGraphViewProps): JSX.Element {
 
   const rendered = useMemo(() => layoutGraph(graph, selectedNodeId), [graph, selectedNodeId]);
 

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
 import type { WorkflowMeta, WorkflowStatus } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
+import type { WorkflowCoreActivity } from '../lib/workflow-core-activity.js';
 import { deriveWorkflowGraph, layoutWorkflowGraph, type WorkflowGraphEdge } from '../lib/workflow-graph.js';
 import { WorkflowNode } from './WorkflowNode.js';
 import {
@@ -29,6 +30,7 @@ interface WorkflowGraphProps {
    */
   cameraCommand?: GraphCameraCommand | null;
   statusFilters: Set<WorkflowStatus>;
+  coreActivityByWorkflow?: Map<string, WorkflowCoreActivity>;
   onSelectWorkflow: (workflowId: string) => void;
   onWorkflowContextMenu: (event: MouseEvent, workflowId: string) => void;
   /** Fired when the user manually pans or zooms the viewport. */
@@ -39,6 +41,7 @@ interface WorkflowNodeData extends Record<string, unknown> {
   workflow: WorkflowMeta;
   selected: boolean;
   dimmed: boolean;
+  coreActivity?: WorkflowCoreActivity;
 }
 
 const nodeTypes = {
@@ -89,6 +92,7 @@ function WorkflowFlowNode({ data }: NodeProps<Node<WorkflowNodeData>>): JSX.Elem
         workflow={data.workflow}
         selected={data.selected}
         dimmed={data.dimmed}
+        coreActivity={data.coreActivity}
         onClick={() => {}}
         onContextMenu={() => {}}
       />
@@ -107,6 +111,7 @@ function WorkflowGraphInner({
   selectedWorkflowId,
   cameraCommand,
   statusFilters,
+  coreActivityByWorkflow,
   onSelectWorkflow,
   onWorkflowContextMenu,
   onManualViewport,
@@ -149,12 +154,13 @@ function WorkflowGraphInner({
           workflow: node.workflow,
           selected: selectedWorkflowId === node.id,
           dimmed,
+          coreActivity: coreActivityByWorkflow?.get(node.id),
         },
       };
     });
     graphMetricsRef.current.objectsMs = performance.now() - startedAt;
     return nextNodes;
-  }, [graph.nodes, positions, selectedWorkflowId, statusFilters]);
+  }, [coreActivityByWorkflow, graph.nodes, positions, selectedWorkflowId, statusFilters]);
 
   const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => {
     const visual = workflowEdgeVisual(edge.kind);

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ReviewGateArtifact, ReviewGateQueryResponse, TaskState, WorkflowMeta } from '../types.js';
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
+import type { ActionGraphNode } from '@invoker/contracts';
 
 type MergeMode = 'manual' | 'automatic' | 'external_review';
 
@@ -13,7 +14,7 @@ interface WorkflowInspectorProps {
   remoteTargets?: string[];
   executionPools?: string[];
   executionAgents?: string[];
-  actionNode?: unknown;
+  actionNode?: ActionGraphNode | null;
   collapsed: boolean;
   advancedExpanded: boolean;
   onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
@@ -118,6 +119,7 @@ export function WorkflowInspector({
   reviewGate,
   executionPools,
   executionAgents,
+  actionNode,
   collapsed,
   advancedExpanded,
   onEditPool,
@@ -305,6 +307,57 @@ export function WorkflowInspector({
             </div>
           )}
         </section>
+
+        {actionNode && (
+          <section data-testid="workflow-inspector-action-node" className="rounded border border-blue-500/40 bg-blue-950/20 p-3">
+            <h3 className="text-[11px] uppercase tracking-wide text-blue-200">Action Graph Detail</h3>
+            <div className="mt-1 text-sm font-medium text-gray-100 break-words">{actionNode.label}</div>
+            <div data-testid="workflow-inspector-action-node-status" className="mt-2 inline-flex rounded border border-blue-300/40 px-2 py-1 text-[10px] font-semibold uppercase text-blue-100">
+              {actionNode.status.toUpperCase()}
+            </div>
+            <dl className="mt-3 space-y-1 text-xs">
+              {[
+                ['type', actionNode.type],
+                ['status', actionNode.status],
+                ['taskId', actionNode.taskId],
+                ['attemptId', actionNode.attemptId],
+                ['intentId', actionNode.intentId],
+                ['ownerId', actionNode.ownerId],
+                ['createdAt', actionNode.createdAt],
+                ['startedAt', actionNode.startedAt],
+                ['completedAt', actionNode.completedAt],
+                ['heartbeatAt', actionNode.heartbeatAt],
+                ['leaseExpiresAt', actionNode.leaseExpiresAt],
+              ].filter(([, value]) => value !== undefined && value !== '').map(([key, value]) => (
+                <div key={String(key)} className="flex justify-between gap-3">
+                  <dt className="shrink-0 text-gray-500">{key}</dt>
+                  <dd className="min-w-0 break-all text-right text-gray-200">{String(value)}</dd>
+                </div>
+              ))}
+              {actionNode.durations && Object.entries(actionNode.durations).map(([key, value]) => (
+                <div key={`duration-${key}`} className="flex justify-between gap-3">
+                  <dt className="shrink-0 text-gray-500">{key}</dt>
+                  <dd className="min-w-0 break-all text-right text-gray-200">{String(value)}</dd>
+                </div>
+              ))}
+            </dl>
+            {actionNode.latestError && (
+              <div className="mt-3 text-xs text-red-300 break-words">{actionNode.latestError}</div>
+            )}
+            {actionNode.suggestedNextAction && (
+              <div className="mt-3 text-xs text-blue-100 break-words">{actionNode.suggestedNextAction}</div>
+            )}
+            {actionNode.history && actionNode.history.length > 0 && (
+              <div className="mt-3 space-y-1 border-t border-blue-400/20 pt-2">
+                {[...actionNode.history].reverse().map((entry) => (
+                  <div key={entry.id} className="text-[11px] text-gray-300">
+                    <span className="text-gray-500">{entry.timestamp}</span> {entry.source}: {entry.message}
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
 
         {task && !task.config.isMergeNode && onEditPool && (
           <section className="rounded border border-gray-700 bg-gray-800/70 p-3">

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -1,11 +1,13 @@
 import type { KeyboardEvent, MouseEvent } from 'react';
 import type { WorkflowMeta, WorkflowStatus } from '../types.js';
 import { isWorkflowStatusActive, workflowStatusVisual } from '../lib/workflow-status.js';
+import type { WorkflowCoreActivity } from '../lib/workflow-core-activity.js';
 
 interface WorkflowNodeProps {
   workflow: WorkflowMeta;
   selected: boolean;
   dimmed: boolean;
+  coreActivity?: WorkflowCoreActivity;
   onClick: () => void;
   onContextMenu: (event: MouseEvent<HTMLDivElement>) => void;
 }
@@ -22,6 +24,7 @@ export function WorkflowNode({
   workflow,
   selected,
   dimmed,
+  coreActivity,
   onClick,
   onContextMenu,
 }: WorkflowNodeProps): JSX.Element {
@@ -76,6 +79,24 @@ export function WorkflowNode({
           className="mt-1 text-[10px] text-gray-300"
         >
           {runningTaskLabel(runningCount)}
+        </div>
+      )}
+      {coreActivity && (
+        <div
+          data-testid={`workflow-node-${workflow.id}-core-activity`}
+          className={[
+            'mt-2 inline-flex items-center gap-1 rounded border px-2 py-1 text-[10px] font-medium',
+            coreActivity.status === 'running'
+              ? 'border-blue-400/60 text-blue-200'
+              : coreActivity.status === 'pending'
+                ? 'border-amber-400/60 text-amber-200'
+                : 'border-red-400/70 text-red-200',
+          ].join(' ')}
+        >
+          {coreActivity.status === 'running' && (
+            <span className="h-1.5 w-1.5 rounded-full bg-blue-300 animate-pulse" />
+          )}
+          {coreActivity.label}
         </div>
       )}
     </div>

--- a/packages/ui/src/hooks/useActionGraphSnapshot.ts
+++ b/packages/ui/src/hooks/useActionGraphSnapshot.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { ActionGraphResponse } from '@invoker/contracts';
+
+export function useActionGraphSnapshot(pollMs = 2000): {
+  graph: ActionGraphResponse | null;
+  error: string | null;
+  refreshActionGraph: () => Promise<void>;
+} {
+  const [graph, setGraph] = useState<ActionGraphResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshActionGraph = useCallback(async () => {
+    try {
+      const response = await window.invoker?.getActionGraph?.();
+      if (response) {
+        setGraph(response);
+        setError(null);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const response = await window.invoker?.getActionGraph?.();
+        if (!cancelled && response) {
+          setGraph(response);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : String(err));
+        }
+      }
+    };
+
+    void poll();
+    const interval = window.setInterval(() => {
+      void poll();
+    }, pollMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [pollMs]);
+
+  return { graph, error, refreshActionGraph };
+}

--- a/packages/ui/src/lib/workflow-core-activity.ts
+++ b/packages/ui/src/lib/workflow-core-activity.ts
@@ -1,0 +1,133 @@
+import type { ActionGraphNode } from '@invoker/contracts';
+
+export type WorkflowCoreActivityStatus = 'pending' | 'running' | 'failed' | 'stalled';
+
+export interface WorkflowCoreActivity {
+  workflowId: string;
+  status: WorkflowCoreActivityStatus;
+  label: string;
+  nodeId: string;
+  nodeType: ActionGraphNode['type'];
+  taskId?: string;
+  durationMs?: number;
+}
+
+type Candidate = WorkflowCoreActivity & { rank: number; sortTime: number };
+
+const IGNORED_NODE_TYPES = new Set<ActionGraphNode['type']>([
+  'mutation-intent',
+  'mutation-lease',
+  'user-action',
+]);
+
+function timestampMs(node: ActionGraphNode): number {
+  const raw = node.startedAt ?? node.createdAt;
+  if (!raw) return 0;
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function durationMs(node: ActionGraphNode): number | undefined {
+  return node.durations?.runningMs
+    ?? node.durations?.queuedMs
+    ?? node.durations?.pendingMs
+    ?? node.durations?.stalledMs;
+}
+
+function candidateForNode(node: ActionGraphNode): Candidate | undefined {
+  const workflowId = node.workflowId;
+  if (!workflowId || IGNORED_NODE_TYPES.has(node.type)) return undefined;
+
+  let rank: number | undefined;
+  let status: WorkflowCoreActivityStatus | undefined;
+  let label: string | undefined;
+
+  if (node.type === 'blocker' && node.status === 'failed') {
+    rank = 1;
+    status = 'failed';
+    label = 'Failed: see details';
+  } else if (node.type === 'task-attempt' && node.status === 'stalled') {
+    rank = 2;
+    status = 'stalled';
+    label = 'Stalled: task heartbeat lost';
+  } else if (node.type === 'task-attempt' && node.status === 'running') {
+    rank = 3;
+    status = 'running';
+    label = 'Running: task executing';
+  } else if (node.type === 'launch-dispatch' && node.status === 'running') {
+    rank = 4;
+    status = 'pending';
+    label = 'Pending: launch accepted';
+  } else if (node.type === 'launch-dispatch' && node.status === 'queued') {
+    rank = 5;
+    status = 'pending';
+    label = 'Pending: queued for launch';
+  } else if (node.type === 'scheduler-job' && node.status === 'running') {
+    rank = 6;
+    status = 'pending';
+    label = 'Pending: scheduler dispatching';
+  } else if (node.type === 'scheduler-job' && node.status === 'queued') {
+    rank = 7;
+    status = 'pending';
+    label = 'Pending: scheduler queued';
+  } else if (
+    node.type === 'task-attempt'
+    && node.status === 'pending'
+    && node.details?.phase === 'launching'
+  ) {
+    rank = 8;
+    status = 'pending';
+    label = 'Pending: task launch';
+  }
+
+  if (rank === undefined || !status || !label) return undefined;
+  return {
+    workflowId,
+    status,
+    label,
+    nodeId: node.id,
+    nodeType: node.type,
+    taskId: node.taskId,
+    durationMs: durationMs(node),
+    rank,
+    sortTime: timestampMs(node),
+  };
+}
+
+function betterCandidate(current: Candidate | undefined, next: Candidate): Candidate {
+  if (!current) return next;
+  if (next.rank < current.rank) return next;
+  if (next.rank > current.rank) return current;
+  return next.sortTime > current.sortTime ? next : current;
+}
+
+function stripCandidate(candidate: Candidate): WorkflowCoreActivity {
+  const { rank: _rank, sortTime: _sortTime, ...activity } = candidate;
+  return activity;
+}
+
+export function selectWorkflowCoreActivity(
+  nodes: readonly ActionGraphNode[],
+  workflowId: string,
+): WorkflowCoreActivity | undefined {
+  let selected: Candidate | undefined;
+  for (const node of nodes) {
+    if (node.workflowId !== workflowId) continue;
+    const candidate = candidateForNode(node);
+    if (!candidate) continue;
+    selected = betterCandidate(selected, candidate);
+  }
+  return selected ? stripCandidate(selected) : undefined;
+}
+
+export function groupWorkflowCoreActivity(
+  nodes: readonly ActionGraphNode[],
+): Map<string, WorkflowCoreActivity> {
+  const selected = new Map<string, Candidate>();
+  for (const node of nodes) {
+    const candidate = candidateForNode(node);
+    if (!candidate) continue;
+    selected.set(candidate.workflowId, betterCandidate(selected.get(candidate.workflowId), candidate));
+  }
+  return new Map([...selected.entries()].map(([workflowId, candidate]) => [workflowId, stripCandidate(candidate)]));
+}


### PR DESCRIPTION
## Summary

Workflow cards now show core task or launch activity, while the inspector keeps the raw mutation label.

The old card could show `Running: invoker:rebase-recreate` while the task was still pending and queued for launch.

Now the card reads filtered action-graph nodes, and the inspector keeps the raw action detail.

<details>
<summary>Review metadata</summary>

Review Claim: The UI now shows workflow-core activity on cards and keeps raw mutation labels in inspector details only.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Card text comes from filtered core action-graph node types, while raw action details stay visible in the inspector.

Slice Rationale: This lands last so the UI reads the proved graph facts and accepted-mutation refresh path.

</details>

## Non-goals

This does not change task scheduling.

This does not remove raw mutation labels from inspector details.

## Architecture

### Before

```mermaid
flowchart LR
  Intent["mutation label"] --> Card["workflow card"]
```

### After

```mermaid
flowchart LR
  Graph["action-graph nodes"] --> Selector["core activity selector"]
  Selector --> Card["workflow card"]
  Graph --> Inspector["action detail"]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-core-activity.test.ts src/__tests__/workflow-graph.test.tsx src/__tests__/workflow-inspector.test.tsx src/__tests__/action-graph-view.test.tsx`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu-e2e.test.tsx -t "workflow context menu shows core pending launch status"`
- [x] `pnpm --filter @invoker/ui build`

## Visual Proof

![Workflow card shows pending launch while inspector keeps the raw mutation label](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260622-9c3a4f/workflow-mutation-status-proof.png)

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 7079f9d0a`
- Post-revert steps: Rebuild `@invoker/ui`.
- Data migration? No.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live action-graph snapshots with periodic refresh to keep workflow/task views current.
  * Workflow nodes can now display a “core activity” badge with status (and timing when available).
  * Workflow inspector can show an “Action Graph Detail” panel for a selected node.
* **Bug Fixes**
  * Improved state synchronization by refreshing workflow/task views only after accepted mutations.
* **Tests**
  * Added/updated unit and end-to-end coverage for core activity selection, graph rendering, and inspector behavior.
* **Chores**
  * Updated the UI build to also bundle the core-activity logic for ESM output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2052