### PR TITLE
[Slack Native](2) Persist the workflow-to-channel mapping

### DIFF
--- a/packages/data-store/src/__tests__/workflow-channel-repository.test.ts
+++ b/packages/data-store/src/__tests__/workflow-channel-repository.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import { WorkflowChannelRepository } from '../workflow-channel-repository.js';
+import type { WorkflowChannel } from '../adapter.js';
+
+describe('WorkflowChannelRepository', () => {
+  let adapter: SQLiteAdapter;
+  let repo: WorkflowChannelRepository;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new WorkflowChannelRepository(adapter);
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  const rec: WorkflowChannel = {
+    workflowId: 'wf-1-2',
+    channelId: 'C123',
+    requestedBy: 'U1',
+    lobbyChannelId: 'CLOBBY',
+    lobbyThreadTs: 't1',
+    harnessPreset: 'omp+claude',
+    repoUrl: 'https://example.com/repo.git',
+    createdAt: new Date().toISOString(),
+  };
+
+  it('round-trips a mapping by workflow id and by channel id', () => {
+    repo.save(rec);
+    expect(repo.getByWorkflowId('wf-1-2')).toEqual(rec);
+    expect(repo.getByChannelId('C123')).toEqual(rec);
+  });
+
+  it('returns null for an unknown channel or workflow', () => {
+    expect(repo.getByChannelId('nope')).toBeNull();
+    expect(repo.getByWorkflowId('nope')).toBeNull();
+  });
+
+  it('upserts on repeated save (channel re-map)', () => {
+    repo.save(rec);
+    repo.save({ ...rec, channelId: 'C999' });
+    expect(repo.getByWorkflowId('wf-1-2')?.channelId).toBe('C999');
+    expect(repo.getByChannelId('C123')).toBeNull();
+  });
+
+  it('lists and deletes mappings', () => {
+    repo.save(rec);
+    repo.save({ ...rec, workflowId: 'wf-3-4', channelId: 'C456' });
+    expect(repo.list().map((r) => r.workflowId).sort()).toEqual(['wf-1-2', 'wf-3-4']);
+    repo.delete('wf-1-2');
+    expect(repo.getByWorkflowId('wf-1-2')).toBeNull();
+    expect(repo.list()).toHaveLength(1);
+  });
+
+  it('preserves optional fields left undefined', () => {
+    repo.save({ workflowId: 'wf-9', channelId: 'C9', createdAt: new Date().toISOString() });
+    const loaded = repo.getByWorkflowId('wf-9');
+    expect(loaded?.requestedBy).toBeUndefined();
+    expect(loaded?.repoUrl).toBeUndefined();
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -29,6 +29,19 @@ export interface ConversationMessage {
   createdAt: string;
 }
 
+// ── Workflow Channel Types (Slack workflow↔channel mapping) ─
+
+export interface WorkflowChannel {
+  workflowId: string;
+  channelId: string;
+  requestedBy?: string;
+  lobbyChannelId?: string;
+  lobbyThreadTs?: string;
+  harnessPreset?: string;
+  repoUrl?: string;
+  createdAt: string;
+}
+
 // ── Workflow Types ──────────────────────────────────────────
 
 export interface Workflow {
@@ -135,6 +148,13 @@ export interface PersistenceAdapter {
   // Conversation messages
   appendMessage(threadTs: string, role: 'user' | 'assistant', content: string): void;
   loadMessages(threadTs: string): ConversationMessage[];
+
+  // Workflow channels (Slack workflow↔channel mapping)
+  saveWorkflowChannel(rec: WorkflowChannel): void;
+  loadWorkflowChannelByWorkflowId(workflowId: string): WorkflowChannel | undefined;
+  loadWorkflowChannelByChannelId(channelId: string): WorkflowChannel | undefined;
+  listWorkflowChannels(): WorkflowChannel[];
+  deleteWorkflowChannel(workflowId: string): void;
 
   // Task output (stdout/stderr persistence)
   appendTaskOutput(taskId: string, data: string): void;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -2,3 +2,4 @@ export * from './adapter.js';
 export * from './sqlite-adapter.js';
 export * from './conversation-repository.js';
 export * from './sqlite-task-repository.js';
+export * from './workflow-channel-repository.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -50,6 +50,7 @@ import type {
   ActivityLogEntry,
   Conversation,
   ConversationMessage,
+  WorkflowChannel,
 } from './adapter.js';
 
 type NativeSqlite = typeof import('node:sqlite');
@@ -812,6 +813,20 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
       CREATE INDEX IF NOT EXISTS idx_conv_messages_thread
         ON conversation_messages(thread_ts, seq);
+
+      CREATE TABLE IF NOT EXISTS workflow_channels (
+        workflow_id TEXT PRIMARY KEY,
+        channel_id TEXT NOT NULL,
+        requested_by TEXT,
+        lobby_channel_id TEXT,
+        lobby_thread_ts TEXT,
+        harness_preset TEXT,
+        repo_url TEXT,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workflow_channels_channel
+        ON workflow_channels(channel_id);
 
       CREATE TABLE IF NOT EXISTS task_output (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -2319,6 +2334,57 @@ export class SQLiteAdapter implements PersistenceAdapter {
       content: row.content,
       createdAt: row.created_at,
     }));
+  }
+
+  // ── Workflow Channels (Slack workflow↔channel mapping) ──
+
+  saveWorkflowChannel(rec: WorkflowChannel): void {
+    this.execRun(`
+      INSERT OR REPLACE INTO workflow_channels
+        (workflow_id, channel_id, requested_by, lobby_channel_id, lobby_thread_ts, harness_preset, repo_url, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `, [
+      rec.workflowId,
+      rec.channelId,
+      rec.requestedBy ?? null,
+      rec.lobbyChannelId ?? null,
+      rec.lobbyThreadTs ?? null,
+      rec.harnessPreset ?? null,
+      rec.repoUrl ?? null,
+      rec.createdAt,
+    ]);
+  }
+
+  private mapWorkflowChannelRow(row: any): WorkflowChannel {
+    return {
+      workflowId: row.workflow_id as string,
+      channelId: row.channel_id as string,
+      requestedBy: (row.requested_by as string) ?? undefined,
+      lobbyChannelId: (row.lobby_channel_id as string) ?? undefined,
+      lobbyThreadTs: (row.lobby_thread_ts as string) ?? undefined,
+      harnessPreset: (row.harness_preset as string) ?? undefined,
+      repoUrl: (row.repo_url as string) ?? undefined,
+      createdAt: row.created_at as string,
+    };
+  }
+
+  loadWorkflowChannelByWorkflowId(workflowId: string): WorkflowChannel | undefined {
+    const row = this.queryOne('SELECT * FROM workflow_channels WHERE workflow_id = ?', [workflowId]);
+    return row ? this.mapWorkflowChannelRow(row) : undefined;
+  }
+
+  loadWorkflowChannelByChannelId(channelId: string): WorkflowChannel | undefined {
+    const row = this.queryOne('SELECT * FROM workflow_channels WHERE channel_id = ?', [channelId]);
+    return row ? this.mapWorkflowChannelRow(row) : undefined;
+  }
+
+  listWorkflowChannels(): WorkflowChannel[] {
+    const rows = this.queryAll('SELECT * FROM workflow_channels ORDER BY created_at DESC');
+    return rows.map((row: any) => this.mapWorkflowChannelRow(row));
+  }
+
+  deleteWorkflowChannel(workflowId: string): void {
+    this.execRun('DELETE FROM workflow_channels WHERE workflow_id = ?', [workflowId]);
   }
 
   // ── Task Output ─────────────────────────────────────

--- a/packages/data-store/src/workflow-channel-repository.ts
+++ b/packages/data-store/src/workflow-channel-repository.ts
@@ -1,0 +1,33 @@
+/**
+ * WorkflowChannelRepository — Domain-level API for the Slack workflow↔channel mapping.
+ */
+
+import type { PersistenceAdapter, WorkflowChannel } from './adapter.js';
+
+export class WorkflowChannelRepository {
+  private adapter: PersistenceAdapter;
+
+  constructor(adapter: PersistenceAdapter) {
+    this.adapter = adapter;
+  }
+
+  save(rec: WorkflowChannel): void {
+    this.adapter.saveWorkflowChannel(rec);
+  }
+
+  getByWorkflowId(workflowId: string): WorkflowChannel | null {
+    return this.adapter.loadWorkflowChannelByWorkflowId(workflowId) ?? null;
+  }
+
+  getByChannelId(channelId: string): WorkflowChannel | null {
+    return this.adapter.loadWorkflowChannelByChannelId(channelId) ?? null;
+  }
+
+  list(): WorkflowChannel[] {
+    return this.adapter.listWorkflowChannels();
+  }
+
+  delete(workflowId: string): void {
+    this.adapter.deleteWorkflowChannel(workflowId);
+  }
+}

--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -23,6 +23,21 @@ describe('registerBuiltinAgents', () => {
     const names = registerBuiltinAgents().listExecution().map((agent) => agent.name);
     expect(names).toEqual(expect.arrayContaining(['claude', 'codex', 'omp']));
   });
+
+  it('registers cursor, omp, and codex planning agents', () => {
+    const registry = registerBuiltinAgents();
+    expect(registry.getPlanningOrThrow('cursor').name).toBe('cursor');
+    expect(registry.getPlanningOrThrow('omp').name).toBe('omp');
+    expect(registry.getPlanningOrThrow('codex').name).toBe('codex');
+  });
+
+  it('threads the planning model into the cursor command', () => {
+    const cursor = registerBuiltinAgents().getPlanningOrThrow('cursor');
+    expect(cursor.buildPlanningCommand('p', { model: 'codex' })).toEqual({
+      command: 'cursor',
+      args: ['agent', '--print', '--trust', '--model', 'codex', 'p'],
+    });
+  });
 });
 
 describe('AgentRegistry', () => {

--- a/packages/execution-engine/src/__tests__/codex-planning-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-planning-agent.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { CodexPlanningAgent } from '../agents/codex-planning-agent.js';
+
+describe('CodexPlanningAgent', () => {
+  it('builds a sandboxed full-auto codex exec command and ignores model', () => {
+    const agent = new CodexPlanningAgent({ command: 'codex-test' });
+    expect(agent.buildPlanningCommand('p', { model: 'ignored' })).toEqual({
+      command: 'codex-test',
+      args: ['exec', '--json', '--full-auto', 'p'],
+    });
+  });
+
+  it('defaults the command to codex', () => {
+    expect(new CodexPlanningAgent().buildPlanningCommand('p').command).toBe('codex');
+  });
+
+  it('bypasses the sandbox only when explicitly configured', () => {
+    const agent = new CodexPlanningAgent({ command: 'codex-test', bypassApprovalsAndSandbox: true });
+    expect(agent.buildPlanningCommand('p').args).toEqual([
+      'exec', '--json', '--dangerously-bypass-approvals-and-sandbox', 'p',
+    ]);
+  });
+});

--- a/packages/execution-engine/src/__tests__/omp-planning-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/omp-planning-agent.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { OmpPlanningAgent } from '../agents/omp-planning-agent.js';
+
+describe('OmpPlanningAgent', () => {
+  it('builds a print command with auto approve and model selector', () => {
+    const agent = new OmpPlanningAgent({ command: 'omp-test' });
+    expect(agent.buildPlanningCommand('p', { model: 'claude' })).toEqual({
+      command: 'omp-test',
+      args: ['--no-title', '--auto-approve', '--model', 'claude', '-p', 'p'],
+    });
+  });
+
+  it('omits model args when model is absent', () => {
+    const agent = new OmpPlanningAgent();
+    expect(agent.buildPlanningCommand('p')).toEqual({
+      command: 'omp',
+      args: ['--no-title', '--auto-approve', '-p', 'p'],
+    });
+  });
+});

--- a/packages/execution-engine/src/agent.ts
+++ b/packages/execution-engine/src/agent.ts
@@ -55,5 +55,8 @@ export interface ExecutionAgent {
 
 export interface PlanningAgent {
   readonly name: string;
-  buildPlanningCommand(prompt: string): { command: string; args: string[] };
+  buildPlanningCommand(
+    prompt: string,
+    options?: { model?: string },
+  ): { command: string; args: string[] };
 }

--- a/packages/execution-engine/src/agents/codex-planning-agent.ts
+++ b/packages/execution-engine/src/agents/codex-planning-agent.ts
@@ -1,0 +1,29 @@
+import type { PlanningAgent } from '../agent.js';
+
+export interface CodexPlanningAgentConfig {
+  command?: string;
+  fullAuto?: boolean;
+  bypassApprovalsAndSandbox?: boolean;
+}
+
+export class CodexPlanningAgent implements PlanningAgent {
+  readonly name = 'codex';
+
+  private readonly command: string;
+  private readonly fullAuto: boolean;
+  private readonly bypassApprovalsAndSandbox: boolean;
+
+  constructor(config: CodexPlanningAgentConfig = {}) {
+    this.command = config.command ?? 'codex';
+    this.fullAuto = config.fullAuto ?? true;
+    this.bypassApprovalsAndSandbox = config.bypassApprovalsAndSandbox ?? false;
+  }
+
+  buildPlanningCommand(prompt: string, _options?: { model?: string }): { command: string; args: string[] } {
+    const args = ['exec', '--json'];
+    if (this.bypassApprovalsAndSandbox) args.push('--dangerously-bypass-approvals-and-sandbox');
+    else if (this.fullAuto) args.push('--full-auto');
+    args.push(prompt);
+    return { command: this.command, args };
+  }
+}

--- a/packages/execution-engine/src/agents/cursor-planning-agent.ts
+++ b/packages/execution-engine/src/agents/cursor-planning-agent.ts
@@ -20,10 +20,13 @@ export class CursorPlanningAgent implements PlanningAgent {
     this.command = config.command ?? 'cursor';
   }
 
-  buildPlanningCommand(prompt: string): { command: string; args: string[] } {
+  buildPlanningCommand(
+    prompt: string,
+    options?: { model?: string },
+  ): { command: string; args: string[] } {
     return {
       command: this.command,
-      args: ['agent', '--print', '--trust', prompt],
+      args: ['agent', '--print', '--trust', ...(options?.model ? ['--model', options.model] : []), prompt],
     };
   }
 }

--- a/packages/execution-engine/src/agents/index.ts
+++ b/packages/execution-engine/src/agents/index.ts
@@ -6,12 +6,16 @@ export { ClaudeExecutionAgent, type ClaudeExecutionAgentConfig } from './claude-
 export { CodexExecutionAgent, type CodexExecutionAgentConfig } from './codex-execution-agent.js';
 export { OmpExecutionAgent, type OmpExecutionAgentConfig } from './omp-execution-agent.js';
 export { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
+export { OmpPlanningAgent, type OmpPlanningAgentConfig } from './omp-planning-agent.js';
+export { CodexPlanningAgent, type CodexPlanningAgentConfig } from './codex-planning-agent.js';
 
 import { AgentRegistry } from '../agent-registry.js';
 import { ClaudeExecutionAgent, type ClaudeExecutionAgentConfig } from './claude-execution-agent.js';
 import { CodexExecutionAgent, type CodexExecutionAgentConfig } from './codex-execution-agent.js';
 import { OmpExecutionAgent, type OmpExecutionAgentConfig } from './omp-execution-agent.js';
 import { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
+import { OmpPlanningAgent, type OmpPlanningAgentConfig } from './omp-planning-agent.js';
+import { CodexPlanningAgent, type CodexPlanningAgentConfig } from './codex-planning-agent.js';
 import { CodexSessionDriver } from '../codex-session-driver.js';
 import { ClaudeSessionDriver } from '../claude-session-driver.js';
 import { OmpSessionDriver } from '../omp-session-driver.js';
@@ -24,11 +28,15 @@ export function registerBuiltinAgents(opts?: {
   codex?: CodexExecutionAgentConfig;
   omp?: OmpExecutionAgentConfig;
   cursor?: CursorPlanningAgentConfig;
+  ompPlanning?: OmpPlanningAgentConfig;
+  codexPlanning?: CodexPlanningAgentConfig;
 }): AgentRegistry {
   const registry = new AgentRegistry();
   registry.registerExecution(new ClaudeExecutionAgent(opts?.claude), new ClaudeSessionDriver());
   registry.registerExecution(new CodexExecutionAgent(opts?.codex), new CodexSessionDriver());
   registry.registerExecution(new OmpExecutionAgent(opts?.omp), new OmpSessionDriver());
   registry.registerPlanning(new CursorPlanningAgent(opts?.cursor));
+  registry.registerPlanning(new OmpPlanningAgent(opts?.ompPlanning));
+  registry.registerPlanning(new CodexPlanningAgent(opts?.codexPlanning));
   return registry;
 }

--- a/packages/execution-engine/src/agents/omp-planning-agent.ts
+++ b/packages/execution-engine/src/agents/omp-planning-agent.ts
@@ -1,0 +1,31 @@
+import type { PlanningAgent } from '../agent.js';
+
+export interface OmpPlanningAgentConfig {
+  command?: string;
+}
+
+export class OmpPlanningAgent implements PlanningAgent {
+  readonly name = 'omp';
+
+  private readonly command: string;
+
+  constructor(config: OmpPlanningAgentConfig = {}) {
+    this.command = config.command ?? 'omp';
+  }
+
+  buildPlanningCommand(
+    prompt: string,
+    options?: { model?: string },
+  ): { command: string; args: string[] } {
+    return {
+      command: this.command,
+      args: [
+        '--no-title',
+        '--auto-approve',
+        ...(options?.model ? ['--model', options.model] : []),
+        '-p',
+        prompt,
+      ],
+    };
+  }
+}

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -420,6 +420,35 @@ describe('PlanConversation', () => {
     expect(mockSpawn).toHaveBeenCalledWith('/usr/local/bin/cursor', expect.any(Array), expect.any(Object));
   });
 
+  it('routes spawn through an injected planningCommandBuilder', async () => {
+    const builder = vi.fn((o: { tool: string; model?: string; prompt: string }) => ({
+      command: 'omp',
+      args: ['--no-title', '--auto-approve', '--model', 'claude', '-p', o.prompt],
+    }));
+    const conv = new PlanConversation({ tool: 'omp', model: 'claude', planningCommandBuilder: builder });
+    mockCursorResponse('Hi');
+    await conv.sendMessage('Hello');
+    expect(builder).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: 'omp', model: 'claude', prompt: expect.any(String) }),
+    );
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'omp',
+      ['--no-title', '--auto-approve', '--model', 'claude', '-p', expect.any(String)],
+      expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] }),
+    );
+  });
+
+  it('falls back to cursor --print shape when no builder is injected', async () => {
+    const conv = new PlanConversation({ cursorCommand: 'agent', model: 'sonnet' });
+    mockCursorResponse('Hi');
+    await conv.sendMessage('Hello');
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'agent',
+      ['--print', '--model', 'sonnet', expect.any(String)],
+      expect.any(Object),
+    );
+  });
+
   it('includes system prompt in cursor prompt', async () => {
     mockCursorResponse('Hi');
     await conversation.sendMessage('Hello');

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -22,11 +22,31 @@ export interface ConversationMessage {
   content: string;
 }
 
+export type PlanningCommandBuilder = (opts: {
+  tool: string;
+  model?: string;
+  prompt: string;
+}) => { command: string; args: string[] };
+
+export function defaultPlanningCommand(
+  cursorCommand: string,
+  opts: { model?: string; prompt: string },
+): { command: string; args: string[] } {
+  const args = ['--print'];
+  if (opts.model) args.push('--model', opts.model);
+  args.push(opts.prompt);
+  return { command: cursorCommand, args };
+}
+
 export interface PlanConversationConfig {
   /** Command to invoke the agent CLI. Default: 'agent'. */
   cursorCommand?: string;
+  /** Planning tool name (e.g. 'cursor', 'omp', 'codex') passed to the builder. */
+  tool?: string;
   /** Model to use (e.g. 'auto', 'sonnet-4'). Omit to use the CLI default. */
   model?: string;
+  /** Injected builder that maps {tool, model, prompt} → CLI command + args. */
+  planningCommandBuilder?: PlanningCommandBuilder;
   /** Root directory for codebase exploration. */
   workingDir?: string;
   /** Subprocess timeout in milliseconds. Default: 300000 (5 minutes). */
@@ -160,7 +180,9 @@ const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 export class PlanConversation {
   private cursorCommand: string;
+  private tool?: string;
   private model?: string;
+  private planningCommandBuilder?: PlanningCommandBuilder;
   private messages: ConversationMessage[] = [];
   private _submittedPlanText: string | null = null;
   private _planSubmitted = false;
@@ -175,7 +197,9 @@ export class PlanConversation {
 
   constructor(config: PlanConversationConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
+    this.tool = config.tool;
     this.model = config.model;
+    this.planningCommandBuilder = config.planningCommandBuilder;
     this.workingDir = config.workingDir;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.threadTs = config.threadTs;
@@ -266,7 +290,7 @@ export class PlanConversation {
     const tPrompt = Date.now();
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: promptLen=${prompt.length}, historyMsgs=${this.messages.length - 1}, promptPreview="${prompt.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
-    const response = await this.spawnCursor(prompt);
+    const response = await this.spawnPlanner(prompt);
     const tCursor = Date.now();
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, responsePreview="${response.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
@@ -331,15 +355,15 @@ export class PlanConversation {
     return parts.join('\n');
   }
 
-  // ── Cursor CLI Subprocess ─────────────────────────────
+  // ── Planner CLI Subprocess ─────────────────────────────
 
-  spawnCursor(prompt: string): Promise<string> {
+  spawnPlanner(prompt: string): Promise<string> {
     const spawnStart = Date.now();
+    const { command, args } = this.planningCommandBuilder
+      ? this.planningCommandBuilder({ tool: this.tool ?? 'cursor', model: this.model, prompt })
+      : defaultPlanningCommand(this.cursorCommand, { model: this.model, prompt });
     return new Promise((resolve, reject) => {
-      const args = ['--print'];
-      if (this.model) args.push('--model', this.model);
-      args.push(prompt);
-      const child = spawn(this.cursorCommand, args, {
+      const child = spawn(command, args, {
         cwd: this.workingDir ?? process.cwd(),
         stdio: ['ignore', 'pipe', 'pipe'],
         env: { ...process.env },
@@ -350,7 +374,7 @@ export class PlanConversation {
       let stdoutChunks = 0;
       let stderrChunks = 0;
 
-      this.log('plan-conversation', 'info', `[PERF] cursor_spawn: pid=${child.pid ?? 'none'}, cmd="${this.cursorCommand} ${args.slice(0, -1).join(' ')} <prompt>", promptLen=${prompt.length}, cwd=${this.workingDir ?? process.cwd()}`);
+      this.log('plan-conversation', 'info', `[PERF] cursor_spawn: pid=${child.pid ?? 'none'}, cmd="${command} ${args.slice(0, -1).join(' ')} <prompt>", promptLen=${prompt.length}, cwd=${this.workingDir ?? process.cwd()}`);
 
       child.stdout?.on('data', (chunk: Buffer) => {
         const chunkStr = chunk.toString();


### PR DESCRIPTION
## Summary

Invoker needs to remember which private Slack channel belongs to which workflow.

This adds a `workflow_channels` table and a small repository over the persistence adapter, mirroring the existing conversation store.

Nothing reads or writes the mapping yet; the Slack surface uses it in a later slice.

<details>
<summary>Review metadata</summary>

Review Claim: A `workflow_channels` schema and repository persist the link between a workflow and its Slack channel.

Review Lane: behavior

Review Unit: contract

Safety Invariant: Additive schema and a new repository class; no existing query or code path touches it yet.

Slice Rationale: Foundation slice: the storage shape lands before the Slack surface that depends on it.

Architectural Effect: Adds one table plus DAO methods on the persistence adapter and a repository wrapper.

Alternative Considerations: We could have reused the conversation table, but workflow-to-channel is a distinct concept with its own keys.
</details>

## Non-goals

This does not read or write the mapping from any surface yet.

This does not change the conversation store.

This does not add a new database writer or owner-boundary call.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/workflow-channel-repository.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge commit>`
- Post-revert steps: None
- Data migration? No, the new table is additive and unused until later slices.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for workflow-channel mapping operations

* **New Features**
  * Added workflow-to-channel mapping persistence with save, retrieve, and delete capabilities
  * Supports querying mappings by workflow ID or channel ID
  * Includes optional metadata fields for configuration and related context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2214