### PR TITLE
[pr-skill robustness](3) Repro scripts for merge-gate and PR-authoring failures

### DIFF
--- a/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192500131-3.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192500131-3.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="__merge__wf-1782192500131-3"
+SOURCE="$ROOT/packages/execution-engine/src/merge-gate-executor.ts"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: merge gate worktree creation ran inside executor.start(), before task.running"
+
+python3 - "$SOURCE" <<'PY'
+import pathlib
+import re
+import sys
+
+source_path = pathlib.Path(sys.argv[1])
+source = source_path.read_text(encoding="utf-8")
+task_id = "__merge__wf-1782192500131-3"
+
+class Task:
+    def __init__(self):
+        self.status = "pending"
+        self.phase = "launching"
+        self.launch_completed_at = None
+        self.running_counted_by_dispatch = True
+        self.real_merge_clone_blocked = True
+
+def pre_fix_start(task: Task) -> bool:
+    # Before the fix, MergeGateExecutor.start awaited createMergeWorktree().
+    # If the clone/fetch path blocked, start() never returned a handle.
+    if task.real_merge_clone_blocked:
+        return False
+    return True
+
+def post_fix_start(task: Task) -> bool:
+    # After the fix, start() creates only a lightweight launch directory and
+    # schedules real merge work asynchronously.
+    return True
+
+def task_runner_launch(task: Task, start_returns: bool) -> None:
+    if not start_returns:
+        return
+    task.status = "running"
+    task.phase = "executing"
+    task.launch_completed_at = "2026-06-23T06:02:27.000Z"
+
+pre = Task()
+task_runner_launch(pre, pre_fix_start(pre))
+assert pre.running_counted_by_dispatch
+assert pre.status == "pending"
+assert pre.phase == "launching"
+assert pre.launch_completed_at is None
+
+post = Task()
+task_runner_launch(post, post_fix_start(post))
+assert post.status == "running"
+assert post.phase == "executing"
+assert post.launch_completed_at is not None
+
+start_match = re.search(r"async start\(request: WorkRequest\): Promise<ExecutorHandle> \{(?P<body>.*?)\n  async kill", source, re.S)
+if not start_match:
+    raise SystemExit("could not locate MergeGateExecutor.start()")
+start_body = start_match.group("body")
+
+required_needles = [
+    "const launchWorkspacePath = this.createLaunchWorkspace(task.id);",
+    "handle.workspacePath = launchWorkspacePath;",
+    "void this.run(handle, task, launchWorkspacePath);",
+    "const result = await runMergeGateActionImpl(this.host, task);",
+    "workspacePath: result.taskChanges.execution.workspacePath ?? launchWorkspacePath",
+]
+missing = [needle for needle in required_needles if needle not in source]
+if missing:
+    raise SystemExit("fixed merge launch handoff source invariant missing: " + ", ".join(missing))
+
+if "await this.host.createMergeWorktree" in start_body or "await this.host.detectDefaultBranch" in start_body:
+    raise SystemExit("MergeGateExecutor.start() still performs blocking merge setup before launch completion")
+
+print("[repro] pre-fix model: dispatch counted running while task stayed pending/launching with no launchCompletedAt")
+print("[repro] post-fix model: start returns a handle, allowing TaskRunner to mark the task running")
+print("[repro] source check: blocking merge worktree creation is outside MergeGateExecutor.start()")
+PY
+
+echo "[repro] passed"

