### PR TITLE
[Sole-owner DB Repair](1) Back viewer memory DB and resume route

### DIFF
--- a/packages/app/src/__tests__/viewer-cache-hydration.test.ts
+++ b/packages/app/src/__tests__/viewer-cache-hydration.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import type { TaskDelta, TaskState } from '@invoker/workflow-core';
+import { applyDelta, TaskSnapshotCache } from '../delta-merge.js';
+import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
+import { seedTaskCachesFromSnapshot } from '../viewer-cache-hydration.js';
+
+function ownerTask(version: number): TaskState {
+  return {
+    id: 'wf-1/task-1',
+    description: 'owner task',
+    status: 'running',
+    dependencies: [],
+    createdAt: new Date('2026-01-01').toISOString(),
+    config: {},
+    execution: {},
+    taskStateVersion: version,
+  } as unknown as TaskState;
+}
+
+function ownerUpdateDelta(): TaskDelta {
+  return {
+    type: 'updated',
+    taskId: 'wf-1/task-1',
+    previousTaskStateVersion: 1,
+    taskStateVersion: 2,
+    changes: { status: 'completed' },
+  } as unknown as TaskDelta;
+}
+
+describe('detached viewer cache hydration', () => {
+  it('repro: an empty viewer cache quarantines (drops) an owner task update', () => {
+    // A detached viewer backed by an empty in-memory DB has an empty cache.
+    const cache = new TaskSnapshotCache();
+    const { quarantined, accepted } = applyDelta(ownerUpdateDelta(), cache);
+    expect(accepted).toBe(false);
+    expect(quarantined).toEqual(['wf-1/task-1']); // the live update is lost
+  });
+
+  it('hydrating the caches from the owner snapshot lets the same update apply', () => {
+    const lastKnownTaskStates = new TaskSnapshotCache();
+    const workflowRollupProjection = new WorkflowRollupProjection();
+    seedTaskCachesFromSnapshot([ownerTask(1)], { lastKnownTaskStates, workflowRollupProjection });
+    const { quarantined, accepted } = applyDelta(ownerUpdateDelta(), lastKnownTaskStates);
+    expect(quarantined).toEqual([]);
+    expect(accepted).toBe(true);
+    // The cache stores the JSON snapshot string; verify the task was actually mutated.
+    const merged = JSON.parse(lastKnownTaskStates.get('wf-1/task-1') ?? '{}') as { status?: string; taskStateVersion?: number };
+    expect(merged.status).toBe('completed');
+    expect(merged.taskStateVersion).toBe(2);
+  });
+});

