### PR TITLE
Document plan parser boundary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -51,6 +51,14 @@ These packages form the foundation and have no dependencies on other workspace p
 - Circular dependencies are **not** allowed
 - Orphaned modules should be removed
 
+## Plan Parser Boundary
+
+Plan parsing currently has separate entry points across layers. The lower-layer path serves reusable workflow consumers, while the app-layer path serves user-facing surfaces that need app configuration, defaulting, and persistence normalization.
+
+Keep shared YAML semantics aligned across those entry points. Do not move app-specific behavior into a lower layer just to remove duplication.
+
+A future consolidation should extract only pure plan-shape parsing and task normalization into a lower layer, leave app-only defaults in an app-layer wrapper, and add parity tests for the shared fields.
+
 ## Enforcement
 
 The dependency rules are enforced through:


### PR DESCRIPTION
## Summary

Document the plan parser boundary in the existing architecture map instead of adding a standalone note.

The note explains why layered parser entry points can exist while shared YAML semantics stay aligned.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the short architecture note for the plan parser boundary.

Review Lane: docs

Review Unit: docs

Safety Invariant: This is Markdown-only and does not change parser imports, defaults, YAML checks, or runtime behavior.

Slice Rationale: The repo already has an architecture map, so this keeps the guidance close to existing package-boundary policy.

</details>

## Non-goals

- Does not add a standalone Markdown file.
- Does not consolidate parser implementations.
- Does not change plan parsing behavior, defaults, or error messages.
- Does not change CLI, Electron, or headless plan-loading paths.

## Test Plan

- [x] `git diff --check`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/inv-214-pr.md`
- [x] `node scripts/create-pr.mjs --title "Document plan parser boundary" --base master --body-file /tmp/inv-214-pr.md --dry-run`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated architectural guidelines documenting the organization and boundaries for plan parsing across application layers, including guidance on shared semantics alignment and future consolidation approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->