### PR TITLE
[Release changelog](2) Record 0.0.5 and 0.0.6 cuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,20 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+- Add Slack-native coding workflows: plan from a lobby `@Invoker` mention against a checked-out repo with a selectable planning harness (`[preset]`/`[repo:]` tags), spin the plan up as a workflow in a private `workflow-<id>` channel, and drive or question that workflow in-channel using only its own planning conversation and task transcripts.
+
+## 0.0.6
+
 - Make `plan-to-invoker` use focused verification by default instead of mandatory `pnpm test` or `pnpm run test:all` gates.
 - Bound Action Graph diagnostics to indexed current task data so large databases return quickly.
 - Split queue assigning work from running work in the UI pills, queue rows, and task graph.
 - Review gates can now track PR stacks with optional dependency order, expose that stack through query surfaces and the side panel, and discard or close stale PRs when the gate is invalidated.
 - Model merge-gate PR status as a single `open`/`closed`/`merged` lifecycle so a PR can never be treated as merged and closed at the same time.
-- Add Slack-native coding workflows: plan from a lobby `@Invoker` mention against a checked-out repo with a selectable planning harness (`[preset]`/`[repo:]` tags), spin the plan up as a workflow in a private `workflow-<id>` channel, and drive or question that workflow in-channel using only its own planning conversation and task transcripts.
+
+## 0.0.5
+
+- Install the bundled `invoker-cli` automatically through the npm UI package and the desktop app.
+
 ## 0.0.4
 
 - Publish complete CLI and desktop release assets for npm launcher packages.

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,49 +1,77 @@
 #!/usr/bin/env node
-// Bumps every release version string in one run, then verifies they agree:
+// Bumps every release version string in one run, rolls the CHANGELOG for the
+// cut, then verifies the versions agree:
 //
-//   node scripts/bump-version.mjs 0.0.5
+//   node scripts/bump-version.mjs 0.0.7
 //
-// Covers the root + four publishable package.json files and the VERSION
-// constant baked into the CLI source. After this, commit and tag (vX.Y.Z) to
-// trigger the release workflow.
+// Covers the root + four publishable package.json files, the VERSION constant
+// baked into the CLI source, and CHANGELOG.md (renames "## Unreleased" to the
+// new version and starts a fresh "## Unreleased"). After this, commit and tag
+// (vX.Y.Z) to trigger the release workflow.
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { spawnSync } from 'node:child_process';
 
 const root = dirname(dirname(fileURLToPath(import.meta.url)));
-const newVersion = process.argv[2];
 
