### PR TITLE
Detach lineage Step 3: add detached-lineage visual proof

### DIFF
--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -71,6 +71,65 @@ describe('Visual proof snapshots', () => {
     });
   });
 
+  it('detached-lineage graph state — detached marker distinct from active dependency edge', async () => {
+    // Deterministic fixture: one shared upstream workflow with two downstreams —
+    // one still actively depending on it, one explicitly detached. Proves the
+    // detached lineage renders as a distinct dashed edge + badge, not as an
+    // active solid edge.
+    const workflows: WorkflowMeta[] = [
+      { id: 'wf-up', name: 'Upstream', status: 'completed' },
+      {
+        id: 'wf-active',
+        name: 'Active downstream',
+        status: 'running',
+        externalDependencies: [{ workflowId: 'wf-up', requiredStatus: 'completed' }],
+      },
+      {
+        id: 'wf-detached',
+        name: 'Detached downstream',
+        status: 'running',
+        detachedExternalDependencies: [
+          {
+            workflowId: 'wf-up',
+            taskId: '__merge__',
+            requiredStatus: 'completed',
+            gatePolicy: 'completed',
+            detachedAt: '2026-01-02T00:00:00.000Z',
+          },
+        ],
+      },
+    ];
+    const upstream = makeUITask({ id: 'task-up', description: 'Upstream task', status: 'completed', workflowId: 'wf-up' });
+    const active = makeUITask({ id: 'task-active', description: 'Active downstream task', status: 'running', workflowId: 'wf-active' });
+    const detached = makeUITask({ id: 'task-detached', description: 'Detached downstream task', status: 'running', workflowId: 'wf-detached' });
+
+    render(<App />);
+    act(() => mock.setTasks([upstream, active, detached], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-active')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-detached')).toBeInTheDocument();
+    });
+
+    // Active dependency: solid edge (no dash), distinct accessible name.
+    const activeEdge = screen.getByTestId('rf__edge-workflow:active:wf-up->wf-active');
+    expect(activeEdge).toHaveAttribute('data-kind', 'active');
+    expect(activeEdge).toHaveAttribute('data-stroke-dasharray', '');
+    expect(activeEdge).toHaveAccessibleName('Active workflow dependency');
+
+    // Detached lineage: dashed edge, distinct kind + accessible name.
+    const detachedEdge = screen.getByTestId('rf__edge-workflow:detached:wf-up->wf-detached');
+    expect(detachedEdge).toHaveAttribute('data-kind', 'detached');
+    expect(detachedEdge).toHaveAttribute('data-stroke-dasharray', '5 6');
+    expect(detachedEdge).toHaveAccessibleName('Detached workflow lineage');
+
+    // The detached downstream carries the "Detached" badge; the active one does not.
+    const badge = screen.getByTestId('workflow-node-wf-detached-detached-lineage');
+    expect(badge).toHaveTextContent('Detached');
+    expect(badge).toHaveAttribute('title', 'Detached from 1 upstream workflow');
+    expect(screen.queryByTestId('workflow-node-wf-active-detached-lineage')).not.toBeInTheDocument();
+  });
+
   it('workflow and task context menus render', async () => {
     const workflows: WorkflowMeta[] = [{ id: 'wf-alpha', name: 'Alpha', status: 'running' }];
     const alpha = makeUITask({ id: 'task-alpha', description: 'First test task', status: 'running', workflowId: 'wf-alpha' });


### PR DESCRIPTION
## Summary

Detached lineage should look different from an active dependency. This adds snapshot coverage that proves the detached-lineage graph state renders a distinct, non-overlapping marker.

The snapshot includes both an active edge and a detached lineage state, so a reviewer can confirm the two are visually distinguishable.

This is test-only proof. It does not change how the graph behaves at runtime beyond deterministic fixtures.

<details>
<summary>Review metadata</summary>

Review Claim: The detached-lineage graph state is visually distinct and non-overlapping versus an active dependency edge, captured as deterministic snapshot coverage.

Review Lane: `proof`

Review Unit: `ui`

Safety Invariant: Visual proof changes are limited to fixtures and tests; runtime graph behavior is unchanged.

Slice Rationale: Screenshot/snapshot coverage belongs last, after graph rendering and the feedback guardrails it verifies.

</details>

## Non-goals

- No runtime change to graph rendering or detach behavior.
- No new product feature; this slice only adds proof coverage.

## Test Plan

- [ ] `cd packages/ui && pnpm test`

## Visual Proof

The end-to-end visual-proof capture could not run in this environment (`vite: command not found` during the UI build), so no screenshots are attached. The detached-lineage state is instead pinned by the deterministic snapshot test added in `packages/ui/src/__tests__/visual-proof-snapshots.test.tsx`, which asserts a distinct, non-overlapping detached marker alongside an active edge.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
