### PR TITLE
policy(skills): point make-pr at the one-unit-per-PR rule

### DIFF
--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -12,6 +12,7 @@ description: >
 Use this skill when the work is already done and the user wants a PR created, updated, or rewritten.
 
 For stacked PRs, apply `skills/review-compression/SKILL.md` before you write titles or PR bodies. If one branch mixes more than one local review claim, split the stack first.
+For decomposition or extraction refactors (splitting a large file into modules), one PR moves one cohesive unit: create the target file, move ONE function/class/phase, re-point references, keep the public surface stable. The next unit is the next PR. Bundling several extractions into one branch ("extract prepare + dispatch + finalize") is the default mistake this rule prevents — see the **Decomposition & Extraction Refactors** section of `skills/review-compression/SKILL.md`.
 
 ## Stack ordering
 


### PR DESCRIPTION
## Summary

This adds one cross-reference line to the make-pr skill so PR authoring points at the new sizing guidance.

The pointer sends authors to the review-compression skill, which holds the canonical text about keeping one cohesive unit per pull request.

<details>
<summary>Review metadata</summary>

Review Claim: Add a one-line pointer in the make-pr skill to the canonical sizing guidance in the review-compression skill.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: A single prose line added to one skill markdown file; no code, behavior, or runtime path changes.

Slice Rationale: The repo classifies the make-pr skill as its own review unit, so this one-line pointer ships apart from the prose guidance in the other two skill files.

</details>

## Non-goals

- No product code, test, or CI changes.
- Does not add the guidance text itself; that lives in the review-compression skill.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for decomposition and extraction refactors.
  * Emphasized that each pull request should cover one cohesive refactor at a time while keeping the public interface unchanged.
  * Added a clearer warning against combining multiple extractions in a single branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->