### PR TITLE
[pr-skill robustness](1) Merge-gate executor lifecycle + accurate clone-skip trace

### DIFF
--- a/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
@@ -1,0 +1,185 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
+import { MergeGateExecutor } from '../merge-gate-executor.js';
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function makeMergeTask(): TaskState {
+  return {
+    id: '__merge__wf-1782192502908-14',
+    description: 'Review gate',
+    status: 'pending',
+    dependencies: ['wf-1782192502908-14/implement-crabbox-target-resolver'],
+    createdAt: new Date('2026-06-23T06:02:15.000Z'),
+    config: {
+      isMergeNode: true,
+      runnerKind: 'merge',
+      workflowId: 'wf-1782192502908-14',
+    },
+    execution: {
+      selectedAttemptId: '__merge__wf-1782192502908-14-adfcaf2a6',
+      generation: 1,
+      phase: 'launching',
+    },
+  } as TaskState;
+}
+
+function makeRequest(task: TaskState): WorkRequest {
+  return {
+    requestId: 'req-merge-start',
+    actionId: task.id,
+    attemptId: task.execution.selectedAttemptId,
+    executionGeneration: task.execution.generation ?? 0,
+    actionType: 'merge_gate',
+    inputs: {
+      description: task.description,
+      baseBranch: 'master',
+    },
+    callbackUrl: '',
+    timestamps: { createdAt: '2026-06-23T06:02:15.000Z' },
+  };
+}
+
+describe('MergeGateExecutor', () => {
+  const tempDirs: string[] = [];
+  const originalInvokerDbDir = process.env.INVOKER_DB_DIR;
+
+  afterEach(() => {
+    if (originalInvokerDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = originalInvokerDbDir;
+    }
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a launch handle before creating the managed merge worktree', async () => {
+    const invokerHome = mkdtempSync(join(tmpdir(), 'invoker-merge-start-test-'));
+    tempDirs.push(invokerHome);
+    process.env.INVOKER_DB_DIR = invokerHome;
+
+    const task = makeMergeTask();
+    const blockedClone = createDeferred<string>();
+    const updateTask = vi.fn();
+    const createMergeWorktree = vi.fn(() => blockedClone.promise);
+    const executor = new MergeGateExecutor({
+      cwd: '/tmp/host-repo',
+      defaultBranch: 'master',
+      persistence: {
+        loadWorkflow: vi.fn(() => ({
+          id: 'wf-1782192502908-14',
+          baseBranch: 'plan/crabbox-ssh-step-1-config-and-metadata',
+          featureBranch: 'plan/crabbox-ssh-step-2-resolver',
+          repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker',
+          onFinish: 'pull_request',
+          mergeMode: 'external_review',
+        })),
+        updateTask,
+      },
+      orchestrator: {
+        getTask: vi.fn(() => task),
+        getAllTasks: vi.fn(() => [task]),
+      },
+      createMergeWorktree,
+      detectDefaultBranch: vi.fn(async () => 'master'),
+      buildMergeSummary: vi.fn(async () => 'summary'),
+      callbacks: {},
+    } as any);
+
+    try {
+      const started = await Promise.race([
+        executor.start(makeRequest(task)).then((handle) => ({ kind: 'started' as const, handle })),
+        new Promise<{ kind: 'blocked' }>((resolve) => setTimeout(() => resolve({ kind: 'blocked' }), 25)),
+      ]);
+
+      expect(started.kind).toBe('started');
+      if (started.kind !== 'started') return;
+      expect(started.handle.workspacePath).toContain('merge-launches');
+      expect(existsSync(started.handle.workspacePath!)).toBe(true);
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(createMergeWorktree).toHaveBeenCalled();
+      expect(updateTask).not.toHaveBeenCalledWith(
+        task.id,
+        expect.objectContaining({
+          execution: expect.objectContaining({
+            workspacePath: expect.stringContaining('gate-__merge__wf-1782192502908-14'),
+          }),
+        }),
+      );
+    } finally {
+      await executor.destroyAll();
+    }
+  });
+
+  it('emits a terminal failure when destroyed while a merge action is in flight', async () => {
+    const invokerHome = mkdtempSync(join(tmpdir(), 'invoker-merge-destroy-test-'));
+    const gateWorkspace = mkdtempSync(join(tmpdir(), 'invoker-merge-gate-test-'));
+    tempDirs.push(invokerHome, gateWorkspace);
+    process.env.INVOKER_DB_DIR = invokerHome;
+
+    const task = makeMergeTask();
+    const blockedSummary = createDeferred<string>();
+    const responses: WorkResponse[] = [];
+    const executor = new MergeGateExecutor({
+      cwd: '/tmp/host-repo',
+      defaultBranch: 'master',
+      persistence: {
+        loadWorkflow: vi.fn(() => ({
+          id: 'wf-1782192502908-14',
+          baseBranch: 'master',
+          featureBranch: 'plan/crabbox-ssh-step-2-resolver',
+          onFinish: 'none',
+          mergeMode: 'manual',
+        })),
+        updateTask: vi.fn(),
+      },
+      orchestrator: {
+        getTask: vi.fn(() => task),
+        getAllTasks: vi.fn(() => [task]),
+      },
+      createMergeWorktree: vi.fn(async () => gateWorkspace),
+      detectDefaultBranch: vi.fn(async () => 'master'),
+      buildMergeSummary: vi.fn(() => blockedSummary.promise),
+      callbacks: {},
+    } as any);
+
+    const handle = await executor.start(makeRequest(task));
+    executor.onComplete(handle, (response) => {
+      responses.push(response);
+    });
+
+    await vi.waitFor(() => {
+      expect((executor as any).host.buildMergeSummary).toHaveBeenCalled();
+    });
+    await executor.destroyAll();
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toMatchObject({
+      actionId: task.id,
+      attemptId: task.execution.selectedAttemptId,
+      status: 'failed',
+      outputs: {
+        exitCode: 1,
+        error: 'Merge gate execution was stopped before completion',
+      },
+    });
+
+    blockedSummary.resolve('summary after destroy');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(responses).toHaveLength(1);
+  });
+});

