### PR TITLE
Add land-stack guard so PR stacks land by verified number, not branch name

### DIFF
--- a/.cursor/rules/land-stack-precedence.mdc
+++ b/.cursor/rules/land-stack-precedence.mdc
@@ -1,0 +1,24 @@
+---
+description: Landing or merging a PR stack must go through the land-stack guard; never identify a PR by branch name
+alwaysApply: true
+---
+
+# Landing a PR stack safely
+
+When the user asks to **land / merge / ship / queue** a PR or PR stack, treat
+`skills/land-stack/SKILL.md` as the source of truth. Before queueing, labeling
+(`admin-bypass`), resolving review threads, or merging **any** PR:
+
+- **Require explicit PR numbers** from the user (bottom of stack first). Never
+  discover the PR to land by branch name — do not use `gh pr list --head <branch>`.
+  Two different PRs can share a branch name.
+- **Run the guard, which must exit 0:**
+  `node scripts/land-stack.mjs <pr> [<pr> ...]`
+  It verifies each PR's head SHA exists locally, the head branch is a real
+  `stack/` branch, the PRs form a proper stack, and all are OPEN.
+- **Land only via** `node scripts/land-stack.mjs <pr> ... --execute`. Do not
+  hand-add `admin-bypass` or run `gh pr merge` to bypass the guard.
+
+Incident this prevents: a raw workflow-branch PR (#505) shared a branch name
+with the intended stack (#2174 / #2175); landing by branch name queued the
+wrong PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,13 @@
   2. **Debug and report** -- Investigate and report: (a) the root cause — why the code is in the buggy state, and (b) the test gap — how the bug escaped existing tests (missing coverage, wrong assumptions, untested edge case, etc.).
   3. **Plan the fix** -- Only after completing steps 1 and 2, create the implementation plan. The plan must include a verification step that re-runs the reproduction case to confirm the fix.
 
+## Landing PR Stacks
+
+- When asked to **land / merge / ship / queue** a PR or PR stack, follow `skills/land-stack/SKILL.md`.
+- **Never identify the PR to land by branch name** (`gh pr list --head <branch>`). Two PRs can share a branch name (a raw workflow branch PR vs the intended `stack/...` PR). Land by **explicit PR number** only.
+- Verify before any write: `node scripts/land-stack.mjs <pr> [<pr> ...]` must exit 0 (checks head SHA is in the local clone, head branch is a real `stack/` branch, the PRs form a proper stack, all OPEN). Land via `node scripts/land-stack.mjs <pr> ... --execute`. Do not hand-add `admin-bypass` or `gh pr merge` to bypass the guard.
+- See `.cursor/rules/land-stack-precedence.mdc` for the always-on summary.
+
 ## SQLite Command Policy
 
 - If you are considering direct SQLite commands, use the corresponding headless command instead.

--- a/scripts/land-stack.mjs
+++ b/scripts/land-stack.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+
+/**
+ * Safely land a Mergify-managed PR stack.
+ *
+ * The hard rule this enforces: never act on a PR identified by branch name.
+ * You pass explicit PR numbers, bottom-of-stack first. Every PR is verified
+ * before any write happens:
+ *   - its head commit SHA exists in the local clone (so it is the code you reviewed),
+ *   - its head branch is a real `stack/` branch (refuses raw workflow branches),
+ *   - the PRs form a proper stack (each PR's base is the previous PR's head branch;
+ *     the bottom PR's base is the trunk),
+ *   - every PR is OPEN.
+ *
+ * Only after ALL checks pass does `--execute` add the `admin-bypass` label to the
+ * bottom-most open PR (the one whose base is the trunk) to trigger the Mergify
+ * merge queue. Re-run after that PR merges and the next one re-targets the trunk.
+ *
+ * Background: a raw workflow branch PR (#505) once shared a branch name with the
+ * intended stack (#2174/#2175). Landing "the PR on this branch" queued the wrong
+ * PR. This guard makes that class of mistake impossible to commit by accident.
+ *
+ * Usage:
+ *   node scripts/land-stack.mjs <pr> [<pr> ...]              # verify only (safe default)
+ *   node scripts/land-stack.mjs <pr> [<pr> ...] --execute    # verify, then queue the bottom PR
+ *   node scripts/land-stack.mjs <pr> ... --base main         # trunk branch (default: master)
+ *   node scripts/land-stack.mjs <pr> ... --stack-prefix s/   # required head-branch prefix
+ *   node scripts/land-stack.mjs --help
+ *
+ * Exit code: 0 when all checks pass (and the queue step, if requested, succeeds);
+ * non-zero on any verification failure or bad input.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export const TRUNK_DEFAULT = 'master';
+export const STACK_PREFIX_DEFAULT = 'stack/';
+
+// ----------------------------- pure verification -----------------------------
+// Kept side-effect free so scripts/test-land-stack.mjs can exercise every branch
+// without touching gh or git.
+
+/**
+ * @param {object} input
+ * @param {Array<{number:number, headRefOid:string, headRefName:string, baseRefName:string, state:string}>} input.prs
+ *   ordered bottom -> top of the stack
+ * @param {(sha:string)=>boolean} input.hasLocalCommit
+ * @param {string} [input.trunk]
+ * @param {string} [input.stackPrefix]
+ * @returns {{ok:boolean, checks:Array<{pr:number,name:string,ok:boolean,detail:string}>}}
+ */
+export function analyzeStack({ prs, hasLocalCommit, trunk = TRUNK_DEFAULT, stackPrefix = STACK_PREFIX_DEFAULT }) {
+  const checks = [];
+  const add = (pr, name, ok, detail) => checks.push({ pr, name, ok, detail });
+
+  if (!Array.isArray(prs) || prs.length === 0) {
+    add(0, 'input', false, 'no PR numbers provided — pass explicit PR numbers, bottom of stack first');
+    return { ok: false, checks };
+  }
+
+  prs.forEach((pr, i) => {
+    const n = pr.number;
+
+    add(n, 'open', pr.state === 'OPEN', `state=${pr.state}`);
+
+    const shaOk = !!pr.headRefOid && hasLocalCommit(pr.headRefOid);
+    add(n, 'sha-local', shaOk,
+      `head ${short(pr.headRefOid)} ${shaOk ? 'present in local clone' : 'NOT found locally — refusing a PR whose code you do not have'}`);
+
+    const branchOk = typeof pr.headRefName === 'string' && pr.headRefName.startsWith(stackPrefix);
+    add(n, 'stack-branch', branchOk,
+      `head branch '${pr.headRefName}' ${branchOk ? 'is' : `is NOT`} a '${stackPrefix}' branch`);
+
+    const expectedBase = i === 0 ? trunk : prs[i - 1].headRefName;
+    const baseOk = pr.baseRefName === expectedBase;
+    add(n, 'base-linkage', baseOk,
+      `base '${pr.baseRefName}' ${baseOk ? '==' : '!='} expected '${expectedBase}'`);
+  });
+
+  return { ok: checks.every((c) => c.ok), checks };
+}
+
+export function short(sha) {
+  return sha ? String(sha).slice(0, 9) : '(none)';
+}
+
+// --------------------------------- CLI glue ----------------------------------
+
+function gh(args) {
+  return execFileSync('gh', args, { encoding: 'utf8' });
+}
+
+function fetchPr(num) {
+  const out = gh(['pr', 'view', String(num), '--json',
+    'number,headRefOid,headRefName,baseRefName,state,mergeStateStatus,reviewDecision']);
+  return JSON.parse(out);
+}
+
+function localCommitChecker() {
+  return (sha) => {
+    try {
+      execFileSync('git', ['cat-file', '-e', `${sha}^{commit}`], { stdio: 'ignore' });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+}
+
+function parseArgs(argv) {
+  const prs = [];
+  let execute = false;
+  let trunk = TRUNK_DEFAULT;
+  let stackPrefix = STACK_PREFIX_DEFAULT;
+  let help = false;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--help' || a === '-h') help = true;
+    else if (a === '--execute') execute = true;
+    else if (a === '--base') trunk = argv[++i];
+    else if (a === '--stack-prefix') stackPrefix = argv[++i];
+    else if (/^\d+$/.test(a)) prs.push(Number(a));
+    else throw new Error(`unrecognized argument: ${a}`);
+  }
+  return { prs, execute, trunk, stackPrefix, help };
+}
+
+const HELP = `land-stack — verify and land a Mergify PR stack by explicit PR number
+
+  node scripts/land-stack.mjs <pr> [<pr> ...]              verify only (safe default)
+  node scripts/land-stack.mjs <pr> [<pr> ...] --execute    verify, then queue the bottom PR
+  node scripts/land-stack.mjs <pr> ... --base <branch>     trunk branch (default: master)
+  node scripts/land-stack.mjs <pr> ... --stack-prefix <p>  required head-branch prefix (default: stack/)
+
+Pass PR numbers bottom-of-stack first. Verification must pass before anything is
+queued. --execute adds the admin-bypass label to the bottom PR (base == trunk).`;
+
+function printReport(result) {
+  const byPr = new Map();
+  for (const c of result.checks) {
+    if (!byPr.has(c.pr)) byPr.set(c.pr, []);
+    byPr.get(c.pr).push(c);
+  }
+  for (const [pr, checks] of byPr) {
+    console.log(`\nPR #${pr}`);
+    for (const c of checks) {
+      console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.name.padEnd(13)} ${c.detail}`);
+    }
+  }
+}
+
+function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (e) {
+    console.error(`error: ${e.message}\n`);
+    console.error(HELP);
+    process.exit(2);
+  }
+  if (args.help) {
+    console.log(HELP);
+    return;
+  }
+  if (args.prs.length === 0) {
+    console.error('error: no PR numbers provided.\n');
+    console.error(HELP);
+    process.exit(2);
+  }
+
+  let prData;
+  try {
+    prData = args.prs.map(fetchPr);
+  } catch (e) {
+    console.error(`error: failed to read PR via gh: ${e.message}`);
+    process.exit(2);
+  }
+
+  const result = analyzeStack({
+    prs: prData,
+    hasLocalCommit: localCommitChecker(),
+    trunk: args.trunk,
+    stackPrefix: args.stackPrefix,
+  });
+  printReport(result);
+
+  // Informational only — Mergify itself blocks the actual merge on these.
+  for (const pr of prData) {
+    if (pr.reviewDecision && pr.reviewDecision !== 'APPROVED') {
+      console.log(`\nnote: PR #${pr.number} reviewDecision=${pr.reviewDecision}, mergeState=${pr.mergeStateStatus}`);
+    }
+  }
+
+  if (!result.ok) {
+    console.error('\nRESULT: FAILED — not touching any PR. Fix the failures above (or confirm you passed the right PR numbers).');
+    process.exit(1);
+  }
+  console.log('\nRESULT: verification passed.');
+
+  if (!args.execute) {
+    console.log('Re-run with --execute to queue the bottom PR (base == trunk) via admin-bypass.');
+    return;
+  }
+
+  const bottom = prData.find((p) => p.state === 'OPEN' && p.baseRefName === args.trunk);
+  if (!bottom) {
+    console.error(`\nerror: no open PR with base '${args.trunk}' to queue. After the bottom PR merges, re-run with the remaining PR numbers.`);
+    process.exit(1);
+  }
+  console.log(`\nExecuting: adding 'admin-bypass' to bottom PR #${bottom.number} (head ${short(bottom.headRefOid)}, base ${bottom.baseRefName}).`);
+  gh(['pr', 'edit', String(bottom.number), '--add-label', 'admin-bypass']);
+  console.log(`Queued PR #${bottom.number}. Once it merges, the next PR re-targets '${args.trunk}'; re-run land-stack with the remaining PR numbers and --execute.`);
+}
+
+const invokedDirectly = (() => {
+  try {
+    return process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) main();

--- a/scripts/test-land-stack.mjs
+++ b/scripts/test-land-stack.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for the land-stack guard's pure verification.
+ * Run: node scripts/test-land-stack.mjs   (exit 0 = pass, non-zero = fail)
+ *
+ * Cases are modeled on the real incident: the intended stack (#2174 -> #2175)
+ * must pass; the raw workflow-branch PR (#505) that shared a branch name must fail.
+ */
+
+import assert from 'node:assert/strict';
+import { analyzeStack } from './land-stack.mjs';
+
+const SHA_2174 = 'db05fa18441693b0a51a8f9c2e2e3f0109d8f7a7';
+const SHA_2175 = '1049a6c76c5f788f31ca9cecaf19812c327bd107';
+const SHA_505 = '8f52adfcf94423c55b6b4fc2af95bbd4d6592eb4';
+
+const STACK_BR_BOTTOM = 'stack/EdbertChan/plan/reduce-large-files-step-3/...--5fb697a6';
+const STACK_BR_TOP = 'stack/EdbertChan/plan/reduce-large-files-step-3/...--8e5f5c84';
+
+// Everything except #505's head is "present locally".
+const localShas = new Set([SHA_2174, SHA_2175]);
+const hasLocal = (sha) => localShas.has(sha);
+
+const check = (res, pr, name) =>
+  res.checks.find((c) => c.pr === pr && c.name === name);
+
+let passed = 0;
+function test(name, fn) {
+  fn();
+  passed++;
+  console.log(`ok - ${name}`);
+}
+
+test('valid bottom->top stack passes every check', () => {
+  const res = analyzeStack({
+    hasLocalCommit: hasLocal,
+    prs: [
+      { number: 2174, headRefOid: SHA_2174, headRefName: STACK_BR_BOTTOM, baseRefName: 'master', state: 'OPEN' },
+      { number: 2175, headRefOid: SHA_2175, headRefName: STACK_BR_TOP, baseRefName: STACK_BR_BOTTOM, state: 'OPEN' },
+    ],
+  });
+  assert.equal(res.ok, true, 'expected the real stack to pass');
+});
+
+test('raw workflow-branch PR (#505) is rejected', () => {
+  const res = analyzeStack({
+    hasLocalCommit: hasLocal,
+    prs: [
+      { number: 505, headRefOid: SHA_505, headRefName: 'plan/reduce-large-files-step-3-orchestrator-ts-decomposition', baseRefName: 'master', state: 'OPEN' },
+    ],
+  });
+  assert.equal(res.ok, false, 'expected #505 to fail');
+  assert.equal(check(res, 505, 'stack-branch').ok, false, 'non-stack branch must fail');
+  assert.equal(check(res, 505, 'sha-local').ok, false, 'head not in local clone must fail');
+});
+
+test('head SHA missing from local clone fails sha-local', () => {
+  const res = analyzeStack({
+    hasLocalCommit: hasLocal,
+    prs: [
+      { number: 2174, headRefOid: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef', headRefName: STACK_BR_BOTTOM, baseRefName: 'master', state: 'OPEN' },
+    ],
+  });
+  assert.equal(res.ok, false);
+  assert.equal(check(res, 2174, 'sha-local').ok, false);
+});
+
+test('broken stack linkage fails base-linkage on the upper PR', () => {
+  const res = analyzeStack({
+    hasLocalCommit: hasLocal,
+    prs: [
+      { number: 2174, headRefOid: SHA_2174, headRefName: STACK_BR_BOTTOM, baseRefName: 'master', state: 'OPEN' },
+      { number: 2175, headRefOid: SHA_2175, headRefName: STACK_BR_TOP, baseRefName: 'master', state: 'OPEN' }, // should be STACK_BR_BOTTOM
+    ],
+  });
+  assert.equal(res.ok, false);
+  assert.equal(check(res, 2175, 'base-linkage').ok, false);
+});
+
+test('bottom PR not based on trunk fails base-linkage', () => {
+  const res = analyzeStack({
+    hasLocalCommit: hasLocal,
+    prs: [
+      { number: 2174, headRefOid: SHA_2174, headRefName: STACK_BR_BOTTOM, baseRefName: 'some-other-branch', state: 'OPEN' },
+    ],
+  });
+  assert.equal(res.ok, false);
+  assert.equal(check(res, 2174, 'base-linkage').ok, false);
+});
+
+test('closed PR fails open check', () => {
+  const res = analyzeStack({
+    hasLocalCommit: hasLocal,
+    prs: [
+      { number: 2174, headRefOid: SHA_2174, headRefName: STACK_BR_BOTTOM, baseRefName: 'master', state: 'MERGED' },
+    ],
+  });
+  assert.equal(res.ok, false);
+  assert.equal(check(res, 2174, 'open').ok, false);
+});
+
+test('empty input fails', () => {
+  const res = analyzeStack({ hasLocalCommit: hasLocal, prs: [] });
+  assert.equal(res.ok, false);
+});
+
+test('custom --base trunk is honored', () => {
+  const res = analyzeStack({
+    hasLocalCommit: hasLocal,
+    trunk: 'main',
+    prs: [
+      { number: 2174, headRefOid: SHA_2174, headRefName: STACK_BR_BOTTOM, baseRefName: 'main', state: 'OPEN' },
+    ],
+  });
+  assert.equal(res.ok, true);
+});
+
+console.log(`\n${passed} tests passed`);

--- a/skills/land-stack/SKILL.md
+++ b/skills/land-stack/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: land-stack
+description: >
+  Land (queue/merge) a Mergify-managed PR stack safely. Trigger when asked to
+  land, merge, ship, or queue a PR or PR stack with Mergify. Enforces that you
+  act on explicit, SHA-verified PR numbers — never a PR found by branch name.
+---
+
+# land-stack
+
+Use this skill whenever the user asks to **land / merge / ship / queue** a PR or a PR stack.
+
+## Hard rule
+
+**Never identify the PR to land by branch name.** Two different PRs can share a
+branch name (an auto-generated workflow branch PR and the intended `stack/...`
+PR). You must land by **explicit PR number**, and every PR must pass the guard
+before any write (label, thread-resolve, queue, merge).
+
+## Steps
+
+1. **Get explicit PR numbers from the user**, bottom of stack first. If they
+   give a URL, read the number from it. Do not run `gh pr list --head <branch>`
+   to discover what to land.
+
+2. **Verify with the guard — it must exit 0:**
+
+   ```bash
+   node scripts/land-stack.mjs <bottom-pr> <next-pr> ...
+   ```
+
+   The guard checks, for each PR: head SHA exists in the local clone (it is the
+   code you reviewed), head branch is a real `stack/` branch (rejects raw
+   workflow branches), the PRs form a proper stack (each base is the previous
+   head; the bottom's base is the trunk), and all are OPEN. If any check FAILs,
+   stop and reconfirm the PR numbers with the user — do not work around it.
+
+3. **Land bottom-up:**
+
+   ```bash
+   node scripts/land-stack.mjs <bottom-pr> ... --execute
+   ```
+
+   This re-verifies, then adds `admin-bypass` to the bottom PR (base == trunk)
+   to enter the Mergify queue. Use `admin-bypass` only because self-authored PRs
+   cannot be self-approved; if a human can approve, prefer a real approval +
+   `ready-to-merge`.
+
+4. **Wait for the bottom PR to merge.** Mergify re-runs the full suite on the
+   queued batch (can take ~20 min). When it merges, the next PR auto-re-targets
+   the trunk.
+
+5. **Re-run step 3 with the remaining PR numbers** until the stack is landed.
+
+## Do not
+
+- Do not `gh pr merge` or hand-add `admin-bypass` to skip the guard.
+- Do not resolve review threads to unblock a merge unless the user has decided
+  to defer those findings; record the deferral on the PR.
+- Do not act on a PR whose head SHA is not in your local clone.
+
+## Why this exists
+
+A raw workflow-branch PR (#505) shared a branch name with the intended stack
+(#2174 / #2175). Landing "the PR on this branch" by name queued the wrong PR.
+The guard makes that mistake fail closed instead of merging silently.


### PR DESCRIPTION
## Summary

Landing a PR stack now refuses to act on a PR found by branch name.

You pass explicit PR numbers, and a guard verifies each one before anything is queued or merged.

The guard checks the head commit is in your local clone, the head branch is a real `stack/` branch, the PRs form a proper stack, and all are open.

This closes the gap that let a raw workflow-branch PR get queued because it shared a branch name with the intended stack.

<details>
<summary>Review metadata</summary>

Review Claim: Approve adding the `land-stack` guard, skill, and always-on rule that force stack landing to go through explicit, SHA-verified PR numbers.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Adds new tooling, a skill, a rule, and a docs pointer only. Touches no product code under `packages/`; existing behavior is unchanged.

Slice Rationale: This is a self-contained guardrail. It is split from any landing action so the enforcement lands and can be reviewed on its own.

</details>

## Non-goals

- Does not change any product code under `packages/`.
- Does not change Mergify configuration or queue rules.
- Does not auto-resolve review threads or auto-approve PRs.

## Test Plan

- [ ] `node scripts/test-land-stack.mjs`
- [ ] `node scripts/land-stack.mjs --help`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a guided workflow for landing PR stacks with built-in validation to ensure stack integrity before merging.

* **Documentation**
  * Added comprehensive guidance on safely landing PR stack sequences, including validation requirements and operational procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->