### PR TITLE
[Workflow Progress Surfaces](3) Add the web bridge backend (HTTP + SSE), dormant

### DIFF
--- a/packages/app/src/__tests__/start-web-surface.test.ts
+++ b/packages/app/src/__tests__/start-web-surface.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  resolveWebToken,
+  resolveWebHost,
+  resolveWebPort,
+  startHeadlessWebSurface,
+} from '../web/start-web-surface.js';
+
+const ENV_KEYS = ['INVOKER_WEB_TOKEN', 'INVOKER_WEB_HOST', 'INVOKER_WEB_PORT'] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe('web surface configuration resolution', () => {
+  it('prefers env token over config and is undefined when neither is set', () => {
+    expect(resolveWebToken({})).toBeUndefined();
+    expect(resolveWebToken({ webToken: 'cfg' })).toBe('cfg');
+    process.env.INVOKER_WEB_TOKEN = 'env';
+    expect(resolveWebToken({ webToken: 'cfg' })).toBe('env');
+  });
+
+  it('resolves host/port with env precedence and sane defaults', () => {
+    expect(resolveWebHost({})).toBe('127.0.0.1');
+    expect(resolveWebHost({ webHost: '0.0.0.0' })).toBe('0.0.0.0');
+    process.env.INVOKER_WEB_HOST = '10.0.0.1';
+    expect(resolveWebHost({ webHost: '0.0.0.0' })).toBe('10.0.0.1');
+
+    expect(resolveWebPort({})).toBe(4200);
+    expect(resolveWebPort({ webPort: 5000 })).toBe(5000);
+    process.env.INVOKER_WEB_PORT = '6000';
+    expect(resolveWebPort({ webPort: 5000 })).toBe(6000);
+  });
+});
+
+describe('startHeadlessWebSurface token gate', () => {
+  it('returns null and starts no server when no token is configured', () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() };
+    const subscribe = vi.fn();
+    const result = startHeadlessWebSurface({
+      logger: logger as never,
+      orchestrator: {} as never,
+      persistence: {} as never,
+      messageBus: { subscribe } as never,
+      agentRegistry: {} as never,
+      mutations: {} as never,
+      deleteWorkflow: vi.fn(),
+      detachWorkflow: vi.fn(),
+      loadConfig: () => ({}),
+      config: {},
+      appRootDir: '/tmp',
+    });
+    expect(result).toBeNull();
+    // No token => no task.delta subscription, no server wiring.
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/__tests__/web-bridge-server.test.ts
+++ b/packages/app/src/__tests__/web-bridge-server.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import http from 'node:http';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { startWebBridge, type WebBridge } from '../web/web-bridge-server.js';
+
+const TOKEN = 'secret-token';
+
+function makeBus() {
+  const subs = new Map<string, Set<(payload: unknown) => void>>();
+  return {
+    subscribe(channel: string, cb: (payload: unknown) => void) {
+      let set = subs.get(channel);
+      if (!set) {
+        set = new Set();
+        subs.set(channel, set);
+      }
+      set.add(cb);
+      return () => set!.delete(cb);
+    },
+    publish(channel: string, payload: unknown) {
+      for (const cb of subs.get(channel) ?? []) cb(payload);
+    },
+  };
+}
+
+interface RequestResult {
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+function request(
+  port: number,
+  path: string,
+  options: { method?: string; headers?: Record<string, string>; body?: string } = {},
+): Promise<RequestResult> {
+  const { promise, resolve, reject } = Promise.withResolvers<RequestResult>();
+  const req = http.request(
+    { host: '127.0.0.1', port, path, method: options.method ?? 'GET', headers: options.headers },
+    (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (c) => chunks.push(c as Buffer));
+      res.on('end', () =>
+        resolve({ status: res.statusCode ?? 0, headers: res.headers, body: Buffer.concat(chunks).toString('utf8') }),
+      );
+    },
+  );
+  req.on('error', reject);
+  if (options.body) req.write(options.body);
+  req.end();
+  return promise;
+}
+
+let bridge: WebBridge | null = null;
+
+async function startBridge(dispatch = vi.fn(async () => ({ ok: true }))) {
+  const bus = makeBus();
+  bridge = startWebBridge({
+    dispatch: dispatch as never,
+    messageBus: bus as never,
+    persistence: { getActivityLogs: () => [], listWorkflows: () => [] } as never,
+    uiDistDir: tmpdir(),
+    token: TOKEN,
+    host: '127.0.0.1',
+    port: 0,
+  });
+  const port = await bridge.whenReady;
+  return { port, bus, dispatch };
+}
+
+afterEach(async () => {
+  await bridge?.close();
+  bridge = null;
+});
+
+describe('startWebBridge', () => {
+  it('rejects /invoke without a cookie or token header', async () => {
+    const { port } = await startBridge();
+    const res = await request(port, '/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ channel: 'invoker:get-status', args: [] }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('exchanges ?token for a Set-Cookie and redirects to /', async () => {
+    const { port } = await startBridge();
+    const res = await request(port, `/?token=${TOKEN}`);
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/');
+    expect(String(res.headers['set-cookie'])).toContain('invoker_web=');
+  });
+
+  it('rejects the handshake with a bad token', async () => {
+    const { port } = await startBridge();
+    const res = await request(port, '/?token=wrong');
+    expect(res.status).toBe(401);
+  });
+
+  it('runs /invoke with a valid cookie and wraps the dispatch result', async () => {
+    const dispatch = vi.fn(async () => ({ value: 42 }));
+    const { port } = await startBridge(dispatch);
+    const res = await request(port, '/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `invoker_web=${TOKEN}` },
+      body: JSON.stringify({ channel: 'invoker:get-status', args: [] }),
+    });
+    expect(res.status).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ ok: true, result: { value: 42 } });
+    expect(dispatch).toHaveBeenCalledWith('invoker:get-status', []);
+  });
+
+  it('reports dispatch failures as { ok: false, error }', async () => {
+    const dispatch = vi.fn(async () => {
+      const err = new Error('nope') as Error & { code: string };
+      err.code = 'unknown_channel';
+      throw err;
+    });
+    const { port } = await startBridge(dispatch);
+    const res = await request(port, '/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `invoker_web=${TOKEN}` },
+      body: JSON.stringify({ channel: 'invoker:x', args: [] }),
+    });
+    expect(JSON.parse(res.body)).toEqual({ ok: false, error: { message: 'nope', code: 'unknown_channel' } });
+  });
+
+  it('streams broadcast and TASK_OUTPUT events over /events', async () => {
+    const { port, bus } = await startBridge();
+    const { promise, resolve, reject } = Promise.withResolvers<string>();
+    const req = http.request(
+      { host: '127.0.0.1', port, path: '/events', headers: { cookie: `invoker_web=${TOKEN}` } },
+      (res) => {
+        expect(res.statusCode).toBe(200);
+        let buffer = '';
+        res.on('data', (c) => {
+          buffer += (c as Buffer).toString('utf8');
+          if (buffer.includes('event: invoker:task-output')) {
+            req.destroy();
+            resolve(buffer);
+          }
+        });
+      },
+    );
+    req.on('error', () => { /* destroyed after resolve */ });
+    req.end();
+    // Give the SSE connection a tick to register, then publish a task.output.
+    await new Promise((r) => setTimeout(r, 50));
+    bridge!.broadcast('invoker:task-graph-event', { type: 'snapshot' });
+    bus.publish('task.output', { taskId: 'wf-1/task-1', chunk: 'hello' });
+    const received = await Promise.race([
+      promise,
+      new Promise<string>((_, rej) => setTimeout(() => rej(new Error('SSE timeout')), 2000)),
+    ]);
+    expect(received).toContain('event: invoker:task-graph-event');
+    expect(received).toContain('event: invoker:task-output');
+    expect(received).toContain('"taskId":"wf-1/task-1"');
+  });
+});
+
+describe('startWebBridge static serving', () => {
+  function makeDist(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-web-dist-'));
+    writeFileSync(join(dir, 'web.html'), '<!doctype html><div id="root">SHELL</div>');
+    mkdirSync(join(dir, 'assets'));
+    writeFileSync(join(dir, 'assets', 'web-abc.js'), 'console.log("app");');
+    return dir;
+  }
+
+  async function startStaticBridge() {
+    const bus = makeBus();
+    bridge = startWebBridge({
+      dispatch: (async () => ({})) as never,
+      messageBus: bus as never,
+      persistence: { getActivityLogs: () => [], listWorkflows: () => [] } as never,
+      uiDistDir: makeDist(),
+      token: TOKEN,
+      host: '127.0.0.1',
+      port: 0,
+    });
+    return await bridge.whenReady;
+  }
+
+  it('requires the cookie for the page and assets', async () => {
+    const port = await startStaticBridge();
+    expect((await request(port, '/')).status).toBe(401);
+    expect((await request(port, '/assets/web-abc.js')).status).toBe(401);
+  });
+
+  it('serves the shell and assets with the right content types once authed', async () => {
+    const port = await startStaticBridge();
+    const cookie = `invoker_web=${TOKEN}`;
+    const shell = await request(port, '/', { headers: { cookie } });
+    expect(shell.status).toBe(200);
+    expect(shell.headers['content-type']).toContain('text/html');
+    expect(shell.body).toContain('SHELL');
+    const asset = await request(port, '/assets/web-abc.js', { headers: { cookie } });
+    expect(asset.status).toBe(200);
+    expect(asset.headers['content-type']).toContain('javascript');
+    // Unknown non-asset route falls back to the SPA shell.
+    const spa = await request(port, '/workflow/wf-1', { headers: { cookie } });
+    expect(spa.status).toBe(200);
+    expect(spa.body).toContain('SHELL');
+  });
+});

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildWebInvokerDispatch } from '../web/web-invoker-dispatch.js';
+
+function makeTask(id: string) {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2026-01-01'),
+    config: {},
+    execution: {},
+  };
+}
+
+function makeDispatch(overrides: Record<string, unknown> = {}) {
+  const approveTask = vi.fn(async () => ({ ok: true }));
+  const deps = {
+    orchestrator: {
+      getAllTasks: () => [makeTask('wf-1/task-1')],
+      getWorkflowStatus: () => ({ total: 1, completed: 0, failed: 0, closed: 0, running: 0, pending: 1 }),
+      getTask: () => null,
+    },
+    persistence: {
+      listWorkflows: () => [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
+    },
+    mutations: { approveTask },
+    agentRegistry: { listExecution: () => [] },
+    loadConfig: () => ({}),
+    getStreamSequence: () => 7,
+    refreshTaskGraph: vi.fn(async () => {}),
+    deleteWorkflow: vi.fn(async () => {}),
+    detachWorkflow: vi.fn(async () => {}),
+    ...overrides,
+  };
+  return { dispatch: buildWebInvokerDispatch(deps as never), approveTask };
+}
+
+describe('buildWebInvokerDispatch', () => {
+  it('list-workflows returns the persisted workflows', async () => {
+    const { dispatch } = makeDispatch();
+    expect(await dispatch('invoker:list-workflows', [])).toEqual([
+      { id: 'wf-1', name: 'Workflow 1', status: 'pending' },
+    ]);
+  });
+
+  it('get-tasks returns the { tasks, workflows, streamSequence } snapshot', async () => {
+    const { dispatch } = makeDispatch();
+    expect(await dispatch('invoker:get-tasks', [])).toEqual({
+      tasks: [makeTask('wf-1/task-1')],
+      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
+      streamSequence: 7,
+    });
+  });
+
+  it('approve routes to the mutation facade', async () => {
+    const { dispatch, approveTask } = makeDispatch();
+    await dispatch('invoker:approve', ['wf/x']);
+    expect(approveTask).toHaveBeenCalledWith('wf/x');
+  });
+
+  it('open-terminal degrades gracefully instead of rejecting', async () => {
+    const { dispatch } = makeDispatch();
+    expect(await dispatch('invoker:open-terminal', ['t'])).toEqual({
+      opened: false,
+      reason: expect.any(String),
+    });
+  });
+
+  it('a global-lifecycle channel rejects as unsupported_on_web', async () => {
+    const { dispatch } = makeDispatch();
+    await expect(dispatch('invoker:start', [])).rejects.toMatchObject({ code: 'unsupported_on_web' });
+  });
+
+  it('an unknown channel rejects with code unknown_channel', async () => {
+    const { dispatch } = makeDispatch();
+    await expect(dispatch('invoker:does-not-exist', [])).rejects.toMatchObject({ code: 'unknown_channel' });
+  });
+});

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -12,6 +12,23 @@ import { homedir } from 'node:os';
 export interface InvokerConfig {
   defaultBranch?: string;
   /**
+   * Web surface (browser mirror of the desktop app) shared-secret token.
+   * When set (or via INVOKER_WEB_TOKEN), the owner process serves the UI at
+   * http://<webHost>:<webPort>/?token=<token>. Unset disables the web surface.
+   * INVOKER_WEB_TOKEN takes precedence over this value.
+   */
+  webToken?: string;
+  /**
+   * Host the web surface binds to. Default '127.0.0.1' (localhost only).
+   * Set '0.0.0.0' to expose it on a remote box (e.g. the DigitalOcean host).
+   * INVOKER_WEB_HOST takes precedence.
+   */
+  webHost?: string;
+  /**
+   * Port the web surface binds to. Default 4200. INVOKER_WEB_PORT takes precedence.
+   */
+  webPort?: number;
+  /**
    * When true, skip relaunching orphaned running tasks on GUI startup.
    * Useful when you want to inspect state before tasks resume automatically.
    * Default: false

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -7,6 +7,7 @@ import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { MessageBus } from '@invoker/transport';
 import { loadConfig } from './config.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
+import { buildTaskGraphSnapshot } from './web/task-graph-snapshot.js';
 
 export interface RegisterReadOnlyIpcHandlersContext {
   ipcMain: IpcMain;
@@ -122,9 +123,11 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
       );
     }
 
-    const tasks = orchestrator.getAllTasks();
-    const workflows = persistence.listWorkflows();
-    const streamSequence = getTaskDeltaStreamSequence();
+    const { tasks, workflows, streamSequence } = buildTaskGraphSnapshot({
+      orchestrator,
+      persistence,
+      getStreamSequence: getTaskDeltaStreamSequence,
+    });
     logger.info(
       `get-tasks returning ${tasks.length} tasks, ${workflows.length} workflows`,
       { module: 'ipc' },

--- a/packages/app/src/task-graph-event-publisher.ts
+++ b/packages/app/src/task-graph-event-publisher.ts
@@ -19,6 +19,7 @@ export interface CreateTaskGraphEventPublisherOptions {
   stampDelta: (delta: TaskDelta) => TaskDelta;
   getStreamSequence: () => number;
   onLargeBatch?: (stats: { batchSize: number; remaining: number }) => void;
+  onEvent?: (event: TaskGraphEvent) => void;
 }
 
 export function createTaskGraphEventPublisher(
@@ -55,6 +56,7 @@ export function createTaskGraphEventPublisher(
   };
 
   const publishEvent = (event: TaskGraphEvent): void => {
+    options.onEvent?.(event);
     const mainWindow = options.getMainWindow();
     if (!mainWindow || mainWindow.isDestroyed() || !options.isUiInteractive()) {
       return;

--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -1,0 +1,188 @@
+/**
+ * Headless web-surface bootstrap.
+ *
+ * The GUI owner already builds a `WorkflowRollupProjection` + task-graph
+ * publisher and subscribes to `task.delta`; it wires the web bridge directly
+ * onto that existing publisher. Headless owners (the DO box, standalone /
+ * owner-serve, `--headless run|resume|slack`) have no such pipeline, so this
+ * helper stands up a sink-only projection + publisher and feeds the web
+ * bridge's SSE stream — keeping a single projection instance per process.
+ *
+ * Returns `null` (and logs one line) when no web token is configured, so call
+ * sites can unconditionally invoke it.
+ */
+
+import type {
+  BundledSkillsStatus,
+  Logger,
+  WorkflowMeta,
+} from '@invoker/contracts';
+import { Channels, type MessageBus } from '@invoker/transport';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import { registerBuiltinAgents, type AgentRegistry } from '@invoker/execution-engine';
+import type { Orchestrator, TaskDelta } from '@invoker/workflow-core';
+import { loadConfig, type InvokerConfig } from '../config.js';
+import type { ApiMutationFacade } from '../api-server.js';
+import { createTaskGraphEventPublisher } from '../task-graph-event-publisher.js';
+import { createTaskDeltaStreamSequence } from '../task-delta-stream-sequence.js';
+import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
+import { buildWebInvokerDispatch } from './web-invoker-dispatch.js';
+import { startWebBridge, resolveWebUiDistDir, type WebBridge } from './web-bridge-server.js';
+
+const DEFAULT_WEB_HOST = '127.0.0.1';
+const DEFAULT_WEB_PORT = 4200;
+
+/** Shared secret enabling the web surface; env wins over config. Undefined disables it. */
+export function resolveWebToken(config: Pick<InvokerConfig, 'webToken'>): string | undefined {
+  const fromEnv = process.env.INVOKER_WEB_TOKEN;
+  return fromEnv && fromEnv.length > 0 ? fromEnv : config.webToken;
+}
+
+export function resolveWebHost(config: Pick<InvokerConfig, 'webHost'>): string {
+  return process.env.INVOKER_WEB_HOST ?? config.webHost ?? DEFAULT_WEB_HOST;
+}
+
+export function resolveWebPort(config: Pick<InvokerConfig, 'webPort'>): number {
+  const raw = process.env.INVOKER_WEB_PORT ?? (config.webPort != null ? String(config.webPort) : undefined);
+  const parsed = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : DEFAULT_WEB_PORT;
+}
+
+export interface StartHeadlessWebSurfaceDeps {
+  logger: Logger;
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  messageBus: MessageBus;
+  agentRegistry: AgentRegistry;
+  mutations: ApiMutationFacade;
+  deleteWorkflow: (workflowId: string) => Promise<void>;
+  detachWorkflow: (workflowId: string, upstreamWorkflowId: string) => Promise<void>;
+  loadConfig: () => InvokerConfig;
+  config: InvokerConfig;
+  /** Main process dist directory (`__dirname` of main.js) used to locate the built UI. */
+  appRootDir: string;
+  getBundledSkillsStatus?: () => BundledSkillsStatus;
+}
+
+export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebBridge | null {
+  const token = resolveWebToken(deps.config);
+  if (!token) {
+    deps.logger.info(
+      'Web surface disabled — set INVOKER_WEB_TOKEN (or config.webToken) to enable it',
+      { module: 'web-bridge' },
+    );
+    return null;
+  }
+
+  const host = resolveWebHost(deps.config);
+  const port = resolveWebPort(deps.config);
+  const uiDistDir = resolveWebUiDistDir(deps.appRootDir);
+
+  const streamSeq = createTaskDeltaStreamSequence();
+  const projection = new WorkflowRollupProjection();
+  let bridge: WebBridge | null = null;
+
+  const publisher = createTaskGraphEventPublisher({
+    getMainWindow: () => null,
+    isUiInteractive: () => false,
+    stampDelta: (delta) => streamSeq.stamp(delta),
+    getStreamSequence: () => streamSeq.current(),
+    onEvent: (event) => bridge?.broadcast('invoker:task-graph-event', event),
+  });
+
+  const unsubscribe = deps.messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
+    const d = delta as TaskDelta;
+    const rollups = projection.applyDelta(d);
+    publisher.publishDelta(d, rollups);
+  });
+
+  const refreshTaskGraph = async (): Promise<void> => {
+    deps.orchestrator.syncAllFromDb();
+    const tasks = deps.orchestrator.getAllTasks();
+    projection.replaceAll(tasks);
+    publisher.publishSnapshot(
+      'refresh-task-graph',
+      tasks,
+      deps.persistence.listWorkflows() as WorkflowMeta[],
+    );
+  };
+
+  const dispatch = buildWebInvokerDispatch({
+    orchestrator: deps.orchestrator,
+    persistence: deps.persistence,
+    mutations: deps.mutations,
+    agentRegistry: deps.agentRegistry,
+    loadConfig: deps.loadConfig,
+    getStreamSequence: () => streamSeq.current(),
+    refreshTaskGraph,
+    deleteWorkflow: deps.deleteWorkflow,
+    detachWorkflow: deps.detachWorkflow,
+    getBundledSkillsStatus: deps.getBundledSkillsStatus,
+    logger: deps.logger,
+  });
+
+  bridge = startWebBridge({
+    logger: deps.logger,
+    dispatch,
+    messageBus: deps.messageBus,
+    persistence: deps.persistence,
+    uiDistDir,
+    token,
+    host,
+    port,
+  });
+
+  const originalClose = bridge.close;
+  return {
+    whenReady: bridge.whenReady,
+    broadcast: bridge.broadcast,
+    get port(): number {
+      return bridge!.port;
+    },
+    close: async (): Promise<void> => {
+      unsubscribe?.();
+      await originalClose();
+    },
+  };
+}
+
+/** Structural subset of HeadlessDeps the web surface needs (avoids importing headless-shared and the import cycle it would create). */
+export interface HeadlessWebSurfaceHost {
+  logger: Logger;
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  messageBus: MessageBus;
+  executionAgentRegistry?: AgentRegistry;
+  invokerConfig: InvokerConfig;
+  appRootDir?: string;
+  getBundledSkillsStatus?: () => BundledSkillsStatus;
+}
+
+/**
+ * Start the optional web surface for a headless command, reusing the mutation
+ * facade already built for the REST api-server. Returns null when no web token
+ * is configured. Callers close the returned bridge alongside `api.close()`.
+ */
+export function startWebSurfaceForHeadless(
+  host: HeadlessWebSurfaceHost,
+  apiServerDeps: {
+    mutations: ApiMutationFacade;
+    deleteWorkflow: (workflowId: string) => Promise<void>;
+    detachWorkflow: (workflowId: string, upstreamWorkflowId: string) => Promise<void>;
+  },
+): WebBridge | null {
+  return startHeadlessWebSurface({
+    logger: host.logger,
+    orchestrator: host.orchestrator,
+    persistence: host.persistence,
+    messageBus: host.messageBus,
+    agentRegistry: host.executionAgentRegistry ?? registerBuiltinAgents(),
+    mutations: apiServerDeps.mutations,
+    deleteWorkflow: apiServerDeps.deleteWorkflow,
+    detachWorkflow: apiServerDeps.detachWorkflow,
+    loadConfig,
+    config: host.invokerConfig,
+    appRootDir: host.appRootDir ?? __dirname,
+    getBundledSkillsStatus: host.getBundledSkillsStatus,
+  });
+}

