### PR TITLE
fix(data-store): bound activity_log on write to prevent DB bloat

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -70,6 +70,13 @@ export interface InvokerConfig {
   slackRepos?: Record<string, string>;
   /** Repo URL used for Slack planning when the message carries no `[repo:]` tag. */
   defaultRepoUrl?: string;
+  /**
+   * Cap on retained ~/.invoker activity_log rows. The table is pruned on write
+   * down to its most recent N entries, bounding DB file growth (unbounded
+   * logging previously grew the DB to ~1GB and caused SIGBUS crashes).
+   * Default: 100000. Set to 0 to disable retention.
+   */
+  activityLogMaxRows?: number;
   /** Maximum number of tasks that can run concurrently. Default: 6. */
   maxConcurrency?: number;
   /** Browser executable for opening external URLs (e.g. "firefox"). Default: Chrome. */

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -665,6 +665,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
   persistence = await SQLiteAdapter.create(dbPath, {
     readOnly,
     ownerCapability: !readOnly, // writable mode requires owner capability
+    activityLogMaxRows: invokerConfig.activityLogMaxRows,
   });
   // Upgrade root logger with DB persistence now that SQLiteAdapter is ready.
   logger = new FileAndDbLogger({ module: 'main' }, { persistence });

--- a/packages/data-store/src/__tests__/activity-log-retention.test.ts
+++ b/packages/data-store/src/__tests__/activity-log-retention.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+// Throttle constant baked into the adapter: it prunes at most once per N writes,
+// so the on-write bound is `maxRows + ACTIVITY_LOG_PRUNE_INTERVAL`.
+const PRUNE_INTERVAL = 1_000;
+
+describe('activity_log retention', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    while (adapters.length) adapters.pop()?.close();
+  });
+
+  async function makeAdapter(activityLogMaxRows?: number): Promise<SQLiteAdapter> {
+    const adapter = await SQLiteAdapter.create(':memory:', { activityLogMaxRows });
+    adapters.push(adapter);
+    return adapter;
+  }
+
+  function rowCount(adapter: SQLiteAdapter): number {
+    // getActivityLogs is id-ascending; page through to count without a cap.
+    let total = 0;
+    let sinceId = 0;
+    for (;;) {
+      const batch = adapter.getActivityLogs(sinceId, 1_000);
+      if (batch.length === 0) break;
+      total += batch.length;
+      sinceId = batch[batch.length - 1].id;
+    }
+    return total;
+  }
+
+  it('pruneActivityLog keeps the newest N rows and reports the deletion count', async () => {
+    const adapter = await makeAdapter(100_000); // default-sized cap, prune explicitly
+    for (let i = 0; i < 50; i += 1) {
+      adapter.writeActivityLog('test', 'info', `msg-${i}`);
+    }
+    const deleted = adapter.pruneActivityLog(10);
+    expect(deleted).toBe(40);
+    expect(rowCount(adapter)).toBe(10);
+
+    // The retained rows must be the newest ones (msg-40 .. msg-49).
+    const remaining = adapter.getActivityLogs(0, 1_000).map((r) => r.message);
+    expect(remaining).toContain('msg-49');
+    expect(remaining).not.toContain('msg-39');
+  });
+
+  it('bounds the table on write without an explicit prune call', async () => {
+    const cap = 500;
+    const adapter = await makeAdapter(cap);
+    const writes = 2 * PRUNE_INTERVAL + 500; // 2500 — crosses the throttle twice
+    for (let i = 0; i < writes; i += 1) {
+      adapter.writeActivityLog('flood', 'info', `entry-${i}`);
+    }
+    const count = rowCount(adapter);
+    // Never unbounded: stays within one throttle window above the cap.
+    expect(count).toBeLessThanOrEqual(cap + PRUNE_INTERVAL);
+    expect(count).toBeGreaterThanOrEqual(cap);
+    // Most-recent entry survives; an early one does not.
+    const newest = adapter.getActivityLogs(0, writes).map((r) => r.message);
+    expect(newest).toContain(`entry-${writes - 1}`);
+    expect(newest).not.toContain('entry-0');
+  });
+
+  it('treats maxRows <= 0 as retention disabled (reproduces the unbounded growth)', async () => {
+    const adapter = await makeAdapter(0);
+    const writes = PRUNE_INTERVAL + 200; // 1200 — would trigger a prune if enabled
+    for (let i = 0; i < writes; i += 1) {
+      adapter.writeActivityLog('flood', 'info', `entry-${i}`);
+    }
+    // Disabled cap means every row is retained — this is the pre-fix behavior.
+    expect(rowCount(adapter)).toBe(writes);
+    // Explicit prune with a disabled cap is also a no-op.
+    expect(adapter.pruneActivityLog(0)).toBe(0);
+    expect(rowCount(adapter)).toBe(writes);
+  });
+
+  it('is a no-op when the table already fits under the cap', async () => {
+    const adapter = await makeAdapter(100_000);
+    for (let i = 0; i < 5; i += 1) {
+      adapter.writeActivityLog('test', 'info', `msg-${i}`);
+    }
+    expect(adapter.pruneActivityLog(100)).toBe(0);
+    expect(rowCount(adapter)).toBe(5);
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -64,6 +64,19 @@ function loadNativeSqlite(): Promise<NativeSqlite> {
 }
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
+/**
+ * Default cap on retained `activity_log` rows. Bounds DB growth so the
+ * memory-mapped SQLite file cannot bloat into multi-hundred-MB territory —
+ * unbounded activity logging grew the file to ~1GB and triggered SIGBUS
+ * crashes during write-heavy operations. Set to 0 to disable pruning.
+ */
+const DEFAULT_ACTIVITY_LOG_MAX_ROWS = 100_000;
+/**
+ * Enforce the cap at most once every N activity_log writes. Keeps steady-state
+ * write cost negligible while bounding the table to roughly maxRows + this.
+ */
+const ACTIVITY_LOG_PRUNE_INTERVAL = 1_000;
+
 const OUTPUT_DIAGNOSTIC_TAIL_CHARS = 8_000;
 
 
@@ -95,6 +108,8 @@ interface SQLiteAdapterOptions {
   ownerCapability?: boolean;
   outputTailLimit?: number;
   outputDir?: string;
+  /** Cap on retained activity_log rows. Defaults to DEFAULT_ACTIVITY_LOG_MAX_ROWS; 0 disables retention. */
+  activityLogMaxRows?: number;
 }
 
 export type WorkflowMutationPriority = 'high' | 'normal';
@@ -276,6 +291,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private spoolNextOffsetCache = new Map<string, number>();
   private writeTransactionDepth = 0;
   private lastWorkflowTaskSnapshotStats: Record<string, unknown> | null = null;
+  private readonly activityLogMaxRows: number;
+  private activityLogWritesSincePrune = 0;
 
   /** Use SQLiteAdapter.create() instead. */
   private constructor(db: DatabaseSync, dbPath: string | null, options?: SQLiteAdapterOptions) {
@@ -285,6 +302,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.readOnly = options?.readOnly === true;
     this.outputTailLimit = options?.outputTailLimit ?? 100;
     this.outputDir = options?.outputDir ?? this.resolveOutputDir(dbPath);
+    this.activityLogMaxRows = options?.activityLogMaxRows ?? DEFAULT_ACTIVITY_LOG_MAX_ROWS;
     this.configureConnection(dbPath !== null);
     if (!this.readOnly) {
       this.initSchema();
@@ -2738,6 +2756,40 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'INSERT INTO activity_log (source, level, message) VALUES (?, ?, ?)',
       [source, level, message],
     );
+    this.activityLogWritesSincePrune += 1;
+    if (this.activityLogWritesSincePrune >= ACTIVITY_LOG_PRUNE_INTERVAL) {
+      this.activityLogWritesSincePrune = 0;
+      try {
+        this.pruneActivityLog();
+      } catch {
+        /* Retention is best-effort; never let pruning break a log write. */
+      }
+    }
+  }
+
+  /**
+   * Bound `activity_log` to its most recent `maxRows` entries, deleting older
+   * rows. Returns the number of rows deleted. No-op when read-only or when the
+   * cap is disabled (<= 0). Enforced automatically on write (throttled to once
+   * per ACTIVITY_LOG_PRUNE_INTERVAL writes) and callable directly to compact an
+   * already-bloated table in one shot.
+   */
+  pruneActivityLog(maxRows: number = this.activityLogMaxRows): number {
+    if (this.readOnly || !Number.isFinite(maxRows) || maxRows <= 0) return 0;
+    const total = this.queryOne('SELECT COUNT(*) AS c FROM activity_log') as
+      | { c: number }
+      | undefined;
+    const count = total?.c ?? 0;
+    if (count <= maxRows) return 0;
+    // Keep the newest `maxRows` rows; the row at OFFSET maxRows (and every older
+    // row) is deleted. ids are monotonic so this is gap-safe.
+    const boundary = this.queryOne(
+      'SELECT id FROM activity_log ORDER BY id DESC LIMIT 1 OFFSET ?',
+      [maxRows],
+    ) as { id: number } | undefined;
+    if (!boundary) return 0;
+    this.execRun('DELETE FROM activity_log WHERE id <= ?', [boundary.id]);
+    return count - maxRows;
   }
 
   getActivityLogs(sinceId = 0, limit = 200): ActivityLogEntry[] {


### PR DESCRIPTION
activity_log appended a row per log line with no retention, growing ~/.invoker/invoker.db to ~1GB (2.58M rows) and triggering SIGBUS on the memory-mapped file during write-heavy work.

writeActivityLog now prunes to the most recent N rows (config activityLogMaxRows, default 100000), throttled to once per 1000 writes, plus a pruneActivityLog method for one-shot compaction. Adds unit coverage for the bound.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit for retained activity log entries.
  * Activity logs are now automatically pruned during writes to keep recent entries within the configured cap.

* **Bug Fixes**
  * Improved activity log retention behavior so older entries are removed consistently.
  * Set the limit to `0` to disable retention and keep all log entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->