--- a/packages/app/src/__tests__/viewer-detached-db.test.ts
+++ b/packages/app/src/__tests__/viewer-detached-db.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { Workflow } from '@invoker/data-store';
+
+/**
+ * The GUI viewer is wired (main.ts initServices, detachedViewer) to back its
+ * in-process services with `SQLiteAdapter.create(':memory:')` instead of opening
+ * `invoker.db`. This proves the safety property that decision relies on: an
+ * in-memory adapter is fully functional yet opens no database file, so it maps
+ * no `-shm` wal-index — the sidecar whose truncation under a live mmap causes
+ * the SIGBUS this whole stack eliminates.
+ */
+
+const dirs: string[] = [];
+function makeDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'viewer-detached-'));
+  dirs.push(dir);
+  return dir;
+}
+afterEach(() => {
+  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+const wf: Workflow = {
+  id: 'wf-1',
+  name: 'wf',
+  status: 'running',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+describe('detached viewer in-memory persistence', () => {
+  it('is usable but opens no database file (no -shm to truncate)', async () => {
+    const dir = makeDir();
+    const probeDbPath = join(dir, 'invoker.db');
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      // Fully functional: schema is present and writes/reads work in memory.
+      expect(adapter.listWorkflows()).toEqual([]);
+      adapter.saveWorkflow(wf);
+      expect(adapter.listWorkflows().map((w) => w.id)).toEqual(['wf-1']);
+      // Telemetry writes the viewer's logger attempts must not throw in memory.
+      expect(() => adapter.writeActivityLog('viewer', 'info', 'hello')).not.toThrow();
+
+      // The immunity property: no file, no -wal, no -shm anywhere.
+      expect(existsSync(probeDbPath)).toBe(false);
+      expect(existsSync(`${probeDbPath}-shm`)).toBe(false);
+      expect(existsSync(`${probeDbPath}-wal`)).toBe(false);
+      expect(readdirSync(dir)).toEqual([]);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('does not require owner capability (it never touches the shared file)', async () => {
+    // File-backed writable opens demand ownerCapability; in-memory must not.
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      expect(adapter).toBeDefined();
+    } finally {
+      adapter.close();
+    }
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -186,6 +186,7 @@ import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.j
 import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from './delta-merge.js';
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
 import { WorkflowRollupProjection } from './workflow-rollup-projection.js';
+import { seedTaskCachesFromSnapshot } from './viewer-cache-hydration.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -594,6 +595,15 @@ function assertDeleteAllEnabled(): void {
 
 interface InitServicesOptions {
   readOnly?: boolean;
+  /**
+   * GUI viewer mode: never open `invoker.db`. A writable owner is always present
+   * in this mode, so the renderer's reads delegate to the owner over IPC and
+   * live updates arrive via TASK_DELTA/TASK_OUTPUT. We back the in-process
+   * services with a private empty in-memory database so no `-shm` is mapped on
+   * the real file — that is what lets the owner run WAL exclusive locking and be
+   * immune to the `-shm` truncation SIGBUS. Implies non-owner (readOnly) semantics.
+   */
+  detachedViewer?: boolean;
   executionAgentRegistry?: AgentRegistry;
   startupSyncMode?: 'all' | 'none';
 }
@@ -642,7 +652,9 @@ function updateInvokerCliFromMenu(): void {
 async function initServices(options?: InitServicesOptions): Promise<void> {
   const invokerHomeRoot = resolveInvokerHomeRoot();
   mkdirSync(invokerHomeRoot, { recursive: true });
-  const readOnly = options?.readOnly === true;
+  const detachedViewer = options?.detachedViewer === true;
+  // Detached viewer mode is a non-owner mode (no writer lock, no backups).
+  const readOnly = options?.readOnly === true || detachedViewer;
   const previousMessageBus = typeof messageBus === 'undefined' ? null : messageBus;
   previousMessageBus?.disconnect();
   const serviceMessageBus = new IpcBus(undefined, { allowServe: !readOnly });
@@ -652,10 +664,14 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
   if (!readOnly) {
     writerLock = acquireDbWriterLock(dbPath, `main:initServices pid=${process.pid}`);
   }
-  persistence = await SQLiteAdapter.create(dbPath, {
-    readOnly,
-    ownerCapability: !readOnly, // writable mode requires owner capability
-  });
+  persistence = detachedViewer
+    // Private empty in-memory database: never opens invoker.db, never maps -shm.
+    // Real data reaches the renderer by delegating reads to the owner over IPC.
+    ? await SQLiteAdapter.create(':memory:')
+    : await SQLiteAdapter.create(dbPath, {
+      readOnly,
+      ownerCapability: !readOnly, // writable mode requires owner capability
+    });
   // Upgrade root logger with DB persistence now that SQLiteAdapter is ready.
   logger = new FileAndDbLogger({ module: 'main' }, { persistence });
   const shellEnv = await initializeShellEnvironment();
@@ -2006,6 +2022,14 @@ function createEmbeddedTerminalBackendFromConfig(
   let lastKnownWorkflowCount = 0;
   let lastActivityLogId = 0;
   let startupWorkflowId: string | null = null;
+  // In detached viewer mode the local DB is an empty in-memory copy. Workflow
+  // metadata for the bootstrap getter comes from the owner snapshot; task state
+  // is derived live from `lastKnownTaskStates` (kept current by deltas).
+  let detachedViewerWorkflows: unknown[] | null = null;
+  // While the detached viewer hydrates, owner deltas are buffered here and
+  // replayed after the cache is seeded, so an update arriving mid-hydration is
+  // not applied against an empty cache (quarantined and dropped).
+  let detachedDeltaBuffer: TaskDelta[] | null = null;
   let uiInteractive = false;
   let deferredStartupTriggered = false;
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
@@ -2876,11 +2900,83 @@ function createEmbeddedTerminalBackendFromConfig(
 
   function seedUiSnapshotCache(): void {
     lastKnownWorkflowCount = persistence.listWorkflows().length;
-    const tasks = orchestrator.getAllTasks();
-    lastKnownTaskStates.clear();
-    workflowRollupProjection.replaceAll(tasks);
-    for (const task of tasks) {
-      lastKnownTaskStates.set(task.id, JSON.stringify(task));
+    seedTaskCachesFromSnapshot(orchestrator.getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
+  }
+
+  // Detached viewer: the local DB is empty, so seed the delta caches and
+  // bootstrap snapshot from the owner. Without this, the empty cache quarantines
+  // every `updated` delta for a task the viewer has not seen (dropping live
+  // updates), and bootstrap getters return nothing. Failures are non-fatal — the
+  // renderer's delegated reads still populate the view.
+  async function hydrateDetachedViewerFromOwner(): Promise<void> {
+    try {
+      const snapshot = await messageBus.request<{ kind: string }, { tasks?: TaskState[]; workflows?: unknown[] }>(
+        'headless.query',
+        { kind: 'tasks' },
+      );
+      const tasks = Array.isArray(snapshot?.tasks) ? snapshot.tasks : [];
+      const workflows = Array.isArray(snapshot?.workflows) ? snapshot.workflows : [];
+      detachedViewerWorkflows = workflows;
+      seedTaskCachesFromSnapshot(tasks, { lastKnownTaskStates, workflowRollupProjection });
+      lastKnownWorkflowCount = workflows.length;
+      startupWorkflowId = [...workflows]
+        .map((wf) => wf as { id?: string; updatedAt?: string; createdAt?: string })
+        .sort((left, right) => (Date.parse(right.updatedAt ?? '') || 0) - (Date.parse(left.updatedAt ?? '') || 0))[0]?.id ?? null;
+      logger.info(
+        `[init] Hydrated detached viewer from owner: ${tasks.length} tasks across ${workflows.length} workflows`,
+        { module: 'init' },
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(`detached viewer hydration from owner failed; relying on delegated reads: ${message}`, { module: 'init' });
+    } finally {
+      // Resume direct delta processing and replay anything buffered during
+      // hydration (in arrival order). Always runs, so a hydration failure can
+      // never leave deltas buffered forever.
+      const buffered = detachedDeltaBuffer ?? [];
+      detachedDeltaBuffer = null;
+      for (const delta of buffered) processIncomingTaskDelta(delta);
+    }
+  }
+
+  // Current task states for the detached viewer's bootstrap getter, derived from
+  // the live delta cache so a renderer reload never sees the stale hydration
+  // snapshot.
+  function detachedViewerTasks(): TaskState[] {
+    return [...lastKnownTaskStates.keys()].map(
+      (taskId) => JSON.parse(lastKnownTaskStates.get(taskId) ?? '{}') as TaskState,
+    );
+  }
+
+  // Apply one owner task delta to the local cache and forward results to the
+  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
+  // can replay deltas that were buffered during hydration.
+  function processIncomingTaskDelta(d: TaskDelta): void {
+    uiPerfStats.mainDeltaToUi += 1;
+    if (traceUiDeltaFlow) {
+      logger.debug(`delta→ui: ${JSON.stringify(d)}`, { module: 'ui' });
+    }
+    const deltaTaskId = d.type === 'updated' || d.type === 'removed' ? d.taskId : undefined;
+    if (d.type === 'updated' && d.changes.status === 'failed') {
+      const cancellationError = shouldSkipAutoFixForError(d.changes.execution?.error);
+      const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(d.taskId);
+      logAutoFixDebug(d.taskId, 'delta-failed', {
+        shouldSkipForCancellation: cancellationError,
+        shouldAutoFixFromOrchestrator,
+      });
+      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
+        logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
+        scheduleAutoFix(deltaTaskId);
+      } else if (deltaTaskId) {
+        logAutoFixDebug(deltaTaskId, 'delta-skip', {
+          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
+          shouldSkipForCancellation: cancellationError,
+          shouldAutoFixFromOrchestrator,
+        });
+      }
+    }
+    for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(d)) {
+      publishTaskDeltaToRenderer(rendererDelta);
     }
   }
 
@@ -3288,7 +3384,7 @@ function createEmbeddedTerminalBackendFromConfig(
       guiUsingDaemonOwner = true;
       try {
         recordStartupMark('initServices.readOnly.start');
-        await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+        await initServices({ detachedViewer: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
         recordStartupMark('initServices.readOnly.end', { ownerMode: false, daemonOwner: true });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -3311,7 +3407,7 @@ function createEmbeddedTerminalBackendFromConfig(
           return;
         }
         recordStartupMark('initServices.readOnly.start');
-        await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+        await initServices({ detachedViewer: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
         ownerMode = false;
         guiUsingDaemonOwner = false;
         recordStartupMark('initServices.readOnly.end', { ownerMode: false });
@@ -3467,8 +3563,8 @@ function createEmbeddedTerminalBackendFromConfig(
       recordStartupMark('owner-ipc-ready');
     }
 
-    bootstrapInitialWorkflowState();
     if (ownerMode) {
+      bootstrapInitialWorkflowState();
       startLifecycleEventBridge({
         messageBus,
         getInitialTasks: () => orchestrator.getAllTasks(),
@@ -3502,38 +3598,17 @@ function createEmbeddedTerminalBackendFromConfig(
 
     // Forward deltas to renderer and keep snapshot cache in sync so
     // the db-poll doesn't re-emit deltas the messageBus already delivered.
+    // Detached viewer: buffer owner deltas until hydration seeds the cache.
+    if (!ownerMode) {
+      detachedDeltaBuffer = [];
+    }
     messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
-      uiPerfStats.mainDeltaToUi += 1;
       const d = delta as TaskDelta;
-      if (traceUiDeltaFlow) {
-        logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
+      if (detachedDeltaBuffer) {
+        detachedDeltaBuffer.push(d);
+        return;
       }
-
-      const deltaTaskId = d.type === 'updated' || d.type === 'removed'
-        ? d.taskId
-        : undefined;
-      if (d.type === 'updated' && d.changes.status === 'failed') {
-        const cancellationError = shouldSkipAutoFixForError(d.changes.execution?.error);
-        const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(d.taskId);
-        logAutoFixDebug(d.taskId, 'delta-failed', {
-          shouldSkipForCancellation: cancellationError,
-          shouldAutoFixFromOrchestrator,
-        });
-        if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
-          logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
-          scheduleAutoFix(deltaTaskId);
-        } else if (deltaTaskId) {
-          logAutoFixDebug(deltaTaskId, 'delta-skip', {
-            reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
-            shouldSkipForCancellation: cancellationError,
-            shouldAutoFixFromOrchestrator,
-          });
-        }
-      }
-
-      for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(d)) {
-        publishTaskDeltaToRenderer(rendererDelta);
-      }
+      processIncomingTaskDelta(d);
     });
 
     uiPerfLogInterval = setInterval(() => {
@@ -3558,8 +3633,8 @@ function createEmbeddedTerminalBackendFromConfig(
     // Register IPC handlers
     registerBootstrapStateIpc({
       ipcMain,
-      getTasks: () => orchestrator.getAllTasks(),
-      getWorkflows: () => listWorkflowsByStartupRecency(),
+      getTasks: () => (ownerMode ? orchestrator.getAllTasks() : detachedViewerTasks()),
+      getWorkflows: () => detachedViewerWorkflows ?? listWorkflowsByStartupRecency(),
       getInitialWorkflowId: () => startupWorkflowId,
       appStartedAtEpochMs: appProcessStartedAt,
       getTaskDeltaStreamSequence,
@@ -4787,7 +4862,11 @@ function createEmbeddedTerminalBackendFromConfig(
       ),
     );
 
-    seedUiSnapshotCache();
+    if (ownerMode) {
+      seedUiSnapshotCache();
+    } else {
+      await hydrateDetachedViewerFromOwner();
+    }
     createWindow();
     recordStartupMark('createWindow.end');
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2744,8 +2744,9 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'invoker:clear':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
-        const workflows = persistence.listWorkflows();
-        const workflowId = workflows[0]?.id;
+        const workflows = detachedViewerWorkflows ?? persistence.listWorkflows();
+        const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
+        const workflowId = typeof firstWorkflow?.id === 'string' ? firstWorkflow.id : undefined;
         if (!workflowId) return null;
         return { channel: 'headless.resume', request: { workflowId } };
       }

--- a/packages/app/src/viewer-cache-hydration.ts
+++ b/packages/app/src/viewer-cache-hydration.ts
@@ -1,0 +1,25 @@
+import type { TaskState } from '@invoker/workflow-core';
+import type { TaskSnapshotCache } from './delta-merge.js';
+import type { WorkflowRollupProjection } from './workflow-rollup-projection.js';
+
+export interface ViewerTaskCaches {
+  lastKnownTaskStates: TaskSnapshotCache;
+  workflowRollupProjection: WorkflowRollupProjection;
+}
+
+/**
+ * Replace the main-process delta caches with an authoritative task list.
+ *
+ * Shared by the owner's local seeding (`seedUiSnapshotCache`,
+ * `publishOrchestratorSnapshotToRenderer`) and by the detached viewer, which
+ * seeds from the owner's delegated snapshot. Seeding the cache is what gives
+ * incoming `updated` deltas a base entry; without it every delta for a task the
+ * viewer has not seen is quarantined and effectively dropped.
+ */
+export function seedTaskCachesFromSnapshot(tasks: readonly TaskState[], caches: ViewerTaskCaches): void {
+  caches.lastKnownTaskStates.clear();
+  caches.workflowRollupProjection.replaceAll(tasks);
+  for (const task of tasks) {
+    caches.lastKnownTaskStates.set(task.id, JSON.stringify(task));
+  }
+}


### PR DESCRIPTION
## Summary

The GUI viewer now hydrates a memory-only database from the owner instead of opening the live database file. Viewer resume also uses that hydrated workflow data.

This keeps renderer reads and resume safe after the viewer stops touching the live database file.

<details>
<summary>Review metadata</summary>

Review Claim: The GUI viewer can use a hydrated memory database for renderer reads and resume routing instead of opening the live database file.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Owner mode keeps the normal file-backed adapter; viewer mode hydrates only workflows and tasks, and resume still falls back to the local adapter when no hydrated viewer data exists.

Slice Rationale: The resume route must land with the detached viewer database, or the bottom PR breaks viewer resume before WAL exclusive locking is enabled.

</details>

## Non-goals

Does not enable exclusive locking. Does not change mutation handling. Does not mirror task output, activity log, or other high-volume tables into the viewer.

## Architecture

### Before

```mermaid
graph TD
    Viewer["Viewer process"] --> DB["invoker.db"]
    Owner["Owner process"] --> DB
```

### After

```mermaid
graph TD
    Owner["Owner process"] --> DB["invoker.db"]
    Owner --> Snapshot["workflow/task snapshot"]
    Snapshot --> Viewer["Viewer memory database"]
```

## Test Plan

- [x] `pnpm --dir packages/app exec vitest run src/__tests__/viewer-cache-hydration.test.ts src/__tests__/viewer-detached-db.test.ts`
- [x] `pnpm --dir packages/app run test:e2e -- e2e/task-new-attempt-reset.spec.ts`
- [x] `pnpm run check:types`

## Visual Proof

No visual surface changed; this is main-process read routing. Reference current app walkthrough: [video](https://github.com/Neko-Catpital-Labs/Invoker/raw/master/docs/assets/invoker-preview.mp4)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

## Files (4)

- packages/app/src/__tests__/viewer-cache-hydration.test.ts [ADDED] (+51 -0)
- packages/app/src/__tests__/viewer-detached-db.test.ts [ADDED] (+67 -0)
- packages/app/src/main.ts [MODIFIED]
- packages/app/src/viewer-cache-hydration.ts [ADDED] (+25 -0)
