### PR TITLE
Recovery Lifecycle 2i Step 1: Worker registry contract

### DIFF
--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+
+import { RECOVERY_WORKER_KIND, type AutoFixRecoveryStore, type AutoFixRecoverySubmitter } from '../auto-fix-recovery.js';
+import {
+  AUTO_FIX_WORKER_KIND,
+  createWorkerRegistry,
+  registerAutoFixWorker,
+  type WorkerRuntimeDependencies,
+} from '../worker-registry.js';
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => silentLogger,
+};
+
+const emptyStore: AutoFixRecoveryStore = {
+  listWorkflows: () => [],
+  loadTasks: () => [],
+  listWorkflowMutationIntents: () => [],
+};
+
+const noopSubmitter: AutoFixRecoverySubmitter = {
+  submit: () => 0,
+};
+
+function deps(): WorkerRuntimeDependencies {
+  return { store: emptyStore, submitter: noopSubmitter, logger: silentLogger };
+}
+
+describe('worker registry', () => {
+  it('starts empty before anything is registered', () => {
+    const registry = createWorkerRegistry();
+    expect(registry.list()).toEqual([]);
+    expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeUndefined();
+  });
+
+  it('returns the auto-fix definition by its kind once registered', () => {
+    const registry = registerAutoFixWorker(createWorkerRegistry());
+
+    const definition = registry.get(AUTO_FIX_WORKER_KIND);
+    expect(definition).toBeDefined();
+    expect(definition?.kind).toBe(AUTO_FIX_WORKER_KIND);
+    expect(definition?.note.length).toBeGreaterThan(0);
+    expect(typeof definition?.factory).toBe('function');
+
+    expect(registry.list().map((d) => d.kind)).toEqual([AUTO_FIX_WORKER_KIND]);
+  });
+
+  it('returns nothing for an unknown kind', () => {
+    const registry = registerAutoFixWorker(createWorkerRegistry());
+    expect(registry.get('does-not-exist')).toBeUndefined();
+  });
+
+  it('builds a recovery worker runtime from the auto-fix factory', () => {
+    const registry = registerAutoFixWorker(createWorkerRegistry());
+    const definition = registry.get(AUTO_FIX_WORKER_KIND);
+    expect(definition).toBeDefined();
+
+    const runtime = definition!.factory(deps());
+    // The registry kind is `autofix`, but it reuses the recovery worker, whose
+    // runtime identity keeps the underlying recovery kind.
+    expect(runtime.identity.kind).toBe(RECOVERY_WORKER_KIND);
+    expect(runtime.isRunning()).toBe(false);
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -33,6 +33,7 @@ export * from './codex-session-driver.js';
 export * from './claude-session-driver.js';
 export * from './omp-session-driver.js';
 export * from './worker-runtime.js';
+export * from './worker-registry.js';
 export * from './worker-lock.js';
 export * from './auto-fix-recovery.js';
 export * from './auto-fix-gating.js';

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -1,0 +1,109 @@
+/**
+ * Worker registry: a single declaration surface for the long-running workers
+ * Invoker can run.
+ *
+ * Each worker is declared once as a {@link WorkerDefinition} — its `kind`, an
+ * operator-facing `note`, and a `factory` that builds the worker runtime from
+ * injected dependencies. Today the only built-in is the auto-fix recovery
+ * worker; centralizing worker knowledge here lets future workers be declared
+ * uniformly instead of being implied by a single hard-coded auto-fix branch.
+ */
+
+import type { Logger } from '@invoker/contracts';
+import type { MessageBus } from '@invoker/transport';
+
+import {
+  createRecoveryWorker,
+  type AutoFixRecoveryStore,
+  type AutoFixRecoverySubmitter,
+} from './auto-fix-recovery.js';
+import type { WorkerRuntime } from './worker-runtime.js';
+
+/** Registry kind for the built-in auto-fix recovery worker. */
+export const AUTO_FIX_WORKER_KIND = 'autofix';
+
+/** Auto-fix tuning handed to a worker factory. */
+export interface AutoFixWorkerConfig {
+  /** Default attempt budget when a task does not override it. */
+  defaultAutoFixRetries?: number;
+  /** Resolves the agent that performs each auto-fix, when one is configured. */
+  getAutoFixAgent?: () => string | undefined;
+}
+
+/** Dependencies injected into a worker factory when its runtime is built. */
+export interface WorkerRuntimeDependencies {
+  /** Persisted workflow/task state accessor. */
+  store: AutoFixRecoveryStore;
+  /** Action-output channel used to submit follow-up mutation intents. */
+  submitter: AutoFixRecoverySubmitter;
+  /** Operator logger. */
+  logger: Logger;
+  /** Optional bus that turns lifecycle events into immediate wakeups. */
+  messageBus?: MessageBus;
+  /** Auto-fix tuning. */
+  autoFix?: AutoFixWorkerConfig;
+}
+
+/** Builds a worker runtime from injected dependencies. */
+export type WorkerFactory = (deps: WorkerRuntimeDependencies) => WorkerRuntime;
+
+/** A single worker declared in the registry. */
+export interface WorkerDefinition {
+  /** Stable registry kind, e.g. `'autofix'`. */
+  readonly kind: string;
+  /** Human-readable note surfaced in operator output. */
+  readonly note: string;
+  /** Builds the worker runtime from injected dependencies. */
+  readonly factory: WorkerFactory;
+}
+
+/** Mutable collection of worker definitions keyed by kind. */
+export interface WorkerRegistry {
+  /** Register (or replace) a definition by its kind. */
+  register(definition: WorkerDefinition): void;
+  /** Look up a definition by kind, or `undefined` when none is registered. */
+  get(kind: string): WorkerDefinition | undefined;
+  /** Every registered definition, in registration order. */
+  list(): WorkerDefinition[];
+}
+
+/** Create an empty worker registry. */
+export function createWorkerRegistry(): WorkerRegistry {
+  const byKind = new Map<string, WorkerDefinition>();
+  return {
+    register(definition: WorkerDefinition): void {
+      byKind.set(definition.kind, definition);
+    },
+    get(kind: string): WorkerDefinition | undefined {
+      return byKind.get(kind);
+    },
+    list(): WorkerDefinition[] {
+      return [...byKind.values()];
+    },
+  };
+}
+
+/**
+ * Register the built-in auto-fix worker under {@link AUTO_FIX_WORKER_KIND},
+ * reusing the existing recovery worker factory ({@link createRecoveryWorker})
+ * so the runtime it builds behaves exactly as the auto-fix path always has.
+ * Returns the registry so calls can be chained with {@link createWorkerRegistry}.
+ */
+export function registerAutoFixWorker(registry: WorkerRegistry): WorkerRegistry {
+  registry.register({
+    kind: AUTO_FIX_WORKER_KIND,
+    note: 'Auto-fixes failed tasks by submitting fix-with-agent recovery intents.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createRecoveryWorker({
+        logger: deps.logger,
+        messageBus: deps.messageBus,
+        autoFix: {
+          store: deps.store,
+          submitter: deps.submitter,
+          defaultAutoFixRetries: deps.autoFix?.defaultAutoFixRetries,
+          getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
+        },
+      }),
+  });
+  return registry;
+}


### PR DESCRIPTION
Add createWorkerRegistry plus a built-in auto-fix registration in
@invoker/execution-engine. Workers are declared by kind and fetched by
name; the existing auto-fix worker is registered as the first built-in
default. Nothing reaches the registry yet, so the auto-fix path and
runtime behavior are unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a centralized worker registry in the execution engine.
  * Introduced built-in support for registering and retrieving the auto-fix recovery worker.
  * Extended public exports so the worker registry is available to other parts of the app.

* **Tests**
  * Added coverage for registry behavior, including empty lookup results, worker registration, listing, and recovery worker startup state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->