### PR TITLE
[Slack Native](1) Add selectable planning agents

### DIFF
--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -23,6 +23,21 @@ describe('registerBuiltinAgents', () => {
     const names = registerBuiltinAgents().listExecution().map((agent) => agent.name);
     expect(names).toEqual(expect.arrayContaining(['claude', 'codex', 'omp']));
   });
+
+  it('registers cursor, omp, and codex planning agents', () => {
+    const registry = registerBuiltinAgents();
+    expect(registry.getPlanningOrThrow('cursor').name).toBe('cursor');
+    expect(registry.getPlanningOrThrow('omp').name).toBe('omp');
+    expect(registry.getPlanningOrThrow('codex').name).toBe('codex');
+  });
+
+  it('threads the planning model into the cursor command', () => {
+    const cursor = registerBuiltinAgents().getPlanningOrThrow('cursor');
+    expect(cursor.buildPlanningCommand('p', { model: 'codex' })).toEqual({
+      command: 'cursor',
+      args: ['agent', '--print', '--trust', '--model', 'codex', 'p'],
+    });
+  });
 });
 
 describe('AgentRegistry', () => {

--- a/packages/execution-engine/src/__tests__/codex-planning-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-planning-agent.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { CodexPlanningAgent } from '../agents/codex-planning-agent.js';
+
+describe('CodexPlanningAgent', () => {
+  it('builds a sandboxed full-auto codex exec command and ignores model', () => {
+    const agent = new CodexPlanningAgent({ command: 'codex-test' });
+    expect(agent.buildPlanningCommand('p', { model: 'ignored' })).toEqual({
+      command: 'codex-test',
+      args: ['exec', '--json', '--full-auto', 'p'],
+    });
+  });
+
+  it('defaults the command to codex', () => {
+    expect(new CodexPlanningAgent().buildPlanningCommand('p').command).toBe('codex');
+  });
+
+  it('bypasses the sandbox only when explicitly configured', () => {
+    const agent = new CodexPlanningAgent({ command: 'codex-test', bypassApprovalsAndSandbox: true });
+    expect(agent.buildPlanningCommand('p').args).toEqual([
+      'exec', '--json', '--dangerously-bypass-approvals-and-sandbox', 'p',
+    ]);
+  });
+});

--- a/packages/execution-engine/src/__tests__/omp-planning-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/omp-planning-agent.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { OmpPlanningAgent } from '../agents/omp-planning-agent.js';
+
+describe('OmpPlanningAgent', () => {
+  it('builds a print command with auto approve and model selector', () => {
+    const agent = new OmpPlanningAgent({ command: 'omp-test' });
+    expect(agent.buildPlanningCommand('p', { model: 'claude' })).toEqual({
+      command: 'omp-test',
+      args: ['--no-title', '--auto-approve', '--model', 'claude', '-p', 'p'],
+    });
+  });
+
+  it('omits model args when model is absent', () => {
+    const agent = new OmpPlanningAgent();
+    expect(agent.buildPlanningCommand('p')).toEqual({
+      command: 'omp',
+      args: ['--no-title', '--auto-approve', '-p', 'p'],
+    });
+  });
+});

--- a/packages/execution-engine/src/agent.ts
+++ b/packages/execution-engine/src/agent.ts
@@ -55,5 +55,8 @@ export interface ExecutionAgent {
 
 export interface PlanningAgent {
   readonly name: string;
-  buildPlanningCommand(prompt: string): { command: string; args: string[] };
+  buildPlanningCommand(
+    prompt: string,
+    options?: { model?: string },
+  ): { command: string; args: string[] };
 }

--- a/packages/execution-engine/src/agents/codex-planning-agent.ts
+++ b/packages/execution-engine/src/agents/codex-planning-agent.ts
@@ -1,0 +1,29 @@
+import type { PlanningAgent } from '../agent.js';
+
+export interface CodexPlanningAgentConfig {
+  command?: string;
+  fullAuto?: boolean;
+  bypassApprovalsAndSandbox?: boolean;
+}
+
+export class CodexPlanningAgent implements PlanningAgent {
+  readonly name = 'codex';
+
+  private readonly command: string;
+  private readonly fullAuto: boolean;
+  private readonly bypassApprovalsAndSandbox: boolean;
+
+  constructor(config: CodexPlanningAgentConfig = {}) {
+    this.command = config.command ?? 'codex';
+    this.fullAuto = config.fullAuto ?? true;
+    this.bypassApprovalsAndSandbox = config.bypassApprovalsAndSandbox ?? false;
+  }
+
+  buildPlanningCommand(prompt: string, _options?: { model?: string }): { command: string; args: string[] } {
+    const args = ['exec', '--json'];
+    if (this.bypassApprovalsAndSandbox) args.push('--dangerously-bypass-approvals-and-sandbox');
+    else if (this.fullAuto) args.push('--full-auto');
+    args.push(prompt);
+    return { command: this.command, args };
+  }
+}

--- a/packages/execution-engine/src/agents/cursor-planning-agent.ts
+++ b/packages/execution-engine/src/agents/cursor-planning-agent.ts
@@ -20,10 +20,13 @@ export class CursorPlanningAgent implements PlanningAgent {
     this.command = config.command ?? 'cursor';
   }
 
-  buildPlanningCommand(prompt: string): { command: string; args: string[] } {
+  buildPlanningCommand(
+    prompt: string,
+    options?: { model?: string },
+  ): { command: string; args: string[] } {
     return {
       command: this.command,
-      args: ['agent', '--print', '--trust', prompt],
+      args: ['agent', '--print', '--trust', ...(options?.model ? ['--model', options.model] : []), prompt],
     };
   }
 }

--- a/packages/execution-engine/src/agents/index.ts
+++ b/packages/execution-engine/src/agents/index.ts
@@ -6,12 +6,16 @@ export { ClaudeExecutionAgent, type ClaudeExecutionAgentConfig } from './claude-
 export { CodexExecutionAgent, type CodexExecutionAgentConfig } from './codex-execution-agent.js';
 export { OmpExecutionAgent, type OmpExecutionAgentConfig } from './omp-execution-agent.js';
 export { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
+export { OmpPlanningAgent, type OmpPlanningAgentConfig } from './omp-planning-agent.js';
+export { CodexPlanningAgent, type CodexPlanningAgentConfig } from './codex-planning-agent.js';
 
 import { AgentRegistry } from '../agent-registry.js';
 import { ClaudeExecutionAgent, type ClaudeExecutionAgentConfig } from './claude-execution-agent.js';
 import { CodexExecutionAgent, type CodexExecutionAgentConfig } from './codex-execution-agent.js';
 import { OmpExecutionAgent, type OmpExecutionAgentConfig } from './omp-execution-agent.js';
 import { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
+import { OmpPlanningAgent, type OmpPlanningAgentConfig } from './omp-planning-agent.js';
+import { CodexPlanningAgent, type CodexPlanningAgentConfig } from './codex-planning-agent.js';
 import { CodexSessionDriver } from '../codex-session-driver.js';
 import { ClaudeSessionDriver } from '../claude-session-driver.js';
 import { OmpSessionDriver } from '../omp-session-driver.js';
@@ -24,11 +28,15 @@ export function registerBuiltinAgents(opts?: {
   codex?: CodexExecutionAgentConfig;
   omp?: OmpExecutionAgentConfig;
   cursor?: CursorPlanningAgentConfig;
+  ompPlanning?: OmpPlanningAgentConfig;
+  codexPlanning?: CodexPlanningAgentConfig;
 }): AgentRegistry {
   const registry = new AgentRegistry();
   registry.registerExecution(new ClaudeExecutionAgent(opts?.claude), new ClaudeSessionDriver());
   registry.registerExecution(new CodexExecutionAgent(opts?.codex), new CodexSessionDriver());
   registry.registerExecution(new OmpExecutionAgent(opts?.omp), new OmpSessionDriver());
   registry.registerPlanning(new CursorPlanningAgent(opts?.cursor));
+  registry.registerPlanning(new OmpPlanningAgent(opts?.ompPlanning));
+  registry.registerPlanning(new CodexPlanningAgent(opts?.codexPlanning));
   return registry;
 }

--- a/packages/execution-engine/src/agents/omp-planning-agent.ts
+++ b/packages/execution-engine/src/agents/omp-planning-agent.ts
@@ -1,0 +1,31 @@
+import type { PlanningAgent } from '../agent.js';
+
+export interface OmpPlanningAgentConfig {
+  command?: string;
+}
+
+export class OmpPlanningAgent implements PlanningAgent {
+  readonly name = 'omp';
+
+  private readonly command: string;
+
+  constructor(config: OmpPlanningAgentConfig = {}) {
+    this.command = config.command ?? 'omp';
+  }
+
+  buildPlanningCommand(
+    prompt: string,
+    options?: { model?: string },
+  ): { command: string; args: string[] } {
+    return {
+      command: this.command,
+      args: [
+        '--no-title',
+        '--auto-approve',
+        ...(options?.model ? ['--model', options.model] : []),
+        '-p',
+        prompt,
+      ],
+    };
+  }
+}

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -420,6 +420,35 @@ describe('PlanConversation', () => {
     expect(mockSpawn).toHaveBeenCalledWith('/usr/local/bin/cursor', expect.any(Array), expect.any(Object));
   });
 
+  it('routes spawn through an injected planningCommandBuilder', async () => {
+    const builder = vi.fn((o: { tool: string; model?: string; prompt: string }) => ({
+      command: 'omp',
+      args: ['--no-title', '--auto-approve', '--model', 'claude', '-p', o.prompt],
+    }));
+    const conv = new PlanConversation({ tool: 'omp', model: 'claude', planningCommandBuilder: builder });
+    mockCursorResponse('Hi');
+    await conv.sendMessage('Hello');
+    expect(builder).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: 'omp', model: 'claude', prompt: expect.any(String) }),
+    );
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'omp',
+      ['--no-title', '--auto-approve', '--model', 'claude', '-p', expect.any(String)],
+      expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] }),
+    );
+  });
+
+  it('falls back to cursor --print shape when no builder is injected', async () => {
+    const conv = new PlanConversation({ cursorCommand: 'agent', model: 'sonnet' });
+    mockCursorResponse('Hi');
+    await conv.sendMessage('Hello');
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'agent',
+      ['--print', '--model', 'sonnet', expect.any(String)],
+      expect.any(Object),
+    );
+  });
+
   it('includes system prompt in cursor prompt', async () => {
     mockCursorResponse('Hi');
     await conversation.sendMessage('Hello');

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -22,11 +22,31 @@ export interface ConversationMessage {
   content: string;
 }
 
+export type PlanningCommandBuilder = (opts: {
+  tool: string;
+  model?: string;
+  prompt: string;
+}) => { command: string; args: string[] };
+
+export function defaultPlanningCommand(
+  cursorCommand: string,
+  opts: { model?: string; prompt: string },
+): { command: string; args: string[] } {
+  const args = ['--print'];
+  if (opts.model) args.push('--model', opts.model);
+  args.push(opts.prompt);
+  return { command: cursorCommand, args };
+}
+
 export interface PlanConversationConfig {
   /** Command to invoke the agent CLI. Default: 'agent'. */
   cursorCommand?: string;
+  /** Planning tool name (e.g. 'cursor', 'omp', 'codex') passed to the builder. */
+  tool?: string;
   /** Model to use (e.g. 'auto', 'sonnet-4'). Omit to use the CLI default. */
   model?: string;
+  /** Injected builder that maps {tool, model, prompt} → CLI command + args. */
+  planningCommandBuilder?: PlanningCommandBuilder;
   /** Root directory for codebase exploration. */
   workingDir?: string;
   /** Subprocess timeout in milliseconds. Default: 300000 (5 minutes). */
@@ -160,7 +180,9 @@ const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 export class PlanConversation {
   private cursorCommand: string;
+  private tool?: string;
   private model?: string;
+  private planningCommandBuilder?: PlanningCommandBuilder;
   private messages: ConversationMessage[] = [];
   private _submittedPlanText: string | null = null;
   private _planSubmitted = false;
@@ -175,7 +197,9 @@ export class PlanConversation {
 
   constructor(config: PlanConversationConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
+    this.tool = config.tool;
     this.model = config.model;
+    this.planningCommandBuilder = config.planningCommandBuilder;
     this.workingDir = config.workingDir;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.threadTs = config.threadTs;
@@ -266,7 +290,7 @@ export class PlanConversation {
     const tPrompt = Date.now();
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: promptLen=${prompt.length}, historyMsgs=${this.messages.length - 1}, promptPreview="${prompt.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
-    const response = await this.spawnCursor(prompt);
+    const response = await this.spawnPlanner(prompt);
     const tCursor = Date.now();
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, responsePreview="${response.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
@@ -331,15 +355,15 @@ export class PlanConversation {
     return parts.join('\n');
   }
 
-  // ── Cursor CLI Subprocess ─────────────────────────────
+  // ── Planner CLI Subprocess ─────────────────────────────
 
-  spawnCursor(prompt: string): Promise<string> {
+  spawnPlanner(prompt: string): Promise<string> {
     const spawnStart = Date.now();
+    const { command, args } = this.planningCommandBuilder
+      ? this.planningCommandBuilder({ tool: this.tool ?? 'cursor', model: this.model, prompt })
+      : defaultPlanningCommand(this.cursorCommand, { model: this.model, prompt });
     return new Promise((resolve, reject) => {
-      const args = ['--print'];
-      if (this.model) args.push('--model', this.model);
-      args.push(prompt);
-      const child = spawn(this.cursorCommand, args, {
+      const child = spawn(command, args, {
         cwd: this.workingDir ?? process.cwd(),
         stdio: ['ignore', 'pipe', 'pipe'],
         env: { ...process.env },
@@ -350,7 +374,7 @@ export class PlanConversation {
       let stdoutChunks = 0;
       let stderrChunks = 0;
 
-      this.log('plan-conversation', 'info', `[PERF] cursor_spawn: pid=${child.pid ?? 'none'}, cmd="${this.cursorCommand} ${args.slice(0, -1).join(' ')} <prompt>", promptLen=${prompt.length}, cwd=${this.workingDir ?? process.cwd()}`);
+      this.log('plan-conversation', 'info', `[PERF] cursor_spawn: pid=${child.pid ?? 'none'}, cmd="${command} ${args.slice(0, -1).join(' ')} <prompt>", promptLen=${prompt.length}, cwd=${this.workingDir ?? process.cwd()}`);
 
       child.stdout?.on('data', (chunk: Buffer) => {
         const chunkStr = chunk.toString();


### PR DESCRIPTION
## Summary

Invoker can now pick which tool plans a change, the same way it already picks which tool executes a task.

The planning agent gains a small typed interface that accepts an optional model, alongside cursor, omp, and codex implementations.

Nothing selects the new agents yet; a later slice wires them into the Slack planning flow.

<details>
<summary>Review metadata</summary>

Review Claim: The planning agent interface accepts an optional model and has cursor, omp, and codex implementations.

Review Lane: behavior

Review Unit: contract

Safety Invariant: The new agents are registered but no caller selects them yet, so existing planning behavior is unchanged.

Slice Rationale: Foundation first: the interface and implementations land before any planning caller selects a harness.

Architectural Effect: Adds planning entries to the agent registry; no control flow changes yet.

Alternative Considerations: We could hardcode each tool at the call site, but a registry keeps planning symmetric with execution.
</details>

## Non-goals

This does not change how tasks execute.

This does not wire planning selection into Slack; that is a later slice.

This does not add a model flag to codex planning.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/agent-registry.test.ts src/__tests__/omp-planning-agent.test.ts src/__tests__/codex-planning-agent.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge commit>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Planning agents now available for OMP and Codex in addition to Cursor
  * Added model selection capability for planning commands
  * Introduced pluggable planning command builder for enhanced flexibility

* **Tests**
  * Added comprehensive test coverage for new planning agents and agent registry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->