### PR TITLE
[Sole-owner DB](2) Add exclusive-locking option (no -shm) to SQLiteAdapter

### DIFF
--- a/packages/data-store/src/__tests__/exclusive-locking.test.ts
+++ b/packages/data-store/src/__tests__/exclusive-locking.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+
+/**
+ * WAL `locking_mode = EXCLUSIVE` keeps the wal-index in heap memory, so SQLite
+ * never creates the `-shm` file. That sidecar is the one whose in-place
+ * truncation under a live memory-map kills the process with SIGBUS
+ * (see scripts/repro/repro-wal-shm-sigbus.sh). No `-shm` => no such crash.
+ */
+
+const dirs: string[] = [];
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'excl-lock-'));
+  dirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const wf: Workflow = {
+  id: 'wf-1',
+  name: 'wf',
+  status: 'running',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe('SQLiteAdapter exclusiveLocking', () => {
+  it('keeps the wal-index in heap so no -shm file is created', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true, exclusiveLocking: true });
+    try {
+      adapter.saveWorkflow(wf);
+      expect(adapter.listWorkflows().map((w) => w.id)).toEqual(['wf-1']); // fully functional
+      expect(existsSync(`${dbPath}-shm`)).toBe(false); // the immunity property
+      expect(existsSync(`${dbPath}-wal`)).toBe(true); // still WAL, just heap wal-index
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('control: default WAL locking creates the mappable -shm sidecar', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      adapter.saveWorkflow(wf);
+      adapter.listWorkflows();
+      expect(existsSync(`${dbPath}-shm`)).toBe(true); // the file that, truncated under mmap, causes SIGBUS
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('rejects exclusiveLocking on a read-only open (only the sole owner may use it)', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    // Seed the file so a read-only open is otherwise valid.
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    owner.close();
+    await expect(
+      SQLiteAdapter.create(dbPath, { readOnly: true, exclusiveLocking: true }),
+    ).rejects.toThrow(/sole opener/);
+  });
+
+  it('rejects exclusiveLocking on a non-owner writable open', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    await expect(
+      SQLiteAdapter.create(dbPath, { exclusiveLocking: true }),
+    ).rejects.toThrow(/sole opener/);
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -124,6 +124,13 @@ interface SQLiteAdapterOptions {
   outputDir?: string;
   /** Max retained activity_log rows; 0 disables retention. */
   activityLogMaxRows?: number;
+  /**
+   * Open WAL in exclusive locking mode: the wal-index lives in heap memory and
+   * no `-shm` file is created, making the process immune to the SIGBUS that a
+   * truncated memory-mapped `-shm` causes. Requires this process to be the SOLE
+   * opener of the database file — a concurrent open is rejected with SQLITE_BUSY.
+   */
+  exclusiveLocking?: boolean;
 }
 
 export type WorkflowMutationPriority = 'high' | 'normal';
@@ -307,6 +314,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private lastWorkflowTaskSnapshotStats: Record<string, unknown> | null = null;
   private readonly activityLogMaxRows: number;
   private activityLogWritesSincePrune = 0;
+  private readonly exclusiveLocking: boolean;
 
   /** Use SQLiteAdapter.create() instead. */
   private constructor(db: DatabaseSync, dbPath: string | null, options?: SQLiteAdapterOptions) {
@@ -317,6 +325,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.outputTailLimit = options?.outputTailLimit ?? 100;
     this.outputDir = options?.outputDir ?? this.resolveOutputDir(dbPath);
     this.activityLogMaxRows = options?.activityLogMaxRows ?? DEFAULT_ACTIVITY_LOG_MAX_ROWS;
+    this.exclusiveLocking = options?.exclusiveLocking === true;
     this.configureConnection(dbPath !== null);
     if (!this.readOnly) {
       this.initSchema();
@@ -334,6 +343,16 @@ export class SQLiteAdapter implements PersistenceAdapter {
   static async create(dbPath: string = ':memory:', options?: SQLiteAdapterOptions): Promise<SQLiteAdapter> {
     const isFile = dbPath !== ':memory:';
     const requestWritable = options?.readOnly !== true;
+
+    // Exclusive (heap wal-index, no -shm) locking is reserved for the sole
+    // opener: only the writable owner of a file-backed database may request it.
+    // A read-only or non-owner caller opting in would contend with the real
+    // owner (SQLITE_BUSY) or get a cryptic open failure.
+    if (isFile && options?.exclusiveLocking === true && (!requestWritable || !options?.ownerCapability)) {
+      throw new Error(
+        'exclusiveLocking requires the writable owner process to be the sole opener of the database file.',
+      );
+    }
 
     // Enforce owner-only writable initialization for file-backed databases
     if (isFile && requestWritable && !options?.ownerCapability) {
@@ -384,6 +403,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.nativeDb.exec('PRAGMA busy_timeout = 5000');
     this.nativeDb.exec('PRAGMA foreign_keys = ON');
     if (fileBacked) {
+      if (this.exclusiveLocking) {
+        // Heap wal-index (no -shm file). MUST precede `journal_mode = WAL`.
+        this.nativeDb.exec('PRAGMA locking_mode = EXCLUSIVE');
+      }
       this.nativeDb.exec('PRAGMA journal_mode = WAL');
       this.nativeDb.exec('PRAGMA synchronous = FULL');
       this.nativeDb.exec('PRAGMA wal_autocheckpoint = 1000');


### PR DESCRIPTION
<!-- sole-owner-ticket -->
# Sole-owner DB — design decision & alternatives (tracking ticket)

> This PR (#2384) is the tracking ticket for the sole-owner DB stack (#2384 → #2394). The decision below governs the whole stack; each downstream slice links back here.

## TL;DR

The SIGBUS crash is real and verified. **Before committing to the full sole-owner / IPC stack, evaluate the much cheaper `journal_mode = DELETE` fix**, which removes the same crash in ~1 line with no architecture change. The in-memory GUI viewer (slice 7, #2392) reintroduces a memory cache — the exact pattern behind our earlier sql.js OOMs — so it must stay strictly bounded.

## What's verified (reproduced locally)

- In WAL mode SQLite memory-maps `invoker.db-shm` in **every** connection. Truncating it in place while mapped → SIGBUS that kills the whole process. `scripts/repro/repro-wal-shm-sigbus.sh` exits **138** (128 + signal 10) deterministically; rename/replace of the file is safe (the inode is preserved).
- `PRAGMA locking_mode = EXCLUSIVE` set **before** `journal_mode = WAL` → **no `-shm`**, reads/writes still work. Order matters: WAL-then-EXCLUSIVE keeps the `-shm`.
- Under exclusive locking a second concurrent opener is rejected (`SQLITE_BUSY`, "database is locked"). **Exclusive locking therefore requires the owner to be the sole opener** — the reason this whole stack exists.
- `journal_mode = DELETE` (rollback journal) → **no `-shm` and no `-wal`**, and does **not** require sole-ownership; multiple processes can still open the file.
- `mmap_size` default is **0**, so `-shm` is the only memory-mapped region. Removing it (either route) grants full immunity to this crash class.

## History — why this keeps biting us

- We originally ran sql.js (whole DB held in WASM memory, flushed as a full image). That caused repeated OOMs (#355–#360, #661, #693; live DB ~615 MB, `task_output` ~357 MB) and corruption-on-crash (the atomic write-temp-then-rename workaround).
- #689 "Move data-store persistence to native SQLite WAL" fixed that — DB stayed ~1.3 MiB, peak RSS ~62 MiB on a 1 GiB-output workload. WAL's price is the `-shm` mmap, which is today's SIGBUS. **This crash is the tail cost of the cure for the OOM problem.**

## Options

1. **Small plan — `journal_mode = DELETE`.** ~1-line change in `packages/data-store/src/sqlite-adapter.ts` plus test updates (one test asserts `journal_mode === 'wal'`). Removes the crash, no sole-owner refactor, no memory cache anywhere. Cost: readers wait their turn during writes (`busy_timeout` is already 5 s); needs contention measurement under realistic owner write rates.
2. **Big plan — sole-owner + IPC (this stack, #2384 → #2394).** Keeps WAL's read-while-write speed *and* removes the crash, but turns the synchronous read surface into IPC and adds an in-memory viewer. **Slice 7 (#2392) is a memory cache**; it must hold only the UI working set (workflows / tasks / live deltas) and fetch output / activity-log / audit on demand — never mirror the high-volume tables, or the sql.js OOM returns in the viewer process.

## Recommendation

Do the **small plan first and measure** read-wait contention. Only proceed with the big plan if DELETE-mode latency is demonstrably unacceptable. If the big plan proceeds, **gate slice 7 (#2392) with a test that fails if the in-memory view's memory footprint scales with output volume** — the guardrail sql.js never had.

Refs: PR #689 (native WAL), OOM stack #355–#360 / #661 / #693, repro `scripts/repro/repro-wal-shm-sigbus.sh`.


---

## Summary

SQLite in WAL mode keeps a small index file (`invoker.db-shm`) memory-mapped in every connection.

If that file is shortened while mapped, the next read crashes the whole process with a bus error.

This adds an option to open the database in exclusive locking mode. SQLite then keeps that index in memory and never creates the `-shm` file.

With no file, there is nothing to map and nothing to fault on.

The option is off by default. It needs the process to be the only one opening the database, so later slices turn it on for the owner.

<details>
<summary>Review metadata</summary>

Review Claim: Adds an off-by-default option to open the database with no memory-mapped -shm file (WAL exclusive locking).

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: Off by default, so no existing path changes; the new branch runs only when the option is set. Unit-tested both ways: with it on no -shm file exists and reads/writes work; the control proves the default still creates -shm.

Slice Rationale: Foundational primitive for the sole-owner stack; it is switched on for the owner only after later slices have other readers go through IPC instead of opening the file.

</details>

## Non-goals

Does not enable exclusive locking anywhere yet, does not change the owner/reader model, and does not touch backups or WAL tuning.

## Test Plan

- [ ] `cd packages/data-store && pnpm exec vitest run src/__tests__/exclusive-locking.test.ts`
- [ ] `cd packages/data-store && pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional exclusive locking support for file-backed SQLite usage.
  * When enabled, the adapter configures SQLite for exclusive locking before switching to WAL mode, avoiding creation of the shared-memory sidecar (`-shm`).
  * Exclusive locking is allowed only for a sole writable opener; read-only or non-sole-opener opens are rejected.

* **Tests**
  * Added end-to-end coverage for exclusive locking, validating `-wal`/`-shm` sidecar behavior and rejection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->