### PR TITLE
[Crabbox SSH](4) cleanup policy

### DIFF
--- a/packages/execution-engine/src/__tests__/crabbox-target-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/crabbox-target-resolver.test.ts
@@ -3,6 +3,9 @@ import {
   CrabboxTargetResolver,
   buildCrabboxWarmupArgs,
   buildCrabboxStatusArgs,
+  buildCrabboxStopArgs,
+  resolveCrabboxCleanupPolicy,
+  shouldStopCrabboxLease,
   type CrabboxCommandResult,
   type CrabboxCommandRunner,
   type CrabboxResolverTargetConfig,
@@ -233,5 +236,100 @@ describe('CrabboxTargetResolver.resolve', () => {
     await expect(
       new CrabboxTargetResolver(runner).resolve(baseConfig),
     ).rejects.toThrow(/did not return valid JSON/);
+  });
+});
+
+describe('buildCrabboxStopArgs', () => {
+  it('builds `stop <leaseId>` plus configured stopArgs', () => {
+    expect(
+      buildCrabboxStopArgs(
+        { id: 'crab1', crabboxCommand: 'crabbox', stopArgs: ['--force'] },
+        'lease-123',
+      ),
+    ).toEqual(['stop', 'lease-123', '--force']);
+  });
+
+  it('omits stopArgs when none are configured', () => {
+    expect(
+      buildCrabboxStopArgs({ id: 'crab1', crabboxCommand: 'crabbox' }, 'lease-9'),
+    ).toEqual(['stop', 'lease-9']);
+  });
+});
+
+describe('CrabboxTargetResolver.stop', () => {
+  it('runs `crabbox stop <leaseId>` with stopArgs and resolves on exit 0', async () => {
+    const { runner, calls } = scriptRunner([ok('stopped')]);
+
+    await new CrabboxTargetResolver(runner).stop(
+      { id: 'crab1', crabboxCommand: '/usr/local/bin/crabbox', stopArgs: ['--now'] },
+      'lease-123',
+    );
+
+    expect(calls[0]).toEqual({
+      command: '/usr/local/bin/crabbox',
+      args: ['stop', 'lease-123', '--now'],
+    });
+  });
+
+  it('throws an actionable error when stop exits non-zero', async () => {
+    const { runner } = scriptRunner([
+      { stdout: '', stderr: 'lease not found', exitCode: 3 },
+    ]);
+
+    await expect(
+      new CrabboxTargetResolver(runner).stop(
+        { id: 'crab1', crabboxCommand: 'crabbox' },
+        'lease-123',
+      ),
+    ).rejects.toThrow(/Crabbox stop failed for lease "lease-123".*crab1.*lease not found/s);
+  });
+});
+
+describe('resolveCrabboxCleanupPolicy', () => {
+  it('defaults stopAfter to success and keepOnFailure to true', () => {
+    expect(resolveCrabboxCleanupPolicy(undefined, undefined)).toEqual({
+      stopAfter: 'success',
+      keepOnFailure: true,
+    });
+  });
+
+  it('treats the legacy "completed" value as success', () => {
+    expect(resolveCrabboxCleanupPolicy('completed', false)).toEqual({
+      stopAfter: 'success',
+      keepOnFailure: false,
+    });
+  });
+
+  it('passes through known policies', () => {
+    expect(resolveCrabboxCleanupPolicy('always', false).stopAfter).toBe('always');
+    expect(resolveCrabboxCleanupPolicy('never', true).stopAfter).toBe('never');
+    expect(resolveCrabboxCleanupPolicy('failure', false).stopAfter).toBe('failure');
+  });
+});
+
+describe('shouldStopCrabboxLease', () => {
+  it('success policy stops on success only', () => {
+    const policy = { stopAfter: 'success' as const, keepOnFailure: false };
+    expect(shouldStopCrabboxLease(policy, true)).toBe(true);
+    expect(shouldStopCrabboxLease(policy, false)).toBe(false);
+  });
+
+  it('keepOnFailure preserves a failed lease regardless of stopAfter', () => {
+    expect(
+      shouldStopCrabboxLease({ stopAfter: 'always', keepOnFailure: true }, false),
+    ).toBe(false);
+    expect(
+      shouldStopCrabboxLease({ stopAfter: 'success', keepOnFailure: true }, false),
+    ).toBe(false);
+  });
+
+  it('always stops; never keeps', () => {
+    expect(shouldStopCrabboxLease({ stopAfter: 'always', keepOnFailure: false }, false)).toBe(true);
+    expect(shouldStopCrabboxLease({ stopAfter: 'never', keepOnFailure: false }, true)).toBe(false);
+  });
+
+  it('failure policy stops only on failure', () => {
+    expect(shouldStopCrabboxLease({ stopAfter: 'failure', keepOnFailure: false }, false)).toBe(true);
+    expect(shouldStopCrabboxLease({ stopAfter: 'failure', keepOnFailure: false }, true)).toBe(false);
   });
 });

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2178,7 +2178,8 @@ describe('TaskRunner', () => {
           keepOnFailure: config.keepOnFailure,
         },
       }));
