### PR TITLE
Recovery Lifecycle 2i Step 1: Worker registry contract

### DIFF
--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { AUTO_FIX_WORKER_KIND, createWorkerRegistry } from '../worker-registry.js';
+
+describe('WorkerRegistry', () => {
+  it('registers the built-in autofix worker by kind', () => {
+    const registry = createWorkerRegistry();
+
+    const definition = registry.getByKind(AUTO_FIX_WORKER_KIND);
+    expect(definition).toBeDefined();
+    expect(definition?.kind).toBe(AUTO_FIX_WORKER_KIND);
+    expect(definition?.operatorNote).toContain('autofix');
+  });
+
+  it('returns undefined for an unknown kind', () => {
+    const registry = createWorkerRegistry();
+
+    expect(registry.getByKind('nonexistent')).toBeUndefined();
+  });
+
+  it('exposes the registered definitions', () => {
+    const registry = createWorkerRegistry();
+
+    expect(registry.getAll()).toHaveLength(1);
+    expect(registry.getAll()[0]?.kind).toBe(AUTO_FIX_WORKER_KIND);
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -33,6 +33,7 @@ export * from './codex-session-driver.js';
 export * from './claude-session-driver.js';
 export * from './worker-runtime.js';
 export * from './worker-lock.js';
+export * from './worker-registry.js';
 export * from './auto-fix-recovery.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -1,0 +1,73 @@
+import type { Logger } from '@invoker/contracts';
+
+import { createAutoFixRecoveryWorker } from './auto-fix-recovery.js';
+import type { WorkerRuntime } from './worker-runtime.js';
+
+export const AUTO_FIX_WORKER_KIND = 'autofix';
+
+export interface WorkerStateAccessor {
+  loadTask(taskId: string): unknown;
+}
+
+export interface WorkerOutputChannel {
+  append(taskId: string, data: string): void;
+}
+
+export interface AutoFixWorkerRuntimeConfig {
+  defaultAttemptBudget: number;
+  chosenAgent: string;
+  intervalMs?: number;
+  instanceId?: string;
+  tickOnStart?: boolean;
+}
+
+export interface WorkerFactoryDependencies {
+  state: WorkerStateAccessor;
+  actionOutput: WorkerOutputChannel;
+  logger: Logger;
+  autoFix: AutoFixWorkerRuntimeConfig;
+}
+
+export interface WorkerDefinition {
+  kind: string;
+  operatorNote: string;
+  createRuntime(deps: WorkerFactoryDependencies): WorkerRuntime;
+}
+
+export class WorkerRegistry {
+  private definitions = new Map<string, WorkerDefinition>();
+
+  register(definition: WorkerDefinition): void {
+    this.definitions.set(definition.kind, definition);
+  }
+
+  getByKind(kind: string): WorkerDefinition | undefined {
+    return this.definitions.get(kind);
+  }
+
+  getAll(): WorkerDefinition[] {
+    return [...this.definitions.values()];
+  }
+}
+
+export function createAutoFixWorkerDefinition(): WorkerDefinition {
+  return {
+    kind: AUTO_FIX_WORKER_KIND,
+    operatorNote: 'Shared recovery worker for task autofix.',
+    createRuntime: (deps: WorkerFactoryDependencies): WorkerRuntime => createAutoFixRecoveryWorker({
+      logger: deps.logger,
+      instanceId: deps.autoFix.instanceId,
+      intervalMs: deps.autoFix.intervalMs,
+      tickOnStart: deps.autoFix.tickOnStart,
+    }),
+  };
+}
+
+export function registerBuiltinAutoFixWorker(registry: WorkerRegistry): WorkerRegistry {
+  registry.register(createAutoFixWorkerDefinition());
+  return registry;
+}
+
+export function createWorkerRegistry(): WorkerRegistry {
+  return registerBuiltinAutoFixWorker(new WorkerRegistry());
+}


### PR DESCRIPTION
## Summary

Introduce an explicit worker registry in `@invoker/execution-engine` so workers are declared by kind and looked up by name. The existing auto-fix worker is registered as the built-in default.

This step only adds the registry surface. No entry point uses it yet, so runtime behavior stays unchanged.

## Architecture

### Before

```mermaid
graph TD
  A[Execution engine] --> B[Hard-coded auto-fix worker]
```

### After

```mermaid
graph TD
  A[Execution engine] --> B[Worker registry]
  B --> C[Builtin auto-fix worker]
  D[App and CLI entry points] -. not wired yet .-> B
```

## Test Plan

- `cd packages/execution-engine && pnpm test`
- `grep -R "createWorkerRegistry" packages/execution-engine/src`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No