### PR TITLE
[Crabbox SSH step 6: docs and examples](1) Document Crabbox-backed SSH targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,29 @@ tasks:
 
 Use this when you want Invoker to spread work across machines you already manage. The SSH executor does not provision the hosts for you; it connects to the target you name and runs there.
 
+### Crabbox-backed SSH targets
+
+When you don't have a host ready, a `type: crabbox` target lets Invoker lease one. Invoker warms up a Crabbox box, reads its SSH details, then runs the **same SSH executor** against it — tasks still use `runnerKind: ssh`, never `runnerKind: crabbox`.
+
+```json
+"remoteTargets": {
+  "crab-builder": {
+    "type": "crabbox",
+    "crabboxCommand": "crabbox",
+    "provider": "fly",
+    "class": "performance-4x",
+    "ttl": "30m",
+    "idleTimeout": "10m",
+    "network": "default",
+    "target": "ubuntu-22",
+    "stopAfter": "success",
+    "keepOnFailure": true
+  }
+}
+```
+
+`stopAfter` controls when Invoker stops the lease (`success`/`failure`/`always`/`never`). `keepOnFailure: true` keeps a failed task's box alive so you can debug it — but it does **not** override Crabbox's own `ttl` or `idleTimeout`, so a kept box still goes away on its own. To inspect or clean up a kept lease: `crabbox ssh --id <lease>` and `crabbox stop <lease>`. Full details: [docs/remote-ssh-targets.md](docs/remote-ssh-targets.md#crabbox-backed-targets).
+
 ## Quick start
 
 For a guided first run, use [the first agent workflow tutorial](docs/tutorial-first-agent-workflow.md). It gives you a toy repo and exact UI checkpoints.

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -42,6 +42,20 @@
       "remoteInvokerHome": "~/.invoker",
       "provisionCommand": "pnpm install --frozen-lockfile",
       "remoteHeartbeatIntervalSeconds": 30
+    },
+    "crab-builder": {
+      "comment": "Crabbox-backed target: Invoker leases a box, then runs the normal SSH executor against it. Tasks still use runnerKind: ssh and poolMemberId: crab-builder.",
+      "type": "crabbox",
+      "crabboxCommand": "crabbox",
+      "provider": "fly",
+      "class": "performance-4x",
+      "ttl": "30m",
+      "idleTimeout": "10m",
+      "network": "default",
+      "target": "ubuntu-22",
+      "stopAfter": "success",
+      "keepOnFailure": true,
+      "port": 22
     }
   },
 

--- a/docs/remote-ssh-targets.md
+++ b/docs/remote-ssh-targets.md
@@ -77,6 +77,77 @@ tasks:
 
 This is the supported way to run multiple SSH executors in one workflow: define multiple targets, then attach different tasks to different target IDs.
 
+## Crabbox-backed Targets
+
+Crabbox is a machine supplier. Invoker leases a box from Crabbox first, then runs the **same SSH executor** against it. There is no `runnerKind: crabbox` — tasks still use `runnerKind: ssh`. The only difference is the target config: it has `type: crabbox`, so Invoker warms up a lease and reads its SSH host/user/key before connecting.
+
+Add a Crabbox target under `remoteTargets`:
+
+```json
+{
+  "remoteTargets": {
+    "crab-builder": {
+      "type": "crabbox",
+      "crabboxCommand": "crabbox",
+      "provider": "fly",
+      "class": "performance-4x",
+      "ttl": "30m",
+      "idleTimeout": "10m",
+      "network": "default",
+      "target": "ubuntu-22",
+      "stopAfter": "success",
+      "keepOnFailure": true,
+      "port": 22
+    }
+  }
+}
+```
+
+Tasks reference it exactly like any other SSH target:
+
+```yaml
+tasks:
+  - id: build
+    description: "Build on a leased Crabbox machine"
+    command: "pnpm run build"
+    runnerKind: ssh
+    poolMemberId: crab-builder
+```
+
+### Lifecycle
+
+1. Invoker runs `crabbox warmup ...` to create or find the leased machine.
+2. It reads the lease's SSH host, user, and key from `crabbox status`.
+3. The normal `SshExecutor` connects and runs the task command.
+4. After the task settles, Invoker stops the lease based on `stopAfter` and `keepOnFailure`.
+
+### Cleanup policy
+
+`stopAfter` decides when Invoker stops the lease after a task finishes:
+
+| Value | Stops the lease when |
+|-------|----------------------|
+| `success` | the task succeeded (default — don't leak machines) |
+| `failure` | the task failed |
+| `always` | the task succeeded or failed |
+| `never` | never; you stop it yourself |
+
+`keepOnFailure: true` (default) overrides `stopAfter` on failure: a failed task's machine is kept alive so you can SSH in and debug. With `keepOnFailure: false`, failures follow `stopAfter` like any other outcome.
+
+> **Warning:** `keepOnFailure` only keeps Invoker from stopping the lease. It does **not** defeat Crabbox's own `ttl` (lease time-to-live) or `idleTimeout` cleanup. A kept machine still disappears once its TTL expires or it sits idle past the idle timeout. Debug it promptly, or raise `ttl`/`idleTimeout` for that target.
+
+### Recovery commands
+
+When a lease is kept after a failure, Invoker logs the lease id. To inspect or clean it up manually:
+
+```bash
+# Open an interactive SSH session to the kept lease
+crabbox ssh --id <lease>
+
+# Stop (release) the lease when you're done debugging
+crabbox stop <lease>
+```
+
 ## Usage in Plans
 
 Reference a remote target in a plan YAML task:


### PR DESCRIPTION
## Summary

This updates the SSH target documentation with Crabbox examples.

The README and sample Invoker config now point readers to that guidance.

The wording keeps Crabbox documented as an SSH target supplier.

<details>
<summary>Review metadata</summary>

Review Claim: Required Crabbox wording appears in the edited documentation and examples.

Review Lane: docs

Review Unit: docs

Safety Invariant: This changes Markdown and the example JSON only; source files are untouched.

Slice Rationale: The documentation update is separate from the earlier Crabbox implementation slices.

</details>

## Non-goals

This does not add a Crabbox runner kind.

This does not change SSH execution behavior or lease cleanup behavior.

## Test Plan

- [x] `rg -n '"type": "crabbox"' docs/remote-ssh-targets.md`
- [x] `rg -n 'keepOnFailure' docs/remote-ssh-targets.md`
- [x] `rg -n 'crabbox ssh --id' docs/remote-ssh-targets.md`
- [x] `rg -n 'runnerKind.*ssh|runnerKind.*"ssh"|"runnerKind": "ssh"' docs/remote-ssh-targets.md`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/crabbox-step-6-pr-body.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 1950f29b5`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for Crabbox-backed SSH targets, enabling users to lease on-demand hosts for task execution
  * Documented configuration of remote targets with `type: crabbox` including lifecycle settings like `stopAfter` and `keepOnFailure` behavior
  * Added configuration examples and recovery procedures including cleanup and manual inspection commands for managing leased machines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->