### PR TITLE
refactor(app): extract headless-run-resume from headless.ts

### DIFF
--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -1,0 +1,849 @@
+/**
+ * Headless "execute" command family: run / resume / watch and the
+ * retry · recreate · rebase · fork · fix · resolve-conflict handlers.
+ *
+ * These commands load or re-drive workflow execution. They depend only on
+ * `headless-shared.ts` for cross-cutting infrastructure (TaskRunner wiring,
+ * workflow tracking, restore/preemption helpers) — never on the other
+ * command-family modules — keeping the import graph acyclic.
+ */
+
+import { makeEnvelope } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
+import {
+  remoteFetchForPool,
+  registerBuiltinAgents,
+  assertPlanExecutionAgentsRegistered,
+} from '@invoker/execution-engine';
+import { backupPlan } from './plan-backup.js';
+import { startApiServer } from './api-server.js';
+import {
+  fixWithAgentAction,
+  rebaseRetry,
+  rebaseRecreate,
+  resolveConflictAction,
+  forkWorkflow as sharedForkWorkflow,
+} from './workflow-actions.js';
+import { parseHeadlessFixArgs } from './auto-fix-intents.js';
+import {
+  dispatchStartedTasksWithGlobalTopup,
+  executeGlobalTopup,
+  finalizeMutationWithGlobalTopup,
+  isDispatchableLaunch,
+} from './global-topup.js';
+import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
+import { preemptWorkflowBeforeMutation } from './workflow-preemption.js';
+import {
+  type HeadlessDeps,
+  BOLD,
+  RESET,
+  createHeadlessExecutor,
+  wireHeadlessApproveHook,
+  wireHeadlessAutoFix,
+  buildHeadlessApiServerDeps,
+  trackHeadlessWorkflow,
+  restoreWorkflowForTaskUnlessDeleteAllWon,
+  withRestoredTaskUnlessDeleteAllWon,
+  preemptTaskSubgraph,
+  preemptWorkflowExecution,
+} from './headless-shared.js';
+
+export async function headlessWatch(workflowId: string | undefined, deps: HeadlessDeps): Promise<void> {
+  const workflows = deps.persistence.listWorkflows();
+  if (workflows.length === 0) {
+    process.stdout.write('No workflows found. Run a plan first.\n');
+    return;
+  }
+  const targetWorkflowId = workflowId ?? workflows[0]?.id;
+  const workflow = workflows.find((item) => item.id === targetWorkflowId);
+  if (!workflow || !targetWorkflowId) {
+    throw new Error(`Workflow "${workflowId}" not found.`);
+  }
+
+  process.stdout.write(`${BOLD}Watching workflow: ${workflow.id}${RESET}\n\n`);
+  const result = await trackHeadlessWorkflow(workflow.id, deps, {
+    printSnapshot: true,
+    printSummary: true,
+    printTaskOutput: false,
+    allowSignals: true,
+    syncFromDb: true,
+    setExitCodeOnFailure: true,
+  });
+  process.stdout.write(`\n[watch] done — ${result.status.completed} completed, ${result.status.failed} failed, ${result.status.closed} closed\n`);
+}
+
+export async function headlessRun(
+  planPath: string,
+  deps: HeadlessDeps,
+  waitForApproval?: boolean,
+  noTrack?: boolean,
+): Promise<void> {
+  const { orchestrator, repoRoot, invokerConfig } = deps;
+  if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
+
+  const { readFile } = await import('node:fs/promises');
+  const { parsePlanFile } = await import('./plan-parser.js');
+
+  const yamlSource = await readFile(planPath, 'utf-8');
+  const plan = await parsePlanFile(planPath);
+  const execRegistry = deps.executionAgentRegistry ?? registerBuiltinAgents();
+  assertPlanExecutionAgentsRegistered(plan, execRegistry);
+  backupPlan(plan, yamlSource, deps.logger);
+  process.stdout.write(`${BOLD}Loading plan: ${plan.name}${RESET}\n`);
+  process.stdout.write(`Tasks: ${plan.tasks.length}\n\n`);
+
+  const taskExecutor = createHeadlessExecutor(deps);
+  wireHeadlessApproveHook(deps, taskExecutor);
+  const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
+
+  const api = startApiServer({
+    logger: deps.logger,
+    orchestrator,
+    persistence: deps.persistence,
+    executorRegistry: deps.executorRegistry,
+    ...buildHeadlessApiServerDeps(deps, taskExecutor),
+  });
+
+  const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
+  orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+  const currentWorkflowId = orchestrator.getWorkflowIds().find((id) => !wfIdsBefore.has(id));
+  if (currentWorkflowId) process.stdout.write(`Workflow ID: ${currentWorkflowId}\n`);
+
+  const started = orchestrator.startExecution();
+
+  if (noTrack) {
+    if (started.length > 0) {
+      void Promise.resolve()
+        .then(() => taskExecutor.executeTasks(started))
+        .catch((err) => {
+          deps.logger.error(
+            `background no-track run failed for ${currentWorkflowId ?? 'unknown'}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+            { module: 'headless' },
+          );
+        });
+    }
+    process.stdout.write('[headless] --no-track enabled: submission accepted; exiting without tracking.\n');
+    await api.close().catch(() => {});
+    return;
+  }
+
+  if (started.length > 0) {
+    await taskExecutor.executeTasks(started);
+  }
+
+  if (currentWorkflowId) {
+    await trackHeadlessWorkflow(currentWorkflowId, deps, {
+      waitForApproval,
+      hasBackgroundWork: autoFix.isBusy,
+      printSnapshot: true,
+      printSummary: true,
+      printTaskOutput: true,
+      setExitCodeOnFailure: true,
+    });
+  }
+
+  await api.close().catch(() => {});
+  autoFix.unsubscribe();
+}
+
+export async function headlessResume(
+  workflowId: string,
+  deps: HeadlessDeps,
+  waitForApproval?: boolean,
+  noTrack?: boolean,
+): Promise<void> {
+  const { orchestrator } = deps;
+  if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
+
+  process.stdout.write(`${BOLD}Resuming workflow: ${workflowId}${RESET}\n\n`);
+
+  const taskExecutor = createHeadlessExecutor(deps);
+  wireHeadlessApproveHook(deps, taskExecutor);
+  const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
+
+  const api = startApiServer({
+    logger: deps.logger,
+    orchestrator,
+    persistence: deps.persistence,
+    executorRegistry: deps.executorRegistry,
+    ...buildHeadlessApiServerDeps(deps, taskExecutor),
+  });
+
+  orchestrator.syncFromDb(workflowId);
+  const allStarted = orchestrator.startExecution();
+
+  if (noTrack) {
+    if (allStarted.length > 0) {
+      void Promise.resolve()
+        .then(() => taskExecutor.executeTasks(allStarted))
+        .catch((err) => {
+          deps.logger.error(
+            `background no-track resume failed for ${workflowId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+            { module: 'headless' },
+          );
+        });
+    }
+    process.stdout.write('[headless] --no-track enabled: resume accepted; exiting without tracking.\n');
+    await api.close().catch(() => {});
+    autoFix.unsubscribe();
+    return;
+  }
+
+  if (allStarted.length === 0) {
+    await api.close().catch(() => {});
+    autoFix.unsubscribe();
+    return;
+  }
+
+  await taskExecutor.executeTasks(allStarted);
+
+  await trackHeadlessWorkflow(workflowId, deps, {
+    waitForApproval,
+    hasBackgroundWork: autoFix.isBusy,
+    printSnapshot: true,
+    printSummary: true,
+    printTaskOutput: true,
+    setExitCodeOnFailure: true,
+  });
+
+  await api.close().catch(() => {});
+  autoFix.unsubscribe();
+}
+
+export async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<void> {
+  if (!taskId) throw new Error('Missing arguments. Usage: --headless retry-task <taskId>');
+  await withRestoredTaskUnlessDeleteAllWon(taskId, deps, 'retry-task', async (restored) => {
+    taskId = restored.resolvedTaskId;
+    if (deps.mutationTiming) {
+      await deps.mutationTiming.span(
+        'headless.retry-task.preemptTaskSubgraph',
+        { taskId },
+        () => preemptTaskSubgraph(taskId, deps),
+      );
+    } else {
+      await preemptTaskSubgraph(taskId, deps);
+    }
+
+    const envelope = makeEnvelope('restart-task', 'headless', 'task', { taskId });
+    const result = deps.mutationTiming
+      ? await deps.mutationTiming.span(
+        'headless.retry-task.commandService.retryTask',
+        { taskId },
+        () => deps.commandService.retryTask(envelope),
+      )
+      : await deps.commandService.retryTask(envelope);
+    if (!result.ok) throw new Error(result.error.message);
+    const runnable = result.data.filter(isDispatchableLaunch);
+    process.stdout.write(`Restarted task "${taskId}" — ${runnable.length} task(s) to execute\n`);
+
+    if (deps.noTrack) {
+      const runningKey = (task: TaskState): string => {
+        const attemptId = task.execution.selectedAttemptId?.trim();
+        return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
+      };
+      const scopedKeys = new Set(runnable.map((task) => runningKey(task)));
+      const globalTopup = deps.orchestrator
+        .startExecution()
+        .filter(isDispatchableLaunch)
+        .filter((task) => !scopedKeys.has(runningKey(task)));
+      const dispatchable = [...runnable, ...globalTopup];
+      if (dispatchable.length > 0) {
+        if (deps.deferRunnableTasks) {
+          deps.deferRunnableTasks(dispatchable, restored.workflowId);
+        } else {
+          const taskExecutor = createHeadlessExecutor(deps);
+          const launch = setTimeout(() => {
+            void taskExecutor.executeTasks(dispatchable).catch((err) => {
+              deps.logger.error(
+                `background no-track task retry failed for ${taskId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+                { module: 'headless' },
+              );
+            });
+          }, 25);
+          launch.unref?.();
+        }
+      }
+      process.stdout.write('[headless] --no-track enabled: retry-task accepted; exiting without tracking.\n');
+      return;
+    }
+
+    const taskExecutor = createHeadlessExecutor(deps);
+    const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
+    const { topup } = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor,
+      logger: deps.logger,
+      context: 'headless.restart-task',
+      started: result.data,
+      scopedTaskIds: [taskId],
+      mutationTiming: deps.mutationTiming,
+    });
+    if (runnable.length + topup.length === 0) {
+      autoFix.unsubscribe();
+      return;
+    }
+    await trackHeadlessWorkflow(restored.workflowId, deps, {
+      hasBackgroundWork: autoFix.isBusy,
+      printSummary: false,
+      printTaskOutput: true,
+      setExitCodeOnFailure: false,
+    });
+    autoFix.unsubscribe();
+  });
+}
+
+export async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promise<void> {
+  const parsed = parseHeadlessFixArgs(rawArgs);
+  let taskId = parsed.taskId;
+  if (!taskId) throw new Error('Missing taskId. Usage: --headless fix <taskId> [claude|codex] [--auto-fix]');
+  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'fix');
+  if (!restored) return;
+  taskId = restored.resolvedTaskId;
+
+  if (parsed.autoFix) {
+    const task = deps.orchestrator.getTask(taskId);
+    const attemptsBefore = task?.execution.autoFixAttempts ?? 0;
+    deps.persistence.updateTask(taskId, { execution: { autoFixAttempts: attemptsBefore + 1 } });
+  }
+
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  const agent = (parsed.agentName ?? 'claude').toLowerCase();
+  try {
+    const result = await fixWithAgentAction(taskId, {
+      logger: deps.logger,
+      orchestrator: deps.orchestrator,
+      persistence: deps.persistence,
+      commandService: deps.commandService,
+      taskExecutor: te,
+      mutationTiming: deps.mutationTiming,
+      autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
+    }, {
+      agentName: agent,
+      recreateOutputLabel: 'Fix with AI',
+      failureOutputLabel: 'Fix with AI',
+      reviewGateContext: parsed.reviewGateContext,
+      signal: deps.signal,
+    });
+    await finalizeMutationWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: te,
+      logger: deps.logger,
+      context: 'headless.fix-with-agent',
+      started: result.started,
+      mutationTiming: deps.mutationTiming,
+      ...(result.kind === 'recreateWorkflowFromFreshBase'
+        ? { scopedWorkflowId: result.workflowId }
+        : { scopedTaskIds: [taskId] }),
+    });
+    if (result.kind === 'recreateWorkflowFromFreshBase') {
+      process.stdout.write(
+        `Startup merge conflict detected; recreated workflow ${result.workflowId} from a fresh base.\n`,
+      );
+      return;
+    }
+    process.stdout.write(
+      result.autoApproved
+        ? `Fix applied and auto-approved for task: ${taskId} (${agent}).\n`
+        : `Fix applied for task: ${taskId} (${agent}). Use 'approve ${taskId}' or 'reject ${taskId}' to finalize.\n`,
+    );
+  } catch (err) {
+    await finalizeMutationWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: te,
+      logger: deps.logger,
+      context: 'headless.fix-with-agent.failure',
+      mutationTiming: deps.mutationTiming,
+    });
+    throw err;
+  } finally {
+    autoFix.unsubscribe();
+  }
+}
+
+export async function headlessResolveConflict(taskId: string, deps: HeadlessDeps, agentArg?: string): Promise<void> {
+  if (!taskId) throw new Error('Missing taskId. Usage: --headless resolve-conflict <taskId> [claude|codex]');
+  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'resolve-conflict');
+  if (!restored) return;
+  taskId = restored.resolvedTaskId;
+
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  const agent = (agentArg ?? 'claude').toLowerCase();
+  try {
+    const result = await resolveConflictAction(taskId, {
+      ...deps,
+      taskExecutor: te,
+      autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
+    }, agent, deps.signal);
+    await finalizeMutationWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: te,
+      logger: deps.logger,
+      context: 'headless.resolve-conflict',
+      started: result.started,
+      mutationTiming: deps.mutationTiming,
+      scopedTaskIds: [taskId],
+    });
+    process.stdout.write(
+      deps.invokerConfig.autoApproveAIFixes
+        ? `Conflict resolved and auto-approved for task: ${taskId} (${agent}).\n`
+        : `Conflict resolved for task: ${taskId} (${agent}). Use 'approve ${taskId}' or 'reject ${taskId}' to finalize.\n`,
+    );
+  } catch (err) {
+    await finalizeMutationWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: te,
+      logger: deps.logger,
+      context: 'headless.resolve-conflict.failure',
+      mutationTiming: deps.mutationTiming,
+    });
+    throw err;
+  } finally {
+    autoFix.unsubscribe();
+  }
+}
+
+export async function headlessRebaseRetry(target: string, deps: HeadlessDeps): Promise<void> {
+  if (!target) throw new Error('Missing arguments. Usage: --headless rebase-retry <workflowId|mergeTaskId|taskId>');
+  const workflowId = resolveHeadlessTargetWorkflowId(target, deps.persistence);
+  await preemptWorkflowBeforeMutation(workflowId, {
+    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
+    logger: deps.logger,
+    context: 'headless.rebase-retry',
+    mutationTiming: deps.mutationTiming,
+  });
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  const started = await rebaseRetry(target, {
+    ...deps,
+    logger: deps.logger,
+    commandService: deps.commandService,
+    taskExecutor: te,
+    mutationTiming: deps.mutationTiming,
+  });
+  const runnable = started.filter(isDispatchableLaunch);
+  const { topup } = await dispatchStartedTasksWithGlobalTopup({
+    orchestrator: deps.orchestrator,
+    taskExecutor: te,
+    logger: deps.logger,
+    context: 'headless.rebase-retry',
+    started,
+    scopedWorkflowId: workflowId,
+    mutationTiming: deps.mutationTiming,
+  });
+  if (runnable.length + topup.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: rebase-retry accepted; exiting without tracking.\n');
+    autoFix.unsubscribe();
+    return;
+  }
+  await trackHeadlessWorkflow(workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
+  autoFix.unsubscribe();
+
+  const tasksStarted = runnable.length;
+  process.stdout.write(`Rebase-retry: retried workflow from fresh base (${tasksStarted} task(s))\n`);
+}
+
+export async function headlessRebaseRecreate(workflowTarget: string, deps: HeadlessDeps): Promise<void> {
+  if (!workflowTarget) throw new Error('Missing arguments. Usage: --headless rebase-recreate <workflowId|mergeTaskId|taskId>');
+  const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, deps.persistence);
+  await preemptWorkflowBeforeMutation(workflowId, {
+    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
+    logger: deps.logger,
+    context: 'headless.rebase-recreate',
+    mutationTiming: deps.mutationTiming,
+  });
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  const started = await rebaseRecreate(workflowTarget, {
+    ...deps,
+    logger: deps.logger,
+    commandService: deps.commandService,
+    taskExecutor: te,
+    mutationTiming: deps.mutationTiming,
+  });
+  const runnable = started.filter(isDispatchableLaunch);
+  const { topup } = await dispatchStartedTasksWithGlobalTopup({
+    orchestrator: deps.orchestrator,
+    taskExecutor: te,
+    logger: deps.logger,
+    context: 'headless.rebase-recreate',
+    started,
+    scopedWorkflowId: workflowId,
+    mutationTiming: deps.mutationTiming,
+  });
+  if (runnable.length + topup.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: rebase-recreate accepted; exiting without tracking.\n');
+    autoFix.unsubscribe();
+    return;
+  }
+  await trackHeadlessWorkflow(workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
+  autoFix.unsubscribe();
+
+  const tasksStarted = runnable.length;
+  process.stdout.write(`Rebase-recreate: recreated workflow from fresh base (${tasksStarted} task(s))\n`);
+}
+
+export async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {
+  if (!workflowId) {
+    throw new Error('Missing arguments. Usage: --headless recreate <workflowId>');
+  }
+  await preemptWorkflowBeforeMutation(workflowId, {
+    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
+    logger: deps.logger,
+    context: 'headless.recreate-workflow',
+    mutationTiming: deps.mutationTiming,
+  });
+  const recreateWfEnvelope = makeEnvelope('recreate-workflow', 'headless', 'workflow', { workflowId });
+  const recreateWfResult = deps.mutationTiming
+    ? await deps.mutationTiming.span(
+      'headless.recreate-workflow.commandService.recreateWorkflow',
+      undefined,
+      () => deps.commandService.recreateWorkflow(recreateWfEnvelope),
+    )
+    : await deps.commandService.recreateWorkflow(recreateWfEnvelope);
+  if (!recreateWfResult.ok) throw new Error(recreateWfResult.error.message);
+  const started = recreateWfResult.data;
+  const runnable = started.filter(isDispatchableLaunch);
+  if (runnable.length > 0) {
+    const te = createHeadlessExecutor(deps);
+    const autoFix = wireHeadlessAutoFix(deps, te);
+    remoteFetchForPool.enabled = false;
+    let topup: TaskState[] = [];
+    try {
+      await te.executeTasks(runnable);
+      topup = await executeGlobalTopup({
+        orchestrator: deps.orchestrator,
+        taskExecutor: te,
+        logger: deps.logger,
+        context: 'headless.recreate-workflow',
+        alreadyDispatched: runnable,
+        mutationTiming: deps.mutationTiming,
+      });
+    } finally {
+      remoteFetchForPool.enabled = true;
+    }
+    if (runnable.length + topup.length === 0) {
+      autoFix.unsubscribe();
+      return;
+    }
+    if (deps.noTrack) {
+      process.stdout.write('[headless] --no-track enabled: recreate accepted; exiting without tracking.\n');
+      autoFix.unsubscribe();
+      return;
+    }
+    await trackHeadlessWorkflow(workflowId, deps, {
+      hasBackgroundWork: autoFix.isBusy,
+      printSummary: false,
+      printTaskOutput: true,
+      setExitCodeOnFailure: false,
+    });
+    autoFix.unsubscribe();
+  }
+  const tasksStarted = runnable.length;
+  process.stdout.write(`Recreate workflow "${workflowId}" — ${tasksStarted} task(s) to execute (pool fetch skipped)\n`);
+}
+
+export async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise<void> {
+  if (!taskId) {
+    throw new Error('Missing arguments. Usage: --headless recreate-task <taskId>');
+  }
+  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'recreate-task');
+  if (!restored) return;
+  taskId = restored.resolvedTaskId;
+  if (deps.mutationTiming) {
+    await deps.mutationTiming.span(
+      'headless.recreate-task.preemptTaskSubgraph',
+      { taskId },
+      () => preemptTaskSubgraph(taskId, deps),
+    );
+  } else {
+    await preemptTaskSubgraph(taskId, deps);
+  }
+
+  const recreateTaskEnvelope = makeEnvelope('recreate-task', 'headless', 'task', { taskId });
+  const recreateTaskResult = deps.mutationTiming
+    ? await deps.mutationTiming.span(
+      'headless.recreate-task.commandService.recreateTask',
+      { taskId },
+      () => deps.commandService.recreateTask(recreateTaskEnvelope),
+    )
+    : await deps.commandService.recreateTask(recreateTaskEnvelope);
+  if (!recreateTaskResult.ok) throw new Error(recreateTaskResult.error.message);
+  const started = recreateTaskResult.data;
+  const runnable = started.filter(isDispatchableLaunch);
+  const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
+  process.stdout.write(`Recreate task "${taskId}" (+ downstream) — ${runnable.length} task(s) to execute (pool fetch skipped)\n`);
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  remoteFetchForPool.enabled = false;
+  let topup: TaskState[] = [];
+  try {
+    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: te,
+      logger: deps.logger,
+      context: 'headless.recreate-task',
+      started,
+      mutationTiming: deps.mutationTiming,
+    }));
+  } finally {
+    remoteFetchForPool.enabled = true;
+  }
+  if (runnable.length + topup.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: recreate-task accepted; exiting without tracking.\n');
+    autoFix.unsubscribe();
+    return;
+  }
+  if (workflowId) {
+    await trackHeadlessWorkflow(workflowId, deps, {
+      hasBackgroundWork: autoFix.isBusy,
+      printSummary: false,
+      printTaskOutput: true,
+      setExitCodeOnFailure: false,
+    });
+  }
+  autoFix.unsubscribe();
+}
+
+export async function headlessRecreateDownstream(taskId: string, deps: HeadlessDeps): Promise<void> {
+  if (!taskId) {
+    throw new Error('Missing arguments. Usage: --headless recreate-downstream <taskId>');
+  }
+  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'recreate-downstream');
+  if (!restored) return;
+  taskId = restored.resolvedTaskId;
+  if (deps.mutationTiming) {
+    await deps.mutationTiming.span(
+      'headless.recreate-downstream.preemptTaskSubgraph',
+      { taskId },
+      () => preemptTaskSubgraph(taskId, deps),
+    );
+  } else {
+    await preemptTaskSubgraph(taskId, deps);
+  }
+
+  const envelope = makeEnvelope('recreate-downstream', 'headless', 'task', { taskId });
+  const result = deps.mutationTiming
+    ? await deps.mutationTiming.span(
+      'headless.recreate-downstream.commandService.recreateDownstream',
+      { taskId },
+      () => deps.commandService.recreateDownstream(envelope),
+    )
+    : await deps.commandService.recreateDownstream(envelope);
+  if (!result.ok) throw new Error(result.error.message);
+  const started = result.data;
+  const runnable = started.filter(isDispatchableLaunch);
+  const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
+  process.stdout.write(`Recreate downstream of "${taskId}" — ${runnable.length} task(s) to execute (pool fetch skipped)\n`);
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  remoteFetchForPool.enabled = false;
+  let topup: TaskState[] = [];
+  try {
+    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: te,
+      logger: deps.logger,
+      context: 'headless.recreate-downstream',
+      started,
+      mutationTiming: deps.mutationTiming,
+    }));
+  } finally {
+    remoteFetchForPool.enabled = true;
+  }
+  if (runnable.length + topup.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: recreate-downstream accepted; exiting without tracking.\n');
+    autoFix.unsubscribe();
+    return;
+  }
+  if (workflowId) {
+    await trackHeadlessWorkflow(workflowId, deps, {
+      hasBackgroundWork: autoFix.isBusy,
+      printSummary: false,
+      printTaskOutput: true,
+      setExitCodeOnFailure: false,
+    });
+  }
+  autoFix.unsubscribe();
+}
+
+export async function headlessForkWorkflow(
+  workflowId: string,
+  deps: HeadlessDeps,
+): Promise<void> {
+  if (!workflowId) {
+    throw new Error('Missing arguments. Usage: --headless fork-workflow <workflowId>');
+  }
+  const result = sharedForkWorkflow(workflowId, {
+    orchestrator: deps.orchestrator,
+    logger: deps.logger,
+  });
+  const taskExecutor = createHeadlessExecutor(deps);
+  const { runnable } = await dispatchStartedTasksWithGlobalTopup({
+    orchestrator: deps.orchestrator,
+    taskExecutor,
+    logger: deps.logger,
+    context: 'headless.fork-workflow',
+    started: result.started,
+    scopedWorkflowId: result.forkedWorkflowId,
+  });
+  process.stdout.write(
+    `Forked workflow ${result.sourceWorkflowId} → ${result.forkedWorkflowId}; ` +
+      `launched ${runnable.length} task(s)\n`,
+  );
+}
+
+export async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {
+  if (!workflowId) {
+    throw new Error('Missing arguments. Usage: --headless retry <workflowId>');
+  }
+  deps.logger.info(`headlessRetryWorkflow begin workflow="${workflowId}" noTrack=${deps.noTrack ? 'true' : 'false'}`, {
+    module: 'headless',
+  });
+  await preemptWorkflowBeforeMutation(workflowId, {
+    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
+    logger: deps.logger,
+    context: 'headless.retry-workflow',
+    mutationTiming: deps.mutationTiming,
+  });
+  const envelope = makeEnvelope('retry-workflow', 'headless', 'workflow', { workflowId });
+  const result = deps.mutationTiming
+    ? await deps.mutationTiming.span(
+      'headless.retry-workflow.commandService.retryWorkflow',
+      undefined,
+      () => deps.commandService.retryWorkflow(envelope),
+    )
+    : await deps.commandService.retryWorkflow(envelope);
+  if (!result.ok) throw new Error(result.error.message);
+  const statusCounts = result.data.reduce<Record<string, number>>((acc, task) => {
+    acc[task.status] = (acc[task.status] ?? 0) + 1;
+    return acc;
+  }, {});
+  deps.logger.info(
+    `headlessRetryWorkflow trace workflow="${workflowId}" retryResult total=${result.data.length} statusCounts=${JSON.stringify(statusCounts)}`,
+    { module: 'headless' },
+  );
+  const retryRunningSummary = result.data
+    .filter(isDispatchableLaunch)
+    .map((task) => `${task.id}(${task.config.workflowId ?? 'unknown'})`);
+  if (retryRunningSummary.length > 0) {
+    deps.logger.info(
+      `headlessRetryWorkflow trace workflow="${workflowId}" retryResult running=[${retryRunningSummary.join(', ')}]`,
+      { module: 'headless' },
+    );
+  }
+  const runnable = result.data.filter(isDispatchableLaunch);
+  const crossWorkflow = runnable.filter((t) => t.config.workflowId !== workflowId);
+  if (crossWorkflow.length > 0) {
+    deps.logger.info(
+      `headlessRetryWorkflow dispatching cross-workflow runnable tasks for "${workflowId}": ${crossWorkflow.map((task) => `${task.id}(${task.config.workflowId ?? 'unknown'})`).join(', ')}`,
+      { module: 'headless' },
+    );
+  }
+  deps.logger.info(`headlessRetryWorkflow retry complete workflow="${workflowId}" runnable=${runnable.length}`, {
+    module: 'headless',
+  });
+
+  const runningKey = (task: TaskState): string => {
+    const attemptId = task.execution.selectedAttemptId?.trim();
+    return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
+  };
+  const scopedKeys = new Set(runnable.map((task) => runningKey(task)));
+  const globalTopup = deps.orchestrator
+    .startExecution()
+    .filter(isDispatchableLaunch)
+    .filter((task) => !scopedKeys.has(runningKey(task)));
+  deps.logger.info(
+    `headlessRetryWorkflow trace workflow="${workflowId}" postStartExecution globalTopup=${globalTopup.length}`,
+    { module: 'headless' },
+  );
+  if (globalTopup.length > 0) {
+    deps.logger.info(
+      `headlessRetryWorkflow trace workflow="${workflowId}" globalTopup running=[${globalTopup.map((task) => `${task.id}(${task.config.workflowId ?? 'unknown'})`).join(', ')}]`,
+      { module: 'headless' },
+    );
+  }
+  const dispatchable = [...runnable, ...globalTopup];
+  deps.logger.info(
+    `headlessRetryWorkflow trace workflow="${workflowId}" dispatchable=${dispatchable.length} ids=[${dispatchable.map((task) => `${task.id}(${task.config.workflowId ?? 'unknown'})`).join(', ')}]`,
+    { module: 'headless' },
+  );
+
+  process.stdout.write(`Retry workflow "${workflowId}" — ${dispatchable.length} task(s) to execute (completed tasks preserved)\n`);
+  if (dispatchable.length === 0) return;
+
+  if (deps.noTrack) {
+    if (deps.deferRunnableTasks) {
+      deps.deferRunnableTasks(dispatchable, workflowId);
+    } else {
+      const te = createHeadlessExecutor(deps);
+      const launch = setTimeout(() => {
+        void te.executeTasks(dispatchable).catch((err) => {
+          deps.logger.error(
+            `background no-track workflow retry failed for ${workflowId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+            { module: 'headless' },
+          );
+        });
+      }, 25);
+      launch.unref?.();
+    }
+    process.stdout.write('[headless] --no-track enabled: retry accepted; exiting without tracking.\n');
+    return;
+  }
+
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  remoteFetchForPool.enabled = false;
+  let topup: TaskState[] = [];
+  try {
+    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: te,
+      logger: deps.logger,
+      context: 'headless.retry-workflow',
+      started: dispatchable,
+      scopedWorkflowId: workflowId,
+      mutationTiming: deps.mutationTiming,
+    }));
+  } finally {
+    remoteFetchForPool.enabled = true;
+  }
+  if (runnable.length + topup.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  await trackHeadlessWorkflow(workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
+  autoFix.unsubscribe();
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1,93 +1,72 @@
 /**
  * Headless CLI logic extracted from main.ts.
  *
- * All functions that implement `--headless <command>` live here.
- * They receive shared services via a `HeadlessDeps` object instead of
- * accessing module-level variables directly.
+ * This file owns the headless command router (`runHeadless`), the usage text,
+ * the `set <sub>` configure family, and the long-running `slack`/`worker`
+ * commands. The per-family command handlers live in dedicated modules:
  *
- * Business logic (orchestrator mutations) lives in workflow-actions.ts.
- * This file handles CLI parsing, TaskRunner lifecycle, and output formatting.
+ *   - `headless-shared.ts`        — shared infra (HeadlessDeps, TaskRunner
+ *                                    wiring, workflow tracking, restore /
+ *                                    preemption / flag-parsing helpers)
+ *   - `headless-run-resume.ts`    — run / resume / watch / retry / recreate /
+ *                                    rebase / fork / fix / resolve-conflict
+ *   - `headless-query-list.ts`    — read-only `query <sub>` + cost + session
+ *   - `headless-approve-delete.ts`— approve / reject / input / select +
+ *                                    cancel / delete / detach / open-terminal
+ *
+ * The public surface (consumed by main.ts, IPC, and tests) is re-exported
+ * below so import sites are unchanged. Business logic (orchestrator
+ * mutations) lives in workflow-actions.ts.
  */
 
-import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@invoker/contracts';
+import type { BundledSkillsInstallMode } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
-import type { AgentSessionData } from '@invoker/contracts';
-import { OrchestratorErrorCode } from '@invoker/workflow-core';
-import type { Attempt, Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
-import type { SQLiteAdapter } from '@invoker/data-store';
-import { Channels } from '@invoker/transport';
-import type { MessageBus } from '@invoker/transport';
-import {
-  ExecutorRegistry,
-  TaskRunner,
-  GitHubMergeGateProvider,
-  ReviewProviderRegistry,
-  remoteFetchForPool,
-  registerBuiltinAgents,
-  assertPlanExecutionAgentsRegistered,
-  type AgentRegistry,
-  type TaskHeartbeatEvent,
-} from '@invoker/execution-engine';
-import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from './config.js';
-import { backupPlan } from './plan-backup.js';
+import type { TaskState } from '@invoker/workflow-core';
+import type { TaskRunner } from '@invoker/execution-engine';
 import { startApiServer } from './api-server.js';
-import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
   parseMetadataValue,
   setTaskMetadata,
   setWorkflowMetadata,
 } from './metadata-setter.js';
 import {
-  approveTask,
-  autoFixOnReviewGateFailure,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
-  fixWithAgentAction,
-  rebaseRetry,
-  rebaseRecreate,
-  resolveConflictAction,
-  forkWorkflow as sharedForkWorkflow,
   setWorkflowMergeMode,
 } from './workflow-actions.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
-import { parseHeadlessFixArgs } from './auto-fix-intents.js';
-import type { CostGroupDimension } from './cost-rollup.js';
-import { openExternalTerminalForTask } from './open-terminal-for-task.js';
-import {
-  dispatchStartedTasksWithGlobalTopup,
-  executeGlobalTopup,
-  finalizeMutationWithGlobalTopup,
-  isDispatchableLaunch,
-} from './global-topup.js';
+import { isDispatchableLaunch } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import { createAutoFixRecoveryTick, RECOVERY_WORKER_KIND } from './workers/auto-fix-recovery.js';
-import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
-import { trackWorkflow } from './headless-watch.js';
-import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
-import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
-import type { RuntimeServices } from '@invoker/runtime-service';
-
 import {
   type HeadlessDeps,
-  type QueryFlags,
-  type HeadlessAutoFixController,
-  RESET,
   BOLD,
+  RESET,
   YELLOW,
-  buildHeadlessApiServerDeps,
   createHeadlessExecutor,
-  wireHeadlessAutoFix,
   wireHeadlessApproveHook,
-  parseQueryFlags,
+  wireHeadlessAutoFix,
+  buildHeadlessApiServerDeps,
   trackHeadlessWorkflow,
   restoreWorkflowForTask,
-  tryRestoreWorkflowForTask,
   restoreWorkflowForTaskUnlessDeleteAllWon,
   withRestoredTaskUnlessDeleteAllWon,
-  waitForCompletion,
-  preemptTaskSubgraph,
-  preemptWorkflowExecution,
 } from './headless-shared.js';
+import {
+  headlessRun,
+  headlessResume,
+  headlessWatch,
+  headlessRetryWorkflow,
+  headlessRetryTask,
+  headlessRecreateWorkflow,
+  headlessRecreateTask,
+  headlessRecreateDownstream,
+  headlessForkWorkflow,
+  headlessRebaseRetry,
+  headlessRebaseRecreate,
+  headlessFix,
+  headlessResolveConflict,
+} from './headless-run-resume.js';
 import {
   headlessQuery,
   headlessQuerySelect,
@@ -103,6 +82,9 @@ import {
   headlessDetachWorkflow,
   headlessOpenTerminal,
 } from './headless-approve-delete.js';
+
+// ── Public re-exports (stable surface for main.ts, IPC, and tests) ──
+
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
   WORKFLOW_DELEGATION_TIMEOUT_MS,
@@ -115,11 +97,28 @@ export {
   tryDelegateRun,
 } from './headless-delegation.js';
 export type { DelegationOutcome } from './headless-delegation.js';
-export { resolveAgentSession } from './headless-query-list.js';
-export { createHeadlessExecutor, wireHeadlessAutoFix, wireHeadlessApproveHook, parseQueryFlags };
-export type { HeadlessDeps, QueryFlags, HeadlessAutoFixController };
 
-// ── HeadlessDeps interface ───────────────────────────────────
+export { createHeadlessExecutor, wireHeadlessAutoFix, wireHeadlessApproveHook };
+export { parseQueryFlags } from './headless-shared.js';
+export type { HeadlessDeps, QueryFlags, HeadlessAutoFixController } from './headless-shared.js';
+export { resolveAgentSession } from './headless-query-list.js';
+
+// ── Deprecation Warning ─────────────────────────────────────
+
+function warnDeprecated(oldCmd: string, newCmd: string): void {
+  process.stderr.write(
+    `${YELLOW}[deprecated]${RESET} "${oldCmd}" is deprecated. Use "${newCmd}" instead.\n`,
+  );
+}
+
+function assertDeleteAllEnabled(): void {
+  if (process.env.INVOKER_ALLOW_DELETE_ALL === '1') return;
+  throw new Error(
+    'delete-all is disabled by default. Set INVOKER_ALLOW_DELETE_ALL=1 to enable it explicitly.',
+  );
+}
+
+// ── Runnable-task dispatch (set/edit family) ─────────────────
 
 async function dispatchHeadlessRunnableTasks(
   deps: HeadlessDeps,
@@ -162,20 +161,7 @@ async function dispatchHeadlessRunnableTasks(
   await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
-function warnDeprecated(oldCmd: string, newCmd: string): void {
-  process.stderr.write(
-    `${YELLOW}[deprecated]${RESET} "${oldCmd}" is deprecated. Use "${newCmd}" instead.\n`,
-  );
-}
-
-function assertDeleteAllEnabled(): void {
-  if (process.env.INVOKER_ALLOW_DELETE_ALL === '1') return;
-  throw new Error(
-    'delete-all is disabled by default. Set INVOKER_ALLOW_DELETE_ALL=1 to enable it explicitly.',
-  );
-}
-
-// ── Query Flag Parsing ──────────────────────────────────────
+// ── Set Router ──────────────────────────────────────────────
 
 async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0];
@@ -575,809 +561,8 @@ ${BOLD}Options:${RESET}
 `);
 }
 
-async function headlessWatch(workflowId: string | undefined, deps: HeadlessDeps): Promise<void> {
-  const workflows = deps.persistence.listWorkflows();
-  if (workflows.length === 0) {
-    process.stdout.write('No workflows found. Run a plan first.\n');
-    return;
-  }
-  const targetWorkflowId = workflowId ?? workflows[0]?.id;
-  const workflow = workflows.find((item) => item.id === targetWorkflowId);
-  if (!workflow || !targetWorkflowId) {
-    throw new Error(`Workflow "${workflowId}" not found.`);
-  }
+// ── Configure: edit family ───────────────────────────────────
 
-  process.stdout.write(`${BOLD}Watching workflow: ${workflow.id}${RESET}\n\n`);
-  const result = await trackHeadlessWorkflow(workflow.id, deps, {
-    printSnapshot: true,
-    printSummary: true,
-    printTaskOutput: false,
-    allowSignals: true,
-    syncFromDb: true,
-    setExitCodeOnFailure: true,
-  });
-  process.stdout.write(`\n[watch] done — ${result.status.completed} completed, ${result.status.failed} failed, ${result.status.closed} closed\n`);
-}
-
-// ── Headless Commands ────────────────────────────────────────
-
-async function headlessRun(
-  planPath: string,
-  deps: HeadlessDeps,
-  waitForApproval?: boolean,
-  noTrack?: boolean,
-): Promise<void> {
-  const { orchestrator, repoRoot, invokerConfig } = deps;
-  if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-
-  const { readFile } = await import('node:fs/promises');
-  const { parsePlanFile } = await import('./plan-parser.js');
-
-  const yamlSource = await readFile(planPath, 'utf-8');
-  const plan = await parsePlanFile(planPath);
-  const execRegistry = deps.executionAgentRegistry ?? registerBuiltinAgents();
-  assertPlanExecutionAgentsRegistered(plan, execRegistry);
-  backupPlan(plan, yamlSource, deps.logger);
-  process.stdout.write(`${BOLD}Loading plan: ${plan.name}${RESET}\n`);
-  process.stdout.write(`Tasks: ${plan.tasks.length}\n\n`);
-
-  const taskExecutor = createHeadlessExecutor(deps);
-  wireHeadlessApproveHook(deps, taskExecutor);
-  const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
-
-  const api = startApiServer({
-    logger: deps.logger,
-    orchestrator,
-    persistence: deps.persistence,
-    executorRegistry: deps.executorRegistry,
-    ...buildHeadlessApiServerDeps(deps, taskExecutor),
-  });
-
-  const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
-  orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
-  const currentWorkflowId = orchestrator.getWorkflowIds().find((id) => !wfIdsBefore.has(id));
-  if (currentWorkflowId) process.stdout.write(`Workflow ID: ${currentWorkflowId}\n`);
-
-  const started = orchestrator.startExecution();
-
-  if (noTrack) {
-    if (started.length > 0) {
-      void Promise.resolve()
-        .then(() => taskExecutor.executeTasks(started))
-        .catch((err) => {
-          deps.logger.error(
-            `background no-track run failed for ${currentWorkflowId ?? 'unknown'}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-            { module: 'headless' },
-          );
-        });
-    }
-    process.stdout.write('[headless] --no-track enabled: submission accepted; exiting without tracking.\n');
-    await api.close().catch(() => {});
-    return;
-  }
-
-  if (started.length > 0) {
-    await taskExecutor.executeTasks(started);
-  }
-
-  if (currentWorkflowId) {
-    await trackHeadlessWorkflow(currentWorkflowId, deps, {
-      waitForApproval,
-      hasBackgroundWork: autoFix.isBusy,
-      printSnapshot: true,
-      printSummary: true,
-      printTaskOutput: true,
-      setExitCodeOnFailure: true,
-    });
-  }
-
-  await api.close().catch(() => {});
-  autoFix.unsubscribe();
-}
-
-async function headlessResume(
-  workflowId: string,
-  deps: HeadlessDeps,
-  waitForApproval?: boolean,
-  noTrack?: boolean,
-): Promise<void> {
-  const { orchestrator } = deps;
-  if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-
-  process.stdout.write(`${BOLD}Resuming workflow: ${workflowId}${RESET}\n\n`);
-
-  const taskExecutor = createHeadlessExecutor(deps);
-  wireHeadlessApproveHook(deps, taskExecutor);
-  const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
-
-  const api = startApiServer({
-    logger: deps.logger,
-    orchestrator,
-    persistence: deps.persistence,
-    executorRegistry: deps.executorRegistry,
-    ...buildHeadlessApiServerDeps(deps, taskExecutor),
-  });
-
-  orchestrator.syncFromDb(workflowId);
-  const allStarted = orchestrator.startExecution();
-
-  if (noTrack) {
-    if (allStarted.length > 0) {
-      void Promise.resolve()
-        .then(() => taskExecutor.executeTasks(allStarted))
-        .catch((err) => {
-          deps.logger.error(
-            `background no-track resume failed for ${workflowId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-            { module: 'headless' },
-          );
-        });
-    }
-    process.stdout.write('[headless] --no-track enabled: resume accepted; exiting without tracking.\n');
-    await api.close().catch(() => {});
-    autoFix.unsubscribe();
-    return;
-  }
-
-  if (allStarted.length === 0) {
-    await api.close().catch(() => {});
-    autoFix.unsubscribe();
-    return;
-  }
-
-  await taskExecutor.executeTasks(allStarted);
-
-  await trackHeadlessWorkflow(workflowId, deps, {
-    waitForApproval,
-    hasBackgroundWork: autoFix.isBusy,
-    printSnapshot: true,
-    printSummary: true,
-    printTaskOutput: true,
-    setExitCodeOnFailure: true,
-  });
-
-  await api.close().catch(() => {});
-  autoFix.unsubscribe();
-}
-
-async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<void> {
-  if (!taskId) throw new Error('Missing arguments. Usage: --headless retry-task <taskId>');
-  await withRestoredTaskUnlessDeleteAllWon(taskId, deps, 'retry-task', async (restored) => {
-    taskId = restored.resolvedTaskId;
-    if (deps.mutationTiming) {
-      await deps.mutationTiming.span(
-        'headless.retry-task.preemptTaskSubgraph',
-        { taskId },
-        () => preemptTaskSubgraph(taskId, deps),
-      );
-    } else {
-      await preemptTaskSubgraph(taskId, deps);
-    }
-
-    const envelope = makeEnvelope('restart-task', 'headless', 'task', { taskId });
-    const result = deps.mutationTiming
-      ? await deps.mutationTiming.span(
-        'headless.retry-task.commandService.retryTask',
-        { taskId },
-        () => deps.commandService.retryTask(envelope),
-      )
-      : await deps.commandService.retryTask(envelope);
-    if (!result.ok) throw new Error(result.error.message);
-    const runnable = result.data.filter(isDispatchableLaunch);
-    process.stdout.write(`Restarted task "${taskId}" — ${runnable.length} task(s) to execute\n`);
-
-    if (deps.noTrack) {
-      const runningKey = (task: TaskState): string => {
-        const attemptId = task.execution.selectedAttemptId?.trim();
-        return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
-      };
-      const scopedKeys = new Set(runnable.map((task) => runningKey(task)));
-      const globalTopup = deps.orchestrator
-        .startExecution()
-        .filter(isDispatchableLaunch)
-        .filter((task) => !scopedKeys.has(runningKey(task)));
-      const dispatchable = [...runnable, ...globalTopup];
-      if (dispatchable.length > 0) {
-        if (deps.deferRunnableTasks) {
-          deps.deferRunnableTasks(dispatchable, restored.workflowId);
-        } else {
-          const taskExecutor = createHeadlessExecutor(deps);
-          const launch = setTimeout(() => {
-            void taskExecutor.executeTasks(dispatchable).catch((err) => {
-              deps.logger.error(
-                `background no-track task retry failed for ${taskId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-                { module: 'headless' },
-              );
-            });
-          }, 25);
-          launch.unref?.();
-        }
-      }
-      process.stdout.write('[headless] --no-track enabled: retry-task accepted; exiting without tracking.\n');
-      return;
-    }
-
-    const taskExecutor = createHeadlessExecutor(deps);
-    const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
-    const { topup } = await dispatchStartedTasksWithGlobalTopup({
-      orchestrator: deps.orchestrator,
-      taskExecutor,
-      logger: deps.logger,
-      context: 'headless.restart-task',
-      started: result.data,
-      scopedTaskIds: [taskId],
-      mutationTiming: deps.mutationTiming,
-    });
-    if (runnable.length + topup.length === 0) {
-      autoFix.unsubscribe();
-      return;
-    }
-    await trackHeadlessWorkflow(restored.workflowId, deps, {
-      hasBackgroundWork: autoFix.isBusy,
-      printSummary: false,
-      printTaskOutput: true,
-      setExitCodeOnFailure: false,
-    });
-    autoFix.unsubscribe();
-  });
-}
-
-async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promise<void> {
-  const parsed = parseHeadlessFixArgs(rawArgs);
-  let taskId = parsed.taskId;
-  if (!taskId) throw new Error('Missing taskId. Usage: --headless fix <taskId> [claude|codex] [--auto-fix]');
-  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'fix');
-  if (!restored) return;
-  taskId = restored.resolvedTaskId;
-
-  if (parsed.autoFix) {
-    const task = deps.orchestrator.getTask(taskId);
-    const attemptsBefore = task?.execution.autoFixAttempts ?? 0;
-    deps.persistence.updateTask(taskId, { execution: { autoFixAttempts: attemptsBefore + 1 } });
-  }
-
-  const te = createHeadlessExecutor(deps);
-  const autoFix = wireHeadlessAutoFix(deps, te);
-  const agent = (parsed.agentName ?? 'claude').toLowerCase();
-  try {
-    const result = await fixWithAgentAction(taskId, {
-      logger: deps.logger,
-      orchestrator: deps.orchestrator,
-      persistence: deps.persistence,
-      commandService: deps.commandService,
-      taskExecutor: te,
-      mutationTiming: deps.mutationTiming,
-      autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
-    }, {
-      agentName: agent,
-      recreateOutputLabel: 'Fix with AI',
-      failureOutputLabel: 'Fix with AI',
-      reviewGateContext: parsed.reviewGateContext,
-      signal: deps.signal,
-    });
-    await finalizeMutationWithGlobalTopup({
-      orchestrator: deps.orchestrator,
-      taskExecutor: te,
-      logger: deps.logger,
-      context: 'headless.fix-with-agent',
-      started: result.started,
-      mutationTiming: deps.mutationTiming,
-      ...(result.kind === 'recreateWorkflowFromFreshBase'
-        ? { scopedWorkflowId: result.workflowId }
-        : { scopedTaskIds: [taskId] }),
-    });
-    if (result.kind === 'recreateWorkflowFromFreshBase') {
-      process.stdout.write(
-        `Startup merge conflict detected; recreated workflow ${result.workflowId} from a fresh base.\n`,
-      );
-      return;
-    }
-    process.stdout.write(
-      result.autoApproved
-        ? `Fix applied and auto-approved for task: ${taskId} (${agent}).\n`
-        : `Fix applied for task: ${taskId} (${agent}). Use 'approve ${taskId}' or 'reject ${taskId}' to finalize.\n`,
-    );
-  } catch (err) {
-    await finalizeMutationWithGlobalTopup({
-      orchestrator: deps.orchestrator,
-      taskExecutor: te,
-      logger: deps.logger,
-      context: 'headless.fix-with-agent.failure',
-      mutationTiming: deps.mutationTiming,
-    });
-    throw err;
-  } finally {
-    autoFix.unsubscribe();
-  }
-}
-
-async function headlessResolveConflict(taskId: string, deps: HeadlessDeps, agentArg?: string): Promise<void> {
-  if (!taskId) throw new Error('Missing taskId. Usage: --headless resolve-conflict <taskId> [claude|codex]');
-  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'resolve-conflict');
-  if (!restored) return;
-  taskId = restored.resolvedTaskId;
-
-  const te = createHeadlessExecutor(deps);
-  const autoFix = wireHeadlessAutoFix(deps, te);
-  const agent = (agentArg ?? 'claude').toLowerCase();
-  try {
-    const result = await resolveConflictAction(taskId, {
-      ...deps,
-      taskExecutor: te,
-      autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
-    }, agent, deps.signal);
-    await finalizeMutationWithGlobalTopup({
-      orchestrator: deps.orchestrator,
-      taskExecutor: te,
-      logger: deps.logger,
-      context: 'headless.resolve-conflict',
-      started: result.started,
-      mutationTiming: deps.mutationTiming,
-      scopedTaskIds: [taskId],
-    });
-    process.stdout.write(
-      deps.invokerConfig.autoApproveAIFixes
-        ? `Conflict resolved and auto-approved for task: ${taskId} (${agent}).\n`
-        : `Conflict resolved for task: ${taskId} (${agent}). Use 'approve ${taskId}' or 'reject ${taskId}' to finalize.\n`,
-    );
-  } catch (err) {
-    await finalizeMutationWithGlobalTopup({
-      orchestrator: deps.orchestrator,
-      taskExecutor: te,
-      logger: deps.logger,
-      context: 'headless.resolve-conflict.failure',
-      mutationTiming: deps.mutationTiming,
-    });
-    throw err;
-  } finally {
-    autoFix.unsubscribe();
-  }
-}
-
-async function headlessRebaseRetry(target: string, deps: HeadlessDeps): Promise<void> {
-  if (!target) throw new Error('Missing arguments. Usage: --headless rebase-retry <workflowId|mergeTaskId|taskId>');
-  const workflowId = resolveHeadlessTargetWorkflowId(target, deps.persistence);
-  await preemptWorkflowBeforeMutation(workflowId, {
-    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
-    logger: deps.logger,
-    context: 'headless.rebase-retry',
-    mutationTiming: deps.mutationTiming,
-  });
-  const te = createHeadlessExecutor(deps);
-  const autoFix = wireHeadlessAutoFix(deps, te);
-  const started = await rebaseRetry(target, {
-    ...deps,
-    logger: deps.logger,
-    commandService: deps.commandService,
-    taskExecutor: te,
-    mutationTiming: deps.mutationTiming,
-  });
-  const runnable = started.filter(isDispatchableLaunch);
-  const { topup } = await dispatchStartedTasksWithGlobalTopup({
-    orchestrator: deps.orchestrator,
-    taskExecutor: te,
-    logger: deps.logger,
-    context: 'headless.rebase-retry',
-    started,
-    scopedWorkflowId: workflowId,
-    mutationTiming: deps.mutationTiming,
-  });
-  if (runnable.length + topup.length === 0) {
-    autoFix.unsubscribe();
-    return;
-  }
-  if (deps.noTrack) {
-    process.stdout.write('[headless] --no-track enabled: rebase-retry accepted; exiting without tracking.\n');
-    autoFix.unsubscribe();
-    return;
-  }
-  await trackHeadlessWorkflow(workflowId, deps, {
-    hasBackgroundWork: autoFix.isBusy,
-    printSummary: false,
-    printTaskOutput: true,
-    setExitCodeOnFailure: false,
-  });
-  autoFix.unsubscribe();
-
-  const tasksStarted = runnable.length;
-  process.stdout.write(`Rebase-retry: retried workflow from fresh base (${tasksStarted} task(s))\n`);
-}
-
-async function headlessRebaseRecreate(workflowTarget: string, deps: HeadlessDeps): Promise<void> {
-  if (!workflowTarget) throw new Error('Missing arguments. Usage: --headless rebase-recreate <workflowId|mergeTaskId|taskId>');
-  const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, deps.persistence);
-  await preemptWorkflowBeforeMutation(workflowId, {
-    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
-    logger: deps.logger,
-    context: 'headless.rebase-recreate',
-    mutationTiming: deps.mutationTiming,
-  });
-  const te = createHeadlessExecutor(deps);
-  const autoFix = wireHeadlessAutoFix(deps, te);
-  const started = await rebaseRecreate(workflowTarget, {
-    ...deps,
-    logger: deps.logger,
-    commandService: deps.commandService,
-    taskExecutor: te,
-    mutationTiming: deps.mutationTiming,
-  });
-  const runnable = started.filter(isDispatchableLaunch);
-  const { topup } = await dispatchStartedTasksWithGlobalTopup({
-    orchestrator: deps.orchestrator,
-    taskExecutor: te,
-    logger: deps.logger,
-    context: 'headless.rebase-recreate',
-    started,
-    scopedWorkflowId: workflowId,
-    mutationTiming: deps.mutationTiming,
-  });
-  if (runnable.length + topup.length === 0) {
-    autoFix.unsubscribe();
-    return;
-  }
-  if (deps.noTrack) {
-    process.stdout.write('[headless] --no-track enabled: rebase-recreate accepted; exiting without tracking.\n');
-    autoFix.unsubscribe();
-    return;
-  }
-  await trackHeadlessWorkflow(workflowId, deps, {
-    hasBackgroundWork: autoFix.isBusy,
-    printSummary: false,
-    printTaskOutput: true,
-    setExitCodeOnFailure: false,
-  });
-  autoFix.unsubscribe();
-
-  const tasksStarted = runnable.length;
-  process.stdout.write(`Rebase-recreate: recreated workflow from fresh base (${tasksStarted} task(s))\n`);
-}
-
-async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {
-  if (!workflowId) {
-    throw new Error('Missing arguments. Usage: --headless recreate <workflowId>');
-  }
-  await preemptWorkflowBeforeMutation(workflowId, {
-    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
-    logger: deps.logger,
-    context: 'headless.recreate-workflow',
-    mutationTiming: deps.mutationTiming,
-  });
-  const recreateWfEnvelope = makeEnvelope('recreate-workflow', 'headless', 'workflow', { workflowId });
-  const recreateWfResult = deps.mutationTiming
-    ? await deps.mutationTiming.span(
-      'headless.recreate-workflow.commandService.recreateWorkflow',
-      undefined,
-      () => deps.commandService.recreateWorkflow(recreateWfEnvelope),
-    )
-    : await deps.commandService.recreateWorkflow(recreateWfEnvelope);
-  if (!recreateWfResult.ok) throw new Error(recreateWfResult.error.message);
-  const started = recreateWfResult.data;
-  const runnable = started.filter(isDispatchableLaunch);
-  if (runnable.length > 0) {
-    const te = createHeadlessExecutor(deps);
-    const autoFix = wireHeadlessAutoFix(deps, te);
-    remoteFetchForPool.enabled = false;
-    let topup: TaskState[] = [];
-    try {
-      await te.executeTasks(runnable);
-      topup = await executeGlobalTopup({
-        orchestrator: deps.orchestrator,
-        taskExecutor: te,
-        logger: deps.logger,
-        context: 'headless.recreate-workflow',
-        alreadyDispatched: runnable,
-        mutationTiming: deps.mutationTiming,
-      });
-    } finally {
-      remoteFetchForPool.enabled = true;
-    }
-    if (runnable.length + topup.length === 0) {
-      autoFix.unsubscribe();
-      return;
-    }
-    if (deps.noTrack) {
-      process.stdout.write('[headless] --no-track enabled: recreate accepted; exiting without tracking.\n');
-      autoFix.unsubscribe();
-      return;
-    }
-    await trackHeadlessWorkflow(workflowId, deps, {
-      hasBackgroundWork: autoFix.isBusy,
-      printSummary: false,
-      printTaskOutput: true,
-      setExitCodeOnFailure: false,
-    });
-    autoFix.unsubscribe();
-  }
-  const tasksStarted = runnable.length;
-  process.stdout.write(`Recreate workflow "${workflowId}" — ${tasksStarted} task(s) to execute (pool fetch skipped)\n`);
-}
-
-async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise<void> {
-  if (!taskId) {
-    throw new Error('Missing arguments. Usage: --headless recreate-task <taskId>');
-  }
-  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'recreate-task');
-  if (!restored) return;
-  taskId = restored.resolvedTaskId;
-  if (deps.mutationTiming) {
-    await deps.mutationTiming.span(
-      'headless.recreate-task.preemptTaskSubgraph',
-      { taskId },
-      () => preemptTaskSubgraph(taskId, deps),
-    );
-  } else {
-    await preemptTaskSubgraph(taskId, deps);
-  }
-
-  const recreateTaskEnvelope = makeEnvelope('recreate-task', 'headless', 'task', { taskId });
-  const recreateTaskResult = deps.mutationTiming
-    ? await deps.mutationTiming.span(
-      'headless.recreate-task.commandService.recreateTask',
-      { taskId },
-      () => deps.commandService.recreateTask(recreateTaskEnvelope),
-    )
-    : await deps.commandService.recreateTask(recreateTaskEnvelope);
-  if (!recreateTaskResult.ok) throw new Error(recreateTaskResult.error.message);
-  const started = recreateTaskResult.data;
-  const runnable = started.filter(isDispatchableLaunch);
-  const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
-  process.stdout.write(`Recreate task "${taskId}" (+ downstream) — ${runnable.length} task(s) to execute (pool fetch skipped)\n`);
-  const te = createHeadlessExecutor(deps);
-  const autoFix = wireHeadlessAutoFix(deps, te);
-  remoteFetchForPool.enabled = false;
-  let topup: TaskState[] = [];
-  try {
-    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
-      orchestrator: deps.orchestrator,
-      taskExecutor: te,
-      logger: deps.logger,
-      context: 'headless.recreate-task',
-      started,
-      mutationTiming: deps.mutationTiming,
-    }));
-  } finally {
-    remoteFetchForPool.enabled = true;
-  }
-  if (runnable.length + topup.length === 0) {
-    autoFix.unsubscribe();
-    return;
-  }
-  if (deps.noTrack) {
-    process.stdout.write('[headless] --no-track enabled: recreate-task accepted; exiting without tracking.\n');
-    autoFix.unsubscribe();
-    return;
-  }
-  if (workflowId) {
-    await trackHeadlessWorkflow(workflowId, deps, {
-      hasBackgroundWork: autoFix.isBusy,
-      printSummary: false,
-      printTaskOutput: true,
-      setExitCodeOnFailure: false,
-    });
-  }
-  autoFix.unsubscribe();
-}
-
-async function headlessRecreateDownstream(taskId: string, deps: HeadlessDeps): Promise<void> {
-  if (!taskId) {
-    throw new Error('Missing arguments. Usage: --headless recreate-downstream <taskId>');
-  }
-  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'recreate-downstream');
-  if (!restored) return;
-  taskId = restored.resolvedTaskId;
-  if (deps.mutationTiming) {
-    await deps.mutationTiming.span(
-      'headless.recreate-downstream.preemptTaskSubgraph',
-      { taskId },
-      () => preemptTaskSubgraph(taskId, deps),
-    );
-  } else {
-    await preemptTaskSubgraph(taskId, deps);
-  }
-
-  const envelope = makeEnvelope('recreate-downstream', 'headless', 'task', { taskId });
-  const result = deps.mutationTiming
-    ? await deps.mutationTiming.span(
-      'headless.recreate-downstream.commandService.recreateDownstream',
-      { taskId },
-      () => deps.commandService.recreateDownstream(envelope),
-    )
-    : await deps.commandService.recreateDownstream(envelope);
-  if (!result.ok) throw new Error(result.error.message);
-  const started = result.data;
-  const runnable = started.filter(isDispatchableLaunch);
-  const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
-  process.stdout.write(`Recreate downstream of "${taskId}" — ${runnable.length} task(s) to execute (pool fetch skipped)\n`);
-  const te = createHeadlessExecutor(deps);
-  const autoFix = wireHeadlessAutoFix(deps, te);
-  remoteFetchForPool.enabled = false;
-  let topup: TaskState[] = [];
-  try {
-    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
-      orchestrator: deps.orchestrator,
-      taskExecutor: te,
-      logger: deps.logger,
-      context: 'headless.recreate-downstream',
-      started,
-      mutationTiming: deps.mutationTiming,
-    }));
-  } finally {
-    remoteFetchForPool.enabled = true;
-  }
-  if (runnable.length + topup.length === 0) {
-    autoFix.unsubscribe();
-    return;
-  }
-  if (deps.noTrack) {
-    process.stdout.write('[headless] --no-track enabled: recreate-downstream accepted; exiting without tracking.\n');
-    autoFix.unsubscribe();
-    return;
-  }
-  if (workflowId) {
-    await trackHeadlessWorkflow(workflowId, deps, {
-      hasBackgroundWork: autoFix.isBusy,
-      printSummary: false,
-      printTaskOutput: true,
-      setExitCodeOnFailure: false,
-    });
-  }
-  autoFix.unsubscribe();
-}
-
-async function headlessForkWorkflow(
-  workflowId: string,
-  deps: HeadlessDeps,
-): Promise<void> {
-  if (!workflowId) {
-    throw new Error('Missing arguments. Usage: --headless fork-workflow <workflowId>');
-  }
-  const result = sharedForkWorkflow(workflowId, {
-    orchestrator: deps.orchestrator,
-    logger: deps.logger,
-  });
-  const taskExecutor = createHeadlessExecutor(deps);
-  const { runnable } = await dispatchStartedTasksWithGlobalTopup({
-    orchestrator: deps.orchestrator,
-    taskExecutor,
-    logger: deps.logger,
-    context: 'headless.fork-workflow',
-    started: result.started,
-    scopedWorkflowId: result.forkedWorkflowId,
-  });
-  process.stdout.write(
-    `Forked workflow ${result.sourceWorkflowId} → ${result.forkedWorkflowId}; ` +
-      `launched ${runnable.length} task(s)\n`,
-  );
-}
-
-async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {
-  if (!workflowId) {
-    throw new Error('Missing arguments. Usage: --headless retry <workflowId>');
-  }
-  deps.logger.info(`headlessRetryWorkflow begin workflow="${workflowId}" noTrack=${deps.noTrack ? 'true' : 'false'}`, {
-    module: 'headless',
-  });
-  await preemptWorkflowBeforeMutation(workflowId, {
-    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
-    logger: deps.logger,
-    context: 'headless.retry-workflow',
-    mutationTiming: deps.mutationTiming,
-  });
-  const envelope = makeEnvelope('retry-workflow', 'headless', 'workflow', { workflowId });
-  const result = deps.mutationTiming
-    ? await deps.mutationTiming.span(
-      'headless.retry-workflow.commandService.retryWorkflow',
-      undefined,
-      () => deps.commandService.retryWorkflow(envelope),
-    )
-    : await deps.commandService.retryWorkflow(envelope);
-  if (!result.ok) throw new Error(result.error.message);
-  const statusCounts = result.data.reduce<Record<string, number>>((acc, task) => {
-    acc[task.status] = (acc[task.status] ?? 0) + 1;
-    return acc;
-  }, {});
-  deps.logger.info(
-    `headlessRetryWorkflow trace workflow="${workflowId}" retryResult total=${result.data.length} statusCounts=${JSON.stringify(statusCounts)}`,
-    { module: 'headless' },
-  );
-  const retryRunningSummary = result.data
-    .filter(isDispatchableLaunch)
-    .map((task) => `${task.id}(${task.config.workflowId ?? 'unknown'})`);
-  if (retryRunningSummary.length > 0) {
-    deps.logger.info(
-      `headlessRetryWorkflow trace workflow="${workflowId}" retryResult running=[${retryRunningSummary.join(', ')}]`,
-      { module: 'headless' },
-    );
-  }
-  const runnable = result.data.filter(isDispatchableLaunch);
-  const crossWorkflow = runnable.filter((t) => t.config.workflowId !== workflowId);
-  if (crossWorkflow.length > 0) {
-    deps.logger.info(
-      `headlessRetryWorkflow dispatching cross-workflow runnable tasks for "${workflowId}": ${crossWorkflow.map((task) => `${task.id}(${task.config.workflowId ?? 'unknown'})`).join(', ')}`,
-      { module: 'headless' },
-    );
-  }
-  deps.logger.info(`headlessRetryWorkflow retry complete workflow="${workflowId}" runnable=${runnable.length}`, {
-    module: 'headless',
-  });
-
-  const runningKey = (task: TaskState): string => {
-    const attemptId = task.execution.selectedAttemptId?.trim();
-    return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
-  };
-  const scopedKeys = new Set(runnable.map((task) => runningKey(task)));
-  const globalTopup = deps.orchestrator
-    .startExecution()
-    .filter(isDispatchableLaunch)
-    .filter((task) => !scopedKeys.has(runningKey(task)));
-  deps.logger.info(
-    `headlessRetryWorkflow trace workflow="${workflowId}" postStartExecution globalTopup=${globalTopup.length}`,
-    { module: 'headless' },
-  );
-  if (globalTopup.length > 0) {
-    deps.logger.info(
-      `headlessRetryWorkflow trace workflow="${workflowId}" globalTopup running=[${globalTopup.map((task) => `${task.id}(${task.config.workflowId ?? 'unknown'})`).join(', ')}]`,
-      { module: 'headless' },
-    );
-  }
-  const dispatchable = [...runnable, ...globalTopup];
-  deps.logger.info(
-    `headlessRetryWorkflow trace workflow="${workflowId}" dispatchable=${dispatchable.length} ids=[${dispatchable.map((task) => `${task.id}(${task.config.workflowId ?? 'unknown'})`).join(', ')}]`,
-    { module: 'headless' },
-  );
-
-  process.stdout.write(`Retry workflow "${workflowId}" — ${dispatchable.length} task(s) to execute (completed tasks preserved)\n`);
-  if (dispatchable.length === 0) return;
-
-  if (deps.noTrack) {
-    if (deps.deferRunnableTasks) {
-      deps.deferRunnableTasks(dispatchable, workflowId);
-    } else {
-      const te = createHeadlessExecutor(deps);
-      const launch = setTimeout(() => {
-        void te.executeTasks(dispatchable).catch((err) => {
-          deps.logger.error(
-            `background no-track workflow retry failed for ${workflowId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-            { module: 'headless' },
-          );
-        });
-      }, 25);
-      launch.unref?.();
-    }
-    process.stdout.write('[headless] --no-track enabled: retry accepted; exiting without tracking.\n');
-    return;
-  }
-
-  const te = createHeadlessExecutor(deps);
-  const autoFix = wireHeadlessAutoFix(deps, te);
-  remoteFetchForPool.enabled = false;
-  let topup: TaskState[] = [];
-  try {
-    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
-      orchestrator: deps.orchestrator,
-      taskExecutor: te,
-      logger: deps.logger,
-      context: 'headless.retry-workflow',
-      started: dispatchable,
-      scopedWorkflowId: workflowId,
-      mutationTiming: deps.mutationTiming,
-    }));
-  } finally {
-    remoteFetchForPool.enabled = true;
-  }
-  if (runnable.length + topup.length === 0) {
-    autoFix.unsubscribe();
-    return;
-  }
-  await trackHeadlessWorkflow(workflowId, deps, {
-    hasBackgroundWork: autoFix.isBusy,
-    printSummary: false,
-    printTaskOutput: true,
-    setExitCodeOnFailure: false,
-  });
-  autoFix.unsubscribe();
-}
-
-/** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
 async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDeps): Promise<void> {
   if (!taskId || !newCommand) throw new Error('Missing arguments. Usage: --headless edit <taskId> <newCommand>');
   const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'set command');
@@ -1522,6 +707,36 @@ async function headlessEditAgent(taskId: string, agentName: string, deps: Headle
   autoFix.unsubscribe();
 }
 
+/**
+ * Headless `set merge-mode` — **retry-class** invalidation route per
+ * Step 9 of `docs/architecture/task-invalidation-roadmap.md` (chart
+ * Decision Table row "Change merge mode";
+ * `MUTATION_POLICIES.mergeMode` → `retryTask` / task scope, scoped
+ * to the merge node). Mirrors the Step 5 `set type` headless pattern
+ * (retry-class, preserves branch / workspacePath lineage) rather
+ * than the Step 2/3/4 recreate-class headless paths
+ * (`set command` / `set prompt` / `set agent`).
+ *
+ * Step 9 routes the headless surface through
+ * `commandService.editTaskMergeMode` so the orchestrator's
+ * cancel-first seam (`Orchestrator.editTaskMergeMode`) runs under
+ * the workflow mutex; same-mode no-op detection,
+ * `persistence.updateWorkflow({ mergeMode })`, and the single
+ * `withBumpedExecutionGeneration` bump live in `restartTask` (today's
+ * `retryTask` compatibility wire — see `MUTATION_POLICIES.mergeMode`
+ * and `buildInvalidationDeps`).
+ *
+ * The CLI argument is still a workflow id (matches the legacy
+ * `set-merge-mode <workflowId> <mode>` surface and the
+ * `invoker:set-merge-mode` IPC). `mergeMode` is normalized at the
+ * app boundary because that concerns UI/CLI input parsing, not the
+ * chart's invalidation routing. The merge-task-id translation
+ * (`workflowId → __merge__<workflowId>`) happens here because the
+ * orchestrator seam speaks merge-node task ids. When the workflow
+ * has no merge node (degenerate workflows that opted out of a merge
+ * gate) we persist the new mode directly via the shared
+ * `setWorkflowMergeMode` action — there is nothing to retry.
+ */
 async function headlessSetMergeMode(
   workflowId: string,
   mergeMode: string,
@@ -1762,5 +977,3 @@ async function headlessSlack(deps: HeadlessDeps): Promise<void> {
     process.on('SIGTERM', shutdown);
   });
 }
-
-// ── Headless Helpers ─────────────────────────────────────────


### PR DESCRIPTION
Moves the execute family (run/resume/watch, retry/recreate/rebase/fork, fix/resolve-conflict) out of headless.ts into headless-run-resume.ts, behavior unchanged.
One atomic slice of the step-4 large-file decomposition.

Depends-On: #2326