### PR TITLE
refactor(data-store): extract sqlite-row-mappers from sqlite-adapter

### DIFF
--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -29,8 +29,6 @@ import type {
   WorkflowRollup,
   WorkflowRollupTaskSummary,
   ExternalDependency,
-  ExternalDependencyChange,
-  DetachedExternalDependency,
 } from '@invoker/workflow-core';
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
 import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
@@ -58,6 +56,14 @@ import {
   WORKFLOWS_REBUILD_TABLE_DDL,
   WORKFLOWS_REBUILD_INSERT_DDL,
 } from './sqlite-schema.js';
+import {
+  mapRowToWorkflow,
+  mapRowToTask,
+  mapRowToAttempt,
+  mapRowToTaskLaunchDispatch,
+  mapRowToWorkflowMutationIntent,
+  mapRowToWorkflowMutationLease,
+} from './sqlite-row-mappers.js';
 
 type NativeSqlite = typeof import('node:sqlite');
 
@@ -2340,106 +2346,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   private rowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
-    return {
-      id: row.id,
-      name: row.name,
-      description: row.description ?? undefined,
-      visualProof: row.visual_proof === 1,
-      status: rollup?.status ?? 'pending',
-      rollup,
-      planFile: row.plan_file ?? undefined,
-      repoUrl: row.repo_url ?? undefined,
-      intermediateRepoUrl: row.intermediate_repo_url ?? undefined,
-      branch: row.branch ?? undefined,
-      onFinish: row.on_finish ?? undefined,
-      baseBranch: row.base_branch ?? undefined,
-      featureBranch: row.feature_branch ?? undefined,
-      mergeMode: row.merge_mode ?? undefined,
-      reviewProvider: row.review_provider ?? undefined,
-      externalDependencies: row.external_dependencies ? JSON.parse(row.external_dependencies) : undefined,
-      externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
-      detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
-      generation: row.generation ?? 0,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-    };
+    return mapRowToWorkflow(row, rollup);
   }
 
   private rowToTask(row: any): TaskState {
-    const normalizedStatus = row.status as TaskStatus;
-    return {
-      id: row.id,
-      description: row.description,
-      status: normalizedStatus,
-      dependencies: JSON.parse(row.dependencies || '[]'),
-      createdAt: new Date(row.created_at),
-      config: {
-        workflowId: row.workflow_id ?? undefined,
-        parentTask: row.parent_task ?? undefined,
-        command: row.command ?? undefined,
-        prompt: row.prompt ?? undefined,
-        externalDependencies: row.external_dependencies ? JSON.parse(row.external_dependencies) : undefined,
-        experimentPrompt: row.experiment_prompt ?? undefined,
-        pivot: row.pivot === 1 ? true : undefined,
-        experimentVariants: row.experiment_variants ? JSON.parse(row.experiment_variants) : undefined,
-        isReconciliation: row.is_reconciliation === 1 ? true : undefined,
-        requiresManualApproval: row.requires_manual_approval === 1 ? true : undefined,
-        featureBranch: row.feature_branch ?? undefined,
-        poolId: row.pool_id ?? undefined,
-        runnerKind: normalizeRunnerKind(row.runner_kind ?? undefined),
-        ...((row.pool_member_id ?? undefined) ? { poolMemberId: row.pool_member_id } : {}),
-        dockerImage: row.docker_image ?? undefined,
-        isMergeNode: row.is_merge_node === 1 ? true : undefined,
-        summary: row.summary ?? undefined,
-        problem: row.problem ?? undefined,
-        approach: row.approach ?? undefined,
-        testPlan: row.test_plan ?? undefined,
-        reproCommand: row.repro_command ?? undefined,
-        fixPrompt: row.fix_prompt ?? undefined,
-        fixContext: row.fix_context ?? undefined,
-        executionAgent: row.execution_agent ?? undefined,
-      },
-      execution: {
-        blockedBy: row.blocked_by ?? undefined,
-        inputPrompt: row.input_prompt ?? undefined,
-        exitCode: row.exit_code ?? undefined,
-        error: row.error ?? undefined,
-        protocolErrorCode: row.protocol_error_code ?? undefined,
-        protocolErrorMessage: row.protocol_error_message ?? undefined,
-        startedAt: row.started_at ? new Date(row.started_at) : undefined,
-        completedAt: row.completed_at ? new Date(row.completed_at) : undefined,
-        lastHeartbeatAt: row.last_heartbeat_at ? new Date(row.last_heartbeat_at) : undefined,
-        actionRequestId: row.action_request_id ?? undefined,
-        branch: row.branch ?? undefined,
-        commit: row.commit_hash ?? undefined,
-        fixedIntegrationSha: row.fixed_integration_sha ?? undefined,
-        fixedIntegrationRecordedAt: row.fixed_integration_recorded_at ? new Date(row.fixed_integration_recorded_at) : undefined,
-        fixedIntegrationSource: row.fixed_integration_source ?? undefined,
-        agentSessionId: row.agent_session_id || undefined,
-        lastAgentSessionId: row.last_agent_session_id || undefined,
-        agentName: row.agent_name ?? undefined,
-        lastAgentName: row.last_agent_name ?? undefined,
-        workspacePath: row.workspace_path ?? undefined,
-        containerId: row.container_id ?? undefined,
-        experiments: row.experiments ? JSON.parse(row.experiments) : undefined,
-        selectedExperiment: row.selected_experiment ?? undefined,
-        selectedExperiments: row.selected_experiments ? JSON.parse(row.selected_experiments) : undefined,
-        experimentResults: row.experiment_results ? JSON.parse(row.experiment_results) : undefined,
-        pendingFixError: row.pending_fix_error ?? undefined,
-        reviewUrl: row.review_url ?? undefined,
-        reviewId: row.review_id ?? undefined,
-        reviewStatus: row.review_status ?? undefined,
-        reviewProviderId: row.review_provider_id ?? undefined,
-        reviewGate: row.review_gate ? JSON.parse(row.review_gate) : undefined,
-        phase: row.launch_phase ?? undefined,
-        launchStartedAt: row.launch_started_at ? new Date(row.launch_started_at) : undefined,
-        launchCompletedAt: row.launch_completed_at ? new Date(row.launch_completed_at) : undefined,
-        generation: row.execution_generation ?? 0,
-        selectedAttemptId: row.selected_attempt_id ?? undefined,
-        autoFixAttempts: row.auto_fix_attempts ?? undefined,
-      },
-      taskStateVersion: row.task_state_version ?? 1,
-    };
+    return mapRowToTask(row);
   }
 
   private reconcileTaskFromSelectedAttempt(task: TaskState): TaskState {
@@ -2518,33 +2429,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   private rowToAttempt(row: any): Attempt {
-    return {
-      id: row.id,
-      nodeId: row.node_id,
-      queuePriority: Number(row.queue_priority ?? 0),
-      status: row.status,
-      claimedAt: row.claimed_at ? new Date(row.claimed_at) : undefined,
-      snapshotCommit: row.snapshot_commit ?? undefined,
-      baseBranch: row.base_branch ?? undefined,
-      upstreamAttemptIds: JSON.parse(row.upstream_attempt_ids || '[]'),
-      commandOverride: row.command_override ?? undefined,
-      promptOverride: row.prompt_override ?? undefined,
-      startedAt: row.started_at ? new Date(row.started_at) : undefined,
-      completedAt: row.completed_at ? new Date(row.completed_at) : undefined,
-      exitCode: row.exit_code ?? undefined,
-      error: row.error ?? undefined,
-      lastHeartbeatAt: row.last_heartbeat_at ? new Date(row.last_heartbeat_at) : undefined,
-      leaseExpiresAt: row.lease_expires_at ? new Date(row.lease_expires_at) : undefined,
-      branch: row.branch ?? undefined,
-      commit: row.commit_hash ?? undefined,
-      summary: row.summary ?? undefined,
-      workspacePath: row.workspace_path ?? undefined,
-      agentSessionId: row.agent_session_id || undefined,
-      containerId: row.container_id ?? undefined,
-      supersedesAttemptId: row.supersedes_attempt_id ?? undefined,
-      createdAt: new Date(row.created_at),
-      mergeConflict: row.merge_conflict ? JSON.parse(row.merge_conflict) : undefined,
-    };
+    return mapRowToAttempt(row);
   }
 
   enqueueWorkflowMutationIntent(
@@ -3309,25 +3194,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   private rowToTaskLaunchDispatch(row: Record<string, unknown>): TaskLaunchDispatch {
-    const priorityRaw = String(row.priority ?? 'normal');
-    const priority: TaskLaunchDispatchPriority =
-      priorityRaw === 'high' || priorityRaw === 'low' ? priorityRaw : 'normal';
-    return {
-      id: Number(row.id),
-      taskId: String(row.task_id),
-      attemptId: String(row.attempt_id),
-      workflowId: String(row.workflow_id),
-      state: String(row.state ?? 'enqueued') as TaskLaunchDispatchState,
-      priority,
-      dispatchOwner: row.dispatch_owner ? String(row.dispatch_owner) : undefined,
-      enqueuedAt: String(row.enqueued_at),
-      leasedAt: row.leased_at ? String(row.leased_at) : undefined,
-      completedAt: row.completed_at ? String(row.completed_at) : undefined,
-      fencedUntil: row.fenced_until ? String(row.fenced_until) : undefined,
-      attemptsCount: Number(row.attempts_count ?? 0),
-      lastError: row.last_error ? String(row.last_error) : undefined,
-      generation: Number(row.generation ?? 0),
-    };
+    return mapRowToTaskLaunchDispatch(row);
   }
 
   listWorkflowMutationLeases(): WorkflowMutationLease[] {
@@ -3367,33 +3234,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   private rowToWorkflowMutationIntent(row: Record<string, unknown>): WorkflowMutationIntent {
-    return {
-      id: Number(row.id),
-      workflowId: String(row.workflow_id),
-      channel: String(row.channel),
-      args: JSON.parse(String(row.args_json ?? '[]')),
-      priority: row.priority === 'high' ? 'high' : 'normal',
-      status: (row.status as WorkflowMutationIntentStatus) ?? 'queued',
-      ownerId: (row.owner_id as string) ?? undefined,
-      error: (row.error as string) ?? undefined,
-      createdAt: String(row.created_at),
-      startedAt: (row.started_at as string) ?? undefined,
-      completedAt: (row.completed_at as string) ?? undefined,
-    };
+    return mapRowToWorkflowMutationIntent(row);
   }
 
   private rowToWorkflowMutationLease(row: Record<string, unknown>): WorkflowMutationLease {
-    return {
-      workflowId: String(row.workflow_id),
-      ownerId: String(row.owner_id),
-      activeIntentId: row.active_intent_id === null || row.active_intent_id === undefined
-        ? undefined
-        : Number(row.active_intent_id),
-      activeMutationKind: row.active_mutation_kind ? String(row.active_mutation_kind) : undefined,
-      leasedAt: String(row.leased_at),
-      lastHeartbeatAt: String(row.last_heartbeat_at),
-      leaseExpiresAt: String(row.lease_expires_at),
-    };
+    return mapRowToWorkflowMutationLease(row);
   }
 
   private requeueWorkflowMutationLease(workflowId: string): void {

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -1,0 +1,212 @@
+/**
+ * Pure row → domain-object mappers for {@link SQLiteAdapter}.
+ *
+ * These functions translate raw SQLite result rows into the shapes the adapter
+ * returns to callers. They have no dependency on adapter state, so query
+ * semantics are unchanged — the adapter delegates to them from its `rowTo*`
+ * methods.
+ */
+
+import type {
+  TaskState,
+  TaskStatus,
+  Attempt,
+  WorkflowRollup,
+  ExternalDependencyChange,
+  DetachedExternalDependency,
+} from '@invoker/workflow-core';
+import { normalizeRunnerKind } from '@invoker/workflow-core';
+import type { Workflow } from './adapter.js';
+import type {
+  TaskLaunchDispatch,
+  TaskLaunchDispatchPriority,
+  TaskLaunchDispatchState,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationLease,
+} from './sqlite-adapter.js';
+
+export function mapRowToWorkflow(row: any, rollup?: WorkflowRollup): Workflow {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description ?? undefined,
+    visualProof: row.visual_proof === 1,
+    status: rollup?.status ?? 'pending',
+    rollup,
+    planFile: row.plan_file ?? undefined,
+    repoUrl: row.repo_url ?? undefined,
+    intermediateRepoUrl: row.intermediate_repo_url ?? undefined,
+    branch: row.branch ?? undefined,
+    onFinish: row.on_finish ?? undefined,
+    baseBranch: row.base_branch ?? undefined,
+    featureBranch: row.feature_branch ?? undefined,
+    mergeMode: row.merge_mode ?? undefined,
+    reviewProvider: row.review_provider ?? undefined,
+    externalDependencies: row.external_dependencies ? JSON.parse(row.external_dependencies) : undefined,
+    externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
+    detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) as DetachedExternalDependency[] : undefined,
+    generation: row.generation ?? 0,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export function mapRowToTask(row: any): TaskState {
+  const normalizedStatus = row.status as TaskStatus;
+  return {
+    id: row.id,
+    description: row.description,
+    status: normalizedStatus,
+    dependencies: JSON.parse(row.dependencies || '[]'),
+    createdAt: new Date(row.created_at),
+    config: {
+      workflowId: row.workflow_id ?? undefined,
+      parentTask: row.parent_task ?? undefined,
+      command: row.command ?? undefined,
+      prompt: row.prompt ?? undefined,
+      externalDependencies: row.external_dependencies ? JSON.parse(row.external_dependencies) : undefined,
+      experimentPrompt: row.experiment_prompt ?? undefined,
+      pivot: row.pivot === 1 ? true : undefined,
+      experimentVariants: row.experiment_variants ? JSON.parse(row.experiment_variants) : undefined,
+      isReconciliation: row.is_reconciliation === 1 ? true : undefined,
+      requiresManualApproval: row.requires_manual_approval === 1 ? true : undefined,
+      featureBranch: row.feature_branch ?? undefined,
+      poolId: row.pool_id ?? undefined,
+      runnerKind: normalizeRunnerKind(row.runner_kind ?? undefined),
+      ...((row.pool_member_id ?? undefined) ? { poolMemberId: row.pool_member_id } : {}),
+      dockerImage: row.docker_image ?? undefined,
+      isMergeNode: row.is_merge_node === 1 ? true : undefined,
+      summary: row.summary ?? undefined,
+      problem: row.problem ?? undefined,
+      approach: row.approach ?? undefined,
+      testPlan: row.test_plan ?? undefined,
+      reproCommand: row.repro_command ?? undefined,
+      fixPrompt: row.fix_prompt ?? undefined,
+      fixContext: row.fix_context ?? undefined,
+      executionAgent: row.execution_agent ?? undefined,
+    },
+    execution: {
+      blockedBy: row.blocked_by ?? undefined,
+      inputPrompt: row.input_prompt ?? undefined,
+      exitCode: row.exit_code ?? undefined,
+      error: row.error ?? undefined,
+      protocolErrorCode: row.protocol_error_code ?? undefined,
+      protocolErrorMessage: row.protocol_error_message ?? undefined,
+      startedAt: row.started_at ? new Date(row.started_at) : undefined,
+      completedAt: row.completed_at ? new Date(row.completed_at) : undefined,
+      lastHeartbeatAt: row.last_heartbeat_at ? new Date(row.last_heartbeat_at) : undefined,
+      actionRequestId: row.action_request_id ?? undefined,
+      branch: row.branch ?? undefined,
+      commit: row.commit_hash ?? undefined,
+      fixedIntegrationSha: row.fixed_integration_sha ?? undefined,
+      fixedIntegrationRecordedAt: row.fixed_integration_recorded_at ? new Date(row.fixed_integration_recorded_at) : undefined,
+      fixedIntegrationSource: row.fixed_integration_source ?? undefined,
+      agentSessionId: row.agent_session_id || undefined,
+      lastAgentSessionId: row.last_agent_session_id || undefined,
+      agentName: row.agent_name ?? undefined,
+      lastAgentName: row.last_agent_name ?? undefined,
+      workspacePath: row.workspace_path ?? undefined,
+      containerId: row.container_id ?? undefined,
+      experiments: row.experiments ? JSON.parse(row.experiments) : undefined,
+      selectedExperiment: row.selected_experiment ?? undefined,
+      selectedExperiments: row.selected_experiments ? JSON.parse(row.selected_experiments) : undefined,
+      experimentResults: row.experiment_results ? JSON.parse(row.experiment_results) : undefined,
+      pendingFixError: row.pending_fix_error ?? undefined,
+      reviewUrl: row.review_url ?? undefined,
+      reviewId: row.review_id ?? undefined,
+      reviewStatus: row.review_status ?? undefined,
+      reviewProviderId: row.review_provider_id ?? undefined,
+      reviewGate: row.review_gate ? JSON.parse(row.review_gate) : undefined,
+      phase: row.launch_phase ?? undefined,
+      launchStartedAt: row.launch_started_at ? new Date(row.launch_started_at) : undefined,
+      launchCompletedAt: row.launch_completed_at ? new Date(row.launch_completed_at) : undefined,
+      generation: row.execution_generation ?? 0,
+      selectedAttemptId: row.selected_attempt_id ?? undefined,
+      autoFixAttempts: row.auto_fix_attempts ?? undefined,
+    },
+    taskStateVersion: row.task_state_version ?? 1,
+  };
+}
+
+export function mapRowToAttempt(row: any): Attempt {
+  return {
+    id: row.id,
+    nodeId: row.node_id,
+    queuePriority: Number(row.queue_priority ?? 0),
+    status: row.status,
+    claimedAt: row.claimed_at ? new Date(row.claimed_at) : undefined,
+    snapshotCommit: row.snapshot_commit ?? undefined,
+    baseBranch: row.base_branch ?? undefined,
+    upstreamAttemptIds: JSON.parse(row.upstream_attempt_ids || '[]'),
+    commandOverride: row.command_override ?? undefined,
+    promptOverride: row.prompt_override ?? undefined,
+    startedAt: row.started_at ? new Date(row.started_at) : undefined,
+    completedAt: row.completed_at ? new Date(row.completed_at) : undefined,
+    exitCode: row.exit_code ?? undefined,
+    error: row.error ?? undefined,
+    lastHeartbeatAt: row.last_heartbeat_at ? new Date(row.last_heartbeat_at) : undefined,
+    leaseExpiresAt: row.lease_expires_at ? new Date(row.lease_expires_at) : undefined,
+    branch: row.branch ?? undefined,
+    commit: row.commit_hash ?? undefined,
+    summary: row.summary ?? undefined,
+    workspacePath: row.workspace_path ?? undefined,
+    agentSessionId: row.agent_session_id || undefined,
+    containerId: row.container_id ?? undefined,
+    supersedesAttemptId: row.supersedes_attempt_id ?? undefined,
+    createdAt: new Date(row.created_at),
+    mergeConflict: row.merge_conflict ? JSON.parse(row.merge_conflict) : undefined,
+  };
+}
+
+export function mapRowToTaskLaunchDispatch(row: Record<string, unknown>): TaskLaunchDispatch {
+  const priorityRaw = String(row.priority ?? 'normal');
+  const priority: TaskLaunchDispatchPriority =
+    priorityRaw === 'high' || priorityRaw === 'low' ? priorityRaw : 'normal';
+  return {
+    id: Number(row.id),
+    taskId: String(row.task_id),
+    attemptId: String(row.attempt_id),
+    workflowId: String(row.workflow_id),
+    state: String(row.state ?? 'enqueued') as TaskLaunchDispatchState,
+    priority,
+    dispatchOwner: row.dispatch_owner ? String(row.dispatch_owner) : undefined,
+    enqueuedAt: String(row.enqueued_at),
+    leasedAt: row.leased_at ? String(row.leased_at) : undefined,
+    completedAt: row.completed_at ? String(row.completed_at) : undefined,
+    fencedUntil: row.fenced_until ? String(row.fenced_until) : undefined,
+    attemptsCount: Number(row.attempts_count ?? 0),
+    lastError: row.last_error ? String(row.last_error) : undefined,
+    generation: Number(row.generation ?? 0),
+  };
+}
+
+export function mapRowToWorkflowMutationIntent(row: Record<string, unknown>): WorkflowMutationIntent {
+  return {
+    id: Number(row.id),
+    workflowId: String(row.workflow_id),
+    channel: String(row.channel),
+    args: JSON.parse(String(row.args_json ?? '[]')),
+    priority: row.priority === 'high' ? 'high' : 'normal',
+    status: (row.status as WorkflowMutationIntentStatus) ?? 'queued',
+    ownerId: (row.owner_id as string) ?? undefined,
+    error: (row.error as string) ?? undefined,
+    createdAt: String(row.created_at),
+    startedAt: (row.started_at as string) ?? undefined,
+    completedAt: (row.completed_at as string) ?? undefined,
+  };
+}
+
+export function mapRowToWorkflowMutationLease(row: Record<string, unknown>): WorkflowMutationLease {
+  return {
+    workflowId: String(row.workflow_id),
+    ownerId: String(row.owner_id),
+    activeIntentId: row.active_intent_id === null || row.active_intent_id === undefined
+      ? undefined
+      : Number(row.active_intent_id),
+    activeMutationKind: row.active_mutation_kind ? String(row.active_mutation_kind) : undefined,
+    leasedAt: String(row.leased_at),
+    lastHeartbeatAt: String(row.last_heartbeat_at),
+    leaseExpiresAt: String(row.lease_expires_at),
+  };
+}


### PR DESCRIPTION
Moves the row -> domain object mapping helpers out of sqlite-adapter into sqlite-row-mappers, behavior unchanged.
One atomic slice of the step-4 large-file decomposition.

Depends-On: #2321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified data loading by centralizing how database rows are converted into app records.
  * Improved consistency across workflows, tasks, attempts, dispatches, mutation intents, and leases.

* **Bug Fixes**
  * Standardized handling of optional values, timestamps, booleans, and JSON-backed fields to reduce data inconsistencies.
  * Improved default values for several records when database fields are missing or null.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->