### PR TITLE
[Slack Lobby Routing](1) Add workflow-op contract, verb parser, and plan summarizer

### DIFF
--- a/packages/surfaces/src/__tests__/lobby-control.test.ts
+++ b/packages/surfaces/src/__tests__/lobby-control.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { parseLobbyControl } from '../slack/lobby-control.js';
+
+describe('parseLobbyControl', () => {
+  it('parses submit (with optional "to invoker" and trailing punctuation)', () => {
+    expect(parseLobbyControl('submit')).toEqual({ kind: 'submit' });
+    expect(parseLobbyControl('submit to invoker')).toEqual({ kind: 'submit' });
+    expect(parseLobbyControl('  Submit!  ')).toEqual({ kind: 'submit' });
+  });
+
+  it('parses bulk ops via "all" and "all workflows"', () => {
+    expect(parseLobbyControl('recreate all')).toEqual({ kind: 'op', operation: 'recreate', target: { all: true } });
+    expect(parseLobbyControl('recreate all workflows')).toEqual({ kind: 'op', operation: 'recreate', target: { all: true } });
+    expect(parseLobbyControl('cancel ALL')).toEqual({ kind: 'op', operation: 'cancel', target: { all: true } });
+  });
+
+  it('maps rebase aliases to canonical operations', () => {
+    expect(parseLobbyControl('rebase all')).toEqual({ kind: 'op', operation: 'rebase-recreate', target: { all: true } });
+    expect(parseLobbyControl('rebase-retry wf-1')).toEqual({ kind: 'op', operation: 'rebase-retry', target: { workflow: 'wf-1' } });
+    expect(parseLobbyControl('rebase-recreate all')).toEqual({ kind: 'op', operation: 'rebase-recreate', target: { all: true } });
+  });
+
+  it('parses single-workflow targets', () => {
+    expect(parseLobbyControl('retry wf-123')).toEqual({ kind: 'op', operation: 'retry', target: { workflow: 'wf-123' } });
+    expect(parseLobbyControl('status my-flow')).toEqual({ kind: 'op', operation: 'status', target: { workflow: 'my-flow' } });
+  });
+
+  it('defaults bare status to all; a bare mutation verb is ambiguous (null)', () => {
+    expect(parseLobbyControl('status')).toEqual({ kind: 'op', operation: 'status', target: { all: true } });
+    expect(parseLobbyControl('recreate')).toBeNull();
+    expect(parseLobbyControl('cancel')).toBeNull();
+  });
+
+  it('returns null for prose and non-commands (routes to conversation/classifier)', () => {
+    expect(parseLobbyControl('recreate the login flow as a plan')).toBeNull();
+    expect(parseLobbyControl('how many workflows are running?')).toBeNull();
+    expect(parseLobbyControl('add a /health endpoint')).toBeNull();
+    expect(parseLobbyControl('recreate + rebase all workflows')).toBeNull();
+    expect(parseLobbyControl('')).toBeNull();
+  });
+});

