### PR TITLE
Load ~/.invoker/.env in invoker-cli setup slack --check

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
   buildDoctorChecks,
   generateSlackManifest,
+  loadInvokerEnv,
   REQUIRED_BOT_SCOPES,
+  slackCredsFromEnv,
   upsertEnvLines,
   validateSlackCredentials,
   type CliConfigState,
@@ -98,3 +103,48 @@ describe('buildDoctorChecks', () => {
     expect(checks.find((c) => c.id === 'default-preset')?.status).toBe('ok');
   });
 });
+
+describe('loadInvokerEnv', () => {
+  it('loads SLACK_* from ~/.invoker/.env without overriding real env vars', () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-env-'));
+    const saved = {
+      HOME: process.env.HOME,
+      bot: process.env.SLACK_BOT_TOKEN,
+      app: process.env.SLACK_APP_TOKEN,
+      sign: process.env.SLACK_SIGNING_SECRET,
+      chan: process.env.SLACK_CHANNEL_ID,
+    };
+    try {
+      process.env.HOME = home;
+      mkdirSync(join(home, '.invoker'), { recursive: true });
+      writeFileSync(
+        join(home, '.invoker', '.env'),
+        '# slack creds\nSLACK_BOT_TOKEN=xoxb-fromfile\nSLACK_APP_TOKEN=xapp-fromfile\nSLACK_CHANNEL_ID=C123\n',
+      );
+      delete process.env.SLACK_BOT_TOKEN;
+      delete process.env.SLACK_APP_TOKEN;
+      delete process.env.SLACK_CHANNEL_ID;
+      process.env.SLACK_SIGNING_SECRET = 'real-env-wins';
+
+      loadInvokerEnv();
+
+      const creds = slackCredsFromEnv();
+      expect(creds.botToken).toBe('xoxb-fromfile');
+      expect(creds.appToken).toBe('xapp-fromfile');
+      expect(creds.channelId).toBe('C123');
+      expect(creds.signingSecret).toBe('real-env-wins');
+    } finally {
+      restoreEnv('HOME', saved.HOME);
+      restoreEnv('SLACK_BOT_TOKEN', saved.bot);
+      restoreEnv('SLACK_APP_TOKEN', saved.app);
+      restoreEnv('SLACK_SIGNING_SECRET', saved.sign);
+      restoreEnv('SLACK_CHANNEL_ID', saved.chan);
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key];
+  else process.env[key] = value;
+}

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -298,12 +298,41 @@ export function slackCredsFromEnv(): SlackCredentials {
   };
 }
 
+/** Apply KEY=VALUE pairs from a dotenv-style file to process.env without overriding existing vars. */
+function loadEnvFile(path: string): void {
+  if (!existsSync(path)) return;
+  for (const rawLine of readFileSync(path, 'utf8').split('\n')) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    const eq = line.indexOf('=');
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    if (key in process.env) continue;
+    let value = line.slice(eq + 1).trim();
+    if (value.length >= 2
+      && ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))) {
+      value = value.slice(1, -1);
+    }
+    process.env[key] = value;
+  }
+}
+
+/**
+ * Load secrets from ~/.invoker/.env (canonical) then <cwd>/.env (fallback), mirroring the app's
+ * startup loader, so `setup slack --check` validates the saved file. Existing env vars always win.
+ */
+export function loadInvokerEnv(): void {
+  loadEnvFile(envFilePath());
+  loadEnvFile(join(process.cwd(), '.env'));
+}
+
 export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promise<number> {
   const wantSlack = argv[0] === 'slack';
   const checkOnly = argv.includes('--check');
   const rl = (io as { rl?: { close: () => void } }).rl;
   try {
     if (checkOnly) {
+      loadInvokerEnv();
       const checks = await validateSlackCredentials(slackCredsFromEnv());
       const report = buildReport(checks);
       io.print(formatReport(report, { json: argv.includes('--json') }));


### PR DESCRIPTION
## Summary

After the setup wizard saved Slack tokens to `~/.invoker/.env`, `invoker-cli setup slack --check` still reported them as not set unless the same shell already had them.

The check read `process.env` directly and never loaded the saved file, so a correct setup looked broken.

The fix loads `~/.invoker/.env` (then `<cwd>/.env`) before the check, the same files the app reads at startup; values already in the environment still win.

<details>
<summary>Review metadata</summary>

Review Claim: `invoker-cli setup slack --check` loads `~/.invoker/.env` so it confirms the saved credentials instead of reading only the live shell environment.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Only the `--check` path gains a file load; the interactive wizard, doctor, and credential checks are unchanged, and existing environment variables are never overwritten.

Slice Rationale: Self-contained CLI onboarding fix, independent of the planner error-label change shipped separately.

</details>

## Non-goals

- No change to the interactive `setup slack` wizard or to `doctor`.
- Adds no new dependency; the loader is a small inline parser.

## Test Plan

- [ ] `pnpm --filter @invoker/contracts build`
- [ ] `pnpm --filter @invoker/cli exec vitest run src/__tests__/onboarding.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The onboarding check now reads Slack credentials from the expected local environment file before validating setup.
  * Existing environment variables remain unchanged, while missing values can be loaded from a project or home directory env file.
  * Expanded test coverage to verify the correct credentials are used during onboarding checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->