### PR TITLE
[pr-skill robustness](6) Validate the published PR body, not the agent-reported one

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1385,6 +1385,58 @@ describe('TaskRunner', () => {
       })).rejects.toThrow(/invalid PR body — .*Non-goals/);
     });
 
+    it('publishReviewStackWithMakePrSkill validates the published body, not just the agent-reported one', async () => {
+      // Agent reports a fully compliant body in JSON...
+      const goodBody = [
+        '## Summary', '', 'x', '', '<details>', '<summary>Review metadata</summary>', '',
+        'Review Claim: c', 'Review Lane: cleanup', 'Review Unit: scalar',
+        'Safety Invariant: s', 'Slice Rationale: r', '', '</details>', '',
+        '## Non-goals', '- none', '', '## Test Plan', '- [x] t', '', '## Revert Plan', '- yes',
+      ].join('\n');
+      const tempHome = createTempWorkspace();
+      mkdirSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+      const agent = {
+        name: 'claude',
+        stdinMode: 'ignore' as const,
+        bundledSkills: ['make-pr'],
+        bundledSkillRoot: join(tempHome, '.claude', 'skills'),
+        buildCommand: () => ({
+          cmd: 'node',
+          args: ['-e', `var b=${JSON.stringify(goodBody)};process.stdout.write(JSON.stringify({artifacts:[{id:"only",title:"Only",url:"https://example.test/pr/1",providerId:"1",branch:"stack/only",baseBranch:"master",body:b}]}))`],
+          sessionId: 'good',
+        }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+      const executor = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: vi.fn().mockReturnValue(agent),
+          getOrThrow: vi.fn(),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([agent]),
+        } as any,
+        // ...but the body actually published on GitHub is a bare commit message.
+        mergeGateProvider: {
+          name: 'github',
+          createReview: vi.fn(),
+          checkApproval: vi.fn(),
+          getReviewBody: vi.fn().mockResolvedValue('Just a commit message subject\n\nsome body line'),
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await expect((executor as any).publishReviewStackWithMakePrSkill({
+        workflowId: 'wf-1',
+        title: 'Stack',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        workflowSummary: 'summary',
+        cwd: '/tmp',
+      })).rejects.toThrow(/invalid PR body — .*\[published\]/);
+    });
 
     it('authorPrBodyWithSkill falls back to canonical body when authored body is invalid and no other agents available', async () => {
       const tempHome = createTempWorkspace();

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -79,6 +79,19 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     ], cwd));
   }
 