--- a/packages/surfaces/src/__tests__/plan-summary.test.ts
+++ b/packages/surfaces/src/__tests__/plan-summary.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { summarizePlanText } from '../slack/plan-summary.js';
+
+describe('summarizePlanText', () => {
+  it('returns name, one step per task, and taskCount for a valid 2-task plan', () => {
+    const yaml = `
+name: Build the thing
+tasks:
+  - id: a
+    description: First task
+  - id: b
+    description: Second task
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    expect(summary!.name).toBe('Build the thing');
+    expect(summary!.steps).toEqual(['First task', 'Second task']);
+    expect(summary!.taskCount).toBe(2);
+  });
+
+  it('orders tasks in execution order via dependencies', () => {
+    const yaml = `
+name: Ordered plan
+tasks:
+  - id: b
+    description: Depends on A
+    dependencies: [a]
+  - id: a
+    description: Runs first
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    expect(summary!.steps).toEqual(['Runs first', 'Depends on A']);
+    expect(summary!.taskCount).toBe(2);
+  });
+
+  it('truncates a description longer than 30 words to 30 words + ellipsis', () => {
+    const words = Array.from({ length: 40 }, (_, i) => `word${i + 1}`);
+    const yaml = `
+name: Long plan
+tasks:
+  - id: a
+    description: ${words.join(' ')}
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    const expected = words.slice(0, 30).join(' ') + ' …';
+    expect(summary!.steps[0]).toBe(expected);
+    expect(summary!.steps[0].split(' ')).toHaveLength(31); // 30 words + the ellipsis token
+  });
+
+  it('collapses whitespace and newlines in descriptions', () => {
+    const yaml = `
+name: Whitespace plan
+tasks:
+  - id: a
+    description: "First   line\\n\\n  second line"
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    expect(summary!.steps[0]).toBe('First line second line');
+  });
+
+  it('returns null when name is missing', () => {
+    const yaml = `
+tasks:
+  - id: a
+    description: Something
+`;
+    expect(summarizePlanText(yaml)).toBeNull();
+  });
+
+  it('returns null when tasks is empty', () => {
+    const yaml = `
+name: Empty plan
+tasks: []
+`;
+    expect(summarizePlanText(yaml)).toBeNull();
+  });
+
+  it('returns null when a task is missing its description', () => {
+    const yaml = `
+name: Bad task plan
+tasks:
+  - id: a
+    description: Fine
+  - id: b
+`;
+    expect(summarizePlanText(yaml)).toBeNull();
+  });
+
+  it('returns null for non-YAML garbage', () => {
+    expect(summarizePlanText(': : : not [ valid } yaml :')).toBeNull();
+  });
+
+  it('returns null for a YAML scalar (non-object) plan', () => {
+    expect(summarizePlanText('just a string')).toBeNull();
+  });
+
+  it('does not throw on a dependency cycle and still returns a summary', () => {
+    const yaml = `
+name: Cyclic plan
+tasks:
+  - id: a
+    description: Task A
+    dependencies: [b]
+  - id: b
+    description: Task B
+    dependencies: [a]
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    expect(summary!.taskCount).toBe(2);
+    expect(summary!.steps).toHaveLength(2);
+  });
+
+  it('falls back to listed order when a dependency id is unknown', () => {
+    const yaml = `
+name: Unknown dep plan
+tasks:
+  - id: a
+    description: Task A
+    dependencies: [ghost]
+  - id: b
+    description: Task B
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    expect(summary!.steps).toEqual(['Task A', 'Task B']);
+    expect(summary!.taskCount).toBe(2);
+  });
+});

