### PR TITLE
Detach lineage Step 3: harden detach action feedback

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -2777,8 +2777,11 @@ async function headlessDetachWorkflow(
   });
   const result = await deps.commandService.detachWorkflow(envelope);
   if (!result.ok) throw new Error(result.error.message);
+  // Spell out the outcome so automation logs can correlate this mutation with
+  // the detached-lineage provenance recorded on the workflow.
   process.stdout.write(
-    `Detached workflow ${workflowId} from upstream workflow ${upstreamWorkflowId}\n`,
+    `Detached workflow ${workflowId} from upstream workflow ${upstreamWorkflowId}. ` +
+      `Active dependency removed; detached lineage remains visible.\n`,
   );
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -126,7 +126,10 @@ interface WorkflowContextMenuProps {
   onRecreateWorkflow: (workflowId: string) => void;
   onCancelWorkflow: (workflowId: string) => void;
   onDeleteWorkflow: (workflowId: string) => void;
+  onDetachWorkflow: (workflowId: string) => void;
   onCopyWorkflowId: (workflowId: string) => void;
+  /** True when this workflow has exactly one upstream dependency that can be detached from the UI. */
+  canDetach: boolean;
   onClose: (options?: ContextMenuCloseOptions) => void;
   autoFocus?: boolean;
 }
@@ -161,7 +164,9 @@ function WorkflowContextMenu({
   onRecreateWorkflow,
   onCancelWorkflow,
   onDeleteWorkflow,
+  onDetachWorkflow,
   onCopyWorkflowId,
+  canDetach,
   onClose,
   autoFocus = false,
 }: WorkflowContextMenuProps): JSX.Element {
@@ -246,6 +251,9 @@ function WorkflowContextMenu({
           { id: 'rebase-recreate', label: 'Rebase and Recreate', className: dangerButtonClass, action: () => runAction(onRebaseRecreate) },
           { id: 'recreate-workflow', label: 'Recreate Workflow', className: dangerButtonClass, action: () => runAction(onRecreateWorkflow) },
           { id: 'cancel-workflow', label: 'Cancel Workflow', className: dangerButtonClass, action: () => runAction(onCancelWorkflow) },
+          ...(canDetach
+            ? [{ id: 'detach-workflow', label: 'Detach Upstream Workflow', className: dangerButtonClass, action: () => runAction(onDetachWorkflow) }]
+            : []),
           { id: 'delete-workflow', label: 'Delete Workflow', className: dangerButtonClass, action: () => runAction(onDeleteWorkflow) },
         ]),
   ];
@@ -421,6 +429,8 @@ export function App() {
   const [terminalSessions, setTerminalSessions] = useState<TerminalSessionDescriptor[]>([]);
   const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null);
   const [workflowContextMenu, setWorkflowContextMenu] = useState<WorkflowContextMenuState | null>(null);
+  // Transient, user-visible outcome line for a confirmed workflow detach.
+  const [detachNotice, setDetachNotice] = useState<string | null>(null);
   const [keyboardRegion, setKeyboardRegion] = useState<KeyboardRegion>('workflowGraph');
   const [previousGraphRegion, setPreviousGraphRegion] = useState<KeyboardRegion>('workflowGraph');
   // Typed graph camera state. The graph viewport is user-owned after the
@@ -1396,6 +1406,39 @@ export function App() {
     }
   }, [refreshTaskGraph, selectedWorkflowId]);
 
