### PR TITLE
[Fix intent cancellation Step 7](1) Fix intent cancellation Step 7: post-start generation guard (regression gated v2)

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -354,3 +354,91 @@ describe('TaskRunner launch-dispatch wiring', () => {
     expect(env.executor.start).not.toHaveBeenCalled();
   });
 });
+
+describe('TaskRunner post-start lineage guard', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function workspaceWrites(updateTask: ReturnType<typeof vi.fn>): unknown[] {
+    return updateTask.mock.calls
+      .map(([, changes]: any) => changes?.execution?.workspacePath)
+      .filter((ws: unknown) => ws !== undefined);
+  }
+
+  it('drops stale post-start metadata when generation advances while attempt id is unchanged', async () => {
+    // Launch is accepted at generation 1; executor.start resolves only after
+    // the live task has advanced to generation 2 (same selectedAttemptId, as a
+    // same-attempt restart would produce). markTaskRunningAfterLaunch would
+    // accept this (attempt id matches), so the lineage guard must catch it.
+    let env!: RunnerEnv;
+    const task = makeTask(); // generation 1, selectedAttemptId 'attempt-1'
+    const advanced = makeTask({
+      execution: { selectedAttemptId: 'attempt-1', generation: 2, phase: 'executing' },
+    });
+    env = buildRunnerEnv(task, {
+      startImpl: async (request) => {
+        // Generation advances while executor.start() is in flight.
+        env.orchestrator.getTask.mockReturnValue(advanced);
+        return {
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/tmp/stale-ws',
+          branch: `experiment/${request.actionId}-stale`,
+          agentSessionId: 'sess-stale',
+          containerId: 'container-stale',
+        };
+      },
+    });
+    const launchOutbox = makeLaunchOutbox();
+
+    await env.runner.executeTask(task, { dispatchId: 77, launchOutbox });
+
+    // executor.start resolved, but the launch is recognized as superseded.
+    expect(env.executor.start).toHaveBeenCalledTimes(1);
+    // The generation gap is caught before promoting the launch to running.
+    expect(env.orchestrator.markTaskRunningAfterLaunch).not.toHaveBeenCalled();
+    // No stale workspace/branch/session/container metadata reaches the task row.
+    expect(workspaceWrites(env.persistence.updateTask)).toHaveLength(0);
+    // The spawned handle is killed, consistent with the stale-attempt path.
+    expect(env.executor.kill).toHaveBeenCalledTimes(1);
+    // No active execution is registered for the superseded launch.
+    expect((env.runner as any).activeExecutions.size).toBe(0);
+    // The dispatch row is failed the same way a stale-attempt rejection fails it.
+    expect(launchOutbox.completeCalls).toHaveLength(0);
+    expect(launchOutbox.failCalls).toHaveLength(1);
+    expect(launchOutbox.failCalls[0][0]).toBe(77);
+    expect((launchOutbox.failCalls[0][1] as Error).message).toMatch(/Launch rejected/);
+    // Observability: the guard records why the launch was dropped.
+    expect(env.persistence.logEvent).toHaveBeenCalledWith(
+      task.id,
+      'task.executor.stale_post_start_launch',
+      expect.objectContaining({
+        attemptId: 'attempt-1',
+        startGeneration: 1,
+        currentGeneration: 2,
+      }),
+    );
+  });
+
+  it('persists start metadata and registers the execution for a current (non-stale) launch', async () => {
+    const task = makeTask(); // generation stays 1 throughout
+    const env = buildRunnerEnv(task);
+    const launchOutbox = makeLaunchOutbox();
+
+    const run = env.runner.executeTask(task, { dispatchId: 88, launchOutbox });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // The valid launch is promoted to running and persists its metadata.
+    expect(env.orchestrator.markTaskRunningAfterLaunch).toHaveBeenCalledWith(task.id, 'attempt-1');
+    expect(workspaceWrites(env.persistence.updateTask)).toContain('/tmp/mock-ws');
+    expect(env.executor.kill).not.toHaveBeenCalled();
+    expect((env.runner as any).activeExecutions.size).toBe(1);
+
+    env.triggerComplete();
+    await run;
+
+    expect(launchOutbox.completeCalls).toEqual([88]);
+    expect(launchOutbox.failCalls).toHaveLength(0);
+  });
+});

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -568,6 +568,31 @@ export class TaskRunner {
     return false;
   }
 
