### PR TITLE
[Slack Native](8) Add Slack setup preflight

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  checkSlackSetup,
+  DEFAULT_SLACK_HARNESS_PRESETS,
+  formatSlackSetupPreflight,
   loadConfig,
   resolveEmbeddedTerminalBackendConfig,
 } from '../config.js';
@@ -221,6 +224,59 @@ describe('loadConfig', () => {
 
 });
 
+describe('checkSlackSetup', () => {
+  const slackEnv = {
+    SLACK_BOT_TOKEN: 'xoxb-token',
+    SLACK_APP_TOKEN: 'xapp-token',
+    SLACK_SIGNING_SECRET: 'secret',
+    SLACK_CHANNEL_ID: 'C123',
+  };
+
+  it('accepts the built-in Slack harness defaults when Slack env is present', () => {
+    const result = checkSlackSetup({}, slackEnv);
+    expect(result.missingEnv).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.defaultHarnessPreset).toBe('cursor+claude');
+    expect(result.harnessPresets).toEqual(DEFAULT_SLACK_HARNESS_PRESETS);
+  });
+
+  it('reports all missing Slack env vars before startup', () => {
+    const result = checkSlackSetup({}, { SLACK_BOT_TOKEN: 'xoxb-token' });
+    expect(result.missingEnv).toEqual([
+      'SLACK_APP_TOKEN',
+      'SLACK_SIGNING_SECRET',
+      'SLACK_CHANNEL_ID',
+    ]);
+
+    expect(formatSlackSetupPreflight(result)).toContain(
+      'Missing env vars: SLACK_APP_TOKEN, SLACK_SIGNING_SECRET, SLACK_CHANNEL_ID.',
+    );
+  });
+
+  it('rejects a default Slack preset missing from a custom preset override', () => {
+    const result = checkSlackSetup({
+      slackHarnessPresets: {
+        'omp+claude': { tool: 'omp', model: 'anthropic/claude-opus-4' },
+      },
+      defaultSlackHarnessPreset: 'cursor+claude',
+    }, slackEnv);
+
+    expect(result.errors).toContain(
+      'defaultSlackHarnessPreset "cursor+claude" is not defined in slackHarnessPresets. Configured presets: omp+claude.',
+    );
+  });
+
+  it('rejects malformed Slack repo aliases with actionable errors', () => {
+    const result = checkSlackSetup({
+      slackRepos: {
+        web: '',
+      },
+    }, slackEnv);
+
+    expect(result.errors).toContain('slackRepos.web must be a non-empty git URL.');
+  });
+});
+
 describe('resolveEmbeddedTerminalBackendConfig', () => {
   it('defaults GUI embedded terminals to the PTY backend', () => {
     expect(resolveEmbeddedTerminalBackendConfig({}, {})).toBe('pty');
@@ -253,4 +309,3 @@ describe('resolveEmbeddedTerminalBackendConfig', () => {
     )).toThrow(/Invalid embedded terminal backend/);
   });
 });
-

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -216,6 +216,123 @@ export interface InvokerConfig {
   }>;
 }
 
