### PR TITLE
Fix intent cancellation Step 8: merge-gate side-effect lineage guard (regression gated v2)

### DIFF
--- a/packages/execution-engine/src/__tests__/merge-gate-metadata-guard.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-gate-metadata-guard.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression coverage for the merge-gate side-effect lineage guard.
+ *
+ * Merge-gate execution metadata (branch, workspacePath, review fields,
+ * fixed-integration fields) is written straight to persistence *before*
+ * emitComplete / handleWorkerResponse run the normal worker-response lineage
+ * guard. `persistMergeGateMetadata` routes those writes through the
+ * orchestrator's `applyMergeGateExecutionMetadata` guard so a stale gate run
+ * cannot clobber a task that has advanced to a newer attempt/generation.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { persistMergeGateMetadata } from '../merge-runner.js';
+import type { MergeRunnerHost } from '../merge-runner.js';
+import type { TaskStateChanges } from '@invoker/workflow-core';
+
+const STALE_CHANGES: TaskStateChanges = {
+  execution: {
+    branch: 'feature/stale',
+    workspacePath: '/tmp/stale-gate',
+    reviewUrl: 'https://example.test/stale',
+    reviewId: 'owner/repo#stale',
+  },
+};
+
+describe('persistMergeGateMetadata lineage routing', () => {
+  it('drops a stale write by delegating to the orchestrator guard (no direct persistence write)', () => {
+    const updateTask = vi.fn();
+    // A real-shaped orchestrator that rejects the write as stale.
+    const applyMergeGateExecutionMetadata = vi.fn(() => false);
+    const host = {
+      orchestrator: { applyMergeGateExecutionMetadata },
+      persistence: { updateTask },
+    } as unknown as MergeRunnerHost;
+
+    const applied = persistMergeGateMetadata(host, 'merge-1', STALE_CHANGES, {
+      attemptId: 'attempt-old',
+      executionGeneration: 1,
+    });
+
+    expect(applied).toBe(false);
+    expect(applyMergeGateExecutionMetadata).toHaveBeenCalledWith(
+      'merge-1',
+      STALE_CHANGES,
+      { attemptId: 'attempt-old', executionGeneration: 1 },
+    );
+    // The guard owns the write; the helper must NOT also write directly.
+    expect(updateTask).not.toHaveBeenCalled();
+  });
+
+  it('applies a valid write through the orchestrator guard', () => {
+    const updateTask = vi.fn();
+    const applyMergeGateExecutionMetadata = vi.fn(() => true);
+    const host = {
+      orchestrator: { applyMergeGateExecutionMetadata },
+      persistence: { updateTask },
+    } as unknown as MergeRunnerHost;
+
+    const applied = persistMergeGateMetadata(host, 'merge-1', STALE_CHANGES, {
+      attemptId: 'attempt-current',
+      executionGeneration: 2,
+    });
+
+    expect(applied).toBe(true);
+    expect(applyMergeGateExecutionMetadata).toHaveBeenCalledTimes(1);
+    expect(updateTask).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a direct persistence write for hosts without the guard (legacy/test doubles)', () => {
+    const updateTask = vi.fn();
+    const host = {
+      orchestrator: {},
+      persistence: { updateTask },
+    } as unknown as MergeRunnerHost;
+
+    const applied = persistMergeGateMetadata(host, 'merge-1', STALE_CHANGES, {
+      attemptId: 'attempt-current',
+      executionGeneration: 2,
+    });
+
+    expect(applied).toBe(true);
+    expect(updateTask).toHaveBeenCalledWith('merge-1', STALE_CHANGES);
+  });
+});

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -354,3 +354,91 @@ describe('TaskRunner launch-dispatch wiring', () => {
     expect(env.executor.start).not.toHaveBeenCalled();
   });
 });
