### PR TITLE
Crabbox SSH step 3: runtime wiring

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
+import { SshExecutor } from '../ssh-executor.js';
 import { ResourceLimitError } from '../repo-pool.js';
 import { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
@@ -298,6 +299,141 @@ describe('SSH pool member capacity', () => {
       { err: killErr },
     );
   });
+  it('does not resolve crabbox for a static pool member (resolver untouched)', () => {
+    const resolve = vi.fn();
+    // A registry with no pre-registered ssh executor so the lazy SSH path runs.
+    const staticRunner = new TaskRunner({
+      orchestrator: { getTask: () => null, getAllTasks: () => [], deferTask: vi.fn() } as any,
+      persistence: { logEvent: vi.fn() } as any,
+      executorRegistry: {
+        getDefault: () => ({ type: 'worktree' }),
+        get: () => null,
+        getAll: () => [],
+        register: vi.fn(),
+      } as any,
+      cwd: '/tmp',
+      remoteTargetsProvider: () => ({
+        'remote-a': { host: 'remote-a.example.com', user: 'invoker', sshKeyPath: '/tmp/fake-a' },
+      }),
+      executionPoolsProvider: () => ({
+        'ssh-pool': { selectionStrategy: 'leastLoaded', maxConcurrentTasksPerMember: 1, members: [{ id: 'remote-a', type: 'ssh' as const, maxConcurrentTasks: 1 }] },
+      }),
+      crabboxResolver: { resolve },
+    });
+
+    const executor = staticRunner.selectExecutor(makeTask('wf-1/task-a'));
+    expect(executor.type).toBe('ssh');
+    expect((executor as any).host).toBe('remote-a.example.com');
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  it('keys the execution resource lease on the resolved crabbox endpoint while keeping the pool member id', async () => {
+    vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (this: any, request: any) {
+      return {
+        executionId: `exec-${request.actionId}`,
+        taskId: request.actionId,
+        workspacePath: `/remote/${request.actionId}`,
+        branch: `branch-${request.actionId}`,
+      };
+    });
+    const completeByTask = new Map<string, (response: any) => void>();
+    vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation((handle: any, cb: any) => {
+      completeByTask.set(handle.taskId, cb);
+    });
+    vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+    vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+    vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+
+    try {
+      const resolve = vi.fn(async (config: any) => ({
+        sshTarget: { host: 'leased.crab', user: 'crab', sshKeyPath: '/leased/key', port: 2200 },
+        remoteLeaseMetadata: {
+          provider: 'crabbox' as const,
+          leaseId: 'L1',
+          slug: 'lease-slug',
+          targetId: config.id,
+          sshHost: 'leased.crab',
+          sshUser: 'crab',
+          sshPort: 2200,
+          sshKeyPath: '/leased/key',
+          expiresAt: '',
+          stopAfter: config.stopAfter,
+          keepOnFailure: config.keepOnFailure,
+        },
+      }));
+      const claimCalls: any[] = [];
+      const task = makeTask('wf/crab');
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => (id === task.id ? task : null),
+          getAllTasks: () => [task],
+          markTaskRunningAfterLaunch: () => true,
+          handleWorkerResponse: () => [],
+          deferTask: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask: vi.fn(),
+          updateAttempt: vi.fn(),
+          appendTaskOutput: vi.fn(),
+          logEvent: vi.fn(),
+          loadAttempts: () => [],
+          claimExecutionResourceLease: (args: any) => { claimCalls.push(args); return true; },
+          renewExecutionResourceLease: vi.fn(),
+          releaseExecutionResourceLease: vi.fn(),
+        } as any,
+        executorRegistry: {
+          getDefault: () => ({ type: 'worktree' }),
+          get: () => null,
+          getAll: () => [],
+          register: vi.fn(),
+        } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'crab-a': {
+            type: 'crabbox' as const,
+            crabboxCommand: 'crabbox',
+            provider: 'do',
+            class: 'medium',
+            ttl: '30m',
+            idleTimeout: '10m',
+            network: 'default',
+            target: 'ubuntu-22',
+            stopAfter: 'completed',
+            keepOnFailure: false,
+          },
+        }),
+        executionPoolsProvider: () => ({
+          'ssh-pool': {
+            selectionStrategy: 'leastLoaded',
+            maxConcurrentTasksPerMember: 1,
+            members: [{ id: 'crab-a', type: 'ssh' as const, maxConcurrentTasks: 1 }],
+          },
+        }),
+        crabboxResolver: { resolve },
+      });
+
+      const run = runner.executeTask(task);
+      await vi.waitFor(() => expect(SshExecutor.prototype.start).toHaveBeenCalledTimes(1));
+
+      expect(resolve).toHaveBeenCalledTimes(1);
+      expect(claimCalls).toHaveLength(1);
+      // Resource key uses the RESOLVED endpoint; the pool member id is preserved.
+      expect(claimCalls[0].resourceKey).toBe('ssh:crab@leased.crab:2200');
+      expect(claimCalls[0].poolMemberId).toBe('crab-a');
+
+      completeByTask.get(task.id)?.({
+        requestId: 'r',
+        actionId: task.id,
+        attemptId: task.execution.selectedAttemptId,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+      await run;
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
   it('uses execution resource leases to defer across TaskRunner instances', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     try {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2155,6 +2155,181 @@ describe('TaskRunner', () => {
     });
   });
 
+  describe('crabbox target resolution', () => {
+    function makeFakeResolver() {
+      const resolve = vi.fn(async (config: any) => ({
+        sshTarget: {
+          host: 'lease-host.crabbox.dev',
+          user: 'crab',
+          sshKeyPath: '/leased/key',
+          port: 2222,
+        },
+        remoteLeaseMetadata: {
+          provider: 'crabbox' as const,
+          leaseId: 'lease-123',
+          slug: 'happy-lease',
+          targetId: config.id,
+          sshHost: 'lease-host.crabbox.dev',
+          sshUser: 'crab',
+          sshPort: 2222,
+          sshKeyPath: '/leased/key',
+          expiresAt: '2099-01-01T00:00:00Z',
+          stopAfter: config.stopAfter,
+          keepOnFailure: config.keepOnFailure,
+        },
+      }));
+      return { resolve };
+    }
+
+    const crabboxTarget = {
+      type: 'crabbox' as const,
+      crabboxCommand: 'crabbox',
+      provider: 'do',
+      class: 'medium',
+      ttl: '30m',
+      idleTimeout: '10m',
+      network: 'default',
+      target: 'ubuntu-22',
+      stopAfter: 'completed',
+      keepOnFailure: false,
+    };
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('does not call the resolver for a static SSH target', () => {
+      const resolver = makeFakeResolver();
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'static-a': { host: 'static.example.com', user: 'deployer', sshKeyPath: '/keys/static' },
+        }),
+        crabboxResolver: resolver,
+      });
+
+      const task = makeTask({
+        id: 'static-task',
+        config: { runnerKind: 'ssh', poolMemberId: 'static-a' },
+      });
+
+      const executor = runner.selectExecutor(task);
+      expect(executor.type).toBe('ssh');
+      expect((executor as any).host).toBe('static.example.com');
+      expect(resolver.resolve).not.toHaveBeenCalled();
+    });
+
+    it('resolves a crabbox target through the injected resolver and uses the leased endpoint', async () => {
+      const completeByTask = new Map<string, (response: WorkResponse) => void>();
+      const starts: Array<{ host: string; user: string; sshKeyPath: string; port: number }> = [];
+      vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (this: any, request: any) {
+        starts.push({ host: this.host, user: this.user, sshKeyPath: this.sshKeyPath, port: this.port });
+        return {
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: `/remote/${request.actionId}`,
+          branch: `branch-${request.actionId}`,
+        };
+      });
+      vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation((handle: any, cb: any) => {
+        completeByTask.set(handle.taskId, cb);
+      });
+      vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+
+      const resolver = makeFakeResolver();
+      const task = makeTask({
+        id: 'wf/crab-task',
+        config: { runnerKind: 'ssh', poolMemberId: 'crab-target' },
+        execution: { selectedAttemptId: 'crab-task-attempt', generation: 0 },
+      });
+      const updateTask = vi.fn();
+      const updateAttempt = vi.fn();
+      const logEvent = vi.fn();
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => (id === task.id ? task : null),
+          getAllTasks: () => [task],
+          markTaskRunningAfterLaunch: () => true,
+          handleWorkerResponse: () => [],
+          deferTask: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask,
+          updateAttempt,
+          appendTaskOutput: vi.fn(),
+          logEvent,
+          loadAttempts: () => [],
+        } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({ 'crab-target': crabboxTarget }),
+        crabboxResolver: resolver,
+      });
+
+      const run = runner.executeTask(task);
+      await vi.waitFor(() => expect(starts.length).toBe(1));
+
+      // Resolver called exactly once, with the configured crabbox lease inputs.
+      expect(resolver.resolve).toHaveBeenCalledTimes(1);
+      expect(resolver.resolve.mock.calls[0][0]).toMatchObject({
+        id: 'crab-target',
+        crabboxCommand: 'crabbox',
+        provider: 'do',
+        class: 'medium',
+        ttl: '30m',
+        idleTimeout: '10m',
+        network: 'default',
+        target: 'ubuntu-22',
+        stopAfter: 'completed',
+        keepOnFailure: false,
+      });
+
+      // SshExecutor was built from the resolved (leased) endpoint.
+      expect(starts[0]).toMatchObject({
+        host: 'lease-host.crabbox.dev',
+        user: 'crab',
+        sshKeyPath: '/leased/key',
+        port: 2222,
+      });
+
+      // Lease metadata persisted with the start-metadata update.
+      const persisted = updateTask.mock.calls.find(
+        ([, changes]: [string, any]) => changes.execution?.remoteLeaseMetadata,
+      );
+      expect(persisted?.[1].execution.remoteLeaseMetadata).toMatchObject({
+        provider: 'crabbox',
+        leaseId: 'lease-123',
+        targetId: 'crab-target',
+        sshHost: 'lease-host.crabbox.dev',
+      });
+
+      // selected payload reports the resolved endpoint + lease metadata.
+      const selected = logEvent.mock.calls.find(
+        ([, event]: [string, string]) => event === 'task.executor.selected',
+      );
+      expect(selected?.[2]).toMatchObject({
+        remoteHost: 'lease-host.crabbox.dev',
+        remoteUser: 'crab',
+        port: 2222,
+        remoteLeaseMetadata: { leaseId: 'lease-123' },
+      });
+
+      completeByTask.get(task.id)?.({
+        requestId: 'r',
+        actionId: task.id,
+        attemptId: 'crab-task-attempt',
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      } as WorkResponse);
+      await run;
+    });
+  });
+
   describe('publishAfterFix', () => {
     function setupPublishAfterFix(opts: {
       mergeMode?: string;

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2328,6 +2328,259 @@ describe('TaskRunner', () => {
       } as WorkResponse);
       await run;
     });
+
+    it('builds from the selected crabbox target snapshot after async resolution', async () => {
+      const completeByTask = new Map<string, (response: WorkResponse) => void>();
+      const starts: Array<{ host: string; user: string; sshKeyPath: string; port: number }> = [];
+      vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (this: any, request: any) {
+        starts.push({ host: this.host, user: this.user, sshKeyPath: this.sshKeyPath, port: this.port });
+        return {
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: `/remote/${request.actionId}`,
+          branch: `branch-${request.actionId}`,
+        };
+      });
+      vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation((handle: any, cb: any) => {
+        completeByTask.set(handle.taskId, cb);
+      });
+      vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+
+      let providerCalls = 0;
+      const resolver = makeFakeResolver();
+      const task = makeTask({
+        id: 'wf/crab-snapshot',
+        config: { runnerKind: 'ssh', poolMemberId: 'crab-target' },
+        execution: { selectedAttemptId: 'crab-snapshot-attempt', generation: 0 },
+      });
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => (id === task.id ? task : null),
+          getAllTasks: () => [task],
+          markTaskRunningAfterLaunch: () => true,
+          handleWorkerResponse: () => [],
+          deferTask: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask: vi.fn(),
+          updateAttempt: vi.fn(),
+          appendTaskOutput: vi.fn(),
+          logEvent: vi.fn(),
+          loadAttempts: () => [],
+        } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => {
+          providerCalls += 1;
+          return providerCalls === 1 ? { 'crab-target': crabboxTarget } : {};
+        },
+        crabboxResolver: resolver,
+      });
+
+      const run = runner.executeTask(task);
+      await vi.waitFor(() => expect(starts.length).toBe(1));
+      expect(starts[0]).toMatchObject({
+        host: 'lease-host.crabbox.dev',
+        user: 'crab',
+        sshKeyPath: '/leased/key',
+        port: 2222,
+      });
+
+      completeByTask.get(task.id)?.({
+        requestId: 'r',
+        actionId: task.id,
+        attemptId: 'crab-snapshot-attempt',
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      } as WorkResponse);
+      await run;
+    });
+
+    it('dedupes concurrent crabbox resolution for the same target', async () => {
+      const completeByTask = new Map<string, (response: WorkResponse) => void>();
+      const starts: Array<{ taskId: string; host: string }> = [];
+      vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (this: any, request: any) {
+        starts.push({ taskId: request.actionId, host: this.host });
+        return {
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: `/remote/${request.actionId}`,
+          branch: `branch-${request.actionId}`,
+        };
+      });
+      vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation((handle: any, cb: any) => {
+        completeByTask.set(handle.taskId, cb);
+      });
+      vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+
+      let releaseResolve: () => void = () => {};
+      const gate = new Promise<void>((resolve) => { releaseResolve = resolve; });
+      let resolveCount = 0;
+      const resolver = {
+        resolve: vi.fn(async (config: any) => {
+          resolveCount += 1;
+          const n = resolveCount;
+          await gate;
+          return {
+            sshTarget: {
+              host: `lease-${n}.crabbox.dev`,
+              user: 'crab',
+              sshKeyPath: `/leased/key-${n}`,
+              port: 2200 + n,
+            },
+            remoteLeaseMetadata: {
+              provider: 'crabbox' as const,
+              leaseId: `lease-${n}`,
+              slug: `lease-${n}`,
+              targetId: config.id,
+              sshHost: `lease-${n}.crabbox.dev`,
+              sshUser: 'crab',
+              sshPort: 2200 + n,
+              sshKeyPath: `/leased/key-${n}`,
+              expiresAt: '2099-01-01T00:00:00Z',
+              stopAfter: config.stopAfter,
+              keepOnFailure: config.keepOnFailure,
+            },
+          };
+        }),
+      };
+      const taskA = makeTask({
+        id: 'wf/crab-dedupe-a',
+        config: { runnerKind: 'ssh', poolMemberId: 'crab-target' },
+        execution: { selectedAttemptId: 'crab-dedupe-a-attempt', generation: 0 },
+      });
+      const taskB = makeTask({
+        id: 'wf/crab-dedupe-b',
+        config: { runnerKind: 'ssh', poolMemberId: 'crab-target' },
+        execution: { selectedAttemptId: 'crab-dedupe-b-attempt', generation: 0 },
+      });
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => (id === taskA.id ? taskA : id === taskB.id ? taskB : null),
+          getAllTasks: () => [taskA, taskB],
+          markTaskRunningAfterLaunch: () => true,
+          handleWorkerResponse: () => [],
+          deferTask: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask: vi.fn(),
+          updateAttempt: vi.fn(),
+          appendTaskOutput: vi.fn(),
+          logEvent: vi.fn(),
+          loadAttempts: () => [],
+        } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({ 'crab-target': crabboxTarget }),
+        crabboxResolver: resolver,
+      });
+
+      const runA = runner.executeTask(taskA);
+      const runB = runner.executeTask(taskB);
+      await vi.waitFor(() => expect(resolver.resolve).toHaveBeenCalledTimes(1));
+      releaseResolve();
+      await vi.waitFor(() => expect(starts.length).toBe(2));
+      expect(starts.map((start) => start.host)).toEqual(['lease-1.crabbox.dev', 'lease-1.crabbox.dev']);
+
+      for (const task of [taskA, taskB]) {
+        completeByTask.get(task.id)?.({
+          requestId: 'r',
+          actionId: task.id,
+          attemptId: task.execution.selectedAttemptId,
+          status: 'completed',
+          outputs: { exitCode: 0 },
+        } as WorkResponse);
+      }
+      await Promise.all([runA, runB]);
+    });
+
+    it('clears pending pool selection when crabbox resolution fails', async () => {
+      const task = makeTask({
+        id: 'wf/crab-fails',
+        config: { runnerKind: 'ssh', poolId: 'ssh-pool' },
+        execution: { selectedAttemptId: 'crab-fails-attempt', generation: 0 },
+      });
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => (id === task.id ? task : null),
+          getAllTasks: () => [task],
+          handleWorkerResponse: () => [],
+          deferTask: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask: vi.fn(),
+          updateAttempt: vi.fn(),
+          appendTaskOutput: vi.fn(),
+          logEvent: vi.fn(),
+          loadAttempts: () => [],
+        } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({ 'crab-target': crabboxTarget }),
+        executionPoolsProvider: () => ({
+          'ssh-pool': {
+            selectionStrategy: 'leastLoaded',
+            maxConcurrentTasksPerMember: 1,
+            members: [{ id: 'crab-target', type: 'ssh' as const, maxConcurrentTasks: 1 }],
+          },
+        }),
+        crabboxResolver: { resolve: vi.fn(async () => { throw new Error('crabbox unavailable'); }) },
+      });
+
+      await runner.executeTask(task);
+      expect([...(runner as any).pendingPoolSelections.values()]).toHaveLength(0);
+    });
+
+    it('rehydrates crabbox endpoints from persisted lease metadata', () => {
+      const resolver = makeFakeResolver();
+      const task = makeTask({
+        id: 'wf/crab-restart',
+        config: { runnerKind: 'ssh', poolMemberId: 'crab-target' },
+        execution: {
+          selectedAttemptId: 'crab-restart-attempt',
+          generation: 0,
+          remoteLeaseMetadata: {
+            provider: 'crabbox' as const,
+            leaseId: 'persisted-lease',
+            slug: 'persisted-lease',
+            targetId: 'crab-target',
+            sshHost: 'persisted.crabbox.dev',
+            sshUser: 'persisted-user',
+            sshPort: 2205,
+            sshKeyPath: '/persisted/key',
+            expiresAt: '2099-01-01T00:00:00Z',
+            stopAfter: 'completed',
+            keepOnFailure: false,
+          },
+        },
+      });
+      const runner = new TaskRunner({
+        orchestrator: { getTask: (id: string) => (id === task.id ? task : null), getAllTasks: () => [task] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({ 'crab-target': crabboxTarget }),
+        crabboxResolver: resolver,
+      });
+
+      const executor = runner.selectExecutor(task);
+      expect(executor.type).toBe('ssh');
+      expect((executor as any).host).toBe('persisted.crabbox.dev');
+      expect((executor as any).user).toBe('persisted-user');
+      expect((executor as any).sshKeyPath).toBe('/persisted/key');
+      expect((executor as any).port).toBe(2205);
+      expect(runner.getRemoteTargetConfig('crab-target', task)).toMatchObject({
+        host: 'persisted.crabbox.dev',
+        user: 'persisted-user',
+        sshKeyPath: '/persisted/key',
+        port: 2205,
+      });
+      expect(resolver.resolve).not.toHaveBeenCalled();
+    });
   });
 
   describe('publishAfterFix', () => {

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -11,7 +11,7 @@ import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import type { Orchestrator } from '@invoker/workflow-core';
+import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import { OrchestratorError, OrchestratorErrorCode, parseMergeConflictError } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { cleanElectronEnv, resolveExecutableOnCurrentPath } from './process-utils.js';
@@ -51,7 +51,7 @@ export interface ConflictResolverHost {
   createMergeWorktree(ref: string, label: string, repoUrl?: string): Promise<string>;
   removeMergeWorktree(dir: string): Promise<void>;
   spawnAgentFix(prompt: string, cwd: string, agentName?: string): Promise<{ stdout: string; sessionId: string }>;
-  getRemoteTargetConfig?(targetId: string): RemoteTargetConfig | undefined;
+  getRemoteTargetConfig?(targetId: string, task?: TaskState): RemoteTargetConfig | undefined;
 }
 
 const DEFAULT_MAX_INLINE_PROMPT_BYTES = 64 * 1024;
@@ -212,7 +212,7 @@ export async function resolveConflictImpl(
       poolMemberId,
       workspacePath: rawCwd,
     });
-    const target = host.getRemoteTargetConfig?.(poolMemberId);
+    const target = host.getRemoteTargetConfig?.(poolMemberId, task);
     if (!target) {
       throw new Error(`No remote target config for "${poolMemberId}" — cannot resolve conflict on remote`);
     }
@@ -492,7 +492,7 @@ export async function fixWithAgentImpl(
       poolMemberId,
       workspacePath,
     });
