### PR TITLE
[DB file safety](2) Bound the hourly database backups

### DIFF
--- a/packages/app/src/__tests__/delete-all-snapshot.test.ts
+++ b/packages/app/src/__tests__/delete-all-snapshot.test.ts
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   mkdirSync,
   readFileSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
@@ -13,6 +14,7 @@ import { tmpdir } from 'node:os';
 import {
   createDeleteAllSnapshot,
   createHourlySnapshot,
+  pruneHourlySnapshots,
   resolveInvokerHomeRoot,
 } from '../delete-all-snapshot.js';
 
@@ -29,6 +31,7 @@ afterEach(() => {
     rmSync(root, { recursive: true, force: true });
   }
   delete process.env.INVOKER_DB_DIR;
+  delete process.env.INVOKER_HOURLY_BACKUP_RETENTION;
 });
 
 describe('delete-all-snapshot', () => {
@@ -82,5 +85,115 @@ describe('delete-all-snapshot', () => {
 
     const snapshot = createDeleteAllSnapshot(root);
     expect(readFileSync(snapshot, 'utf-8')).toBe('restored-db');
+  });
+});
+
+function seedHourly(backupDir: string, count: number, withSidecars = false): void {
+  mkdirSync(backupDir, { recursive: true });
+  for (let i = 0; i < count; i += 1) {
+    const base = join(backupDir, `invoker.db.hourly-auto-20260101-${String(i).padStart(6, '0')}-000Z`);
+    writeFileSync(base, `main-${i}`);
+    if (withSidecars) {
+      writeFileSync(`${base}-wal`, `wal-${i}`);
+      writeFileSync(`${base}-shm`, `shm-${i}`);
+    }
+  }
+}
+
+function hourlyBaseNames(backupDir: string): string[] {
+  return readdirSync(backupDir).filter(
+    (n) => n.startsWith('invoker.db.hourly-auto-') && !n.endsWith('-wal') && !n.endsWith('-shm'),
+  );
+}
+
+describe('hourly snapshot retention', () => {
+  it('createHourlySnapshot prunes the oldest snapshots beyond the retention limit', () => {
+    const root = makeDbRoot();
+    writeFileSync(join(root, 'invoker.db'), 'db-main');
+    const backupDir = join(root, 'db-backups');
+    seedHourly(backupDir, 5);
+
+    const snapshot = createHourlySnapshot(root, 3);
+
+    expect(snapshot).not.toBeNull();
+    expect(existsSync(snapshot as string)).toBe(true); // newest survives
+    expect(hourlyBaseNames(backupDir)).toHaveLength(3);
+    // the three oldest seeded snapshots were removed
+    expect(existsSync(join(backupDir, 'invoker.db.hourly-auto-20260101-000000-000Z'))).toBe(false);
+    expect(existsSync(join(backupDir, 'invoker.db.hourly-auto-20260101-000004-000Z'))).toBe(true);
+  });
+
+  it('pruneHourlySnapshots deletes the -wal/-shm sidecars of pruned snapshots', () => {
+    const root = makeDbRoot();
+    const backupDir = join(root, 'db-backups');
+    seedHourly(backupDir, 4, true);
+
+    expect(pruneHourlySnapshots(backupDir, 1)).toBe(3);
+
+    for (let i = 0; i < 3; i += 1) {
+      const base = `invoker.db.hourly-auto-20260101-${String(i).padStart(6, '0')}-000Z`;
+      expect(existsSync(join(backupDir, base))).toBe(false);
+      expect(existsSync(join(backupDir, `${base}-wal`))).toBe(false);
+      expect(existsSync(join(backupDir, `${base}-shm`))).toBe(false);
+    }
+    expect(existsSync(join(backupDir, 'invoker.db.hourly-auto-20260101-000003-000Z'))).toBe(true);
+  });
+
+  it('pruneHourlySnapshots never deletes non-hourly snapshots', () => {
+    const root = makeDbRoot();
+    const backupDir = join(root, 'db-backups');
+    seedHourly(backupDir, 3);
+    writeFileSync(join(backupDir, 'invoker.db.before-delete-all-20260101-000000-000Z'), 'keep');
+    writeFileSync(join(backupDir, 'invoker.db.before-prod-recreate-20260101-000000'), 'keep');
+
+    pruneHourlySnapshots(backupDir, 1);
+
+    expect(existsSync(join(backupDir, 'invoker.db.before-delete-all-20260101-000000-000Z'))).toBe(true);
+    expect(existsSync(join(backupDir, 'invoker.db.before-prod-recreate-20260101-000000'))).toBe(true);
+  });
+
+  it('pruneHourlySnapshots with retain <= 0 disables pruning', () => {
+    const root = makeDbRoot();
+    const backupDir = join(root, 'db-backups');
+    seedHourly(backupDir, 3);
+
+    expect(pruneHourlySnapshots(backupDir, 0)).toBe(0);
+    expect(hourlyBaseNames(backupDir)).toHaveLength(3);
+  });
+
+  it('createHourlySnapshot honors INVOKER_HOURLY_BACKUP_RETENTION', () => {
+    const root = makeDbRoot();
+    writeFileSync(join(root, 'invoker.db'), 'db-main');
+    const backupDir = join(root, 'db-backups');
+    seedHourly(backupDir, 4);
+    process.env.INVOKER_HOURLY_BACKUP_RETENTION = '2';
+
+    createHourlySnapshot(root);
+
+    expect(hourlyBaseNames(backupDir)).toHaveLength(2);
+  });
+
+  it('treats empty/blank INVOKER_HOURLY_BACKUP_RETENTION as unset, not as "disable pruning"', () => {
+    // Regression: Number('') === 0 slipped through Number.isFinite && >= 0 and
+    // disabled pruning, silently reintroducing unbounded growth. Empty/blank must
+    // behave exactly like an unset variable. Seed above the default so pruning must
+    // engage — the assertion compares blank vs unset rather than a hard-coded count.
+    const seed = 60;
+    const keptWith = (value: string | undefined): number => {
+      const root = makeDbRoot();
+      writeFileSync(join(root, 'invoker.db'), 'db-main');
+      const backupDir = join(root, 'db-backups');
+      seedHourly(backupDir, seed);
+      if (value === undefined) delete process.env.INVOKER_HOURLY_BACKUP_RETENTION;
+      else process.env.INVOKER_HOURLY_BACKUP_RETENTION = value;
+      createHourlySnapshot(root);
+      return hourlyBaseNames(backupDir).length;
+    };
+
+    const unsetKept = keptWith(undefined);
+    expect(unsetKept).toBeLessThan(seed + 1); // sanity: default pruning engaged
+    for (const blank of ['', '   ']) {
+      expect(keptWith(blank)).toBe(unsetKept); // blank == unset, NOT disabled (would keep seed + 1)
+    }
   });
 });

