### PR TITLE
[Activity log retention](1) Cap activity_log size on write

### DIFF
--- a/packages/data-store/src/__tests__/activity-log-retention.test.ts
+++ b/packages/data-store/src/__tests__/activity-log-retention.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+const PRUNE_INTERVAL = 1_000; // matches ACTIVITY_LOG_PRUNE_INTERVAL in sqlite-adapter.ts
+
+describe('activity_log retention', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    while (adapters.length) adapters.pop()?.close();
+  });
+
+  async function makeAdapter(activityLogMaxRows?: number): Promise<SQLiteAdapter> {
+    const adapter = await SQLiteAdapter.create(':memory:', { activityLogMaxRows });
+    adapters.push(adapter);
+    return adapter;
+  }
+
+  function rowCount(adapter: SQLiteAdapter): number {
+    let total = 0;
+    let sinceId = 0;
+    for (;;) {
+      const batch = adapter.getActivityLogs(sinceId, 1_000);
+      if (batch.length === 0) break;
+      total += batch.length;
+      sinceId = batch[batch.length - 1].id;
+    }
+    return total;
+  }
+
+  it('pruneActivityLog keeps the newest N rows and reports the deletion count', async () => {
+    const adapter = await makeAdapter(100_000);
+    for (let i = 0; i < 50; i += 1) {
+      adapter.writeActivityLog('test', 'info', `msg-${i}`);
+    }
+    expect(adapter.pruneActivityLog(10)).toBe(40);
+    expect(rowCount(adapter)).toBe(10);
+
+    const remaining = adapter.getActivityLogs(0, 1_000).map((r) => r.message);
+    expect(remaining).toContain('msg-49');
+    expect(remaining).not.toContain('msg-39');
+  });
+
+  it('bounds the table on write without an explicit prune call', async () => {
+    const cap = 500;
+    const adapter = await makeAdapter(cap);
+    const writes = 2 * PRUNE_INTERVAL + 500;
+    for (let i = 0; i < writes; i += 1) {
+      adapter.writeActivityLog('flood', 'info', `entry-${i}`);
+    }
+    const count = rowCount(adapter);
+    expect(count).toBeLessThanOrEqual(cap + PRUNE_INTERVAL);
+    expect(count).toBeGreaterThanOrEqual(cap);
+
+    const newest = adapter.getActivityLogs(0, writes).map((r) => r.message);
+    expect(newest).toContain(`entry-${writes - 1}`);
+    expect(newest).not.toContain('entry-0');
+  });
+
+  it('treats maxRows <= 0 as retention disabled (reproduces the unbounded growth)', async () => {
+    const adapter = await makeAdapter(0);
+    const writes = PRUNE_INTERVAL + 200;
+    for (let i = 0; i < writes; i += 1) {
+      adapter.writeActivityLog('flood', 'info', `entry-${i}`);
+    }
+    expect(rowCount(adapter)).toBe(writes);
+    expect(adapter.pruneActivityLog(0)).toBe(0);
+    expect(rowCount(adapter)).toBe(writes);
+  });
+
+  it('is a no-op when the table already fits under the cap', async () => {
+    const adapter = await makeAdapter(100_000);
+    for (let i = 0; i < 5; i += 1) {
+      adapter.writeActivityLog('test', 'info', `msg-${i}`);
+    }
+    expect(adapter.pruneActivityLog(100)).toBe(0);
+    expect(rowCount(adapter)).toBe(5);
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -64,6 +64,10 @@ function loadNativeSqlite(): Promise<NativeSqlite> {
 }
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
+// activity_log is capped to its most recent rows so the DB file stays bounded; 0 disables.
+const DEFAULT_ACTIVITY_LOG_MAX_ROWS = 100_000;
+const ACTIVITY_LOG_PRUNE_INTERVAL = 1_000; // prune at most once per N writes
+
 const OUTPUT_DIAGNOSTIC_TAIL_CHARS = 8_000;
 
 
@@ -95,6 +99,8 @@ interface SQLiteAdapterOptions {
   ownerCapability?: boolean;
   outputTailLimit?: number;
   outputDir?: string;
+  /** Max retained activity_log rows; 0 disables retention. */
+  activityLogMaxRows?: number;
 }
 
 export type WorkflowMutationPriority = 'high' | 'normal';
@@ -276,6 +282,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private spoolNextOffsetCache = new Map<string, number>();
   private writeTransactionDepth = 0;
   private lastWorkflowTaskSnapshotStats: Record<string, unknown> | null = null;
+  private readonly activityLogMaxRows: number;
+  private activityLogWritesSincePrune = 0;
 
   /** Use SQLiteAdapter.create() instead. */
   private constructor(db: DatabaseSync, dbPath: string | null, options?: SQLiteAdapterOptions) {
@@ -285,6 +293,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.readOnly = options?.readOnly === true;
     this.outputTailLimit = options?.outputTailLimit ?? 100;
     this.outputDir = options?.outputDir ?? this.resolveOutputDir(dbPath);
+    this.activityLogMaxRows = options?.activityLogMaxRows ?? DEFAULT_ACTIVITY_LOG_MAX_ROWS;
     this.configureConnection(dbPath !== null);
     if (!this.readOnly) {
       this.initSchema();
@@ -2738,6 +2747,33 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'INSERT INTO activity_log (source, level, message) VALUES (?, ?, ?)',
       [source, level, message],
     );
+    this.activityLogWritesSincePrune += 1;
+    if (this.activityLogWritesSincePrune >= ACTIVITY_LOG_PRUNE_INTERVAL) {
+      this.activityLogWritesSincePrune = 0;
+      try {
+        this.pruneActivityLog();
+      } catch {
+        /* best-effort: a prune failure must not break logging */
+      }
+    }
+  }
+
+  /** Bound activity_log to its newest `maxRows` rows; returns rows deleted. No-op when read-only or maxRows <= 0. */
+  pruneActivityLog(maxRows: number = this.activityLogMaxRows): number {
+    if (this.readOnly || !Number.isFinite(maxRows) || maxRows <= 0) return 0;
+    const total = this.queryOne('SELECT COUNT(*) AS c FROM activity_log') as
+      | { c: number }
+      | undefined;
+    const count = total?.c ?? 0;
+    if (count <= maxRows) return 0;
+    // keep newest maxRows; ids are monotonic so OFFSET is gap-safe
+    const boundary = this.queryOne(
+      'SELECT id FROM activity_log ORDER BY id DESC LIMIT 1 OFFSET ?',
+      [maxRows],
+    ) as { id: number } | undefined;
+    if (!boundary) return 0;
+    this.execRun('DELETE FROM activity_log WHERE id <= ?', [boundary.id]);
+    return count - maxRows;
   }
 
   getActivityLogs(sinceId = 0, limit = 200): ActivityLogEntry[] {


### PR DESCRIPTION
## Summary

Invoker added a row to the `activity_log` table for every log line and kept all of them forever.

Over about six weeks that table reached 2.58M rows and the database file grew to roughly one gigabyte.

A file that large, memory-mapped by SQLite, began faulting with a bus error during write-heavy work, which crashed the app.

The persistence adapter now caps the table to its most recent rows and prunes older entries as new ones are written, so the file stays bounded.

<details>
<summary>Review metadata</summary>

Review Claim: `activity_log` is capped to its most recent rows as entries are written (default 100000), so the database file cannot grow without bound.

Review Lane: behavior

Review Unit: write-path

Safety Invariant: Recent entries are still written and read back in order. Only entries older than the cap are pruned, at most once per 1000 writes; pruning is wrapped so a failure can never break a log write, and is skipped for read-only adapters or a cap of 0.

Slice Rationale: The cap lives entirely in the persistence adapter so the size guarantee is reviewable on its own, separate from the repro and changelog slices.

</details>

## Non-goals

This does not change what gets logged or the on-disk log file (`~/.invoker/invoker.log`).

This does not read the cap from `config.json`; it is a fixed default for now, with a constructor option left for future wiring.

This does not VACUUM an already-bloated database; it only bounds future growth. Recovering an existing oversized DB still needs a one-time prune plus VACUUM.

## Architecture

### Before

```mermaid
graph TD
    A["writeActivityLog(...)"] --> B["INSERT row"]
    B --> C["table grows without bound"]
```

### After

```mermaid
graph TD
    A["writeActivityLog(...)"] --> B["INSERT row"]
    B --> C["writes since prune >= 1000?"]
    C -->|"no"| D["return"]
    C -->|"yes"| E["pruneActivityLog(): keep newest rows, prune older"]
    E --> D
```

## Test Plan

- [x] `pnpm --filter @invoker/data-store test -- activity-log-retention`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No