### PR TITLE
[Activity log retention](2) Repro proving the bound holds

### DIFF
--- a/packages/data-store/src/__tests__/activity-log-bloat.repro.test.ts
+++ b/packages/data-store/src/__tests__/activity-log-bloat.repro.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+const PRUNE_INTERVAL = 1_000; // matches ACTIVITY_LOG_PRUNE_INTERVAL in sqlite-adapter.ts
+
+// Regression repro for the ~1GB invoker.db / SIGBUS incident: proves on a real
+// on-disk database that retention bounds both row count and file size.
+describe('activity_log on-disk bloat is bounded by retention', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+      dir = undefined;
+    }
+  });
+
+  async function floodPhase(maxRows: number, writes: number): Promise<{ rows: number; bytes: number }> {
+    dir ??= mkdtempSync(join(tmpdir(), 'invoker-activity-bloat-'));
+    const dbPath = join(dir, `phase-${maxRows}.db`);
+    const adapter = await SQLiteAdapter.create(dbPath, {
+      ownerCapability: true,
+      activityLogMaxRows: maxRows,
+    });
+    // One transaction keeps the flood fast while still exercising the throttled prune.
+    adapter.runInTransaction(() => {
+      for (let i = 0; i < writes; i += 1) {
+        adapter.writeActivityLog('flood', 'info', `entry-${i}-payload-padding-to-mimic-real-log-lines`);
+      }
+    });
+    let rows = 0;
+    let sinceId = 0;
+    for (;;) {
+      const batch = adapter.getActivityLogs(sinceId, 5_000);
+      if (batch.length === 0) break;
+      rows += batch.length;
+      sinceId = batch[batch.length - 1].id;
+    }
+    adapter.close();
+    let bytes = 0;
+    for (const suffix of ['', '-wal']) {
+      try { bytes += statSync(`${dbPath}${suffix}`).size; } catch { /* sidecar may be gone */ }
+    }
+    return { rows, bytes };
+  }
+
+  it('grows unbounded with retention disabled but stays bounded when enabled', async () => {
+    const writes = 10_000;
+    const cap = 500;
+
+    const disabled = await floodPhase(0, writes);
+    const enabled = await floodPhase(cap, writes);
+
+    expect(disabled.rows).toBe(writes);
+    expect(enabled.rows).toBeLessThanOrEqual(cap + PRUNE_INTERVAL);
+    expect(enabled.bytes * 2).toBeLessThan(disabled.bytes);
+  });
+});

