### PR TITLE
Recovery Lifecycle 2g: Worker observability and final verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ If you need to turn a product or implementation plan into an Invoker workflow, i
 
 If you need to operate existing workflows or tasks, use the `invoker-ops` skill.
 
-Use `--output text|label|json|jsonl` on headless `query` commands. Use `./run.sh --headless retry-tasks --status pending|failed --parallel 8` for bulk safe retries. Only **one** process should **write** the workflow database at a time; see [docs/persistence-architecture-single-writer.md](docs/persistence-architecture-single-writer.md).
+Use `--output text|label|json|jsonl` on headless `query` commands. Use `./run.sh --headless retry-tasks --status pending|failed --parallel 8` for bulk safe retries. Inspect recovery ownership and decisions with `./run.sh --headless worker status --output text|json|jsonl`. Normal `run`, `resume`, and retry commands do not start recovery loops; recovery is owned by the explicit recovery worker path. Only **one** process should **write** the workflow database at a time; see [docs/persistence-architecture-single-writer.md](docs/persistence-architecture-single-writer.md).
 
 ## Architecture (at a glance)
 

--- a/docs/architecture/recovery-lifecycle-workers.md
+++ b/docs/architecture/recovery-lifecycle-workers.md
@@ -84,6 +84,17 @@ The worker should only act when persisted state shows that:
 
 When those checks pass, the auto-fix worker submits the normal fix command. It must not be invoked directly by the producer that recorded the failed transition.
 
+## Operator Status
+
+Operators can inspect recovery ownership and recent decisions with:
+
+```bash
+./run.sh --headless worker status --output text
+./run.sh --headless worker status --output json
+```
+
+The status view is audit-backed and read-only. It reports the recovery worker id, owner, last wakeup, last scan, last submitted recovery command, and the latest skip reason. Status reporting must not change recovery eligibility or command submission ordering.
+
 ## External Recovery Worker
 
 The external recovery worker owns integration with external recovery automation. It subscribes to lifecycle wakeups, scans persisted state, and decides whether an external recovery command should be submitted or whether an external process should be coordinated through a command route.

--- a/packages/app/src/__tests__/recovery-worker-observability.test.ts
+++ b/packages/app/src/__tests__/recovery-worker-observability.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildRecoveryWorkerAuditPayload,
+  collectRecoveryWorkerStatus,
+  recoveryWorkerEventType,
+} from '../recovery-worker-observability.js';
+
+describe('recovery-worker-observability', () => {
+  it('derives recovery ownership and latest decisions from task audit events', () => {
+    const workflows = [{ id: 'wf-1' }];
+    const tasks = [{ id: 'wf-1/task-a' }, { id: 'wf-1/task-b' }];
+    const eventsByTask = new Map([
+      ['wf-1/task-a', [
+        {
+          id: 1,
+          taskId: 'wf-1/task-a',
+          eventType: recoveryWorkerEventType('wakeup'),
+          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('wakeup', 'delta-failed', { workflowId: 'wf-1' })),
+          createdAt: '2026-06-22T10:00:00.000Z',
+        },
+        {
+          id: 2,
+          taskId: 'wf-1/task-a',
+          eventType: recoveryWorkerEventType('skip'),
+          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('skip', 'delta-skip', { workflowId: 'wf-1', reason: 'cancellation-error' })),
+          createdAt: '2026-06-22T10:00:01.000Z',
+        },
+      ]],
+      ['wf-1/task-b', [
+        {
+          id: 3,
+          taskId: 'wf-1/task-b',
+          eventType: recoveryWorkerEventType('scan'),
+          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('scan', 'schedule-enter', { workflowId: 'wf-1' })),
+          createdAt: '2026-06-22T10:00:02.000Z',
+        },
+        {
+          id: 4,
+          taskId: 'wf-1/task-b',
+          eventType: recoveryWorkerEventType('submit'),
+          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('submit', 'schedule-enqueued', { workflowId: 'wf-1' })),
+          createdAt: '2026-06-22T10:00:03.000Z',
+        },
+        {
+          id: 5,
+          taskId: 'wf-1/task-b',
+          eventType: recoveryWorkerEventType('skip'),
+          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('skip', 'schedule-skip', { workflowId: 'wf-1', reason: 'already-queued-intent' })),
+          createdAt: '2026-06-22T10:00:04.000Z',
+        },
+      ]],
+    ]);
+
+    const status = collectRecoveryWorkerStatus({
+      listWorkflows: () => workflows as never,
+      loadTasks: () => tasks as never,
+      getEvents: (taskId) => (eventsByTask.get(taskId) ?? []) as never,
+    });
+
+    expect(status).toMatchObject({
+      kind: 'recovery',
+      workerId: 'auto-fix-recovery',
+      owner: 'auto-fix',
+      lastWakeupAt: '2026-06-22T10:00:00.000Z',
+      lastScanAt: '2026-06-22T10:00:02.000Z',
+      lastSubmitAt: '2026-06-22T10:00:03.000Z',
+      lastSkipAt: '2026-06-22T10:00:04.000Z',
+      lastSkipReason: 'already-queued-intent',
+      lastSkipTaskId: 'wf-1/task-b',
+      wakeups: 1,
+      scans: 1,
+      submissions: 1,
+      skips: 2,
+    });
+    expect(status.recent[0]).toMatchObject({
+      action: 'skip',
+      taskId: 'wf-1/task-b',
+      reason: 'already-queued-intent',
+    });
+  });
+});

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -66,6 +66,10 @@ import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './work
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import { publishReviewGateCiFailedLifecycleEvent } from './lifecycle-event-bridge.js';
+import {
+  collectRecoveryWorkerStatus,
+  type RecoveryWorkerStatus,
+} from './recovery-worker-observability.js';
 
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
@@ -1074,7 +1078,7 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessQuerySelect(args[1], deps);
       break;
     case 'worker':
