### PR TITLE
Reject whitespace-only review-gate artifact ids

### DIFF
--- a/packages/contracts/src/__tests__/repro-review-gate-validation-guards.test.ts
+++ b/packages/contracts/src/__tests__/repro-review-gate-validation-guards.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+
+import { validateWorkResponse } from '../validation.js';
+
+// Repro guards for the #1757 bug class as it occurs in the CORE contract validator
+// (sibling of the make-pr stack validator in execution-engine/pr-authoring.ts).
+//
+// Class: identifier fields were validated with `.length === 0`, so a
+// whitespace-only id / dependency ("   ") passed validation and could be
+// persisted as a blank identifier, causing downstream identifier mismatches.
+// Fixed by validating trimmed content (`.trim().length === 0`).
+
+interface ReviewArtifact {
+  id: string;
+  title: string;
+  required: boolean;
+  status: string;
+  generation: number;
+  dependsOn?: string[];
+}
+
+function workResponseWithArtifacts(artifacts: ReviewArtifact[]): unknown {
+  return {
+    requestId: 'req-1',
+    actionId: 'task-1',
+    executionGeneration: 0,
+    status: 'completed',
+    outputs: {
+      exitCode: 0,
+      reviewGate: {
+        activeGeneration: 1,
+        completion: { required: 'all', status: 'approved' },
+        artifacts,
+      },
+    },
+  };
+}
+
+describe('repro #1757 (contracts): review-gate artifact identifier validation', () => {
+  it('rejects a whitespace-only artifact id (was accepted via .length === 0)', () => {
+    const result = validateWorkResponse(workResponseWithArtifacts([
+      { id: '   ', title: 'Blank', required: true, status: 'open', generation: 1 },
+    ]));
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('outputs.reviewGate.artifacts[0].id must be a non-empty string');
+  });
+
+  it('rejects a whitespace-only dependency (was accepted via .length === 0)', () => {
+    const result = validateWorkResponse(workResponseWithArtifacts([
+      { id: 'a', title: 'A', required: true, status: 'approved', generation: 1 },
+      { id: 'b', title: 'B', required: true, status: 'open', generation: 1, dependsOn: ['   '] },
+    ]));
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('dependsOn must contain non-empty artifact ids');
+  });
+
+  it('still accepts a well-formed two-artifact stack (no false positives)', () => {
+    const result = validateWorkResponse(workResponseWithArtifacts([
+      { id: 'a', title: 'A', required: true, status: 'approved', generation: 1 },
+      { id: 'b', title: 'B', required: true, status: 'open', generation: 1, dependsOn: ['a'] },
+    ]));
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -117,7 +117,7 @@ function validateReviewGateArtifacts(args: {
 
     const record = artifact as Record<string, unknown>;
     artifactRecords.push(record);
-    if (typeof record.id !== 'string' || record.id.length === 0) {
+    if (typeof record.id !== 'string' || record.id.trim().length === 0) {
       return { valid: false, error: `${artifactPrefix}.id must be a non-empty string` };
     }
     if (ids.has(record.id)) {
@@ -184,7 +184,7 @@ function validateReviewGate(reviewGate: unknown): ValidationResult {
     const dependsOn = (record.dependsOn ?? []) as unknown[];
     const artifactDependencies: string[] = [];
     for (const dependency of dependsOn) {
-      if (typeof dependency !== 'string' || dependency.length === 0) {
+      if (typeof dependency !== 'string' || dependency.trim().length === 0) {
         return { valid: false, error: `${artifactPrefix}.dependsOn must contain non-empty artifact ids` };
       }
       if (!ids.has(dependency)) {


### PR DESCRIPTION
## Summary

The shared request/response schema accepted blank artifact identifiers: a whitespace-only id passed the non-empty check and could be stored as a blank identifier.

It now requires non-empty trimmed identifiers, matching the make-pr stack parser hardened in #1757.

A real-code guard exercises the schema through its public entry point.

<details>
<summary>Review metadata</summary>

Review Claim: Require non-empty trimmed review-gate artifact identifiers in the shared schema.

Review Lane: behavior

Review Unit: contract

Safety Invariant: Pure input-tightening on one schema check plus a guard; the existing contract suite still passes.

Slice Rationale: One schema change with its guard; the same-class runtime fix is the next PR in the stack.

</details>

## Non-goals

No change to runtime poll/approval flow or storage. `packages/contracts/src/validation.ts` is the only production file; the new test exercises `validateWorkResponse`.

## Test Plan

- [ ] `pnpm --filter @invoker/contracts exec vitest run`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation for review-gate artifacts to properly reject whitespace-only values in artifact identifiers and dependency references, preventing invalid configurations from being accepted.

* **Tests**
  * Added regression test suite for review-gate validator to ensure whitespace-only inputs are correctly rejected while valid dependency chains remain accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->