### PR TITLE
[Slack Native](5) Document Slack-native workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to Invoker will be documented in this file.
 - Split queue assigning work from running work in the UI pills, queue rows, and task graph.
 - Review gates can now track PR stacks with optional dependency order, expose that stack through query surfaces and the side panel, and discard or close stale PRs when the gate is invalidated.
 - Model merge-gate PR status as a single `open`/`closed`/`merged` lifecycle so a PR can never be treated as merged and closed at the same time.
+- Add Slack-native coding workflows: plan from a lobby `@Invoker` mention against a checked-out repo with a selectable planning harness (`[preset]`/`[repo:]` tags), spin the plan up as a workflow in a private `workflow-<id>` channel, and drive or question that workflow in-channel using only its own planning conversation and task transcripts.
 ## 0.0.4
 
 - Publish complete CLI and desktop release assets for npm launcher packages.

--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ Layer rules: [ARCHITECTURE.md](ARCHITECTURE.md). Agent/repo conventions: [CLAUDE
 | [docs/invoker-config-example.json](docs/invoker-config-example.json) | Example `config.json` with local and remote executor settings |
 | [docs/remote-ssh-targets.md](docs/remote-ssh-targets.md) | SSH executor setup, target fields, and plan examples |
 | [docs/docker-executor.md](docs/docker-executor.md) | Docker executor configuration and runtime notes |
+| [docs/slack-native-workflows.md](docs/slack-native-workflows.md) | Plan & drive workflows from Slack: lobby mentions, harness presets, per-workflow channels |
 
 ## Troubleshooting
 

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -77,6 +77,20 @@
     }
   ],
 
+  "slackHarnessPresets": {
+    "comment": "Slack planning harness presets: preset key -> CLI tool + optional model. Selected via a leading [preset] tag in the lobby @Invoker message. Omit to use built-ins (cursor+claude / cursor+codex / omp / omp+claude / codex).",
+    "omp+claude": { "tool": "omp", "model": "anthropic/claude-opus-4" },
+    "cursor+codex": { "tool": "cursor", "model": "gpt-5-codex" },
+    "codex": { "tool": "codex" }
+  },
+  "defaultSlackHarnessPreset": "cursor+claude",
+  "slackRepos": {
+    "comment": "Slack repo aliases: alias -> git URL, resolved from a [repo:<alias>] tag",
+    "web": "git@github.com:acme/web.git",
+    "api": "git@github.com:acme/api.git"
+  },
+  "defaultRepoUrl": "git@github.com:acme/web.git",
+
   "autoFixRetries": 3,
   "autoApproveAIFixes": true,
   "autoFixCi": false,

