### PR TITLE
[pr-skill robustness](3) Fix stale merge-gate terminal workspace path

### DIFF
--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -21,11 +21,14 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
 
   async start(request: WorkRequest): Promise<ExecutorHandle> {
     const task = this.resolveTask(request);
+    const workflow = task.config.workflowId
+      ? this.host.persistence.loadWorkflow(task.config.workflowId)
+      : undefined;
     const launchWorkspacePath = this.createLaunchWorkspace(task.id);
 
     const handle = this.createHandle(request);
     handle.workspacePath = launchWorkspacePath;
-    handle.branch = undefined;
+    handle.branch = workflow?.featureBranch ?? undefined;
 
     const entry: MergeGateEntry = {
       request,
@@ -165,6 +168,15 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
         return;
       }
 
+      // Point the handle at the real gate clone before cleanup removes the launch
+      // workspace, so restored terminals (getTerminalSpec) never target a deleted
+      // directory.
+      if (executionChanges?.workspacePath) {
+        handle.workspacePath = executionChanges.workspacePath;
+      }
+      if (executionChanges?.branch) {
+        handle.branch = executionChanges.branch;
+      }
       if (executionChanges) {
         this.host.persistence.updateTask(task.id, {
           execution: executionChanges,

--- a/scripts/repro/repro-stale-merge-terminal-workspace-path.sh
+++ b/scripts/repro/repro-stale-merge-terminal-workspace-path.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+SOURCE="$ROOT/packages/execution-engine/src/merge-gate-executor.ts"
+echo "[repro] problem: restored merge-gate terminal targeted a deleted launch workspace"
+echo "[repro] root cause: handle.workspacePath stayed pinned to the launch dir that run() later deletes"
+
+python3 - "$SOURCE" <<'PY'
+import pathlib, sys
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+
+class Handle:
+    def __init__(self): self.workspacePath = "/launch/tmp"
+def get_terminal_spec(h): return {"cwd": h.workspacePath}
+
+def pre_fix_run(h):
+    deleted = h.workspacePath           # cleanup removes the launch dir; handle never repointed
+    return get_terminal_spec(h), deleted
+def post_fix_run(h, real_path):
+    h.workspacePath = real_path         # repoint to the gate clone before cleanup
+    return get_terminal_spec(h), "/launch/tmp"
+
+pre_spec, pre_deleted = pre_fix_run(Handle())
+assert pre_spec["cwd"] == pre_deleted, "pre-fix model should leave terminal pointing at the deleted launch dir"
+
+post_spec, post_deleted = post_fix_run(Handle(), "/real/gate")
+assert post_spec["cwd"] == "/real/gate" and post_spec["cwd"] != post_deleted, \
+    "fixed model should point the terminal at the real gate clone, not the deleted launch dir"
+
+assign = source.find("handle.workspacePath = executionChanges.workspacePath")
+last_cleanup = source.rfind("this.cleanupLaunchWorkspace(launchWorkspacePath")
+if assign == -1 or last_cleanup == -1 or assign > last_cleanup:
+    raise SystemExit("fixed invariant missing: run() must set handle.workspacePath before the final cleanupLaunchWorkspace")
+
+print("[repro] pre-fix model: terminal cwd == deleted launch dir")
+print("[repro] post-fix model: terminal cwd == real gate clone (launch dir safely removed)")
+print("[repro] source check: run() repoints handle.workspacePath to the gate clone before cleanup")
+PY
+echo "[repro] passed"


### PR DESCRIPTION
Restored merge-gate terminals no longer target a deleted directory. The async
launch workspace is removed once the real gate clone exists, but `run()` left
`handle.workspacePath` pinned to the launch dir, so `getTerminalSpec()` could hand
back a path that no longer exists. `run()` now repoints `handle.workspacePath` and
`handle.branch` at the real gate clone before cleanup.

Repro: scripts/repro/repro-stale-merge-terminal-workspace-path.sh



Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #2235