### PR TITLE
[Crabbox SSH step 4: cleanup policy](1) Add cleanup policy

### DIFF
--- a/packages/execution-engine/src/__tests__/crabbox-target-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/crabbox-target-resolver.test.ts
@@ -3,6 +3,9 @@ import {
   CrabboxTargetResolver,
   buildCrabboxWarmupArgs,
   buildCrabboxStatusArgs,
+  buildCrabboxStopArgs,
+  resolveCrabboxCleanupPolicy,
+  shouldStopCrabboxLease,
   type CrabboxCommandResult,
   type CrabboxCommandRunner,
   type CrabboxResolverTargetConfig,
@@ -233,5 +236,100 @@ describe('CrabboxTargetResolver.resolve', () => {
     await expect(
       new CrabboxTargetResolver(runner).resolve(baseConfig),
     ).rejects.toThrow(/did not return valid JSON/);
+  });
+});
+
+describe('buildCrabboxStopArgs', () => {
+  it('builds `stop <leaseId>` plus configured stopArgs', () => {
+    expect(
+      buildCrabboxStopArgs(
+        { id: 'crab1', crabboxCommand: 'crabbox', stopArgs: ['--force'] },
+        'lease-123',
+      ),
+    ).toEqual(['stop', 'lease-123', '--force']);
+  });
+
+  it('omits stopArgs when none are configured', () => {
+    expect(
+      buildCrabboxStopArgs({ id: 'crab1', crabboxCommand: 'crabbox' }, 'lease-9'),
+    ).toEqual(['stop', 'lease-9']);
+  });
+});
+
+describe('CrabboxTargetResolver.stop', () => {
+  it('runs `crabbox stop <leaseId>` with stopArgs and resolves on exit 0', async () => {
+    const { runner, calls } = scriptRunner([ok('stopped')]);
+
+    await new CrabboxTargetResolver(runner).stop(
+      { id: 'crab1', crabboxCommand: '/usr/local/bin/crabbox', stopArgs: ['--now'] },
+      'lease-123',
+    );
+
+    expect(calls[0]).toEqual({
+      command: '/usr/local/bin/crabbox',
+      args: ['stop', 'lease-123', '--now'],
+    });
+  });
+
+  it('throws an actionable error when stop exits non-zero', async () => {
+    const { runner } = scriptRunner([
+      { stdout: '', stderr: 'lease not found', exitCode: 3 },
+    ]);
+
+    await expect(
+      new CrabboxTargetResolver(runner).stop(
+        { id: 'crab1', crabboxCommand: 'crabbox' },
+        'lease-123',
+      ),
+    ).rejects.toThrow(/Crabbox stop failed for lease "lease-123".*crab1.*lease not found/s);
+  });
+});
+
+describe('resolveCrabboxCleanupPolicy', () => {
+  it('defaults stopAfter to success and keepOnFailure to true', () => {
+    expect(resolveCrabboxCleanupPolicy(undefined, undefined)).toEqual({
+      stopAfter: 'success',
+      keepOnFailure: true,
+    });
+  });
+
+  it('treats the legacy "completed" value as success', () => {
+    expect(resolveCrabboxCleanupPolicy('completed', false)).toEqual({
+      stopAfter: 'success',
+      keepOnFailure: false,
+    });
+  });
+
+  it('passes through known policies', () => {
+    expect(resolveCrabboxCleanupPolicy('always', false).stopAfter).toBe('always');
+    expect(resolveCrabboxCleanupPolicy('never', true).stopAfter).toBe('never');
+    expect(resolveCrabboxCleanupPolicy('failure', false).stopAfter).toBe('failure');
+  });
+});
+
+describe('shouldStopCrabboxLease', () => {
+  it('success policy stops on success only', () => {
+    const policy = { stopAfter: 'success' as const, keepOnFailure: false };
+    expect(shouldStopCrabboxLease(policy, true)).toBe(true);
+    expect(shouldStopCrabboxLease(policy, false)).toBe(false);
+  });
+
+  it('keepOnFailure preserves a failed lease regardless of stopAfter', () => {
+    expect(
+      shouldStopCrabboxLease({ stopAfter: 'always', keepOnFailure: true }, false),
+    ).toBe(false);
+    expect(
+      shouldStopCrabboxLease({ stopAfter: 'success', keepOnFailure: true }, false),
+    ).toBe(false);
+  });
+
+  it('always stops; never keeps', () => {
+    expect(shouldStopCrabboxLease({ stopAfter: 'always', keepOnFailure: false }, false)).toBe(true);
+    expect(shouldStopCrabboxLease({ stopAfter: 'never', keepOnFailure: false }, true)).toBe(false);
+  });
+
+  it('failure policy stops only on failure', () => {
+    expect(shouldStopCrabboxLease({ stopAfter: 'failure', keepOnFailure: false }, false)).toBe(true);
+    expect(shouldStopCrabboxLease({ stopAfter: 'failure', keepOnFailure: false }, true)).toBe(false);
   });
 });

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2178,7 +2178,8 @@ describe('TaskRunner', () => {
           keepOnFailure: config.keepOnFailure,
         },
       }));
