### PR TITLE
Mergify: admin-bypass queue batch_size 1 (isolate flaky speculative checks)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -39,7 +39,7 @@ queue_rules:
 
   - name: admin-bypass
     merge_method: squash
-    batch_size: 5
+    batch_size: 1
     batch_max_wait_time: 5min
     queue_conditions:
       - base=master


### PR DESCRIPTION
## Summary

The admin-bypass merge queue batched up to 5 PRs into one speculative merge. A single flaky check (dry-run / playwright / Vitest Workspace) failed the whole batch and dequeued every PR, so stacked PRs couldn't land.

Setting the admin-bypass queue to `batch_size: 1` tests each PR alone, so a flake only affects that one PR (Mergify auto-retries) and stacks land reliably. The default queue is unchanged.

## Test Plan
- [x] Config-only change; `.mergify.yml` default queue untouched (still batch_size 5), admin-bypass now batch_size 1.

## Revert Plan
- Safe to revert? Yes — `git revert <sha>`. Config-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted merge queue settings to process fewer changes in parallel for one rule, which may make merges more controlled and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->