### PR TITLE
[Add workflow GitHub review gate control](1) Expose merge-mode control in workflow inspector

### DIFF
--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -608,4 +608,129 @@ describe('WorkflowInspector', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Reject Fix' }));
     expect(onReject).toHaveBeenCalledWith(task);
   });
+
+  it('converts a review-ready merge gate to external review from the workflow-level button', () => {
+    const onSetMergeMode = vi.fn();
+
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready', mergeMode: 'manual' }}
+        task={makeTask({
+          id: '__merge__wf-1',
+          description: 'Review gate',
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+          execution: {},
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onSetMergeMode={onSetMergeMode}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    const button = screen.getByTestId('convert-to-external-review-button');
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(onSetMergeMode).toHaveBeenCalledWith('wf-1', 'external_review');
+  });
+
+  it('shows the conversion button for a workflow-only selection whose merge gate is pending without a review URL', () => {
+    const mergeTask = makeTask({
+      id: '__merge__wf-1',
+      description: 'Merge gate',
+      status: 'pending',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {},
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'running', onFinish: 'pull_request', mergeMode: 'manual' }}
+        task={null}
+        workflowTasks={new Map([[mergeTask.id, mergeTask]])}
+        collapsed={false}
+        advancedExpanded={false}
+        onSetMergeMode={() => Promise.resolve()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('convert-to-external-review-button')).toBeInTheDocument();
+  });
+
+  it('hides the conversion button once the workflow is already in external review mode', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready', mergeMode: 'external_review' }}
+        task={makeTask({
+          id: '__merge__wf-1',
+          description: 'Review gate',
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+          execution: {},
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onSetMergeMode={() => Promise.resolve()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId('convert-to-external-review-button')).not.toBeInTheDocument();
+  });
+
+  it('hides the conversion button when the merge gate already has a review URL', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready', mergeMode: 'manual' }}
+        task={makeTask({
+          id: '__merge__wf-1',
+          description: 'Review gate',
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+          execution: { reviewUrl: 'https://github.com/org/repo/pull/34' },
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onSetMergeMode={() => Promise.resolve()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId('convert-to-external-review-button')).not.toBeInTheDocument();
+  });
+
+  it('keeps the merge mode control visible for a gate with a review URL even though conversion is hidden', () => {
+    const onSetMergeMode = vi.fn();
+
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready', mergeMode: 'manual' }}
+        task={makeTask({
+          id: '__merge__wf-1',
+          description: 'Review gate',
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+          execution: { reviewUrl: 'https://github.com/org/repo/pull/34' },
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onSetMergeMode={onSetMergeMode}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId('convert-to-external-review-button')).not.toBeInTheDocument();
+
+    const select = screen.getByTestId('merge-mode-select');
+    expect(select).toHaveValue('manual');
+    fireEvent.change(select, { target: { value: 'external_review' } });
+    expect(onSetMergeMode).toHaveBeenCalledWith('wf-1', 'external_review');
+  });
 });

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -61,6 +61,19 @@ function getMergeNodeReviewUrl(
   return undefined;
 }
 
+/** The merge gate task for the selected workflow, whether or not it is the selected node. */
+function getMergeGateTask(
+  task: TaskState | null,
+  tasks: Map<string, TaskState> | undefined,
+): TaskState | null {
+  if (task?.config.isMergeNode) return task;
+  if (!tasks) return null;
+  for (const candidate of tasks.values()) {
+    if (candidate.config.isMergeNode) return candidate;
+  }
+  return null;
+}
+
 
 function artifactLabel(artifact: ReviewGateArtifact): string {
   return artifact.title || artifact.url || (artifact.providerId ? `#${artifact.providerId}` : artifact.id);
@@ -163,6 +176,15 @@ export function WorkflowInspector({
   const nodeTitle = task?.description ?? workflowTitle ?? 'No node selected';
   const showsWorkflowMergeDetails = Boolean(!task && workflow?.id && workflow.onFinish === 'pull_request');
   const isMergeNode = Boolean((task?.config.isMergeNode || showsWorkflowMergeDetails) && workflow?.id);
+  const mergeGateTask = getMergeGateTask(task, workflowTasks);
+  const canConvertToExternalReview = Boolean(
+    workflow?.id
+    && onSetMergeMode
+    && mergeModeValue(workflow.mergeMode) !== 'external_review'
+    && mergeGateTask
+    && (mergeGateTask.status === 'pending' || mergeGateTask.status === 'review_ready')
+    && !mergeGateTask.execution.reviewUrl,
+  );
   const currentAgent = task?.config.executionAgent ?? task?.execution.agentName ?? 'claude';
   const agentOptions = useMemo(() => {
     const names = new Set(executionAgents ?? []);
@@ -384,6 +406,19 @@ export function WorkflowInspector({
                   <option value="external_review">External review (GitHub)</option>
                 </select>
               </label>
+            )}
+            {canConvertToExternalReview && onSetMergeMode && workflow?.id && (
+              <button
+                type="button"
+                onClick={() => void onSetMergeMode(workflow.id, 'external_review')}
+                disabled={isTaskBusy}
+                data-testid="convert-to-external-review-button"
+                data-sidebar-nav-item
+                data-sidebar-nav-order="17"
+                className="w-full rounded border border-blue-500/50 bg-blue-600/20 px-2 py-1 text-xs font-medium text-blue-200 hover:bg-blue-600/30 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Convert to GitHub review
+              </button>
             )}
             {workflow?.repoUrl && (
               <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
## Summary

Add a visible workflow-level control so a workflow's merge gate can be turned into External review (GitHub) right from the workflow inspector.

Before, this action was hidden. You had to pick the merge-node task and open its Advanced panel. A workflow could sit review-ready with no PR and no obvious next step.

Now the workflow inspector exposes the current merge mode and a one-click action to switch to External review (GitHub). It reuses the existing set-merge-mode path.

<details>
<summary>Review metadata</summary>

Review Claim: The workflow inspector exposes a working control to convert a merge gate to External review (GitHub) without opening the hidden merge-node task.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The existing TaskPanel merge-node Advanced selector and the underlying set-merge-mode behavior are unchanged; this only adds a second entry point at the workflow level.

Slice Rationale: Behavior and its unit test ship together as one reviewable claim. Visual proof artifacts are kept separate in the following slice.

</details>

## Non-goals

- No backend mutation is added; the control reuses the existing set-merge-mode path.
- The TaskPanel merge-node Advanced selector is not removed or changed.
- Gate recreation and persistence semantics are not touched.

## Test Plan

- [ ] `cd packages/ui && pnpm test`

## Visual Proof

After: the workflow inspector shows the review gate affordance in the app shell.

![Workflow inspector review gate control](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260624-e1382d/review-gate-stack-side-panel.png)

![Merge-mode actions in the side panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260624-e1382d/approve-fix-task-panel-actions.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Convert to GitHub review" button for workflow merge gates, enabling quick conversion of review-ready gates to external review mode when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->