### PR TITLE
[pr-skill robustness](5) Enforce make-pr schema on review-stack PR bodies (#2170)

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -6,9 +6,12 @@ import { describe, it, expect, afterEach } from 'vitest';
 
 import {
   buildCanonicalPrBody,
+  buildMakePrStackPublishPrompt,
+  parseMakePrStackPublishResult,
   resolveSkillPathViaAgent,
   spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
+  validateReviewStackPrBody,
 } from '../pr-authoring.js';
 import type { ExecutionAgent } from '../agent.js';
 
@@ -121,6 +124,166 @@ describe('buildCanonicalPrBody', () => {
 
     const errors = validateCanonicalPrBody(body);
     expect(errors).toEqual([]);
+  });
+});
+
+// ── validateReviewStackPrBody ────────────────────────────
+
+// Shape of the body PR #2170 actually shipped: canonical sections + an
+// Architecture block, but none of the review-compression sections. It passes
+// the canonical validator yet must be rejected for an Invoker review stack.
+const PR_2170_COMMIT_MESSAGE_BODY = [
+  '## Summary',
+  '',
+  'Cut over recovery ownership to the explicit worker.',
+  '',
+  '## Architecture',
+  '',
+  '### Before',
+  '```mermaid',
+  'graph TD',
+  '  A["hidden hook"]',
+  '```',
+  '',
+  '### After',
+  '```mermaid',
+  'graph TD',
+  '  A["worker autofix"]',
+  '```',
+  '',
+  '## Test Plan',
+  '',
+  '- [x] `pnpm test`',
+  '',
+  '## Revert Plan',
+  '',
+  '- Safe to revert? Yes',
+].join('\n');
+
+// Canonical shape: review-compression fields live in a collapsed Review
+// metadata block inside ## Summary; Non-goals/Test Plan/Revert Plan are
+// top-level. Mirrors scripts/validate-pr-body.mjs.
+const COMPLIANT_REVIEW_STACK_BODY = [
+  '## Summary',
+  '',
+  'Plain explanation of the slice.',
+  '',
+  '<details>',
+  '<summary>Review metadata</summary>',
+  '',
+  'Review Claim: Approve the one thing this slice does.',
+  'Review Lane: cleanup',
+  'Review Unit: scalar',
+  'Safety Invariant: Why this slice is safe to review locally.',
+  'Slice Rationale: Why the work is split here.',
+  '',
+  '</details>',
+  '',
+  '## Non-goals',
+  '',
+  '- Does not change behavior.',
+  '',
+  '## Test Plan',
+  '',
+  '- [x] `pnpm test`',
+  '',
+  '## Revert Plan',
+  '',
+  '- Safe to revert? Yes',
+].join('\n');
+
+describe('validateReviewStackPrBody', () => {
+  it('rejects a commit-message body that lacks the review metadata block + Non-goals (PR #2170)', () => {
+    const errors = validateReviewStackPrBody(PR_2170_COMMIT_MESSAGE_BODY);
+    expect(errors).toContain('Missing required section: ## Non-goals');
+    expect(errors).toContain(
+      '## Summary must include a collapsed <details> block with <summary>Review metadata</summary>.',
+    );
+    // The same body passes the looser canonical validator — proving why #2170
+    // shipped: the Invoker stack path never applied the stricter schema.
+    expect(validateCanonicalPrBody(PR_2170_COMMIT_MESSAGE_BODY)).toEqual([]);
+  });
+
+  it('accepts a body carrying the full review-stack schema', () => {
+    expect(validateReviewStackPrBody(COMPLIANT_REVIEW_STACK_BODY)).toEqual([]);
+  });
+
+  it('rejects visible top-level metadata sections', () => {
+    const visible = COMPLIANT_REVIEW_STACK_BODY + '\n\n## Review Claim\n\nshould be in metadata';
+    const errors = validateReviewStackPrBody(visible);
+    expect(errors.some((e) => e.includes('## Review Claim belongs in the collapsed Review metadata block'))).toBe(true);
+  });
+
+  it('rejects a metadata block missing a required field', () => {
+    const missingUnit = COMPLIANT_REVIEW_STACK_BODY.replace('Review Unit: scalar\n', '');
+    const errors = validateReviewStackPrBody(missingUnit);
+    expect(errors).toContain('Review metadata is missing required field: Review Unit:');
+  });
+
+  it('rejects an empty body with a schema hint', () => {
+    const errors = validateReviewStackPrBody('');
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('Review metadata block');
+  });
+
+  it('does not count schema headings that appear inside fenced code blocks', () => {
+    const fenced = COMPLIANT_REVIEW_STACK_BODY.replace(
+      '## Non-goals\n',
+      '```md\n## Non-goals\n```\n',
+    );
+    const errors = validateReviewStackPrBody(fenced);
+    expect(errors).toContain('Missing required section: ## Non-goals');
+  });
+
+  it('requires real Markdown headings, not section names mentioned inline', () => {
+    // Mentions "## Non-goals" only inside prose, not as a heading line.
+    const inlineOnly = COMPLIANT_REVIEW_STACK_BODY.replace(
+      '## Non-goals\n',
+      'This PR has no `## Non-goals` to speak of.\n',
+    );
+    const errors = validateReviewStackPrBody(inlineOnly);
+    expect(errors).toContain('Missing required section: ## Non-goals');
+  });
+});
+
+// ── make-pr stack publish prompt + parsing ───────────────
+
+describe('make-pr stack publish body contract', () => {
+  it('prompt requires an explicit schema-compliant body per artifact', () => {
+    const prompt = buildMakePrStackPublishPrompt({
+      skillPath: '/skills/invoker-make-pr',
+      title: 'My stack',
+      baseBranch: 'master',
+      featureBranch: 'feature',
+      workflowSummary: 'summary',
+      cwd: '/repo',
+    });
+    expect(prompt).toContain('"body":"string"');
+    expect(prompt).toContain('artifact.body MUST be the exact PR body');
+    expect(prompt).toContain('Review metadata');
+    expect(prompt).toContain('Review Unit');
+    expect(prompt).toContain('Do NOT let Mergify default the PR body');
+  });
+
+  it('parses the body field for each artifact', () => {
+    const raw = JSON.stringify({
+      artifacts: [
+        { id: 'a', url: 'https://x/1', body: COMPLIANT_REVIEW_STACK_BODY },
+        { id: 'b', url: 'https://x/2', dependsOn: ['a'], body: COMPLIANT_REVIEW_STACK_BODY },
+      ],
+    });
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]?.body).toBe(COMPLIANT_REVIEW_STACK_BODY);
+    expect(parsed[1]?.body).toBe(COMPLIANT_REVIEW_STACK_BODY);
+  });
+
+  it('leaves body undefined when the agent omits it (caller then rejects it)', () => {
+    const raw = JSON.stringify({ artifacts: [{ id: 'a', url: 'https://x/1' }] });
+    const parsed = parseMakePrStackPublishResult(raw);
+    expect(parsed[0]?.body).toBeUndefined();
+    // The caller validates this empty body and falls through to the next agent.
+    expect(validateReviewStackPrBody(parsed[0]?.body ?? '').length).toBeGreaterThan(0);
   });
 });
 

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1237,7 +1237,7 @@ describe('TaskRunner', () => {
             attempts.push('codex');
             return {
               cmd: 'node',
-              args: ['-e', 'process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master"},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"]}]}))'],
+              args: ['-e', 'var b=["## Summary","","Slice prose.","","<details>","<summary>Review metadata</summary>","","Review Claim: c","Review Lane: cleanup","Review Unit: scalar","Safety Invariant: s","Slice Rationale: r","","</details>","","## Non-goals","- none","","## Test Plan","- [x] pnpm test","","## Revert Plan","- Safe to revert? Yes"].join("\\n");process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master",body:b},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"],body:b}]}))'],
               sessionId: 'sess-codex',
             };
           },
@@ -1341,6 +1341,50 @@ describe('TaskRunner', () => {
         cwd: '/tmp',
       })).rejects.toThrow('make-pr skill is required to publish Invoker review stacks');
     });