+  const handleDetachWorkflow = useCallback(async (workflowId: string) => {
+    setWorkflowContextMenu(null);
+    const workflow = workflows.get(workflowId);
+    const deps = workflow?.externalDependencies ?? [];
+    // UI detach targets a single upstream edge so the confirmation can name
+    // both endpoints. Multi-upstream detach stays on the headless/API surface.
+    if (deps.length !== 1) return;
+    const upstreamWorkflowId = deps[0].workflowId;
+    const downstreamName = workflow?.name ?? workflowId;
+    const upstreamName = workflows.get(upstreamWorkflowId)?.name ?? upstreamWorkflowId;
+    const confirmed = window.confirm(
+      `Detach "${downstreamName}" from upstream "${upstreamName}"?\n\n` +
+      `This removes the active dependency so "${downstreamName}" no longer waits on "${upstreamName}". ` +
+      `The detached lineage stays visible in the graph. Neither workflow is deleted.`,
+    );
+    if (!confirmed) return;
+    try {
+      await window.invoker?.detachWorkflow(workflowId, upstreamWorkflowId);
+      setDetachNotice(
+        `Detached "${downstreamName}" from upstream "${upstreamName}". The active dependency was removed; detached lineage remains visible.`,
+      );
+      refreshTaskGraph();
+    } catch (err) {
+      console.error('Detach Workflow failed:', err);
+    }
+  }, [workflows, refreshTaskGraph]);
+
+  useEffect(() => {
+    if (!detachNotice) return;
+    const timer = setTimeout(() => setDetachNotice(null), 6000);
+    return () => clearTimeout(timer);
+  }, [detachNotice]);
+
   const handleFix = useCallback(async (taskId: string, agentName: string) => {
     setContextMenu(null);
     const task = tasks.get(taskId);
@@ -2199,10 +2242,23 @@ export function App() {
           onRecreateWorkflow={(workflowId) => void handleRecreateWorkflow(workflowId)}
           onCancelWorkflow={(workflowId) => void handleCancelWorkflow(workflowId)}
           onDeleteWorkflow={(workflowId) => void handleDeleteWorkflow(workflowId)}
+          onDetachWorkflow={(workflowId) => void handleDetachWorkflow(workflowId)}
+          canDetach={(workflows.get(workflowContextMenu.workflowId)?.externalDependencies?.length ?? 0) === 1}
           onCopyWorkflowId={handleCopyWorkflowId}
           onClose={closeContextMenu}
           autoFocus={Boolean(workflowContextMenu.returnFocusRegion)}
         />
+      )}
+
+      {detachNotice && (
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="detach-feedback"
+          className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-sm text-gray-100 shadow-xl"
+        >
+          {detachNotice}
+        </div>
       )}
 
       {contextMenu && contextMenuTask && (

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -278,6 +278,92 @@ describe('Context menu (component)', () => {
     await waitFor(() => expect(mock.api.deleteWorkflow).toHaveBeenCalledWith('wf-1'));
   });
 
+  describe('workflow detach', () => {
+    const upTask = makeUITask({
+      id: 'task-up',
+      description: 'Upstream task',
+      status: 'completed',
+      command: 'echo up',
+      workflowId: 'wf-up',
+    });
+    const downTask = makeUITask({
+      id: 'task-down',
+      description: 'Downstream task',
+      status: 'pending',
+      command: 'echo down',
+      workflowId: 'wf-down',
+    });
+    const stackWorkflows: WorkflowMeta[] = [
+      { id: 'wf-up', name: 'Upstream Workflow', status: 'running', baseBranch: 'master' },
+      {
+        id: 'wf-down',
+        name: 'Downstream Workflow',
+        status: 'running',
+        baseBranch: 'master',
+        externalDependencies: [{ workflowId: 'wf-up', requiredStatus: 'completed' }],
+      },
+    ];
+
+    async function setupStack() {
+      render(<App />);
+      act(() => mock.setTasks([upTask, downTask], stackWorkflows));
+      await waitFor(() => {
+        expect(screen.getByTestId('workflow-node-wf-down')).toBeInTheDocument();
+      });
+    }
+
+    it('offers detach for a workflow with a single upstream dependency', async () => {
+      await setupStack();
+
+      fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-down'));
+      fireEvent.click(await screen.findByText('More'));
+      expect(await screen.findByText('Detach Upstream Workflow')).toBeInTheDocument();
+    });
+
+    it('hides detach for a workflow with no upstream dependency', async () => {
+      await setupStack();
+
+      fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-up'));
+      fireEvent.click(await screen.findByText('More'));
+      expect(screen.queryByText('Detach Upstream Workflow')).not.toBeInTheDocument();
+    });
+
+    it('confirms naming both workflows, then detaches once and shows feedback', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      await setupStack();
+
+      fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-down'));
+      fireEvent.click(await screen.findByText('More'));
+      fireEvent.click(await screen.findByText('Detach Upstream Workflow'));
+
+      await waitFor(() =>
+        expect(mock.api.detachWorkflow).toHaveBeenCalledWith('wf-down', 'wf-up'),
+      );
+      expect(mock.api.detachWorkflow).toHaveBeenCalledTimes(1);
+
+      const confirmMessage = confirmSpy.mock.calls.at(-1)?.[0] as string;
+      expect(confirmMessage).toContain('Downstream Workflow');
+      expect(confirmMessage).toContain('Upstream Workflow');
+
+      const feedback = await screen.findByTestId('detach-feedback');
+      expect(feedback).toHaveTextContent('Downstream Workflow');
+      expect(feedback).toHaveTextContent('Upstream Workflow');
+    });
+
+    it('does not detach when the confirmation is cancelled', async () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(false);
+      await setupStack();
+
+      fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-down'));
+      fireEvent.click(await screen.findByText('More'));
+      fireEvent.click(await screen.findByText('Detach Upstream Workflow'));
+
+      await waitFor(() => expect(window.confirm).toHaveBeenCalled());
+      expect(mock.api.detachWorkflow).not.toHaveBeenCalled();
+      expect(screen.queryByTestId('detach-feedback')).not.toBeInTheDocument();
+    });
+  });
+
   it('workflow context menu copies workflow id', async () => {
     await setup();
     fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -180,6 +180,7 @@ export function createMockInvoker(
     deleteAllWorkflows: vi.fn(async () => {}),
     deleteAllWorkflowsBulk: vi.fn(async () => {}),
     deleteWorkflow: vi.fn(async () => {}),
+    detachWorkflow: vi.fn(async () => {}),
     cleanupWorktrees: vi.fn(async () => ({ removed: [], errors: [] })),
     recreateWorkflow: vi.fn(async () => {}),
     recreateTask: vi.fn(async () => {}),


### PR DESCRIPTION
## Summary

Detaching a workflow used to change the graph silently. Now the app asks you to confirm first, naming both the upstream and downstream workflow.

After a successful detach, the app tells you the active dependency was removed and that the detached lineage stays visible on the graph.

Headless and API detach still work for automation. Their output now logs the removed upstream and any base-branch rewrite so you can trace the change. Scheduling behavior is unchanged.

<details>
<summary>Review metadata</summary>

Review Claim: Topology-changing detach now requires explicit confirmation naming both workflows and reports a clear outcome, without changing scheduling semantics.

Review Lane: `behavior`

Review Unit: `routing`

Safety Invariant: The same detach mutation route is called as before; only confirmation and outcome feedback are added, and headless/API automation stays available.

Slice Rationale: User-facing guardrails belong after the provenance and graph-rendering slices, so this is the third step in the detach-lineage stack.

</details>

## Non-goals

- No change to detach scheduling semantics or the underlying mutation route.
- No removal or disabling of detach; it stays a supported recovery operation.
- No change to graph rendering of detached lineage (covered by the next slice).

## Test Plan

- [ ] `cd packages/ui && pnpm test`
- [ ] `cd packages/app && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
