### PR TITLE
refactor(execution-engine): extract task-runner-phase-host from task-runner

### DIFF
--- a/packages/execution-engine/src/task-runner-phase-host.ts
+++ b/packages/execution-engine/src/task-runner-phase-host.ts
@@ -1,0 +1,46 @@
+/**
+ * Host surface shared by the task-runner execution phases.
+ *
+ * Each phase module (prepare / dispatch / finalize) takes a
+ * `TaskRunnerPhaseHost` — a subset of `TaskRunner`'s capabilities — as its
+ * first parameter. Defining it as a `Pick<TaskRunner, …>` keeps the phase
+ * signatures locked to the runner's real method shapes (no drift) while the
+ * type-only import avoids a runtime cycle with `task-runner.ts`.
+ */
+
+import type { TaskRunner } from './task-runner.js';
+
+export type TaskRunnerPhaseHost = Pick<
+  TaskRunner,
+  // Shared collaborators
+  | 'orchestrator'
+  | 'persistence'
+  | 'callbacks'
+  | 'logger'
+  | 'defaultBranch'
+  // Runner state touched across phases
+  | 'freshBaseCommits'
+  | 'pendingPoolSelections'
+  | 'activeExecutions'
+  | 'getExecutionPools'
+  // Prepare-phase helpers
+  | 'buildUpstreamContext'
+  | 'collectUpstreamBranches'
+  | 'buildAlternatives'
+  | 'resolveExternalDependencyTask'
+  | 'shouldUseFreshWorkspace'
+  | 'determineActionType'
+  // Dispatch-phase helpers
+  | 'selectExecutor'
+  | 'acquirePoolSelectionLease'
+  | 'renewPoolSelectionLease'
+  | 'releasePoolSelectionLease'
+  | 'logExecutorSelected'
+  | 'selectedRemoteTargetId'
+  | 'poolMemberKey'
+  // Shared lifecycle helpers
+  | 'isLaunchStale'
+  | 'executeNewlyStartedTasks'
+  | 'cleanupPerTaskDockerExecutor'
+  | 'runSerializedCompletion'
+>;


### PR DESCRIPTION
Moves the TaskRunnerPhaseHost seam type (the Pick<TaskRunner, ...> surface the execution phases consume) out of task-runner into task-runner-phase-host, behavior unchanged.
One atomic slice of the step-4 large-file decomposition.

Depends-On: #2316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal task-runner structure to better share common execution-phase behavior.
  * Reduced the risk of runtime dependency issues by making the shared surface type-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->