### PR TITLE
[Slack Native](7) Make Slack config docs copy-paste safe

### DIFF
--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -78,14 +78,12 @@
   ],
 
   "slackHarnessPresets": {
-    "comment": "Slack planning harness presets: preset key -> CLI tool + optional model. Selected via a leading [preset] tag in the lobby @Invoker message. Omit to use built-ins (cursor+claude / cursor+codex / omp / omp+claude / codex).",
     "omp+claude": { "tool": "omp", "model": "anthropic/claude-opus-4" },
     "cursor+codex": { "tool": "cursor", "model": "gpt-5-codex" },
     "codex": { "tool": "codex" }
   },
-  "defaultSlackHarnessPreset": "cursor+claude",
+  "defaultSlackHarnessPreset": "omp+claude",
   "slackRepos": {
-    "comment": "Slack repo aliases: alias -> git URL, resolved from a [repo:<alias>] tag",
     "web": "git@github.com:acme/web.git",
     "api": "git@github.com:acme/api.git"
   },

--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -47,6 +47,10 @@ Override them in `~/.invoker/config.json`:
 }
 ```
 
+`slackHarnessPresets` replaces the built-in preset map when set, so
+`defaultSlackHarnessPreset` must name one of the configured keys. `slackRepos`
+maps short `[repo:<alias>]` tags to Git URLs.
+
 Model strings are passed verbatim to the CLI's `--model`; set exact ids your CLI accepts. Plain `codex` ignores the model (uses the CLI default). The generated workflow's per-task `executionAgent` is whatever the `plan-to-invoker` skill writes, defaulting to the chosen preset's tool when the skill leaves it unset.
 
 ## Environment
@@ -80,5 +84,6 @@ Without `groups:write`, channel creation fails; without `groups:history`, the in
 ## Scope notes
 
 - Runs on the existing bring-your-own-machine / DigitalOcean SSH single-owner model. No hosted AWS env is required.
+- This guide describes the current embedded owner / bring-your-own-machine path; hosted or sandboxed Slack-worker deployment is a separate architecture slice.
 - Workflow creation uses `orchestrator.loadPlan` (the same path headless `run` uses); there is no separate HTTP/facade create route today.
 - One owner process serves all workflows; "spinning up a planning bot" is a per-thread planning conversation in a per-repo checkout plus a per-workflow channel, all under that one process.


### PR DESCRIPTION
## Summary

The Slack config example is now safe to copy into a real config file.

The example no longer uses JSON fields as comments, and its default Slack harness names a preset that exists in the override.

The workflow guide now carries the removed field explanations and keeps hosted Slack-worker deployment as a separate architecture slice.

<details>
<summary>Review metadata</summary>

Review Claim: Slack-native operator docs now describe copy-paste-safe config and the current embedded deployment scope.

Review Lane: docs

Review Unit: docs

Safety Invariant: This only changes docs and the example config; runtime behavior is unchanged.

Slice Rationale: This lands after the Slack owner-boundary slice so operator docs describe the current safe path without mixing behavior and docs in one PR.

</details>

## Non-goals

This does not change Slack runtime behavior.

This does not add hosted or sandboxed Slack-worker support.

This does not add Slack manifest automation or setup preflight checks.

## Test Plan

- [x] `node -e "JSON.parse(require('fs').readFileSync('docs/invoker-config-example.json','utf8'))"`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-slack-config-docs-safe.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge commit>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2279

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Slack harness preset configuration: custom `slackHarnessPresets` now replaces built-in presets, and `defaultSlackHarnessPreset` must reference a configured key.
  * Improved guidance for mapping repository aliases (`[repo:<alias>]`) to Git URLs.
  * Refined scope notes to explicitly cover the embedded owner / bring-your-own-machine path, with hosted/sandboxed Slack-worker deployment called out separately.
  * Updated the example configuration’s default Slack harness preset value and removed the associated inline comment text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->