### PR TITLE
Record workflow task graph divergence proof

### DIFF
--- a/packages/ui/src/__tests__/workflow-task-graph-status-divergence-repro.test.tsx
+++ b/packages/ui/src/__tests__/workflow-task-graph-status-divergence-repro.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Repro: a workflow label can show a failed WorkflowMeta.status while its
+ * selected task-graph node still shows a RUNNING TaskState.status.
+ *
+ * The two come from separate renderer channels:
+ *   - Workflow node labels read WorkflowMeta.status.
+ *   - Selected mini-DAG task nodes read TaskState.status.
+ *   - workflow-rollup returns 'failed' as soon as any task is failed, even when
+ *     another task is still running.
+ *   - Workflow metadata (onWorkflowsChanged) can arrive after the task deltas
+ *     that move a task back to running, so the label lags the task graph.
+ *
+ * This test preserves the divergence — it does not assert any product fix.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, act, waitFor, fireEvent, within } from '@testing-library/react';
+import { computeWorkflowRollupFromSummaries } from '@invoker/workflow-graph';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { TaskState, WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+/** Build WorkflowMeta whose status/rollup come from the real workflow rollup. */
+function workflowMetaFromTasks(
+  tasks: TaskState[],
+  name = 'Divergence Proof Workflow',
+): WorkflowMeta {
+  const rollup = computeWorkflowRollupFromSummaries(
+    tasks.map((task) => ({
+      id: task.id,
+      description: task.description,
+      status: task.status,
+      dependencies: task.dependencies,
+      execution: task.execution,
+    })),
+  );
+
+  return {
+    id: 'wf-diverge',
+    name,
+    status: rollup.status,
+    rollup,
+    baseBranch: 'main',
+  };
+}
+
+/** Render App, push a snapshot, select the workflow, return its mini-DAG. */
+async function renderWorkflow(
+  mock: MockInvoker,
+  tasks: TaskState[],
+  workflows: WorkflowMeta[],
+): Promise<HTMLElement> {
+  render(<App />);
+  act(() => mock.setTasks(tasks, workflows));
+
+  await waitFor(() => {
+    expect(screen.getByTestId('workflow-node-wf-diverge')).toBeInTheDocument();
+  });
+
+  fireEvent.click(screen.getByTestId('workflow-node-wf-diverge'));
+
+  return screen.findByTestId('selected-workflow-mini-dag');
+}
+
+describe('workflow / task-graph status divergence', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('shows a failed workflow beside a running task when the real rollup has both statuses', async () => {
+    const runningTask = makeUITask({
+      id: 'wf-diverge/running-task',
+      description: 'Still running task',
+      status: 'running',
+      workflowId: 'wf-diverge',
+      execution: { phase: 'executing' },
+      taskStateVersion: 1,
+    });
+    const failedTask = makeUITask({
+      id: 'wf-diverge/failed-task',
+      description: 'Already failed task',
+      status: 'failed',
+      workflowId: 'wf-diverge',
+      taskStateVersion: 1,
+    });
+
+    const workflow = workflowMetaFromTasks([runningTask, failedTask]);
+    expect(workflow.status).toBe('failed');
+
+    const miniDag = await renderWorkflow(mock, [runningTask, failedTask], [workflow]);
+
+    expect(screen.getByTestId('workflow-node-wf-diverge')).toHaveTextContent('failed');
+
+    await waitFor(() => {
+      expect(miniDag).toHaveTextContent('Still running task');
+      expect(miniDag).toHaveTextContent('RUNNING · EXECUTING');
+      expect(miniDag).toHaveTextContent('Already failed task');
+      expect(miniDag).toHaveTextContent('FAILED');
+    });
+  });
+
+  it('keeps the workflow label on older metadata until the workflow metadata channel catches up', async () => {
+    const failedTask = makeUITask({
+      id: 'wf-diverge/task-a',
+      description: 'Task that restarts',
+      status: 'failed',
+      workflowId: 'wf-diverge',
+      taskStateVersion: 1,
+    });
+
+    const failedWorkflow = workflowMetaFromTasks([failedTask]);
+    const miniDag = await renderWorkflow(mock, [failedTask], [failedWorkflow]);
+
+    expect(screen.getByTestId('workflow-node-wf-diverge')).toHaveTextContent('failed');
+    await waitFor(() => {
+      expect(miniDag).toHaveTextContent('FAILED');
+    });
+
+    // Task delta restarts the task — the task graph updates ahead of metadata.
+    act(() =>
+      mock.fireDelta({
+        type: 'updated',
+        taskId: 'wf-diverge/task-a',
+        changes: { status: 'running', execution: { phase: 'executing' } },
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
+        streamSequence: 1,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(miniDag).toHaveTextContent('RUNNING · EXECUTING');
+    });
+
+    // Label still reads the older failed metadata: separate renderer channels.
+    expect(screen.getByTestId('workflow-node-wf-diverge')).toHaveTextContent('failed');
+
+    const runningTask: TaskState = {
+      ...failedTask,
+      status: 'running',
+      execution: { phase: 'executing' },
+      taskStateVersion: 2,
+    };
+    const runningWorkflow = workflowMetaFromTasks([runningTask]);
+    expect(runningWorkflow.status).toBe('running');
+
+    act(() => mock.fireWorkflowsChanged([runningWorkflow]));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-diverge')).toHaveTextContent('running');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused UI repro test for the workflow label and selected task graph showing divergent statuses.

The repro targets the workflow-status stack that introduced the split: [#1800](https://github.com/Neko-Catpital-Labs/Invoker/pull/1800), [#1805](https://github.com/Neko-Catpital-Labs/Invoker/pull/1805), [#1806](https://github.com/Neko-Catpital-Labs/Invoker/pull/1806), and [#1807](https://github.com/Neko-Catpital-Labs/Invoker/pull/1807).

Records the proof summary under repro artifacts so the cause is easy to find without changing product behavior.

<details>
<summary>Review metadata</summary>

Review Claim: This PR captures the workflow/task graph status divergence as executable proof and a short repro note.

Review Lane: proof

Review Unit: proof

Safety Invariant: The slice adds only a repro test and proof artifact; it does not change runtime code.

Slice Rationale: Keeping the repro separate lets a later behavior fix cite this proof without mixing diagnosis and repair.

</details>

## Non-goals

No product behavior change.

No workflow status repair.

No renderer channel refactor.

## Test Plan

- [x] `pnpm install`
- [x] `pnpm --filter @invoker/ui test -- workflow-task-graph-status-divergence-repro.test.tsx`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/invoker-workflow-task-graph-divergence-pr.md --require-visual-proof`

## Visual Proof

No screenshot is required for this test-only UI proof; product rendering is unchanged.

[Walkthrough repro test](https://github.com/Neko-Catpital-Labs/Invoker/blob/pr/workflow-task-graph-divergence-proof/packages/ui/src/__tests__/workflow-task-graph-status-divergence-repro.test.tsx)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 842ad98a2`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test suite for workflow and task status synchronization to ensure the UI accurately reflects status changes when workflow and task updates occur asynchronously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->