### PR TITLE
[CLI Onboarding](4) Document onboarding and add the invoker-setup skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to Invoker will be documented in this file.
 - Add Slack-native coding workflows: plan from a lobby `@Invoker` mention against a checked-out repo with a selectable planning harness (`[preset]`/`[repo:]` tags), spin the plan up as a workflow in a private `workflow-<id>` channel, and drive or question that workflow in-channel using only its own planning conversation and task transcripts.
 - Key the single-instance worker lock by worker kind, so different worker kinds can run at once while a second start of an already-running kind is still refused across both worker doors. The worker kind is validated before it becomes the lock filename, so it cannot escape the locks directory.
 - Cap the `activity_log` table to its most recent 100000 rows, pruned as new entries are written, so `~/.invoker/invoker.db` can no longer grow without bound and trigger SIGBUS crashes.
+- Add `invoker-cli doctor` (config-aware environment validation) and an `invoker-cli setup slack` wizard. Doctor checks tools, config, and that your default planning preset's CLI is actually installed (the gap behind silent `spawn cursor ENOENT` failures); setup runs those checks, then — only if you opt in — writes a ready-to-paste Slack app manifest, validates your tokens against the live Slack API, and saves them to `~/.invoker/.env`. The app now loads `~/.invoker/.env` before the Slack startup check (so a populated file just works) and warns on launch when the default preset's tool is missing.
 
 ## 0.0.6
 
@@ -19,6 +20,7 @@ All notable changes to Invoker will be documented in this file.
 ## 0.0.5
 
 - Install the bundled `invoker-cli` automatically through the npm UI package and the desktop app.
+
 ## 0.0.4
 
 - Publish complete CLI and desktop release assets for npm launcher packages.

--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -51,7 +51,15 @@ Model strings are passed verbatim to the CLI's `--model`; set exact ids your CLI
 
 ## Environment
 
-Set in `<repoRoot>/.env` (loaded on startup) or the environment, then run `./run.sh`:
+The fastest path is the setup wizard. It validates your tools, writes a ready-to-paste Slack app
+manifest, checks your tokens against the live Slack API, and saves them to `~/.invoker/.env`:
+
+```
+invoker-cli setup slack
+```
+
+To configure by hand, put these in `~/.invoker/.env` (canonical, loaded on startup before the Slack
+check) or `<repoRoot>/.env` (fallback), then run `./run.sh`:
 
 ```
 SLACK_BOT_TOKEN=xoxb-...
@@ -63,6 +71,8 @@ INVOKER_REPO_URL=git@github.com:acme/web.git   # optional; default repo (else gi
 CURSOR_COMMAND=cursor            # optional planning CLI override
 CURSOR_MODEL=...                 # optional planning model override
 ```
+
+Run `invoker-cli doctor` to confirm your tools, config, and that your default preset's CLI is installed.
 
 ## Slack app scopes
 