--- a/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192502908-14.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192502908-14.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="__merge__wf-1782192502908-14"
+SOURCE="$ROOT/packages/execution-engine/src/merge-gate-executor.ts"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: MergeGateExecutor.start() performed managed merge clone setup before returning a launch handle"
+
+python3 - "$SOURCE" <<'PY'
+import pathlib
+import re
+import sys
+
+source_path = pathlib.Path(sys.argv[1])
+source = source_path.read_text(encoding="utf-8")
+task_id = "__merge__wf-1782192502908-14"
+
+class Task:
+    def __init__(self):
+        self.status = "pending"
+        self.phase = "launching"
+        self.launch_completed_at = None
+        self.dispatch_state = "leased"
+        self.real_merge_clone_blocked = True
+
+def pre_fix_start(task: Task) -> bool:
+    # Before the fix, MergeGateExecutor.start awaited createMergeWorktree().
+    # A slow clone/fetch path meant no handle was returned to TaskRunner.
+    if task.real_merge_clone_blocked:
+        return False
+    return True
+
+def post_fix_start(task: Task) -> bool:
+    # After the fix, start() creates only a lightweight launch directory and
+    # schedules the managed merge clone asynchronously.
+    return True
+
+def task_runner_launch(task: Task, start_returns: bool) -> None:
+    if not start_returns:
+        return
+    task.status = "running"
+    task.phase = "executing"
+    task.launch_completed_at = "2026-06-23T07:04:36.475Z"
+
+pre = Task()
+task_runner_launch(pre, pre_fix_start(pre))
+assert pre.dispatch_state == "leased"
+assert pre.status == "pending"
+assert pre.phase == "launching"
+assert pre.launch_completed_at is None
+
+post = Task()
+task_runner_launch(post, post_fix_start(post))
+assert post.status == "running"
+assert post.phase == "executing"
+assert post.launch_completed_at is not None
+
+start_match = re.search(r"async start\(request: WorkRequest\): Promise<ExecutorHandle> \{(?P<body>.*?)\n  async kill", source, re.S)
+if not start_match:
+    raise SystemExit("could not locate MergeGateExecutor.start()")
+start_body = start_match.group("body")
+
+required_needles = [
+    "const launchWorkspacePath = this.createLaunchWorkspace(task.id);",
+    "handle.workspacePath = launchWorkspacePath;",
+    "void this.run(handle, task, launchWorkspacePath);",
+    "const result = await runMergeGateActionImpl(this.host, task);",
+    "workspacePath: result.taskChanges.execution.workspacePath ?? launchWorkspacePath",
+]
+missing = [needle for needle in required_needles if needle not in source]
+if missing:
+    raise SystemExit("fixed merge launch handoff source invariant missing: " + ", ".join(missing))
+
+if "await this.host.createMergeWorktree" in start_body or "await this.host.detectDefaultBranch" in start_body:
+    raise SystemExit("MergeGateExecutor.start() still performs blocking merge setup before launch completion")
+
+print("[repro] pre-fix model: dispatch was leased while the task stayed pending/launching with no launchCompletedAt")
+print("[repro] post-fix model: start returns a handle, so TaskRunner can mark the task running")
+print("[repro] source check: blocking managed merge clone setup is outside MergeGateExecutor.start()")
+PY
+
+pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/merge-gate-executor.test.ts
+
+echo "[repro] passed"

--- a/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192504872-23.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192504872-23.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="__merge__wf-1782192504872-23"
+SOURCE="$ROOT/packages/execution-engine/src/pr-authoring.ts"
+TEST_SOURCE="$ROOT/packages/execution-engine/src/__tests__/pr-authoring.test.ts"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: external-review make-pr agent publication had no timeout, so the processless merge executor could heartbeat forever after task.running"
+
+python3 - "$SOURCE" "$TEST_SOURCE" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+test_source = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+
+class MergeTask:
+    def __init__(self):
+        self.status = "running"
+        self.phase = "executing"
+        self.launch_completed_at = "2026-06-23T08:45:42.355Z"
+        self.executor_selected = True
+        self.heartbeats = 30
+        self.review_ready = False
+        self.completed = False
+        self.failed = False
+
+def pre_fix_publish_make_pr(task: MergeTask) -> str:
+    # Before the fix, spawnAgentPrAuthorViaRegistry waited only for child close.
+    # A hung make-pr agent left runMergeGateActionImpl unresolved while the
+    # processless MergeGateExecutor heartbeat timer kept the task alive.
+    return "pending-forever"
+
+def post_fix_publish_make_pr(task: MergeTask) -> str:
+    task.failed = True
+    return "timeout-failed"
+
+pre = MergeTask()
+assert pre_fix_publish_make_pr(pre) == "pending-forever"
+assert pre.status == "running"
+assert pre.phase == "executing"
+assert pre.launch_completed_at is not None
+assert pre.executor_selected
+assert pre.heartbeats > 0
+assert not pre.review_ready and not pre.completed and not pre.failed
+
+post = MergeTask()
+assert post_fix_publish_make_pr(post) == "timeout-failed"
+assert post.failed
+
+required_source = [
+    "DEFAULT_PR_AUTHORING_TIMEOUT_MS",
+    "INVOKER_PR_AUTHORING_TIMEOUT_MS",
+    "killProcessGroup(child, 'SIGTERM')",
+    "killProcessGroup(child, 'SIGKILL')",
+    "detached: process.platform !== 'win32'",
+    "PR authoring exceeded timeout",
+]
+missing = [needle for needle in required_source if needle not in source]
+if missing:
+    raise SystemExit("fixed PR-authoring timeout invariant missing: " + ", ".join(missing))
+
+if "times out and rejects when the PR-authoring agent never exits" not in test_source:
+    raise SystemExit("focused hung PR-authoring regression test is missing")
+
+print("[repro] pre-fix model: task is running/executing with launchCompletedAt, but make-pr publication never resolves")
+print("[repro] post-fix model: hung make-pr publication rejects, allowing the merge executor to complete failed")
+print("[repro] source check: PR-authoring child processes are now bounded and killed on timeout")
+PY
+
+pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-authoring.test.ts -t 'times out and rejects when the PR-authoring agent never exits'
+
+echo "[repro] passed"

