### PR TITLE
[Sole-owner DB Repair](2) Route viewer resume through hydrated workflow

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2744,8 +2744,9 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'invoker:clear':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
-        const workflows = persistence.listWorkflows();
-        const workflowId = workflows[0]?.id;
+        const workflows = detachedViewerWorkflows ?? persistence.listWorkflows();
+        const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
+        const workflowId = typeof firstWorkflow?.id === 'string' ? firstWorkflow.id : undefined;
         if (!workflowId) return null;
         return { channel: 'headless.resume', request: { workflowId } };
       }


### PR DESCRIPTION
## Summary

Viewer-mode resume now chooses the workflow from the hydrated viewer data.

That keeps resume working after the viewer stops opening the live database file directly.

<details>
<summary>Review metadata</summary>

Review Claim: Viewer-mode resume routes through the hydrated workflow data when the viewer database is detached from the live file.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The fallback still uses the local adapter when no hydrated viewer data exists, and the command still returns null when no workflow is available.

Slice Rationale: This is a small follow-up to the detached viewer slice, kept reviewable on its own because it touches only resume routing.

</details>

## Non-goals

Does not change how workflows are resumed by the owner. Does not change task execution, mutation submission, or exclusive locking.

## Test Plan

- [x] `pnpm --dir packages/app exec vitest run src/__tests__/viewer-cache-hydration.test.ts src/__tests__/viewer-detached-db.test.ts`
- [x] `pnpm run check:types`

## Visual Proof

No visual surface changed; this is main-process command routing. Reference current app walkthrough: [video](https://github.com/Neko-Catpital-Labs/Invoker/raw/master/docs/assets/invoker-preview.mp4)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
