### PR TITLE
[Add workflow GitHub review gate control][D1] Expose workflow gate mode control

### DIFF
--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -134,6 +134,105 @@ describe('WorkflowInspector', () => {
     expect(onSetMergeMode).toHaveBeenCalledWith('wf-1', 'external_review');
   });
 
+  it('shows a one-click conversion affordance for a review-ready merge gate without a reviewUrl and converts to external_review', () => {
+    const onSetMergeMode = vi.fn();
+
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready', mergeMode: 'manual' }}
+        task={makeTask({
+          id: '__merge__wf-1',
+          description: 'Review gate',
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+          execution: {},
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onSetMergeMode={onSetMergeMode}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    const button = screen.getByTestId('convert-to-external-review-button');
+    expect(button).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(onSetMergeMode).toHaveBeenCalledWith('wf-1', 'external_review');
+  });
+
+  it('shows the conversion affordance at the workflow level when the merge gate is the workflow merge node', () => {
+    const onSetMergeMode = vi.fn();
+    const mergeTask = makeTask({
+      id: '__merge__wf-1',
+      description: 'Review gate',
+      status: 'pending',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {},
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'running', mergeMode: 'manual' }}
+        task={null}
+        workflowTasks={new Map([[mergeTask.id, mergeTask]])}
+        collapsed={false}
+        advancedExpanded={false}
+        onSetMergeMode={onSetMergeMode}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('convert-to-external-review-button'));
+    expect(onSetMergeMode).toHaveBeenCalledWith('wf-1', 'external_review');
+  });
+
+  it('hides the conversion affordance once the merge gate already has a reviewUrl', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready', mergeMode: 'manual' }}
+        task={makeTask({
+          id: '__merge__wf-1',
+          description: 'Review gate',
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+          execution: { reviewUrl: 'https://github.com/org/repo/pull/34' },
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onSetMergeMode={() => Promise.resolve()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId('convert-to-external-review-button')).not.toBeInTheDocument();
+  });
+
+  it('hides the conversion affordance when the workflow is already external_review', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready', mergeMode: 'external_review' }}
+        task={makeTask({
+          id: '__merge__wf-1',
+          description: 'Review gate',
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+          execution: {},
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onSetMergeMode={() => Promise.resolve()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId('convert-to-external-review-button')).not.toBeInTheDocument();
+  });
+
   it('disables merge mode while a merge gate is running', () => {
     render(
       <WorkflowInspector

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -57,6 +57,25 @@ function getReviewReadyMergeNodeReviewUrl(
   return undefined;
 }
 
+/**
+ * Find the workflow's merge gate task — the selected task when it is the merge
+ * node, otherwise the merge node within the workflow's task set. Lets the
+ * inspector show merge-gate controls at the workflow level without the user
+ * having to select the hidden `__merge__…` task.
+ */
+function getMergeGateTask(
+  task: TaskState | null,
+  tasks: Map<string, TaskState> | undefined,
+): TaskState | null {
+  if (task?.config.isMergeNode) return task;
+  if (tasks) {
+    for (const candidate of tasks.values()) {
+      if (candidate.config.isMergeNode) return candidate;
+    }
+  }
+  return null;
+}
+
 
 function artifactLabel(artifact: ReviewGateArtifact): string {
   return artifact.title || artifact.url || (artifact.providerId ? `#${artifact.providerId}` : artifact.id);
@@ -157,8 +176,20 @@ export function WorkflowInspector({
       : undefined;
   const workflowTitle = workflow ? workflow.name || workflow.id : null;
   const nodeTitle = task?.description ?? workflowTitle ?? 'No node selected';
-  const showsWorkflowMergeDetails = Boolean(!task && workflow?.id && workflow.onFinish === 'pull_request');
+  const mergeGateTask = getMergeGateTask(task, workflowTasks);
+  const showsWorkflowMergeDetails = Boolean(
+    !task
+    && workflow?.id
+    && (workflow.onFinish === 'pull_request' || workflow.mergeMode || mergeGateTask),
+  );
   const isMergeNode = Boolean((task?.config.isMergeNode || showsWorkflowMergeDetails) && workflow?.id);
+  const canConvertToExternalReview = Boolean(
+    workflow?.id
+    && mergeModeValue(workflow.mergeMode) !== 'external_review'
+    && mergeGateTask
+    && (mergeGateTask.status === 'pending' || mergeGateTask.status === 'review_ready')
+    && !mergeGateTask.execution.reviewUrl,
+  );
   const currentAgent = task?.config.executionAgent ?? task?.execution.agentName ?? 'claude';
   const agentOptions = useMemo(() => {
     const names = new Set(executionAgents ?? []);
@@ -380,6 +411,19 @@ export function WorkflowInspector({
                   <option value="external_review">External review (GitHub)</option>
                 </select>
               </label>
+            )}
+            {onSetMergeMode && workflow?.id && canConvertToExternalReview && (
+              <button
+                type="button"
+                onClick={() => void onSetMergeMode(workflow.id, 'external_review')}
+                disabled={isTaskBusy}
+                data-testid="convert-to-external-review-button"
+                title="Convert this merge gate to an External review (GitHub) gate"
+                className="flex w-full items-center justify-center gap-1.5 rounded border border-blue-500/60 bg-blue-600/20 px-2 py-1 text-xs text-blue-200 hover:bg-blue-600/30 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <span aria-hidden="true">⛙</span>
+                Convert to External review (GitHub)
+              </button>
             )}
             {workflow?.repoUrl && (
               <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
## Summary

The workflow inspector now exposes merge mode on workflows that own a merge gate.

Users can convert a local or manual gate to External review without selecting the hidden merge task.

<details>
<summary>Review metadata</summary>

Review Claim: The workflow inspector exposes workflow gate review activation directly.
Review Lane: behavior
Review Unit: activation-surface
Safety Invariant: The existing merge-node Advanced selector and backend merge-mode mutation remain unchanged.
Slice Rationale: The inspector surface and existing mutation wiring must land together for a usable workflow-level action.

</details>

## Non-goals

This does not change merge-mode persistence, review-gate recreation semantics, or the existing merge-node TaskPanel Advanced selector.

## Architecture

### Before

```mermaid
graph TD
    A["Select hidden merge task"] --> B["Open Advanced panel"]
    B --> C["Call setMergeMode"]
```

### After

```mermaid
graph TD
    A["Select workflow"] --> B["Workflow inspector merge mode control"]
    B --> C["Call setMergeMode"]
    D["Select hidden merge task"] --> E["Advanced panel remains available"]
    E --> C
```

## Test Plan

- [x] `pnpm --filter @invoker/ui test -- workflow-inspector.test.tsx`

## Visual Proof

The stack includes a follow-up visual proof artifact slice for the workflow-level External review affordance.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No