### PR TITLE
[Sole-owner DB](9) Guard the viewer persistence boundary

### DIFF
--- a/scripts/check-owner-boundary.sh
+++ b/scripts/check-owner-boundary.sh
@@ -17,7 +17,7 @@ if command -v rg >/dev/null 2>&1; then
     --glob '!**/dist/**' \
     --glob '!**/e2e/**' \
     --glob '!**/node_modules/**' \
-    --glob '!packages/app/src/main.ts' \
+    --glob '!packages/app/src/viewer-db-boundary.ts' \
     --glob '!packages/cli/src/index.ts' \
     --glob '!packages/persistence/src/sqlite-adapter.ts' \
     --glob '!packages/data-store/src/sqlite-adapter.ts' || true)"
@@ -31,12 +31,27 @@ if command -v rg >/dev/null 2>&1; then
     --glob '!**/dist/**' \
     --glob '!**/e2e/**' \
     --glob '!**/node_modules/**' \
-    --glob '!packages/app/src/main.ts' \
+    --glob '!packages/app/src/viewer-db-boundary.ts' \
     --glob '!packages/cli/src/index.ts' || true)"
 
-  # 3) Owner init path in main.ts must explicitly pass ownerCapability.
-  if ! rg -n "ownerCapability:\s*!readOnly" packages/app/src/main.ts >/dev/null; then
-    echo "[owner-boundary] main.ts initServices must pass ownerCapability: !readOnly" >&2
+  raw_memory_violations="$(rg -n "SQLiteAdapter\\.create\\(['\"]:memory:" packages \
+    --glob '!**/__tests__/**' \
+    --glob '!**/*.test.ts' \
+    --glob '!**/*.d.ts' \
+    --glob '!**/dist/**' \
+    --glob '!**/e2e/**' \
+    --glob '!**/node_modules/**' \
+    --glob '!packages/data-store/src/sqlite-adapter.ts' || true)"
+
+  # 3) Owner opener path must explicitly pass ownerCapability.
+  if ! rg -n "ownerCapability:\s*!options\.readOnly" packages/app/src/viewer-db-boundary.ts >/dev/null; then
+    echo "[owner-boundary] viewer-db-boundary.ts must pass ownerCapability: !options.readOnly" >&2
+    fail=1
+  fi
+
+  if rg -n "SQLiteAdapter\\.create\\(" packages/app/src/main.ts >/dev/null \
+    || ! rg -n "openMainProcessDatabase\\(\\{" packages/app/src/main.ts >/dev/null; then
+    echo "[owner-boundary] main.ts must open persistence through openMainProcessDatabase()." >&2
     fail=1
   fi
 else
@@ -48,7 +63,7 @@ else
     --exclude-dir="node_modules" \
     --exclude="*.d.ts" \
     --exclude="*.test.ts" \
-    | grep -v '^packages/app/src/main.ts:' \
+    | grep -v '^packages/app/src/viewer-db-boundary.ts:' \
     | grep -v '^packages/cli/src/index.ts:' \
     | grep -v '^packages/persistence/src/sqlite-adapter.ts:' \
     | grep -v '^packages/data-store/src/sqlite-adapter.ts:' || true)"
@@ -60,11 +75,26 @@ else
     --exclude-dir="node_modules" \
     --exclude="*.d.ts" \
     --exclude="*.test.ts" \
-    | grep -v '^packages/app/src/main.ts:' \
+    | grep -v '^packages/app/src/viewer-db-boundary.ts:' \
     | grep -v '^packages/cli/src/index.ts:' || true)"
 
-  if ! grep -nE "ownerCapability:[[:space:]]*!readOnly" packages/app/src/main.ts >/dev/null; then
-    echo "[owner-boundary] main.ts initServices must pass ownerCapability: !readOnly" >&2
+  raw_memory_violations="$(grep -RInE "SQLiteAdapter\\.create\\(['\"]:memory:" packages \
+    --exclude-dir="__tests__" \
+    --exclude-dir="dist" \
+    --exclude-dir="e2e" \
+    --exclude-dir="node_modules" \
+    --exclude="*.d.ts" \
+    --exclude="*.test.ts" \
+    | grep -v '^packages/data-store/src/sqlite-adapter.ts:' || true)"
+
+  if ! grep -nE "ownerCapability:[[:space:]]*!options\\.readOnly" packages/app/src/viewer-db-boundary.ts >/dev/null; then
+    echo "[owner-boundary] viewer-db-boundary.ts must pass ownerCapability: !options.readOnly" >&2
+    fail=1
+  fi
+
+  if grep -nE "SQLiteAdapter\\.create\\(" packages/app/src/main.ts >/dev/null \
+    || ! grep -nE "openMainProcessDatabase\\(\\{" packages/app/src/main.ts >/dev/null; then
+    echo "[owner-boundary] main.ts must open persistence through openMainProcessDatabase()." >&2
     fail=1
   fi
 fi
@@ -78,6 +108,12 @@ fi
 if [[ -n "$value_import_violations" ]]; then
   echo "[owner-boundary] Disallowed runtime value-import of SQLiteAdapter outside owner modules:" >&2
   echo "$value_import_violations" >&2
+  fail=1
+fi
+
+if [[ -n "$raw_memory_violations" ]]; then
+  echo "[owner-boundary] Runtime raw SQLite :memory: opens are forbidden; use openDetachedViewerDatabase() or SQLiteAdapter.createEphemeral()." >&2
+  echo "$raw_memory_violations" >&2
   fail=1
 fi
 


### PR DESCRIPTION
## Summary

Depends-On: #2440

The static owner-boundary check now protects the new viewer opener.

It no longer allows `main.ts` to open SQLite directly, and it fails raw runtime `SQLiteAdapter.create(':memory:')` calls.

The guard also checks the fallback `grep` path, so CI without ripgrep enforces the same rule.

<details>
<summary>Review metadata</summary>

Review Claim: Runtime code cannot bypass the viewer persistence boundary without `scripts/check-owner-boundary.sh` failing.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This only changes a policy script; the app behavior already landed in the prior slice.

Slice Rationale: The guard is split from routing so reviewers can inspect enforcement without re-reviewing the app opener.

</details>

## Non-goals

This does not change runtime code, tests, or the database adapter.

## Test Plan

- [x] `bash scripts/check-owner-boundary.sh`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 275bfd6f0`
- Post-revert steps: None
- Data migration? No
