### PR TITLE
[Sole-owner DB](4) Delegate the viewer's read IPC handlers to the owner

### DIFF
--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -124,4 +124,39 @@ describe('registerReadOnlyIpcHandlers', () => {
     expectReadContextWriteToolsAreAbsent();
   });
 
+  function registerViewer(requestImpl: () => Promise<unknown>) {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler);
+      }),
+    };
+    registerReadOnlyIpcHandlers({
+      ipcMain: ipcMain as never,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+      persistence: { listWorkflows: vi.fn(() => [{ id: 'LOCAL-FALLBACK' }]) } as never,
+      getOrchestrator: () => ({}) as never,
+      agentRegistry: {} as never,
+      loadTaskByIdFromPersistence: () => undefined,
+      resolveAgentSession: vi.fn(async () => null),
+      getOwnerMode: () => false, // viewer mode → delegates to owner
+      getMessageBus: () => ({ request: vi.fn(requestImpl) }),
+      recordStartupDuration: vi.fn(),
+      getTaskDeltaStreamSequence: () => 0,
+    });
+    return handlers;
+  }
+
+  it('rethrows owner errors instead of silently serving local data (timeout)', async () => {
+    const handlers = registerViewer(() =>
+      Promise.reject(Object.assign(new Error('owner timed out'), { code: 'REQUEST_TIMEOUT' })));
+    await expect(handlers.get('invoker:list-workflows')?.({})).rejects.toThrow(/owner timed out/);
+  });
+
+  it('falls back to local only when the owner has no handler', async () => {
+    const handlers = registerViewer(() =>
+      Promise.reject(Object.assign(new Error('No request handler registered for channel: headless.query'), { code: 'NO_HANDLER' })));
+    await expect(handlers.get('invoker:list-workflows')?.({})).resolves.toEqual([{ id: 'LOCAL-FALLBACK' }]);
+  });
+
 });

--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { answerOwnerReadQuery, type OwnerReadQueryHandlers } from '../owner-read-query.js';
+import {
+  answerOwnerReadQuery,
+  buildOwnerReadQueryHandlers,
+  type OwnerReadQueryHandlers,
+} from '../owner-read-query.js';
 
 function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQueryHandlers {
   return {
@@ -11,6 +15,16 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
     getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
     getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
+    listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+    loadWorkflowBundle: vi.fn((id: string) => ({ workflow: { id }, tasks: [] })),
+    getReviewGate: vi.fn(() => ({ gate: true })),
+    getEvents: vi.fn(() => [{ e: 1 }]),
+    getTaskById: vi.fn((id: string) => ({ id })),
+    getTaskOutput: vi.fn(() => 'output-text'),
+    getOutputChunks: vi.fn(() => [{ c: 1 }]),
+    getOutputTail: vi.fn(() => ({ tail: 1 })),
+    replayOutput: vi.fn((id: string, off: number) => [{ id, off }]),
+    getAllCompletedTasks: vi.fn(() => [{ id: 'done' }]),
     ...over,
   };
 }
@@ -24,7 +38,7 @@ describe('answerOwnerReadQuery', () => {
     expect(h.resetUiPerfStats).toHaveBeenCalledTimes(1);
   });
 