--- a/packages/app/src/web/task-graph-snapshot.ts
+++ b/packages/app/src/web/task-graph-snapshot.ts
@@ -1,0 +1,31 @@
+/**
+ * Single source for the `{ tasks, workflows, streamSequence }` task-graph
+ * snapshot shape returned by `invoker:get-tasks`. Both the Electron read
+ * handler (ipc-read-handlers.ts) and the web bridge dispatch
+ * (web-invoker-dispatch.ts) build the snapshot through this function so the
+ * two transports never diverge.
+ */
+
+import type { WorkflowMeta } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+
+export interface TaskGraphSnapshot {
+  tasks: TaskState[];
+  workflows: WorkflowMeta[];
+  streamSequence: number;
+}
+
+export interface BuildTaskGraphSnapshotDeps {
+  orchestrator: Pick<Orchestrator, 'getAllTasks'>;
+  persistence: Pick<SQLiteAdapter, 'listWorkflows'>;
+  getStreamSequence: () => number;
+}
+
+export function buildTaskGraphSnapshot(deps: BuildTaskGraphSnapshotDeps): TaskGraphSnapshot {
+  return {
+    tasks: deps.orchestrator.getAllTasks(),
+    workflows: deps.persistence.listWorkflows() as WorkflowMeta[],
+    streamSequence: deps.getStreamSequence(),
+  };
+}

