### PR TITLE
[Sole-owner DB](3) Share one owner read-query responder across both owners

### DIFF
--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+import { answerOwnerReadQuery, type OwnerReadQueryHandlers } from '../owner-read-query.js';
+
+function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQueryHandlers {
+  return {
+    ownerModeLabel: 'gui',
+    onActivity: vi.fn(),
+    getUiPerfStats: vi.fn(() => ({ mainDeltaToUi: 7 })),
+    resetUiPerfStats: vi.fn(),
+    getQueueStatus: vi.fn(() => ({ runningCount: 2 })),
+    getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
+    getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
+    getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
+    ...over,
+  };
+}
+
+describe('answerOwnerReadQuery', () => {
+  it('ui-perf merges the owner label with the stats; reset only when asked', () => {
+    const h = makeHandlers({ ownerModeLabel: 'standalone' });
+    expect(answerOwnerReadQuery({ kind: 'ui-perf' }, h)).toEqual({ ownerMode: 'standalone', mainDeltaToUi: 7 });
+    expect(h.resetUiPerfStats).not.toHaveBeenCalled();
+    answerOwnerReadQuery({ kind: 'ui-perf', reset: true }, h);
+    expect(h.resetUiPerfStats).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes each read kind to its handler', () => {
+    const h = makeHandlers();
+    expect(answerOwnerReadQuery({ kind: 'queue' }, h)).toEqual({ runningCount: 2 });
+    expect(answerOwnerReadQuery({ kind: 'workflow-status' }, h)).toEqual({ 'wf-1': 'running' });
+    expect(answerOwnerReadQuery({ kind: 'action-graph' }, h)).toEqual({ nodes: [] });
+  });
+
+  it('refreshes the snapshot only for task-graph-refresh', () => {
+    const h = makeHandlers();
+    expect(answerOwnerReadQuery({ kind: 'tasks' }, h)).toMatchObject({ refreshed: false });
+    expect(answerOwnerReadQuery({ kind: 'task-graph-refresh' }, h)).toMatchObject({ refreshed: true });
+    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(1, { refresh: false });
+    expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(2, { refresh: true });
+  });
+
+  it('calls onActivity once per query and rejects unknown kinds', () => {
+    const h = makeHandlers();
+    answerOwnerReadQuery({ kind: 'queue' }, h);
+    expect(h.onActivity).toHaveBeenCalledTimes(1);
+    expect(() => answerOwnerReadQuery({ kind: 'bogus' }, h)).toThrow(/Unsupported headless query: bogus/);
+    expect(() => answerOwnerReadQuery({}, h)).toThrow(/Unsupported headless query: undefined/);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -209,6 +209,7 @@ import {
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
+import { answerOwnerReadQuery } from './owner-read-query.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import {
   createGuiMutationRegistrars,
@@ -1680,40 +1681,26 @@ function startHeadlessMode(): void {
             mode: 'standalone',
           };
         });
-        messageBus.onRequest('headless.query', async (req: unknown) => {
-          noteStandaloneOwnerActivity();
-          const { kind, reset } = req as { kind?: string; reset?: boolean };
-          if (kind === 'ui-perf') {
-            if (reset) {
-              headlessDeps.resetUiPerfStats?.();
-            }
-            return {
-              ownerMode: 'standalone',
-              ...(headlessDeps.getUiPerfStats?.() ?? {}),
-            };
-          }
-          if (kind === 'queue') {
-            return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
-          }
-          if (kind === 'workflow-status') {
-            return orchestrator.getWorkflowStatus();
-          }
-          if (kind === 'tasks' || kind === 'task-graph-refresh') {
-            if (kind === 'task-graph-refresh') {
-              orchestrator.syncAllFromDb();
-            }
-            return {
-              tasks: orchestrator.getAllTasks(),
-              workflows: persistence.listWorkflows(),
-              streamSequence: 0,
-              invokerHomeRoot: resolveInvokerHomeRoot(),
-            };
-          }
-          if (kind === 'action-graph') {
-            return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
-          }
-          throw new Error(`Unsupported headless query: ${String(kind)}`);
-        });
+        messageBus.onRequest('headless.query', async (req: unknown) =>
+          answerOwnerReadQuery(req, {
+            ownerModeLabel: 'standalone',
+            onActivity: noteStandaloneOwnerActivity,
+            getUiPerfStats: () => headlessDeps.getUiPerfStats?.() ?? {},
+            resetUiPerfStats: () => headlessDeps.resetUiPerfStats?.(),
+            getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
+            getWorkflowStatus: () => orchestrator.getWorkflowStatus(),
+            getTasksSnapshot: ({ refresh }) => {
+              if (refresh) orchestrator.syncAllFromDb();
+              return {
+                tasks: orchestrator.getAllTasks(),
+                workflows: persistence.listWorkflows(),
+                streamSequence: 0,
+                invokerHomeRoot: resolveInvokerHomeRoot(),
+              };
+            },
+            getActionGraphSnapshot: () =>
+              buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
+          }));
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId, traceId } = req as { workflowId: string; traceId?: string };
@@ -3253,39 +3240,25 @@ function createEmbeddedTerminalBackendFromConfig(
         ownerId: workflowMutationOwnerId,
         mode: 'gui',
       }));