-  it('routes each read kind to its handler', () => {
+  it('routes the snapshot kinds to their handlers', () => {
     const h = makeHandlers();
     expect(answerOwnerReadQuery({ kind: 'queue' }, h)).toEqual({ runningCount: 2 });
     expect(answerOwnerReadQuery({ kind: 'workflow-status' }, h)).toEqual({ 'wf-1': 'running' });
@@ -39,11 +53,130 @@ describe('answerOwnerReadQuery', () => {
     expect(h.getTasksSnapshot).toHaveBeenNthCalledWith(2, { refresh: true });
   });
 
+  it('wraps and routes the param-bearing read kinds', () => {
+    const h = makeHandlers();
+    expect(answerOwnerReadQuery({ kind: 'workflows' }, h)).toEqual({ workflows: [{ id: 'wf-1' }] });
+    expect(answerOwnerReadQuery({ kind: 'workflow', workflowId: 'wf-9' }, h)).toEqual({ workflow: { id: 'wf-9' }, tasks: [] });
+    expect(h.loadWorkflowBundle).toHaveBeenCalledWith('wf-9');
+    expect(answerOwnerReadQuery({ kind: 'review-gate', workflowId: 'wf-9' }, h)).toEqual({ reviewGate: { gate: true } });
+    expect(answerOwnerReadQuery({ kind: 'events', taskId: 't-1' }, h)).toEqual({ events: [{ e: 1 }] });
+    expect(h.getEvents).toHaveBeenCalledWith('t-1');
+    expect(answerOwnerReadQuery({ kind: 'task-by-id', taskId: 't-1' }, h)).toEqual({ task: { id: 't-1' } });
+    expect(answerOwnerReadQuery({ kind: 'task-output', taskId: 't-1' }, h)).toEqual({ output: 'output-text' });
+    expect(answerOwnerReadQuery({ kind: 'output-chunks', taskId: 't-1' }, h)).toEqual({ chunks: [{ c: 1 }] });
+    expect(answerOwnerReadQuery({ kind: 'output-tail', taskId: 't-1' }, h)).toEqual({ tail: { tail: 1 } });
+    expect(answerOwnerReadQuery({ kind: 'replay-output', taskId: 't-1', fromOffset: 42 }, h)).toEqual({ chunks: [{ id: 't-1', off: 42 }] });
+    expect(h.replayOutput).toHaveBeenCalledWith('t-1', 42);
+    expect(answerOwnerReadQuery({ kind: 'all-completed-tasks' }, h)).toEqual({ tasks: [{ id: 'done' }] });
+  });
+
+  it('null-coalesces task-by-id, review-gate, and output-tail', () => {
+    const h = makeHandlers({
+      getTaskById: vi.fn(() => undefined),
+      getReviewGate: vi.fn(() => undefined),
+      getOutputTail: vi.fn(() => undefined),
+    });
+    expect(answerOwnerReadQuery({ kind: 'task-by-id', taskId: 'x' }, h)).toEqual({ task: null });
+    expect(answerOwnerReadQuery({ kind: 'review-gate', workflowId: 'x' }, h)).toEqual({ reviewGate: null });
+    expect(answerOwnerReadQuery({ kind: 'output-tail', taskId: 'x' }, h)).toEqual({ tail: null });
+  });
+
   it('calls onActivity once per query and rejects unknown kinds', () => {
     const h = makeHandlers();
     answerOwnerReadQuery({ kind: 'queue' }, h);
     expect(h.onActivity).toHaveBeenCalledTimes(1);
     expect(() => answerOwnerReadQuery({ kind: 'bogus' }, h)).toThrow(/Unsupported headless query: bogus/);
     expect(() => answerOwnerReadQuery({}, h)).toThrow(/Unsupported headless query: undefined/);
+  });
+
+  it('rejects malformed params before invoking handlers', () => {
+    const h = makeHandlers();
+    // Missing workflowId must not reach loadWorkflowBundle('') (which would
+    // syncFromDb('') and mutate the owner cache for an invalid id).
+    expect(() => answerOwnerReadQuery({ kind: 'workflow' }, h)).toThrow(/workflowId/);
+    expect(h.loadWorkflowBundle).not.toHaveBeenCalled();
+    expect(() => answerOwnerReadQuery({ kind: 'review-gate' }, h)).toThrow(/workflowId/);
+    expect(() => answerOwnerReadQuery({ kind: 'events' }, h)).toThrow(/taskId/);
+    expect(() => answerOwnerReadQuery({ kind: 'task-by-id' }, h)).toThrow(/taskId/);
+    expect(h.getEvents).not.toHaveBeenCalled();
+    // Non-finite / negative replay offsets must be rejected too.
+    expect(() => answerOwnerReadQuery({ kind: 'replay-output', taskId: 't', fromOffset: -1 }, h)).toThrow(/fromOffset/);
+    expect(() => answerOwnerReadQuery({ kind: 'replay-output', taskId: 't', fromOffset: Number.NaN }, h)).toThrow(/fromOffset/);
+    expect(h.replayOutput).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildOwnerReadQueryHandlers', () => {
+  function fakes() {
+    return {
+      orchestrator: {
+        getQueueStatus: () => ({ q: 1 }),
+        getWorkflowStatus: () => ({ w: 1 }),
+        getAllTasks: () => [{ id: 't' }],
+        syncAllFromDb: vi.fn(),
+        syncFromDb: vi.fn(),
+      },
+      persistence: {
+        listWorkflows: () => [{ id: 'wf' }],
+        loadWorkflow: (id: string) => (id === 'missing' ? undefined : { id, name: 'n' }),
+        loadTasks: () => [{ id: 't', config: {} }],
+        loadTask: (id: string) => ({ id }),
+        getEvents: () => [{ e: 1 }],
+        getTaskOutput: () => 'out',
+        getOutputChunks: () => [{ c: 1 }],
+        getOutputTail: () => ({ t: 1 }),
+        replayOutputFrom: (id: string, off: number) => [{ id, off }],
+        loadAllCompletedTasks: () => [{ id: 'done' }],
+      },
+    };
+  }
+  function build(orch: Record<string, unknown> = {}, persist: Record<string, unknown> = {}) {
+    const f = fakes();
+    return buildOwnerReadQueryHandlers({
+      ownerModeLabel: 'gui',
+      getUiPerfStats: () => ({}),
+      resetUiPerfStats: () => {},
+      getStreamSequence: () => 5,
+      resolveInvokerHomeRoot: () => '/home',
+      orchestrator: { ...f.orchestrator, ...orch } as never,
+      persistence: { ...f.persistence, ...persist } as never,
+      getActionGraphSnapshot: () => ({ ag: 1 }),
+    });
+  }
+
+  it('passes reads straight through to persistence', () => {
+    const h = build();
+    expect(h.listWorkflows()).toEqual([{ id: 'wf' }]);
+    expect(h.getEvents('t1')).toEqual([{ e: 1 }]);
+    expect(h.getTaskOutput('t1')).toBe('out');
+    expect(h.getTaskById('t1')).toEqual({ id: 't1' });
+    expect(h.getOutputChunks('t1')).toEqual([{ c: 1 }]);
+    expect(h.replayOutput('t1', 9)).toEqual([{ id: 't1', off: 9 }]);
+    expect(h.getAllCompletedTasks()).toEqual([{ id: 'done' }]);
+  });
+
+  it('loadWorkflowBundle syncs that workflow first, then returns workflow + tasks', () => {
+    const syncFromDb = vi.fn();
+    const h = build({ syncFromDb });
+    expect(h.loadWorkflowBundle('wf-9')).toEqual({ workflow: { id: 'wf-9', name: 'n' }, tasks: [{ id: 't', config: {} }] });
+    expect(syncFromDb).toHaveBeenCalledWith('wf-9');
+  });
+
+  it('getReviewGate returns null for an unknown workflow', () => {
+    expect(build().getReviewGate('missing')).toBeNull();
+  });
+
+  it('getTasksSnapshot refreshes only when asked', () => {
+    const syncAllFromDb = vi.fn();
+    const h = build({ syncAllFromDb });
+    expect(h.getTasksSnapshot({ refresh: false })).toEqual({
+      tasks: [{ id: 't' }],
+      workflows: [{ id: 'wf' }],
+      streamSequence: 5,
+      invokerHomeRoot: '/home',
+    });
+    expect(syncAllFromDb).not.toHaveBeenCalled();
+    h.getTasksSnapshot({ refresh: true });
+    expect(syncAllFromDb).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -65,24 +65,51 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
 
   async function delegateOwnerQuery<T>(kind: string, request: Record<string, unknown> = {}): Promise<T | null> {
     if (getOwnerMode?.() !== false) return null;
+    const bus = getMessageBus?.();
+    if (!bus) return null;
     try {
-      return await getMessageBus?.().request<Record<string, unknown>, T>('headless.query', { kind, ...request }) ?? null;
+      return await bus.request<Record<string, unknown>, T>('headless.query', { kind, ...request }) ?? null;
     } catch (err) {
+      // Only the "no owner / no handler" transport case is a safe local
+      // fallback. Timeouts, owner DB errors, and disconnects must surface —
+      // silently serving the viewer's local snapshot would hide owner failures
+      // and reintroduce stale/empty reads.
+      const message = err instanceof Error ? err.message : String(err);
+      const code = typeof err === 'object' && err !== null && 'code' in err
+        ? String((err as { code?: unknown }).code)
+        : '';
+      if (code !== 'NO_HANDLER' && !message.includes('No request handler registered')) {
+        throw err;
+      }
       logger.warn(
-        `${kind} owner delegation failed; falling back to local read-only snapshot: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
+        `${kind} owner delegation found no owner handler; falling back to local read-only snapshot: ${message}`,
         { module: 'ipc' },
       );
       return null;
     }
   }
 
-  ipcMain.handle('invoker:list-workflows', () => persistence.listWorkflows());
+  // Delegate a single-field read to the owner (viewer mode); fall back to the
+  // local read-only DB only when there is no owner to answer.
+  async function delegatedRead<T>(
+    kind: string,
+    request: Record<string, unknown>,
+    field: string,
+    local: () => T,
+  ): Promise<T> {
+    const res = await delegateOwnerQuery<Record<string, unknown>>(kind, request);
+    if (res && field in res) return res[field] as T;
+    return local();
+  }
+
+  ipcMain.handle('invoker:list-workflows', () =>
+    delegatedRead('workflows', {}, 'workflows', () => persistence.listWorkflows()));
   ipcMain.handle('invoker:get-execution-pools', () => Object.keys(loadConfig().executionPools ?? {}));
 
-  ipcMain.handle('invoker:load-workflow', (_event, workflowId: string) => {
+  ipcMain.handle('invoker:load-workflow', async (_event, workflowId: string) => {
     logger.info(`load-workflow: "${workflowId}"`, { module: 'ipc' });
+    const delegated = await delegateOwnerQuery<{ workflow: unknown; tasks: unknown[] }>('workflow', { workflowId });
+    if (delegated) return delegated;
     const orchestrator = getOrchestrator();
     orchestrator.syncFromDb(workflowId);
     const tasks = persistence.loadTasks(workflowId);
@@ -91,7 +118,9 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     return { workflow, tasks };
   });
 
-  ipcMain.handle('invoker:get-review-gate', (_event, workflowId: string) => {
+  ipcMain.handle('invoker:get-review-gate', async (_event, workflowId: string) => {
+    const delegated = await delegateOwnerQuery<{ reviewGate: unknown }>('review-gate', { workflowId });
+    if (delegated && 'reviewGate' in delegated) return delegated.reviewGate;
     const workflow = persistence.loadWorkflow(workflowId);
     if (!workflow) return null;
     const tasks = persistence.loadTasks(workflowId);
@@ -132,18 +161,23 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     return { tasks, workflows, streamSequence };
   });
 
-  ipcMain.handle('invoker:get-events', (_event, taskId: string) => persistence.getEvents(taskId));
+  ipcMain.handle('invoker:get-events', (_event, taskId: string) =>
+    delegatedRead('events', { taskId }, 'events', () => persistence.getEvents(taskId)));
   ipcMain.handle('invoker:get-status', async () => (
     await delegateOwnerQuery('workflow-status') ?? getOrchestrator().getWorkflowStatus()
   ));
-  ipcMain.handle('invoker:get-task-by-id', (_event, taskId: string) => loadTaskByIdFromPersistence(taskId) ?? null);
-  ipcMain.handle('invoker:get-task-output', (_event, taskId: string) => persistence.getTaskOutput(taskId));
-  ipcMain.handle('invoker:get-output-chunks', (_event, taskId: string) => persistence.getOutputChunks(taskId));
+  ipcMain.handle('invoker:get-task-by-id', (_event, taskId: string) =>
+    delegatedRead('task-by-id', { taskId }, 'task', () => loadTaskByIdFromPersistence(taskId) ?? null));
+  ipcMain.handle('invoker:get-task-output', (_event, taskId: string) =>
+    delegatedRead('task-output', { taskId }, 'output', () => persistence.getTaskOutput(taskId)));
+  ipcMain.handle('invoker:get-output-chunks', (_event, taskId: string) =>
+    delegatedRead('output-chunks', { taskId }, 'chunks', () => persistence.getOutputChunks(taskId)));
   ipcMain.handle('invoker:replay-output-from', (_event, taskId: string, fromOffset: number) =>
-    persistence.replayOutputFrom(taskId, fromOffset)
-  );
-  ipcMain.handle('invoker:get-output-tail', (_event, taskId: string) => persistence.getOutputTail(taskId));
-  ipcMain.handle('invoker:get-all-completed-tasks', () => persistence.loadAllCompletedTasks());
+    delegatedRead('replay-output', { taskId, fromOffset }, 'chunks', () => persistence.replayOutputFrom(taskId, fromOffset)));
+  ipcMain.handle('invoker:get-output-tail', (_event, taskId: string) =>
+    delegatedRead('output-tail', { taskId }, 'tail', () => persistence.getOutputTail(taskId)));
+  ipcMain.handle('invoker:get-all-completed-tasks', () =>
+    delegatedRead('all-completed-tasks', {}, 'tasks', () => persistence.loadAllCompletedTasks()));
 
   ipcMain.handle('invoker:get-claude-session', async (_event, sessionId: string) => {
     logger.info(`get-claude-session: "${sessionId}"`, { module: 'ipc' });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -209,7 +209,7 @@ import {
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
-import { answerOwnerReadQuery } from './owner-read-query.js';
+import { answerOwnerReadQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import {
   createGuiMutationRegistrars,
@@ -1682,25 +1682,18 @@ function startHeadlessMode(): void {
           };
         });
         messageBus.onRequest('headless.query', async (req: unknown) =>
-          answerOwnerReadQuery(req, {
+          answerOwnerReadQuery(req, buildOwnerReadQueryHandlers({
             ownerModeLabel: 'standalone',
             onActivity: noteStandaloneOwnerActivity,
             getUiPerfStats: () => headlessDeps.getUiPerfStats?.() ?? {},
             resetUiPerfStats: () => headlessDeps.resetUiPerfStats?.(),
-            getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
-            getWorkflowStatus: () => orchestrator.getWorkflowStatus(),
-            getTasksSnapshot: ({ refresh }) => {
-              if (refresh) orchestrator.syncAllFromDb();
-              return {
-                tasks: orchestrator.getAllTasks(),
-                workflows: persistence.listWorkflows(),
-                streamSequence: 0,
-                invokerHomeRoot: resolveInvokerHomeRoot(),
-              };
-            },
+            getStreamSequence: () => 0,
+            resolveInvokerHomeRoot,
+            orchestrator,
+            persistence,
             getActionGraphSnapshot: () =>
               buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
-          }));
+          })));
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId, traceId } = req as { workflowId: string; traceId?: string };
@@ -3241,24 +3234,17 @@ function createEmbeddedTerminalBackendFromConfig(
         mode: 'gui',
       }));
       messageBus.onRequest('headless.query', async (req: unknown) =>
-        answerOwnerReadQuery(req, {
+        answerOwnerReadQuery(req, buildOwnerReadQueryHandlers({
           ownerModeLabel: 'gui',
           getUiPerfStats: () => getUiPerfStats(),
           resetUiPerfStats: () => resetUiPerfStats(),
-          getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
-          getWorkflowStatus: () => orchestrator.getWorkflowStatus(),
-          getTasksSnapshot: ({ refresh }) => {
-            if (refresh) orchestrator.syncAllFromDb();
-            return {
-              tasks: orchestrator.getAllTasks(),
-              workflows: persistence.listWorkflows(),
-              streamSequence: getTaskDeltaStreamSequence(),
-              invokerHomeRoot: resolveInvokerHomeRoot(),
-            };
-          },
+          getStreamSequence: () => getTaskDeltaStreamSequence(),
+          resolveInvokerHomeRoot,
+          orchestrator,
+          persistence,
           getActionGraphSnapshot: () =>
             buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
-        }));
+        })));
       messageBus.onRequest('headless.run', async (req: unknown) => {
         const { planPath, traceId } = req as { planPath: string; traceId?: string };
         logger.info(

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -1,36 +1,71 @@
+import type { Orchestrator } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import { buildReviewGateQueryResponse } from './review-gate-query.js';
+
 /**
  * Shared dispatcher for the owner's `headless.query` IPC channel.
  *
  * Non-owner processes read database-derived state by sending a
  * `{ kind }`-discriminated request over IpcBus; the writable owner answers it.
- * The GUI owner and the standalone headless owner previously each carried an
- * identical if-chain — this is the single place that maps a query kind to a
- * response, so new read kinds (the sole-owner rearchitecture routes every read
- * through here) are added once and stay consistent across both owners.
+ * The GUI owner and the standalone headless owner share this single mapping so
+ * every read kind (the sole-owner rearchitecture routes every read through here)
+ * is defined once and answered the same way by both owners.
  *
- * The per-owner differences (owner label, task-delta stream sequence, the
- * standalone keep-alive ping, the ui-perf source) are injected via handlers.
+ * Per-owner differences (owner label, task-delta stream sequence, the standalone
+ * keep-alive ping, the ui-perf source) are injected via `buildOwnerReadQueryHandlers`.
+ * Param-bearing read kinds take their argument from the request body.
+ *
+ * Each handler returns a JSON object; scalar/array reads are wrapped (e.g.
+ * `{ events }`, `{ output }`) so the wire response is always a record and the
+ * client unwraps the named field.
  */
 export interface OwnerReadQueryHandlers {
-  /** Label echoed back on the ui-perf response ('gui' | 'standalone'). */
   ownerModeLabel: string;
-  /** Called once per query (the standalone owner uses it to defer idle shutdown). */
   onActivity?: () => void;
   getUiPerfStats: () => Record<string, unknown>;
   resetUiPerfStats: () => void;
   getQueueStatus: () => Record<string, unknown>;
   getWorkflowStatus: () => Record<string, unknown>;
-  /** Build the task/workflow snapshot; `refresh` re-syncs the orchestrator from the DB first. */
   getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
   getActionGraphSnapshot: () => Record<string, unknown>;
+  listWorkflows: () => unknown[];
+  loadWorkflowBundle: (workflowId: string) => Record<string, unknown>;
+  getReviewGate: (workflowId: string) => unknown;
+  getEvents: (taskId: string) => unknown[];
+  getTaskById: (taskId: string) => unknown;
+  getTaskOutput: (taskId: string) => string;
+  getOutputChunks: (taskId: string) => unknown[];
+  getOutputTail: (taskId: string) => unknown;
+  replayOutput: (taskId: string, fromOffset: number) => unknown;
+  getAllCompletedTasks: () => unknown[];
 }
 
 export function answerOwnerReadQuery(
   req: unknown,
   handlers: OwnerReadQueryHandlers,
 ): Record<string, unknown> {
-  const { kind, reset } = (req ?? {}) as { kind?: string; reset?: boolean };
+  const body = (req ?? {}) as {
+    kind?: string;
+    reset?: boolean;
+    workflowId?: string;
+    taskId?: string;
+    fromOffset?: number;
+  };
+  const { kind, reset } = body;
   handlers.onActivity?.();
+  const requiredString = (value: unknown, name: string): string => {
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new Error(`Missing headless query parameter: ${name}`);
+    }
+    return value;
+  };
+  const replayOffset = (value: unknown): number => {
+    const offset = Number(value ?? 0);
+    if (!Number.isFinite(offset) || offset < 0) {
+      throw new Error('Invalid headless query parameter: fromOffset');
+    }
+    return offset;
+  };
 
   switch (kind) {
     case 'ui-perf':
@@ -46,7 +81,101 @@ export function answerOwnerReadQuery(
       return handlers.getTasksSnapshot({ refresh: true });
     case 'action-graph':
       return handlers.getActionGraphSnapshot();
+    case 'workflows':
+      return { workflows: handlers.listWorkflows() };
+    case 'workflow':
+      return handlers.loadWorkflowBundle(requiredString(body.workflowId, 'workflowId'));
+    case 'review-gate':
+      return { reviewGate: handlers.getReviewGate(requiredString(body.workflowId, 'workflowId')) ?? null };
+    case 'events':
+      return { events: handlers.getEvents(requiredString(body.taskId, 'taskId')) };
+    case 'task-by-id':
+      return { task: handlers.getTaskById(requiredString(body.taskId, 'taskId')) ?? null };
+    case 'task-output':
+      return { output: handlers.getTaskOutput(requiredString(body.taskId, 'taskId')) };
+    case 'output-chunks':
+      return { chunks: handlers.getOutputChunks(requiredString(body.taskId, 'taskId')) };
+    case 'output-tail':
+      return { tail: handlers.getOutputTail(requiredString(body.taskId, 'taskId')) ?? null };
+    case 'replay-output':
+      return { chunks: handlers.replayOutput(requiredString(body.taskId, 'taskId'), replayOffset(body.fromOffset)) };
+    case 'all-completed-tasks':
+      return { tasks: handlers.getAllCompletedTasks() };
     default:
       throw new Error(`Unsupported headless query: ${String(kind)}`);
   }
+}
+
+type ReadOrchestrator = Pick<
+  Orchestrator,
+  'getQueueStatus' | 'getWorkflowStatus' | 'getAllTasks' | 'syncAllFromDb' | 'syncFromDb'
+>;
+type ReadPersistence = Pick<
+  SQLiteAdapter,
+  | 'listWorkflows'
+  | 'loadWorkflow'
+  | 'loadTasks'
+  | 'loadTask'
+  | 'getEvents'
+  | 'getTaskOutput'
+  | 'getOutputChunks'
+  | 'getOutputTail'
+  | 'replayOutputFrom'
+  | 'loadAllCompletedTasks'
+>;
+
+export interface OwnerReadQueryDeps {
+  ownerModeLabel: string;
+  onActivity?: () => void;
+  getUiPerfStats: () => Record<string, unknown>;
+  resetUiPerfStats: () => void;
+  getStreamSequence: () => number;
+  resolveInvokerHomeRoot: () => string;
+  orchestrator: ReadOrchestrator;
+  persistence: ReadPersistence;
+  /** App-level action-graph projection (needs invokerConfig, which lives in the app). */
+  getActionGraphSnapshot: () => Record<string, unknown>;
+}
+
+/** Build the handler set both owners pass to {@link answerOwnerReadQuery}. */
+export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerReadQueryHandlers {
+  const { orchestrator, persistence } = deps;
+  return {
+    ownerModeLabel: deps.ownerModeLabel,
+    onActivity: deps.onActivity,
+    getUiPerfStats: deps.getUiPerfStats,
+    resetUiPerfStats: deps.resetUiPerfStats,
+    getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
+    getWorkflowStatus: () => orchestrator.getWorkflowStatus() as unknown as Record<string, unknown>,
+    getTasksSnapshot: ({ refresh }) => {
+      if (refresh) orchestrator.syncAllFromDb();
+      return {
+        tasks: orchestrator.getAllTasks(),
+        workflows: persistence.listWorkflows(),
+        streamSequence: deps.getStreamSequence(),
+        invokerHomeRoot: deps.resolveInvokerHomeRoot(),
+      };
+    },
+    getActionGraphSnapshot: deps.getActionGraphSnapshot,
+    listWorkflows: () => persistence.listWorkflows(),
+    loadWorkflowBundle: (workflowId: string) => {
+      orchestrator.syncFromDb(workflowId);
+      return {
+        workflow: persistence.loadWorkflow(workflowId),
+        tasks: persistence.loadTasks(workflowId),
+      };
+    },
+    getReviewGate: (workflowId: string) => {
+      const workflow = persistence.loadWorkflow(workflowId);
+      if (!workflow) return null;
+      return buildReviewGateQueryResponse({ workflowId, workflow, tasks: persistence.loadTasks(workflowId) });
+    },
+    getEvents: (taskId: string) => persistence.getEvents(taskId),
+    getTaskById: (taskId: string) => persistence.loadTask(taskId),
+    getTaskOutput: (taskId: string) => persistence.getTaskOutput(taskId),
+    getOutputChunks: (taskId: string) => persistence.getOutputChunks(taskId),
+    getOutputTail: (taskId: string) => persistence.getOutputTail(taskId),
+    replayOutput: (taskId: string, fromOffset: number) => persistence.replayOutputFrom(taskId, fromOffset),
+    getAllCompletedTasks: () => persistence.loadAllCompletedTasks(),
+  };
 }


### PR DESCRIPTION
In viewer mode (a daemon owns the DB) the renderer's read handlers read the
local read-only database directly, which keeps the viewer mapping the WAL -shm.
Route them through the owner over IPC instead, like `get-tasks`/`get-status`
already do.

Adds the read kinds the renderer needs to the shared responder via a tested
factory `buildOwnerReadQueryHandlers`, and converts list-workflows, load-workflow,
get-review-gate, get-events, get-task-by-id, task-output, output-chunks,
output-tail, replay-output and all-completed-tasks to delegate-first with a local
fallback when no owner is present.

Owner mode is unchanged (delegation returns null -> local read). This shrinks the
viewer's direct DB reads; a later slice removes the viewer's DB open entirely so
the owner can use exclusive locking.

packages/app/src/owner-read-query.ts (+ test); main.ts; ipc-read-handlers.ts

Depends-On: #2435

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded read access to more workflow, task, event, and output details.
  * Added support for delegating more reads to the owner mode when available.

* **Bug Fixes**
  * Improved fallback behavior when owner delegation is unavailable.
  * Ensured timeout-like owner failures are surfaced instead of hidden by local data.
  * Added stricter validation for invalid request shapes and missing fields.

* **Tests**
  * Added coverage for owner delegation, local fallback, and expanded read-query routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->