--- a/packages/app/src/web/web-bridge-server.ts
+++ b/packages/app/src/web/web-bridge-server.ts
@@ -1,0 +1,352 @@
+/**
+ * Web bridge HTTP server.
+ *
+ * Serves the built Electron React UI over HTTP and exposes the same
+ * `InvokerAPI` the renderer uses, via two transports the web shim
+ * (packages/ui/src/web/web-invoker-client.ts) speaks:
+ *   - `POST /invoke`  request/response → `deps.dispatch(channel, args)`
+ *   - `GET  /events`  Server-Sent Events push (task graph, output, activity)
+ *
+ * Auth is a single shared secret (no user accounts). `GET /?token=<t>` sets an
+ * HttpOnly cookie and redirects to `/` (dropping the token from the URL).
+ * Page + asset requests require the cookie; `/invoke` and `/events` accept the
+ * cookie OR an `x-invoker-token` header (for non-browser clients). Same-origin
+ * only — no CORS headers are emitted.
+ *
+ * Plain `node:http` + `node:fs` — no new runtime dependency.
+ */
+
+import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { join, normalize, sep, extname } from 'node:path';
+import { timingSafeEqual } from 'node:crypto';
+import type { Logger } from '@invoker/contracts';
+import { Channels, type MessageBus } from '@invoker/transport';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { WebInvokerDispatch } from './web-invoker-dispatch.js';
+
+const COOKIE_NAME = 'invoker_web';
+const MAX_INVOKE_BODY_BYTES = 1024 * 1024; // 1 MiB
+const MAX_SSE_CLIENTS = 64;
+const SSE_PING_INTERVAL_MS = 20_000;
+const ACTIVITY_POLL_INTERVAL_MS = 2_000;
+const WORKFLOWS_POLL_INTERVAL_MS = 2_000;
+const SSE_DROP_BUFFER_BYTES = 8 * 1024 * 1024; // drop a client whose backlog exceeds this
+
+export interface WebBridgeDeps {
+  logger?: Logger;
+  dispatch: WebInvokerDispatch;
+  messageBus: Pick<MessageBus, 'subscribe'>;
+  persistence: Pick<SQLiteAdapter, 'getActivityLogs' | 'listWorkflows'>;
+  uiDistDir: string;
+  token: string;
+  host: string;
+  port: number;
+}
+
+export interface WebBridge {
+  close: () => Promise<void>;
+  /** Resolves with the actually-bound port once the server is listening. */
+  whenReady: Promise<number>;
+  /** Best-effort current bound port (use `whenReady` when port was 0). */
+  readonly port: number;
+  /** Push a Server-Sent Event to every connected client. */
+  broadcast: (channel: string, data: unknown) => void;
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    const key = part.slice(0, eq).trim();
+    if (key) out[key] = part.slice(eq + 1).trim();
+  }
+  return out;
+}
+
+const CONTENT_TYPES: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.map': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.ico': 'image/x-icon',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ttf': 'font/ttf',
+};
+
+function contentTypeFor(filePath: string): string {
+  return CONTENT_TYPES[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' });
+  res.end(payload);
+}
+
+/**
+ * Resolve the directory holding the built UI (`web.html` + assets), mirroring
+ * window-lifecycle's packaged-vs-repo resolution. `appRootDir` is the main
+ * process dist directory (`__dirname` of main.js).
+ */
+export function resolveWebUiDistDir(appRootDir: string): string {
+  const packaged = join(appRootDir, 'ui');
+  const repo = join(appRootDir, '..', '..', 'ui', 'dist');
+  return existsSync(join(packaged, 'web.html')) ? packaged : repo;
+}
+
+export function startWebBridge(deps: WebBridgeDeps): WebBridge {
+  const { logger, dispatch, messageBus, persistence, uiDistDir, token, host, port } = deps;
+  const distRoot = normalize(uiDistDir);
+
+  const clients = new Set<ServerResponse>();
+
+  const broadcast = (channel: string, data: unknown): void => {
+    if (clients.size === 0) return;
+    const frame = `event: ${channel}\ndata: ${JSON.stringify(data)}\n\n`;
+    for (const client of clients) {
+      if (client.writableEnded || client.writableLength > SSE_DROP_BUFFER_BYTES) {
+        clients.delete(client);
+        client.destroy();
+        continue;
+      }
+      client.write(frame);
+    }
+  };
+
+  const cookieValid = (req: IncomingMessage): boolean => {
+    const cookie = parseCookies(req.headers.cookie)[COOKIE_NAME];
+    return typeof cookie === 'string' && safeEqual(cookie, token);
+  };
+
+  const headerValid = (req: IncomingMessage): boolean => {
+    const header = req.headers['x-invoker-token'];
+    return typeof header === 'string' && safeEqual(header, token);
+  };
+
+  const serveStatic = (res: ServerResponse, pathname: string): void => {
+    const rel = pathname === '/' ? 'web.html' : pathname.replace(/^\/+/, '');
+    const resolved = normalize(join(distRoot, rel));
+    if (resolved !== distRoot && !resolved.startsWith(distRoot + sep)) {
+      sendJson(res, 403, { error: 'forbidden' });
+      return;
+    }
+    if (!existsSync(resolved) || !statSync(resolved).isFile()) {
+      // SPA fallback: unknown non-asset paths render the app shell.
+      if (extname(resolved) === '') {
+        serveStatic(res, '/');
+        return;
+      }
+      sendJson(res, 404, { error: 'not_found' });
+      return;
+    }
+    const isShell = resolved.endsWith('web.html');
+    res.writeHead(200, {
+      'content-type': contentTypeFor(resolved),
+      'cache-control': isShell ? 'no-cache' : 'public, max-age=31536000, immutable',
+    });
+    createReadStream(resolved).pipe(res);
+  };
+
+  const handleInvoke = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+    let aborted = false;
+    for await (const chunk of req) {
+      total += (chunk as Buffer).length;
+      if (total > MAX_INVOKE_BODY_BYTES) {
+        aborted = true;
+        sendJson(res, 413, { ok: false, error: { message: 'request body too large' } });
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk as Buffer);
+    }
+    if (aborted) return;
+
+    let parsed: { channel?: unknown; args?: unknown };
+    try {
+      parsed = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
+    } catch {
+      sendJson(res, 400, { ok: false, error: { message: 'invalid JSON body' } });
+      return;
+    }
+    if (typeof parsed.channel !== 'string') {
+      sendJson(res, 400, { ok: false, error: { message: 'missing "channel"' } });
+      return;
+    }
+    const args = Array.isArray(parsed.args) ? parsed.args : [];
+    try {
+      const result = await dispatch(parsed.channel, args);
+      sendJson(res, 200, { ok: true, result });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const code = (err as { code?: string }).code;
+      sendJson(res, 200, { ok: false, error: code ? { message, code } : { message } });
+    }
+  };
+
+  const handleEvents = (req: IncomingMessage, res: ServerResponse): void => {
+    if (clients.size >= MAX_SSE_CLIENTS) {
+      sendJson(res, 503, { error: 'too_many_clients' });
+      return;
+    }
+    res.writeHead(200, {
+      'content-type': 'text/event-stream; charset=utf-8',
+      'cache-control': 'no-cache, no-transform',
+      connection: 'keep-alive',
+    });
+    res.write('retry: 3000\n\n');
+    clients.add(res);
+    const cleanup = (): void => {
+      clients.delete(res);
+    };
+    req.on('close', cleanup);
+    res.on('error', cleanup);
+  };
+
+  const server: Server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    void (async () => {
+      try {
+        const method = req.method ?? 'GET';
+        const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+        const pathname = url.pathname;
+
+        if (method === 'POST' && pathname === '/invoke') {
+          if (!cookieValid(req) && !headerValid(req)) {
+            sendJson(res, 401, { error: 'unauthorized' });
+            return;
+          }
+          await handleInvoke(req, res);
+          return;
+        }
+
+        if (method === 'GET' && pathname === '/events') {
+          if (!cookieValid(req) && !headerValid(req)) {
+            sendJson(res, 401, { error: 'unauthorized' });
+            return;
+          }
+          handleEvents(req, res);
+          return;
+        }
+
+        if (method !== 'GET' && method !== 'HEAD') {
+          sendJson(res, 405, { error: 'method_not_allowed' });
+          return;
+        }
+
+        // Token handshake: exchange `?token=` for an HttpOnly cookie, then
+        // redirect to a clean URL so the secret never lingers in history.
+        const queryToken = url.searchParams.get('token');
+        if (pathname === '/' && queryToken !== null) {
+          if (!safeEqual(queryToken, token)) {
+            sendJson(res, 401, { error: 'unauthorized' });
+            return;
+          }
+          res.writeHead(302, {
+            'set-cookie': `${COOKIE_NAME}=${token}; HttpOnly; SameSite=Strict; Path=/`,
+            location: '/',
+          });
+          res.end();
+          return;
+        }
+
+        if (!cookieValid(req)) {
+          sendJson(res, 401, { error: 'unauthorized' });
+          return;
+        }
+        serveStatic(res, pathname);
+      } catch (err) {
+        logger?.error(`web bridge request error: ${err instanceof Error ? err.message : String(err)}`, {
+          module: 'web-bridge',
+        });
+        if (!res.headersSent) sendJson(res, 500, { error: 'internal_error' });
+      }
+    })();
+  });
+
+  const unsubscribeOutput = messageBus.subscribe(Channels.TASK_OUTPUT, (payload: unknown) => {
+    broadcast('invoker:task-output', payload);
+  });
+
+  let activityWatermark = 0;
+  const activityTimer = setInterval(() => {
+    try {
+      const entries = persistence.getActivityLogs(activityWatermark, 200);
+      if (entries.length === 0) return;
+      activityWatermark = Math.max(activityWatermark, ...entries.map((e) => e.id));
+      broadcast('invoker:activity-log', entries);
+    } catch {
+      // DB may be briefly locked; next tick retries.
+    }
+  }, ACTIVITY_POLL_INTERVAL_MS);
+  activityTimer.unref?.();
+
+  let workflowsSignature = '';
+  const workflowsTimer = setInterval(() => {
+    try {
+      const workflows = persistence.listWorkflows();
+      const signature = workflows.map((w) => `${w.id}:${w.status}:${w.updatedAt}`).join('|');
+      if (signature === workflowsSignature) return;
+      workflowsSignature = signature;
+      broadcast('invoker:workflows-changed', workflows);
+    } catch {
+      // DB may be briefly locked; next tick retries.
+    }
+  }, WORKFLOWS_POLL_INTERVAL_MS);
+  workflowsTimer.unref?.();
+
+  const pingTimer = setInterval(() => {
+    for (const client of clients) {
+      if (!client.writableEnded) client.write(': ping\n\n');
+    }
+  }, SSE_PING_INTERVAL_MS);
+  pingTimer.unref?.();
+
+  const { promise: whenReady, resolve: resolveReady } = Promise.withResolvers<number>();
+  server.listen(port, host, () => {
+    const address = server.address();
+    const boundPort = typeof address === 'object' && address ? address.port : port;
+    logger?.info(`Web surface listening on http://${host}:${boundPort}`, { module: 'web-bridge' });
+    resolveReady(boundPort);
+  });
+
+  const close = async (): Promise<void> => {
+    clearInterval(activityTimer);
+    clearInterval(workflowsTimer);
+    clearInterval(pingTimer);
+    unsubscribeOutput?.();
+    for (const client of clients) client.end();
+    clients.clear();
+    const { promise, resolve } = Promise.withResolvers<void>();
+    server.close(() => resolve());
+    await promise;
+  };
+
+  return {
+    close,
+    whenReady,
+    broadcast,
+    get port(): number {
+      const address = server.address();
+      return typeof address === 'object' && address ? address.port : port;
+    },
+  };
+}

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -1,0 +1,255 @@
+/**
+ * Transport-neutral `InvokerAPI` dispatch for the web bridge.
+ *
+ * `buildWebInvokerDispatch` returns a single function `(channel, args)` that
+ * mirrors the Electron IPC handlers (reads in ipc-read-handlers.ts / main.ts,
+ * mutations in api-server.ts) by calling the owner-process objects directly.
+ * It runs ONLY in the owner process (the same process the REST api-server runs
+ * in), so there is no IPC delegation path here.
+ *
+ * The web shim (packages/ui/src/web/web-invoker-client.ts) POSTs
+ * `{ channel, args }`; the bridge invokes this dispatch and serialises the
+ * result. Channels with no meaningful web behaviour resolve a benign value
+ * (terminals) or reject with a structured `{ code }` error (everything else).
+ */
+
+import type {
+  BundledSkillsStatus,
+  Logger,
+  SystemDiagnostics,
+} from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { AgentRegistry } from '@invoker/execution-engine';
+import type { ExternalGatePolicyUpdate, Orchestrator } from '@invoker/workflow-core';
+import type { InvokerConfig } from '../config.js';
+import type { ApiMutationFacade } from '../api-server.js';
+import { buildReviewGateQueryResponse } from '../review-gate-query.js';
+import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
+import { collectSystemDiagnostics } from '../system-diagnostics.js';
+import { resolveAgentSession } from '../headless-query-list.js';
+import { buildTaskGraphSnapshot } from './task-graph-snapshot.js';
+
+export interface WebInvokerDispatchDeps {
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  mutations: ApiMutationFacade;
+  agentRegistry: AgentRegistry;
+  loadConfig: () => InvokerConfig;
+  /** Monotonic task-delta stream watermark used by the snapshot resync contract. */
+  getStreamSequence: () => number;
+  /** Resync the owner graph and push a fresh snapshot to live (SSE) clients. */
+  refreshTaskGraph: () => Promise<void>;
+  deleteWorkflow: (workflowId: string) => Promise<void>;
+  detachWorkflow: (workflowId: string, upstreamWorkflowId: string) => Promise<void>;
+  /** Optional richer reads available in the GUI owner; safe fallbacks otherwise. */
+  getSystemDiagnostics?: () => SystemDiagnostics;
+  getBundledSkillsStatus?: () => BundledSkillsStatus;
+  checkPrStatuses?: () => void | Promise<void>;
+  logger?: Logger;
+}
+
+export type WebInvokerDispatch = (channel: string, args: unknown[]) => Promise<unknown>;
+
+class WebDispatchError extends Error {
+  readonly code: string;
+  readonly channel: string;
+  constructor(code: string, channel: string, message: string) {
+    super(message);
+    this.name = 'WebDispatchError';
+    this.code = code;
+    this.channel = channel;
+  }
+}
+
+function unsupported(channel: string): never {
+  throw new WebDispatchError(
+    'unsupported_on_web',
+    channel,
+    `Channel "${channel}" is not supported on the web surface`,
+  );
+}
+
+export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvokerDispatch {
+  const { orchestrator, persistence, mutations, agentRegistry } = deps;
+
+  const reviewGate = (workflowId: string) => {
+    const workflow = persistence.loadWorkflow(workflowId);
+    if (!workflow) return null;
+    const tasks = persistence.loadTasks(workflowId);
+    return buildReviewGateQueryResponse({ workflowId, workflow, tasks });
+  };
+
+  return async function dispatch(channel: string, args: unknown[]): Promise<unknown> {
+    switch (channel) {
+      // ── Reads ─────────────────────────────────────────────
+      case 'invoker:get-tasks':
+        return buildTaskGraphSnapshot({
+          orchestrator,
+          persistence,
+          getStreamSequence: deps.getStreamSequence,
+        });
+      case 'invoker:refresh-task-graph':
+        await deps.refreshTaskGraph();
+        return undefined;
+      case 'invoker:list-workflows':
+        return persistence.listWorkflows();
+      case 'invoker:load-workflow': {
+        const workflowId = String(args[0]);
+        orchestrator.syncFromDb(workflowId);
+        return {
+          workflow: persistence.loadWorkflow(workflowId),
+          tasks: persistence.loadTasks(workflowId),
+        };
+      }
+      case 'invoker:get-status':
+        return orchestrator.getWorkflowStatus();
+      case 'invoker:get-queue-status':
+        return orchestrator.getQueueStatus();
+      case 'invoker:get-action-graph':
+        return buildCurrentActionGraphSnapshot({
+          orchestrator,
+          persistence,
+          invokerConfig: deps.loadConfig(),
+        });
+      case 'invoker:get-events':
+        return persistence.getEvents(String(args[0]));
+      case 'invoker:get-task-output':
+        return persistence.getTaskOutput(String(args[0]));
+      case 'invoker:get-task-by-id':
+        return orchestrator.getTask(String(args[0])) ?? null;
+      case 'invoker:get-all-completed-tasks':
+        return persistence.loadAllCompletedTasks();
+      case 'invoker:get-review-gate':
+        return reviewGate(String(args[0]));
+      case 'invoker:get-claude-session':
+        return resolveAgentSession(String(args[0]), 'claude', agentRegistry, orchestrator.getAllTasks());
+      case 'invoker:get-agent-session':
+        return resolveAgentSession(
+          String(args[0]),
+          args[1] ? String(args[1]) : 'claude',
+          agentRegistry,
+          orchestrator.getAllTasks(),
+        );
+      case 'invoker:get-remote-targets':
+        return Object.keys(deps.loadConfig().remoteTargets ?? {});
+      case 'invoker:get-execution-pools':
+        return Object.keys(deps.loadConfig().executionPools ?? {});
+      case 'invoker:get-execution-agents':
+        return agentRegistry.listExecution().map((a) => a.name);
+      case 'invoker:get-system-diagnostics':
+        return (
+          deps.getSystemDiagnostics?.() ??
+          collectSystemDiagnostics({
+            appVersion: 'unknown',
+            isPackaged: false,
+            platform: process.platform,
+            arch: process.arch,
+          })
+        );
+      case 'invoker:get-bundled-skills-status':
+        if (!deps.getBundledSkillsStatus) return unsupported(channel);
+        return deps.getBundledSkillsStatus();
+      case 'invoker:get-activity-logs':
+        return persistence.getActivityLogs(
+          typeof args[0] === 'number' ? (args[0] as number) : 0,
+          typeof args[1] === 'number' ? (args[1] as number) : 2000,
+        );
+      case 'invoker:search':
+        return persistence.searchWorkflowsAndTasks(
+          String(args[0]),
+          (args[1] as Parameters<SQLiteAdapter['searchWorkflowsAndTasks']>[1]) ?? undefined,
+        );
+      case 'invoker:get-ui-perf-stats':
+        return {};
+      case 'invoker:report-ui-perf':
+        return undefined;
+      case 'invoker:check-pr-statuses':
+      case 'invoker:check-pr-status':
+        await deps.checkPrStatuses?.();
+        return undefined;
+
+      // ── Mutations (route to the facade exactly as api-server.ts) ──
+      case 'invoker:approve':
+        return mutations.approveTask(String(args[0]));
+      case 'invoker:reject':
+        return mutations.rejectTask(String(args[0]), args[1] === undefined ? undefined : String(args[1]));
+      case 'invoker:provide-input':
+        return mutations.provideInput(String(args[0]), String(args[1]));
+      case 'invoker:restart-task':
+        return mutations.retryTask(String(args[0]));
+      case 'invoker:recreate-task':
+        return mutations.recreateTask(String(args[0]));
+      case 'invoker:recreate-downstream':
+        return mutations.recreateDownstream(String(args[0]));
+      case 'invoker:cancel-task':
+        return mutations.cancelTask(String(args[0]));
+      case 'invoker:recreate-workflow':
+        return mutations.recreateWorkflow(String(args[0]));
+      case 'invoker:retry-workflow':
+        return mutations.retryWorkflow(String(args[0]));
+      case 'invoker:cancel-workflow':
+        return mutations.cancelWorkflow(String(args[0]));
+      case 'invoker:rebase-retry':
+        return mutations.rebaseRetry(String(args[0]));
+      case 'invoker:rebase-recreate':
+        return mutations.rebaseRecreate(String(args[0]));
+      case 'invoker:edit-task-command':
+        return mutations.editTaskCommand(String(args[0]), String(args[1]));
+      case 'invoker:edit-task-prompt':
+        return mutations.editTaskPrompt(String(args[0]), String(args[1]));
+      case 'invoker:edit-task-agent':
+        return mutations.editTaskAgent(String(args[0]), String(args[1]));
+      case 'invoker:edit-task-type':
+        return mutations.editTaskType(
+          String(args[0]),
+          String(args[1]),
+          args[2] === undefined ? undefined : String(args[2]),
+        );
+      case 'invoker:set-task-external-gate-policies':
+        return mutations.setTaskExternalGatePolicies(
+          String(args[0]),
+          (args[1] as ExternalGatePolicyUpdate[]) ?? [],
+        );
+      case 'invoker:resolve-conflict':
+        return mutations.resolveConflict(String(args[0]), args[1] === undefined ? undefined : String(args[1]));
+      case 'invoker:set-merge-mode':
+        return mutations.setWorkflowMergeMode(String(args[0]), String(args[1]));
+      case 'invoker:detach-workflow':
+        return deps.detachWorkflow(String(args[0]), String(args[1]));
+      case 'invoker:delete-workflow':
+        return deps.deleteWorkflow(String(args[0]));
+
+      // ── Terminals: no pty over HTTP — degrade gracefully ──
+      case 'invoker:open-terminal':
+        return { opened: false, reason: 'Terminals are not available in the web UI' };
+      case 'invoker:terminal-list':
+        return [];
+      case 'invoker:terminal-write':
+      case 'invoker:terminal-resize':
+      case 'invoker:terminal-close':
+        return { ok: false, reason: 'unsupported' };
+
+      // ── Mutations not exposed on the facade / global lifecycle ──
+      case 'invoker:select-experiment':
+      case 'invoker:set-merge-branch':
+      case 'invoker:approve-merge':
+      case 'invoker:fix-with-agent':
+      case 'invoker:edit-task-pool':
+      case 'invoker:replace-task':
+      case 'invoker:load-plan':
+      case 'invoker:start':
+      case 'invoker:stop':
+      case 'invoker:clear':
+      case 'invoker:resume-workflow':
+      case 'invoker:delete-all-workflows':
+      case 'invoker:delete-all-workflows-bulk':
+      case 'invoker:cleanup-worktrees':
+      case 'invoker:install-bundled-skills':
+      case 'invoker:update-invoker-cli':
+        return unsupported(channel);
+
+      default:
+        throw new WebDispatchError('unknown_channel', channel, `Unknown channel "${channel}"`);
+    }
+  };
+}

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -5,6 +5,7 @@
     "incremental": false,
     "noEmit": true,
     "allowImportingTsExtensions": true,
