### PR TITLE
Name the actual planner in Slack plan-conversation errors

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -558,7 +558,7 @@ describe('PlanConversation', () => {
 
   it('handles Cursor CLI error', async () => {
     mockSpawn.mockReturnValueOnce(createErrorProcess('Command not found'));
-    await expect(conversation.sendMessage('Hello')).rejects.toThrow('Failed to spawn Cursor CLI');
+    await expect(conversation.sendMessage('Hello')).rejects.toThrow('Failed to spawn agent');
   });
 
   it('handles non-zero exit code', async () => {
@@ -575,7 +575,29 @@ describe('PlanConversation', () => {
       proc.emit('close', 1);
     }, 0);
 
-    await expect(promise).rejects.toThrow('Cursor CLI exited with code 1');
+    await expect(promise).rejects.toThrow('agent exited with code 1');
+  });
+
+  it('names the planner tool (omp), not "Cursor", on non-zero exit', async () => {
+    const conv = new PlanConversation({
+      tool: 'omp',
+      planningCommandBuilder: () => ({ command: 'omp', args: ['--no-title', '--auto-approve', '-p', 'x'] }),
+    });
+    const proc = new EventEmitter() as any;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = vi.fn();
+    mockSpawn.mockReturnValueOnce(proc);
+
+    const promise = conv.sendMessage('Hello');
+    setTimeout(() => {
+      proc.stderr.emit('data', Buffer.from('No models available'));
+      proc.emit('close', 1);
+    }, 0);
+
+    const err = await promise.then(() => null, (e) => e as Error);
+    expect(err?.message).toContain('omp exited with code 1');
+    expect(err?.message).not.toContain('Cursor');
   });
 });
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -362,6 +362,7 @@ export class PlanConversation {
     const { command, args } = this.planningCommandBuilder
       ? this.planningCommandBuilder({ tool: this.tool ?? 'cursor', model: this.model, prompt })
       : defaultPlanningCommand(this.cursorCommand, { model: this.model, prompt });
+    const plannerLabel = this.tool ?? command;
     return new Promise((resolve, reject) => {
       const child = spawn(command, args, {
         cwd: this.workingDir ?? process.cwd(),
@@ -393,7 +394,7 @@ export class PlanConversation {
       const timer = setTimeout(() => {
         this.log('plan-conversation', 'error', `[PERF] cursor_timeout: pid=${child.pid ?? 'none'}, stdoutBytes=${stdout.length}, stderrBytes=${stderr.length}, stdoutChunks=${stdoutChunks}, stderrChunks=${stderrChunks}, elapsed=${Date.now() - spawnStart}ms, stderrTail="${stderr.slice(-500).replace(/\n/g, '\\n')}"`);
         try { child.kill('SIGTERM'); } catch { /* already dead */ }
-        reject(new Error(`Cursor CLI timed out after ${this.timeoutMs}ms`));
+        reject(new Error(`${plannerLabel} timed out after ${this.timeoutMs}ms`));
       }, this.timeoutMs);
 
       child.on('close', (code) => {
@@ -403,13 +404,13 @@ export class PlanConversation {
           resolve(stdout.trim() || '(no output)');
         } else {
           const errMsg = stderr.trim() || stdout.trim() || 'Unknown error';
-          reject(new Error(`Cursor CLI exited with code ${code}: ${errMsg}`));
+          reject(new Error(`${plannerLabel} exited with code ${code}: ${errMsg}`));
         }
       });
 
       child.on('error', (err) => {
         clearTimeout(timer);
-        reject(new Error(`Failed to spawn Cursor CLI: ${err.message}`));
+        reject(new Error(`Failed to spawn ${plannerLabel}: ${err.message}`));
       });
     });
   }


### PR DESCRIPTION
## Summary

Slack planning failures always read "Cursor CLI exited…" even when the planner that actually ran was omp or codex.

The label was hardcoded in three error paths — timeout, non-zero exit, and spawn failure — so an omp credential problem surfaced as a confusing "Cursor CLI" message.

The fix uses the active tool name (or the spawned command) in those messages, so the error names the planner CLI that really ran.

<details>
<summary>Review metadata</summary>

Review Claim: Slack plan-conversation subprocess errors name the planner CLI that actually ran (omp/codex/cursor), not always "Cursor CLI".

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Only the three error-message strings change; the spawned command, args, control flow, and success path stay the same.

Slice Rationale: Self-contained one-file label fix, independent of the env-loading change shipped separately.

</details>

## Non-goals

- No change to which planner runs, or to its command, args, or timeout.
- Does not touch the internal `[PERF]` debug log labels.

## Test Plan

- [ ] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-conversation.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