--- a/packages/data-store/src/__tests__/activity-log-retention.test.ts
+++ b/packages/data-store/src/__tests__/activity-log-retention.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+const PRUNE_INTERVAL = 1_000; // matches ACTIVITY_LOG_PRUNE_INTERVAL in sqlite-adapter.ts
+
+describe('activity_log retention', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    while (adapters.length) adapters.pop()?.close();
+  });
+
+  async function makeAdapter(activityLogMaxRows?: number): Promise<SQLiteAdapter> {
+    const adapter = await SQLiteAdapter.create(':memory:', { activityLogMaxRows });
+    adapters.push(adapter);
+    return adapter;
+  }
+
+  function rowCount(adapter: SQLiteAdapter): number {
+    let total = 0;
+    let sinceId = 0;
+    for (;;) {
+      const batch = adapter.getActivityLogs(sinceId, 1_000);
+      if (batch.length === 0) break;
+      total += batch.length;
+      sinceId = batch[batch.length - 1].id;
+    }
+    return total;
+  }
+
+  it('pruneActivityLog keeps the newest N rows and reports the deletion count', async () => {
+    const adapter = await makeAdapter(100_000);
+    for (let i = 0; i < 50; i += 1) {
+      adapter.writeActivityLog('test', 'info', `msg-${i}`);
+    }
+    expect(adapter.pruneActivityLog(10)).toBe(40);
+    expect(rowCount(adapter)).toBe(10);
+
+    const remaining = adapter.getActivityLogs(0, 1_000).map((r) => r.message);
+    expect(remaining).toContain('msg-49');
+    expect(remaining).not.toContain('msg-39');
+  });
+
+  it('bounds the table on write without an explicit prune call', async () => {
+    const cap = 500;
+    const adapter = await makeAdapter(cap);
+    const writes = 2 * PRUNE_INTERVAL + 500;
+    for (let i = 0; i < writes; i += 1) {
+      adapter.writeActivityLog('flood', 'info', `entry-${i}`);
+    }
+    const count = rowCount(adapter);
+    expect(count).toBeLessThanOrEqual(cap + PRUNE_INTERVAL);
+    expect(count).toBeGreaterThanOrEqual(cap);
+
+    const newest = adapter.getActivityLogs(0, writes).map((r) => r.message);
+    expect(newest).toContain(`entry-${writes - 1}`);
+    expect(newest).not.toContain('entry-0');
+  });
+
+  it('treats maxRows <= 0 as retention disabled (reproduces the unbounded growth)', async () => {
+    const adapter = await makeAdapter(0);
+    const writes = PRUNE_INTERVAL + 200;
+    for (let i = 0; i < writes; i += 1) {
+      adapter.writeActivityLog('flood', 'info', `entry-${i}`);
+    }
+    expect(rowCount(adapter)).toBe(writes);
+    expect(adapter.pruneActivityLog(0)).toBe(0);
+    expect(rowCount(adapter)).toBe(writes);
+  });
+
+  it('is a no-op when the table already fits under the cap', async () => {
+    const adapter = await makeAdapter(100_000);
+    for (let i = 0; i < 5; i += 1) {
+      adapter.writeActivityLog('test', 'info', `msg-${i}`);
+    }
+    expect(adapter.pruneActivityLog(100)).toBe(0);
+    expect(rowCount(adapter)).toBe(5);
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -64,6 +64,10 @@ function loadNativeSqlite(): Promise<NativeSqlite> {
 }
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
+// activity_log is capped to its most recent rows so the DB file stays bounded; 0 disables.
+const DEFAULT_ACTIVITY_LOG_MAX_ROWS = 100_000;
+const ACTIVITY_LOG_PRUNE_INTERVAL = 1_000; // prune at most once per N writes
+
 const OUTPUT_DIAGNOSTIC_TAIL_CHARS = 8_000;
 
 
@@ -95,6 +99,8 @@ interface SQLiteAdapterOptions {
   ownerCapability?: boolean;
   outputTailLimit?: number;
   outputDir?: string;
+  /** Max retained activity_log rows; 0 disables retention. */
+  activityLogMaxRows?: number;
 }
 
 export type WorkflowMutationPriority = 'high' | 'normal';
@@ -276,6 +282,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private spoolNextOffsetCache = new Map<string, number>();
   private writeTransactionDepth = 0;
   private lastWorkflowTaskSnapshotStats: Record<string, unknown> | null = null;
+  private readonly activityLogMaxRows: number;
+  private activityLogWritesSincePrune = 0;
 
   /** Use SQLiteAdapter.create() instead. */
   private constructor(db: DatabaseSync, dbPath: string | null, options?: SQLiteAdapterOptions) {
@@ -285,6 +293,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.readOnly = options?.readOnly === true;
     this.outputTailLimit = options?.outputTailLimit ?? 100;
     this.outputDir = options?.outputDir ?? this.resolveOutputDir(dbPath);
+    this.activityLogMaxRows = options?.activityLogMaxRows ?? DEFAULT_ACTIVITY_LOG_MAX_ROWS;
     this.configureConnection(dbPath !== null);
     if (!this.readOnly) {
       this.initSchema();
@@ -2738,6 +2747,33 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'INSERT INTO activity_log (source, level, message) VALUES (?, ?, ?)',
       [source, level, message],
     );
+    this.activityLogWritesSincePrune += 1;
+    if (this.activityLogWritesSincePrune >= ACTIVITY_LOG_PRUNE_INTERVAL) {
+      this.activityLogWritesSincePrune = 0;
+      try {
+        this.pruneActivityLog();
+      } catch {
+        /* best-effort: a prune failure must not break logging */
+      }
+    }
+  }
+
+  /** Bound activity_log to its newest `maxRows` rows; returns rows deleted. No-op when read-only or maxRows <= 0. */
+  pruneActivityLog(maxRows: number = this.activityLogMaxRows): number {
+    if (this.readOnly || !Number.isFinite(maxRows) || maxRows <= 0) return 0;
+    const total = this.queryOne('SELECT COUNT(*) AS c FROM activity_log') as
+      | { c: number }
+      | undefined;
+    const count = total?.c ?? 0;
+    if (count <= maxRows) return 0;
+    // keep newest maxRows; ids are monotonic so OFFSET is gap-safe
+    const boundary = this.queryOne(
+      'SELECT id FROM activity_log ORDER BY id DESC LIMIT 1 OFFSET ?',
+      [maxRows],
+    ) as { id: number } | undefined;
+    if (!boundary) return 0;
+    this.execRun('DELETE FROM activity_log WHERE id <= ?', [boundary.id]);
+    return count - maxRows;
   }
 
   getActivityLogs(sinceId = 0, limit = 200): ActivityLogEntry[] {

--- a/scripts/repro/repro-activity-log-bloat.sh
+++ b/scripts/repro/repro-activity-log-bloat.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Repro: activity_log grew unbounded and bloated ~/.invoker/invoker.db to ~1GB,
+# faulting with SIGBUS during write-heavy work. Proves the fix: the on-disk spec
+# floods activity_log with retention off (grows) vs on (bounded in rows + size).
+#
+# Usage: bash scripts/repro/repro-activity-log-bloat.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+SPEC="src/__tests__/activity-log-bloat.repro.test.ts"
+
+cd "$REPO_ROOT/packages/data-store"
+
+echo "[repro] running on-disk activity_log bloat proof ..."
+if pnpm exec vitest run "$SPEC"; then
+  echo "[repro] PASS: activity_log retention bounds the database; the ~1GB/SIGBUS bloat cannot recur."
+  exit 0
+fi
+
+echo "[repro] FAIL: activity_log was not bounded by retention."
+exit 1


### PR DESCRIPTION
## Summary

This adds a repro that proves the `activity_log` cap actually keeps the database bounded.

A bash script and an on-disk spec flood the table twice: once with retention off and once with it on.

With retention off the table grows one-to-one with input, matching the original bloat. With it on, both the row count and the database file stay bounded.

<details>
<summary>Review metadata</summary>

Review Claim: The repro and regression spec demonstrate that `activity_log` stays bounded in both row count and on-disk size once retention is on.

Review Lane: proof

Review Unit: proof

Safety Invariant: Test-only. The spec and script exercise the adapter against throwaway databases and add no runtime code.

Slice Rationale: The proof is kept on its own so the regression evidence is reviewable apart from the adapter behavior it covers.

</details>

## Non-goals

This adds no runtime behavior and changes no product code. It does not VACUUM or alter any real database.

## Test Plan

- [x] `bash scripts/repro/repro-activity-log-bloat.sh`
- [x] `pnpm --filter @invoker/data-store test -- activity-log-bloat.repro`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2275