--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -1,0 +1,84 @@
+# Slack-native coding workflows
+
+Drive Invoker from Slack: mention `@Invoker` in a shared **lobby** channel to plan a change against a checked-out repo, then spin the agreed plan up as a workflow. When a workflow starts, Invoker creates a **private `workflow-<id>` channel**, invites you, and posts the workflow there. Mentioning `@Invoker` inside that channel answers using **only that workflow's context** (its planning conversation plus every task transcript) and runs control actions on it.
+
+## Flow
+
+1. **Plan in the lobby.** In the lobby channel: `@Invoker [cursor+codex] [repo:web] add a /health endpoint`. Invoker checks out the repo and runs a planning conversation in the thread.
+2. **Confirm.** Reply `go` (or `yes`/`ship it`) to submit the generated YAML plan.
+3. **Workflow channel appears.** Invoker creates private `workflow-<id>`, invites you, posts the workflow summary there, and links it from the lobby thread.
+4. **Operate in the channel.** `@Invoker status`, `@Invoker approve <task>`, `@Invoker reject <task>`, `@Invoker retry <task>`, `@Invoker input <task>: <text>`, or ask a free-form question (answered only from this workflow's planning + task transcripts).
+
+## Message tags (lobby only)
+
+Leading `[...]` tags select how planning runs. Order does not matter; everything after the tags is the request.
+
+- `[<preset>]` — pick a harness preset (CLI tool + model). No tag ⇒ the default preset.
+- `[repo:<alias|git-url>]` — pick the target repo. No tag ⇒ `defaultRepoUrl`.
+
+`@Invoker raise a PR that adds rate limiting` (no tags) uses the default preset and default repo.
+
+## Harness presets
+
+A preset names the **CLI tool** that both plans conversationally and converts the plan to Invoker YAML, plus the **model** it runs. Built-in presets (used when `slackHarnessPresets` is unset):
+
+| Preset | Tool | Model |
+| --- | --- | --- |
+| `cursor+claude` (default) | cursor | claude |
+| `cursor+codex` | cursor | codex |
+| `omp+claude` | omp | claude |
+| `omp` | omp | (CLI default) |
+| `codex` | codex | (CLI default) |
+
+Override them in `~/.invoker/config.json`:
+
+```json
+{
+  "slackHarnessPresets": {
+    "omp+claude": { "tool": "omp", "model": "anthropic/claude-opus-4" },
+    "codex": { "tool": "codex" }
+  },
+  "defaultSlackHarnessPreset": "omp+claude",
+  "slackRepos": {
+    "web": "git@github.com:acme/web.git",
+    "api": "git@github.com:acme/api.git"
+  },
+  "defaultRepoUrl": "git@github.com:acme/web.git"
+}
+```
+
+Model strings are passed verbatim to the CLI's `--model`; set exact ids your CLI accepts. Plain `codex` ignores the model (uses the CLI default). The generated workflow's per-task `executionAgent` is whatever the `plan-to-invoker` skill writes, defaulting to the chosen preset's tool when the skill leaves it unset.
+
+## Environment
+
+Set in `<repoRoot>/.env` (loaded on startup) or the environment, then run `./run.sh`:
+
+```
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_APP_TOKEN=xapp-...
+SLACK_SIGNING_SECRET=...
+SLACK_CHANNEL_ID=C...            # lobby channel (fallback for SLACK_LOBBY_CHANNEL_ID)
+SLACK_LOBBY_CHANNEL_ID=C...      # optional; defaults to SLACK_CHANNEL_ID
+INVOKER_REPO_URL=git@github.com:acme/web.git   # optional; default repo (else git remote origin)
+CURSOR_COMMAND=cursor            # optional planning CLI override
+CURSOR_MODEL=...                 # optional planning model override
+```
+
+## Slack app scopes
+
+The bot runs in Socket Mode. Add these bot scopes to the app manifest (reinstall after changing):
+
+- `app_mentions:read` — receive `@Invoker` mentions.
+- `chat:write` — post messages.
+- `channels:history` — read lobby thread replies (public lobby channel).
+- `groups:write` — **create** private `workflow-<id>` channels and invite users.
+- `groups:history` — receive mentions/replies **inside** the private workflow channels.
+- `users:read` — resolve users for invites.
+
+Without `groups:write`, channel creation fails; without `groups:history`, the in-channel assistant never sees mentions.
+
+## Scope notes
+
+- Runs on the existing bring-your-own-machine / DigitalOcean SSH single-owner model. No hosted AWS env is required.
+- Workflow creation uses `orchestrator.loadPlan` (the same path headless `run` uses); there is no separate HTTP/facade create route today.
+- One owner process serves all workflows; "spinning up a planning bot" is a per-thread planning conversation in a per-repo checkout plus a per-workflow channel, all under that one process.

--- a/packages/app/src/__tests__/slack-workflow-context.test.ts
+++ b/packages/app/src/__tests__/slack-workflow-context.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
+import { registerBuiltinAgents } from '@invoker/execution-engine';
+import type { TaskState } from '@invoker/workflow-core';
+import type { AgentSessionData } from '@invoker/contracts';
+import { presetToExecutionAgent, gatherWorkflowContext } from '../slack-workflow-context.js';
+
+const silent = () => {};
+
+const PRESETS = {
+  'cursor+claude': { tool: 'cursor', model: 'claude' },
+  'cursor+codex': { tool: 'cursor', model: 'codex' },
+  'omp+claude': { tool: 'omp', model: 'claude' },
+  codex: { tool: 'codex' },
+};
+const REGISTERED = new Set(['claude', 'codex', 'omp']);
+
+describe('presetToExecutionAgent', () => {
+  it('uses the preset tool when it is a registered execution agent', () => {
+    expect(presetToExecutionAgent('omp+claude', PRESETS, REGISTERED, 'claude')).toBe('omp');
+    expect(presetToExecutionAgent('codex', PRESETS, REGISTERED, 'claude')).toBe('codex');
+  });
+
+  it('falls back to the preset model when the tool is not an execution agent', () => {
+    expect(presetToExecutionAgent('cursor+codex', PRESETS, REGISTERED, 'claude')).toBe('codex');
+    expect(presetToExecutionAgent('cursor+claude', PRESETS, REGISTERED, 'claude')).toBe('claude');
+  });
+
+  it('uses the default agent for unknown or missing presets', () => {
+    expect(presetToExecutionAgent('mystery', PRESETS, REGISTERED, 'claude')).toBe('claude');
+    expect(presetToExecutionAgent(undefined, PRESETS, REGISTERED, 'claude')).toBe('claude');
+  });
+});
+
+describe('gatherWorkflowContext', () => {
+  let adapter: SQLiteAdapter;
+  let conversationRepo: ConversationRepository;
+  let workflowChannelRepo: WorkflowChannelRepository;
+
+  const apiTask: TaskState = {
+    id: 'wf-1/api',
+    description: 'api',
+    status: 'completed',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { workflowId: 'wf-1' },
+    execution: { agentSessionId: 'sess-1', agentName: 'claude' },
+    taskStateVersion: 1,
+  };
+  const mergeTask: TaskState = {
+    id: '__merge__wf-1',
+    description: 'merge',
+    status: 'pending',
+    dependencies: ['wf-1/api'],
+    createdAt: new Date(),
+    config: { workflowId: 'wf-1', isMergeNode: true },
+    execution: {},
+    taskStateVersion: 1,
+  };
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    conversationRepo = new ConversationRepository(adapter, { info: silent, warn: silent, error: silent });
+    conversationRepo.saveConversation('t1', [{ role: 'user', content: 'plan this' }], null, false, 'CLOBBY', 'U1');
+    workflowChannelRepo = new WorkflowChannelRepository(adapter);
+    workflowChannelRepo.save({ workflowId: 'wf-1', channelId: 'C123', lobbyThreadTs: 't1', createdAt: new Date().toISOString() });
+  });
+
+  afterEach(() => { adapter.close(); });
+
+  it('returns the planning conversation plus one entry per non-merge task with its transcript', async () => {
+    const resolveSession = async (sessionId: string, agentName: string): Promise<AgentSessionData> => ({
+      agentName,
+      sessionId,
+      state: 'finished',
+      messages: [{ role: 'assistant', content: 'did X on api', timestamp: '' }],
+    });
+
+    const ctx = await gatherWorkflowContext(
+      {
+        persistence: {
+          loadTasks: () => [mergeTask, apiTask],
+          getTaskOutput: (id) => (id === 'wf-1/api' ? 'added /health' : ''),
+        },
+        conversationRepo,
+        workflowChannelRepo,
+        agentRegistry: registerBuiltinAgents(),
+        resolveSession,
+      },
+      'wf-1',
+    );
+
+    expect(ctx.workflowId).toBe('wf-1');
+    expect(ctx.planning).toEqual([{ role: 'user', content: 'plan this' }]);
+    expect(ctx.tasks).toEqual([
+      {
+        id: 'wf-1/api',
+        status: 'completed',
+        agentName: 'claude',
+        transcript: [{ role: 'assistant', content: 'did X on api' }],
+        output: 'added /health',
+      },
+    ]);
+  });
+
+  it('tolerates a session load failure and still lists the task', async () => {
+    const resolveSession = async (): Promise<AgentSessionData> => { throw new Error('boom'); };
+    const ctx = await gatherWorkflowContext(
+      {
+        persistence: { loadTasks: () => [apiTask], getTaskOutput: () => '' },
+        conversationRepo,
+        workflowChannelRepo,
+        agentRegistry: registerBuiltinAgents(),
+        resolveSession,
+        log: silent,
+      },
+      'wf-1',
+    );
+    expect(ctx.tasks).toEqual([
+      { id: 'wf-1/api', status: 'completed', agentName: 'claude', transcript: [], output: undefined },
+    ]);
+  });
+});

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -62,6 +62,14 @@ export interface InvokerConfig {
   planningTimeoutSeconds?: number;
   /** Interval for heartbeat messages posted to Slack during planning in seconds. Default: 120 (2 minutes). Set to 0 to disable. */
   planningHeartbeatIntervalSeconds?: number;
+  /** Named Slack planning harness presets: preset key → {tool, model}; built-ins apply when omitted. */
+  slackHarnessPresets?: Record<string, { tool: 'cursor' | 'omp' | 'codex'; model?: string }>;
+  /** Default harness preset key when the message carries no `[preset]` tag. Default: 'cursor+claude'. */
+  defaultSlackHarnessPreset?: string;
+  /** Slack repo aliases: alias → git URL, resolved from a `[repo:<alias>]` tag. */
+  slackRepos?: Record<string, string>;
+  /** Repo URL used for Slack planning when the message carries no `[repo:]` tag. */
+  defaultRepoUrl?: string;
   /** Maximum number of tasks that can run concurrently. Default: 6. */
   maxConcurrency?: number;
   /** Browser executable for opening external URLs (e.g. "firefox"). Default: Chrome. */

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -77,7 +77,7 @@ import {
   resolveRepoRoot,
 } from '@invoker/contracts';
 import type { ActionGraphResponse, WorkflowMeta, WorkResponse } from '@invoker/contracts';
-import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
+import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
   WorkspaceProbeAdapter,
@@ -95,6 +95,8 @@ import {
   RESTART_TO_BRANCH_TRACE,
   remoteFetchForPool,
   registerBuiltinAgents,
+  RepoPool,
+  DEFAULT_EXECUTION_AGENT,
 } from '@invoker/execution-engine';
 import type { Logger } from '@invoker/contracts';
 import { FileAndDbLogger } from './logger.js';
@@ -139,6 +141,7 @@ import {
   type HeadlessDeps,
 } from './headless.js';
 import { resolveRefreshTaskGraphSnapshot } from './refresh-task-graph.js';
+import { presetToExecutionAgent, gatherWorkflowContext as gatherWorkflowContextImpl } from './slack-workflow-context.js';
 import {
   startStandaloneLaunchDispatcher,
   type StandaloneLaunchDispatcherController,
@@ -778,6 +781,14 @@ function loadSurfaces(): any {
 
 // ── Shared Slack Bot Wiring ──────────────────────────────────
 
+const DEFAULT_SLACK_HARNESS_PRESETS: Record<string, { tool: 'cursor' | 'omp' | 'codex'; model?: string }> = {
+  'cursor+claude': { tool: 'cursor', model: 'claude' },
+  'cursor+codex': { tool: 'cursor', model: 'codex' },
+  'omp+claude': { tool: 'omp', model: 'claude' },
+  omp: { tool: 'omp' },
+  codex: { tool: 'codex' },
+};
+
 interface SlackBotDeps {
   executor: TaskRunner;
   logFn: (source: string, level: string, message: string) => void;
@@ -816,6 +827,37 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
     }
   }
 
+  // ── Slack-native workflow wiring ──────────────────────────
+  const planningRegistry = registerBuiltinAgents();
+  const planningCommandBuilder = (
+    opts: { tool: string; model?: string; prompt: string },
+  ): { command: string; args: string[] } =>
+    planningRegistry.getPlanningOrThrow(opts.tool).buildPlanningCommand(opts.prompt, { model: opts.model });
+
+  const planningRepoPool = new RepoPool({ cacheDir: path.join(resolveInvokerHomeRoot(), 'planning-clones') });
+  const prepareRepoCheckout = async (url: string): Promise<string> =>
+    planningRepoPool.ensureCloneThroughRepoQueue(url);
+
+  const workflowChannelRepo = new WorkflowChannelRepository(persistence);
+
+  const harnessPresets = invokerConfig.slackHarnessPresets ?? DEFAULT_SLACK_HARNESS_PRESETS;
+  const defaultHarnessPreset = invokerConfig.defaultSlackHarnessPreset ?? 'cursor+claude';
+  const registeredExecutionAgents = new Set(planningRegistry.listExecution().map((a) => a.name));
+  const resolveFallbackExecutionAgent = (presetKey?: string): string =>
+    presetToExecutionAgent(presetKey, harnessPresets, registeredExecutionAgents, DEFAULT_EXECUTION_AGENT);
+
+  const gatherWorkflowContext = (workflowId: string) =>
+    gatherWorkflowContextImpl(
+      {
+        persistence,
+        conversationRepo,
+        workflowChannelRepo,
+        agentRegistry: planningRegistry,
+        log: (level, message) => deps.logFn('slack', level, message),
+      },
+      workflowId,
+    );
+
   const slack = new surfaces.SlackSurface({
     botToken: process.env.SLACK_BOT_TOKEN!,
     appToken: process.env.SLACK_APP_TOKEN!,
@@ -830,6 +872,15 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
     log: deps.logFn,
     planningTimeoutSeconds: invokerConfig.planningTimeoutSeconds,
     planningHeartbeatIntervalSeconds: invokerConfig.planningHeartbeatIntervalSeconds,
+    lobbyChannelId: process.env.SLACK_LOBBY_CHANNEL_ID ?? process.env.SLACK_CHANNEL_ID,
+    planningCommandBuilder,
+    prepareRepoCheckout,
+    harnessPresets,
+    defaultHarnessPreset,
+    repoAliases: invokerConfig.slackRepos,
+    defaultRepoUrl: invokerConfig.defaultRepoUrl ?? repoUrl,
+    workflowChannelRepo,
+    gatherWorkflowContext,
   });
 
   await slack.start(async (command: any) => {
@@ -874,17 +925,55 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
       case 'provide_input':
         orchestrator.provideInput(command.taskId, command.input);
         break;
-      case 'get_status':
+      case 'retry': {
+        const taskId = command.taskId as string;
+        const result = await commandService.retryTask(
+          makeEnvelope('retry-task', 'surface', 'task', { taskId }),
+        );
+        if (!result.ok) throw new Error(result.error.message);
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: deps.executor,
+          logger,
+          context: 'surface.retry-task',
+          started: result.data,
+          scopedTaskIds: [taskId],
+        });
         break;
+      }
+      case 'get_status': {
+        const workflowId = command.workflowId as string | undefined;
+        const status = orchestrator.getWorkflowStatus(workflowId);
+        await slack.handleEvent({ type: 'workflow_status', status, workflowId });
+        break;
+      }
       case 'start_plan': {
         const { parsePlan } = await import('./plan-parser.js');
         const planText = command.planText as string;
         const plan = parsePlan(planText);
-        deps.logFn('trace', 'info', `slackBot: loading plan "${plan.name}" (${plan.tasks.length} tasks)`);
+        const harnessPreset = command.harnessPreset as string | undefined;
+        const fallbackAgent = resolveFallbackExecutionAgent(harnessPreset);
+        for (const task of plan.tasks) {
+          if (!task.executionAgent) task.executionAgent = fallbackAgent;
+        }
+        deps.logFn('trace', 'info', `slackBot: loading plan "${plan.name}" (${plan.tasks.length} tasks, defaultAgent=${fallbackAgent})`);
         deps.onStartPlan?.();
         deps.onPlanLoaded?.(plan);
         backupPlan(plan, undefined, logger);
+        const before = new Set(orchestrator.getWorkflowIds());
         orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+        const workflowId = orchestrator.getWorkflowIds().find((id) => !before.has(id));
+        if (workflowId) {
+          await slack.handleEvent({
+            type: 'workflow_created',
+            workflowId,
+            requestedBy: command.requestedBy as string | undefined,
+            lobbyChannel: command.lobbyChannel as string | undefined,
+            lobbyThreadTs: command.lobbyThreadTs as string | undefined,
+            harnessPreset,
+            repoUrl: command.repoUrl as string | undefined,
+          });
+        }
         const started = orchestrator.startExecution();
         deps.logFn('trace', 'info', `slackBot: startExecution returned ${started.length} tasks: [${started.map((t: any) => t.id).join(', ')}]`);
         break;
@@ -2247,12 +2336,12 @@ function createEmbeddedTerminalBackendFromConfig(
     rebuildTaskRunnerWiring({
       orchestrator,
       persistence,
-      messageBus,
       executorRegistry,
       executionAgentRegistry: agentRegistry,
       repoRoot,
       invokerConfig,
       logger,
+      messageBus,
       taskHandles,
       enqueueTaskOutput,
       flushTaskOutput,

--- a/packages/app/src/slack-workflow-context.ts
+++ b/packages/app/src/slack-workflow-context.ts
@@ -1,0 +1,89 @@
+import type { PersistenceAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
+import type { AgentRegistry } from '@invoker/execution-engine';
+import { resolveSessionId, resolveAgentName } from './cost-rollup.js';
+import { resolveAgentSession } from './headless.js';
+
+export interface WorkflowContextResult {
+  workflowId: string;
+  planning: { role: string; content: string }[];
+  tasks: Array<{ id: string; status: string; agentName: string; transcript: { role: string; content: string }[]; output?: string }>;
+}
+
+export interface HarnessPresetSpec {
+  tool: string;
+  model?: string;
+}
+
+export function presetToExecutionAgent(
+  presetKey: string | undefined,
+  harnessPresets: Record<string, HarnessPresetSpec>,
+  registeredExecutionAgents: ReadonlySet<string>,
+  defaultAgent: string,
+): string {
+  const preset = presetKey ? harnessPresets[presetKey] : undefined;
+  if (preset?.tool && registeredExecutionAgents.has(preset.tool)) return preset.tool;
+  if (preset?.model && registeredExecutionAgents.has(preset.model)) return preset.model;
+  return defaultAgent;
+}
+
+export interface GatherWorkflowContextDeps {
+  persistence: Pick<PersistenceAdapter, 'loadTasks' | 'getTaskOutput'>;
+  conversationRepo: Pick<ConversationRepository, 'loadConversation'>;
+  workflowChannelRepo: Pick<WorkflowChannelRepository, 'getByWorkflowId'>;
+  agentRegistry: AgentRegistry;
+  resolveSession?: typeof resolveAgentSession;
+  log?: (level: 'info' | 'warn' | 'error', message: string) => void;
+}
+
+export async function gatherWorkflowContext(
+  deps: GatherWorkflowContextDeps,
+  workflowId: string,
+): Promise<WorkflowContextResult> {
+  const { persistence, conversationRepo, workflowChannelRepo, agentRegistry } = deps;
+  const resolveSession = deps.resolveSession ?? resolveAgentSession;
+
+  const tasks = persistence.loadTasks(workflowId);
+  const contextTasks: WorkflowContextResult['tasks'] = [];
+  for (const task of tasks) {
+    if (task.config.isMergeNode) continue;
+    const sessionId = resolveSessionId({
+      id: task.id,
+      workflowId,
+      runnerKind: '',
+      agentSessionId: task.execution.agentSessionId,
+      lastAgentSessionId: task.execution.lastAgentSessionId,
+      agentName: task.execution.agentName,
+      lastAgentName: task.execution.lastAgentName,
+    });
+    const agentName = resolveAgentName({
+      id: task.id,
+      workflowId,
+      runnerKind: '',
+      agentName: task.execution.agentName,
+      lastAgentName: task.execution.lastAgentName,
+    });
+    let transcript: { role: string; content: string }[] = [];
+    if (sessionId) {
+      try {
+        const session = await resolveSession(sessionId, agentName, agentRegistry, tasks);
+        transcript = (session?.messages ?? []).map((m) => ({ role: m.role, content: m.content }));
+      } catch (err) {
+        deps.log?.('warn', `gatherWorkflowContext: session load failed for ${task.id}: ${err}`);
+      }
+    }
+    const output = persistence.getTaskOutput(task.id);
+    contextTasks.push({ id: task.id, status: task.status, agentName, transcript, output: output || undefined });
+  }
+
+  let planning: { role: string; content: string }[] = [];
+  const mapping = workflowChannelRepo.getByWorkflowId(workflowId);
+  if (mapping?.lobbyThreadTs) {
+    const convo = conversationRepo.loadConversation(mapping.lobbyThreadTs);
+    planning = (convo?.messages ?? []).map((m) => ({
+      role: m.role,
+      content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+    }));
+  }
+
+  return { workflowId, planning, tasks: contextTasks };
+}

--- a/packages/data-store/src/__tests__/workflow-channel-repository.test.ts
+++ b/packages/data-store/src/__tests__/workflow-channel-repository.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import { WorkflowChannelRepository } from '../workflow-channel-repository.js';
+import type { WorkflowChannel } from '../adapter.js';
+
+describe('WorkflowChannelRepository', () => {
+  let adapter: SQLiteAdapter;
+  let repo: WorkflowChannelRepository;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new WorkflowChannelRepository(adapter);
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  const rec: WorkflowChannel = {
+    workflowId: 'wf-1-2',
+    channelId: 'C123',
+    requestedBy: 'U1',
+    lobbyChannelId: 'CLOBBY',
+    lobbyThreadTs: 't1',
+    harnessPreset: 'omp+claude',
+    repoUrl: 'https://example.com/repo.git',
+    createdAt: new Date().toISOString(),
+  };
+
+  it('round-trips a mapping by workflow id and by channel id', () => {
+    repo.save(rec);
+    expect(repo.getByWorkflowId('wf-1-2')).toEqual(rec);
+    expect(repo.getByChannelId('C123')).toEqual(rec);
+  });
+
+  it('returns null for an unknown channel or workflow', () => {
+    expect(repo.getByChannelId('nope')).toBeNull();
+    expect(repo.getByWorkflowId('nope')).toBeNull();
+  });
+
+  it('upserts on repeated save (channel re-map)', () => {
+    repo.save(rec);
+    repo.save({ ...rec, channelId: 'C999' });
+    expect(repo.getByWorkflowId('wf-1-2')?.channelId).toBe('C999');
+    expect(repo.getByChannelId('C123')).toBeNull();
+  });
+
+  it('lists and deletes mappings', () => {
+    repo.save(rec);
+    repo.save({ ...rec, workflowId: 'wf-3-4', channelId: 'C456' });
+    expect(repo.list().map((r) => r.workflowId).sort()).toEqual(['wf-1-2', 'wf-3-4']);
+    repo.delete('wf-1-2');
+    expect(repo.getByWorkflowId('wf-1-2')).toBeNull();
+    expect(repo.list()).toHaveLength(1);
+  });
+
+  it('preserves optional fields left undefined', () => {
+    repo.save({ workflowId: 'wf-9', channelId: 'C9', createdAt: new Date().toISOString() });
+    const loaded = repo.getByWorkflowId('wf-9');
+    expect(loaded?.requestedBy).toBeUndefined();
+    expect(loaded?.repoUrl).toBeUndefined();
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -29,6 +29,19 @@ export interface ConversationMessage {
   createdAt: string;
 }
 
+// ── Workflow Channel Types (Slack workflow↔channel mapping) ─
+
+export interface WorkflowChannel {
+  workflowId: string;
+  channelId: string;
+  requestedBy?: string;
+  lobbyChannelId?: string;
+  lobbyThreadTs?: string;
+  harnessPreset?: string;
+  repoUrl?: string;
+  createdAt: string;
+}
+
 // ── Workflow Types ──────────────────────────────────────────
 
 export interface Workflow {
@@ -135,6 +148,13 @@ export interface PersistenceAdapter {
   // Conversation messages
   appendMessage(threadTs: string, role: 'user' | 'assistant', content: string): void;
   loadMessages(threadTs: string): ConversationMessage[];
+
+  // Workflow channels (Slack workflow↔channel mapping)
+  saveWorkflowChannel(rec: WorkflowChannel): void;
+  loadWorkflowChannelByWorkflowId(workflowId: string): WorkflowChannel | undefined;
+  loadWorkflowChannelByChannelId(channelId: string): WorkflowChannel | undefined;
+  listWorkflowChannels(): WorkflowChannel[];
+  deleteWorkflowChannel(workflowId: string): void;
 
   // Task output (stdout/stderr persistence)
   appendTaskOutput(taskId: string, data: string): void;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -2,3 +2,4 @@ export * from './adapter.js';
 export * from './sqlite-adapter.js';
 export * from './conversation-repository.js';
 export * from './sqlite-task-repository.js';
+export * from './workflow-channel-repository.js';

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -50,6 +50,7 @@ import type {
   ActivityLogEntry,
   Conversation,
   ConversationMessage,
+  WorkflowChannel,
 } from './adapter.js';
 
 type NativeSqlite = typeof import('node:sqlite');
@@ -812,6 +813,20 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
       CREATE INDEX IF NOT EXISTS idx_conv_messages_thread
         ON conversation_messages(thread_ts, seq);
+
+      CREATE TABLE IF NOT EXISTS workflow_channels (
+        workflow_id TEXT PRIMARY KEY,
+        channel_id TEXT NOT NULL,
+        requested_by TEXT,
+        lobby_channel_id TEXT,
+        lobby_thread_ts TEXT,
+        harness_preset TEXT,
+        repo_url TEXT,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_workflow_channels_channel
+        ON workflow_channels(channel_id);
 
       CREATE TABLE IF NOT EXISTS task_output (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -2319,6 +2334,57 @@ export class SQLiteAdapter implements PersistenceAdapter {
       content: row.content,
       createdAt: row.created_at,
     }));
+  }
+
+  // ── Workflow Channels (Slack workflow↔channel mapping) ──
+
+  saveWorkflowChannel(rec: WorkflowChannel): void {
+    this.execRun(`
+      INSERT OR REPLACE INTO workflow_channels
+        (workflow_id, channel_id, requested_by, lobby_channel_id, lobby_thread_ts, harness_preset, repo_url, created_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `, [
+      rec.workflowId,
+      rec.channelId,
+      rec.requestedBy ?? null,
+      rec.lobbyChannelId ?? null,
+      rec.lobbyThreadTs ?? null,
+      rec.harnessPreset ?? null,
+      rec.repoUrl ?? null,
+      rec.createdAt,
+    ]);
+  }
+
+  private mapWorkflowChannelRow(row: any): WorkflowChannel {
+    return {
+      workflowId: row.workflow_id as string,
+      channelId: row.channel_id as string,
+      requestedBy: (row.requested_by as string) ?? undefined,
+      lobbyChannelId: (row.lobby_channel_id as string) ?? undefined,
+      lobbyThreadTs: (row.lobby_thread_ts as string) ?? undefined,
+      harnessPreset: (row.harness_preset as string) ?? undefined,
+      repoUrl: (row.repo_url as string) ?? undefined,
+      createdAt: row.created_at as string,
+    };
+  }
+
+  loadWorkflowChannelByWorkflowId(workflowId: string): WorkflowChannel | undefined {
+    const row = this.queryOne('SELECT * FROM workflow_channels WHERE workflow_id = ?', [workflowId]);
+    return row ? this.mapWorkflowChannelRow(row) : undefined;
+  }
+
+  loadWorkflowChannelByChannelId(channelId: string): WorkflowChannel | undefined {
+    const row = this.queryOne('SELECT * FROM workflow_channels WHERE channel_id = ?', [channelId]);
+    return row ? this.mapWorkflowChannelRow(row) : undefined;
+  }
+
+  listWorkflowChannels(): WorkflowChannel[] {
+    const rows = this.queryAll('SELECT * FROM workflow_channels ORDER BY created_at DESC');
+    return rows.map((row: any) => this.mapWorkflowChannelRow(row));
+  }
+
+  deleteWorkflowChannel(workflowId: string): void {
+    this.execRun('DELETE FROM workflow_channels WHERE workflow_id = ?', [workflowId]);
   }
 
   // ── Task Output ─────────────────────────────────────

--- a/packages/data-store/src/workflow-channel-repository.ts
+++ b/packages/data-store/src/workflow-channel-repository.ts
@@ -1,0 +1,33 @@
+/**
+ * WorkflowChannelRepository — Domain-level API for the Slack workflow↔channel mapping.
+ */
+
+import type { PersistenceAdapter, WorkflowChannel } from './adapter.js';
+
+export class WorkflowChannelRepository {
+  private adapter: PersistenceAdapter;
+
+  constructor(adapter: PersistenceAdapter) {
+    this.adapter = adapter;
+  }
+
+  save(rec: WorkflowChannel): void {
+    this.adapter.saveWorkflowChannel(rec);
+  }
+
+  getByWorkflowId(workflowId: string): WorkflowChannel | null {
+    return this.adapter.loadWorkflowChannelByWorkflowId(workflowId) ?? null;
+  }
+
+  getByChannelId(channelId: string): WorkflowChannel | null {
+    return this.adapter.loadWorkflowChannelByChannelId(channelId) ?? null;
+  }
+
+  list(): WorkflowChannel[] {
+    return this.adapter.listWorkflowChannels();
+  }
+
+  delete(workflowId: string): void {
+    this.adapter.deleteWorkflowChannel(workflowId);
+  }
+}

--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -23,6 +23,21 @@ describe('registerBuiltinAgents', () => {
     const names = registerBuiltinAgents().listExecution().map((agent) => agent.name);
     expect(names).toEqual(expect.arrayContaining(['claude', 'codex', 'omp']));
   });
+
+  it('registers cursor, omp, and codex planning agents', () => {
+    const registry = registerBuiltinAgents();
+    expect(registry.getPlanningOrThrow('cursor').name).toBe('cursor');
+    expect(registry.getPlanningOrThrow('omp').name).toBe('omp');
+    expect(registry.getPlanningOrThrow('codex').name).toBe('codex');
+  });
+
+  it('threads the planning model into the cursor command', () => {
+    const cursor = registerBuiltinAgents().getPlanningOrThrow('cursor');
+    expect(cursor.buildPlanningCommand('p', { model: 'codex' })).toEqual({
+      command: 'cursor',
+      args: ['agent', '--print', '--trust', '--model', 'codex', 'p'],
+    });
+  });
 });
 
 describe('AgentRegistry', () => {

--- a/packages/execution-engine/src/__tests__/codex-planning-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-planning-agent.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { CodexPlanningAgent } from '../agents/codex-planning-agent.js';
+
+describe('CodexPlanningAgent', () => {
+  it('builds a sandboxed full-auto codex exec command and ignores model', () => {
+    const agent = new CodexPlanningAgent({ command: 'codex-test' });
+    expect(agent.buildPlanningCommand('p', { model: 'ignored' })).toEqual({
+      command: 'codex-test',
+      args: ['exec', '--json', '--full-auto', 'p'],
+    });
+  });
+
+  it('defaults the command to codex', () => {
+    expect(new CodexPlanningAgent().buildPlanningCommand('p').command).toBe('codex');
+  });
+
+  it('bypasses the sandbox only when explicitly configured', () => {
+    const agent = new CodexPlanningAgent({ command: 'codex-test', bypassApprovalsAndSandbox: true });
+    expect(agent.buildPlanningCommand('p').args).toEqual([
+      'exec', '--json', '--dangerously-bypass-approvals-and-sandbox', 'p',
+    ]);
+  });
+});

--- a/packages/execution-engine/src/__tests__/omp-planning-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/omp-planning-agent.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { OmpPlanningAgent } from '../agents/omp-planning-agent.js';
+
+describe('OmpPlanningAgent', () => {
+  it('builds a print command with auto approve and model selector', () => {
+    const agent = new OmpPlanningAgent({ command: 'omp-test' });
+    expect(agent.buildPlanningCommand('p', { model: 'claude' })).toEqual({
+      command: 'omp-test',
+      args: ['--no-title', '--auto-approve', '--model', 'claude', '-p', 'p'],
+    });
+  });
+
+  it('omits model args when model is absent', () => {
+    const agent = new OmpPlanningAgent();
+    expect(agent.buildPlanningCommand('p')).toEqual({
+      command: 'omp',
+      args: ['--no-title', '--auto-approve', '-p', 'p'],
+    });
+  });
+});

--- a/packages/execution-engine/src/agent.ts
+++ b/packages/execution-engine/src/agent.ts
@@ -55,5 +55,8 @@ export interface ExecutionAgent {
 
 export interface PlanningAgent {
   readonly name: string;
-  buildPlanningCommand(prompt: string): { command: string; args: string[] };
+  buildPlanningCommand(
+    prompt: string,
+    options?: { model?: string },
+  ): { command: string; args: string[] };
 }

--- a/packages/execution-engine/src/agents/codex-planning-agent.ts
+++ b/packages/execution-engine/src/agents/codex-planning-agent.ts
@@ -1,0 +1,29 @@
+import type { PlanningAgent } from '../agent.js';
+
+export interface CodexPlanningAgentConfig {
+  command?: string;
+  fullAuto?: boolean;
+  bypassApprovalsAndSandbox?: boolean;
+}
+
+export class CodexPlanningAgent implements PlanningAgent {
+  readonly name = 'codex';
+
+  private readonly command: string;
+  private readonly fullAuto: boolean;
+  private readonly bypassApprovalsAndSandbox: boolean;
+
+  constructor(config: CodexPlanningAgentConfig = {}) {
+    this.command = config.command ?? 'codex';
+    this.fullAuto = config.fullAuto ?? true;
+    this.bypassApprovalsAndSandbox = config.bypassApprovalsAndSandbox ?? false;
+  }
+
+  buildPlanningCommand(prompt: string, _options?: { model?: string }): { command: string; args: string[] } {
+    const args = ['exec', '--json'];
+    if (this.bypassApprovalsAndSandbox) args.push('--dangerously-bypass-approvals-and-sandbox');
+    else if (this.fullAuto) args.push('--full-auto');
+    args.push(prompt);
+    return { command: this.command, args };
+  }
+}

--- a/packages/execution-engine/src/agents/cursor-planning-agent.ts
+++ b/packages/execution-engine/src/agents/cursor-planning-agent.ts
@@ -20,10 +20,13 @@ export class CursorPlanningAgent implements PlanningAgent {
     this.command = config.command ?? 'cursor';
   }
 
-  buildPlanningCommand(prompt: string): { command: string; args: string[] } {
+  buildPlanningCommand(
+    prompt: string,
+    options?: { model?: string },
+  ): { command: string; args: string[] } {
     return {
       command: this.command,
-      args: ['agent', '--print', '--trust', prompt],
+      args: ['agent', '--print', '--trust', ...(options?.model ? ['--model', options.model] : []), prompt],
     };
   }
 }

--- a/packages/execution-engine/src/agents/index.ts
+++ b/packages/execution-engine/src/agents/index.ts
@@ -6,12 +6,16 @@ export { ClaudeExecutionAgent, type ClaudeExecutionAgentConfig } from './claude-
 export { CodexExecutionAgent, type CodexExecutionAgentConfig } from './codex-execution-agent.js';
 export { OmpExecutionAgent, type OmpExecutionAgentConfig } from './omp-execution-agent.js';
 export { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
+export { OmpPlanningAgent, type OmpPlanningAgentConfig } from './omp-planning-agent.js';
+export { CodexPlanningAgent, type CodexPlanningAgentConfig } from './codex-planning-agent.js';
 
 import { AgentRegistry } from '../agent-registry.js';
 import { ClaudeExecutionAgent, type ClaudeExecutionAgentConfig } from './claude-execution-agent.js';
 import { CodexExecutionAgent, type CodexExecutionAgentConfig } from './codex-execution-agent.js';
 import { OmpExecutionAgent, type OmpExecutionAgentConfig } from './omp-execution-agent.js';
 import { CursorPlanningAgent, type CursorPlanningAgentConfig } from './cursor-planning-agent.js';
+import { OmpPlanningAgent, type OmpPlanningAgentConfig } from './omp-planning-agent.js';
+import { CodexPlanningAgent, type CodexPlanningAgentConfig } from './codex-planning-agent.js';
 import { CodexSessionDriver } from '../codex-session-driver.js';
 import { ClaudeSessionDriver } from '../claude-session-driver.js';
 import { OmpSessionDriver } from '../omp-session-driver.js';
@@ -24,11 +28,15 @@ export function registerBuiltinAgents(opts?: {
   codex?: CodexExecutionAgentConfig;
   omp?: OmpExecutionAgentConfig;
   cursor?: CursorPlanningAgentConfig;
+  ompPlanning?: OmpPlanningAgentConfig;
+  codexPlanning?: CodexPlanningAgentConfig;
 }): AgentRegistry {
   const registry = new AgentRegistry();
   registry.registerExecution(new ClaudeExecutionAgent(opts?.claude), new ClaudeSessionDriver());
   registry.registerExecution(new CodexExecutionAgent(opts?.codex), new CodexSessionDriver());
   registry.registerExecution(new OmpExecutionAgent(opts?.omp), new OmpSessionDriver());
   registry.registerPlanning(new CursorPlanningAgent(opts?.cursor));
+  registry.registerPlanning(new OmpPlanningAgent(opts?.ompPlanning));
+  registry.registerPlanning(new CodexPlanningAgent(opts?.codexPlanning));
   return registry;
 }

--- a/packages/execution-engine/src/agents/omp-planning-agent.ts
+++ b/packages/execution-engine/src/agents/omp-planning-agent.ts
@@ -1,0 +1,31 @@
+import type { PlanningAgent } from '../agent.js';
+
+export interface OmpPlanningAgentConfig {
+  command?: string;
+}
+
+export class OmpPlanningAgent implements PlanningAgent {
+  readonly name = 'omp';
+
+  private readonly command: string;
+
+  constructor(config: OmpPlanningAgentConfig = {}) {
+    this.command = config.command ?? 'omp';
+  }
+
+  buildPlanningCommand(
+    prompt: string,
+    options?: { model?: string },
+  ): { command: string; args: string[] } {
+    return {
+      command: this.command,
+      args: [
+        '--no-title',
+        '--auto-approve',
+        ...(options?.model ? ['--model', options.model] : []),
+        '-p',
+        prompt,
+      ],
+    };
+  }
+}

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -420,6 +420,35 @@ describe('PlanConversation', () => {
     expect(mockSpawn).toHaveBeenCalledWith('/usr/local/bin/cursor', expect.any(Array), expect.any(Object));
   });
 
+  it('routes spawn through an injected planningCommandBuilder', async () => {
+    const builder = vi.fn((o: { tool: string; model?: string; prompt: string }) => ({
+      command: 'omp',
+      args: ['--no-title', '--auto-approve', '--model', 'claude', '-p', o.prompt],
+    }));
+    const conv = new PlanConversation({ tool: 'omp', model: 'claude', planningCommandBuilder: builder });
+    mockCursorResponse('Hi');
+    await conv.sendMessage('Hello');
+    expect(builder).toHaveBeenCalledWith(
+      expect.objectContaining({ tool: 'omp', model: 'claude', prompt: expect.any(String) }),
+    );
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'omp',
+      ['--no-title', '--auto-approve', '--model', 'claude', '-p', expect.any(String)],
+      expect.objectContaining({ stdio: ['ignore', 'pipe', 'pipe'] }),
+    );
+  });
+
+  it('falls back to cursor --print shape when no builder is injected', async () => {
+    const conv = new PlanConversation({ cursorCommand: 'agent', model: 'sonnet' });
+    mockCursorResponse('Hi');
+    await conv.sendMessage('Hello');
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'agent',
+      ['--print', '--model', 'sonnet', expect.any(String)],
+      expect.any(Object),
+    );
+  });
+
   it('includes system prompt in cursor prompt', async () => {
     mockCursorResponse('Hi');
     await conversation.sendMessage('Hello');

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import * as child_process from 'node:child_process';
+import { SlackSurface, parsePlanningRequest } from '../slack/slack-surface.js';
+import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
+import type { SurfaceCommand } from '../surface.js';
+import type { WorkflowContext } from '../slack/workflow-assistant.js';
+
+// ── Mocks ────────────────────────────────────────────────────
+
+interface MockHandler {
+  pattern: string | RegExp;
+  handler: Function;
+}
+
+vi.mock('@slack/bolt', () => {
+  class MockApp {
+    _eventHandlers: MockHandler[] = [];
+    _actionHandlers: MockHandler[] = [];
+    _commandHandlers: MockHandler[] = [];
+    command = vi.fn((name: string, handler: Function) => { this._commandHandlers.push({ pattern: name, handler }); });
+    action = vi.fn((pattern: string | RegExp, handler: Function) => { this._actionHandlers.push({ pattern, handler }); });
+    event = vi.fn((name: string, handler: Function) => { this._eventHandlers.push({ pattern: name, handler }); });
+    start = vi.fn().mockResolvedValue(undefined);
+    stop = vi.fn().mockResolvedValue(undefined);
+    client = {
+      chat: {
+        postMessage: vi.fn().mockResolvedValue({ ts: '1.1' }),
+        update: vi.fn().mockResolvedValue({}),
+        delete: vi.fn().mockResolvedValue({}),
+      },
+      auth: { test: vi.fn().mockResolvedValue({ user_id: 'U_BOT' }) },
+      reactions: { add: vi.fn().mockResolvedValue({}), remove: vi.fn().mockResolvedValue({}) },
+      conversations: {
+        create: vi.fn().mockResolvedValue({ channel: { id: 'C_NEW' } }),
+        invite: vi.fn().mockResolvedValue({}),
+        list: vi.fn().mockResolvedValue({ channels: [] }),
+      },
+    };
+  }
+  return { App: MockApp };
+});
+
+const planConversationConfigs: any[] = [];
+vi.mock('../slack/plan-conversation.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../slack/plan-conversation.js')>();
+  return {
+    ...actual,
+    PlanConversation: vi.fn((config: unknown) => {
+      planConversationConfigs.push(config);
+      return {
+        sendMessage: vi.fn().mockResolvedValue('planner reply'),
+        submittedPlanText: null,
+        planSubmitted: false,
+        init: vi.fn().mockResolvedValue(undefined),
+      };
+    }),
+  };
+});
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof child_process>();
+  return { ...actual, spawn: vi.fn() };
+});
+const mockSpawn = vi.mocked(child_process.spawn);
+
+function mockProcess(stdout: string, exitCode = 0): any {
+  const proc = new EventEmitter() as any;
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.kill = vi.fn();
+  // Defer the emit to the next microtask so the close listener is attached first.
+  queueMicrotask(() => {
+    proc.stdout.emit('data', Buffer.from(stdout));
+    proc.emit('close', exitCode);
+  });
+  return proc;
+}
+
+const silentLog = () => {};
+
+function baseConfig() {
+  return {
+    botToken: 'xoxb', appToken: 'xapp', signingSecret: 's', channelId: 'CLOBBY', log: silentLog,
+  };
+}
+
+function mentionHandler(surface: SlackSurface): Function {
+  const app = surface.getApp() as any;
+  return app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')!.handler;
+}
+
+// ── parsePlanningRequest ─────────────────────────────────────
+
+describe('parsePlanningRequest', () => {
+  const keys = ['cursor+claude', 'cursor+codex', 'omp', 'omp+claude', 'codex'];
+
+  it('parses preset + repo tags and request text', () => {
+    expect(parsePlanningRequest('<@BOT> [omp+claude] [repo:web] do X', keys, 'cursor+claude')).toEqual({
+      presetKey: 'omp+claude',
+      repo: 'web',
+      text: 'do X',
+    });
+  });
+
+  it('defaults the preset and leaves repo undefined when no tags', () => {
+    expect(parsePlanningRequest('<@BOT> do X', keys, 'cursor+claude')).toEqual({
+      presetKey: 'cursor+claude',
+      repo: undefined,
+      text: 'do X',
+    });
+  });
+
+  it('normalizes a "plain <tool>" tag and stops at unknown tags', () => {
+    expect(parsePlanningRequest('[plain codex] go', keys, 'cursor+claude')).toEqual({
+      presetKey: 'codex',
+      repo: undefined,
+      text: 'go',
+    });
+    expect(parsePlanningRequest('[unknown] go', keys, 'cursor+claude')).toEqual({
+      presetKey: 'cursor+claude',
+      repo: undefined,
+      text: '[unknown] go',
+    });
+  });
+
+  it('resolves a bare omp preset', () => {
+    expect(parsePlanningRequest('[omp] add a /health endpoint', keys, 'cursor+claude')).toEqual({
+      presetKey: 'omp',
+      repo: undefined,
+      text: 'add a /health endpoint',
+    });
+  });
+
+  it('flags a tool-shaped tag that matches no preset', () => {
+    expect(parsePlanningRequest('[cursor] go', keys, 'cursor+claude')).toEqual({
+      presetKey: 'cursor+claude',
+      repo: undefined,
+      text: 'go',
+      unknownPreset: 'cursor',
+    });
+    expect(parsePlanningRequest('[omp+gpt5] go', keys, 'cursor+claude')).toEqual({
+      presetKey: 'cursor+claude',
+      repo: undefined,
+      text: 'go',
+      unknownPreset: 'omp+gpt5',
+    });
+  });
+});
+
+// ── Harness routing ──────────────────────────────────────────
+
+describe('harness routing', () => {
+  beforeEach(() => { planConversationConfigs.length = 0; });
+
+  it('constructs the planning conversation with the preset tool/model and injected builder', async () => {
+    const builder = vi.fn(() => ({ command: 'cursor', args: [] }));
+    const surface = new SlackSurface({ ...baseConfig(), planningCommandBuilder: builder });
+    await surface.start(async () => {});
+
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> [cursor+codex] add a /health endpoint', ts: 't1', user: 'U1' },
+      say: vi.fn().mockResolvedValue({ ts: 'ack' }),
+    });
+
+    const cfg = planConversationConfigs.at(-1);
+    expect(cfg.tool).toBe('cursor');
+    expect(cfg.model).toBe('codex');
+    expect(cfg.planningCommandBuilder).toBe(builder);
+  });
+});
+
+// ── Channel creation ─────────────────────────────────────────
+
+describe('workflow channel creation', () => {
+  let adapter: SQLiteAdapter;
+  let repo: WorkflowChannelRepository;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new WorkflowChannelRepository(adapter);
+  });
+
+  it('creates a private channel, invites the requester, persists, and posts both places', async () => {
+    const surface = new SlackSurface({ ...baseConfig(), workflowChannelRepo: repo });
+    const client = (surface.getApp() as any).client;
+
+    await surface.handleEvent({
+      type: 'workflow_created', workflowId: 'wf-1-2', requestedBy: 'U1',
+      lobbyChannel: 'CLOBBY', lobbyThreadTs: 't1', harnessPreset: 'omp+claude', repoUrl: 'r',
+    });
+
+    expect(client.conversations.create).toHaveBeenCalledWith({ name: 'workflow-1-2', is_private: true });
+    expect(client.conversations.invite).toHaveBeenCalledWith({ channel: 'C_NEW', users: 'U1' });
+    expect(repo.getByWorkflowId('wf-1-2')?.channelId).toBe('C_NEW');
+    const postChannels = client.chat.postMessage.mock.calls.map((c: any[]) => c[0].channel);
+    expect(postChannels).toContain('C_NEW');
+    expect(postChannels).toContain('CLOBBY');
+  });
+
+  it('reuses an existing channel id on name_taken', async () => {
+    const surface = new SlackSurface({ ...baseConfig(), workflowChannelRepo: repo });
+    const client = (surface.getApp() as any).client;
+    client.conversations.create.mockRejectedValueOnce({ data: { error: 'name_taken' } });
+    client.conversations.list.mockResolvedValueOnce({ channels: [{ name: 'workflow-1-2', id: 'C_EXIST' }] });
+
+    await surface.handleEvent({ type: 'workflow_created', workflowId: 'wf-1-2', requestedBy: 'U1' });
+
+    expect(repo.getByWorkflowId('wf-1-2')?.channelId).toBe('C_EXIST');
+  });
+});
+
+// ── Outbound routing ─────────────────────────────────────────
+
+describe('outbound routing', () => {
+  let adapter: SQLiteAdapter;
+  let repo: WorkflowChannelRepository;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new WorkflowChannelRepository(adapter);
+    repo.save({ workflowId: 'wf-1-2', channelId: 'C123', createdAt: new Date().toISOString() });
+  });
+
+  it('posts a mapped workflow delta to its channel', async () => {
+    const surface = new SlackSurface({ ...baseConfig(), workflowChannelRepo: repo });
+    const client = (surface.getApp() as any).client;
+    await surface.handleEvent({
+      type: 'task_delta',
+      delta: { type: 'updated', taskId: 'wf-1-2/api', changes: { status: 'running' }, taskStateVersion: 1, previousTaskStateVersion: 0 },
+    });
+    expect(client.chat.postMessage).toHaveBeenCalledWith(expect.objectContaining({ channel: 'C123' }));
+  });
+
+  it('falls back to the lobby channel for an unmapped workflow', async () => {
+    const surface = new SlackSurface({ ...baseConfig(), workflowChannelRepo: repo });
+    const client = (surface.getApp() as any).client;
+    await surface.handleEvent({
+      type: 'task_delta',
+      delta: { type: 'updated', taskId: 'wf-9/api', changes: { status: 'running' }, taskStateVersion: 1, previousTaskStateVersion: 0 },
+    });
+    expect(client.chat.postMessage).toHaveBeenCalledWith(expect.objectContaining({ channel: 'CLOBBY' }));
+  });
+});
+
+// ── In-channel assistant ─────────────────────────────────────
+
+describe('in-channel workflow assistant', () => {
+  let adapter: SQLiteAdapter;
+  let repo: WorkflowChannelRepository;
+  let convoRepo: ConversationRepository;
+  let received: SurfaceCommand[];
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    repo = new WorkflowChannelRepository(adapter);
+    convoRepo = new ConversationRepository(adapter, { info: silentLog, warn: silentLog, error: silentLog });
+    repo.save({ workflowId: 'wf-1-2', channelId: 'C123', harnessPreset: 'omp+claude', createdAt: new Date().toISOString() });
+    received = [];
+    mockSpawn.mockReset();
+  });
+
+  function assistantSurface(gather?: (id: string) => Promise<WorkflowContext>) {
+    const surface = new SlackSurface({
+      ...baseConfig(),
+      conversationRepo: convoRepo,
+      workflowChannelRepo: repo,
+      planningCommandBuilder: () => ({ command: 'cursor', args: ['--print', 'x'] }),
+      gatherWorkflowContext: gather,
+    });
+    return surface;
+  }
+
+  it('routes a status verb to get_status scoped to the workflow', async () => {
+    const surface = assistantSurface();
+    await surface.start(async (cmd) => { received.push(cmd); });
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> status', ts: 't1', user: 'U1', channel: 'C123' },
+      say: vi.fn().mockResolvedValue({ ts: 'a' }),
+    });
+    expect(received).toContainEqual({ type: 'get_status', workflowId: 'wf-1-2' });
+  });
+
+  it('scopes an approve verb to the workflow task id', async () => {
+    const surface = assistantSurface();
+    await surface.start(async (cmd) => { received.push(cmd); });
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> approve api', ts: 't1', user: 'U1', channel: 'C123' },
+      say: vi.fn().mockResolvedValue({ ts: 'a' }),
+    });
+    expect(received).toContainEqual({ type: 'approve', taskId: 'wf-1-2/api' });
+  });
+
+  it('answers a free-form question only from the gathered workflow context', async () => {
+    const gather = vi.fn(async (): Promise<WorkflowContext> => ({
+      workflowId: 'wf-1-2',
+      planning: [{ role: 'user', content: 'add health endpoint' }],
+      tasks: [{ id: 'wf-1-2/api', status: 'completed', agentName: 'omp', transcript: [], output: 'added /health' }],
+    }));
+    mockSpawn.mockImplementationOnce(() => mockProcess('the api task added /health'));
+    const surface = assistantSurface(gather);
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> what did the api task change?', ts: 't1', user: 'U1', channel: 'C123' },
+      say,
+    });
+    expect(gather).toHaveBeenCalledWith('wf-1-2');
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('/health') }));
+    expect(received).toHaveLength(0);
+  });
+});

