### PR TITLE
fix(data-store): cap activity_log retention to prevent DB bloat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to Invoker will be documented in this file.
 - Review gates can now track PR stacks with optional dependency order, expose that stack through query surfaces and the side panel, and discard or close stale PRs when the gate is invalidated.
 - Model merge-gate PR status as a single `open`/`closed`/`merged` lifecycle so a PR can never be treated as merged and closed at the same time.
 - Add Slack-native coding workflows: plan from a lobby `@Invoker` mention against a checked-out repo with a selectable planning harness (`[preset]`/`[repo:]` tags), spin the plan up as a workflow in a private `workflow-<id>` channel, and drive or question that workflow in-channel using only its own planning conversation and task transcripts.
+- Cap the `activity_log` table to its most recent rows (config `activityLogMaxRows`, default 100000), pruned on write, so `~/.invoker/invoker.db` can no longer bloat unbounded and trigger SIGBUS crashes.
 ## 0.0.4
 
 - Publish complete CLI and desktop release assets for npm launcher packages.

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -94,6 +94,8 @@
   "autoFixRetries": 3,
   "autoApproveAIFixes": true,
   "autoFixCi": false,
+  "activityLogMaxRows": 100000,
+  "activityLogMaxRows_comment": "Cap on retained ~/.invoker activity_log rows. Pruned on write to the most recent N entries so the DB cannot bloat. Default: 100000. Set to 0 to disable retention.",
 
   "notes": {
     "fetch_behavior": "Git fetch failures always abort the task. Fix the underlying network/auth issue and rerun.",

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -70,6 +70,13 @@ export interface InvokerConfig {
   slackRepos?: Record<string, string>;
   /** Repo URL used for Slack planning when the message carries no `[repo:]` tag. */
   defaultRepoUrl?: string;
+  /**
+   * Cap on retained ~/.invoker activity_log rows. The table is pruned on write
+   * down to its most recent N entries, bounding DB file growth (unbounded
+   * logging previously grew the DB to ~1GB and caused SIGBUS crashes).
+   * Default: 100000. Set to 0 to disable retention.
+   */
+  activityLogMaxRows?: number;
   /** Maximum number of tasks that can run concurrently. Default: 6. */
   maxConcurrency?: number;
   /** Browser executable for opening external URLs (e.g. "firefox"). Default: Chrome. */

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -665,6 +665,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
   persistence = await SQLiteAdapter.create(dbPath, {
     readOnly,
     ownerCapability: !readOnly, // writable mode requires owner capability
+    activityLogMaxRows: invokerConfig.activityLogMaxRows,
   });
   // Upgrade root logger with DB persistence now that SQLiteAdapter is ready.
   logger = new FileAndDbLogger({ module: 'main' }, { persistence });

--- a/packages/data-store/src/__tests__/activity-log-bloat.repro.test.ts
+++ b/packages/data-store/src/__tests__/activity-log-bloat.repro.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+// Must match ACTIVITY_LOG_PRUNE_INTERVAL in sqlite-adapter.ts.
+const PRUNE_INTERVAL = 1_000;
+
+/**
+ * Regression repro for the ~1GB invoker.db / SIGBUS incident: activity_log grew
+ * unbounded (2.58M rows / 424MB live + ~600MB free pages) and the memory-mapped
+ * file faulted with SIGBUS during write-heavy operations.
+ *
+ * This drives a real on-disk database and proves that retention bounds BOTH the
+ * row count and the file size, so the bloat cannot recur. Also exercised by
+ * scripts/repro/repro-activity-log-bloat.sh.
+ */
+describe('activity_log on-disk bloat is bounded by retention', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+      dir = undefined;
+    }
+  });
+
+  async function floodPhase(maxRows: number, writes: number): Promise<{ rows: number; bytes: number }> {
+    dir ??= mkdtempSync(join(tmpdir(), 'invoker-activity-bloat-'));
+    const dbPath = join(dir, `phase-${maxRows}.db`);
+    const adapter = await SQLiteAdapter.create(dbPath, {
+      ownerCapability: true,
+      activityLogMaxRows: maxRows,
+    });
+    // A single transaction keeps the flood fast (one fsync) while still
+    // exercising the per-write throttled prune inside writeActivityLog.
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < writes; i += 1) {
+        adapter.writeActivityLog('flood', 'info', `entry-${i}-payload-padding-to-mimic-real-log-lines`);
+      }
+    });
+    let rows = 0;
+    let sinceId = 0;
+    for (;;) {
+      const batch = adapter.getActivityLogs(sinceId, 5_000);
+      if (batch.length === 0) break;
+      rows += batch.length;
+      sinceId = batch[batch.length - 1].id;
+    }
+    adapter.close(); // checkpoints WAL into the main DB file
+    let bytes = 0;
+    for (const suffix of ['', '-wal']) {
+      try { bytes += statSync(`${dbPath}${suffix}`).size; } catch { /* sidecar may be gone */ }
+    }
+    return { rows, bytes };
+  }
+
+  it('grows unbounded with retention disabled but stays bounded when enabled', async () => {
+    const writes = 10_000;
+    const cap = 500;
+
+    const disabled = await floodPhase(0, writes); // pre-fix behavior
+    const enabled = await floodPhase(cap, writes); // with retention
+
+    // Disabled: every row retained — this is exactly how the DB ballooned.
+    expect(disabled.rows).toBe(writes);
+    // Enabled: row count capped to one throttle window above maxRows.
+    expect(enabled.rows).toBeLessThanOrEqual(cap + PRUNE_INTERVAL);
+    // Enabled: the on-disk file does not grow with input — bloat cannot recur.
+    expect(enabled.bytes * 2).toBeLessThan(disabled.bytes);
+  });
+});