--- a/skills/invoker-setup/SKILL.md
+++ b/skills/invoker-setup/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: invoker-setup
+description: >
+  Get a new machine "good to go" for Invoker and optionally wire up the Slack integration.
+  Trigger when asked to set up Invoker, run the setup/tutorial, check the environment,
+  fix missing tools, or configure the Slack bot ("set up slack", "/setup", "am I good to go?").
+---
+
+# invoker-setup
+
+Agent-driven onboarding. It validates the environment, then — only if the user wants it — walks
+them through the Slack integration. Slack is optional; never push it on a user who declines.
+
+## 1. Validate the environment
+
+```bash
+invoker-cli doctor --json
+```
+
+Read the JSON `checks`. Each has `status` (`ok` | `warn` | `error`), `detail`, and `remediation`.
+
+- `error` blocks "good to go" — surface the `remediation` verbatim.
+- `warn` is advisory (an optional tool / preset not installed) — mention it, don't block.
+- The `default-preset` and `planning-tools` checks are config-aware: an `error` there means the
+  configured `defaultSlackHarnessPreset` points at a CLI that is not installed. This is the most
+  common Slack failure ("spawn cursor ENOENT") — fix it before going further.
+
+Offer to auto-install missing installable tools:
+
+```bash
+invoker-cli doctor --fix
+```
+
+`--fix` covers git, pnpm, gh, docker, ssh, codex, claude. `cursor` and `omp` are installed manually
+(report their `remediation`).
+
+## 2. Ask about Slack
+
+Ask plainly: "Do you want to set up the Slack integration now?" If no, stop — report that they are
+good to go for CLI and UI workflows and that `invoker-cli setup slack` can add Slack later.
+
+## 3. Guided Slack setup (only if they said yes)
+
+Run the wizard, which writes a ready-to-paste app manifest to `~/.invoker/slack-app-manifest.json`
+and prompts for the tokens:
+
+```bash
+invoker-cli setup slack
+```
+
+If you are doing it on the user's behalf (you cannot click api.slack.com), drive it manually:
+
+1. Generate the manifest (the wizard writes it, or you can): it requests bot scopes
+   `app_mentions:read, chat:write, channels:history, groups:write, groups:history, users:read`,
+   enables Socket Mode, and subscribes to the `app_mention` event.
+2. Tell the user: open https://api.slack.com/apps → **Create New App → From a manifest**, pick the
+   workspace, paste the manifest JSON, create the app.
+3. **Install to Workspace** → copy the Bot User OAuth Token (`xoxb-…`).
+4. **Basic Information → App-Level Tokens** → generate one with `connections:write` → copy (`xapp-…`).
+5. **Basic Information → App Credentials** → copy the Signing Secret.
+6. Invite the bot to the lobby channel; copy that channel ID (starts with `C`).
+
+### The scope gotcha
+
+Adding scopes after install does **not** update the existing token. The user MUST click
+**Reinstall to Workspace** or the bot keeps the old (insufficient) scopes. If the scope check fails,
+tell them to add the scope **and reinstall**.
+
+## 4. Validate credentials
+
+After the user provides the four values, write them to `~/.invoker/.env` (the wizard does this) and
+confirm against the live Slack API:
+
+```bash
+invoker-cli setup slack --check
+```
+
+This runs `auth.test` (bot token + scopes via the `x-oauth-scopes` header),
+`apps.connections.open` (app token / Socket Mode), and `conversations.info` (the lobby channel).
+Surface each failing check's `remediation`.
+
+## 5. Done
+
+Tell the user to restart Invoker (or that the next launch picks up `~/.invoker/.env`). On launch the
+app logs a one-line prerequisites summary; if the default preset's tool is missing it warns but still starts, and
+if Slack env is incomplete it logs exactly which variable is missing and to run `invoker-cli setup slack`.
+
+## Hard rules
+
+- Never write secrets anywhere except `~/.invoker/.env` (the wizard writes it `0600`). Never echo full
+  tokens back to the user or into logs.
+- Never invent Slack tokens or fake a successful check. If validation fails, report it.
+- Slack is optional. A user who declines is still "good to go" for CLI and UI workflows.


### PR DESCRIPTION
## Summary

This updates the documentation for the new onboarding flow.

The Slack workflow doc now points at the guided setup steps and explains where the canonical env file lives.

It also adds an `invoker-setup` skill and a changelog note.

<details>
<summary>Review metadata</summary>

Review Claim: Document the onboarding flow and add the `invoker-setup` skill.

Review Lane: docs

Review Unit: docs

Safety Invariant: Documentation and a skill file only; no code or behavior changes.

Slice Rationale: Docs land last, after the slices they describe, and stay separate from implementation.

</details>

## Non-goals

- No code changes; this slice is documentation and a skill file only.

## Test Plan

- [x] `node scripts/validate-pr-body.mjs --body-file <this file>`
- [x] Manual read-through of the updated Slack workflow doc and the new skill.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guided setup instructions for configuring Slack and validating the environment with built-in checks.
* **Documentation**
  * Updated Slack workflow docs to recommend a faster setup path with automated validation and credential saving.
  * Added onboarding guidance for machine setup, including prerequisite checks, optional fixes, and Slack configuration steps.
* **Bug Fixes**
  * Clarified startup behavior when required tools are missing and how to resolve configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->