### PR TITLE
Fix intent cancellation Step 6: worker response lineage guard (restacked v3)

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -855,6 +855,62 @@ describe('Orchestrator', () => {
       }
     });
 
+    it('rejects a completion signal when the current attemptId carries a stale executionGeneration', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        orchestrator.loadPlan({
+          name: 'reject-stale-generation-with-current-attempt',
+          onFinish: 'none',
+          tasks: [
+            { id: 'A', description: 'Root', command: 'echo A' },
+          ],
+        });
+        orchestrator.startExecution();
+        const taskId = orchestrator.getAllTasks().find((task) => task.id === 'A' || task.id.endsWith('/A'))?.id ?? 'A';
+
+        // recreateWorkflow bumps the live generation to 1 and selects a fresh
+        // attempt. The stale worker still carries the *current* attempt id but
+        // the *previous* generation (0).
+        const workflowId = orchestrator.getWorkflowIds()[0]!;
+        orchestrator.recreateWorkflow(workflowId);
+
+        const before = orchestrator.getTask(taskId)!;
+        const currentAttemptId = before.execution.selectedAttemptId;
+        expect(currentAttemptId).toBeTruthy();
+        expect(before.execution.generation).toBe(1);
+        expect(before.status).toBe('running');
+        const beforeBranch = before.execution.branch;
+        const beforeWorkspacePath = before.execution.workspacePath;
+
+        orchestrator.handleWorkerResponse(
+          makeResponse({
+            actionId: taskId,
+            attemptId: currentAttemptId,
+            executionGeneration: 0,
+            status: 'completed',
+            outputs: { exitCode: 0, branch: 'stale-branch' },
+          }),
+        );
+
+        const after = orchestrator.getTask(taskId)!;
+        expect(after.status).toBe('running');
+        expect(after.execution.selectedAttemptId).toBe(currentAttemptId);
+        expect(after.execution.branch).toBe(beforeBranch);
+        expect(after.execution.workspacePath).toBe(beforeWorkspacePath);
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[worker-response] STALE_GENERATION_REJECTED',
+          expect.objectContaining({
+            taskId,
+            responseGeneration: 0,
+            activeGeneration: 1,
+            workerResponseStatus: 'completed',
+          }),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it('ignores a stale completed response after restartTask resets descendants', () => {
       const reproPersistence = new InMemoryPersistence();
       const reproBus = new InMemoryBus();

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1584,11 +1584,6 @@ export class Orchestrator {
           });
           return [];
         }
-        // Validate execution-generation lineage whenever the producer
-        // supplied it. Older producers may omit either the attempt id or the
-        // generation; we only enforce the fields that are present. When both
-        // are present they must both match the live task, so a response that
-        // carries the current attempt id but a stale generation is rejected.
         const activeGeneration = this.getExecutionGeneration(earlyTask);
         if (
           response.executionGeneration !== undefined &&

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1584,9 +1584,13 @@ export class Orchestrator {
           });
           return [];
         }
+        // Validate execution-generation lineage whenever the producer
+        // supplied it. Older producers may omit either the attempt id or the
+        // generation; we only enforce the fields that are present. When both
+        // are present they must both match the live task, so a response that
+        // carries the current attempt id but a stale generation is rejected.
         const activeGeneration = this.getExecutionGeneration(earlyTask);
         if (
-          !response.attemptId &&
           response.executionGeneration !== undefined &&
           response.executionGeneration !== activeGeneration
         ) {


### PR DESCRIPTION
## Summary

Workers can finish a task long after the orchestrator has moved on. We use an execution generation number to tell "this answer is from the current run" apart from "this answer is stale."

The guard that rejects a stale generation only ran when a response had no attempt id. So a late response that carried the current attempt id but an old generation slipped through and got applied.

This change always checks the generation when the worker supplies one. A response must match both the live attempt id and the live generation, so a current-attempt-but-stale-generation answer is now rejected.

<details>
<summary>Review metadata</summary>

Review Claim: Approve that a worker response carrying the current attempt id but a stale execution generation is now rejected.

Review Lane: `behavior`

Review Unit: `routing`

Safety Invariant: The guard only tightens acceptance. Fields are still optional, so older producers that omit a field are unaffected; only a present-and-mismatched generation is rejected.

Slice Rationale: This is the single change produced by the workflow task; it touches one guard plus its test and is reviewed on its own.

</details>

## Non-goals

- Does not change how execution generations are assigned or incremented.
- Does not change attempt-id selection or the superseded-attempt guard.
- No change to worker or producer message formats.

## Test Plan

- [ ] `cd packages/workflow-core && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced worker response validation to properly reject stale execution generations regardless of whether the attempt ID is current. This ensures consistent workflow state and prevents potential execution issues that could occur when workers respond with outdated generation information during task completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->