### PR TITLE
Add built-in omp+codex Slack planning harness preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to Invoker will be documented in this file.
 - Key the single-instance worker lock by worker kind, so different worker kinds can run at once while a second start of an already-running kind is still refused across both worker doors. The worker kind is validated before it becomes the lock filename, so it cannot escape the locks directory.
 - Cap the `activity_log` table to its most recent 100000 rows, pruned as new entries are written, so `~/.invoker/invoker.db` can no longer grow without bound and trigger SIGBUS crashes.
 - Add `invoker-cli doctor` (config-aware environment validation) and an `invoker-cli setup slack` wizard. Doctor checks tools, config, and that your default planning preset's CLI is actually installed (the gap behind silent `spawn cursor ENOENT` failures); setup runs those checks, then — only if you opt in — writes a ready-to-paste Slack app manifest, validates your tokens against the live Slack API, and saves them to `~/.invoker/.env`. The app now loads `~/.invoker/.env` before the Slack startup check (so a populated file just works) and warns on launch when the default preset's tool is missing.
+- Add a built-in `omp+codex` Slack planning harness preset (`omp` tool, `codex` model), so `[omp+codex]` lobby tags and a `defaultSlackHarnessPreset` of `omp+codex` resolve without redefining `slackHarnessPresets`.
 
 ## 0.0.6
 

--- a/docs/slack-native-workflows.md
+++ b/docs/slack-native-workflows.md
@@ -27,6 +27,7 @@ A preset names the **CLI tool** that both plans conversationally and converts th
 | `cursor+claude` (default) | cursor | claude |
 | `cursor+codex` | cursor | codex |
 | `omp+claude` | omp | claude |
+| `omp+codex` | omp | codex |
 | `omp` | omp | (CLI default) |
 | `codex` | codex | (CLI default) |
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -770,6 +770,7 @@ const DEFAULT_SLACK_HARNESS_PRESETS: Record<string, { tool: 'cursor' | 'omp' | '
   'cursor+claude': { tool: 'cursor', model: 'claude' },
   'cursor+codex': { tool: 'cursor', model: 'codex' },
   'omp+claude': { tool: 'omp', model: 'claude' },
+  'omp+codex': { tool: 'omp', model: 'codex' },
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
 };

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import * as child_process from 'node:child_process';
-import { SlackSurface, parsePlanningRequest } from '../slack/slack-surface.js';
+import { SlackSurface, parsePlanningRequest, BUILTIN_HARNESS_PRESETS } from '../slack/slack-surface.js';
 import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import type { SurfaceCommand } from '../surface.js';
 import type { WorkflowContext } from '../slack/workflow-assistant.js';
@@ -144,6 +144,23 @@ describe('parsePlanningRequest', () => {
       repo: undefined,
       text: 'go',
       unknownPreset: 'omp+gpt5',
+    });
+  });
+});
+
+// ── Built-in harness presets ─────────────────────────────────
+
+describe('BUILTIN_HARNESS_PRESETS', () => {
+  it('ships an omp+codex preset that runs omp with the codex model', () => {
+    expect(BUILTIN_HARNESS_PRESETS['omp+codex']).toEqual({ tool: 'omp', model: 'codex' });
+  });
+
+  it('lets a lobby [omp+codex] tag select the omp+codex preset', () => {
+    const keys = Object.keys(BUILTIN_HARNESS_PRESETS);
+    expect(parsePlanningRequest('<@BOT> [omp+codex] add a /health endpoint', keys, 'cursor+claude')).toEqual({
+      presetKey: 'omp+codex',
+      repo: undefined,
+      text: 'add a /health endpoint',
     });
   });
 });

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -88,6 +88,7 @@ export const BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },
   'cursor+codex': { tool: 'cursor', model: 'codex' },
   'omp+claude': { tool: 'omp', model: 'claude' },
+  'omp+codex': { tool: 'omp', model: 'codex' },
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
 };


### PR DESCRIPTION
## Summary

The Slack planner ships presets for `omp`, `codex`, and `omp` with Claude, but never one for `omp` driving the `codex` model.

This adds `omp+codex` to the built-in planning presets.

A lobby `[omp+codex]` tag, or a `defaultSlackHarnessPreset` of `omp+codex`, now resolves on its own.

You no longer have to hand-define that preset under `slackHarnessPresets` to use it.

The default preset is unchanged.

<details>
<summary>Review metadata</summary>

Review Claim: Shipping `omp+codex` as a built-in Slack planning preset is correct and safe.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The change only appends one `omp+codex` entry to the two built-in preset maps, plus a doc row, a changelog line, and a unit test. The default preset stays `cursor+claude` and every existing preset is untouched, so nothing changes unless a config explicitly selects `omp+codex`.

Slice Rationale: This is a self-contained gap-fill in the preset catalog, with no larger feature to bundle it with.

</details>

## Non-goals

- Does not change the default harness preset.
- Does not change how a task's `executionAgent` or `executionModel` is chosen.
- Does not touch model auth or credential resolution.

## Test Plan

- [ ] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/slack-surface-workflows.test.ts`
- [ ] `pnpm --filter @invoker/surfaces build`
- [ ] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new built-in Slack planning preset, `omp+codex`, so `[omp+codex]` tags now resolve automatically.
  * Updated planning documentation and release notes to include the new preset.

* **Tests**
  * Added coverage to confirm the new preset is available and selected correctly when used in a planning request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->