### PR TITLE
[pr-skill robustness](2) Enforce make-pr schema on review-stack PR bodies + bound authoring agents

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -6,8 +6,12 @@ import { describe, it, expect, afterEach } from 'vitest';
 
 import {
   buildCanonicalPrBody,
+  buildMakePrStackPublishPrompt,
+  parseMakePrStackPublishResult,
   resolveSkillPathViaAgent,
+  spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
+  validateReviewStackPrBody,
 } from '../pr-authoring.js';
 import type { ExecutionAgent } from '../agent.js';
 
@@ -123,6 +127,157 @@ describe('buildCanonicalPrBody', () => {
   });
 });
 
+// ── validateReviewStackPrBody ────────────────────────────
+
+// Shape of the body PR #2170 actually shipped: canonical sections + an
+// Architecture block, but none of the review-compression sections. It passes
+// the canonical validator yet must be rejected for an Invoker review stack.
+const PR_2170_COMMIT_MESSAGE_BODY = [
+  '## Summary',
+  '',
+  'Cut over recovery ownership to the explicit worker.',
+  '',
+  '## Architecture',
+  '',
+  '### Before',
+  '```mermaid',
+  'graph TD',
+  '  A["hidden hook"]',
+  '```',
+  '',
+  '### After',
+  '```mermaid',
+  'graph TD',
+  '  A["worker autofix"]',
+  '```',
+  '',
+  '## Test Plan',
+  '',
+  '- [x] `pnpm test`',
+  '',
+  '## Revert Plan',
+  '',
+  '- Safe to revert? Yes',
+].join('\n');
+
+// Canonical shape: review-compression fields live in a collapsed Review
+// metadata block inside ## Summary; Non-goals/Test Plan/Revert Plan are
+// top-level. Mirrors scripts/validate-pr-body.mjs.
+const COMPLIANT_REVIEW_STACK_BODY = [
+  '## Summary',
+  '',
+  'Plain explanation of the slice.',
+  '',
+  '<details>',
+  '<summary>Review metadata</summary>',
+  '',
+  'Review Claim: Approve the one thing this slice does.',
+  'Review Lane: cleanup',
+  'Review Unit: scalar',
+  'Safety Invariant: Why this slice is safe to review locally.',
+  'Slice Rationale: Why the work is split here.',
+  '',
+  '</details>',
+  '',
+  '## Non-goals',
+  '',
+  '- Does not change behavior.',
+  '',
+  '## Test Plan',
+  '',
+  '- [x] `pnpm test`',
+  '',
+  '## Revert Plan',
+  '',
+  '- Safe to revert? Yes',
+].join('\n');
+
+describe('validateReviewStackPrBody', () => {
+  it('rejects a commit-message body that lacks the review metadata block + Non-goals (PR #2170)', () => {
+    const errors = validateReviewStackPrBody(PR_2170_COMMIT_MESSAGE_BODY);
+    expect(errors).toContain('Missing required section: ## Non-goals');
+    expect(errors).toContain(
+      '## Summary must include a collapsed <details> block with <summary>Review metadata</summary>.',
+    );
+    // The same body passes the looser canonical validator — proving why #2170
+    // shipped: the Invoker stack path never applied the stricter schema.
+    expect(validateCanonicalPrBody(PR_2170_COMMIT_MESSAGE_BODY)).toEqual([]);
+  });
+
+  it('accepts a body carrying the full review-stack schema', () => {
+    expect(validateReviewStackPrBody(COMPLIANT_REVIEW_STACK_BODY)).toEqual([]);
+  });
+
+  it('rejects visible top-level metadata sections', () => {
+    const visible = COMPLIANT_REVIEW_STACK_BODY + '\n\n## Review Claim\n\nshould be in metadata';
+    const errors = validateReviewStackPrBody(visible);
+    expect(errors.some((e) => e.includes('## Review Claim belongs in the collapsed Review metadata block'))).toBe(true);
+  });
+
+  it('rejects a metadata block missing a required field', () => {
+    const missingUnit = COMPLIANT_REVIEW_STACK_BODY.replace('Review Unit: scalar\n', '');
+    const errors = validateReviewStackPrBody(missingUnit);
+    expect(errors).toContain('Review metadata is missing required field: Review Unit:');
+  });
+
+  it('rejects an empty body with a schema hint', () => {
+    const errors = validateReviewStackPrBody('');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Review metadata block');
+  });
+
+  it('requires real Markdown headings, not section names mentioned inline', () => {
+    // Mentions "## Non-goals" only inside prose, not as a heading line.
+    const inlineOnly = COMPLIANT_REVIEW_STACK_BODY.replace(
+      '## Non-goals\n',
+      'This PR has no `## Non-goals` to speak of.\n',
+    );
+    const errors = validateReviewStackPrBody(inlineOnly);
+    expect(errors).toContain('Missing required section: ## Non-goals');
+  });
+});
+
+// ── make-pr stack publish prompt + parsing ───────────────
+
+describe('make-pr stack publish body contract', () => {
+  it('prompt requires an explicit schema-compliant body per artifact', () => {
+    const prompt = buildMakePrStackPublishPrompt({
+      skillPath: '/skills/invoker-make-pr',
+      title: 'My stack',
+      baseBranch: 'master',
+      featureBranch: 'feature',
+      workflowSummary: 'summary',
+      cwd: '/repo',
+    });
+    expect(prompt).toContain('"body":"string"');
+    expect(prompt).toContain('artifact.body MUST be the exact PR body');
+    expect(prompt).toContain('Review metadata');
+    expect(prompt).toContain('Review Unit');
+    expect(prompt).toContain('Do NOT let Mergify default the PR body');
+  });
+
+  it('parses the body field for each artifact', () => {
+    const raw = JSON.stringify({
+      artifacts: [
+        { id: 'a', url: 'https://x/1', body: COMPLIANT_REVIEW_STACK_BODY },
+        { id: 'b', url: 'https://x/2', dependsOn: ['a'], body: COMPLIANT_REVIEW_STACK_BODY },
+      ],
+    });
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]?.body).toBe(COMPLIANT_REVIEW_STACK_BODY);
+    expect(parsed[1]?.body).toBe(COMPLIANT_REVIEW_STACK_BODY);
+  });
+
+  it('leaves body undefined when the agent omits it (caller then rejects it)', () => {
+    const raw = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed[0]?.body).toBeUndefined();
+    // The caller validates this empty body and falls through to the next agent.
+    expect(validateReviewStackPrBody(parsed[0]?.body ?? '').length).toBeGreaterThan(0);
+  });
+});
+
 // ── resolveSkillPathViaAgent ─────────────────────────────
 
 describe('resolveSkillPathViaAgent', () => {
@@ -164,5 +319,38 @@ describe('resolveSkillPathViaAgent', () => {
     const agent = makeAgent('claude', { bundledSkillRoot: tmpDir });
     const result = resolveSkillPathViaAgent(agent, 'make-pr');
     expect(result).toBe(skillDir);
+  });
+});
+
+// ── spawnAgentPrAuthorViaRegistry ───────────────────────
+
+describe('spawnAgentPrAuthorViaRegistry', () => {
+  it('times out and rejects when the PR-authoring agent never exits', async () => {
+    const tmpDir = createTempDir();
+    const previousTimeout = process.env.INVOKER_PR_AUTHORING_TIMEOUT_MS;
+    process.env.INVOKER_PR_AUTHORING_TIMEOUT_MS = '25';
+
+    const agent: ExecutionAgent = {
+      name: 'codex',
+      stdinMode: 'ignore',
+      buildCommand: () => ({
+        cmd: process.execPath,
+        args: ['-e', 'setInterval(() => {}, 1000)'],
+        sessionId: 'hung-pr-author',
+      }),
+      buildResumeArgs: () => ({ cmd: process.execPath, args: ['-e', ''] }),
+    };
+
+    try {
+      await expect(
+        spawnAgentPrAuthorViaRegistry('publish stack', tmpDir, agent),
+      ).rejects.toThrow(/codex PR authoring exceeded timeout \(25ms\)/);
+    } finally {
+      if (previousTimeout === undefined) {
+        delete process.env.INVOKER_PR_AUTHORING_TIMEOUT_MS;
+      } else {
+        process.env.INVOKER_PR_AUTHORING_TIMEOUT_MS = previousTimeout;
+      }
+    }
   });
 });

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1237,7 +1237,7 @@ describe('TaskRunner', () => {
             attempts.push('codex');
             return {
               cmd: 'node',
-              args: ['-e', 'process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master"},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"]}]}))'],
+              args: ['-e', 'var b=["## Summary","","Slice prose.","","<details>","<summary>Review metadata</summary>","","Review Claim: c","Review Lane: cleanup","Review Unit: scalar","Safety Invariant: s","Slice Rationale: r","","</details>","","## Non-goals","- none","","## Test Plan","- [x] pnpm test","","## Revert Plan","- Safe to revert? Yes"].join("\\n");process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master",body:b},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"],body:b}]}))'],
               sessionId: 'sess-codex',
             };
           },
@@ -1340,6 +1340,94 @@ describe('TaskRunner', () => {
         workflowSummary: 'summary',
         cwd: '/tmp',
       })).rejects.toThrow('make-pr skill is required to publish Invoker review stacks');
