### PR TITLE
[Recovery Lifecycle 2i Step 3: Registry-driven door dispatch](1)

### DIFF
--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -86,4 +86,27 @@ describe('headless worker autofix', () => {
       'normal',
     );
   });
+
+  it('lists worker kinds from the registry', async () => {
+    let stdout = '';
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+      stdout += chunk.toString();
+      return true;
+    });
+
+    try {
+      await runHeadless(['worker', 'list'], {} as any);
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(stdout).toContain('Worker kinds');
+    expect(stdout).toContain('autofix');
+  });
+
+  it('rejects unknown worker kinds with a clear error', async () => {
+    await expect(runHeadless(['worker', 'missing-kind'], {} as any)).rejects.toThrow(
+      'Unknown worker kind: "missing-kind"',
+    );
+  });
 });

--- a/packages/app/src/cli-installer.ts
+++ b/packages/app/src/cli-installer.ts
@@ -116,6 +116,10 @@ function isWritableDir(dir: string): boolean {
   }
 }
 
+function canWriteCliTarget(cliPath: string): boolean {
+  return isWritableDir(dirname(cliPath));
+}
+
 export function selectInstallDir(
   context: CliInstallerContext,
 ): { dir: string; warning?: string } | null {
@@ -209,10 +213,11 @@ export function updateInvokerCli(context: CliInstallerContext): CliInstallResult
     if (installed?.version === context.appVersion) {
       return { ok: true, updated: false, installedTo: installed.path, status: resolveCliInstallerStatus(context) };
     }
-    // Prefer updating an existing install in place — its dir is already on
-    // the user's effective PATH.
+    // Prefer updating an existing install in place when the app can replace
+    // it. If PATH exposes a system-level install, fall back to a writable
+    // candidate instead of failing the whole install.
     let targetPath: string;
-    if (installed) {
+    if (installed && canWriteCliTarget(installed.path)) {
       targetPath = installed.path;
     } else {
       const selection = selectInstallDir(context);

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -13,8 +13,11 @@ import type { BundledSkillsInstallMode } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import {
+  AUTO_FIX_WORKER_KIND,
   TaskRunner,
   acquireWorkerLock,
+  createWorkerRegistry,
+  registerAutoFixWorker,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
 } from '@invoker/execution-engine';
@@ -34,7 +37,6 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
-import { createAutoFixRecoveryTick, RECOVERY_WORKER_KIND } from './workers/auto-fix-recovery.js';
 import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
 import {
   collectRecoveryWorkerStatus,
@@ -417,89 +419,78 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
   }
 }
 
-/**
- * Worker kinds exposed to the CLI.
- */
-const HEADLESS_WORKER_KINDS: ReadonlyArray<{ kind: string; available: boolean; note: string }> = [
-  {
-    kind: 'autofix',
-    available: true,
-    note: 'scans persisted failed tasks and submits normal auto-fix command intents',
-  },
-];
-
 async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0] ?? 'list';
-  if (subCommand === 'autofix') {
-    // Single-instance guard across both doors (this dev door and the production
-    // `invoker-cli worker autofix`): refuse rather than run a recovery scan that
-    // competes with a worker already holding the cross-process lock.
-    let lock;
-    try {
-      lock = acquireWorkerLock({ kind: RECOVERY_WORKER_KIND, homeRoot: resolveInvokerHomeRoot(), logger: deps.logger });
-    } catch (err) {
-      if (err instanceof WorkerLockHeldError) {
-        // Surface via the app's throw-based error convention.
-        throw new Error(err.message);
-      }
-      throw err;
-    }
-    try {
-      const tick = createAutoFixRecoveryTick({
-        store: deps.persistence,
-        submitter: {
-          submit: (workflowId, priority, channel, mutationArgs) => (
-            deps.persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority)
-          ),
-        },
-        logger: deps.logger,
-        defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
-        getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
-      });
-      await tick({
-        identity: { kind: RECOVERY_WORKER_KIND, instanceId: 'headless-worker-autofix' },
-        reason: 'manual',
-        tickNumber: 1,
-      });
-    } finally {
-      // Release deterministically so a clean run never leaves a stale lock that
-      // blocks the next legitimate start.
-      lock.release();
-    }
-    process.stdout.write('Auto-fix worker scan completed.\n');
-    return;
-  }
-
-  if (subCommand !== 'list' && subCommand !== 'status') {
-    throw new Error(`Unknown worker sub-command: "${subCommand}". Use: autofix, list, status`);
-  }
+  const registry = registerAutoFixWorker(createWorkerRegistry());
 
   if (subCommand === 'list') {
     process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);
