### PR TITLE
refactor(execution-engine): extract task-runner-phase-host from task-runner

### DIFF
--- a/packages/execution-engine/src/task-runner-phase-host.ts
+++ b/packages/execution-engine/src/task-runner-phase-host.ts
@@ -1,0 +1,46 @@
+/**
+ * Host surface shared by the task-runner execution phases.
+ *
+ * Each phase module (prepare / dispatch / finalize) takes a
+ * `TaskRunnerPhaseHost` — a subset of `TaskRunner`'s capabilities — as its
+ * first parameter. Defining it as a `Pick<TaskRunner, …>` keeps the phase
+ * signatures locked to the runner's real method shapes (no drift) while the
+ * type-only import avoids a runtime cycle with `task-runner.ts`.
+ */
+
+import type { TaskRunner } from './task-runner.js';
+
+export type TaskRunnerPhaseHost = Pick<
+  TaskRunner,
+  // Shared collaborators
+  | 'orchestrator'
+  | 'persistence'
+  | 'callbacks'
+  | 'logger'
+  | 'defaultBranch'
+  // Runner state touched across phases
+  | 'freshBaseCommits'
+  | 'pendingPoolSelections'
+  | 'activeExecutions'
+  | 'getExecutionPools'
+  // Prepare-phase helpers
+  | 'buildUpstreamContext'
+  | 'collectUpstreamBranches'
+  | 'buildAlternatives'
+  | 'resolveExternalDependencyTask'
+  | 'shouldUseFreshWorkspace'
+  | 'determineActionType'
+  // Dispatch-phase helpers
+  | 'selectExecutor'
+  | 'acquirePoolSelectionLease'
+  | 'renewPoolSelectionLease'
+  | 'releasePoolSelectionLease'
+  | 'logExecutorSelected'
+  | 'selectedRemoteTargetId'
+  | 'poolMemberKey'
+  // Shared lifecycle helpers
+  | 'isLaunchStale'
+  | 'executeNewlyStartedTasks'
+  | 'cleanupPerTaskDockerExecutor'
+  | 'runSerializedCompletion'
+>;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal execution-engine structure by defining a clearer shared interface for phase-related task runner capabilities.
  * Tightened the set of available runner operations used across execution phases, helping keep behavior consistent and easier to maintain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->