+  /**
+   * Narrow post-start lineage check: returns `true` only when the live
+   * task's `generation` has advanced past the launch-time generation.
+   *
+   * Unlike {@link isLaunchStale} this deliberately does NOT reject on a
+   * `selectedAttemptId` mismatch — the post-start promotion already routes
+   * attempt-id mismatches through `markTaskRunningAfterLaunch`, and
+   * legitimate concurrent attempts of the same task must still register as
+   * active executions so they can be killed later. This guard is the missing
+   * piece: `markTaskRunningAfterLaunch` ignores the launch-time generation,
+   * so a launch accepted at generation N could otherwise persist metadata
+   * after the task advanced to N+1 with the same attempt id.
+   */
+  private hasGenerationAdvancedSinceLaunch(
+    taskId: string,
+    startGeneration: number,
+  ): boolean {
+    const current = this.orchestrator.getTask(taskId);
+    // If the task is no longer visible we cannot confirm the generation
+    // advanced — defer to the normal promotion path rather than dropping
+    // the launch here.
+    if (!current) return false;
+    return (current.execution.generation ?? 0) !== startGeneration;
+  }
+
   async executeTask(task: TaskState, dispatchOpts?: LaunchDispatchOptions): Promise<void> {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} TaskRunner.executeTask BEGIN taskId=${task.id} isMergeNode=${Boolean(task.config.isMergeNode)} status=${task.status}`,
@@ -1067,12 +1092,42 @@ export class TaskRunner {
       hasWorkspacePath: Boolean(handle.workspacePath),
       hasAgentSessionId: Boolean(handle.agentSessionId),
     });
-    const launchAccepted =
-      this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true;
+    // Post-start lineage guard. `executor.start()` can take minutes (SSH
+    // provisioning), and the live task may advance to a new generation while
+    // it is in flight — e.g. a restart that reuses the same attempt id but
+    // bumps the generation. `markTaskRunningAfterLaunch` only rejects a
+    // mismatched selectedAttemptId; it does NOT compare the launch-time
+    // generation (it even stamps the *current* generation when promoting
+    // pending→running). So a launch accepted at generation N could otherwise
+    // persist workspacePath/branch/agentSessionId/containerId/heartbeat
+    // metadata and register an active execution after the task moved to N+1.
+    // Detect that here and route through the same kill/cleanup path as the
+    // stale-attempt rejection, before any post-start metadata is written.
+    // The check is narrow on purpose: only a *generation* advance is caught
+    // here. Attempt-id mismatches stay the responsibility of
+    // markTaskRunningAfterLaunch, so legitimate concurrent same-task attempts
+    // still register as active executions.
+    const launchStaleAfterStart = this.hasGenerationAdvancedSinceLaunch(task.id, startGeneration);
+    const launchAccepted = launchStaleAfterStart
+      ? false
+      : (this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true);
     if (!launchAccepted) {
       this.logger.warn(
-        `[TaskRunner] launch rejected as stale/non-executable for task=${task.id} attemptId=${attemptId}; killing spawned process`,
+        `[TaskRunner] launch rejected as stale/non-executable for task=${task.id} attemptId=${attemptId} ` +
+          `(staleGeneration=${launchStaleAfterStart} startGeneration=${startGeneration}); killing spawned process`,
       );
+      if (launchStaleAfterStart) {
+        this.persistence.logEvent?.(task.id, 'task.executor.stale_post_start_launch', {
+          attemptId,
+          executorType: executor.type,
+          startGeneration,
+          currentGeneration: this.orchestrator.getTask(task.id)?.execution.generation ?? null,
+          workspacePath: handle.workspacePath,
+          branch: handle.branch,
+          hasAgentSessionId: Boolean(handle.agentSessionId),
+          hasContainerId: Boolean(handle.containerId),
+        });
+      }
       try {
         await executor.kill(handle);
       } catch (killErr) {
@@ -1087,7 +1142,7 @@ export class TaskRunner {
           new Error('Launch rejected as stale or non-executable after executor start'),
         );
       }
-      bench('markTaskRunningAfterLaunch.rejected');
+      bench(launchStaleAfterStart ? 'postStartLineageGuard.rejected' : 'markTaskRunningAfterLaunch.rejected');
       return;
     }
     bench('markTaskRunningAfterLaunch.accepted');

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -6998,6 +6998,50 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(taskId)?.status).toBe('running');
     });
 
+    it('rejects a response carrying the current attempt id but a stale executionGeneration', () => {
+      orchestrator.loadPlan({
+        name: 'stale-generation-with-current-attempt',
+        tasks: [{ id: 't1', description: 'Task 1' }],
+      });
+      orchestrator.startExecution();
+
+      const taskId = sid(orchestrator, 0, 't1');
+      const liveTask = orchestrator.getTask(taskId)!;
+      const activeAttemptId = liveTask.execution.selectedAttemptId!;
+      const staleGeneration = liveTask.execution.generation ?? 0;
+
+      // The execution generation moves on while the selected attempt id is
+      // unchanged: an in-flight worker launched at the old generation can
+      // still report the live attempt id. Seed live branch/workspacePath so
+      // we can prove a stale completion does not overwrite them.
+      orchestrator.refreshFromDb();
+      persistence.updateTask(taskId, {
+        execution: {
+          generation: staleGeneration + 1,
+          branch: 'live/feature',
+          workspacePath: '/live/ws',
+        },
+      });
+
+      const staleResult = orchestrator.handleWorkerResponse(
+        makeResponse({
+          actionId: taskId,
+          attemptId: activeAttemptId,
+          executionGeneration: staleGeneration,
+          status: 'completed',
+          outputs: { exitCode: 0, branch: 'stale/feature' },
+        }),
+      );
+
+      expect(staleResult).toEqual([]);
+      const after = orchestrator.getTask(taskId)!;
+      expect(after.status).toBe('running');
+      expect(after.execution.selectedAttemptId).toBe(activeAttemptId);
+      expect(after.execution.branch).toBe('live/feature');
+      expect(after.execution.workspacePath).toBe('/live/ws');
+      expect(persistence.loadAttempt(activeAttemptId)?.status).toBe('running');
+    });
+
     it('recreateWorkflow selects a fresh persisted attempt for recreated tasks', () => {
       orchestrator.loadPlan({
         name: 'recreate-attempt-refresh',

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1584,9 +1584,15 @@ export class Orchestrator {
           });
           return [];
         }
+        // Lineage check on executionGeneration. Validate it whenever the
+        // response carries one — not only when attemptId is absent. A
+        // response can reuse a still-current selectedAttemptId while the
+        // execution generation has moved on; such a response is stale and
+        // must be rejected. Backwards compatible: producers that omit the
+        // field (undefined) are not subject to this check, but when both
+        // attemptId and executionGeneration are present, both must match.
         const activeGeneration = this.getExecutionGeneration(earlyTask);
         if (
-          !response.attemptId &&
           response.executionGeneration !== undefined &&
           response.executionGeneration !== activeGeneration
         ) {


### PR DESCRIPTION
## Summary

Step 7 closes a post-start metadata gap in the task runner. A launch accepted at one generation could finish starting after the live task advanced to a newer generation.

When that happened, the old launch still wrote post-start metadata over the live attempt's state — workspace path, branch, session id, and heartbeat.

The fix adds a narrow lineage check after start resolves, comparing the launch-time generation against the live generation.

A superseded launch is now routed through the existing kill-and-teardown path instead of persisting metadata or registering an active execution.

A best-effort diagnostic records what was dropped — attempt ids, both generations, and runner kind — for later analysis.

<details>
<summary>Review metadata</summary>

Review Claim: A start that resolves after its launch generation was superseded must route to teardown, not persist post-start metadata.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Only the post-start metadata path gains a generation check; when the launch generation still matches, behavior is identical to before.

Slice Rationale: This slice only covers the post-start metadata window in the task runner; earlier lineage and gating steps ship in their own PRs.

</details>

## Non-goals

- Does not change the existing attempt-id match; it only adds the generation comparison alongside it.
- Does not touch worker-response lineage (Step 6) or any earlier step.
- No data migration and no schema change.

## Architecture

### Before

```mermaid
graph TD
    A["Launch captures startGeneration N"] --> B["executor.start resolves"]
    B --> C["markTaskRunningAfterLaunch checks attemptId"]
    C --> D["Persist post-start metadata"]
    D --> E["Register active execution"]
```

### After

```mermaid
graph TD
    A["Launch captures startGeneration N"] --> B["executor.start resolves"]
    B --> G["hasGenerationAdvancedSinceLaunch?"]
    G --> H["Superseded: log diagnostic, kill, teardown"]
    G --> C["Live: markTaskRunningAfterLaunch checks attemptId"]
    C --> D["Persist post-start metadata"]
    D --> E["Register active execution"]
```

## Test Plan

- [ ] `cd packages/execution-engine && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No
