### PR TITLE
Reinstall stale workspace deps in run.sh instead of skipping

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,18 +9,31 @@ cd "$REPO_ROOT"
 # from this launcher even if the caller's environment opts into it.
 export INVOKER_ENABLE_WORKSPACE_CLEANUP=0
 
+BOOTSTRAP_STAMP="$REPO_ROOT/node_modules/.invoker-bootstrap-stamp"
+
 has_bootstrap_artifacts() {
   [ -f "$REPO_ROOT/node_modules/.modules.yaml" ] \
     && [ -x "$REPO_ROOT/packages/app/node_modules/.bin/electron" ]
 }
 
+# An existing install goes stale when the lockfile changes (e.g. a git pull
+# adds a dependency) but node_modules is left untouched. The artifacts check
+# above only proves *some* install exists, so without this check run.sh would
+# skip the reinstall and then fail the build on the now-missing package. Treat
+# the install as stale when we have no record of it, or when pnpm-lock.yaml is
+# newer than the stamp written after the last successful install.
+workspace_install_is_stale() {
+  [ ! -f "$BOOTSTRAP_STAMP" ] || [ "$REPO_ROOT/pnpm-lock.yaml" -nt "$BOOTSTRAP_STAMP" ]
+}
+
 ensure_workspace_bootstrapped() {
-  if has_bootstrap_artifacts && [ "${INVOKER_FORCE_BOOTSTRAP:-0}" != "1" ]; then
+  if has_bootstrap_artifacts && ! workspace_install_is_stale && [ "${INVOKER_FORCE_BOOTSTRAP:-0}" != "1" ]; then
     return 0
   fi
 
   echo "Bootstrapping workspace dependencies..." >&2
   pnpm install --frozen-lockfile >&2
+  touch "$BOOTSTRAP_STAMP"
 }
 
 expand_home_path() {


### PR DESCRIPTION
## Summary

`./run.sh` could fail with `ERR_MODULE_NOT_FOUND` after a dependency was added, even though the lockfile and CI were fine.

`run.sh`'s bootstrap guard reinstalled only when no install existed at all. It never checked whether an existing install was current.

So after the lockfile changed but `node_modules` was left untouched, `run.sh` skipped the reinstall and failed the build on the missing package.

This adds a freshness check. `run.sh` writes a stamp after each successful install and reinstalls whenever `pnpm-lock.yaml` is newer than that stamp, or the stamp is absent.

The build now self-heals against a stale install instead of failing. A steady-state run still skips the reinstall, so there is no per-run slowdown.

<details>
<summary>Review metadata</summary>

Review Claim: `run.sh` reinstalls workspace dependencies when the lockfile is newer than the last install, instead of skipping reinstall whenever any install exists.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Touches only the bootstrap guard in `run.sh`. When the install is current the guard still returns early, so the launch path is unchanged; the only new behavior is an extra `pnpm install --frozen-lockfile` when the lockfile is newer than the stamp.

Slice Rationale: This is the launcher-side robustness fix for stale installs. The separate dependency-declaration fix (PR #2139) is a distinct claim and ships on its own.

</details>

## Non-goals

- No change to the GUI/headless launch path or build commands.
- No change to which packages get built or in what order.
- Does not declare any package dependency; that is PR #2139.

## Test Plan

- [ ] `touch node_modules/.invoker-bootstrap-stamp && rm -rf node_modules/@mergifyio node_modules/.pnpm/@mergifyio+* && sleep 1 && touch pnpm-lock.yaml && ./run.sh --headless query workflows` (expect "Bootstrapping workspace dependencies..." and exit 0)
- [ ] `./run.sh --headless query workflows` (run again; expect no "Bootstrapping..." line and exit 0)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workspace initialization with enhanced dependency state tracking to ensure reliable builds and consistent development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->