### PR TITLE
[Slack Lobby Routing](2) Route lobby mentions by explicit verb, converse by default, submit explicitly

### DIFF
--- a/packages/surfaces/src/__tests__/lobby-control.test.ts
+++ b/packages/surfaces/src/__tests__/lobby-control.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { parseLobbyControl } from '../slack/lobby-control.js';
+
+describe('parseLobbyControl', () => {
+  it('parses submit (with optional "to invoker" and trailing punctuation)', () => {
+    expect(parseLobbyControl('submit')).toEqual({ kind: 'submit' });
+    expect(parseLobbyControl('submit to invoker')).toEqual({ kind: 'submit' });
+    expect(parseLobbyControl('  Submit!  ')).toEqual({ kind: 'submit' });
+  });
+
+  it('parses bulk ops via "all" and "all workflows"', () => {
+    expect(parseLobbyControl('recreate all')).toEqual({ kind: 'op', operation: 'recreate', target: { all: true } });
+    expect(parseLobbyControl('recreate all workflows')).toEqual({ kind: 'op', operation: 'recreate', target: { all: true } });
+    expect(parseLobbyControl('cancel ALL')).toEqual({ kind: 'op', operation: 'cancel', target: { all: true } });
+  });
+
+  it('maps rebase aliases to canonical operations', () => {
+    expect(parseLobbyControl('rebase all')).toEqual({ kind: 'op', operation: 'rebase-recreate', target: { all: true } });
+    expect(parseLobbyControl('rebase-retry wf-1')).toEqual({ kind: 'op', operation: 'rebase-retry', target: { workflow: 'wf-1' } });
+    expect(parseLobbyControl('rebase-recreate all')).toEqual({ kind: 'op', operation: 'rebase-recreate', target: { all: true } });
+  });
+
+  it('parses single-workflow targets', () => {
+    expect(parseLobbyControl('retry wf-123')).toEqual({ kind: 'op', operation: 'retry', target: { workflow: 'wf-123' } });
+    expect(parseLobbyControl('status my-flow')).toEqual({ kind: 'op', operation: 'status', target: { workflow: 'my-flow' } });
+  });
+
+  it('defaults bare status to all; a bare mutation verb is ambiguous (null)', () => {
+    expect(parseLobbyControl('status')).toEqual({ kind: 'op', operation: 'status', target: { all: true } });
+    expect(parseLobbyControl('recreate')).toBeNull();
+    expect(parseLobbyControl('cancel')).toBeNull();
+  });
+
+  it('returns null for prose and non-commands (routes to conversation/classifier)', () => {
+    expect(parseLobbyControl('recreate the login flow as a plan')).toBeNull();
+    expect(parseLobbyControl('how many workflows are running?')).toBeNull();
+    expect(parseLobbyControl('add a /health endpoint')).toBeNull();
+    expect(parseLobbyControl('recreate + rebase all workflows')).toBeNull();
+    expect(parseLobbyControl('')).toBeNull();
+  });
+});

--- a/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
@@ -111,16 +111,17 @@ describe('PlanConversation persistence', () => {
       expect(saved!.extractedPlan).toBeNull();
     });
 