-    for (const worker of HEADLESS_WORKER_KINDS) {
-      const status = worker.available ? 'available' : 'unavailable';
-      process.stdout.write(`  ${worker.kind} — ${status} (${worker.note})\n`);
+    for (const worker of registry.list()) {
+      process.stdout.write(`  ${worker.kind} — available (${worker.note})\n`);
     }
     return;
   }
 
-  const flags = parseQueryFlags(args.slice(1));
-  const status = collectRecoveryWorkerStatus(deps.persistence);
-  const { formatAsJson, formatAsJsonl } = await import('./formatter.js');
-  switch (flags.output) {
-    case 'label':
-      process.stdout.write(`${status.workerId}\n`);
-      break;
-    case 'json':
-      process.stdout.write(formatAsJson(status) + '\n');
-      break;
-    case 'jsonl':
-      process.stdout.write(formatAsJsonl([status]) + '\n');
-      break;
-    default:
-      process.stdout.write(formatRecoveryWorkerStatus(status) + '\n');
-      break;
+  if (subCommand === 'status') {
+    const flags = parseQueryFlags(args.slice(1));
+    const status = collectRecoveryWorkerStatus(deps.persistence);
+    const { formatAsJson, formatAsJsonl } = await import('./formatter.js');
+    switch (flags.output) {
+      case 'label':
+        process.stdout.write(`${status.workerId}\n`);
+        break;
+      case 'json':
+        process.stdout.write(formatAsJson(status) + '\n');
+        break;
+      case 'jsonl':
+        process.stdout.write(formatAsJsonl([status]) + '\n');
+        break;
+      default:
+        process.stdout.write(formatRecoveryWorkerStatus(status) + '\n');
+        break;
+    }
+    return;
   }
+
+  const definition = registry.get(subCommand);
+  if (!definition) {
+    const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
+    throw new Error(`Unknown worker kind: "${subCommand}". Use: ${knownKinds}, list, status`);
+  }
+
+  let lock;
+  try {
+    lock = acquireWorkerLock({ kind: definition.kind, homeRoot: resolveInvokerHomeRoot(), logger: deps.logger });
+  } catch (err) {
+    if (err instanceof WorkerLockHeldError) {
+      // Surface via the app's throw-based error convention.
+      throw new Error(err.message);
+    }
+    throw err;
+  }
+  try {
+    const worker = definition.factory({
+      store: deps.persistence,
+      submitter: {
+        submit: (workflowId, priority, channel, mutationArgs) => (
+          deps.persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority)
+        ),
+      },
+      logger: deps.logger,
+      autoFix: {
+        defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
+        getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
+      },
+    });
+    await worker.tick('manual');
+    await worker.stop();
+  } finally {
+    // Release deterministically so a clean run never leaves a stale lock that
+    // blocks the next legitimate start.
+    lock.release();
+  }
+  const label = definition.kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : definition.kind;
+  process.stdout.write(`${label} worker scan completed.\n`);
 }
 
 function formatRecoveryWorkerStatus(status: RecoveryWorkerStatus): string {
@@ -609,7 +600,7 @@ ${BOLD}Lifecycle:${RESET}
   delete-all                                          Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
   open-terminal <taskId>                              Open OS terminal for a task
   slack                                               Start Slack bot (long-running)
-  worker [autofix|list|status]                        Run/list worker kinds (autofix scans failed tasks)
+  worker [kind|list|status]                           Run/list registry worker kinds (autofix scans failed tasks)
 
 ${BOLD}Deprecated${RESET} (use new names above):
   list → query workflows       status → query tasks       task-status → query task

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -18,10 +18,26 @@ function writeStandalonePlan(dir: string, body: string): string {
   return planPath;
 }
 
-function runCli(args: string[]) {
-  return spawnSync(process.execPath, [cliPath, ...args], {
-    cwd: repoRoot,
-    encoding: 'utf8',
+function runCli(args: string[]): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.once('error', rejectRun);
+    child.once('close', (status) => {
+      resolveRun({ status, stdout, stderr });
+    });
   });
 }
 
@@ -66,17 +82,42 @@ describe('invoker-cli', () => {
     expect(lockfile).toContain('  zod@4.4.3:');
   });
 
-  it('--help exits 0', () => {
-    const result = runCli(['--help']);
+  it('--help exits 0', async () => {
+    const result = await runCli(['--help']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('invoker-cli run <plan.yaml>');
   });
 
-  it('--help lists the MCP server command and JSON-only output contract', () => {
-    const result = runCli(['--help']);
+  it('--help lists the MCP server command and JSON-only output contract', async () => {
+    const result = await runCli(['--help']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('invoker-cli mcp');
     expect(result.stdout).toContain('Emit only a machine-readable result summary on stdout.');
+  });
+
+  it('lists worker kinds from the registry', async () => {
+    const output = captureProcessOutput();
+
+    const code = await main(['worker', 'list'], {
+      createMessageBus: () => {
+        throw new Error('worker list should not open IPC');
+      },
+    });
+
+    expect(code).toBe(0);
+    expect(output.stdout).toContain('Worker kinds');
+    expect(output.stdout).toContain('autofix');
+    output.restore();
+  });
+
+  it('rejects unknown worker kinds with a clear non-zero error', async () => {
+    const output = captureProcessOutput();
+
+    const code = await main(['worker', 'missing-kind']);
+
+    expect(code).toBe(1);
+    expect(output.stderr).toContain('Unknown worker kind: "missing-kind"');
+    output.restore();
   });
 
   it('mcp command starts the MCP server runner', async () => {
@@ -88,16 +129,16 @@ describe('invoker-cli', () => {
     expect(runMcpServer).toHaveBeenCalledTimes(1);
   });
 
-  it('runs the hello-world fixture with an isolated db dir', () => {
+  it('runs the hello-world fixture with an isolated db dir', async () => {
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-test-db-'));
-    const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir]);
+    const result = await runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir]);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('hello-from-invoker-cli');
   });
 
-  it('--json emits only a workflow result object on stdout', () => {
+  it('--json emits only a workflow result object on stdout', async () => {
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-json-db-'));
-    const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir, '--json']);
+    const result = await runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir, '--json']);
     expect(result.status).toBe(0);
     const json = JSON.parse(result.stdout);
     expect(json.workflow.status).toBe('success');
@@ -105,11 +146,11 @@ describe('invoker-cli', () => {
     expect(result.stderr).toBe('');
   });
 
-  it('invalid YAML exits non-zero with a validation error', () => {
+  it('invalid YAML exits non-zero with a validation error', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-invalid-'));
     const invalidPlan = join(dir, 'invalid.yaml');
     writeFileSync(invalidPlan, 'name: [broken\n', 'utf8');
-    const result = runCli(['run', invalidPlan, '--standalone', '--db-dir', join(dir, 'db')]);
+    const result = await runCli(['run', invalidPlan, '--standalone', '--db-dir', join(dir, 'db')]);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('Invalid YAML');
   });
@@ -212,7 +253,7 @@ tasks:
     output.restore();
   }, 60_000);
 
-  it('standalone prompt-only plans route through the execution engine', () => {
+  it('standalone prompt-only plans route through the execution engine', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-prompt-'));
     const planPath = writeStandalonePlan(dir, `name: Prompt-only standalone
 repoUrl: __REPO_ROOT__
@@ -224,7 +265,7 @@ tasks:
     executionAgent: missing-agent
 `);
 
-    const result = runCli(['run', planPath, '--standalone', '--db-dir', join(dir, 'db'), '--json']);
+    const result = await runCli(['run', planPath, '--standalone', '--db-dir', join(dir, 'db'), '--json']);
 
     expect(result.status).not.toBe(0);
     const json = JSON.parse(result.stdout);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,14 +5,16 @@ import { pathToFileURL } from 'node:url';
 import { resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
 import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
 import {
+  AUTO_FIX_WORKER_KIND,
   ExecutorRegistry,
   TaskRunner,
   WorktreeExecutor,
-  createRecoveryWorker,
   acquireWorkerLock,
-  RECOVERY_WORKER_KIND,
+  createWorkerRegistry,
+  registerAutoFixWorker,
   WorkerLockHeldError,
   registerBuiltinAgents,
+  type WorkerDefinition,
 } from '@invoker/execution-engine';
 import {
   IpcBus,
@@ -118,7 +120,7 @@ function usage(): string {
     '  invoker-cli doctor [--fix] [--json]',
     '  invoker-cli setup [slack] [--check]',
     '  invoker-cli mcp',
-    '  invoker-cli worker autofix',
+    '  invoker-cli worker [autofix|list]',
     '  invoker-cli --help',
     '  invoker-cli --version',
     '',
@@ -127,7 +129,7 @@ function usage(): string {
     '  doctor          Validate tools, config, and your default planning preset.',
     '  setup [slack]    Validate the environment, then optionally configure Slack.',
     '  mcp             Start the Invoker MCP stdio server.',
-    '  worker autofix  Run the shared auto-fix recovery worker in the foreground.',
+    '  worker [kind|list]  Run a registry-selected worker or list available worker kinds.',
     '',
     'Options:',
     '  --live           Require a running Invoker UI owner and submit over IPC.',
@@ -459,27 +461,38 @@ function readAutoFixWorkerConfig(homeRoot: string): { autoFixRetries?: number; a
   }
 }
 
+function workerDisplayName(kind: string): string {
+  return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind;
+}
+
+function printWorkerKinds(): void {
+  const registry = registerAutoFixWorker(createWorkerRegistry());
+  process.stdout.write('Worker kinds\n');
+  for (const worker of registry.list()) {
+    process.stdout.write(`  ${worker.kind} — available (${worker.note})\n`);
+  }
+}
+
 /**
- * Run the auto-fix recovery worker in the foreground. There is exactly one
- * auto-fix engine: this builds the shared `createRecoveryWorker` from
- * `@invoker/execution-engine` (the same engine the app door uses) instead of a
- * private poll loop, so the two doors can never run competing scans. The shared
- * engine owns the scan, cadence, and lifecycle-wakeup subscription; the CLI owns
- * only the foreground lifetime — owner discovery, connect message, the
- * SIGINT/SIGTERM block, and a deterministic stop.
+ * Run a registry-selected worker in the foreground. There is exactly one
+ * auto-fix engine: the built-in registry entry builds the shared
+ * `createRecoveryWorker` from `@invoker/execution-engine` instead of a private
+ * poll loop, so the two doors can never run competing scans. The CLI owns the
+ * foreground lifetime — owner discovery, connect message, the SIGINT/SIGTERM
+ * block, and a deterministic stop.
  */
-async function runAutoFixWorker(bus: MessageBus): Promise<number> {
+async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
   const { autoFixRetries, autoFixAgent } = readAutoFixWorkerConfig(homeRoot);
 
-  // Single-instance guard: refuse if another auto-fix worker (this door or the
-  // dev `--headless worker autofix` door) already holds the cross-process lock,
-  // rather than spawning a second recovery loop that competes over the same
-  // failed tasks.
+  // Single-instance guard: refuse if another worker of this kind (this door or
+  // the dev `--headless worker <kind>` door) already holds the cross-process
+  // lock, rather than spawning a second recovery loop that competes over the
+  // same failed tasks.
   let lock;
   try {
-    lock = acquireWorkerLock({ kind: RECOVERY_WORKER_KIND, homeRoot, logger: silentLogger });
+    lock = acquireWorkerLock({ kind: definition.kind, homeRoot, logger: silentLogger });
   } catch (err) {
     if (err instanceof WorkerLockHeldError) {
       process.stderr.write(`${err.message}\n`);
@@ -495,19 +508,15 @@ async function runAutoFixWorker(bus: MessageBus): Promise<number> {
   // always closed even if construction or start throws (otherwise the SQLite
   // handle leaks when control unwinds to main()'s catch).
   try {
-    // The CLI owns the foreground signals so shutdown ordering is deterministic
-    // (signal -> unblock -> engine.stop() -> close); the engine does not also
-    // install its own handlers.
-    const worker = createRecoveryWorker({
+    const worker = definition.factory({
       logger: silentLogger,
-      installSignalHandlers: false,
       messageBus: bus,
+      store: persistence,
+      submitter: {
+        submit: (workflowId, priority, channel, mutationArgs) =>
+          persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority),
+      },
       autoFix: {
-        store: persistence,
-        submitter: {
-          submit: (workflowId, priority, channel, mutationArgs) =>
-            persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority),
-        },
         defaultAutoFixRetries: autoFixRetries,
         getAutoFixAgent: () => autoFixAgent,
       },
@@ -515,7 +524,7 @@ async function runAutoFixWorker(bus: MessageBus): Promise<number> {
 
     worker.start();
     const ownerSuffix = owner?.ownerId ? ` to owner ${owner.ownerId}` : '';
-    process.stdout.write(`Auto-fix worker connected${ownerSuffix}.\n`);
+    process.stdout.write(`${workerDisplayName(definition.kind)} worker connected${ownerSuffix}.\n`);
 
     await new Promise<void>((resolveShutdown) => {
       const shutdown = (): void => resolveShutdown();
@@ -529,7 +538,7 @@ async function runAutoFixWorker(bus: MessageBus): Promise<number> {
     lock.release();
     persistence.close();
   }
-  process.stdout.write('Auto-fix worker stopped.\n');
+  process.stdout.write(`${workerDisplayName(definition.kind)} worker stopped.\n`);
   return 0;
 }
 
@@ -547,12 +556,19 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
       return 0;
     }
     if (argv[0] === 'worker') {
-      const subcommand = argv[1];
-      if (subcommand !== 'autofix') {
-        throw new Error(`Unknown worker subcommand: ${subcommand ?? '(none)'}. Usage: invoker-cli worker autofix`);
+      const subcommand = argv[1] ?? 'list';
+      const registry = registerAutoFixWorker(createWorkerRegistry());
+      if (subcommand === 'list') {
+        printWorkerKinds();
+        return 0;
+      }
+      const definition = registry.get(subcommand);
+      if (!definition) {
+        const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
+        throw new Error(`Unknown worker kind: "${subcommand}". Usage: invoker-cli worker <${knownKinds}|list>`);
       }
       bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());
-      return await runAutoFixWorker(bus);
+      return await runWorker(definition, bus);
     }
     const parsed = parseArgs(argv);
     if (!parsed.command || parsed.command === '--help') {


### PR DESCRIPTION
## Summary

Both worker entry points now resolve the worker to run by kind from the registry.

The headless door and the CLI door stop branching on a hard-coded auto-fix name. The built-in autofix kind keeps its current behavior, so the existing command path stays intact.

After this slice, autofix is reached the same way as any other registered worker, and adding a worker no longer means editing a door branch.

<details>
<summary>Review metadata</summary>

Review Claim: Both worker doors select the worker to run by kind from the registry instead of a hard-coded auto-fix branch, and the built-in autofix keeps its current behavior.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The autofix kind resolves to the same worker as before, so the existing command behaves as the prior stack left it; behavior is unchanged for the existing command path.

Slice Rationale: Centralizing door selection on the registry is one selection-path claim, separable from the registry primitive and the per-kind lock.

</details>

## Non-goals

Does not change the auto-fix recovery logic.

Does not add external workers; that is a later step.

Does not touch the registry primitive or the per-kind lock, which landed in earlier slices.

## Architecture

### Before

```mermaid
graph TD
    headless["Headless door"] --> branch["Hard-coded auto-fix branch"]
    cli["CLI door"] --> branch
    branch --> worker["Built-in autofix worker"]
```

### After

```mermaid
graph TD
    headless["Headless door"] --> registry["Registry lookup by kind"]
    cli["CLI door"] --> registry
    registry --> lock["Per-kind lock"]
    lock --> worker["Worker selected by kind"]
```

## Test Plan

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/cli && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `worker` command now runs a selected worker kind and supports `worker list` (and `worker status`) with valid options shown when omitted.
  * Headless worker commands improved to support registry-driven `list`/`status` behavior.

* **Bug Fixes**
  * Unknown worker kinds now fail with a clearer error message listing valid kinds.
  * Worker runs now use per-worker-kind locking to reduce cross-process conflicts.

* **Tests**
  * Expanded worker CLI/headless test coverage and updated the CLI test runner to use async process execution.

* **Chores**
  * CLI installer now reuses an existing install location only when it’s writable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->