### PR TITLE
[pr-skill robustness](2) Fix orphaned merge completion: terminal failure on destroy

### DIFF
--- a/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { WorkRequest } from '@invoker/contracts';
+import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import { MergeGateExecutor } from '../merge-gate-executor.js';
 
@@ -123,5 +123,63 @@ describe('MergeGateExecutor', () => {
     } finally {
       await executor.destroyAll();
     }
+  });
+
+  it('emits a terminal failure when destroyed while a merge action is in flight', async () => {
+    const invokerHome = mkdtempSync(join(tmpdir(), 'invoker-merge-destroy-test-'));
+    const gateWorkspace = mkdtempSync(join(tmpdir(), 'invoker-merge-gate-test-'));
+    tempDirs.push(invokerHome, gateWorkspace);
+    process.env.INVOKER_DB_DIR = invokerHome;
+
+    const task = makeMergeTask();
+    const blockedSummary = createDeferred<string>();
+    const responses: WorkResponse[] = [];
+    const executor = new MergeGateExecutor({
+      cwd: '/tmp/host-repo',
+      defaultBranch: 'master',
+      persistence: {
+        loadWorkflow: vi.fn(() => ({
+          id: 'wf-1782192502908-14',
+          baseBranch: 'master',
+          featureBranch: 'plan/crabbox-ssh-step-2-resolver',
+          onFinish: 'none',
+          mergeMode: 'manual',
+        })),
+        updateTask: vi.fn(),
+      },
+      orchestrator: {
+        getTask: vi.fn(() => task),
+        getAllTasks: vi.fn(() => [task]),
+      },
+      createMergeWorktree: vi.fn(async () => gateWorkspace),
+      detectDefaultBranch: vi.fn(async () => 'master'),
+      buildMergeSummary: vi.fn(() => blockedSummary.promise),
+      callbacks: {},
+    } as any);
+
+    const handle = await executor.start(makeRequest(task));
+    executor.onComplete(handle, (response) => {
+      responses.push(response);
+    });
+
+    await vi.waitFor(() => {
+      expect((executor as any).host.buildMergeSummary).toHaveBeenCalled();
+    });
+    await executor.destroyAll();
+
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toMatchObject({
+      actionId: task.id,
+      attemptId: task.execution.selectedAttemptId,
+      status: 'failed',
+      outputs: {
+        exitCode: 1,
+        error: 'Merge gate execution was stopped before completion',
+      },
+    });
+
+    blockedSummary.resolve('summary after destroy');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(responses).toHaveLength(1);
   });
 });

--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -97,6 +97,21 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
   async destroyAll(): Promise<void> {
     for (const [executionId, entry] of this.entries) {
       if (entry.heartbeatTimer) clearInterval(entry.heartbeatTimer);
+      entry.heartbeatTimer = undefined;
+      if (!entry.completed) {
+        entry.killed = true;
+        this.emitComplete(executionId, {
+          requestId: entry.request.requestId,
+          actionId: entry.request.actionId,
+          attemptId: entry.request.attemptId,
+          executionGeneration: entry.request.executionGeneration,
+          status: 'failed',
+          outputs: {
+            exitCode: 1,
+            error: 'Merge gate execution was stopped before completion',
+          },
+        });
+      }
       this.entries.delete(executionId);
     }
   }
@@ -140,6 +155,16 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
           workspacePath: result.taskChanges.execution.workspacePath ?? launchWorkspacePath,
         }
         : undefined;
