### PR TITLE
[Slack Native](6) Complete workflow-channel control wiring

### DIFF
--- a/packages/app/src/__tests__/slack-owner-boundary.test.ts
+++ b/packages/app/src/__tests__/slack-owner-boundary.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function slackCommandHandlerSource(): string {
+  const source = readFileSync(new URL('../main.ts', import.meta.url), 'utf8');
+  const start = source.indexOf('await slack.start(async (command: any) => {');
+  const end = source.indexOf('\n  });\n\n  return slack;', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+describe('Slack owner mutation boundary', () => {
+  it('routes task-control mutations through CommandService instead of direct orchestrator calls', () => {
+    const handler = slackCommandHandlerSource();
+
+    expect(handler).toContain('commandService.selectExperiment');
+    expect(handler).toContain('commandService.provideInput');
+    expect(handler).toContain('dispatchStartedTasksWithGlobalTopup');
+
+    expect(handler).not.toMatch(/\borchestrator\.selectExperiment\s*\(/);
+    expect(handler).not.toMatch(/\borchestrator\.provideInput\s*\(/);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -919,12 +919,32 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
         break;
       }
       case 'select_experiment': {
-        const started = orchestrator.selectExperiment(command.taskId, command.experimentId);
+        const taskId = command.taskId as string;
+        const experimentId = command.experimentId as string;
+        const result = await commandService.selectExperiment(
+          makeEnvelope('select-experiment', 'surface', 'task', { taskId, experimentId }),
+        );
+        if (!result.ok) throw new Error(result.error.message);
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: deps.executor,
+          logger,
+          context: 'surface.select-experiment',
+          started: result.data,
+          scopedTaskIds: [taskId],
+        });
         break;
       }
-      case 'provide_input':
-        orchestrator.provideInput(command.taskId, command.input);
+      case 'provide_input': {
+        const result = await commandService.provideInput(
+          makeEnvelope('provide-input', 'surface', 'task', {
+            taskId: command.taskId as string,
+            input: command.input as string,
+          }),
+        );
+        if (!result.ok) throw new Error(result.error.message);
         break;
+      }
       case 'retry': {
         const taskId = command.taskId as string;
         const result = await commandService.retryTask(


### PR DESCRIPTION
## Summary

Slack-native workflow channels gained in-channel controls in the previous stack.

Two of those controls still used direct host calls when the embedded Slack surface handled them.

This sends `select_experiment` and `provide_input` through `CommandService`, matching the rest of the embedded Slack control handling.

<details>
<summary>Review metadata</summary>

Review Claim: Slack-native workflow-channel controls now use `CommandService` for `select_experiment` and `provide_input`.

Review Lane: behavior

Review Unit: ownership-refactor

Safety Invariant: This only changes embedded Slack handling for two existing workflow-channel controls; the surface command shapes and orchestrator primitives are unchanged.

Slice Rationale: This completes the Slack-native control wiring before the stack moves on to setup hardening.

</details>

## Non-goals

This does not move Slack out of the app process.

This does not change Slack planning, private channel creation, or workflow context gathering.

This does not introduce a new owner API or hosted deployment model.

## Architecture

### Before

```mermaid
graph TD
    C["Slack workflow-channel control"] --> H["embedded host handler"]
    H --> O["direct orchestrator mutation"]
```

### After

```mermaid
graph TD
    C["Slack workflow-channel control"] --> H["embedded host handler"]
    H --> S["CommandService envelope"]
    S --> O["orchestrator mutation"]
    S --> D["dispatch and topup when work starts"]
```

## Test Plan

- [x] `corepack pnpm --filter @invoker/app exec vitest run src/__tests__/slack-owner-boundary.test.ts`
- [x] `corepack pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge commit>`
- Post-revert steps: None
- Data migration? No