### PR TITLE
[Merge Gate Recovery](1) Surface broken fix workspaces

### DIFF
--- a/packages/app/e2e/invalid-merge-workspace-visual.spec.ts
+++ b/packages/app/e2e/invalid-merge-workspace-visual.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect, loadPlan, injectTaskStates, captureScreenshot, getTasks, E2E_REPO_URL } from './fixtures/electron-app.js';
+
+type TaskLike = {
+  id: string;
+  config?: {
+    isMergeNode?: boolean;
+  };
+};
+
+function asTaskList(value: unknown): TaskLike[] {
+  const candidate = Array.isArray(value)
+    ? value
+    : value && typeof value === 'object' && 'tasks' in value
+      ? (value as { tasks: unknown }).tasks
+      : [];
+  if (!Array.isArray(candidate)) return [];
+  return candidate.filter((entry): entry is TaskLike => {
+    return Boolean(
+      entry &&
+      typeof entry === 'object' &&
+      'id' in entry &&
+      typeof (entry as { id: unknown }).id === 'string',
+    );
+  });
+}
+
+const PLAN = {
+  name: 'Invalid merge workspace visual proof',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'pull_request' as const,
+  mergeMode: 'external_review',
+  tasks: [
+    {
+      id: 'implementation',
+      description: 'Implementation task before merge gate',
+      command: 'echo ok',
+      dependencies: [] as string[],
+    },
+  ],
+};
+
+test('invalid merge workspace error appears in task panel', async ({ page }) => {
+  await loadPlan(page, PLAN);
+
+  const tasks = asTaskList(await getTasks(page));
+  const mergeTask = tasks.find((task) => task.config?.isMergeNode === true);
+  expect(mergeTask, 'merge gate task exists').toBeTruthy();
+  if (!mergeTask) return;
+
+  const message = "[Fix with Agent failed] Cannot apply a fix because this merge gate's saved workspace is missing or is not a git repository: /Users/edbertchan/.invoker/merge-launches/launch-__merge__wf-1782192504629-22-f7dhPo. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.\n\nUnable to resolve merge worktree ref \"plan/old-base\"";
+
+  await injectTaskStates(page, [
+    {
+      taskId: mergeTask.id,
+      changes: {
+        status: 'failed',
+        execution: {
+          error: message,
+          workspacePath: '/Users/edbertchan/.invoker/merge-launches/launch-__merge__wf-1782192504629-22-f7dhPo',
+          pendingFixError: undefined,
+          completedAt: new Date(),
+        },
+      },
+    },
+  ]);
+
+  await page.getByTestId(`rf__node-${mergeTask.id}`).click();
+  await expect(page.getByText('Cannot apply a fix because this merge gate')).toBeVisible({ timeout: 5000 });
+  await captureScreenshot(page, 'invalid-merge-workspace-error');
+});

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -308,6 +308,44 @@ describe('approveTask', () => {
     expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
+  it('surfaces corrupt merge-gate fix approvals without recreating the task', async () => {
+    const approvedTask = makeTask({
+      id: 'merge-a',
+      status: 'awaiting_approval',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        pendingFixError: 'original gate failure',
+        workspacePath: '/tmp/invoker-empty-launch-placeholder',
+      },
+    });
+    const orchestrator = {
+      approve: vi.fn(),
+      getTask: vi.fn().mockReturnValue(approvedTask),
+      resumeTaskAfterFixApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const taskExecutor = {
+      commitApprovedFix: vi.fn().mockRejectedValue(new Error('git status --porcelain failed (code 128): fatal: not a git repository')),
+      publishAfterFix: vi.fn(),
+      executeTasks: vi.fn(),
+    };
+
+    const result = await approveTask('merge-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    expect(result).toEqual({ approvedTask, fixedTask: true, started: [] });
+    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith(
+      'merge-a',
+      'original gate failure',
+      expect.stringContaining('Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository: /tmp/invoker-empty-launch-placeholder. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.'),
+    );
+    expect(orchestrator.resumeTaskAfterFixApproval).not.toHaveBeenCalled();
+    expect(orchestrator.approve).not.toHaveBeenCalled();
+    expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
+  });
+
   it('commits approved fixes and returns non-merge launch claims for the caller to dispatch', async () => {
     const started = [makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } })];
     const approvedTask = makeTask({
@@ -1307,6 +1345,66 @@ describe('fixWithAgentAction', () => {
       workflowId: 'wf-1',
       started: [expect.objectContaining({ id: 'task-a', status: 'running' })],
     });
+  });
+
+  it('surfaces corrupt merge gates when the saved fix workspace is not a git repo', async () => {
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        id: 'merge-a',
+        status: 'failed',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: {
+          error: 'Unable to resolve merge worktree ref "plan/old-base"',
+          workspacePath: '/tmp/invoker-empty-launch-placeholder',
+        },
+      })),
+      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 2 })),
+      updateWorkflow: vi.fn(),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      recreateWorkflowFromFreshBase: vi.fn(async () => [makeRunningTask({ id: 'merge-a', status: 'running' })]),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
+      beginConflictResolution: vi.fn(),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      appendTaskOutput: vi.fn(),
+      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 2 })),
+      updateWorkflow: vi.fn(),
+      getTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      preparePoolForRebaseRetry: vi.fn().mockResolvedValue(undefined),
+      execGitIn: vi.fn().mockRejectedValue(new Error('fatal: not a git repository')),
+      fixWithAgent: vi.fn(),
+      resolveConflict: vi.fn(),
+    };
+
+    await expect(fixWithAgentAction('merge-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+      commandService: makeCommandService(),
+    }, {
+      failureOutputLabel: 'Fix with AI',
+    })).rejects.toThrow('Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository');
+
+    expect(taskExecutor.execGitIn).toHaveBeenCalledWith(
+      ['rev-parse', '--is-inside-work-tree'],
+      '/tmp/invoker-empty-launch-placeholder',
+    );
+    expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
+    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
+      'merge-a',
+      expect.stringContaining('Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository: /tmp/invoker-empty-launch-placeholder. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.'),
+    );
+    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith(
+      'merge-a',
+      'Unable to resolve merge worktree ref "plan/old-base"',
+      expect.stringContaining('Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository: /tmp/invoker-empty-launch-placeholder. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.'),
+    );
+    expect(orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -165,7 +165,19 @@ export async function approveTask(
   const task = deps.orchestrator.getTask?.(taskId);
   const fixedTask = task?.execution.pendingFixError !== undefined;
   if (fixedTask && task && deps.taskExecutor) {
-    await deps.taskExecutor.commitApprovedFix(task);
+    try {
+      await deps.taskExecutor.commitApprovedFix(task);
+    } catch (err) {
+      if (!task.config.isMergeNode || !isInvalidGitWorkspaceError(err)) {
+        throw err;
+      }
+      const msg = invalidMergeWorkspaceMessage({
+        kind: 'invalidMergeWorkspace',
+        workspacePath: task.execution.workspacePath?.trim() || undefined,
+      });
+      deps.orchestrator.revertConflictResolution(taskId, task.execution.pendingFixError ?? '', msg);
+      return { approvedTask: task, started: [], fixedTask };
+    }
   }
 
   const shouldResume =
@@ -833,12 +845,19 @@ export async function fixWithAgentAction(
   }
 
   const savedError = task.execution.error ?? '';
-  const recoveryRoute = options.recoveryRoute ?? selectFailureRecoveryRoute(task, savedError);
+  const recoveryRoute = await selectFailureRecoveryRouteForAction(task, savedError, taskExecutor, options.recoveryRoute);
+  if (recoveryRoute.kind === 'invalidMergeWorkspace') {
+    const msg = invalidMergeWorkspaceMessage(recoveryRoute);
+    const errorLabel = options.failureOutputLabel ?? `Fix with ${options.agentName ?? 'Claude'}`;
+    persistence.appendTaskOutput(taskId, `\n[${errorLabel}] ${msg}`);
+    orchestrator.revertConflictResolution(taskId, savedError, msg);
+    throw new Error(msg);
+  }
   if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
     if (options.recreateOutputLabel) {
       persistence.appendTaskOutput(
         taskId,
-        `\n[${options.recreateOutputLabel}] Startup merge conflict detected; recreating workflow ${recoveryRoute.workflowId} from a fresh base.`,
+        `\n[${options.recreateOutputLabel}] ${freshBaseRecoveryMessage(recoveryRoute)}; recreating workflow ${recoveryRoute.workflowId} from a fresh base.`,
       );
     }
     const started = await recreateWorkflowFromFreshBase(recoveryRoute.workflowId, deps);
@@ -914,7 +933,8 @@ export async function finalizeAppliedFix(
 export type FailureRecoveryRoute =
   | { kind: 'fixWithAgent' }
   | { kind: 'resolveConflict' }
-  | { kind: 'recreateWorkflowFromFreshBase'; workflowId: string };
+  | { kind: 'recreateWorkflowFromFreshBase'; workflowId: string }
+  | { kind: 'invalidMergeWorkspace'; workspacePath?: string };
 
 export function selectFailureRecoveryRoute(
   task: TaskState,
@@ -935,6 +955,44 @@ export function selectFailureRecoveryRoute(
   }
 
   return { kind: 'recreateWorkflowFromFreshBase', workflowId };
+}
+
+async function selectFailureRecoveryRouteForAction(
+  task: TaskState,
+  savedError: string,
+  taskExecutor: TaskRunner,
+  initialRoute?: FailureRecoveryRoute,
+): Promise<FailureRecoveryRoute> {
+  const route = initialRoute ?? selectFailureRecoveryRoute(task, savedError);
+  if (route.kind !== 'fixWithAgent' || !task.config.isMergeNode) {
+    return route;
+  }
+
+  const workspacePath = task.execution.workspacePath?.trim();
+  if (!workspacePath) {
+    return { kind: 'invalidMergeWorkspace' };
+  }
+
+  try {
+    await taskExecutor.execGitIn(['rev-parse', '--is-inside-work-tree'], workspacePath);
+    return route;
+  } catch {
+    return { kind: 'invalidMergeWorkspace', workspacePath };
+  }
+}
+
+function freshBaseRecoveryMessage(_route: Extract<FailureRecoveryRoute, { kind: 'recreateWorkflowFromFreshBase' }>): string {
+  return 'Startup merge conflict detected';
+}
+
+function invalidMergeWorkspaceMessage(route: Extract<FailureRecoveryRoute, { kind: 'invalidMergeWorkspace' }>): string {
+  const suffix = route.workspacePath ? `: ${route.workspacePath}` : '';
+  return `Cannot apply a fix because this merge gate's saved workspace is missing or is not a git repository${suffix}. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.`;
+}
+
+function isInvalidGitWorkspaceError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes('not a git repository') || msg.includes('No such file or directory');
 }
 
 function tailText(value: unknown, maxChars: number = 2000): string | undefined {


### PR DESCRIPTION
## Summary

Merge-gate fixes now stop when the saved fix workspace is missing or is not a git repo.

Invoker used to treat a broken launch placeholder like a real workspace. Starting or approving a fix could then fail with `fatal: not a git repository`.

The fix surfaces the broken task state in the task error panel and tells the user to recreate the merge-gate task.

<details>
<summary>Review metadata</summary>

Review Claim: Fix start and fix approval now expose broken merge-gate workspaces as a user-facing error instead of continuing an uncommittable flow.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Only merge-node fix actions inspect the saved workspace; normal fixes and conflict fixes keep their existing behavior.

Slice Rationale: This is the smallest activation-surface change that explains the broken task and avoids automatic recovery.

</details>

## Visual proof

![Invalid merge workspace error](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260628-fa5600/invalid-merge-workspace-error.png)

## Non-goals

This does not automatically recreate merge gates.

This does not change startup merge-conflict recovery, which already recreates workflows without a workspace.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/workflow-actions.test.ts`
- [x] `pnpm run check:types`
- [x] `CAPTURE_MODE=after pnpm --filter @invoker/app test:e2e -- invalid-merge-workspace-visual.spec.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0960e28`
- Post-revert steps: None
- Data migration? No
