### PR TITLE
[Release changelog](3) Note activity_log retention cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to Invoker will be documented in this file.
 
 - Add Slack-native coding workflows: plan from a lobby `@Invoker` mention against a checked-out repo with a selectable planning harness (`[preset]`/`[repo:]` tags), spin the plan up as a workflow in a private `workflow-<id>` channel, and drive or question that workflow in-channel using only its own planning conversation and task transcripts.
 - Key the single-instance worker lock by worker kind, so different worker kinds can run at once while a second start of an already-running kind is still refused across both worker doors. The worker kind is validated before it becomes the lock filename, so it cannot escape the locks directory.
+- Cap the `activity_log` table to its most recent 100000 rows, pruned as new entries are written, so `~/.invoker/invoker.db` can no longer grow without bound and trigger SIGBUS crashes.
 
 ## 0.0.6
 


### PR DESCRIPTION
## Summary

This records the `activity_log` retention cap in the changelog.

It is stacked on the changelog reorg so the note lands under the corrected `## Unreleased`, not the stale one.

<details>
<summary>Review metadata</summary>

Review Claim: The changelog notes, under `## Unreleased`, that `activity_log` is now capped so the database cannot grow without bound.

Review Lane: docs

Review Unit: docs

Safety Invariant: Documentation only. No code or runtime behavior changes.

Slice Rationale: The activity_log changelog note kept on its own, stacked on the reorg it depends on. Supersedes the earlier standalone #2277.

</details>

## Non-goals

This changes no code and no runtime behavior. It only adds one changelog line.

## Test Plan

- [x] `git diff --stat` shows only `CHANGELOG.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The activity log is now kept to the most recent 100,000 entries, helping prevent the local database from growing indefinitely and reducing the risk of crash issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->