### PR TITLE
Workflow task graph divergence repro — record proof summary

### DIFF
--- a/proof/workflow-task-graph-divergence-report.md
+++ b/proof/workflow-task-graph-divergence-report.md
@@ -1,9 +1,9 @@
-# Workflow / Task-Graph Status Divergence — Proof Report
+# Workflow / Task-Graph Status Divergence Proof Report
 
 ## What this proves
 
-A workflow label can show a **failed** `WorkflowMeta.status` right next to a
-selected task-graph node that still shows a **RUNNING** `TaskState.status`.
+A workflow label can show a failed `WorkflowMeta.status` while the selected
+task-graph node still shows a running `TaskState.status`.
 
 The executable proof lives in:
 
@@ -11,27 +11,22 @@ The executable proof lives in:
 packages/ui/src/__tests__/workflow-task-graph-status-divergence-repro.test.tsx
 ```
 
-Later workflow command tasks run that test to confirm the divergence. This
-report is just the scaffold that records the expected cause; it does not assert
-or contain any product fix.
+## Commands checked
 
-## Expected cause: split renderer state
+Primary repro command: `run-primary-divergence-repro`.
 
-The workflow label and the task-graph nodes are fed by **separate renderer
-paths**, so they can disagree:
+Adjacent check commands: `run-adjacent-state-checks`.
 
-- **Workflow labels read `WorkflowMeta.status`.** The workflow node renders the
-  rolled-up workflow status.
-- **Task-graph nodes read `TaskState.status`.** The selected mini-DAG renders
-  each task's own status (e.g. `RUNNING · EXECUTING`).
-- **Workflow rollups return `failed` before `running`.**
-  `packages/workflow-graph/src/workflow-rollup.ts` reports `failed` as soon as
-  any task has failed, even while another task is still running.
-- **Workflow metadata updates can arrive after task deltas.**
-  `packages/ui/src/hooks/useTasks.ts` updates tasks and workflows through
-  separate renderer paths, so an `onWorkflowsChanged` update can land after the
-  task delta that moved a task back to running — the label lags the task graph.
+Both command tasks exited with code `0`.
 
-## Expected pass condition
+## Cause
 
-The later command tasks that run this proof exit with code `0`.
+Workflow labels read `WorkflowMeta.status`, while task-graph nodes read
+`TaskState.status`. `WorkflowMeta.status` is an aggregate rollup, and
+`packages/workflow-graph/src/workflow-rollup.ts` reports `failed` as soon as any
+task has failed, even while a separate live task status is still `running`.
+
+Task deltas and workflow metadata also travel through separate renderer update
+paths in `packages/ui/src/hooks/useTasks.ts`. That creates a workflow-metadata
+catch-up seam: the task graph can show the latest live task state before the
+workflow label receives the metadata update that catches it up.


### PR DESCRIPTION
## Summary

Rewrites the proof report into its final summary after the repro and adjacent checks pass.

The report now names the primary repro command (run-primary-divergence-repro) and the adjacent check commands (run-adjacent-state-checks).

It records the cause: the aggregate WorkflowMeta.status can be "failed" while the live TaskState.status is still "running", with a separate workflow-metadata catch-up seam between the two renderer paths.

This is a proof artifact only. It changes no product code.

## Test Plan

- [ ] cd packages/ui && pnpm test workflow-task-graph-status-divergence-repro

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2168