### PR TITLE
[Fix intent cancellation Step 6: worker response lineage guard (restacked v3)](1) Require worker responses to match both selectedAttemptId and executionGeneration

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -855,6 +855,62 @@ describe('Orchestrator', () => {
       }
     });
 
+    it('rejects a completion signal when the current attemptId carries a stale executionGeneration', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        orchestrator.loadPlan({
+          name: 'reject-stale-generation-with-current-attempt',
+          onFinish: 'none',
+          tasks: [
+            { id: 'A', description: 'Root', command: 'echo A' },
+          ],
+        });
+        orchestrator.startExecution();
+        const taskId = orchestrator.getAllTasks().find((task) => task.id === 'A' || task.id.endsWith('/A'))?.id ?? 'A';
+
+        // recreateWorkflow bumps the live generation to 1 and selects a fresh
+        // attempt. The stale worker still carries the *current* attempt id but
+        // the *previous* generation (0).
+        const workflowId = orchestrator.getWorkflowIds()[0]!;
+        orchestrator.recreateWorkflow(workflowId);
+
+        const before = orchestrator.getTask(taskId)!;
+        const currentAttemptId = before.execution.selectedAttemptId;
+        expect(currentAttemptId).toBeTruthy();
+        expect(before.execution.generation).toBe(1);
+        expect(before.status).toBe('running');
+        const beforeBranch = before.execution.branch;
+        const beforeWorkspacePath = before.execution.workspacePath;
+
+        orchestrator.handleWorkerResponse(
+          makeResponse({
+            actionId: taskId,
+            attemptId: currentAttemptId,
+            executionGeneration: 0,
+            status: 'completed',
+            outputs: { exitCode: 0, branch: 'stale-branch' },
+          }),
+        );
+
+        const after = orchestrator.getTask(taskId)!;
+        expect(after.status).toBe('running');
+        expect(after.execution.selectedAttemptId).toBe(currentAttemptId);
+        expect(after.execution.branch).toBe(beforeBranch);
+        expect(after.execution.workspacePath).toBe(beforeWorkspacePath);
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[worker-response] STALE_GENERATION_REJECTED',
+          expect.objectContaining({
+            taskId,
+            responseGeneration: 0,
+            activeGeneration: 1,
+            workerResponseStatus: 'completed',
+          }),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it('ignores a stale completed response after restartTask resets descendants', () => {
       const reproPersistence = new InMemoryPersistence();
       const reproBus = new InMemoryBus();

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1584,9 +1584,13 @@ export class Orchestrator {
           });
           return [];
         }
+        // Validate execution-generation lineage whenever the producer
+        // supplied it. Older producers may omit either the attempt id or the
+        // generation; we only enforce the fields that are present. When both
+        // are present they must both match the live task, so a response that
+        // carries the current attempt id but a stale generation is rejected.
         const activeGeneration = this.getExecutionGeneration(earlyTask);
         if (
-          !response.attemptId &&
           response.executionGeneration !== undefined &&
           response.executionGeneration !== activeGeneration
         ) {


### PR DESCRIPTION
## Summary

The orchestrator routes each worker response to the task attempt that asked for it. This change tightens which responses it will accept.

A worker response is now honored only when it carries the currently selected attempt id and the current execution generation together.

If a response arrives with the right attempt id but an out-of-date generation, the orchestrator drops it instead of routing it through.

This keeps a leftover reply from a superseded run from landing on a task that has already advanced.

<details>
<summary>Review metadata</summary>

Review Claim: A worker response is honored only when it carries the live attempt id and the live execution generation together.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The change only narrows which worker responses the orchestrator routes; older replies that omit a field keep their prior handling, so nothing new is accepted.

Slice Rationale: This slice carries one orchestrator routing guard and nothing else, so it can be reviewed on its own.

</details>

## Non-goals

This does not change how attempts are started, how generations are assigned, or any persistence behavior.

## Test Plan

- [ ] `cd packages/workflow-core && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 80ce3087db6b623159f4b690e1180587f11709f1`
- Post-revert steps: None
- Data migration? No