--- a/packages/surfaces/src/slack/lobby-control.ts
+++ b/packages/surfaces/src/slack/lobby-control.ts
@@ -1,0 +1,60 @@
+/**
+ * Lobby command parser — deterministic verb grammar for lobby/DM mentions and
+ * the `/invoker` slash command. Mirrors `parseWorkflowControl` (workflow channels)
+ * but for lobby-scoped verbs: workflow operations and plan submission.
+ *
+ * Pure function, no Slack SDK. Returns `null` for anything that isn't an
+ * unambiguous command, so the caller falls through to conversation.
+ */
+
+import type { WorkflowOpName } from '../surface.js';
+
+export type LobbyControl =
+  | { kind: 'op'; operation: WorkflowOpName; target: { all: true } | { workflow: string } }
+  | { kind: 'submit' };
+
+// Verb spellings → canonical operation. Bare `rebase` means recreate-after-rebase.
+const OP_ALIASES: Record<string, WorkflowOpName> = {
+  status: 'status',
+  recreate: 'recreate',
+  rebase: 'rebase-recreate',
+  'rebase-recreate': 'rebase-recreate',
+  'rebase-retry': 'rebase-retry',
+  retry: 'retry',
+  cancel: 'cancel',
+};
+
+const VERB_PATTERN = /^(rebase-recreate|rebase-retry|recreate|rebase|retry|cancel|status)\b([\s\S]*)$/i;
+const TARGET_TOKEN = /^[\w./-]+$/;
+
+/**
+ * Parse a lobby command. Recognizes:
+ *   - `submit` / `submit to invoker`
+ *   - `<op> all` / `<op> <workflow-id-or-name>`  (op ∈ recreate|rebase|rebase-recreate|rebase-retry|retry|cancel|status)
+ *   - `status` with no target → all workflows
+ * Returns null for missing/ambiguous targets and for prose, so the message is
+ * treated as conversation (or routed to the classifier fallback).
+ */
+export function parseLobbyControl(text: string): LobbyControl | null {
+  const trimmed = text.trim();
+
+  if (/^submit(\s+to\s+invoker)?\s*[.!?]*$/i.test(trimmed)) return { kind: 'submit' };
+
+  const match = VERB_PATTERN.exec(trimmed);
+  if (!match) return null;
+
+  const operation = OP_ALIASES[match[1].toLowerCase()];
+  const rest = match[2].trim().replace(/[.!?]+$/, '').trim();
+
+  if (/^all(\s+workflows?)?$/i.test(rest)) return { kind: 'op', operation, target: { all: true } };
+
+  if (rest === '') {
+    // Status defaults to all; a bare mutation verb is ambiguous → not a command.
+    return operation === 'status' ? { kind: 'op', operation, target: { all: true } } : null;
+  }
+
+  // A single id/name token is a concrete target; prose is not a command.
+  if (TARGET_TOKEN.test(rest)) return { kind: 'op', operation, target: { workflow: rest } };
+
+  return null;
+}

--- a/packages/surfaces/src/slack/plan-summary.ts
+++ b/packages/surfaces/src/slack/plan-summary.ts
@@ -1,0 +1,120 @@
+/**
+ * plan-summary — Distill a YAML plan into a short, ordered, human summary.
+ *
+ * Parses an Invoker plan YAML, validates its shape, orders the tasks in
+ * execution order (topological sort over `dependencies`), and renders one
+ * short step line per task. Never throws: invalid input returns null.
+ */
+
+import { parse as parseYaml } from 'yaml';
+
+// ── Types ───────────────────────────────────────────────────
+
+export interface PlanSummary {
+  name: string;
+  steps: string[];
+  taskCount: number;
+}
+
+interface PlanTask {
+  id: string;
+  description: string;
+  dependencies: string[];
+}
+
+const MAX_WORDS = 30;
+
+// ── Public API ──────────────────────────────────────────────
+
+export function summarizePlanText(planText: string): PlanSummary | null {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(planText);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed)) return null;
+
+  const name = parsed.name;
+  if (typeof name !== 'string' || name.trim().length === 0) return null;
+
+  const rawTasks = parsed.tasks;
+  if (!Array.isArray(rawTasks) || rawTasks.length === 0) return null;
+
+  const tasks: PlanTask[] = [];
+  for (const raw of rawTasks) {
+    if (!isRecord(raw)) return null;
+    const id = raw.id;
+    const description = raw.description;
+    if (typeof id !== 'string' || id.trim().length === 0) return null;
+    if (typeof description !== 'string' || description.trim().length === 0) return null;
+    const dependencies = Array.isArray(raw.dependencies)
+      ? raw.dependencies.filter((d): d is string => typeof d === 'string')
+      : [];
+    tasks.push({ id, description, dependencies });
+  }
+
+  const ordered = topoSort(tasks);
+  const steps = ordered.map((t) => summarizeDescription(t.description));
+
+  return { name, steps, taskCount: tasks.length };
+}
+
+// ── Internals ───────────────────────────────────────────────
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Kahn's algorithm — stable topological sort preserving original listed order
+ * when several tasks are ready. Falls back to the original order on a cycle or
+ * an unknown dependency id.
+ */
+function topoSort(tasks: PlanTask[]): PlanTask[] {
+  const byId = new Map<string, PlanTask>();
+  for (const task of tasks) byId.set(task.id, task);
+
+  const indegree = new Map<string, number>();
+  const dependents = new Map<string, string[]>();
+  for (const task of tasks) {
+    indegree.set(task.id, 0);
+    dependents.set(task.id, []);
+  }
+
+  for (const task of tasks) {
+    for (const dep of task.dependencies) {
+      if (!byId.has(dep)) return tasks; // unknown dependency → original order
+      indegree.set(task.id, (indegree.get(task.id) ?? 0) + 1);
+      dependents.get(dep)!.push(task.id);
+    }
+  }
+
+  // Ready queue, seeded in original listed order for stability.
+  const ready: string[] = [];
+  for (const task of tasks) {
+    if ((indegree.get(task.id) ?? 0) === 0) ready.push(task.id);
+  }
+
+  const result: PlanTask[] = [];
+  while (ready.length > 0) {
+    const id = ready.shift()!;
+    result.push(byId.get(id)!);
+    for (const next of dependents.get(id)!) {
+      const remaining = (indegree.get(next) ?? 0) - 1;
+      indegree.set(next, remaining);
+      if (remaining === 0) ready.push(next);
+    }
+  }
+
+  if (result.length !== tasks.length) return tasks; // cycle → original order
+  return result;
+}
+
+function summarizeDescription(description: string): string {
+  const normalized = description.replace(/\s+/g, ' ').trim();
+  const words = normalized.split(' ');
+  if (words.length <= MAX_WORDS) return normalized;
+  return words.slice(0, MAX_WORDS).join(' ') + ' …';
+}

