### PR TITLE
[Fix intent cancellation](9) Fix intent cancellation Step 9: launch dispatch generation validation (regression gated v2)

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -665,7 +665,7 @@ describe('LaunchDispatcher', () => {
       expect(adapter.loadLaunchDispatchById(1)?.lastError).toBeUndefined();
     });
 
-    it('abandons a dispatch row when the selected attempt changed after lease', () => {
+    it('abandons a dispatch row when both the selected attempt and generation changed after lease', () => {
       const task = seedWorkflowAndTask('wf-a/t-stale', 'wf-a', {
         selectedAttemptId: 'attempt-old',
         generation: 0,
@@ -700,9 +700,119 @@ describe('LaunchDispatcher', () => {
       expect(executeTask).not.toHaveBeenCalled();
       const after = adapter.loadLaunchDispatchById(enq.id);
       expect(after?.state).toBe('abandoned');
-      expect(after?.lastError).toMatch(/selected attempt or generation changed/);
+      expect(after?.lastError).toMatch(/selected attempt and execution generation changed/);
       const events = adapter.getEvents(task.id);
-      expect(events.some((event) => event.eventType === 'task.launch_dispatch_invalidated')).toBe(true);
+      const invalidated = events.find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(invalidated).toBeDefined();
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        reason: 'selected_attempt_and_generation_changed',
+        mismatchedFields: ['attemptId', 'generation'],
+        dispatchAttemptId: 'attempt-old',
+        dispatchGeneration: 0,
+        selectedAttemptId: 'attempt-current',
+        selectedGeneration: 1,
+      });
+    });
+
+    it('does not hand a dispatch row to the TaskRunner when only the generation differs', () => {
+      const task = seedWorkflowAndTask('wf-a/t-gen', 'wf-a', {
+        selectedAttemptId: 'attempt-gen',
+        generation: 0,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-gen',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      // Same selected attempt, but the task advanced to a newer execution
+      // generation after the row was enqueued.
+      const currentTask = {
+        ...task,
+        execution: {
+          ...task.execution,
+          selectedAttemptId: 'attempt-gen',
+          generation: 2,
+        },
+      };
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(currentTask as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/execution generation changed/);
+      const events = adapter.getEvents(task.id);
+      const invalidated = events.find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(invalidated).toBeDefined();
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        reason: 'execution_generation_changed',
+        mismatchedFields: ['generation'],
+        dispatchGeneration: 0,
+        selectedGeneration: 2,
+      });
+    });
+
+    it('does not hand a dispatch row to the TaskRunner when only the selected attempt differs', () => {
+      const task = seedWorkflowAndTask('wf-a/t-attempt', 'wf-a', {
+        selectedAttemptId: 'attempt-original',
+        generation: 3,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-original',
+        workflowId: 'wf-a',
+        generation: 3,
+      });
+      // Same generation, but a different attempt was selected (e.g. the
+      // user picked a different attempt) after the row was enqueued.
+      const currentTask = {
+        ...task,
+        execution: {
+          ...task.execution,
+          selectedAttemptId: 'attempt-reselected',
+          generation: 3,
+        },
+      };
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(currentTask as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/selected attempt changed/);
+      const events = adapter.getEvents(task.id);
+      const invalidated = events.find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(invalidated).toBeDefined();
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        reason: 'selected_attempt_changed',
+        mismatchedFields: ['attemptId'],
+        dispatchAttemptId: 'attempt-original',
+        selectedAttemptId: 'attempt-reselected',
+      });
     });
 
     it('abandons the dispatch when readiness is blocked', () => {

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -156,12 +156,14 @@ export class LaunchDispatcher {
         }
         task = readiness.task;
       }
-      if (!this.dispatchMatchesTask(leased, task)) {
+      const lineage = this.classifyLineageMismatch(leased, task);
+      if (lineage) {
         this.abandonInvalidDispatch(
           leased,
-          `Launch dispatch ${leased.id} is stale: selected attempt or generation changed`,
-          'selected_attempt_changed',
+          `Launch dispatch ${leased.id} is stale: ${lineage.summary}`,
+          lineage.reason,
           {
+            mismatchedFields: lineage.mismatchedFields,
             selectedAttemptId: task.execution.selectedAttemptId,
             selectedGeneration: task.execution.generation ?? 0,
           },
@@ -207,9 +209,41 @@ export class LaunchDispatcher {
     return this.orchestrator?.getTask?.(dispatch.taskId);
   }
 
-  private dispatchMatchesTask(dispatch: TaskLaunchDispatch, task: TaskState): boolean {
-    return task.execution.selectedAttemptId === dispatch.attemptId
-      && (task.execution.generation ?? 0) === (dispatch.generation ?? 0);
+  /**
+   * Compare a leased dispatch row against the task's live lineage. A row
+   * carries the `attemptId` and `generation` that were current when
+   * `drainScheduler` enqueued it; if the task has since selected a
+   * different attempt or bumped its execution generation, launching this
+   * row would start a stale attempt. Returns `null` when the row still
+   * matches (safe to launch), otherwise a descriptor naming exactly which
+   * lineage dimension(s) drifted so the abandon path can emit a precise,
+   * inspectable audit reason rather than collapsing both into one label.
+   */
+  private classifyLineageMismatch(
+    dispatch: TaskLaunchDispatch,
+    task: TaskState,
+  ): { reason: string; summary: string; mismatchedFields: string[] } | null {
+    const attemptChanged = task.execution.selectedAttemptId !== dispatch.attemptId;
+    const generationChanged = (task.execution.generation ?? 0) !== (dispatch.generation ?? 0);
+    if (!attemptChanged && !generationChanged) return null;
+
+    const mismatchedFields: string[] = [];
+    if (attemptChanged) mismatchedFields.push('attemptId');
+    if (generationChanged) mismatchedFields.push('generation');
+
+    let reason: string;
+    let summary: string;
+    if (attemptChanged && generationChanged) {
+      reason = 'selected_attempt_and_generation_changed';
+      summary = 'selected attempt and execution generation changed';
+    } else if (attemptChanged) {
+      reason = 'selected_attempt_changed';
+      summary = 'selected attempt changed';
+    } else {
+      reason = 'execution_generation_changed';
+      summary = 'execution generation changed';
+    }
+    return { reason, summary, mismatchedFields };
   }
 
   private abandonInvalidDispatch(


### PR DESCRIPTION
## Summary

Leftover launch dispatch rows can point at an older task run after a task is relaunched.

This change compares each leased row with the task's current attempt and generation before runner handoff.

Rows from obsolete lineage are abandoned with precise audit details instead of starting obsolete work.

<details>
<summary>Review metadata</summary>

Review Claim: Approve that launch dispatch routes only rows whose stored attempt and generation still match the task before runner handoff.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Matching rows still reach the runner unchanged; only rows with obsolete attempt or generation lineage are abandoned.

Slice Rationale: This slice is limited to launch-dispatch routing and its direct regression coverage after the merge-gate lineage guard slice.

</details>

## Non-goals

This does not change dispatch row creation, attempt selection, generation assignment, or merge-gate behavior.

## Architecture

### Before

```mermaid
graph TD
    A["Lease launch dispatch row"] --> B["Load task"]
    B --> C["Check launch readiness"]
    C --> D["TaskRunner.executeTask"]
```

### After

```mermaid
graph TD
    A["Lease launch dispatch row"] --> B["Load task"]
    B --> C["Check launch readiness"]
    C --> D["Compare row attempt and generation"]
    D --> E["TaskRunner.executeTask"]
    D --> F["Abandon obsolete row with audit reason"]
```

## Test Plan

- [ ] `pnpm --filter @invoker/app test -- src/__tests__/launch-dispatcher.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