+
+describe('TaskRunner post-start lineage guard', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function workspaceWrites(updateTask: ReturnType<typeof vi.fn>): unknown[] {
+    return updateTask.mock.calls
+      .map(([, changes]: any) => changes?.execution?.workspacePath)
+      .filter((ws: unknown) => ws !== undefined);
+  }
+
+  it('drops stale post-start metadata when generation advances while attempt id is unchanged', async () => {
+    // Launch is accepted at generation 1; executor.start resolves only after
+    // the live task has advanced to generation 2 (same selectedAttemptId, as a
+    // same-attempt restart would produce). markTaskRunningAfterLaunch would
+    // accept this (attempt id matches), so the lineage guard must catch it.
+    let env!: RunnerEnv;
+    const task = makeTask(); // generation 1, selectedAttemptId 'attempt-1'
+    const advanced = makeTask({
+      execution: { selectedAttemptId: 'attempt-1', generation: 2, phase: 'executing' },
+    });
+    env = buildRunnerEnv(task, {
+      startImpl: async (request) => {
+        // Generation advances while executor.start() is in flight.
+        env.orchestrator.getTask.mockReturnValue(advanced);
+        return {
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/tmp/stale-ws',
+          branch: `experiment/${request.actionId}-stale`,
+          agentSessionId: 'sess-stale',
+          containerId: 'container-stale',
+        };
+      },
+    });
+    const launchOutbox = makeLaunchOutbox();
+
+    await env.runner.executeTask(task, { dispatchId: 77, launchOutbox });
+
+    // executor.start resolved, but the launch is recognized as superseded.
+    expect(env.executor.start).toHaveBeenCalledTimes(1);
+    // The generation gap is caught before promoting the launch to running.
+    expect(env.orchestrator.markTaskRunningAfterLaunch).not.toHaveBeenCalled();
+    // No stale workspace/branch/session/container metadata reaches the task row.
+    expect(workspaceWrites(env.persistence.updateTask)).toHaveLength(0);
+    // The spawned handle is killed, consistent with the stale-attempt path.
+    expect(env.executor.kill).toHaveBeenCalledTimes(1);
+    // No active execution is registered for the superseded launch.
+    expect((env.runner as any).activeExecutions.size).toBe(0);
+    // The dispatch row is failed the same way a stale-attempt rejection fails it.
+    expect(launchOutbox.completeCalls).toHaveLength(0);
+    expect(launchOutbox.failCalls).toHaveLength(1);
+    expect(launchOutbox.failCalls[0][0]).toBe(77);
+    expect((launchOutbox.failCalls[0][1] as Error).message).toMatch(/Launch rejected/);
+    // Observability: the guard records why the launch was dropped.
+    expect(env.persistence.logEvent).toHaveBeenCalledWith(
+      task.id,
+      'task.executor.stale_post_start_launch',
+      expect.objectContaining({
+        attemptId: 'attempt-1',
+        startGeneration: 1,
+        currentGeneration: 2,
+      }),
+    );
+  });
+
+  it('persists start metadata and registers the execution for a current (non-stale) launch', async () => {
+    const task = makeTask(); // generation stays 1 throughout
+    const env = buildRunnerEnv(task);
+    const launchOutbox = makeLaunchOutbox();
+
+    const run = env.runner.executeTask(task, { dispatchId: 88, launchOutbox });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    // The valid launch is promoted to running and persists its metadata.
+    expect(env.orchestrator.markTaskRunningAfterLaunch).toHaveBeenCalledWith(task.id, 'attempt-1');
+    expect(workspaceWrites(env.persistence.updateTask)).toContain('/tmp/mock-ws');
+    expect(env.executor.kill).not.toHaveBeenCalled();
+    expect((env.runner as any).activeExecutions.size).toBe(1);
+
+    env.triggerComplete();
+    await run;
+
+    expect(launchOutbox.completeCalls).toEqual([88]);
+    expect(launchOutbox.failCalls).toHaveLength(0);
+  });
+});

