### PR TITLE
Repro guards for review-gate logic findings

### DIFF
--- a/packages/contracts/src/__tests__/repro-review-gate-validation-guards.test.ts
+++ b/packages/contracts/src/__tests__/repro-review-gate-validation-guards.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+
+import { validateWorkResponse } from '../validation.js';
+
+// Repro guards for the #1757 bug class as it occurs in the CORE contract validator
+// (sibling of the make-pr stack validator in execution-engine/pr-authoring.ts).
+//
+// Class: identifier fields were validated with `.length === 0`, so a
+// whitespace-only id / dependency ("   ") passed validation and could be
+// persisted as a blank identifier, causing downstream identifier mismatches.
+// Fixed by validating trimmed content (`.trim().length === 0`).
+
+interface ReviewArtifact {
+  id: string;
+  title: string;
+  required: boolean;
+  status: string;
+  generation: number;
+  dependsOn?: string[];
+}
+
+function workResponseWithArtifacts(artifacts: ReviewArtifact[]): unknown {
+  return {
+    requestId: 'req-1',
+    actionId: 'task-1',
+    executionGeneration: 0,
+    status: 'completed',
+    outputs: {
+      exitCode: 0,
+      reviewGate: {
+        activeGeneration: 1,
+        completion: { required: 'all', status: 'approved' },
+        artifacts,
+      },
+    },
+  };
+}
+
+describe('repro #1757 (contracts): review-gate artifact identifier validation', () => {
+  it('rejects a whitespace-only artifact id (was accepted via .length === 0)', () => {
+    const result = validateWorkResponse(workResponseWithArtifacts([
+      { id: '   ', title: 'Blank', required: true, status: 'open', generation: 1 },
+    ]));
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('outputs.reviewGate.artifacts[0].id must be a non-empty string');
+  });
+
+  it('rejects a whitespace-only dependency (was accepted via .length === 0)', () => {
+    const result = validateWorkResponse(workResponseWithArtifacts([
+      { id: 'a', title: 'A', required: true, status: 'approved', generation: 1 },
+      { id: 'b', title: 'B', required: true, status: 'open', generation: 1, dependsOn: ['   '] },
+    ]));
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('dependsOn must contain non-empty artifact ids');
+  });
+
+  it('still accepts a well-formed two-artifact stack (no false positives)', () => {
+    const result = validateWorkResponse(workResponseWithArtifacts([
+      { id: 'a', title: 'A', required: true, status: 'approved', generation: 1 },
+      { id: 'b', title: 'B', required: true, status: 'open', generation: 1, dependsOn: ['a'] },
+    ]));
+    expect(result.valid).toBe(true);
+  });
+});

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -117,7 +117,7 @@ function validateReviewGateArtifacts(args: {
 
     const record = artifact as Record<string, unknown>;
     artifactRecords.push(record);
-    if (typeof record.id !== 'string' || record.id.length === 0) {
+    if (typeof record.id !== 'string' || record.id.trim().length === 0) {
       return { valid: false, error: `${artifactPrefix}.id must be a non-empty string` };
     }
     if (ids.has(record.id)) {
@@ -184,7 +184,7 @@ function validateReviewGate(reviewGate: unknown): ValidationResult {
     const dependsOn = (record.dependsOn ?? []) as unknown[];
     const artifactDependencies: string[] = [];
     for (const dependency of dependsOn) {
-      if (typeof dependency !== 'string' || dependency.length === 0) {
+      if (typeof dependency !== 'string' || dependency.trim().length === 0) {
         return { valid: false, error: `${artifactPrefix}.dependsOn must contain non-empty artifact ids` };
       }
       if (!ids.has(dependency)) {

--- a/packages/execution-engine/src/__tests__/repro-review-gate-logic-guards.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-review-gate-logic-guards.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest';
+
+import { isInvokerRepoUrl, parseMakePrStackPublishResult } from '../pr-authoring.js';
+import { TaskRunner, type TaskRunnerConfig } from '../task-runner.js';
+import type { TaskState } from '@invoker/workflow-core';
+
+// Real-code repro guards for the review-gate "logic" bugs found while landing the
+// Multi PR Review Gate stack, plus the sibling sites they also occur in.
+//
+//  #1757  isInvokerRepoUrl / parseMakePrStackPublishResult (pr-authoring)
+//  #1811  mapReviewGateArtifactStatus closed-vs-approved precedence (task-runner)
+//  #1865  reviewPollStillMatches stale-write guard (task-runner)
+//  #1811 sibling: pollMergeGateTask scalar (legacy single-PR) path completing a closed PR
+
+// ── helpers ──────────────────────────────────────────────
+
+// Minimal collaborators: the probed methods below are pure / read only their
+// arguments, so unrelated collaborator methods are never invoked.
+function makeRunner(overrides: Partial<TaskRunnerConfig> = {}): TaskRunner {
+  const baseOrchestrator = { getTask: () => undefined };
+  const baseRegistry = { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] };
+  return new TaskRunner({
+    // test stubs: only the fields touched by the probed code paths are populated
+    orchestrator: baseOrchestrator as unknown as TaskRunnerConfig['orchestrator'],
+    persistence: {} as unknown as TaskRunnerConfig['persistence'],
+    executorRegistry: baseRegistry as unknown as TaskRunnerConfig['executorRegistry'],
+    cwd: '/tmp',
+    ...overrides,
+  });
+}
+
+interface ApprovalStatusInput {
+  approved?: boolean;
+  rejected?: boolean;
+  closed?: boolean;
+  statusText?: string;
+}
+
+interface LineageTaskShape {
+  status?: string;
+  execution: { selectedAttemptId?: string; generation?: number; reviewGate?: unknown; reviewId?: string };
+}
+
+// Probe the private methods through a precise structural type (test-only boundary).
+interface ReviewGateProbe {
+  mapReviewGateArtifactStatus(status: ApprovalStatusInput): string;
+  reviewPollStillMatches(before: LineageTaskShape, current: LineageTaskShape | undefined, providerId: string): boolean;
+}
+function probe(runner: TaskRunner): ReviewGateProbe {
+  return runner as unknown as ReviewGateProbe;
+}
+
+// ── #1757: isInvokerRepoUrl ──────────────────────────────
+
+describe('repro #1757: isInvokerRepoUrl accepts valid remote forms', () => {
+  it('accepts a trailing-slash https remote (was rejected -> routed to non-Invoker path)', () => {
+    expect(isInvokerRepoUrl('https://github.com/Neko-Catpital-Labs/Invoker/')).toBe(true);
+  });
+
+  it('still accepts the canonical https / ssh / .git forms', () => {
+    expect(isInvokerRepoUrl('https://github.com/Neko-Catpital-Labs/Invoker')).toBe(true);
+    expect(isInvokerRepoUrl('https://github.com/EdbertChan/Invoker.git')).toBe(true);
+    expect(isInvokerRepoUrl('git@github.com:Neko-Catpital-Labs/Invoker.git')).toBe(true);
+    expect(isInvokerRepoUrl('git@github.com:EdbertChan/Invoker.git/')).toBe(true);
+  });
+
+  it('rejects non-Invoker repos', () => {
+    expect(isInvokerRepoUrl('https://github.com/other/repo')).toBe(false);
+    expect(isInvokerRepoUrl(undefined)).toBe(false);
+  });
+});
+
+// ── #1757: parseMakePrStackPublishResult ─────────────────
+
+describe('repro #1757: parseMakePrStackPublishResult normalizes/validates identifiers', () => {
+  const wrap = (artifacts: unknown[]): string => JSON.stringify({ artifacts });
+
+  it('rejects whitespace-only id / url / dependency', () => {
+    expect(() => parseMakePrStackPublishResult(wrap([{ id: '   ', url: 'u' }])))
+      .toThrow(/id must be a non-empty string/);
+    expect(() => parseMakePrStackPublishResult(wrap([{ id: 'a', url: '   ' }])))
+      .toThrow(/url must be a non-empty string/);
+    expect(() => parseMakePrStackPublishResult(wrap([
+      { id: 'a', url: 'u' },
+      { id: 'b', url: 'u2', dependsOn: ['  '] },
+    ]))).toThrow(/dependsOn must contain non-empty artifact ids/);
+  });
+
+  it('trims padded id / url / dependency before persistence (no blank identifiers leak)', () => {
+    const out = parseMakePrStackPublishResult(wrap([
+      { id: '  a  ', url: '  https://x/1  ' },
+      { id: '  b  ', url: 'https://x/2', dependsOn: ['  a  '] },
+    ]));
+    expect(out[0].id).toBe('a');
+    expect(out[0].url).toBe('https://x/1');
+    expect(out[1].id).toBe('b');
+    expect(out[1].dependsOn).toEqual(['a']);
+  });
+});
+
+// ── #1811: mapReviewGateArtifactStatus ───────────────────
+
+describe('repro #1811: mapReviewGateArtifactStatus gives closed precedence over approved', () => {
+  it('maps a closed-but-approved PR to "closed" (so it cannot complete the gate)', () => {
+    const p = probe(makeRunner());
+    expect(p.mapReviewGateArtifactStatus({ approved: true, rejected: false, closed: true })).toBe('closed');
+  });
+
+  it('preserves the other mappings', () => {
+    const p = probe(makeRunner());
+    expect(p.mapReviewGateArtifactStatus({ approved: true })).toBe('approved');
+    expect(p.mapReviewGateArtifactStatus({ rejected: true })).toBe('changes_requested');
+    expect(p.mapReviewGateArtifactStatus({ closed: true })).toBe('closed');
+    expect(p.mapReviewGateArtifactStatus({})).toBe('open');
+  });
+});
+
+// ── #1865 / #1809: reviewPollStillMatches stale-write guard ──
+
+describe('repro #1865: reviewPollStillMatches blocks writes after the task left approval', () => {
+  const before: LineageTaskShape = {
+    execution: { selectedAttemptId: 'att1', generation: 0, reviewGate: undefined, reviewId: 'pr#1' },
+  };
+
+  it('rejects a late poll when the task has since failed (matching lineage)', () => {
+    const p = probe(makeRunner());
+    const failed: LineageTaskShape = {
+      status: 'failed',
+      execution: { selectedAttemptId: 'att1', generation: 0, reviewGate: undefined, reviewId: 'pr#1' },
+    };
+    expect(p.reviewPollStillMatches(before, failed, 'pr#1')).toBe(false);
+  });
+
+  it('still allows a poll while the task is review_ready', () => {
+    const p = probe(makeRunner());
+    const reviewReady: LineageTaskShape = {
+      status: 'review_ready',
+      execution: { selectedAttemptId: 'att1', generation: 0, reviewGate: undefined, reviewId: 'pr#1' },
+    };
+    expect(p.reviewPollStillMatches(before, reviewReady, 'pr#1')).toBe(true);
+  });
+});
+
+// ── #1811 sibling: scalar (legacy single-PR) poll path ───
+
+describe('repro #1811 sibling: a closed PR must not complete a scalar merge gate', () => {
+  it('does not approve when checkApproval reports approved AND closed', async () => {
+    const task = {
+      id: '__merge__wf-1',
+      description: 'merge gate',
+      status: 'review_ready',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { isMergeNode: true, workflowId: 'wf-1' },
+      execution: { selectedAttemptId: 'att1', generation: 0, reviewId: 'pr#1' },
+    } as unknown as TaskState; // test fixture: only fields read by the poll path are set
+    const tasks = new Map<string, TaskState>([[task.id, task]]);
+
+    let approveCalled = false;
+    const updateCalls: Array<{ id: string; changes: unknown }> = [];
+
+    const orchestrator = {
+      getTask: (id: string) => tasks.get(id),
+      approve: async () => { approveCalled = true; return []; },
+    };
+    const persistence = {
+      updateTask: (id: string, changes: unknown) => { updateCalls.push({ id, changes }); return tasks.get(id); },
+    };
+    const mergeGateProvider = {
+      checkApproval: async () => ({ approved: true, closed: true, rejected: false, statusText: 'Closed (approved)' }),
+    };
+
+    const runner = makeRunner({
+      orchestrator: orchestrator as unknown as TaskRunnerConfig['orchestrator'],
+      persistence: persistence as unknown as TaskRunnerConfig['persistence'],
+      mergeGateProvider: mergeGateProvider as unknown as TaskRunnerConfig['mergeGateProvider'],
+    });
+
+    await runner.checkPrApprovalNow(task.id);
+
+    expect(approveCalled).toBe(false);
+    // the closed status is persisted, not merely that "some" update fired
+    const taskUpdate = updateCalls.find((c) => c.id === task.id);
+    expect(taskUpdate).toBeDefined();
+    expect((taskUpdate!.changes as { status?: string }).status).toBe('closed');
+  });
+});

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -2589,7 +2589,7 @@ export class TaskRunner {
         ...(status.closed ? { status: 'closed' as const } : {}),
         execution: { reviewStatus: status.statusText },
       });
-      if (!approvedGate && status.approved) {
+      if (!approvedGate && status.approved && !status.closed) {
         approvedGate = true;
         await this.handleApprovedMergeGate(task.id, providerId, source);
       } else if (status.rejected) {

--- a/scripts/repro/repro-review-gate-logic-guards.sh
+++ b/scripts/repro/repro-review-gate-logic-guards.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Repro guards for the review-gate "logic" bugs found while landing the
+# Multi PR Review Gate stack (#1757 / #1811 / #1865) and the sibling sites
+# the same bug classes also occur in.
+#
+#   #1757  github remote trailing-slash rejected; whitespace-only / un-normalized
+#          artifact identifiers accepted (pr-authoring AND contracts validation).
+#   #1811  closed-but-approved PR mapped to "approved" -> completes a closed gate
+#          (mapReviewGateArtifactStatus AND the scalar single-PR poll path).
+#   #1865  late/post-approval poll could still write review-gate state.
+#   #1760  plan-validator error index drifted after a skipped invalid artifact.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] contracts: review-gate artifact identifier validation (#1757 sibling)"
+pnpm --filter @invoker/contracts exec vitest run \
+  src/__tests__/repro-review-gate-validation-guards.test.ts
+
+echo "[repro] execution-engine: pr-authoring + status precedence + stale-poll guard (#1757/#1811/#1865)"
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/repro-review-gate-logic-guards.test.ts
+
+echo "[repro] plan validator: error index must track the ORIGINAL artifact index (#1760)"
+plan="$(mktemp "${TMPDIR:-/tmp}/invoker-review-gate-drift.XXXXXX.yaml")"
+trap 'rm -f "$plan"' EXIT
+cat > "$plan" <<'EOF'
+name: drift
+onFinish: none
+mergeMode: manual
+repoUrl: git@github.com:user/repo.git
+tasks:
+  - id: t
+    description: t
+    command: printf 'ok\n'
+    dependencies: []
+reviewGate:
+  artifacts:
+    - title: no-id-here
+      required: true
+    - id: a
+      title: A
+      required: true
+    - id: b
+      title: B
+      required: true
+EOF
+set +e
+out="$(bash skills/plan-to-invoker/scripts/validate-plan.sh "$plan" 2>&1)"
+exit_code=$?
+set -e
+if [[ $exit_code -eq 0 ]]; then
+  echo "[repro] FAIL: validator must reject branched review-gate artifacts (non-zero exit)"
+  echo "$out"
+  exit 1
+fi
+# The dependency error must point at the ORIGINAL index [2] (artifact 'b'), not a
+# re-indexed [1] after the invalid artifact[0] is skipped (#1760 index drift).
+if ! echo "$out" | jq -e '
+  [.[] | select(.errorType == "invalid_dependency_reference")] as $dep
+  | ($dep | length) == 1
+    and $dep[0].field == "reviewGate.artifacts[2].dependsOn"
+    and ($dep[0].message | test("must be \\[\"a\"\\] to keep the review-gate stack linear"))
+' >/dev/null; then
+  echo "[repro] FAIL: linear-dependency error should point at original index [2] (artifact 'b')"
+  echo "$out"
+  exit 1
+fi
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

A repro runner that drives the guards added by the two PRs below, plus the plan-validator error-index check from #1760.

It pins the review-gate logic findings from the Multi PR Review Gate stack so they cannot silently return.

<details>
<summary>Review metadata</summary>

Review Claim: A repro runner for the review-gate logic guards.

Review Lane: proof

Review Unit: proof

Safety Invariant: Adds only a script under scripts/repro; no production code changes.

Slice Rationale: A process script grouped on top of the two fixes it exercises.

</details>

## Non-goals

No production code changes. Adds `scripts/repro/repro-review-gate-logic-guards.sh` only.

## Test Plan

- [ ] `bash scripts/repro/repro-review-gate-logic-guards.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new reproduction and validation script to strengthen test coverage for review-gate logic verification. The script validates artifact identifier handling and dependency reference resolution, ensuring correct system behavior across all scenarios. This enhancement improves overall testing infrastructure for both planning and execution workflow components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->