-      return { resolve };
+      const stop = vi.fn(async () => {});
+      return { resolve, stop };
     }
 
     const crabboxTarget = {
@@ -2327,6 +2328,190 @@ describe('TaskRunner', () => {
         outputs: { exitCode: 0 },
       } as WorkResponse);
       await run;
+    });
+  });
+
+  describe('crabbox cleanup policy', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    const baseCrabboxTarget = {
+      type: 'crabbox' as const,
+      crabboxCommand: '/usr/bin/crabbox',
+      provider: 'do',
+      class: 'medium',
+      ttl: '30m',
+      idleTimeout: '10m',
+      network: 'default',
+      target: 'ubuntu-22',
+      stopAfter: 'success',
+      keepOnFailure: true,
+      stopArgs: ['--force'],
+    };
+
+    async function runCrabboxTask(opts: {
+      targetOverrides?: Record<string, unknown>;
+      final: { status: WorkResponse['status']; exitCode: number };
+      stopRejects?: boolean;
+    }) {
+      const completeByTask = new Map<string, (r: WorkResponse) => void>();
+      vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (this: any, request: any) {
+        return {
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: `/remote/${request.actionId}`,
+          branch: `branch-${request.actionId}`,
+        };
+      });
+      vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation((handle: any, cb: any) => {
+        completeByTask.set(handle.taskId, cb);
+      });
+      vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+
+      const resolve = vi.fn(async (config: any) => ({
+        sshTarget: { host: 'leased.crab', user: 'crab', sshKeyPath: '/leased/key', port: 2222 },
+        remoteLeaseMetadata: {
+          provider: 'crabbox' as const,
+          leaseId: 'lease-xyz',
+          slug: 'happy-lease',
+          targetId: config.id,
+          sshHost: 'leased.crab',
+          sshUser: 'crab',
+          sshPort: 2222,
+          sshKeyPath: '/leased/key',
+          expiresAt: '2099-01-01T00:00:00Z',
+          stopAfter: config.stopAfter,
+          keepOnFailure: config.keepOnFailure,
+        },
+      }));
+      const stop = vi.fn(async () => {
+        if (opts.stopRejects) throw new Error('crabbox stop boom');
+      });
+
+      const appendTaskOutput = vi.fn();
+      const logEvent = vi.fn();
+      const onOutput = vi.fn();
+      const onComplete = vi.fn();
+      const task = makeTask({
+        id: 'wf/crab-task',
+        config: { runnerKind: 'ssh', poolMemberId: 'crab-target' },
+        execution: { selectedAttemptId: 'crab-attempt', generation: 0 },
+      });
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => (id === task.id ? task : null),
+          getAllTasks: () => [task],
+          markTaskRunningAfterLaunch: () => true,
+          handleWorkerResponse: () => [],
+          deferTask: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask: vi.fn(),
+          updateAttempt: vi.fn(),
+          appendTaskOutput,
+          logEvent,
+          loadAttempts: () => [],
+        } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({ 'crab-target': { ...baseCrabboxTarget, ...opts.targetOverrides } }),
+        crabboxResolver: { resolve, stop },
+        callbacks: { onOutput, onComplete },
+      });
+
+      const run = runner.executeTask(task);
+      await vi.waitFor(() => expect(SshExecutor.prototype.start).toHaveBeenCalledTimes(1));
+      completeByTask.get(task.id)?.({
+        requestId: 'r',
+        actionId: task.id,
+        attemptId: 'crab-attempt',
+        status: opts.final.status,
+        outputs: { exitCode: opts.final.exitCode },
+      } as WorkResponse);
+      await run;
+
+      const event = (name: string) => logEvent.mock.calls.find(([, e]: [string, string]) => e === name)?.[2];
+      return { stop, logEvent, appendTaskOutput, onOutput, onComplete, event };
+    }
+
+    it('stops the lease on success (default policy) and forwards stopArgs', async () => {
+      const { stop, event } = await runCrabboxTask({
+        final: { status: 'completed', exitCode: 0 },
+      });
+
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(stop).toHaveBeenCalledWith(
+        { id: 'crab-target', crabboxCommand: '/usr/bin/crabbox', stopArgs: ['--force'] },
+        'lease-xyz',
+      );
+      expect(event('task.executor.crabbox-stopped')).toMatchObject({
+        leaseId: 'lease-xyz',
+        stopAfter: 'success',
+        succeeded: true,
+      });
+    });
+
+    it('keeps the lease on failure and appends connect/stop commands', async () => {
+      const { stop, event, appendTaskOutput, onOutput } = await runCrabboxTask({
+        final: { status: 'failed', exitCode: 1 },
+      });
+
+      expect(stop).not.toHaveBeenCalled();
+      const skipped = event('task.executor.crabbox-cleanup-skipped');
+      expect(skipped).toMatchObject({
+        leaseId: 'lease-xyz',
+        reason: 'keepOnFailure',
+        sshCommand: '/usr/bin/crabbox ssh --id lease-xyz',
+        stopCommand: '/usr/bin/crabbox stop lease-xyz',
+      });
+      const printed = appendTaskOutput.mock.calls.map(([, msg]) => msg).join('');
+      expect(printed).toContain('/usr/bin/crabbox ssh --id lease-xyz');
+      expect(printed).toContain('/usr/bin/crabbox stop lease-xyz');
+      const echoed = onOutput.mock.calls.map(([, msg]) => msg).join('');
+      expect(echoed).toContain('kept for debugging after failure');
+    });
+
+    it('always: stops even a failed lease when keepOnFailure is false', async () => {
+      const { stop } = await runCrabboxTask({
+        targetOverrides: { stopAfter: 'always', keepOnFailure: false },
+        final: { status: 'failed', exitCode: 1 },
+      });
+
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(stop).toHaveBeenCalledWith(expect.objectContaining({ id: 'crab-target' }), 'lease-xyz');
+    });
+
+    it('never: leaves the lease running even on success', async () => {
+      const { stop, logEvent } = await runCrabboxTask({
+        targetOverrides: { stopAfter: 'never', keepOnFailure: false },
+        final: { status: 'completed', exitCode: 0 },
+      });
+
+      expect(stop).not.toHaveBeenCalled();
+      const stopped = logEvent.mock.calls.find(([, e]: [string, string]) => e === 'task.executor.crabbox-stopped');
+      expect(stopped).toBeUndefined();
+    });
+
+    it('logs crabbox-cleanup-failed and does not rewrite the exit code when stop fails', async () => {
+      const { stop, event, onComplete } = await runCrabboxTask({
+        targetOverrides: { stopAfter: 'always', keepOnFailure: false },
+        final: { status: 'failed', exitCode: 7 },
+        stopRejects: true,
+      });
+
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(event('task.executor.crabbox-cleanup-failed')).toMatchObject({
+        leaseId: 'lease-xyz',
+        error: expect.stringContaining('crabbox stop boom'),
+      });
+      // Cleanup failure must not change the task outcome.
+      expect(onComplete).toHaveBeenCalledWith(
+        'wf/crab-task',
+        expect.objectContaining({ status: 'failed', outputs: { exitCode: 7 } }),
+      );
     });
   });
 

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2320,13 +2320,15 @@ describe('TaskRunner', () => {
         remoteLeaseMetadata: { leaseId: 'lease-123' },
       });
 
