### PR TITLE
test(data-store): repro proving activity_log bloat is bounded

### DIFF
--- a/packages/data-store/src/__tests__/activity-log-bloat.repro.test.ts
+++ b/packages/data-store/src/__tests__/activity-log-bloat.repro.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+// Must match ACTIVITY_LOG_PRUNE_INTERVAL in sqlite-adapter.ts.
+const PRUNE_INTERVAL = 1_000;
+
+/**
+ * Regression repro for the ~1GB invoker.db / SIGBUS incident: activity_log grew
+ * unbounded (2.58M rows / 424MB live + ~600MB free pages) and the memory-mapped
+ * file faulted with SIGBUS during write-heavy operations.
+ *
+ * This drives a real on-disk database and proves that retention bounds BOTH the
+ * row count and the file size, so the bloat cannot recur. Also exercised by
+ * scripts/repro/repro-activity-log-bloat.sh.
+ */
+describe('activity_log on-disk bloat is bounded by retention', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+      dir = undefined;
+    }
+  });
+
+  async function floodPhase(maxRows: number, writes: number): Promise<{ rows: number; bytes: number }> {
+    dir ??= mkdtempSync(join(tmpdir(), 'invoker-activity-bloat-'));
+    const dbPath = join(dir, `phase-${maxRows}.db`);
+    const adapter = await SQLiteAdapter.create(dbPath, {
+      ownerCapability: true,
+      activityLogMaxRows: maxRows,
+    });
+    // A single transaction keeps the flood fast (one fsync) while still
+    // exercising the per-write throttled prune inside writeActivityLog.
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < writes; i += 1) {
+        adapter.writeActivityLog('flood', 'info', `entry-${i}-payload-padding-to-mimic-real-log-lines`);
+      }
+    });
+    let rows = 0;
+    let sinceId = 0;
+    for (;;) {
+      const batch = adapter.getActivityLogs(sinceId, 5_000);
+      if (batch.length === 0) break;
+      rows += batch.length;
+      sinceId = batch[batch.length - 1].id;
+    }
+    adapter.close(); // checkpoints WAL into the main DB file
+    let bytes = 0;
+    for (const suffix of ['', '-wal']) {
+      try { bytes += statSync(`${dbPath}${suffix}`).size; } catch { /* sidecar may be gone */ }
+    }
+    return { rows, bytes };
+  }
+
+  it('grows unbounded with retention disabled but stays bounded when enabled', async () => {
+    const writes = 10_000;
+    const cap = 500;
+
+    const disabled = await floodPhase(0, writes); // pre-fix behavior
+    const enabled = await floodPhase(cap, writes); // with retention
+
+    // Disabled: every row retained — this is exactly how the DB ballooned.
+    expect(disabled.rows).toBe(writes);
+    // Enabled: row count capped to one throttle window above maxRows.
+    expect(enabled.rows).toBeLessThanOrEqual(cap + PRUNE_INTERVAL);
+    // Enabled: the on-disk file does not grow with input — bloat cannot recur.
+    expect(enabled.bytes * 2).toBeLessThan(disabled.bytes);
+  });
+});

--- a/scripts/repro/repro-activity-log-bloat.sh
+++ b/scripts/repro/repro-activity-log-bloat.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Repro: unbounded activity_log growth bloats ~/.invoker/invoker.db.
+#
+# Background: activity_log was written on every log line with no retention. Over
+# ~45 days it reached 2.58M rows / 424MB live data plus ~600MB of unreclaimed
+# free pages, pushing invoker.db to ~1GB. The memory-mapped SQLite file then
+# faulted with SIGBUS during write-heavy operations (e.g. workflow deletes).
+#
+# This proves the fix end-to-end: the SQLiteAdapter now caps activity_log to its
+# most recent N rows (config `activityLogMaxRows`, default 100000), enforced on
+# write. The spec floods a real on-disk database with retention disabled (the old
+# behavior) and enabled, and asserts the enabled run stays bounded in both row
+# count and file size.
+#
+# Runs through the project's TS test runner so workspace/TS resolution matches
+# production. Exit 0 = PASS, non-zero = FAIL.
+#
+# Usage: bash scripts/repro/repro-activity-log-bloat.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SPEC="src/__tests__/activity-log-bloat.repro.test.ts"
+
+cd "$REPO_ROOT/packages/data-store"
+
+echo "[repro] running on-disk activity_log bloat proof ..."
+if pnpm exec vitest run "$SPEC"; then
+  echo "[repro] PASS: activity_log retention bounds the database; the ~1GB/SIGBUS bloat cannot recur."
+  exit 0
+fi
+
+echo "[repro] FAIL: activity_log was not bounded by retention."
+exit 1


### PR DESCRIPTION
Adds a bash repro and on-disk regression spec that flood activity_log with retention disabled (old behavior, grows unbounded) versus enabled, asserting the enabled run stays bounded in row count and file size.

Depends-On: #2272