### PR TITLE
[Workflow Progress Surfaces](1) Share the IPC channel-name derivation in contracts

### DIFF
--- a/packages/app/src/preload.ts
+++ b/packages/app/src/preload.ts
@@ -10,21 +10,8 @@
  */
 
 import { contextBridge, ipcRenderer } from 'electron';
-import { IpcChannels, IpcTestOnlyChannels, IpcEventChannels } from '@invoker/contracts';
+import { IpcChannels, IpcTestOnlyChannels, IpcEventChannels, channelToMethod, channelToEventMethod } from '@invoker/contracts';
 import type { InvokerAPI } from '@invoker/contracts';
-
-// ── Runtime channel-name → method-name conversion ───────────
-// Mirrors the type-level ChannelToMethod: strip "invoker:" prefix, kebab → camelCase.
-
-function channelToMethod(channel: string): string {
-  const stripped = channel.startsWith('invoker:') ? channel.slice(8) : channel;
-  return stripped.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
-}
-
-function channelToEventMethod(channel: string): string {
-  const base = channelToMethod(channel);
-  return `on${base.charAt(0).toUpperCase()}${base.slice(1)}`;
-}
 
 // ── Build the API object from the channel registries ────────
 

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -9,6 +9,11 @@
       "types": "./src/index.ts",
       "import": "./src/index.ts",
       "require": "./src/index.ts"
+    },
+    "./ipc-channels": {
+      "types": "./src/ipc-channels.ts",
+      "import": "./src/ipc-channels.ts",
+      "require": "./src/ipc-channels.ts"
     }
   },
   "scripts": {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -755,6 +755,18 @@ type KebabToCamel<S extends string> =
 /** Convert an IPC channel name to its API method name. e.g. 'invoker:load-plan' → 'loadPlan' */
 type ChannelToMethod<S extends string> = KebabToCamel<StripPrefix<S>>;
 
+/** Convert an IPC channel name to its API method name. e.g. 'invoker:get-tasks' → 'getTasks'. */
+export function channelToMethod(channel: string): string {
+  const stripped = channel.startsWith('invoker:') ? channel.slice(8) : channel;
+  return stripped.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
+/** Convert an event channel name to its `on*` subscription method. e.g. 'invoker:task-graph-event' → 'onTaskGraphEvent'. */
+export function channelToEventMethod(channel: string): string {
+  const base = channelToMethod(channel);
+  return `on${base.charAt(0).toUpperCase()}${base.slice(1)}`;
+}
+
 // ── Derived InvokerAPI ──────────────────────────────────────
 
 type InvokeChannels = typeof IpcChannels;


### PR DESCRIPTION
## Summary

`@invoker/contracts` gains two runtime helpers that turn an IPC channel name into its API method name and its `on*` event-method name.

The Electron preload bridge now imports those helpers instead of keeping a private copy, so one definition feeds every caller.

A browser-safe subpath entry point also lets a future browser client read the channel registry without pulling node-only modules into a web bundle.

<details>
<summary>Review metadata</summary>

Review Claim: The preload and a future browser client derive API method names from one shared helper in `@invoker/contracts`.

Review Lane: refactor

Review Unit: contract

Safety Invariant: The new helpers reproduce the preload's previous private logic exactly; the preload's derived method names are identical before and after.

Slice Rationale: Foundation first. The shared helper and the browser-safe entry point land before any code that consumes them.

</details>

## Non-goals

- No behavior change: the preload bridge derives the same method names as before.
- Does not add the browser client, the bridge server, or any new channel.

## Test Plan

- [ ] `pnpm --filter @invoker/contracts test`
- [ ] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared runtime helpers to consistently convert IPC channel names into corresponding API method and event subscription names.
  * Exposed a new contracts subpath so these naming helpers can be reused across runtime environments.

* **Refactor**
  * Updated the preload bridge to use the shared conversion helpers instead of local implementations for mapping channels to the exposed `window.invoker` API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->