### PR TITLE
[Workflow Progress Surfaces](2) Add an optional sink to the task-graph publisher

### DIFF
--- a/packages/app/src/task-graph-event-publisher.ts
+++ b/packages/app/src/task-graph-event-publisher.ts
@@ -19,6 +19,7 @@ export interface CreateTaskGraphEventPublisherOptions {
   stampDelta: (delta: TaskDelta) => TaskDelta;
   getStreamSequence: () => number;
   onLargeBatch?: (stats: { batchSize: number; remaining: number }) => void;
+  onEvent?: (event: TaskGraphEvent) => void;
 }
 
 export function createTaskGraphEventPublisher(
@@ -55,6 +56,7 @@ export function createTaskGraphEventPublisher(
   };
 
   const publishEvent = (event: TaskGraphEvent): void => {
+    options.onEvent?.(event);
     const mainWindow = options.getMainWindow();
     if (!mainWindow || mainWindow.isDestroyed() || !options.isUiInteractive()) {
       return;


### PR DESCRIPTION
## Summary

The task-graph publisher gains an optional sink that receives every produced event.

The sink fires before the renderer-window check, so a second consumer can observe the same event stream even when no desktop window is attached.

<details>
<summary>Review metadata</summary>

Review Claim: The task-graph publisher can hand every produced event to an optional sink, independent of any attached window.

Review Lane: refactor

Review Unit: routing

Safety Invariant: The sink is optional and additive; when unset, windowed delivery behaves exactly as before.

Slice Rationale: This seam is the one change to an existing core module; it lands on its own so the new web subsystem that consumes it stays a separate diff.

</details>

## Non-goals

- No behavior change for the renderer: existing windowed delivery is unchanged.
- Does not add any consumer of the new sink.

## Test Plan

- [ ] `pnpm run check:types`
- [ ] `pnpm --filter @invoker/app test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional callback to receive the full task graph event stream.
  * This callback is invoked for every produced event, even if UI delivery is skipped due to window availability or interactivity checks.
  * Existing buffering and UI-gated event delivery behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->