--- a/packages/app/src/delete-all-snapshot.ts
+++ b/packages/app/src/delete-all-snapshot.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync } from 'node:fs';
 import * as path from 'node:path';
 import { resolveInvokerHomeRoot } from '@invoker/contracts';
 
@@ -44,7 +44,77 @@ export function createDeleteAllSnapshot(invokerHomeRoot: string = resolveInvoker
   return createDbSnapshot('before-delete-all', invokerHomeRoot);
 }
 
-/** Hourly periodic backup snapshot. */
-export function createHourlySnapshot(invokerHomeRoot: string = resolveInvokerHomeRoot()): string | null {
-  return createDbSnapshot('hourly-auto', invokerHomeRoot);
+const DEFAULT_HOURLY_SNAPSHOT_RETENTION = 48;
+const HOURLY_SNAPSHOT_PREFIX = 'invoker.db.hourly-auto-';
+
+function hourlySnapshotRetention(): number {
+  const raw = process.env.INVOKER_HOURLY_BACKUP_RETENTION;
+  // Treat empty/blank as unset: Number('') and Number('   ') are 0, which would
+  // otherwise pass the >= 0 check and silently disable pruning (reintroducing the
+  // unbounded growth this guards against). `export VAR=` should fall back, not disable.
+  if (raw === undefined || raw.trim() === '') return DEFAULT_HOURLY_SNAPSHOT_RETENTION;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0
+    ? Math.floor(parsed)
+    : DEFAULT_HOURLY_SNAPSHOT_RETENTION;
+}
+
+/**
+ * Delete the oldest `hourly-auto` snapshots (and their -wal/-shm sidecars) so at
+ * most `retain` remain. Without this the hourly backup grows without bound — a
+ * single host accumulated 1,554 snapshots (~363 GB). `retain <= 0` disables
+ * pruning. Only `hourly-auto` snapshots are pruned; manual and pre-delete-all
+ * snapshots are left untouched. Returns the number of snapshots removed.
+ */
+export function pruneHourlySnapshots(backupDir: string, retain: number): number {
+  if (retain <= 0) return 0;
+  let entries: string[];
+  try {
+    entries = readdirSync(backupDir);
+  } catch {
+    return 0;
+  }
+  // Base snapshot files only; the timestamp suffix (YYYYMMDD-HHMMSS-mmmZ) sorts
+  // chronologically, so the oldest snapshots come first.
+  const snapshots = entries
+    .filter(
+      (name) =>
+        name.startsWith(HOURLY_SNAPSHOT_PREFIX) &&
+        !name.endsWith('-wal') &&
+        !name.endsWith('-shm'),
+    )
+    .sort();
+  const excess = snapshots.length - retain;
+  if (excess <= 0) return 0;
+  let removed = 0;
+  for (const name of snapshots.slice(0, excess)) {
+    for (const suffix of ['', '-wal', '-shm']) {
+      try {
+        rmSync(path.join(backupDir, `${name}${suffix}`), { force: true });
+      } catch (err) {
+        // Best effort: a transient error must not abort backup, but never swallow
+        // it silently — surface it so a persistent failure is visible.
+        // (rmSync with force:true already ignores a missing file.)
+        console.warn(
+          `[delete-all-snapshot] failed to prune snapshot file ${name}${suffix}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+    removed += 1;
+  }
+  return removed;
+}
+
+/** Hourly periodic backup snapshot, bounded by `INVOKER_HOURLY_BACKUP_RETENTION`. */
+export function createHourlySnapshot(
+  invokerHomeRoot: string = resolveInvokerHomeRoot(),
+  retain: number = hourlySnapshotRetention(),
+): string | null {
+  const snapshotPath = createDbSnapshot('hourly-auto', invokerHomeRoot);
+  if (snapshotPath !== null) {
+    pruneHourlySnapshots(path.join(invokerHomeRoot, 'db-backups'), retain);
+  }
+  return snapshotPath;
 }

--- a/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  readdirSync,
+  existsSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter, isDatabaseCorruptionError } from '../sqlite-adapter.js';
+
+/**
+ * SQLiteAdapter.create() recovers a corrupt database by renaming it (and its
+ * -wal/-shm sidecars) aside and starting fresh. That recovery is destructive,
+ * so it must fire ONLY for genuine corruption. A transient/operational failure
+ * (a concurrent process holding a lock, an IO error) must propagate untouched —
+ * otherwise the live database and the -shm other connections have memory-mapped
+ * would be ripped away, losing data and crashing those readers with SIGBUS.
+ */
+
+const dirs: string[] = [];
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'sqlite-recovery-'));
+  dirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('isDatabaseCorruptionError', () => {
+  it('treats SQLITE_CORRUPT (11), SQLITE_NOTADB (26) and their extended variants as corruption', () => {
+    expect(isDatabaseCorruptionError({ errcode: 11 })).toBe(true);
+    expect(isDatabaseCorruptionError({ errcode: 26 })).toBe(true);
+    // Extended result codes carry the primary code in the low byte and must
+    // still classify: SQLITE_CORRUPT_VTAB=267, SQLITE_CORRUPT_SEQUENCE=523,
+    // SQLITE_CORRUPT_INDEX=779 (all & 0xff === 11).
+    for (const errcode of [267, 523, 779]) {
+      expect(isDatabaseCorruptionError({ errcode })).toBe(true);
+    }
+  });
+
+  it('does NOT treat transient/operational result codes (incl. extended) as corruption', () => {
+    // Primary: SQLITE_BUSY=5, SQLITE_LOCKED=6, SQLITE_IOERR=10, SQLITE_CANTOPEN=14.
+    // Extended: SQLITE_BUSY_RECOVERY=261, SQLITE_IOERR_READ=266, SQLITE_CANTOPEN_FULLPATH=782
+    // (none of which mask to 11 or 26).
+    for (const errcode of [5, 6, 10, 14, 261, 266, 782]) {
+      expect(isDatabaseCorruptionError({ errcode })).toBe(false);
+    }
+  });
+
+  it('falls back to message text when no numeric errcode is present', () => {
+    expect(isDatabaseCorruptionError(new Error('database disk image is malformed'))).toBe(true);
+    expect(isDatabaseCorruptionError(new Error('file is not a database'))).toBe(true);
+    expect(isDatabaseCorruptionError(new Error('database is locked'))).toBe(false);
+    expect(isDatabaseCorruptionError(new Error('unable to open database file'))).toBe(false);
+    expect(isDatabaseCorruptionError('not even an error')).toBe(false);
+  });
+});
+
+describe('SQLiteAdapter.create recovery', () => {
+  it('recovers a genuinely corrupt database by backing it up and starting fresh', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const garbage = Buffer.from('xx not a sqlite header xx '.repeat(50));
+    writeFileSync(dbPath, garbage);
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      expect(adapter.listWorkflows()).toEqual([]); // fresh, usable database
+    } finally {
+      adapter.close();
+    }
+
+    const corruptBackups = readdirSync(dir).filter(
+      (name) => name.includes('.corrupt-') && !name.endsWith('-wal') && !name.endsWith('-shm'),
+    );
+    expect(corruptBackups).toHaveLength(1);
+    expect(readFileSync(join(dir, corruptBackups[0]))).toEqual(garbage); // original bytes preserved
+  });
+
+  it('rethrows a non-corruption open failure WITHOUT the destructive recovery', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    // A directory at dbPath makes SQLite fail with SQLITE_CANTOPEN (operational,
+    // not corruption). A sentinel inside proves the path is never renamed away.
+    mkdirSync(dbPath);
+    mkdirSync(join(dbPath, 'sentinel'));
+
+    await expect(SQLiteAdapter.create(dbPath, { ownerCapability: true })).rejects.toThrow();
+
+    expect(readdirSync(dir).some((name) => name.includes('.corrupt-'))).toBe(false);
+    expect(existsSync(join(dbPath, 'sentinel'))).toBe(true);
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -156,6 +156,38 @@ function sqlStringLiteral(value: string): string {
   return `'${value.replaceAll("'", "''")}'`;
 }
 
+/**
+ * SQLite result codes that mean the database file itself is unreadable and a
+ * fresh start is the only recovery: SQLITE_CORRUPT (11) and SQLITE_NOTADB (26).
+ * Transient/operational failures (e.g. SQLITE_BUSY=5, SQLITE_LOCKED=6,
+ * SQLITE_CANTOPEN=14) MUST NOT trigger destructive recovery: a concurrent
+ * process briefly holding a lock would otherwise rename the live database and
+ * its -wal/-shm sidecars away, losing data and (because other connections have
+ * the -shm memory-mapped) crashing them with SIGBUS.
+ */
+const SQLITE_CORRUPT = 11;
+const SQLITE_NOTADB = 26;
+// Extended result codes pack the primary code in the low 8 bits (e.g.
+// SQLITE_CORRUPT_VTAB = 267 -> 267 & 0xff = 11), so mask before comparing or
+// extended corruption variants slip through as "not corruption".
+const SQLITE_PRIMARY_RESULT_CODE_MASK = 0xff;
+
+/**
+ * True when `err` is a SQLite open failure caused by an unreadable database file
+ * (SQLITE_CORRUPT / SQLITE_NOTADB, including their extended variants) — the only
+ * class of failure for which destructive backup-and-recreate recovery is safe.
+ */
+export function isDatabaseCorruptionError(err: unknown): boolean {
+  const errcode = (err as { errcode?: unknown } | null)?.errcode;
+  if (typeof errcode === 'number') {
+    const primary = errcode & SQLITE_PRIMARY_RESULT_CODE_MASK;
+    return primary === SQLITE_CORRUPT || primary === SQLITE_NOTADB;
+  }
+  // Fallback for runtimes that do not surface a numeric errcode.
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return message.includes('malformed') || message.includes('not a database');
+}
+
 class NativeStatementCompat {
   private boundParams: SQLiteParams = [];
   private iterator: Iterator<Record<string, unknown>> | null = null;
@@ -351,7 +383,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       const db = new DatabaseSync(dbPath, { readOnly: options?.readOnly === true });
       return new SQLiteAdapter(db, isFile ? dbPath : null, options);
     } catch (err) {
-      if (!isFile || options?.readOnly === true || !existsSync(dbPath)) {
+      if (!isFile || options?.readOnly === true || !existsSync(dbPath) || !isDatabaseCorruptionError(err)) {
         throw err;
       }
       const backupPath = `${dbPath}.corrupt-${Date.now()}`;


### PR DESCRIPTION
## Summary

Invoker copies its database to a backup folder every hour. Nothing ever cleared the folder, so it grew forever — one machine reached over 1,500 copies and hundreds of gigabytes.

The hourly backup now keeps only the most recent copies and clears older ones. The count is configurable, with a safe default.

Manual and pre-wipe backups are never touched. Only the automatic hourly copies are bounded.

<details>
<summary>Review metadata</summary>

Review Claim: Hourly database backups are bounded to a fixed number of recent copies so the backup folder cannot grow forever.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Bounding runs after a fresh hourly copy exists, only over hourly-auto files, and is best-effort so a failure never aborts the backup. Count, sidecars, non-hourly safety, and the disable switch each have a unit case.

Slice Rationale: This is the backup-folder growth only. The database-opener fix is a separate concern shipped in slice (1).

</details>

## Non-goals

No change to how a backup is taken, to manual or pre-wipe backups, or to the database itself. No change to WAL settings or the owner/reader model.

## Test Plan

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/delete-all-snapshot.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hourly backups now automatically prune older hourly snapshots after reaching a retention limit.
  * Retention is configurable via an environment variable (defaulting to 48) and can be disabled with non-positive or invalid values; blank values are treated as unset.

* **Bug Fixes**
  * Pruning now also removes related side files for deleted hourly snapshots.
  * Backup cleanup/pruning is best-effort and won’t stop due to individual delete failures.

* **Tests**
  * Improved deterministic coverage for hourly snapshot retention and cleanup behavior, including environment leakage prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->