### PR TITLE
Fix intent cancellation Step 7: post-start generation guard (regression gated v2)

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -353,4 +353,90 @@ describe('TaskRunner launch-dispatch wiring', () => {
     // The executor must NOT have been called — pivot short-circuits.
     expect(env.executor.start).not.toHaveBeenCalled();
   });
+
+  it('rejects post-start metadata when generation advances during executor.start (attempt id unchanged)', async () => {
+    // Lineage race: executor.start() resolves only after the live task has
+    // advanced to generation N+1, while selectedAttemptId is unchanged.
+    // markTaskRunningAfterLaunch (attempt-id only) would accept it; the
+    // generation guard must reject it before any metadata is persisted.
+    const task = makeTask(); // generation 1, attempt-1
+    const liveTask = makeTask(); // mutable live orchestrator view
+    let resolveStart: (() => void) | undefined;
+    const env = buildRunnerEnv(task, {
+      startImpl: (request) => new Promise((resolve) => {
+        resolveStart = () => resolve({
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/tmp/stale-ws',
+          branch: `experiment/${request.actionId}-stale`,
+          agentSessionId: 'sess-stale',
+          containerId: 'container-stale',
+        });
+      }),
+    });
+    env.orchestrator.getTask.mockImplementation(() => liveTask);
+    const launchOutbox = makeLaunchOutbox();
+
+    const run = env.runner.executeTask(task, { dispatchId: 55, launchOutbox });
+    await vi.waitFor(() => expect(env.executor.start).toHaveBeenCalledTimes(1));
+    // Live task advances a generation while start is still pending; attempt
+    // id stays 'attempt-1' so the attempt-only guard would not catch it.
+    (liveTask.execution as any).generation = 2;
+    resolveStart?.();
+    await run;
+
+    // Generation guard fires before the attempt-only check.
+    expect(env.orchestrator.markTaskRunningAfterLaunch).not.toHaveBeenCalled();
+    // Spawned handle is killed, consistent with the stale-attempt path.
+    expect(env.executor.kill).toHaveBeenCalledTimes(1);
+    // No stale start metadata reached the task row.
+    const stalePersist = env.persistence.updateTask.mock.calls.find(
+      ([, changes]: [string, any]) =>
+        changes?.execution?.workspacePath === '/tmp/stale-ws'
+        || changes?.execution?.agentSessionId === 'sess-stale'
+        || changes?.execution?.containerId === 'container-stale',
+    );
+    expect(stalePersist).toBeUndefined();
+    // No active execution registered for the superseded launch.
+    expect((env.runner as any).activeExecutions.size).toBe(0);
+    // A diagnostic event records the rejection.
+    expect(env.persistence.logEvent).toHaveBeenCalledWith(
+      task.id,
+      'task.executor.stale_post_start',
+      expect.objectContaining({ attemptId: 'attempt-1', launchGeneration: 1, currentGeneration: 2 }),
+    );
+    // Dispatch row is failed, not completed.
+    expect(launchOutbox.completeCalls).toHaveLength(0);
+    expect(launchOutbox.failCalls).toHaveLength(1);
+    expect(launchOutbox.failCalls[0][0]).toBe(55);
+  });
+
+  it('persists start metadata and registers the execution for the current valid launch', async () => {
+    // Control: generation is unchanged across executor.start(), so the launch
+    // is still current and the post-start metadata write must proceed.
+    const task = makeTask();
+    const env = buildRunnerEnv(task); // start resolves immediately, generation stays 1
+    const launchOutbox = makeLaunchOutbox();
+
+    const run = env.runner.executeTask(task, { dispatchId: 77, launchOutbox });
+    await vi.waitFor(() => expect(env.executor.onComplete).toHaveBeenCalled());
+
+    expect(env.orchestrator.markTaskRunningAfterLaunch).toHaveBeenCalledWith(task.id, 'attempt-1');
+    expect(env.executor.kill).not.toHaveBeenCalled();
+    const metaPersist = env.persistence.updateTask.mock.calls.find(
+      ([, changes]: [string, any]) => changes?.execution?.workspacePath === '/tmp/mock-ws',
+    );
+    expect(metaPersist).toBeDefined();
+    expect((env.runner as any).activeExecutions.size).toBe(1);
+    expect(env.persistence.logEvent).not.toHaveBeenCalledWith(
+      task.id,
+      'task.executor.stale_post_start',
+      expect.anything(),
+    );
+
+    env.triggerComplete();
+    await run;
+    expect(launchOutbox.completeCalls).toEqual([77]);
+    expect(launchOutbox.failCalls).toHaveLength(0);
+  });
 });

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1071,11 +1071,38 @@ export class TaskRunner {
       hasWorkspacePath: Boolean(handle.workspacePath),
       hasAgentSessionId: Boolean(handle.agentSessionId),
     });