-      completeByTask.get(task.id)?.({
+      const response: WorkResponse = {
         requestId: 'r',
         actionId: task.id,
         attemptId: 'crab-task-attempt',
+        executionGeneration: 0,
         status: 'completed',
         outputs: { exitCode: 0 },
-      } as WorkResponse);
+      };
+      completeByTask.get(task.id)?.(response);
       await run;
     });
   });
@@ -2434,13 +2436,15 @@ describe('TaskRunner', () => {
 
       const run = runner.executeTask(task);
       await vi.waitFor(() => expect(SshExecutor.prototype.start).toHaveBeenCalledTimes(1));
-      completeByTask.get(task.id)?.({
+      const response: WorkResponse = {
         requestId: 'r',
         actionId: task.id,
         attemptId: 'crab-attempt',
+        executionGeneration: 0,
         status: opts.final.status,
         outputs: { exitCode: opts.final.exitCode },
-      } as WorkResponse);
+      };
+      completeByTask.get(task.id)?.(response);
       await run;
 
       const event = (name: string) => logEvent.mock.calls.find(([, e]: [string, string]) => e === name)?.[2];

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2354,6 +2354,9 @@ describe('TaskRunner', () => {
       targetOverrides?: Record<string, unknown>;
       final: { status: WorkResponse['status']; exitCode: number };
       stopRejects?: boolean;
+      omitStop?: boolean;
+      newlyStarted?: TaskState[];
+      captureDispatchOrder?: boolean;
     }) {
       const completeByTask = new Map<string, (r: WorkResponse) => void>();
       vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (this: any, request: any) {
@@ -2387,7 +2390,9 @@ describe('TaskRunner', () => {
           keepOnFailure: config.keepOnFailure,
         },
       }));
+      const order: string[] = [];
       const stop = vi.fn(async () => {
+        order.push('stop');
         if (opts.stopRejects) throw new Error('crabbox stop boom');
       });
 
@@ -2405,7 +2410,7 @@ describe('TaskRunner', () => {
           getTask: (id: string) => (id === task.id ? task : null),
           getAllTasks: () => [task],
           markTaskRunningAfterLaunch: () => true,
-          handleWorkerResponse: () => [],
+          handleWorkerResponse: () => opts.newlyStarted ?? [],
           deferTask: vi.fn(),
         } as any,
         persistence: {
@@ -2418,9 +2423,14 @@ describe('TaskRunner', () => {
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
         cwd: '/tmp',
         remoteTargetsProvider: () => ({ 'crab-target': { ...baseCrabboxTarget, ...opts.targetOverrides } }),
-        crabboxResolver: { resolve, stop },
+        crabboxResolver: opts.omitStop ? { resolve } : { resolve, stop },
         callbacks: { onOutput, onComplete },
       });
+      if (opts.captureDispatchOrder) {
+        (runner as any).executeNewlyStartedTasks = vi.fn(() => {
+          order.push('dispatch');
+        });
+      }
 
       const run = runner.executeTask(task);
       await vi.waitFor(() => expect(SshExecutor.prototype.start).toHaveBeenCalledTimes(1));
@@ -2434,7 +2444,7 @@ describe('TaskRunner', () => {
       await run;
 
       const event = (name: string) => logEvent.mock.calls.find(([, e]: [string, string]) => e === name)?.[2];
-      return { stop, logEvent, appendTaskOutput, onOutput, onComplete, event };
+      return { stop, logEvent, appendTaskOutput, onOutput, onComplete, event, order };
     }
 
     it('stops the lease on success (default policy) and forwards stopArgs', async () => {
@@ -2465,11 +2475,11 @@ describe('TaskRunner', () => {
         leaseId: 'lease-xyz',
         reason: 'keepOnFailure',
         sshCommand: '/usr/bin/crabbox ssh --id lease-xyz',
-        stopCommand: '/usr/bin/crabbox stop lease-xyz',
+        stopCommand: '/usr/bin/crabbox stop lease-xyz --force',
       });
       const printed = appendTaskOutput.mock.calls.map(([, msg]) => msg).join('');
       expect(printed).toContain('/usr/bin/crabbox ssh --id lease-xyz');
-      expect(printed).toContain('/usr/bin/crabbox stop lease-xyz');
+      expect(printed).toContain('/usr/bin/crabbox stop lease-xyz --force');
       const echoed = onOutput.mock.calls.map(([, msg]) => msg).join('');
       expect(echoed).toContain('kept for debugging after failure');
     });
@@ -2495,6 +2505,17 @@ describe('TaskRunner', () => {
       expect(stopped).toBeUndefined();
     });
 
+
+    it('stops a completed lease before dispatching newly ready tasks', async () => {
+      const downstream = makeTask({ id: 'wf/downstream', status: 'pending' });
+      const { order } = await runCrabboxTask({
+        final: { status: 'completed', exitCode: 0 },
+        newlyStarted: [downstream],
+        captureDispatchOrder: true,
+      });
+
+      expect(order).toEqual(['stop', 'dispatch']);
+    });
     it('logs crabbox-cleanup-failed and does not rewrite the exit code when stop fails', async () => {
       const { stop, event, onComplete } = await runCrabboxTask({
         targetOverrides: { stopAfter: 'always', keepOnFailure: false },
@@ -2512,6 +2533,20 @@ describe('TaskRunner', () => {
         'wf/crab-task',
         expect.objectContaining({ status: 'failed', outputs: { exitCode: 7 } }),
       );
+    });
+
+    it('logs cleanup failure instead of success when resolver cannot stop', async () => {
+      const { event, logEvent } = await runCrabboxTask({
+        final: { status: 'completed', exitCode: 0 },
+        omitStop: true,
+      });
+
+      expect(event('task.executor.crabbox-cleanup-failed')).toMatchObject({
+        leaseId: 'lease-xyz',
+        error: expect.stringContaining('Crabbox resolver does not support stop cleanup'),
+      });
+      const stopped = logEvent.mock.calls.find(([, e]: [string, string]) => e === 'task.executor.crabbox-stopped');
+      expect(stopped).toBeUndefined();
     });
   });
 

--- a/packages/execution-engine/src/crabbox-target-resolver.ts
+++ b/packages/execution-engine/src/crabbox-target-resolver.ts
@@ -64,6 +64,90 @@ export interface CrabboxResolverTargetConfig {
   readonly warmupArgs?: readonly string[];
   /** Optional extra args appended to the status subcommand. */
   readonly statusArgs?: readonly string[];
+  /** Optional extra args appended to the stop subcommand. */
+  readonly stopArgs?: readonly string[];
+}
+
+/**
+ * Inputs needed to stop (clean up) a Crabbox lease. A subset of
+ * {@link CrabboxResolverTargetConfig}: stopping only needs the CLI entrypoint,
+ * the target id (for error messages), and any configured stop args.
+ */
+export interface CrabboxStopConfig {
+  /** Config key of the remote target. Named in errors. */
+  readonly id: string;
+  /** CLI entrypoint that stops Crabbox leases. */
+  readonly crabboxCommand: string;
+  /** Optional extra args appended to the stop subcommand. */
+  readonly stopArgs?: readonly string[];
+}
+
+/** When to stop a Crabbox lease relative to the task's final status. */
+export type CrabboxStopAfter = 'success' | 'failure' | 'always' | 'never';
+
+/** Crabbox should not leak machines by default: stop on success. */
+export const DEFAULT_CRABBOX_STOP_AFTER: CrabboxStopAfter = 'success';
+/** Failed tasks keep their machine by default so they can be debugged. */
+export const DEFAULT_CRABBOX_KEEP_ON_FAILURE = true;
+
+/** Normalized cleanup policy for a Crabbox lease. */
+export interface CrabboxCleanupPolicy {
+  readonly stopAfter: CrabboxStopAfter;
+  readonly keepOnFailure: boolean;
+}
+
+/**
+ * Apply default Crabbox cleanup policy to raw (possibly missing/legacy) config.
+ *
+ * Defaults: `stopAfter` → 'success' (don't leak machines), `keepOnFailure` →
+ * true (preserve failed machines for debugging). The legacy `'completed'`
+ * value is treated as `'success'`.
+ */
+export function resolveCrabboxCleanupPolicy(
+  stopAfter: string | undefined,
+  keepOnFailure: boolean | undefined,
+): CrabboxCleanupPolicy {
+  return {
+    stopAfter: normalizeStopAfter(stopAfter),
+    keepOnFailure: keepOnFailure ?? DEFAULT_CRABBOX_KEEP_ON_FAILURE,
+  };
+}
+
+function normalizeStopAfter(value: string | undefined): CrabboxStopAfter {
+  switch (value) {
+    case 'success':
+    case 'failure':
+    case 'always':
+    case 'never':
+      return value;
+    case 'completed':
+      // Legacy alias from earlier config: stop once the task completes ok.
+      return 'success';
+    default:
+      return DEFAULT_CRABBOX_STOP_AFTER;
+  }
+}
+
+/**
+ * Decide whether to stop a Crabbox lease given its policy and the task's
+ * outcome. `keepOnFailure` wins on failure (debug-preserving), so a failed
+ * task with `keepOnFailure` is never stopped regardless of `stopAfter`.
+ */
+export function shouldStopCrabboxLease(
+  policy: CrabboxCleanupPolicy,
+  succeeded: boolean,
+): boolean {
+  if (!succeeded && policy.keepOnFailure) return false;
+  switch (policy.stopAfter) {
+    case 'always':
+      return true;
+    case 'never':
+      return false;
+    case 'success':
+      return succeeded;
+    case 'failure':
+      return !succeeded;
+  }
 }
 
 /** A fixed SSH host the SSH executor can connect to directly. */
@@ -165,6 +249,17 @@ export function buildCrabboxStatusArgs(
   ];
 }
 
+/**
+ * Build the stop args that tear down a lease: `stop <leaseId>` plus any
+ * caller-supplied stopArgs.
+ */
+export function buildCrabboxStopArgs(
+  config: CrabboxStopConfig,
+  leaseId: string,
+): string[] {
+  return ['stop', leaseId, ...(config.stopArgs ?? [])];
+}
+
 function asNonEmptyString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
@@ -206,6 +301,24 @@ export class CrabboxTargetResolver {
       );
     }
     return this.buildResolvedTarget(config, status, leaseRef);
+  }
+
+  /**
+   * Stop (release) a Crabbox lease via `crabbox stop <leaseId>`. Throws an
+   * actionable error when the stop command exits non-zero so callers can log
+   * a cleanup failure without re-deriving the lease.
+   */
+  async stop(config: CrabboxStopConfig, leaseId: string): Promise<void> {
+    const result = await this.run(
+      config.crabboxCommand,
+      buildCrabboxStopArgs(config, leaseId),
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Crabbox stop failed for lease "${leaseId}" on remote target "${config.id}" ` +
+          `(exit ${result.exitCode}): ${result.stderr.trim() || result.stdout.trim()}`,
+      );
+    }
   }
 
   /** Read the lease id (or slug) that warmup printed for the status call. */

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 
 import { scopePlanTaskId } from '@invoker/workflow-core';
-import type { Orchestrator, TaskState, ExperimentVariant, RunnerKind } from '@invoker/workflow-core';
+import type { Orchestrator, TaskState, ExperimentVariant, RunnerKind, CrabboxRemoteLeaseMetadata } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
@@ -34,7 +34,10 @@ import { formatLifecycleTag, extractAttemptSuffix } from './branch-utils.js';
 import { SshExecutor } from './ssh-executor.js';
 import {
   CrabboxTargetResolver,
+  resolveCrabboxCleanupPolicy,
+  shouldStopCrabboxLease,
   type CrabboxResolverTargetConfig,
+  type CrabboxStopConfig,
   type ResolvedCrabboxTarget,
 } from './crabbox-target-resolver.js';
 
@@ -166,14 +169,21 @@ type RemoteTargetDisplay = {
   keepOnFailure?: boolean;
   warmupArgs?: readonly string[];
   statusArgs?: readonly string[];
+  stopArgs?: readonly string[];
 };
 
 /**
  * Injectable dependency that turns a Crabbox remote target into a ready SSH
- * endpoint plus durable lease metadata. Defaults to {@link CrabboxTargetResolver}.
+ * endpoint plus durable lease metadata, and stops the lease during cleanup.
+ * Defaults to {@link CrabboxTargetResolver}.
  */
 export interface CrabboxResolver {
   resolve(config: CrabboxResolverTargetConfig): Promise<ResolvedCrabboxTarget>;
+  /**
+   * Stop (release) a leased machine. Optional so test fakes that never reach
+   * cleanup can omit it; the real resolver always implements it.
+   */
+  stop?(config: CrabboxStopConfig, leaseId: string): Promise<void>;
 }
 
 /**
@@ -360,6 +370,7 @@ export interface TaskRunnerConfig {
     keepOnFailure?: boolean;
     warmupArgs?: readonly string[];
     statusArgs?: readonly string[];
+    stopArgs?: readonly string[];
   }>;
   /**
    * Resolves `type: 'crabbox'` remote targets into ready SSH endpoints.
@@ -1188,6 +1199,10 @@ export class TaskRunner {
     }
     bench('markTaskRunningAfterLaunch.accepted');
 
+    // Durable Crabbox lease metadata for this attempt, captured at start so the
+    // completion handler can apply the cleanup policy (stop / keep-for-debug).
+    let crabboxLeaseMetadata: CrabboxRemoteLeaseMetadata | undefined;
+
     // Persist execution metadata immediately at task start — all fields explicit
     {
       // Fail-fast: workspacePath must be provided by all executors
@@ -1216,6 +1231,7 @@ export class TaskRunner {
       const remoteLeaseMetadata = selectedSshTargetId
         ? this.resolvedCrabboxTargets.get(selectedSshTargetId)?.remoteLeaseMetadata
         : undefined;
+      crabboxLeaseMetadata = remoteLeaseMetadata;
       const changes = {
         config: {
           runnerKind: executor.type as RunnerKind,
@@ -1389,6 +1405,11 @@ export class TaskRunner {
             }
 
             this.executeNewlyStartedTasks(newlyStarted, dispatchOpts);
+
+            // Apply the Crabbox cleanup policy for SSH tasks backed by a lease.
+            // Runs on the live completion path only (stale completions return
+            // earlier) so a superseded attempt never stops a reused machine.
+            await this.maybeCleanupCrabboxLease(task, crabboxLeaseMetadata, normalizedResponse);
           } finally {
             // Clean up per-task Docker executor to avoid resource leaks
             try {
@@ -1908,6 +1929,98 @@ export class TaskRunner {
       );
     }
     return config;
+  }
+
+  /** A completion counts as success unless it failed or reported a non-zero exit. */
+  private responseSucceeded(response: WorkResponse): boolean {
+    if (response.status === 'failed') return false;
+    const exitCode = response.outputs?.exitCode;
+    if (typeof exitCode === 'number' && exitCode !== 0) return false;
+    return true;
+  }
+
+  /**
+   * Apply the Crabbox cleanup policy after an SSH task settles.
+   *
+   * Default policy: stop the lease on success; keep it on failure so it can be
+   * debugged. When the lease is kept after a failure, append the connect/stop
+   * commands to the task output so the operator can reach (or tear down) the
+   * machine. Stop failures are logged via `task.executor.crabbox-cleanup-failed`
+   * and never rewrite the task's exit code.
+   *
+   * Safe to call for any task — it is a no-op unless the task carried Crabbox
+   * lease metadata. Never throws; all failures are logged.
+   */
+  private async maybeCleanupCrabboxLease(
+    task: TaskState,
+    metadata: CrabboxRemoteLeaseMetadata | undefined,
+    response: WorkResponse,
+  ): Promise<void> {
+    if (!metadata || metadata.provider !== 'crabbox') return;
+
+    const succeeded = this.responseSucceeded(response);
+    const policy = resolveCrabboxCleanupPolicy(metadata.stopAfter, metadata.keepOnFailure);
+    const target = this.getRemoteTargets()[metadata.targetId];
+    const crabboxCommand = target?.crabboxCommand ?? 'crabbox';
+
+    if (!shouldStopCrabboxLease(policy, succeeded)) {
+      // Lease is being kept. If a failure is being preserved for debugging,
+      // surface the commands to connect to and later stop the leased machine.
+      if (!succeeded && policy.keepOnFailure) {
+        const sshCommand = `${crabboxCommand} ssh --id ${metadata.leaseId}`;
+        const stopCommand = `${crabboxCommand} stop ${metadata.leaseId}`;
+        const message =
+          `Crabbox lease ${metadata.slug} (${metadata.leaseId}) kept for debugging after failure.\n` +
+          `  Connect: ${sshCommand}\n` +
+          `  Stop:    ${stopCommand}\n`;
+        this.callbacks.onOutput?.(task.id, message);
+        try {
+          this.persistence.appendTaskOutput(task.id, message);
+        } catch {
+          // Output persistence is best-effort; the lease is still preserved.
+        }
+        this.persistence.logEvent?.(task.id, 'task.executor.crabbox-cleanup-skipped', {
+          leaseId: metadata.leaseId,
+          slug: metadata.slug,
+          targetId: metadata.targetId,
+          reason: 'keepOnFailure',
+          sshCommand,
+          stopCommand,
+        });
+      }
+      return;
+    }
+
+    const stopConfig: CrabboxStopConfig = {
+      id: metadata.targetId,
+      crabboxCommand,
+      stopArgs: target?.stopArgs,
+    };
+    try {
+      await this.crabboxResolver.stop?.(stopConfig, metadata.leaseId);
+      // Drop the cached lease so a later task re-leases instead of reusing a
+      // machine we just asked Crabbox to stop.
+      this.resolvedCrabboxTargets.delete(metadata.targetId);
+      this.persistence.logEvent?.(task.id, 'task.executor.crabbox-stopped', {
+        leaseId: metadata.leaseId,
+        slug: metadata.slug,
+        targetId: metadata.targetId,
+        stopAfter: policy.stopAfter,
+        succeeded,
+      });
+    } catch (err) {
+      // Cleanup failure must not change the task's outcome — just record it.
+      this.persistence.logEvent?.(task.id, 'task.executor.crabbox-cleanup-failed', {
+        leaseId: metadata.leaseId,
+        slug: metadata.slug,
+        targetId: metadata.targetId,
+        error: err instanceof Error ? (err.stack ?? err.message) : String(err),
+      });
+      this.logger.warn(
+        `[TaskRunner] crabbox cleanup failed for task=${task.id} lease=${metadata.leaseId}`,
+        { err },
+      );
+    }
   }
 
   /**

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1404,12 +1404,12 @@ export class TaskRunner {
               this.logger.error(`[TaskRunner] completion callback observer failed for task=${task.id}`, { err });
             }
 
-            this.executeNewlyStartedTasks(newlyStarted, dispatchOpts);
-
             // Apply the Crabbox cleanup policy for SSH tasks backed by a lease.
             // Runs on the live completion path only (stale completions return
             // earlier) so a superseded attempt never stops a reused machine.
             await this.maybeCleanupCrabboxLease(task, crabboxLeaseMetadata, normalizedResponse);
+
+            this.executeNewlyStartedTasks(newlyStarted, dispatchOpts);
           } finally {
             // Clean up per-task Docker executor to avoid resource leaks
             try {
@@ -1968,7 +1968,7 @@ export class TaskRunner {
       // surface the commands to connect to and later stop the leased machine.
       if (!succeeded && policy.keepOnFailure) {
         const sshCommand = `${crabboxCommand} ssh --id ${metadata.leaseId}`;
-        const stopCommand = `${crabboxCommand} stop ${metadata.leaseId}`;
+        const stopCommand = [crabboxCommand, 'stop', metadata.leaseId, ...(target?.stopArgs ?? [])].join(' ');
         const message =
           `Crabbox lease ${metadata.slug} (${metadata.leaseId}) kept for debugging after failure.\n` +
           `  Connect: ${sshCommand}\n` +
@@ -1997,7 +1997,8 @@ export class TaskRunner {
       stopArgs: target?.stopArgs,
     };
     try {
-      await this.crabboxResolver.stop?.(stopConfig, metadata.leaseId);
+      if (!this.crabboxResolver.stop) throw new Error('Crabbox resolver does not support stop cleanup.');
+      await this.crabboxResolver.stop(stopConfig, metadata.leaseId);
       // Drop the cached lease so a later task re-leases instead of reusing a
       // machine we just asked Crabbox to stop.
       this.resolvedCrabboxTargets.delete(metadata.targetId);

--- a/scripts/repro/repro-coderabbit-pr2199-cleanup-before-dispatch.sh
+++ b/scripts/repro/repro-coderabbit-pr2199-cleanup-before-dispatch.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+pnpm --dir "$ROOT_DIR" --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "stops a completed lease before dispatching newly ready tasks"
+
+echo "PASS: Crabbox cleanup runs before downstream SSH dispatch can reuse the target"

--- a/scripts/repro/repro-coderabbit-pr2199-missing-stop-implementation.sh
+++ b/scripts/repro/repro-coderabbit-pr2199-missing-stop-implementation.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+pnpm --dir "$ROOT_DIR" --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "logs cleanup failure instead of success when resolver cannot stop"
+
+echo "PASS: missing Crabbox resolver stop implementation is logged as cleanup failure"

--- a/scripts/repro/repro-coderabbit-pr2199-stop-args-in-printed-command.sh
+++ b/scripts/repro/repro-coderabbit-pr2199-stop-args-in-printed-command.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+pnpm --dir "$ROOT_DIR" --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "keeps the lease on failure and appends connect/stop commands"
+
+echo "PASS: preserved Crabbox leases print the configured stopArgs in the stop command"

--- a/scripts/repro/repro-coderabbit-pr2199-workresponse-generation.sh
+++ b/scripts/repro/repro-coderabbit-pr2199-workresponse-generation.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET="$ROOT_DIR/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts"
+
+node --input-type=module - "$TARGET" <<'NODE'
+import { readFileSync } from 'node:fs';
+
+const file = process.argv[2];
+const src = readFileSync(file, 'utf8');
+const inlineCasts = [...src.matchAll(/completeByTask\.get\(task\.id\)\?\.\(\{[\s\S]*?\}\s+as WorkResponse\);/g)];
+if (inlineCasts.length > 0) {
+  console.error(`FAIL: ${file} still casts inline completion payloads as WorkResponse`);
+  process.exit(1);
+}
+
+const typedPayloads = [
+  ...src.matchAll(/const response: WorkResponse = \{([\s\S]*?)\};\s*completeByTask\.get\(task\.id\)\?\.\(response\);/g),
+];
+if (typedPayloads.length < 2) {
+  console.error(`FAIL: expected typed WorkResponse completion payloads in ${file}`);
+  process.exit(1);
+}
+
+const missingGeneration = typedPayloads.filter((match) => !/\bexecutionGeneration\s*:/.test(match[1] ?? ''));
+if (missingGeneration.length > 0) {
+  console.error('FAIL: a synthetic WorkResponse completion payload is missing executionGeneration');
+  process.exit(1);
+}
+NODE
+
+echo "PASS: synthetic WorkResponse completion payloads are typed and include executionGeneration"


### PR DESCRIPTION
## Summary

When an Invoker SSH task finishes on a Crabbox box, Invoker now decides whether to shut the box down or keep it alive.

A leased box costs money, so a passing task shuts its box down by default.

A failing task can keep its box, so a person can log in and see what broke.

This is configurable per target. `stopAfter` picks `success`, `always`, or `never`, and `keepOnFailure` controls whether failures stay up for debugging.

When a box is kept after a failure, Invoker writes the exact `crabbox ssh` and `crabbox stop` lines into the run log.

Getting back in or tearing the box down by hand is then one copy-paste away.

This work never blocks the task result. If the stop step itself fails, Invoker writes that to the log instead of crashing the run or leaking the box.

<details>
<summary>Review metadata</summary>

Review Claim: Approve that a finished Crabbox SSH task follows its configured stop-or-keep rule, and that kept boxes get their `crabbox ssh` / `crabbox stop` lines written to the log.

Review Lane: behavior

Review Unit: routing

Safety Invariant: `runnerKind: ssh` stays the only runtime executor shape for Crabbox-backed work. This slice only adds an after-the-run rule and does not change how a task executes.

Slice Rationale: This step owns only the after-task stop-or-keep rule for one workflow step. Choosing and wiring the box happen in earlier stacked PRs.

</details>

## Non-goals

This does not change how a Crabbox box is chosen or connected.

It does not change how a task runs over SSH.

It does not introduce a new runner shape; `runnerKind: ssh` stays the only one.

## Architecture

### Before

```mermaid
graph TD
    A["SSH task finishes on a Crabbox box"] --> B["Record task result"]
    B --> C["Leased box stays up"]
```

### After

```mermaid
graph TD
    A["SSH task finishes on a Crabbox box"] --> B["Record task result"]
    B --> C{"Stop or keep?"}
    C -->|stop| D["Stop the lease"]
    C -->|keep on failure| E["Write crabbox ssh / crabbox stop lines to log"]
    D -->|stop fails| F["Log it, do not crash the run"]
```

## Test Plan

- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert -m 1 e8a37c263` (or use the PR revert button once merged)
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Crabbox lease cleanup on task completion with policies for success/failure/always/never, including legacy `completed` normalization to `success` and optional `stopArgs` passthrough.
  * Implemented resolver-backed `crabbox stop` execution with improved non-zero exit error details.
* **Bug Fixes**
  * Cleanup failures no longer affect the original task outcome.
  * Ensured completed leases are stopped before newly ready tasks are dispatched; added fallback behavior when a resolver stop is unavailable.
* **Tests**
  * Expanded coverage for stop argument building, policy decisions, stop/skip/fail event emission, and stop-vs-dispatch ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->