--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -1,11 +1,12 @@
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import type { MergeRunnerHost } from './merge-runner.js';
 import { runMergeGateActionImpl } from './merge-runner.js';
-import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 
 interface MergeGateEntry extends BaseEntry {
   killed?: boolean;
@@ -23,16 +24,10 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
     const workflow = task.config.workflowId
       ? this.host.persistence.loadWorkflow(task.config.workflowId)
       : undefined;
-    const baseBranch = workflow?.baseBranch ?? this.host.defaultBranch ?? await this.host.detectDefaultBranch();
-    const baseCheckoutRef = normalizeBranchForGithubCli(baseBranch);
-    const workspacePath = await this.host.createMergeWorktree(
-      baseCheckoutRef,
-      'gate-' + task.id.replace(/[^a-zA-Z0-9_-]/g, '-'),
-      workflow?.repoUrl,
-    );
+    const launchWorkspacePath = this.createLaunchWorkspace(task.id);
 
     const handle = this.createHandle(request);
-    handle.workspacePath = workspacePath;
+    handle.workspacePath = launchWorkspacePath;
     handle.branch = workflow?.featureBranch ?? undefined;
 
     const entry: MergeGateEntry = {
@@ -56,7 +51,7 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
     }, this.heartbeatIntervalMs);
 
     setImmediate(() => {
-      void this.run(handle, task, workspacePath);
+      void this.run(handle, task, launchWorkspacePath);
     });
 
     return handle;
@@ -105,6 +100,21 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
   async destroyAll(): Promise<void> {
     for (const [executionId, entry] of this.entries) {
       if (entry.heartbeatTimer) clearInterval(entry.heartbeatTimer);
+      entry.heartbeatTimer = undefined;
+      if (!entry.completed) {
+        entry.killed = true;
+        this.emitComplete(executionId, {
+          requestId: entry.request.requestId,
+          actionId: entry.request.actionId,
+          attemptId: entry.request.attemptId,
+          executionGeneration: entry.request.executionGeneration,
+          status: 'failed',
+          outputs: {
+            exitCode: 1,
+            error: 'Merge gate execution was stopped before completion',
+          },
+        });
+      }
       this.entries.delete(executionId);
     }
   }
@@ -117,18 +127,62 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
     return task;
   }
 
