### PR TITLE
Recovery Lifecycle 2h Step 4: Sweep-and-assert guard, docs, full regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,10 @@ If you need to operate existing workflows or tasks, use the `invoker-ops` skill.
 
 Use `--output text|label|json|jsonl` on headless `query` commands. Use `./run.sh --headless retry-tasks --status pending|failed --parallel 8` for bulk safe retries. Inspect recovery ownership and decisions with `./run.sh --headless worker status --output text|json|jsonl`. Normal `run`, `resume`, and retry commands do not start recovery loops; recovery is owned by the explicit recovery worker path. Only **one** process should **write** the workflow database at a time; see [docs/persistence-architecture-single-writer.md](docs/persistence-architecture-single-writer.md).
 
+### Auto-fix worker (single shared engine)
+
+Auto-fix recovery runs through **one** shared worker engine in `@invoker/execution-engine`. Two doors reach that same single engine: `invoker-cli worker autofix` (production) and `./run.sh --headless worker autofix` (dev). Whichever door you use, the worker is **foreground** — it lives and dies with the process, with no detached background service. A single-instance lock means only one auto-fix worker runs at a time: a second start, from either door, refuses rather than spawning a second loop. A sweep-and-assert guard test fails the build if auto-fix is ever triggered outside this shared worker engine. See [docs/architecture/recovery-lifecycle-workers.md](docs/architecture/recovery-lifecycle-workers.md).
+
 ## Architecture (at a glance)
 
 ```mermaid

--- a/docs/architecture/recovery-lifecycle-workers.md
+++ b/docs/architecture/recovery-lifecycle-workers.md
@@ -6,19 +6,25 @@ State transitions publish lifecycle events. Recovery behavior is owned by subscr
 
 The producer of a persisted workflow or task state change is responsible for publishing a lifecycle wakeup after the durable state change is recorded. The producer must not directly auto-fix, recreate, or launch external recovery scripts as part of handling a failed delta. Auto-fix and external recovery are worker responsibilities, and workers must act through the same normal command routes used by operators.
 
-This is a docs-only architecture note. It describes the target contract and does not change runtime behavior.
+This is a docs-only architecture note. It describes the achieved contract and does not change runtime behavior.
 
-## Current Overlap
+## Resolved Overlap (Single Engine)
 
-Auto-fix and external recovery both respond to failed deltas today, but they do so as separate direct handlers. That makes failed-delta recovery ownership ambiguous:
+Earlier, auto-fix ran from more than one place: a producer could schedule auto-fix directly from failure handling, and a separate worker loop could also act on the same failed state. Two engines could observe the same failure and compete over what recovery meant.
 
-1. Auto-fix can be scheduled directly from failure handling.
-2. External recovery can be launched directly from failure handling.
-3. Both paths can observe the same failed state and compete to decide what recovery means.
+That overlap is now resolved. There is exactly **one** shared auto-fix worker engine, and it lives in `@invoker/execution-engine`. Both entry points drive that same single engine instead of running their own loops:
 
-The overlap is not only duplication. It hides recovery policy inside producers that should be responsible for state transition and publication, not for choosing a recovery implementation.
+1. The production door: `invoker-cli worker autofix`.
+2. The dev door: `./run.sh --headless worker autofix`.
 
-## Target Model
+Two properties keep the single engine truly single:
+
+- **Foreground lifetime.** The worker lives and dies with its process. There is no detached or background recovery service; stopping the process stops the engine.
+- **Single-instance lock.** A cross-door lock refuses a second concurrent start. If one door already runs the engine, the other door refuses to start a second loop rather than spawning one.
+
+A **sweep-and-assert guard** test fails the build if auto-fix is triggered from any code path outside the shared worker engine (with an allowlist for the engine itself and the sanctioned operator fix command). This locks the single-engine invariant in against future drift, so a new direct auto-fix call cannot reintroduce a second recovery path.
+
+## Achieved Model
 
 Lifecycle events are ephemeral wakeups, not durable truth. Persisted workflow and task state remains authoritative.
 
@@ -32,7 +38,7 @@ flowchart LR
   Command --> PersistedChange
 ```
 
-The target model separates responsibilities:
+The achieved model separates responsibilities:
 
 | Responsibility | Owner | Contract |
 | --- | --- | --- |
@@ -73,16 +79,21 @@ Workers may subscribe to the same lifecycle event stream. Contention is controll
 
 ## Auto-Fix Worker
 