--- a/packages/surfaces/src/__tests__/workflow-assistant.test.ts
+++ b/packages/surfaces/src/__tests__/workflow-assistant.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { buildAssistantPrompt, parseWorkflowControl } from '../slack/workflow-assistant.js';
+import type { WorkflowContext } from '../slack/workflow-assistant.js';
+
+describe('parseWorkflowControl', () => {
+  it('parses status', () => {
+    expect(parseWorkflowControl('status')).toEqual({ kind: 'status' });
+    expect(parseWorkflowControl('  STATUS please ')).toEqual({ kind: 'status' });
+  });
+
+  it('parses approve/reject/retry with a task id', () => {
+    expect(parseWorkflowControl('approve api')).toEqual({ kind: 'approve', task: 'api' });
+    expect(parseWorkflowControl('reject db')).toEqual({ kind: 'reject', task: 'db' });
+    expect(parseWorkflowControl('retry web')).toEqual({ kind: 'retry', task: 'web' });
+  });
+
+  it('parses input with a task id and trailing text', () => {
+    expect(parseWorkflowControl('input api: use port 8080')).toEqual({
+      kind: 'input',
+      task: 'api',
+      text: 'use port 8080',
+    });
+  });
+
+  it('returns null for free-form questions', () => {
+    expect(parseWorkflowControl('what did the api task change?')).toBeNull();
+    expect(parseWorkflowControl('approve')).toBeNull(); // verb without a task id
+  });
+});
+
+describe('buildAssistantPrompt', () => {
+  const ctx: WorkflowContext = {
+    workflowId: 'wf-1-2',
+    planning: [{ role: 'user', content: 'add a health endpoint' }],
+    tasks: [
+      { id: 'wf-1-2/api', status: 'completed', agentName: 'omp', transcript: [{ role: 'assistant', content: 'added /health' }], output: 'done' },
+    ],
+  };
+
+  it('embeds the workflow id, planning, transcripts, and the question', () => {
+    const prompt = buildAssistantPrompt('what changed?', ctx);
+    expect(prompt).toContain('wf-1-2');
+    expect(prompt).toContain('add a health endpoint');
+    expect(prompt).toContain('Task wf-1-2/api');
+    expect(prompt).toContain('added /health');
+    expect(prompt).toContain('what changed?');
+    expect(prompt).toContain('Answer ONLY from');
+  });
+});

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -22,11 +22,31 @@ export interface ConversationMessage {
   content: string;
 }
 
