### PR TITLE
[Release changelog](1) Roll CHANGELOG on version cut

### DIFF
--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,49 +1,77 @@
 #!/usr/bin/env node
-// Bumps every release version string in one run, then verifies they agree:
+// Bumps every release version string in one run, rolls the CHANGELOG for the
+// cut, then verifies the versions agree:
 //
-//   node scripts/bump-version.mjs 0.0.5
+//   node scripts/bump-version.mjs 0.0.7
 //
-// Covers the root + four publishable package.json files and the VERSION
-// constant baked into the CLI source. After this, commit and tag (vX.Y.Z) to
-// trigger the release workflow.
+// Covers the root + four publishable package.json files, the VERSION constant
+// baked into the CLI source, and CHANGELOG.md (renames "## Unreleased" to the
+// new version and starts a fresh "## Unreleased"). After this, commit and tag
+// (vX.Y.Z) to trigger the release workflow.
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
-const newVersion = process.argv[2];
 
-if (!newVersion || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(newVersion)) {
-  console.error('Usage: node scripts/bump-version.mjs <semver, e.g. 0.0.5>');
-  process.exit(64);
+// Roll the CHANGELOG for a release: rename the top "## Unreleased" section to
+// "## <version>" and start a fresh empty "## Unreleased" above it. Throws when
+// there is no "## Unreleased" section so a cut fails loudly instead of silently
+// shipping a version with no changelog heading.
+export function applyChangelogRelease(changelog, version) {
+  const lines = changelog.split('\n');
+  const index = lines.findIndex((line) => line.trim() === '## Unreleased');
+  if (index === -1) {
+    throw new Error(
+      'CHANGELOG.md has no "## Unreleased" section to release. Add one with this release\'s notes before cutting a version.',
+    );
+  }
+  lines.splice(index, 1, '## Unreleased', '', `## ${version}`);
+  return lines.join('\n');
 }
 
-const packageJsonPaths = [
-  'package.json',
-  'packages/app/package.json',
-  'packages/cli/package.json',
-  'packages/npm-cli/package.json',
-  'packages/npm-ui/package.json',
-];
+function main() {
+  const newVersion = process.argv[2];
+  if (!newVersion || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(newVersion)) {
+    console.error('Usage: node scripts/bump-version.mjs <semver, e.g. 0.0.7>');
+    process.exit(64);
+  }
 
-for (const relPath of packageJsonPaths) {
-  const absPath = join(root, relPath);
-  const pkg = JSON.parse(readFileSync(absPath, 'utf8'));
-  const oldVersion = pkg.version;
-  pkg.version = newVersion;
-  writeFileSync(absPath, `${JSON.stringify(pkg, null, 2)}\n`);
-  console.log(`${relPath}: ${oldVersion} -> ${newVersion}`);
+  const packageJsonPaths = [
+    'package.json',
+    'packages/app/package.json',
+    'packages/cli/package.json',
+    'packages/npm-cli/package.json',
+    'packages/npm-ui/package.json',
+  ];
+
+  for (const relPath of packageJsonPaths) {
+    const absPath = join(root, relPath);
+    const pkg = JSON.parse(readFileSync(absPath, 'utf8'));
+    const oldVersion = pkg.version;
+    pkg.version = newVersion;
+    writeFileSync(absPath, `${JSON.stringify(pkg, null, 2)}\n`);
+    console.log(`${relPath}: ${oldVersion} -> ${newVersion}`);
+  }
+
+  const cliSourcePath = join(root, 'packages/cli/src/index.ts');
+  const cliSource = readFileSync(cliSourcePath, 'utf8');
+  if (!/^const VERSION = '[^']+';$/m.test(cliSource)) {
+    console.error(`Could not find "const VERSION = '...'" in ${cliSourcePath}`);
+    process.exit(1);
+  }
+  writeFileSync(cliSourcePath, cliSource.replace(/^const VERSION = '[^']+';$/m, `const VERSION = '${newVersion}';`));
+  console.log(`packages/cli/src/index.ts: VERSION -> ${newVersion}`);
+
+  const changelogPath = join(root, 'CHANGELOG.md');
+  writeFileSync(changelogPath, applyChangelogRelease(readFileSync(changelogPath, 'utf8'), newVersion));
+  console.log(`CHANGELOG.md: ## Unreleased -> ## ${newVersion} (fresh ## Unreleased added)`);
+
+  const check = spawnSync(process.execPath, [join(root, 'scripts/check-version-sync.mjs')], { stdio: 'inherit' });
+  process.exit(check.status ?? 1);
 }
 
-const cliSourcePath = join(root, 'packages/cli/src/index.ts');
-const cliSource = readFileSync(cliSourcePath, 'utf8');
-if (!/^const VERSION = '[^']+';$/m.test(cliSource)) {
-  console.error(`Could not find "const VERSION = '...'" in ${cliSourcePath}`);
-  process.exit(1);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
 }
-writeFileSync(cliSourcePath, cliSource.replace(/^const VERSION = '[^']+';$/m, `const VERSION = '${newVersion}';`));
-console.log(`packages/cli/src/index.ts: VERSION -> ${newVersion}`);
-
-const check = spawnSync(process.execPath, [join(root, 'scripts/check-version-sync.mjs')], { stdio: 'inherit' });
-process.exit(check.status ?? 1);

--- a/scripts/test-bump-version-changelog.mjs
+++ b/scripts/test-bump-version-changelog.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Standalone test for the CHANGELOG release roll in bump-version.mjs.
+// Run: node scripts/test-bump-version-changelog.mjs
+import assert from 'node:assert/strict';
+import { applyChangelogRelease } from './bump-version.mjs';
+
+// Renames the top Unreleased to the cut version and starts a fresh empty one.
+{
+  const input = [
+    '# Changelog',
+    '',
+    '## Unreleased',
+    '',
+    '- shipped thing',
+    '',
+    '## 0.0.4',
+    '',
+    '- older thing',
+    '',
+  ].join('\n');
+  const out = applyChangelogRelease(input, '0.0.7');
+  assert.match(out, /## Unreleased\n\n## 0\.0\.7\n\n- shipped thing/, 'Unreleased notes should move under ## 0.0.7');
+  const fresh = out.slice(out.indexOf('## Unreleased') + '## Unreleased'.length, out.indexOf('## 0.0.7'));
+  assert.equal(fresh.trim(), '', 'the fresh ## Unreleased must be empty');
+  assert.equal((out.match(/^## Unreleased$/gm) || []).length, 1, 'exactly one ## Unreleased remains');
+  assert.equal((out.match(/^## 0\.0\.4$/gm) || []).length, 1, 'older sections are left intact');
+}
+
+// Fails loudly when there is nothing staged to release.
+{
+  assert.throws(
+    () => applyChangelogRelease('# Changelog\n\n## 0.0.4\n\n- old\n', '0.0.7'),
+    /no "## Unreleased"/,
+    'must throw when there is no Unreleased section to roll',
+  );
+}
+
+console.log('ok bump-version changelog roll');


### PR DESCRIPTION
## Summary

Cutting a release runs `bump-version.mjs`, which rewrote every version string but never touched the changelog.

So a cut never renamed `## Unreleased` to the new version — `0.0.5` and `0.0.6` both shipped with no changelog heading, and notes piled up under `## Unreleased`.

The script now rolls the changelog on a cut: it renames the top `## Unreleased` to the new version and starts a fresh empty `## Unreleased`.

It also fails loudly when there is no `## Unreleased` to roll, instead of silently shipping an unlabeled version.

<details>
<summary>Review metadata</summary>

Review Claim: `bump-version.mjs` renames the top `## Unreleased` to the cut version and starts a fresh `## Unreleased`, and aborts when none exists.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Only the release cut path changes. The module now guards its `main()` so importing it (for the test, or check-version-sync) runs no side effects.

Slice Rationale: The script change plus its directly-affected test, kept apart from the one-time changelog correction it enables.

</details>

## Non-goals

This does not change `release.yml`, publishing, or version-string syncing. It does not retroactively fix the existing changelog — the next slice does that.

## Test Plan

- [x] `node scripts/test-bump-version-changelog.mjs`
- [x] `node scripts/check-version-sync.mjs`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
