### PR TITLE
Recovery Lifecycle 2h Step 3: Single-instance lock across both doors

### DIFF
--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -1,4 +1,6 @@
-import { readFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it, vi } from 'vitest';
 import { runHeadless } from '../headless.js';
@@ -42,7 +44,7 @@ describe('headless auto-fix cutover', () => {
 });
 
 describe('headless worker autofix', () => {
-  it('runs a one-shot scan and enqueues the normal fix command intent', async () => {
+  it('runs a one-shot scan under the single-instance lock and enqueues the normal fix command intent', async () => {
     const task = makeTask();
     const enqueueWorkflowMutationIntent = vi.fn((
       _workflowId: string,
@@ -51,6 +53,11 @@ describe('headless worker autofix', () => {
       _priority: WorkflowMutationPriority,
     ) => 1);
     const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    // Point the worker lock at a throwaway home so the scan never touches the
+    // real Invoker home (the door acquires/releases the cross-process lock).
+    const homeRoot = mkdtempSync(join(tmpdir(), 'invoker-headless-autofix-'));
+    const previousDbDir = process.env.INVOKER_DB_DIR;
+    process.env.INVOKER_DB_DIR = homeRoot;
 
     try {
       await runHeadless(['worker', 'autofix'], {
@@ -67,6 +74,9 @@ describe('headless worker autofix', () => {
       } as any);
     } finally {
       write.mockRestore();
+      if (previousDbDir === undefined) delete process.env.INVOKER_DB_DIR;
+      else process.env.INVOKER_DB_DIR = previousDbDir;
+      rmSync(homeRoot, { recursive: true, force: true });
     }
 
     expect(enqueueWorkflowMutationIntent).toHaveBeenCalledWith(

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -25,6 +25,9 @@ import {
   remoteFetchForPool,
   registerBuiltinAgents,
   assertPlanExecutionAgentsRegistered,
+  acquireRecoveryWorkerLock,
+  resolveInvokerHomeRoot,
+  WorkerLockHeldError,
   type AgentRegistry,
   type TaskHeartbeatEvent,
 } from '@invoker/execution-engine';
@@ -1150,22 +1153,41 @@ const HEADLESS_WORKER_KINDS: ReadonlyArray<{ kind: string; available: boolean; n
 async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0] ?? 'list';
   if (subCommand === 'autofix') {
-    const tick = createAutoFixRecoveryTick({
-      store: deps.persistence,
-      submitter: {
-        submit: (workflowId, priority, channel, mutationArgs) => (
-          deps.persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority)
-        ),
-      },
-      logger: deps.logger,
-      defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
-      getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
-    });
-    await tick({
-      identity: { kind: RECOVERY_WORKER_KIND, instanceId: 'headless-worker-autofix' },
-      reason: 'manual',
-      tickNumber: 1,
-    });
+    // Single-instance guard across both doors (this dev door and the production
+    // `invoker-cli worker autofix`): refuse rather than run a recovery scan that
+    // competes with a worker already holding the cross-process lock.
+    let lock;
+    try {
+      lock = acquireRecoveryWorkerLock({ homeRoot: resolveInvokerHomeRoot(), logger: deps.logger });
+    } catch (err) {
+      if (err instanceof WorkerLockHeldError) {
+        // Surface via the app's throw-based error convention.
+        throw new Error(err.message);
+      }
+      throw err;
+    }
+    try {
+      const tick = createAutoFixRecoveryTick({
+        store: deps.persistence,
+        submitter: {
+          submit: (workflowId, priority, channel, mutationArgs) => (
+            deps.persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority)
+          ),
+        },
+        logger: deps.logger,
+        defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
+        getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
+      });
+      await tick({
+        identity: { kind: RECOVERY_WORKER_KIND, instanceId: 'headless-worker-autofix' },
+        reason: 'manual',
+        tickNumber: 1,
+      });
+    } finally {
+      // Release deterministically so a clean run never leaves a stale lock that
+      // blocks the next legitimate start.
+      lock.release();
+    }
     process.stdout.write('Auto-fix worker scan completed.\n');
     return;
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,8 @@ import {
   TaskRunner,
   WorktreeExecutor,
   createRecoveryWorker,
+  acquireRecoveryWorkerLock,
+  WorkerLockHeldError,
   registerBuiltinAgents,
 } from '@invoker/execution-engine';
 import {
@@ -566,6 +568,21 @@ async function runAutoFixWorker(bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
   const { autoFixRetries, autoFixAgent } = readAutoFixWorkerConfig(homeRoot);
+
+  // Single-instance guard: refuse if another auto-fix worker (this door or the
+  // dev `--headless worker autofix` door) already holds the cross-process lock,
+  // rather than spawning a second recovery loop that competes over the same
+  // failed tasks.
+  let lock;
+  try {
+    lock = acquireRecoveryWorkerLock({ homeRoot, logger: silentLogger });
+  } catch (err) {
+    if (err instanceof WorkerLockHeldError) {
+      process.stderr.write(`${err.message}\n`);
+      return 1;
+    }
+    throw err;
+  }
   const persistence = await SQLiteAdapter.create(join(homeRoot, 'invoker.db'), {
     outputDir: join(homeRoot, 'outputs'),
   });
@@ -603,6 +620,9 @@ async function runAutoFixWorker(bus: MessageBus): Promise<number> {
     });
     await worker.stop();
   } finally {
+    // Release deterministically so a clean shutdown never leaves a stale lock
+    // that blocks the next legitimate start.
+    lock.release();
     persistence.close();
   }
   process.stdout.write('Auto-fix worker stopped.\n');

--- a/packages/execution-engine/src/__tests__/worker-lock.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-lock.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  acquireRecoveryWorkerLock,
+  acquireWorkerLock,
+  WorkerLockHeldError,
+} from '../worker-lock.js';
+import { RECOVERY_WORKER_KIND } from '../auto-fix-recovery.js';
+
+describe('worker single-instance lock', () => {
+  let homeRoot: string;
+
+  beforeEach(() => {
+    homeRoot = mkdtempSync(join(tmpdir(), 'invoker-lock-'));
+  });
+
+  afterEach(() => {
+    rmSync(homeRoot, { recursive: true, force: true });
+  });
+
+  it('refuses a second start while a worker holds the lock, then allows start after release', () => {
+    // First start acquires the lock.
+    const first = acquireRecoveryWorkerLock({ homeRoot });
+    expect(existsSync(first.path)).toBe(true);
+
+    // A second start (same kind, same Invoker home) must refuse — no second
+    // concurrent loop — because a live process already holds the lock.
+    expect(() => acquireRecoveryWorkerLock({ homeRoot })).toThrow(WorkerLockHeldError);
+
+    // stop() releases the lock...
+    first.release();
+    expect(existsSync(first.path)).toBe(false);
+
+    // ...so a subsequent legitimate start succeeds.
+    const second = acquireRecoveryWorkerLock({ homeRoot });
+    expect(existsSync(second.path)).toBe(true);
+    second.release();
+  });
+
+  it('release is idempotent and only removes a lock this process owns', () => {
+    const handle = acquireRecoveryWorkerLock({ homeRoot });
+    handle.release();
+    // A second release is a no-op and does not throw.
+    expect(() => handle.release()).not.toThrow();
+    expect(existsSync(handle.path)).toBe(false);
+  });
+
+  it('reclaims a stale lock left by a dead process', () => {
+    const lockPath = join(homeRoot, 'locks', `worker-${RECOVERY_WORKER_KIND}.lock`);
+    rmSync(join(homeRoot, 'locks'), { recursive: true, force: true });
+    // Simulate a crash: a lock file naming a pid that no longer exists.
+    mkdirSync(join(homeRoot, 'locks'), { recursive: true });
+    writeFileSync(
+      lockPath,
+      JSON.stringify({ kind: RECOVERY_WORKER_KIND, pid: 2147483646, acquiredAt: 1 }),
+    );
+
+    // Acquiring must not be wedged by the stale lock — it reclaims it.
+    const handle = acquireRecoveryWorkerLock({ homeRoot });
+    expect(handle.record.pid).toBe(process.pid);
+    handle.release();
+  });
+
+  it('isolates locks by worker kind', () => {
+    const recovery = acquireWorkerLock({ homeRoot, kind: 'recovery' });
+    // A different kind has its own lock file and is unaffected.
+    const other = acquireWorkerLock({ homeRoot, kind: 'other' });
+    expect(recovery.path).not.toBe(other.path);
+    recovery.release();
+    other.release();
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -33,6 +33,7 @@ export * from './codex-session-driver.js';
 export * from './claude-session-driver.js';
 export * from './omp-session-driver.js';
 export * from './worker-runtime.js';
+export * from './worker-lock.js';
 export * from './auto-fix-recovery.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';

--- a/packages/execution-engine/src/worker-lock.ts
+++ b/packages/execution-engine/src/worker-lock.ts
@@ -1,0 +1,199 @@
+/**
+ * Single-instance lock for long-running Invoker workers.
+ *
+ * Both doors that can start the auto-fix recovery worker — the production door
+ * (`invoker-cli worker autofix`) and the dev door (`./run.sh --headless worker
+ * autofix`) — may be different OS processes, so an in-process boolean cannot
+ * keep them mutually exclusive. This module provides a cross-process lock keyed
+ * to the worker kind, stored as an exclusive lock file under the Invoker home
+ * (`<invokerHome>/locks/worker-<kind>.lock`).
+ *
+ * Contract:
+ *   - Acquiring fails fast with {@link WorkerLockHeldError} when the lock is
+ *     already held by a *live* process. Callers refuse rather than spawn a
+ *     second loop.
+ *   - The lock file records the holder pid, so a lock left behind by a crashed
+ *     process is detected (the pid is dead) and reclaimed — a crash never
+ *     permanently wedges the worker.
+ *   - {@link WorkerLockHandle.release} is deterministic and idempotent: it
+ *     removes the file only while this process still owns it.
+ */
+
+import { existsSync, mkdirSync, openSync, closeSync, readFileSync, unlinkSync, writeSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
+import { RECOVERY_WORKER_KIND } from './auto-fix-recovery.js';
+
+// Re-export the canonical Invoker home resolver so both worker doors can reach
+// it from the engine. The single source of truth lives in `@invoker/contracts`
+// (it is test-mode aware), so the lock never diverges from the rest of the app.
+export { resolveInvokerHomeRoot };
+
+/** Metadata persisted into a lock file so a holder can be identified. */
+interface WorkerLockRecord {
+  kind: string;
+  pid: number;
+  instanceId?: string;
+  acquiredAt: number;
+}
+
+/** A held worker lock. `release()` frees it for the next legitimate start. */
+export interface WorkerLockHandle {
+  /** Absolute path of the lock file. */
+  readonly path: string;
+  /** The recorded holder metadata. */
+  readonly record: WorkerLockRecord;
+  /** Remove the lock if this process still owns it. Idempotent. */
+  release(): void;
+}
+
+/** Thrown when a worker lock is already held by another live process. */
+export class WorkerLockHeldError extends Error {
+  constructor(
+    readonly kind: string,
+    readonly holderPid: number,
+    readonly lockPath: string,
+  ) {
+    super(
+      `An auto-fix worker (kind=${kind}) is already running (pid ${holderPid}). ` +
+        `Refusing to start a second one. Lock: ${lockPath}`,
+    );
+    this.name = 'WorkerLockHeldError';
+  }
+}
+
+export interface AcquireWorkerLockOptions {
+  /** Worker family this lock guards. Defaults to the recovery worker kind. */
+  kind?: string;
+  /** Invoker home root. Defaults to {@link resolveInvokerHomeRoot}. */
+  homeRoot?: string;
+  /** Instance id recorded for diagnostics. */
+  instanceId?: string;
+  /** Process id to record. Defaults to the current process. */
+  pid?: number;
+  logger?: Logger;
+}
+
+/** Is `pid` a live process this user can observe? */
+function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    // Signal 0 performs error checking without delivering a signal.
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    // ESRCH → no such process (dead). EPERM → exists but not ours (alive).
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function readLockRecord(path: string): WorkerLockRecord | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<WorkerLockRecord>;
+    if (typeof parsed?.pid !== 'number' || typeof parsed?.kind !== 'string') return null;
+    return {
+      kind: parsed.kind,
+      pid: parsed.pid,
+      instanceId: parsed.instanceId,
+      acquiredAt: typeof parsed.acquiredAt === 'number' ? parsed.acquiredAt : 0,
+    };
+  } catch {
+    // Missing or corrupt file: treat as no valid holder so it can be reclaimed.
+    return null;
+  }
+}
+
+/**
+ * Acquire the single-instance lock for a worker kind. Throws
+ * {@link WorkerLockHeldError} when a live process already holds it; reclaims a
+ * stale lock left by a dead holder. The returned handle must be released on
+ * shutdown so a clean stop never blocks the next start.
+ */
+export function acquireWorkerLock(options: AcquireWorkerLockOptions = {}): WorkerLockHandle {
+  const kind = options.kind ?? RECOVERY_WORKER_KIND;
+  const homeRoot = options.homeRoot ?? resolveInvokerHomeRoot();
+  const pid = options.pid ?? process.pid;
+  const locksDir = join(homeRoot, 'locks');
+  const lockPath = join(locksDir, `worker-${kind}.lock`);
+  const logFields = { module: 'worker-lock', kind, lockPath };
+
+  mkdirSync(locksDir, { recursive: true });
+
+  const record: WorkerLockRecord = { kind, pid, instanceId: options.instanceId, acquiredAt: nowMs() };
+  const payload = JSON.stringify(record);
+
+  // Bounded retry: each pass either wins the exclusive create or reclaims a
+  // provably-dead holder. The cap prevents a livelock if two starts race to
+  // reclaim the same stale lock.
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    let fd: number;
+    try {
+      // 'wx' fails with EEXIST if the file exists — the atomic create that
+      // makes this lock exclusive across processes.
+      fd = openSync(lockPath, 'wx');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+      const holder = readLockRecord(lockPath);
+      if (holder && isProcessAlive(holder.pid)) {
+        throw new WorkerLockHeldError(kind, holder.pid, lockPath);
+      }
+      // Stale lock (corrupt, or holder pid is dead): reclaim and retry.
+      options.logger?.warn?.(
+        `[worker-lock] reclaiming stale lock for ${kind} (holder pid ${holder?.pid ?? 'unknown'} is gone)`,
+        logFields,
+      );
+      try {
+        unlinkSync(lockPath);
+      } catch (unlinkErr) {
+        if ((unlinkErr as NodeJS.ErrnoException).code !== 'ENOENT') throw unlinkErr;
+      }
+      continue;
+    }
+    try {
+      writeSync(fd, payload);
+    } finally {
+      closeSync(fd);
+    }
+    options.logger?.info?.(`[worker-lock] acquired lock for ${kind} (pid ${pid})`, logFields);
+
+    let released = false;
+    return {
+      path: lockPath,
+      record,
+      release(): void {
+        if (released) return;
+        released = true;
+        // Only remove the file while we still own it, so a reclaimed-and-
+        // re-acquired lock held by another process is never clobbered.
+        const current = existsSync(lockPath) ? readLockRecord(lockPath) : null;
+        if (current && current.pid === pid && current.acquiredAt === record.acquiredAt) {
+          try {
+            unlinkSync(lockPath);
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+          }
+        }
+        options.logger?.info?.(`[worker-lock] released lock for ${kind} (pid ${pid})`, logFields);
+      },
+    };
+  }
+
+  // Exhausted reclaim attempts: another racer keeps winning the lock.
+  const holder = readLockRecord(lockPath);
+  throw new WorkerLockHeldError(kind, holder?.pid ?? -1, lockPath);
+}
+
+/** Acquire the single-instance lock for the auto-fix recovery worker. */
+export function acquireRecoveryWorkerLock(
+  options: Omit<AcquireWorkerLockOptions, 'kind'> = {},
+): WorkerLockHandle {
+  return acquireWorkerLock({ ...options, kind: RECOVERY_WORKER_KIND });
+}
+
+/**
+ * Current time in ms. Isolated so the lock module has a single clock source and
+ * tests can reason about `acquiredAt`.
+ */
+function nowMs(): number {
+  return Date.now();
+}


### PR DESCRIPTION
## Summary

Only one auto-fix worker can run at a time now. Starting a second one refuses instead of spawning a competing recovery loop.

Before, the production door (`invoker-cli worker autofix`) and the dev door (`./run.sh --headless worker autofix`) could each start their own loop.

Two loops would then fight over the same failed tasks.

The guard is a single-instance lock that lives in the shared engine package, so both doors take the same lock. The second start fails loudly with a clear message.

The lock is foreground-scoped. It is held for the life of the worker process and released on a clean stop or on SIGINT/SIGTERM.

So a normal exit never leaves a stale lock behind.

## Architecture

### Before

```mermaid
graph TD
    CLI[CLI door: worker autofix] --> E1[Recovery engine loop]
    APP[Dev door: headless worker autofix] --> E2[Recovery engine loop]
    E1 --> T[(Failed tasks)]
    E2 --> T
```

### After

```mermaid
graph TD
    CLI[CLI door: worker autofix] --> L{Single-instance lock}
    APP[Dev door: headless worker autofix] --> L
    L -->|acquired| E[Recovery engine loop]
    L -->|contended| R[Refuse: second worker not started]
    E --> T[(Failed tasks)]
```

## Test Plan

- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `cd packages/cli && pnpm test`
- [ ] `cd packages/app && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>` or drop the branch from the stack
- Post-revert steps: None. Reverting removes the lock gate; both doors return to their prior start behavior.
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented cross-process single-instance locking for the autofix worker to prevent concurrent execution, with automatic stale lock recovery and deterministic cleanup.

* **Tests**
  * Added comprehensive test coverage for worker lock acquisition, conflict detection, idempotent release, automatic stale lock recovery, and worker type isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->