-    const target = host.getRemoteTargetConfig?.(poolMemberId);
+    const target = host.getRemoteTargetConfig?.(poolMemberId, task);
     if (!target) {
       throw new Error(`No remote target config for "${poolMemberId}" — cannot fix on remote`);
     }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -32,6 +32,11 @@ import { MergeGateExecutor } from './merge-gate-executor.js';
 import { isInvokerManagedPoolBranch } from './plan-base-remote.js';
 import { formatLifecycleTag, extractAttemptSuffix } from './branch-utils.js';
 import { SshExecutor } from './ssh-executor.js';
+import {
+  CrabboxTargetResolver,
+  type CrabboxResolverTargetConfig,
+  type ResolvedCrabboxTarget,
+} from './crabbox-target-resolver.js';
 
 import {
   executeMergeNodeImpl,
@@ -134,9 +139,14 @@ type FreshBaseCommit = {
 };
 
 type RemoteTargetDisplay = {
-  host: string;
-  user: string;
-  sshKeyPath: string;
+  /** Target shape. Omit (or 'static') for a fixed SSH host; 'crabbox' for an on-demand lease. */
+  type?: 'static' | 'crabbox';
+  /** Present for static targets; resolved from the lease for crabbox targets. */
+  host?: string;
+  /** Present for static targets; resolved from the lease for crabbox targets. */
+  user?: string;
+  /** Present for static targets; resolved from the lease for crabbox targets. */
+  sshKeyPath?: string;
   port?: number;
   managedWorkspaces?: boolean;
   remoteInvokerHome?: string;
@@ -144,7 +154,44 @@ type RemoteTargetDisplay = {
   use_api_key?: boolean;
   secretsFile?: string;
   remoteHeartbeatIntervalSeconds?: number;
+  // ── Crabbox lease inputs (only present when type === 'crabbox') ──
+  crabboxCommand?: string;
+  provider?: string;
+  class?: string;
+  ttl?: string;
+  idleTimeout?: string;
+  network?: string;
+  target?: string;
+  stopAfter?: string;
+  keepOnFailure?: boolean;
+  warmupArgs?: readonly string[];
+  statusArgs?: readonly string[];
 };
+
+/**
+ * Injectable dependency that turns a Crabbox remote target into a ready SSH
+ * endpoint plus durable lease metadata. Defaults to {@link CrabboxTargetResolver}.
+ */
+export interface CrabboxResolver {
+  resolve(config: CrabboxResolverTargetConfig): Promise<ResolvedCrabboxTarget>;
+}
+
+/**
+ * Thrown by {@link TaskRunner.selectExecutor} when a `type: 'crabbox'` target
+ * has not been resolved yet. `executeTaskInner` catches it, runs the async
+ * resolver once, caches the result, and builds the SSH executor from the
+ * resolved endpoint — keeping `selectExecutor` synchronous (and static SSH
+ * behavior byte-for-byte equivalent) while still leasing on demand.
+ */
+class CrabboxResolutionRequiredError extends Error {
+  constructor(
+    readonly targetId: string,
+    readonly resolverConfig: CrabboxResolverTargetConfig,
+  ) {
+    super(`Crabbox remote target "${targetId}" must be resolved before use`);
+    this.name = 'CrabboxResolutionRequiredError';
+  }
+}
 
 export interface ReviewGateCiFailureTrigger {
   taskId: string;
@@ -289,9 +336,11 @@ export interface TaskRunnerConfig {
    * Called at task-execution time so config file changes take effect on retry.
    */
   remoteTargetsProvider?: () => Record<string, {
-    host: string;
-    user: string;
-    sshKeyPath: string;
+    /** Target shape. Omit (or 'static') for a fixed SSH host; 'crabbox' for an on-demand lease. */
+    type?: 'static' | 'crabbox';
+    host?: string;
+    user?: string;
+    sshKeyPath?: string;
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
@@ -299,7 +348,24 @@ export interface TaskRunnerConfig {
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;
+    // Crabbox lease inputs (only present when type === 'crabbox').
+    crabboxCommand?: string;
+    provider?: string;
+    class?: string;
+    ttl?: string;
+    idleTimeout?: string;
+    network?: string;
+    target?: string;
+    stopAfter?: string;
+    keepOnFailure?: boolean;
+    warmupArgs?: readonly string[];
+    statusArgs?: readonly string[];
   }>;
+  /**
+   * Resolves `type: 'crabbox'` remote targets into ready SSH endpoints.
+   * Defaults to a real {@link CrabboxTargetResolver}; tests inject a fake.
+   */
+  crabboxResolver?: CrabboxResolver;
   executionPoolsProvider?: () => Record<string, {
     members: Array<
       | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
@@ -341,6 +407,10 @@ export class TaskRunner {
   private readonly runnerInstanceId = randomUUID();
   /** Cache for SSH executors, keyed by poolMemberId. One instance per target for correct git locking. */
   private sshExecutorCache = new Map<string, SshExecutor>();
+  /** Resolves crabbox targets into SSH endpoints. */
+  private crabboxResolver: CrabboxResolver;
+  /** Resolved crabbox leases, keyed by remote target id. One lease per target until cleared. */
+  private resolvedCrabboxTargets = new Map<string, ResolvedCrabboxTarget>();
   private poolRoundRobinCursor = new Map<string, number>();
   private pendingPoolSelections = new Map<string, PoolSelection>();
   private freshBaseCommits = new Map<string, FreshBaseCommit>();
@@ -437,6 +507,7 @@ export class TaskRunner {
     this.reviewProviderRegistry = config.reviewProviderRegistry;
     this.onReviewGateCiFailure = config.onReviewGateCiFailure;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
+    this.crabboxResolver = config.crabboxResolver ?? new CrabboxTargetResolver();
     this.getExecutionPools = config.executionPoolsProvider ?? (() => ({}));
     this.dockerConfig = config.dockerConfig ?? {};
     this.executionAgentRegistry = config.executionAgentRegistry;
@@ -901,7 +972,32 @@ export class TaskRunner {
     let handle!: ExecutorHandle;
     while (true) {
       bench('selectExecutor.start');
-      executor = this.selectExecutor(task, attemptedPoolMemberKeys);
+      try {
+        executor = this.selectExecutor(task, attemptedPoolMemberKeys);
+      } catch (err) {
+        if (!(err instanceof CrabboxResolutionRequiredError)) throw err;
+        // The pool member was already selected (pendingPoolSelections is set);
+        // lease the machine once, cache it, then build the executor from the
+        // resolved endpoint WITHOUT re-running selection (which would advance
+        // round-robin / re-pick a different member).
+        bench('crabbox.resolve.start', { targetId: err.targetId });
+        const resolved = await this.crabboxResolver.resolve(err.resolverConfig);
+        this.resolvedCrabboxTargets.set(err.targetId, resolved);
+        bench('crabbox.resolve.end', {
+          targetId: err.targetId,
+          host: resolved.sshTarget.host,
+          leaseId: resolved.remoteLeaseMetadata.leaseId,
+        });
+        this.persistence.logEvent?.(task.id, 'task.executor.crabbox_resolved', {
+          targetId: err.targetId,
+          leaseId: resolved.remoteLeaseMetadata.leaseId,
+          slug: resolved.remoteLeaseMetadata.slug,
+          sshHost: resolved.sshTarget.host,
+          sshPort: resolved.sshTarget.port,
+        });
+        const target = this.getRemoteTargets()[err.targetId];
+        executor = this.buildSshExecutorForTarget(task.id, err.targetId, target, resolved);
+      }
       const poolSelectionForStart = this.pendingPoolSelections.get(task.id);
       if (!this.acquirePoolSelectionLease(task, attemptId, poolSelectionForStart)) {
         if (poolSelectionForStart) {
@@ -1115,6 +1211,11 @@ export class TaskRunner {
       const selectedSshTargetId = executor.type === 'ssh'
         ? this.selectedRemoteTargetId(task, poolSelection)
         : undefined;
+      // Crabbox-backed SSH tasks carry durable lease metadata so cleanup and
+      // terminal restore can find the leased host after a restart.
+      const remoteLeaseMetadata = selectedSshTargetId
+        ? this.resolvedCrabboxTargets.get(selectedSshTargetId)?.remoteLeaseMetadata
+        : undefined;
       const changes = {
         config: {
           runnerKind: executor.type as RunnerKind,
@@ -1128,6 +1229,7 @@ export class TaskRunner {
           agentName: actionType === 'ai_task' ? executionAgent : undefined,
           lastAgentName: actionType === 'ai_task' ? executionAgent : undefined,
           containerId: handle.containerId ?? undefined,
+          remoteLeaseMetadata: remoteLeaseMetadata ?? undefined,
         },
       };
       this.persistence.updateTask(task.id, changes);
@@ -1139,6 +1241,7 @@ export class TaskRunner {
         this.persistence.updateAttempt?.(attemptId, {
           branch: handle.branch ?? undefined,
           workspacePath: handle.workspacePath,
+          remoteLeaseMetadata: remoteLeaseMetadata ?? undefined,
         } as any);
       } catch (err) {
         traceExecution(
@@ -1426,7 +1529,20 @@ export class TaskRunner {
     if (!selection || selection.member.type !== 'ssh') return true;
     const target = this.getRemoteTargets()[selection.member.id];
     if (!target) return true;
-    const resourceKey = this.sshResourceKey(target);
+    // For crabbox targets the resource key must reflect the resolved (leased)
+    // SSH endpoint, not the empty config host/user, so two tasks on the same
+    // leased machine contend on the same lease. The pool member id is still
+    // used as the holder/poolMemberId below.
+    const resolved = this.resolvedCrabboxTargets.get(selection.member.id);
+    const resourceKey = this.sshResourceKey(
+      resolved
+        ? {
+          host: resolved.sshTarget.host,
+          user: resolved.sshTarget.user,
+          port: resolved.sshTarget.port,
+        }
+        : target,
+    );
     const holderId = this.leaseHolderId(task.id, attemptId);
     const acquired = this.persistence.claimExecutionResourceLease?.({
       resourceKey,
@@ -1483,12 +1599,21 @@ export class TaskRunner {
 
     if (executor.type === 'ssh') {
       const targetId = this.selectedRemoteTargetId(task, poolSelection);
-      const target = targetId ? this.getRemoteTargets()[targetId] : undefined;
       if (targetId) payload.poolMemberId = targetId;
-      if (target) {
-        payload.remoteHost = target.host;
-        payload.remoteUser = target.user;
-        payload.port = target.port;
+      const resolved = targetId ? this.resolvedCrabboxTargets.get(targetId) : undefined;
+      if (resolved) {
+        // Crabbox: report the resolved (leased) endpoint plus durable lease metadata.
+        payload.remoteHost = resolved.sshTarget.host;
+        payload.remoteUser = resolved.sshTarget.user;
+        payload.port = resolved.sshTarget.port;
+        payload.remoteLeaseMetadata = resolved.remoteLeaseMetadata;
+      } else {
+        const target = targetId ? this.getRemoteTargets()[targetId] : undefined;
+        if (target) {
+          payload.remoteHost = target.host;
+          payload.remoteUser = target.user;
+          payload.port = target.port;
+        }
       }
     }
 
@@ -1654,58 +1779,135 @@ export class TaskRunner {
           );
         }
 
-        // Build a config fingerprint so cache invalidates when target config changes.
-        const configFingerprint = JSON.stringify({
-          host: target.host,
-          user: target.user,
-          sshKeyPath: target.sshKeyPath,
-          port: target.port,
-          managedWorkspaces: target.managedWorkspaces,
-          remoteInvokerHome: target.remoteInvokerHome,
-          provisionCommand: target.provisionCommand,
-          use_api_key: target.use_api_key === true,
-          secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
-          remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
-        });
-        const cacheKey = `${targetId}|${configFingerprint}`;
-
-        // Return cached executor if it exists for this target+config combo
-        const cached = this.sshExecutorCache.get(cacheKey);
-        if (cached) {
-          traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (cached)`);
-          return cached;
-        }
-
-        // Drop any stale entries for this targetId so we don't accumulate dead caches.
-        for (const key of this.sshExecutorCache.keys()) {
-          if (key.startsWith(`${targetId}|`)) {
-            this.sshExecutorCache.delete(key);
+        // Crabbox targets supply a machine on demand: resolve the lease into a
+        // ready SSH endpoint before building the fingerprint/executor. Resolution
+        // is async, so if it hasn't run yet we signal executeTaskInner to run the
+        // resolver once and retry the build with the cached endpoint. Static SSH
+        // targets skip all of this and behave exactly as before.
+        let resolvedCrabbox: ResolvedCrabboxTarget | undefined;
+        if (target.type === 'crabbox') {
+          resolvedCrabbox = this.resolvedCrabboxTargets.get(targetId);
+          if (!resolvedCrabbox) {
+            throw new CrabboxResolutionRequiredError(
+              targetId,
+              this.buildCrabboxResolverConfig(targetId, target),
+            );
           }
         }
 
-        const ssh = new SshExecutor({
-          host: target.host,
-          user: target.user,
-          sshKeyPath: target.sshKeyPath,
-          port: target.port,
-          agentRegistry: this.executionAgentRegistry,
-          managedWorkspaces: target.managedWorkspaces,
-          remoteInvokerHome: target.remoteInvokerHome,
-          provisionCommand: target.provisionCommand,
-          useApiKey: target.use_api_key === true,
-          secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
-          remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
-        });
-
-        this.sshExecutorCache.set(cacheKey, ssh);
-        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (new, cached)`);
-        return ssh;
+        return this.buildSshExecutorForTarget(task.id, targetId, target, resolvedCrabbox);
       }
     }
 
     const defaultExecutor = this.executorRegistry.getDefault();
     traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=${effectiveType ?? 'none'} → ${defaultExecutor.type} (default)`);
     return defaultExecutor;
+  }
+
+  /**
+   * Build (and cache) the SSH executor for a remote target. For static targets
+   * the endpoint is the target's own host/user/key; for resolved crabbox leases
+   * it is the leased machine's SSH coordinates. The fingerprint includes the
+   * effective endpoint, so a new lease (different host/key) replaces the cached
+   * executor. Shared by the cache-hit path inside selectExecutor and the
+   * post-resolution path in executeTaskInner.
+   */
+  private buildSshExecutorForTarget(
+    taskId: string,
+    targetId: string,
+    target: RemoteTargetDisplay,
+    resolved: ResolvedCrabboxTarget | undefined,
+  ): SshExecutor {
+    const host = resolved?.sshTarget.host ?? target.host;
+    const user = resolved?.sshTarget.user ?? target.user;
+    const sshKeyPath = resolved?.sshTarget.sshKeyPath ?? target.sshKeyPath;
+    const port = resolved?.sshTarget.port ?? target.port;
+    if (!host || !user || !sshKeyPath) {
+      throw new Error(
+        `Task ${taskId} references remote target "${targetId}" but it has no usable ` +
+        `SSH endpoint (host/user/sshKeyPath missing).`,
+      );
+    }
+
+    // Build a config fingerprint so cache invalidates when target config changes.
+    const configFingerprint = JSON.stringify({
+      host,
+      user,
+      sshKeyPath,
+      port,
+      managedWorkspaces: target.managedWorkspaces,
+      remoteInvokerHome: target.remoteInvokerHome,
+      provisionCommand: target.provisionCommand,
+      use_api_key: target.use_api_key === true,
+      secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
+      remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
+    });
+    const cacheKey = `${targetId}|${configFingerprint}`;
+
+    // Return cached executor if it exists for this target+config combo
+    const cached = this.sshExecutorCache.get(cacheKey);
+    if (cached) {
+      traceExecution(`[trace] TaskRunner.selectExecutor: task=${taskId} effectiveType=ssh remoteTarget=${targetId} → ssh (cached)`);
+      return cached;
+    }
+
+    // Drop any stale entries for this targetId so we don't accumulate dead caches.
+    for (const key of this.sshExecutorCache.keys()) {
+      if (key.startsWith(`${targetId}|`)) {
+        this.sshExecutorCache.delete(key);
+      }
+    }
+
+    const ssh = new SshExecutor({
+      host,
+      user,
+      sshKeyPath,
+      port,
+      agentRegistry: this.executionAgentRegistry,
+      managedWorkspaces: target.managedWorkspaces,
+      remoteInvokerHome: target.remoteInvokerHome,
+      provisionCommand: target.provisionCommand,
+      useApiKey: target.use_api_key === true,
+      secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
+      remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
+    });
+
+    this.sshExecutorCache.set(cacheKey, ssh);
+    traceExecution(`[trace] TaskRunner.selectExecutor: task=${taskId} effectiveType=ssh remoteTarget=${targetId} → ssh (new, cached)`);
+    return ssh;
+  }
+
+  /** Map a configured crabbox remote target into the resolver's input config. */
+  private buildCrabboxResolverConfig(
+    targetId: string,
+    target: RemoteTargetDisplay,
+  ): CrabboxResolverTargetConfig {
+    const missing: string[] = [];
+    const require = (value: string | undefined, name: string): string => {
+      if (!value) missing.push(name);
+      return value ?? '';
+    };
+    const config: CrabboxResolverTargetConfig = {
+      id: targetId,
+      crabboxCommand: require(target.crabboxCommand, 'crabboxCommand'),
+      provider: require(target.provider, 'provider'),
+      class: require(target.class, 'class'),
+      ttl: require(target.ttl, 'ttl'),
+      idleTimeout: require(target.idleTimeout, 'idleTimeout'),
+      network: require(target.network, 'network'),
+      target: require(target.target, 'target'),
+      stopAfter: require(target.stopAfter, 'stopAfter'),
+      keepOnFailure: target.keepOnFailure === true,
+      port: target.port,
+      warmupArgs: target.warmupArgs,
+      statusArgs: target.statusArgs,
+    };
+    if (missing.length > 0) {
+      throw new Error(
+        `Crabbox remote target "${targetId}" is missing required field(s): ${missing.join(', ')}.`,
+      );
+    }
+    return config;
   }
 
   /**
@@ -2901,8 +3103,20 @@ export class TaskRunner {
   } | undefined {
     const target = this.getRemoteTargets()[targetId];
     if (!target) return undefined;
+    // Overlay the resolved crabbox endpoint so post-execution flows (publish,
+    // conflict resolution, terminal restore) reach the leased machine, not the
+    // empty config host. Static targets pass through unchanged.
+    const resolved = this.resolvedCrabboxTargets.get(targetId);
+    const host = resolved?.sshTarget.host ?? target.host;
+    const user = resolved?.sshTarget.user ?? target.user;
+    const sshKeyPath = resolved?.sshTarget.sshKeyPath ?? target.sshKeyPath;
+    if (!host || !user || !sshKeyPath) return undefined;
     return {
       ...target,
+      host,
+      user,
+      sshKeyPath,
+      port: resolved?.sshTarget.port ?? target.port,
       secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
     };
   }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 
 import { scopePlanTaskId } from '@invoker/workflow-core';
-import type { Orchestrator, TaskState, ExperimentVariant, RunnerKind } from '@invoker/workflow-core';
+import type { Orchestrator, TaskState, ExperimentVariant, RunnerKind, CrabboxRemoteLeaseMetadata } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
@@ -186,6 +186,7 @@ export interface CrabboxResolver {
 class CrabboxResolutionRequiredError extends Error {
   constructor(
     readonly targetId: string,
+    readonly target: RemoteTargetDisplay,
     readonly resolverConfig: CrabboxResolverTargetConfig,
   ) {
     super(`Crabbox remote target "${targetId}" must be resolved before use`);
@@ -411,6 +412,8 @@ export class TaskRunner {
   private crabboxResolver: CrabboxResolver;
   /** Resolved crabbox leases, keyed by remote target id. One lease per target until cleared. */
   private resolvedCrabboxTargets = new Map<string, ResolvedCrabboxTarget>();
+  /** In-flight crabbox resolutions, keyed by remote target id, to avoid double-leasing. */
+  private resolvingCrabboxTargets = new Map<string, Promise<ResolvedCrabboxTarget>>();
   private poolRoundRobinCursor = new Map<string, number>();
   private pendingPoolSelections = new Map<string, PoolSelection>();
   private freshBaseCommits = new Map<string, FreshBaseCommit>();
@@ -975,14 +978,24 @@ export class TaskRunner {
       try {
         executor = this.selectExecutor(task, attemptedPoolMemberKeys);
       } catch (err) {
-        if (!(err instanceof CrabboxResolutionRequiredError)) throw err;
+        const pendingSelection = this.pendingPoolSelections.get(task.id);
+        if (!(err instanceof CrabboxResolutionRequiredError)) {
+          this.pendingPoolSelections.delete(task.id);
+          throw err;
+        }
         // The pool member was already selected (pendingPoolSelections is set);
         // lease the machine once, cache it, then build the executor from the
         // resolved endpoint WITHOUT re-running selection (which would advance
         // round-robin / re-pick a different member).
         bench('crabbox.resolve.start', { targetId: err.targetId });
-        const resolved = await this.crabboxResolver.resolve(err.resolverConfig);
-        this.resolvedCrabboxTargets.set(err.targetId, resolved);
+        let resolved: ResolvedCrabboxTarget;
+        try {
+          resolved = await this.resolveCrabboxTarget(err.targetId, err.resolverConfig);
+        } catch (resolveErr) {
+          this.pendingPoolSelections.delete(task.id);
+          this.releasePoolSelectionLease(pendingSelection);
+          throw resolveErr;
+        }
         bench('crabbox.resolve.end', {
           targetId: err.targetId,
           host: resolved.sshTarget.host,
@@ -995,8 +1008,7 @@ export class TaskRunner {
           sshHost: resolved.sshTarget.host,
           sshPort: resolved.sshTarget.port,
         });
-        const target = this.getRemoteTargets()[err.targetId];
-        executor = this.buildSshExecutorForTarget(task.id, err.targetId, target, resolved);
+        executor = this.buildSshExecutorForTarget(task.id, err.targetId, err.target, resolved);
       }
       const poolSelectionForStart = this.pendingPoolSelections.get(task.id);
       if (!this.acquirePoolSelectionLease(task, attemptId, poolSelectionForStart)) {
@@ -1786,11 +1798,20 @@ export class TaskRunner {
         // targets skip all of this and behave exactly as before.
         let resolvedCrabbox: ResolvedCrabboxTarget | undefined;
         if (target.type === 'crabbox') {
-          resolvedCrabbox = this.resolvedCrabboxTargets.get(targetId);
+          resolvedCrabbox = this.resolvedCrabboxTargets.get(targetId)
+            ?? this.seedResolvedCrabboxTargetFromTask(targetId, task);
           if (!resolvedCrabbox) {
+            let resolverConfig: CrabboxResolverTargetConfig;
+            try {
+              resolverConfig = this.buildCrabboxResolverConfig(targetId, target);
+            } catch (err) {
+              this.pendingPoolSelections.delete(task.id);
+              throw err;
+            }
             throw new CrabboxResolutionRequiredError(
               targetId,
-              this.buildCrabboxResolverConfig(targetId, target),
+              target,
+              resolverConfig,
             );
           }
         }
@@ -1875,6 +1896,56 @@ export class TaskRunner {
     this.sshExecutorCache.set(cacheKey, ssh);
     traceExecution(`[trace] TaskRunner.selectExecutor: task=${taskId} effectiveType=ssh remoteTarget=${targetId} → ssh (new, cached)`);
     return ssh;
+  }
+
+  private async resolveCrabboxTarget(
+    targetId: string,
+    resolverConfig: CrabboxResolverTargetConfig,
+  ): Promise<ResolvedCrabboxTarget> {
+    const existing = this.resolvedCrabboxTargets.get(targetId);
+    if (existing) return existing;
+
+    let pending = this.resolvingCrabboxTargets.get(targetId);
+    if (!pending) {
+      pending = this.crabboxResolver.resolve(resolverConfig).then((resolved) => {
+        this.resolvedCrabboxTargets.set(targetId, resolved);
+        return resolved;
+      });
+      this.resolvingCrabboxTargets.set(targetId, pending);
+    }
+
+    try {
+      return await pending;
+    } finally {
+      if (this.resolvingCrabboxTargets.get(targetId) === pending) {
+        this.resolvingCrabboxTargets.delete(targetId);
+      }
+    }
+  }
+
+  private seedResolvedCrabboxTargetFromTask(
+    targetId: string,
+    task: TaskState,
+  ): ResolvedCrabboxTarget | undefined {
+    const resolved = this.resolvedCrabboxTargetFromMetadata(targetId, task.execution.remoteLeaseMetadata);
+    if (resolved) this.resolvedCrabboxTargets.set(targetId, resolved);
+    return resolved;
+  }
+
+  private resolvedCrabboxTargetFromMetadata(
+    targetId: string,
+    metadata: CrabboxRemoteLeaseMetadata | undefined,
+  ): ResolvedCrabboxTarget | undefined {
+    if (!metadata || metadata.provider !== 'crabbox' || metadata.targetId !== targetId) return undefined;
+    return {
+      sshTarget: {
+        host: metadata.sshHost,
+        user: metadata.sshUser,
+        sshKeyPath: metadata.sshKeyPath,
+        port: metadata.sshPort,
+      },
+      remoteLeaseMetadata: metadata,
+    };
   }
 
   /** Map a configured crabbox remote target into the resolver's input config. */
@@ -1977,7 +2048,7 @@ export class TaskRunner {
     let publishWorkspacePath = workspacePath;
     if (task.config.runnerKind === 'ssh') {
       const poolMemberId = resolveSelectedRemoteTargetId(this, task.id, task);
-      const target = poolMemberId ? this.getRemoteTargetConfig(poolMemberId) : undefined;
+      const target = poolMemberId ? this.getRemoteTargetConfig(poolMemberId, task) : undefined;
       if (target) {
         const repairedWorkspacePath = await resolveRemoteBranchOwnerPath(branch, workspacePath, target);
         if (repairedWorkspacePath && repairedWorkspacePath !== workspacePath) {
@@ -3089,7 +3160,7 @@ export class TaskRunner {
     return this.executionAgentRegistry;
   }
 
-  getRemoteTargetConfig(targetId: string): {
+  getRemoteTargetConfig(targetId: string, task?: TaskState): {
     host: string;
     user: string;
     sshKeyPath: string;
@@ -3106,7 +3177,8 @@ export class TaskRunner {
     // Overlay the resolved crabbox endpoint so post-execution flows (publish,
     // conflict resolution, terminal restore) reach the leased machine, not the
     // empty config host. Static targets pass through unchanged.
-    const resolved = this.resolvedCrabboxTargets.get(targetId);
+    const resolved = this.resolvedCrabboxTargets.get(targetId)
+      ?? (task ? this.seedResolvedCrabboxTargetFromTask(targetId, task) : undefined);
     const host = resolved?.sshTarget.host ?? target.host;
     const user = resolved?.sshTarget.user ?? target.user;
     const sshKeyPath = resolved?.sshTarget.sshKeyPath ?? target.sshKeyPath;

--- a/scripts/repro/repro-coderabbit-pr2193-clear-pending-selection.sh
+++ b/scripts/repro/repro-coderabbit-pr2193-clear-pending-selection.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+cd "$repo_root"
+pnpm --dir packages/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "clears pending pool selection when crabbox resolution fails"
+
+echo "PASS: failed crabbox resolution clears pending SSH pool selection"

--- a/scripts/repro/repro-coderabbit-pr2193-dedupe-resolution.sh
+++ b/scripts/repro/repro-coderabbit-pr2193-dedupe-resolution.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+cd "$repo_root"
+pnpm --dir packages/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "dedupes concurrent crabbox resolution for the same target"
+
+echo "PASS: concurrent crabbox launches share one in-flight resolution"

--- a/scripts/repro/repro-coderabbit-pr2193-rehydrate-lease-metadata.sh
+++ b/scripts/repro/repro-coderabbit-pr2193-rehydrate-lease-metadata.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+cd "$repo_root"
+pnpm --dir packages/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "rehydrates crabbox endpoints from persisted lease metadata"
+
+echo "PASS: persisted crabbox lease metadata rehydrates SSH endpoint after restart"

--- a/scripts/repro/repro-coderabbit-pr2193-target-snapshot.sh
+++ b/scripts/repro/repro-coderabbit-pr2193-target-snapshot.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+cd "$repo_root"
+pnpm --dir packages/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "builds from the selected crabbox target snapshot after async resolution"
+
+echo "PASS: crabbox executor construction uses the selected target snapshot after async resolution"


### PR DESCRIPTION
## Summary

TaskRunner now routes Crabbox-backed SSH work through the resolver before it builds the SSH executor. Static SSH targets keep the direct route.

Crabbox stays outside the executor. The runner turns the lease result into ordinary SSH connection settings first.

The selected executor event now includes the pool member and resolved endpoint. Task start metadata also persists the remote lease details.

This is step 3 of the Crabbox SSH stack. Step 2 added the resolver; this step wires it into runtime routing.

<details>
<summary>Review metadata</summary>

Review Claim: TaskRunner routes Crabbox pool members through endpoint resolution before starting `SshExecutor`, while static SSH targets keep their existing route.

Review Lane: behavior

Review Unit: routing

Safety Invariant: `runnerKind: ssh` remains the only runtime executor shape for Crabbox-backed work; Crabbox only supplies machine details.

Slice Rationale: This slice only connects the existing resolver to TaskRunner so downstream work can handle later lease release behavior separately.

</details>

## Non-goals

- This does not add a Crabbox executor.
- This does not change static SSH target configuration or selection semantics.
- This does not implement later lease release policy.
- This does not change workflow graph scheduling.

## Architecture

This change inserts async target resolution between pool selection and SSH executor startup.

### Before

```mermaid
graph TD
    A["TaskRunner starts SSH task"] --> B["Select pool member"]
    B --> C["Read static SSH target"]
    C --> D["Start SshExecutor"]
    D --> E["Run task"]
```

### After

```mermaid
graph TD
    A["TaskRunner starts SSH task"] --> B["Select pool member"]
    B --> C{"Remote target"}
    C -->|"static"| E["Start SshExecutor"]
    C -->|"crabbox"| D["Resolve Crabbox lease"]
    D --> F["Record endpoint and lease metadata"]
    F --> E
    E --> G["Run task"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/ssh-pool-member-capacity.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/crabbox-step3-pr.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Static SSH targets remain on their pre-existing route.
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for dynamically resolved SSH targets via crabbox lease management, including caching of resolved endpoints and persistence of lease metadata across task execution.
  * Extended execution telemetry to report leased connection details when a crabbox target is used.
* **Bug Fixes**
  * Ensured concurrent tasks share a single in-flight crabbox resolution, and cleared any pending pool selection state when resolution fails.
  * Updated lease-based resource contention so tasks contend correctly on the leased endpoint.
* **Tests**
  * Expanded coverage for static vs crabbox-resolved SSH selection, lease rehydration, and concurrency/deduping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->