+type SlackHarnessPresetMap = NonNullable<InvokerConfig['slackHarnessPresets']>;
+
+export const REQUIRED_SLACK_ENV_VARS = [
+  'SLACK_BOT_TOKEN',
+  'SLACK_APP_TOKEN',
+  'SLACK_SIGNING_SECRET',
+  'SLACK_CHANNEL_ID',
+] as const;
+
+export const DEFAULT_SLACK_HARNESS_PRESETS: SlackHarnessPresetMap = {
+  'cursor+claude': { tool: 'cursor', model: 'claude' },
+  'cursor+codex': { tool: 'cursor', model: 'codex' },
+  'omp+claude': { tool: 'omp', model: 'claude' },
+  omp: { tool: 'omp' },
+  codex: { tool: 'codex' },
+};
+
+export const DEFAULT_SLACK_HARNESS_PRESET = 'cursor+claude';
+
+export interface SlackSetupPreflightResult {
+  missingEnv: string[];
+  errors: string[];
+  harnessPresets: SlackHarnessPresetMap;
+  defaultHarnessPreset: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isSlackHarnessTool(value: unknown): value is 'cursor' | 'omp' | 'codex' {
+  return value === 'cursor' || value === 'omp' || value === 'codex';
+}
+
+export function checkSlackSetup(
+  config: InvokerConfig,
+  env: NodeJS.ProcessEnv = process.env,
+): SlackSetupPreflightResult {
+  const missingEnv = REQUIRED_SLACK_ENV_VARS.filter((name) => !env[name]);
+  const errors: string[] = [];
+
+  const configuredPresets = config.slackHarnessPresets as unknown;
+  const usesCustomPresets = configuredPresets !== undefined;
+  const harnessPresets: SlackHarnessPresetMap = usesCustomPresets && isRecord(configuredPresets)
+    ? configuredPresets as SlackHarnessPresetMap
+    : DEFAULT_SLACK_HARNESS_PRESETS;
+  const defaultHarnessPreset = config.defaultSlackHarnessPreset ?? DEFAULT_SLACK_HARNESS_PRESET;
+
+  if (usesCustomPresets) {
+    if (!isRecord(configuredPresets)) {
+      errors.push('slackHarnessPresets must be an object mapping preset names to { tool, model? }.');
+    } else if (Object.keys(configuredPresets).length === 0) {
+      errors.push('slackHarnessPresets must define at least one preset when set.');
+    }
+  }
+
+  if (typeof defaultHarnessPreset !== 'string' || defaultHarnessPreset.trim() === '') {
+    errors.push('defaultSlackHarnessPreset must be a non-empty preset key.');
+  } else if (!harnessPresets[defaultHarnessPreset]) {
+    errors.push(
+      `defaultSlackHarnessPreset "${defaultHarnessPreset}" is not defined in slackHarnessPresets. ` +
+      `Configured presets: ${Object.keys(harnessPresets).join(', ') || '(none)'}.`,
+    );
+  }
+
+  for (const [key, preset] of Object.entries(harnessPresets)) {
+    if (!key.trim()) {
+      errors.push('slackHarnessPresets contains an empty preset key.');
+      continue;
+    }
+    if (!isRecord(preset)) {
+      errors.push(`slackHarnessPresets.${key} must be an object with a supported tool.`);
+      continue;
+    }
+    if (!isSlackHarnessTool(preset.tool)) {
+      errors.push(`slackHarnessPresets.${key}.tool must be one of: cursor, omp, codex.`);
+    }
+    if (preset.model !== undefined && typeof preset.model !== 'string') {
+      errors.push(`slackHarnessPresets.${key}.model must be a string when set.`);
+    }
+  }
+
+  const slackRepos = config.slackRepos as unknown;
+  if (slackRepos !== undefined) {
+    if (!isRecord(slackRepos)) {
+      errors.push('slackRepos must be an object mapping repo aliases to git URLs.');
+    } else {
+      for (const [alias, url] of Object.entries(slackRepos)) {
+        if (!alias.trim()) errors.push('slackRepos contains an empty alias.');
+        if (typeof url !== 'string' || url.trim() === '') {
+          errors.push(`slackRepos.${alias || '(empty)'} must be a non-empty git URL.`);
+        }
+      }
+    }
+  }
+
+  if (config.defaultRepoUrl !== undefined && (
+    typeof config.defaultRepoUrl !== 'string' || config.defaultRepoUrl.trim() === ''
+  )) {
+    errors.push('defaultRepoUrl must be a non-empty git URL when set.');
+  }
+
+  return { missingEnv, errors, harnessPresets, defaultHarnessPreset };
+}
+
+export function formatSlackSetupPreflight(result: SlackSetupPreflightResult): string {
+  const lines = ['Slack bot not started: setup preflight failed.'];
+  if (result.missingEnv.length > 0) {
+    lines.push(`Missing env vars: ${result.missingEnv.join(', ')}.`);
+  }
+  for (const error of result.errors) {
+    lines.push(`Config error: ${error}`);
+  }
+  lines.push('Fix ~/.invoker/config.json or the Slack environment, then restart Invoker.');
+  return lines.join(' ');
+}
+
 function readJsonSafe(path: string): InvokerConfig {
   if (!existsSync(path)) {
     return {};

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -102,6 +102,9 @@ import type { Logger } from '@invoker/contracts';
 import { FileAndDbLogger } from './logger.js';
 import type { TaskOutputData } from './types.js';
 import {
+  checkSlackSetup,
+  DEFAULT_SLACK_HARNESS_PRESETS,
+  formatSlackSetupPreflight,
   loadConfig,
   resolveEmbeddedTerminalBackendConfig,
   type EmbeddedTerminalBackendConfig,
@@ -781,14 +784,6 @@ function loadSurfaces(): any {
 
 // ── Shared Slack Bot Wiring ──────────────────────────────────
 
-const DEFAULT_SLACK_HARNESS_PRESETS: Record<string, { tool: 'cursor' | 'omp' | 'codex'; model?: string }> = {
-  'cursor+claude': { tool: 'cursor', model: 'claude' },
-  'cursor+codex': { tool: 'cursor', model: 'codex' },
-  'omp+claude': { tool: 'omp', model: 'claude' },
-  omp: { tool: 'omp' },
-  codex: { tool: 'codex' },
-};
-
 interface SlackBotDeps {
   executor: TaskRunner;
   logFn: (source: string, level: string, message: string) => void;
@@ -806,9 +801,9 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
     // dotenv not installed — rely on environment variables
   }
 
-  const requiredVars = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'];
-  for (const v of requiredVars) {
-    if (!process.env[v]) throw new Error(`Missing env var: ${v}. Set it in .env or environment.`);
+  const setup = checkSlackSetup(invokerConfig, process.env);
+  if (setup.missingEnv.length > 0 || setup.errors.length > 0) {
+    throw new Error(formatSlackSetupPreflight(setup));
   }
 
   const surfaces = loadSurfaces();
@@ -2984,10 +2979,9 @@ function createEmbeddedTerminalBackendFromConfig(
       // the ESM loader gets stuck behind other startup work (e.g. the docker
       // CLI hang we observed). startSlackBot would throw on missing env vars
       // immediately after dotenv anyway.
-      const slackEnvVars = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'];
-      const slackEnvMissing = slackEnvVars.filter((v) => !process.env[v]);
-      if (slackEnvMissing.length > 0) {
-        logger.info(`Slack bot not started (missing env: ${slackEnvMissing.join(', ')})`, { module: 'slack' });
+      const slackSetup = checkSlackSetup(invokerConfig, process.env);
+      if (slackSetup.missingEnv.length > 0 || slackSetup.errors.length > 0) {
+        logger.info(formatSlackSetupPreflight(slackSetup), { module: 'slack' });
       } else {
         startSlackBot(requireTaskExecutor(), taskHandles).catch((err) => {
           logger.info(`Not started: ${err instanceof Error ? err.message : String(err)}`, { module: 'slack' });


### PR DESCRIPTION
## Summary

Slack startup now routes bot boot through a shared setup preflight before constructing `SlackSurface`.

Bad Slack env, preset overrides, repo aliases, or default repo settings now stop startup with one actionable message.

This makes the onboarding failure happen at boot instead of inside the first Slack workflow thread.

<details>
<summary>Review metadata</summary>

Review Claim: Slack bot startup now goes through one setup preflight before the bot is wired.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The gate runs before SlackSurface construction and does not change Slack commands or workflow execution.

Slice Rationale: This is the smallest onboarding behavior slice: catch setup problems before Slack workflow handling starts.

</details>

## Non-goals

This does not change Slack command parsing.

This does not add Slack manifest automation or scope introspection.

This does not change hosted or sandboxed Slack-worker deployment.

This does not change workflow execution, planning prompts, or channel behavior.

## Architecture

### Before

Slack startup used ad hoc env checks, then relied on later runtime fallbacks for preset and repo setup mistakes.

### After

Embedded startup and Slack bot wiring both route through `checkSlackSetup` before `SlackSurface` construction.

```mermaid
graph TD
    A["Invoker config + Slack env"] --> B["checkSlackSetup"]
    B --> C["actionable setup message"]
    B --> D["SlackSurface construction"]
```

## Test Plan

- [x] `corepack pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts`
- [x] `corepack pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge commit>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Slack setup preflight check that validates required settings before startup.
  * Improved startup feedback with clearer, formatted messages when Slack configuration is incomplete or invalid.

* **Bug Fixes**
  * Prevents Slack bot startup when required settings are missing or malformed.
  * Ensures invalid Slack repository and preset settings are reported clearly instead of failing later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->