### PR TITLE
[Sole-owner DB](6) Answer delegated read-only CLI queries from the owner

### DIFF
--- a/packages/app/src/__tests__/owner-headless-query.test.ts
+++ b/packages/app/src/__tests__/owner-headless-query.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  answerOwnerHeadlessQuery,
+  type OwnerReadQueryHandlers,
+} from '../owner-read-query.js';
+import { type HeadlessQueryDeps } from '../headless-query-list.js';
+
+function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQueryHandlers {
+  return {
+    ownerModeLabel: 'standalone',
+    onActivity: vi.fn(),
+    getUiPerfStats: vi.fn(() => ({})),
+    resetUiPerfStats: vi.fn(),
+    getQueueStatus: vi.fn(() => ({ runningCount: 3 })),
+    getWorkflowStatus: vi.fn(() => ({})),
+    getTasksSnapshot: vi.fn(() => ({ tasks: [], workflows: [] })),
+    getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
+    listWorkflows: vi.fn(() => []),
+    loadWorkflowBundle: vi.fn(() => ({ workflow: null, tasks: [] })),
+    getReviewGate: vi.fn(() => null),
+    getEvents: vi.fn(() => []),
+    getTaskById: vi.fn(() => null),
+    getTaskOutput: vi.fn(() => ''),
+    getOutputChunks: vi.fn(() => []),
+    getOutputTail: vi.fn(() => null),
+    replayOutput: vi.fn(() => []),
+    getAllCompletedTasks: vi.fn(() => []),
+    ...over,
+  };
+}
+
+function makeQueryDeps(listWorkflows: () => Array<{ id: string; status?: string }>): HeadlessQueryDeps {
+  return {
+    persistence: { listWorkflows } as unknown as HeadlessQueryDeps['persistence'],
+    orchestrator: {} as unknown as HeadlessQueryDeps['orchestrator'],
+    executionAgentRegistry: undefined,
+    invokerConfig: {} as unknown as HeadlessQueryDeps['invokerConfig'],
+    getUiPerfStats: () => ({}),
+    resetUiPerfStats: () => {},
+  };
+}
+
+describe('answerOwnerHeadlessQuery', () => {
+  it('runs a cli-query on the owner and returns the rendered output', async () => {
+    const handlers = makeHandlers();
+    const deps = makeQueryDeps(() => [{ id: 'wf-1' }]);
+    const result = await answerOwnerHeadlessQuery(
+      { kind: 'cli-query', args: ['query', 'workflows', '--output', 'label'] },
+      handlers,
+      deps,
+    );
+    expect(result).toEqual({ output: 'wf-1\n' });
+    expect(handlers.onActivity).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to delegate a mutating command via cli-query', async () => {
+    const handlers = makeHandlers();
+    const deps = makeQueryDeps(() => []);
+    await expect(
+      answerOwnerHeadlessQuery({ kind: 'cli-query', args: ['run', 'plan.yaml'] }, handlers, deps),
+    ).rejects.toThrow(/non-read-only command/);
+  });
+
+  it('falls through to the structured dispatcher for non cli-query kinds', async () => {
+    const handlers = makeHandlers();
+    const deps = makeQueryDeps(() => []);
+    const result = await answerOwnerHeadlessQuery({ kind: 'queue' }, handlers, deps);
+    expect(result).toEqual({ runningCount: 3 });
+    expect(handlers.getQueueStatus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -209,7 +209,7 @@ import {
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
-import { answerOwnerReadQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
+import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import {
   createGuiMutationRegistrars,
@@ -1682,7 +1682,7 @@ function startHeadlessMode(): void {
           };
         });
         messageBus.onRequest('headless.query', async (req: unknown) =>
-          answerOwnerReadQuery(req, buildOwnerReadQueryHandlers({
+          answerOwnerHeadlessQuery(req, buildOwnerReadQueryHandlers({
             ownerModeLabel: 'standalone',
             onActivity: noteStandaloneOwnerActivity,
             getUiPerfStats: () => headlessDeps.getUiPerfStats?.() ?? {},
@@ -1693,7 +1693,14 @@ function startHeadlessMode(): void {
             persistence,
             getActionGraphSnapshot: () =>
               buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
-          })));
+          }), {
+            orchestrator,
+            persistence,
+            invokerConfig,
+            executionAgentRegistry: headlessDeps.executionAgentRegistry,
+            getUiPerfStats: headlessDeps.getUiPerfStats,
+            resetUiPerfStats: headlessDeps.resetUiPerfStats,
+          }));
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId, traceId } = req as { workflowId: string; traceId?: string };
@@ -3234,7 +3241,7 @@ function createEmbeddedTerminalBackendFromConfig(
         mode: 'gui',
       }));
       messageBus.onRequest('headless.query', async (req: unknown) =>
-        answerOwnerReadQuery(req, buildOwnerReadQueryHandlers({
+        answerOwnerHeadlessQuery(req, buildOwnerReadQueryHandlers({
           ownerModeLabel: 'gui',
           getUiPerfStats: () => getUiPerfStats(),
           resetUiPerfStats: () => resetUiPerfStats(),
@@ -3244,7 +3251,14 @@ function createEmbeddedTerminalBackendFromConfig(
           persistence,
           getActionGraphSnapshot: () =>
             buildCurrentActionGraphSnapshot({ orchestrator, persistence, invokerConfig }) as unknown as Record<string, unknown>,
-        })));
+        }), {
+          orchestrator,
+          persistence,
+          invokerConfig,
+          executionAgentRegistry: agentRegistry,
+          getUiPerfStats,
+          resetUiPerfStats,
+        }));
       messageBus.onRequest('headless.run', async (req: unknown) => {
         const { planPath, traceId } = req as { planPath: string; traceId?: string };
         logger.info(

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -1,6 +1,8 @@
 import type { Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
+import { isHeadlessReadOnlyCommand } from './headless-command-classification.js';
+import { runReadOnlyHeadlessQueryToString, type HeadlessQueryDeps } from './headless-query-list.js';
 
 /**
  * Shared dispatcher for the owner's `headless.query` IPC channel.
@@ -104,6 +106,30 @@ export function answerOwnerReadQuery(
     default:
       throw new Error(`Unsupported headless query: ${String(kind)}`);
   }
+}
+
+/**
+ * Async wrapper around {@link answerOwnerReadQuery} that also answers the
+ * generic `cli-query` kind: it runs a read-only headless command on the owner
+ * and returns its rendered text, so a non-owner caller never opens the database
+ * file. Mutating commands are refused. Every other kind falls through to the
+ * synchronous structured dispatcher.
+ */
+export async function answerOwnerHeadlessQuery(
+  req: unknown,
+  handlers: OwnerReadQueryHandlers,
+  queryDeps: HeadlessQueryDeps,
+): Promise<Record<string, unknown>> {
+  const body = (req ?? {}) as { kind?: string; args?: unknown };
+  if (body.kind === 'cli-query') {
+    const args = Array.isArray(body.args) ? body.args.map((arg) => String(arg)) : [];
+    if (!isHeadlessReadOnlyCommand(args)) {
+      throw new Error(`Refusing to delegate non-read-only command via cli-query: ${args[0] ?? '<missing>'}`);
+    }
+    handlers.onActivity?.();
+    return { output: await runReadOnlyHeadlessQueryToString(args, queryDeps) };
+  }
+  return answerOwnerReadQuery(req, handlers);
 }
 
 type ReadOrchestrator = Pick<


### PR DESCRIPTION


Depends-On: #2437

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Headless query handling now supports read-only CLI queries and returns rendered output directly.

* **Bug Fixes**
  * Non-read-only CLI commands are now rejected instead of being executed.
  * Other headless query types continue to route to the correct status handlers.

* **Tests**
  * Added coverage for read-only CLI execution, invalid command rejection, and non-CLI query dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->