### PR TITLE
Surface review gate changes without downstream mutation

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2085,9 +2085,50 @@ describe('Orchestrator', () => {
       expect(afterPrereqTask.map((t) => t.id)).not.toContain(sid(orchestrator, 1, 'leaf-a'));
 
       orchestrator.setTaskAwaitingApproval(prereqMergeId);
-      const afterMergeAwaitingApproval = orchestrator.startExecution();
-      expect(afterMergeAwaitingApproval.map((t) => t.id)).toContain(sid(orchestrator, 1, 'leaf-a'));
       expect(orchestrator.getTask(sid(orchestrator, 1, 'leaf-a'))!.status).toBe('running');
+    });
+
+    it('review_ready merge-gate transition unblocks downstream without mutating dependency metadata', () => {
+      orchestrator.loadPlan({
+        name: 'prereq-public-review',
+        tasks: [{ id: 'publish-pr', description: 'Publish public PR' }],
+      });
+      const prereqTaskId = sid(orchestrator, 0, 'publish-pr');
+      const prereqWfId = prereqTaskId.split('/')[0]!;
+      const prereqMergeId = `__merge__${prereqWfId}`;
+
+      orchestrator.loadPlan({
+        name: 'workflow-waits-on-public-pr',
+        tasks: [
+          {
+            id: 'leaf-a',
+            description: 'leaf waits for upstream public review gate',
+            externalDependencies: [{ workflowId: prereqWfId, gatePolicy: 'review_ready' }],
+          },
+        ],
+      });
+      const downstreamTaskId = sid(orchestrator, 1, 'leaf-a');
+      const downstreamWfId = downstreamTaskId.split('/')[0]!;
+      const depsBefore = (persistence.loadWorkflow(downstreamWfId)!.externalDependencies ?? [])
+        .map((dep) => ({ ...dep }));
+      const taskDepsBefore = (orchestrator.getTask(downstreamTaskId)!.config.externalDependencies ?? [])
+        .map((dep) => ({ ...dep }));
+
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(makeResponse({ actionId: prereqTaskId, status: 'completed' }));
+
+      orchestrator.setTaskReviewReady(prereqMergeId, {
+        execution: {
+          reviewId: 'owner/repo#229',
+          reviewUrl: 'https://github.com/owner/repo/pull/229',
+          reviewStatus: 'Awaiting review',
+        },
+      });
+
+      expect(orchestrator.getTask(sid(orchestrator, 1, 'leaf-a'))!.status).toBe('running');
+      expect(persistence.loadWorkflow(downstreamWfId)!.externalDependencies).toEqual(depsBefore);
+      expect(orchestrator.getTask(downstreamTaskId)!.config.externalDependencies ?? []).toEqual(taskDepsBefore);
+      expect(persistence.events.map((event) => event.eventType)).not.toContain('workflow.external_dependency_policy_updated');
     });
 
     it('approved merge-gate dependency keeps downstream pending when upstream is awaiting_approval', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1786,6 +1786,11 @@ export class Orchestrator {
     const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(id, eventName, changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+
+    if (task.config.isMergeNode) {
+      this.autoStartExternallyUnblockedReadyTasks();
+      this.checkWorkflowCompletion();
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

INV-229 is about review gates that have already changed upstream.

When a merge gate becomes review-ready, downstream workflows should notice that state. They should not need a downstream dependency edit to wake up.

This routes merge-gate review transitions through the existing external-unblock pass.

The downstream dependency metadata stays unchanged. The scheduler re-reads persisted upstream state and starts tasks that are now runnable.

<details>
<summary>Review metadata</summary>

Review Claim: Approve routing merge-gate review-ready and awaiting-approval transitions through the existing external-unblock pass.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Only merge-node review transitions get the extra unblock pass. The downstream dependency definitions are not rewritten.

Slice Rationale: This is the smallest engine slice for INV-229. It fixes the surfacing behavior without changing review publication or gate-policy editing.

</details>

## Non-goals

- This does not change how PRs are published.
- This does not change review provider polling or approval semantics.
- This does not change stored external dependency policies.
- This does not remove the explicit gate-policy editing command.

## Architecture

### Before

`setTaskReviewReady` and `setTaskAwaitingApproval` persisted the merge task state and stopped. A downstream workflow could remain pending until another command re-ran scheduling.

### After

Merge-node review transitions persist the upstream gate state, then run the existing external-unblock pass. That pass reads persisted dependencies and starts tasks whose gates are already satisfied.

```mermaid
graph TD
    A["merge gate becomes review_ready"] --> B["persist merge task state"]
    B --> C["run external unblock pass"]
    C --> D["read downstream dependencies"]
    D --> E["start runnable downstream tasks"]
```

## Test Plan

- [x] `corepack pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts --testNamePattern "review_ready merge-gate transition unblocks downstream|review_ready merge-gate dependency starts downstream"`
- [x] `corepack pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts`
- [x] `corepack pnpm --filter @invoker/workflow-core test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 70590c29`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task progression for merge-related approvals so downstream work can start immediately when review becomes ready.
  * Preserved external dependency settings during approval status updates, preventing unintended changes.
  * Removed an unnecessary event emission during this transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->