--- a/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192505728-27.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192505728-27.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="__merge__wf-1782192505728-27"
+SOURCE="$ROOT/packages/execution-engine/src/merge-gate-executor.ts"
+TEST_SOURCE="$ROOT/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: processless merge executor destroyAll() dropped the active completion listener"
+
+python3 - "$SOURCE" "$TEST_SOURCE" <<'PY'
+import pathlib
+import re
+import sys
+
+source_path = pathlib.Path(sys.argv[1])
+test_path = pathlib.Path(sys.argv[2])
+source = source_path.read_text(encoding="utf-8")
+test_source = test_path.read_text(encoding="utf-8")
+
+task_id = "__merge__wf-1782192505728-27"
+
+class MergeEntry:
+    def __init__(self):
+        self.completed = False
+        self.listeners = [lambda response: responses.append(response)]
+
+responses = []
+
+def emit_complete(entry, response: dict) -> None:
+    if entry is None or entry.completed:
+        return
+    entry.completed = True
+    for listener in entry.listeners:
+        listener(response)
+
+def pre_fix_destroy_all(entries: dict[str, MergeEntry]) -> None:
+    # Before the fix, MergeGateExecutor.destroyAll() cleared entries without a
+    # terminal response. The async merge action could later finish, but
+    # emitComplete() had no entry/listener to notify.
+    entries.clear()
+
+def post_fix_destroy_all(entries: dict[str, MergeEntry]) -> None:
+    for execution_id, entry in list(entries.items()):
+        if not entry.completed:
+            emit_complete(entry, {
+                "status": "failed",
+                "error": "Merge gate execution was stopped before completion",
+            })
+        entries.pop(execution_id, None)
+
+pre_entries = {"exec": MergeEntry()}
+pre_fix_destroy_all(pre_entries)
+emit_complete(pre_entries.get("exec"), {"status": "review_ready"})
+assert responses == [], "pre-fix model should drop the terminal merge completion"
+
+post_entries = {"exec": MergeEntry()}
+post_fix_destroy_all(post_entries)
+emit_complete(post_entries.get("exec"), {"status": "review_ready"})
+assert responses == [{
+    "status": "failed",
+    "error": "Merge gate execution was stopped before completion",
+}], "fixed model should terminally fail exactly once"
+
+destroy_match = re.search(r"async destroyAll\(\): Promise<void> \{(?P<body>.*?)\n  \}", source, re.S)
+if not destroy_match:
+    raise SystemExit("could not locate MergeGateExecutor.destroyAll()")
+destroy_body = destroy_match.group("body")
+
+required_source = [
+    "entry.killed = true;",
+    "this.emitComplete(executionId, {",
+    "Merge gate execution was stopped before completion",
+]
+missing = [needle for needle in required_source if needle not in destroy_body]
+if missing:
+    raise SystemExit("fixed destroyAll terminal response invariant missing: " + ", ".join(missing))
+
+if "emits a terminal failure when destroyed while a merge action is in flight" not in test_source:
+    raise SystemExit("focused merge executor destroyAll regression test is missing")
+
+print("[repro] pre-fix model: merge action can finish after destroyAll with no entry/listener, leaving task running")
+print("[repro] post-fix model: destroyAll emits one failed terminal response before removing the entry")
+print("[repro] source check: MergeGateExecutor.destroyAll() now terminally fails active processless runs")
+PY
+
+pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/merge-gate-executor.test.ts
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

This slice adds regression repro scripts for the merge gate and PR-authoring failures fixed earlier in the stack.

Each script reproduces one observed failure and asserts the fixed invariant, matching the existing scripts/repro convention.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the regression repro scripts that pin the four fixed merge gate and PR-authoring failures.
Review Lane: proof
Review Unit: proof
Safety Invariant: These are repro scripts only; they add no product runtime behavior.
Slice Rationale: Proof artifacts belong in their own slice, separate from the behavior changes in slices 1 and 2.

</details>

## Non-goals

- Does not change any product runtime behavior.
- Does not modify the fixes themselves, only their reproductions.

## Test Plan

- [x] `bash scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192505728-27.sh`
- [x] `bash scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192504872-23.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new Bash-based reproduction harnesses with embedded checks to validate three merge-gate regressions end-to-end:
    * “Pending task did not run” handoff behavior
    * PR authoring hang prevention when an external agent never exits
    * Correct terminal failure emission when execution is stopped before completion
  * Extended the harnesses with static source invariant validations and ran the focused Vitest coverage for the relevant merge-gate tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2211