+    // Lineage guard: executor.start() can resolve minutes after launch (SSH
+    // provisioning/setup is slow). If the live task advanced to a newer
+    // generation in the meantime — e.g. recreate-task bumped the generation
+    // while leaving selectedAttemptId unchanged — markTaskRunningAfterLaunch
+    // (which only validates selectedAttemptId) would still accept this
+    // superseded launch, letting it persist workspace/branch/session/container
+    // metadata, write heartbeat metadata, and register an active execution
+    // over the live attempt. Check the launch-time generation captured by
+    // TaskRunner before marking running so a stale launch is rejected here,
+    // exactly like a stale attempt id, instead of clobbering the live row.
+    const launchStaleAfterStart = this.isLaunchStale(task.id, attemptId, startGeneration);
+    if (launchStaleAfterStart) {
+      this.persistence.logEvent?.(task.id, 'task.executor.stale_post_start', {
+        attemptId,
+        executorType: executor.type,
+        launchGeneration: startGeneration,
+        currentGeneration: this.orchestrator.getTask(task.id)?.execution.generation ?? null,
+        workspacePath: handle.workspacePath,
+        branch: handle.branch,
+        hasAgentSessionId: Boolean(handle.agentSessionId),
+        hasContainerId: Boolean(handle.containerId),
+      });
+    }
+    // Short-circuit so a generation-stale launch never marks the live task
+    // running, then falls through to the shared stale/non-executable cleanup.
     const launchAccepted =
-      this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true;
+      !launchStaleAfterStart
+      && (this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true);
     if (!launchAccepted) {
       this.logger.warn(
-        `[TaskRunner] launch rejected as stale/non-executable for task=${task.id} attemptId=${attemptId}; killing spawned process`,
+        `[TaskRunner] launch rejected as stale/non-executable for task=${task.id} attemptId=${attemptId} ` +
+          `launchGeneration=${startGeneration} stalePostStart=${launchStaleAfterStart}; killing spawned process`,
       );
       try {
         await executor.kill(handle);


### PR DESCRIPTION
## Summary

Step 7 closes a post-start metadata gap in the task runner. A launch accepted at one generation could finish starting after the live task advanced to a newer generation.

When that happened, the old launch still wrote post-start metadata over the live attempt's state — workspace path, branch, session id, and heartbeat.

The fix adds a narrow lineage check after start resolves, comparing the launch-time generation against the live generation.

A superseded launch is now routed through the existing kill-and-teardown path instead of persisting metadata or registering an active execution.

A best-effort diagnostic records what was dropped — attempt ids, both generations, and runner kind — for later analysis.

<details>
<summary>Review metadata</summary>

Review Claim: A start that resolves after its launch generation was superseded must route to teardown, not persist post-start metadata.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Only the post-start metadata path gains a generation check; when the launch generation still matches, behavior is identical to before.

Slice Rationale: This slice only covers the post-start metadata window in the task runner; earlier lineage and gating steps ship in their own PRs.

</details>

## Non-goals

- Does not change the existing attempt-id match; it only adds the generation comparison alongside it.
- Does not touch worker-response lineage (Step 6) or any earlier step.
- No data migration and no schema change.

## Architecture

### Before

```mermaid
graph TD
    A["Launch captures startGeneration N"] --> B["executor.start resolves"]
    B --> C["markTaskRunningAfterLaunch checks attemptId only"]
    C --> D["Persist post-start metadata"]
    D --> E["Register active execution"]
```

### After

```mermaid
graph TD
    A["Launch captures startGeneration N"] --> B["executor.start resolves"]
    B --> G["isLaunchStale checks attemptId and startGeneration"]
    G --> H["Superseded launch: log diagnostic, kill, teardown"]
    G --> C["Live launch: markTaskRunningAfterLaunch"]
    C --> D["Persist post-start metadata"]
    D --> E["Register active execution"]
```

## Test Plan

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/task-runner-launch-dispatch.test.ts` — 12 passed; covers the post-start generation guard added here.
- [ ] `cd packages/execution-engine && pnpm test` — currently fails: two existing `task-runner.test.ts` assertions about older-attempt kill counts no longer hold, because the new guard kills a superseded launch. Those expectations need updating before this lands.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert -m 1 d44c60e80` (or revert the squash-merge commit once this PR lands on its base branch)
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced task execution reliability with generation-based lineage validation to detect and properly handle stale launches during executor initialization.
  * Improved executor cleanup and dispatch handling when launch rejection occurs, with enhanced diagnostic logging.

* **Tests**
  * Added test coverage for post-start metadata handling during task lineage transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->