### PR TITLE
[DB file safety](1) Restrict database recovery to genuine corruption

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  existsSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter, isDatabaseCorruptionError } from '../sqlite-adapter.js';
+
+/**
+ * SQLiteAdapter.create() recovers a corrupt database by renaming it (and its
+ * -wal/-shm sidecars) aside and starting fresh. That recovery is destructive,
+ * so it must fire ONLY for genuine corruption. A transient/operational failure
+ * (a concurrent process holding a lock, an IO error) must propagate untouched —
+ * otherwise the live database and the -shm other connections have memory-mapped
+ * would be ripped away, losing data and crashing those readers with SIGBUS.
+ */
+
+const dirs: string[] = [];
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'sqlite-recovery-'));
+  dirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('isDatabaseCorruptionError', () => {
+  it('treats SQLITE_CORRUPT (11), SQLITE_NOTADB (26) and their extended variants as corruption', () => {
+    expect(isDatabaseCorruptionError({ errcode: 11 })).toBe(true);
+    expect(isDatabaseCorruptionError({ errcode: 26 })).toBe(true);
+    // Extended result codes carry the primary code in the low byte and must
+    // still classify: SQLITE_CORRUPT_VTAB=267, SQLITE_CORRUPT_SEQUENCE=523,
+    // SQLITE_CORRUPT_INDEX=779 (all & 0xff === 11).
+    for (const errcode of [267, 523, 779]) {
+      expect(isDatabaseCorruptionError({ errcode })).toBe(true);
+    }
+  });
+
+  it('does NOT treat transient/operational result codes (incl. extended) as corruption', () => {
+    // Primary: SQLITE_BUSY=5, SQLITE_LOCKED=6, SQLITE_IOERR=10, SQLITE_CANTOPEN=14.
+    // Extended: SQLITE_BUSY_RECOVERY=261, SQLITE_IOERR_READ=266, SQLITE_CANTOPEN_FULLPATH=782
+    // (none of which mask to 11 or 26).
+    for (const errcode of [5, 6, 10, 14, 261, 266, 782]) {
+      expect(isDatabaseCorruptionError({ errcode })).toBe(false);
+    }
+  });
+
+  it('falls back to message text when no numeric errcode is present', () => {
+    expect(isDatabaseCorruptionError(new Error('database disk image is malformed'))).toBe(true);
+    expect(isDatabaseCorruptionError(new Error('file is not a database'))).toBe(true);
+    expect(isDatabaseCorruptionError(new Error('database is locked'))).toBe(false);
+    expect(isDatabaseCorruptionError(new Error('unable to open database file'))).toBe(false);
+    expect(isDatabaseCorruptionError('not even an error')).toBe(false);
+  });
+});
+
+describe('SQLiteAdapter.create recovery', () => {
+  it('recovers a genuinely corrupt database by backing it up and starting fresh', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const garbage = Buffer.from('xx not a sqlite header xx '.repeat(50));
+    writeFileSync(dbPath, garbage);
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      expect(adapter.listWorkflows()).toEqual([]); // fresh, usable database
+    } finally {
+      adapter.close();
+    }
+
+    const corruptBackups = readdirSync(dir).filter(
+      (name) => name.includes('.corrupt-') && !name.endsWith('-wal') && !name.endsWith('-shm'),
+    );
+    expect(corruptBackups).toHaveLength(1);
+    expect(readFileSync(join(dir, corruptBackups[0]))).toEqual(garbage); // original bytes preserved
+  });
+
+  it('rethrows a non-corruption open failure WITHOUT the destructive recovery', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    // A directory at dbPath makes SQLite fail with SQLITE_CANTOPEN (operational,
+    // not corruption). A sentinel inside proves the path is never renamed away.
+    mkdirSync(dbPath);
+    mkdirSync(join(dbPath, 'sentinel'));
+
+    await expect(SQLiteAdapter.create(dbPath, { ownerCapability: true })).rejects.toThrow();
+
+    expect(readdirSync(dir).some((name) => name.includes('.corrupt-'))).toBe(false);
+    expect(existsSync(join(dbPath, 'sentinel'))).toBe(true);
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -156,6 +156,38 @@ function sqlStringLiteral(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
+/**
+ * SQLite result codes that mean the database file itself is unreadable and a
+ * fresh start is the only recovery: SQLITE_CORRUPT (11) and SQLITE_NOTADB (26).
+ * Transient/operational failures (e.g. SQLITE_BUSY=5, SQLITE_LOCKED=6,
+ * SQLITE_CANTOPEN=14) MUST NOT trigger destructive recovery: a concurrent
+ * process briefly holding a lock would otherwise rename the live database and
+ * its -wal/-shm sidecars away, losing data and (because other connections have
+ * the -shm memory-mapped) crashing them with SIGBUS.
+ */
+const SQLITE_CORRUPT = 11;
+const SQLITE_NOTADB = 26;
+// Extended result codes pack the primary code in the low 8 bits (e.g.
+// SQLITE_CORRUPT_VTAB = 267 -> 267 & 0xff = 11), so mask before comparing or
+// extended corruption variants slip through as "not corruption".
+const SQLITE_PRIMARY_RESULT_CODE_MASK = 0xff;
+
+/**
+ * True when `err` is a SQLite open failure caused by an unreadable database file
+ * (SQLITE_CORRUPT / SQLITE_NOTADB, including their extended variants) — the only
+ * class of failure for which destructive backup-and-recreate recovery is safe.
+ */
+export function isDatabaseCorruptionError(err: unknown): boolean {
+  const errcode = (err as { errcode?: unknown } | null)?.errcode;
+  if (typeof errcode === 'number') {
+    const primary = errcode & SQLITE_PRIMARY_RESULT_CODE_MASK;
+    return primary === SQLITE_CORRUPT || primary === SQLITE_NOTADB;
+  }
+  // Fallback for runtimes that do not surface a numeric errcode.
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return message.includes('malformed') || message.includes('not a database');
+}
+
 class NativeStatementCompat {
   private boundParams: SQLiteParams = [];
   private iterator: Iterator<Record<string, unknown>> | null = null;
@@ -351,7 +383,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       const db = new DatabaseSync(dbPath, { readOnly: options?.readOnly === true });
       return new SQLiteAdapter(db, isFile ? dbPath : null, options);
     } catch (err) {
-      if (!isFile || options?.readOnly === true || !existsSync(dbPath)) {
+      if (!isFile || options?.readOnly === true || !existsSync(dbPath) || !isDatabaseCorruptionError(err)) {
         throw err;
       }
       const backupPath = `${dbPath}.corrupt-${Date.now()}`;


### PR DESCRIPTION
## Summary

Invoker's database opener tried to self-heal on any failure to open the database file. It renamed the live database and its sidecar files aside, then started empty.

That is correct only for a genuinely unreadable file. A brief failure from another process was mistaken for permanent damage, so a healthy database got thrown away.

The opener now self-heals only for the two result codes that mean the file itself is unreadable. Every other failure is raised to the caller, leaving the files alone.

<details>
<summary>Review metadata</summary>

Review Claim: The database opener resets the file only when SQLite reports the file itself is unreadable.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: One pure-function decision plus its call site in create(); a healthy database is never renamed for a non-fatal failure. Each result code is covered by a unit case.

Slice Rationale: This is the opener decision only. Bounding the hourly backups is a separate concern shipped in slice (2).

</details>

## Non-goals

No change to how a genuinely unreadable database is handled — it is still moved aside and a fresh one started. No change to backups, WAL settings, or the owner/reader model.

## Test Plan

- [ ] `cd packages/data-store && pnpm exec vitest run src/__tests__/sqlite-adapter-corruption-recovery.test.ts`
- [ ] `cd packages/data-store && pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database startup handling to better distinguish true SQLite corruption from other open errors.
  * Corrupted databases are now recovered more safely, while non-corruption failures are left untouched.
  * Added better handling for corrupted database side files during recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->