### PR TITLE
[Sole-owner DB](9) Document the sole-owner read path and exclusive locking

### DIFF
--- a/docs/persistence-architecture-single-writer.md
+++ b/docs/persistence-architecture-single-writer.md
@@ -2,11 +2,19 @@
 
 ## Problem
 
-The Invoker persistence layer (SQLiteAdapter) is backed by sql.js (WASM SQLite), which flushes in-memory changes to disk asynchronously. Multiple processes opening the same database file in writable mode leads to lost writes when processes flush stale buffers over each other's changes.
+The Invoker persistence layer (SQLiteAdapter, backed by `node:sqlite`) stores state in a WAL-mode SQLite database. Multiple processes opening the same file in writable mode lead to lost writes when their buffers overwrite each other's changes.
 
 ## Solution
 
 **Single-writer owner model**: exactly one process owns writable access to the database. All other processes delegate mutations via IPC or open the database in read-only mode.
+
+## Update: Sole-Owner Read Path & Exclusive Locking
+
+The owner boundary now covers **reads** as well as writes, so the writable owner can be the *only* process that opens `invoker.db`. See Linear [INV-240](https://linear.app/invokerorchestrator/issue/INV-240) for the full design and rationale.
+
+- **GUI viewer** runs against a private empty in-memory database and never opens `invoker.db`; its renderer reads delegate to the owner over IPC and live updates arrive via `TASK_DELTA` / `TASK_OUTPUT`.
+- **Read-only headless commands** delegate to the owner over IPC (`headless.query` `cli-query`) when an owner is present, and open the file directly only when none is. In that fallback path they remain read-only callers that may coexist with other readers; this does not imply exclusive ownership.
+- **The owner opens WAL in `locking_mode = EXCLUSIVE`**, keeping the wal-index in heap so no `-shm` file exists. This makes the `-shm`-truncation SIGBUS (crash report `Electron-2026-06-24-222052.ips`; repro `scripts/repro/repro-wal-shm-sigbus.sh`) impossible. Kill-switch: `INVOKER_DISABLE_EXCLUSIVE_LOCKING=1` reverts to shared-`-shm` WAL.
 
 ## Owner Boundary Contract
 
@@ -67,13 +75,13 @@ This table lists every mutating command path and how the owner-boundary contract
 | `set executor` | headless.ts:841 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
 | `set agent` | headless.ts:853 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
 | `set merge-mode` | headless.ts:1011 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| **Headless Read-Only Commands** (never delegate, always read-only) |
-| `query workflows` | headless.ts:193 | No | Opens DB with `readOnly: true` (main.ts:386) | Safe: no writes |
-| `query tasks` | headless.ts:206 | No | Opens DB with `readOnly: true` | Safe: no writes |
-| `query task` | headless.ts:257 | No | Opens DB with `readOnly: true` | Safe: no writes |
-| `query queue` | headless.ts:272 | No | Opens DB with `readOnly: true` | Safe: no writes |
-| `query audit` | headless.ts:295 | No | Opens DB with `readOnly: true` | Safe: no writes |
-| `query session` | headless.ts:308 | No | Opens DB with `readOnly: true` | Safe: no writes |
+| **Headless Read-Only Commands** | | | | delegate to the owner when present; open `readOnly` only when none |
+| `query workflows` | headless.ts:193 | **Yes** (cli-query) | Owner answers over IPC, else opens `readOnly: true` | Safe: no writes |
+| `query tasks` | headless.ts:206 | **Yes** (cli-query) | Owner answers over IPC, else opens `readOnly: true` | Safe: no writes |
+| `query task` | headless.ts:257 | **Yes** (cli-query) | Owner answers over IPC, else opens `readOnly: true` | Safe: no writes |
+| `query queue` | headless.ts:272 | **Yes** (owner-required) | Owner answers over IPC | Live scheduler state; requires an owner |
+| `query audit` | headless.ts:295 | **Yes** (cli-query) | Owner answers over IPC, else opens `readOnly: true` | Safe: no writes |
+| `query session` | headless.ts:308 | **Yes** (cli-query) | Owner answers over IPC, else opens `readOnly: true` | Safe: no writes |
 | **Workflow Actions** (shared library, always called by owner) |
 | `rejectTask()` | workflow-actions.ts:54 | N/A | Called by owner (GUI/headless standalone) → orchestrator → persistence | Shared library assumes writable context |
 | `restartTask()` | workflow-actions.ts:75 | N/A | Called by owner → orchestrator → persistence | |


### PR DESCRIPTION
<!-- sole-owner-ticket -->
> **Sole-owner DB — design decision / ticket:** the approach decision and alternatives (cheap `journal_mode = DELETE` fix vs this full sole-owner / IPC stack) are tracked in #2384. Please read that first.

> **Landing note:** GitHub marked this PR merged into #2392's branch, not into `master`. The docs change is not on `master` unless the #2392 branch is restored and merged.

> **Design ticket:** [INV-240 — Sole-owner database (WAL exclusive locking, no `-shm`)](https://linear.app/invokerorchestrator/issue/INV-240)

---

## Summary

The persistence architecture doc now describes the sole-owner read path.

It explains the memory-only viewer, owner-served read-only callers, and WAL exclusive locking.

It also links the Linear design ticket.

<details>
<summary>Review metadata</summary>

Review Claim: The persistence architecture doc reflects the sole-owner read path, in-memory viewer, exclusive locking, and INV-240 design reference.

Review Lane: docs

Review Unit: docs

Safety Invariant: Documentation only. Runtime behavior, database files, and guard scripts are unchanged by this slice.

Slice Rationale: Documentation lands after the behavior it describes, so the canonical persistence doc matches the stack's final design.

</details>

## Non-goals

No runtime code changes. No change to the owner-boundary guard script.

## Test Plan

- [ ] Prose review of `docs/persistence-architecture-single-writer.md`
- [ ] `bash scripts/check-owner-boundary.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2393
