### PR TITLE
Fix intent cancellation Step 6: worker response lineage guard (restacked v3)

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -855,6 +855,62 @@ describe('Orchestrator', () => {
       }
     });
 
+    it('rejects a completion signal when the current attemptId carries a stale executionGeneration', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        orchestrator.loadPlan({
+          name: 'reject-stale-generation-with-current-attempt',
+          onFinish: 'none',
+          tasks: [
+            { id: 'A', description: 'Root', command: 'echo A' },
+          ],
+        });
+        orchestrator.startExecution();
+        const taskId = orchestrator.getAllTasks().find((task) => task.id === 'A' || task.id.endsWith('/A'))?.id ?? 'A';
+
+        // recreateWorkflow bumps the live generation to 1 and selects a fresh
+        // attempt. The stale worker still carries the *current* attempt id but
+        // the *previous* generation (0).
+        const workflowId = orchestrator.getWorkflowIds()[0]!;
+        orchestrator.recreateWorkflow(workflowId);
+
+        const before = orchestrator.getTask(taskId)!;
+        const currentAttemptId = before.execution.selectedAttemptId;
+        expect(currentAttemptId).toBeTruthy();
+        expect(before.execution.generation).toBe(1);
+        expect(before.status).toBe('running');
+        const beforeBranch = before.execution.branch;
+        const beforeWorkspacePath = before.execution.workspacePath;
+
+        orchestrator.handleWorkerResponse(
+          makeResponse({
+            actionId: taskId,
+            attemptId: currentAttemptId,
+            executionGeneration: 0,
+            status: 'completed',
+            outputs: { exitCode: 0, branch: 'stale-branch' },
+          }),
+        );
+
+        const after = orchestrator.getTask(taskId)!;
+        expect(after.status).toBe('running');
+        expect(after.execution.selectedAttemptId).toBe(currentAttemptId);
+        expect(after.execution.branch).toBe(beforeBranch);
+        expect(after.execution.workspacePath).toBe(beforeWorkspacePath);
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[worker-response] STALE_GENERATION_REJECTED',
+          expect.objectContaining({
+            taskId,
+            responseGeneration: 0,
+            activeGeneration: 1,
+            workerResponseStatus: 'completed',
+          }),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it('ignores a stale completed response after restartTask resets descendants', () => {
       const reproPersistence = new InMemoryPersistence();
       const reproBus = new InMemoryBus();

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1584,9 +1584,13 @@ export class Orchestrator {
           });
           return [];
         }
+        // Validate execution-generation lineage whenever the producer
+        // supplied it. Older producers may omit either the attempt id or the
+        // generation; we only enforce the fields that are present. When both
+        // are present they must both match the live task, so a response that
+        // carries the current attempt id but a stale generation is rejected.
         const activeGeneration = this.getExecutionGeneration(earlyTask);
         if (
-          !response.attemptId &&
           response.executionGeneration !== undefined &&
           response.executionGeneration !== activeGeneration
         ) {


### PR DESCRIPTION
## Summary

Worker responses now have to prove they belong to the task's current run before the orchestrator accepts their output.

Before, a response that carried the live attempt id but a stale execution generation slipped through. The lineage check only ran when the attempt id was missing.

Now the orchestrator validates whichever lineage fields the producer sent. When both the attempt id and the execution generation are present, both must match the live task.

This closes Step 6 of the intent-cancellation fix: a late response from a superseded run can no longer overwrite the work of the current run.

<details>
<summary>Review metadata</summary>

Review Claim: A worker response carrying the current attempt id but a stale execution generation is rejected.

Review Lane: `behavior`

Review Unit: `routing`

Safety Invariant: The guard only tightens acceptance; responses that already matched both fields still pass, and producers that omit a field keep their old leniency.

Slice Rationale: This is the single orchestrator guard for Step 6, kept separate from the earlier cancellation steps so the lineage check reviews on its own.

</details>

## Non-goals

- No change to how execution generations are assigned or bumped.
- No change to producers that omit the attempt id or the generation.
- No change to cancellation Steps 1 through 5.

## Test Plan

- [ ] `cd packages/workflow-core && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced workflow execution handling to properly reject stale generation responses, preventing outdated execution states from being incorrectly processed even when the attempt ID matches the current selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->