### PR TITLE
[Plan Execution Model](1) Parse executionModel in the core plan parser

### DIFF
--- a/packages/workflow-core/src/__tests__/plan-parser.test.ts
+++ b/packages/workflow-core/src/__tests__/plan-parser.test.ts
@@ -47,4 +47,48 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow('Task at index 0 must be an object with an "id" field');
   });
+
+  it('parses and trims executionModel from task definitions', () => {
+    const yaml = `
+name: Model Plan
+repoUrl: git@github.com:test/repo.git
+baseBranch: main
+tasks:
+  - id: claude-task
+    description: Uses claude model
+    command: echo "hi"
+    executionModel: claude
+  - id: padded-task
+    description: Padded model
+    command: echo "hi"
+    executionModel: "  claude  "
+  - id: empty-task
+    description: Empty model
+    command: echo "hi"
+    executionModel: ""
+  - id: default-task
+    description: No model
+    command: echo "hi"
+`;
+    const plan = parsePlan(yaml);
+    expect(plan.tasks[0].executionModel).toBe('claude');
+    expect(plan.tasks[1].executionModel).toBe('claude');
+    expect(plan.tasks[2].executionModel).toBeUndefined();
+    expect(plan.tasks[3].executionModel).toBeUndefined();
+  });
+
+  it('rejects a non-string executionModel with PlanParseError', () => {
+    const yaml = `
+name: Bad Model Plan
+repoUrl: git@github.com:test/repo.git
+baseBranch: main
+tasks:
+  - id: t1
+    description: Bad model
+    command: echo "hi"
+    executionModel: 123
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(/executionModel/);
+  });
 });

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -35,6 +35,7 @@ export interface RawPlanTask {
   dockerImage?: string;
   poolId?: string;
   executionAgent?: string;
+  executionModel?: string;
 }
 
 export interface RawPlan {
@@ -237,6 +238,10 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       );
     }
 
+    if (task.executionModel !== undefined && typeof task.executionModel !== 'string') {
+      throw new PlanParseError(`Task "${task.id}" field "executionModel" must be a string when provided`);
+    }
+
     return {
       id: task.id,
       description: task.description,
@@ -255,6 +260,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       dockerImage: task.dockerImage,
       poolId: task.poolId,
       executionAgent: task.executionAgent?.trim() || undefined,
+      executionModel: task.executionModel?.trim() || undefined,
     };
   });
 


### PR DESCRIPTION
## Summary

Plans can already name which harness runs a task with `executionAgent`. This adds the matching `executionModel` so a plan can also name the model per task.

The core plan parser now reads `executionModel` from each task in the plan YAML, trims it, and treats a blank value as unset.

Without this, the orchestrator already forwarded a task's `executionModel`, but the parser never filled it in, so a model named in a plan file was silently dropped.

<details>
<summary>Review metadata</summary>

Review Claim: The core plan parser reads and trims a task's `executionModel` from plan YAML.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The new field is optional; tasks that omit `executionModel` parse exactly as before, and nothing new reads the field in this slice.

Slice Rationale: Core parsing comes first; the app-side parser, serializer, and editor follow as slice 2.

</details>

## Non-goals

- Does not change the app plan parser, task serializer, or model editor (slice 2).
- Does not add model selection to any harness or runner.
- Does not change behavior for tasks that omit `executionModel`.

## Test Plan

- [ ] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/plan-parser.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of task execution model values by trimming extra whitespace and treating empty values as unset.
  * Added validation so invalid execution model values now return a clear parse error.

* **Tests**
  * Added coverage for trimming, empty/omitted values, and invalid execution model inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->