### PR TITLE
[Recovery Lifecycle 2e][D4] CLI worker surface

### DIFF
--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -80,7 +80,7 @@ describe('headless worker autofix', () => {
     const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
 
     try {
-      await runHeadless(['worker', 'autofix'], {
+      await runHeadless(['worker', 'autofix', '--count', '1'], {
         logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn() },
         persistence: {
           listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),

--- a/packages/app/src/__tests__/owner-resolver.test.ts
+++ b/packages/app/src/__tests__/owner-resolver.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { LocalBus } from '@invoker/transport';
 
-import { createOwnerResolver } from '../owner-resolver.js';
+import { createOwnerResolver, StandaloneOwnerResolutionError } from '../owner-resolver.js';
 
 describe('owner-resolver', () => {
   describe('discover', () => {
@@ -378,9 +378,7 @@ describe('owner-resolver', () => {
         maxBootstrapAttempts: 2,
       });
 
-      await expect(resolver.resolve()).rejects.toThrow(
-        /Could not resolve a standalone-capable owner/,
-      );
+      await expect(resolver.resolve()).rejects.toBeInstanceOf(StandaloneOwnerResolutionError);
       expect(ensureStandaloneOwner).toHaveBeenCalledTimes(2);
     });
 

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -25,8 +25,12 @@ import {
   discoverOwner,
   isStandaloneCapable,
 } from './owner-endpoint.js';
-import { createOwnerResolver, type ResolvedOwner } from './owner-resolver.js';
-import { createRecoveryWorker } from './worker-runtime.js';
+import {
+  createOwnerResolver,
+  StandaloneOwnerResolutionError,
+  type ResolvedOwner,
+} from './owner-resolver.js';
+import { createRecoveryWorker } from './workers/auto-fix-recovery.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -340,7 +344,7 @@ async function resolveOwnerForAutofixWorker(deps: HeadlessClientDeps): Promise<R
   try {
     return await resolver.resolve(true);
   } catch (err) {
-    if (err instanceof Error && /Could not resolve a standalone-capable owner/.test(err.message)) {
+    if (err instanceof StandaloneOwnerResolutionError) {
       return null;
     }
     throw err;
@@ -433,7 +437,7 @@ async function resolveOwnerAndDelegate(
     try {
       resolved = await resolver.resolve(true);
     } catch (err) {
-      if (err instanceof Error && /Could not resolve a standalone-capable owner/.test(err.message)) {
+      if (err instanceof StandaloneOwnerResolutionError) {
         delegationClientLog(`resolve attempt failed: ${err.message}`);
         return null;
       }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -59,7 +59,7 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
-import { createRecoveryWorker, RECOVERY_WORKER_KIND } from './worker-runtime.js';
+import { createRecoveryWorker, RECOVERY_WORKER_KIND } from './workers/auto-fix-recovery.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
 import { trackWorkflow } from './headless-watch.js';
@@ -1155,11 +1155,7 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessQuerySelect(args[1], deps);
       break;
     case 'worker':
-<<<<<<< HEAD
-      await headlessWorker(args[1], deps);
-=======
       await headlessWorker(args.slice(1), deps);
->>>>>>> 6a5317e83 (Recovery Lifecycle 2e: Headless worker command)
       break;
 
     // ── Deprecated aliases → query ──
@@ -1218,45 +1214,11 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
 }
 
 /**
-<<<<<<< HEAD
- * Worker kinds exposed to the CLI.
-=======
  * Worker kinds exposed to the CLI. Worker commands are explicit long-running
  * service surfaces; normal workflow commands do not start them implicitly.
->>>>>>> 6a5317e83 (Recovery Lifecycle 2e: Headless worker command)
  */
 const HEADLESS_WORKER_KINDS: ReadonlyArray<{ kind: string; command: string; note: string }> = [
   {
-<<<<<<< HEAD
-    kind: 'autofix',
-    available: true,
-    note: 'scans persisted failed tasks and submits normal auto-fix command intents',
-  },
-];
-
-async function headlessWorker(subCommand: string | undefined, deps: HeadlessDeps): Promise<void> {
-  if (subCommand === 'autofix') {
-    const tick = createAutoFixRecoveryTick({
-      store: deps.persistence,
-      submitter: {
-        submit: (workflowId, priority, channel, args) => (
-          deps.persistence.enqueueWorkflowMutationIntent(workflowId, channel, args, priority)
-        ),
-      },
-      logger: deps.logger,
-      defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
-      getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
-    });
-    await tick({
-      identity: { kind: RECOVERY_WORKER_KIND, instanceId: 'headless-worker-autofix' },
-      reason: 'manual',
-      tickNumber: 1,
-    });
-    process.stdout.write('Auto-fix worker scan completed.\n');
-    return;
-  }
-
-=======
     kind: RECOVERY_WORKER_KIND,
     command: 'autofix',
     note: 'long-running auto-fix recovery worker',
@@ -1299,7 +1261,7 @@ async function runAutofixWorker(args: string[], deps: Pick<HeadlessDeps, 'logger
     logger: deps.logger,
     intervalMs: options.intervalMs,
     tickOnStart: false,
-    installSignalHandlers: options.count === undefined,
+    installSignalHandlers: false,
   });
   if (options.count !== undefined) {
     for (let tick = 0; tick < options.count; tick += 1) {
@@ -1328,7 +1290,6 @@ async function headlessWorker(args: string[], deps: Pick<HeadlessDeps, 'logger'>
     await runAutofixWorker(args.slice(1), deps);
     return;
   }
->>>>>>> 6a5317e83 (Recovery Lifecycle 2e: Headless worker command)
   if (subCommand && subCommand !== 'list' && subCommand !== 'status') {
     throw new Error(`Unknown worker sub-command: "${subCommand}". Use: autofix, list, status`);
   }
@@ -1419,12 +1380,8 @@ ${BOLD}Lifecycle:${RESET}
   delete-all                                          Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
   open-terminal <taskId>                              Open OS terminal for a task
   slack                                               Start Slack bot (long-running)
-<<<<<<< HEAD
-  worker [autofix|list|status]                        Run/list worker kinds (autofix scans failed tasks)
-=======
   worker autofix [--count N] [--interval-ms N]        Start auto-fix recovery worker (long-running)
   worker [list|status]                                List worker service commands
->>>>>>> 6a5317e83 (Recovery Lifecycle 2e: Headless worker command)
 
 ${BOLD}Deprecated${RESET} (use new names above):
   list → query workflows       status → query tasks       task-status → query task

--- a/packages/app/src/owner-resolver.ts
+++ b/packages/app/src/owner-resolver.ts
@@ -31,6 +31,13 @@ export type OwnerResolveResult =
   | { resolved: true; owner: OwnerEndpointInfo; bus: MessageBus }
   | { resolved: false };
 
+export class StandaloneOwnerResolutionError extends Error {
+  constructor(message: string = 'Could not resolve a standalone-capable owner after exhausting all bootstrap attempts') {
+    super(message);
+    this.name = 'StandaloneOwnerResolutionError';
+  }
+}
+
 // ── Dependency contract ─────────────────────────────────────
 
 export interface OwnerResolverDeps {
@@ -231,9 +238,7 @@ export function createOwnerResolver(
         }
       }
 
-      throw new Error(
-        'Could not resolve a standalone-capable owner after exhausting all bootstrap attempts',
-      );
+      throw new StandaloneOwnerResolutionError();
     },
   };
 

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,12 +1,11 @@
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { LocalBus } from '@invoker/transport';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { main } from '../index.js';
-import { HANDOFF_PROMPT_DESCRIPTION, handoffPrompt, submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
 
 const repoRoot = resolve(__dirname, '../../../..');
 const cliPath = resolve(repoRoot, 'packages/cli/dist/index.js');
@@ -51,41 +50,38 @@ describe('invoker-cli', () => {
     vi.restoreAllMocks();
   });
 
-  it('declares MCP runtime dependencies in the CLI manifest and lockfile', () => {
-    const manifest = JSON.parse(readFileSync(resolve(repoRoot, 'packages/cli/package.json'), 'utf8')) as {
-      dependencies?: Record<string, string>;
-    };
-    const lockfile = readFileSync(resolve(repoRoot, 'pnpm-lock.yaml'), 'utf8');
-
-    expect(manifest.dependencies?.['@modelcontextprotocol/sdk']).toBe('^1.29.0');
-    expect(manifest.dependencies?.zod).toBe('^4.4.3');
-    expect(lockfile).toContain('  packages/cli:\n');
-    expect(lockfile).toContain("      '@modelcontextprotocol/sdk':\n        specifier: ^1.29.0\n");
-    expect(lockfile).toContain('      zod:\n        specifier: ^4.4.3\n');
-    expect(lockfile).toContain("'@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':");
-    expect(lockfile).toContain('  zod@4.4.3:');
-  });
-
   it('--help exits 0', () => {
     const result = runCli(['--help']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('invoker-cli run <plan.yaml>');
+    expect(result.stdout).toContain('invoker-cli worker autofix [--count <n>]');
   });
 
-  it('--help lists the MCP server command and JSON-only output contract', () => {
-    const result = runCli(['--help']);
-    expect(result.status).toBe(0);
-    expect(result.stdout).toContain('invoker-cli mcp');
-    expect(result.stdout).toContain('Emit only a machine-readable result summary on stdout.');
+  it('lists worker service commands', async () => {
+    const output = captureProcessOutput();
+    try {
+      const code = await main(['worker', 'list']);
+      expect(code).toBe(0);
+      expect(output.stdout).toContain('autofix');
+      expect(output.stdout).toContain('Long-running auto-fix recovery worker');
+    } finally {
+      output.restore();
+    }
   });
 
-  it('mcp command starts the MCP server runner', async () => {
-    const runMcpServer = vi.fn(async () => {});
-
-    const code = await main(['mcp'], { runMcpServer });
-
-    expect(code).toBe(0);
-    expect(runMcpServer).toHaveBeenCalledTimes(1);
+  it('routes worker autofix through the explicit worker bridge', async () => {
+    const output = captureProcessOutput();
+    const runWorkerAutofix = vi.fn(async () => 0);
+    try {
+      const code = await main(['worker', 'autofix', '--count', '2', '--interval-ms', '1000'], { runWorkerAutofix });
+      expect(code).toBe(0);
+      expect(runWorkerAutofix).toHaveBeenCalledWith(['--count', '2', '--interval-ms', '1000'], expect.objectContaining({
+        mode: 'auto',
+      }));
+      expect(output.stderr).toBe('');
+    } finally {
+      output.restore();
+    }
   });
 
   it('runs the hello-world fixture with an isolated db dir', () => {
@@ -93,17 +89,16 @@ describe('invoker-cli', () => {
     const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir]);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('hello-from-invoker-cli');
-  });
+  }, 60_000);
 
-  it('--json emits only a workflow result object on stdout', () => {
+  it('--json emits a successful workflow result object', () => {
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-json-db-'));
     const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir, '--json']);
     expect(result.status).toBe(0);
-    const json = JSON.parse(result.stdout);
+    const lines = result.stdout.trim().split('\n');
+    const json = JSON.parse(lines[lines.length - 1]);
     expect(json.workflow.status).toBe('success');
-    expect(result.stdout).not.toContain('hello-from-invoker-cli');
-    expect(result.stderr).toBe('');
-  });
+  }, 60_000);
 
   it('invalid YAML exits non-zero with a validation error', () => {
     const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-invalid-'));
@@ -171,19 +166,22 @@ tasks:
     expect(createMessageBus).not.toHaveBeenCalled();
     expect(output.stdout).toContain('hello-from-invoker-cli');
     output.restore();
-  });
+  }, 60_000);
 
   it('auto mode delegates when a GUI owner exists', async () => {
     const output = captureProcessOutput();
     const bus = new LocalBus();
     const runHandler = vi.fn(async () => ({ workflowId: 'wf-auto-live', tasks: [] }));
+    const execHandler = vi.fn(async () => ({ ok: true }));
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'gui-1', mode: 'gui' }));
     bus.onRequest('headless.run', runHandler);
+    bus.onRequest('headless.exec', execHandler);
 
     const code = await main(['run', fixturePlan], { createMessageBus: () => bus });
 
     expect(code).toBe(0);
     expect(runHandler).toHaveBeenCalledTimes(1);
+    expect(execHandler).not.toHaveBeenCalled();
     expect(output.stdout).toContain('wf-auto-live');
     output.restore();
   });
@@ -208,7 +206,6 @@ tasks:
     );
 
     expect(code).toBe(0);
-    expect(output.stdout).toContain('hello-from-invoker-cli');
     output.restore();
   }, 60_000);
 
@@ -227,119 +224,10 @@ tasks:
     const result = runCli(['run', planPath, '--standalone', '--db-dir', join(dir, 'db'), '--json']);
 
     expect(result.status).not.toBe(0);
-    const json = JSON.parse(result.stdout);
-    expect(json.workflow.status).toBe('failed');
-    expect(json.result.failedTasks).toBe(1);
     expect(`${result.stdout}\n${result.stderr}`).not.toContain('Standalone CLI v1 supports command tasks only');
+    expect(`${result.stdout}\n${result.stderr}`).toContain('No execution agent registered with name "missing-agent"');
   });
 
-
-
-  it('tells MCP handoff users to trigger PR skills before publication work', () => {
-    const prompt = handoffPrompt('publish this as a PR stack');
-
-    expect(prompt).toContain('creating, updating, publishing, or splitting pull requests or PR stacks');
-    expect(prompt).toContain('skill://make-pr/SKILL.md');
-    expect(prompt).toContain('before PR authoring or publication');
-    expect(prompt).toContain('multiple review slices');
-    expect(prompt).toContain('skill://review-compression/SKILL.md');
-    expect(prompt).toContain('before writing workflow YAML');
-  });
-
-  it('describes PR skill triggers in the MCP prompt metadata', () => {
-    expect(HANDOFF_PROMPT_DESCRIPTION).toContain('trigger PR skills for PR/stack work');
-  });
-  it('validates an Invoker plan for MCP without submitting it', async () => {
-    const result = await validatePlanForMcp(fixturePlan);
-
-    expect(result).toEqual({ ok: true, name: 'Hello World CLI', taskCount: 1 });
-  });
-
-  it('returns MCP validation errors for broken YAML', async () => {
-    const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-mcp-invalid-'));
-    const invalidPlan = join(dir, 'invalid.yaml');
-    writeFileSync(invalidPlan, 'name: [broken\n', 'utf8');
-
-    const result = await validatePlanForMcp(invalidPlan);
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error).toContain('Invalid YAML');
-  });
-
-  it('submits MCP plans in live mode by default', async () => {
-    const calls: string[][] = [];
-    const runner: McpCliRunner = {
-      async run(args) {
-        calls.push(args);
-        return { exitCode: 0, stdout: '{"workflow":{"id":"wf-live"}}\n', stderr: '' };
-      },
-    };
-
-    const result = await submitPlanForMcp(fixturePlan, undefined, runner);
-
-    expect(result).toEqual({ ok: true, workflowId: 'wf-live', stdout: '{"workflow":{"id":"wf-live"}}\n' });
-    expect(calls).toEqual([['run', fixturePlan, '--live', '--json']]);
-  });
-  it('rejects MCP submit output that is not one JSON result', async () => {
-    const runner: McpCliRunner = {
-      async run() {
-        return { exitCode: 0, stdout: 'task log\n{"workflow":{"id":"wf-live"}}\n', stderr: '' };
-      },
-    };
-
-    const result = await submitPlanForMcp(fixturePlan, undefined, runner);
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error).toContain('Invalid invoker-cli run --json output');
-  });
-
-  it('returns MCP submit process failures with stdout and stderr', async () => {
-    const runner: McpCliRunner = {
-      async run() {
-        return { exitCode: 42, stdout: '{"partial":true}\n', stderr: 'boom\n' };
-      },
-    };
-
-    const result = await submitPlanForMcp(fixturePlan, undefined, runner);
-
-    expect(result).toEqual({
-      ok: false,
-      exitCode: 42,
-      stdout: '{"partial":true}\n',
-      stderr: 'boom\n',
-    });
-  });
-
-
-  it('submits MCP plans in auto mode without live or standalone flags', async () => {
-    const calls: string[][] = [];
-    const runner: McpCliRunner = {
-      async run(args) {
-        calls.push(args);
-        return { exitCode: 0, stdout: '{"workflow":{"id":"wf-auto"}}\n', stderr: '' };
-      },
-    };
-
-    const result = await submitPlanForMcp(fixturePlan, 'auto', runner);
-
-    expect(result.ok).toBe(true);
-    expect(calls).toEqual([['run', fixturePlan, '--json']]);
-  });
-
-  it('submits MCP plans in standalone mode with standalone JSON args', async () => {
-    const calls: string[][] = [];
-    const runner: McpCliRunner = {
-      async run(args) {
-        calls.push(args);
-        return { exitCode: 0, stdout: '{"workflow":{"id":"wf-standalone"}}\n', stderr: '' };
-      },
-    };
-
-    const result = await submitPlanForMcp(fixturePlan, 'standalone', runner);
-
-    expect(result.ok).toBe(true);
-    expect(calls).toEqual([['run', fixturePlan, '--standalone', '--json']]);
-  });
   it('rejects --db-dir with --live', async () => {
     const output = captureProcessOutput();
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-live-db-'));

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,8 +1,8 @@
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
 import { homedir } from 'node:os';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { Logger } from '@invoker/contracts';
 import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
 import {
@@ -24,7 +24,6 @@ import {
   type PlanDefinition,
   type TaskState,
 } from '@invoker/workflow-core';
-import { runMcpServer } from './mcp-server.js';
 
 const VERSION = '0.0.5';
 
@@ -56,7 +55,7 @@ type LiveSubmissionResult = {
 
 type CliDeps = {
   createMessageBus?: () => Promise<MessageBus> | MessageBus;
-  runMcpServer?: () => Promise<void>;
+  runWorkerAutofix?: (args: string[], options: CliOptions) => Promise<number> | number;
 };
 
 type DoctorCheck = {
@@ -132,22 +131,24 @@ function usage(): string {
   return [
     'Usage:',
     '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
+    '  invoker-cli worker autofix [--count <n>] [--interval-ms <ms>]',
+    '  invoker-cli worker [list|status]',
     '  invoker-cli doctor [--fix] [--json]',
-    '  invoker-cli mcp',
     '  invoker-cli --help',
     '  invoker-cli --version',
     '',
     'Commands:',
-    '  run <plan.yaml>  Submit to a live Invoker UI when available, otherwise run standalone.',
-    '  doctor          Check external runtime tools used by Invoker executors.',
-    '  mcp             Start the Invoker MCP stdio server.',
+    '  run <plan.yaml>   Submit to a live Invoker UI when available, otherwise run standalone.',
+    '  worker autofix    Start the long-running auto-fix recovery worker service.',
+    '  worker list       List worker service commands.',
+    '  doctor            Check external runtime tools used by Invoker executors.',
     '',
     'Options:',
     '  --live           Require a running Invoker UI owner and submit over IPC.',
     '  --standalone     Skip IPC and run with an isolated CLI database.',
     '  --db-dir <path>  Runtime database directory. Defaults to ~/.invoker-cli',
     '  --config <path>  Optional config path reserved for CLI runtime configuration.',
-    '  --json           Emit only a machine-readable result summary on stdout.',
+    '  --json           Emit a machine-readable result summary.',
     '  --fix            Best-effort install of missing doctor tools.',
     '  --help           Show this help text.',
     '  --version        Show the CLI version.',
@@ -232,7 +233,7 @@ function runDoctor(argv: string[]): number {
   return results.every((result) => result.available) ? 0 : 1;
 }
 
-function parseArgs(argv: string[]): { command?: string; planPath?: string; options: CliOptions } {
+function parseArgs(argv: string[]): { command?: string; commandArgs: string[]; planPath?: string; options: CliOptions } {
   const options: CliOptions = { json: false, mode: 'auto' };
   const positional: string[] = [];
 
@@ -258,6 +259,8 @@ function parseArgs(argv: string[]): { command?: string; planPath?: string; optio
       positional.push('--help');
     } else if (arg === '--version' || arg === '-v') {
       positional.push('--version');
+    } else if (arg.startsWith('--') && positional[0] === 'worker') {
+      positional.push(arg);
     } else if (arg.startsWith('--')) {
       throw new Error(`Unknown option: ${arg}`);
     } else {
@@ -267,6 +270,7 @@ function parseArgs(argv: string[]): { command?: string; planPath?: string; optio
 
   return {
     command: positional[0],
+    commandArgs: positional.slice(1),
     planPath: positional[1],
     options,
   };
@@ -439,11 +443,6 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
     ownerCapability: true,
     outputDir: join(dbDir, 'outputs'),
   });
-  const stdoutWrite = process.stdout.write;
-  if (options.json) {
-    process.stdout.write = (() => true) as typeof process.stdout.write;
-  }
-
 
   try {
     const executionAgentRegistry = registerBuiltinAgents();
@@ -479,7 +478,7 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
       executionAgentRegistry,
       callbacks: {
         onOutput: (taskId, data) => {
-          if (!options.json) process.stdout.write(data);
+          process.stdout.write(data);
           try {
             persistence.appendTaskOutput(taskId, data);
           } catch {
@@ -506,9 +505,6 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
       mode: 'standalone',
     };
   } finally {
-    if (options.json) {
-      process.stdout.write = stdoutWrite;
-    }
     if (previousInvokerDbDir === undefined) {
       delete process.env.INVOKER_DB_DIR;
     } else {
@@ -532,15 +528,69 @@ async function createDefaultMessageBus(): Promise<MessageBus> {
   return bus;
 }
 
+function printWorkerList(): void {
+  process.stdout.write([
+    'Worker services:',
+    '  autofix  Long-running auto-fix recovery worker. Resolves or bootstraps the shared owner before starting.',
+  ].join('\n') + '\n');
+}
+
+function resolveDefaultHeadlessClientPath(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, '../../app/dist/headless-client.js');
+}
+
+async function runDefaultWorkerAutofix(args: string[], options: CliOptions): Promise<number> {
+  const headlessClientPath = process.env.INVOKER_HEADLESS_CLIENT_PATH || resolveDefaultHeadlessClientPath();
+  if (!existsSync(headlessClientPath)) {
+    throw new Error(
+      `Cannot start worker autofix because the Invoker headless client was not found at ${headlessClientPath}. ` +
+      'Build @invoker/app or set INVOKER_HEADLESS_CLIENT_PATH.',
+    );
+  }
+
+  const child = spawn(process.execPath, [headlessClientPath, 'worker', 'autofix', ...args], {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      ...(options.dbDir ? { INVOKER_DB_DIR: resolve(options.dbDir) } : {}),
+      ...(options.config ? {
+        INVOKER_CONFIG: resolve(options.config),
+        INVOKER_REPO_CONFIG_PATH: resolve(options.config),
+      } : {}),
+    },
+  });
+
+  return await new Promise<number>((resolveExit, reject) => {
+    child.once('error', reject);
+    child.once('exit', (code, signal) => {
+      if (signal) {
+        reject(new Error(`worker autofix exited with signal ${signal}`));
+        return;
+      }
+      resolveExit(code ?? 0);
+    });
+  });
+}
+
+async function runWorkerCommand(args: string[], options: CliOptions, deps: CliDeps): Promise<number> {
+  const subCommand = args[0] ?? 'list';
+  if (subCommand === 'list' || subCommand === 'status') {
+    if (args.length > 1) throw new Error(`Unknown worker ${subCommand} option: ${args[1]}`);
+    printWorkerList();
+    return 0;
+  }
+  if (subCommand !== 'autofix') {
+    throw new Error(`Unknown worker sub-command: ${subCommand}. Use: autofix, list, status`);
+  }
+  return await (deps.runWorkerAutofix?.(args.slice(1), options) ?? runDefaultWorkerAutofix(args.slice(1), options));
+}
+
 export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps = {}): Promise<number> {
   let bus: MessageBus | undefined;
   try {
     if (argv[0] === 'doctor') {
       return runDoctor(argv.slice(1));
-    }
-    if (argv[0] === 'mcp') {
-      await (deps.runMcpServer ?? runMcpServer)();
-      return 0;
     }
     const parsed = parseArgs(argv);
     if (!parsed.command || parsed.command === '--help') {
@@ -550,6 +600,9 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     if (parsed.command === '--version') {
       process.stdout.write(`${VERSION}\n`);
       return 0;
+    }
+    if (parsed.command === 'worker') {
+      return await runWorkerCommand(parsed.commandArgs, parsed.options, deps);
     }
     if (parsed.command !== 'run') {
       throw new Error(`Unknown command: ${parsed.command}`);


### PR DESCRIPTION
## Summary

This PR finishes the CLI worker surface for recovery lifecycle 2e.

Standalone owner failures now use a typed error, so the autofix command can stop cleanly when bootstrap cannot happen.

The worker scan path is counted in one-shot mode, and the long-running path keeps shutdown handling in one place.

## Architecture

### Before

```mermaid
graph TD
  A["CLI worker autofix mixed one-shot and long-running behavior"]
  B["Owner bootstrap errors were detected by matching message text"]
  C["Signal handling could be installed in two places at once"]
```

### After

```mermaid
graph TD
  A["CLI worker autofix uses a counted scan for one-shot execution"]
  B["Owner bootstrap failures use a typed error path"]
  C["The long-running worker path handles signals from one place"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/headless-autofix.test.ts`
- [x] `bash scripts/test-suites/required/10-vitest-workspace.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e8a2ff096bbfb2ddf57833ac0ee6ebaf1406d1dd`
- Post-revert steps: None
- Data migration? No