+    "lib": ["ES2024"],
     "rootDir": ".",
     "outDir": "./dist-typecheck"
   },


### PR DESCRIPTION
## Summary

A new owner-process module serves the desktop UI bundle over HTTP and answers the same `InvokerAPI` calls a browser makes, using request/response plus Server-Sent Events.

A headless bootstrap helper stands up the bridge and feeds it the live event stream, so a no-desktop owner can serve the UI too.

Nothing starts the bridge yet; this slice only adds the dormant subsystem and its unit tests.

<details>
<summary>Review metadata</summary>

Review Claim: Add a dormant owner-process web bridge that serves the UI and answers `InvokerAPI` calls over HTTP and SSE.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: All new files plus their unit tests; no caller wires the bridge in yet, so running behavior is unchanged. Auth is a constant-time shared-secret cookie, same-origin only.

Slice Rationale: One cohesive new subsystem under `packages/app/src/web`. It lands dormant so the wiring that starts it stays a separate, smaller diff.

</details>

## Non-goals

- Does not start the bridge anywhere; the GUI and headless owners are wired in a later slice.
- Does not change the desktop UI, the REST api-server, or any existing channel handler.
- Terminals are intentionally not served over HTTP.

## Test Plan

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/web-invoker-dispatch.test.ts src/__tests__/web-bridge-server.test.ts src/__tests__/start-web-surface.test.ts`
- [ ] `pnpm run check:types && pnpm run check:deps`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional web surface with configurable host, port, and access token (environment overrides supported).
  * Introduced a secure HTTP web bridge with token-gated UI access, `/invoke` API, and live `/events` streaming.
  * Added a shared task-graph snapshot used across web and desktop, keeping task data consistent.

* **Bug Fixes**
  * Improved web startup/token gating (disabled when no token is configured) and set sensible default host/port values.

* **Tests**
  * Added Vitest coverage for web-surface resolution, headless startup gating, bridge auth/routes/SSE, and web dispatch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2402