### PR TITLE
[Sole-owner DB](8) Open the owner database with WAL exclusive locking

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -671,6 +671,12 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     : await SQLiteAdapter.create(dbPath, {
       readOnly,
       ownerCapability: !readOnly, // writable mode requires owner capability
+      // The writable owner is the sole opener (the viewer runs in-memory and
+      // read-only callers delegate over IPC), so it opens WAL in EXCLUSIVE
+      // locking mode: the wal-index stays in heap, no -shm file exists, and the
+      // -shm-truncation SIGBUS becomes impossible. Kill-switch:
+      // INVOKER_DISABLE_EXCLUSIVE_LOCKING=1 reverts to shared -shm WAL.
+      exclusiveLocking: !readOnly && process.env.INVOKER_DISABLE_EXCLUSIVE_LOCKING !== '1',
     });
   // Upgrade root logger with DB persistence now that SQLiteAdapter is ready.
   logger = new FileAndDbLogger({ module: 'main' }, { persistence });


### PR DESCRIPTION
<!-- sole-owner-ticket -->
> **Sole-owner DB — design decision / ticket:** the approach decision and alternatives (cheap `journal_mode = DELETE` fix vs this full sole-owner / IPC stack) are tracked in #2384. Please read that first.

> **Landing note:** GitHub marked this PR merged into #2392's branch, not into `master`. The change is not on `master` unless the #2392 branch is restored and merged.

---

## Summary

The writable owner opens WAL in `locking_mode = EXCLUSIVE`.

That keeps the WAL index in process memory, so the owner does not create the `invoker.db-shm` sidecar.

An environment flag keeps the previous shared-locking behavior available.

<details>
<summary>Review metadata</summary>

Review Claim: The writable owner opens its database with WAL exclusive locking so no `-shm` sidecar is created.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Only the writable owner open changes. Read-only fallback opens keep the previous behavior, and `INVOKER_DISABLE_EXCLUSIVE_LOCKING=1` restores shared locking.

Slice Rationale: This belongs after the earlier owner-boundary slices, because exclusive locking is only safe after file readers are behind the owner.

</details>

## Non-goals

Read-only no-owner fallback opens keep their old mode. The on-disk schema and mutation owner boundary are unchanged.

## Architecture

### Before

The owner used WAL with shared locking, which could create and map `invoker.db-shm`.

### After

The writable owner opens WAL with exclusive locking, keeping the WAL index private to the owner process.

## Test Plan

- [ ] `cd packages/data-store && pnpm exec vitest run src/__tests__/exclusive-locking.test.ts`
- [ ] `pnpm run check:types`
- [ ] `bash scripts/check-owner-boundary.sh`

## Visual Proof

No visual change. This only changes how the writable owner opens its database file.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>` or set `INVOKER_DISABLE_EXCLUSIVE_LOCKING=1`
- Post-revert steps: None
- Data migration? No

Depends-On: #2392
