### PR TITLE
[CLI Onboarding](2) Add invoker-cli doctor and setup slack

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildDoctorChecks,
+  generateSlackManifest,
+  REQUIRED_BOT_SCOPES,
+  upsertEnvLines,
+  validateSlackCredentials,
+  type CliConfigState,
+} from '../onboarding.js';
+
+describe('generateSlackManifest', () => {
+  it('requests the required bot scopes, socket mode, and app_mention events', () => {
+    const m = generateSlackManifest();
+    expect(m.oauth_config.scopes.bot).toEqual([...REQUIRED_BOT_SCOPES]);
+    expect(m.settings.socket_mode_enabled).toBe(true);
+    expect(m.settings.event_subscriptions.bot_events).toContain('app_mention');
+    expect(m.features.bot_user.display_name).toBe('Invoker');
+  });
+});
+
+function mockFetch(routes: Record<string, { body: unknown; scopes?: string }>) {
+  return async (url: string) => {
+    const key = Object.keys(routes).find((k) => url.includes(k));
+    const route = key ? routes[key] : { body: { ok: false, error: 'unmocked' }, scopes: undefined };
+    return {
+      json: async () => route.body,
+      headers: { get: (h: string) => (h === 'x-oauth-scopes' ? route.scopes ?? '' : null) },
+    };
+  };
+}
+
+describe('validateSlackCredentials', () => {
+  const creds = { botToken: 'xoxb-x', appToken: 'xapp-x', signingSecret: 's', channelId: 'C123' };
+
+  it('passes when tokens, scopes, and channel all resolve', async () => {
+    const fetchImpl = mockFetch({
+      'auth.test': { body: { ok: true, user: 'invoker', team: 'Acme' }, scopes: REQUIRED_BOT_SCOPES.join(',') },
+      'apps.connections.open': { body: { ok: true } },
+      'conversations.info': { body: { ok: true, channel: { name: 'lobby' } } },
+    });
+    const checks = await validateSlackCredentials(creds, fetchImpl as never);
+    expect(checks.every((c) => c.status === 'ok')).toBe(true);
+  });
+
+  it('flags a missing bot scope with a reinstall remediation', async () => {
+    const partial = REQUIRED_BOT_SCOPES.filter((s) => s !== 'users:read').join(',');
+    const fetchImpl = mockFetch({
+      'auth.test': { body: { ok: true, user: 'invoker', team: 'Acme' }, scopes: partial },
+      'apps.connections.open': { body: { ok: true } },
+      'conversations.info': { body: { ok: true, channel: { name: 'lobby' } } },
+    });
+    const checks = await validateSlackCredentials(creds, fetchImpl as never);
+    const scopeCheck = checks.find((c) => c.id === 'slack-scopes');
+    expect(scopeCheck?.status).toBe('error');
+    expect(scopeCheck?.detail).toContain('users:read');
+    expect(scopeCheck?.remediation).toContain('Reinstall');
+  });
+
+  it('errors on invalid bot and app tokens', async () => {
+    const fetchImpl = mockFetch({
+      'auth.test': { body: { ok: false, error: 'invalid_auth' } },
+      'apps.connections.open': { body: { ok: false, error: 'invalid_auth' } },
+    });
+    const checks = await validateSlackCredentials(creds, fetchImpl as never);
+    expect(checks.find((c) => c.id === 'slack-bot-token')?.status).toBe('error');
+    expect(checks.find((c) => c.id === 'slack-app-token')?.status).toBe('error');
+  });
+});
+
+describe('upsertEnvLines', () => {
+  it('overwrites existing keys and preserves unrelated lines', () => {
+    const out = upsertEnvLines('FOO=bar\nSLACK_BOT_TOKEN=old\n', { SLACK_BOT_TOKEN: 'new', SLACK_CHANNEL_ID: 'C9' });
+    expect(out).toContain('FOO=bar');
+    expect(out).toContain('SLACK_BOT_TOKEN=new');
+    expect(out).not.toContain('SLACK_BOT_TOKEN=old');
+    expect(out).toContain('SLACK_CHANNEL_ID=C9');
+  });
+});
+
+describe('buildDoctorChecks', () => {
+  const cfg: CliConfigState = {
+    path: '/x/config.json',
+    exists: true,
+    presets: { omp: { tool: 'omp' }, 'cursor+claude': { tool: 'cursor', model: 'claude' } },
+    defaultPreset: 'cursor+claude',
+  };
+
+  it('fails the default-preset check when its tool is not on PATH', () => {
+    const checks = buildDoctorChecks(cfg, (cmd) => cmd === 'omp' || cmd === 'git' || cmd === 'pnpm');
+    const def = checks.find((c) => c.id === 'default-preset');
+    expect(def?.status).toBe('error');
+    expect(def?.detail).toContain('cursor');
+  });
+
+  it('passes the default-preset check when its tool is installed', () => {
+    const checks = buildDoctorChecks({ ...cfg, defaultPreset: 'omp' }, (cmd) => cmd === 'omp');
+    expect(checks.find((c) => c.id === 'default-preset')?.status).toBe('ok');
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,3 @@
-import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
 import { homedir } from 'node:os';
@@ -28,6 +27,7 @@ import {
   type TaskState,
 } from '@invoker/workflow-core';
 import { runMcpServer } from './mcp-server.js';
+import { runDoctor, runSetup } from './onboarding.js';
 
 const VERSION = '0.0.6';
 
@@ -60,17 +60,6 @@ type LiveSubmissionResult = {
 type CliDeps = {
   createMessageBus?: () => Promise<MessageBus> | MessageBus;
   runMcpServer?: () => Promise<void>;
-};
-
-type DoctorCheck = {
-  name: string;
-  command: string;
-  requiredFor: string;
-  install?: {
-    brew?: string[];
-    apt?: string[];
-    npm?: string[];
-  };
 };
 
 type CliRuntimeConfig = {
@@ -109,16 +98,6 @@ type CliRuntimeConfig = {
   }>;
 };
 
-const doctorChecks: DoctorCheck[] = [
-  { name: 'git', command: 'git', requiredFor: 'repository checkout, branches, and merges', install: { brew: ['git'], apt: ['git'] } },
-  { name: 'pnpm', command: 'pnpm', requiredFor: 'workspace dependency installs and local builds', install: { brew: ['pnpm'], npm: ['pnpm'] } },
-  { name: 'gh', command: 'gh', requiredFor: 'GitHub PR and release workflows', install: { brew: ['gh'], apt: ['gh'] } },
-  { name: 'Docker', command: 'docker', requiredFor: 'container executors', install: { brew: ['docker'], apt: ['docker.io'] } },
-  { name: 'Codex CLI', command: 'codex', requiredFor: 'Codex-backed task execution', install: { npm: ['@openai/codex'] } },
-  { name: 'Claude CLI', command: 'claude', requiredFor: 'Claude-backed task execution', install: { npm: ['@anthropic-ai/claude-code'] } },
-  { name: 'ssh', command: 'ssh', requiredFor: 'remote SSH executors', install: { apt: ['openssh-client'] } },
-];
-
 const silentLogger: Logger = {
   debug() {},
   info() {},
@@ -136,6 +115,7 @@ function usage(): string {
     'Usage:',
     '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
     '  invoker-cli doctor [--fix] [--json]',
+    '  invoker-cli setup [slack] [--check]',
     '  invoker-cli mcp',
     '  invoker-cli worker autofix',
     '  invoker-cli --help',
@@ -143,7 +123,8 @@ function usage(): string {
     '',
     'Commands:',
     '  run <plan.yaml>  Submit to a live Invoker UI when available, otherwise run standalone.',
-    '  doctor          Check external runtime tools used by Invoker executors.',
+    '  doctor          Validate tools, config, and your default planning preset.',
+    '  setup [slack]    Validate the environment, then optionally configure Slack.',
     '  mcp             Start the Invoker MCP stdio server.',
     '  worker autofix  Run the shared auto-fix recovery worker in the foreground.',
     '',
@@ -157,84 +138,6 @@ function usage(): string {
     '  --help           Show this help text.',
     '  --version        Show the CLI version.',
   ].join('\n');
-}
-
-function commandExists(command: string): boolean {
-  return spawnSync('sh', ['-c', `command -v ${command} >/dev/null 2>&1`], {
-    stdio: 'ignore',
-  }).status === 0;
-}
-
-function runInstall(command: string, args: string[]): number {
-  const result = spawnSync(command, args, { stdio: 'inherit' });
-  return result.status ?? 1;
-}
-
-function installDoctorTool(check: DoctorCheck): { attempted: boolean; ok: boolean; detail: string } {
-  if (process.platform === 'darwin' && commandExists('brew') && check.install?.brew?.length) {
-    const code = runInstall('brew', ['install', ...check.install.brew]);
-    return { attempted: true, ok: code === 0, detail: `brew install ${check.install.brew.join(' ')}` };
-  }
-  if (process.platform === 'linux' && commandExists('apt-get') && check.install?.apt?.length) {
-    const runner = typeof process.getuid === 'function' && process.getuid() === 0 ? 'apt-get' : commandExists('sudo') ? 'sudo' : '';
-    if (runner) {
-      const args = runner === 'sudo'
-        ? ['apt-get', 'install', '-y', ...check.install.apt]
-        : ['install', '-y', ...check.install.apt];
-      const code = runInstall(runner, args);
-      return { attempted: true, ok: code === 0, detail: `${runner} ${args.join(' ')}` };
-    }
-  }
-  if (commandExists('npm') && check.install?.npm?.length) {
-    const code = runInstall('npm', ['install', '-g', ...check.install.npm]);
-    return { attempted: true, ok: code === 0, detail: `npm install -g ${check.install.npm.join(' ')}` };
-  }
-  return { attempted: false, ok: false, detail: 'No supported installer available' };
-}
-
-function parseDoctorArgs(argv: string[]): { fix: boolean; json: boolean } {
-  const options = { fix: false, json: false };
-  for (const arg of argv) {
-    if (arg === '--fix') options.fix = true;
-    else if (arg === '--json') options.json = true;
-    else throw new Error(`Unknown doctor option: ${arg}`);
-  }
-  return options;
-}
-
-function runDoctor(argv: string[]): number {
-  const options = parseDoctorArgs(argv);
-  const results = doctorChecks.map((check) => {
-    let available = commandExists(check.command);
-    let fix: ReturnType<typeof installDoctorTool> | undefined;
-    if (!available && options.fix) {
-      fix = installDoctorTool(check);
-      available = commandExists(check.command);
-    }
-    return {
-      name: check.name,
-      command: check.command,
-      requiredFor: check.requiredFor,
-      available,
-      fix,
-    };
-  });
-
-  if (options.json) {
-    process.stdout.write(`${JSON.stringify({ ok: results.every((result) => result.available), checks: results })}\n`);
-  } else {
-    for (const result of results) {
-      const status = result.available ? 'ok' : 'missing';
-      const fix = result.fix ? ` (${result.fix.detail}: ${result.fix.ok ? 'ok' : 'failed'})` : '';
-      process.stdout.write(`${status.padEnd(7)} ${result.command.padEnd(8)} ${result.requiredFor}${fix}\n`);
-    }
-    const missing = results.filter((result) => !result.available);
-    if (missing.length > 0) {
-      process.stdout.write('\nAuthentication-dependent setup, such as gh auth login and provider CLI login, remains manual.\n');
-    }
-  }
-
-  return results.every((result) => result.available) ? 0 : 1;
 }
 
 function parseArgs(argv: string[]): { command?: string; planPath?: string; options: CliOptions } {
@@ -634,6 +537,9 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
   try {
     if (argv[0] === 'doctor') {
       return runDoctor(argv.slice(1));
+    }
+    if (argv[0] === 'setup') {
+      return await runSetup(argv.slice(1));
     }
     if (argv[0] === 'mcp') {
       await (deps.runMcpServer ?? runMcpServer)();

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -1,0 +1,356 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { createInterface } from 'node:readline/promises';
+import {
+  assembleReadinessChecks,
+  buildReport,
+  formatReport,
+  DEFAULT_TOOL_REQUIREMENTS,
+  type IsInstalled,
+  type PlanningPresetSpec,
+  type PrerequisiteCheck,
+} from '@invoker/contracts';
+
+// ── Paths ────────────────────────────────────────────────────
+
+export function invokerHomeDir(): string {
+  return join(homedir(), '.invoker');
+}
+export function defaultConfigPath(): string {
+  return process.env.INVOKER_REPO_CONFIG_PATH ?? join(invokerHomeDir(), 'config.json');
+}
+export function envFilePath(): string {
+  return join(invokerHomeDir(), '.env');
+}
+export function manifestFilePath(): string {
+  return join(invokerHomeDir(), 'slack-app-manifest.json');
+}
+
+// ── Tool probing & install ───────────────────────────────────
+
+export function commandExists(command: string): boolean {
+  return spawnSync('sh', ['-c', `command -v ${command} >/dev/null 2>&1`], { stdio: 'ignore' }).status === 0;
+}
+
+const INSTALL_SPECS: Record<string, { brew?: string[]; apt?: string[]; npm?: string[] }> = {
+  git: { brew: ['git'], apt: ['git'] },
+  pnpm: { npm: ['pnpm'] },
+  gh: { brew: ['gh'], apt: ['gh'] },
+  docker: { brew: ['docker'], apt: ['docker.io'] },
+  ssh: { apt: ['openssh-client'] },
+  codex: { npm: ['@openai/codex'] },
+  claude: { npm: ['@anthropic-ai/claude-code'] },
+};
+
+/** Best-effort install of a tool by check id; returns the command attempted, or undefined when unsupported. */
+export function installTool(id: string): string | undefined {
+  const spec = INSTALL_SPECS[id];
+  if (!spec) return undefined;
+  const run = (cmd: string, args: string[]) => (spawnSync(cmd, args, { stdio: 'inherit' }).status ?? 1) === 0;
+  if (process.platform === 'darwin' && commandExists('brew') && spec.brew?.length) {
+    return run('brew', ['install', ...spec.brew]) ? `brew install ${spec.brew.join(' ')}` : undefined;
+  }
+  if (process.platform === 'linux' && commandExists('apt-get') && spec.apt?.length) {
+    const sudo = typeof process.getuid === 'function' && process.getuid() === 0 ? [] : commandExists('sudo') ? ['sudo'] : null;
+    if (sudo) return run(sudo[0] ?? 'apt-get', [...(sudo[0] ? ['apt-get'] : []), 'install', '-y', ...spec.apt]) ? `apt-get install ${spec.apt.join(' ')}` : undefined;
+  }
+  if (commandExists('npm') && spec.npm?.length) {
+    return run('npm', ['install', '-g', ...spec.npm]) ? `npm install -g ${spec.npm.join(' ')}` : undefined;
+  }
+  return undefined;
+}
+
+// ── Config ───────────────────────────────────────────────────
+
+export interface CliConfigState {
+  path: string;
+  exists: boolean;
+  error?: string;
+  presets: Record<string, PlanningPresetSpec>;
+  defaultPreset?: string;
+}
+
+export function loadCliConfig(configPath: string = defaultConfigPath()): CliConfigState {
+  if (!existsSync(configPath)) return { path: configPath, exists: false, presets: {} };
+  try {
+    const cfg = JSON.parse(readFileSync(configPath, 'utf8')) as {
+      slackHarnessPresets?: Record<string, PlanningPresetSpec>;
+      defaultSlackHarnessPreset?: string;
+    };
+    return { path: configPath, exists: true, presets: cfg.slackHarnessPresets ?? {}, defaultPreset: cfg.defaultSlackHarnessPreset };
+  } catch (err) {
+    return { path: configPath, exists: true, error: err instanceof Error ? err.message : String(err), presets: {} };
+  }
+}
+
+export function buildDoctorChecks(cfg: CliConfigState, isInstalled: IsInstalled = commandExists): PrerequisiteCheck[] {
+  return assembleReadinessChecks({
+    tools: DEFAULT_TOOL_REQUIREMENTS,
+    isInstalled,
+    config: { path: cfg.path, exists: cfg.exists, error: cfg.error },
+    presets: cfg.presets,
+    defaultPreset: cfg.defaultPreset,
+  });
+}
+
+// ── doctor command ───────────────────────────────────────────
+
+export function runDoctor(argv: string[]): number {
+  let fix = false;
+  let json = false;
+  for (const arg of argv) {
+    if (arg === '--fix') fix = true;
+    else if (arg === '--json') json = true;
+    else throw new Error(`Unknown doctor option: ${arg}`);
+  }
+
+  let checks = buildDoctorChecks(loadCliConfig());
+  if (fix) {
+    for (const check of checks) {
+      if (check.status !== 'ok' && INSTALL_SPECS[check.id]) installTool(check.id);
+    }
+    checks = buildDoctorChecks(loadCliConfig());
+  }
+
+  const report = buildReport(checks);
+  process.stdout.write(`${formatReport(report, { json })}\n`);
+  if (!json && !report.ok) {
+    process.stdout.write('\nFix the items above, then re-run `invoker-cli doctor`. For Slack, run `invoker-cli setup slack`.\n');
+  }
+  return report.ok ? 0 : 1;
+}
+
+// ── Slack manifest ───────────────────────────────────────────
+
+export const REQUIRED_BOT_SCOPES = [
+  'app_mentions:read',
+  'chat:write',
+  'channels:history',
+  'groups:write',
+  'groups:history',
+  'users:read',
+] as const;
+
+export interface SlackAppManifest {
+  display_information: { name: string };
+  features: { bot_user: { display_name: string; always_online: boolean } };
+  oauth_config: { scopes: { bot: string[] } };
+  settings: {
+    event_subscriptions: { bot_events: string[] };
+    interactivity: { is_enabled: boolean };
+    org_deploy_enabled: boolean;
+    socket_mode_enabled: boolean;
+    token_rotation_enabled: boolean;
+  };
+}
+
+export function generateSlackManifest(name = 'Invoker'): SlackAppManifest {
+  return {
+    display_information: { name },
+    features: { bot_user: { display_name: name, always_online: true } },
+    oauth_config: { scopes: { bot: [...REQUIRED_BOT_SCOPES] } },
+    settings: {
+      event_subscriptions: { bot_events: ['app_mention'] },
+      interactivity: { is_enabled: false },
+      org_deploy_enabled: false,
+      socket_mode_enabled: true,
+      token_rotation_enabled: false,
+    },
+  };
+}
+
+// ── Slack credential validation ──────────────────────────────
+
+export interface SlackCredentials {
+  botToken?: string;
+  appToken?: string;
+  signingSecret?: string;
+  channelId?: string;
+}
+
+type FetchLike = (url: string, init?: { method?: string; headers?: Record<string, string> }) => Promise<{
+  json: () => Promise<any>;
+  headers: { get: (name: string) => string | null };
+}>;
+
+/** Validate Slack credentials against the live Web API. `fetchImpl` is injectable for tests. */
+export async function validateSlackCredentials(
+  creds: SlackCredentials,
+  fetchImpl: FetchLike = fetch as unknown as FetchLike,
+): Promise<PrerequisiteCheck[]> {
+  const checks: PrerequisiteCheck[] = [];
+
+  if (!creds.botToken) {
+    checks.push({ id: 'slack-bot-token', name: 'Bot token', status: 'error', detail: 'SLACK_BOT_TOKEN is not set', remediation: 'Paste the xoxb- bot token from OAuth & Permissions' });
+  } else {
+    const res = await fetchImpl('https://slack.com/api/auth.test', { method: 'POST', headers: { Authorization: `Bearer ${creds.botToken}` } });
+    const body = await res.json();
+    if (body.ok) {
+      checks.push({ id: 'slack-bot-token', name: 'Bot token', status: 'ok', detail: `Authenticated as ${body.user} in ${body.team}` });
+      const granted = (res.headers.get('x-oauth-scopes') ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+      const missing = REQUIRED_BOT_SCOPES.filter((s) => !granted.includes(s));
+      checks.push(missing.length === 0
+        ? { id: 'slack-scopes', name: 'Bot scopes', status: 'ok', detail: 'All required scopes granted' }
+        : { id: 'slack-scopes', name: 'Bot scopes', status: 'error', detail: `Missing scopes: ${missing.join(', ')}`, remediation: 'Add the scopes in OAuth & Permissions, then Reinstall to Workspace to activate them' });
+    } else {
+      checks.push({ id: 'slack-bot-token', name: 'Bot token', status: 'error', detail: `auth.test failed: ${body.error}`, remediation: 'Recheck the xoxb- token; reinstall the app if it was revoked' });
+    }
+  }
+
+  if (!creds.appToken) {
+    checks.push({ id: 'slack-app-token', name: 'App token', status: 'error', detail: 'SLACK_APP_TOKEN is not set', remediation: 'Create an app-level token with connections:write (Basic Information)' });
+  } else {
+    const res = await fetchImpl('https://slack.com/api/apps.connections.open', { method: 'POST', headers: { Authorization: `Bearer ${creds.appToken}` } });
+    const body = await res.json();
+    checks.push(body.ok
+      ? { id: 'slack-app-token', name: 'App token', status: 'ok', detail: 'Socket Mode connection authorized' }
+      : { id: 'slack-app-token', name: 'App token', status: 'error', detail: `apps.connections.open failed: ${body.error}`, remediation: 'Recheck the xapp- token; it needs the connections:write scope' });
+  }
+
+  checks.push(creds.signingSecret
+    ? { id: 'slack-signing-secret', name: 'Signing secret', status: 'ok', detail: 'Present' }
+    : { id: 'slack-signing-secret', name: 'Signing secret', status: 'warn', detail: 'SLACK_SIGNING_SECRET is not set', remediation: 'Copy it from Basic Information > App Credentials' });
+
+  if (creds.channelId && creds.botToken) {
+    const res = await fetchImpl(`https://slack.com/api/conversations.info?channel=${encodeURIComponent(creds.channelId)}`, { headers: { Authorization: `Bearer ${creds.botToken}` } });
+    const body = await res.json();
+    checks.push(body.ok
+      ? { id: 'slack-channel', name: 'Lobby channel', status: 'ok', detail: `#${body.channel?.name ?? creds.channelId}` }
+      : { id: 'slack-channel', name: 'Lobby channel', status: body.error === 'channel_not_found' ? 'error' : 'warn', detail: `conversations.info: ${body.error}`, remediation: 'Invite the bot to the lobby channel and use its channel ID (starts with C)' });
+  } else if (!creds.channelId) {
+    checks.push({ id: 'slack-channel', name: 'Lobby channel', status: 'error', detail: 'SLACK_CHANNEL_ID is not set', remediation: 'Use the lobby channel ID (starts with C) where you @mention Invoker' });
+  }
+
+  return checks;
+}
+
+// ── .env writing ─────────────────────────────────────────────
+
+const SLACK_ENV_KEYS = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'] as const;
+
+/** Upsert KEY=VALUE pairs into existing .env content, preserving unrelated lines. */
+export function upsertEnvLines(existing: string, values: Record<string, string>): string {
+  const keys = new Set(Object.keys(values));
+  const kept = existing
+    .split('\n')
+    .filter((line) => {
+      const eq = line.indexOf('=');
+      return eq === -1 ? line.trim() !== '' || false : !keys.has(line.slice(0, eq).trim());
+    });
+  const added = Object.entries(values).map(([k, v]) => `${k}=${v}`);
+  return [...kept.filter((l) => l.trim() !== ''), ...added].join('\n') + '\n';
+}
+
+export function writeSlackEnv(creds: Required<Pick<SlackCredentials, 'botToken' | 'appToken' | 'signingSecret' | 'channelId'>>): string {
+  const path = envFilePath();
+  mkdirSync(dirname(path), { recursive: true });
+  const existing = existsSync(path) ? readFileSync(path, 'utf8') : '';
+  const next = upsertEnvLines(existing, {
+    SLACK_BOT_TOKEN: creds.botToken,
+    SLACK_APP_TOKEN: creds.appToken,
+    SLACK_SIGNING_SECRET: creds.signingSecret,
+    SLACK_CHANNEL_ID: creds.channelId,
+  });
+  writeFileSync(path, next, { mode: 0o600 });
+  return path;
+}
+
+// ── setup command ────────────────────────────────────────────
+
+export interface SetupIO {
+  print: (line: string) => void;
+  prompt: (question: string) => Promise<string>;
+}
+
+function defaultIO(): SetupIO & { rl: ReturnType<typeof createInterface> } {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return {
+    rl,
+    print: (line) => process.stdout.write(`${line}\n`),
+    prompt: async (q) => (await rl.question(q)).trim(),
+  };
+}
+
+function manifestSteps(manifestPath: string): string {
+  return [
+    'Slack app setup (guided):',
+    `  1. A manifest was written to ${manifestPath}`,
+    '  2. Open https://api.slack.com/apps → Create New App → From a manifest',
+    '  3. Pick your workspace, paste the manifest JSON, and create the app',
+    '  4. Install to Workspace (OAuth & Permissions) → copy the Bot User OAuth Token (xoxb-...)',
+    '  5. Basic Information → App-Level Tokens → Generate a token with connections:write → copy it (xapp-...)',
+    '  6. Basic Information → App Credentials → copy the Signing Secret',
+    '  7. Invite the bot to your lobby channel and copy that channel ID (starts with C)',
+    '',
+    'After adding scopes you MUST click "Reinstall to Workspace" or the tokens stay stale.',
+  ].join('\n');
+}
+
+/** Read Slack credentials from the environment (after .env load) for non-interactive checks. */
+export function slackCredsFromEnv(): SlackCredentials {
+  return {
+    botToken: process.env.SLACK_BOT_TOKEN,
+    appToken: process.env.SLACK_APP_TOKEN,
+    signingSecret: process.env.SLACK_SIGNING_SECRET,
+    channelId: process.env.SLACK_CHANNEL_ID,
+  };
+}
+
+export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promise<number> {
+  const wantSlack = argv[0] === 'slack';
+  const checkOnly = argv.includes('--check');
+  const rl = (io as { rl?: { close: () => void } }).rl;
+  try {
+    if (checkOnly) {
+      const checks = await validateSlackCredentials(slackCredsFromEnv());
+      const report = buildReport(checks);
+      io.print(formatReport(report, { json: argv.includes('--json') }));
+      return report.ok ? 0 : 1;
+    }
+
+    io.print('Invoker setup\n');
+    const core = buildReport(buildDoctorChecks(loadCliConfig()));
+    io.print(formatReport(core));
+    io.print('');
+
+    let doSlack = wantSlack;
+    if (!wantSlack) {
+      const answer = (await io.prompt('Set up the Slack integration now? [y/N] ')).toLowerCase();
+      doSlack = answer === 'y' || answer === 'yes';
+    }
+    if (!doSlack) {
+      io.print('\nYou are good to go for CLI and UI workflows. Run `invoker-cli setup slack` later to add Slack.');
+      return core.ok ? 0 : 1;
+    }
+
+    const manifestPath = manifestFilePath();
+    mkdirSync(invokerHomeDir(), { recursive: true });
+    writeFileSync(manifestPath, `${JSON.stringify(generateSlackManifest(), null, 2)}\n`);
+    io.print(`\n${manifestSteps(manifestPath)}\n`);
+
+    const botToken = await io.prompt('Bot User OAuth Token (xoxb-...): ');
+    const appToken = await io.prompt('App-Level Token (xapp-...): ');
+    const signingSecret = await io.prompt('Signing Secret: ');
+    const channelId = await io.prompt('Lobby channel ID (C...): ');
+
+    const checks = await validateSlackCredentials({ botToken, appToken, signingSecret, channelId });
+    const report = buildReport(checks);
+    io.print(`\n${formatReport(report)}`);
+
+    if (!report.ok) {
+      const proceed = (await io.prompt('\nSome checks failed. Save these values anyway? [y/N] ')).toLowerCase();
+      if (proceed !== 'y' && proceed !== 'yes') {
+        io.print('Nothing written. Fix the items above and re-run `invoker-cli setup slack`.');
+        return 1;
+      }
+    }
+
+    const envPath = writeSlackEnv({ botToken, appToken, signingSecret, channelId });
+    io.print(`\nWrote Slack credentials to ${envPath}. Restart Invoker (or it picks them up on next launch).`);
+    return report.ok ? 0 : 1;
+  } finally {
+    rl?.close();
+  }
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -4,5 +4,9 @@ import sharedConfig from '../../vitest.shared.ts';
 export default mergeConfig(sharedConfig, defineConfig({
   test: {
     exclude: ['**/node_modules/**', '**/dist/**'],
+    // cli.test.ts runs heavy e2e (real engine, git, IPC). Run files sequentially and give the
+    // ~18s workflow runs ample headroom so a busy machine doesn't brush the global 20s timeout.
+    fileParallelism: false,
+    testTimeout: 60_000,
   },
 }));

--- a/packages/contracts/src/__tests__/prerequisites.test.ts
+++ b/packages/contracts/src/__tests__/prerequisites.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildReport,
+  checkConfig,
+  checkDefaultPresetTool,
+  checkPlanningToolsPresent,
+  checkTool,
+  formatReport,
+  type PlanningPresetSpec,
+} from '../prerequisites.js';
+
+const installed = (...tools: string[]) => (cmd: string) => tools.includes(cmd);
+const presets: Record<string, PlanningPresetSpec> = {
+  'cursor+claude': { tool: 'cursor', model: 'claude' },
+  omp: { tool: 'omp' },
+  codex: { tool: 'codex' },
+};
+
+describe('checkTool', () => {
+  it('passes when the command is installed', () => {
+    expect(checkTool({ id: 'git', name: 'Git', command: 'git', requiredFor: 'checkout', required: true }, installed('git')).status).toBe('ok');
+  });
+
+  it('errors for a missing required tool and warns for a missing optional one', () => {
+    const req = { id: 'docker', name: 'Docker', command: 'docker', requiredFor: 'containers', installHint: 'brew install docker' };
+    expect(checkTool({ ...req, required: true }, installed()).status).toBe('error');
+    const optional = checkTool(req, installed());
+    expect(optional.status).toBe('warn');
+    expect(optional.remediation).toBe('brew install docker');
+  });
+});
+
+describe('checkConfig', () => {
+  it('is ok when no config file exists', () => {
+    expect(checkConfig({ path: '/x/config.json', exists: false }).status).toBe('ok');
+  });
+
+  it('is ok when the file parses', () => {
+    expect(checkConfig({ path: '/x/config.json', exists: true }).status).toBe('ok');
+  });
+
+  it('errors with the parse message when the JSON is invalid', () => {
+    const c = checkConfig({ path: '/x/config.json', exists: true, error: 'Unexpected token }' });
+    expect(c.status).toBe('error');
+    expect(c.remediation).toContain('Unexpected token }');
+  });
+});
+
+describe('checkDefaultPresetTool', () => {
+  it('passes when the default preset tool is installed', () => {
+    expect(checkDefaultPresetTool(presets, 'omp', installed('omp')).status).toBe('ok');
+  });
+
+  it('errors when the default preset tool is not on PATH', () => {
+    const c = checkDefaultPresetTool(presets, 'cursor+claude', installed('omp'));
+    expect(c.status).toBe('error');
+    expect(c.detail).toContain('cursor');
+    expect(c.remediation).toContain('defaultSlackHarnessPreset');
+  });
+
+  it('errors and lists valid keys when the default preset is undefined', () => {
+    const c = checkDefaultPresetTool(presets, 'mystery', installed('omp'));
+    expect(c.status).toBe('error');
+    expect(c.remediation).toContain('omp');
+  });
+});
+
+describe('checkPlanningToolsPresent', () => {
+  it('passes when any preset tool is installed', () => {
+    expect(checkPlanningToolsPresent(presets, installed('codex')).status).toBe('ok');
+  });
+
+  it('errors when no planning tool is installed', () => {
+    const c = checkPlanningToolsPresent(presets, installed('git'));
+    expect(c.status).toBe('error');
+    expect(c.remediation).toContain('cursor');
+  });
+});
+
+describe('buildReport / formatReport', () => {
+  it('marks the report not-ok when any check errors', () => {
+    const report = buildReport([
+      checkTool({ id: 'git', name: 'Git', command: 'git', requiredFor: 'checkout', required: true }, installed('git')),
+      checkPlanningToolsPresent(presets, installed()),
+    ]);
+    expect(report.ok).toBe(false);
+  });
+
+  it('stays ok when only warnings are present', () => {
+    const report = buildReport([
+      checkTool({ id: 'docker', name: 'Docker', command: 'docker', requiredFor: 'containers' }, installed()),
+    ]);
+    expect(report.ok).toBe(true);
+  });
+
+  it('emits machine-readable JSON and shows remediation in text mode', () => {
+    const report = buildReport([checkPlanningToolsPresent(presets, installed())]);
+    expect(JSON.parse(formatReport(report, { json: true }))).toEqual(report);
+    expect(formatReport(report)).toContain('-> Install at least one');
+  });
+});

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -9,3 +9,4 @@ export * from './repo-root.ts';
 export * from './cost-types.ts';
 export * from './launch-timeouts.ts';
 export * from './invoker-home.ts';
+export * from './prerequisites.ts';

--- a/packages/contracts/src/prerequisites.ts
+++ b/packages/contracts/src/prerequisites.ts
@@ -1,0 +1,172 @@
+// Config-aware prerequisite checks shared by `invoker-cli doctor` and the app launch check.
+// Pure and browser-safe: callers inject the `isInstalled` probe (Node `spawn`) and the parsed
+// config, so this module never imports `node:child_process`/`node:fs` (the UI bundles contracts).
+
+export type PrerequisiteStatus = 'ok' | 'warn' | 'error';
+
+export interface PrerequisiteCheck {
+  id: string;
+  name: string;
+  status: PrerequisiteStatus;
+  detail: string;
+  remediation?: string;
+}
+
+export interface PlanningPresetSpec {
+  tool: string;
+  model?: string;
+}
+
+export type IsInstalled = (command: string) => boolean;
+
+export interface ToolRequirement {
+  id: string;
+  name: string;
+  command: string;
+  requiredFor: string;
+  /** Missing required tools are `error`; missing optional ones are advisory `warn`. */
+  required?: boolean;
+  installHint?: string;
+}
+
+export function checkTool(req: ToolRequirement, isInstalled: IsInstalled): PrerequisiteCheck {
+  if (isInstalled(req.command)) {
+    return { id: req.id, name: req.name, status: 'ok', detail: `${req.command} found` };
+  }
+  return {
+    id: req.id,
+    name: req.name,
+    status: req.required ? 'error' : 'warn',
+    detail: `${req.command} not found (needed for ${req.requiredFor})`,
+    remediation: req.installHint,
+  };
+}
+
+/** Config readiness from a pre-read parse state, so this stays free of `node:fs`. */
+export function checkConfig(state: { path: string; exists: boolean; error?: string }): PrerequisiteCheck {
+  if (!state.exists) {
+    return { id: 'config', name: 'Config file', status: 'ok', detail: `No config at ${state.path}; using defaults` };
+  }
+  if (!state.error) {
+    return { id: 'config', name: 'Config file', status: 'ok', detail: `Parsed ${state.path}` };
+  }
+  return {
+    id: 'config',
+    name: 'Config file',
+    status: 'error',
+    detail: `Invalid JSON at ${state.path}`,
+    remediation: `Fix the JSON syntax: ${state.error}`,
+  };
+}
+
+/** The default planning preset must map to a tool on PATH — the gap behind silent cursor fallbacks. */
+export function checkDefaultPresetTool(
+  presets: Record<string, PlanningPresetSpec>,
+  defaultPresetKey: string,
+  isInstalled: IsInstalled,
+): PrerequisiteCheck {
+  const keys = Object.keys(presets);
+  const preset = presets[defaultPresetKey];
+  if (!preset) {
+    return {
+      id: 'default-preset',
+      name: 'Default planning preset',
+      status: 'error',
+      detail: `Default preset "${defaultPresetKey}" is not defined`,
+      remediation: keys.length
+        ? `Set defaultSlackHarnessPreset to one of: ${keys.join(', ')}`
+        : 'Define slackHarnessPresets and defaultSlackHarnessPreset in config',
+    };
+  }
+  if (!isInstalled(preset.tool)) {
+    return {
+      id: 'default-preset',
+      name: 'Default planning preset',
+      status: 'error',
+      detail: `Default preset "${defaultPresetKey}" needs "${preset.tool}", which is not on PATH`,
+      remediation: `Install ${preset.tool}, or set defaultSlackHarnessPreset to a preset whose tool is installed`,
+    };
+  }
+  return {
+    id: 'default-preset',
+    name: 'Default planning preset',
+    status: 'ok',
+    detail: `"${defaultPresetKey}" -> ${preset.tool} (installed)`,
+  };
+}
+
+/** At least one configured preset's tool is installed, so some planning works. */
+export function checkPlanningToolsPresent(
+  presets: Record<string, PlanningPresetSpec>,
+  isInstalled: IsInstalled,
+): PrerequisiteCheck {
+  const tools = [...new Set(Object.values(presets).map((p) => p.tool))];
+  const installed = tools.filter(isInstalled);
+  if (installed.length > 0) {
+    return { id: 'planning-tools', name: 'Planning tools', status: 'ok', detail: `Installed: ${installed.join(', ')}` };
+  }
+  const wanted = tools.length ? tools.join(', ') : 'cursor, omp, codex';
+  return {
+    id: 'planning-tools',
+    name: 'Planning tools',
+    status: 'error',
+    detail: `No planning tool installed (need one of: ${wanted})`,
+    remediation: `Install at least one of: ${wanted}`,
+  };
+}
+
+export interface PrerequisiteReport {
+  ok: boolean;
+  checks: PrerequisiteCheck[];
+}
+
+export function buildReport(checks: PrerequisiteCheck[]): PrerequisiteReport {
+  return { ok: checks.every((c) => c.status !== 'error'), checks };
+}
+
+const STATUS_LABEL: Record<PrerequisiteStatus, string> = { ok: 'ok  ', warn: 'warn', error: 'FAIL' };
+
+export function formatReport(report: PrerequisiteReport, options: { json?: boolean } = {}): string {
+  if (options.json) return JSON.stringify(report);
+  return report.checks
+    .map((c) => {
+      const head = `${STATUS_LABEL[c.status]}  ${c.name}: ${c.detail}`;
+      return c.remediation && c.status !== 'ok' ? `${head}\n        -> ${c.remediation}` : head;
+    })
+    .join('\n');
+}
+
+/** Canonical tools Invoker uses. `cursor`/`omp`/`codex`/`claude` are the planning/execution agents. */
+export const DEFAULT_TOOL_REQUIREMENTS: ToolRequirement[] = [
+  { id: 'git', name: 'Git', command: 'git', requiredFor: 'repo checkout, branches, merges', required: true, installHint: 'brew install git (or apt-get install git)' },
+  { id: 'pnpm', name: 'pnpm', command: 'pnpm', requiredFor: 'workspace installs and builds', required: true, installHint: 'npm install -g pnpm' },
+  { id: 'gh', name: 'GitHub CLI', command: 'gh', requiredFor: 'GitHub PR and release flows', installHint: 'brew install gh' },
+  { id: 'docker', name: 'Docker', command: 'docker', requiredFor: 'container executors', installHint: 'brew install docker' },
+  { id: 'ssh', name: 'OpenSSH', command: 'ssh', requiredFor: 'remote SSH executors', installHint: 'apt-get install openssh-client' },
+  { id: 'codex', name: 'Codex CLI', command: 'codex', requiredFor: 'codex presets', installHint: 'npm install -g @openai/codex' },
+  { id: 'claude', name: 'Claude CLI', command: 'claude', requiredFor: 'claude-model presets', installHint: 'npm install -g @anthropic-ai/claude-code' },
+  { id: 'cursor', name: 'Cursor Agent', command: 'cursor', requiredFor: 'cursor presets', installHint: 'install Cursor, then enable the agent CLI' },
+  { id: 'omp', name: 'omp', command: 'omp', requiredFor: 'omp presets', installHint: 'install the omp CLI' },
+];
+
+export interface ReadinessInput {
+  tools: ToolRequirement[];
+  isInstalled: IsInstalled;
+  config?: { path: string; exists: boolean; error?: string };
+  /** Effective Slack planning presets (config or built-ins); empty skips preset checks. */
+  presets?: Record<string, PlanningPresetSpec>;
+  defaultPreset?: string;
+}
+
+/** Ordered prerequisite checks shared by `invoker-cli doctor` and the app launch check. */
+export function assembleReadinessChecks(input: ReadinessInput): PrerequisiteCheck[] {
+  const checks: PrerequisiteCheck[] = [];
+  if (input.config) checks.push(checkConfig(input.config));
+  for (const tool of input.tools) checks.push(checkTool(tool, input.isInstalled));
+  const presets = input.presets ?? {};
+  if (Object.keys(presets).length > 0) {
+    checks.push(checkPlanningToolsPresent(presets, input.isInstalled));
+    if (input.defaultPreset) checks.push(checkDefaultPresetTool(presets, input.defaultPreset, input.isInstalled));
+  }
+  return checks;
+}


### PR DESCRIPTION
## Summary

This adds two commands to the `invoker-cli` command-line tool: `doctor` and `setup`.

`doctor` reports whether the tools and config a machine needs are present, including whether the default planning preset's program is actually installed.

`setup` is an interactive command that, if you opt in, writes a Slack app manifest, checks your tokens against Slack, and saves them.

Both are new commands. No existing command path changes.

<details>
<summary>Review metadata</summary>

Review Claim: Add `doctor` and `setup` commands to the `invoker-cli` command-line tool.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Both are new entries in the command-line tool's dispatch; existing commands and their output are untouched.

Slice Rationale: Kept separate from the shared module and the desktop app, these are the user-facing command-line entry points and review as one surface.

</details>

## Non-goals

- Does not change the app startup path or how `.env` is read (a separate slice).
- Does not add an automatic first-run prompt; the commands are invoked explicitly.

## Test Plan

- [x] `pnpm --filter @invoker/cli exec vitest run`
- [x] `node packages/cli/dist/index.js doctor` (and the cursor-default-missing path exits 1)
- [x] `node packages/cli/dist/index.js setup slack --check` (no creds reports each missing value, exits 1, no hang)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2287