+
+      // The merge action may have taken minutes; destroyAll() can have killed or
+      // deleted this entry meanwhile and already emitted a terminal failure. Do
+      // not persist late execution state or complete again over that.
+      const liveEntry = this.getEntry(handle);
+      if (!liveEntry || liveEntry.completed || liveEntry.killed || entry.killed) {
+        this.cleanupLaunchWorkspace(launchWorkspacePath, executionChanges?.workspacePath);
+        return;
+      }
+
       if (executionChanges) {
         this.host.persistence.updateTask(task.id, {
           execution: executionChanges,

--- a/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192505728-27.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192505728-27.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="__merge__wf-1782192505728-27"
+SOURCE="$ROOT/packages/execution-engine/src/merge-gate-executor.ts"
+TEST_SOURCE="$ROOT/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: processless merge executor destroyAll() dropped the active completion listener"
+
+python3 - "$SOURCE" "$TEST_SOURCE" <<'PY'
+import pathlib
+import re
+import sys
+
+source_path = pathlib.Path(sys.argv[1])
+test_path = pathlib.Path(sys.argv[2])
+source = source_path.read_text(encoding="utf-8")
+test_source = test_path.read_text(encoding="utf-8")
+
+task_id = "__merge__wf-1782192505728-27"
+
+class MergeEntry:
+    def __init__(self):
+        self.completed = False
+        self.listeners = [lambda response: responses.append(response)]
+
+responses = []
+
+def emit_complete(entry, response: dict) -> None:
+    if entry is None or entry.completed:
+        return
+    entry.completed = True
+    for listener in entry.listeners:
+        listener(response)
+
+def pre_fix_destroy_all(entries: dict[str, MergeEntry]) -> None:
+    # Before the fix, MergeGateExecutor.destroyAll() cleared entries without a
+    # terminal response. The async merge action could later finish, but
+    # emitComplete() had no entry/listener to notify.
+    entries.clear()
+
+def post_fix_destroy_all(entries: dict[str, MergeEntry]) -> None:
+    for execution_id, entry in list(entries.items()):
+        if not entry.completed:
+            emit_complete(entry, {
+                "status": "failed",
+                "error": "Merge gate execution was stopped before completion",
+            })
+        entries.pop(execution_id, None)
+
+pre_entries = {"exec": MergeEntry()}
+pre_fix_destroy_all(pre_entries)
+emit_complete(pre_entries.get("exec"), {"status": "review_ready"})
+assert responses == [], "pre-fix model should drop the terminal merge completion"
+
+post_entries = {"exec": MergeEntry()}
+post_fix_destroy_all(post_entries)
+emit_complete(post_entries.get("exec"), {"status": "review_ready"})
+assert responses == [{
+    "status": "failed",
+    "error": "Merge gate execution was stopped before completion",
+}], "fixed model should terminally fail exactly once"
+
+destroy_match = re.search(r"async destroyAll\(\): Promise<void> \{(?P<body>.*?)\n  \}", source, re.S)
+if not destroy_match:
+    raise SystemExit("could not locate MergeGateExecutor.destroyAll()")
+destroy_body = destroy_match.group("body")
+
+required_source = [
+    "entry.killed = true;",
+    "this.emitComplete(executionId, {",
+    "Merge gate execution was stopped before completion",
+]
+missing = [needle for needle in required_source if needle not in destroy_body]
+if missing:
+    raise SystemExit("fixed destroyAll terminal response invariant missing: " + ", ".join(missing))
+
+if "emits a terminal failure when destroyed while a merge action is in flight" not in test_source:
+    raise SystemExit("focused merge executor destroyAll regression test is missing")
+
+print("[repro] pre-fix model: merge action can finish after destroyAll with no entry/listener, leaving task running")
+print("[repro] post-fix model: destroyAll emits one failed terminal response before removing the entry")
+print("[repro] source check: MergeGateExecutor.destroyAll() now terminally fails active processless runs")
+PY
+
+pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/merge-gate-executor.test.ts
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

A merge gate that finishes after teardown no longer orphans the task in a running state. destroyAll() now emits one failed terminal response for any in-flight merge gate before removing its entry, and run() re-checks killed/deleted state after the awaited merge action.

This PR bundles the regression repro **with** its fix (one problem = one repro = one fix).

<details>
<summary>Review metadata</summary>

Review Claim: Approve that teardown during an in-flight merge always reaches a terminal task state.
Review Lane: behavior
Review Unit: routing
Safety Invariant: Existing healthy merge/PR-authoring flows behave exactly as before; only the failure path changes.
Slice Rationale: One reproduced problem per PR, with its repro committed alongside the fix.

</details>

## Non-goals

- Does not change the launch-workspace path or PR-authoring.

## Test Plan

- [x] `bash scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192505728-27.sh`
- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/merge-gate-executor.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved shutdown behavior for merge gate executions: heartbeat timers are cleared, unfinished work is marked as killed, and a single terminal failure is emitted when execution stops before completion (with the message “Merge gate execution was stopped before completion”).
  * Avoided late or duplicate completion/persistence by ensuring executions are still eligible to finish after shutdown.

* **Tests**
  * Added coverage for shutdown occurring while merge summary is still pending, verifying exactly one expected failure completion is produced.

* **Chores**
  * Added a regression repro script to validate the destroy-before-completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->