### PR TITLE
[Fix intent cancellation](5) Fix intent cancellation Step 5: repro and regression verification (regression gated v2)

### DIFF
--- a/packages/app/src/__tests__/shutdown-diagnostic.test.ts
+++ b/packages/app/src/__tests__/shutdown-diagnostic.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
 import {
   persistShutdownDiagnostic,
+  persistStartupFailureDiagnostic,
   SHUTDOWN_DIAGNOSTIC_TAIL_CHARS,
+  STARTUP_FAILURE_DIAGNOSTIC_LABEL,
   type ShutdownDiagnosticDb,
 } from '../shutdown-diagnostic.js';
 
@@ -214,5 +216,55 @@ describe('persistShutdownDiagnostic', () => {
     const output = db.appended[0];
     expect(output).not.toContain('forcedStopReason=');
     expect(output).toContain('error=real error');
+  });
+
+  it('records failureDetail as a detail line', () => {
+    const task = makeTask({ status: 'running', execution: {} });
+    const db = makeDb(['startup stderr tail\n']);
+
+    persistShutdownDiagnostic(task, db, {
+      failureDetail: 'Executor startup failed (worktree): missing repoUrl',
+    });
+
+    const output = db.appended[0];
+    expect(output).toContain('detail=Executor startup failed (worktree): missing repoUrl');
+    expect(output).toContain('startup stderr tail');
+  });
+
+  it('omits the detail line when failureDetail is not provided', () => {
+    const task = makeTask({ execution: { error: 'real error' } });
+    const db = makeDb();
+
+    persistShutdownDiagnostic(task, db);
+
+    const output = db.appended[0];
+    expect(output).not.toContain('detail=');
+  });
+});
+
+describe('persistStartupFailureDiagnostic', () => {
+  it('labels the block as a startup failure and keeps the concrete detail and tail', () => {
+    const task = makeTask({ status: 'running', execution: {} });
+    const db = makeDb(['FAIL src/startup.test.ts\n']);
+
+    persistStartupFailureDiagnostic(task, db, {
+      forcedStopReason: 'Executor startup failed (worktree)',
+      failureDetail: 'Executor startup failed (worktree): boom',
+    });
+
+    const output = db.appended[0];
+    expect(output).toContain(`[${STARTUP_FAILURE_DIAGNOSTIC_LABEL}]`);
+    expect(output).toContain('forcedStopReason=Executor startup failed (worktree)');
+    expect(output).toContain('detail=Executor startup failed (worktree): boom');
+    expect(output).toContain('FAIL src/startup.test.ts');
+  });
+
+  it('lets an explicit label override the startup default', () => {
+    const task = makeTask();
+    const db = makeDb();
+
+    persistStartupFailureDiagnostic(task, db, { label: 'Custom Label' });
+
+    expect(db.appended[0]).toContain('[Custom Label]');
   });
 });

--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -146,6 +146,95 @@ describe('task-runner-wiring', () => {
     });
   });
 