-    it('persists planSubmitted state when user confirms', async () => {
+    it('a drafted plan is recoverable from persistence via getDraftedPlan', async () => {
       const conv = createConversation('ts-submit');
       mockCursorResponse(VALID_YAML_PLAN);
       await conv.sendMessage('Generate a plan');
+      expect(conv.planSubmitted).toBe(false);
 
-      await conv.sendMessage('yes');
-      expect(conv.planSubmitted).toBe(true);
-
-      const saved = repo.loadConversation('ts-submit');
-      expect(saved!.planSubmitted).toBe(true);
+      const recovered = createConversation('ts-submit');
+      await recovered.init();
+      const drafted = recovered.getDraftedPlan();
+      expect(drafted).not.toBeNull();
+      expect(drafted).toContain('Test Plan');
     });
 
     it('does not persist when no repo is configured', async () => {
@@ -155,7 +156,7 @@ describe('PlanConversation persistence', () => {
       );
     });
 
-    it('recovered session can submit plan via confirmation', async () => {
+    it('recovered session exposes the drafted plan via getDraftedPlan', async () => {
       const conv1 = createConversation('ts-plan-recover');
       mockCursorResponse(VALID_YAML_PLAN);
       await conv1.sendMessage('Generate a plan for REST API');
@@ -163,18 +164,19 @@ describe('PlanConversation persistence', () => {
       const conv2 = createConversation('ts-plan-recover');
       await conv2.init();
 
-      const reply = await conv2.sendMessage('yes');
-      expect(reply).toContain('submitted for execution');
-      expect(conv2.submittedPlanText).not.toBeNull();
-      expect(typeof conv2.submittedPlanText).toBe('string');
-      expect(conv2.submittedPlanText).toContain('Test Plan');
+      const drafted = conv2.getDraftedPlan();
+      expect(drafted).not.toBeNull();
+      expect(typeof drafted).toBe('string');
+      expect(drafted).toContain('Test Plan');
     });
 
     it('recovers planSubmitted state from a previous session', async () => {
-      const conv1 = createConversation('ts-submitted-recover');
-      mockCursorResponse(VALID_YAML_PLAN);
-      await conv1.sendMessage('Generate a plan');
-      await conv1.sendMessage('yes');
+      // The conversation flow never flips planSubmitted, but a value already
+      // persisted in the repo must still round-trip back through init().
+      repo.saveConversation('ts-submitted-recover', [
+        { role: 'user', content: 'Generate a plan' },
+        { role: 'assistant', content: VALID_YAML_PLAN },
+      ], null, true);
 
       const conv2 = createConversation('ts-submitted-recover');
       await conv2.init();
@@ -271,7 +273,7 @@ describe('PlanConversation persistence', () => {
   // ── Plan extraction and submission state ───────────────
 
   describe('plan extraction and submission persistence', () => {
-    it('confirmation picks up the latest plan from history', async () => {
+    it('getDraftedPlan picks up the latest plan from history', async () => {
       const conv = createConversation('ts-plan-update');
 
       mockCursorResponse('```yaml\nname: "Plan A"\ntasks:\n  - id: t1\n    description: "Task A"\n    dependencies: []\n```');
@@ -280,12 +282,13 @@ describe('PlanConversation persistence', () => {
       mockCursorResponse('```yaml\nname: "Plan B"\ntasks:\n  - id: t1\n    description: "Task B"\n    dependencies: []\n```');
       await conv.sendMessage('Actually, generate plan B');
 
-      const reply = await conv.sendMessage('yes');
-      expect(reply).toContain('Plan B');
-      expect(conv.submittedPlanText).toContain('Plan B');
+      const drafted = conv.getDraftedPlan();
+      expect(drafted).not.toBeNull();
+      expect(drafted).toContain('Plan B');
+      expect(conv.planSubmitted).toBe(false);
     });
 
-    it('complex plan is correctly found by confirmation', async () => {
+    it('complex plan is correctly found by getDraftedPlan', async () => {
       const complexYaml = `\`\`\`yaml
 name: "Complex Plan"
 onFinish: pull_request
@@ -321,14 +324,12 @@ tasks:
       mockCursorResponse(complexYaml);
       await conv.sendMessage('Generate a complex plan');
 
-      const reply = await conv.sendMessage('yes');
-      expect(reply).toContain('submitted for execution');
-
-      const planText = conv.submittedPlanText!;
+      const planText = conv.getDraftedPlan();
+      expect(planText).not.toBeNull();
       expect(typeof planText).toBe('string');
       // Parse to verify structure is preserved
       const { parse: parseYaml } = await import('yaml');
-      const plan = parseYaml(planText) as Record<string, any>;
+      const plan = parseYaml(planText!) as Record<string, any>;
       expect(plan.name).toBe('Complex Plan');
       expect(plan.onFinish).toBe('pull_request');
       expect(plan.baseBranch).toBe('develop');
@@ -383,7 +384,7 @@ tasks:
   // ── E2E: full round-trip with restart ──────────────────
 
   describe('E2E: full round-trip with restart', () => {
-    it('recovers conversation after restart, confirmation submits plan', async () => {
+    it('recovers conversation after restart and exposes the drafted plan', async () => {
       const threadTs = 'ts-e2e-roundtrip';
 
       const conv1 = createConversation(threadTs);
@@ -400,15 +401,10 @@ tasks:
       expect(conv2.history.length).toBeGreaterThanOrEqual(2);
       expect(conv2.history[0].content).toContain('Add a login form');
 
-      const reply = await conv2.sendMessage('execute');
-
-      expect(conv2.planSubmitted).toBe(true);
-      expect(conv2.submittedPlanText).not.toBeNull();
-      expect(conv2.submittedPlanText).toContain('Test Plan');
-
-      const saved2 = repo.loadConversation(threadTs);
-      expect(saved2!.messages.length).toBeGreaterThanOrEqual(4);
-      expect(saved2!.planSubmitted).toBe(true);
+      const drafted = conv2.getDraftedPlan();
+      expect(drafted).not.toBeNull();
+      expect(drafted).toContain('Test Plan');
+      expect(conv2.planSubmitted).toBe(false);
     });
 
     it('recovered conversation retains message count for context', async () => {

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -476,7 +476,7 @@ describe('PlanConversation', () => {
     expect(conversation.submittedPlanText).toBeNull();
   });
 
-  it('confirmation extracts and submits the latest plan as text', async () => {
+  it('getDraftedPlan returns the latest valid plan text drafted across turns', async () => {
     const firstYaml = '```yaml\nname: "First"\ntasks:\n  - id: t1\n    description: "one"\n    dependencies: []\n```';
     const secondYaml = '```yaml\nname: "Second"\ntasks:\n  - id: t2\n    description: "two"\n    dependencies: []\n```';
 
@@ -485,36 +485,34 @@ describe('PlanConversation', () => {
     mockCursorResponse(secondYaml);
     await conversation.sendMessage('Change the name');
 
-    const reply = await conversation.sendMessage('yes');
-    expect(reply).toContain('Second');
-    expect(typeof conversation.submittedPlanText).toBe('string');
-    const plan = parsePlanText(conversation.submittedPlanText!);
+    const drafted = conversation.getDraftedPlan();
+    expect(typeof drafted).toBe('string');
+    const plan = parsePlanText(drafted!);
     expect(plan.name).toBe('Second');
-    expect(conversation.planSubmitted).toBe(true);
-    expect(mockSpawn).toHaveBeenCalledTimes(2); // not called for confirmation
-  });
-
-  it('confirmation without plan returns explicit error', async () => {
-    const reply = await conversation.sendMessage('yes');
-    expect(reply).toContain("couldn't find a complete YAML plan");
-    expect(reply).toContain('regenerate the plan');
     expect(conversation.planSubmitted).toBe(false);
-    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(conversation.submittedPlanText).toBeNull();
   });
 
-  it('confirmation with broken YAML returns error, does not call Cursor', async () => {
-    // Simulate an assistant message with invalid YAML
+  it('getDraftedPlan returns null when history has no plan', async () => {
+    expect(conversation.getDraftedPlan()).toBeNull();
+
+    // "yes" no longer auto-submits — it takes the normal planner path and spawns the CLI.
+    mockCursorResponse('What would you like to build?');
+    await conversation.sendMessage('yes');
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(conversation.planSubmitted).toBe(false);
+    expect(conversation.getDraftedPlan()).toBeNull();
+  });
+
+  it('getDraftedPlan returns null when the latest plan YAML is broken', async () => {
     mockCursorResponse('Here is a plan:\n```yaml\nname: "Broken\ntasks: [invalid');
     await conversation.sendMessage('Generate a plan');
 
-    const reply = await conversation.sendMessage('yes');
-    expect(reply).toContain("couldn't find a complete YAML plan");
+    expect(conversation.getDraftedPlan()).toBeNull();
     expect(conversation.planSubmitted).toBe(false);
-    // Only 1 spawn call for the first message, not the confirmation
-    expect(mockSpawn).toHaveBeenCalledTimes(1);
   });
 
-  it('does not pick up illustrative YAML from earlier assistant messages', async () => {
+  it('getDraftedPlan does not pick up illustrative YAML from earlier assistant messages', async () => {
     const illustrativeYaml = '```yaml\nname: "Example Plan"\ntasks:\n  - id: example\n    description: "illustrative example"\n    dependencies: []\n```';
     mockCursorResponse(`Here is an example of the format:\n\n${illustrativeYaml}\n\nWant me to generate a real plan?`);
     await conversation.sendMessage('How do plans work?');
@@ -522,10 +520,9 @@ describe('PlanConversation', () => {
     mockCursorResponse('Sure, what feature would you like to build?');
     await conversation.sendMessage('Tell me more');
 
-    const reply = await conversation.sendMessage('yes');
-    expect(reply).toContain("couldn't find a complete YAML plan");
+    // The latest assistant message has no plan, so nothing complete is drafted.
+    expect(conversation.getDraftedPlan()).toBeNull();
     expect(conversation.planSubmitted).toBe(false);
-    expect(mockSpawn).toHaveBeenCalledTimes(2);
   });
 
   it('planSubmitted starts as false', () => {
@@ -535,12 +532,12 @@ describe('PlanConversation', () => {
   it('reset clears history and submitted plan text', async () => {
     mockCursorResponse(VALID_YAML_PLAN);
     await conversation.sendMessage('Generate plan');
-    await conversation.sendMessage('yes');
 
     conversation.reset();
     expect(conversation.history).toHaveLength(0);
     expect(conversation.submittedPlanText).toBeNull();
     expect(conversation.planSubmitted).toBe(false);
+    expect(conversation.getDraftedPlan()).toBeNull();
   });
 
   it('includes conversation history in prompt for multi-turn', async () => {
@@ -696,23 +693,26 @@ describe('PlanConversation instrumentation', () => {
     expect(perfLines[0]).toMatch(/total=\d+ms/);
   });
 
-  it('emits [PERF] sendMessage summary on confirmation path', async () => {
+  it('emits [PERF] sendMessage summary when a "yes" takes the normal planner path', async () => {
     const conv = createInstrumentedConversation();
     mockCursorResponse(VALID_YAML_PLAN);
     await conv.sendMessage('Generate plan');
+    mockCursorResponse('Anything else?');
     await conv.sendMessage('yes');
 
-    const perfLines = logMessages().filter(m => m.startsWith('[PERF] sendMessage (confirmation):'));
-    expect(perfLines).toHaveLength(1);
-    expect(perfLines[0]).toMatch(/init=\d+ms/);
-    expect(perfLines[0]).toMatch(/total=\d+ms/);
+    const perfLines = logMessages().filter(m => m.startsWith('[PERF] sendMessage:'));
+    expect(perfLines).toHaveLength(2);
+    expect(perfLines[1]).toMatch(/init=\d+ms/);
+    expect(perfLines[1]).toMatch(/cursor=\d+ms/);
+    expect(perfLines[1]).toMatch(/total=\d+ms/);
   });
 
-  it('emits [PERF] sendMessage summary on failed confirmation path', async () => {
+  it('emits [PERF] sendMessage summary for a "yes" with no drafted plan', async () => {
     const conv = createInstrumentedConversation();
+    mockCursorResponse('What would you like to build?');
     await conv.sendMessage('yes');
 
-    const perfLines = logMessages().filter(m => m.startsWith('[PERF] sendMessage (confirmation-failed):'));
+    const perfLines = logMessages().filter(m => m.startsWith('[PERF] sendMessage:'));
     expect(perfLines).toHaveLength(1);
     expect(perfLines[0]).toMatch(/init=\d+ms/);
     expect(perfLines[0]).toMatch(/total=\d+ms/);
@@ -795,16 +795,17 @@ describe('PlanConversation instrumentation', () => {
     expect(exitLines[0]).toMatch(/elapsed=\d+ms/);
   });
 
-  it('does not emit [CONV] on confirmation path', async () => {
+  it('emits [CONV] for a "yes" message on the normal planner path', async () => {
     const conv = createInstrumentedConversation();
     mockCursorResponse(VALID_YAML_PLAN);
     await conv.sendMessage('Generate plan');
     logSpy.mockClear();
 
+    mockCursorResponse('Anything else?');
     await conv.sendMessage('yes');
 
     const convLines = logMessages().filter(m => m.startsWith('[CONV]'));
-    expect(convLines).toHaveLength(0);
+    expect(convLines).toHaveLength(2);
   });
 
   it('reports growing historyMsgs across turns', async () => {

--- a/packages/surfaces/src/__tests__/plan-summary.test.ts
+++ b/packages/surfaces/src/__tests__/plan-summary.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from 'vitest';
+import { summarizePlanText } from '../slack/plan-summary.js';
+
+describe('summarizePlanText', () => {
+  it('returns name, one step per task, and taskCount for a valid 2-task plan', () => {
+    const yaml = `
+name: Build the thing
+tasks:
+  - id: a
+    description: First task
+  - id: b
+    description: Second task
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    expect(summary!.name).toBe('Build the thing');
+    expect(summary!.steps).toEqual(['First task', 'Second task']);
+    expect(summary!.taskCount).toBe(2);
+  });
+
+  it('orders tasks in execution order via dependencies', () => {
+    const yaml = `
+name: Ordered plan
+tasks:
+  - id: b
+    description: Depends on A
+    dependencies: [a]
+  - id: a
+    description: Runs first
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    expect(summary!.steps).toEqual(['Runs first', 'Depends on A']);
+    expect(summary!.taskCount).toBe(2);
+  });
+
+  it('truncates a description longer than 30 words to 30 words + ellipsis', () => {
+    const words = Array.from({ length: 40 }, (_, i) => `word${i + 1}`);
+    const yaml = `
+name: Long plan
+tasks:
+  - id: a
+    description: ${words.join(' ')}
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    const expected = words.slice(0, 30).join(' ') + ' …';
+    expect(summary!.steps[0]).toBe(expected);
+    expect(summary!.steps[0].split(' ')).toHaveLength(31); // 30 words + the ellipsis token
+  });
+
+  it('collapses whitespace and newlines in descriptions', () => {
+    const yaml = `
+name: Whitespace plan
+tasks:
+  - id: a
+    description: "First   line\\n\\n  second line"
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    expect(summary!.steps[0]).toBe('First line second line');
+  });
+
+  it('returns null when name is missing', () => {
+    const yaml = `
+tasks:
+  - id: a
+    description: Something
+`;
+    expect(summarizePlanText(yaml)).toBeNull();
+  });
+
+  it('returns null when tasks is empty', () => {
+    const yaml = `
+name: Empty plan
+tasks: []
+`;
+    expect(summarizePlanText(yaml)).toBeNull();
+  });
+
+  it('returns null when a task is missing its description', () => {
+    const yaml = `
+name: Bad task plan
+tasks:
+  - id: a
+    description: Fine
+  - id: b
+`;
+    expect(summarizePlanText(yaml)).toBeNull();
+  });
+
+  it('returns null for non-YAML garbage', () => {
+    expect(summarizePlanText(': : : not [ valid } yaml :')).toBeNull();
+  });
+
+  it('returns null for a YAML scalar (non-object) plan', () => {
+    expect(summarizePlanText('just a string')).toBeNull();
+  });
+
+  it('does not throw on a dependency cycle and still returns a summary', () => {
+    const yaml = `
+name: Cyclic plan
+tasks:
+  - id: a
+    description: Task A
+    dependencies: [b]
+  - id: b
+    description: Task B
+    dependencies: [a]
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    expect(summary!.taskCount).toBe(2);
+    expect(summary!.steps).toHaveLength(2);
+  });
+
+  it('falls back to listed order when a dependency id is unknown', () => {
+    const yaml = `
+name: Unknown dep plan
+tasks:
+  - id: a
+    description: Task A
+    dependencies: [ghost]
+  - id: b
+    description: Task B
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    expect(summary!.steps).toEqual(['Task A', 'Task B']);
+    expect(summary!.taskCount).toBe(2);
+  });
+});

--- a/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
@@ -103,14 +103,17 @@ vi.mock('@slack/bolt', () => {
 
 // Mock PlanConversation to control response timing
 const mockSendMessage = vi.fn();
+let mockDraftedPlan: string | null = null;
 const mockPlanConversation = {
   sendMessage: mockSendMessage,
+  getDraftedPlan: () => mockDraftedPlan,
   submittedPlanText: null as any,
   planSubmitted: false,
   init: vi.fn().mockResolvedValue(undefined),
 };
 
-vi.mock('../slack/plan-conversation.js', () => ({
+vi.mock('../slack/plan-conversation.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../slack/plan-conversation.js')>()),
   PlanConversation: vi.fn(() => mockPlanConversation),
 }));
 
@@ -126,6 +129,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
     mockSendMessage.mockReset();
     mockPlanConversation.submittedPlanText = null;
     mockPlanConversation.planSubmitted = false;
+    mockDraftedPlan = null;
   });
 
   afterEach(async () => {
@@ -195,7 +199,7 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
       expect(actualCall).toBe('help me debug this issue');
     });
 
-    it('handles plan submission flow correctly', async () => {
+    it('handles the explicit plan submission flow correctly', async () => {
       surface = new SlackSurface({
         botToken: 'xoxb-test',
         appToken: 'xapp-test',
@@ -204,55 +208,46 @@ describe('SlackSurface Immediate Response - Integration Tests', () => {
         anthropicApiKey: 'test-anthropic-key',
       });
 
-      const planText = 'name: "Debug Issue"\ntasks:\n  - id: t1\n    description: "Run debugger"\n    dependencies: []\n';
-
-      mockSendMessage.mockImplementation(async () => {
-        mockPlanConversation.submittedPlanText = planText;
-        mockPlanConversation.planSubmitted = true;
-        return 'Plan ready. Submitting now...';
-      });
+      const planText = 'name: "Debug Issue"\ntasks:\n  - id: t1\n    description: "Run the debugger"\n    dependencies: []\n';
+      mockSendMessage.mockResolvedValue('Plan ready. Say `submit` to run it.');
+      mockDraftedPlan = planText;
 
       await surface.start(async (cmd) => {
         receivedCommands.push(cmd);
       });
 
       const app = surface.getApp() as any;
-      const mentionHandler = app._eventHandlers.find(
-        (h: MockHandler) => h.pattern === 'app_mention'
-      )?.handler;
+      const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+      const messageHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'message')?.handler;
 
-      const say = vi.fn().mockImplementation(async ({ text, thread_ts }) => {
+      const say = vi.fn().mockImplementation(async ({ text }) => {
         const ts = `${Date.now()}.${Math.random().toString(36).substr(2, 6)}`;
         apiCalls.push({ method: 'postMessage', channel: 'C-test', text, ts });
         return { ts, ok: true };
       });
 
+      // Build request → immediate ack, replaced with the drafted-plan reply. No submission.
       await mentionHandler({
-        event: {
-          text: '<@UBOT123456> create a plan for me',
-          ts: '1111.001',
-          thread_ts: undefined,
-          user: 'U123',
-        },
+        event: { text: '<@UBOT123456> create a plan for me', ts: '1111.001', thread_ts: undefined, user: 'U123' },
         say,
       });
-
-      // Verify flow: ack → replace → execution message
-      expect(apiCalls.length).toBeGreaterThanOrEqual(3);
-
-      // 1. Immediate ack
-      expect(apiCalls[0].method).toBe('postMessage');
       expect(apiCalls[0].text).toBe('Processing your request...');
-
-      // 2. Replace ack with response
       expect(apiCalls[1].method).toBe('update');
-      expect(apiCalls[1].text).toBe('Plan ready. Submitting now...');
+      expect(apiCalls[1].text).toBe('Plan ready. Say `submit` to run it.');
+      expect(receivedCommands).toHaveLength(0);
 
-      // 3. Execution started message
-      expect(apiCalls[2].method).toBe('postMessage');
-      expect(apiCalls[2].text).toContain('Starting');
+      // Explicit submit → summary + confirmation, still no start_plan.
+      await mentionHandler({
+        event: { text: '<@UBOT123456> submit', ts: '1111.5', thread_ts: '1111.001', user: 'U123' },
+        say,
+      });
+      expect(receivedCommands).toHaveLength(0);
 
-      // 4. Command should be emitted with raw plan text
+      // Confirm → start_plan with the raw plan text.
+      await messageHandler({
+        event: { text: 'yes', ts: '1111.6', thread_ts: '1111.001', user: 'U123' },
+        say,
+      });
       expect(receivedCommands).toEqual([
         expect.objectContaining({ type: 'start_plan', planText }),
       ]);

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import * as child_process from 'node:child_process';
-import { SlackSurface, parsePlanningRequest, BUILTIN_HARNESS_PRESETS } from '../slack/slack-surface.js';
+import { SlackSurface, parsePlanningRequest, parseLobbyClassification, BUILTIN_HARNESS_PRESETS } from '../slack/slack-surface.js';
 import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import type { SurfaceCommand } from '../surface.js';
 import type { WorkflowContext } from '../slack/workflow-assistant.js';
@@ -42,6 +42,7 @@ vi.mock('@slack/bolt', () => {
 });
 
 const planConversationConfigs: any[] = [];
+let draftedPlanForMock: string | null = null;
 vi.mock('../slack/plan-conversation.js', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../slack/plan-conversation.js')>();
   return {
@@ -50,6 +51,7 @@ vi.mock('../slack/plan-conversation.js', async (importOriginal) => {
       planConversationConfigs.push(config);
       return {
         sendMessage: vi.fn().mockResolvedValue('planner reply'),
+        getDraftedPlan: vi.fn(() => draftedPlanForMock),
         submittedPlanText: null,
         planSubmitted: false,
         init: vi.fn().mockResolvedValue(undefined),
@@ -88,6 +90,13 @@ function baseConfig() {
 function mentionHandler(surface: SlackSurface): Function {
   const app = surface.getApp() as any;
   return app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')!.handler;
+}
+
+function actionHandler(surface: SlackSurface, id: string): Function {
+  const app = surface.getApp() as any;
+  return app._actionHandlers.find((h: MockHandler) =>
+    typeof h.pattern === 'string' ? h.pattern === id : h.pattern.test(id),
+  )!.handler;
 }
 
 // ── parsePlanningRequest ─────────────────────────────────────
@@ -325,5 +334,276 @@ describe('in-channel workflow assistant', () => {
     expect(gather).toHaveBeenCalledWith('wf-1-2');
     expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('/health') }));
     expect(received).toHaveLength(0);
+  });
+});
+
+// ── Lobby classification parsing ─────────────────────────────
+
+function messageHandler(surface: SlackSurface): Function {
+  const app = surface.getApp() as any;
+  return app._eventHandlers.find((h: MockHandler) => h.pattern === 'message')!.handler;
+}
+
+describe('parseLobbyClassification', () => {
+  it('maps a bulk rebase-recreate command', () => {
+    expect(parseLobbyClassification('{"intent":"command","operation":"rebase-recreate","target":"all"}'))
+      .toEqual({ intent: 'command', operation: 'rebase-recreate', target: { all: true } });
+  });
+
+  it('maps a single-workflow retry command', () => {
+    expect(parseLobbyClassification('{"intent":"command","operation":"retry","target":"wf-123"}'))
+      .toEqual({ intent: 'command', operation: 'retry', target: { workflow: 'wf-123' } });
+  });
+
+  it('defaults a targetless status command to all workflows', () => {
+    expect(parseLobbyClassification('{"intent":"command","operation":"status","target":"none"}'))
+      .toEqual({ intent: 'command', operation: 'status', target: { all: true } });
+  });
+
+  it('classifies questions and plans', () => {
+    expect(parseLobbyClassification('{"intent":"question","operation":"none","target":"none"}'))
+      .toEqual({ intent: 'question' });
+    expect(parseLobbyClassification('{"intent":"plan","operation":"none","target":"none"}'))
+      .toEqual({ intent: 'plan' });
+  });
+
+  it('extracts JSON embedded in surrounding prose', () => {
+    expect(parseLobbyClassification('Sure: {"intent":"command","operation":"cancel","target":"wf-9"} ok'))
+      .toEqual({ intent: 'command', operation: 'cancel', target: { workflow: 'wf-9' } });
+  });
+
+  it('falls back to plan on malformed output', () => {
+    expect(parseLobbyClassification('not json at all')).toEqual({ intent: 'plan' });
+    expect(parseLobbyClassification('{bad json}')).toEqual({ intent: 'plan' });
+  });
+
+  it('rejects an unmappable operation as invalid-command', () => {
+    expect(parseLobbyClassification('{"intent":"command","operation":"none","target":"all"}'))
+      .toEqual({ intent: 'invalid-command' });
+    expect(parseLobbyClassification('{"intent":"command","operation":"frobnicate","target":"all"}'))
+      .toEqual({ intent: 'invalid-command' });
+  });
+
+  it('rejects a non-status mutation with no target as invalid-command', () => {
+    expect(parseLobbyClassification('{"intent":"command","operation":"retry","target":"none"}'))
+      .toEqual({ intent: 'invalid-command' });
+  });
+});
+
+// ── Lobby intent routing (command / question / plan) ─────────
+
+describe('lobby verb routing', () => {
+  let received: SurfaceCommand[];
+  let runWorkflowOp: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    planConversationConfigs.length = 0;
+    mockSpawn.mockReset();
+    received = [];
+    runWorkflowOp = vi.fn();
+    draftedPlanForMock = null;
+  });
+
+  function lobbySurface(withOp = true) {
+    return new SlackSurface({
+      ...baseConfig(),
+      enableImmediateAck: false,
+      planningCommandBuilder: () => ({ command: 'cursor', args: ['--print', 'x'] }),
+      ...(withOp ? { runWorkflowOp } : {}),
+    });
+  }
+
+  it('stages a bulk verb for confirmation, then runs it on a plain `yes`', async () => {
+    runWorkflowOp.mockResolvedValue({ ok: true, summary: 'recreate: 3 ok' });
+    const surface = lobbySurface();
+    await surface.start(async (cmd) => { received.push(cmd); });
+
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> recreate all workflows', ts: 't1', user: 'U1' }, say });
+
+    // Deterministic verb — no classifier spawn, nothing run yet, just a confirmation.
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(planConversationConfigs).toHaveLength(0);
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('ALL workflows') }));
+
+    const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
+    await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'yes' }, say: say2 });
+    expect(runWorkflowOp).toHaveBeenCalledTimes(1);
+    expect(runWorkflowOp).toHaveBeenCalledWith({ operation: 'recreate', target: { all: true } });
+    expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: 'recreate: 3 ok' }));
+  });
+
+  it('cancels a staged bulk verb on a plain `no`', async () => {
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> recreate all', ts: 't1', user: 'U1' }, say });
+
+    const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
+    await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'no' }, say: say2 });
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+    expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: 'Cancelled.' }));
+  });
+  it('confirms a bulk verb via the Approve button: acks instantly and posts the result in-thread', async () => {
+    runWorkflowOp.mockResolvedValue({ ok: true, summary: 'recreate: 3 ok' });
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const app = surface.getApp() as any;
+
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> recreate all', ts: 't1', user: 'U1' }, say });
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+
+    app.client.chat.postMessage.mockClear();
+    const ack = vi.fn().mockResolvedValue(undefined);
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await actionHandler(surface, 'lobby_confirm')({
+      action: { type: 'button', value: 't1' },
+      body: { channel: { id: 'C1' }, message: { thread_ts: 't1' } },
+      ack,
+      respond,
+    });
+
+    expect(ack).toHaveBeenCalled();
+    // Buttons are replaced immediately so the click is visibly acknowledged.
+    expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: '✅ Approved.', replace_original: true }));
+    expect(runWorkflowOp).toHaveBeenCalledWith({ operation: 'recreate', target: { all: true } });
+    // The result posts durably in-thread via the bot client, not the expiring response_url.
+    expect(app.client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'C1', thread_ts: 't1', text: 'recreate: 3 ok' }),
+    );
+  });
+
+  it('cancels via the Cancel button and clears the buttons', async () => {
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> recreate all', ts: 't1', user: 'U1' }, say });
+
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await actionHandler(surface, 'lobby_cancel')({
+      action: { type: 'button', value: 't1' },
+      body: {},
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond,
+    });
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: '❌ Cancelled.', replace_original: true }));
+  });
+
+  it('Approve on an expired confirmation reports it and runs nothing', async () => {
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const respond = vi.fn().mockResolvedValue(undefined);
+    await actionHandler(surface, 'lobby_confirm')({
+      action: { type: 'button', value: 'gone' },
+      body: { channel: { id: 'C1' } },
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond,
+    });
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('expired'), replace_original: true }));
+  });
+
+  it('runs a single-workflow verb immediately (no confirmation)', async () => {
+    runWorkflowOp.mockResolvedValue({ ok: true, summary: 'retry: 1 ok' });
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> retry wf-123', ts: 't1', user: 'U1' }, say });
+    expect(runWorkflowOp).toHaveBeenCalledWith({ operation: 'retry', target: { workflow: 'wf-123' } });
+    expect(planConversationConfigs).toHaveLength(0);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('runs status immediately', async () => {
+    runWorkflowOp.mockResolvedValue({ ok: true, summary: '`wf-1`: 1 running, 0 pending, 2 done, 0 failed' });
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> status', ts: 't1', user: 'U1' }, say });
+    expect(runWorkflowOp).toHaveBeenCalledWith({ operation: 'status', target: { all: true } });
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('running') }));
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('uses the classifier only for fuzzy operational text, and always confirms before running', async () => {
+    mockSpawn.mockImplementationOnce(() => mockProcess('{"intent":"command","operation":"recreate","target":"all"}'));
+    runWorkflowOp.mockResolvedValue({ ok: true, summary: 'recreate: 2 ok' });
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> can you recreate everything please', ts: 't1', user: 'U1' }, say });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('recreate') }));
+
+    const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
+    await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'yes' }, say: say2 });
+    expect(runWorkflowOp).toHaveBeenCalledWith({ operation: 'recreate', target: { all: true } });
+  });
+
+  it('answers a question with no session, workflow, or start_plan', async () => {
+    mockSpawn
+      .mockImplementationOnce(() => mockProcess('{"intent":"question","operation":"none","target":"none"}'))
+      .mockImplementationOnce(() => mockProcess('There are 3 workflows running.'));
+    const surface = lobbySurface();
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> how many workflows are running?', ts: 't1', user: 'U1' }, say });
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('3 workflows running') }));
+    expect(planConversationConfigs).toHaveLength(0);
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+    expect(received).toHaveLength(0);
+  });
+
+  it('routes a build request to a planning conversation without classifying', async () => {
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> add a /health endpoint', ts: 't1', user: 'U1' }, say });
+    expect(planConversationConfigs).toHaveLength(1);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+  });
+
+  it('submit with no drafted plan asks the user to describe one', async () => {
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> submit', ts: 't1', user: 'U1' }, say });
+    expect(received).toHaveLength(0);
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('No planning conversation') }));
+  });
+
+  it('submit shows a plain-English plan summary and emits start_plan on confirmation', async () => {
+    const surface = lobbySurface();
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    // Open a planning conversation in the thread, then arm its drafted plan.
+    await mentionHandler(surface)({ event: { text: '<@BOT> add a /health endpoint', ts: 't1', user: 'U1' }, say });
+    draftedPlanForMock = 'name: "Health API"\ntasks:\n  - id: t1\n    description: "Add the /health endpoint to the API"\n    dependencies: []\n';
+
+    const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> submit', thread_ts: 't1', ts: 't2', user: 'U1' }, say: say2 });
+    // Shows the ELI5 step summary, does not submit yet.
+    expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Add the /health endpoint') }));
+    expect(received.some((c) => c.type === 'start_plan')).toBe(false);
+
+    const say3 = vi.fn().mockResolvedValue({ ts: 'c' });
+    await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't3', user: 'U1', text: 'yes' }, say: say3 });
+    const startPlan = received.find((c) => c.type === 'start_plan') as Extract<SurfaceCommand, { type: 'start_plan' }> | undefined;
+    expect(startPlan).toBeDefined();
+    expect(startPlan!.planText).toContain('Health API');
+  });
+
+  it('reports when workflow operations are not wired in this deployment', async () => {
+    const surface = lobbySurface(false);
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> status', ts: 't1', user: 'U1' }, say });
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('not available') }));
   });
 });

--- a/packages/surfaces/src/__tests__/slack-surface.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface.test.ts
@@ -47,13 +47,16 @@ vi.mock('@slack/bolt', () => {
 });
 
 const mockSendMessage = vi.fn();
+let mockDraftedPlan: string | null = null;
 const mockPlanConversation = {
   sendMessage: mockSendMessage,
+  getDraftedPlan: () => mockDraftedPlan,
   submittedPlanText: null as any,
   planSubmitted: false,
 };
 
-vi.mock('../slack/plan-conversation.js', () => ({
+vi.mock('../slack/plan-conversation.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../slack/plan-conversation.js')>()),
   PlanConversation: vi.fn(() => mockPlanConversation),
 }));
 
@@ -89,8 +92,8 @@ describe('SlackSurface', () => {
     it('registers action handlers for approve, reject, select, input', async () => {
       await surface.start(async () => {});
       const app = surface.getApp() as any;
-      // 4 action registrations: approve:, reject:, select:, input:
-      expect(app.action).toHaveBeenCalledTimes(4);
+      // 6 action registrations: approve:, reject:, select:, input:, lobby_confirm, lobby_cancel
+      expect(app.action).toHaveBeenCalledTimes(6);
     });
 
     it('registers app_mention and message event handlers', async () => {
@@ -490,6 +493,7 @@ describe('SlackSurface', () => {
       mockSendMessage.mockReset();
       mockPlanConversation.submittedPlanText = null;
       mockPlanConversation.planSubmitted = false;
+      mockDraftedPlan = null;
 
       surfaceWithApi = new SlackSurface({
         botToken: 'xoxb-test',
@@ -500,13 +504,10 @@ describe('SlackSurface', () => {
       });
     });
 
-    it('calls start_plan when planSubmitted is true after sendMessage', async () => {
-      const planText = 'name: "Test Plan"\ntasks:\n  - id: t1\n    description: "Do something"\n    dependencies: []\n';
-      mockSendMessage.mockImplementation(async () => {
-        mockPlanConversation.submittedPlanText = planText;
-        mockPlanConversation.planSubmitted = true;
-        return 'Submitting plan now.';
-      });
+    it('submits the drafted plan only after an explicit submit + confirmation', async () => {
+      const planText = 'name: "Test Plan"\ntasks:\n  - id: t1\n    description: "Do something useful"\n    dependencies: []\n';
+      mockSendMessage.mockResolvedValue('Here is your plan.');
+      mockDraftedPlan = planText;
 
       await surfaceWithApi.start(async (cmd) => {
         receivedCommands.push(cmd);
@@ -514,25 +515,22 @@ describe('SlackSurface', () => {
 
       const app = surfaceWithApi.getApp() as any;
       const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
+      const messageHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'message')?.handler;
 
-      const say = vi.fn().mockResolvedValue({ ts: '1111.001' });
-      await mentionHandler({
-        event: { text: '<@U_BOT> build me a REST API', ts: '1111', thread_ts: undefined },
-        say,
-      });
+      // Build request → a planning conversation in the thread; nothing submitted.
+      const say1 = vi.fn().mockResolvedValue({ ts: '1111.001' });
+      await mentionHandler({ event: { text: '<@U_BOT> build me a REST API', ts: '1111', thread_ts: undefined }, say: say1 });
+      expect(receivedCommands).toHaveLength(0);
 
-      // Should post immediate ack (via say), replace it with actual response (via update), then post execution message
-      expect(say).toHaveBeenNthCalledWith(1, expect.objectContaining({ text: 'Processing your request...' }));
-      expect(app.client.chat.update).toHaveBeenCalledWith(expect.objectContaining({
-        channel: 'C-test',
-        ts: '1111.001',
-        text: 'Submitting plan now.',
-      }));
-      expect(say).toHaveBeenCalledWith(expect.objectContaining({
-        text: expect.stringContaining('Starting'),
-      }));
+      // Explicit submit → plain-English summary + confirmation, still no start_plan.
+      const say2 = vi.fn().mockResolvedValue({ ts: '1111.002' });
+      await mentionHandler({ event: { text: '<@UBOT> submit', ts: '1111.5', thread_ts: '1111' }, say: say2 });
+      expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Do something useful') }));
+      expect(receivedCommands).toHaveLength(0);
 
-      // Should emit start_plan command with raw plan text
+      // Confirm → start_plan with the raw plan text.
+      const say3 = vi.fn().mockResolvedValue({ ts: '1111.003' });
+      await messageHandler({ event: { text: 'yes', ts: '1111.6', thread_ts: '1111', user: 'U1' }, say: say3 });
       expect(receivedCommands).toEqual([
         expect.objectContaining({ type: 'start_plan', planText }),
       ]);

--- a/packages/surfaces/src/__tests__/slack-thread-isolation.test.ts
+++ b/packages/surfaces/src/__tests__/slack-thread-isolation.test.ts
@@ -46,13 +46,15 @@ vi.mock('@slack/bolt', () => {
 const conversationInstances = new Map<string, any>();
 const mockPlanConversationCtor = vi.fn();
 
-vi.mock('../slack/plan-conversation.js', () => ({
+vi.mock('../slack/plan-conversation.js', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../slack/plan-conversation.js')>()),
   PlanConversation: vi.fn((...args: any[]) => {
     const config = args[0];
     const instance = {
       _config: config,
       _messages: [] as Array<{ role: string; content: string }>,
       submittedPlanText: null as any,
+      getDraftedPlan: () => instance.submittedPlanText,
       planSubmitted: false,
       init: vi.fn().mockResolvedValue(undefined),
       sendMessage: vi.fn().mockImplementation(async (text: string) => {
@@ -311,9 +313,10 @@ describe('Slack thread isolation', () => {
   });
 
   describe('plan submission removes conversation from thread map', () => {
-    it('removes conversation after plan submission via sendMessage', async () => {
+    it('submits via an explicit submit verb + confirmation, then emits start_plan', async () => {
       await surface.start(async (cmd) => { receivedCommands.push(cmd); });
       const mentionHandler = getMentionHandler(surface);
+      const messageHandler = getMessageHandler(surface);
       const say = vi.fn();
 
       await mentionHandler({
@@ -322,18 +325,21 @@ describe('Slack thread isolation', () => {
       });
 
       const conv = conversationInstances.get('thread-submit');
-      // Simulate plan submission (sets both planSubmitted and submittedPlanText)
-      conv.submittedPlanText = 'name: "Submit Test"\ntasks:\n  - id: t1\n    description: "Test"\n    dependencies: []\n';
-      conv.planSubmitted = true;
-      conv.sendMessage.mockResolvedValueOnce('Submitting plan.');
+      // The conversation has drafted a plan (exposed via getDraftedPlan).
+      conv.submittedPlanText = 'name: "Submit Test"\ntasks:\n  - id: t1\n    description: "Run the test"\n    dependencies: []\n';
 
-      // Follow-up that triggers submission
+      // Explicit submit verb → confirmation only, no start_plan yet.
       await mentionHandler({
-        event: { text: '<@U_BOT> go ahead', ts: '500.500', thread_ts: 'thread-submit', user: 'U1' },
+        event: { text: '<@UBOT> submit', ts: '500.400', thread_ts: 'thread-submit', user: 'U1' },
         say,
       });
+      expect(receivedCommands.some((c) => c.type === 'start_plan')).toBe(false);
 
-      // Should have emitted start_plan command
+      // Confirm → start_plan emitted.
+      await messageHandler({
+        event: { text: 'yes', ts: '500.500', thread_ts: 'thread-submit', user: 'U1' },
+        say,
+      });
       expect(receivedCommands).toContainEqual(
         expect.objectContaining({ type: 'start_plan' }),
       );
@@ -605,71 +611,55 @@ Want me to execute this?`;
     });
   });
 
-  it('mention → plan response → user confirms → submit_plan → start_plan', async () => {
+  it('mention → plan drafted → explicit submit → confirm → start_plan', async () => {
     await surface.start(async (cmd) => { receivedCommands.push(cmd); });
     const mentionHandler = getMentionHandler(surface);
     const messageHandler = getMessageHandler(surface);
     const say = vi.fn();
 
-    // Step 1: User @mentions with a request
+    // Step 1: User @mentions with a request → planning conversation.
     await mentionHandler({
       event: { text: '<@U_BOT> build a REST API', ts: 'thread-e2e', thread_ts: undefined, user: 'U1' },
       say,
     });
-
     const conv = conversationInstances.get('thread-e2e');
     expect(conv).toBeDefined();
     expect(conv.sendMessage).toHaveBeenCalledTimes(1);
 
-    // Step 2: Mock sendMessage to return a YAML plan response
+    // Step 2: Bot drafts a YAML plan; nothing submitted.
     say.mockClear();
     conv.sendMessage.mockResolvedValueOnce(YAML_PLAN);
-
     await messageHandler({
       event: { text: 'I want GET and POST for /users', ts: '100.100', thread_ts: 'thread-e2e', user: 'U1' },
       say,
     });
-
-    // Should post the plan text to the thread
     expect(say).toHaveBeenCalledWith(
       expect.objectContaining({ text: YAML_PLAN, thread_ts: 'thread-e2e' }),
     );
-    // No start_plan yet — Claude hasn't called submit_plan
-    expect(receivedCommands).not.toContainEqual(
-      expect.objectContaining({ type: 'start_plan' }),
-    );
+    expect(receivedCommands).not.toContainEqual(expect.objectContaining({ type: 'start_plan' }));
 
-    // Step 3: User confirms → planSubmitted + submittedPlanText set
+    // Step 3: Explicit submit → plain-English summary + confirmation, still no start_plan.
     say.mockClear();
-    const expectedPlanText = 'name: "Add REST API"\ntasks:\n  - id: implement\n    description: "Implement the REST API endpoints"\n  - id: test\n    description: "Test the endpoints"\n    command: "pnpm test"\n';
-    conv.sendMessage.mockImplementationOnce(async () => {
-      conv.planSubmitted = true;
-      conv.submittedPlanText = expectedPlanText;
-      return 'Plan submitted! Starting execution now.';
-    });
-
-    await messageHandler({
-      event: { text: 'execute', ts: '200.200', thread_ts: 'thread-e2e', user: 'U1' },
+    const expectedPlanText = 'name: "Add REST API"\ntasks:\n  - id: implement\n    description: "Implement the REST API endpoints"\n    dependencies: []\n';
+    conv.submittedPlanText = expectedPlanText; // exposed via getDraftedPlan()
+    await mentionHandler({
+      event: { text: '<@UBOT> submit', ts: '150.150', thread_ts: 'thread-e2e', user: 'U1' },
       say,
     });
+    expect(receivedCommands).not.toContainEqual(expect.objectContaining({ type: 'start_plan' }));
 
-    // Should post Claude's reply
-    expect(say).toHaveBeenCalledWith(
-      expect.objectContaining({ text: 'Plan submitted! Starting execution now.', thread_ts: 'thread-e2e' }),
-    );
-
-    // Should post the "Starting" execution message
+    // Step 4: User confirms → start_plan with the raw plan text.
+    say.mockClear();
+    await messageHandler({
+      event: { text: 'yes', ts: '200.200', thread_ts: 'thread-e2e', user: 'U1' },
+      say,
+    });
     expect(say).toHaveBeenCalledWith(
       expect.objectContaining({ text: expect.stringContaining('Starting') }),
     );
-
-    // Should emit start_plan command with the raw plan text
     expect(receivedCommands).toHaveLength(1);
     expect(receivedCommands[0]).toEqual(
-      expect.objectContaining({
-        type: 'start_plan',
-        planText: expectedPlanText,
-      }),
+      expect.objectContaining({ type: 'start_plan', planText: expectedPlanText }),
     );
   });
 });

--- a/packages/surfaces/src/slack/lobby-control.ts
+++ b/packages/surfaces/src/slack/lobby-control.ts
@@ -1,0 +1,60 @@
+/**
+ * Lobby command parser — deterministic verb grammar for lobby/DM mentions and
+ * the `/invoker` slash command. Mirrors `parseWorkflowControl` (workflow channels)
+ * but for lobby-scoped verbs: workflow operations and plan submission.
+ *
+ * Pure function, no Slack SDK. Returns `null` for anything that isn't an
+ * unambiguous command, so the caller falls through to conversation.
+ */
+
+import type { WorkflowOpName } from '../surface.js';
+
+export type LobbyControl =
+  | { kind: 'op'; operation: WorkflowOpName; target: { all: true } | { workflow: string } }
+  | { kind: 'submit' };
+
+// Verb spellings → canonical operation. Bare `rebase` means recreate-after-rebase.
+const OP_ALIASES: Record<string, WorkflowOpName> = {
+  status: 'status',
+  recreate: 'recreate',
+  rebase: 'rebase-recreate',
+  'rebase-recreate': 'rebase-recreate',
+  'rebase-retry': 'rebase-retry',
+  retry: 'retry',
+  cancel: 'cancel',
+};
+
+const VERB_PATTERN = /^(rebase-recreate|rebase-retry|recreate|rebase|retry|cancel|status)\b([\s\S]*)$/i;
+const TARGET_TOKEN = /^[\w./-]+$/;
+
+/**
+ * Parse a lobby command. Recognizes:
+ *   - `submit` / `submit to invoker`
+ *   - `<op> all` / `<op> <workflow-id-or-name>`  (op ∈ recreate|rebase|rebase-recreate|rebase-retry|retry|cancel|status)
+ *   - `status` with no target → all workflows
+ * Returns null for missing/ambiguous targets and for prose, so the message is
+ * treated as conversation (or routed to the classifier fallback).
+ */
+export function parseLobbyControl(text: string): LobbyControl | null {
+  const trimmed = text.trim();
+
+  if (/^submit(\s+to\s+invoker)?\s*[.!?]*$/i.test(trimmed)) return { kind: 'submit' };
+
+  const match = VERB_PATTERN.exec(trimmed);
+  if (!match) return null;
+
+  const operation = OP_ALIASES[match[1].toLowerCase()];
+  const rest = match[2].trim().replace(/[.!?]+$/, '').trim();
+
+  if (/^all(\s+workflows?)?$/i.test(rest)) return { kind: 'op', operation, target: { all: true } };
+
+  if (rest === '') {
+    // Status defaults to all; a bare mutation verb is ambiguous → not a command.
+    return operation === 'status' ? { kind: 'op', operation, target: { all: true } } : null;
+  }
+
+  // A single id/name token is a concrete target; prose is not a command.
+  if (TARGET_TOKEN.test(rest)) return { kind: 'op', operation, target: { workflow: rest } };
+
+  return null;
+}

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -89,6 +89,22 @@ export function isConfirmation(text: string): boolean {
   return CONFIRMATION_PATTERNS.some((re) => re.test(trimmed));
 }
 
+const NEGATION_PATTERNS = [
+  /^no$/i,
+  /^n$/i,
+  /^nope$/i,
+  /^cancel$/i,
+  /^stop$/i,
+  /^abort$/i,
+  /^nvm$/i,
+  /^never ?mind$/i,
+];
+
+export function isNegation(text: string): boolean {
+  const trimmed = text.trim().replace(/[.?!]+$/, '');
+  return NEGATION_PATTERNS.some((re) => re.test(trimmed));
+}
+
 // ── System Prompt ───────────────────────────────────────────
 
 function buildSystemPrompt(defaultBranch: string, repoUrl?: string): string {
@@ -254,9 +270,9 @@ export class PlanConversation {
   }
 
   /**
-   * Send a user message and get Cursor's response.
-   * If the message is a confirmation (e.g. "yes", "go"), extracts the last
-   * YAML plan from history and submits it. Otherwise spawns the Cursor CLI.
+   * Send a user message to the planner and return its reply. Pure conversation:
+   * drafting a plan never auto-submits it — submission is an explicit step
+   * driven by the surface (the `submit` verb), so a stray "yes" can't ship a plan.
    */
   async sendMessage(userMessage: string): Promise<string> {
     const t0 = Date.now();
@@ -267,29 +283,6 @@ export class PlanConversation {
     const tInit = Date.now();
 
     this.messages.push({ role: 'user', content: userMessage });
-
-    if (isConfirmation(userMessage)) {
-      const planText = this.extractLastPlanFromMessages();
-      if (planText) {
-        this._submittedPlanText = planText;
-        this._planSubmitted = true;
-        // Extract plan name from the text for the reply message
-        const parsed = parseYaml(planText) as Record<string, unknown>;
-        const planName = (parsed?.name as string) ?? 'Untitled';
-        const reply = `Plan "${planName}" submitted for execution.`;
-        this.messages.push({ role: 'assistant', content: reply });
-        this.saveState();
-        const tEnd = Date.now();
-        this.log('plan-conversation', 'info', `[PERF] sendMessage (confirmation): init=${tInit - t0}ms, total=${tEnd - t0}ms`);
-        return reply;
-      }
-      const errorReply = "I couldn't find a complete YAML plan in this conversation. Could you ask me to regenerate the plan?";
-      this.messages.push({ role: 'assistant', content: errorReply });
-      this.saveState();
-      const tEnd = Date.now();
-      this.log('plan-conversation', 'info', `[PERF] sendMessage (confirmation-failed): init=${tInit - t0}ms, total=${tEnd - t0}ms`);
-      return errorReply;
-    }
 
     const prompt = this.buildCursorPrompt();
     const tPrompt = Date.now();
@@ -315,6 +308,11 @@ export class PlanConversation {
   /** Returns true if the user confirmed and a plan was extracted. */
   get planSubmitted(): boolean {
     return this._planSubmitted;
+  }
+
+  /** Returns the last complete YAML plan drafted in this conversation, or null. */
+  getDraftedPlan(): string | null {
+    return this.extractLastPlanFromMessages();
   }
 
   /** Returns the conversation history. */

--- a/packages/surfaces/src/slack/plan-summary.ts
+++ b/packages/surfaces/src/slack/plan-summary.ts
@@ -1,0 +1,120 @@
+/**
+ * plan-summary — Distill a YAML plan into a short, ordered, human summary.
+ *
+ * Parses an Invoker plan YAML, validates its shape, orders the tasks in
+ * execution order (topological sort over `dependencies`), and renders one
+ * short step line per task. Never throws: invalid input returns null.
+ */
+
+import { parse as parseYaml } from 'yaml';
+
+// ── Types ───────────────────────────────────────────────────
+
+export interface PlanSummary {
+  name: string;
+  steps: string[];
+  taskCount: number;
+}
+
+interface PlanTask {
+  id: string;
+  description: string;
+  dependencies: string[];
+}
+
+const MAX_WORDS = 30;
+
+// ── Public API ──────────────────────────────────────────────
+
+export function summarizePlanText(planText: string): PlanSummary | null {
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(planText);
+  } catch {
+    return null;
+  }
+
+  if (!isRecord(parsed)) return null;
+
+  const name = parsed.name;
+  if (typeof name !== 'string' || name.trim().length === 0) return null;
+
+  const rawTasks = parsed.tasks;
+  if (!Array.isArray(rawTasks) || rawTasks.length === 0) return null;
+
+  const tasks: PlanTask[] = [];
+  for (const raw of rawTasks) {
+    if (!isRecord(raw)) return null;
+    const id = raw.id;
+    const description = raw.description;
+    if (typeof id !== 'string' || id.trim().length === 0) return null;
+    if (typeof description !== 'string' || description.trim().length === 0) return null;
+    const dependencies = Array.isArray(raw.dependencies)
+      ? raw.dependencies.filter((d): d is string => typeof d === 'string')
+      : [];
+    tasks.push({ id, description, dependencies });
+  }
+
+  const ordered = topoSort(tasks);
+  const steps = ordered.map((t) => summarizeDescription(t.description));
+
+  return { name, steps, taskCount: tasks.length };
+}
+
+// ── Internals ───────────────────────────────────────────────
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Kahn's algorithm — stable topological sort preserving original listed order
+ * when several tasks are ready. Falls back to the original order on a cycle or
+ * an unknown dependency id.
+ */
+function topoSort(tasks: PlanTask[]): PlanTask[] {
+  const byId = new Map<string, PlanTask>();
+  for (const task of tasks) byId.set(task.id, task);
+
+  const indegree = new Map<string, number>();
+  const dependents = new Map<string, string[]>();
+  for (const task of tasks) {
+    indegree.set(task.id, 0);
+    dependents.set(task.id, []);
+  }
+
+  for (const task of tasks) {
+    for (const dep of task.dependencies) {
+      if (!byId.has(dep)) return tasks; // unknown dependency → original order
+      indegree.set(task.id, (indegree.get(task.id) ?? 0) + 1);
+      dependents.get(dep)!.push(task.id);
+    }
+  }
+
+  // Ready queue, seeded in original listed order for stability.
+  const ready: string[] = [];
+  for (const task of tasks) {
+    if ((indegree.get(task.id) ?? 0) === 0) ready.push(task.id);
+  }
+
+  const result: PlanTask[] = [];
+  while (ready.length > 0) {
+    const id = ready.shift()!;
+    result.push(byId.get(id)!);
+    for (const next of dependents.get(id)!) {
+      const remaining = (indegree.get(next) ?? 0) - 1;
+      indegree.set(next, remaining);
+      if (remaining === 0) ready.push(next);
+    }
+  }
+
+  if (result.length !== tasks.length) return tasks; // cycle → original order
+  return result;
+}
+
+function summarizeDescription(description: string): string {
+  const normalized = description.replace(/\s+/g, ' ').trim();
+  const words = normalized.split(' ');
+  if (words.length <= MAX_WORDS) return normalized;
+  return words.slice(0, MAX_WORDS).join(' ') + ' …';
+}

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -5,16 +5,19 @@
  * Inbound: Slash commands + interactive buttons → SurfaceCommand
  */
 
-import { App } from '@slack/bolt';
+import { App, type RespondFn } from '@slack/bolt';
 import { spawn } from 'node:child_process';
-import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn } from '../surface.js';
+import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn, WorkflowOp, WorkflowOpResult, WorkflowOpName } from '../surface.js';
 import { parseSlackCommand } from './slack-commands.js';
 import type { ConversationCommand } from './slack-commands.js';
 import { formatSurfaceEvent, formatWorkflowStatus } from './slack-formatter.js';
 import { splitForSlack, sanitizeSlashCommands } from './slack-message-helpers.js';
 import type { SlackMessage } from './slack-formatter.js';
-import { PlanConversation, defaultPlanningCommand } from './plan-conversation.js';
+import { PlanConversation, defaultPlanningCommand, isConfirmation, isNegation } from './plan-conversation.js';
 import type { PlanningCommandBuilder } from './plan-conversation.js';
+import { parseLobbyControl } from './lobby-control.js';
+import type { LobbyControl } from './lobby-control.js';
+import { summarizePlanText } from './plan-summary.js';
 import { SessionManager, SessionIdentifier } from './thread-session-manager.js';
 import { buildAssistantPrompt, parseWorkflowControl } from './workflow-assistant.js';
 import type { WorkflowContext, WorkflowControl } from './workflow-assistant.js';
@@ -77,6 +80,8 @@ export interface SlackSurfaceConfig {
   workflowChannelRepo?: WorkflowChannelRepository;
   /** Gathers a workflow's planning convo + task transcripts for the in-channel assistant. */
   gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
+  /** Executes a workflow operation (recreate/rebase/retry/status/cancel) and returns a summary. Injected by main.ts. */
+  runWorkflowOp?: (op: WorkflowOp) => Promise<WorkflowOpResult>;
 }
 
 export interface HarnessPreset {
@@ -149,20 +154,109 @@ export function parsePlanningRequest(
   return { presetKey, repo, text: rest.trim(), unknownPreset };
 }
 
+// ── Lobby intent routing ─────────────────────────────────────
+
+/** Result of classifying a lobby/DM mention before any planning runs. */
+export type LobbyClassification =
+  | { intent: 'plan' }
+  | { intent: 'question' }
+  | { intent: 'invalid-command' }
+  | { intent: 'command'; operation: WorkflowOpName; target: { all: true } | { workflow: string } };
+
+const WORKFLOW_OP_NAMES: readonly WorkflowOpName[] = [
+  'recreate',
+  'rebase-recreate',
+  'rebase-retry',
+  'retry',
+  'status',
+  'cancel',
+];
+
+/** Router prompt: classify a lobby mention into command / question / plan as single-line JSON. */
+function buildLobbyClassifierPrompt(text: string): string {
+  return `You are a router for the Invoker orchestrator. Classify the user's Slack message into exactly one intent and reply with ONLY a single-line JSON object, no prose, no code fence, and do NOT use any tools or explore the repo.
+
+Schema: {"intent":"plan|command|question","operation":"recreate|rebase-recreate|rebase-retry|retry|status|cancel|none","target":"all|none|<workflow id or name>"}
+
+- "command": an operational request to act on EXISTING Invoker workflows (recreate, rebase, rebase+recreate, retry, cancel, or ask their status). Set operation and target. "recreate + rebase" / "rebase and recreate" => operation "rebase-recreate".
+- "question": asking for information/an explanation/a count; answerable without changing code or workflows. operation "none", target "none".
+- "plan": a request to build, change, fix, or refactor code in a repository. operation "none", target "none".
+
+Examples:
+"recreate + rebase all workflows" => {"intent":"command","operation":"rebase-recreate","target":"all"}
+"retry workflow wf-123" => {"intent":"command","operation":"retry","target":"wf-123"}
+"status" => {"intent":"command","operation":"status","target":"all"}
+"how many workflows are running?" => {"intent":"question","operation":"none","target":"none"}
+"add a /health endpoint to the api" => {"intent":"plan","operation":"none","target":"none"}
+
+Message:
+<<<
+${text}
+>>>`;
+}
+
+/** Q&A prompt for a lobby question: answer directly, never emit a plan. */
+function buildLobbyQuestionPrompt(text: string): string {
+  return `Answer the user's question about this repository and Invoker. Explore the codebase if needed. Do NOT generate a YAML plan and do NOT create a workflow. Question:\n${text}`;
+}
+
+/** Parse the classifier's raw stdout into a validated classification; never throws. */
+export function parseLobbyClassification(raw: string): LobbyClassification {
+  const match = raw.match(/\{[\s\S]*\}/);
+  if (!match) return { intent: 'plan' };
+  let parsed: { intent?: unknown; operation?: unknown; target?: unknown };
+  try {
+    parsed = JSON.parse(match[0]);
+  } catch {
+    return { intent: 'plan' };
+  }
+  if (parsed.intent === 'question') return { intent: 'question' };
+  if (parsed.intent !== 'command') return { intent: 'plan' };
+
+  const operation = parsed.operation;
+  if (typeof operation !== 'string' || !WORKFLOW_OP_NAMES.includes(operation as WorkflowOpName)) {
+    return { intent: 'invalid-command' };
+  }
+  const op = operation as WorkflowOpName;
+  const rawTarget = typeof parsed.target === 'string' ? parsed.target.trim() : '';
+  const targetless = rawTarget === '' || rawTarget.toLowerCase() === 'none';
+  if (rawTarget === 'all') return { intent: 'command', operation: op, target: { all: true } };
+  if (op === 'status') {
+    return targetless
+      ? { intent: 'command', operation: op, target: { all: true } }
+      : { intent: 'command', operation: op, target: { workflow: rawTarget } };
+  }
+  if (targetless) return { intent: 'invalid-command' };
+  return { intent: 'command', operation: op, target: { workflow: rawTarget } };
+}
+
+const OPERATIONAL_HINT = /\b(recreate|rebase|retry|retries|cancel|status|workflows?)\b/i;
+
+/** Cheap pre-filter: does a non-verb message look operational enough to spend an LLM classify? */
+export function looksOperational(text: string): boolean {
+  return OPERATIONAL_HINT.test(text);
+}
+
 // ── ConversationLike ─────────────────────────────────────────
 
 /** Shared interface between SessionHandle and PlanConversation for handler code. */
 interface ConversationLike {
   sendMessage(message: string): Promise<string>;
+  getDraftedPlan(): string | null;
   readonly planSubmitted: boolean;
   readonly submittedPlanText: string | null;
 }
+
+/** An action staged for a thread, awaiting a yes/no (text or button) confirmation. */
+type PendingConfirm =
+  | { kind: 'op'; op: WorkflowOp }
+  | { kind: 'submit'; planText: string; ctx?: PlanningContext; channel: string; lobbyThreadTs: string };
 
 interface SayResult {
   ts?: string;
 }
 
-type SayFn = (msg: { text: string; thread_ts: string }) => Promise<SayResult>;
+type SayFn = (msg: { text: string; thread_ts: string; blocks?: unknown[] }) => Promise<SayResult>;
 
 interface SlackMentionEvent {
   text?: string;
@@ -215,6 +309,8 @@ export class SlackSurface implements Surface {
   private ackMessages = new Map<string, string>();
   /** Maps thread_ts → planning context carried into start_plan. */
   private planningContexts = new Map<string, PlanningContext>();
+  /** Maps thread_ts → an action awaiting yes/no (or button) confirmation. */
+  private pendingConfirms = new Map<string, PendingConfirm>();
 
   // ── Slack-native workflow extensions ──────────────────────
   private lobbyChannelId: string;
@@ -226,6 +322,7 @@ export class SlackSurface implements Surface {
   private defaultRepoUrl?: string;
   private workflowChannelRepo?: WorkflowChannelRepository;
   private gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
+  private runWorkflowOp?: (op: WorkflowOp) => Promise<WorkflowOpResult>;
 
   constructor(config: SlackSurfaceConfig) {
     this.app = new App({
@@ -258,6 +355,7 @@ export class SlackSurface implements Surface {
     this.defaultRepoUrl = config.defaultRepoUrl ?? config.repoUrl;
     this.workflowChannelRepo = config.workflowChannelRepo;
     this.gatherWorkflowContext = config.gatherWorkflowContext;
+    this.runWorkflowOp = config.runWorkflowOp;
     this.log = config.log ?? ((source, level, msg) => {
       const fn = level === 'error' ? console.error : console.log;
       fn(`[${source}] ${msg}`);
@@ -403,6 +501,13 @@ export class SlackSurface implements Surface {
       await ack();
       this.log('slack', 'info', `Slash command: /invoker ${command.text} (user=${command.user_name})`);
 
+      // Deterministic verb commands (ops + submit) take priority over admin conversation commands.
+      const ctrl = parseLobbyControl(command.text);
+      if (ctrl) {
+        await this.handleSlashControl(ctrl, command, respond);
+        return;
+      }
+
       const result = parseSlackCommand(command.text);
       if (!result.ok) {
         this.log('slack', 'error', `Invalid command: ${result.error}`);
@@ -459,6 +564,33 @@ export class SlackSurface implements Surface {
         text: `To provide input for task \`${action.value}\`, reply in this thread with your text.`,
         response_type: 'ephemeral',
       });
+    });
+
+    this.app.action('lobby_confirm', async ({ action, body, ack, respond }) => {
+      await ack();
+      if (action.type !== 'button' || !action.value) return;
+      const key = action.value;
+      const pending = this.pendingConfirms.get(key);
+      if (!pending) {
+        await respond?.({ text: 'This confirmation has expired.', replace_original: true });
+        return;
+      }
+      this.pendingConfirms.delete(key);
+      this.log('slack', 'info', `Button: lobby_confirm key=${key} kind=${pending.kind}`);
+      // Acknowledge instantly by replacing the buttons. The op itself can take
+      // minutes (e.g. rebase-recreate all), and silence here reads as "nothing happened".
+      await respond?.({ text: '✅ Approved.', replace_original: true });
+      // Follow-ups post in-thread via the bot client: a response_url expires after
+      // 30 minutes / 5 uses, which a long bulk op can outlast.
+      await this.executeConfirm(pending, key, this.lobbyButtonSay(body, respond));
+    });
+
+    this.app.action('lobby_cancel', async ({ action, ack, respond }) => {
+      await ack();
+      if (action.type !== 'button' || !action.value) return;
+      if (!this.pendingConfirms.delete(action.value)) return;
+      this.log('slack', 'info', `Button: lobby_cancel key=${action.value}`);
+      await respond?.({ text: '❌ Cancelled.', replace_original: true });
     });
   }
 
@@ -522,6 +654,37 @@ export class SlackSurface implements Surface {
 
     const threadTs = event.thread_ts ?? event.ts;
 
+    // Confirm/cancel a staged action first (plain yes/no in-thread).
+    if (await this.resolveConfirm(threadTs, parsed.text, say)) return;
+
+    // Deterministic verb commands take priority over the planning/LLM path.
+    const ctrl = parseLobbyControl(parsed.text);
+    if (ctrl?.kind === 'op') {
+      await this.handleLobbyOp(ctrl, threadTs, channel, say);
+      return;
+    }
+    if (ctrl?.kind === 'submit') {
+      await this.handleLobbySubmit(channel, threadTs, event.user ?? 'unknown', say);
+      return;
+    }
+
+    // Fallback classifier: only when a non-verb message looks operational.
+    if (looksOperational(parsed.text)) {
+      const cls = await this.classifyLobbyIntent(parsed.text, preset);
+      this.log('slack', 'info', `[CLASSIFY] thread_ts=${threadTs} intent=${cls.intent}`);
+      if (cls.intent === 'command') {
+        await this.proposeLobbyOp(cls, threadTs, channel, say);
+        return;
+      }
+      if (cls.intent === 'question') {
+        await this.answerLobbyQuestion(parsed.text, preset, threadTs, say);
+        return;
+      }
+      // invalid-command / plan → fall through to a planning conversation.
+    }
+
+    // Default: a plain planning conversation (drafts a plan, never auto-submits).
+
     if (this.enableImmediateAck) {
       try {
         const ackResult = await say({ text: this.immediateAckMessage, thread_ts: threadTs });
@@ -561,6 +724,275 @@ export class SlackSurface implements Surface {
     });
 
     await this.handleConversationMessage(conversation, parsed.text, threadTs, say, channel);
+  }
+
+  private async classifyLobbyIntent(text: string, harness: HarnessPreset): Promise<LobbyClassification> {
+    let raw: string;
+    try {
+      raw = await this.runOneShotPlanner(harness, buildLobbyClassifierPrompt(text));
+    } catch (err) {
+      this.log('slack', 'warn', `[CLASSIFY] planner failed, defaulting to plan: ${err instanceof Error ? err.message : String(err)}`);
+      return { intent: 'plan' };
+    }
+    return parseLobbyClassification(raw);
+  }
+
+  private async handleLobbyOp(
+    ctrl: Extract<LobbyControl, { kind: 'op' }>,
+    threadTs: string,
+    channel: string,
+    say: SayFn,
+  ): Promise<void> {
+    if (!this.runWorkflowOp) {
+      await say({ text: 'Workflow operations are not available in this deployment.', thread_ts: threadTs });
+      return;
+    }
+    const op: WorkflowOp = { operation: ctrl.operation, target: ctrl.target };
+    // Destructive bulk mutations require explicit confirmation; status and single-workflow ops run now.
+    if (ctrl.operation !== 'status' && 'all' in ctrl.target) {
+      await this.stageConfirm(threadTs, channel, { kind: 'op', op }, `This will \`${ctrl.operation}\` ALL workflows.`, say);
+      return;
+    }
+    await this.runConfirmedOp(op, threadTs, say);
+  }
+
+  /** A classifier-inferred op is fuzzy, so always confirm before running it. */
+  private async proposeLobbyOp(
+    cls: Extract<LobbyClassification, { intent: 'command' }>,
+    threadTs: string,
+    channel: string,
+    say: SayFn,
+  ): Promise<void> {
+    if (!this.runWorkflowOp) {
+      await say({ text: 'Workflow operations are not available in this deployment.', thread_ts: threadTs });
+      return;
+    }
+    const op: WorkflowOp = { operation: cls.operation, target: cls.target };
+    const label = 'all' in cls.target ? 'ALL workflows' : `\`${cls.target.workflow}\``;
+    await this.stageConfirm(threadTs, channel, { kind: 'op', op }, `It sounds like you want to \`${cls.operation}\` ${label}.`, say);
+  }
+
+  private async runConfirmedOp(op: WorkflowOp, threadTs: string, say: SayFn): Promise<void> {
+    await say({ text: `On it — ${this.describeOp(op)}. I'll post a summary here when it finishes.`, thread_ts: threadTs });
+    try {
+      const result = await this.runWorkflowOp!(op);
+      await say({ text: result.summary, thread_ts: threadTs });
+    } catch (err) {
+      await say({ text: `Operation failed: ${err instanceof Error ? err.message : String(err)}`, thread_ts: threadTs });
+    }
+  }
+
+  /** Build a say() for a button action: posts in-thread via the bot client so
+   *  follow-ups survive past the 30-minute response_url window; falls back to respond(). */
+  private lobbyButtonSay(body: unknown, respond?: RespondFn): SayFn {
+    const b = body as { channel?: { id?: string }; message?: { thread_ts?: string }; container?: { thread_ts?: string } };
+    const channel = b?.channel?.id;
+    const threadTs = b?.message?.thread_ts ?? b?.container?.thread_ts;
+    return async ({ text, blocks }) => {
+      if (channel) {
+        const res = await this.app.client.chat.postMessage({
+          channel,
+          text,
+          ...(threadTs ? { thread_ts: threadTs } : {}),
+          ...(blocks ? { blocks: blocks as never } : {}),
+        });
+        return { ts: res.ts as string };
+      }
+      await respond?.({ text, replace_original: false });
+      return {};
+    };
+  }
+
+  private describeOp(op: WorkflowOp): string {
+    const target = 'all' in op.target ? 'ALL workflows' : `\`${op.target.workflow}\``;
+    return `${op.operation} ${target}`;
+  }
+
+  /** Submit the plan drafted in this thread, after an explicit, summarized confirmation. */
+  private async handleLobbySubmit(channel: string, threadTs: string, userId: string, say: SayFn): Promise<void> {
+    const conversation = await this.getSession(channel, threadTs, userId, false);
+    if (!conversation) {
+      await say({ text: "No planning conversation here yet. Tell me what you want to build and I'll draft a plan.", thread_ts: threadTs });
+      return;
+    }
+    const planText = conversation.getDraftedPlan();
+    if (!planText) {
+      await say({ text: "I don't see a complete plan drafted yet — describe what you want and I'll put one together.", thread_ts: threadTs });
+      return;
+    }
+    const summary = summarizePlanText(planText);
+    if (!summary) {
+      await say({ text: "I found a draft plan but couldn't read it. Ask me to regenerate the plan, then submit again.", thread_ts: threadTs });
+      return;
+    }
+    const ctx = this.planningContexts.get(threadTs);
+    await this.stageConfirm(threadTs, channel, { kind: 'submit', planText, ctx, channel, lobbyThreadTs: threadTs }, this.renderPlanSummary(summary), say);
+  }
+
+  /** Plain-English plan view: one numbered sentence per step — the user approves this, not YAML. */
+  private renderPlanSummary(summary: { name: string; steps: string[]; taskCount: number }): string {
+    const lines = summary.steps.map((step, i) => `${i + 1}. ${step}`);
+    return [`*${summary.name}* — ${summary.taskCount} step${summary.taskCount === 1 ? '' : 's'}:`, ...lines].join('\n');
+  }
+
+  private buildConfirmBlocks(prompt: string, confirmKey: string): unknown[] {
+    return [
+      { type: 'section', text: { type: 'mrkdwn', text: prompt } },
+      {
+        type: 'actions',
+        elements: [
+          { type: 'button', action_id: 'lobby_confirm', style: 'primary', text: { type: 'plain_text', text: 'Approve' }, value: confirmKey },
+          { type: 'button', action_id: 'lobby_cancel', text: { type: 'plain_text', text: 'Cancel' }, value: confirmKey },
+        ],
+      },
+    ];
+  }
+
+  /** Stage an action and post the prompt with Approve/Cancel buttons (plain yes/no also works). */
+  private async stageConfirm(
+    threadTs: string,
+    _channel: string,
+    pending: PendingConfirm,
+    prompt: string,
+    say: SayFn,
+  ): Promise<void> {
+    this.pendingConfirms.set(threadTs, pending);
+    await say({
+      text: `${prompt}\n_Approve to proceed, or reply \`no\` to cancel._`,
+      thread_ts: threadTs,
+      blocks: this.buildConfirmBlocks(prompt, threadTs),
+    });
+  }
+
+
+  /** Resolve a staged action from a plain-text reply. Returns true if the reply was consumed. */
+  private async resolveConfirm(threadTs: string, text: string, say: SayFn): Promise<boolean> {
+    const pending = this.pendingConfirms.get(threadTs);
+    if (!pending) return false;
+    if (isConfirmation(text)) {
+      this.pendingConfirms.delete(threadTs);
+      await this.executeConfirm(pending, threadTs, say);
+      return true;
+    }
+    if (isNegation(text)) {
+      this.pendingConfirms.delete(threadTs);
+      await say({ text: 'Cancelled.', thread_ts: threadTs });
+      return true;
+    }
+    // Neither: abandon the staged action so the new text is routed fresh.
+    this.pendingConfirms.delete(threadTs);
+    return false;
+  }
+
+  /** Run a confirmed action — a workflow op, or a plan submission. */
+  private async executeConfirm(pending: PendingConfirm, threadTs: string, say: SayFn): Promise<void> {
+    if (pending.kind === 'op') {
+      if (!this.runWorkflowOp) {
+        await say({ text: 'Workflow operations are not available in this deployment.', thread_ts: threadTs });
+        return;
+      }
+      await this.runConfirmedOp(pending.op, threadTs, say);
+      return;
+    }
+    await say({ text: 'Starting plan execution…', thread_ts: threadTs });
+    const ctx = pending.ctx;
+    await this.onCommand?.({
+      type: 'start_plan',
+      planText: pending.planText,
+      repoUrl: ctx?.repoUrl,
+      harnessPreset: ctx?.presetKey,
+      requestedBy: ctx?.requestedBy,
+      lobbyChannel: ctx?.lobbyChannel ?? pending.channel,
+      lobbyThreadTs: pending.lobbyThreadTs,
+    });
+    this.planningContexts.delete(pending.lobbyThreadTs);
+    this.cleanupSession(pending.lobbyThreadTs, 'plan_submitted');
+  }
+
+  /** Route a deterministic verb from `/invoker` (channel-level — slash can't run in a thread). */
+  private async handleSlashControl(
+    ctrl: LobbyControl,
+    command: { channel_id: string; user_id: string },
+    respond: RespondFn,
+  ): Promise<void> {
+    const channel = command.channel_id;
+    if (ctrl.kind === 'submit') {
+      const resolved = this.resolveRecentPlanThread(channel, command.user_id);
+      if (resolved === 'none') {
+        await respond({ text: "I don't see a plan you've drafted in this channel. Draft one with `@Invoker …` in a thread, then submit.", response_type: 'ephemeral' });
+        return;
+      }
+      if (resolved === 'ambiguous') {
+        await respond({ text: 'You have more than one active planning thread here. Open the one you want and run `@Invoker submit` in it.', response_type: 'ephemeral' });
+        return;
+      }
+      const conversation = await this.getSession(channel, resolved, command.user_id, false);
+      const planText = conversation?.getDraftedPlan() ?? null;
+      const summary = planText ? summarizePlanText(planText) : null;
+      if (!planText || !summary) {
+        await respond({ text: "I found your thread but couldn't read a complete plan. Ask me to regenerate it, then submit.", response_type: 'ephemeral' });
+        return;
+      }
+      const ctx = this.planningContexts.get(resolved);
+      const key = `slash:${channel}:${command.user_id}:${Date.now()}`;
+      this.pendingConfirms.set(key, { kind: 'submit', planText, ctx, channel, lobbyThreadTs: resolved });
+      const prompt = this.renderPlanSummary(summary);
+      await respond({ text: prompt, response_type: 'ephemeral', blocks: this.buildConfirmBlocks(prompt, key) as never });
+      return;
+    }
+
+    if (!this.runWorkflowOp) {
+      await respond({ text: 'Workflow operations are not available in this deployment.', response_type: 'ephemeral' });
+      return;
+    }
+    const op: WorkflowOp = { operation: ctrl.operation, target: ctrl.target };
+    if (ctrl.operation !== 'status' && 'all' in ctrl.target) {
+      const key = `slash:${channel}:${command.user_id}:${Date.now()}`;
+      this.pendingConfirms.set(key, { kind: 'op', op });
+      const prompt = `This will \`${ctrl.operation}\` ALL workflows.`;
+      await respond({ text: prompt, response_type: 'ephemeral', blocks: this.buildConfirmBlocks(prompt, key) as never });
+      return;
+    }
+    try {
+      const result = await this.runWorkflowOp(op);
+      await respond({ text: result.summary, response_type: 'ephemeral' });
+    } catch (err) {
+      await respond({ text: `Operation failed: ${err instanceof Error ? err.message : String(err)}`, response_type: 'ephemeral' });
+    }
+  }
+
+  /** The invoking user's planning thread in a channel: a threadTs, or 'none'/'ambiguous'. */
+  private resolveRecentPlanThread(channel: string, userId: string): string | 'none' | 'ambiguous' {
+    const matches: string[] = [];
+    for (const [threadTs, ctx] of this.planningContexts) {
+      if (ctx.requestedBy === userId && (ctx.lobbyChannel ?? this.lobbyChannelId) === channel) {
+        matches.push(threadTs);
+      }
+    }
+    if (matches.length === 0) return 'none';
+    if (matches.length > 1) return 'ambiguous';
+    return matches[0];
+  }
+
+  private async answerLobbyQuestion(
+    text: string,
+    harness: HarnessPreset,
+    threadTs: string,
+    say: SayFn,
+  ): Promise<void> {
+    try {
+      const reply = await this.runOneShotPlanner(harness, buildLobbyQuestionPrompt(text));
+      const chunks = splitForSlack(sanitizeSlashCommands(reply));
+      for (let i = 0; i < chunks.length; i++) {
+        if (i > 0) await this.sleep(this.messagePacingMs);
+        await this.sayWithRateLimitRetry(say, { text: chunks[i], thread_ts: threadTs });
+      }
+    } catch (err) {
+      await this.sayWithRateLimitRetry(say, {
+        text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+        thread_ts: threadTs,
+      });
+    }
   }
 
   private resolveHarnessPreset(presetKey: string): HarnessPreset {
@@ -787,10 +1219,12 @@ export class SlackSurface implements Surface {
       const channel = (msg.channel as string | undefined) ?? this.channelId;
       if (msg.channel && this.workflowChannelRepo?.getByChannelId(msg.channel)) return;
 
+      const text = (msg.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
+      if (text && (await this.resolveConfirm(msg.thread_ts, text, say))) return;
+
       // Look up or recover session (don't create new sessions for random thread replies in fallback mode)
       const conversation = await this.getSession(channel, msg.thread_ts, msg.user ?? 'unknown', false);
       if (!conversation) return;
-      const text = (msg.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
       if (!text) return;
 
       this.log('slack', 'info', `[SESSION_MESSAGE] Thread reply (thread_ts=${msg.thread_ts}, user=${msg.user}, preview="${text.slice(0, 100)}${text.length > 100 ? '...' : ''}")`);
@@ -878,25 +1312,6 @@ export class SlackSurface implements Surface {
       }
       const tPosting = Date.now();
 
-      if (conversation.planSubmitted && conversation.submittedPlanText) {
-        this.log('slack', 'info', `[SESSION_SUBMIT] Plan submitted via confirmation (thread_ts=${threadTs})`);
-        await this.sayWithRateLimitRetry(say, {
-          text: `Starting plan execution...`,
-          thread_ts: threadTs,
-        });
-        const ctx = this.planningContexts.get(threadTs);
-        await this.onCommand?.({
-          type: 'start_plan',
-          planText: conversation.submittedPlanText,
-          repoUrl: ctx?.repoUrl,
-          harnessPreset: ctx?.presetKey,
-          requestedBy: ctx?.requestedBy,
-          lobbyChannel: ctx?.lobbyChannel ?? channel,
-          lobbyThreadTs: threadTs,
-        });
-        this.planningContexts.delete(threadTs);
-        this.cleanupSession(threadTs, 'plan_submitted');
-      }
       const tEnd = Date.now();
 
       this.log('slack', 'info', `[PERF] thread_ts=${threadTs} setup=${tSetup - tEntry}ms cursor=${tCursor - tSetup}ms heartbeatCleanup=${tHeartbeatCleanup - tCursor}ms posting=${tPosting - tHeartbeatCleanup}ms chunks=${chunks.length} total=${tEnd - tEntry}ms`);

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -113,6 +113,11 @@ export class SessionHandle {
     return this.conversation.planSubmitted;
   }
 
+  /** Returns the last complete YAML plan drafted in this conversation, or null. */
+  getDraftedPlan(): string | null {
+    return this.conversation.getDraftedPlan();
+  }
+
   /**
    * Mark the plan as submitted (terminal state).
    */

--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -27,6 +27,26 @@ export type SurfaceCommand =
       lobbyThreadTs?: string;
     };
 
+// ── Workflow operations (Surface → Orchestrator, lobby command routing) ──
+
+export type WorkflowOpName =
+  | 'recreate'
+  | 'rebase-recreate'
+  | 'rebase-retry'
+  | 'retry'
+  | 'status'
+  | 'cancel';
+
+export interface WorkflowOp {
+  operation: WorkflowOpName;
+  target: { all: true } | { workflow: string };
+}
+
+export interface WorkflowOpResult {
+  ok: boolean;
+  summary: string;
+}
+
 // ── Events (Orchestrator → Surface) ────────────────────────
 
 export interface WorkflowStatus {


### PR DESCRIPTION
## Summary

Routes each lobby or DM mention by an explicit verb before any planning runs.

A message with no verb is a plain conversation that may draft a plan but never publishes it on its own; publishing is a separate explicit step.

A fuzzy operational message instead asks the planner to label it, then waits for a yes before doing anything.

<details>
<summary>Review metadata</summary>

Review Claim: Approve routing a lobby mention by verb instead of always opening a plan.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Without an injected executor the verbs reply that operations are unavailable; the planner conversation and questions keep working, and a stray confirmation can no longer publish a plan.

Slice Rationale: The surface routing logic and its tests review on their own, apart from the host binding and the manifest.

</details>

## Non-goals

Does not implement the host executor (slice 3) or the manifest (slice 4). The recreate/rebase/retry/cancel/status verbs and submit are recognized here but execute through injected callbacks.

## Test Plan

- [x] `CI=1 pnpm --filter @invoker/surfaces test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for recovering and viewing drafted plans after a restart.
  * Introduced clearer Slack workflow controls with explicit submit, confirm, and cancel interactions.
  * Improved routing of Slack messages into plans, questions, and operational commands.
* **Bug Fixes**
  * Fixed plan submission so drafted plans are no longer auto-submitted; execution happens only after an explicit confirmation.
  * Preserved drafted plan details more consistently across conversation restarts and thread interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2444