### PR TITLE
[Sole-owner DB](3) Share one owner read-query responder across both owners

### DIFF
--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { answerOwnerReadQuery, type OwnerReadQueryHandlers } from '../owner-read-query.js';
+
+function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQueryHandlers {
+  return {
+    ownerModeLabel: 'gui',
+    onActivity: vi.fn(),
+    getUiPerfStats: vi.fn(() => ({ mainDeltaToUi: 7 })),
+    resetUiPerfStats: vi.fn(),
+    getQueueStatus: vi.fn(() => ({ runningCount: 2 })),
+    getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
+    getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
+    getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
+    ...over,
+  };
+}
+
+describe('answerOwnerReadQuery', () => {
+  it('ui-perf merges the owner label with the stats; reset only when asked', () => {
+    const h = makeHandlers({ ownerModeLabel: 'standalone' });
+    expect(answerOwnerReadQuery({ kind: 'ui-perf' }, h)).toEqual({ ownerMode: 'standalone', mainDeltaToUi: 7 });
+    expect(h.resetUiPerfStats).not.toHaveBeenCalled();
+    answerOwnerReadQuery({ kind: 'ui-perf', reset: true }, h);
+    expect(h.resetUiPerfStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes each read kind to its handler', () => {
+    const h = makeHandlers();
+    expect(answerOwnerReadQuery({ kind: 'queue' }, h)).toEqual({ runningCount: 2 });
+    expect(answerOwnerReadQuery({ kind: 'workflow-status' }, h)).toEqual({ 'wf-1': 'running' });
+    expect(answerOwnerReadQuery({ kind: 'action-graph' }, h)).toEqual({ nodes: [] });
+  });
+
+  it('refreshes the snapshot only for task-graph-refresh', () => {
+    const h = makeHandlers();
+    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toMatchObject({ refreshed: false });
+    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toMatchObject({ refreshed: true });
+    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(1, { refresh: false });
+    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(2, { refresh: true });
+  });
+
+  it('calls onActivity once per query and rejects unknown kinds', () => {
+    const h = makeHandlers();
+    answerOwnerReadQuery({ kind: 'queue' }, h);
+    expect(h.onActivity).toHaveBeenCalledTimes(1);
+    expect(() => answerOwnerReadQuery({ kind: 'bogus' }, h)).toThrow(/Unsupported headless query: bogus/);
+    expect(() => answerOwnerReadQuery({}, h)).toThrow(/Unsupported headless query: undefined/);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -209,6 +209,7 @@ import {
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
+import { answerOwnerReadQuery } from './owner-read-query.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import {
   createGuiMutationRegistrars,
@@ -1680,40 +1681,26 @@ function startHeadlessMode(): void {
             mode: 'standalone',
           };
         });
-        messageBus.onRequest('headless.query', async (req: unknown) => {
-          noteStandaloneOwnerActivity();
-          const { kind, reset } = req as { kind?: string; reset?: boolean };
-          if (kind === 'ui-perf') {
-            if (reset) {
-              headlessDeps.resetUiPerfStats?.();
-            }
-            return {
-              ownerMode: 'standalone',
-              ...(headlessDeps.getUiPerfStats?.() ?? {}),
-            };
-          }
-          if (kind === 'queue') {
-            return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
-          }
-          if (kind === 'workflow-status') {
-            return orchestrator.getWorkflowStatus();
-          }
-          if (kind === 'tasks' || kind === 'task-graph-refresh') {
-            if (kind === 'task-graph-refresh') {
-              orchestrator.syncAllFromDb();
-            }
-            return {
-              tasks: orchestrator.getAllTasks(),
-              workflows: persistence.listWorkflows(),
-              streamSequence: 0,
-              invokerHomeRoot: resolveInvokerHomeRoot(),
-            };
-          }
-          if (kind === 'action-graph') {
-            return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
-          }
-          throw new Error(`Unsupported headless query: ${String(kind)}`);
-        });
+        messageBus.onRequest('headless.query', async (req: unknown) =>
+          answerOwnerReadQuery(req, {
+            ownerModeLabel: 'standalone',
+            onActivity: noteStandaloneOwnerActivity,
+            getUiPerfStats: () => headlessDeps.getUiPerfStats?.() ?? {},
+            resetUiPerfStats: () => headlessDeps.resetUiPerfStats?.(),
+            getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
+            getWorkflowStatus: () => orchestrator.getWorkflowStatus(),
+            getTasksSnapshot: ({ refresh }) => {
+              if (refresh) orchestrator.syncAllFromDb();
+              return {
+                tasks: orchestrator.getAllTasks(),
+                workflows: persistence.listWorkflows(),
+                streamSequence: 0,
+                invokerHomeRoot: resolveInvokerHomeRoot(),
+              };
+            },
+            getActionGraphSnapshot: () =>
+              buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
+          }));
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId, traceId } = req as { workflowId: string; traceId?: string };
@@ -3253,39 +3240,25 @@ function createEmbeddedTerminalBackendFromConfig(
         ownerId: workflowMutationOwnerId,
         mode: 'gui',
       }));
-      messageBus.onRequest('headless.query', async (req: unknown) => {
-        const { kind, reset } = req as { kind?: string; reset?: boolean };
-        if (kind === 'ui-perf') {
-          if (reset) {
-            resetUiPerfStats();
-          }
-          return {
-            ownerMode: 'gui',
-            ...getUiPerfStats(),
-          };
-        }
-        if (kind === 'queue') {
-          return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
-        }
-        if (kind === 'workflow-status') {
-          return orchestrator.getWorkflowStatus();
-        }
-        if (kind === 'tasks' || kind === 'task-graph-refresh') {
-          if (kind === 'task-graph-refresh') {
-            orchestrator.syncAllFromDb();
-          }
-          return {
-            tasks: orchestrator.getAllTasks(),
-            workflows: persistence.listWorkflows(),
-            streamSequence: getTaskDeltaStreamSequence(),
-            invokerHomeRoot: resolveInvokerHomeRoot(),
-          };
-        }
-        if (kind === 'action-graph') {
-          return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
-        }
-        throw new Error(`Unsupported headless query: ${String(kind)}`);
-      });
+      messageBus.onRequest('headless.query', async (req: unknown) =>
+        answerOwnerReadQuery(req, {
+          ownerModeLabel: 'gui',
+          getUiPerfStats: () => getUiPerfStats(),
+          resetUiPerfStats: () => resetUiPerfStats(),
+          getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
+          getWorkflowStatus: () => orchestrator.getWorkflowStatus(),
+          getTasksSnapshot: ({ refresh }) => {
+            if (refresh) orchestrator.syncAllFromDb();
+            return {
+              tasks: orchestrator.getAllTasks(),
+              workflows: persistence.listWorkflows(),
+              streamSequence: getTaskDeltaStreamSequence(),
+              invokerHomeRoot: resolveInvokerHomeRoot(),
+            };
+          },
+          getActionGraphSnapshot: () =>
+            buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
+        }));
       messageBus.onRequest('headless.run', async (req: unknown) => {
         const { planPath, traceId } = req as { planPath: string; traceId?: string };
         logger.info(

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared dispatcher for the owner's `headless.query` IPC channel.
+ *
+ * Non-owner processes read database-derived state by sending a
+ * `{ kind }`-discriminated request over IpcBus; the writable owner answers it.
+ * The GUI owner and the standalone headless owner previously each carried an
+ * identical if-chain — this is the single place that maps a query kind to a
+ * response, so new read kinds (the sole-owner rearchitecture routes every read
+ * through here) are added once and stay consistent across both owners.
+ *
+ * The per-owner differences (owner label, task-delta stream sequence, the
+ * standalone keep-alive ping, the ui-perf source) are injected via handlers.
+ */
+export interface OwnerReadQueryHandlers {
+  /** Label echoed back on the ui-perf response ('gui' | 'standalone'). */
+  ownerModeLabel: string;
+  /** Called once per query (the standalone owner uses it to defer idle shutdown). */
+  onActivity?: () => void;
+  getUiPerfStats: () => Record<string, unknown>;
+  resetUiPerfStats: () => void;
+  getQueueStatus: () => Record<string, unknown>;
+  getWorkflowStatus: () => Record<string, unknown>;
+  /** Build the task/workflow snapshot; `refresh` re-syncs the orchestrator from the DB first. */
+  getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
+  getActionGraphSnapshot: () => Record<string, unknown>;
+}
+
+export function answerOwnerReadQuery(
+  req: unknown,
+  handlers: OwnerReadQueryHandlers,
+): Record<string, unknown> {
+  const { kind, reset } = (req ?? {}) as { kind?: string; reset?: boolean };
+  handlers.onActivity?.();
+
+  switch (kind) {
+    case 'ui-perf':
+      if (reset) handlers.resetUiPerfStats();
+      return { ownerMode: handlers.ownerModeLabel, ...handlers.getUiPerfStats() };
+    case 'queue':
+      return handlers.getQueueStatus();
+    case 'workflow-status':
+      return handlers.getWorkflowStatus();
+    case 'tasks':
+      return handlers.getTasksSnapshot({ refresh: false });
+    case 'task-graph-refresh':
+      return handlers.getTasksSnapshot({ refresh: true });
+    case 'action-graph':
+      return handlers.getActionGraphSnapshot();
+    default:
+      throw new Error(`Unsupported headless query: ${String(kind)}`);
+  }
+}

--- a/packages/data-store/src/__tests__/exclusive-locking.test.ts
+++ b/packages/data-store/src/__tests__/exclusive-locking.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+
+/**
+ * WAL `locking_mode = EXCLUSIVE` keeps the wal-index in heap memory, so SQLite
+ * never creates the `-shm` file. That sidecar is the one whose in-place
+ * truncation under a live memory-map kills the process with SIGBUS
+ * (see scripts/repro/repro-wal-shm-sigbus.sh). No `-shm` => no such crash.
+ */
+
+const dirs: string[] = [];
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'excl-lock-'));
+  dirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const wf: Workflow = {
+  id: 'wf-1',
+  name: 'wf',
+  status: 'running',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe('SQLiteAdapter exclusiveLocking', () => {
+  it('keeps the wal-index in heap so no -shm file is created', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true, exclusiveLocking: true });
+    try {
+      adapter.saveWorkflow(wf);
+      expect(adapter.listWorkflows().map((w) => w.id)).toEqual(['wf-1']); // fully functional
+      expect(existsSync(`${dbPath}-shm`)).toBe(false); // the immunity property
+      expect(existsSync(`${dbPath}-wal`)).toBe(true); // still WAL, just heap wal-index
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('control: default WAL locking creates the mappable -shm sidecar', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      adapter.saveWorkflow(wf);
+      adapter.listWorkflows();
+      expect(existsSync(`${dbPath}-shm`)).toBe(true); // the file that, truncated under mmap, causes SIGBUS
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('rejects exclusiveLocking on a read-only open (only the sole owner may use it)', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    // Seed the file so a read-only open is otherwise valid.
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    owner.close();
+    await expect(
+      SQLiteAdapter.create(dbPath, { readOnly: true, exclusiveLocking: true }),
+    ).rejects.toThrow(/sole opener/);
+  });
+
+  it('rejects exclusiveLocking on a non-owner writable open', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    await expect(
+      SQLiteAdapter.create(dbPath, { exclusiveLocking: true }),
+    ).rejects.toThrow(/sole opener/);
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -124,6 +124,13 @@ interface SQLiteAdapterOptions {
   outputDir?: string;
   /** Max retained activity_log rows; 0 disables retention. */
   activityLogMaxRows?: number;
+  /**
+   * Open WAL in exclusive locking mode: the wal-index lives in heap memory and
+   * no `-shm` file is created, making the process immune to the SIGBUS that a
+   * truncated memory-mapped `-shm` causes. Requires this process to be the SOLE
+   * opener of the database file — a concurrent open is rejected with SQLITE_BUSY.
+   */
+  exclusiveLocking?: boolean;
 }
 
 export type WorkflowMutationPriority = 'high' | 'normal';
@@ -307,6 +314,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private lastWorkflowTaskSnapshotStats: Record<string, unknown> | null = null;
   private readonly activityLogMaxRows: number;
   private activityLogWritesSincePrune = 0;
+  private readonly exclusiveLocking: boolean;
 
   /** Use SQLiteAdapter.create() instead. */
   private constructor(db: DatabaseSync, dbPath: string | null, options?: SQLiteAdapterOptions) {
@@ -317,6 +325,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.outputTailLimit = options?.outputTailLimit ?? 100;
     this.outputDir = options?.outputDir ?? this.resolveOutputDir(dbPath);
     this.activityLogMaxRows = options?.activityLogMaxRows ?? DEFAULT_ACTIVITY_LOG_MAX_ROWS;
+    this.exclusiveLocking = options?.exclusiveLocking === true;
     this.configureConnection(dbPath !== null);
     if (!this.readOnly) {
       this.initSchema();
@@ -334,6 +343,16 @@ export class SQLiteAdapter implements PersistenceAdapter {
   static async create(dbPath: string = ':memory:', options?: SQLiteAdapterOptions): Promise<SQLiteAdapter> {
     const isFile = dbPath !== ':memory:';
     const requestWritable = options?.readOnly !== true;
+
+    // Exclusive (heap wal-index, no -shm) locking is reserved for the sole
+    // opener: only the writable owner of a file-backed database may request it.
+    // A read-only or non-owner caller opting in would contend with the real
+    // owner (SQLITE_BUSY) or get a cryptic open failure.
+    if (isFile && options?.exclusiveLocking === true && (!requestWritable || !options?.ownerCapability)) {
+      throw new Error(
+        'exclusiveLocking requires the writable owner process to be the sole opener of the database file.',
+      );
+    }
 
     // Enforce owner-only writable initialization for file-backed databases
     if (isFile && requestWritable && !options?.ownerCapability) {
@@ -384,6 +403,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.nativeDb.exec('PRAGMA busy_timeout = 5000');
     this.nativeDb.exec('PRAGMA foreign_keys = ON');
     if (fileBacked) {
+      if (this.exclusiveLocking) {
+        // Heap wal-index (no -shm file). MUST precede `journal_mode = WAL`.
+        this.nativeDb.exec('PRAGMA locking_mode = EXCLUSIVE');
+      }
       this.nativeDb.exec('PRAGMA journal_mode = WAL');
       this.nativeDb.exec('PRAGMA synchronous = FULL');
       this.nativeDb.exec('PRAGMA wal_autocheckpoint = 1000');


### PR DESCRIPTION
<!-- sole-owner-ticket -->
> **Sole-owner DB — design decision / ticket:** the approach decision and alternatives (cheap `journal_mode = DELETE` fix vs this full sole-owner / IPC stack) are tracked in #2384. Please read that first.

---

## Summary

The GUI owner and the standalone owner each had an identical block that answered database-read requests over IPC, mapping a request kind to a response.

This puts that mapping in one shared function both owners call, with the few per-owner differences passed in.

It is the single place the rest of this stack adds new read kinds to, so every owner answers them the same way.

<details>
<summary>Review metadata</summary>

Review Claim: Both owners answer the read-query IPC channel through one shared responder instead of duplicated code.

Review Lane: refactor

Review Unit: routing

Safety Invariant: Pure consolidation — both owners now call one function whose per-kind output matches the previous inline code; covered by unit cases for every kind plus the unknown-kind error.

Slice Rationale: Done as its own change so the consolidation is reviewable before later slices add read kinds and consumers.

</details>

## Non-goals

No behavior change: each query kind returns exactly what it did before. No new read kinds, and no enabling of exclusive locking.

## Test Plan

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/owner-read-query.test.ts`
- [ ] `pnpm run check:types`

## Visual Proof

Not applicable. This is a backend IPC-handler consolidation; `packages/ui` is untouched, so there is no visual change. The `optional / Visual Proof Validate` UI snapshot suite passes unchanged.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in owner status queries across UI performance, queue, workflow, task snapshots, and action-graph results.
  * UI performance stats now reset only when explicitly requested.
  * Task snapshot refresh now triggers only for refresh-specific requests.
  * Invalid or unsupported query types now return a clear error.
* **Tests**
  * Added coverage for UI performance, query routing, task refresh behavior, and per-query activity handling to reduce regression risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2384
