### PR TITLE
Recovery Lifecycle 2i Step 2: Per-kind single-instance lock

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -25,9 +25,10 @@ import {
   registerBuiltinAgents,
   assertPlanExecutionAgentsRegistered,
   createAutoFixRecoveryWorker,
-  acquireRecoveryWorkerLock,
+  acquireWorkerLock,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
+  RECOVERY_WORKER_KIND,
   type AgentRegistry,
   type TaskHeartbeatEvent,
 } from '@invoker/execution-engine';
@@ -1152,7 +1153,11 @@ const HEADLESS_WORKER_KINDS: ReadonlyArray<{ kind: string; available: boolean; n
 async function headlessWorkerAutofix(deps: Pick<HeadlessDeps, 'logger'>): Promise<void> {
   let lock;
   try {
-    lock = acquireRecoveryWorkerLock({ homeRoot: resolveInvokerHomeRoot(), logger: deps.logger });
+    lock = acquireWorkerLock({
+      homeRoot: resolveInvokerHomeRoot(),
+      kind: RECOVERY_WORKER_KIND,
+      logger: deps.logger,
+    });
   } catch (err) {
     if (err instanceof WorkerLockHeldError) {
       // Refuse explicitly per the app's throw-based error convention.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,9 +10,10 @@ import {
   TaskRunner,
   WorktreeExecutor,
   createAutoFixRecoveryWorker,
-  acquireRecoveryWorkerLock,
+  acquireWorkerLock,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
+  RECOVERY_WORKER_KIND,
   registerBuiltinAgents,
 } from '@invoker/execution-engine';
 import {
@@ -544,7 +545,11 @@ async function runAutoFixWorker(bus: MessageBus): Promise<number> {
   // failed tasks.
   let lock;
   try {
-    lock = acquireRecoveryWorkerLock({ homeRoot: resolveInvokerHomeRoot(), logger: silentLogger });
+    lock = acquireWorkerLock({
+      homeRoot: resolveInvokerHomeRoot(),
+      kind: RECOVERY_WORKER_KIND,
+      logger: silentLogger,
+    });
   } catch (err) {
     if (err instanceof WorkerLockHeldError) {
       process.stderr.write(`${err.message}\n`);

--- a/packages/execution-engine/src/__tests__/worker-lock.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-lock.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import {
   acquireRecoveryWorkerLock,
   acquireWorkerLock,
+  resolveWorkerLockPath,
   WorkerLockHeldError,
 } from '../worker-lock.js';
 import { RECOVERY_WORKER_KIND } from '../worker-runtime.js';
@@ -20,23 +21,25 @@ describe('worker single-instance lock', () => {
     rmSync(homeRoot, { recursive: true, force: true });
   });
 
-  it('refuses a second start while a worker holds the lock, then allows start after release', () => {
-    // First start acquires the lock.
-    const first = acquireRecoveryWorkerLock({ homeRoot });
-    expect(existsSync(first.path)).toBe(true);
+  it('allows different kinds to run together but refuses a second start of the same kind', () => {
+    const recovery = acquireWorkerLock({ homeRoot, kind: RECOVERY_WORKER_KIND });
+    const otherKind = 'other-kind';
+    const other = acquireWorkerLock({ homeRoot, kind: otherKind });
 
-    // A second start (same kind, same Invoker home) must refuse — no second
-    // concurrent loop — because a live process already holds the lock.
-    expect(() => acquireRecoveryWorkerLock({ homeRoot })).toThrow(WorkerLockHeldError);
+    expect(recovery.path).toBe(resolveWorkerLockPath(homeRoot, RECOVERY_WORKER_KIND));
+    expect(other.path).toBe(resolveWorkerLockPath(homeRoot, otherKind));
+    expect(recovery.path).not.toBe(other.path);
+    expect(existsSync(recovery.path)).toBe(true);
+    expect(existsSync(other.path)).toBe(true);
 
-    // stop() releases the lock...
-    first.release();
-    expect(existsSync(first.path)).toBe(false);
+    expect(() => acquireWorkerLock({ homeRoot, kind: RECOVERY_WORKER_KIND })).toThrow(WorkerLockHeldError);
 
-    // ...so a subsequent legitimate start succeeds.
-    const second = acquireRecoveryWorkerLock({ homeRoot });
-    expect(existsSync(second.path)).toBe(true);
-    second.release();
+    recovery.release();
+    other.release();
+
+    const restarted = acquireWorkerLock({ homeRoot, kind: RECOVERY_WORKER_KIND });
+    expect(existsSync(restarted.path)).toBe(true);
+    restarted.release();
   });
 
   it('release is idempotent and only removes a lock this process owns', () => {
@@ -48,7 +51,7 @@ describe('worker single-instance lock', () => {
   });
 
   it('reclaims a stale lock left by a dead process', () => {
-    const lockPath = join(homeRoot, 'locks', `worker-${RECOVERY_WORKER_KIND}.lock`);
+    const lockPath = resolveWorkerLockPath(homeRoot, RECOVERY_WORKER_KIND);
     rmSync(join(homeRoot, 'locks'), { recursive: true, force: true });
     // Simulate a crash: a lock file naming a pid that no longer exists.
     mkdirSync(join(homeRoot, 'locks'), { recursive: true });

--- a/packages/execution-engine/src/worker-lock.ts
+++ b/packages/execution-engine/src/worker-lock.ts
@@ -75,6 +75,11 @@ export interface AcquireWorkerLockOptions {
   logger?: Logger;
 }
 
+/** Resolve the on-disk lock path for a worker kind. */
+export function resolveWorkerLockPath(homeRoot: string, kind: string): string {
+  return join(homeRoot, 'locks', `worker-${kind}.lock`);
+}
+
 /** Is `pid` a live process this user can observe? */
 function isProcessAlive(pid: number): boolean {
   if (!Number.isInteger(pid) || pid <= 0) return false;
@@ -115,7 +120,7 @@ export function acquireWorkerLock(options: AcquireWorkerLockOptions = {}): Worke
   const homeRoot = options.homeRoot ?? resolveInvokerHomeRoot();
   const pid = options.pid ?? process.pid;
   const locksDir = join(homeRoot, 'locks');
-  const lockPath = join(locksDir, `worker-${kind}.lock`);
+  const lockPath = resolveWorkerLockPath(homeRoot, kind);
   const logFields = { module: 'worker-lock', kind, lockPath };
 
   mkdirSync(locksDir, { recursive: true });


### PR DESCRIPTION
## Summary

The worker lock key now comes from the worker kind instead of one fixed name.

Different kinds can run together, while a second start of the same kind is still refused.

## Architecture

### Before

```mermaid
graph TD
    A[Single fixed worker lock] --> B[All worker kinds contend]
```

### After

```mermaid
graph TD
    A[Per-kind worker lock] --> B[Different kinds run concurrently]
    A --> C[Second start of same kind is refused]
```

## Test Plan

- [ ] `cd packages/execution-engine && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert cc6665bd6c8a8c064a0c4f5d607f150351fef3de`
- Post-revert steps: None
- Data migration? No
