### PR TITLE
[Sole-owner DB](5) Answer read-only headless CLI queries from the owner

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -404,6 +404,40 @@ describe('headless-client', () => {
     expect(refreshMessageBus).toHaveBeenCalled();
   }, 15_000);
 
+  it('refreshes and retries generic read queries when a live owner is not ready', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    let queryCalls = 0;
+
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-generic', mode: 'standalone' }));
+    secondBus.onRequest('headless.query', async () => {
+      queryCalls += 1;
+      if (queryCalls === 1) {
+        return await new Promise(() => {});
+      }
+      return { output: 'wf-1\n' };
+    });
+
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValue(secondBus);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const runElectronHeadless = vi.fn(async () => 0);
+
+    const exitCode = await runHeadlessClientCommand(['query', 'workflows', '--output', 'label'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      refreshMessageBus,
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(queryCalls).toBe(2);
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+    expect(stdout).toHaveBeenCalledWith('wf-1\n');
+    stdout.mockRestore();
+  }, 15_000);
+
   it('refreshes past a non-mutation owner before delegating a mutation', async () => {
     const firstBus = new LocalBus();
     const secondBus = new LocalBus();

--- a/packages/app/src/__tests__/headless-query-capture.test.ts
+++ b/packages/app/src/__tests__/headless-query-capture.test.ts
@@ -31,6 +31,31 @@ describe('runReadOnlyHeadlessQueryToString', () => {
     }
   });
 
+  it('captures review-gate output instead of writing to process.stdout', async () => {
+    const deps = makeQueryDeps(() => []);
+    deps.persistence = {
+      ...deps.persistence,
+      findReviewGateByPr: () => ({
+        workflowId: 'wf-review',
+        reviewId: 123,
+        workflowStatus: 'running',
+        workflowGeneration: 7,
+        branch: 'stack/review',
+      }),
+    } as unknown as HeadlessQueryDeps['persistence'];
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    try {
+      const output = await runReadOnlyHeadlessQueryToString(
+        ['query', 'review-gate', '123', '--output', 'label'],
+        deps,
+      );
+      expect(output).toBe('wf-review\n');
+      expect(writeSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
   it('maps the deprecated alias `list` to `query workflows`', async () => {
     const deps = makeQueryDeps(() => [{ id: 'wf-9' }]);
     const output = await runReadOnlyHeadlessQueryToString(['list', '--output', 'label'], deps);

--- a/packages/app/src/__tests__/headless-query-capture.test.ts
+++ b/packages/app/src/__tests__/headless-query-capture.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runReadOnlyHeadlessQueryToString,
+  type HeadlessQueryDeps,
+} from '../headless-query-list.js';
+
+function makeQueryDeps(listWorkflows: () => Array<{ id: string; status?: string }>): HeadlessQueryDeps {
+  return {
+    persistence: { listWorkflows } as unknown as HeadlessQueryDeps['persistence'],
+    orchestrator: {} as unknown as HeadlessQueryDeps['orchestrator'],
+    executionAgentRegistry: undefined,
+    invokerConfig: {} as unknown as HeadlessQueryDeps['invokerConfig'],
+    getUiPerfStats: () => ({}),
+    resetUiPerfStats: () => {},
+  };
+}
+
+describe('runReadOnlyHeadlessQueryToString', () => {
+  it('captures rendered output instead of writing to process.stdout', async () => {
+    const deps = makeQueryDeps(() => [{ id: 'wf-1' }, { id: 'wf-2' }]);
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    try {
+      const output = await runReadOnlyHeadlessQueryToString(
+        ['query', 'workflows', '--output', 'label'],
+        deps,
+      );
+      expect(output).toBe('wf-1\nwf-2\n');
+      expect(writeSpy).not.toHaveBeenCalled();
+    } finally {
+      writeSpy.mockRestore();
+    }
+  });
+
+  it('maps the deprecated alias `list` to `query workflows`', async () => {
+    const deps = makeQueryDeps(() => [{ id: 'wf-9' }]);
+    const output = await runReadOnlyHeadlessQueryToString(['list', '--output', 'label'], deps);
+    expect(output).toBe('wf-9\n');
+  });
+
+  it('rejects a command that is not a delegatable read-only query', async () => {
+    const deps = makeQueryDeps(() => []);
+    await expect(runReadOnlyHeadlessQueryToString(['watch', 'wf-1'], deps)).rejects.toThrow(
+      /not a delegatable read-only query/,
+    );
+  });
+
+  it('rejects `query ui-perf --reset` so delegation cannot clear owner stats', async () => {
+    const resetUiPerfStats = vi.fn();
+    const deps = { ...makeQueryDeps(() => []), resetUiPerfStats, getUiPerfStats: () => ({}) };
+    await expect(
+      runReadOnlyHeadlessQueryToString(['query', 'ui-perf', '--reset'], deps),
+    ).rejects.toThrow(/read-only/);
+    expect(resetUiPerfStats).not.toHaveBeenCalled();
+  });
+
+  it('still allows non-destructive `query ui-perf`', async () => {
+    const resetUiPerfStats = vi.fn();
+    const deps = { ...makeQueryDeps(() => []), resetUiPerfStats, getUiPerfStats: () => ({ mainDeltaToUi: 1 }) };
+    await expect(runReadOnlyHeadlessQueryToString(['query', 'ui-perf'], deps)).resolves.toContain('mainDeltaToUi');
+    expect(resetUiPerfStats).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -124,4 +124,39 @@ describe('registerReadOnlyIpcHandlers', () => {
     expectReadContextWriteToolsAreAbsent();
   });
 
+  function registerViewer(requestImpl: () => Promise<unknown>) {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler);
+      }),
+    };
+    registerReadOnlyIpcHandlers({
+      ipcMain: ipcMain as never,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+      persistence: { listWorkflows: vi.fn(() => [{ id: 'LOCAL-FALLBACK' }]) } as never,
+      getOrchestrator: () => ({}) as never,
+      agentRegistry: {} as never,
+      loadTaskByIdFromPersistence: () => undefined,
+      resolveAgentSession: vi.fn(async () => null),
+      getOwnerMode: () => false, // viewer mode → delegates to owner
+      getMessageBus: () => ({ request: vi.fn(requestImpl) }),
+      recordStartupDuration: vi.fn(),
+      getTaskDeltaStreamSequence: () => 0,
+    });
+    return handlers;
+  }
+
+  it('rethrows owner errors instead of silently serving local data (timeout)', async () => {
+    const handlers = registerViewer(() =>
+      Promise.reject(Object.assign(new Error('owner timed out'), { code: 'REQUEST_TIMEOUT' })));
+    await expect(handlers.get('invoker:list-workflows')?.({})).rejects.toThrow(/owner timed out/);
+  });
+
+  it('falls back to local only when the owner has no handler', async () => {
+    const handlers = registerViewer(() =>
+      Promise.reject(Object.assign(new Error('No request handler registered for channel: headless.query'), { code: 'NO_HANDLER' })));
+    await expect(handlers.get('invoker:list-workflows')?.({})).resolves.toEqual([{ id: 'LOCAL-FALLBACK' }]);
+  });
+
 });

--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { answerOwnerReadQuery, type OwnerReadQueryHandlers } from '../owner-read-query.js';
+import {
+  answerOwnerReadQuery,
+  buildOwnerReadQueryHandlers,
+  type OwnerReadQueryHandlers,
+} from '../owner-read-query.js';
 
 function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQueryHandlers {
   return {
@@ -11,6 +15,16 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
     getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
     getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
+    listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+    loadWorkflowBundle: vi.fn((id: string) => ({ workflow: { id }, tasks: [] })),
+    getReviewGate: vi.fn(() => ({ gate: true })),
+    getEvents: vi.fn(() => [{ e: 1 }]),
+    getTaskById: vi.fn((id: string) => ({ id })),
+    getTaskOutput: vi.fn(() => 'output-text'),
+    getOutputChunks: vi.fn(() => [{ c: 1 }]),
+    getOutputTail: vi.fn(() => ({ tail: 1 })),
+    replayOutput: vi.fn((id: string, off: number) => [{ id, off }]),
+    getAllCompletedTasks: vi.fn(() => [{ id: 'done' }]),
     ...over,
   };
 }
@@ -24,7 +38,7 @@ describe('answerOwnerReadQuery', () => {
     expect(h.resetUiPerfStats).toHaveBeenCalledTimes(1);
   });
 
-  it('routes each read kind to its handler', () => {
+  it('routes the snapshot kinds to their handlers', () => {
     const h = makeHandlers();
     expect(answerOwnerReadQuery({ kind: 'queue' }, h)).toEqual({ runningCount: 2 });
     expect(answerOwnerReadQuery({ kind: 'workflow-status' }, h)).toEqual({ 'wf-1': 'running' });
@@ -39,11 +53,130 @@ describe('answerOwnerReadQuery', () => {
     expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(2, { refresh: true });
   });
 
+  it('wraps and routes the param-bearing read kinds', () => {
+    const h = makeHandlers();
+    expect(answerOwnerReadQuery({ kind: 'workflows' }, h)).toEqual({ workflows: [{ id: 'wf-1' }] });
+    expect(answerOwnerReadQuery({ kind: 'workflow', workflowId: 'wf-9' }, h)).toEqual({ workflow: { id: 'wf-9' }, tasks: [] });
+    expect(h.loadWorkflowBundle).toHaveBeenCalledWith('wf-9');
+    expect(answerOwnerReadQuery({ kind: 'review-gate', workflowId: 'wf-9' }, h)).toEqual({ reviewGate: { gate: true } });
+    expect(answerOwnerReadQuery({ kind: 'events', taskId: 't-1' }, h)).toEqual({ events: [{ e: 1 }] });
+    expect(h.getEvents).toHaveBeenCalledWith('t-1');
+    expect(answerOwnerReadQuery({ kind: 'task-by-id', taskId: 't-1' }, h)).toEqual({ task: { id: 't-1' } });
+    expect(answerOwnerReadQuery({ kind: 'task-output', taskId: 't-1' }, h)).toEqual({ output: 'output-text' });
+    expect(answerOwnerReadQuery({ kind: 'output-chunks', taskId: 't-1' }, h)).toEqual({ chunks: [{ c: 1 }] });
+    expect(answerOwnerReadQuery({ kind: 'output-tail', taskId: 't-1' }, h)).toEqual({ tail: { tail: 1 } });
+    expect(answerOwnerReadQuery({ kind: 'replay-output', taskId: 't-1', fromOffset: 42 }, h)).toEqual({ chunks: [{ id: 't-1', off: 42 }] });
+    expect(h.replayOutput).toHaveBeenCalledWith('t-1', 42);
+    expect(answerOwnerReadQuery({ kind: 'all-completed-tasks' }, h)).toEqual({ tasks: [{ id: 'done' }] });
+  });
+
+  it('null-coalesces task-by-id, review-gate, and output-tail', () => {
+    const h = makeHandlers({
+      getTaskById: vi.fn(() => undefined),
+      getReviewGate: vi.fn(() => undefined),
+      getOutputTail: vi.fn(() => undefined),
+    });
+    expect(answerOwnerReadQuery({ kind: 'task-by-id', taskId: 'x' }, h)).toEqual({ task: null });
+    expect(answerOwnerReadQuery({ kind: 'review-gate', workflowId: 'x' }, h)).toEqual({ reviewGate: null });
+    expect(answerOwnerReadQuery({ kind: 'output-tail', taskId: 'x' }, h)).toEqual({ tail: null });
+  });
+
   it('calls onActivity once per query and rejects unknown kinds', () => {
     const h = makeHandlers();
     answerOwnerReadQuery({ kind: 'queue' }, h);
     expect(h.onActivity).toHaveBeenCalledTimes(1);
     expect(() => answerOwnerReadQuery({ kind: 'bogus' }, h)).toThrow(/Unsupported headless query: bogus/);
     expect(() => answerOwnerReadQuery({}, h)).toThrow(/Unsupported headless query: undefined/);
+  });
+
+  it('rejects malformed params before invoking handlers', () => {
+    const h = makeHandlers();
+    // Missing workflowId must not reach loadWorkflowBundle('') (which would
+    // syncFromDb('') and mutate the owner cache for an invalid id).
+    expect(() => answerOwnerReadQuery({ kind: 'workflow' }, h)).toThrow(/workflowId/);
+    expect(h.loadWorkflowBundle).not.toHaveBeenCalled();
+    expect(() => answerOwnerReadQuery({ kind: 'review-gate' }, h)).toThrow(/workflowId/);
+    expect(() => answerOwnerReadQuery({ kind: 'events' }, h)).toThrow(/taskId/);
+    expect(() => answerOwnerReadQuery({ kind: 'task-by-id' }, h)).toThrow(/taskId/);
+    expect(h.getEvents).not.toHaveBeenCalled();
+    // Non-finite / negative replay offsets must be rejected too.
+    expect(() => answerOwnerReadQuery({ kind: 'replay-output', taskId: 't', fromOffset: -1 }, h)).toThrow(/fromOffset/);
+    expect(() => answerOwnerReadQuery({ kind: 'replay-output', taskId: 't', fromOffset: Number.NaN }, h)).toThrow(/fromOffset/);
+    expect(h.replayOutput).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildOwnerReadQueryHandlers', () => {
+  function fakes() {
+    return {
+      orchestrator: {
+        getQueueStatus: () => ({ q: 1 }),
+        getWorkflowStatus: () => ({ w: 1 }),
+        getAllTasks: () => [{ id: 't' }],
+        syncAllFromDb: vi.fn(),
+        syncFromDb: vi.fn(),
+      },
+      persistence: {
+        listWorkflows: () => [{ id: 'wf' }],
+        loadWorkflow: (id: string) => (id === 'missing' ? undefined : { id, name: 'n' }),
+        loadTasks: () => [{ id: 't', config: {} }],
+        loadTask: (id: string) => ({ id }),
+        getEvents: () => [{ e: 1 }],
+        getTaskOutput: () => 'out',
+        getOutputChunks: () => [{ c: 1 }],
+        getOutputTail: () => ({ t: 1 }),
+        replayOutputFrom: (id: string, off: number) => [{ id, off }],
+        loadAllCompletedTasks: () => [{ id: 'done' }],
+      },
+    };
+  }
+  function build(orch: Record<string, unknown> = {}, persist: Record<string, unknown> = {}) {
+    const f = fakes();
+    return buildOwnerReadQueryHandlers({
+      ownerModeLabel: 'gui',
+      getUiPerfStats: () => ({}),
+      resetUiPerfStats: () => {},
+      getStreamSequence: () => 5,
+      resolveInvokerHomeRoot: () => '/home',
+      orchestrator: { ...f.orchestrator, ...orch } as never,
+      persistence: { ...f.persistence, ...persist } as never,
+      getActionGraphSnapshot: () => ({ ag: 1 }),
+    });
+  }
+
+  it('passes reads straight through to persistence', () => {
+    const h = build();
+    expect(h.listWorkflows()).toEqual([{ id: 'wf' }]);
+    expect(h.getEvents('t1')).toEqual([{ e: 1 }]);
+    expect(h.getTaskOutput('t1')).toBe('out');
+    expect(h.getTaskById('t1')).toEqual({ id: 't1' });
+    expect(h.getOutputChunks('t1')).toEqual([{ c: 1 }]);
+    expect(h.replayOutput('t1', 9)).toEqual([{ id: 't1', off: 9 }]);
+    expect(h.getAllCompletedTasks()).toEqual([{ id: 'done' }]);
+  });
+
+  it('loadWorkflowBundle syncs that workflow first, then returns workflow + tasks', () => {
+    const syncFromDb = vi.fn();
+    const h = build({ syncFromDb });
+    expect(h.loadWorkflowBundle('wf-9')).toEqual({ workflow: { id: 'wf-9', name: 'n' }, tasks: [{ id: 't', config: {} }] });
+    expect(syncFromDb).toHaveBeenCalledWith('wf-9');
+  });
+
+  it('getReviewGate returns null for an unknown workflow', () => {
+    expect(build().getReviewGate('missing')).toBeNull();
+  });
+
+  it('getTasksSnapshot refreshes only when asked', () => {
+    const syncAllFromDb = vi.fn();
+    const h = build({ syncAllFromDb });
+    expect(h.getTasksSnapshot({ refresh: false })).toEqual({
+      tasks: [{ id: 't' }],
+      workflows: [{ id: 'wf' }],
+      streamSequence: 5,
+      invokerHomeRoot: '/home',
+    });
+    expect(syncAllFromDb).not.toHaveBeenCalled();
+    h.getTasksSnapshot({ refresh: true });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -14,6 +14,7 @@ import {
   tryDelegateQueryUiPerf,
   tryDelegateResume,
   tryDelegateRun,
+  tryPingHeadlessOwner,
   type DelegationOutcome,
 } from './headless-delegation.js';
 import {
@@ -92,6 +93,7 @@ const POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS = 90_000;
 const POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 8_000;
+const GENERIC_READ_OWNER_PING_TIMEOUT_MS = 1_500;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
 const DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS = 60_000;
 
@@ -142,6 +144,40 @@ async function delegateMutation(
   return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
 }
 
+const GENERIC_DELEGATABLE_READ_COMMANDS = new Set([
+  'list', 'status', 'task-status', 'audit', 'session', 'query-select',
+]);
+
+/**
+ * Read-only query commands the owner can answer over the generic `cli-query`
+ * channel. `queue`, `ui-perf`, and `action-graph` are excluded here — they have
+ * bespoke owner-required handling in {@link delegateReadOnlyQuery}.
+ */
+function isGenericDelegatableReadCommand(args: string[]): boolean {
+  const command = args[0];
+  if (command === 'query') {
+    const sub = args[1];
+    return sub !== undefined && sub !== 'queue' && sub !== 'ui-perf' && sub !== 'action-graph';
+  }
+  return command !== undefined && GENERIC_DELEGATABLE_READ_COMMANDS.has(command);
+}
+
+/**
+ * Delegate a read-only query to the writable owner so this process never opens
+ * the database file. Returns false when the command is not delegatable or no
+ * owner is present, letting the caller open the database directly (it is then
+ * the sole opener — safe).
+ */
+async function delegateGenericReadQuery(args: string[], bus: MessageBus): Promise<boolean> {
+  if (!isGenericDelegatableReadCommand(args)) return false;
+  const owner = await tryPingHeadlessOwner(bus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
+  if (!owner) return false;
+  const response = await tryDelegateQuery(bus, { kind: 'cli-query', args }, READ_ONLY_QUERY_REQUEST_TIMEOUT_MS);
+  if (!response || typeof response.output !== 'string') return false;
+  process.stdout.write(response.output);
+  return true;
+}
+
 async function delegateReadOnlyQuery(
   args: string[],
   bus: MessageBus,
@@ -151,7 +187,7 @@ async function delegateReadOnlyQuery(
   const isQueue = (args[0] === 'query' && args[1] === 'queue') || args[0] === 'queue';
   const isActionGraph = args[0] === 'query' && args[1] === 'action-graph';
   if (!isUiPerf && !isQueue && !isActionGraph) {
-    return false;
+    return delegateGenericReadQuery(args, bus);
   }
 
   // Use the resolver to wait for any reachable owner

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -168,14 +168,46 @@ function isGenericDelegatableReadCommand(args: string[]): boolean {
  * owner is present, letting the caller open the database directly (it is then
  * the sole opener — safe).
  */
-async function delegateGenericReadQuery(args: string[], bus: MessageBus): Promise<boolean> {
+async function delegateGenericReadQuery(
+  args: string[],
+  bus: MessageBus,
+  refreshMessageBus?: () => Promise<MessageBus>,
+): Promise<boolean> {
   if (!isGenericDelegatableReadCommand(args)) return false;
-  const owner = await tryPingHeadlessOwner(bus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
-  if (!owner) return false;
-  const response = await tryDelegateQuery(bus, { kind: 'cli-query', args }, READ_ONLY_QUERY_REQUEST_TIMEOUT_MS);
-  if (!response || typeof response.output !== 'string') return false;
-  process.stdout.write(response.output);
-  return true;
+
+  if (!refreshMessageBus) {
+    const owner = await tryPingHeadlessOwner(bus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
+    if (!owner) return false;
+  }
+
+  const resolver = refreshMessageBus
+    ? createOwnerResolver(
+      { messageBus: bus, refreshMessageBus, ensureStandaloneOwner: async () => {} },
+      { discoveryTimeoutMs: GENERIC_READ_OWNER_PING_TIMEOUT_MS },
+    )
+    : null;
+  const ownerResult = resolver
+    ? await resolver.waitForAny(READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS)
+    : { resolved: true as const, bus };
+  if (!ownerResult.resolved) return false;
+  let messageBus = ownerResult.bus;
+  const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const response = await tryDelegateQuery(
+      messageBus,
+      { kind: 'cli-query', args },
+      READ_ONLY_QUERY_REQUEST_TIMEOUT_MS,
+    );
+    if (response && typeof response.output === 'string') {
+      process.stdout.write(response.output);
+      return true;
+    }
+    if (!refreshMessageBus) break;
+    messageBus = await refreshMessageBus();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error('Live owner is present but did not serve cli-query');
 }
 
 async function delegateReadOnlyQuery(
@@ -187,7 +219,7 @@ async function delegateReadOnlyQuery(
   const isQueue = (args[0] === 'query' && args[1] === 'queue') || args[0] === 'queue';
   const isActionGraph = args[0] === 'query' && args[1] === 'action-graph';
   if (!isUiPerf && !isQueue && !isActionGraph) {
-    return delegateGenericReadQuery(args, bus);
+    return delegateGenericReadQuery(args, bus, refreshMessageBus);
   }
 
   // Use the resolver to wait for any reachable owner

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -164,10 +164,10 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       if (!prNumber) throw new Error(`Could not parse a PR number from "${arg}".`);
       const record = deps.persistence.findReviewGateByPr(prNumber);
       switch (flags.output) {
-        case 'label': process.stdout.write(`${record?.workflowId ?? ''}\n`); break;
-        case 'json':  process.stdout.write(formatAsJson(record ?? {}) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl(record ? [record] : []) + '\n'); break;
-        default:      process.stdout.write(
+        case 'label': writeOut(`${record?.workflowId ?? ''}\n`); break;
+        case 'json':  writeOut(formatAsJson(record ?? {}) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl(record ? [record] : []) + '\n'); break;
+        default:      writeOut(
           record
             ? `${record.workflowId}\t${record.reviewId ?? prNumber}\t${record.workflowStatus}\tgen=${record.workflowGeneration}\t${record.branch ?? ''}\n`
             : `No Invoker workflow found for PR ${prNumber}.\n`,

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -10,6 +10,7 @@
  * module depends only on `headless-shared.ts`.
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Attempt, TaskState } from '@invoker/workflow-core';
 import type { AgentSessionData, NormalizedCostEvent } from '@invoker/contracts';
 import type { AgentRegistry } from '@invoker/execution-engine';
@@ -22,7 +23,34 @@ import {
   restoreWorkflowForTask,
 } from './headless-shared.js';
 
-export async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> {
+/**
+ * The read-query family writes its formatted output through {@link writeOut}.
+ * Locally (no active sink) it goes straight to `process.stdout`. When the
+ * writable owner answers a delegated `cli-query` it runs the same code inside
+ * {@link runReadOnlyHeadlessQueryToString}, which installs a buffering sink via
+ * AsyncLocalStorage so the rendered text is captured and returned over IPC
+ * instead of printed on the owner. AsyncLocalStorage keeps the sink isolated
+ * per request, so concurrent delegated queries never cross output.
+ */
+const queryOutputSink = new AsyncLocalStorage<(chunk: string) => void>();
+
+function writeOut(chunk: string): void {
+  const sink = queryOutputSink.getStore();
+  if (sink) sink(chunk);
+  else process.stdout.write(chunk);
+}
+
+/**
+ * Dependency subset the read-query path needs. Narrow enough that both the
+ * standalone and GUI owners can supply it without building a full
+ * {@link HeadlessDeps}.
+ */
+export type HeadlessQueryDeps = Pick<
+  HeadlessDeps,
+  'orchestrator' | 'persistence' | 'executionAgentRegistry' | 'invokerConfig' | 'getUiPerfStats' | 'resetUiPerfStats'
+>;
+
+export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
     throw new Error('Missing query sub-command. Usage: --headless query <workflows|workflow|tasks|task|queue|review-gate|action-graph|audit|session|cost|cost-events|costs|ui-perf|stats>');
@@ -43,10 +71,10 @@ export async function headlessQuery(args: string[], deps: HeadlessDeps): Promise
         workflows = workflows.filter(wf => wf.status === flags.status);
       }
       switch (flags.output) {
-        case 'label': process.stdout.write(formatAsLabel(workflows) + '\n'); break;
-        case 'json':  process.stdout.write(formatAsJson(workflows.map(serializeWorkflow)) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl(workflows.map(serializeWorkflow)) + '\n'); break;
-        default:      process.stdout.write(formatWorkflowList(workflows) + '\n'); break;
+        case 'label': writeOut(formatAsLabel(workflows) + '\n'); break;
+        case 'json':  writeOut(formatAsJson(workflows.map(serializeWorkflow)) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl(workflows.map(serializeWorkflow)) + '\n'); break;
+        default:      writeOut(formatWorkflowList(workflows) + '\n'); break;
       }
       break;
     }
@@ -56,10 +84,10 @@ export async function headlessQuery(args: string[], deps: HeadlessDeps): Promise
       const workflow = deps.persistence.loadWorkflow(workflowId);
       if (!workflow) throw new Error(`Workflow "${workflowId}" not found.`);
       switch (flags.output) {
-        case 'label': process.stdout.write(`${workflow.id}\n`); break;
-        case 'json':  process.stdout.write(formatAsJson(serializeWorkflow(workflow)) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl([serializeWorkflow(workflow)]) + '\n'); break;
-        default:      process.stdout.write(formatWorkflowList([workflow]) + '\n'); break;
+        case 'label': writeOut(`${workflow.id}\n`); break;
+        case 'json':  writeOut(formatAsJson(serializeWorkflow(workflow)) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl([serializeWorkflow(workflow)]) + '\n'); break;
+        default:      writeOut(formatWorkflowList([workflow]) + '\n'); break;
       }
       break;
     }
@@ -67,7 +95,7 @@ export async function headlessQuery(args: string[], deps: HeadlessDeps): Promise
       const { orchestrator, persistence } = deps;
       const workflows = persistence.listWorkflows();
       if (workflows.length === 0) {
-        process.stdout.write('No workflows found. Run a plan first.\n');
+        writeOut('No workflows found. Run a plan first.\n');
         return;
       }
 
@@ -102,13 +130,13 @@ export async function headlessQuery(args: string[], deps: HeadlessDeps): Promise
       }
 
       switch (flags.output) {
-        case 'label': process.stdout.write(formatAsLabel(allTasks) + '\n'); break;
-        case 'json':  process.stdout.write(formatAsJson(allTasks.map(serializeTask)) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl(allTasks.map(serializeTask)) + '\n'); break;
+        case 'label': writeOut(formatAsLabel(allTasks) + '\n'); break;
+        case 'json':  writeOut(formatAsJson(allTasks.map(serializeTask)) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl(allTasks.map(serializeTask)) + '\n'); break;
         default: {
-          for (const task of allTasks) process.stdout.write(formatTaskStatus(task) + '\n');
+          for (const task of allTasks) writeOut(formatTaskStatus(task) + '\n');
           const status = orchestrator.getWorkflowStatus();
-          process.stdout.write(`\n${formatWorkflowStatus(status)}\n`);
+          writeOut(`\n${formatWorkflowStatus(status)}\n`);
           break;
         }
       }
@@ -122,10 +150,10 @@ export async function headlessQuery(args: string[], deps: HeadlessDeps): Promise
       if (!task) throw new Error(`Task "${taskId}" not found`);
 
       switch (flags.output) {
-        case 'label': process.stdout.write(task.id + '\n'); break;
-        case 'json':  process.stdout.write(formatAsJson(serializeTask(task)) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl([serializeTask(task)]) + '\n'); break;
-        default:      process.stdout.write(task.status + '\n'); break;
+        case 'label': writeOut(task.id + '\n'); break;
+        case 'json':  writeOut(formatAsJson(serializeTask(task)) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl([serializeTask(task)]) + '\n'); break;
+        default:      writeOut(task.status + '\n'); break;
       }
       break;
     }
@@ -157,16 +185,16 @@ export async function headlessQuery(args: string[], deps: HeadlessDeps): Promise
       switch (flags.output) {
         case 'label': {
           const ids = [...status.running.map(t => t.taskId), ...status.queued.map(t => t.taskId)];
-          process.stdout.write(ids.join('\n') + '\n');
+          writeOut(ids.join('\n') + '\n');
           break;
         }
-        case 'json':  process.stdout.write(formatAsJson(status) + '\n'); break;
+        case 'json':  writeOut(formatAsJson(status) + '\n'); break;
         case 'jsonl': {
-          for (const t of status.running) process.stdout.write(JSON.stringify({ ...t, state: 'running' }) + '\n');
-          for (const t of status.queued) process.stdout.write(JSON.stringify({ ...t, state: 'queued' }) + '\n');
+          for (const t of status.running) writeOut(JSON.stringify({ ...t, state: 'running' }) + '\n');
+          for (const t of status.queued) writeOut(JSON.stringify({ ...t, state: 'queued' }) + '\n');
           break;
         }
-        default: process.stdout.write(formatQueueStatus(status) + '\n'); break;
+        default: writeOut(formatQueueStatus(status) + '\n'); break;
       }
       break;
     }
@@ -178,19 +206,19 @@ export async function headlessQuery(args: string[], deps: HeadlessDeps): Promise
       });
       switch (flags.output) {
         case 'label':
-          process.stdout.write(graph.nodes.map((node) => node.id).join('\n') + '\n');
+          writeOut(graph.nodes.map((node) => node.id).join('\n') + '\n');
           break;
         case 'jsonl':
           for (const node of graph.nodes) {
-            process.stdout.write(JSON.stringify({ kind: 'node', ...node }) + '\n');
+            writeOut(JSON.stringify({ kind: 'node', ...node }) + '\n');
           }
           for (const edge of graph.edges) {
-            process.stdout.write(JSON.stringify({ kind: 'edge', ...edge }) + '\n');
+            writeOut(JSON.stringify({ kind: 'edge', ...edge }) + '\n');
           }
           break;
         case 'json':
         default:
-          process.stdout.write(formatAsJson(graph) + '\n');
+          writeOut(formatAsJson(graph) + '\n');
           break;
       }
       break;
@@ -201,10 +229,10 @@ export async function headlessQuery(args: string[], deps: HeadlessDeps): Promise
       const events = deps.persistence.getEvents(taskId);
 
       switch (flags.output) {
-        case 'label': process.stdout.write(events.map(e => `${e.taskId}:${e.eventType}`).join('\n') + '\n'); break;
-        case 'json':  process.stdout.write(formatAsJson(events.map(serializeEvent)) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl(events.map(serializeEvent)) + '\n'); break;
-        default:      process.stdout.write(formatEventLog(events) + '\n'); break;
+        case 'label': writeOut(events.map(e => `${e.taskId}:${e.eventType}`).join('\n') + '\n'); break;
+        case 'json':  writeOut(formatAsJson(events.map(serializeEvent)) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl(events.map(serializeEvent)) + '\n'); break;
+        default:      writeOut(formatEventLog(events) + '\n'); break;
       }
       break;
     }
@@ -233,16 +261,16 @@ export async function headlessQuery(args: string[], deps: HeadlessDeps): Promise
       };
       switch (flags.output) {
         case 'label':
-          process.stdout.write(String((stats as Record<string, unknown>).maxRendererEventLoopLagMs ?? 0) + '\n');
+          writeOut(String((stats as Record<string, unknown>).maxRendererEventLoopLagMs ?? 0) + '\n');
           break;
         case 'json':
-          process.stdout.write(formatAsJson(stats) + '\n');
+          writeOut(formatAsJson(stats) + '\n');
           break;
         case 'jsonl':
-          process.stdout.write(formatAsJsonl([stats]) + '\n');
+          writeOut(formatAsJsonl([stats]) + '\n');
           break;
         default:
-          process.stdout.write(`${JSON.stringify(stats, null, 2)}\n`);
+          writeOut(`${JSON.stringify(stats, null, 2)}\n`);
           break;
       }
       break;
@@ -293,10 +321,10 @@ export async function headlessQuery(args: string[], deps: HeadlessDeps): Promise
       };
 
       switch (flags.output) {
-        case 'label': process.stdout.write(`${successRate.toFixed(1)}%\n`); break;
-        case 'json':  process.stdout.write(formatAsJson(stats) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl([stats]) + '\n'); break;
-        default:      process.stdout.write(formatWorkflowStats(stats) + '\n'); break;
+        case 'label': writeOut(`${successRate.toFixed(1)}%\n`); break;
+        case 'json':  writeOut(formatAsJson(stats) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl([stats]) + '\n'); break;
+        default:      writeOut(formatWorkflowStats(stats) + '\n'); break;
       }
       break;
     }
@@ -346,7 +374,7 @@ async function headlessCosts(
   const allEvents = await collectCostEvents(flags, deps);
 
   if (allEvents.length === 0) {
-    process.stdout.write('No cost data available.\n');
+    writeOut('No cost data available.\n');
     return;
   }
 
@@ -356,10 +384,10 @@ async function headlessCosts(
 
   switch (flags.output) {
     case 'label':
-      process.stdout.write(`${totalRollup.totalTokens} tokens $${totalRollup.totalCostUsd.toFixed(4)}\n`);
+      writeOut(`${totalRollup.totalTokens} tokens $${totalRollup.totalCostUsd.toFixed(4)}\n`);
       break;
     case 'json':
-      process.stdout.write(formatAsJson({
+      writeOut(formatAsJson({
         groups: grouped.map(serializeGroupedRollup),
         total: totalRollup,
         events: allEvents.map(serializeCostEvent),
@@ -367,13 +395,13 @@ async function headlessCosts(
       break;
     case 'jsonl':
       for (const event of allEvents) {
-        process.stdout.write(JSON.stringify(serializeCostEvent(event)) + '\n');
+        writeOut(JSON.stringify(serializeCostEvent(event)) + '\n');
       }
       break;
     default:
-      process.stdout.write(formatGroupedCostRollups(grouped) + '\n');
-      process.stdout.write('\n');
-      process.stdout.write(formatCostRollup(totalRollup) + '\n');
+      writeOut(formatGroupedCostRollups(grouped) + '\n');
+      writeOut('\n');
+      writeOut(formatCostRollup(totalRollup) + '\n');
       break;
   }
 }
@@ -485,7 +513,7 @@ async function headlessCost(
   const allEvents = await collectCostEvents(flags, deps);
 
   if (allEvents.length === 0) {
-    process.stdout.write('No cost data available.\n');
+    writeOut('No cost data available.\n');
     return;
   }
 
@@ -496,10 +524,10 @@ async function headlessCost(
 
   switch (flags.output) {
     case 'label':
-      process.stdout.write(`${totals.totalTokens} tokens $${totals.totalCostUsd.toFixed(4)}\n`);
+      writeOut(`${totals.totalTokens} tokens $${totals.totalCostUsd.toFixed(4)}\n`);
       break;
     case 'json':
-      process.stdout.write(formatAsJson({
+      writeOut(formatAsJson({
         scope,
         groupBy,
         totals,
@@ -509,13 +537,13 @@ async function headlessCost(
       break;
     case 'jsonl':
       for (const group of grouped) {
-        process.stdout.write(JSON.stringify(serializeGroupedRollup(group)) + '\n');
+        writeOut(JSON.stringify(serializeGroupedRollup(group)) + '\n');
       }
       break;
     default:
-      process.stdout.write(formatGroupedCostRollups(grouped) + '\n');
-      process.stdout.write('\n');
-      process.stdout.write(formatCostRollup(totals) + '\n');
+      writeOut(formatGroupedCostRollups(grouped) + '\n');
+      writeOut('\n');
+      writeOut(formatCostRollup(totals) + '\n');
       break;
   }
 }
@@ -532,25 +560,25 @@ async function headlessCostEvents(
   const allEvents = await collectCostEvents(flags, deps);
 
   if (allEvents.length === 0) {
-    process.stdout.write('No cost events found.\n');
+    writeOut('No cost events found.\n');
     return;
   }
 
   switch (flags.output) {
     case 'label':
       for (const event of allEvents) {
-        process.stdout.write(`${event.attribution.taskId}:${event.identity.eventId}\n`);
+        writeOut(`${event.attribution.taskId}:${event.identity.eventId}\n`);
       }
       break;
     case 'json':
-      process.stdout.write(formatAsJson(allEvents.map(serializeCostEvent)) + '\n');
+      writeOut(formatAsJson(allEvents.map(serializeCostEvent)) + '\n');
       break;
     case 'jsonl':
-      process.stdout.write(formatAsJsonl(allEvents.map(serializeCostEvent)) + '\n');
+      writeOut(formatAsJsonl(allEvents.map(serializeCostEvent)) + '\n');
       break;
     default:
       for (const event of allEvents) {
-        process.stdout.write(formatCostEvent(event) + '\n');
+        writeOut(formatCostEvent(event) + '\n');
       }
       break;
   }
@@ -559,7 +587,7 @@ async function headlessCostEvents(
 export async function headlessQuerySelect(taskId: string, deps: Pick<HeadlessDeps, 'persistence'>): Promise<void> {
   if (!taskId) throw new Error('Missing taskId.');
   const selected = deps.persistence.getSelectedExperiment(taskId);
-  process.stdout.write((selected
+  writeOut((selected
     ? `Selected experiment for ${taskId}: ${selected}`
     : `No experiment selected for ${taskId}`) + '\n');
 }
@@ -665,7 +693,7 @@ export async function headlessSession(taskId: string | undefined, deps: Pick<Hea
           if (exec.agentName) {
             agentName = String(exec.agentName);
           }
-          process.stdout.write(`Recovered agent session from event log: ${sessionId}\n`);
+          writeOut(`Recovered agent session from event log: ${sessionId}\n`);
           break;
         }
       } catch {
@@ -675,23 +703,69 @@ export async function headlessSession(taskId: string | undefined, deps: Pick<Hea
   }
 
   if (!sessionId) {
-    process.stdout.write(`No agent session for task "${taskId}"\n`);
+    writeOut(`No agent session for task "${taskId}"\n`);
     return;
   }
 
-  process.stdout.write(`agent=${agentName} sessionId=${sessionId}\n`);
+  writeOut(`agent=${agentName} sessionId=${sessionId}\n`);
 
   const allTasks = deps.orchestrator.getAllTasks();
   const result = await resolveAgentSession(sessionId, agentName, deps.executionAgentRegistry, allTasks);
   if (!result) {
-    process.stdout.write('Session lookup failed\n');
+    writeOut('Session lookup failed\n');
     return;
   }
-  process.stdout.write(`state=${result.state}${result.source ? ` source=${result.source}` : ''}\n`);
+  writeOut(`state=${result.state}${result.source ? ` source=${result.source}` : ''}\n`);
   if (result.reason) {
-    process.stdout.write(`${result.reason}\n`);
+    writeOut(`${result.reason}\n`);
   }
   for (const msg of result.messages) {
-    process.stdout.write(`[${msg.role}] ${msg.content}\n`);
+    writeOut(`[${msg.role}] ${msg.content}\n`);
   }
+}
+
+/**
+ * Top-level read-only headless commands that the writable owner can answer on
+ * behalf of a non-owner caller. Mirrors the read-command routing in
+ * `headless.ts` (`runHeadless`) but needs only {@link HeadlessQueryDeps}.
+ */
+async function dispatchReadOnlyHeadlessQuery(args: string[], deps: HeadlessQueryDeps): Promise<void> {
+  const command = args[0];
+  switch (command) {
+    case 'query':
+      // `query ui-perf --reset` clears the owner's UI-perf stats; that is a
+      // mutation, not a read, so it must never run through the delegated path.
+      if (args[1] === 'ui-perf' && parseQueryFlags(args.slice(2)).reset) {
+        throw new Error('query ui-perf --reset is not a delegatable read-only query');
+      }
+      return headlessQuery(args.slice(1), deps);
+    case 'query-select':
+      return headlessQuerySelect(args[1], deps);
+    // Deprecated top-level aliases → canonical `query <sub>`.
+    case 'list':
+      return headlessQuery(['workflows', ...args.slice(1)], deps);
+    case 'status':
+      return headlessQuery(['tasks', ...args.slice(1)], deps);
+    case 'task-status':
+      return headlessQuery(['task', ...args.slice(1)], deps);
+    case 'queue':
+      return headlessQuery(['queue', ...args.slice(1)], deps);
+    case 'audit':
+      return headlessQuery(['audit', ...args.slice(1)], deps);
+    case 'session':
+      return headlessQuery(['session', ...args.slice(1)], deps);
+    default:
+      throw new Error(`Command "${String(command)}" is not a delegatable read-only query`);
+  }
+}
+
+/**
+ * Run a read-only headless command on the writable owner and capture its
+ * rendered stdout instead of printing it. Used by the owner's `cli-query`
+ * IPC handler so a non-owner caller never has to open the database file.
+ */
+export async function runReadOnlyHeadlessQueryToString(args: string[], deps: HeadlessQueryDeps): Promise<string> {
+  const chunks: string[] = [];
+  await queryOutputSink.run((chunk) => { chunks.push(chunk); }, () => dispatchReadOnlyHeadlessQuery(args, deps));
+  return chunks.join('');
 }

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -66,24 +66,51 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
 
   async function delegateOwnerQuery<T>(kind: string, request: Record<string, unknown> = {}): Promise<T | null> {
     if (getOwnerMode?.() !== false) return null;
+    const bus = getMessageBus?.();
+    if (!bus) return null;
     try {
-      return await getMessageBus?.().request<Record<string, unknown>, T>('headless.query', { kind, ...request }) ?? null;
+      return await bus.request<Record<string, unknown>, T>('headless.query', { kind, ...request }) ?? null;
     } catch (err) {
+      // Only the "no owner / no handler" transport case is a safe local
+      // fallback. Timeouts, owner DB errors, and disconnects must surface —
+      // silently serving the viewer's local snapshot would hide owner failures
+      // and reintroduce stale/empty reads.
+      const message = err instanceof Error ? err.message : String(err);
+      const code = typeof err === 'object' && err !== null && 'code' in err
+        ? String((err as { code?: unknown }).code)
+        : '';
+      if (code !== 'NO_HANDLER' && !message.includes('No request handler registered')) {
+        throw err;
+      }
       logger.warn(
-        `${kind} owner delegation failed; falling back to local read-only snapshot: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
+        `${kind} owner delegation found no owner handler; falling back to local read-only snapshot: ${message}`,
         { module: 'ipc' },
       );
       return null;
     }
   }
 
-  ipcMain.handle('invoker:list-workflows', () => persistence.listWorkflows());
+  // Delegate a single-field read to the owner (viewer mode); fall back to the
+  // local read-only DB only when there is no owner to answer.
+  async function delegatedRead<T>(
+    kind: string,
+    request: Record<string, unknown>,
+    field: string,
+    local: () => T,
+  ): Promise<T> {
+    const res = await delegateOwnerQuery<Record<string, unknown>>(kind, request);
+    if (res && field in res) return res[field] as T;
+    return local();
+  }
+
+  ipcMain.handle('invoker:list-workflows', () =>
+    delegatedRead('workflows', {}, 'workflows', () => persistence.listWorkflows()));
   ipcMain.handle('invoker:get-execution-pools', () => Object.keys(loadConfig().executionPools ?? {}));
 
-  ipcMain.handle('invoker:load-workflow', (_event, workflowId: string) => {
+  ipcMain.handle('invoker:load-workflow', async (_event, workflowId: string) => {
     logger.info(`load-workflow: "${workflowId}"`, { module: 'ipc' });
+    const delegated = await delegateOwnerQuery<{ workflow: unknown; tasks: unknown[] }>('workflow', { workflowId });
+    if (delegated) return delegated;
     const orchestrator = getOrchestrator();
     orchestrator.syncFromDb(workflowId);
     const tasks = persistence.loadTasks(workflowId);
@@ -92,7 +119,9 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     return { workflow, tasks };
   });
 
-  ipcMain.handle('invoker:get-review-gate', (_event, workflowId: string) => {
+  ipcMain.handle('invoker:get-review-gate', async (_event, workflowId: string) => {
+    const delegated = await delegateOwnerQuery<{ reviewGate: unknown }>('review-gate', { workflowId });
+    if (delegated && 'reviewGate' in delegated) return delegated.reviewGate;
     const workflow = persistence.loadWorkflow(workflowId);
     if (!workflow) return null;
     const tasks = persistence.loadTasks(workflowId);
@@ -135,18 +164,23 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     return { tasks, workflows, streamSequence };
   });
 
-  ipcMain.handle('invoker:get-events', (_event, taskId: string) => persistence.getEvents(taskId));
+  ipcMain.handle('invoker:get-events', (_event, taskId: string) =>
+    delegatedRead('events', { taskId }, 'events', () => persistence.getEvents(taskId)));
   ipcMain.handle('invoker:get-status', async () => (
     await delegateOwnerQuery('workflow-status') ?? getOrchestrator().getWorkflowStatus()
   ));
-  ipcMain.handle('invoker:get-task-by-id', (_event, taskId: string) => loadTaskByIdFromPersistence(taskId) ?? null);
-  ipcMain.handle('invoker:get-task-output', (_event, taskId: string) => persistence.getTaskOutput(taskId));
-  ipcMain.handle('invoker:get-output-chunks', (_event, taskId: string) => persistence.getOutputChunks(taskId));
+  ipcMain.handle('invoker:get-task-by-id', (_event, taskId: string) =>
+    delegatedRead('task-by-id', { taskId }, 'task', () => loadTaskByIdFromPersistence(taskId) ?? null));
+  ipcMain.handle('invoker:get-task-output', (_event, taskId: string) =>
+    delegatedRead('task-output', { taskId }, 'output', () => persistence.getTaskOutput(taskId)));
+  ipcMain.handle('invoker:get-output-chunks', (_event, taskId: string) =>
+    delegatedRead('output-chunks', { taskId }, 'chunks', () => persistence.getOutputChunks(taskId)));
   ipcMain.handle('invoker:replay-output-from', (_event, taskId: string, fromOffset: number) =>
-    persistence.replayOutputFrom(taskId, fromOffset)
-  );
-  ipcMain.handle('invoker:get-output-tail', (_event, taskId: string) => persistence.getOutputTail(taskId));
-  ipcMain.handle('invoker:get-all-completed-tasks', () => persistence.loadAllCompletedTasks());
+    delegatedRead('replay-output', { taskId, fromOffset }, 'chunks', () => persistence.replayOutputFrom(taskId, fromOffset)));
+  ipcMain.handle('invoker:get-output-tail', (_event, taskId: string) =>
+    delegatedRead('output-tail', { taskId }, 'tail', () => persistence.getOutputTail(taskId)));
+  ipcMain.handle('invoker:get-all-completed-tasks', () =>
+    delegatedRead('all-completed-tasks', {}, 'tasks', () => persistence.loadAllCompletedTasks()));
 
   ipcMain.handle('invoker:get-claude-session', async (_event, sessionId: string) => {
     logger.info(`get-claude-session: "${sessionId}"`, { module: 'ipc' });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -210,7 +210,7 @@ import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
-import { answerOwnerReadQuery } from './owner-read-query.js';
+import { answerOwnerReadQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import { buildWebInvokerDispatch } from './web/web-invoker-dispatch.js';
 import { startWebBridge, resolveWebUiDistDir, type WebBridge } from './web/web-bridge-server.js';
@@ -1771,25 +1771,18 @@ function startHeadlessMode(): void {
           };
         });
         messageBus.onRequest('headless.query', async (req: unknown) =>
-          answerOwnerReadQuery(req, {
+          answerOwnerReadQuery(req, buildOwnerReadQueryHandlers({
             ownerModeLabel: 'standalone',
             onActivity: noteStandaloneOwnerActivity,
             getUiPerfStats: () => headlessDeps.getUiPerfStats?.() ?? {},
             resetUiPerfStats: () => headlessDeps.resetUiPerfStats?.(),
-            getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
-            getWorkflowStatus: () => orchestrator.getWorkflowStatus(),
-            getTasksSnapshot: ({ refresh }) => {
-              if (refresh) orchestrator.syncAllFromDb();
-              return {
-                tasks: orchestrator.getAllTasks(),
-                workflows: persistence.listWorkflows(),
-                streamSequence: 0,
-                invokerHomeRoot: resolveInvokerHomeRoot(),
-              };
-            },
+            getStreamSequence: () => 0,
+            resolveInvokerHomeRoot,
+            orchestrator,
+            persistence,
             getActionGraphSnapshot: () =>
               buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
-          }));
+          })));
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId, traceId } = req as { workflowId: string; traceId?: string };
@@ -3378,24 +3371,17 @@ function createEmbeddedTerminalBackendFromConfig(
         mode: 'gui',
       }));
       messageBus.onRequest('headless.query', async (req: unknown) =>
-        answerOwnerReadQuery(req, {
+        answerOwnerReadQuery(req, buildOwnerReadQueryHandlers({
           ownerModeLabel: 'gui',
           getUiPerfStats: () => getUiPerfStats(),
           resetUiPerfStats: () => resetUiPerfStats(),
-          getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
-          getWorkflowStatus: () => orchestrator.getWorkflowStatus(),
-          getTasksSnapshot: ({ refresh }) => {
-            if (refresh) orchestrator.syncAllFromDb();
-            return {
-              tasks: orchestrator.getAllTasks(),
-              workflows: persistence.listWorkflows(),
-              streamSequence: getTaskDeltaStreamSequence(),
-              invokerHomeRoot: resolveInvokerHomeRoot(),
-            };
-          },
+          getStreamSequence: () => getTaskDeltaStreamSequence(),
+          resolveInvokerHomeRoot,
+          orchestrator,
+          persistence,
           getActionGraphSnapshot: () =>
             buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
-        }));
+        })));
       messageBus.onRequest('headless.run', async (req: unknown) => {
         const { planPath, traceId } = req as { planPath: string; traceId?: string };
         logger.info(

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -1,36 +1,71 @@
+import type { Orchestrator } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import { buildReviewGateQueryResponse } from './review-gate-query.js';
+
 /**
  * Shared dispatcher for the owner's `headless.query` IPC channel.
  *
  * Non-owner processes read database-derived state by sending a
  * `{ kind }`-discriminated request over IpcBus; the writable owner answers it.
- * The GUI owner and the standalone headless owner previously each carried an
- * identical if-chain — this is the single place that maps a query kind to a
- * response, so new read kinds (the sole-owner rearchitecture routes every read
- * through here) are added once and stay consistent across both owners.
+ * The GUI owner and the standalone headless owner share this single mapping so
+ * every read kind (the sole-owner rearchitecture routes every read through here)
+ * is defined once and answered the same way by both owners.
  *
- * The per-owner differences (owner label, task-delta stream sequence, the
- * standalone keep-alive ping, the ui-perf source) are injected via handlers.
+ * Per-owner differences (owner label, task-delta stream sequence, the standalone
+ * keep-alive ping, the ui-perf source) are injected via `buildOwnerReadQueryHandlers`.
+ * Param-bearing read kinds take their argument from the request body.
+ *
+ * Each handler returns a JSON object; scalar/array reads are wrapped (e.g.
+ * `{ events }`, `{ output }`) so the wire response is always a record and the
+ * client unwraps the named field.
  */
 export interface OwnerReadQueryHandlers {
-  /** Label echoed back on the ui-perf response ('gui' | 'standalone'). */
   ownerModeLabel: string;
-  /** Called once per query (the standalone owner uses it to defer idle shutdown). */
   onActivity?: () => void;
   getUiPerfStats: () => Record<string, unknown>;
   resetUiPerfStats: () => void;
   getQueueStatus: () => Record<string, unknown>;
   getWorkflowStatus: () => Record<string, unknown>;
-  /** Build the task/workflow snapshot; `refresh` re-syncs the orchestrator from the DB first. */
   getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
   getActionGraphSnapshot: () => Record<string, unknown>;
+  listWorkflows: () => unknown[];
+  loadWorkflowBundle: (workflowId: string) => Record<string, unknown>;
+  getReviewGate: (workflowId: string) => unknown;
+  getEvents: (taskId: string) => unknown[];
+  getTaskById: (taskId: string) => unknown;
+  getTaskOutput: (taskId: string) => string;
+  getOutputChunks: (taskId: string) => unknown[];
+  getOutputTail: (taskId: string) => unknown;
+  replayOutput: (taskId: string, fromOffset: number) => unknown;
+  getAllCompletedTasks: () => unknown[];
 }
 
 export function answerOwnerReadQuery(
   req: unknown,
   handlers: OwnerReadQueryHandlers,
 ): Record<string, unknown> {
-  const { kind, reset } = (req ?? {}) as { kind?: string; reset?: boolean };
+  const body = (req ?? {}) as {
+    kind?: string;
+    reset?: boolean;
+    workflowId?: string;
+    taskId?: string;
+    fromOffset?: number;
+  };
+  const { kind, reset } = body;
   handlers.onActivity?.();
+  const requiredString = (value: unknown, name: string): string => {
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new Error(`Missing headless query parameter: ${name}`);
+    }
+    return value;
+  };
+  const replayOffset = (value: unknown): number => {
+    const offset = Number(value ?? 0);
+    if (!Number.isFinite(offset) || offset < 0) {
+      throw new Error('Invalid headless query parameter: fromOffset');
+    }
+    return offset;
+  };
 
   switch (kind) {
     case 'ui-perf':
@@ -46,7 +81,101 @@ export function answerOwnerReadQuery(
       return handlers.getTasksSnapshot({ refresh: true });
     case 'action-graph':
       return handlers.getActionGraphSnapshot();
+    case 'workflows':
+      return { workflows: handlers.listWorkflows() };
+    case 'workflow':
+      return handlers.loadWorkflowBundle(requiredString(body.workflowId, 'workflowId'));
+    case 'review-gate':
+      return { reviewGate: handlers.getReviewGate(requiredString(body.workflowId, 'workflowId')) ?? null };
+    case 'events':
+      return { events: handlers.getEvents(requiredString(body.taskId, 'taskId')) };
+    case 'task-by-id':
+      return { task: handlers.getTaskById(requiredString(body.taskId, 'taskId')) ?? null };
+    case 'task-output':
+      return { output: handlers.getTaskOutput(requiredString(body.taskId, 'taskId')) };
+    case 'output-chunks':
+      return { chunks: handlers.getOutputChunks(requiredString(body.taskId, 'taskId')) };
+    case 'output-tail':
+      return { tail: handlers.getOutputTail(requiredString(body.taskId, 'taskId')) ?? null };
+    case 'replay-output':
+      return { chunks: handlers.replayOutput(requiredString(body.taskId, 'taskId'), replayOffset(body.fromOffset)) };
+    case 'all-completed-tasks':
+      return { tasks: handlers.getAllCompletedTasks() };
     default:
       throw new Error(`Unsupported headless query: ${String(kind)}`);
   }
+}
+
+type ReadOrchestrator = Pick<
+  Orchestrator,
+  'getQueueStatus' | 'getWorkflowStatus' | 'getAllTasks' | 'syncAllFromDb' | 'syncFromDb'
+>;
+type ReadPersistence = Pick<
+  SQLiteAdapter,
+  | 'listWorkflows'
+  | 'loadWorkflow'
+  | 'loadTasks'
+  | 'loadTask'
+  | 'getEvents'
+  | 'getTaskOutput'
+  | 'getOutputChunks'
+  | 'getOutputTail'
+  | 'replayOutputFrom'
+  | 'loadAllCompletedTasks'
+>;
+
+export interface OwnerReadQueryDeps {
+  ownerModeLabel: string;
+  onActivity?: () => void;
+  getUiPerfStats: () => Record<string, unknown>;
+  resetUiPerfStats: () => void;
+  getStreamSequence: () => number;
+  resolveInvokerHomeRoot: () => string;
+  orchestrator: ReadOrchestrator;
+  persistence: ReadPersistence;
+  /** App-level action-graph projection (needs invokerConfig, which lives in the app). */
+  getActionGraphSnapshot: () => Record<string, unknown>;
+}
+
+/** Build the handler set both owners pass to {@link answerOwnerReadQuery}. */
+export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerReadQueryHandlers {
+  const { orchestrator, persistence } = deps;
+  return {
+    ownerModeLabel: deps.ownerModeLabel,
+    onActivity: deps.onActivity,
+    getUiPerfStats: deps.getUiPerfStats,
+    resetUiPerfStats: deps.resetUiPerfStats,
+    getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
+    getWorkflowStatus: () => orchestrator.getWorkflowStatus() as unknown as Record<string, unknown>,
+    getTasksSnapshot: ({ refresh }) => {
+      if (refresh) orchestrator.syncAllFromDb();
+      return {
+        tasks: orchestrator.getAllTasks(),
+        workflows: persistence.listWorkflows(),
+        streamSequence: deps.getStreamSequence(),
+        invokerHomeRoot: deps.resolveInvokerHomeRoot(),
+      };
+    },
+    getActionGraphSnapshot: deps.getActionGraphSnapshot,
+    listWorkflows: () => persistence.listWorkflows(),
+    loadWorkflowBundle: (workflowId: string) => {
+      orchestrator.syncFromDb(workflowId);
+      return {
+        workflow: persistence.loadWorkflow(workflowId),
+        tasks: persistence.loadTasks(workflowId),
+      };
+    },
+    getReviewGate: (workflowId: string) => {
+      const workflow = persistence.loadWorkflow(workflowId);
+      if (!workflow) return null;
+      return buildReviewGateQueryResponse({ workflowId, workflow, tasks: persistence.loadTasks(workflowId) });
+    },
+    getEvents: (taskId: string) => persistence.getEvents(taskId),
+    getTaskById: (taskId: string) => persistence.loadTask(taskId),
+    getTaskOutput: (taskId: string) => persistence.getTaskOutput(taskId),
+    getOutputChunks: (taskId: string) => persistence.getOutputChunks(taskId),
+    getOutputTail: (taskId: string) => persistence.getOutputTail(taskId),
+    replayOutput: (taskId: string, fromOffset: number) => persistence.replayOutputFrom(taskId, fromOffset),
+    getAllCompletedTasks: () => persistence.loadAllCompletedTasks(),
+  };
 }


### PR DESCRIPTION
<!-- sole-owner-ticket -->
> **Sole-owner DB — design decision / ticket:** the approach decision and alternatives (cheap `journal_mode = DELETE` fix vs this full sole-owner / IPC stack) are tracked in #2384. Please read that first.

---

## Summary

Read-only `--headless` query commands open the database file themselves to render their answer.

This adds a path that renders that answer into a string and, when a writable owner is present, asks the owner for it over IPC.

With no owner present the command still reads the file directly, so it stays the only opener.

<details>
<summary>Review metadata</summary>

Review Claim: Read-only headless query commands render their output through a sink and ask a present owner over IPC, falling back to a direct read when no owner is present.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: With no owner the command runs locally and prints exactly as before — the sink defaults to stdout. Asking the owner only happens when a ping succeeds; any failure falls back to the direct read. Covered by the output-capture unit tests plus the existing client and query suites.

Slice Rationale: This is the caller half; the owner side that answers these requests is a separate routing slice that lands next.

</details>

## Non-goals

The GUI viewer still opens the database (a later slice ends that). Owner mode, the database files, and exclusive locking are unchanged.

## Test Plan

- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/headless-query-capture.test.ts`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/headless-client.test.ts`
- [ ] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to capture delegated read-only CLI query output and return it as a string.
  * Enhanced `query`/alias routing so approved read-only subcommands are delegated to the runnable headless owner and their results are printed.
* **Bug Fixes**
  * Improved delegation fallback behavior for general read-only queries.
  * Enforced stricter rejection of non-supported operations, including rejecting `query ui-perf --reset` while allowing non-destructive `query ui-perf`.
* **Tests**
  * Expanded coverage for delegated output capture and `ui-perf` reset/allowed behavior, including confirming resets are not executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2387
