### PR TITLE
Model merge-gate PR status as one lifecycle

### DIFF
--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -1164,7 +1164,7 @@ describe('Flow 9c: set-merge-mode external_review', () => {
       identifier: 'owner/repo#99',
     }),
     checkApproval: async () => ({
-      approved: false,
+      lifecycle: 'open',
       rejected: false,
       statusText: 'Open',
       url: 'https://github.com/owner/repo/pull/99',

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -477,7 +477,7 @@ describe('GitHubMergeGateProvider', () => {
 
       const result = await provider.checkApproval({ identifier: '1', cwd: '/tmp/repo' });
 
-      expect(result.approved).toBe(true);
+      expect(result.lifecycle).toBe('merged');
       expect(result.rejected).toBe(false);
       expect(result.statusText).toBe('Merged');
     });
@@ -500,7 +500,7 @@ describe('GitHubMergeGateProvider', () => {
 
       const result = await provider.checkApproval({ identifier: '2', cwd: '/tmp/repo' });
 
-      expect(result.approved).toBe(false);
+      expect(result.lifecycle).toBe('open');
       expect(result.rejected).toBe(false);
       expect(result.statusText).toBe('Approved, awaiting merge');
     });
@@ -523,9 +523,8 @@ describe('GitHubMergeGateProvider', () => {
 
       const result = await provider.checkApproval({ identifier: '3', cwd: '/tmp/repo' });
 
-      expect(result.approved).toBe(false);
+      expect(result.lifecycle).toBe('closed');
       expect(result.rejected).toBe(false);
-      expect(result.closed).toBe(true);
       expect(result.statusText).toBe('Closed');
     });
 

--- a/packages/execution-engine/src/__tests__/repro-review-gate-logic-guards.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-review-gate-logic-guards.test.ts
@@ -8,7 +8,7 @@ import type { TaskState } from '@invoker/workflow-core';
 // Multi PR Review Gate stack, plus the sibling sites they also occur in.
 //
 //  #1757  isInvokerRepoUrl / parseMakePrStackPublishResult (pr-authoring)
-//  #1811  mapReviewGateArtifactStatus closed-vs-approved precedence (task-runner)
+//  #1811  mapReviewGateArtifactStatus lifecycle/review-decision collapse (task-runner)
 //  #1865  reviewPollStillMatches stale-write guard (task-runner)
 //  #1811 sibling: pollMergeGateTask scalar (legacy single-PR) path completing a closed PR
 
@@ -30,9 +30,8 @@ function makeRunner(overrides: Partial<TaskRunnerConfig> = {}): TaskRunner {
 }
 
 interface ApprovalStatusInput {
-  approved?: boolean;
+  lifecycle?: 'open' | 'closed' | 'merged';
   rejected?: boolean;
-  closed?: boolean;
   statusText?: string;
 }
 
@@ -100,18 +99,19 @@ describe('repro #1757: parseMakePrStackPublishResult normalizes/validates identi
 
 // ── #1811: mapReviewGateArtifactStatus ───────────────────
 
-describe('repro #1811: mapReviewGateArtifactStatus gives closed precedence over approved', () => {
-  it('maps a closed-but-approved PR to "closed" (so it cannot complete the gate)', () => {
+describe('repro #1811: mapReviewGateArtifactStatus collapses lifecycle + review decision', () => {
+  it('maps a closed PR to "closed" even when changes were requested (lifecycle wins)', () => {
     const p = probe(makeRunner());
-    expect(p.mapReviewGateArtifactStatus({ approved: true, rejected: false, closed: true })).toBe('closed');
+    // closed+merged is now unrepresentable; closed+rejected is the real overlap.
+    expect(p.mapReviewGateArtifactStatus({ lifecycle: 'closed', rejected: true })).toBe('closed');
   });
 
   it('preserves the other mappings', () => {
     const p = probe(makeRunner());
-    expect(p.mapReviewGateArtifactStatus({ approved: true })).toBe('approved');
-    expect(p.mapReviewGateArtifactStatus({ rejected: true })).toBe('changes_requested');
-    expect(p.mapReviewGateArtifactStatus({ closed: true })).toBe('closed');
-    expect(p.mapReviewGateArtifactStatus({})).toBe('open');
+    expect(p.mapReviewGateArtifactStatus({ lifecycle: 'merged', rejected: false })).toBe('approved');
+    expect(p.mapReviewGateArtifactStatus({ lifecycle: 'open', rejected: true })).toBe('changes_requested');
+    expect(p.mapReviewGateArtifactStatus({ lifecycle: 'closed', rejected: false })).toBe('closed');
+    expect(p.mapReviewGateArtifactStatus({ lifecycle: 'open', rejected: false })).toBe('open');
   });
 });
 
@@ -144,7 +144,7 @@ describe('repro #1865: reviewPollStillMatches blocks writes after the task left 
 // ── #1811 sibling: scalar (legacy single-PR) poll path ───
 
 describe('repro #1811 sibling: a closed PR must not complete a scalar merge gate', () => {
-  it('does not approve when checkApproval reports approved AND closed', async () => {
+  it('does not complete the gate when the PR is closed', async () => {
     const task = {
       id: '__merge__wf-1',
       description: 'merge gate',
@@ -167,7 +167,7 @@ describe('repro #1811 sibling: a closed PR must not complete a scalar merge gate
       updateTask: (id: string, changes: unknown) => { updateCalls.push({ id, changes }); return tasks.get(id); },
     };
     const mergeGateProvider = {
-      checkApproval: async () => ({ approved: true, closed: true, rejected: false, statusText: 'Closed (approved)' }),
+      checkApproval: async () => ({ lifecycle: 'closed', rejected: false, statusText: 'Closed' }),
     };
 
     const runner = makeRunner({

--- a/packages/execution-engine/src/__tests__/review-provider-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/review-provider-registry.test.ts
@@ -6,7 +6,7 @@ function makeFakeProvider(name: string): MergeGateProvider {
   return {
     name,
     createReview: async () => ({ url: `https://example.com/${name}/1`, identifier: `${name}#1` }),
-    checkApproval: async () => ({ approved: false, rejected: false, statusText: 'pending', url: '' }),
+    checkApproval: async () => ({ lifecycle: 'open' as const, rejected: false, statusText: 'pending', url: '' }),
   };
 }
 

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -4467,7 +4467,7 @@ console.log(JSON.stringify(out));
       };
       const mergeGateProvider = {
         checkApproval: vi.fn().mockResolvedValue({
-          approved: false,
+          lifecycle: 'open',
           rejected: false,
           statusText: 'Awaiting review',
           url: 'https://github.com/owner/repo/pull/42',
@@ -4513,7 +4513,7 @@ console.log(JSON.stringify(out));
       };
       const mergeGateProvider = {
         checkApproval: vi.fn().mockResolvedValue({
-          approved: true,
+          lifecycle: 'merged',
           rejected: false,
           statusText: 'Merged',
           url: 'https://github.com/owner/repo/pull/42',
@@ -4552,7 +4552,7 @@ console.log(JSON.stringify(out));
       };
       const mergeGateProvider = {
         checkApproval: vi.fn().mockResolvedValue({
-          approved: false,
+          lifecycle: 'open',
           rejected: false,
           statusText: 'Approved, awaiting merge',
           url: 'https://github.com/owner/repo/pull/42',
@@ -4589,7 +4589,7 @@ console.log(JSON.stringify(out));
       };
       const mergeGateProvider = {
         checkApproval: vi.fn().mockResolvedValue({
-          approved: false,
+          lifecycle: 'open',
           rejected: true,
           statusText: 'Changes requested',
           url: 'https://github.com/owner/repo/pull/42',
@@ -4628,9 +4628,8 @@ console.log(JSON.stringify(out));
       };
       const mergeGateProvider = {
         checkApproval: vi.fn().mockResolvedValue({
-          approved: false,
+          lifecycle: 'closed',
           rejected: false,
-          closed: true,
           statusText: 'Closed',
           url: 'https://github.com/owner/repo/pull/43',
         }),
@@ -4673,7 +4672,7 @@ console.log(JSON.stringify(out));
       };
       const mergeGateProvider = {
         checkApproval: vi.fn().mockResolvedValue({
-          approved: true,
+          lifecycle: 'merged',
           rejected: false,
           statusText: 'Merged',
           url: 'https://github.com/owner/repo/pull/42',
@@ -4774,7 +4773,7 @@ console.log(JSON.stringify(out));
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: false,
+            lifecycle: 'open',
             rejected: false,
             statusText: 'Pending',
             url: 'https://github.com/owner/repo/pull/99',
@@ -4809,7 +4808,7 @@ console.log(JSON.stringify(out));
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: false,
+            lifecycle: 'open',
             rejected: false,
             statusText: 'Pending',
             url: 'https://github.com/owner/repo/pull/100',
@@ -4851,7 +4850,7 @@ console.log(JSON.stringify(out));
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: true,
+            lifecycle: 'merged',
             rejected: false,
             statusText: 'Merged',
             url: 'https://github.com/owner/repo/pull/101',
@@ -4937,7 +4936,7 @@ console.log(JSON.stringify(out));
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: false,
+            lifecycle: 'open',
             rejected: false,
             statusText: 'Pending',
           }),
@@ -4977,7 +4976,7 @@ console.log(JSON.stringify(out));
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: false,
+            lifecycle: 'open',
             rejected: false,
             statusText: 'Pending',
           }),
@@ -5033,10 +5032,10 @@ console.log(JSON.stringify(out));
         };
         const mergeGateProvider = {
           checkApproval: vi.fn()
-            .mockResolvedValueOnce({ approved: true, rejected: false, statusText: 'Approved one' })
-            .mockResolvedValueOnce({ approved: false, rejected: false, statusText: 'Pending second' })
-            .mockResolvedValueOnce({ approved: true, rejected: false, statusText: 'Still approved' })
-            .mockResolvedValueOnce({ approved: true, rejected: false, statusText: 'Approved both' }),
+            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved one' })
+            .mockResolvedValueOnce({ lifecycle: 'open', rejected: false, statusText: 'Pending second' })
+            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Still approved' })
+            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved both' })
         };
 
         const executor = new TaskRunner({
@@ -5073,6 +5072,61 @@ console.log(JSON.stringify(out));
           expect.objectContaining({ id: 'contracts', status: 'approved' }),
           expect.objectContaining({ id: 'runtime', status: 'approved' }),
         ]);
+      });
+
+      it('marks a structured reviewGate task closed when a required artifact PR is closed', async () => {
+        const reviewGate = {
+          activeGeneration: 4,
+          completion: { required: 'all' as const, status: 'approved' as const },
+          artifacts: [
+            { id: 'contracts', providerId: 'pr-1', required: true, status: 'open' as const, generation: 4 },
+          ],
+        };
+        const task = makeTask({
+          id: 'merge-stack-closed',
+          status: 'review_ready',
+          config: { isMergeNode: true },
+          execution: {
+            generation: 4,
+            selectedAttemptId: 'attempt-1',
+            reviewGate,
+            workspacePath: '/workspace/stack-closed',
+          },
+        });
+        const orchestrator = {
+          getTask: (id: string) => (id === task.id ? task : undefined),
+          getAllTasks: () => [task],
+          approve: vi.fn(),
+        };
+        const persistence = {
+          updateTask: vi.fn((id: string, changes: any) => {
+            if (id === task.id) {
+              (task as any).status = changes.status ?? task.status;
+              if (changes.execution) {
+                (task as any).execution = { ...task.execution, ...changes.execution };
+              }
+            }
+          }),
+        };
+        const mergeGateProvider = {
+          checkApproval: vi.fn().mockResolvedValue({ lifecycle: 'closed', rejected: false, statusText: 'Closed' }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: persistence as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/runner-base-cwd',
+          mergeGateProvider: mergeGateProvider as any,
+        });
+        vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
+
+        await executor.checkMergeGateStatuses();
+
+        expect(persistence.updateTask).toHaveBeenCalledWith('merge-stack-closed', expect.objectContaining({
+          status: 'closed',
+        }));
+        expect(orchestrator.approve).not.toHaveBeenCalled();
       });
 
       it('skips stale reviewGate poll results when the task generation changes before applying them', async () => {
@@ -5116,7 +5170,7 @@ console.log(JSON.stringify(out));
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: true,
+            lifecycle: 'merged',
             rejected: false,
             statusText: 'Approved stale',
           }),
@@ -5165,7 +5219,7 @@ console.log(JSON.stringify(out));
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: true,
+            lifecycle: 'merged',
             rejected: false,
             statusText: 'Merged',
           }),
@@ -5213,7 +5267,7 @@ console.log(JSON.stringify(out));
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: false,
+            lifecycle: 'open',
             rejected: false,
             statusText: 'Approved, awaiting merge',
           }),
@@ -5259,7 +5313,7 @@ console.log(JSON.stringify(out));
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: false,
+            lifecycle: 'open',
             rejected: true,
             statusText: 'Changes requested',
           }),
@@ -5307,9 +5361,8 @@ console.log(JSON.stringify(out));
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: false,
+            lifecycle: 'closed',
             rejected: false,
-            closed: true,
             statusText: 'Closed',
           }),
         };
@@ -5355,9 +5408,8 @@ console.log(JSON.stringify(out));
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: false,
+            lifecycle: 'closed',
             rejected: false,
-            closed: true,
             statusText: 'Closed',
           }),
         };
@@ -5405,9 +5457,8 @@ console.log(JSON.stringify(out));
         };
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
-            approved: false,
+            lifecycle: 'closed',
             rejected: false,
-            closed: true,
             statusText: 'Closed',
           }),
         };

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -4,6 +4,7 @@ import type {
   MergeGateProvider,
   MergeGateProviderResult,
   MergeGateApprovalStatus,
+  MergeGatePrLifecycle,
   MergeGateFailedCheck,
 } from './merge-gate-provider.js';
 import { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
@@ -101,8 +102,8 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       statusCheckRollup?: unknown[];
     };
 
-    const approved = data.state === 'MERGED';
-    const closed = data.state === 'CLOSED';
+    const lifecycle: MergeGatePrLifecycle =
+      data.state === 'MERGED' ? 'merged' : data.state === 'CLOSED' ? 'closed' : 'open';
     const rejected = data.reviewDecision === 'CHANGES_REQUESTED';
 
     let statusText: string;
@@ -119,9 +120,8 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     }
 
     return {
-      approved,
+      lifecycle,
       rejected,
-      closed,
       statusText,
       url: data.url,
       headSha: data.headRefOid,

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -26,10 +26,22 @@ export interface MergeGateCheckSummary {
   failed: MergeGateFailedCheck[];
 }
 
+/**
+ * PR lifecycle — exactly one of these by construction. Both `merged` and
+ * `closed` derive from a single GitHub PR `state`, so a merge gate can never
+ * observe a PR that is simultaneously merged and closed. Modelling it as one
+ * field (instead of separate `approved`/`closed` booleans) makes that illegal
+ * combination unrepresentable rather than something each consumer must guard.
+ */
+export type MergeGatePrLifecycle = 'open' | 'closed' | 'merged';
+
 export interface MergeGateApprovalStatus {
-  approved: boolean;
+  lifecycle: MergeGatePrLifecycle;
+  /**
+   * Review decision is an independent axis from lifecycle: a PR can have changes
+   * requested AND be closed, so this stays a separate flag, not a lifecycle case.
+   */
   rejected: boolean;
-  closed?: boolean;
   statusText: string;
   url: string;
   headSha?: string;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -2458,8 +2458,8 @@ export class TaskRunner {
   }
 
   private mapReviewGateArtifactStatus(status: MergeGateApprovalStatus): ReviewGateArtifactStatus {
-    if (status.closed) return 'closed';
-    if (status.approved) return 'approved';
+    if (status.lifecycle === 'closed') return 'closed';
+    if (status.lifecycle === 'merged') return 'approved';
     if (status.rejected) return 'changes_requested';
     return 'open';
   }
@@ -2572,6 +2572,7 @@ export class TaskRunner {
       if (currentGate) {
         latestGate = this.updateReviewGateArtifact(currentGate, providerId, status);
         this.persistence.updateTask(task.id, {
+          ...(status.lifecycle === 'closed' ? { status: 'closed' as const } : {}),
           execution: { reviewGate: latestGate, reviewStatus: status.statusText },
         });
         if (!approvedGate && this.reviewGateIsApproved(latestGate)) {
@@ -2579,22 +2580,22 @@ export class TaskRunner {
           await this.handleApprovedMergeGate(task.id, providerId, source);
         } else if (status.rejected) {
           this.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
-        } else if (!status.closed && !status.approved) {
+        } else if (status.lifecycle === 'open') {
           await this.maybeTriggerReviewGateCiFix(current!, status, providerId);
         }
         continue;
       }
 
       this.persistence.updateTask(task.id, {
-        ...(status.closed ? { status: 'closed' as const } : {}),
+        ...(status.lifecycle === 'closed' ? { status: 'closed' as const } : {}),
         execution: { reviewStatus: status.statusText },
       });
-      if (!approvedGate && status.approved && !status.closed) {
+      if (!approvedGate && status.lifecycle === 'merged') {
         approvedGate = true;
         await this.handleApprovedMergeGate(task.id, providerId, source);
       } else if (status.rejected) {
         this.logger.info(`[merge-gate] PR ${providerId} rejected (${source}): ${status.statusText}`);
-      } else if (!status.closed) {
+      } else if (status.lifecycle === 'open') {
         await this.maybeTriggerReviewGateCiFix(current!, status, providerId);
       }
     }


### PR DESCRIPTION
## Summary

A merge gate tracked whether a pull request was merged or closed using two separate flags.

Both flags came from one underlying pull-request value, so they could never both be true.

Yet the old shape let code write that impossible pair, so every reader had to guard against it by hand.

This stores one status value instead — open, closed, or merged — so the impossible pair can no longer be written down, and the hand guards are gone.

For a single PR the merge gate behaves as before.

It also closes one gap the new shape revealed: a multi-PR gate now records the closed status when a required PR is closed, matching the single-PR path.

<details>
<summary>Review metadata</summary>

Review Claim: Store the merge-gate pull-request status as one open/closed/merged value, and record the closed status on the multi-PR path the same way the single-PR path already does.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Single-PR behavior is unchanged; the multi-PR path now mirrors it when a required PR is closed. Existing execution-engine merge-gate suites and the app bridge suite pass, plus a new regression test, and typecheck is clean.

Slice Rationale: One representation change with its tests; the changelog line ships as a separate docs PR in this stack.

</details>

## Non-goals

Does not change merge-gate behavior for open, merged, or changes-requested pull requests. The review-decision axis is untouched — changes-requested stays its own flag, separate from lifecycle. Persistence, the merge queue, and the UI are unchanged. No other status enum is changed.

## Test Plan

- [ ] `pnpm run check:types`
- [ ] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts src/__tests__/github-merge-gate-provider.test.ts src/__tests__/repro-review-gate-logic-guards.test.ts src/__tests__/review-provider-registry.test.ts`
- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/bridge-orchestrator-executor.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