-      await headlessWorker(args[1], deps);
+      await headlessWorker(args.slice(1), deps);
       break;
 
     // ── Deprecated aliases → query ──
@@ -1143,13 +1147,14 @@ const HEADLESS_WORKER_KINDS: ReadonlyArray<{ kind: string; available: boolean; n
   },
 ];
 
-async function headlessWorker(subCommand: string | undefined, deps: HeadlessDeps): Promise<void> {
+async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {
+  const subCommand = args[0] ?? 'list';
   if (subCommand === 'autofix') {
     const tick = createAutoFixRecoveryTick({
       store: deps.persistence,
       submitter: {
-        submit: (workflowId, priority, channel, args) => (
-          deps.persistence.enqueueWorkflowMutationIntent(workflowId, channel, args, priority)
+        submit: (workflowId, priority, channel, mutationArgs) => (
+          deps.persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority)
         ),
       },
       logger: deps.logger,
@@ -1165,14 +1170,60 @@ async function headlessWorker(subCommand: string | undefined, deps: HeadlessDeps
     return;
   }
 
-  if (subCommand && subCommand !== 'list' && subCommand !== 'status') {
+  if (subCommand !== 'list' && subCommand !== 'status') {
     throw new Error(`Unknown worker sub-command: "${subCommand}". Use: autofix, list, status`);
   }
-  process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);
-  for (const worker of HEADLESS_WORKER_KINDS) {
-    const status = worker.available ? 'available' : 'unavailable';
-    process.stdout.write(`  ${worker.kind} — ${status} (${worker.note})\n`);
+
+  if (subCommand === 'list') {
+    process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);
+    for (const worker of HEADLESS_WORKER_KINDS) {
+      const status = worker.available ? 'available' : 'unavailable';
+      process.stdout.write(`  ${worker.kind} — ${status} (${worker.note})\n`);
+    }
+    return;
   }
+
+  const flags = parseQueryFlags(args.slice(1));
+  const status = collectRecoveryWorkerStatus(deps.persistence);
+  const { formatAsJson, formatAsJsonl } = await import('./formatter.js');
+  switch (flags.output) {
+    case 'label':
+      process.stdout.write(`${status.workerId}\n`);
+      break;
+    case 'json':
+      process.stdout.write(formatAsJson(status) + '\n');
+      break;
+    case 'jsonl':
+      process.stdout.write(formatAsJsonl([status]) + '\n');
+      break;
+    default:
+      process.stdout.write(formatRecoveryWorkerStatus(status) + '\n');
+      break;
+  }
+}
+
+function formatRecoveryWorkerStatus(status: RecoveryWorkerStatus): string {
+  const lines = [
+    `${BOLD}Recovery worker${RESET}`,
+    `  kind: ${status.kind}`,
+    `  workerId: ${status.workerId}`,
+    `  owner: ${status.owner}`,
+    `  lastWakeupAt: ${status.lastWakeupAt ?? 'never'}`,
+    `  lastScanAt: ${status.lastScanAt ?? 'never'}`,
+    `  lastSubmitAt: ${status.lastSubmitAt ?? 'never'}`,
+    `  lastSkip: ${status.lastSkipAt ?? 'never'}${status.lastSkipReason ? ` (${status.lastSkipReason} task=${status.lastSkipTaskId})` : ''}`,
+    `  counts: wakeups=${status.wakeups} scans=${status.scans} submissions=${status.submissions} skips=${status.skips}`,
+  ];
+  if (status.recent.length > 0) {
+    lines.push('');
+    lines.push(`${BOLD}Recent recovery decisions${RESET}`);
+    for (const event of status.recent) {
+      const reason = event.reason ? ` reason=${event.reason}` : '';
+      const phase = event.phase ? ` phase=${event.phase}` : '';
+      lines.push(`  ${event.at} ${event.taskId} ${event.action}${phase}${reason}`);
+    }
+  }
+  return lines.join('\n');
 }
 
 async function headlessOwnerServe(deps: Pick<HeadlessDeps, 'isStandaloneOwnerIdle'>): Promise<void> {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -217,6 +217,11 @@ import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import { startLifecycleEventBridge, type LifecycleEventBridge } from './lifecycle-event-bridge.js';
 import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
 import {
+  buildRecoveryWorkerAuditPayload,
+  classifyAutoFixRecoveryPhase,
+  recoveryWorkerEventType,
+} from './recovery-worker-observability.js';
+import {
   executeNoTrackHeadlessBatch,
   type HeadlessBatchExecRequest,
   type HeadlessExecMutationPayload,
@@ -1436,6 +1441,14 @@ function startHeadlessMode(): void {
             ...details,
           };
           persistence.logEvent?.(taskId, 'debug.auto-fix', payload);
+          const recoveryAction = classifyAutoFixRecoveryPhase(phase, payload);
+          if (recoveryAction) {
+            persistence.logEvent?.(
+              taskId,
+              recoveryWorkerEventType(recoveryAction),
+              buildRecoveryWorkerAuditPayload(recoveryAction, phase, payload),
+            );
+          }
           logger.info(
             `[auto-fix-debug][standalone] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}`,
             { module: 'auto-fix' },
@@ -1514,6 +1527,11 @@ function startHeadlessMode(): void {
             scheduleStandaloneAutoFix(task.id);
             return true;
           }
+          logStandaloneAutoFixDebug(task.id, `${trigger}-skip`, {
+            reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
+            shouldSkipForCancellation: cancellationError,
+            shouldAutoFixFromOrchestrator,
+          });
           return false;
         };
 
@@ -2076,6 +2094,14 @@ function createEmbeddedTerminalBackendFromConfig(
       ...details,
     };
     persistence.logEvent?.(taskId, 'debug.auto-fix', payload);
+    const recoveryAction = classifyAutoFixRecoveryPhase(phase, payload);
+    if (recoveryAction) {
+      persistence.logEvent?.(
+        taskId,
+        recoveryWorkerEventType(recoveryAction),
+        buildRecoveryWorkerAuditPayload(recoveryAction, phase, payload),
+      );
+    }
     logger.info(
       `[auto-fix-debug] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}`,
       { module: 'auto-fix' },
@@ -3278,6 +3304,12 @@ function createEmbeddedTerminalBackendFromConfig(
         if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
           logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
           scheduleAutoFix(deltaTaskId);
+        } else if (deltaTaskId) {
+          logAutoFixDebug(deltaTaskId, 'delta-skip', {
+            reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
+            shouldSkipForCancellation: cancellationError,
+            shouldAutoFixFromOrchestrator,
+          });
         }
       }
 

--- a/packages/app/src/recovery-worker-observability.ts
+++ b/packages/app/src/recovery-worker-observability.ts
@@ -1,0 +1,222 @@
+import type { TaskEvent, Workflow } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { RECOVERY_WORKER_KIND } from './workers/auto-fix-recovery.js';
+
+export const RECOVERY_WORKER_ID = 'auto-fix-recovery';
+export const RECOVERY_WORKER_OWNER = 'auto-fix';
+
+export type RecoveryWorkerAuditAction = 'wakeup' | 'scan' | 'submit' | 'skip';
+export type RecoveryWorkerAuditEventType = `recovery.worker.${RecoveryWorkerAuditAction}`;
+
+export interface RecoveryWorkerAuditPayload {
+  readonly workerId: string;
+  readonly kind: string;
+  readonly owner: string;
+  readonly action: RecoveryWorkerAuditAction;
+  readonly phase: string;
+  readonly reason?: string;
+  readonly trigger?: string;
+  readonly status?: string;
+  readonly workflowId?: string | null;
+  readonly autoFixAttempts?: number | null;
+  readonly details?: Record<string, unknown>;
+}
+
+export interface RecoveryWorkerStatus {
+  readonly kind: string;
+  readonly workerId: string;
+  readonly owner: string;
+  readonly lastWakeupAt?: string;
+  readonly lastScanAt?: string;
+  readonly lastSubmitAt?: string;
+  readonly lastSkipAt?: string;
+  readonly lastSkipReason?: string;
+  readonly lastSkipTaskId?: string;
+  readonly wakeups: number;
+  readonly scans: number;
+  readonly submissions: number;
+  readonly skips: number;
+  readonly recent: RecoveryWorkerStatusEvent[];
+}
+
+export interface RecoveryWorkerStatusEvent {
+  readonly at: string;
+  readonly taskId: string;
+  readonly eventType: RecoveryWorkerAuditEventType;
+  readonly action: RecoveryWorkerAuditAction;
+  readonly phase?: string;
+  readonly reason?: string;
+  readonly workflowId?: string | null;
+}
+
+export interface RecoveryWorkerStatusPersistence {
+  listWorkflows(): Workflow[];
+  loadTasks(workflowId: string): TaskState[];
+  getEvents(taskId: string): TaskEvent[];
+}
+
+const RECOVERY_EVENT_TYPES: Record<RecoveryWorkerAuditAction, RecoveryWorkerAuditEventType> = {
+  wakeup: 'recovery.worker.wakeup',
+  scan: 'recovery.worker.scan',
+  submit: 'recovery.worker.submit',
+  skip: 'recovery.worker.skip',
+};
+
+export function recoveryWorkerEventType(action: RecoveryWorkerAuditAction): RecoveryWorkerAuditEventType {
+  return RECOVERY_EVENT_TYPES[action];
+}
+
+export function classifyAutoFixRecoveryPhase(
+  phase: string,
+  details: Record<string, unknown> = {},
+): RecoveryWorkerAuditAction | undefined {
+  if (phase === 'delta-failed') return 'wakeup';
+  if (phase === 'poll-failed' || phase === 'schedule-enter') return 'scan';
+  if (phase === 'schedule-enqueued') return 'submit';
+  if (phase === 'schedule-skip' || phase.endsWith('-skip')) return 'skip';
+  if (details.reason && (phase.includes('skip') || phase.includes('error'))) return 'skip';
+  return undefined;
+}
+
+export function buildRecoveryWorkerAuditPayload(
+  action: RecoveryWorkerAuditAction,
+  phase: string,
+  details: Record<string, unknown> = {},
+): RecoveryWorkerAuditPayload {
+  const reason = typeof details.reason === 'string' ? details.reason : undefined;
+  const trigger = phase.startsWith('delta-')
+    ? 'delta'
+    : phase.startsWith('poll-')
+      ? 'poll'
+      : undefined;
+  const workflowId = typeof details.workflowId === 'string' || details.workflowId === null
+    ? details.workflowId
+    : undefined;
+  const status = typeof details.status === 'string' ? details.status : undefined;
+  const autoFixAttempts = typeof details.autoFixAttempts === 'number' || details.autoFixAttempts === null
+    ? details.autoFixAttempts
+    : undefined;
+
+  return {
+    workerId: RECOVERY_WORKER_ID,
+    kind: RECOVERY_WORKER_KIND,
+    owner: RECOVERY_WORKER_OWNER,
+    action,
+    phase,
+    ...(reason !== undefined ? { reason } : {}),
+    ...(trigger !== undefined ? { trigger } : {}),
+    ...(status !== undefined ? { status } : {}),
+    ...(workflowId !== undefined ? { workflowId } : {}),
+    ...(autoFixAttempts !== undefined ? { autoFixAttempts } : {}),
+    details,
+  };
+}
+
+export function collectRecoveryWorkerStatus(
+  persistence: RecoveryWorkerStatusPersistence,
+): RecoveryWorkerStatus {
+  const status = emptyRecoveryWorkerStatus();
+  const events: RecoveryWorkerStatusEvent[] = [];
+
+  for (const workflow of persistence.listWorkflows()) {
+    for (const task of persistence.loadTasks(workflow.id)) {
+      for (const event of persistence.getEvents(task.id)) {
+        if (!isRecoveryWorkerAuditEventType(event.eventType)) continue;
+        const payload = parsePayload(event.payload);
+        const action = actionForEventType(event.eventType);
+        events.push({
+          at: event.createdAt,
+          taskId: event.taskId,
+          eventType: event.eventType,
+          action,
+          ...(typeof payload.phase === 'string' ? { phase: payload.phase } : {}),
+          ...(typeof payload.reason === 'string' ? { reason: payload.reason } : {}),
+          ...(typeof payload.workflowId === 'string' || payload.workflowId === null ? { workflowId: payload.workflowId } : {}),
+        });
+      }
+    }
+  }
+
+  events.sort((a, b) => a.at.localeCompare(b.at) || a.taskId.localeCompare(b.taskId));
+
+  let lastWakeupAt: string | undefined;
+  let lastScanAt: string | undefined;
+  let lastSubmitAt: string | undefined;
+  let lastSkip: RecoveryWorkerStatusEvent | undefined;
+  let wakeups = 0;
+  let scans = 0;
+  let submissions = 0;
+  let skips = 0;
+
+  for (const event of events) {
+    if (event.action === 'wakeup') {
+      wakeups += 1;
+      lastWakeupAt = event.at;
+    } else if (event.action === 'scan') {
+      scans += 1;
+      lastScanAt = event.at;
+    } else if (event.action === 'submit') {
+      submissions += 1;
+      lastSubmitAt = event.at;
+    } else if (event.action === 'skip') {
+      skips += 1;
+      lastSkip = event;
+    }
+  }
+
+  return {
+    ...status,
+    ...(lastWakeupAt !== undefined ? { lastWakeupAt } : {}),
+    ...(lastScanAt !== undefined ? { lastScanAt } : {}),
+    ...(lastSubmitAt !== undefined ? { lastSubmitAt } : {}),
+    ...(lastSkip !== undefined ? {
+      lastSkipAt: lastSkip.at,
+      lastSkipReason: lastSkip.reason ?? 'unknown',
+      lastSkipTaskId: lastSkip.taskId,
+    } : {}),
+    wakeups,
+    scans,
+    submissions,
+    skips,
+    recent: events.slice(-10).reverse(),
+  };
+}
+
+function emptyRecoveryWorkerStatus(): RecoveryWorkerStatus {
+  return {
+    kind: RECOVERY_WORKER_KIND,
+    workerId: RECOVERY_WORKER_ID,
+    owner: RECOVERY_WORKER_OWNER,
+    wakeups: 0,
+    scans: 0,
+    submissions: 0,
+    skips: 0,
+    recent: [],
+  };
+}
+
+function parsePayload(payload: unknown): Record<string, unknown> {
+  if (!payload) return {};
+  if (typeof payload === 'object' && !Array.isArray(payload)) return payload as Record<string, unknown>;
+  if (typeof payload !== 'string') return {};
+  try {
+    const parsed = JSON.parse(payload);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function isRecoveryWorkerAuditEventType(value: string): value is RecoveryWorkerAuditEventType {
+  return value === 'recovery.worker.wakeup'
+    || value === 'recovery.worker.scan'
+    || value === 'recovery.worker.submit'
+    || value === 'recovery.worker.skip';
+}
+
+function actionForEventType(eventType: RecoveryWorkerAuditEventType): RecoveryWorkerAuditAction {
+  return eventType.slice('recovery.worker.'.length) as RecoveryWorkerAuditAction;
+}


### PR DESCRIPTION
## Summary

Adds operator-facing status for the explicit auto-fix recovery worker.

Workers now record ownership, wakeups, scans, submitted fixes, and skip reasons through existing activity and audit surfaces.

The status path is observational only. Recovery eligibility and command submission still come from the worker policy and normal fix route.

This also completes focused worker verification and the full repository regression gate for the explicit-worker cutover.

## Architecture

### Before

```mermaid
graph TD
    State[Persisted task state] --> Wakeup[Lifecycle wakeup]
    Wakeup --> Worker[Explicit auto-fix worker]
    Worker --> Policy[Recovery policy scan]
    Policy --> Fix[Normal fix command route]
    Worker -. no durable status .-> Operator[Operator]
```

### After

```mermaid
graph TD
    State[Persisted task state] --> Wakeup[Lifecycle wakeup]
    Wakeup --> Worker[Explicit auto-fix worker]
    Worker --> Policy[Recovery policy scan]
    Policy --> Fix[Normal fix command route]
    Worker --> Activity[Worker activity log]
    Policy --> Audit[Task audit events]
    Activity --> Status[worker status]
    Audit --> Query[query audit]
    Status --> Operator[Operator]
    Query --> Operator
    Complete[Task completion] --> Dispatcher[Launch dispatcher poll]
```

## Test Plan

- [x] `cd packages/app && pnpm test -- src/__tests__/worker-runtime.test.ts src/__tests__/headless-autofix.test.ts src/__tests__/headless-client.test.ts`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <commit-sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `worker status` command to inspect recovery worker ownership and audit history in multiple output formats (text, JSON, JSONL).
  * Added `worker list` command to display supported recovery worker types and availability.

* **Documentation**
  * Expanded README with recovery behavior guidance for bulk retries and headless operations.
  * Added operator status documentation describing audit-backed recovery worker inspection capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->