### PR TITLE
Reduce Large Files Step 3: orchestrator.ts decomposition — merge and events

### DIFF
--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -26,7 +26,6 @@ import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
 import type { Logger, WorkResponse } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import { normalizeRunnerKind } from '@invoker/workflow-graph';
-import { parseMergeConflictError } from './merge-conflict-error.js';
 import {
   buildExecutorRoutedPayload,
   buildHeavyweightRoutingRules,
@@ -103,6 +102,19 @@ import {
   checkWorkflowCompletionImpl,
 } from './orchestrator/transitions.js';
 import type { TransitionHost } from './orchestrator/transitions.js';
+import {
+  buildTaskUpdateDelta,
+  buildTaskRemoveDelta,
+} from './orchestrator/events.js';
+import {
+  recreateWorkflowFromFreshBaseImpl,
+  getKnownFreshBaseCommitImpl,
+  beginConflictResolutionImpl,
+  beginAutoFixSessionImpl,
+  revertConflictResolutionImpl,
+  getMergeNodeImpl,
+} from './orchestrator/merge.js';
+import type { MergeHost } from './orchestrator/merge.js';
 import { buildPlanLocalToScopedIdMap, scopePlanTaskId } from './task-id-scope.js';
 import type { TaskRepository } from './task-repository.js';
 import {
@@ -170,7 +182,6 @@ const RECREATE_RESET_CHANGES: TaskStateChanges = {
   },
 };
 
-const FIX_FAILURE_PREFIX_RE = /^\[Fix with (?:Claude|Agent) failed\] [^\n]*\n\n/;
 const TRACE_PERSIST_SYNC = process.env.INVOKER_TRACE_PERSIST_SYNC === '1';
 const TRACE_WORKER_RESPONSE = process.env.INVOKER_TRACE_WORKER_RESPONSE === '1';
 const noopLogger: Logger = {
@@ -180,10 +191,6 @@ const noopLogger: Logger = {
   error() {},
   child() { return noopLogger; },
 };
-
-function stripFixFailureWrapper(errorText: string): string {
-  return errorText.replace(FIX_FAILURE_PREFIX_RE, '');
-}
 
 function nextLeaseExpiry(from: Date): Date {
   return new Date(from.getTime() + ATTEMPT_LEASE_MS);
@@ -779,24 +786,14 @@ export class Orchestrator {
    * returned by writeAndSync.
    */
   private buildUpdateDelta(before: TaskState, after: TaskState, changes: TaskStateChanges): TaskDelta {
-    return {
-      type: 'updated',
-      taskId: after.id,
-      changes,
-      taskStateVersion: after.taskStateVersion,
-      previousTaskStateVersion: before.taskStateVersion,
-    };
+    return buildTaskUpdateDelta(before, after, changes);
   }
 
   /**
    * Build a 'removed' TaskDelta with the task's last known task-state version.
    */
   private buildRemoveDelta(task: TaskState): TaskDelta {
-    return {
-      type: 'removed',
-      taskId: task.id,
-      previousTaskStateVersion: task.taskStateVersion,
-    };
+    return buildTaskRemoveDelta(task);
   }
 
   private touchWorkflow(workflowId: string): void {
@@ -2649,26 +2646,7 @@ export class Orchestrator {
       ) => Promise<{ commit?: string; branch?: string } | undefined | void>;
     },
   ): Promise<TaskState[]> {
-    if (options?.refreshBase) {
-      const fresh = await options.refreshBase(workflowId);
-      if (fresh && typeof fresh === 'object') {
-        if (typeof fresh.commit === 'string' && fresh.commit.length > 0) {
-          this.knownFreshBaseCommits.set(workflowId, fresh.commit);
-          this.logger.info('[orchestrator] recreateWorkflowFromFreshBase fresh base commit', {
-            workflowId,
-            freshBaseCommit: fresh.commit.slice(0, 12),
-          });
-        }
-        if (typeof fresh.branch === 'string' && fresh.branch.length > 0 && this.persistence.updateWorkflow) {
-          this.persistence.updateWorkflow(workflowId, { baseBranch: fresh.branch });
-          this.logger.info('[orchestrator] recreateWorkflowFromFreshBase fresh base branch', {
-            workflowId,
-            freshBaseBranch: fresh.branch,
-          });
-        }
-      }
-    }
-    return this.recreateWorkflow(workflowId);
+    return recreateWorkflowFromFreshBaseImpl(this as unknown as MergeHost, workflowId, options);
   }
 
   /**
@@ -2684,7 +2662,7 @@ export class Orchestrator {
    * prove the fresh-base step actually advanced.
    */
   getKnownFreshBaseCommit(workflowId: string): string | undefined {
-    return this.knownFreshBaseCommits.get(workflowId);
+    return getKnownFreshBaseCommitImpl(this as unknown as MergeHost, workflowId);
   }
 
   /**
@@ -2693,51 +2671,7 @@ export class Orchestrator {
    * Returns the saved error string so the caller can revert on failure.
    */
   beginConflictResolution(taskId: string, expectedLineage?: TaskLineageExpectation): { savedError: string } {
-    this.refreshFromDb();
-    const task = this.stateGetTask(taskId);
-    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-    if (!this.taskMatchesLineageExpectation(task, expectedLineage)) {
-      throw new Error(`Task ${taskId} lineage is stale for conflict resolution start`);
-    }
-    if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
-
-    const savedError = task.execution.error ?? '';
-    const startedAt = new Date();
-
-    const id = task.id;
-    const changes: TaskStateChanges = {
-      status: 'fixing_with_ai',
-      execution: {
-        error: undefined,
-        exitCode: undefined,
-        completedAt: undefined,
-        mergeConflict: undefined,
-        isFixingWithAI: false,
-        startedAt,
-        lastHeartbeatAt: startedAt,
-      },
-    };
-    const changesWithGeneration = this.withBumpedExecutionGeneration(task, changes);
-    const conflictUpdated = this.writeAndSync(taskId, changesWithGeneration);
-    const attemptId = this.replaceSelectedAttempt(task);
-    this.taskRepository.updateAttempt(attemptId, {
-      status: 'running',
-      startedAt,
-      lastHeartbeatAt: startedAt,
-      branch: task.execution.branch,
-      commit: task.execution.commit,
-      workspacePath: task.execution.workspacePath,
-      agentSessionId: task.execution.agentSessionId,
-      containerId: task.execution.containerId,
-      mergeConflict: undefined,
-      error: undefined,
-      exitCode: undefined,
-    });
-    const delta: TaskDelta = this.buildUpdateDelta(task, conflictUpdated, changesWithGeneration);
-    this.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
-    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
-
-    return { savedError };
+    return beginConflictResolutionImpl(this as unknown as MergeHost, taskId, expectedLineage);
   }
 
   /**
@@ -2749,55 +2683,7 @@ export class Orchestrator {
     taskId: string,
     opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
   ): { savedError: string } {
-    this.refreshFromDb();
-    const task = this.stateGetTask(taskId);
-    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-    if (!this.taskMatchesLineageExpectation(task, opts.expectedLineage)) {
-      throw new Error(`Task ${taskId} lineage is stale for auto-fix start`);
-    }
-    if (
-      task.status !== 'failed' &&
-      task.status !== 'review_ready' &&
-      task.status !== 'awaiting_approval'
-    ) {
-      throw new Error(`Task ${taskId} is not in an auto-fixable state (status: ${task.status})`);
-    }
-
-    const savedError = opts.savedError ?? task.execution.error ?? '';
-    const startedAt = new Date();
-    const id = task.id;
-    const changes: TaskStateChanges = {
-      status: 'fixing_with_ai',
-      execution: {
-        error: undefined,
-        exitCode: undefined,
-        completedAt: undefined,
-        mergeConflict: undefined,
-        isFixingWithAI: false,
-        startedAt,
-        lastHeartbeatAt: startedAt,
-      },
-    };
-    const changesWithGeneration = this.withBumpedExecutionGeneration(task, changes);
-    const updated = this.writeAndSync(id, changesWithGeneration);
-    const attemptId = this.replaceSelectedAttempt(task);
-    this.taskRepository.updateAttempt(attemptId, {
-      status: 'running',
-      startedAt,
-      lastHeartbeatAt: startedAt,
-      branch: task.execution.branch,
-      commit: task.execution.commit,
-      workspacePath: task.execution.workspacePath,
-      agentSessionId: task.execution.agentSessionId,
-      containerId: task.execution.containerId,
-      mergeConflict: undefined,
-      error: undefined,
-      exitCode: undefined,
-    });
-    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changesWithGeneration);
-    this.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
-    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
-    return { savedError };
+    return beginAutoFixSessionImpl(this as unknown as MergeHost, taskId, opts);
   }
 
   /**
@@ -2810,40 +2696,7 @@ export class Orchestrator {
     fixError?: string,
     expectedLineage?: TaskLineageExpectation,
   ): void {
-    this.refreshFromDb();
-    const task = this.stateGetTask(taskId);
-    if (!task) {
-      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-    }
-    if (!this.taskMatchesLineageExpectation(task, expectedLineage)) return;
-    const id = task.id;
-
-    const normalizedSavedError = stripFixFailureWrapper(savedError);
-    const mergeConflict = parseMergeConflictError(normalizedSavedError);
-
-    const displayError = fixError
-      ? `[Fix with Agent failed] ${fixError}\n\n${normalizedSavedError}`
-      : savedError;
-    const completedAt = new Date();
-    const changes: TaskStateChanges = {
-      status: 'failed',
-      execution: {
-        error: displayError,
-        mergeConflict,
-        isFixingWithAI: false,
-        completedAt,
-      },
-    };
-    const revertUpdated = this.writeAndSync(taskId, changes);
-    this.updateSelectedAttempt(taskId, {
-      status: 'failed',
-      error: displayError,
-      mergeConflict,
-      completedAt,
-    });
-    const delta: TaskDelta = this.buildUpdateDelta(task, revertUpdated, changes);
-    this.persistence.logEvent?.(id, 'task.failed', changes);
-    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+    revertConflictResolutionImpl(this as unknown as MergeHost, taskId, savedError, fixError, expectedLineage);
   }
 
   /**
@@ -4010,9 +3863,7 @@ export class Orchestrator {
    * Find the terminal merge node for a given workflow.
    */
   getMergeNode(workflowId: string): TaskState | undefined {
-    return this.stateMachine.getAllTasks().find(
-      (t) => t.config.workflowId === workflowId && t.config.isMergeNode,
-    );
+    return getMergeNodeImpl(this as unknown as MergeHost, workflowId);
   }
 
   getWorkflowStatus(workflowId?: string): {

--- a/packages/workflow-core/src/orchestrator/events.ts
+++ b/packages/workflow-core/src/orchestrator/events.ts
@@ -1,0 +1,56 @@
+/**
+ * Extracted event-publication domain.
+ *
+ * Centralizes the `task.delta` event contract: the channel constant, the
+ * `TaskDelta` builders, and the MessageBus publish helper. The Orchestrator
+ * and the other extracted domains (scheduler, transitions, merge) build and
+ * publish deltas through these functions, keeping the delta payload shape and
+ * channel name defined in exactly one place (see `graph-mutation.ts` for the
+ * same host-delegation pattern).
+ *
+ * Behavior is intentionally identical to the previous in-class helpers:
+ * the `updated`/`removed` payload fields, task-state continuity metadata, and
+ * the `task.delta` channel are preserved exactly so the TASK_DELTA publication
+ * contract stays stable.
+ */
+
+import type { TaskState, TaskDelta, TaskStateChanges } from '@invoker/workflow-graph';
+import type { OrchestratorMessageBus } from '../orchestrator.js';
+
+/** Channel on which all task deltas are published. */
+export const TASK_DELTA_CHANNEL = 'task.delta';
+
+/**
+ * Build an 'updated' TaskDelta with task-state continuity metadata.
+ * `before` is the task state before the mutation, `after` is the state
+ * returned by writeAndSync.
+ */
+export function buildTaskUpdateDelta(
+  before: TaskState,
+  after: TaskState,
+  changes: TaskStateChanges,
+): TaskDelta {
+  return {
+    type: 'updated',
+    taskId: after.id,
+    changes,
+    taskStateVersion: after.taskStateVersion,
+    previousTaskStateVersion: before.taskStateVersion,
+  };
+}
+
+/**
+ * Build a 'removed' TaskDelta with the task's last known task-state version.
+ */
+export function buildTaskRemoveDelta(task: TaskState): TaskDelta {
+  return {
+    type: 'removed',
+    taskId: task.id,
+    previousTaskStateVersion: task.taskStateVersion,
+  };
+}
+
+/** Publish a task delta on the canonical `task.delta` channel. */
+export function publishTaskDelta(messageBus: OrchestratorMessageBus, delta: TaskDelta): void {
+  messageBus.publish(TASK_DELTA_CHANNEL, delta);
+}

--- a/packages/workflow-core/src/orchestrator/merge.ts
+++ b/packages/workflow-core/src/orchestrator/merge.ts
@@ -1,0 +1,288 @@
+/**
+ * Extracted merge / conflict-resolution domain.
+ *
+ * These functions implement the merge-experiment lifecycle that lives on the
+ * orchestrator rather than in the graph layer: the fresh-base recreate flow,
+ * the AI conflict-resolution / auto-fix session transitions, and merge-node
+ * lookup. They run as standalone functions operating on a `MergeHost`, with
+ * the Orchestrator delegating to them for API compatibility (see
+ * `graph-mutation.ts` for the same host-delegation pattern; the structural
+ * merge-leaf invariants stay in `graph-mutation.ts`).
+ *
+ * Behavior is intentionally identical to the previous in-class methods: write
+ * order, attempt dual-writes, event names, and delta publication are preserved
+ * exactly so merge/experiment behavior and the TASK_DELTA contract stay stable.
+ */
+
+import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '@invoker/workflow-graph';
+import type { Logger } from '@invoker/contracts';
+import { parseMergeConflictError } from '../merge-conflict-error.js';
+import type { TaskStateMachine } from '../state-machine.js';
+import type { TaskRepository } from '../task-repository.js';
+import {
+  OrchestratorError,
+  OrchestratorErrorCode,
+} from '../orchestrator.js';
+import type {
+  OrchestratorPersistence,
+  TaskLineageExpectation,
+} from '../orchestrator.js';
+import { buildTaskUpdateDelta, publishTaskDelta } from './events.js';
+
+const FIX_FAILURE_PREFIX_RE = /^\[Fix with (?:Claude|Agent) failed\] [^\n]*\n\n/;
+
+function stripFixFailureWrapper(errorText: string): string {
+  return errorText.replace(FIX_FAILURE_PREFIX_RE, '');
+}
+
+// ── Host Interface ──────────────────────────────────────────
+
+/**
+ * Subset of Orchestrator that the merge functions need.
+ * Keeps the extracted functions decoupled from the full Orchestrator class.
+ */
+export interface MergeHost {
+  readonly stateMachine: TaskStateMachine;
+  readonly persistence: OrchestratorPersistence;
+  readonly messageBus: { publish<T>(channel: string, message: T): void };
+  readonly logger: Logger;
+  readonly taskRepository: TaskRepository;
+  readonly knownFreshBaseCommits: Map<string, string>;
+
+  refreshFromDb(): void;
+  stateGetTask(taskId: string): TaskState | undefined;
+  taskMatchesLineageExpectation(task: TaskState, expected?: TaskLineageExpectation): boolean;
+  withBumpedExecutionGeneration(task: TaskState, changes: TaskStateChanges): TaskStateChanges;
+  writeAndSync(
+    taskId: string,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): TaskState;
+  replaceSelectedAttempt(
+    task: TaskState,
+    opts?: Partial<Omit<Attempt, 'id' | 'nodeId' | 'createdAt'>>,
+    writeOpts?: { skipWorkflowStatusSync?: boolean },
+  ): string;
+  updateSelectedAttempt(
+    taskId: string,
+    changes: Partial<
+      Pick<
+        Attempt,
+        | 'status'
+        | 'claimedAt'
+        | 'startedAt'
+        | 'completedAt'
+        | 'exitCode'
+        | 'error'
+        | 'lastHeartbeatAt'
+        | 'leaseExpiresAt'
+        | 'branch'
+        | 'commit'
+        | 'summary'
+        | 'workspacePath'
+        | 'agentSessionId'
+        | 'containerId'
+        | 'mergeConflict'
+      >
+    >,
+  ): void;
+  buildUpdateDelta(before: TaskState, after: TaskState, changes: TaskStateChanges): TaskDelta;
+  recreateWorkflow(workflowId: string): TaskState[];
+}
+
+// ── Extracted Functions ─────────────────────────────────────
+
+export async function recreateWorkflowFromFreshBaseImpl(
+  host: MergeHost,
+  workflowId: string,
+  options?: {
+    refreshBase?: (
+      workflowId: string,
+    ) => Promise<{ commit?: string; branch?: string } | undefined | void>;
+  },
+): Promise<TaskState[]> {
+  if (options?.refreshBase) {
+    const fresh = await options.refreshBase(workflowId);
+    if (fresh && typeof fresh === 'object') {
+      if (typeof fresh.commit === 'string' && fresh.commit.length > 0) {
+        host.knownFreshBaseCommits.set(workflowId, fresh.commit);
+        host.logger.info('[orchestrator] recreateWorkflowFromFreshBase fresh base commit', {
+          workflowId,
+          freshBaseCommit: fresh.commit.slice(0, 12),
+        });
+      }
+      if (typeof fresh.branch === 'string' && fresh.branch.length > 0 && host.persistence.updateWorkflow) {
+        host.persistence.updateWorkflow(workflowId, { baseBranch: fresh.branch });
+        host.logger.info('[orchestrator] recreateWorkflowFromFreshBase fresh base branch', {
+          workflowId,
+          freshBaseBranch: fresh.branch,
+        });
+      }
+    }
+  }
+  return host.recreateWorkflow(workflowId);
+}
+
+export function getKnownFreshBaseCommitImpl(host: MergeHost, workflowId: string): string | undefined {
+  return host.knownFreshBaseCommits.get(workflowId);
+}
+
+export function beginConflictResolutionImpl(
+  host: MergeHost,
+  taskId: string,
+  expectedLineage?: TaskLineageExpectation,
+): { savedError: string } {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+  if (!host.taskMatchesLineageExpectation(task, expectedLineage)) {
+    throw new Error(`Task ${taskId} lineage is stale for conflict resolution start`);
+  }
+  if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
+
+  const savedError = task.execution.error ?? '';
+  const startedAt = new Date();
+
+  const id = task.id;
+  const changes: TaskStateChanges = {
+    status: 'fixing_with_ai',
+    execution: {
+      error: undefined,
+      exitCode: undefined,
+      completedAt: undefined,
+      mergeConflict: undefined,
+      isFixingWithAI: false,
+      startedAt,
+      lastHeartbeatAt: startedAt,
+    },
+  };
+  const changesWithGeneration = host.withBumpedExecutionGeneration(task, changes);
+  const conflictUpdated = host.writeAndSync(taskId, changesWithGeneration);
+  const attemptId = host.replaceSelectedAttempt(task);
+  host.taskRepository.updateAttempt(attemptId, {
+    status: 'running',
+    startedAt,
+    lastHeartbeatAt: startedAt,
+    branch: task.execution.branch,
+    commit: task.execution.commit,
+    workspacePath: task.execution.workspacePath,
+    agentSessionId: task.execution.agentSessionId,
+    containerId: task.execution.containerId,
+    mergeConflict: undefined,
+    error: undefined,
+    exitCode: undefined,
+  });
+  const delta: TaskDelta = host.buildUpdateDelta(task, conflictUpdated, changesWithGeneration);
+  host.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
+  publishTaskDelta(host.messageBus, delta);
+
+  return { savedError };
+}
+
+export function beginAutoFixSessionImpl(
+  host: MergeHost,
+  taskId: string,
+  opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
+): { savedError: string } {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+  if (!host.taskMatchesLineageExpectation(task, opts.expectedLineage)) {
+    throw new Error(`Task ${taskId} lineage is stale for auto-fix start`);
+  }
+  if (
+    task.status !== 'failed' &&
+    task.status !== 'review_ready' &&
+    task.status !== 'awaiting_approval'
+  ) {
+    throw new Error(`Task ${taskId} is not in an auto-fixable state (status: ${task.status})`);
+  }
+
+  const savedError = opts.savedError ?? task.execution.error ?? '';
+  const startedAt = new Date();
+  const id = task.id;
+  const changes: TaskStateChanges = {
+    status: 'fixing_with_ai',
+    execution: {
+      error: undefined,
+      exitCode: undefined,
+      completedAt: undefined,
+      mergeConflict: undefined,
+      isFixingWithAI: false,
+      startedAt,
+      lastHeartbeatAt: startedAt,
+    },
+  };
+  const changesWithGeneration = host.withBumpedExecutionGeneration(task, changes);
+  const updated = host.writeAndSync(id, changesWithGeneration);
+  const attemptId = host.replaceSelectedAttempt(task);
+  host.taskRepository.updateAttempt(attemptId, {
+    status: 'running',
+    startedAt,
+    lastHeartbeatAt: startedAt,
+    branch: task.execution.branch,
+    commit: task.execution.commit,
+    workspacePath: task.execution.workspacePath,
+    agentSessionId: task.execution.agentSessionId,
+    containerId: task.execution.containerId,
+    mergeConflict: undefined,
+    error: undefined,
+    exitCode: undefined,
+  });
+  const delta: TaskDelta = host.buildUpdateDelta(task, updated, changesWithGeneration);
+  host.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
+  publishTaskDelta(host.messageBus, delta);
+  return { savedError };
+}
+
+export function revertConflictResolutionImpl(
+  host: MergeHost,
+  taskId: string,
+  savedError: string,
+  fixError?: string,
+  expectedLineage?: TaskLineageExpectation,
+): void {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) {
+    throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+  }
+  if (!host.taskMatchesLineageExpectation(task, expectedLineage)) return;
+  const id = task.id;
+
+  const normalizedSavedError = stripFixFailureWrapper(savedError);
+  const mergeConflict = parseMergeConflictError(normalizedSavedError);
+
+  const displayError = fixError
+    ? `[Fix with Agent failed] ${fixError}\n\n${normalizedSavedError}`
+    : savedError;
+  const completedAt = new Date();
+  const changes: TaskStateChanges = {
+    status: 'failed',
+    execution: {
+      error: displayError,
+      mergeConflict,
+      isFixingWithAI: false,
+      completedAt,
+    },
+  };
+  const revertUpdated = host.writeAndSync(taskId, changes);
+  host.updateSelectedAttempt(taskId, {
+    status: 'failed',
+    error: displayError,
+    mergeConflict,
+    completedAt,
+  });
+  const delta: TaskDelta = host.buildUpdateDelta(task, revertUpdated, changes);
+  host.persistence.logEvent?.(id, 'task.failed', changes);
+  publishTaskDelta(host.messageBus, delta);
+}
+
+/**
+ * Find the terminal merge node for a given workflow.
+ */
+export function getMergeNodeImpl(host: MergeHost, workflowId: string): TaskState | undefined {
+  return host.stateMachine.getAllTasks().find(
+    (t) => t.config.workflowId === workflowId && t.config.isMergeNode,
+  );
+}


### PR DESCRIPTION
## Summary

This change moves the merge and experiment orchestration path, plus delta publication helpers, out of `orchestrator.ts` into focused modules.

The orchestrator keeps the same public API, the same `TASK_DELTA` shape, and the same publish ordering. Only internal helpers move.

This is the second slice. It builds on the scheduler and transition extraction.

<details>
<summary>Review metadata</summary>

Review Claim: Approve extracting merge/experiment and delta-publication helpers into dedicated modules with no behavior change.

Review Lane: refactor

Review Unit: ownership-refactor

Safety Invariant: Pure code movement; merge behavior and the `TASK_DELTA` publish shape and sequencing stay identical.

Slice Rationale: Merge and publication helpers are split here because they evolve independently from the core scheduling path.

</details>

## Non-goals

- No behavior change; merge and publish behavior stays unchanged.
- Does not alter the `TASK_DELTA` shape or the publish ordering.

## Test Plan

- [ ] `cd packages/workflow-core && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2174