### PR TITLE
Roadmap Core WF-INV-97: Long prompt/command handoff hardening — implementation outcome

### DIFF
--- a/docs/context/inv-97/experiment-brief.md
+++ b/docs/context/inv-97/experiment-brief.md
@@ -133,3 +133,13 @@ proven by Commands A and B above. The competing **direct in-process dispatch** d
 explicitly rejected: its failure mode is exactly what these tests catch (a populated
 `workspacePath` / non-empty `topup` at mutation time). Re-running the two commands is the
 deterministic, reviewable evidence for any change that touches the launch path.
+
+## 8. Implementation outcome
+
+**Status:** consumed — the shipped code already matches this brief.
+
+The Durable Launch Outbox described in Section 1 is the design that currently lives in
+the codebase. This note closes the loop between the written decision and what shipped, so
+a later reader can trust that the brief is a record of the landed behavior, not just a
+proposal. Commands A and B in Section 4 remain the deterministic evidence; re-running them
+re-confirms that the implementation still honors the documented handoff invariant.


### PR DESCRIPTION
## Summary

This updates the INV-97 brief to record the implementation outcome.

It adds a short closing note saying the codebase already follows the chosen design from the brief.

The document now reads as a finished record, linking the written decision to what shipped.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the closing-note edit that ties the INV-97 brief to the shipped outcome.

Review Lane: docs

Review Unit: docs

Safety Invariant: This slice edits only one Markdown document and changes no runtime behavior.

Slice Rationale: The outcome note is a separate edit so the brief's first version stays reviewable on its own.

</details>

## Non-goals

This does not add or change product code. It only edits the documentation.

## Test Plan

- [ ] `node scripts/validate-pr-body.mjs --body-file /tmp/inv97-pr2.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2161