### PR TITLE
[Sole-owner DB](2) Add exclusive-locking option (no -shm) to SQLiteAdapter

### DIFF
--- a/packages/data-store/src/__tests__/exclusive-locking.test.ts
+++ b/packages/data-store/src/__tests__/exclusive-locking.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+
+/**
+ * WAL `locking_mode = EXCLUSIVE` keeps the wal-index in heap memory, so SQLite
+ * never creates the `-shm` file. That sidecar is the one whose in-place
+ * truncation under a live memory-map kills the process with SIGBUS
+ * (see scripts/repro/repro-wal-shm-sigbus.sh). No `-shm` => no such crash.
+ */
+
+const dirs: string[] = [];
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'excl-lock-'));
+  dirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const wf: Workflow = {
+  id: 'wf-1',
+  name: 'wf',
+  status: 'running',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe('SQLiteAdapter exclusiveLocking', () => {
+  it('keeps the wal-index in heap so no -shm file is created', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true, exclusiveLocking: true });
+    try {
+      adapter.saveWorkflow(wf);
+      expect(adapter.listWorkflows().map((w) => w.id)).toEqual(['wf-1']); // fully functional
+      expect(existsSync(`${dbPath}-shm`)).toBe(false); // the immunity property
+      expect(existsSync(`${dbPath}-wal`)).toBe(true); // still WAL, just heap wal-index
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('control: default WAL locking creates the mappable -shm sidecar', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      adapter.saveWorkflow(wf);
+      adapter.listWorkflows();
+      expect(existsSync(`${dbPath}-shm`)).toBe(true); // the file that, truncated under mmap, causes SIGBUS
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('rejects exclusiveLocking on a read-only open (only the sole owner may use it)', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    // Seed the file so a read-only open is otherwise valid.
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    owner.close();
+    await expect(
+      SQLiteAdapter.create(dbPath, { readOnly: true, exclusiveLocking: true }),
+    ).rejects.toThrow(/sole opener/);
+  });
+
+  it('rejects exclusiveLocking on a non-owner writable open', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    await expect(
+      SQLiteAdapter.create(dbPath, { exclusiveLocking: true }),
+    ).rejects.toThrow(/sole opener/);
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -124,6 +124,13 @@ interface SQLiteAdapterOptions {
   outputDir?: string;
   /** Max retained activity_log rows; 0 disables retention. */
   activityLogMaxRows?: number;
+  /**
+   * Open WAL in exclusive locking mode: the wal-index lives in heap memory and
+   * no `-shm` file is created, making the process immune to the SIGBUS that a
+   * truncated memory-mapped `-shm` causes. Requires this process to be the SOLE
+   * opener of the database file — a concurrent open is rejected with SQLITE_BUSY.
+   */
+  exclusiveLocking?: boolean;
 }
 
 export type WorkflowMutationPriority = 'high' | 'normal';
@@ -339,6 +346,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private lastWorkflowTaskSnapshotStats: Record<string, unknown> | null = null;
   private readonly activityLogMaxRows: number;
   private activityLogWritesSincePrune = 0;
+  private readonly exclusiveLocking: boolean;
 
   /** Use SQLiteAdapter.create() instead. */
   private constructor(db: DatabaseSync, dbPath: string | null, options?: SQLiteAdapterOptions) {
@@ -349,6 +357,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.outputTailLimit = options?.outputTailLimit ?? 100;
     this.outputDir = options?.outputDir ?? this.resolveOutputDir(dbPath);
     this.activityLogMaxRows = options?.activityLogMaxRows ?? DEFAULT_ACTIVITY_LOG_MAX_ROWS;
+    this.exclusiveLocking = options?.exclusiveLocking === true;
     this.configureConnection(dbPath !== null);
     if (!this.readOnly) {
       this.initSchema();
@@ -366,6 +375,16 @@ export class SQLiteAdapter implements PersistenceAdapter {
   static async create(dbPath: string = ':memory:', options?: SQLiteAdapterOptions): Promise<SQLiteAdapter> {
     const isFile = dbPath !== ':memory:';
     const requestWritable = options?.readOnly !== true;
+
+    // Exclusive (heap wal-index, no -shm) locking is reserved for the sole
+    // opener: only the writable owner of a file-backed database may request it.
+    // A read-only or non-owner caller opting in would contend with the real
+    // owner (SQLITE_BUSY) or get a cryptic open failure.
+    if (isFile && options?.exclusiveLocking === true && (!requestWritable || !options?.ownerCapability)) {
+      throw new Error(
+        'exclusiveLocking requires the writable owner process to be the sole opener of the database file.',
+      );
+    }
 
     // Enforce owner-only writable initialization for file-backed databases
     if (isFile && requestWritable && !options?.ownerCapability) {
@@ -416,6 +435,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.nativeDb.exec('PRAGMA busy_timeout = 5000');
     this.nativeDb.exec('PRAGMA foreign_keys = ON');
     if (fileBacked) {
+      if (this.exclusiveLocking) {
+        // Heap wal-index (no -shm file). MUST precede `journal_mode = WAL`.
+        this.nativeDb.exec('PRAGMA locking_mode = EXCLUSIVE');
+      }
       this.nativeDb.exec('PRAGMA journal_mode = WAL');
       this.nativeDb.exec('PRAGMA synchronous = FULL');
       this.nativeDb.exec('PRAGMA wal_autocheckpoint = 1000');


### PR DESCRIPTION
Adds an `exclusiveLocking` option that sets `PRAGMA locking_mode = EXCLUSIVE`
before `journal_mode = WAL`, so SQLite keeps the wal-index in heap memory and
never creates the `-shm` sidecar. A truncated, memory-mapped `-shm` is what kills
the process with SIGBUS (scripts/repro/repro-wal-shm-sigbus.sh); with no -shm the
crash cannot happen.

Off by default. It requires the process to be the sole opener (a concurrent open
is rejected with SQLITE_BUSY), so it is the foundation that later slices switch on
for the owner once every other reader is routed through IPC.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional exclusive-locking mode for SQLite-backed storage to better support single-writer database access.

* **Bug Fixes**
  * Improved validation when opening existing databases, with clearer errors if exclusive locking is requested without the required ownership or writable access.
  * Ensured SQLite locking behavior matches the selected mode, including expected sidecar file creation.

* **Tests**
  * Added coverage for exclusive-locking behavior and related access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->