### PR TITLE
Declare @mergifyio/vitest in @invoker/ui to fix run.sh build

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -21,6 +21,7 @@
     "xterm-addon-fit": "^0.8.0"
   },
   "devDependencies": {
+    "@mergifyio/vitest": "^0.3.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.0.0",
     "@types/js-yaml": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,6 +500,9 @@ importers:
         specifier: ^0.8.0
         version: 0.8.0(xterm@5.3.0)
     devDependencies:
+      '@mergifyio/vitest':
+        specifier: ^0.3.0
+        version: 0.3.0(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@1.21.7)(jsdom@25.0.1)(yaml@2.8.2))
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -4986,6 +4989,13 @@ snapshots:
       '@opentelemetry/exporter-trace-otlp-proto': 0.218.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+
+  '@mergifyio/vitest@0.3.0(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@1.21.7)(jsdom@25.0.1)(yaml@2.8.2))':
+    dependencies:
+      '@mergifyio/ci-core': 0.3.0
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@1.21.7)(jsdom@25.0.1)(yaml@2.8.2)
 
   '@mergifyio/vitest@0.3.0(vitest@3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2))':
     dependencies:


### PR DESCRIPTION
## Summary

`./run.sh` failed locally with `ERR_MODULE_NOT_FOUND: Cannot find package '@mergifyio/vitest'` during the `@invoker/ui` build.

`packages/ui/vite.config.ts` imports `@mergifyio/vitest` for its Vitest reporter, but the package was only declared in the root `package.json`, not in `packages/ui/package.json`.

Vite loads `vite.config.ts` at the top level during `vite build`, so the import must resolve. It only resolved by walking up to the root `node_modules` — a phantom dependency.

CI passed because it runs a clean `pnpm install --frozen-lockfile`, after which the root devDependency is reachable from the subpackage.

It broke locally because `run.sh`'s bootstrap guard skips reinstall when build artifacts already exist, leaving stale `node_modules` that predated the root dependency.

This declares `@mergifyio/vitest` as a devDependency of `@invoker/ui` so the package owns what it imports and the build no longer relies on hoisting.

<details>
<summary>Review metadata</summary>

Review Claim: `@invoker/ui` now declares the `@mergifyio/vitest` package it imports in `vite.config.ts`, fixing the `run.sh` build.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Adds one devDependency already pinned in the lockfile at the same version used at root. No source, config behavior, or test settings change.

Slice Rationale: The UI package is the only Vitest config outside the shared root config, so its missing dependency declaration is fixed on its own.

</details>

## Non-goals

- No change to UI source, test globals, environment, or setup files.
- No change to `run.sh` or its bootstrap guard.
- No new reporter behavior; the reporter was already wired.

## Test Plan

- [ ] `pnpm install --frozen-lockfile`
- [ ] `pnpm --filter @invoker/ui build`
- [ ] `./run.sh --headless query workflows`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: run `pnpm install --frozen-lockfile`
- Data migration? No
