### PR TITLE
[pr-skill robustness](8) Surface merge-gate clone provisioning in task output

### DIFF
--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -151,6 +151,13 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
 
     try {
       this.emitOutput(handle.executionId, `[merge] Starting merge gate action: ${task.id}\n`);
+      // Surface that the running phase begins with provisioning, not the merge
+      // itself — the gate clone can take a while on large repos, and without this
+      // the task just reads as "Executing" with no visible progress.
+      this.emitOutput(
+        handle.executionId,
+        `[merge] Preparing gate workspace (cloning/provisioning; this can take a while on large repos)…\n`,
+      );
       // Capture launch lineage so a stale (relaunched) run's direct metadata
       // write is suppressed.
       const lineage: MergeGateLineage = {

--- a/scripts/repro/repro-merge-gate-provisioning-not-surfaced.sh
+++ b/scripts/repro/repro-merge-gate-provisioning-not-surfaced.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+SOURCE="$ROOT/packages/execution-engine/src/merge-gate-executor.ts"
+echo "[repro] problem: a merge gate reads as 'Executing' with no progress while it is really cloning/provisioning the gate workspace"
+echo "[repro] root cause: run() entered the merge action without surfacing that the running phase starts with provisioning"
+
+python3 - "$SOURCE" <<'PY'
+import pathlib, sys
+src = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+
+# The provisioning notice must be emitted BEFORE the merge action (the clone happens inside it).
+notice = src.find("Preparing gate workspace")
+action = src.find("await runMergeGateActionImpl(this.host, task)")
+if notice == -1:
+    raise SystemExit("missing provisioning notice in merge gate run()")
+if action == -1 or notice > action:
+    raise SystemExit("provisioning notice must be emitted before runMergeGateActionImpl")
+
+# Recovery is unchanged: still runs under the executing-stall-protected running phase (no phase downgrade).
+if "phase: 'launching'" in src:
+    raise SystemExit("must NOT move the clone into launching phase (would lose executing-stall recovery)")
+
+print("[repro] post-fix: run() emits a 'Preparing gate workspace' provisioning notice before the merge action")
+print("[repro] invariant: clone stays in the executing-stall-protected running phase (recovery unchanged)")
+PY
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

A merge gate spends the first part of its "running" time cloning/provisioning the gate workspace, which on large repos can take a while.

With no output, that window just reads as "Executing" with no visible progress. `run()` now emits a clear `Preparing gate workspace (cloning/provisioning…)` line before the merge action.

This is output only — deliberately not a phase change. The clone stays in the executing-stall-protected running phase, so the hung-clone recovery from slice 1 is unchanged.

This PR bundles its repro with the fix.

<details>
<summary>Review metadata</summary>

Review Claim: Approve surfacing gate-clone provisioning as task output, with no change to phase or recovery.
Review Lane: behavior
Review Unit: routing
Safety Invariant: No phase/status/recovery change — the clone stays running/executing (executing-stall covered); only a progress line is added.
Slice Rationale: Light-touch follow-up to slice 1's async launch, addressing the "reads as Executing while really cloning" gap without touching the stall watchdog.

</details>

## Non-goals

- Does not move the clone into the launching phase (that would lose executing-stall recovery).
- Does not change merge/clone behavior — output only.

## Test Plan

- [x] `bash scripts/repro/repro-merge-gate-provisioning-not-surfaced.sh`
- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/merge-gate-executor.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Merge gate execution now displays an early **“Preparing gate workspace (cloning/provisioning…)”** progress message, making long setup phases visible sooner.

* **Tests**
  * Added a repro/verification script to confirm the message appears before merge execution proceeds and to ensure no new **“launching”** phase indicator is introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->