-      return { resolve };
+      const stop = vi.fn(async () => {});
+      return { resolve, stop };
     }
 
     const crabboxTarget = {
@@ -2327,6 +2328,190 @@ describe('TaskRunner', () => {
         outputs: { exitCode: 0 },
       } as WorkResponse);
       await run;
+    });
+  });
+
+  describe('crabbox cleanup policy', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    const baseCrabboxTarget = {
+      type: 'crabbox' as const,
+      crabboxCommand: '/usr/bin/crabbox',
+      provider: 'do',
+      class: 'medium',
+      ttl: '30m',
+      idleTimeout: '10m',
+      network: 'default',
+      target: 'ubuntu-22',
+      stopAfter: 'success',
+      keepOnFailure: true,
+      stopArgs: ['--force'],
+    };
+
+    async function runCrabboxTask(opts: {
+      targetOverrides?: Record<string, unknown>;
+      final: { status: WorkResponse['status']; exitCode: number };
+      stopRejects?: boolean;
+    }) {
+      const completeByTask = new Map<string, (r: WorkResponse) => void>();
+      vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (this: any, request: any) {
+        return {
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: `/remote/${request.actionId}`,
+          branch: `branch-${request.actionId}`,
+        };
+      });
+      vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation((handle: any, cb: any) => {
+        completeByTask.set(handle.taskId, cb);
+      });
+      vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+      vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+
+      const resolve = vi.fn(async (config: any) => ({
+        sshTarget: { host: 'leased.crab', user: 'crab', sshKeyPath: '/leased/key', port: 2222 },
+        remoteLeaseMetadata: {
+          provider: 'crabbox' as const,
+          leaseId: 'lease-xyz',
+          slug: 'happy-lease',
+          targetId: config.id,
+          sshHost: 'leased.crab',
+          sshUser: 'crab',
+          sshPort: 2222,
+          sshKeyPath: '/leased/key',
+          expiresAt: '2099-01-01T00:00:00Z',
+          stopAfter: config.stopAfter,
+          keepOnFailure: config.keepOnFailure,
+        },
+      }));
+      const stop = vi.fn(async () => {
+        if (opts.stopRejects) throw new Error('crabbox stop boom');
+      });
+
+      const appendTaskOutput = vi.fn();
+      const logEvent = vi.fn();
+      const onOutput = vi.fn();
+      const onComplete = vi.fn();
+      const task = makeTask({
+        id: 'wf/crab-task',
+        config: { runnerKind: 'ssh', poolMemberId: 'crab-target' },
+        execution: { selectedAttemptId: 'crab-attempt', generation: 0 },
+      });
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => (id === task.id ? task : null),
+          getAllTasks: () => [task],
+          markTaskRunningAfterLaunch: () => true,
+          handleWorkerResponse: () => [],
+          deferTask: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask: vi.fn(),
+          updateAttempt: vi.fn(),
+          appendTaskOutput,
+          logEvent,
+          loadAttempts: () => [],
+        } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({ 'crab-target': { ...baseCrabboxTarget, ...opts.targetOverrides } }),
+        crabboxResolver: { resolve, stop },
+        callbacks: { onOutput, onComplete },
+      });
+
+      const run = runner.executeTask(task);
+      await vi.waitFor(() => expect(SshExecutor.prototype.start).toHaveBeenCalledTimes(1));
+      completeByTask.get(task.id)?.({
+        requestId: 'r',
+        actionId: task.id,
+        attemptId: 'crab-attempt',
+        status: opts.final.status,
+        outputs: { exitCode: opts.final.exitCode },
+      } as WorkResponse);
+      await run;
+
+      const event = (name: string) => logEvent.mock.calls.find(([, e]: [string, string]) => e === name)?.[2];
+      return { stop, logEvent, appendTaskOutput, onOutput, onComplete, event };
+    }
+
+    it('stops the lease on success (default policy) and forwards stopArgs', async () => {
+      const { stop, event } = await runCrabboxTask({
+        final: { status: 'completed', exitCode: 0 },
+      });
+
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(stop).toHaveBeenCalledWith(
+        { id: 'crab-target', crabboxCommand: '/usr/bin/crabbox', stopArgs: ['--force'] },
+        'lease-xyz',
+      );
+      expect(event('task.executor.crabbox-stopped')).toMatchObject({
+        leaseId: 'lease-xyz',
+        stopAfter: 'success',
+        succeeded: true,
+      });
+    });
+
+    it('keeps the lease on failure and appends connect/stop commands', async () => {
+      const { stop, event, appendTaskOutput, onOutput } = await runCrabboxTask({
+        final: { status: 'failed', exitCode: 1 },
+      });
+
+      expect(stop).not.toHaveBeenCalled();
+      const skipped = event('task.executor.crabbox-cleanup-skipped');
+      expect(skipped).toMatchObject({
+        leaseId: 'lease-xyz',
+        reason: 'keepOnFailure',
+        sshCommand: '/usr/bin/crabbox ssh --id lease-xyz',
+        stopCommand: '/usr/bin/crabbox stop lease-xyz',
+      });
+      const printed = appendTaskOutput.mock.calls.map(([, msg]) => msg).join('');
+      expect(printed).toContain('/usr/bin/crabbox ssh --id lease-xyz');
+      expect(printed).toContain('/usr/bin/crabbox stop lease-xyz');
+      const echoed = onOutput.mock.calls.map(([, msg]) => msg).join('');
+      expect(echoed).toContain('kept for debugging after failure');
+    });
+
+    it('always: stops even a failed lease when keepOnFailure is false', async () => {
+      const { stop } = await runCrabboxTask({
+        targetOverrides: { stopAfter: 'always', keepOnFailure: false },
+        final: { status: 'failed', exitCode: 1 },
+      });
+
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(stop).toHaveBeenCalledWith(expect.objectContaining({ id: 'crab-target' }), 'lease-xyz');
+    });
+
+    it('never: leaves the lease running even on success', async () => {
+      const { stop, logEvent } = await runCrabboxTask({
+        targetOverrides: { stopAfter: 'never', keepOnFailure: false },
+        final: { status: 'completed', exitCode: 0 },
+      });
+
+      expect(stop).not.toHaveBeenCalled();
+      const stopped = logEvent.mock.calls.find(([, e]: [string, string]) => e === 'task.executor.crabbox-stopped');
+      expect(stopped).toBeUndefined();
+    });
+
+    it('logs crabbox-cleanup-failed and does not rewrite the exit code when stop fails', async () => {
+      const { stop, event, onComplete } = await runCrabboxTask({
+        targetOverrides: { stopAfter: 'always', keepOnFailure: false },
+        final: { status: 'failed', exitCode: 7 },
+        stopRejects: true,
+      });
+
+      expect(stop).toHaveBeenCalledTimes(1);
+      expect(event('task.executor.crabbox-cleanup-failed')).toMatchObject({
+        leaseId: 'lease-xyz',
+        error: expect.stringContaining('crabbox stop boom'),
+      });
+      // Cleanup failure must not change the task outcome.
+      expect(onComplete).toHaveBeenCalledWith(
+        'wf/crab-task',
+        expect.objectContaining({ status: 'failed', outputs: { exitCode: 7 } }),
+      );
     });
   });
 

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2352,11 +2352,17 @@ describe('TaskRunner', () => {
 
     async function runCrabboxTask(opts: {
       targetOverrides?: Record<string, unknown>;
+      targetOverridesAfterStart?: Record<string, unknown>;
       final: { status: WorkResponse['status']; exitCode: number };
       stopRejects?: boolean;
+      omitStop?: boolean;
+      newlyStarted?: TaskState[];
     }) {
+      let targetOverrides = opts.targetOverrides;
+      const order: string[] = [];
       const completeByTask = new Map<string, (r: WorkResponse) => void>();
       vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (this: any, request: any) {
+        order.push(`start:${request.actionId}`);
         return {
           executionId: `exec-${request.actionId}`,
           taskId: request.actionId,
@@ -2388,6 +2394,7 @@ describe('TaskRunner', () => {
         },
       }));
       const stop = vi.fn(async () => {
+        order.push('stop');
         if (opts.stopRejects) throw new Error('crabbox stop boom');
       });
 
@@ -2402,10 +2409,10 @@ describe('TaskRunner', () => {
       });
       const runner = new TaskRunner({
         orchestrator: {
-          getTask: (id: string) => (id === task.id ? task : null),
-          getAllTasks: () => [task],
+          getTask: (id: string) => [task, ...(opts.newlyStarted ?? [])].find((t) => t.id === id) ?? null,
+          getAllTasks: () => [task, ...(opts.newlyStarted ?? [])],
           markTaskRunningAfterLaunch: () => true,
-          handleWorkerResponse: () => [],
+          handleWorkerResponse: () => opts.newlyStarted ?? [],
           deferTask: vi.fn(),
         } as any,
         persistence: {
@@ -2417,14 +2424,18 @@ describe('TaskRunner', () => {
         } as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
         cwd: '/tmp',
-        remoteTargetsProvider: () => ({ 'crab-target': { ...baseCrabboxTarget, ...opts.targetOverrides } }),
-        crabboxResolver: { resolve, stop },
+        remoteTargetsProvider: () => ({ 'crab-target': { ...baseCrabboxTarget, ...targetOverrides } }),
+        crabboxResolver: opts.omitStop ? { resolve } : { resolve, stop },
         callbacks: { onOutput, onComplete },
       });
 
       const run = runner.executeTask(task);
       await vi.waitFor(() => expect(SshExecutor.prototype.start).toHaveBeenCalledTimes(1));
-      completeByTask.get(task.id)?.({
+      await vi.waitFor(() => expect(completeByTask.has(task.id)).toBe(true));
+      targetOverrides = opts.targetOverridesAfterStart ?? targetOverrides;
+      const complete = completeByTask.get(task.id);
+      expect(complete).toBeTypeOf('function');
+      complete!({
         requestId: 'r',
         actionId: task.id,
         attemptId: 'crab-attempt',
@@ -2434,7 +2445,7 @@ describe('TaskRunner', () => {
       await run;
 
       const event = (name: string) => logEvent.mock.calls.find(([, e]: [string, string]) => e === name)?.[2];
-      return { stop, logEvent, appendTaskOutput, onOutput, onComplete, event };
+      return { stop, logEvent, appendTaskOutput, onOutput, onComplete, event, order };
     }
 
     it('stops the lease on success (default policy) and forwards stopArgs', async () => {
@@ -2465,11 +2476,11 @@ describe('TaskRunner', () => {
         leaseId: 'lease-xyz',
         reason: 'keepOnFailure',
         sshCommand: '/usr/bin/crabbox ssh --id lease-xyz',
-        stopCommand: '/usr/bin/crabbox stop lease-xyz',
+        stopCommand: '/usr/bin/crabbox stop lease-xyz --force',
       });
       const printed = appendTaskOutput.mock.calls.map(([, msg]) => msg).join('');
       expect(printed).toContain('/usr/bin/crabbox ssh --id lease-xyz');
-      expect(printed).toContain('/usr/bin/crabbox stop lease-xyz');
+      expect(printed).toContain('/usr/bin/crabbox stop lease-xyz --force');
       const echoed = onOutput.mock.calls.map(([, msg]) => msg).join('');
       expect(echoed).toContain('kept for debugging after failure');
     });
@@ -2482,6 +2493,63 @@ describe('TaskRunner', () => {
 
       expect(stop).toHaveBeenCalledTimes(1);
       expect(stop).toHaveBeenCalledWith(expect.objectContaining({ id: 'crab-target' }), 'lease-xyz');
+    });
+
+    it('defaults omitted keepOnFailure to keeping failed leases for debugging', async () => {
+      const { stop, event } = await runCrabboxTask({
+        targetOverrides: { stopAfter: 'always', keepOnFailure: undefined },
+        final: { status: 'failed', exitCode: 1 },
+      });
+
+      expect(stop).not.toHaveBeenCalled();
+      expect(event('task.executor.crabbox-cleanup-skipped')).toMatchObject({
+        leaseId: 'lease-xyz',
+        reason: 'keepOnFailure',
+      });
+    });
+
+    it('uses the launch-time stop config even if remoteTargets changes before cleanup', async () => {
+      const { stop } = await runCrabboxTask({
+        targetOverridesAfterStart: {
+          crabboxCommand: '/mutated/crabbox',
+          stopArgs: ['--mutated'],
+        },
+        final: { status: 'completed', exitCode: 0 },
+      });
+
+      expect(stop).toHaveBeenCalledWith(
+        { id: 'crab-target', crabboxCommand: '/usr/bin/crabbox', stopArgs: ['--force'] },
+        'lease-xyz',
+      );
+    });
+
+    it('logs cleanup failure instead of success when the resolver cannot stop leases', async () => {
+      const { event, logEvent } = await runCrabboxTask({
+        final: { status: 'completed', exitCode: 0 },
+        omitStop: true,
+      });
+
+      expect(event('task.executor.crabbox-cleanup-failed')).toMatchObject({
+        leaseId: 'lease-xyz',
+        error: expect.stringContaining('does not implement stop'),
+      });
+      const stopped = logEvent.mock.calls.find(([, e]: [string, string]) => e === 'task.executor.crabbox-stopped');
+      expect(stopped).toBeUndefined();
+    });
+
+    it('cleans the current Crabbox lease before launching downstream tasks', async () => {
+      const downstream = makeTask({
+        id: 'wf/downstream',
+        config: { runnerKind: 'ssh', poolMemberId: 'crab-target' },
+        execution: { selectedAttemptId: 'downstream-attempt', generation: 0 },
+      });
+      const { order } = await runCrabboxTask({
+        final: { status: 'completed', exitCode: 0 },
+        newlyStarted: [downstream],
+      });
+
+      await vi.waitFor(() => expect(order).toContain('start:wf/downstream'));
+      expect(order).toEqual(['start:wf/crab-task', 'stop', 'start:wf/downstream']);
     });
 
     it('never: leaves the lease running even on success', async () => {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2320,7 +2320,10 @@ describe('TaskRunner', () => {
         remoteLeaseMetadata: { leaseId: 'lease-123' },
       });
 
-      completeByTask.get(task.id)?.({
+      await vi.waitFor(() => expect(completeByTask.has(task.id)).toBe(true));
+      const complete = completeByTask.get(task.id);
+      expect(complete).toBeTypeOf('function');
+      complete!({
         requestId: 'r',
         actionId: task.id,
         attemptId: 'crab-task-attempt',

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2359,6 +2359,7 @@ describe('TaskRunner', () => {
       final: { status: WorkResponse['status']; exitCode: number };
       stopRejects?: boolean;
       omitStop?: boolean;
+      stopNeverResolves?: boolean;
       newlyStarted?: TaskState[];
     }) {
       let targetOverrides = opts.targetOverrides;
@@ -2399,6 +2400,7 @@ describe('TaskRunner', () => {
       const stop = vi.fn(async () => {
         order.push('stop');
         if (opts.stopRejects) throw new Error('crabbox stop boom');
+        if (opts.stopNeverResolves) await new Promise<void>(() => {});
       });
 
       const appendTaskOutput = vi.fn();
@@ -2538,6 +2540,34 @@ describe('TaskRunner', () => {
       });
       const stopped = logEvent.mock.calls.find(([, e]: [string, string]) => e === 'task.executor.crabbox-stopped');
       expect(stopped).toBeUndefined();
+    });
+
+    it('times out a hung Crabbox stop so completion processing continues', async () => {
+      const previousTimeout = process.env.INVOKER_CRABBOX_STOP_TIMEOUT_MS;
+      process.env.INVOKER_CRABBOX_STOP_TIMEOUT_MS = '10';
+      try {
+        const result = runCrabboxTask({
+          final: { status: 'completed', exitCode: 0 },
+          stopNeverResolves: true,
+        });
+        const timeout = new Promise<never>((_resolve, reject) => {
+          setTimeout(() => reject(new Error('cleanup did not time out hung stop')), 250);
+        });
+
+        const { stop, event } = await Promise.race([result, timeout]);
+
+        expect(stop).toHaveBeenCalledTimes(1);
+        expect(event('task.executor.crabbox-cleanup-failed')).toMatchObject({
+          leaseId: 'lease-xyz',
+          error: expect.stringContaining('exceeded Crabbox stop timeout (10ms)'),
+        });
+      } finally {
+        if (previousTimeout === undefined) {
+          delete process.env.INVOKER_CRABBOX_STOP_TIMEOUT_MS;
+        } else {
+          process.env.INVOKER_CRABBOX_STOP_TIMEOUT_MS = previousTimeout;
+        }
+      }
     });
 
     it('cleans the current Crabbox lease before launching downstream tasks', async () => {

--- a/packages/execution-engine/src/crabbox-target-resolver.ts
+++ b/packages/execution-engine/src/crabbox-target-resolver.ts
@@ -64,6 +64,90 @@ export interface CrabboxResolverTargetConfig {
   readonly warmupArgs?: readonly string[];
   /** Optional extra args appended to the status subcommand. */
   readonly statusArgs?: readonly string[];
+  /** Optional extra args appended to the stop subcommand. */
+  readonly stopArgs?: readonly string[];
+}
+
+/**
+ * Inputs needed to stop (clean up) a Crabbox lease. A subset of
+ * {@link CrabboxResolverTargetConfig}: stopping only needs the CLI entrypoint,
+ * the target id (for error messages), and any configured stop args.
+ */
+export interface CrabboxStopConfig {
+  /** Config key of the remote target. Named in errors. */
+  readonly id: string;
+  /** CLI entrypoint that stops Crabbox leases. */
+  readonly crabboxCommand: string;
+  /** Optional extra args appended to the stop subcommand. */
+  readonly stopArgs?: readonly string[];
+}
+
+/** When to stop a Crabbox lease relative to the task's final status. */
+export type CrabboxStopAfter = 'success' | 'failure' | 'always' | 'never';
+
+/** Crabbox should not leak machines by default: stop on success. */
+export const DEFAULT_CRABBOX_STOP_AFTER: CrabboxStopAfter = 'success';
+/** Failed tasks keep their machine by default so they can be debugged. */
+export const DEFAULT_CRABBOX_KEEP_ON_FAILURE = true;
+
+/** Normalized cleanup policy for a Crabbox lease. */
+export interface CrabboxCleanupPolicy {
+  readonly stopAfter: CrabboxStopAfter;
+  readonly keepOnFailure: boolean;
+}
+
+/**
+ * Apply default Crabbox cleanup policy to raw (possibly missing/legacy) config.
+ *
+ * Defaults: `stopAfter` → 'success' (don't leak machines), `keepOnFailure` →
+ * true (preserve failed machines for debugging). The legacy `'completed'`
+ * value is treated as `'success'`.
+ */
+export function resolveCrabboxCleanupPolicy(
+  stopAfter: string | undefined,
+  keepOnFailure: boolean | undefined,
+): CrabboxCleanupPolicy {
+  return {
+    stopAfter: normalizeStopAfter(stopAfter),
+    keepOnFailure: keepOnFailure ?? DEFAULT_CRABBOX_KEEP_ON_FAILURE,
+  };
+}
+
+function normalizeStopAfter(value: string | undefined): CrabboxStopAfter {
+  switch (value) {
+    case 'success':
+    case 'failure':
+    case 'always':
+    case 'never':
+      return value;
+    case 'completed':
+      // Legacy alias from earlier config: stop once the task completes ok.
+      return 'success';
+    default:
+      return DEFAULT_CRABBOX_STOP_AFTER;
+  }
+}
+
+/**
+ * Decide whether to stop a Crabbox lease given its policy and the task's
+ * outcome. `keepOnFailure` wins on failure (debug-preserving), so a failed
+ * task with `keepOnFailure` is never stopped regardless of `stopAfter`.
+ */
+export function shouldStopCrabboxLease(
+  policy: CrabboxCleanupPolicy,
+  succeeded: boolean,
+): boolean {
+  if (!succeeded && policy.keepOnFailure) return false;
+  switch (policy.stopAfter) {
+    case 'always':
+      return true;
+    case 'never':
+      return false;
+    case 'success':
+      return succeeded;
+    case 'failure':
+      return !succeeded;
+  }
 }
 
 /** A fixed SSH host the SSH executor can connect to directly. */
@@ -165,6 +249,17 @@ export function buildCrabboxStatusArgs(
   ];
 }
 
+/**
+ * Build the stop args that tear down a lease: `stop <leaseId>` plus any
+ * caller-supplied stopArgs.
+ */
+export function buildCrabboxStopArgs(
+  config: CrabboxStopConfig,
+  leaseId: string,
+): string[] {
+  return ['stop', leaseId, ...(config.stopArgs ?? [])];
+}
+
 function asNonEmptyString(value: unknown): string | undefined {
   return typeof value === 'string' && value.length > 0 ? value : undefined;
 }
@@ -206,6 +301,24 @@ export class CrabboxTargetResolver {
       );
     }
     return this.buildResolvedTarget(config, status, leaseRef);
+  }
+
+  /**
+   * Stop (release) a Crabbox lease via `crabbox stop <leaseId>`. Throws an
+   * actionable error when the stop command exits non-zero so callers can log
+   * a cleanup failure without re-deriving the lease.
+   */
+  async stop(config: CrabboxStopConfig, leaseId: string): Promise<void> {
+    const result = await this.run(
+      config.crabboxCommand,
+      buildCrabboxStopArgs(config, leaseId),
+    );
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Crabbox stop failed for lease "${leaseId}" on remote target "${config.id}" ` +
+          `(exit ${result.exitCode}): ${result.stderr.trim() || result.stdout.trim()}`,
+      );
+    }
   }
 
   /** Read the lease id (or slug) that warmup printed for the status call. */

--- a/packages/execution-engine/src/crabbox-target-resolver.ts
+++ b/packages/execution-engine/src/crabbox-target-resolver.ts
@@ -56,8 +56,8 @@ export interface CrabboxResolverTargetConfig {
   readonly target: string;
   /** When to stop the lease after the task settles (e.g. 'completed', 'never'). */
   readonly stopAfter: string;
-  /** Keep the lease alive on failure for debugging instead of stopping it. */
-  readonly keepOnFailure: boolean;
+  /** Keep the lease alive on failure for debugging instead of stopping it. Default: true. */
+  readonly keepOnFailure?: boolean;
   /** SSH port to fall back to when the lease status omits one. Default: 22. */
   readonly port?: number;
   /** Optional extra args appended to the warmup subcommand. */

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -12,7 +12,7 @@ import { randomUUID } from 'node:crypto';
 import { homedir } from 'node:os';
 
 import { scopePlanTaskId } from '@invoker/workflow-core';
-import type { Orchestrator, TaskState, ExperimentVariant, RunnerKind } from '@invoker/workflow-core';
+import type { Orchestrator, TaskState, ExperimentVariant, RunnerKind, CrabboxRemoteLeaseMetadata } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
@@ -34,7 +34,10 @@ import { formatLifecycleTag, extractAttemptSuffix } from './branch-utils.js';
 import { SshExecutor } from './ssh-executor.js';
 import {
   CrabboxTargetResolver,
+  resolveCrabboxCleanupPolicy,
+  shouldStopCrabboxLease,
   type CrabboxResolverTargetConfig,
+  type CrabboxStopConfig,
   type ResolvedCrabboxTarget,
 } from './crabbox-target-resolver.js';
 
@@ -166,14 +169,21 @@ type RemoteTargetDisplay = {
   keepOnFailure?: boolean;
   warmupArgs?: readonly string[];
   statusArgs?: readonly string[];
+  stopArgs?: readonly string[];
 };
 
 /**
  * Injectable dependency that turns a Crabbox remote target into a ready SSH
- * endpoint plus durable lease metadata. Defaults to {@link CrabboxTargetResolver}.
+ * endpoint plus durable lease metadata, and stops the lease during cleanup.
+ * Defaults to {@link CrabboxTargetResolver}.
  */
 export interface CrabboxResolver {
   resolve(config: CrabboxResolverTargetConfig): Promise<ResolvedCrabboxTarget>;
+  /**
+   * Stop (release) a leased machine. Optional so test fakes that never reach
+   * cleanup can omit it; the real resolver always implements it.
+   */
+  stop?(config: CrabboxStopConfig, leaseId: string): Promise<void>;
 }
 
 /**
@@ -360,6 +370,7 @@ export interface TaskRunnerConfig {
     keepOnFailure?: boolean;
     warmupArgs?: readonly string[];
     statusArgs?: readonly string[];
+    stopArgs?: readonly string[];
   }>;
   /**
    * Resolves `type: 'crabbox'` remote targets into ready SSH endpoints.
@@ -1188,6 +1199,10 @@ export class TaskRunner {
     }
     bench('markTaskRunningAfterLaunch.accepted');
 
+    // Durable Crabbox lease metadata for this attempt, captured at start so the
+    // completion handler can apply the cleanup policy (stop / keep-for-debug).
+    let crabboxLeaseMetadata: CrabboxRemoteLeaseMetadata | undefined;
+
     // Persist execution metadata immediately at task start — all fields explicit
     {
       // Fail-fast: workspacePath must be provided by all executors
@@ -1216,6 +1231,7 @@ export class TaskRunner {
       const remoteLeaseMetadata = selectedSshTargetId
         ? this.resolvedCrabboxTargets.get(selectedSshTargetId)?.remoteLeaseMetadata
         : undefined;
+      crabboxLeaseMetadata = remoteLeaseMetadata;
       const changes = {
         config: {
           runnerKind: executor.type as RunnerKind,
@@ -1389,6 +1405,11 @@ export class TaskRunner {
             }
 
             this.executeNewlyStartedTasks(newlyStarted, dispatchOpts);
+
+            // Apply the Crabbox cleanup policy for SSH tasks backed by a lease.
+            // Runs on the live completion path only (stale completions return
+            // earlier) so a superseded attempt never stops a reused machine.
+            await this.maybeCleanupCrabboxLease(task, crabboxLeaseMetadata, normalizedResponse);
           } finally {
             // Clean up per-task Docker executor to avoid resource leaks
             try {
@@ -1908,6 +1929,98 @@ export class TaskRunner {
       );
     }
     return config;
+  }
+
+  /** A completion counts as success unless it failed or reported a non-zero exit. */
+  private responseSucceeded(response: WorkResponse): boolean {
+    if (response.status === 'failed') return false;
+    const exitCode = response.outputs?.exitCode;
+    if (typeof exitCode === 'number' && exitCode !== 0) return false;
+    return true;
+  }
+
+  /**
+   * Apply the Crabbox cleanup policy after an SSH task settles.
+   *
+   * Default policy: stop the lease on success; keep it on failure so it can be
+   * debugged. When the lease is kept after a failure, append the connect/stop
+   * commands to the task output so the operator can reach (or tear down) the
+   * machine. Stop failures are logged via `task.executor.crabbox-cleanup-failed`
+   * and never rewrite the task's exit code.
+   *
+   * Safe to call for any task — it is a no-op unless the task carried Crabbox
+   * lease metadata. Never throws; all failures are logged.
+   */
+  private async maybeCleanupCrabboxLease(
+    task: TaskState,
+    metadata: CrabboxRemoteLeaseMetadata | undefined,
+    response: WorkResponse,
+  ): Promise<void> {
+    if (!metadata || metadata.provider !== 'crabbox') return;
+
+    const succeeded = this.responseSucceeded(response);
+    const policy = resolveCrabboxCleanupPolicy(metadata.stopAfter, metadata.keepOnFailure);
+    const target = this.getRemoteTargets()[metadata.targetId];
+    const crabboxCommand = target?.crabboxCommand ?? 'crabbox';
+
+    if (!shouldStopCrabboxLease(policy, succeeded)) {
+      // Lease is being kept. If a failure is being preserved for debugging,
+      // surface the commands to connect to and later stop the leased machine.
+      if (!succeeded && policy.keepOnFailure) {
+        const sshCommand = `${crabboxCommand} ssh --id ${metadata.leaseId}`;
+        const stopCommand = `${crabboxCommand} stop ${metadata.leaseId}`;
+        const message =
+          `Crabbox lease ${metadata.slug} (${metadata.leaseId}) kept for debugging after failure.\n` +
+          `  Connect: ${sshCommand}\n` +
+          `  Stop:    ${stopCommand}\n`;
+        this.callbacks.onOutput?.(task.id, message);
+        try {
+          this.persistence.appendTaskOutput(task.id, message);
+        } catch {
+          // Output persistence is best-effort; the lease is still preserved.
+        }
+        this.persistence.logEvent?.(task.id, 'task.executor.crabbox-cleanup-skipped', {
+          leaseId: metadata.leaseId,
+          slug: metadata.slug,
+          targetId: metadata.targetId,
+          reason: 'keepOnFailure',
+          sshCommand,
+          stopCommand,
+        });
+      }
+      return;
+    }
+
+    const stopConfig: CrabboxStopConfig = {
+      id: metadata.targetId,
+      crabboxCommand,
+      stopArgs: target?.stopArgs,
+    };
+    try {
+      await this.crabboxResolver.stop?.(stopConfig, metadata.leaseId);
+      // Drop the cached lease so a later task re-leases instead of reusing a
+      // machine we just asked Crabbox to stop.
+      this.resolvedCrabboxTargets.delete(metadata.targetId);
+      this.persistence.logEvent?.(task.id, 'task.executor.crabbox-stopped', {
+        leaseId: metadata.leaseId,
+        slug: metadata.slug,
+        targetId: metadata.targetId,
+        stopAfter: policy.stopAfter,
+        succeeded,
+      });
+    } catch (err) {
+      // Cleanup failure must not change the task's outcome — just record it.
+      this.persistence.logEvent?.(task.id, 'task.executor.crabbox-cleanup-failed', {
+        leaseId: metadata.leaseId,
+        slug: metadata.slug,
+        targetId: metadata.targetId,
+        error: err instanceof Error ? (err.stack ?? err.message) : String(err),
+      });
+      this.logger.warn(
+        `[TaskRunner] crabbox cleanup failed for task=${task.id} lease=${metadata.leaseId}`,
+        { err },
+      );
+    }
   }
 
   /**

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -422,6 +422,8 @@ export class TaskRunner {
   private crabboxResolver: CrabboxResolver;
   /** Resolved crabbox leases, keyed by remote target id. One lease per target until cleared. */
   private resolvedCrabboxTargets = new Map<string, ResolvedCrabboxTarget>();
+  /** Launch-time Crabbox stop config, keyed by remote target id. */
+  private crabboxStopConfigs = new Map<string, CrabboxStopConfig>();
   private poolRoundRobinCursor = new Map<string, number>();
   private pendingPoolSelections = new Map<string, PoolSelection>();
   private freshBaseCommits = new Map<string, FreshBaseCommit>();
@@ -994,6 +996,7 @@ export class TaskRunner {
         bench('crabbox.resolve.start', { targetId: err.targetId });
         const resolved = await this.crabboxResolver.resolve(err.resolverConfig);
         this.resolvedCrabboxTargets.set(err.targetId, resolved);
+        this.crabboxStopConfigs.set(err.targetId, this.crabboxStopConfigFromResolverConfig(err.resolverConfig));
         bench('crabbox.resolve.end', {
           targetId: err.targetId,
           host: resolved.sshTarget.host,
@@ -1199,9 +1202,11 @@ export class TaskRunner {
     }
     bench('markTaskRunningAfterLaunch.accepted');
 
-    // Durable Crabbox lease metadata for this attempt, captured at start so the
-    // completion handler can apply the cleanup policy (stop / keep-for-debug).
+    // Durable Crabbox lease metadata and launch-time stop config for this
+    // attempt, captured at start so the completion handler can apply the
+    // cleanup policy without re-reading a dynamic remote target provider.
     let crabboxLeaseMetadata: CrabboxRemoteLeaseMetadata | undefined;
+    let crabboxStopConfig: CrabboxStopConfig | undefined;
 
     // Persist execution metadata immediately at task start — all fields explicit
     {
@@ -1227,11 +1232,16 @@ export class TaskRunner {
         ? this.selectedRemoteTargetId(task, poolSelection)
         : undefined;
       // Crabbox-backed SSH tasks carry durable lease metadata so cleanup and
-      // terminal restore can find the leased host after a restart.
-      const remoteLeaseMetadata = selectedSshTargetId
-        ? this.resolvedCrabboxTargets.get(selectedSshTargetId)?.remoteLeaseMetadata
+      // terminal restore can find the leased host after a restart. The stop
+      // config is launch-time data; do not re-read remoteTargets at cleanup.
+      const resolvedCrabboxTarget = selectedSshTargetId
+        ? this.resolvedCrabboxTargets.get(selectedSshTargetId)
         : undefined;
+      const remoteLeaseMetadata = resolvedCrabboxTarget?.remoteLeaseMetadata;
       crabboxLeaseMetadata = remoteLeaseMetadata;
+      crabboxStopConfig = selectedSshTargetId
+        ? this.crabboxStopConfigs.get(selectedSshTargetId)
+        : undefined;
       const changes = {
         config: {
           runnerKind: executor.type as RunnerKind,
@@ -1404,12 +1414,11 @@ export class TaskRunner {
               this.logger.error(`[TaskRunner] completion callback observer failed for task=${task.id}`, { err });
             }
 
-            this.executeNewlyStartedTasks(newlyStarted, dispatchOpts);
+            // Apply the Crabbox cleanup policy before dispatching downstream
+            // tasks so they cannot reuse a lease that is being torn down.
+            await this.maybeCleanupCrabboxLease(task, crabboxLeaseMetadata, crabboxStopConfig, normalizedResponse);
 
-            // Apply the Crabbox cleanup policy for SSH tasks backed by a lease.
-            // Runs on the live completion path only (stale completions return
-            // earlier) so a superseded attempt never stops a reused machine.
-            await this.maybeCleanupCrabboxLease(task, crabboxLeaseMetadata, normalizedResponse);
+            this.executeNewlyStartedTasks(newlyStarted, dispatchOpts);
           } finally {
             // Clean up per-task Docker executor to avoid resource leaks
             try {
@@ -1918,10 +1927,11 @@ export class TaskRunner {
       network: require(target.network, 'network'),
       target: require(target.target, 'target'),
       stopAfter: require(target.stopAfter, 'stopAfter'),
-      keepOnFailure: target.keepOnFailure === true,
+      keepOnFailure: target.keepOnFailure,
       port: target.port,
       warmupArgs: target.warmupArgs,
       statusArgs: target.statusArgs,
+      stopArgs: target.stopArgs,
     };
     if (missing.length > 0) {
       throw new Error(
@@ -1929,6 +1939,14 @@ export class TaskRunner {
       );
     }
     return config;
+  }
+
+  private crabboxStopConfigFromResolverConfig(config: CrabboxResolverTargetConfig): CrabboxStopConfig {
+    return {
+      id: config.id,
+      crabboxCommand: config.crabboxCommand,
+      stopArgs: config.stopArgs,
+    };
   }
 
   /** A completion counts as success unless it failed or reported a non-zero exit. */
@@ -1954,21 +1972,22 @@ export class TaskRunner {
   private async maybeCleanupCrabboxLease(
     task: TaskState,
     metadata: CrabboxRemoteLeaseMetadata | undefined,
+    stopConfig: CrabboxStopConfig | undefined,
     response: WorkResponse,
   ): Promise<void> {
     if (!metadata || metadata.provider !== 'crabbox') return;
 
     const succeeded = this.responseSucceeded(response);
     const policy = resolveCrabboxCleanupPolicy(metadata.stopAfter, metadata.keepOnFailure);
-    const target = this.getRemoteTargets()[metadata.targetId];
-    const crabboxCommand = target?.crabboxCommand ?? 'crabbox';
+    const effectiveStopConfig = stopConfig ?? { id: metadata.targetId, crabboxCommand: 'crabbox' };
+    const crabboxCommand = effectiveStopConfig.crabboxCommand;
 
     if (!shouldStopCrabboxLease(policy, succeeded)) {
       // Lease is being kept. If a failure is being preserved for debugging,
       // surface the commands to connect to and later stop the leased machine.
       if (!succeeded && policy.keepOnFailure) {
         const sshCommand = `${crabboxCommand} ssh --id ${metadata.leaseId}`;
-        const stopCommand = `${crabboxCommand} stop ${metadata.leaseId}`;
+        const stopCommand = [crabboxCommand, 'stop', metadata.leaseId, ...(effectiveStopConfig.stopArgs ?? [])].join(' ');
         const message =
           `Crabbox lease ${metadata.slug} (${metadata.leaseId}) kept for debugging after failure.\n` +
           `  Connect: ${sshCommand}\n` +
@@ -1991,16 +2010,15 @@ export class TaskRunner {
       return;
     }
 
-    const stopConfig: CrabboxStopConfig = {
-      id: metadata.targetId,
-      crabboxCommand,
-      stopArgs: target?.stopArgs,
-    };
     try {
-      await this.crabboxResolver.stop?.(stopConfig, metadata.leaseId);
+      if (!this.crabboxResolver.stop) {
+        throw new Error('Crabbox resolver does not implement stop()');
+      }
+      await this.crabboxResolver.stop(effectiveStopConfig, metadata.leaseId);
       // Drop the cached lease so a later task re-leases instead of reusing a
       // machine we just asked Crabbox to stop.
       this.resolvedCrabboxTargets.delete(metadata.targetId);
+      this.crabboxStopConfigs.delete(metadata.targetId);
       this.persistence.logEvent?.(task.id, 'task.executor.crabbox-stopped', {
         leaseId: metadata.leaseId,
         slug: metadata.slug,

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -83,6 +83,7 @@ type ReviewGateArtifactStatus = ReviewGateArtifact['status'];
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_EXECUTOR_START_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_GIT_OPERATION_TIMEOUT_MS = 15 * 60 * 1000;
+const DEFAULT_CRABBOX_STOP_TIMEOUT_MS = 60_000;
 const GITHUB_TARGET_REPO_ENV = 'INVOKER_GITHUB_TARGET_REPO';
 
 type StartupFailureMetadata = {
@@ -236,6 +237,53 @@ function getGitOperationTimeoutMs(): number {
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_GIT_OPERATION_TIMEOUT_MS;
   return parsed;
+}
+
+function getCrabboxStopTimeoutMs(): number {
+  const raw = process.env.INVOKER_CRABBOX_STOP_TIMEOUT_MS?.trim();
+  if (raw === '0') return 0;
+  if (!raw) return DEFAULT_CRABBOX_STOP_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_CRABBOX_STOP_TIMEOUT_MS;
+  return parsed;
+}
+
+function withCrabboxStopTimeout(
+  stop: Promise<void>,
+  leaseId: string,
+  targetId: string,
+): Promise<void> {
+  const timeoutMs = getCrabboxStopTimeoutMs();
+  if (timeoutMs === 0) return stop;
+
+  return new Promise((resolvePromise, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error(
+        `Crabbox stop for lease "${leaseId}" on remote target "${targetId}" ` +
+          `exceeded Crabbox stop timeout (${timeoutMs}ms). ` +
+          'Set INVOKER_CRABBOX_STOP_TIMEOUT_MS to adjust (0 = unbounded).',
+      ));
+    }, timeoutMs);
+    timeout.unref?.();
+
+    stop.then(
+      () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolvePromise();
+      },
+      (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        reject(err);
+      },
+    );
+  });
 }
 
 function execGitWithTimeout(args: string[], cwd: string): Promise<string> {
@@ -2014,7 +2062,11 @@ export class TaskRunner {
       if (!this.crabboxResolver.stop) {
         throw new Error('Crabbox resolver does not implement stop()');
       }
-      await this.crabboxResolver.stop(effectiveStopConfig, metadata.leaseId);
+      await withCrabboxStopTimeout(
+        this.crabboxResolver.stop(effectiveStopConfig, metadata.leaseId),
+        metadata.leaseId,
+        metadata.targetId,
+      );
       // Drop the cached lease so a later task re-leases instead of reusing a
       // machine we just asked Crabbox to stop.
       this.resolvedCrabboxTargets.delete(metadata.targetId);

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -163,8 +163,8 @@ export interface CrabboxRemoteLeaseMetadata {
   readonly expiresAt: string;
   /** When to stop the lease after the task settles (e.g. 'completed', 'never'). */
   readonly stopAfter: string;
-  /** Keep the lease alive on failure for debugging instead of stopping it. */
-  readonly keepOnFailure: boolean;
+  /** Keep the lease alive on failure for debugging instead of stopping it. Default: true. */
+  readonly keepOnFailure?: boolean;
 }
 
 /** Provider-tagged durable lease metadata for a remote target. */

--- a/scripts/repro/repro-coderabbit-pr2202-cleanup-before-downstream.sh
+++ b/scripts/repro/repro-coderabbit-pr2202-cleanup-before-downstream.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] verifying Crabbox cleanup runs before downstream launch"
+if pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "cleans the current Crabbox lease before launching downstream tasks" \
+  --reporter=verbose; then
+  echo "PASS: downstream launch waits for Crabbox cleanup"
+else
+  echo "FAIL: downstream task can launch before Crabbox cleanup" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr2202-completion-callback-registration.sh
+++ b/scripts/repro/repro-coderabbit-pr2202-completion-callback-registration.sh
@@ -4,12 +4,12 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
-echo "[repro] verifying Crabbox cleanup helper registers completion before delivering response"
+echo "[repro] verifying Crabbox tests register completion before delivering responses"
 if pnpm --filter @invoker/execution-engine exec vitest run \
   src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
-  -t "stops the lease on success" \
+  -t "resolves a crabbox target through the injected resolver|stops the lease on success" \
   --reporter=verbose; then
-  echo "PASS: completion response reaches the registered callback"
+  echo "PASS: completion responses reach registered callbacks"
 else
   echo "FAIL: completion response can be skipped before callback registration" >&2
   exit 1

--- a/scripts/repro/repro-coderabbit-pr2202-completion-callback-registration.sh
+++ b/scripts/repro/repro-coderabbit-pr2202-completion-callback-registration.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] verifying Crabbox cleanup helper registers completion before delivering response"
+if pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "stops the lease on success" \
+  --reporter=verbose; then
+  echo "PASS: completion response reaches the registered callback"
+else
+  echo "FAIL: completion response can be skipped before callback registration" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr2202-crabbox-cleanup.sh
+++ b/scripts/repro/repro-coderabbit-pr2202-crabbox-cleanup.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] running all PR #2202 CodeRabbit Crabbox cleanup regressions"
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "crabbox cleanup policy" \
+  --reporter=verbose
+
+echo "PASS: all Crabbox cleanup regressions are covered"

--- a/scripts/repro/repro-coderabbit-pr2202-crabbox-stop-timeout.sh
+++ b/scripts/repro/repro-coderabbit-pr2202-crabbox-stop-timeout.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] verifying hung Crabbox stop times out during cleanup"
+if pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "times out a hung Crabbox stop so completion processing continues" \
+  --reporter=verbose; then
+  echo "PASS: hung Crabbox stop is timed out and logged as cleanup failure"
+else
+  echo "FAIL: hung Crabbox stop blocked completion processing" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr2202-keep-on-failure-default.sh
+++ b/scripts/repro/repro-coderabbit-pr2202-keep-on-failure-default.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] verifying omitted keepOnFailure keeps failed Crabbox leases"
+if pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "defaults omitted keepOnFailure to keeping failed leases for debugging" \
+  --reporter=verbose; then
+  echo "PASS: omitted keepOnFailure uses the default debug-preserving policy"
+else
+  echo "FAIL: omitted keepOnFailure was treated as false" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr2202-launch-time-stop-config.sh
+++ b/scripts/repro/repro-coderabbit-pr2202-launch-time-stop-config.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] verifying cleanup uses the launch-time Crabbox stop config"
+if pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "uses the launch-time stop config even if remoteTargets changes before cleanup" \
+  --reporter=verbose; then
+  echo "PASS: cleanup uses the launch-time stop config"
+else
+  echo "FAIL: cleanup re-read mutable remoteTargets at completion time" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr2202-manual-stop-args.sh
+++ b/scripts/repro/repro-coderabbit-pr2202-manual-stop-args.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] verifying manual Crabbox stop text includes configured stopArgs"
+if pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "keeps the lease on failure and appends connect/stop commands" \
+  --reporter=verbose; then
+  echo "PASS: manual stop command includes stopArgs"
+else
+  echo "FAIL: manual stop command omitted stopArgs" >&2
+  exit 1
+fi

--- a/scripts/repro/repro-coderabbit-pr2202-missing-stop-guard.sh
+++ b/scripts/repro/repro-coderabbit-pr2202-missing-stop-guard.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] verifying missing Crabbox stop implementation logs cleanup failure"
+if pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "logs cleanup failure instead of success when the resolver cannot stop leases" \
+  --reporter=verbose; then
+  echo "PASS: missing stop implementation is not logged as successful cleanup"
+else
+  echo "FAIL: missing stop implementation was treated as successful cleanup" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

TaskRunner now routes Crabbox lease handling through the resolver when SSH tasks finish.

Success, failure, and retained leases follow target policy, with recovery text logged for inspection.

<details>
<summary>Review metadata</summary>

Review Claim: Approve that TaskRunner routes Crabbox lease stop decisions through the resolver without adding another executor shape.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Crabbox-backed work still uses runnerKind: ssh and the existing SshExecutor path.

Slice Rationale: This slice owns one TaskRunner routing path so later Crabbox work can build on a stable lease policy.

</details>

## Non-goals

This does not add a Crabbox executor or change SSH execution ownership.

This does not change the earlier Crabbox target config schema.

## Architecture

### Before

```mermaid
graph TD
    A["TaskRunner finishes SSH task"] --> B["Lease metadata remains recorded"]
    B --> C["Operator handles Crabbox leases manually"]
```

### After

```mermaid
graph TD
    A["TaskRunner finishes SSH task"] --> B["TaskRunner routes lease policy to resolver"]
    B --> C["Resolver service stops eligible leases"]
    B --> D["Kept leases log recovery text"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/crabbox-target-resolver.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic Crabbox durable-lease cleanup for SSH-backed tasks, including configurable stop timing and cleanup policies (success/always/never/failure), optional stop arguments, and `keepOnFailure` handling.
* **Bug Fixes**
  * Ensures cleanup happens before downstream task launch using the launch-time stop configuration; skipped/failed cleanup now emits clear events, and hung “stop” operations time out so completion isn’t blocked.
* **Tests**
  * Expanded coverage for cleanup policy resolution, stop command construction/execution, event sequencing, and timeout/skipped/error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->