### PR TITLE
docs(skills): document one cohesive unit per PR for decompositions

### DIFF
--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -101,6 +101,13 @@ requires them. Split optional cleanup, special cases, behavior-plus-rename,
 default-flip-plus-deletion, benchmark-before-fix proof, refactor-before-fields,
 and product-code-plus-policy/docs follow-ups.
 
+Decomposition refactors split one move per workflow: create one module, move
+ONE cohesive unit (function/class/phase/command family), re-point references,
+keep the public surface stable; the next unit is the next workflow. A file that
+yields six helper modules is six chained workflows, not one "extract phases"
+task. See the **Decomposition & Extraction Refactors** section of
+`../review-compression/SKILL.md`.
+
 ### Cross-layer direction
 
 - Dependencies should flow from lower/foundational layers to higher/integration layers.

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -95,6 +95,48 @@ Split changes when they introduce a different claim:
 - benchmark/repro/proof harness plus the fix it is meant to justify
 - product code plus planning/policy/docs updates
 - broad mechanical moves too large to inspect comfortably
+- multiple distinct extractions from one file (one move per slice)
+
+## Decomposition & Extraction Refactors
+
+When you split a large file by extracting cohesive units (functions, classes,
+phases, command families) into new modules, treat each extraction as its own
+slice: create the target file, move ONE cohesive unit, re-point its references,
+and keep the public surface (facade, exports, dispatcher) stable. Do not batch
+several distinct extractions into one diff.
+
+Each move is a separate review claim. Every extraction has its own seam and its
+own "is behavior preserved?" question, so the reviewer checks one move at a
+time. "Extract prepare + dispatch + finalize" is three moves, three claims,
+three slices — not one.
+
+This does NOT contradict grouping the "exact same mechanical migration across
+many files." That rule is one transformation applied to N call sites (one
+claim). Decomposition is N distinct transformations (N claims): different code,
+different seams, different risk.
+
+Slice shape for one move:
+
+- `Review claim:` "Move <unit> out of <file> into <new module>, behavior
+  unchanged."
+- create the new module and move exactly one cohesive unit into it
+- update imports/facade so the public surface is byte-for-byte identical to
+  callers
+- keep directly affected tests with the move; they prove behavior is preserved
+- no behavior change in a move slice (Fowler's "two hats": never refactor and
+  change behavior in the same diff)
+
+Sequence the decomposition stack as:
+
+1. one slice per extracted unit (create-and-move), foundational unit first
+2. re-point remaining callers once a unit is extracted
+3. delete now-dead original code in its own slice, as soon as it is unused
+
+Grounding: Fowler, *Refactoring* — "Move Function" applied as small
+behavior-preserving steps (compile-test-commit each); Beck, *Tidy First?* —
+keep structural changes isolated from behavioral ones, each in its own
+PR/commit; industry guidance (Graphite, Artsy) — one module/class per PR keeps
+diffs near the 50–200 line review sweet spot.
 
 ## PR Body Guidance
 


### PR DESCRIPTION
## Summary

This adds written guidance to two skill files about how big one pull request should be when you break a large source file into several smaller ones.

The guidance says each cohesive unit becomes its own pull request, with the public surface kept stable and behavior unchanged, so a reviewer reads one thing at a time.

The canonical text lives in the review-compression skill, and the plan-to-invoker reference now points at it so Invoker workflow planning follows the same guidance.

<details>
<summary>Review metadata</summary>

Review Claim: Add written guidance about per-pull-request sizing, with the canonical text in the review-compression skill and a pointer to it from the plan-to-invoker reference.

Review Lane: docs

Review Unit: docs

Safety Invariant: Prose-only additions to two skill markdown files; no code, behavior, or runtime path changes, and the skill check suite still passes.

Slice Rationale: Documentation only, grouped as one guidance change across the two prose files; the cross-reference in the make-pr skill ships on its own because the repo classifies that file as a different review unit.

</details>

## Non-goals

- No product code, test, or CI changes.
- Does not modify lint rules or fixtures, only adds guidance prose.
- Does not change the make-pr skill; that one-line pointer ships in its own PR.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for breaking down large refactors into smaller, consistent steps.
  * Added instructions for keeping the user-facing surface stable while updating internal structure.
  * Improved review guidance for separating refactoring work from behavior changes and handling extracted pieces one at a time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->