+    });
+
+    it('publishReviewStackWithMakePrSkill rejects a commit-message body lacking review-compression sections (PR #2170 regression)', async () => {
+      // Valid artifact JSON + valid linear stack, but the body is a bare
+      // commit-message body (## Summary / ## Test Plan / ## Revert Plan only,
+      // no review-compression sections) — exactly what PR #2170 shipped.
+      const commitMsgBodyAgent = {
+        name: 'claude',
+        stdinMode: 'ignore' as const,
+        bundledSkills: ['make-pr'],
+        buildCommand: () => ({
+          cmd: 'node',
+          args: ['-e', 'var b="## Summary x ## Test Plan y ## Revert Plan z";process.stdout.write(JSON.stringify({artifacts:[{id:"only",title:"Only",url:"https://example.test/pr/1",providerId:"1",branch:"stack/only",baseBranch:"master",body:b}]}))'],
+          sessionId: 'commit-msg',
+        }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      // A bare commit-message body: no ## Non-goals, no collapsed Review metadata block.
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: vi.fn().mockReturnValue(commitMsgBodyAgent),
+          getOrThrow: vi.fn(),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([commitMsgBodyAgent]),
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await expect((executor as any).publishReviewStackWithMakePrSkill({
+        workflowId: 'wf-1',
+        title: 'Stack',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        workflowSummary: 'summary',
+        cwd: '/tmp',
+      })).rejects.toThrow(/invalid PR body — .*Non-goals/);
+    });
+
+    it('publishReviewStackWithMakePrSkill validates the published body, not just the agent-reported one', async () => {
+      // Agent reports a fully compliant body in JSON...
+      const goodBody = [
+        '## Summary', '', 'x', '', '<details>', '<summary>Review metadata</summary>', '',
+        'Review Claim: c', 'Review Lane: cleanup', 'Review Unit: scalar',
+        'Safety Invariant: s', 'Slice Rationale: r', '', '</details>', '',
+        '## Non-goals', '- none', '', '## Test Plan', '- [x] t', '', '## Revert Plan', '- yes',
+      ].join('\n');
+      const agent = {
+        name: 'claude',
+        stdinMode: 'ignore' as const,
+        bundledSkills: ['make-pr'],
+        buildCommand: () => ({
+          cmd: 'node',
+          args: ['-e', `var b=${JSON.stringify(goodBody)};process.stdout.write(JSON.stringify({artifacts:[{id:"only",title:"Only",url:"https://example.test/pr/1",providerId:"1",branch:"stack/only",baseBranch:"master",body:b}]}))`],
+          sessionId: 'good',
+        }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: vi.fn().mockReturnValue(agent),
+          getOrThrow: vi.fn(),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([agent]),
+        } as any,
+        // ...but the body actually published on GitHub is a bare commit message.
+        mergeGateProvider: {
+          name: 'github',
+          createReview: vi.fn(),
+          checkApproval: vi.fn(),
+          getReviewBody: vi.fn().mockResolvedValue('Just a commit message subject\n\nsome body line'),
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await expect((executor as any).publishReviewStackWithMakePrSkill({
+        workflowId: 'wf-1',
+        title: 'Stack',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        workflowSummary: 'summary',
+        cwd: '/tmp',
+      })).rejects.toThrow(/invalid PR body — .*\[published\]/);
     });
 
     it('authorPrBodyWithSkill falls back to canonical body when authored body is invalid and no other agents available', async () => {

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -79,6 +79,19 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     ], cwd));
   }
 
+  async getReviewBody(opts: {
+    identifier: string;
+    cwd: string;
+  }): Promise<string> {
+    const { identifier, cwd } = opts;
+    const targetRepo = await this.resolveTargetRepo(cwd);
+    const stdout = await retryTransientGitHubCli(() => this.exec('gh', [
+      'api', `repos/${targetRepo}/pulls/${identifier}`,
+      '--jq', '.body',
+    ], cwd));
+    return stdout.trim();
+  }
+
   async checkApproval(opts: {
     identifier: string;
     cwd: string;

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -67,4 +67,7 @@ export interface MergeGateProvider {
   checkApproval(opts: MergeGateCheckApprovalOptions): Promise<MergeGateApprovalStatus>;
 
   closeReview?(opts: MergeGateCloseReviewOptions): Promise<void>;
+
+  /** Read the live PR body as published on the provider (e.g. GitHub). */
+  getReviewBody?(opts: { identifier: string; cwd: string }): Promise<string>;
 }

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -6,7 +6,7 @@ import { homedir, tmpdir } from 'node:os';
 
 import type { ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
-import { cleanElectronEnv, resolveExecutableOnCurrentPath } from './process-utils.js';
+import { cleanElectronEnv, killProcessGroup, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 
 export interface MakePrStackArtifactOutput {
   readonly id: string;
@@ -16,6 +16,8 @@ export interface MakePrStackArtifactOutput {
   readonly branch?: string;
   readonly baseBranch?: string;
   readonly dependsOn?: readonly string[];
+  /** Published PR body. Validated against the make-pr review-stack schema. */
+  readonly body?: string;
 }
 
 // ── Structured PR-authoring context ──────────────────────
@@ -49,8 +51,34 @@ export interface PrAuthoringContext {
 }
 
 const REQUIRED_SECTIONS = ['## Summary', '## Test Plan', '## Revert Plan'] as const;
+// Canonical review-stack schema, mirrored structurally from
+// scripts/validate-pr-body.mjs — the authoritative validator the make-pr skill
+// runs. The review-compression fields live INSIDE a collapsed
+// <details>Review metadata</details> block in ## Summary, not as visible
+// top-level sections, so a bare commit-message body (e.g. PR #2170) is rejected.
+const REVIEW_STACK_REQUIRED_SECTIONS = [
+  '## Summary',
+  '## Non-goals',
+  '## Test Plan',
+  '## Revert Plan',
+] as const;
+const REVIEW_STACK_VISIBLE_METADATA_SECTIONS = [
+  '## Review Claim',
+  '## Review Lane',
+  '## Review Unit',
+  '## Safety Invariant',
+  '## Slice Rationale',
+] as const;
+const REVIEW_STACK_METADATA_LABELS = [
+  'Review Claim',
+  'Review Lane',
+  'Review Unit',
+  'Safety Invariant',
+  'Slice Rationale',
+] as const;
 const DISCOURAGED_HEADINGS = ['## Testing', '## Notes'] as const;
 const DEFAULT_MAX_INLINE_PROMPT_BYTES = 64 * 1024;
+const DEFAULT_PR_AUTHORING_TIMEOUT_MS = 20 * 60 * 1000;
 const MAX_INLINE_PROMPT_BYTES = (() => {
   const raw = process.env.INVOKER_MAX_INLINE_AGENT_PROMPT_BYTES;
   if (!raw) return DEFAULT_MAX_INLINE_PROMPT_BYTES;
@@ -58,34 +86,155 @@ const MAX_INLINE_PROMPT_BYTES = (() => {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_INLINE_PROMPT_BYTES;
 })();
 
-export function validateCanonicalPrBody(body: string): string[] {
+function getPrAuthoringTimeoutMs(): number {
+  const raw = process.env.INVOKER_PR_AUTHORING_TIMEOUT_MS?.trim();
+  if (raw === '0') return 0;
+  if (!raw) return DEFAULT_PR_AUTHORING_TIMEOUT_MS;
+  // Validate the whole string: Number.parseInt would silently accept a numeric
+  // prefix, turning "20m" into 20ms and failing authoring almost immediately.
+  if (!/^(0|[1-9]\d*)$/.test(raw)) return DEFAULT_PR_AUTHORING_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) return DEFAULT_PR_AUTHORING_TIMEOUT_MS;
+  return parsed;
+}
+
+/** True when `heading` appears as a real Markdown heading line, not as prose/code text. */
+function hasMarkdownHeading(body: string, heading: string): boolean {
+  const expected = heading.trim().toLowerCase();
+  return body.split(/\r?\n/).some((line) => line.trim().toLowerCase() === expected);
+}
+
+function validateBodyAgainstSections(
+  body: string,
+  requiredSections: readonly string[],
+  emptyMessage: string,
+): string[] {
   const errors: string[] = [];
   const trimmed = body.trim();
 
   if (!trimmed) {
-    return [
-      'PR body is empty. Use the canonical schema: ## Summary, ## Test Plan, ## Revert Plan, plus optional ## Architecture.',
-    ];
+    return [emptyMessage];
   }
 
-  for (const heading of REQUIRED_SECTIONS) {
-    if (!trimmed.includes(heading)) {
+  for (const heading of requiredSections) {
+    if (!hasMarkdownHeading(trimmed, heading)) {
       errors.push(`Missing required section: ${heading}`);
     }
   }
 
   for (const heading of DISCOURAGED_HEADINGS) {
-    if (trimmed.includes(heading)) {
+    if (hasMarkdownHeading(trimmed, heading)) {
       errors.push(
         `Unsupported section: ${heading}. Do not use the lightweight PR format; use ## Test Plan and ## Revert Plan instead.`,
       );
     }
   }
 
-  if (trimmed.includes('## Architecture')) {
+  if (hasMarkdownHeading(trimmed, '## Architecture')) {
     for (const subsection of ['### Before', '### After']) {
-      if (!trimmed.includes(subsection)) {
+      if (!hasMarkdownHeading(trimmed, subsection)) {
         errors.push(`Architecture section is missing required subsection: ${subsection}`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+export function validateCanonicalPrBody(body: string): string[] {
+  return validateBodyAgainstSections(
+    body,
+    REQUIRED_SECTIONS,
+    'PR body is empty. Use the canonical schema: ## Summary, ## Test Plan, ## Revert Plan, plus optional ## Architecture.',
+  );
+}
+
+/** Collect the lines under a `## Heading` until the next `## ` heading. */
+function getMarkdownSection(body: string, heading: string): string {
+  const lines = body.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim().toLowerCase() === heading.toLowerCase());
+  if (start === -1) return '';
+  const out: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^##\s+/.test(line.trim())) break;
+    out.push(line);
+  }
+  return out.join('\n').trim();
+}
+
+/** Extract the collapsed `<details><summary>Review metadata</summary>` block from ## Summary. */
+function getReviewMetadataBlock(body: string): { body: string; openAttributes: string } | null {
+  const summary = getMarkdownSection(body, '## Summary');
+  const match = summary.match(
+    /<details\b([^>]*)>\s*<summary>\s*Review metadata\s*<\/summary>([\s\S]*?)<\/details>/i,
+  );
+  if (!match) return null;
+  return { body: match[2].trim(), openAttributes: match[1] };
+}
+
+/** True when the metadata block carries a non-empty `Label:` field. */
+function hasMetadataLabel(metadata: string, label: string): boolean {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(^|\\n)\\s*${escaped}:\\s*\\S`, 'i').test(metadata);
+}
+
+/**
+ * Validate a published Invoker review-stack PR body. This mirrors the structural
+ * checks in scripts/validate-pr-body.mjs (the authoritative validator the make-pr
+ * skill is told to run): required top-level sections, no visible metadata
+ * sections, and a collapsed Review metadata block carrying every required field.
+ * A mergify-default commit-message body cannot pass. The deeper review-unit and
+ * mermaid rules stay in validate-pr-body.mjs; this is the in-process backstop.
+ */
+export function validateReviewStackPrBody(body: string): string[] {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return [
+      'PR body is empty. Use the canonical review-stack schema: ## Summary with a collapsed '
+        + 'Review metadata block, ## Non-goals, ## Test Plan, and ## Revert Plan.',
+    ];
+  }
+
+  const errors: string[] = [];
+  for (const heading of REVIEW_STACK_REQUIRED_SECTIONS) {
+    if (!hasMarkdownHeading(trimmed, heading)) {
+      errors.push(`Missing required section: ${heading}`);
+    }
+  }
+  for (const heading of REVIEW_STACK_VISIBLE_METADATA_SECTIONS) {
+    if (hasMarkdownHeading(trimmed, heading)) {
+      errors.push(
+        `${heading} belongs in the collapsed Review metadata block inside ## Summary, `
+          + 'not as a visible top-level section.',
+      );
+    }
+  }
+  for (const heading of DISCOURAGED_HEADINGS) {
+    if (hasMarkdownHeading(trimmed, heading)) {
+      errors.push(
+        `Unsupported section: ${heading}. Do not use the lightweight PR format; `
+          + 'use the canonical review-compression schema instead.',
+      );
+    }
+  }
+  if (hasMarkdownHeading(trimmed, '## Architecture')) {
+    for (const subsection of ['### Before', '### After']) {
+      if (!hasMarkdownHeading(trimmed, subsection)) {
+        errors.push(`Architecture section is missing required subsection: ${subsection}`);
+      }
+    }
+  }
+
+  const metadata = getReviewMetadataBlock(trimmed);
+  if (!metadata) {
+    errors.push('## Summary must include a collapsed <details> block with <summary>Review metadata</summary>.');
+  } else {
+    if (/\bopen\b/i.test(metadata.openAttributes)) {
+      errors.push('Review metadata details must be collapsed by default; remove the open attribute.');
+    }
+    for (const label of REVIEW_STACK_METADATA_LABELS) {
+      if (!hasMetadataLabel(metadata.body, label)) {
+        errors.push(`Review metadata is missing required field: ${label}:`);
       }
     }
   }
@@ -197,13 +346,20 @@ export function buildMakePrStackPublishPrompt(args: {
     '- Use the repo-local PR workflow and validation tools from the skill.',
     '- Output only JSON. Do not include markdown, commentary, explanations, or code fences.',
     '- The JSON shape must be exactly:',
-    '{"artifacts":[{"id":"string","title":"string","url":"string","providerId":"string","branch":"string","baseBranch":"string","dependsOn":["string"]}]}',
+    '{"artifacts":[{"id":"string","title":"string","url":"string","providerId":"string","branch":"string","baseBranch":"string","dependsOn":["string"],"body":"string"}]}',
     '- artifacts are already listed in stack order.',
     '- artifacts[0].dependsOn must be omitted or [].',
     '- For every i > 0, artifacts[i].dependsOn must be exactly [artifacts[i - 1].id].',
     '- Do not emit branches, merges, skipped predecessors, or multiple dependencies.',
     '- Do not add fixed PR-count fields.',
     '- Do not add Mergify-specific fields to the JSON.',
+    '- Each artifact.body MUST be the exact PR body you published for that PR.',
+    '- Each body MUST follow the canonical review-stack schema and pass '
+      + '`node scripts/validate-pr-body.mjs`. Required: ## Summary containing a collapsed '
+      + '<details><summary>Review metadata</summary> block with Review Claim, Review Lane, '
+      + 'Review Unit, Safety Invariant, and Slice Rationale fields; plus top-level ## Non-goals, '
+      + '## Test Plan, and ## Revert Plan. Do not use visible ## Review Claim / ## Review Lane sections.',
+    '- Do NOT let Mergify default the PR body to the commit message; author the body explicitly.',
     '',
     'Workflow summary:',
     '```md',
@@ -275,6 +431,7 @@ export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactO
       branch: typeof record.branch === 'string' ? record.branch : undefined,
       baseBranch: typeof record.baseBranch === 'string' ? record.baseBranch : undefined,
       dependsOn: normalizedDependsOn,
+      body: typeof record.body === 'string' ? record.body : undefined,
     });
   }
 
@@ -438,28 +595,72 @@ export function spawnAgentPrAuthorViaRegistry(
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: cleanElectronEnv(),
+      detached: process.platform !== 'win32',
     });
 
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    let timedOut = false;
+    let timeoutError: Error | undefined;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let forceKillTimeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutMs = getPrAuthoringTimeoutMs();
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
+      promptTransport.cleanup();
+      fn();
+    };
+
+    if (timeoutMs > 0) {
+      timeout = setTimeout(() => {
+        if (settled || timedOut) return;
+        timedOut = true;
+        timeoutError = new Error(
+          `${agent.name} PR authoring exceeded timeout (${timeoutMs}ms) in ${cwd}. ` +
+          'Set INVOKER_PR_AUTHORING_TIMEOUT_MS to adjust (0 = unbounded).',
+        );
+        if (timeout) clearTimeout(timeout);
+        killProcessGroup(child, 'SIGTERM');
+        // Reject only after the process is forcibly killed, so the caller cannot
+        // launch the next make-pr agent while this one may still be mutating PRs.
+        forceKillTimeout = setTimeout(() => {
+          killProcessGroup(child, 'SIGKILL');
+          finish(() => reject(timeoutError!));
+        }, SIGKILL_TIMEOUT_MS);
+        forceKillTimeout.unref?.();
+      }, timeoutMs);
+      timeout.unref?.();
+    }
+
     child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
     child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
     child.on('close', (code) => {
-      const realId = driver?.extractSessionId?.(stdout);
-      const effectiveSessionId = realId ?? sessionId;
-      const displayStdout = driver ? driver.processOutput(effectiveSessionId, stdout) : stdout;
-      if (code === 0) {
-        const body = extractAssistantBody(driver, effectiveSessionId, displayStdout);
-        promptTransport.cleanup();
-        resolve({ body, stdout: displayStdout, sessionId: effectiveSessionId });
+      if (settled) return;
+      // The timed-out process exited on SIGTERM before the SIGKILL timer fired;
+      // it is already gone, so settle with the timeout error now.
+      if (timedOut) {
+        finish(() => reject(timeoutError!));
         return;
       }
-      promptTransport.cleanup();
-      reject(new Error(`${agent.name} PR authoring exited with code ${code}: ${stderr.trim()}`));
+      finish(() => {
+        const realId = driver?.extractSessionId?.(stdout);
+        const effectiveSessionId = realId ?? sessionId;
+        const displayStdout = driver ? driver.processOutput(effectiveSessionId, stdout) : stdout;
+        if (code === 0) {
+          const body = extractAssistantBody(driver, effectiveSessionId, displayStdout);
+          resolve({ body, stdout: displayStdout, sessionId: effectiveSessionId });
+          return;
+        }
+        reject(new Error(`${agent.name} PR authoring exited with code ${code}: ${stderr.trim()}`));
+      });
     });
     child.on('error', (err) => {
-      promptTransport.cleanup();
-      reject(err);
+      finish(() => reject(err));
     });
   });
 }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -59,6 +59,7 @@ import {
   resolveSkillPathViaAgent,
   spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
+  validateReviewStackPrBody,
   type PrAuthoringContext,
 } from './pr-authoring.js';
 import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
@@ -2732,14 +2733,23 @@ export class TaskRunner {
       });
 
       try {
+        this.logger.info(
+          `[pr-authoring] body authoring starting agent=${agent.name} `
+            + `workflow=${args.workflowId ?? 'unknown'} skill=invoker-make-pr`,
+        );
         const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
         const validationErrors = validateCanonicalPrBody(result.body);
         if (validationErrors.length > 0) {
+          this.logger.warn(
+            `[pr-authoring] body validation failed agent=${agent.name} `
+              + `errors=${validationErrors.join('; ')}`,
+          );
           errors.push(
             `${agent.name}: invalid PR body — ${validationErrors.join('; ')}`,
           );
           continue;
         }
+        this.logger.info(`[pr-authoring] body authored agent=${agent.name} validated`);
         return { body: result.body, sessionId: result.sessionId, agentName: agent.name };
       } catch (err) {
         errors.push(
@@ -2798,11 +2808,54 @@ export class TaskRunner {
       });
 
       try {
+        this.logger.info(
+          `[pr-authoring] review-stack publish starting agent=${agent.name} `
+            + `workflow=${args.workflowId ?? 'unknown'} skill=invoker-make-pr cwd=${args.cwd}`,
+        );
         const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
         const parsedArtifacts = parseMakePrStackPublishResult(result.body);
+
+        // Enforce the make-pr review-stack schema on every published body. Prefer
+        // the body actually published on the provider: a lazy agent could report a
+        // compliant body in JSON while letting Mergify default the real PR to the
+        // commit message — the exact PR #2170 failure. Fall back to the
+        // agent-reported body only when the live body cannot be read.
+        const bodyErrors: string[] = [];
+        for (let index = 0; index < parsedArtifacts.length; index += 1) {
+          const artifact = parsedArtifacts[index];
+          let bodyToCheck = artifact.body ?? '';
+          let bodySource = 'agent-reported';
+          if (this.mergeGateProvider?.getReviewBody && artifact.providerId) {
+            try {
+              bodyToCheck = await this.mergeGateProvider.getReviewBody({
+                identifier: artifact.providerId,
+                cwd: args.cwd,
+              });
+              bodySource = 'published';
+            } catch (fetchErr) {
+              this.logger.warn(
+                `[pr-authoring] could not read published body for PR ${artifact.providerId}; `
+                  + `validating agent-reported body instead: `
+                  + `${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}`,
+              );
+            }
+          }
+          for (const error of validateReviewStackPrBody(bodyToCheck)) {
+            bodyErrors.push(`artifact[${index}] (${artifact.url}) [${bodySource}]: ${error}`);
+          }
+        }
+        if (bodyErrors.length > 0) {
+          this.logger.warn(
+            `[pr-authoring] review-stack body validation failed agent=${agent.name} `
+              + `errors=${bodyErrors.join('; ')}`,
+          );
+          errors.push(`${agent.name}: invalid PR body — ${bodyErrors.join('; ')}`);
+          continue;
+        }
+
         const nowIso = new Date().toISOString();
         const generation = args.reviewGate?.activeGeneration ?? 0;
-        const artifacts: ReviewGateArtifact[] = parsedArtifacts.map((artifact) => ({
+        const artifacts: ReviewGateArtifact[] = parsedArtifacts.map(({ body: _body, ...artifact }) => ({
           ...artifact,
           provider: 'github',
           baseBranch: artifact.baseBranch ?? args.baseBranch,
@@ -2811,6 +2864,10 @@ export class TaskRunner {
           generation,
           createdAt: nowIso,
         }));
+        this.logger.info(
+          `[pr-authoring] review-stack published agent=${agent.name} artifacts=${artifacts.length} `
+            + 'bodies validated against make-pr schema',
+        );
         return { artifacts, sessionId: result.sessionId, agentName: agent.name };
       } catch (err) {
         errors.push(`${agent.name}: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Summary

PR authoring can no longer hang or publish an unreviewed pull request body.

A runaway make-pr agent is now bounded by a timeout, so a stuck authoring run fails its task instead of heartbeating forever.

Every published Invoker review-stack pull request body is now checked before the gate accepts it, so a mergify-default commit-message body is refused.

Both authoring paths now emit decision log lines so an operator can see which agent authored each pull request.

<details>
<summary>Review metadata</summary>

Review Claim: Approve that PR authoring bounds runaway agents and refuses an unreviewed pull request body.
Review Lane: behavior
Review Unit: routing
Safety Invariant: A compliant authoring run still publishes exactly as before; only hung runs and bare bodies change outcome.
Slice Rationale: PR-authoring robustness is one concern, separate from the merge gate executor in slice 1 and repro proofs in slice 3.

</details>

## Non-goals

- Does not change the merge gate executor lifecycle.
- Does not change review-gate polling or approval behavior.

## Test Plan

- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/pr-authoring.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added robust timeout handling for PR authoring, including graceful termination followed by forced kill if needed.
  * Strengthened review-stack PR body validation, including enforcing a collapsed “Review metadata” block and required review fields.
  * Updated stack publishing to validate the actual published PR body per artifact (falling back to agent output if fetching fails).

* **Tests**
  * Expanded validation tests for review-stack schema compliance and improved error cases.
  * Added regression tests for the stack publish body contract and timeout behavior.

* **Documentation**
  * None.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2210