--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -27,6 +27,26 @@ export type SurfaceCommand =
       lobbyThreadTs?: string;
     };
 
+// ── Workflow operations (Surface → Orchestrator, lobby command routing) ──
+
+export type WorkflowOpName =
+  | 'recreate'
+  | 'rebase-recreate'
+  | 'rebase-retry'
+  | 'retry'
+  | 'status'
+  | 'cancel';
+
+export interface WorkflowOp {
+  operation: WorkflowOpName;
+  target: { all: true } | { workflow: string };
+}
+
+export interface WorkflowOpResult {
+  ok: boolean;
+  summary: string;
+}
+
 // ── Events (Orchestrator → Surface) ────────────────────────
 
 export interface WorkflowStatus {


### PR DESCRIPTION
## Summary

Adds the shared workflow-operation types, a small verb parser, and a plan summarizer. They are the building blocks the lobby rework builds on.

Nothing imports them yet, so this slice is dormant and changes no behavior.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the new workflow-operation types, verb parser, and plan summarizer as a dormant contract.

Review Lane: refactor

Review Unit: contract

Safety Invariant: Pure additions — new exported types plus two self-contained, unit-tested pure functions; no existing code path is touched.

Slice Rationale: Foundation lands first so the behavior slice that consumes these types stays readable.

</details>

## Non-goals

No behavior change. No wiring and no callers — the routing, host binding, and manifest land in later slices.

## Test Plan

- [x] `CI=1 pnpm --filter @invoker/surfaces exec vitest run src/__tests__/lobby-control.test.ts src/__tests__/plan-summary.test.ts`
- [x] `pnpm --filter @invoker/surfaces build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added parsing for Slack lobby/DM workflow control messages, supporting single-workflow actions and bulk “all workflows” actions.
  * Added a compact “plan text” summarizer that produces ordered step descriptions and a task count.
* **Bug Fixes**
  * Improved robustness of command recognition (whitespace/punctuation tolerance, alias normalization, and safe handling of ambiguous or invalid inputs).
* **Tests**
  * Added unit tests covering workflow command parsing and plan summary generation, including edge cases and failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->