+  it('persists a durable startup-failure diagnostic when launch fails before spawn', () => {
+    let currentRunner: any = null;
+    const task = {
+      id: 'task-1',
+      status: 'running',
+      execution: { generation: 1 },
+    };
+    const orchestrator = {
+      getTask: vi.fn(() => task),
+      recordTaskHeartbeat: vi.fn(),
+      setBeforeApproveHook: vi.fn(),
+    };
+    const appended: string[] = [];
+    const persistence = {
+      updateTask: vi.fn(),
+      loadWorkflow: vi.fn(),
+      getOutputTail: vi.fn(() => [{ data: 'FAIL src/startup.test.ts\n', offset: 0 }]),
+      appendTaskOutput: vi.fn((_id: string, data: string) => { appended.push(data); }),
+    };
+    const flushTaskOutput = vi.fn();
+
+    rebuildTaskRunner({
+      orchestrator: orchestrator as any,
+      persistence: persistence as any,
+      executorRegistry: {} as any,
+      repoRoot: '/repo',
+      invokerConfig: {},
+      logger: createLogger() as any,
+      taskHandles: new Map(),
+      enqueueTaskOutput: vi.fn(),
+      flushTaskOutput,
+      assertFatalExecutionCapacity: vi.fn(),
+      getTaskRunner: () => currentRunner,
+      setTaskRunner: (value) => { currentRunner = value; },
+      setLatestTaskExecutor: vi.fn(),
+    });
+
+    const config = taskRunnerConstructor.mock.calls[0]?.[0] as any;
+    config.callbacks.onLaunchFailed(
+      'task-1',
+      new Error('Executor startup failed (worktree): missing repoUrl'),
+      { type: 'worktree' },
+    );
+
+    expect(flushTaskOutput).toHaveBeenCalledWith('task-1');
+    expect(appended).toHaveLength(1);
+    const block = appended[0];
+    expect(block).toContain('[Startup Failure Diagnostic]');
+    expect(block).toContain('forcedStopReason=Executor startup failed (worktree)');
+    expect(block).toContain('detail=Executor startup failed (worktree): missing repoUrl');
+    expect(block).toContain('FAIL src/startup.test.ts');
+  });
+
+  it('does not persist a startup diagnostic when the task is already gone', () => {
+    let currentRunner: any = null;
+    const orchestrator = {
+      getTask: vi.fn(() => undefined),
+      recordTaskHeartbeat: vi.fn(),
+      setBeforeApproveHook: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      loadWorkflow: vi.fn(),
+      getOutputTail: vi.fn(() => []),
+      appendTaskOutput: vi.fn(),
+    };
+
+    rebuildTaskRunner({
+      orchestrator: orchestrator as any,
+      persistence: persistence as any,
+      executorRegistry: {} as any,
+      repoRoot: '/repo',
+      invokerConfig: {},
+      logger: createLogger() as any,
+      taskHandles: new Map(),
+      enqueueTaskOutput: vi.fn(),
+      flushTaskOutput: vi.fn(),
+      assertFatalExecutionCapacity: vi.fn(),
+      getTaskRunner: () => currentRunner,
+      setTaskRunner: (value) => { currentRunner = value; },
+      setLatestTaskExecutor: vi.fn(),
+    });
+
+    const config = taskRunnerConstructor.mock.calls[0]?.[0] as any;
+    config.callbacks.onLaunchFailed('gone', new Error('boom'), { type: 'worktree' });
+
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
+  });
+
   it('keeps review-gate auto-fix and approve hook routed through the current TaskRunner', async () => {
     let currentRunner: any = null;
     const orchestrator = {

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -12,6 +12,7 @@ import {
 import type { Logger } from '@invoker/contracts';
 import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from '../config.js';
 import { autoFixOnReviewGateFailure } from '../workflow-actions.js';
+import { persistStartupFailureDiagnostic } from '../shutdown-diagnostic.js';
 
 export type TaskHandleMap = Map<string, { handle: ExecutorHandle; executor: Executor }>;
 
@@ -119,6 +120,17 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
           `Task "${taskId}" launch failed before spawn (executor: ${executor.type}): ${error.message}`,
           { module: 'exec' },
         );
+        // Preserve the concrete startup failure in durable task output so
+        // post-mortem retrieval keeps the real cause and recent output tail
+        // instead of collapsing to a coarse terminal error.
+        const task = deps.orchestrator.getTask(taskId);
+        if (task) {
+          persistStartupFailureDiagnostic(task, deps.persistence, {
+            flushPendingOutput: deps.flushTaskOutput,
+            forcedStopReason: `Executor startup failed (${executor.type})`,
+            failureDetail: error.message,
+          });
+        }
       },
       onSpawned: (taskId, handle, executor) => {
         deps.flushTaskOutput(taskId);

--- a/packages/app/src/shutdown-diagnostic.ts
+++ b/packages/app/src/shutdown-diagnostic.ts
@@ -22,6 +22,14 @@ export interface PersistShutdownDiagnosticOptions {
    * Use to distinguish e.g. user-stop vs application-quit if needed.
    */
   label?: string;
+  /**
+   * Concrete failure detail recorded as a `detail=` line. Used when the
+   * task record's coarse `execution.error` does not yet hold the real
+   * cause — e.g. an executor startup failure captured before the task
+   * transitions to a terminal state, where the concrete stderr/message
+   * lives on the thrown error rather than on the task record.
+   */
+  failureDetail?: string;
 }
 
 /**
@@ -57,6 +65,9 @@ export function persistShutdownDiagnostic(
     if (task.execution.error) {
       parts.push(`error=${task.execution.error}`);
     }
+    if (opts?.failureDetail) {
+      parts.push(`detail=${opts.failureDetail}`);
+    }
     if (task.execution.exitCode !== undefined && task.execution.exitCode !== null) {
       parts.push(`exitCode=${task.execution.exitCode}`);
     }
@@ -68,4 +79,25 @@ export function persistShutdownDiagnostic(
   } catch {
     // Best-effort: don't let diagnostic persistence block shutdown.
   }
+}
+
+/** Header label used for executor startup-failure diagnostic blocks. */
+export const STARTUP_FAILURE_DIAGNOSTIC_LABEL = 'Startup Failure Diagnostic';
+
+/**
+ * Persist a compact startup-failure diagnostic block into durable task
+ * output. Reuses {@link persistShutdownDiagnostic} so executor launch
+ * failures land in the same durable output path with the same shape as
+ * forced-stop diagnostics — concrete cause plus the recent output tail —
+ * instead of leaving only a coarse terminal error behind.
+ */
+export function persistStartupFailureDiagnostic(
+  task: TaskState,
+  db: ShutdownDiagnosticDb,
+  opts?: PersistShutdownDiagnosticOptions,
+): void {
+  persistShutdownDiagnostic(task, db, {
+    label: STARTUP_FAILURE_DIAGNOSTIC_LABEL,
+    ...opts,
+  });
 }


### PR DESCRIPTION
## Summary

When an executor fails before spawn, the task runner now writes the concrete cause into durable task output.

That preserves the startup failure through the same diagnostic path already used for forced stops, instead of leaving only a coarse terminal error.

Focused tests lock the task-runner wiring and shutdown diagnostics to this behavior.

<details>
<summary>Review metadata</summary>

Review Claim: Approve routing executor startup failures into durable task output as a startup-failure diagnostic block.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Task status and exit semantics stay unchanged. The new path only appends best-effort durable diagnostics, and persistence errors are swallowed so shutdown cannot be blocked.

Slice Rationale: This is the verification slice on top of the Step 4 durable-output base; it stays separate so the diagnostic wiring and repro evidence can be reviewed independently.

</details>

## Non-goals

- No change to task status, terminal state, or exit-code semantics.
- No change to the executor spawn path itself.
- Does not touch the shared repro script or the Step 4 durable-output base.
- No broad lifecycle refactor.

## Architecture

### Before

```mermaid
graph TD
    A["Executor fails before task spawn"] --> B["Task runner only keeps transient failure context"]
    B --> C["Later inspection sees coarse terminal error"]
```

### After

```mermaid
graph TD
    A["Executor fails before task spawn"] --> B["Task runner formats startup diagnostic"]
    B --> C["Durable task output"]
    C --> D["Later inspection sees concrete cause"]
```

## Test Plan

- [x] `cd packages/app && pnpm test`
- [x] `bash scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh --expect fixed`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge commit sha>`
- Post-revert steps: None
- Data migration? No