-if (!newVersion || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(newVersion)) {
-  console.error('Usage: node scripts/bump-version.mjs <semver, e.g. 0.0.5>');
-  process.exit(64);
+// Roll the CHANGELOG for a release: rename the top "## Unreleased" section to
+// "## <version>" and start a fresh empty "## Unreleased" above it. Throws when
+// there is no "## Unreleased" section so a cut fails loudly instead of silently
+// shipping a version with no changelog heading.
+export function applyChangelogRelease(changelog, version) {
+  const lines = changelog.split('\n');
+  const index = lines.findIndex((line) => line.trim() === '## Unreleased');
+  if (index === -1) {
+    throw new Error(
+      'CHANGELOG.md has no "## Unreleased" section to release. Add one with this release\'s notes before cutting a version.',
+    );
+  }
+  lines.splice(index, 1, '## Unreleased', '', `## ${version}`);
+  return lines.join('\n');
 }
 
-const packageJsonPaths = [
-  'package.json',
-  'packages/app/package.json',
-  'packages/cli/package.json',
-  'packages/npm-cli/package.json',
-  'packages/npm-ui/package.json',
-];
+function main() {
+  const newVersion = process.argv[2];
+  if (!newVersion || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(newVersion)) {
+    console.error('Usage: node scripts/bump-version.mjs <semver, e.g. 0.0.7>');
+    process.exit(64);
+  }
 
-for (const relPath of packageJsonPaths) {
-  const absPath = join(root, relPath);
-  const pkg = JSON.parse(readFileSync(absPath, 'utf8'));
-  const oldVersion = pkg.version;
-  pkg.version = newVersion;
-  writeFileSync(absPath, `${JSON.stringify(pkg, null, 2)}\n`);
-  console.log(`${relPath}: ${oldVersion} -> ${newVersion}`);
+  const packageJsonPaths = [
+    'package.json',
+    'packages/app/package.json',
+    'packages/cli/package.json',
+    'packages/npm-cli/package.json',
+    'packages/npm-ui/package.json',
+  ];
+
+  for (const relPath of packageJsonPaths) {
+    const absPath = join(root, relPath);
+    const pkg = JSON.parse(readFileSync(absPath, 'utf8'));
+    const oldVersion = pkg.version;
+    pkg.version = newVersion;
+    writeFileSync(absPath, `${JSON.stringify(pkg, null, 2)}\n`);
+    console.log(`${relPath}: ${oldVersion} -> ${newVersion}`);
+  }
+
+  const cliSourcePath = join(root, 'packages/cli/src/index.ts');
+  const cliSource = readFileSync(cliSourcePath, 'utf8');
+  if (!/^const VERSION = '[^']+';$/m.test(cliSource)) {
+    console.error(`Could not find "const VERSION = '...'" in ${cliSourcePath}`);
+    process.exit(1);
+  }
+  writeFileSync(cliSourcePath, cliSource.replace(/^const VERSION = '[^']+';$/m, `const VERSION = '${newVersion}';`));
+  console.log(`packages/cli/src/index.ts: VERSION -> ${newVersion}`);
+
+  const changelogPath = join(root, 'CHANGELOG.md');
+  writeFileSync(changelogPath, applyChangelogRelease(readFileSync(changelogPath, 'utf8'), newVersion));
+  console.log(`CHANGELOG.md: ## Unreleased -> ## ${newVersion} (fresh ## Unreleased added)`);
+
+  const check = spawnSync(process.execPath, [join(root, 'scripts/check-version-sync.mjs')], { stdio: 'inherit' });
+  process.exit(check.status ?? 1);
 }
 
-const cliSourcePath = join(root, 'packages/cli/src/index.ts');
-const cliSource = readFileSync(cliSourcePath, 'utf8');
-if (!/^const VERSION = '[^']+';$/m.test(cliSource)) {
-  console.error(`Could not find "const VERSION = '...'" in ${cliSourcePath}`);
-  process.exit(1);
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
 }
-writeFileSync(cliSourcePath, cliSource.replace(/^const VERSION = '[^']+';$/m, `const VERSION = '${newVersion}';`));
-console.log(`packages/cli/src/index.ts: VERSION -> ${newVersion}`);
-
-const check = spawnSync(process.execPath, [join(root, 'scripts/check-version-sync.mjs')], { stdio: 'inherit' });
-process.exit(check.status ?? 1);

--- a/scripts/test-bump-version-changelog.mjs
+++ b/scripts/test-bump-version-changelog.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Standalone test for the CHANGELOG release roll in bump-version.mjs.
+// Run: node scripts/test-bump-version-changelog.mjs
+import assert from 'node:assert/strict';
+import { applyChangelogRelease } from './bump-version.mjs';
+
+// Renames the top Unreleased to the cut version and starts a fresh empty one.
+{
+  const input = [
+    '# Changelog',
+    '',
+    '## Unreleased',
+    '',
+    '- shipped thing',
+    '',
+    '## 0.0.4',
+    '',
+    '- older thing',
+    '',
+  ].join('\n');
+  const out = applyChangelogRelease(input, '0.0.7');
+  assert.match(out, /## Unreleased\n\n## 0\.0\.7\n\n- shipped thing/, 'Unreleased notes should move under ## 0.0.7');
+  const fresh = out.slice(out.indexOf('## Unreleased') + '## Unreleased'.length, out.indexOf('## 0.0.7'));
+  assert.equal(fresh.trim(), '', 'the fresh ## Unreleased must be empty');
+  assert.equal((out.match(/^## Unreleased$/gm) || []).length, 1, 'exactly one ## Unreleased remains');
+  assert.equal((out.match(/^## 0\.0\.4$/gm) || []).length, 1, 'older sections are left intact');
+}
+
+// Fails loudly when there is nothing staged to release.
+{
+  assert.throws(
+    () => applyChangelogRelease('# Changelog\n\n## 0.0.4\n\n- old\n', '0.0.7'),
+    /no "## Unreleased"/,
+    'must throw when there is no Unreleased section to roll',
+  );
+}
+
+console.log('ok bump-version changelog roll');


### PR DESCRIPTION
## Summary

Because the cut script never renamed `## Unreleased`, the changelog jumped from `## Unreleased` straight to `## 0.0.4`, even though `0.0.5` and `0.0.6` were both released.

This rebuilds the history from the tags: the entries that were unreleased at the `v0.0.6` cut now sit under `## 0.0.6`, and `0.0.5` gets its own heading for what it shipped.

Only the work merged after `v0.0.6` stays under a fresh `## Unreleased`.

<details>
<summary>Review metadata</summary>

Review Claim: The changelog now records `0.0.5` and `0.0.6` with the entries each shipped, leaving only post-`0.0.6` work under `## Unreleased`.

Review Lane: docs

Review Unit: docs

Safety Invariant: Documentation only — `CHANGELOG.md` text is rearranged; no code changes.

Slice Rationale: A one-time history correction, kept apart from the script fix that prevents recurrence and the new entry stacked on top.

</details>

## Non-goals

This changes no code and does not alter the release script. It records only what the tags shipped.

## Test Plan

- [x] Reviewed the rendered changelog sections against the `v0.0.5`/`v0.0.6` tag contents
- [x] Dry-ran the cut roll on the result: a future cut yields a single empty `## Unreleased`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
