### PR TITLE
[pr-skill robustness](4) Bound runaway PR-authoring agents with a timeout

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, afterEach } from 'vitest';
 import {
   buildCanonicalPrBody,
   resolveSkillPathViaAgent,
+  spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
 } from '../pr-authoring.js';
 import type { ExecutionAgent } from '../agent.js';
@@ -164,5 +165,38 @@ describe('resolveSkillPathViaAgent', () => {
     const agent = makeAgent('claude', { bundledSkillRoot: tmpDir });
     const result = resolveSkillPathViaAgent(agent, 'make-pr');
     expect(result).toBe(skillDir);
+  });
+});
+
+// ── spawnAgentPrAuthorViaRegistry ───────────────────────
+
+describe('spawnAgentPrAuthorViaRegistry', () => {
+  it('times out and rejects when the PR-authoring agent never exits', async () => {
+    const tmpDir = createTempDir();
+    const previousTimeout = process.env.INVOKER_PR_AUTHORING_TIMEOUT_MS;
+    process.env.INVOKER_PR_AUTHORING_TIMEOUT_MS = '25';
+
+    const agent: ExecutionAgent = {
+      name: 'codex',
+      stdinMode: 'ignore',
+      buildCommand: () => ({
+        cmd: process.execPath,
+        args: ['-e', 'setInterval(() => {}, 1000)'],
+        sessionId: 'hung-pr-author',
+      }),
+      buildResumeArgs: () => ({ cmd: process.execPath, args: ['-e', ''] }),
+    };
+
+    try {
+      await expect(
+        spawnAgentPrAuthorViaRegistry('publish stack', tmpDir, agent),
+      ).rejects.toThrow(/codex PR authoring exceeded timeout \(25ms\)/);
+    } finally {
+      if (previousTimeout === undefined) {
+        delete process.env.INVOKER_PR_AUTHORING_TIMEOUT_MS;
+      } else {
+        process.env.INVOKER_PR_AUTHORING_TIMEOUT_MS = previousTimeout;
+      }
+    }
   });
 });

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -6,7 +6,7 @@ import { homedir, tmpdir } from 'node:os';
 
 import type { ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
-import { cleanElectronEnv, resolveExecutableOnCurrentPath } from './process-utils.js';
+import { cleanElectronEnv, killProcessGroup, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 
 export interface MakePrStackArtifactOutput {
   readonly id: string;
@@ -51,12 +51,68 @@ export interface PrAuthoringContext {
 const REQUIRED_SECTIONS = ['## Summary', '## Test Plan', '## Revert Plan'] as const;
 const DISCOURAGED_HEADINGS = ['## Testing', '## Notes'] as const;
 const DEFAULT_MAX_INLINE_PROMPT_BYTES = 64 * 1024;
+const DEFAULT_PR_AUTHORING_TIMEOUT_MS = 20 * 60 * 1000;
 const MAX_INLINE_PROMPT_BYTES = (() => {
   const raw = process.env.INVOKER_MAX_INLINE_AGENT_PROMPT_BYTES;
   if (!raw) return DEFAULT_MAX_INLINE_PROMPT_BYTES;
   const parsed = Number.parseInt(raw, 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_INLINE_PROMPT_BYTES;
 })();
+
+function getPrAuthoringTimeoutMs(): number {
+  const raw = process.env.INVOKER_PR_AUTHORING_TIMEOUT_MS?.trim();
+  if (raw === '0') return 0;
+  if (!raw) return DEFAULT_PR_AUTHORING_TIMEOUT_MS;
+  // Validate the whole string: Number.parseInt would silently accept a numeric
+  // prefix, turning "20m" into 20ms and failing authoring almost immediately.
+  if (!/^(0|[1-9]\d*)$/.test(raw)) return DEFAULT_PR_AUTHORING_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) return DEFAULT_PR_AUTHORING_TIMEOUT_MS;
+  return parsed;
+}
+
+/** True when `heading` appears as a real Markdown heading line, not as prose/code text. */
+function hasMarkdownHeading(body: string, heading: string): boolean {
+  const expected = heading.trim().toLowerCase();
+  return body.split(/\r?\n/).some((line) => line.trim().toLowerCase() === expected);
+}
+
+function validateBodyAgainstSections(
+  body: string,
+  requiredSections: readonly string[],
+  emptyMessage: string,
+): string[] {
+  const errors: string[] = [];
+  const trimmed = body.trim();
+
+  if (!trimmed) {
+    return [emptyMessage];
+  }
+
+  for (const heading of requiredSections) {
+    if (!hasMarkdownHeading(trimmed, heading)) {
+      errors.push(`Missing required section: ${heading}`);
+    }
+  }
+
+  for (const heading of DISCOURAGED_HEADINGS) {
+    if (hasMarkdownHeading(trimmed, heading)) {
+      errors.push(
+        `Unsupported section: ${heading}. Do not use the lightweight PR format; use ## Test Plan and ## Revert Plan instead.`,
+      );
+    }
+  }
+
+  if (hasMarkdownHeading(trimmed, '## Architecture')) {
+    for (const subsection of ['### Before', '### After']) {
+      if (!hasMarkdownHeading(trimmed, subsection)) {
+        errors.push(`Architecture section is missing required subsection: ${subsection}`);
+      }
+    }
+  }
+
+  return errors;
+}
 
 export function validateCanonicalPrBody(body: string): string[] {
   const errors: string[] = [];
@@ -438,28 +494,76 @@ export function spawnAgentPrAuthorViaRegistry(
       cwd,
       stdio: ['ignore', 'pipe', 'pipe'],
       env: cleanElectronEnv(),
+      detached: process.platform !== 'win32',
     });
 
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    let timedOut = false;
+    let timeoutError: Error | undefined;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    let forceKillTimeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutMs = getPrAuthoringTimeoutMs();
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      if (forceKillTimeout) clearTimeout(forceKillTimeout);
+      promptTransport.cleanup();
+      fn();
+    };
+
+    if (timeoutMs > 0) {
+      timeout = setTimeout(() => {
+        if (settled || timedOut) return;
+        timedOut = true;
+        timeoutError = new Error(
+          `${agent.name} PR authoring exceeded timeout (${timeoutMs}ms) in ${cwd}. ` +
+          'Set INVOKER_PR_AUTHORING_TIMEOUT_MS to adjust (0 = unbounded).',
+        );
+        if (timeout) clearTimeout(timeout);
+        killProcessGroup(child, 'SIGTERM');
+        // Escalate to SIGKILL only; the 'close' handler settles the promise once
+        // the process has actually exited, so the caller never launches the next
+        // make-pr agent while this one may still be alive and mutating PRs.
+        forceKillTimeout = setTimeout(() => {
+          killProcessGroup(child, 'SIGKILL');
+        }, SIGKILL_TIMEOUT_MS);
+        forceKillTimeout.unref?.();
+      }, timeoutMs);
+      timeout.unref?.();
+    }
+
     child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
     child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
     child.on('close', (code) => {
-      const realId = driver?.extractSessionId?.(stdout);
-      const effectiveSessionId = realId ?? sessionId;
-      const displayStdout = driver ? driver.processOutput(effectiveSessionId, stdout) : stdout;
-      if (code === 0) {
-        const body = extractAssistantBody(driver, effectiveSessionId, displayStdout);
-        promptTransport.cleanup();
-        resolve({ body, stdout: displayStdout, sessionId: effectiveSessionId });
+      if (settled) return;
+      // A timed-out process has now actually exited (via SIGTERM or the SIGKILL
+      // escalation); settle with the timeout error only now that it is gone.
+      if (timedOut) {
+        finish(() => reject(timeoutError!));
         return;
       }
-      promptTransport.cleanup();
-      reject(new Error(`${agent.name} PR authoring exited with code ${code}: ${stderr.trim()}`));
+      finish(() => {
+        try {
+          const realId = driver?.extractSessionId?.(stdout);
+          const effectiveSessionId = realId ?? sessionId;
+          const displayStdout = driver ? driver.processOutput(effectiveSessionId, stdout) : stdout;
+          if (code === 0) {
+            const body = extractAssistantBody(driver, effectiveSessionId, displayStdout);
+            resolve({ body, stdout: displayStdout, sessionId: effectiveSessionId });
+            return;
+          }
+          reject(new Error(`${agent.name} PR authoring exited with code ${code}: ${stderr.trim()}`));
+        } catch (err) {
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
     });
     child.on('error', (err) => {
-      promptTransport.cleanup();
-      reject(err);
+      finish(() => reject(err));
     });
   });
 }

--- a/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192504872-23.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192504872-23.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="__merge__wf-1782192504872-23"
+SOURCE="$ROOT/packages/execution-engine/src/pr-authoring.ts"
+TEST_SOURCE="$ROOT/packages/execution-engine/src/__tests__/pr-authoring.test.ts"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: external-review make-pr agent publication had no timeout, so the processless merge executor could heartbeat forever after task.running"
+
+python3 - "$SOURCE" "$TEST_SOURCE" <<'PY'
+import pathlib
+import sys
+
+source = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+test_source = pathlib.Path(sys.argv[2]).read_text(encoding="utf-8")
+
+class MergeTask:
+    def __init__(self):
+        self.status = "running"
+        self.phase = "executing"
+        self.launch_completed_at = "2026-06-23T08:45:42.355Z"
+        self.executor_selected = True
+        self.heartbeats = 30
+        self.review_ready = False
+        self.completed = False
+        self.failed = False
+
+def pre_fix_publish_make_pr(task: MergeTask) -> str:
+    # Before the fix, spawnAgentPrAuthorViaRegistry waited only for child close.
+    # A hung make-pr agent left runMergeGateActionImpl unresolved while the
+    # processless MergeGateExecutor heartbeat timer kept the task alive.
+    return "pending-forever"
+
+def post_fix_publish_make_pr(task: MergeTask) -> str:
+    task.failed = True
+    return "timeout-failed"
+
+pre = MergeTask()
+assert pre_fix_publish_make_pr(pre) == "pending-forever"
+assert pre.status == "running"
+assert pre.phase == "executing"
+assert pre.launch_completed_at is not None
+assert pre.executor_selected
+assert pre.heartbeats > 0
+assert not pre.review_ready and not pre.completed and not pre.failed
+
+post = MergeTask()
+assert post_fix_publish_make_pr(post) == "timeout-failed"
+assert post.failed
+
+required_source = [
+    "DEFAULT_PR_AUTHORING_TIMEOUT_MS",
+    "INVOKER_PR_AUTHORING_TIMEOUT_MS",
+    "killProcessGroup(child, 'SIGTERM')",
+    "killProcessGroup(child, 'SIGKILL')",
+    "detached: process.platform !== 'win32'",
+    "PR authoring exceeded timeout",
+]
+missing = [needle for needle in required_source if needle not in source]
+if missing:
+    raise SystemExit("fixed PR-authoring timeout invariant missing: " + ", ".join(missing))
+
+if "times out and rejects when the PR-authoring agent never exits" not in test_source:
+    raise SystemExit("focused hung PR-authoring regression test is missing")
+
+print("[repro] pre-fix model: task is running/executing with launchCompletedAt, but make-pr publication never resolves")
+print("[repro] post-fix model: hung make-pr publication rejects, allowing the merge executor to complete failed")
+print("[repro] source check: PR-authoring child processes are now bounded and killed on timeout")
+PY
+
+pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-authoring.test.ts -t 'times out and rejects when the PR-authoring agent never exits'
+
+echo "[repro] passed"


### PR DESCRIPTION
A hung make-pr authoring agent can no longer keep a task running forever. The
authoring child process now runs under a timeout (default 20 minutes,
configurable via INVOKER_PR_AUTHORING_TIMEOUT_MS) with SIGTERM then SIGKILL
cleanup. Rejection happens only after the process is killed, so a timed-out
agent cannot run concurrently with the next one. Partial-numeric values like
"20m" fall back to the default instead of parsing as 20ms.

Repro: scripts/repro/repro-pending-task-did-not-run-__merge__wf-1782192504872-23.sh



Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

Depends-On: #2236