-The auto-fix worker owns automatic fix attempts for states that qualify for agent-driven repair. It subscribes to lifecycle wakeups, scans persisted state, and decides whether an auto-fix command should be submitted.
+Automatic fix attempts are owned by a **single** shared auto-fix worker engine in `@invoker/execution-engine`. Both doors — `invoker-cli worker autofix` (production) and `./run.sh --headless worker autofix` (dev) — drive that one engine. The engine subscribes to lifecycle wakeups, scans persisted state, and decides whether an auto-fix command should be submitted.
 
-The worker should only act when persisted state shows that:
+Lifetime and concurrency are constrained so the single engine stays single:
+
+- The worker is **foreground**: it lives and dies with its process, with no detached background service.
+- A **single-instance lock** refuses a second concurrent start across both doors, so at most one recovery loop runs process-wide.
+
+The engine should only act when persisted state shows that:
 
 1. The workflow or task is in a state eligible for auto-fix.
 2. No newer generation has superseded the failed state.
 3. Auto-fix policy allows another attempt.
 4. No incompatible recovery action is already in progress.
 
-When those checks pass, the auto-fix worker submits the normal fix command. It must not be invoked directly by the producer that recorded the failed transition.
+When those checks pass, the auto-fix worker submits the normal fix command. It must not be invoked directly by the producer that recorded the failed transition. A sweep-and-assert guard test fails the build if any auto-fix is triggered outside this shared worker engine.
 
 ## Operator Status
 