-      messageBus.onRequest('headless.query', async (req: unknown) => {
-        const { kind, reset } = req as { kind?: string; reset?: boolean };
-        if (kind === 'ui-perf') {
-          if (reset) {
-            resetUiPerfStats();
-          }
-          return {
-            ownerMode: 'gui',
-            ...getUiPerfStats(),
-          };
-        }
-        if (kind === 'queue') {
-          return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
-        }
-        if (kind === 'workflow-status') {
-          return orchestrator.getWorkflowStatus();
-        }
-        if (kind === 'tasks' || kind === 'task-graph-refresh') {
-          if (kind === 'task-graph-refresh') {
-            orchestrator.syncAllFromDb();
-          }
-          return {
-            tasks: orchestrator.getAllTasks(),
-            workflows: persistence.listWorkflows(),
-            streamSequence: getTaskDeltaStreamSequence(),
-            invokerHomeRoot: resolveInvokerHomeRoot(),
-          };
-        }
-        if (kind === 'action-graph') {
-          return buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig });
-        }
-        throw new Error(`Unsupported headless query: ${String(kind)}`);
-      });
+      messageBus.onRequest('headless.query', async (req: unknown) =>
+        answerOwnerReadQuery(req, {
+          ownerModeLabel: 'gui',
+          getUiPerfStats: () => getUiPerfStats(),
+          resetUiPerfStats: () => resetUiPerfStats(),
+          getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
+          getWorkflowStatus: () => orchestrator.getWorkflowStatus(),
+          getTasksSnapshot: ({ refresh }) => {
+            if (refresh) orchestrator.syncAllFromDb();
+            return {
+              tasks: orchestrator.getAllTasks(),
+              workflows: persistence.listWorkflows(),
+              streamSequence: getTaskDeltaStreamSequence(),
+              invokerHomeRoot: resolveInvokerHomeRoot(),
+            };
+          },
+          getActionGraphSnapshot: () =>
+            buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
+        }));
       messageBus.onRequest('headless.run', async (req: unknown) => {
         const { planPath, traceId } = req as { planPath: string; traceId?: string };
         logger.info(

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared dispatcher for the owner's `headless.query` IPC channel.
+ *
+ * Non-owner processes read database-derived state by sending a
+ * `{ kind }`-discriminated request over IpcBus; the writable owner answers it.
+ * The GUI owner and the standalone headless owner previously each carried an
+ * identical if-chain — this is the single place that maps a query kind to a
+ * response, so new read kinds (the sole-owner rearchitecture routes every read
+ * through here) are added once and stay consistent across both owners.
+ *
+ * The per-owner differences (owner label, task-delta stream sequence, the
+ * standalone keep-alive ping, the ui-perf source) are injected via handlers.
+ */
+export interface OwnerReadQueryHandlers {
+  /** Label echoed back on the ui-perf response ('gui' | 'standalone'). */
+  ownerModeLabel: string;
+  /** Called once per query (the standalone owner uses it to defer idle shutdown). */
+  onActivity?: () => void;
+  getUiPerfStats: () => Record<string, unknown>;
+  resetUiPerfStats: () => void;
+  getQueueStatus: () => Record<string, unknown>;
+  getWorkflowStatus: () => Record<string, unknown>;
+  /** Build the task/workflow snapshot; `refresh` re-syncs the orchestrator from the DB first. */
+  getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
+  getActionGraphSnapshot: () => Record<string, unknown>;
+}
+
+export function answerOwnerReadQuery(
+  req: unknown,
+  handlers: OwnerReadQueryHandlers,
+): Record<string, unknown> {
+  const { kind, reset } = (req ?? {}) as { kind?: string; reset?: boolean };
+  handlers.onActivity?.();
+
+  switch (kind) {
+    case 'ui-perf':
+      if (reset) handlers.resetUiPerfStats();
+      return { ownerMode: handlers.ownerModeLabel, ...handlers.getUiPerfStats() };
+    case 'queue':
+      return handlers.getQueueStatus();
+    case 'workflow-status':
+      return handlers.getWorkflowStatus();
+    case 'tasks':
+      return handlers.getTasksSnapshot({ refresh: false });
+    case 'task-graph-refresh':
+      return handlers.getTasksSnapshot({ refresh: true });
+    case 'action-graph':
+      return handlers.getActionGraphSnapshot();
+    default:
+      throw new Error(`Unsupported headless query: ${String(kind)}`);
+  }
+}


### PR DESCRIPTION
The GUI owner and the standalone headless owner each carried an identical
if-chain dispatching the `headless.query` IPC channel by `{kind}`. Extract a
single `answerOwnerReadQuery(req, handlers)` that both call, injecting the only
per-owner differences (owner label, task-delta stream sequence, the standalone
keep-alive ping, the ui-perf source).

Behavior-preserving. This is the seam the sole-owner stack adds read kinds to,
so every read the viewer and headless commands need is defined once and stays
consistent across both owners. Unit-tested.

packages/app/src/owner-read-query.ts (+ test); packages/app/src/main.ts

Depends-On: #2434

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling for headless owner queries across both standalone and GUI modes, with consistent responses for queue, workflow status, action graph, task snapshots, and UI performance data.
  * UI performance results now include the current mode label, and task snapshot refreshes are applied only when explicitly requested.

* **Bug Fixes**
  * Unsupported or missing query types now return a clear error instead of being handled inconsistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->