--- a/packages/data-store/src/__tests__/activity-log-retention.test.ts
+++ b/packages/data-store/src/__tests__/activity-log-retention.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+// Throttle constant baked into the adapter: it prunes at most once per N writes,
+// so the on-write bound is `maxRows + ACTIVITY_LOG_PRUNE_INTERVAL`.
+const PRUNE_INTERVAL = 1_000;
+
+describe('activity_log retention', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    while (adapters.length) adapters.pop()?.close();
+  });
+
+  async function makeAdapter(activityLogMaxRows?: number): Promise<SQLiteAdapter> {
+    const adapter = await SQLiteAdapter.create(':memory:', { activityLogMaxRows });
+    adapters.push(adapter);
+    return adapter;
+  }
+
+  function rowCount(adapter: SQLiteAdapter): number {
+    // getActivityLogs is id-ascending; page through to count without a cap.
+    let total = 0;
+    let sinceId = 0;
+    for (;;) {
+      const batch = adapter.getActivityLogs(sinceId, 1_000);
+      if (batch.length === 0) break;
+      total += batch.length;
+      sinceId = batch[batch.length - 1].id;
+    }
+    return total;
+  }
+
+  it('pruneActivityLog keeps the newest N rows and reports the deletion count', async () => {
+    const adapter = await makeAdapter(100_000); // default-sized cap, prune explicitly
+    for (let i = 0; i < 50; i += 1) {
+      adapter.writeActivityLog('test', 'info', `msg-${i}`);
+    }
+    const deleted = adapter.pruneActivityLog(10);
+    expect(deleted).toBe(40);
+    expect(rowCount(adapter)).toBe(10);
+
+    // The retained rows must be the newest ones (msg-40 .. msg-49).
+    const remaining = adapter.getActivityLogs(0, 1_000).map((r) => r.message);
+    expect(remaining).toContain('msg-49');
+    expect(remaining).not.toContain('msg-39');
+  });
+
+  it('bounds the table on write without an explicit prune call', async () => {
+    const cap = 500;
+    const adapter = await makeAdapter(cap);
+    const writes = 2 * PRUNE_INTERVAL + 500; // 2500 — crosses the throttle twice
+    for (let i = 0; i < writes; i += 1) {
+      adapter.writeActivityLog('flood', 'info', `entry-${i}`);
+    }
+    const count = rowCount(adapter);
+    // Never unbounded: stays within one throttle window above the cap.
+    expect(count).toBeLessThanOrEqual(cap + PRUNE_INTERVAL);
+    expect(count).toBeGreaterThanOrEqual(cap);
+    // Most-recent entry survives; an early one does not.
+    const newest = adapter.getActivityLogs(0, writes).map((r) => r.message);
+    expect(newest).toContain(`entry-${writes - 1}`);
+    expect(newest).not.toContain('entry-0');
+  });
+
+  it('treats maxRows <= 0 as retention disabled (reproduces the unbounded growth)', async () => {
+    const adapter = await makeAdapter(0);
+    const writes = PRUNE_INTERVAL + 200; // 1200 — would trigger a prune if enabled
+    for (let i = 0; i < writes; i += 1) {
+      adapter.writeActivityLog('flood', 'info', `entry-${i}`);
+    }
+    // Disabled cap means every row is retained — this is the pre-fix behavior.
+    expect(rowCount(adapter)).toBe(writes);
+    // Explicit prune with a disabled cap is also a no-op.
+    expect(adapter.pruneActivityLog(0)).toBe(0);
+    expect(rowCount(adapter)).toBe(writes);
+  });
+
+  it('is a no-op when the table already fits under the cap', async () => {
+    const adapter = await makeAdapter(100_000);
+    for (let i = 0; i < 5; i += 1) {
+      adapter.writeActivityLog('test', 'info', `msg-${i}`);
+    }
+    expect(adapter.pruneActivityLog(100)).toBe(0);
+    expect(rowCount(adapter)).toBe(5);
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -64,6 +64,19 @@ function loadNativeSqlite(): Promise<NativeSqlite> {
 }
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
+/**
+ * Default cap on retained `activity_log` rows. Bounds DB growth so the
+ * memory-mapped SQLite file cannot bloat into multi-hundred-MB territory —
+ * unbounded activity logging grew the file to ~1GB and triggered SIGBUS
+ * crashes during write-heavy operations. Set to 0 to disable pruning.
+ */
+const DEFAULT_ACTIVITY_LOG_MAX_ROWS = 100_000;
+/**
+ * Enforce the cap at most once every N activity_log writes. Keeps steady-state
+ * write cost negligible while bounding the table to roughly maxRows + this.
+ */
+const ACTIVITY_LOG_PRUNE_INTERVAL = 1_000;
+
 const OUTPUT_DIAGNOSTIC_TAIL_CHARS = 8_000;
 
 
@@ -95,6 +108,8 @@ interface SQLiteAdapterOptions {
   ownerCapability?: boolean;
   outputTailLimit?: number;
   outputDir?: string;
+  /** Cap on retained activity_log rows. Defaults to DEFAULT_ACTIVITY_LOG_MAX_ROWS; 0 disables retention. */
+  activityLogMaxRows?: number;
 }
 
 export type WorkflowMutationPriority = 'high' | 'normal';
@@ -276,6 +291,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private spoolNextOffsetCache = new Map<string, number>();
   private writeTransactionDepth = 0;
   private lastWorkflowTaskSnapshotStats: Record<string, unknown> | null = null;
+  private readonly activityLogMaxRows: number;
+  private activityLogWritesSincePrune = 0;
 
   /** Use SQLiteAdapter.create() instead. */
   private constructor(db: DatabaseSync, dbPath: string | null, options?: SQLiteAdapterOptions) {
@@ -285,6 +302,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.readOnly = options?.readOnly === true;
     this.outputTailLimit = options?.outputTailLimit ?? 100;
     this.outputDir = options?.outputDir ?? this.resolveOutputDir(dbPath);
+    this.activityLogMaxRows = options?.activityLogMaxRows ?? DEFAULT_ACTIVITY_LOG_MAX_ROWS;
     this.configureConnection(dbPath !== null);
     if (!this.readOnly) {
       this.initSchema();
@@ -2738,6 +2756,40 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'INSERT INTO activity_log (source, level, message) VALUES (?, ?, ?)',
       [source, level, message],
     );
+    this.activityLogWritesSincePrune += 1;
+    if (this.activityLogWritesSincePrune >= ACTIVITY_LOG_PRUNE_INTERVAL) {
+      this.activityLogWritesSincePrune = 0;
+      try {
+        this.pruneActivityLog();
+      } catch {
+        /* Retention is best-effort; never let pruning break a log write. */
+      }
+    }
+  }
+
+  /**
+   * Bound `activity_log` to its most recent `maxRows` entries, deleting older
+   * rows. Returns the number of rows deleted. No-op when read-only or when the
+   * cap is disabled (<= 0). Enforced automatically on write (throttled to once
+   * per ACTIVITY_LOG_PRUNE_INTERVAL writes) and callable directly to compact an
+   * already-bloated table in one shot.
+   */
+  pruneActivityLog(maxRows: number = this.activityLogMaxRows): number {
+    if (this.readOnly || !Number.isFinite(maxRows) || maxRows <= 0) return 0;
+    const total = this.queryOne('SELECT COUNT(*) AS c FROM activity_log') as
+      | { c: number }
+      | undefined;
+    const count = total?.c ?? 0;
+    if (count <= maxRows) return 0;
+    // Keep the newest `maxRows` rows; the row at OFFSET maxRows (and every older
+    // row) is deleted. ids are monotonic so this is gap-safe.
+    const boundary = this.queryOne(
+      'SELECT id FROM activity_log ORDER BY id DESC LIMIT 1 OFFSET ?',
+      [maxRows],
+    ) as { id: number } | undefined;
+    if (!boundary) return 0;
+    this.execRun('DELETE FROM activity_log WHERE id <= ?', [boundary.id]);
+    return count - maxRows;
   }
 
   getActivityLogs(sinceId = 0, limit = 200): ActivityLogEntry[] {

--- a/scripts/repro/repro-activity-log-bloat.sh
+++ b/scripts/repro/repro-activity-log-bloat.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Repro: unbounded activity_log growth bloats ~/.invoker/invoker.db.
+#
+# Background: activity_log was written on every log line with no retention. Over
+# ~45 days it reached 2.58M rows / 424MB live data plus ~600MB of unreclaimed
+# free pages, pushing invoker.db to ~1GB. The memory-mapped SQLite file then
+# faulted with SIGBUS during write-heavy operations (e.g. workflow deletes).
+#
+# This proves the fix end-to-end: the SQLiteAdapter now caps activity_log to its
+# most recent N rows (config `activityLogMaxRows`, default 100000), enforced on
+# write. The spec floods a real on-disk database with retention disabled (the old
+# behavior) and enabled, and asserts the enabled run stays bounded in both row
+# count and file size.
+#
+# Runs through the project's TS test runner so workspace/TS resolution matches
+# production. Exit 0 = PASS, non-zero = FAIL.
+#
+# Usage: bash scripts/repro/repro-activity-log-bloat.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SPEC="src/__tests__/activity-log-bloat.repro.test.ts"
+
+cd "$REPO_ROOT/packages/data-store"
+
+echo "[repro] running on-disk activity_log bloat proof ..."
+if pnpm exec vitest run "$SPEC"; then
+  echo "[repro] PASS: activity_log retention bounds the database; the ~1GB/SIGBUS bloat cannot recur."
+  exit 0
+fi
+
+echo "[repro] FAIL: activity_log was not bounded by retention."
+exit 1


### PR DESCRIPTION
activity_log was appended on every log line with no retention, growing
~/.invoker/invoker.db to ~1GB (2.58M rows / 424MB live + ~600MB free pages)
and triggering SIGBUS crashes during write-heavy operations (e.g. workflow
deletes) on the memory-mapped database.

Cap the table to its most recent N rows (config activityLogMaxRows, default
100000), pruned on write (throttled once per 1000 writes). Add pruneActivityLog
for one-shot compaction, a unit test, and a bash repro proving the bound holds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retention for the activity log, keeping only the most recent entries by default to prevent database growth issues.
  * Introduced a setting to adjust the maximum retained activity-log rows, including an option to disable the cap.

* **Bug Fixes**
  * Reduced the risk of storage-related crashes by pruning old activity-log records during normal writes.

* **Documentation**
  * Updated release notes and configuration examples to describe the new activity-log retention behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->