### PR TITLE
[pr-skill robustness](1) Fix stuck-pending merge gate: async launch workspace

### DIFF
--- a/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
@@ -1,0 +1,127 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkRequest } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
+import { MergeGateExecutor } from '../merge-gate-executor.js';
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function makeMergeTask(): TaskState {
+  return {
+    id: '__merge__wf-1782192502908-14',
+    description: 'Review gate',
+    status: 'pending',
+    dependencies: ['wf-1782192502908-14/implement-crabbox-target-resolver'],
+    createdAt: new Date('2026-06-23T06:02:15.000Z'),
+    config: {
+      isMergeNode: true,
+      runnerKind: 'merge',
+      workflowId: 'wf-1782192502908-14',
+    },
+    execution: {
+      selectedAttemptId: '__merge__wf-1782192502908-14-adfcaf2a6',
+      generation: 1,
+      phase: 'launching',
+    },
+  } as TaskState;
+}
+
+function makeRequest(task: TaskState): WorkRequest {
+  return {
+    requestId: 'req-merge-start',
+    actionId: task.id,
+    attemptId: task.execution.selectedAttemptId,
+    executionGeneration: task.execution.generation ?? 0,
+    actionType: 'merge_gate',
+    inputs: {
+      description: task.description,
+      baseBranch: 'master',
+    },
+    callbackUrl: '',
+    timestamps: { createdAt: '2026-06-23T06:02:15.000Z' },
+  } as WorkRequest;
+}
+
+describe('MergeGateExecutor', () => {
+  const tempDirs: string[] = [];
+  const originalInvokerDbDir = process.env.INVOKER_DB_DIR;
+
+  afterEach(() => {
+    if (originalInvokerDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = originalInvokerDbDir;
+    }
+    while (tempDirs.length > 0) {
+      const dir = tempDirs.pop();
+      if (dir) rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a launch handle before creating the managed merge worktree', async () => {
+    const invokerHome = mkdtempSync(join(tmpdir(), 'invoker-merge-start-test-'));
+    tempDirs.push(invokerHome);
+    process.env.INVOKER_DB_DIR = invokerHome;
+
+    const task = makeMergeTask();
+    const blockedClone = createDeferred<string>();
+    const updateTask = vi.fn();
+    const createMergeWorktree = vi.fn(() => blockedClone.promise);
+    const executor = new MergeGateExecutor({
+      cwd: '/tmp/host-repo',
+      defaultBranch: 'master',
+      persistence: {
+        loadWorkflow: vi.fn(() => ({
+          id: 'wf-1782192502908-14',
+          baseBranch: 'plan/crabbox-ssh-step-1-config-and-metadata',
+          featureBranch: 'plan/crabbox-ssh-step-2-resolver',
+          repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker',
+          onFinish: 'pull_request',
+          mergeMode: 'external_review',
+        })),
+        updateTask,
+      },
+      orchestrator: {
+        getTask: vi.fn(() => task),
+        getAllTasks: vi.fn(() => [task]),
+      },
+      createMergeWorktree,
+      detectDefaultBranch: vi.fn(async () => 'master'),
+      buildMergeSummary: vi.fn(async () => 'summary'),
+      callbacks: {},
+    } as any);
+
+    try {
+      const started = await Promise.race([
+        executor.start(makeRequest(task)).then((handle) => ({ kind: 'started' as const, handle })),
+        new Promise<{ kind: 'blocked' }>((resolve) => setTimeout(() => resolve({ kind: 'blocked' }), 25)),
+      ]);
+
+      expect(started.kind).toBe('started');
+      if (started.kind !== 'started') return;
+      expect(started.handle.workspacePath).toContain('merge-launches');
+      expect(existsSync(started.handle.workspacePath!)).toBe(true);
+
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(createMergeWorktree).toHaveBeenCalled();
+      expect(updateTask).not.toHaveBeenCalledWith(
+        task.id,
+        expect.objectContaining({
+          execution: expect.objectContaining({
+            workspacePath: expect.stringContaining('gate-__merge__wf-1782192502908-14'),
+          }),
+        }),
+      );
+    } finally {
+      await executor.destroyAll();
+    }
+  });
+});

--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -1,11 +1,12 @@
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { resolve } from 'node:path';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import type { MergeRunnerHost } from './merge-runner.js';
 import { runMergeGateActionImpl } from './merge-runner.js';
-import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 
 interface MergeGateEntry extends BaseEntry {
   killed?: boolean;
@@ -20,20 +21,11 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
 
   async start(request: WorkRequest): Promise<ExecutorHandle> {
     const task = this.resolveTask(request);
-    const workflow = task.config.workflowId
-      ? this.host.persistence.loadWorkflow(task.config.workflowId)
-      : undefined;
-    const baseBranch = workflow?.baseBranch ?? this.host.defaultBranch ?? await this.host.detectDefaultBranch();
-    const baseCheckoutRef = normalizeBranchForGithubCli(baseBranch);
-    const workspacePath = await this.host.createMergeWorktree(
-      baseCheckoutRef,
-      'gate-' + task.id.replace(/[^a-zA-Z0-9_-]/g, '-'),
-      workflow?.repoUrl,
-    );
+    const launchWorkspacePath = this.createLaunchWorkspace(task.id);
 
     const handle = this.createHandle(request);
-    handle.workspacePath = workspacePath;
-    handle.branch = workflow?.featureBranch ?? undefined;
+    handle.workspacePath = launchWorkspacePath;
+    handle.branch = undefined;
 
     const entry: MergeGateEntry = {
       request,
@@ -56,7 +48,7 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
     }, this.heartbeatIntervalMs);
 
     setImmediate(() => {
-      void this.run(handle, task, workspacePath);
+      void this.run(handle, task, launchWorkspacePath);
     });
 
     return handle;
@@ -117,18 +109,43 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
     return task;
   }
 
-  private async run(handle: ExecutorHandle, task: TaskState, gateWorkspacePath: string): Promise<void> {
+  private createLaunchWorkspace(taskId: string): string {
+    const invokerHomeRoot = process.env.INVOKER_DB_DIR
+      ? resolve(process.env.INVOKER_DB_DIR)
+      : resolve(homedir(), '.invoker');
+    const launchRoot = resolve(invokerHomeRoot, 'merge-launches');
+    mkdirSync(launchRoot, { recursive: true });
+    return mkdtempSync(resolve(launchRoot, `launch-${taskId.replace(/[^a-zA-Z0-9_-]/g, '-')}-`));
+  }
+
+  private cleanupLaunchWorkspace(launchWorkspacePath: string, realWorkspacePath: string | undefined): void {
+    if (!realWorkspacePath || realWorkspacePath === launchWorkspacePath) return;
+    try {
+      rmSync(launchWorkspacePath, { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup. The real gate clone has already replaced this path.
+    }
+  }
+
+  private async run(handle: ExecutorHandle, task: TaskState, launchWorkspacePath: string): Promise<void> {
     const entry = this.getEntry(handle);
     if (!entry || entry.completed || entry.killed) return;
 
     try {
       this.emitOutput(handle.executionId, `[merge] Starting merge gate action: ${task.id}\n`);
-      const result = await runMergeGateActionImpl(this.host, task, { gateWorkspacePath });
-      if (result.taskChanges.execution) {
+      const result = await runMergeGateActionImpl(this.host, task);
+      const executionChanges = result.taskChanges.execution
+        ? {
+          ...result.taskChanges.execution,
+          workspacePath: result.taskChanges.execution.workspacePath ?? launchWorkspacePath,
+        }
+        : undefined;
+      if (executionChanges) {
         this.host.persistence.updateTask(task.id, {
-          execution: result.taskChanges.execution,
+          execution: executionChanges,
         });
       }
+      this.cleanupLaunchWorkspace(launchWorkspacePath, executionChanges?.workspacePath);
       this.emitOutput(handle.executionId, `[merge] Merge gate action finished: ${task.id} status=${result.response.status}\n`);
       this.emitComplete(handle.executionId, this.withAttempt(entry.request, result.response));
     } catch (err) {

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -522,8 +522,13 @@ export async function runMergeGateActionImpl(
     mergeTrace('GATE_WS_GATE_CLONE_CREATED', { taskId: task.id, gateWorkspacePath });
     console.log(`[merge-gate-workspace] gate clone created task=${task.id} path=${gateWorkspacePath}`);
   } else {
-    mergeTrace('GATE_WS_GATE_CLONE_SKIPPED', { taskId: task.id, reason: 'no_feature_branch' });
-    console.log(`[merge-gate-workspace] gate clone skipped task=${task.id} (no featureBranch on workflow)`);
+    // Distinguish the two skip reasons: a caller-provided gate workspace vs a
+    // workflow with no feature branch. The label was previously hardcoded to
+    // "no_feature_branch", which misdiagnosed runs that simply reused an
+    // already-provided workspace (e.g. PR #2170's gate).
+    const skipReason = gateWorkspacePath ? 'workspace_already_provided' : 'no_feature_branch';
+    mergeTrace('GATE_WS_GATE_CLONE_SKIPPED', { taskId: task.id, reason: skipReason });
+    console.log(`[merge-gate-workspace] gate clone skipped task=${task.id} (${skipReason})`);
   }
 
   if (featureBranch && (onFinish !== 'none' || mergeMode === 'external_review')) {

--- a/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192500131-3.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192500131-3.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="__merge__wf-1782192500131-3"
+SOURCE="$ROOT/packages/execution-engine/src/merge-gate-executor.ts"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: merge gate worktree creation ran inside executor.start(), before task.running"
+
+python3 - "$SOURCE" <<'PY'
+import pathlib
+import re
+import sys
+
+source_path = pathlib.Path(sys.argv[1])
+source = source_path.read_text(encoding="utf-8")
+task_id = "__merge__wf-1782192500131-3"
+
+class Task:
+    def __init__(self):
+        self.status = "pending"
+        self.phase = "launching"
+        self.launch_completed_at = None
+        self.running_counted_by_dispatch = True
+        self.real_merge_clone_blocked = True
+
+def pre_fix_start(task: Task) -> bool:
+    # Before the fix, MergeGateExecutor.start awaited createMergeWorktree().
+    # If the clone/fetch path blocked, start() never returned a handle.
+    if task.real_merge_clone_blocked:
+        return False
+    return True
+
+def post_fix_start(task: Task) -> bool:
+    # After the fix, start() creates only a lightweight launch directory and
+    # schedules real merge work asynchronously.
+    return True
+
+def task_runner_launch(task: Task, start_returns: bool) -> None:
+    if not start_returns:
+        return
+    task.status = "running"
+    task.phase = "executing"
+    task.launch_completed_at = "2026-06-23T06:02:27.000Z"
+
+pre = Task()
+task_runner_launch(pre, pre_fix_start(pre))
+assert pre.running_counted_by_dispatch
+assert pre.status == "pending"
+assert pre.phase == "launching"
+assert pre.launch_completed_at is None
+
+post = Task()
+task_runner_launch(post, post_fix_start(post))
+assert post.status == "running"
+assert post.phase == "executing"
+assert post.launch_completed_at is not None
+
+start_match = re.search(r"async start\(request: WorkRequest\): Promise<ExecutorHandle> \{(?P<body>.*?)\n  async kill", source, re.S)
+if not start_match:
+    raise SystemExit("could not locate MergeGateExecutor.start()")
+start_body = start_match.group("body")
+
+required_needles = [
+    "const launchWorkspacePath = this.createLaunchWorkspace(task.id);",
+    "handle.workspacePath = launchWorkspacePath;",
+    "void this.run(handle, task, launchWorkspacePath);",
+    "const result = await runMergeGateActionImpl(this.host, task);",
+    "workspacePath: result.taskChanges.execution.workspacePath ?? launchWorkspacePath",
+]
+missing = [needle for needle in required_needles if needle not in source]
+if missing:
+    raise SystemExit("fixed merge launch handoff source invariant missing: " + ", ".join(missing))
+
+if "await this.host.createMergeWorktree" in start_body or "await this.host.detectDefaultBranch" in start_body:
+    raise SystemExit("MergeGateExecutor.start() still performs blocking merge setup before launch completion")
+
+print("[repro] pre-fix model: dispatch counted running while task stayed pending/launching with no launchCompletedAt")
+print("[repro] post-fix model: start returns a handle, allowing TaskRunner to mark the task running")
+print("[repro] source check: blocking merge worktree creation is outside MergeGateExecutor.start()")
+PY
+
+echo "[repro] passed"

--- a/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192502908-14.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192502908-14.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="__merge__wf-1782192502908-14"
+SOURCE="$ROOT/packages/execution-engine/src/merge-gate-executor.ts"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: MergeGateExecutor.start() performed managed merge clone setup before returning a launch handle"
+
+python3 - "$SOURCE" <<'PY'
+import pathlib
+import re
+import sys
+
+source_path = pathlib.Path(sys.argv[1])
+source = source_path.read_text(encoding="utf-8")
+task_id = "__merge__wf-1782192502908-14"
+
+class Task:
+    def __init__(self):
+        self.status = "pending"
+        self.phase = "launching"
+        self.launch_completed_at = None
+        self.dispatch_state = "leased"
+        self.real_merge_clone_blocked = True
+
+def pre_fix_start(task: Task) -> bool:
+    # Before the fix, MergeGateExecutor.start awaited createMergeWorktree().
+    # A slow clone/fetch path meant no handle was returned to TaskRunner.
+    if task.real_merge_clone_blocked:
+        return False
+    return True
+
+def post_fix_start(task: Task) -> bool:
+    # After the fix, start() creates only a lightweight launch directory and
+    # schedules the managed merge clone asynchronously.
+    return True
+
+def task_runner_launch(task: Task, start_returns: bool) -> None:
+    if not start_returns:
+        return
+    task.status = "running"
+    task.phase = "executing"
+    task.launch_completed_at = "2026-06-23T07:04:36.475Z"
+
+pre = Task()
+task_runner_launch(pre, pre_fix_start(pre))
+assert pre.dispatch_state == "leased"
+assert pre.status == "pending"
+assert pre.phase == "launching"
+assert pre.launch_completed_at is None
+
+post = Task()
+task_runner_launch(post, post_fix_start(post))
+assert post.status == "running"
+assert post.phase == "executing"
+assert post.launch_completed_at is not None
+
+start_match = re.search(r"async start\(request: WorkRequest\): Promise<ExecutorHandle> \{(?P<body>.*?)\n  async kill", source, re.S)
+if not start_match:
+    raise SystemExit("could not locate MergeGateExecutor.start()")
+start_body = start_match.group("body")
+
+required_needles = [
+    "const launchWorkspacePath = this.createLaunchWorkspace(task.id);",
+    "handle.workspacePath = launchWorkspacePath;",
+    "void this.run(handle, task, launchWorkspacePath);",
+    "const result = await runMergeGateActionImpl(this.host, task);",
+    "workspacePath: result.taskChanges.execution.workspacePath ?? launchWorkspacePath",
+]
+missing = [needle for needle in required_needles if needle not in source]
+if missing:
+    raise SystemExit("fixed merge launch handoff source invariant missing: " + ", ".join(missing))
+
+if "await this.host.createMergeWorktree" in start_body or "await this.host.detectDefaultBranch" in start_body:
+    raise SystemExit("MergeGateExecutor.start() still performs blocking merge setup before launch completion")
+
+print("[repro] pre-fix model: dispatch was leased while the task stayed pending/launching with no launchCompletedAt")
+print("[repro] post-fix model: start returns a handle, so TaskRunner can mark the task running")
+print("[repro] source check: blocking managed merge clone setup is outside MergeGateExecutor.start()")
+PY
+
+pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/merge-gate-executor.test.ts
+
+echo "[repro] passed"


### PR DESCRIPTION
Merge gate tasks no longer get stuck Pending. `MergeGateExecutor.start()` did the
real managed merge clone before returning, so the runner could not mark launch
complete while a slow clone blocked. It now returns a lightweight launch
workspace immediately and runs the real merge clone asynchronously. The gate
clone-skip trace also reports its real reason instead of a hardcoded
no_feature_branch label.

Repro: scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192500131-3.sh
and ...502908-14.sh.



Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>