### PR TITLE
[CLI Onboarding](1) Add shared prerequisites readiness module

### DIFF
--- a/packages/contracts/src/__tests__/prerequisites.test.ts
+++ b/packages/contracts/src/__tests__/prerequisites.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildReport,
+  checkConfig,
+  checkDefaultPresetTool,
+  checkPlanningToolsPresent,
+  checkTool,
+  formatReport,
+  type PlanningPresetSpec,
+} from '../prerequisites.js';
+
+const installed = (...tools: string[]) => (cmd: string) => tools.includes(cmd);
+const presets: Record<string, PlanningPresetSpec> = {
+  'cursor+claude': { tool: 'cursor', model: 'claude' },
+  omp: { tool: 'omp' },
+  codex: { tool: 'codex' },
+};
+
+describe('checkTool', () => {
+  it('passes when the command is installed', () => {
+    expect(checkTool({ id: 'git', name: 'Git', command: 'git', requiredFor: 'checkout', required: true }, installed('git')).status).toBe('ok');
+  });
+
+  it('errors for a missing required tool and warns for a missing optional one', () => {
+    const req = { id: 'docker', name: 'Docker', command: 'docker', requiredFor: 'containers', installHint: 'brew install docker' };
+    expect(checkTool({ ...req, required: true }, installed()).status).toBe('error');
+    const optional = checkTool(req, installed());
+    expect(optional.status).toBe('warn');
+    expect(optional.remediation).toBe('brew install docker');
+  });
+});
+
+describe('checkConfig', () => {
+  it('is ok when no config file exists', () => {
+    expect(checkConfig({ path: '/x/config.json', exists: false }).status).toBe('ok');
+  });
+
+  it('is ok when the file parses', () => {
+    expect(checkConfig({ path: '/x/config.json', exists: true }).status).toBe('ok');
+  });
+
+  it('errors with the parse message when the JSON is invalid', () => {
+    const c = checkConfig({ path: '/x/config.json', exists: true, error: 'Unexpected token }' });
+    expect(c.status).toBe('error');
+    expect(c.remediation).toContain('Unexpected token }');
+  });
+});
+
+describe('checkDefaultPresetTool', () => {
+  it('passes when the default preset tool is installed', () => {
+    expect(checkDefaultPresetTool(presets, 'omp', installed('omp')).status).toBe('ok');
+  });
+
+  it('errors when the default preset tool is not on PATH', () => {
+    const c = checkDefaultPresetTool(presets, 'cursor+claude', installed('omp'));
+    expect(c.status).toBe('error');
+    expect(c.detail).toContain('cursor');
+    expect(c.remediation).toContain('defaultSlackHarnessPreset');
+  });
+
+  it('errors and lists valid keys when the default preset is undefined', () => {
+    const c = checkDefaultPresetTool(presets, 'mystery', installed('omp'));
+    expect(c.status).toBe('error');
+    expect(c.remediation).toContain('omp');
+  });
+});
+
+describe('checkPlanningToolsPresent', () => {
+  it('passes when any preset tool is installed', () => {
+    expect(checkPlanningToolsPresent(presets, installed('codex')).status).toBe('ok');
+  });
+
+  it('errors when no planning tool is installed', () => {
+    const c = checkPlanningToolsPresent(presets, installed('git'));
+    expect(c.status).toBe('error');
+    expect(c.remediation).toContain('cursor');
+  });
+});
+
+describe('buildReport / formatReport', () => {
+  it('marks the report not-ok when any check errors', () => {
+    const report = buildReport([
+      checkTool({ id: 'git', name: 'Git', command: 'git', requiredFor: 'checkout', required: true }, installed('git')),
+      checkPlanningToolsPresent(presets, installed()),
+    ]);
+    expect(report.ok).toBe(false);
+  });
+
+  it('stays ok when only warnings are present', () => {
+    const report = buildReport([
+      checkTool({ id: 'docker', name: 'Docker', command: 'docker', requiredFor: 'containers' }, installed()),
+    ]);
+    expect(report.ok).toBe(true);
+  });
+
+  it('emits machine-readable JSON and shows remediation in text mode', () => {
+    const report = buildReport([checkPlanningToolsPresent(presets, installed())]);
+    expect(JSON.parse(formatReport(report, { json: true }))).toEqual(report);
+    expect(formatReport(report)).toContain('-> Install at least one');
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,3 +9,4 @@ export * from './repo-root.ts';
 export * from './cost-types.ts';
 export * from './launch-timeouts.ts';
 export * from './invoker-home.ts';
+export * from './prerequisites.ts';

--- a/packages/contracts/src/prerequisites.ts
+++ b/packages/contracts/src/prerequisites.ts
@@ -1,0 +1,172 @@
+// Config-aware prerequisite checks shared by `invoker-cli doctor` and the app launch check.
+// Pure and browser-safe: callers inject the `isInstalled` probe (Node `spawn`) and the parsed
+// config, so this module never imports `node:child_process`/`node:fs` (the UI bundles contracts).
+
+export type PrerequisiteStatus = 'ok' | 'warn' | 'error';
+
+export interface PrerequisiteCheck {
+  id: string;
+  name: string;
+  status: PrerequisiteStatus;
+  detail: string;
+  remediation?: string;
+}
+
+export interface PlanningPresetSpec {
+  tool: string;
+  model?: string;
+}
+
+export type IsInstalled = (command: string) => boolean;
+
+export interface ToolRequirement {
+  id: string;
+  name: string;
+  command: string;
+  requiredFor: string;
+  /** Missing required tools are `error`; missing optional ones are advisory `warn`. */
+  required?: boolean;
+  installHint?: string;
+}
+
+export function checkTool(req: ToolRequirement, isInstalled: IsInstalled): PrerequisiteCheck {
+  if (isInstalled(req.command)) {
+    return { id: req.id, name: req.name, status: 'ok', detail: `${req.command} found` };
+  }
+  return {
+    id: req.id,
+    name: req.name,
+    status: req.required ? 'error' : 'warn',
+    detail: `${req.command} not found (needed for ${req.requiredFor})`,
+    remediation: req.installHint,
+  };
+}
+
+/** Config readiness from a pre-read parse state, so this stays free of `node:fs`. */
+export function checkConfig(state: { path: string; exists: boolean; error?: string }): PrerequisiteCheck {
+  if (!state.exists) {
+    return { id: 'config', name: 'Config file', status: 'ok', detail: `No config at ${state.path}; using defaults` };
+  }
+  if (!state.error) {
+    return { id: 'config', name: 'Config file', status: 'ok', detail: `Parsed ${state.path}` };
+  }
+  return {
+    id: 'config',
+    name: 'Config file',
+    status: 'error',
+    detail: `Invalid JSON at ${state.path}`,
+    remediation: `Fix the JSON syntax: ${state.error}`,
+  };
+}
+
+/** The default planning preset must map to a tool on PATH — the gap behind silent cursor fallbacks. */
+export function checkDefaultPresetTool(
+  presets: Record<string, PlanningPresetSpec>,
+  defaultPresetKey: string,
+  isInstalled: IsInstalled,
+): PrerequisiteCheck {
+  const keys = Object.keys(presets);
+  const preset = presets[defaultPresetKey];
+  if (!preset) {
+    return {
+      id: 'default-preset',
+      name: 'Default planning preset',
+      status: 'error',
+      detail: `Default preset "${defaultPresetKey}" is not defined`,
+      remediation: keys.length
+        ? `Set defaultSlackHarnessPreset to one of: ${keys.join(', ')}`
+        : 'Define slackHarnessPresets and defaultSlackHarnessPreset in config',
+    };
+  }
+  if (!isInstalled(preset.tool)) {
+    return {
+      id: 'default-preset',
+      name: 'Default planning preset',
+      status: 'error',
+      detail: `Default preset "${defaultPresetKey}" needs "${preset.tool}", which is not on PATH`,
+      remediation: `Install ${preset.tool}, or set defaultSlackHarnessPreset to a preset whose tool is installed`,
+    };
+  }
+  return {
+    id: 'default-preset',
+    name: 'Default planning preset',
+    status: 'ok',
+    detail: `"${defaultPresetKey}" -> ${preset.tool} (installed)`,
+  };
+}
+
+/** At least one configured preset's tool is installed, so some planning works. */
+export function checkPlanningToolsPresent(
+  presets: Record<string, PlanningPresetSpec>,
+  isInstalled: IsInstalled,
+): PrerequisiteCheck {
+  const tools = [...new Set(Object.values(presets).map((p) => p.tool))];
+  const installed = tools.filter(isInstalled);
+  if (installed.length > 0) {
+    return { id: 'planning-tools', name: 'Planning tools', status: 'ok', detail: `Installed: ${installed.join(', ')}` };
+  }
+  const wanted = tools.length ? tools.join(', ') : 'cursor, omp, codex';
+  return {
+    id: 'planning-tools',
+    name: 'Planning tools',
+    status: 'error',
+    detail: `No planning tool installed (need one of: ${wanted})`,
+    remediation: `Install at least one of: ${wanted}`,
+  };
+}
+
+export interface PrerequisiteReport {
+  ok: boolean;
+  checks: PrerequisiteCheck[];
+}
+
+export function buildReport(checks: PrerequisiteCheck[]): PrerequisiteReport {
+  return { ok: checks.every((c) => c.status !== 'error'), checks };
+}
+
+const STATUS_LABEL: Record<PrerequisiteStatus, string> = { ok: 'ok  ', warn: 'warn', error: 'FAIL' };
+
+export function formatReport(report: PrerequisiteReport, options: { json?: boolean } = {}): string {
+  if (options.json) return JSON.stringify(report);
+  return report.checks
+    .map((c) => {
+      const head = `${STATUS_LABEL[c.status]}  ${c.name}: ${c.detail}`;
+      return c.remediation && c.status !== 'ok' ? `${head}\n        -> ${c.remediation}` : head;
+    })
+    .join('\n');
+}
+
+/** Canonical tools Invoker uses. `cursor`/`omp`/`codex`/`claude` are the planning/execution agents. */
+export const DEFAULT_TOOL_REQUIREMENTS: ToolRequirement[] = [
+  { id: 'git', name: 'Git', command: 'git', requiredFor: 'repo checkout, branches, merges', required: true, installHint: 'brew install git (or apt-get install git)' },
+  { id: 'pnpm', name: 'pnpm', command: 'pnpm', requiredFor: 'workspace installs and builds', required: true, installHint: 'npm install -g pnpm' },
+  { id: 'gh', name: 'GitHub CLI', command: 'gh', requiredFor: 'GitHub PR and release flows', installHint: 'brew install gh' },
+  { id: 'docker', name: 'Docker', command: 'docker', requiredFor: 'container executors', installHint: 'brew install docker' },
+  { id: 'ssh', name: 'OpenSSH', command: 'ssh', requiredFor: 'remote SSH executors', installHint: 'apt-get install openssh-client' },
+  { id: 'codex', name: 'Codex CLI', command: 'codex', requiredFor: 'codex presets', installHint: 'npm install -g @openai/codex' },
+  { id: 'claude', name: 'Claude CLI', command: 'claude', requiredFor: 'claude-model presets', installHint: 'npm install -g @anthropic-ai/claude-code' },
+  { id: 'cursor', name: 'Cursor Agent', command: 'cursor', requiredFor: 'cursor presets', installHint: 'install Cursor, then enable the agent CLI' },
+  { id: 'omp', name: 'omp', command: 'omp', requiredFor: 'omp presets', installHint: 'install the omp CLI' },
+];
+
+export interface ReadinessInput {
+  tools: ToolRequirement[];
+  isInstalled: IsInstalled;
+  config?: { path: string; exists: boolean; error?: string };
+  /** Effective Slack planning presets (config or built-ins); empty skips preset checks. */
+  presets?: Record<string, PlanningPresetSpec>;
+  defaultPreset?: string;
+}
+
+/** Ordered prerequisite checks shared by `invoker-cli doctor` and the app launch check. */
+export function assembleReadinessChecks(input: ReadinessInput): PrerequisiteCheck[] {
+  const checks: PrerequisiteCheck[] = [];
+  if (input.config) checks.push(checkConfig(input.config));
+  for (const tool of input.tools) checks.push(checkTool(tool, input.isInstalled));
+  const presets = input.presets ?? {};
+  if (Object.keys(presets).length > 0) {
+    checks.push(checkPlanningToolsPresent(presets, input.isInstalled));
+    if (input.defaultPreset) checks.push(checkDefaultPresetTool(presets, input.defaultPreset, input.isInstalled));
+  }
+  return checks;
+}


### PR DESCRIPTION
## Summary

This adds a small shared module of types and pure helper functions to the `@invoker/contracts` package.

It describes a machine's readiness as plain data: each result has a status, a message, and an optional fix hint.

The helpers take an "is this program present" probe and return those results, so the module stays free of Node-only imports and is safe for the browser bundle.

Nothing imports it yet. Later slices build on these shared types.

<details>
<summary>Review metadata</summary>

Review Claim: Add a shared, pure readiness-result types module to `@invoker/contracts`, with no consumers yet.

Review Lane: behavior

Review Unit: contract

Safety Invariant: Purely additive — one new file plus one barrel export line. No existing module is touched, so nothing can change at runtime.

Slice Rationale: These shared types are the foundation the later slices depend on, so they land first and on their own.

</details>

## Non-goals

- No new commands and no startup behavior change; this slice only adds types and pure helpers.
- Does not wire the helpers into the command-line tool or the desktop app (later slices).

## Test Plan

- [x] `pnpm --filter @invoker/contracts exec vitest run prerequisites`
- [x] `pnpm check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
