### PR TITLE
Roadmap Core WF-INV-86: Non-Invoker workspace compatibility — implement

### DIFF
--- a/packages/app/src/bundled-skills.ts
+++ b/packages/app/src/bundled-skills.ts
@@ -25,6 +25,12 @@ interface BundledSkillsContext {
   invokerHomeRoot?: string;
 }
 
+/**
+ * INV-86 skill-source resolution (docs/context/inv-86/experiment-brief.md):
+ * the owner resolves skills from `resourcesPath/skills` in a packaged build and
+ * from the repo `skills/` directory otherwise. Resolving the wrong root would
+ * make a packaged owner install from the wrong source.
+ */
 function resolveBundledSkillsSourceRoot(context: BundledSkillsContext): string | null {
   if (context.isPackaged) {
     const resourceRoot = context.resourcesPath ?? process.resourcesPath;

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -305,6 +305,12 @@ function parseArgs(argv: string[]): { args: string[]; waitForApproval?: boolean;
 /**
  * Resolve a writable owner endpoint using the resolver, then delegate.
  *
+ * This is the core of the INV-86 single-writer-owner design
+ * (docs/context/inv-86/experiment-brief.md): every mutating command reaches
+ * exactly one owner that holds the DB writer lock, so concurrent CLI calls can
+ * never each open a writable handle. When no owner exists, phase 4 bootstraps a
+ * standalone owner on demand rather than mutating the DB directly.
+ *
  * This function encapsulates the discover → fallback → bootstrap → delegate
  * policy. Each phase consumes the typed DelegationOutcome to decide its
  * branch behavior:

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -30,6 +30,13 @@
  *   electron dist/main.js --install-skills
  *
  * Using the same Electron binary for both modes provides a consistent runtime.
+ *
+ * Headless architecture (INV-86, see docs/context/inv-86/experiment-brief.md):
+ * single-writer owner with delegation. Mutating commands are delegated over IPC
+ * to one owner process that holds the DB writer lock (acquireDbWriterLock);
+ * read-only commands run in-process. The competing direct-multi-writer design is
+ * rejected because concurrent CLI calls would each open a writable DB handle and
+ * race the single-writer invariant.
  */
 
 import { app, BrowserWindow, ipcMain, nativeImage, shell } from 'electron';
@@ -436,6 +443,10 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
   const readOnly = options?.readOnly === true;
   const dbPath = path.join(invokerHomeRoot, 'invoker.db');
   if (!readOnly) {
+    // INV-86 single-writer invariant: only the writable owner takes this lock.
+    // Read-only commands skip it and never open a writable handle, which is what
+    // lets mutating commands safely delegate to one owner instead of opening
+    // their own writable DB (see docs/context/inv-86/experiment-brief.md).
     writerLock = acquireDbWriterLock(dbPath, `main:initServices pid=${process.pid}`);
   }
   persistence = await SQLiteAdapter.create(dbPath, {
@@ -731,8 +742,11 @@ if (isHeadless) {
       process.stdout.write(`running=${runningCount}/${maxConcurrency} queued=${queued.length}\n`);
     };
 
-    // Try delegation for mutating commands first (owner mode).
-    // In standalone mode we skip delegation and run locally.
+    // INV-86 routing decision (docs/context/inv-86/experiment-brief.md):
+    // command classification (isHeadlessMutatingCommand) is the gate that keeps
+    // the single-writer invariant. Only mutating commands delegate to the owner;
+    // a mutation that ran locally would reintroduce the rejected multi-writer
+    // path. In standalone mode we skip delegation and run locally.
     if (mutatingMode && !standaloneMode) {
       // Delegating headless commands must never become the IPC server.
       // Otherwise a transient submitter can steal the transport socket away


### PR DESCRIPTION
Implement the chosen INV-86 design (non-Invoker workspace compatibility) per
the committed experiment brief: update main.ts, headless-client.ts, and
bundled-skills.ts.

Depends-On: #2165