### PR TITLE
[Experimental Planner](1) Add EXPERIMENTAL_PLANNER flag + dormant planning steer

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -105,6 +105,15 @@ describe('loadConfig', () => {
     expect(config.autoApproveAIFixes).toBe(true);
   });
 
+  it('reads experimentalPlanner from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ experimentalPlanner: true }),
+    );
+    const config = loadConfig();
+    expect(config.experimentalPlanner).toBe(true);
+  });
+
   it('reads autoFixAgent from user config', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -38,6 +38,13 @@ export interface InvokerConfig {
    */
   autoApproveAIFixes?: boolean;
   /**
+   * EXPERIMENTAL_PLANNER. When true, redirect the planning step to the
+   * experimental external planner (via the redirect MCP server) instead of the
+   * native planning skill. The redirect server also reads this flag and serves no
+   * tools when off, so planning falls back to native. Default: false.
+   */
+  experimentalPlanner?: boolean;
+  /**
    * Preferred execution agent for automatic fix retries.
    * When unset, auto-fix falls back to the task's executionAgent,
    * then to the built-in default agent.

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -59,6 +59,9 @@ export interface PlanConversationConfig {
   defaultBranch?: string;
   /** Default repo URL (e.g. "git@github.com:user/repo.git"). Used when plan YAML omits repoUrl. */
   repoUrl?: string;
+  /** EXPERIMENTAL_PLANNER: when true, steer the agent to order the plan via the
+   * experimental planner MCP tool (`plan`). The redirect server enforces the gate. */
+  experimentalPlanner?: boolean;
   /** Logging callback. Defaults to console.log/console.error. */
   log?: LogFn;
 }
@@ -192,6 +195,7 @@ export class PlanConversation {
   private conversationRepo?: ConversationRepository;
   private defaultBranch?: string;
   private repoUrl?: string;
+  private experimentalPlanner?: boolean;
   private log: LogFn;
   private _initialized = false;
 
@@ -206,6 +210,7 @@ export class PlanConversation {
     this.conversationRepo = config.conversationRepo;
     this.defaultBranch = config.defaultBranch;
     this.repoUrl = config.repoUrl;
+    this.experimentalPlanner = config.experimentalPlanner;
     this.log = config.log ?? ((src, lvl, msg) => {
       (lvl === 'error' ? console.error : console.log)(`[${src}] ${msg}`);
     });
@@ -350,6 +355,14 @@ export class PlanConversation {
     if (lastMessage) {
       parts.push(`\nUser's latest message:\n${lastMessage.content}`);
       parts.push('\nRespond to the latest message. If it requires a plan, explore the codebase and generate one.');
+    }
+
+    if (this.experimentalPlanner) {
+      parts.push(
+        '\n[EXPERIMENTAL_PLANNER] Before finalizing the order, call the `plan` MCP ' +
+        'tool with the conversation to get the experimental planner\'s ordered ' +
+        'features/tasks + dependency edges, and base your plan\'s ordering on it. ' +
+        'If the tool is unavailable, order the plan yourself as usual.');
     }
 
     return parts.join('\n');


### PR DESCRIPTION
## Summary

Adds an `experimentalPlanner` flag to the Invoker config and a dormant
planning-prompt steer that reads it.

When the flag is on, the Slack planning prompt tells the agent to call an external
experimental planner (a redirect MCP server, shipped separately) to order the plan.

The real on/off enforcement lives in that redirect server, which serves no tools
while the flag is off, so planning falls back to native.

This slice only adds the flag and the steer. It is off by default and nothing sets
it yet, so it changes no behavior today.

<details>
<summary>Review metadata</summary>

Review Claim: Approve adding the `experimentalPlanner` config flag plus a gated,
currently-dormant planning-prompt steer that reads it.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: The flag defaults to false and the steer string is appended only
when `experimentalPlanner` is true. Nothing sets it in this slice (the
main -> SlackSurface -> PlanConversation threading is a follow-up), so the generated
planning prompt is unchanged. The config field is optional and additive.

Slice Rationale: Split from the redirect MCP server (which lives in the separate
planner repo) and from the surface-config threading, so the flag and steer land as
a tiny, no-op-by-default slice that is trivial to review and revert.

</details>

## Non-goals

- Does not thread the flag from `main.ts` through `SlackSurface` /
  `ThreadSessionManager` to `PlanConversation` (follow-up).
- Does not include the redirect MCP server itself.
- Does not change native planning or the PR-split skill.

## Test Plan

- [ ] `cd packages/app && pnpm vitest run src/__tests__/config.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