+export type PlanningCommandBuilder = (opts: {
+  tool: string;
+  model?: string;
+  prompt: string;
+}) => { command: string; args: string[] };
+
+export function defaultPlanningCommand(
+  cursorCommand: string,
+  opts: { model?: string; prompt: string },
+): { command: string; args: string[] } {
+  const args = ['--print'];
+  if (opts.model) args.push('--model', opts.model);
+  args.push(opts.prompt);
+  return { command: cursorCommand, args };
+}
+
 export interface PlanConversationConfig {
   /** Command to invoke the agent CLI. Default: 'agent'. */
   cursorCommand?: string;
+  /** Planning tool name (e.g. 'cursor', 'omp', 'codex') passed to the builder. */
+  tool?: string;
   /** Model to use (e.g. 'auto', 'sonnet-4'). Omit to use the CLI default. */
   model?: string;
+  /** Injected builder that maps {tool, model, prompt} → CLI command + args. */
+  planningCommandBuilder?: PlanningCommandBuilder;
   /** Root directory for codebase exploration. */
   workingDir?: string;
   /** Subprocess timeout in milliseconds. Default: 300000 (5 minutes). */
@@ -160,7 +180,9 @@ const DEFAULT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 export class PlanConversation {
   private cursorCommand: string;
+  private tool?: string;
   private model?: string;
+  private planningCommandBuilder?: PlanningCommandBuilder;
   private messages: ConversationMessage[] = [];
   private _submittedPlanText: string | null = null;
   private _planSubmitted = false;
@@ -175,7 +197,9 @@ export class PlanConversation {
 
   constructor(config: PlanConversationConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
+    this.tool = config.tool;
     this.model = config.model;
+    this.planningCommandBuilder = config.planningCommandBuilder;
     this.workingDir = config.workingDir;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
     this.threadTs = config.threadTs;
@@ -266,7 +290,7 @@ export class PlanConversation {
     const tPrompt = Date.now();
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: promptLen=${prompt.length}, historyMsgs=${this.messages.length - 1}, promptPreview="${prompt.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
-    const response = await this.spawnCursor(prompt);
+    const response = await this.spawnPlanner(prompt);
     const tCursor = Date.now();
     this.log('plan-conversation', 'info', `[CONV] Turn ${turn}: responseLen=${response.length}, responsePreview="${response.slice(0, 500).replace(/\n/g, '\\n')}"`);
 
@@ -331,15 +355,15 @@ export class PlanConversation {
     return parts.join('\n');
   }
 
-  // ── Cursor CLI Subprocess ─────────────────────────────
+  // ── Planner CLI Subprocess ─────────────────────────────
 
-  spawnCursor(prompt: string): Promise<string> {
+  spawnPlanner(prompt: string): Promise<string> {
     const spawnStart = Date.now();
+    const { command, args } = this.planningCommandBuilder
+      ? this.planningCommandBuilder({ tool: this.tool ?? 'cursor', model: this.model, prompt })
+      : defaultPlanningCommand(this.cursorCommand, { model: this.model, prompt });
     return new Promise((resolve, reject) => {
-      const args = ['--print'];
-      if (this.model) args.push('--model', this.model);
-      args.push(prompt);
-      const child = spawn(this.cursorCommand, args, {
+      const child = spawn(command, args, {
         cwd: this.workingDir ?? process.cwd(),
         stdio: ['ignore', 'pipe', 'pipe'],
         env: { ...process.env },
@@ -350,7 +374,7 @@ export class PlanConversation {
       let stdoutChunks = 0;
       let stderrChunks = 0;
 
-      this.log('plan-conversation', 'info', `[PERF] cursor_spawn: pid=${child.pid ?? 'none'}, cmd="${this.cursorCommand} ${args.slice(0, -1).join(' ')} <prompt>", promptLen=${prompt.length}, cwd=${this.workingDir ?? process.cwd()}`);
+      this.log('plan-conversation', 'info', `[PERF] cursor_spawn: pid=${child.pid ?? 'none'}, cmd="${command} ${args.slice(0, -1).join(' ')} <prompt>", promptLen=${prompt.length}, cwd=${this.workingDir ?? process.cwd()}`);
 
       child.stdout?.on('data', (chunk: Buffer) => {
         const chunkStr = chunk.toString();

--- a/packages/surfaces/src/slack/slack-formatter.ts
+++ b/packages/surfaces/src/slack/slack-formatter.ts
@@ -244,6 +244,8 @@ export function formatSurfaceEvent(event: SurfaceEvent): SlackMessage | null {
     }
     case 'workflow_status':
       return formatWorkflowStatus(event.status);
+    case 'workflow_created':
+      return null;
     case 'error':
       return formatError(event.message);
   }

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -6,15 +6,19 @@
  */
 
 import { App } from '@slack/bolt';
-import type { Surface, CommandHandler, SurfaceEvent, LogFn } from '../surface.js';
+import { spawn } from 'node:child_process';
+import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn } from '../surface.js';
 import { parseSlackCommand } from './slack-commands.js';
 import type { ConversationCommand } from './slack-commands.js';
 import { formatSurfaceEvent, formatWorkflowStatus } from './slack-formatter.js';
 import { splitForSlack, sanitizeSlashCommands } from './slack-message-helpers.js';
 import type { SlackMessage } from './slack-formatter.js';
-import { PlanConversation } from './plan-conversation.js';
+import { PlanConversation, defaultPlanningCommand } from './plan-conversation.js';
+import type { PlanningCommandBuilder } from './plan-conversation.js';
 import { SessionManager, SessionIdentifier } from './thread-session-manager.js';
-import type { ConversationRepository } from '@invoker/data-store';
+import { buildAssistantPrompt, parseWorkflowControl } from './workflow-assistant.js';
+import type { WorkflowContext, WorkflowControl } from './workflow-assistant.js';
+import type { ConversationRepository, WorkflowChannelRepository, WorkflowChannel } from '@invoker/data-store';
 
 // ── Config ──────────────────────────────────────────────────
 
@@ -53,6 +57,95 @@ export interface SlackSurfaceConfig {
   planningTimeoutSeconds?: number;
   /** Interval for heartbeat messages posted to Slack during planning in seconds. Default: 120 (2 minutes). Set to 0 to disable. */
   planningHeartbeatIntervalSeconds?: number;
+
+  // ── Slack-native workflow extensions ──────────────────────
+  /** Lobby channel where `@Invoker` starts planning. Defaults to channelId. */
+  lobbyChannelId?: string;
+  /** Injected planner command builder (registry-backed). Keeps surfaces layer-clean. */
+  planningCommandBuilder?: PlanningCommandBuilder;
+  /** Checks out the target repo for the planning agent; returns the working dir. */
+  prepareRepoCheckout?: (repoUrl: string) => Promise<string>;
+  /** Named harness presets: preset key → {tool, model}. Falls back to built-ins. */
+  harnessPresets?: Record<string, HarnessPreset>;
+  /** Default harness preset key when the message carries no `[preset]` tag. */
+  defaultHarnessPreset?: string;
+  /** Repo aliases: alias → git URL, resolved from a `[repo:<alias>]` tag. */
+  repoAliases?: Record<string, string>;
+  /** Repo URL used when the message carries no `[repo:]` tag. */
+  defaultRepoUrl?: string;
+  /** Persisted workflow↔channel mapping for routing + channel creation. */
+  workflowChannelRepo?: WorkflowChannelRepository;
+  /** Gathers a workflow's planning convo + task transcripts for the in-channel assistant. */
+  gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
+}
+
+export interface HarnessPreset {
+  tool: string;
+  model?: string;
+}
+
+export const BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset> = {
+  'cursor+claude': { tool: 'cursor', model: 'claude' },
+  'cursor+codex': { tool: 'cursor', model: 'codex' },
+  'omp+claude': { tool: 'omp', model: 'claude' },
+  omp: { tool: 'omp' },
+  codex: { tool: 'codex' },
+};
+
+export const DEFAULT_HARNESS_PRESET = 'cursor+claude';
+
+interface PlanningContext {
+  repoUrl?: string;
+  presetKey: string;
+  requestedBy?: string;
+  lobbyChannel?: string;
+}
+
+// ── Planning request parsing ─────────────────────────────────
+
+const PRESET_TOOL_HINTS = ['cursor', 'omp', 'codex', 'claude'];
+
+/** A leading bracket tag is a likely preset attempt when it names a known tool or uses the tool+model form. */
+function looksLikePreset(normalized: string): boolean {
+  return normalized.includes('+') || PRESET_TOOL_HINTS.some((hint) => normalized.includes(hint));
+}
+
+/** Peel leading `[preset]` and `[repo:]` tags off a lobby mention; the rest is the request text. A preset-shaped tag matching no key is returned as `unknownPreset` so the caller can reject it instead of silently using the default. */
+export function parsePlanningRequest(
+  text: string,
+  presetKeys: string[],
+  defaultPresetKey: string,
+): { presetKey: string; repo?: string; text: string; unknownPreset?: string } {
+  let rest = text.replace(/<@[A-Z0-9]+>/g, '').trim();
+  let presetKey = defaultPresetKey;
+  let repo: string | undefined;
+  let unknownPreset: string | undefined;
+  const keyset = new Set(presetKeys.map((k) => k.toLowerCase()));
+  const tagRe = /^\[([^\]]*)\]\s*/;
+
+  for (;;) {
+    const m = tagRe.exec(rest);
+    if (!m) break;
+    const raw = m[1].trim();
+    if (/^repo:/i.test(raw)) {
+      repo = raw.slice(raw.indexOf(':') + 1).trim();
+      rest = rest.slice(m[0].length);
+      continue;
+    }
+    const normalized = raw.toLowerCase().replace(/\s+/g, '').replace(/^plain/, '');
+    if (keyset.has(normalized)) {
+      presetKey = normalized;
+      rest = rest.slice(m[0].length);
+      continue;
+    }
+    if (looksLikePreset(normalized)) {
+      unknownPreset = raw;
+      rest = rest.slice(m[0].length);
+    }
+    break;
+  }
+
+  return { presetKey, repo, text: rest.trim(), unknownPreset };
 }
 
 // ── ConversationLike ─────────────────────────────────────────
@@ -62,6 +155,20 @@ interface ConversationLike {
   sendMessage(message: string): Promise<string>;
   readonly planSubmitted: boolean;
   readonly submittedPlanText: string | null;
+}
+
+interface SayResult {
+  ts?: string;
+}
+
+type SayFn = (msg: { text: string; thread_ts: string }) => Promise<SayResult>;
+
+interface SlackMentionEvent {
+  text?: string;
+  ts: string;
+  thread_ts?: string;
+  user?: string;
+  channel?: string;
 }
 
 // ── SlackSurface ────────────────────────────────────────────
@@ -103,6 +210,19 @@ export class SlackSurface implements Surface {
   };
   /** Maps thread_ts → acknowledgment message timestamp */
   private ackMessages = new Map<string, string>();
+  /** Maps thread_ts → planning context carried into start_plan. */
+  private planningContexts = new Map<string, PlanningContext>();
+
+  // ── Slack-native workflow extensions ──────────────────────
+  private lobbyChannelId: string;
+  private planningCommandBuilder?: PlanningCommandBuilder;
+  private prepareRepoCheckout?: (repoUrl: string) => Promise<string>;
+  private harnessPresets: Record<string, HarnessPreset>;
+  private defaultHarnessPreset: string;
+  private repoAliases: Record<string, string>;
+  private defaultRepoUrl?: string;
+  private workflowChannelRepo?: WorkflowChannelRepository;
+  private gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
 
   constructor(config: SlackSurfaceConfig) {
     this.app = new App({
@@ -126,6 +246,15 @@ export class SlackSurface implements Surface {
     this.useTypingIndicator = config.useTypingIndicator ?? false;
     this.planningTimeoutSeconds = config.planningTimeoutSeconds;
     this.planningHeartbeatIntervalSeconds = config.planningHeartbeatIntervalSeconds;
+    this.lobbyChannelId = config.lobbyChannelId ?? config.channelId;
+    this.planningCommandBuilder = config.planningCommandBuilder;
+    this.prepareRepoCheckout = config.prepareRepoCheckout;
+    this.harnessPresets = config.harnessPresets ?? BUILTIN_HARNESS_PRESETS;
+    this.defaultHarnessPreset = config.defaultHarnessPreset ?? DEFAULT_HARNESS_PRESET;
+    this.repoAliases = config.repoAliases ?? {};
+    this.defaultRepoUrl = config.defaultRepoUrl ?? config.repoUrl;
+    this.workflowChannelRepo = config.workflowChannelRepo;
+    this.gatherWorkflowContext = config.gatherWorkflowContext;
     this.log = config.log ?? ((source, level, msg) => {
       const fn = level === 'error' ? console.error : console.log;
       fn(`[${source}] ${msg}`);
@@ -142,6 +271,7 @@ export class SlackSurface implements Surface {
         repoUrl: config.repoUrl,
         log: this.log,
         timeoutMs: (this.planningTimeoutSeconds ?? 7_200) * 1_000,
+        planningCommandBuilder: config.planningCommandBuilder,
       });
     }
   }
@@ -176,11 +306,23 @@ export class SlackSurface implements Surface {
     }
 
     await this.recoverActiveConversations();
+
+    if (this.workflowChannelRepo) {
+      const mappings = this.workflowChannelRepo.list();
+      this.log('slack', 'info', `[WORKFLOW_CHANNELS] ${mappings.length} workflow channel mapping(s) available for routing`);
+    }
   }
 
   async handleEvent(event: SurfaceEvent): Promise<void> {
+    if (event.type === 'workflow_created') {
+      await this.createWorkflowChannel(event);
+      return;
+    }
+
     const message = formatSurfaceEvent(event);
     if (!message) return;
+
+    const channel = this.resolveChannelForWorkflow(this.deriveWorkflowId(event));
 
     // For task deltas, try to update existing message or post new one
     if (event.type === 'task_delta') {
@@ -189,9 +331,9 @@ export class SlackSurface implements Surface {
 
       const existingTs = this.taskMessages.get(taskId);
       if (existingTs && delta.type === 'updated') {
-        await this.updateMessage(existingTs, message);
+        await this.updateMessage(channel, existingTs, message);
       } else {
-        const ts = await this.postMessage(message);
+        const ts = await this.postMessage(message, channel);
         if (ts) {
           this.taskMessages.set(taskId, ts);
         }
@@ -200,7 +342,24 @@ export class SlackSurface implements Surface {
     }
 
     // For other events, just post
-    await this.postMessage(message);
+    await this.postMessage(message, channel);
+  }
+
+  private deriveWorkflowId(event: SurfaceEvent): string | undefined {
+    if (event.type === 'workflow_status') return event.workflowId;
+    if (event.type === 'task_delta') {
+      const delta = event.delta;
+      const taskId = delta.type === 'created' ? delta.task.id : delta.taskId;
+      if (taskId.startsWith('__merge__')) return taskId.slice('__merge__'.length);
+      const slash = taskId.indexOf('/');
+      return slash === -1 ? undefined : taskId.slice(0, slash);
+    }
+    return undefined;
+  }
+
+  private resolveChannelForWorkflow(workflowId: string | undefined): string {
+    if (!workflowId) return this.lobbyChannelId;
+    return this.workflowChannelRepo?.getByWorkflowId(workflowId)?.channelId ?? this.lobbyChannelId;
   }
 
   async stop(): Promise<void> {
@@ -288,47 +447,310 @@ export class SlackSurface implements Surface {
 
   private registerMentionHandler(): void {
     this.app.event('app_mention', async ({ event, say }) => {
-      const text = event.text.replace(/<@[A-Z0-9]+>/g, '').trim();
-      this.log('slack', 'info', `@mention: "${text.slice(0, 100)}${text.length > 100 ? '...' : ''}" (user=${event.user})`);
-      if (!text) {
-        await say({
-          text: 'Hi! Tag me with a message to start a plan conversation. Example: `@Invoker I want to add a REST API endpoint`',
-          thread_ts: event.ts,
-        });
+      const channel: string | undefined = event.channel;
+
+      const mapping = channel ? this.workflowChannelRepo?.getByChannelId(channel) : null;
+      if (mapping) {
+        await this.handleWorkflowAssistantMention(mapping, event, say);
         return;
       }
 
-      const threadTs = event.thread_ts ?? event.ts;
+      const isLobbyOrDm = !channel || channel === this.lobbyChannelId || channel.startsWith('D');
+      if (!isLobbyOrDm) {
+        this.log('slack', 'info', `Ignoring @mention in non-lobby channel ${channel}`);
+        return;
+      }
 
-      // Send immediate acknowledgment if enabled
-      if (this.enableImmediateAck) {
+      await this.handlePlanningMention(event, say, channel ?? this.lobbyChannelId);
+    });
+  }
+
+  // ── Planning mention (lobby) ───────────────────────────
+
+  private async handlePlanningMention(
+    event: SlackMentionEvent,
+    say: SayFn,
+    channel: string,
+  ): Promise<void> {
+    const parsed = parsePlanningRequest(
+      event.text ?? '',
+      Object.keys(this.harnessPresets),
+      this.defaultHarnessPreset,
+    );
+    this.log('slack', 'info', `@mention: "${parsed.text.slice(0, 100)}${parsed.text.length > 100 ? '...' : ''}" (user=${event.user}, preset=${parsed.presetKey}, repo=${parsed.repo ?? 'default'})`);
+    if (parsed.unknownPreset) {
+      await say({
+        text: `Unknown preset \`[${parsed.unknownPreset}]\`. Valid presets: ${Object.keys(this.harnessPresets).join(', ')}. Omit the tag to use the default (\`${this.defaultHarnessPreset}\`).`,
+        thread_ts: event.ts,
+      });
+      return;
+    }
+    if (!parsed.text) {
+      await say({
+        text: 'Hi! Tag me with a message to start a plan conversation. Example: `@Invoker I want to add a REST API endpoint`',
+        thread_ts: event.ts,
+      });
+      return;
+    }
+
+    const preset = this.resolveHarnessPreset(parsed.presetKey);
+    const repoResolution = this.resolveRepoUrl(parsed.repo);
+    if (repoResolution.error) {
+      await say({ text: repoResolution.error, thread_ts: event.ts });
+      return;
+    }
+    const repoUrl = repoResolution.url;
+
+    const threadTs = event.thread_ts ?? event.ts;
+
+    if (this.enableImmediateAck) {
+      try {
+        const ackResult = await say({ text: this.immediateAckMessage, thread_ts: threadTs });
+        if (ackResult?.ts) this.ackMessages.set(threadTs, ackResult.ts);
+        this.log('slack', 'info', `[ACK] Sent immediate acknowledgment (thread_ts=${threadTs})`);
+      } catch (err) {
+        this.log('slack', 'error', `[ACK] Failed to send immediate acknowledgment: ${err}`);
+      }
+    }
+
+    let workingDir = this.workingDir;
+    if (repoUrl && this.prepareRepoCheckout) {
+      try {
+        workingDir = await this.prepareRepoCheckout(repoUrl);
+      } catch (err) {
+        this.log('slack', 'error', `Failed to prepare repo checkout for ${repoUrl}: ${err}`);
+        await say({ text: `Failed to check out repo: ${err instanceof Error ? err.message : String(err)}`, thread_ts: threadTs });
+        return;
+      }
+    }
+
+    const conversation = await this.getSession(channel, threadTs, event.user ?? 'unknown', true, {
+      tool: preset.tool,
+      model: preset.model,
+      workingDir,
+    });
+    if (!conversation) {
+      await say({ text: 'Too many active conversations. Please wait.', thread_ts: threadTs });
+      return;
+    }
+
+    this.planningContexts.set(threadTs, {
+      repoUrl,
+      presetKey: parsed.presetKey,
+      requestedBy: event.user,
+      lobbyChannel: channel,
+    });
+
+    await this.handleConversationMessage(conversation, parsed.text, threadTs, say, channel);
+  }
+
+  private resolveHarnessPreset(presetKey: string): HarnessPreset {
+    return (
+      this.harnessPresets[presetKey] ??
+      this.harnessPresets[this.defaultHarnessPreset] ??
+      BUILTIN_HARNESS_PRESETS[DEFAULT_HARNESS_PRESET]
+    );
+  }
+
+  private resolveRepoUrl(repo?: string): { url?: string; error?: string } {
+    if (!repo) return { url: this.defaultRepoUrl };
+    const alias = this.repoAliases[repo];
+    if (alias) return { url: alias };
+    if (/^(git@|https?:\/\/|ssh:\/\/)/.test(repo)) return { url: repo };
+    const known = Object.keys(this.repoAliases);
+    const list = known.length ? known.join(', ') : '(none configured)';
+    return { error: `Unknown repo "${repo}". Known aliases: ${list}. Or pass a full git URL.` };
+  }
+
+  // ── In-channel workflow assistant ──────────────────────
+
+  private async handleWorkflowAssistantMention(
+    mapping: WorkflowChannel,
+    event: SlackMentionEvent,
+    say: SayFn,
+  ): Promise<void> {
+    const threadTs = event.thread_ts ?? event.ts;
+    const text = (event.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
+    if (!text) {
+      await say({
+        text: `I answer questions about workflow \`${mapping.workflowId}\` and run controls: \`status\`, \`approve <id>\`, \`reject <id>\`, \`retry <id>\`, \`input <id>: <text>\`.`,
+        thread_ts: threadTs,
+      });
+      return;
+    }
+
+    const ctrl = parseWorkflowControl(text);
+    if (ctrl) {
+      await this.dispatchWorkflowControl(mapping, ctrl, say, threadTs);
+      return;
+    }
+
+    if (!this.gatherWorkflowContext) {
+      await say({ text: 'Workflow context is not available in this deployment.', thread_ts: threadTs });
+      return;
+    }
+
+    try {
+      const ctx = await this.gatherWorkflowContext(mapping.workflowId);
+      const harness = this.resolveHarnessPreset(mapping.harnessPreset ?? this.defaultHarnessPreset);
+      const reply = await this.runOneShotPlanner(harness, buildAssistantPrompt(text, ctx));
+      const chunks = splitForSlack(sanitizeSlashCommands(reply));
+      for (let i = 0; i < chunks.length; i++) {
+        if (i > 0) await this.sleep(this.messagePacingMs);
+        await this.sayWithRateLimitRetry(say, { text: chunks[i], thread_ts: threadTs });
+      }
+    } catch (err) {
+      this.log('slack', 'error', `[ASSISTANT] Q&A failed (workflow=${mapping.workflowId}): ${err}`);
+      await this.sayWithRateLimitRetry(say, {
+        text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+        thread_ts: threadTs,
+      });
+    }
+  }
+
+  private async dispatchWorkflowControl(
+    mapping: WorkflowChannel,
+    ctrl: WorkflowControl,
+    say: SayFn,
+    threadTs: string,
+  ): Promise<void> {
+    const scoped = (task: string): string => `${mapping.workflowId}/${task}`;
+    switch (ctrl.kind) {
+      case 'status':
+        await this.onCommand?.({ type: 'get_status', workflowId: mapping.workflowId });
+        await say({ text: `Fetching status for \`${mapping.workflowId}\`...`, thread_ts: threadTs });
+        return;
+      case 'approve':
+        await this.onCommand?.({ type: 'approve', taskId: scoped(ctrl.task) });
+        await say({ text: `Approving \`${scoped(ctrl.task)}\`.`, thread_ts: threadTs });
+        return;
+      case 'reject':
+        await this.onCommand?.({ type: 'reject', taskId: scoped(ctrl.task) });
+        await say({ text: `Rejecting \`${scoped(ctrl.task)}\`.`, thread_ts: threadTs });
+        return;
+      case 'retry':
+        await this.onCommand?.({ type: 'retry', taskId: scoped(ctrl.task) });
+        await say({ text: `Retrying \`${scoped(ctrl.task)}\`.`, thread_ts: threadTs });
+        return;
+      case 'input':
+        await this.onCommand?.({ type: 'provide_input', taskId: scoped(ctrl.task), input: ctrl.text });
+        await say({ text: `Sent input to \`${scoped(ctrl.task)}\`.`, thread_ts: threadTs });
+        return;
+    }
+  }
+
+  private runOneShotPlanner(harness: HarnessPreset, prompt: string): Promise<string> {
+    const { command, args } = this.planningCommandBuilder
+      ? this.planningCommandBuilder({ tool: harness.tool, model: harness.model, prompt })
+      : defaultPlanningCommand(this.cursorCommand, { model: harness.model, prompt });
+    const timeoutMs = (this.planningTimeoutSeconds ?? 7_200) * 1_000;
+    return new Promise((resolve, reject) => {
+      const child = spawn(command, args, {
+        cwd: this.workingDir ?? process.cwd(),
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env },
+      });
+      let stdout = '';
+      let stderr = '';
+      child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+      child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+      const timer = setTimeout(() => {
+        try { child.kill('SIGTERM'); } catch { /* already dead */ }
+        reject(new Error(`Planner timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        if (code === 0) resolve(stdout.trim() || '(no output)');
+        else reject(new Error(stderr.trim() || stdout.trim() || `Planner exited with code ${code}`));
+      });
+      child.on('error', (err) => {
+        clearTimeout(timer);
+        reject(new Error(`Failed to spawn planner CLI: ${err.message}`));
+      });
+    });
+  }
+
+  // ── Workflow channel creation ──────────────────────────
+
+  private async createWorkflowChannel(
+    event: Extract<SurfaceEvent, { type: 'workflow_created' }>,
+  ): Promise<void> {
+    const client = this.app.client;
+    const name = `workflow-${event.workflowId.replace(/^wf-/, '')}`
+      .toLowerCase()
+      .replace(/[^a-z0-9-_]/g, '-')
+      .slice(0, 80);
+
+    let channelId: string | undefined;
+    try {
+      const created = await client.conversations.create({ name, is_private: true });
+      channelId = created.channel?.id;
+    } catch (err) {
+      const code = this.slackErrorCode(err);
+      if (code === 'name_taken') {
         try {
-          const ackResult = await say({
-            text: this.immediateAckMessage,
-            thread_ts: threadTs,
-          });
-          // Store the ack message timestamp for potential future cleanup
-          if (ackResult?.ts) {
-            this.ackMessages.set(threadTs, ackResult.ts);
-          }
-          this.log('slack', 'info', `[ACK] Sent immediate acknowledgment (thread_ts=${threadTs})`);
-        } catch (err) {
-          this.log('slack', 'error', `[ACK] Failed to send immediate acknowledgment: ${err}`);
-          // Don't fail the request if ack fails - continue processing
+          const list = await client.conversations.list({ types: 'private_channel', limit: 1000 });
+          channelId = (list.channels ?? []).find((c) => c.name === name)?.id;
+        } catch (listErr) {
+          this.log('slack', 'error', `Failed to list channels after name_taken: ${listErr}`);
+        }
+      } else {
+        this.log('slack', 'error', `Failed to create workflow channel ${name}: ${err}`);
+      }
+    }
+
+    if (!channelId) {
+      if (event.lobbyChannel) {
+        await this.postToThread(event.lobbyChannel, event.lobbyThreadTs, `Could not create a channel for workflow \`${event.workflowId}\`.`);
+      }
+      return;
+    }
+
+    if (event.requestedBy) {
+      try {
+        await client.conversations.invite({ channel: channelId, users: event.requestedBy });
+      } catch (err) {
+        const code = this.slackErrorCode(err);
+        if (code !== 'already_in_channel' && code !== 'cant_invite_self') {
+          this.log('slack', 'warn', `Failed to invite ${event.requestedBy} to ${channelId}: ${err}`);
         }
       }
+    }
 
-      this.log('slack', 'info', `[TRACE] getSession start (channelId=${this.channelId}, threadTs=${threadTs}, userId=${event.user}, create=true)`);
-      const conversation = await this.getSession(this.channelId, threadTs, event.user ?? 'unknown');
-      this.log('slack', 'info', `[TRACE] getSession returned ${conversation ? 'session' : 'null'} (threadTs=${threadTs})`);
-      if (!conversation) {
-        await say({ text: 'Too many active conversations. Please wait.', thread_ts: threadTs });
-        return;
-      }
-
-      this.log('slack', 'info', `[TRACE] handleConversationMessage start (threadTs=${threadTs}, textLen=${text.length})`);
-      await this.handleConversationMessage(conversation, text, threadTs, say);
+    this.workflowChannelRepo?.save({
+      workflowId: event.workflowId,
+      channelId,
+      requestedBy: event.requestedBy,
+      lobbyChannelId: event.lobbyChannel,
+      lobbyThreadTs: event.lobbyThreadTs,
+      harnessPreset: event.harnessPreset,
+      repoUrl: event.repoUrl,
+      createdAt: new Date().toISOString(),
     });
+
+    await this.postMessage(
+      {
+        text: `Workflow \`${event.workflowId}\` is running here. Mention me with \`status\`, \`approve <task>\`, \`reject <task>\`, \`retry <task>\`, or ask a question about this workflow.`,
+        blocks: [],
+      },
+      channelId,
+    );
+
+    if (event.lobbyChannel) {
+      await this.postToThread(event.lobbyChannel, event.lobbyThreadTs, `Created <#${channelId}> for workflow \`${event.workflowId}\`.`);
+    }
+  }
+
+  private async postToThread(channel: string, threadTs: string | undefined, text: string): Promise<void> {
+    try {
+      await this.app.client.chat.postMessage({
+        channel,
+        text,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+      });
+    } catch (err) {
+      this.log('slack', 'error', `Failed to post to thread: ${err}`);
+    }
   }
 
   // ── Thread Reply Handler (Continue Plan Conversations) ─
@@ -343,15 +765,18 @@ export class SlackSurface implements Surface {
       // Skip @mentions — already handled by registerMentionHandler
       if (this.botUserId && (msg.text ?? '').includes(`<@${this.botUserId}>`)) return;
 
+      const channel = (msg.channel as string | undefined) ?? this.channelId;
+      if (msg.channel && this.workflowChannelRepo?.getByChannelId(msg.channel)) return;
+
       // Look up or recover session (don't create new sessions for random thread replies in fallback mode)
-      const conversation = await this.getSession(this.channelId, msg.thread_ts, msg.user ?? 'unknown', false);
+      const conversation = await this.getSession(channel, msg.thread_ts, msg.user ?? 'unknown', false);
       if (!conversation) return;
       const text = (msg.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
       if (!text) return;
 
       this.log('slack', 'info', `[SESSION_MESSAGE] Thread reply (thread_ts=${msg.thread_ts}, user=${msg.user}, preview="${text.slice(0, 100)}${text.length > 100 ? '...' : ''}")`);
 
-      await this.handleConversationMessage(conversation, text, msg.thread_ts, say);
+      await this.handleConversationMessage(conversation, text, msg.thread_ts, say, channel);
     });
   }
 
@@ -361,12 +786,13 @@ export class SlackSurface implements Surface {
     conversation: ConversationLike,
     text: string,
     threadTs: string,
-    say: (msg: { text: string; thread_ts: string }) => Promise<any>,
+    say: SayFn,
+    channel: string = this.lobbyChannelId,
   ): Promise<void> {
     const tEntry = Date.now();
     this.log('slack', 'info', `[TRACE] handleConversationMessage (thread_ts=${threadTs}, text="${text.slice(0, 80)}")`);
 
-    const typingStarted = await this.startTypingIndicator(this.channelId, threadTs);
+    const typingStarted = await this.startTypingIndicator(channel, threadTs);
     const tSetup = Date.now();
 
     const heartbeatMs = (this.planningHeartbeatIntervalSeconds ?? 120) * 1_000;
@@ -398,7 +824,7 @@ export class SlackSurface implements Surface {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
       for (const hbTs of heartbeatTimestamps) {
         try {
-          await this.deleteMessage(hbTs);
+          await this.deleteMessage(channel, hbTs);
         } catch (err) {
           this.log('slack', 'warn', `[HEARTBEAT] Failed to delete heartbeat message ${hbTs}: ${err}`);
         }
@@ -407,20 +833,20 @@ export class SlackSurface implements Surface {
       this.log('slack', 'info', `[TRACE] conversation.sendMessage returned (threadTs=${threadTs}, replyLen=${reply.length}, planSubmitted=${conversation.planSubmitted})`);
 
       if (typingStarted) {
-        await this.stopTypingIndicator(this.channelId, threadTs);
+        await this.stopTypingIndicator(channel, threadTs);
       }
 
       const chunks = splitForSlack(sanitizeSlashCommands(reply));
 
       const ackTs = this.ackMessages.get(threadTs);
       if (ackTs) {
-        const updated = await this.updateMessage(ackTs, { text: chunks[0], blocks: [] });
+        const updated = await this.updateMessage(channel, ackTs, { text: chunks[0], blocks: [] });
         this.ackMessages.delete(threadTs);
         if (updated) {
           this.log('slack', 'info', `[ACK] Replaced immediate acknowledgment with actual response (thread_ts=${threadTs}, ack_ts=${ackTs}, chunks=${chunks.length})`);
         } else {
           this.log('slack', 'warn', `[ACK] Failed to replace ack, falling back to new message (thread_ts=${threadTs}, ack_ts=${ackTs})`);
-          await this.deleteMessage(ackTs);
+          await this.deleteMessage(channel, ackTs);
           await this.sayWithRateLimitRetry(say, { text: chunks[0], thread_ts: threadTs });
         }
       } else {
@@ -439,7 +865,17 @@ export class SlackSurface implements Surface {
           text: `Starting plan execution...`,
           thread_ts: threadTs,
         });
-        await this.onCommand?.({ type: 'start_plan', planText: conversation.submittedPlanText });
+        const ctx = this.planningContexts.get(threadTs);
+        await this.onCommand?.({
+          type: 'start_plan',
+          planText: conversation.submittedPlanText,
+          repoUrl: ctx?.repoUrl,
+          harnessPreset: ctx?.presetKey,
+          requestedBy: ctx?.requestedBy,
+          lobbyChannel: ctx?.lobbyChannel ?? channel,
+          lobbyThreadTs: threadTs,
+        });
+        this.planningContexts.delete(threadTs);
         this.cleanupSession(threadTs, 'plan_submitted');
       }
       const tEnd = Date.now();
@@ -449,13 +885,13 @@ export class SlackSurface implements Surface {
       if (heartbeatTimer) clearInterval(heartbeatTimer);
       for (const hbTs of heartbeatTimestamps) {
         try {
-          await this.deleteMessage(hbTs);
+          await this.deleteMessage(channel, hbTs);
         } catch (deleteErr) {
           this.log('slack', 'warn', `[HEARTBEAT] Failed to delete heartbeat message ${hbTs}: ${deleteErr}`);
         }
       }
       if (typingStarted) {
-        await this.stopTypingIndicator(this.channelId, threadTs);
+        await this.stopTypingIndicator(channel, threadTs);
       }
 
       const tErr = Date.now();
@@ -477,6 +913,14 @@ export class SlackSurface implements Surface {
 
   private async sleep(ms: number): Promise<void> {
     await new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private slackErrorCode(err: unknown): string | undefined {
+    if (!err || typeof err !== 'object') return undefined;
+    const e = err as { data?: { error?: unknown }; code?: unknown };
+    if (typeof e.data?.error === 'string') return e.data.error;
+    if (typeof e.code === 'string') return e.code;
+    return undefined;
   }
 
   private getRetryAfterMs(err: unknown): number | null {
@@ -665,7 +1109,13 @@ export class SlackSurface implements Surface {
    * When SessionManager is available, delegates to it.
    * Falls back to the in-memory Map when no persistence is configured.
    */
-  private async getSession(channelId: string, threadTs: string, userId: string, create = true): Promise<ConversationLike | null> {
+  private async getSession(
+    channelId: string,
+    threadTs: string,
+    userId: string,
+    create = true,
+    opts?: { tool?: string; model?: string; workingDir?: string },
+  ): Promise<ConversationLike | null> {
     this.log('slack', 'info', `[TRACE] getSession (channelId=${channelId}, threadTs=${threadTs}, userId=${userId}, create=${create}, hasSessionManager=${!!this.sessionManager})`);
     if (this.sessionManager) {
       if (!create) {
@@ -682,6 +1132,7 @@ export class SlackSurface implements Surface {
       const session = await this.sessionManager.getOrCreateSession(
         new SessionIdentifier(channelId, threadTs),
         userId,
+        opts,
       );
       this.log('slack', 'info', `[TRACE] getOrCreateSession returned ${session ? 'session' : 'null'} (threadTs=${threadTs})`);
       return session;
@@ -694,8 +1145,10 @@ export class SlackSurface implements Surface {
       this.sessionMetrics.created++;
       conversation = new PlanConversation({
         cursorCommand: this.cursorCommand,
-        model: this.model,
-        workingDir: this.workingDir,
+        tool: opts?.tool,
+        model: opts?.model ?? this.model,
+        planningCommandBuilder: this.planningCommandBuilder,
+        workingDir: opts?.workingDir ?? this.workingDir,
         threadTs,
         conversationRepo: this.conversationRepo,
         defaultBranch: this.defaultBranch,
@@ -819,10 +1272,10 @@ export class SlackSurface implements Surface {
     }
   }
 
-  private async postMessage(message: SlackMessage): Promise<string | undefined> {
+  private async postMessage(message: SlackMessage, channel = this.lobbyChannelId): Promise<string | undefined> {
     try {
       const result = await this.app.client.chat.postMessage({
-        channel: this.channelId,
+        channel,
         text: message.text,
         blocks: message.blocks as any,
       });
@@ -834,10 +1287,10 @@ export class SlackSurface implements Surface {
     }
   }
 
-  private async updateMessage(ts: string, message: SlackMessage): Promise<boolean> {
+  private async updateMessage(channel: string, ts: string, message: SlackMessage): Promise<boolean> {
     try {
       await this.app.client.chat.update({
-        channel: this.channelId,
+        channel,
         ts,
         text: message.text,
         blocks: message.blocks as any,
@@ -849,10 +1302,10 @@ export class SlackSurface implements Surface {
     }
   }
 
-  private async deleteMessage(ts: string): Promise<void> {
+  private async deleteMessage(channel: string, ts: string): Promise<void> {
     try {
       await this.app.client.chat.delete({
-        channel: this.channelId,
+        channel,
         ts,
       });
     } catch (err) {

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -14,6 +14,7 @@
  */
 
 import { PlanConversation } from './plan-conversation.js';
+import type { PlanningCommandBuilder } from './plan-conversation.js';
 import type { ConversationRepository } from '@invoker/data-store';
 import type { LogFn } from '../surface.js';
 
@@ -160,8 +161,8 @@ export interface SessionManagerConfig {
   /** Default repo URL (e.g. "git@github.com:user/repo.git"). Passed to PlanConversation. */
   repoUrl?: string;
   log?: LogFn;
-  /** Cursor CLI subprocess timeout in ms. Passed to PlanConversation. */
   timeoutMs?: number;
+  planningCommandBuilder?: PlanningCommandBuilder;
 }
 
 export interface SessionMetrics {
@@ -198,6 +199,7 @@ export class SessionManager {
   private readonly evictionIntervalMs: number;
   private readonly maxActiveSessions: number;
   private readonly timeoutMs?: number;
+  private readonly planningCommandBuilder?: PlanningCommandBuilder;
 
   constructor(config: SessionManagerConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -211,6 +213,7 @@ export class SessionManager {
     this.evictionIntervalMs = config.evictionIntervalMs ?? 5 * 60 * 1000; // 5 minutes
     this.maxActiveSessions = config.maxActiveSessions ?? 100;
     this.timeoutMs = config.timeoutMs;
+    this.planningCommandBuilder = config.planningCommandBuilder;
   }
 
   /**
@@ -246,6 +249,7 @@ export class SessionManager {
   async getOrCreateSession(
     id: SessionIdentifier,
     userId: string,
+    opts?: { tool?: string; model?: string; workingDir?: string },
   ): Promise<SessionHandle | null> {
     const key = id.toString();
 
@@ -288,8 +292,10 @@ export class SessionManager {
       this.log('session-manager', 'info', `[TRACE] Recovery path: creating PlanConversation + init() (threadTs=${id.threadTs})`);
       const conversation = new PlanConversation({
         cursorCommand: this.cursorCommand,
-        model: this.model,
-        workingDir: this.workingDir,
+        tool: opts?.tool,
+        model: opts?.model ?? this.model,
+        planningCommandBuilder: this.planningCommandBuilder,
+        workingDir: opts?.workingDir ?? this.workingDir,
         threadTs: id.threadTs,
         conversationRepo: this.conversationRepo,
         defaultBranch: this.defaultBranch,
@@ -315,8 +321,10 @@ export class SessionManager {
       this.log('session-manager', 'info', `[TRACE] Creation path: new PlanConversation (threadTs=${id.threadTs}, hasConversationRepo=true, skipping init)`);
       const conversation = new PlanConversation({
         cursorCommand: this.cursorCommand,
-        model: this.model,
-        workingDir: this.workingDir,
+        tool: opts?.tool,
+        model: opts?.model ?? this.model,
+        planningCommandBuilder: this.planningCommandBuilder,
+        workingDir: opts?.workingDir ?? this.workingDir,
         threadTs: id.threadTs,
         conversationRepo: this.conversationRepo,
         defaultBranch: this.defaultBranch,

--- a/packages/surfaces/src/slack/workflow-assistant.ts
+++ b/packages/surfaces/src/slack/workflow-assistant.ts
@@ -1,0 +1,62 @@
+// ── Context ──────────────────────────────────────────────────
+
+export interface WorkflowContext {
+  workflowId: string;
+  planning: { role: string; content: string }[];
+  tasks: Array<{
+    id: string;
+    status: string;
+    agentName: string;
+    transcript: { role: string; content: string }[];
+    output?: string;
+  }>;
+}
+
+// ── Q&A prompt ───────────────────────────────────────────────
+
+export function buildAssistantPrompt(question: string, ctx: WorkflowContext): string {
+  const lines: string[] = [
+    `You are answering questions about Invoker workflow \`${ctx.workflowId}\`.`,
+    "Answer ONLY from this workflow's planning conversation and task transcripts below.",
+    'If the answer is not present in this context, say you do not know — never guess or use outside knowledge.',
+    '',
+    '=== Planning conversation ===',
+  ];
+  if (ctx.planning.length === 0) lines.push('(none)');
+  for (const m of ctx.planning) lines.push(`${m.role}: ${m.content}`);
+  lines.push('');
+
+  for (const task of ctx.tasks) {
+    lines.push(`=== Task ${task.id} (status=${task.status}, agent=${task.agentName}) ===`);
+    if (task.transcript.length === 0) lines.push('(no transcript)');
+    for (const m of task.transcript) lines.push(`${m.role}: ${m.content}`);
+    if (task.output) lines.push(`output: ${task.output}`);
+    lines.push('');
+  }
+
+  lines.push('=== Question ===');
+  lines.push(question);
+  return lines.join('\n');
+}
+
+// ── Control verbs ────────────────────────────────────────────
+
+export type WorkflowControl =
+  | { kind: 'status' }
+  | { kind: 'approve' | 'reject' | 'retry'; task: string }
+  | { kind: 'input'; task: string; text: string };
+
+export function parseWorkflowControl(text: string): WorkflowControl | null {
+  const t = text.trim();
+  if (/^status\b/i.test(t)) return { kind: 'status' };
+
+  const input = /^input\s+(\S+)\s*:\s*([\s\S]+)$/i.exec(t);
+  if (input) return { kind: 'input', task: input[1], text: input[2].trim() };
+
+  const action = /^(approve|reject|retry)\s+(\S+)\s*$/i.exec(t);
+  if (action) {
+    return { kind: action[1].toLowerCase() as 'approve' | 'reject' | 'retry', task: action[2] };
+  }
+
+  return null;
+}

--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -15,8 +15,17 @@ export type SurfaceCommand =
   | { type: 'reject'; taskId: string; reason?: string }
   | { type: 'select_experiment'; taskId: string; experimentId: string }
   | { type: 'provide_input'; taskId: string; input: string }
-  | { type: 'get_status' }
-  | { type: 'start_plan'; planText: string };
+  | { type: 'retry'; taskId: string }
+  | { type: 'get_status'; workflowId?: string }
+  | {
+      type: 'start_plan';
+      planText: string;
+      repoUrl?: string;
+      harnessPreset?: string;
+      requestedBy?: string;
+      lobbyChannel?: string;
+      lobbyThreadTs?: string;
+    };
 
 // ── Events (Orchestrator → Surface) ────────────────────────
 
@@ -31,7 +40,16 @@ export interface WorkflowStatus {
 
 export type SurfaceEvent =
   | { type: 'task_delta'; delta: TaskDelta }
-  | { type: 'workflow_status'; status: WorkflowStatus }
+  | { type: 'workflow_status'; status: WorkflowStatus; workflowId?: string }
+  | {
+      type: 'workflow_created';
+      workflowId: string;
+      requestedBy?: string;
+      lobbyChannel?: string;
+      lobbyThreadTs?: string;
+      harnessPreset?: string;
+      repoUrl?: string;
+    }
   | { type: 'error'; message: string };
 
 // ── Logging ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This documents the new Slack workflow for operators.

A new guide plus README and config examples explain the lobby mention, the harness presets, the per-workflow channels, and the required Slack scopes.

It also records the change in the changelog.

<details>
<summary>Review metadata</summary>

Review Claim: Documentation describes how to plan and drive workflows from Slack.

Review Lane: docs

Review Unit: docs

Safety Invariant: Documentation, the config example, and the changelog only; no runtime code changes.

Slice Rationale: Docs land last so they describe shipped behavior.

Architectural Effect: None.

Alternative Considerations: We could skip docs, but the lobby tags and required Slack scopes are not discoverable from code alone.
</details>

## Non-goals

This does not change runtime behavior.

This does not add Slack manifest automation.

## Test Plan

- [x] `node -e "JSON.parse(require('fs').readFileSync('docs/invoker-config-example.json','utf8'))"`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge commit>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added guide for Slack-native coding workflows covering plan initiation via bot mentions, harness preset selection, and in-channel workflow operations using bot commands.
  * Updated documentation table with link to new workflow guide.

* **Chores**
  * Updated configuration examples with Slack harness presets and repository mappings.
  * Added release notes documenting new Slack workflow features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2217