### PR TITLE
[Fix intent cancellation](6) Fix intent cancellation Step 6: worker response lineage guard (regression gated v2)

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -855,6 +855,60 @@ describe('Orchestrator', () => {
       }
     });
 
+    it('rejects a completion signal when attemptId matches but executionGeneration is stale', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        orchestrator.loadPlan({
+          name: 'reject-stale-generation-with-current-attempt',
+          onFinish: 'none',
+          tasks: [
+            { id: 'A', description: 'Root', command: 'echo A' },
+          ],
+        });
+        orchestrator.startExecution();
+        const taskId = orchestrator.getAllTasks().find((task) => task.id === 'A' || task.id.endsWith('/A'))?.id ?? 'A';
+
+        const activeAttemptId = orchestrator.getTask(taskId)?.execution.selectedAttemptId;
+        expect(activeAttemptId).toBeTruthy();
+        const staleGeneration = orchestrator.getTask(taskId)?.execution.generation ?? 0;
+
+        // Advance the live execution generation while keeping the SAME selected
+        // attempt, so the response below carries the current attempt id but an
+        // older generation — the exact stale-lineage shape the guard must reject.
+        persistence.updateTask(taskId, {
+          execution: { generation: staleGeneration + 1, branch: 'live-branch', workspacePath: '/live/ws' },
+        });
+
+        orchestrator.handleWorkerResponse(
+          makeResponse({
+            actionId: taskId,
+            attemptId: activeAttemptId,
+            executionGeneration: staleGeneration,
+            status: 'completed',
+            outputs: { exitCode: 0, branch: 'stale-branch' },
+          }),
+        );
+
+        const after = orchestrator.getTask(taskId);
+        expect(after?.status).toBe('running');
+        expect(after?.execution.selectedAttemptId).toBe(activeAttemptId);
+        expect(after?.execution.branch).toBe('live-branch');
+        expect(after?.execution.workspacePath).toBe('/live/ws');
+        expect(persistence.events.some((event) => event.taskId === taskId && event.eventType === 'task.completed')).toBe(false);
+        expect(warnSpy).toHaveBeenCalledWith(
+          '[worker-response] STALE_GENERATION_REJECTED',
+          expect.objectContaining({
+            taskId,
+            responseGeneration: staleGeneration,
+            activeGeneration: staleGeneration + 1,
+            workerResponseStatus: 'completed',
+          }),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
     it('ignores a stale completed response after restartTask resets descendants', () => {
       const reproPersistence = new InMemoryPersistence();
       const reproBus = new InMemoryBus();

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1585,8 +1585,13 @@ export class Orchestrator {
           return [];
         }
         const activeGeneration = this.getExecutionGeneration(earlyTask);
+        // Lineage guard: a response is in-lineage only when every identity field it
+        // carries still matches the live task. The attempt-id check above already
+        // rejects a mismatched attemptId; here we independently reject a mismatched
+        // executionGeneration. Older producers may omit one field (attemptId is
+        // optional, executionGeneration may be absent), so each check runs only when
+        // its field is present — but when both are present, both must match.
         if (
-          !response.attemptId &&
           response.executionGeneration !== undefined &&
           response.executionGeneration !== activeGeneration
         ) {


### PR DESCRIPTION
## Summary

A worker response that carried an attempt id was accepted even when its execution generation no longer matched the live task.

That gap let an answer from an older run land on the current run and overwrite fresh state.

This change makes the orchestrator check the execution generation on its own, independent of the attempt id.

When both identity fields are present, both must match the live task before the answer is honored.

Older producers may send only one field, so each field is checked only when present. When both are present, both must agree.

<details>
<summary>Review metadata</summary>

Review Claim: Approve guarding worker-response handling so an answer with a matching attempt id but an old execution generation is dropped instead of honored.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Behavior only tightens which worker responses are honored; a response with no execution generation, or one whose execution generation still matches the live task, is handled exactly as before. No stored data shape changes.

Slice Rationale: This slice touches only the worker-response identity guard in the orchestrator. It is kept apart from the Step 5 base it builds on so reviewers can approve one guard in isolation.

</details>

## Non-goals

- Does not change how attempt ids are assigned or selected.
- Does not change how the execution generation counter is advanced.
- Does not change any persisted record shape or migration.
- Does not touch the merge gate, launch dispatch, or any other step in the series.

## Test Plan

- [ ] `cd packages/workflow-core && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
