### PR TITLE
[Crabbox SSH](7) cross-surface regression

### DIFF
--- a/packages/app/src/__tests__/crabbox-ssh-integration.test.ts
+++ b/packages/app/src/__tests__/crabbox-ssh-integration.test.ts
@@ -1,0 +1,401 @@
+/**
+ * Cross-surface regression for Crabbox-backed SSH.
+ *
+ * One Crabbox-leased SSH task is driven through every surface it touches —
+ * with no real Crabbox binary, SSH host, or cloud provider:
+ *
+ *   1. execution-engine runtime selection: a task with `runnerKind: 'ssh'` and
+ *      a `poolMemberId` pointing at a `type: 'crabbox'` remote target resolves
+ *      through a fake resolver (no warmup/status process spawned).
+ *   2. SshExecutor construction: the executor is built from the *resolved*
+ *      lease coordinates (host/user/port/keyPath), not the empty config target.
+ *   3. SQLite metadata: the resolved `remoteLeaseMetadata` is persisted into a
+ *      fake metadata store that mimics the SQLite columns terminal restore reads.
+ *   4. Terminal restore: feeding that *same* store back into the app's terminal
+ *      opener refreshes the lease and opens a terminal to the leased machine.
+ *   5. Cleanup policy: a failed task with `keepOnFailure` keeps the lease (no
+ *      stop), while a successful task under the default policy stops it.
+ *
+ * The whole flow is deterministic: every Crabbox/SSH side effect is mocked.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  TaskRunner,
+  SshExecutor,
+  ExecutorRegistry,
+  CrabboxTargetResolver,
+  type CrabboxCommandResult,
+} from '@invoker/execution-engine';
+import type { TaskState } from '@invoker/workflow-core';
+import type { WorkResponse } from '@invoker/contracts';
+import { openExternalTerminalForTask } from '../open-terminal-for-task.js';
+import * as configModule from '../config.js';
+import * as terminalLaunch from '../terminal-external-launch.js';
+
+// ── Fixtures ──────────────────────────────────────────────────
+
+/** A configured `type: 'crabbox'` remote target. Empty host/user/key on purpose:
+ *  the coordinates only exist after the lease resolves, so any leak of the static
+ *  target into the SSH executor would show up as undefined host. */
+const CRABBOX_TARGET = {
+  type: 'crabbox' as const,
+  crabboxCommand: '/usr/local/bin/crabbox',
+  provider: 'fly',
+  class: 'performance-4x',
+  ttl: '30m',
+  idleTimeout: '10m',
+  network: 'invoker-net',
+  target: 'us-east',
+  stopAfter: 'success',
+  keepOnFailure: true,
+  statusArgs: ['--region', 'iad'],
+};
+
+/** The leased SSH endpoint the fake resolver hands back. */
+const LEASED = {
+  host: '203.0.113.9',
+  user: 'runner',
+  sshKeyPath: '/leased/key',
+  port: 2200,
+};
+
+/** Fake resolver: resolves a lease without spawning Crabbox, and records stops. */
+function makeFakeResolver() {
+  const resolve = vi.fn(async (config: any) => ({
+    sshTarget: { ...LEASED },
+    remoteLeaseMetadata: {
+      provider: 'crabbox' as const,
+      leaseId: 'lease-abc',
+      slug: 'happy-crab',
+      targetId: config.id,
+      sshHost: LEASED.host,
+      sshUser: LEASED.user,
+      sshPort: LEASED.port,
+      sshKeyPath: LEASED.sshKeyPath,
+      expiresAt: '2099-01-01T00:00:00.000Z',
+      stopAfter: config.stopAfter,
+      keepOnFailure: config.keepOnFailure,
+    },
+  }));
+  const stop = vi.fn(async () => {});
+  return { resolve, stop };
+}
+
+function makeTask(overrides: {
+  id?: string;
+  config?: Partial<TaskState['config']>;
+  execution?: Partial<TaskState['execution']>;
+} = {}): TaskState {
+  return {
+    id: overrides.id ?? 'wf/crab-task',
+    description: 'Crabbox SSH task',
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { ...overrides.config },
+    execution: { ...overrides.execution },
+  } as TaskState;
+}
+
+/**
+ * Fake metadata store that plays the role of the SQLite persistence on BOTH
+ * surfaces: it captures the start-metadata `updateTask` writes from the
+ * TaskRunner, and exposes the column getters the terminal opener reads. This is
+ * the cross-surface link — what execution-engine persists is what app reads.
+ */
+function makeMetadataStore() {
+  const rows = new Map<string, Record<string, any>>();
+  const merge = (taskId: string, changes: any) => {
+    const row = rows.get(taskId) ?? {};
+    if (changes.config) Object.assign(row, changes.config);
+    if (changes.execution) Object.assign(row, changes.execution);
+    rows.set(taskId, row);
+  };
+  const col = (taskId: string, key: string) => rows.get(taskId)?.[key] ?? null;
+
+  return {
+    rows,
+    // ── TaskRunner persistence surface ──
+    updateTask: vi.fn((taskId: string, changes: any) => merge(taskId, changes)),
+    updateAttempt: vi.fn(),
+    appendTaskOutput: vi.fn(),
+    logEvent: vi.fn(),
+    loadAttempts: () => [],
+    // ── OpenTerminalPersistence surface (reads the columns above) ──
+    getTaskStatus: vi.fn(() => 'completed'),
+    getRunnerKind: vi.fn((taskId: string) => col(taskId, 'runnerKind')),
+    getAgentSessionId: vi.fn((taskId: string) => col(taskId, 'agentSessionId')),
+    getContainerId: vi.fn((taskId: string) => col(taskId, 'containerId')),
+    getWorkspacePath: vi.fn((taskId: string) => col(taskId, 'workspacePath')),
+    getBranch: vi.fn((taskId: string) => col(taskId, 'branch')),
+    getPoolMemberId: vi.fn((taskId: string) => col(taskId, 'poolMemberId')),
+    getExecutionAgent: vi.fn((taskId: string) => col(taskId, 'agentName')),
+    getRemoteLeaseMetadata: vi.fn((taskId: string) => col(taskId, 'remoteLeaseMetadata')),
+  };
+}
+
+/** Mock SshExecutor lifecycle so no real SSH runs, capturing constructed coords. */
+function stubSshExecutor() {
+  const starts: Array<{ host: string; user: string; sshKeyPath: string; port: number }> = [];
+  const completeByTask = new Map<string, (r: WorkResponse) => void>();
+  vi.spyOn(SshExecutor.prototype, 'start').mockImplementation(async function (this: any, request: any) {
+    starts.push({ host: this.host, user: this.user, sshKeyPath: this.sshKeyPath, port: this.port });
+    return {
+      executionId: `exec-${request.actionId}`,
+      taskId: request.actionId,
+      workspacePath: `~/.invoker/worktrees/abc/experiment-${request.actionId}`,
+      branch: `experiment/${request.actionId}`,
+    };
+  });
+  vi.spyOn(SshExecutor.prototype, 'onComplete').mockImplementation((handle: any, cb: any) => {
+    completeByTask.set(handle.taskId, cb);
+  });
+  vi.spyOn(SshExecutor.prototype, 'onOutput').mockImplementation(() => {});
+  vi.spyOn(SshExecutor.prototype, 'onHeartbeat').mockImplementation(() => {});
+  vi.spyOn(SshExecutor.prototype, 'kill').mockImplementation(async () => {});
+  return { starts, completeByTask };
+}
+
+/** Build a TaskRunner wired to the fake resolver + crabbox target + store. */
+function makeRunner(
+  task: TaskState,
+  store: ReturnType<typeof makeMetadataStore>,
+  resolver: { resolve: any; stop: any },
+  callbacks?: any,
+) {
+  return new TaskRunner({
+    orchestrator: {
+      getTask: (id: string) => (id === task.id ? task : null),
+      getAllTasks: () => [task],
+      markTaskRunningAfterLaunch: () => true,
+      handleWorkerResponse: () => [],
+      deferTask: vi.fn(),
+    } as any,
+    persistence: store as any,
+    executorRegistry: {
+      getDefault: () => ({ type: 'worktree' }),
+      get: () => null,
+      getAll: () => [],
+      register: vi.fn(),
+    } as any,
+    cwd: '/tmp',
+    remoteTargetsProvider: () => ({ 'crab-1': CRABBOX_TARGET }),
+    crabboxResolver: resolver,
+    callbacks,
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── 1+2+3: resolution → SshExecutor construction → persisted metadata ─────────
+
+describe('Crabbox SSH cross-surface: resolution, executor, and persisted lease', () => {
+  it('resolves the lease, builds SshExecutor from the leased endpoint, and persists lease metadata', async () => {
+    const { starts, completeByTask } = stubSshExecutor();
+    const store = makeMetadataStore();
+    const resolver = makeFakeResolver();
+    const task = makeTask({
+      id: 'wf/crab-task',
+      config: { runnerKind: 'ssh', poolMemberId: 'crab-1' },
+      execution: { selectedAttemptId: 'crab-attempt', generation: 0 },
+    });
+    const runner = makeRunner(task, store, resolver);
+
+    const run = runner.executeTask(task);
+    await vi.waitFor(() => expect(starts.length).toBe(1));
+
+    // (1) Resolved exactly once with the configured crabbox lease inputs — no real
+    //     warmup/status process was spawned.
+    expect(resolver.resolve).toHaveBeenCalledTimes(1);
+    expect(resolver.resolve.mock.calls[0][0]).toMatchObject({
+      id: 'crab-1',
+      crabboxCommand: '/usr/local/bin/crabbox',
+      provider: 'fly',
+      class: 'performance-4x',
+      stopAfter: 'success',
+      keepOnFailure: true,
+    });
+
+    // (2) SshExecutor was constructed from the *resolved* endpoint, not the empty
+    //     static target. A leak of the static config would show undefined host.
+    expect(starts[0]).toEqual({
+      host: '203.0.113.9',
+      user: 'runner',
+      sshKeyPath: '/leased/key',
+      port: 2200,
+    });
+
+    // (3) The durable lease metadata + runner kind + pool member landed in the
+    //     metadata store under the columns terminal restore reads.
+    const row = store.rows.get(task.id)!;
+    expect(row.runnerKind).toBe('ssh');
+    expect(row.poolMemberId).toBe('crab-1');
+    expect(row.remoteLeaseMetadata).toMatchObject({
+      provider: 'crabbox',
+      leaseId: 'lease-abc',
+      targetId: 'crab-1',
+      sshHost: '203.0.113.9',
+      sshUser: 'runner',
+      sshPort: 2200,
+      sshKeyPath: '/leased/key',
+    });
+
+    completeByTask.get(task.id)?.({
+      requestId: 'r',
+      actionId: task.id,
+      attemptId: 'crab-attempt',
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    } as WorkResponse);
+    await run;
+  });
+});
+
+// ── 4: terminal restore reads the persisted metadata and refreshes the lease ──
+
+describe('Crabbox SSH cross-surface: terminal restore reads persisted lease', () => {
+  function scriptedResolver(result: CrabboxCommandResult) {
+    const calls: Array<{ command: string; args: readonly string[] }> = [];
+    const resolver = new CrabboxTargetResolver(async (command, args) => {
+      calls.push({ command, args });
+      return result;
+    });
+    return { resolver, calls };
+  }
+
+  it('reads the lease persisted by execution-engine and opens a terminal to the refreshed host', async () => {
+    // First: run the task so the store holds real persisted metadata.
+    const { starts, completeByTask } = stubSshExecutor();
+    const store = makeMetadataStore();
+    const task = makeTask({
+      id: 'wf/crab-restore',
+      config: { runnerKind: 'ssh', poolMemberId: 'crab-1' },
+      execution: { selectedAttemptId: 'crab-attempt', generation: 0 },
+    });
+    const runner = makeRunner(task, store, makeFakeResolver());
+    const run = runner.executeTask(task);
+    await vi.waitFor(() => expect(starts.length).toBe(1));
+    completeByTask.get(task.id)?.({
+      requestId: 'r',
+      actionId: task.id,
+      attemptId: 'crab-attempt',
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    } as WorkResponse);
+    await run;
+    vi.restoreAllMocks();
+
+    // Now restart-style restore: only the persisted store survives. Refreshing the
+    // lease reports NEW coordinates that must override the persisted (now stale) ones.
+    const mockSpawnDetached = vi.fn(async () => ({ opened: true } as const));
+    vi.spyOn(terminalLaunch, 'spawnDetachedTerminal').mockImplementation(mockSpawnDetached as any);
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: { 'crab-1': CRABBOX_TARGET },
+    } as any);
+
+    const { resolver, calls } = scriptedResolver({
+      stdout: JSON.stringify({
+        id: 'lease-abc',
+        slug: 'happy-crab',
+        status: 'ready',
+        expiresAt: '2099-12-01T00:00:00.000Z',
+        sshHost: '198.51.100.7',
+        sshUser: 'fresh-runner',
+        sshPort: 2299,
+        sshKey: '/leased/fresh-key',
+      }),
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const result = await openExternalTerminalForTask({
+      taskId: task.id,
+      persistence: store as any,
+      executorRegistry: new ExecutorRegistry(),
+      repoRoot: '/repo',
+      crabboxResolver: resolver,
+    });
+
+    expect(result.opened).toBe(true);
+
+    // Terminal restore actually read the lease metadata the runner persisted.
+    expect(store.getRemoteLeaseMetadata).toHaveBeenCalledWith(task.id);
+
+    // Refresh ran a no-wait status call against the persisted lease id.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].command).toBe('/usr/local/bin/crabbox');
+    expect(calls[0].args).toEqual([
+      'status', '--id', 'lease-abc', '--json', '--region', 'iad',
+    ]);
+
+    // Terminal opened to the REFRESHED host + the persisted branch; the stale
+    // persisted host must not leak through.
+    const argsJson = JSON.stringify(mockSpawnDetached.mock.calls[0]?.[1]);
+    expect(argsJson).toContain('198.51.100.7');
+    expect(argsJson).toContain('fresh-runner@198.51.100.7');
+    expect(argsJson).toContain('experiment/wf/crab-restore');
+    expect(argsJson).not.toContain('203.0.113.9');
+
+    loadConfigSpy.mockRestore();
+  });
+});
+
+// ── 5: cleanup policy across the success / keep-on-failure split ───────────────
+
+describe('Crabbox SSH cross-surface: cleanup policy', () => {
+  async function runToCompletion(final: { status: WorkResponse['status']; exitCode: number }) {
+    const { starts, completeByTask } = stubSshExecutor();
+    const store = makeMetadataStore();
+    const resolver = makeFakeResolver();
+    const task = makeTask({
+      id: 'wf/crab-cleanup',
+      config: { runnerKind: 'ssh', poolMemberId: 'crab-1' },
+      execution: { selectedAttemptId: 'crab-attempt', generation: 0 },
+    });
+    const onOutput = vi.fn();
+    const runner = makeRunner(task, store, resolver, { onOutput });
+
+    const run = runner.executeTask(task);
+    await vi.waitFor(() => expect(starts.length).toBe(1));
+    completeByTask.get(task.id)?.({
+      requestId: 'r',
+      actionId: task.id,
+      attemptId: 'crab-attempt',
+      status: final.status,
+      outputs: { exitCode: final.exitCode },
+    } as WorkResponse);
+    await run;
+
+    const event = (name: string) =>
+      store.logEvent.mock.calls.find(([, e]: [string, string]) => e === name)?.[2];
+    return { resolver, store, event };
+  }
+
+  it('does NOT stop the lease on failure when keepOnFailure is true', async () => {
+    const { resolver, event } = await runToCompletion({ status: 'failed', exitCode: 1 });
+
+    expect(resolver.stop).not.toHaveBeenCalled();
+    expect(event('task.executor.crabbox-cleanup-skipped')).toMatchObject({
+      leaseId: 'lease-abc',
+      reason: 'keepOnFailure',
+    });
+  });
+
+  it('DOES stop the lease on success under the default policy', async () => {
+    const { resolver, event } = await runToCompletion({ status: 'completed', exitCode: 0 });
+
+    expect(resolver.stop).toHaveBeenCalledTimes(1);
+    expect(resolver.stop).toHaveBeenCalledWith(
+      { id: 'crab-1', crabboxCommand: '/usr/local/bin/crabbox', stopArgs: undefined },
+      'lease-abc',
+    );
+    expect(event('task.executor.crabbox-stopped')).toMatchObject({
+      leaseId: 'lease-abc',
+      stopAfter: 'success',
+      succeeded: true,
+    });
+  });
+});

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -1203,6 +1203,54 @@ describe('Crabbox SSH terminal restore', () => {
     );
   });
 
+  it('rebuilds the SSH endpoint with all four refreshed coordinates (host, user, port, key)', async () => {
+    const mockSpawnDetached = vi.fn(async () => ({ opened: true } as const));
+    const terminalLaunch = await import('../terminal-external-launch.js');
+    vi.spyOn(terminalLaunch, 'spawnDetachedTerminal').mockImplementation(mockSpawnDetached as any);
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: CRABBOX_TARGET_CONFIG,
+    } as any);
+
+    const { resolver } = scriptedResolver({
+      stdout: JSON.stringify({
+        id: 'lease-abc',
+        slug: 'happy-crab',
+        status: 'ready',
+        expiresAt: '2026-12-01T00:00:00.000Z',
+        sshHost: '203.0.113.9',
+        sshUser: 'runner',
+        sshPort: 2200,
+        sshKey: '/home/me/.ssh/fresh',
+      }),
+      stderr: '',
+      exitCode: 0,
+    });
+
+    const result = await openExternalTerminalForTask({
+      taskId: 'crab-ssh-task',
+      persistence: crabboxPersistence() as any,
+      executorRegistry: new ExecutorRegistry(),
+      repoRoot: '/repo',
+      crabboxResolver: resolver,
+    });
+
+    expect(result.opened).toBe(true);
+    // The rebuilt SshExecutor must connect with every refreshed coordinate:
+    // -i <key>, -p <port>, -t <user>@<host>. None may be the stale persisted ones.
+    const argsJson = JSON.stringify(mockSpawnDetached.mock.calls[0]?.[1]);
+    expect(argsJson).toContain('/home/me/.ssh/fresh');
+    expect(argsJson).toContain('2200');
+    expect(argsJson).toContain('runner@203.0.113.9');
+    expect(argsJson).not.toContain('/home/me/.ssh/old');
+    expect(argsJson).not.toContain('2222');
+
+    loadConfigSpy.mockRestore();
+    vi.mocked(terminalLaunch.spawnDetachedTerminal).mockReset();
+    vi.mocked(terminalLaunch.spawnDetachedTerminal).mockImplementation(
+      async () => ({ opened: true } as const),
+    );
+  });
+
   it('refuses with a clear reason when the lease has expired', async () => {
     const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
       remoteTargets: CRABBOX_TARGET_CONFIG,

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -1241,6 +1241,8 @@ describe('Crabbox SSH terminal restore', () => {
     expect(argsJson).toContain('/home/me/.ssh/fresh');
     expect(argsJson).toContain('2200');
     expect(argsJson).toContain('runner@203.0.113.9');
+    // Stale persisted host must not leak through alongside the refreshed one.
+    expect(argsJson).not.toContain('10.0.0.1');
     expect(argsJson).not.toContain('/home/me/.ssh/old');
     expect(argsJson).not.toContain('2222');
 

--- a/packages/execution-engine/src/__tests__/crabbox-target-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/crabbox-target-resolver.test.ts
@@ -239,6 +239,92 @@ describe('CrabboxTargetResolver.resolve', () => {
   });
 });
 
+describe('CrabboxTargetResolver.refreshLease', () => {
+  // Terminal restore re-inspects an already-leased machine by its persisted
+  // lease id (no warmup, no --wait) and rebuilds the SSH endpoint. This is the
+  // cross-surface read path that pairs with resolve()'s persisted metadata.
+
+  const refreshConfig = {
+    id: 'crab1',
+    crabboxCommand: '/usr/local/bin/crabbox',
+    statusArgs: ['--region', 'iad'],
+    port: 2200,
+  };
+
+  it('runs a no-wait status call and returns the refreshed SSH endpoint', async () => {
+    const { runner, calls } = scriptRunner([
+      ok(
+        JSON.stringify({
+          id: 'lease-abc',
+          slug: 'happy-crab',
+          status: 'ready',
+          sshHost: '198.51.100.7',
+          sshUser: 'fresh-runner',
+          sshPort: 2299,
+          sshKey: '/leased/fresh-key',
+        }),
+      ),
+    ]);
+
+    const target = await new CrabboxTargetResolver(runner).refreshLease(
+      refreshConfig,
+      'lease-abc',
+    );
+
+    // Status call omits --wait so a dead/not-ready lease reports immediately.
+    expect(calls[0]).toEqual({
+      command: '/usr/local/bin/crabbox',
+      args: ['status', '--id', 'lease-abc', '--json', '--region', 'iad'],
+    });
+    expect(target).toEqual({
+      host: '198.51.100.7',
+      user: 'fresh-runner',
+      sshKeyPath: '/leased/fresh-key',
+      port: 2299,
+    });
+  });
+
+  it('falls back to the configured port when status omits sshPort', async () => {
+    const { runner } = scriptRunner([
+      ok(
+        JSON.stringify({
+          status: 'ready',
+          sshHost: '198.51.100.7',
+          sshUser: 'fresh-runner',
+          sshKey: '/leased/fresh-key',
+        }),
+      ),
+    ]);
+
+    const target = await new CrabboxTargetResolver(runner).refreshLease(
+      refreshConfig,
+      'lease-abc',
+    );
+
+    expect(target.port).toBe(2200);
+  });
+
+  it('rejects an expired/stopped lease with an actionable error', async () => {
+    const { runner } = scriptRunner([
+      ok(JSON.stringify({ id: 'lease-abc', status: 'expired' })),
+    ]);
+
+    await expect(
+      new CrabboxTargetResolver(runner).refreshLease(refreshConfig, 'lease-abc'),
+    ).rejects.toThrow(/expired or been stopped/);
+  });
+
+  it('rejects when the status call exits non-zero (lease missing/unreachable)', async () => {
+    const { runner } = scriptRunner([
+      { stdout: '', stderr: 'lease not found', exitCode: 4 },
+    ]);
+
+    await expect(
+      new CrabboxTargetResolver(runner).refreshLease(refreshConfig, 'lease-abc'),
+    ).rejects.toThrow(/missing or unreachable.*lease not found/s);
+  });
+});
+
 describe('buildCrabboxStopArgs', () => {
   it('builds `stop <leaseId>` plus configured stopArgs', () => {
     expect(

--- a/scripts/repro/repro-coderabbit-pr2204-stale-host-leak-assertion.sh
+++ b/scripts/repro/repro-coderabbit-pr2204-stale-host-leak-assertion.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Repro for CodeRabbit PR #2204 finding:
+#   packages/app/src/__tests__/open-terminal.test.ts — the "all four refreshed
+#   coordinates" terminal-restore test declares the invariant "None may be the
+#   stale persisted ones", yet it only asserts the stale KEY and stale PORT are
+#   excluded. It never guards the stale HOST. A stale host leaking into the
+#   spawned terminal args ALONGSIDE the refreshed host (i.e. connecting the
+#   operator to the previous machine) would sail past this test undetected.
+#
+# This repro (a) demonstrates the existing assertions cannot see a stale-host
+# leak, and (b) fails until the regression test explicitly excludes the stale
+# persisted host. Exits NON-ZERO on the buggy (unguarded) state.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TEST_FILE="packages/app/src/__tests__/open-terminal.test.ts"
+
+# Stale persisted coordinates (crabboxPersistence fixture) vs the refreshed
+# coordinates the Crabbox `status` call reports. Terminal restore must rebuild
+# the SSH endpoint entirely from the refreshed values.
+STALE_HOST="10.0.0.1"
+STALE_PORT="2222"
+STALE_KEY="/home/me/.ssh/old"
+FRESH_HOST="203.0.113.9"
+FRESH_USER="runner"
+FRESH_PORT="2200"
+FRESH_KEY="/home/me/.ssh/fresh"
+
+contains() { grep -qF -- "$2" <<<"$1"; }
+
+# ── Part A: prove the gap is real ────────────────────────────────────────────
+# Simulate a launch-args payload where the stale host leaked in alongside the
+# refreshed host — the exact failure the "no stale coordinate" invariant guards.
+leaked_args="[\"-i\",\"${FRESH_KEY}\",\"-p\",\"${FRESH_PORT}\",\"-o\",\"StrictHostKeyChecking=accept-new\",\"-t\",\"${FRESH_USER}@${FRESH_HOST}\",\"--fallback\",\"${FRESH_USER}@${STALE_HOST}\"]"
+
+if ! contains "$leaked_args" "$FRESH_KEY" \
+  || ! contains "$leaked_args" "$FRESH_PORT" \
+  || ! contains "$leaked_args" "${FRESH_USER}@${FRESH_HOST}"; then
+  echo "FAIL: repro setup wrong — leaked payload missing a refreshed coordinate" >&2
+  exit 1
+fi
+if contains "$leaked_args" "$STALE_KEY" || contains "$leaked_args" "$STALE_PORT"; then
+  echo "FAIL: repro setup wrong — leaked payload should not carry stale key/port" >&2
+  exit 1
+fi
+if ! contains "$leaked_args" "$STALE_HOST"; then
+  echo "FAIL: repro setup wrong — expected stale host present in leaked payload" >&2
+  exit 1
+fi
+echo "Demonstrated: the existing (stale key + stale port) assertions all hold on a payload that still carries the stale host — the leak is invisible to them."
+
+# ── Part B: the regression test must guard the stale host too ────────────────
+# Slice out the "all four refreshed coordinates" test body and require that it
+# asserts the stale persisted host is excluded from the launch args.
+block="$(awk '/rebuilds the SSH endpoint with all four refreshed coordinates/{f=1} f{print} f&&/^  \}\);/{exit}' "$TEST_FILE")"
+
+if [[ -z "$block" ]]; then
+  echo "FAIL: could not locate the 'all four refreshed coordinates' test in $TEST_FILE" >&2
+  exit 1
+fi
+
+if ! grep -qF "not.toContain('${STALE_HOST}')" <<<"$block"; then
+  echo "FAIL: ${TEST_FILE} — the 'all four refreshed coordinates' test does not assert the stale host (${STALE_HOST}) is excluded from terminal launch args; a stale-host leak alongside the refreshed host would go undetected." >&2
+  exit 1
+fi
+
+echo "PASS: the regression test explicitly excludes the stale persisted host (${STALE_HOST}) from terminal launch args."


### PR DESCRIPTION
## Summary

This change adds tests only. It does not change how the app runs.

The new regression follows one Crabbox-backed SSH run from end to end.

It checks the seams where config, target lookup, runner choice, saved lease data, and terminal restore hand off to each other.

No test needs a real Crabbox binary or a cloud machine. The mocked commands keep the run deterministic.

<details>
<summary>Review metadata</summary>

Review Claim: This regression proves the Crabbox SSH path holds together across config, target resolution, runner choice, saved lease data, and terminal restore, using mocked commands only.

Review Lane: proof

Review Unit: proof

Safety Invariant: Tests only; the runtime executor shape stays ssh and no product code changes, so this cannot alter behavior.

Slice Rationale: This workflow owns one stacked regression step; earlier config, resolver, runner, persistence, and restore slices already shipped separately.

</details>

## Non-goals

- This PR does not change product code, config parsing, the resolver, runner selection, persistence, or cleanup behavior.
- It does not require a real Crabbox binary or any cloud provider.
- It only adds cross-surface regression coverage.

## Test Plan

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/execution-engine && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new integration coverage for Crabbox-backed SSH, including lease resolution, terminal restoration behavior, and cleanup logic on success vs failure.
  * Added a regression test ensuring refreshed SSH connection details are used for terminal commands, preventing stale host/credential leakage.
  * Added resolver tests for lease status refresh, including port fallback and actionable failures for expired or unsuccessful status calls.
* **Chores**
  * Added a standalone repro script to validate the stale-host test coverage gap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->