--- a/packages/app/src/__tests__/no-autofix-outside-worker.test.ts
+++ b/packages/app/src/__tests__/no-autofix-outside-worker.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Guard: "no auto-fix inside Invoker except via the shared worker engine."
+ *
+ * The 2h stack collapses two competing auto-fix recovery engines into one. The
+ * danger is regression by drift: a future edit could add a direct auto-fix
+ * trigger somewhere new and silently recreate a second recovery path.
+ *
+ * This test is a deterministic source sweep. It walks every package's `src`
+ * tree, looks for auto-fix *trigger* signals, and fails the build if any hit
+ * lands outside the small allowlist of sanctioned sites:
+ *   1. the shared worker engine in `@invoker/execution-engine`, and
+ *   2. the operator-facing `fix ... --auto-fix` command route in `@invoker/app`.
+ *
+ * Any other hit names the offending file/line so the regression is actionable.
+ *
+ * Note on the scan-by-identifier choice: we match the `AUTO_FIX_RECOVERY_CHANNEL`
+ * *identifier* rather than its raw string value (`'auto-fix-recovery'`), because
+ * that value coincidentally collides with an unrelated observability id
+ * (`RECOVERY_WORKER_ID`). Matching the identifier tracks real usage of the
+ * channel constant and avoids false positives.
+ */
+
+import { readdirSync, readFileSync, statSync, type Dirent } from 'node:fs';
+import { dirname, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+/** A source file the scanner inspects. `path` is a repo-relative, POSIX path. */
+interface SourceFile {
+  path: string;
+  content: string;
+}
+
+/** A single auto-fix trigger hit found in a source file. */
+interface TriggerHit {
+  path: string;
+  line: number;
+  signal: string;
+  text: string;
+}
+
+/**
+ * Auto-fix *trigger* signals. Each matches a way auto-fix can be submitted or
+ * triggered. They are intentionally narrow (call sites / flag tokens / the
+ * channel identifier) so plumbing, type declarations, and method *definitions*
+ * do not trip the guard.
+ */
+const TRIGGER_SIGNALS: ReadonlyArray<{ name: string; pattern: RegExp }> = [
+  // The auto-fix-on-failure entrypoint being *invoked* (or defined).
+  { name: 'autoFixOnFailure()', pattern: /\bautoFixOnFailure\s*\(/ },
+  // A direct fix submission call on a task executor: `executor.fixWithAgent(...)`.
+  // The method *definition* (`async fixWithAgent(`) has no leading dot and is
+  // intentionally not matched.
+  { name: '.fixWithAgent()', pattern: /\.fixWithAgent\s*\(/ },
+  // The auto-fix CLI flag as a standalone quoted token.
+  { name: "'--auto-fix' flag", pattern: /['"]--auto-fix['"]/ },
+  // Usage of the shared recovery channel constant.
+  { name: 'AUTO_FIX_RECOVERY_CHANNEL', pattern: /\bAUTO_FIX_RECOVERY_CHANNEL\b/ },
+];
+
+/**
+ * The ONLY files permitted to contain auto-fix trigger signals. Two categories:
+ *
+ *  (A) the shared auto-fix worker engine in `@invoker/execution-engine`, and
+ *  (B) the shared fix action / operator-facing `fix ... --auto-fix` command
+ *      route in `@invoker/app` (including the thin re-export shim).
+ *
+ * Adding an entry here is a deliberate act: it declares a new sanctioned
+ * auto-fix site. Anything not listed here that trips a signal fails the build.
+ */
+const ALLOWLIST: ReadonlySet<string> = new Set([
+  // (A) shared worker engine — now extracted into @invoker/execution-engine
+  'packages/execution-engine/src/auto-fix-recovery.ts',
+  'packages/execution-engine/src/worker-runtime.ts',
+  'packages/execution-engine/src/auto-fix-intents.ts',
+  // (B) shared fix action + operator command route in @invoker/app
+  // (`workers/auto-fix-recovery.ts` is the thin re-export shim for the engine).
+  'packages/app/src/workers/auto-fix-recovery.ts',
+  'packages/app/src/workflow-actions.ts',
+  'packages/app/src/headless.ts',
+]);
+
+/** Locate the monorepo root by walking up to the `pnpm-workspace.yaml` marker. */
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 20; i += 1) {
+    try {
+      statSync(join(dir, 'pnpm-workspace.yaml'));
+      return dir;
+    } catch {
+      // keep walking up
+    }
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate repo root (pnpm-workspace.yaml not found).');
+}
+
+/** Recursively collect `.ts` source files, excluding tests and declarations. */
+function collectTsFiles(root: string, absDir: string, out: SourceFile[]): void {
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(absDir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const abs = join(absDir, entry.name);
+    if (entry.isDirectory()) {
+      // Tests legitimately call auto-fix entrypoints; never scan them.
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      collectTsFiles(root, abs, out);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith('.ts')) continue;
+    if (entry.name.endsWith('.d.ts')) continue;
+    if (entry.name.endsWith('.test.ts')) continue;
+    out.push({
+      path: relative(root, abs).split(sep).join('/'),
+      content: readFileSync(abs, 'utf8'),
+    });
+  }
+}
+
+/** Read every package's `src` TypeScript source file under the repo root. */
+function collectRepoSourceFiles(root: string): SourceFile[] {
+  const out: SourceFile[] = [];
+  const packagesDir = join(root, 'packages');
+  let pkgs: Dirent[];
+  try {
+    pkgs = readdirSync(packagesDir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const pkg of pkgs) {
+    if (!pkg.isDirectory()) continue;
+    collectTsFiles(root, join(packagesDir, pkg.name, 'src'), out);
+  }
+  return out;
+}
+
+/** Return every trigger-signal hit across the given files. */
+function scanForAutoFixTriggers(files: ReadonlyArray<SourceFile>): TriggerHit[] {
+  const hits: TriggerHit[] = [];
+  for (const file of files) {
+    const lines = file.content.split('\n');
+    for (let i = 0; i < lines.length; i += 1) {
+      const text = lines[i];
+      for (const signal of TRIGGER_SIGNALS) {
+        if (signal.pattern.test(text)) {
+          hits.push({ path: file.path, line: i + 1, signal: signal.name, text: text.trim() });
+        }
+      }
+    }
+  }
+  return hits;
+}
+
+/** Trigger hits that fall outside the sanctioned allowlist — i.e. violations. */
+function findAutoFixViolations(
+  files: ReadonlyArray<SourceFile>,
+  allowlist: ReadonlySet<string>,
+): TriggerHit[] {
+  return scanForAutoFixTriggers(files).filter((hit) => !allowlist.has(hit.path));
+}
+
+const REPO_ROOT = findRepoRoot();
+
+describe('no auto-fix outside the shared worker engine', () => {
+  it('finds no auto-fix trigger outside the allowlisted engine/command sites', () => {
+    const files = collectRepoSourceFiles(REPO_ROOT);
+    // Sanity: the sweep actually walked a real tree.
+    expect(files.length).toBeGreaterThan(50);
+
+    const violations = findAutoFixViolations(files, ALLOWLIST);
+    const report = violations
+      .map((v) => `  ${v.path}:${v.line}  [${v.signal}]  ${v.text}`)
+      .join('\n');
+
+    expect(
+      violations,
+      `Auto-fix triggered outside the shared worker engine / operator command route.\n` +
+        `Each site below must move into an allowlisted module, or be added to the ` +
+        `ALLOWLIST in this test if it is a newly sanctioned auto-fix site:\n${report}`,
+    ).toEqual([]);
+  });
+
+  it('keeps the allowlist honest: every allowlisted file exists and trips a signal', () => {
+    const files = collectRepoSourceFiles(REPO_ROOT);
+    const byPath = new Map(files.map((f) => [f.path, f]));
+    const hitPaths = new Set(scanForAutoFixTriggers(files).map((h) => h.path));
+
+    for (const allowed of ALLOWLIST) {
+      // Allowlisted file must still exist (catches stale entries after renames).
+      expect(byPath.has(allowed), `Allowlisted file no longer exists: ${allowed}`).toBe(true);
+    }
+    // At least the core engine + action route must still carry signals; if the
+    // whole allowlist goes quiet, the signals likely drifted and the guard is
+    // no longer watching anything real.
+    const allowlistHits = [...hitPaths].filter((p) => ALLOWLIST.has(p));
+    expect(allowlistHits.length).toBeGreaterThan(0);
+  });
+
+  it('FAILS when a direct auto-fix call is added outside the allowlist', () => {
+    // Synthetic regression: a new file sneaks in an automatic auto-fix trigger.
+    const planted: SourceFile = {
+      path: 'packages/app/src/sneaky-recovery.ts',
+      content: [
+        'export async function lurk(taskId: string, deps: unknown) {',
+        '  await autoFixOnFailure(taskId, deps);',
+        '}',
+      ].join('\n'),
+    };
+
+    const violations = findAutoFixViolations([planted], ALLOWLIST);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.path).toBe('packages/app/src/sneaky-recovery.ts');
+    expect(violations[0]?.signal).toBe('autoFixOnFailure()');
+  });
+
+  it('does NOT flag the same call inside an allowlisted module', () => {
+    // Identical trigger, but located in a sanctioned file → permitted.
+    const sanctioned: SourceFile = {
+      path: 'packages/app/src/workflow-actions.ts',
+      content: 'await autoFixOnFailure(taskId, deps);',
+    };
+    expect(findAutoFixViolations([sanctioned], ALLOWLIST)).toEqual([]);
+  });
+
+  it('detects each distinct trigger signal outside the allowlist', () => {
+    const cases: ReadonlyArray<{ content: string; signal: string }> = [
+      { content: "executor.fixWithAgent(taskId, out);", signal: '.fixWithAgent()' },
+      { content: "const f = '--auto-fix';", signal: "'--auto-fix' flag" },
+      { content: 'bus.publish(AUTO_FIX_RECOVERY_CHANNEL);', signal: 'AUTO_FIX_RECOVERY_CHANNEL' },
+      { content: 'await autoFixOnFailure(taskId);', signal: 'autoFixOnFailure()' },
+    ];
+    for (const c of cases) {
+      const file: SourceFile = { path: 'packages/app/src/rogue.ts', content: c.content };
+      const violations = findAutoFixViolations([file], ALLOWLIST);
+      expect(violations.map((v) => v.signal)).toContain(c.signal);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Auto-fix can now only run through the one shared worker engine, and a new test fails the build if any other code path tries to start it.

This is the last step of the Recovery Lifecycle 2h stack. Earlier steps collapsed two competing recovery loops into one engine behind two doors with a single-instance lock.

The risk was drift: someone could later add a direct auto-fix call and quietly recreate the second engine.

A guard test now scans the source and fails on any auto-fix trigger outside the allowlisted engine and operator fix command.

The architecture doc and README are updated to describe the final model: one engine, two doors, foreground lifetime, single-instance lock, and this guard.

No product behavior changes. The guard is assertion-only and the doc edits are Markdown.

## Test Plan

- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `grep -n "single" docs/architecture/recovery-lifecycle-workers.md`
- [ ] `grep -ni "worker" README.md`
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new README guidance for the auto-fix worker, including how to run it and its single-foreground, single-instance execution model.
  * Updated recovery lifecycle/architecture documentation to describe the “resolved overlap (single engine)” contract for auto-fix, including concurrency and ownership constraints.
* **Tests**
  * Added a build-enforcing guard test that fails if auto-fix triggers appear outside the sanctioned shared worker engine flow (with integrity checks and negative/positive coverage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->