+
+    it('publishReviewStackWithMakePrSkill rejects a commit-message body lacking review-compression sections (PR #2170 regression)', async () => {
+      // Valid artifact JSON + valid linear stack, but the body is a bare
+      // commit-message body (## Summary / ## Test Plan / ## Revert Plan only,
+      // no review-compression sections) — exactly what PR #2170 shipped.
+      const tempHome = createTempWorkspace();
+      mkdirSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+      const commitMsgBodyAgent = {
+        name: 'claude',
+        stdinMode: 'ignore' as const,
+        bundledSkills: ['make-pr'],
+        bundledSkillRoot: join(tempHome, '.claude', 'skills'),
+        buildCommand: () => ({
+          cmd: 'node',
+          args: ['-e', 'var b="## Summary x ## Test Plan y ## Revert Plan z";process.stdout.write(JSON.stringify({artifacts:[{id:"only",title:"Only",url:"https://example.test/pr/1",providerId:"1",branch:"stack/only",baseBranch:"master",body:b}]}))'],
+          sessionId: 'commit-msg',
+        }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      // A bare commit-message body: no ## Non-goals, no collapsed Review metadata block.
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: vi.fn().mockReturnValue(commitMsgBodyAgent),
+          getOrThrow: vi.fn(),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([commitMsgBodyAgent]),
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await expect((executor as any).publishReviewStackWithMakePrSkill({
+        workflowId: 'wf-1',
+        title: 'Stack',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        workflowSummary: 'summary',
+        cwd: '/tmp',
+      })).rejects.toThrow(/invalid PR body — .*Non-goals/);
+    });
+
 
     it('authorPrBodyWithSkill falls back to canonical body when authored body is invalid and no other agents available', async () => {
       const tempHome = createTempWorkspace();

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -16,6 +16,8 @@ export interface MakePrStackArtifactOutput {
   readonly branch?: string;
   readonly baseBranch?: string;
   readonly dependsOn?: readonly string[];
+  /** Published PR body. Validated against the make-pr review-stack schema. */
+  readonly body?: string;
 }
 
 // ── Structured PR-authoring context ──────────────────────
@@ -49,6 +51,31 @@ export interface PrAuthoringContext {
 }
 
 const REQUIRED_SECTIONS = ['## Summary', '## Test Plan', '## Revert Plan'] as const;
+// Canonical review-stack schema, mirrored structurally from
+// scripts/validate-pr-body.mjs — the authoritative validator the make-pr skill
+// runs. The review-compression fields live INSIDE a collapsed
+// <details>Review metadata</details> block in ## Summary, not as visible
+// top-level sections, so a bare commit-message body (e.g. PR #2170) is rejected.
+const REVIEW_STACK_REQUIRED_SECTIONS = [
+  '## Summary',
+  '## Non-goals',
+  '## Test Plan',
+  '## Revert Plan',
+] as const;
+const REVIEW_STACK_VISIBLE_METADATA_SECTIONS = [
+  '## Review Claim',
+  '## Review Lane',
+  '## Review Unit',
+  '## Safety Invariant',
+  '## Slice Rationale',
+] as const;
+const REVIEW_STACK_METADATA_LABELS = [
+  'Review Claim',
+  'Review Lane',
+  'Review Unit',
+  'Safety Invariant',
+  'Slice Rationale',
+] as const;
 const DISCOURAGED_HEADINGS = ['## Testing', '## Notes'] as const;
 const DEFAULT_MAX_INLINE_PROMPT_BYTES = 64 * 1024;
 const DEFAULT_PR_AUTHORING_TIMEOUT_MS = 20 * 60 * 1000;
@@ -72,34 +99,159 @@ function getPrAuthoringTimeoutMs(): number {
 }
 
 /** True when `heading` appears as a real Markdown heading line, not as prose/code text. */
-export function validateCanonicalPrBody(body: string): string[] {
+function isFenceLine(line: string): boolean {
+  return /^\s{0,3}(```|~~~)/.test(line);
+}
+
+function hasMarkdownHeading(body: string, heading: string): boolean {
+  const expected = heading.trim().toLowerCase();
+  let inFence = false;
+  for (const line of body.split(/\r?\n/)) {
+    if (isFenceLine(line)) { inFence = !inFence; continue; }
+    if (!inFence && line.trim().toLowerCase() === expected) return true;
+  }
+  return false;
+}
+
+function validateBodyAgainstSections(
+  body: string,
+  requiredSections: readonly string[],
+  emptyMessage: string,
+): string[] {
   const errors: string[] = [];
   const trimmed = body.trim();
 
   if (!trimmed) {
-    return [
-      'PR body is empty. Use the canonical schema: ## Summary, ## Test Plan, ## Revert Plan, plus optional ## Architecture.',
-    ];
+    return [emptyMessage];
   }
 
-  for (const heading of REQUIRED_SECTIONS) {
-    if (!trimmed.includes(heading)) {
+  for (const heading of requiredSections) {
+    if (!hasMarkdownHeading(trimmed, heading)) {
       errors.push(`Missing required section: ${heading}`);
     }
   }
 
   for (const heading of DISCOURAGED_HEADINGS) {
-    if (trimmed.includes(heading)) {
+    if (hasMarkdownHeading(trimmed, heading)) {
       errors.push(
         `Unsupported section: ${heading}. Do not use the lightweight PR format; use ## Test Plan and ## Revert Plan instead.`,
       );
     }
   }
 
-  if (trimmed.includes('## Architecture')) {
+  if (hasMarkdownHeading(trimmed, '## Architecture')) {
     for (const subsection of ['### Before', '### After']) {
-      if (!trimmed.includes(subsection)) {
+      if (!hasMarkdownHeading(trimmed, subsection)) {
         errors.push(`Architecture section is missing required subsection: ${subsection}`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+export function validateCanonicalPrBody(body: string): string[] {
+  return validateBodyAgainstSections(
+    body,
+    REQUIRED_SECTIONS,
+    'PR body is empty. Use the canonical schema: ## Summary, ## Test Plan, ## Revert Plan, plus optional ## Architecture.',
+  );
+}
+
+/** Collect the lines under a `## Heading` until the next `## ` heading. */
+function getMarkdownSection(body: string, heading: string): string {
+  const lines = body.split(/\r?\n/);
+  const expected = heading.trim().toLowerCase();
+  let inFence = false;
+  let start = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (isFenceLine(lines[i])) { inFence = !inFence; continue; }
+    if (!inFence && lines[i].trim().toLowerCase() === expected) { start = i; break; }
+  }
+  if (start === -1) return '';
+  const out: string[] = [];
+  inFence = false;
+  for (const line of lines.slice(start + 1)) {
+    if (isFenceLine(line)) { inFence = !inFence; out.push(line); continue; }
+    if (!inFence && /^##\s+/.test(line.trim())) break;
+    out.push(line);
+  }
+  return out.join('\n').trim();
+}
+
+/** Extract the collapsed `<details><summary>Review metadata</summary>` block from ## Summary. */
+function getReviewMetadataBlock(body: string): { body: string; openAttributes: string } | null {
+  const summary = getMarkdownSection(body, '## Summary');
+  const match = summary.match(
+    /<details\b([^>]*)>\s*<summary>\s*Review metadata\s*<\/summary>([\s\S]*?)<\/details>/i,
+  );
+  if (!match) return null;
+  return { body: match[2].trim(), openAttributes: match[1] };
+}
+
+/** True when the metadata block carries a non-empty `Label:` field. */
+function hasMetadataLabel(metadata: string, label: string): boolean {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`(^|\\n)\\s*${escaped}:\\s*\\S`, 'i').test(metadata);
+}
+
+/**
+ * Validate a published Invoker review-stack PR body. This mirrors the structural
+ * checks in scripts/validate-pr-body.mjs (the authoritative validator the make-pr
+ * skill is told to run): required top-level sections, no visible metadata
+ * sections, and a collapsed Review metadata block carrying every required field.
+ * A mergify-default commit-message body cannot pass. The deeper review-unit and
+ * mermaid rules stay in validate-pr-body.mjs; this is the in-process backstop.
+ */
+export function validateReviewStackPrBody(body: string): string[] {
+  const trimmed = body.trim();
+  if (!trimmed) {
+    return [
+      'PR body is empty. Use the canonical review-stack schema: ## Summary with a collapsed '
+        + 'Review metadata block, ## Non-goals, ## Test Plan, and ## Revert Plan.',
+    ];
+  }
+
+  const errors: string[] = [];
+  for (const heading of REVIEW_STACK_REQUIRED_SECTIONS) {
+    if (!hasMarkdownHeading(trimmed, heading)) {
+      errors.push(`Missing required section: ${heading}`);
+    }
+  }
+  for (const heading of REVIEW_STACK_VISIBLE_METADATA_SECTIONS) {
+    if (hasMarkdownHeading(trimmed, heading)) {
+      errors.push(
+        `${heading} belongs in the collapsed Review metadata block inside ## Summary, `
+          + 'not as a visible top-level section.',
+      );
+    }
+  }
+  for (const heading of DISCOURAGED_HEADINGS) {
+    if (hasMarkdownHeading(trimmed, heading)) {
+      errors.push(
+        `Unsupported section: ${heading}. Do not use the lightweight PR format; `
+          + 'use the canonical review-compression schema instead.',
+      );
+    }
+  }
+  if (hasMarkdownHeading(trimmed, '## Architecture')) {
+    for (const subsection of ['### Before', '### After']) {
+      if (!hasMarkdownHeading(trimmed, subsection)) {
+        errors.push(`Architecture section is missing required subsection: ${subsection}`);
+      }
+    }
+  }
+
+  const metadata = getReviewMetadataBlock(trimmed);
+  if (!metadata) {
+    errors.push('## Summary must include a collapsed <details> block with <summary>Review metadata</summary>.');
+  } else {
+    if (/\bopen\b/i.test(metadata.openAttributes)) {
+      errors.push('Review metadata details must be collapsed by default; remove the open attribute.');
+    }
+    for (const label of REVIEW_STACK_METADATA_LABELS) {
+      if (!hasMetadataLabel(metadata.body, label)) {
+        errors.push(`Review metadata is missing required field: ${label}:`);
       }
     }
   }
@@ -211,13 +363,20 @@ export function buildMakePrStackPublishPrompt(args: {
     '- Use the repo-local PR workflow and validation tools from the skill.',
     '- Output only JSON. Do not include markdown, commentary, explanations, or code fences.',
     '- The JSON shape must be exactly:',
-    '{"artifacts":[{"id":"string","title":"string","url":"string","providerId":"string","branch":"string","baseBranch":"string","dependsOn":["string"]}]}',
+    '{"artifacts":[{"id":"string","title":"string","url":"string","providerId":"string","branch":"string","baseBranch":"string","dependsOn":["string"],"body":"string"}]}',
     '- artifacts are already listed in stack order.',
     '- artifacts[0].dependsOn must be omitted or [].',
     '- For every i > 0, artifacts[i].dependsOn must be exactly [artifacts[i - 1].id].',
     '- Do not emit branches, merges, skipped predecessors, or multiple dependencies.',
     '- Do not add fixed PR-count fields.',
     '- Do not add Mergify-specific fields to the JSON.',
+    '- Each artifact.body MUST be the exact PR body you published for that PR.',
+    '- Each body MUST follow the canonical review-stack schema and pass '
+      + '`node scripts/validate-pr-body.mjs`. Required: ## Summary containing a collapsed '
+      + '<details><summary>Review metadata</summary> block with Review Claim, Review Lane, '
+      + 'Review Unit, Safety Invariant, and Slice Rationale fields; plus top-level ## Non-goals, '
+      + '## Test Plan, and ## Revert Plan. Do not use visible ## Review Claim / ## Review Lane sections.',
+    '- Do NOT let Mergify default the PR body to the commit message; author the body explicitly.',
     '',
     'Workflow summary:',
     '```md',
@@ -289,6 +448,7 @@ export function parseMakePrStackPublishResult(raw: string): MakePrStackArtifactO
       branch: typeof record.branch === 'string' ? record.branch : undefined,
       baseBranch: typeof record.baseBranch === 'string' ? record.baseBranch : undefined,
       dependsOn: normalizedDependsOn,
+      body: typeof record.body === 'string' ? record.body : undefined,
     });
   }
 

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -57,6 +57,7 @@ import {
   resolveSkillPathViaAgent,
   spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
+  validateReviewStackPrBody,
   type PrAuthoringContext,
 } from './pr-authoring.js';
 import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
@@ -2183,14 +2184,23 @@ export class TaskRunner {
       });
 
       try {
+        this.logger.info(
+          `[pr-authoring] body authoring starting agent=${agent.name} `
+            + `workflow=${args.workflowId ?? 'unknown'} skill=invoker-make-pr`,
+        );
         const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
         const validationErrors = validateCanonicalPrBody(result.body);
         if (validationErrors.length > 0) {
+          this.logger.warn(
+            `[pr-authoring] body validation failed agent=${agent.name} `
+              + `errors=${validationErrors.join('; ')}`,
+          );
           errors.push(
             `${agent.name}: invalid PR body — ${validationErrors.join('; ')}`,
           );
           continue;
         }
+        this.logger.info(`[pr-authoring] body authored agent=${agent.name} validated`);
         return { body: result.body, sessionId: result.sessionId, agentName: agent.name };
       } catch (err) {
         errors.push(
@@ -2249,11 +2259,33 @@ export class TaskRunner {
       });
 
       try {
+        this.logger.info(
+          `[pr-authoring] review-stack publish starting agent=${agent.name} `
+            + `workflow=${args.workflowId ?? 'unknown'} skill=invoker-make-pr cwd=${args.cwd}`,
+        );
         const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
         const parsedArtifacts = parseMakePrStackPublishResult(result.body);
+
+        // Enforce the make-pr review-stack schema on every published body.
+        // A mergify-default commit-message body (e.g. PR #2170) fails here and
+        // falls through to the next agent instead of shipping unreviewable.
+        const bodyErrors = parsedArtifacts.flatMap((artifact, index) =>
+          validateReviewStackPrBody(artifact.body ?? '').map(
+            (error) => `artifact[${index}] (${artifact.url}): ${error}`,
+          ),
+        );
+        if (bodyErrors.length > 0) {
+          this.logger.warn(
+            `[pr-authoring] review-stack body validation failed agent=${agent.name} `
+              + `errors=${bodyErrors.join('; ')}`,
+          );
+          errors.push(`${agent.name}: invalid PR body — ${bodyErrors.join('; ')}`);
+          continue;
+        }
+
         const nowIso = new Date().toISOString();
         const generation = args.reviewGate?.activeGeneration ?? 0;
-        const artifacts: ReviewGateArtifact[] = parsedArtifacts.map((artifact) => ({
+        const artifacts: ReviewGateArtifact[] = parsedArtifacts.map(({ body: _body, ...artifact }) => ({
           ...artifact,
           provider: 'github',
           baseBranch: artifact.baseBranch ?? args.baseBranch,
@@ -2262,6 +2294,10 @@ export class TaskRunner {
           generation,
           createdAt: nowIso,
         }));
+        this.logger.info(
+          `[pr-authoring] review-stack published agent=${agent.name} artifacts=${artifacts.length} `
+            + 'bodies validated against make-pr schema',
+        );
         return { artifacts, sessionId: result.sessionId, agentName: agent.name };
       } catch (err) {
         errors.push(`${agent.name}: ${err instanceof Error ? err.message : String(err)}`);

--- a/scripts/repro/repro-unvalidated-review-stack-pr-body.sh
+++ b/scripts/repro/repro-unvalidated-review-stack-pr-body.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+PR_AUTH="$ROOT/packages/execution-engine/src/pr-authoring.ts"
+TASK_RUNNER="$ROOT/packages/execution-engine/src/task-runner.ts"
+echo "[repro] problem: Invoker review-stack PRs shipped commit-message bodies with no review-compression (PR #2170)"
+echo "[repro] root cause: the stack-publish path validated only artifact JSON, never the PR body"
+
+python3 - "$PR_AUTH" "$TASK_RUNNER" <<'PY'
+import pathlib, sys
+pr_auth = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+task_runner = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+
+# Model the schema gate on a #2170-style body: ## Summary/## Test Plan/## Revert Plan,
+# but no collapsed Review metadata block and no ## Non-goals.
+commit_msg_body = "## Summary\n\nCut over recovery.\n\n## Test Plan\n\n- [x] x\n\n## Revert Plan\n\n- yes\n"
+compliant_body = (
+  "## Summary\n\nx\n\n<details>\n<summary>Review metadata</summary>\n\n"
+  "Review Claim: c\nReview Lane: cleanup\nReview Unit: scalar\n"
+  "Safety Invariant: s\nSlice Rationale: r\n\n</details>\n\n"
+  "## Non-goals\n- none\n\n## Test Plan\n- [x] x\n\n## Revert Plan\n- yes\n"
+)
+
+def has_heading(body, h):
+    return any(line.strip().lower() == h.lower() for line in body.splitlines())
+def has_metadata_block(body):
+    return "<summary>Review metadata</summary>" in body
+
+# pre-fix model: nothing validated the body -> commit-message body accepted
+def pre_fix_accepts(body): return True
+assert pre_fix_accepts(commit_msg_body), "pre-fix model accepts any published body"
+
+# post-fix model: require Non-goals heading + Review metadata block
+def post_fix_valid(body):
+    return has_heading(body, "## Non-goals") and has_metadata_block(body)
+assert not post_fix_valid(commit_msg_body), "fixed model must reject the #2170 commit-message body"
+assert post_fix_valid(compliant_body), "fixed model must accept a compliant review-stack body"
+
+# source invariants
+if "export function validateReviewStackPrBody" not in pr_auth:
+    raise SystemExit("missing validateReviewStackPrBody in pr-authoring.ts")
+if "Review metadata" not in pr_auth or "REVIEW_STACK_METADATA_LABELS" not in pr_auth:
+    raise SystemExit("validateReviewStackPrBody must check the Review metadata block")
+if "validateReviewStackPrBody(" not in task_runner:
+    raise SystemExit("publishReviewStackWithMakePrSkill must call validateReviewStackPrBody")
+
+print("[repro] pre-fix model: commit-message body accepted -> PR #2170 shipped unreviewable")
+print("[repro] post-fix model: body without Review metadata block + Non-goals is rejected")
+print("[repro] source check: stack publish validates each body via validateReviewStackPrBody")
+PY
+
+pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-authoring.test.ts >/dev/null 2>&1 && echo "[repro] focused pr-authoring tests pass"
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Invoker review-stack PRs can no longer ship a commit-message body with no review-compression (the PR #2170 failure). The stack-publish path now validates every PR body against the canonical schema (a collapsed Review metadata block plus Non-goals), matching real Markdown headings, and a non-compliant body falls through instead of being accepted.

This PR bundles the regression repro **with** its fix (one problem = one repro = one fix).

<details>
<summary>Review metadata</summary>

Review Claim: Approve that a review-stack PR body missing the schema is rejected, not published.
Review Lane: behavior
Review Unit: routing
Safety Invariant: Existing healthy merge/PR-authoring flows behave exactly as before; only the failure path changes.
Slice Rationale: One reproduced problem per PR, with its repro committed alongside the fix.

</details>

## Non-goals

- Does not fetch the live published body (that is the next slice); validates the agent-reported body here.

## Test Plan

- [x] `bash scripts/repro/repro-unvalidated-review-stack-pr-body.sh`
- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/pr-authoring.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed review-stack PR publishing to reject commit-message-style bodies that omit the required collapsed **“Review metadata”** details (PR **`#2170`** regression).
  * Tightened validation to require real Markdown section headings, disallow visible top-level review-metadata headings, and reject missing/invalid metadata blocks.
* **New Features**
  * Added support for publishing and validating canonical PR bodies per artifact in the review-stack publish flow.
* **Tests**
  * Expanded schema/prompt/parse contract coverage and added regression cases for fallback publish behavior.
* **Chores**
  * Added a repro harness script demonstrating the previous failure mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->