+  async getReviewBody(opts: {
+    identifier: string;
+    cwd: string;
+  }): Promise<string> {
+    const { identifier, cwd } = opts;
+    const targetRepo = await this.resolveTargetRepo(cwd);
+    const stdout = await retryTransientGitHubCli(() => this.exec('gh', [
+      'api', `repos/${targetRepo}/pulls/${identifier}`,
+      '--jq', '.body',
+    ], cwd));
+    return stdout.trim();
+  }
+
   async checkApproval(opts: {
     identifier: string;
     cwd: string;

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -67,4 +67,7 @@ export interface MergeGateProvider {
   checkApproval(opts: MergeGateCheckApprovalOptions): Promise<MergeGateApprovalStatus>;
 
   closeReview?(opts: MergeGateCloseReviewOptions): Promise<void>;
+
+  /** Read the live PR body as published on the provider (e.g. GitHub). */
+  getReviewBody?(opts: { identifier: string; cwd: string }): Promise<string>;
 }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -2266,14 +2266,35 @@ export class TaskRunner {
         const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
         const parsedArtifacts = parseMakePrStackPublishResult(result.body);
 
-        // Enforce the make-pr review-stack schema on every published body.
-        // A mergify-default commit-message body (e.g. PR #2170) fails here and
-        // falls through to the next agent instead of shipping unreviewable.
-        const bodyErrors = parsedArtifacts.flatMap((artifact, index) =>
-          validateReviewStackPrBody(artifact.body ?? '').map(
-            (error) => `artifact[${index}] (${artifact.url}): ${error}`,
-          ),
-        );
+        // Enforce the make-pr review-stack schema on every published body. Prefer
+        // the body actually published on the provider: a lazy agent could report a
+        // compliant body in JSON while letting Mergify default the real PR to the
+        // commit message — the exact PR #2170 failure. Fall back to the
+        // agent-reported body only when the live body cannot be read.
+        const bodyErrors: string[] = [];
+        for (let index = 0; index < parsedArtifacts.length; index += 1) {
+          const artifact = parsedArtifacts[index];
+          let bodyToCheck = artifact.body ?? '';
+          let bodySource = 'agent-reported';
+          if (this.mergeGateProvider?.getReviewBody && artifact.providerId) {
+            try {
+              bodyToCheck = await this.mergeGateProvider.getReviewBody({
+                identifier: artifact.providerId,
+                cwd: args.cwd,
+              });
+              bodySource = 'published';
+            } catch (fetchErr) {
+              this.logger.warn(
+                `[pr-authoring] could not read published body for PR ${artifact.providerId}; `
+                  + `validating agent-reported body instead: `
+                  + `${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}`,
+              );
+            }
+          }
+          for (const error of validateReviewStackPrBody(bodyToCheck)) {
+            bodyErrors.push(`artifact[${index}] (${artifact.url}) [${bodySource}]: ${error}`);
+          }
+        }
         if (bodyErrors.length > 0) {
           this.logger.warn(
             `[pr-authoring] review-stack body validation failed agent=${agent.name} `

--- a/scripts/repro/repro-trusts-agent-reported-pr-body.sh
+++ b/scripts/repro/repro-trusts-agent-reported-pr-body.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+PROVIDER_IF="$ROOT/packages/execution-engine/src/merge-gate-provider.ts"
+PROVIDER="$ROOT/packages/execution-engine/src/github-merge-gate-provider.ts"
+TASK_RUNNER="$ROOT/packages/execution-engine/src/task-runner.ts"
+echo "[repro] problem: stack publish trusted the agent-reported PR body, not the body actually on GitHub"
+echo "[repro] root cause: a lazy agent can report a compliant body while Mergify defaulted the real PR to the commit message"
+
+python3 - "$PROVIDER_IF" "$PROVIDER" "$TASK_RUNNER" <<'PY'
+import pathlib, sys
+provider_if = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+provider = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+task_runner = pathlib.Path(sys.argv[3]).read_text(encoding="utf-8")
+
+# Model: agent reports a compliant body, but the live published body is a commit message.
+reported_body = "## Summary\n<details><summary>Review metadata</summary>\nReview Claim: c\n</details>\n## Non-goals\n## Test Plan\n## Revert Plan"
+published_body = "Just a commit message subject\n\nbody line"
+
+def validate(body):
+    return "<summary>Review metadata</summary>" in body and any(
+        l.strip() == "## Non-goals" for l in body.splitlines())
+
+# pre-fix: validate agent-reported body -> passes, ships a non-compliant published PR
+assert validate(reported_body), "agent-reported body looks compliant"
+# post-fix: validate the published body -> rejected
+assert not validate(published_body), "fixed model validates the live published body and rejects it"
+
+if "getReviewBody" not in provider_if:
+    raise SystemExit("MergeGateProvider must expose getReviewBody")
+if "async getReviewBody" not in provider:
+    raise SystemExit("GitHubMergeGateProvider must implement getReviewBody")
+if "getReviewBody" not in task_runner or "bodySource" not in task_runner:
+    raise SystemExit("publishReviewStackWithMakePrSkill must fetch + validate the published body")
+
+print("[repro] pre-fix model: agent-reported body validated -> non-compliant PR body ships on GitHub")
+print("[repro] post-fix model: live published body fetched + validated -> rejected and falls through")
+print("[repro] source check: provider.getReviewBody exists and stack publish validates the published body")
+PY
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Review-stack publication now validates the body actually published on the provider, not just what the agent reports in JSON. A lazy agent could report a compliant body while Mergify defaulted the real PR to the commit message; a new MergeGateProvider.getReviewBody reads the live body and the publish path validates that, falling back to the reported body only if the read fails.

This PR bundles the regression repro **with** its fix (one problem = one repro = one fix).

<details>
<summary>Review metadata</summary>

Review Claim: Approve that the live published PR body is what gets schema-validated.
Review Lane: behavior
Review Unit: routing
Safety Invariant: Existing healthy merge/PR-authoring flows behave exactly as before; only the failure path changes.
Slice Rationale: One reproduced problem per PR, with its repro committed alongside the fix.

</details>

## Non-goals

- Does not change the schema rules themselves (slice 5); only the source of the validated body.

## Test Plan

- [x] `bash scripts/repro/repro-trusts-agent-reported-pr-body.sh`
- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/task-runner-fix-publish-and-ssh.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional support for retrieving the live published PR body from the merge gate provider.

* **Bug Fixes**
  * Improved PR body validation to prefer the live published PR body when available, with fallback to agent-reported content if retrieval fails—preventing acceptance of mismatched content.

* **Tests**
  * Added a regression test for the publishing mismatch scenario to ensure invalid published PR bodies are rejected.

* **Chores**
  * Added a script to reproduce and diagnose agent-reported vs published PR body mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->