-  private async run(handle: ExecutorHandle, task: TaskState, gateWorkspacePath: string): Promise<void> {
+  private createLaunchWorkspace(taskId: string): string {
+    const invokerHomeRoot = process.env.INVOKER_DB_DIR
+      ? resolve(process.env.INVOKER_DB_DIR)
+      : resolve(homedir(), '.invoker');
+    const launchRoot = resolve(invokerHomeRoot, 'merge-launches');
+    mkdirSync(launchRoot, { recursive: true });
+    return mkdtempSync(resolve(launchRoot, `launch-${taskId.replace(/[^a-zA-Z0-9_-]/g, '-')}-`));
+  }
+
+  private cleanupLaunchWorkspace(launchWorkspacePath: string, realWorkspacePath: string | undefined): void {
+    if (!realWorkspacePath || realWorkspacePath === launchWorkspacePath) return;
+    try {
+      rmSync(launchWorkspacePath, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup. The real gate clone has already replaced this path.
+    }
+  }
+
+  private async run(handle: ExecutorHandle, task: TaskState, launchWorkspacePath: string): Promise<void> {
     const entry = this.getEntry(handle);
     if (!entry || entry.completed || entry.killed) return;
 
     try {
       this.emitOutput(handle.executionId, `[merge] Starting merge gate action: ${task.id}\n`);
-      const result = await runMergeGateActionImpl(this.host, task, { gateWorkspacePath });
-      if (result.taskChanges.execution) {
+      const result = await runMergeGateActionImpl(this.host, task);
+      const executionChanges = result.taskChanges.execution
+        ? {
+          ...result.taskChanges.execution,
+          workspacePath: result.taskChanges.execution.workspacePath ?? launchWorkspacePath,
+        }
+        : undefined;
+
+      // The merge action may have taken minutes; destroyAll() can have killed or
+      // deleted this entry meanwhile and already emitted a terminal failure. Do
+      // not persist late execution state or complete again over that.
+      const liveEntry = this.getEntry(handle);
+      if (!liveEntry || liveEntry.completed || liveEntry.killed || entry.killed) {
+        this.cleanupLaunchWorkspace(launchWorkspacePath, executionChanges?.workspacePath);
+        return;
+      }
+
+      // Point the handle at the real gate clone before cleanup removes the launch
+      // workspace, so restored terminals (getTerminalSpec) never target a deleted
+      // directory.
+      if (executionChanges?.workspacePath) {
+        handle.workspacePath = executionChanges.workspacePath;
+      }
+      if (executionChanges?.branch) {
+        handle.branch = executionChanges.branch;
+      }
+      if (executionChanges) {
         this.host.persistence.updateTask(task.id, {
-          execution: result.taskChanges.execution,
+          execution: executionChanges,
         });
       }
+      this.cleanupLaunchWorkspace(launchWorkspacePath, executionChanges?.workspacePath);
       this.emitOutput(handle.executionId, `[merge] Merge gate action finished: ${task.id} status=${result.response.status}\n`);
       this.emitComplete(handle.executionId, this.withAttempt(entry.request, result.response));
     } catch (err) {

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -522,8 +522,13 @@ export async function runMergeGateActionImpl(
     mergeTrace('GATE_WS_GATE_CLONE_CREATED', { taskId: task.id, gateWorkspacePath });
     console.log(`[merge-gate-workspace] gate clone created task=${task.id} path=${gateWorkspacePath}`);
   } else {
-    mergeTrace('GATE_WS_GATE_CLONE_SKIPPED', { taskId: task.id, reason: 'no_feature_branch' });
-    console.log(`[merge-gate-workspace] gate clone skipped task=${task.id} (no featureBranch on workflow)`);
+    // Distinguish the two skip reasons: a caller-provided gate workspace vs a
+    // workflow with no feature branch. The label was previously hardcoded to
+    // "no_feature_branch", which misdiagnosed runs that simply reused an
+    // already-provided workspace (e.g. PR #2170's gate).
+    const skipReason = gateWorkspacePath ? 'workspace_already_provided' : 'no_feature_branch';
+    mergeTrace('GATE_WS_GATE_CLONE_SKIPPED', { taskId: task.id, reason: skipReason });
+    console.log(`[merge-gate-workspace] gate clone skipped task=${task.id} (${skipReason})`);
   }
 
   if (featureBranch && (onFinish !== 'none' || mergeMode === 'external_review')) {


### PR DESCRIPTION
## Summary

Merge gate tasks no longer get stuck. The executor now returns a launch workspace immediately and runs the real merge clone in the background.

Because launch finishes right away, a slow clone can no longer leave the task pending forever.

Teardown now reports a terminal failure for any merge still in flight, so a merge that finishes after teardown cannot leave the task running with no result.

The merge gate trace now reports the real reason it reused an existing workspace instead of a fixed placeholder.

<details>
<summary>Review metadata</summary>

Review Claim: Approve that merge gate launch and teardown always reach a terminal task state.
Review Lane: behavior
Review Unit: routing
Safety Invariant: The real merge clone still replaces the launch workspace before any result is recorded.
Slice Rationale: Merge gate executor lifecycle is one concern, separate from PR-authoring in slice 2 and repro proofs in slice 3.

</details>

## Non-goals

- Does not change how PR bodies are authored or checked.
- Does not change review-gate polling or approval behavior.

## Test Plan

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/merge-gate-executor.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for merge gate executor startup behavior and for failure reporting when executions are interrupted during an in-flight merge action.
* **Improvements**
  * Updated merge gate execution to use a safer per-task launch workspace flow, improving cleanup and reducing leftover artifacts.
  * Improved shutdown handling by marking unfinished merge executions as failed with a clear “stopped before completion” message.
  * Refined merge gate skip diagnostics to clearly differentiate “workspace already provided” vs “missing feature branch.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->