--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -4,7 +4,7 @@ import type { TaskState } from '@invoker/workflow-core';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import type { MergeRunnerHost } from './merge-runner.js';
-import { runMergeGateActionImpl } from './merge-runner.js';
+import { runMergeGateActionImpl, persistMergeGateMetadata } from './merge-runner.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 
 interface MergeGateEntry extends BaseEntry {
@@ -125,9 +125,27 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
       this.emitOutput(handle.executionId, `[merge] Starting merge gate action: ${task.id}\n`);
       const result = await runMergeGateActionImpl(this.host, task, { gateWorkspacePath });
       if (result.taskChanges.execution) {
-        this.host.persistence.updateTask(task.id, {
-          execution: result.taskChanges.execution,
-        });
+        // Route through the orchestrator's lineage guard rather than writing
+        // straight to persistence. emitComplete below re-checks lineage when the
+        // worker response lands, but the direct metadata write happens first —
+        // so a gate that started against a now-superseded attempt/generation
+        // could otherwise clobber the task's branch/workspacePath/review fields
+        // before that guard ever runs.
+        const applied = persistMergeGateMetadata(
+          this.host,
+          task.id,
+          { execution: result.taskChanges.execution },
+          {
+            attemptId: entry.request.attemptId,
+            executionGeneration: entry.request.executionGeneration,
+          },
+        );
+        if (!applied) {
+          this.emitOutput(
+            handle.executionId,
+            `[merge] Skipped stale merge-gate metadata write for ${task.id} (superseded attempt/generation)\n`,
+          );
+        }
       }
       this.emitOutput(handle.executionId, `[merge] Merge gate action finished: ${task.id} status=${result.response.status}\n`);
       this.emitComplete(handle.executionId, this.withAttempt(entry.request, result.response));

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -42,6 +42,41 @@ function safeGetWorkspacePath(persistence: SQLiteAdapter, taskId: string): strin
     : undefined;
 }
 
