### PR TITLE
[Recovery Lifecycle 2i Step 4: External worker plugin loader](1) Declare external workers in config

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -132,6 +132,32 @@ describe('loadConfig', () => {
     expect(config.browser).toBe('firefox');
   });
 
+  it('defaults externalWorkers to none when absent', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ defaultBranch: 'main' }),
+    );
+    const config = loadConfig();
+    expect(config.externalWorkers ?? []).toEqual([]);
+  });
+
+  it('reads external worker launch config from user config', () => {
+    const externalWorkers = [{
+      kind: 'preview',
+      launch: {
+        executable: '/usr/local/bin/invoker-preview-worker',
+        args: ['--stdio', '--log-level=info'],
+        cwd: '/srv/invoker',
+      },
+    }];
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ externalWorkers }),
+    );
+    const config = loadConfig();
+    expect(config.externalWorkers).toEqual(externalWorkers);
+  });
+
   it('reads imageStorage from user config', () => {
     const imageStorage = {
       provider: 'r2',

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -9,6 +9,22 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 
+export interface ExternalWorkerLaunchConfig {
+  /** Executable used to start the external worker process. */
+  executable: string;
+  /** Optional argv passed after the executable. */
+  args?: string[];
+  /** Optional process working directory for the worker launch. */
+  cwd?: string;
+}
+
+export interface ExternalWorkerConfig {
+  /** Stable worker registry kind declared by the operator. */
+  kind: string;
+  /** Process invocation used by the loader to start the external worker. */
+  launch: ExternalWorkerLaunchConfig;
+}
+
 export interface InvokerConfig {
   defaultBranch?: string;
   /**
@@ -231,6 +247,11 @@ export interface InvokerConfig {
     /** Routing strategy. Defaults to "enforce". */
     strategy?: 'enforce' | 'route';
   }>;
+  /**
+   * Operator-declared external workers keyed by registry kind.
+   * The loader consumes this later; absent means no external workers.
+   */
+  externalWorkers?: ExternalWorkerConfig[];
 }
 
 function readJsonSafe(path: string): InvokerConfig {


### PR DESCRIPTION
## Summary

Operators can now declare external workers in Invoker config. Each entry names a worker by kind and gives a launch invocation.

The fields are optional and default to none, so existing setups are untouched until a later loader reads them.

This is the declaration surface for the bring-your-own-worker slice of the 2i stack.

<details>
<summary>Review metadata</summary>

Review Claim: The Invoker config gains optional fields that declare external workers by kind and a launch invocation.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: The new fields are optional and unread until a later loader consumes them, so existing setups behave exactly as before.

Slice Rationale: The declaration surface is its own small claim, kept separate from the loader that consumes it and from the end-to-end proof.

</details>

## Non-goals

- Does not register or run external workers; that is the loader slice.
- Does not change built-in worker behavior.

## Test Plan

- [ ] `cd packages/app && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