+/**
+ * Persist merge-gate execution side effects (branch, workspacePath, review
+ * metadata, fixed-integration fields) through the orchestrator's lineage guard.
+ *
+ * These fields would otherwise be written straight to persistence *before*
+ * `emitComplete` / `handleWorkerResponse` run the normal worker-response lineage
+ * guard, so a gate run that started against a now-superseded attempt/generation
+ * could clobber a task that has since advanced. Routing through
+ * `applyMergeGateExecutionMetadata` applies the same check those direct writes
+ * skip and drops the write when stale.
+ *
+ * Falls back to a direct persistence write only for partial test-double hosts
+ * whose orchestrator does not implement the guard; the production orchestrator
+ * always does. Returns true when the write was applied.
+ */
+export function persistMergeGateMetadata(
+  host: MergeRunnerHost,
+  taskId: string,
+  changes: TaskStateChanges,
+  expected: { attemptId?: string; executionGeneration?: number },
+): boolean {
+  const orchestrator = host.orchestrator as {
+    applyMergeGateExecutionMetadata?: (
+      taskId: string,
+      changes: TaskStateChanges,
+      expected: { attemptId?: string; executionGeneration?: number },
+    ) => boolean;
+  };
+  if (typeof orchestrator.applyMergeGateExecutionMetadata === 'function') {
+    return orchestrator.applyMergeGateExecutionMetadata(taskId, changes, expected);
+  }
+  host.persistence.updateTask(taskId, changes);
+  return true;
+}
+
 function canonicalMergeMode(mode: string | undefined): 'manual' | 'automatic' | 'external_review' {
   const m = mode ?? 'manual';
   if (m === 'external_review') return 'external_review';
@@ -495,13 +530,23 @@ export async function runMergeGateActionImpl(
       `mergeMode=${mergeMode} onFinish=${onFinish} dbWorkspacePath=${safeGetWorkspacePath(host.persistence, task.id) ?? 'NULL'}`,
   );
 
-  host.persistence.updateTask(task.id, {
-    execution: {
-      reviewUrl: undefined,
-      reviewId: undefined,
-      reviewStatus: undefined,
+  // Lineage-guarded so a stale gate run cannot clear a fresher attempt's review
+  // metadata. Uses the task snapshot captured when this action started.
+  persistMergeGateMetadata(
+    host,
+    task.id,
+    {
+      execution: {
+        reviewUrl: undefined,
+        reviewId: undefined,
+        reviewStatus: undefined,
+      },
     },
-  });
+    {
+      attemptId: task.execution.selectedAttemptId,
+      executionGeneration: task.execution.generation ?? 0,
+    },
+  );
 
   // Create a persistent gate worktree so workspacePath is never the main repo.
   // Use baseBranch as the ref because featureBranch may not exist yet
@@ -1281,10 +1326,20 @@ export async function publishAfterFixImpl(
       });
       const reviewUrl = await host.execPr(baseBranch, featureBranch, workflow?.name ?? 'Workflow', prBody, consolidateDir);
       console.log(`[merge] Post-fix: created pull request ${reviewUrl}`);
-      host.persistence.updateTask(task.id, {
-        config: { summary },
-        execution: { reviewUrl },
-      });
+      // Lineage-guarded: the post-fix run may have been superseded while the PR
+      // was being authored/created, so don't clobber a fresher attempt.
+      persistMergeGateMetadata(
+        host,
+        task.id,
+        {
+          config: { summary },
+          execution: { reviewUrl },
+        },
+        {
+          attemptId: task.execution.selectedAttemptId,
+          executionGeneration: task.execution.generation ?? 0,
+        },
+      );
     }
 
     setMergeGateReviewReady(host, task.id, {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1067,12 +1067,38 @@ export class TaskRunner {
       hasWorkspacePath: Boolean(handle.workspacePath),
       hasAgentSessionId: Boolean(handle.agentSessionId),
     });
-    const launchAccepted =
-      this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true;
+    // Post-start lineage guard. `executor.start()` can take minutes (SSH
+    // provisioning), and the live task may advance to a new generation while
+    // it is in flight — e.g. a restart that reuses the same attempt id but
+    // bumps the generation. `markTaskRunningAfterLaunch` only rejects a
+    // mismatched selectedAttemptId; it does NOT compare the launch-time
+    // generation (it even stamps the *current* generation when promoting
+    // pending→running). So a launch accepted at generation N could otherwise
+    // persist workspacePath/branch/agentSessionId/containerId/heartbeat
+    // metadata and register an active execution after the task moved to N+1.
+    // Detect that here and route through the same kill/cleanup path as the
+    // stale-attempt rejection, before any post-start metadata is written.
+    const launchStaleAfterStart = this.isLaunchStale(task.id, attemptId, startGeneration);
+    const launchAccepted = launchStaleAfterStart
+      ? false
+      : (this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true);
     if (!launchAccepted) {
       this.logger.warn(
-        `[TaskRunner] launch rejected as stale/non-executable for task=${task.id} attemptId=${attemptId}; killing spawned process`,
+        `[TaskRunner] launch rejected as stale/non-executable for task=${task.id} attemptId=${attemptId} ` +
+          `(staleGeneration=${launchStaleAfterStart} startGeneration=${startGeneration}); killing spawned process`,
       );
+      if (launchStaleAfterStart) {
+        this.persistence.logEvent?.(task.id, 'task.executor.stale_post_start_launch', {
+          attemptId,
+          executorType: executor.type,
+          startGeneration,
+          currentGeneration: this.orchestrator.getTask(task.id)?.execution.generation ?? null,
+          workspacePath: handle.workspacePath,
+          branch: handle.branch,
+          hasAgentSessionId: Boolean(handle.agentSessionId),
+          hasContainerId: Boolean(handle.containerId),
+        });
+      }
       try {
         await executor.kill(handle);
       } catch (killErr) {
@@ -1087,7 +1113,7 @@ export class TaskRunner {
           new Error('Launch rejected as stale or non-executable after executor start'),
         );
       }
-      bench('markTaskRunningAfterLaunch.rejected');
+      bench(launchStaleAfterStart ? 'postStartLineageGuard.rejected' : 'markTaskRunningAfterLaunch.rejected');
       return;
     }
     bench('markTaskRunningAfterLaunch.accepted');

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -568,6 +568,31 @@ export class TaskRunner {
     return false;
   }
 
+  /**
+   * Narrow post-start lineage check: returns `true` only when the live
+   * task's `generation` has advanced past the launch-time generation.
+   *
+   * Unlike {@link isLaunchStale} this deliberately does NOT reject on a
+   * `selectedAttemptId` mismatch — the post-start promotion already routes
+   * attempt-id mismatches through `markTaskRunningAfterLaunch`, and
+   * legitimate concurrent attempts of the same task must still register as
+   * active executions so they can be killed later. This guard is the missing
+   * piece: `markTaskRunningAfterLaunch` ignores the launch-time generation,
+   * so a launch accepted at generation N could otherwise persist metadata
+   * after the task advanced to N+1 with the same attempt id.
+   */
+  private hasGenerationAdvancedSinceLaunch(
+    taskId: string,
+    startGeneration: number,
+  ): boolean {
+    const current = this.orchestrator.getTask(taskId);
+    // If the task is no longer visible we cannot confirm the generation
+    // advanced — defer to the normal promotion path rather than dropping
+    // the launch here.
+    if (!current) return false;
+    return (current.execution.generation ?? 0) !== startGeneration;
+  }
+
   async executeTask(task: TaskState, dispatchOpts?: LaunchDispatchOptions): Promise<void> {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} TaskRunner.executeTask BEGIN taskId=${task.id} isMergeNode=${Boolean(task.config.isMergeNode)} status=${task.status}`,
@@ -1078,7 +1103,11 @@ export class TaskRunner {
     // metadata and register an active execution after the task moved to N+1.
     // Detect that here and route through the same kill/cleanup path as the
     // stale-attempt rejection, before any post-start metadata is written.
-    const launchStaleAfterStart = this.isLaunchStale(task.id, attemptId, startGeneration);
+    // The check is narrow on purpose: only a *generation* advance is caught
+    // here. Attempt-id mismatches stay the responsibility of
+    // markTaskRunningAfterLaunch, so legitimate concurrent same-task attempts
+    // still register as active executions.
+    const launchStaleAfterStart = this.hasGenerationAdvancedSinceLaunch(task.id, startGeneration);
     const launchAccepted = launchStaleAfterStart
       ? false
       : (this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true);

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -6998,6 +6998,50 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(taskId)?.status).toBe('running');
     });
 
+    it('rejects a response carrying the current attempt id but a stale executionGeneration', () => {
+      orchestrator.loadPlan({
+        name: 'stale-generation-with-current-attempt',
+        tasks: [{ id: 't1', description: 'Task 1' }],
+      });
+      orchestrator.startExecution();
+
+      const taskId = sid(orchestrator, 0, 't1');
+      const liveTask = orchestrator.getTask(taskId)!;
+      const activeAttemptId = liveTask.execution.selectedAttemptId!;
+      const staleGeneration = liveTask.execution.generation ?? 0;
+
+      // The execution generation moves on while the selected attempt id is
+      // unchanged: an in-flight worker launched at the old generation can
+      // still report the live attempt id. Seed live branch/workspacePath so
+      // we can prove a stale completion does not overwrite them.
+      orchestrator.refreshFromDb();
+      persistence.updateTask(taskId, {
+        execution: {
+          generation: staleGeneration + 1,
+          branch: 'live/feature',
+          workspacePath: '/live/ws',
+        },
+      });
+
+      const staleResult = orchestrator.handleWorkerResponse(
+        makeResponse({
+          actionId: taskId,
+          attemptId: activeAttemptId,
+          executionGeneration: staleGeneration,
+          status: 'completed',
+          outputs: { exitCode: 0, branch: 'stale/feature' },
+        }),
+      );
+
+      expect(staleResult).toEqual([]);
+      const after = orchestrator.getTask(taskId)!;
+      expect(after.status).toBe('running');
+      expect(after.execution.selectedAttemptId).toBe(activeAttemptId);
+      expect(after.execution.branch).toBe('live/feature');
+      expect(after.execution.workspacePath).toBe('/live/ws');
+      expect(persistence.loadAttempt(activeAttemptId)?.status).toBe('running');
+    });
+
     it('recreateWorkflow selects a fresh persisted attempt for recreated tasks', () => {
       orchestrator.loadPlan({
         name: 'recreate-attempt-refresh',

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -582,6 +582,149 @@ describe('Orchestrator', () => {
     });
   });
 
+  describe('applyMergeGateExecutionMetadata lineage guard', () => {
+    it('rejects a stale merge-gate metadata write after the task advanced a generation', () => {
+      orchestrator.loadPlan({
+        name: 'Stale gate metadata generation',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      // The merge task has advanced to generation 2 (e.g. a retry happened
+      // while the gate was running).
+      persistence.updateTask(mergeId, {
+        status: 'running',
+        execution: { generation: 2, selectedAttemptId: 'attempt-current' },
+      });
+
+      // A gate run that started against generation 1 tries to write its
+      // branch/workspace/review metadata.
+      const applied = orchestrator.applyMergeGateExecutionMetadata(
+        mergeId,
+        {
+          execution: {
+            branch: 'feature/stale',
+            workspacePath: '/tmp/stale-gate',
+            reviewUrl: 'https://example.test/stale',
+            reviewId: 'owner/repo#stale',
+            reviewStatus: 'Awaiting review',
+          },
+        },
+        { attemptId: 'attempt-current', executionGeneration: 1 },
+      );
+
+      expect(applied).toBe(false);
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.execution.branch).toBeUndefined();
+      expect(task.execution.workspacePath).toBeUndefined();
+      expect(task.execution.reviewUrl).toBeUndefined();
+      expect(task.execution.reviewId).toBeUndefined();
+    });
+
+    it('rejects a stale merge-gate metadata write after the selected attempt changed', () => {
+      orchestrator.loadPlan({
+        name: 'Stale gate metadata attempt',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      persistence.updateTask(mergeId, {
+        status: 'running',
+        execution: { generation: 0, selectedAttemptId: 'attempt-new' },
+      });
+
+      const applied = orchestrator.applyMergeGateExecutionMetadata(
+        mergeId,
+        { execution: { fixedIntegrationSha: 'deadbeef', branch: 'feature/old' } },
+        { attemptId: 'attempt-old', executionGeneration: 0 },
+      );
+
+      expect(applied).toBe(false);
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.execution.fixedIntegrationSha).toBeUndefined();
+      expect(task.execution.branch).toBeUndefined();
+    });
+
+    it('still rejects the eventual stale worker response for the superseded gate run', () => {
+      orchestrator.loadPlan({
+        name: 'Stale gate worker response',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      persistence.updateTask(mergeId, {
+        status: 'running',
+        execution: { generation: 2, selectedAttemptId: 'attempt-current' },
+      });
+
+      // The direct metadata write is dropped...
+      const applied = orchestrator.applyMergeGateExecutionMetadata(
+        mergeId,
+        { execution: { branch: 'feature/stale', reviewUrl: 'https://example.test/stale' } },
+        { attemptId: 'attempt-current', executionGeneration: 1 },
+      );
+      expect(applied).toBe(false);
+
+      // ...and the worker response that lands afterwards is rejected too.
+      const newlyStarted = orchestrator.handleWorkerResponse(makeResponse({
+        actionId: mergeId,
+        attemptId: 'attempt-current',
+        executionGeneration: 1,
+        status: 'review_ready',
+        outputs: {
+          exitCode: 0,
+          branch: 'feature/stale',
+          reviewUrl: 'https://example.test/stale',
+        },
+      }));
+
+      expect(newlyStarted).toEqual([]);
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.status).toBe('running');
+      expect(task.execution.branch).toBeUndefined();
+      expect(task.execution.reviewUrl).toBeUndefined();
+    });
+
+    it('persists valid merge-gate review-ready metadata when lineage matches', () => {
+      orchestrator.loadPlan({
+        name: 'Valid gate metadata',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      persistence.updateTask(mergeId, {
+        status: 'running',
+        execution: { generation: 3, selectedAttemptId: 'attempt-current' },
+      });
+
+      const applied = orchestrator.applyMergeGateExecutionMetadata(
+        mergeId,
+        {
+          execution: {
+            branch: 'feature/ready',
+            workspacePath: '/tmp/gate-ready',
+            reviewUrl: 'https://github.com/owner/repo/pull/7',
+            reviewId: 'owner/repo#7',
+            reviewStatus: 'Awaiting review',
+          },
+        },
+        { attemptId: 'attempt-current', executionGeneration: 3 },
+      );
+
+      expect(applied).toBe(true);
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.execution.branch).toBe('feature/ready');
+      expect(task.execution.workspacePath).toBe('/tmp/gate-ready');
+      expect(task.execution.reviewUrl).toBe('https://github.com/owner/repo/pull/7');
+      expect(task.execution.reviewId).toBe('owner/repo#7');
+      expect(task.execution.reviewStatus).toBe('Awaiting review');
+    });
+  });
+
   describe('workflow status transitions during retry paths', () => {
     it('stores a newly loaded workflow as pending while all tasks are pending', () => {
       orchestrator.loadPlan({

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1795,6 +1795,76 @@ export class Orchestrator {
     this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', additionalChanges, expectedLineage);
   }
 
+  /**
+   * Lineage-guarded write for merge-gate execution side effects (branch,
+   * workspacePath, review metadata, fixed-integration fields).
+   *
+   * The merge-gate executor and merge runner persist these fields directly,
+   * *before* `emitComplete` / `handleWorkerResponse` run the normal
+   * worker-response lineage guard. A merge gate that started against an older
+   * attempt or generation could therefore clobber a task that has since
+   * advanced to a newer `selectedAttemptId` or `executionGeneration` (e.g. via
+   * retry or workflow recreation). This applies the same lineage check those
+   * direct writes skip — comparing the caller's captured attempt/generation
+   * against the live task — and drops the write when stale.
+   *
+   * Returns true when the write was applied, false when rejected as stale.
+   */
+  applyMergeGateExecutionMetadata(
+    taskId: string,
+    changes: TaskStateChanges,
+    expected: { attemptId?: string; executionGeneration?: number },
+  ): boolean {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) {
+      this.logger.warn('[merge-gate] STALE_METADATA_WRITE_REJECTED', {
+        taskId,
+        reason: 'task_missing',
+      });
+      return false;
+    }
+
+    const activeAttemptId = task.execution.selectedAttemptId;
+    if (
+      expected.attemptId !== undefined &&
+      (activeAttemptId === undefined || expected.attemptId !== activeAttemptId)
+    ) {
+      this.logger.warn('[merge-gate] STALE_METADATA_WRITE_REJECTED', {
+        taskId: task.id,
+        reason: 'attempt',
+        expectedAttemptId: expected.attemptId,
+        activeAttemptId: activeAttemptId ?? 'none',
+      });
+      return false;
+    }
+
+    const activeGeneration = this.getExecutionGeneration(task);
+    if (
+      expected.executionGeneration !== undefined &&
+      expected.executionGeneration !== activeGeneration
+    ) {
+      this.logger.warn('[merge-gate] STALE_METADATA_WRITE_REJECTED', {
+        taskId: task.id,
+        reason: 'generation',
+        expectedGeneration: expected.executionGeneration,
+        activeGeneration,
+      });
+      return false;
+    }
+
+    if (task.config.isMergeNode) {
+      mergeTrace('GATE_WS_APPLY_EXECUTION_METADATA', {
+        taskId: task.id,
+        workspacePath: changes.execution?.workspacePath ?? null,
+        branch: changes.execution?.branch ?? null,
+      });
+    }
+    this.persistence.updateTask(task.id, changes);
+    this.refreshFromDb();
+    return true;
+  }
+
   setFixAwaitingApproval(
     taskId: string,
     originalError: string,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1584,9 +1584,15 @@ export class Orchestrator {
           });
           return [];
         }
+        // Lineage check on executionGeneration. Validate it whenever the
+        // response carries one — not only when attemptId is absent. A
+        // response can reuse a still-current selectedAttemptId while the
+        // execution generation has moved on; such a response is stale and
+        // must be rejected. Backwards compatible: producers that omit the
+        // field (undefined) are not subject to this check, but when both
+        // attemptId and executionGeneration are present, both must match.
         const activeGeneration = this.getExecutionGeneration(earlyTask);
         if (
-          !response.attemptId &&
           response.executionGeneration !== undefined &&
           response.executionGeneration !== activeGeneration
         ) {


### PR DESCRIPTION
## Summary

Merge-gate metadata writes now route through the active task lineage before they persist execution state.

This prevents outdated merge-gate work from overwriting a newer attempt after cancellation or regeneration.

Regression tests cover direct merge-gate writes and orchestrator launch lineage mismatches.

<details>
<summary>Review metadata</summary>

Review Claim: Merge-gate execution metadata writes are ignored when the task attempt or generation no longer matches.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The guard only rejects writes for stale lineage; current merge-gate attempts keep the same metadata path.

Slice Rationale: This closes the merge-gate side-effect path separately from earlier worker-response and post-start guards.

</details>

## Non-goals

This slice does not change merge conflict resolution, experiment branch selection, or worker execution semantics.

It does not alter UI behavior or persistence schema.

## Architecture

### Before

```mermaid
graph TD
    A["Merge gate worker finishes"]
    B["Executor writes task metadata"]
    C["Store accepts execution state"]
    D["Newer launch can be overwritten"]
    A --> B --> C --> D
```

### After

```mermaid
graph TD
    A["Merge gate worker finishes"]
    B["Executor checks selectedAttemptId and executionGeneration"]
    C["Current lineage writes metadata"]
    D["Outdated lineage is ignored"]
    A --> B
    B --> C
    B --> D
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- merge-gate-metadata-guard.test.ts`
- [x] `pnpm --filter @invoker/workflow-core test -- orchestrator.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/step8-pr-body.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run the targeted execution-engine and workflow-core regression tests.
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lineage guard for merge-gate metadata writes to prevent stale or out-of-order writes from corrupting task state during retries and workflow recreation.

* **Tests**
  * Added comprehensive test coverage for merge-gate metadata persistence and orchestrator lineage validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->