### PR TITLE
[Recovery Lifecycle 2i Step 4: External worker plugin loader](2) Register external workers into the registry

### DIFF
--- a/packages/app/src/__tests__/external-worker-loader.test.ts
+++ b/packages/app/src/__tests__/external-worker-loader.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { createWorkerRegistry } from '@invoker/execution-engine';
+
+import { registerExternalWorkers } from '../external-worker-loader.js';
+
+const externalWorkers = [{
+  kind: 'preview',
+  launch: {
+    executable: '/usr/local/bin/invoker-preview-worker',
+    args: ['--stdio'],
+  },
+}];
+
+describe('registerExternalWorkers', () => {
+  it('registers configured external workers by kind', () => {
+    const registry = registerExternalWorkers(createWorkerRegistry(), externalWorkers);
+
+    const definition = registry.get('preview');
+    expect(definition).toBeDefined();
+    expect(definition?.kind).toBe('preview');
+    expect(definition?.note).toContain('/usr/local/bin/invoker-preview-worker');
+    expect(registry.list().map((worker) => worker.kind)).toEqual(['preview']);
+  });
+
+  it('defaults to no registered external workers when config is absent', () => {
+    const registry = registerExternalWorkers(createWorkerRegistry(), undefined);
+
+    expect(registry.list()).toEqual([]);
+    expect(registry.get('preview')).toBeUndefined();
+  });
+});

--- a/packages/app/src/external-worker-loader.ts
+++ b/packages/app/src/external-worker-loader.ts
@@ -1,0 +1,165 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import type {
+  WorkerDefinition,
+  WorkerRegistry,
+  WorkerRuntime,
+  WorkerRuntimeDependencies,
+  WorkerTickReason,
+} from '@invoker/execution-engine';
+
+import type { ExternalWorkerConfig } from './config.js';
+
+const EXTERNAL_WORKER_RUNTIME = Symbol('externalWorkerRuntime');
+const EXTERNAL_WORKER_SHUTDOWN_GRACE_MS = 5_000;
+
+let externalWorkerInstanceCounter = 0;
+
+export interface ExternalWorkerRuntime extends WorkerRuntime {
+  readonly [EXTERNAL_WORKER_RUNTIME]: true;
+  waitForExit(): Promise<void>;
+}
+
+export function isExternalWorkerRuntime(runtime: WorkerRuntime): runtime is ExternalWorkerRuntime {
+  return (runtime as Partial<ExternalWorkerRuntime>)[EXTERNAL_WORKER_RUNTIME] === true;
+}
+
+export function registerExternalWorkers(
+  registry: WorkerRegistry,
+  externalWorkers: readonly ExternalWorkerConfig[] | undefined,
+): WorkerRegistry {
+  if (!externalWorkers || externalWorkers.length === 0) return registry;
+
+  for (const worker of externalWorkers) {
+    if (registry.get(worker.kind)) {
+      throw new Error(`External worker kind is already registered: ${worker.kind}`);
+    }
+
+    registry.register(createExternalWorkerDefinition(worker));
+  }
+
+  return registry;
+}
+
+function createExternalWorkerDefinition(config: ExternalWorkerConfig): WorkerDefinition {
+  return {
+    kind: config.kind,
+    note: `External process: ${config.launch.executable}`,
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => createExternalWorkerRuntime(config, deps),
+  };
+}
+
+function createExternalWorkerRuntime(
+  config: ExternalWorkerConfig,
+  deps: WorkerRuntimeDependencies,
+): ExternalWorkerRuntime {
+  const identity = {
+    kind: config.kind,
+    instanceId: `external-${++externalWorkerInstanceCounter}`,
+  };
+  const logger = deps.logger.child({ module: 'external-worker-loader', kind: config.kind });
+
+  let child: ChildProcess | undefined;
+  let exitPromise: Promise<void> | undefined;
+  let stopping = false;
+
+  const launch = (): Promise<void> => {
+    if (exitPromise) return exitPromise;
+
+    const args = config.launch.args ?? [];
+    logger.info('Starting external worker process', {
+      executable: config.launch.executable,
+      args,
+      cwd: config.launch.cwd,
+    });
+
+    const spawned = spawn(config.launch.executable, args, {
+      cwd: config.launch.cwd,
+      env: process.env,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    child = spawned;
+
+    const currentExitPromise = new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (error?: Error): void => {
+        if (settled) return;
+        settled = true;
+        if (child === spawned) child = undefined;
+        if (error) reject(error);
+        else resolve();
+      };
+
+      spawned.once('error', (error) => {
+        logger.error('External worker process failed to start', { error });
+        finish(error);
+      });
+
+      spawned.once('exit', (code, signal) => {
+        const fields = { code, signal };
+        if (stopping || code === 0) {
+          logger.info('External worker process exited', fields);
+          finish();
+          return;
+        }
+
+        const reason = signal ? `signal ${signal}` : `exit code ${code ?? 'unknown'}`;
+        const error = new Error(`External worker "${config.kind}" exited with ${reason}`);
+        logger.error(error.message, fields);
+        finish(error);
+      });
+    });
+
+    const trackedExitPromise = currentExitPromise.finally(() => {
+      if (exitPromise === trackedExitPromise) exitPromise = undefined;
+      stopping = false;
+    });
+    exitPromise = trackedExitPromise;
+    return trackedExitPromise;
+  };
+
+  const stop = async (): Promise<void> => {
+    const runningChild = child;
+    const runningExit = exitPromise;
+    if (!runningChild || !runningExit) return;
+
+    stopping = true;
+    if (runningChild.exitCode === null && !runningChild.killed) {
+      runningChild.kill('SIGTERM');
+    }
+
+    const killTimer = setTimeout(() => {
+      if (child === runningChild && runningChild.exitCode === null) {
+        runningChild.kill('SIGKILL');
+      }
+    }, EXTERNAL_WORKER_SHUTDOWN_GRACE_MS);
+    killTimer.unref?.();
+
+    try {
+      await runningExit.catch(() => undefined);
+    } finally {
+      clearTimeout(killTimer);
+    }
+  };
+
+  return {
+    [EXTERNAL_WORKER_RUNTIME]: true,
+    identity,
+    start(): void {
+      void launch().catch(() => undefined);
+    },
+    wake(_reason?: WorkerTickReason): void {
+      // External workers do their own work in their process; Invoker only owns lifecycle.
+    },
+    tick(_reason?: WorkerTickReason): Promise<void> {
+      return launch();
+    },
+    stop,
+    isRunning(): boolean {
+      return child !== undefined;
+    },
+    waitForExit(): Promise<void> {
+      return exitPromise ?? Promise.resolve();
+    },
+  };
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -42,6 +42,11 @@ import {
   collectRecoveryWorkerStatus,
   type RecoveryWorkerStatus,
 } from './recovery-worker-observability.js';
+import {
+  isExternalWorkerRuntime,
+  registerExternalWorkers,
+  type ExternalWorkerRuntime,
+} from './external-worker-loader.js';
 
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
@@ -421,7 +426,10 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
 
 async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0] ?? 'list';
-  const registry = registerAutoFixWorker(createWorkerRegistry());
+  const registry = registerExternalWorkers(
+    registerAutoFixWorker(createWorkerRegistry()),
+    deps.invokerConfig?.externalWorkers,
+  );
 
   if (subCommand === 'list') {
     process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);
@@ -482,7 +490,12 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
     });
-    await worker.tick('manual');
+    if (isExternalWorkerRuntime(worker)) {
+      worker.start();
+      await waitForExternalWorkerShutdown(worker);
+    } else {
+      await worker.tick('manual');
+    }
     await worker.stop();
   } finally {
     // Release deterministically so a clean run never leaves a stale lock that
@@ -491,6 +504,31 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   }
   const label = definition.kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : definition.kind;
   process.stdout.write(`${label} worker scan completed.\n`);
+}
+
+async function waitForExternalWorkerShutdown(worker: ExternalWorkerRuntime): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => {
+      process.removeListener('SIGINT', shutdown);
+      process.removeListener('SIGTERM', shutdown);
+    };
+    const shutdown = (): void => {
+      cleanup();
+      resolve();
+    };
+    worker.waitForExit().then(
+      () => {
+        cleanup();
+        resolve();
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+  });
 }
 
 function formatRecoveryWorkerStatus(status: RecoveryWorkerStatus): string {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,13 @@ import {
   WorkerLockHeldError,
   registerBuiltinAgents,
   type WorkerDefinition,
+  type WorkerRegistry,
 } from '@invoker/execution-engine';
+import {
+  isExternalWorkerRuntime,
+  registerExternalWorkers,
+  type ExternalWorkerRuntime,
+} from '../../app/src/external-worker-loader.js';
 import {
   IpcBus,
   TransportError,
@@ -65,6 +71,15 @@ type CliDeps = {
   runMcpServer?: () => Promise<void>;
 };
 
+type ExternalWorkerConfig = {
+  kind: string;
+  launch: {
+    executable: string;
+    args?: string[];
+    cwd?: string;
+  };
+};
+
 type CliRuntimeConfig = {
   defaultBranch?: string;
   maxConcurrency?: number;
@@ -99,6 +114,7 @@ type CliRuntimeConfig = {
     poolId: string;
     strategy?: 'enforce' | 'route';
   }>;
+  externalWorkers?: ExternalWorkerConfig[];
 };
 
 const silentLogger: Logger = {
@@ -120,7 +136,7 @@ function usage(): string {
     '  invoker-cli doctor [--fix] [--json]',
     '  invoker-cli setup [slack] [--check]',
     '  invoker-cli mcp',
-    '  invoker-cli worker [autofix|list]',
+    '  invoker-cli worker [kind|list]',
     '  invoker-cli --help',
     '  invoker-cli --version',
     '',
@@ -447,7 +463,11 @@ async function createDefaultMessageBus(): Promise<MessageBus> {
  * Read the auto-fix policy knobs from the shared Invoker config so the CLI door
  * drives the engine with the same retry budget / agent the GUI owner uses.
  */
-function readAutoFixWorkerConfig(homeRoot: string): { autoFixRetries?: number; autoFixAgent?: string } {
+function readWorkerConfig(homeRoot: string): {
+  autoFixRetries?: number;
+  autoFixAgent?: string;
+  externalWorkers?: ExternalWorkerConfig[];
+} {
   const configPath = join(homeRoot, 'config.json');
   if (!existsSync(configPath)) return {};
   try {
@@ -455,6 +475,9 @@ function readAutoFixWorkerConfig(homeRoot: string): { autoFixRetries?: number; a
     return {
       autoFixRetries: typeof parsed.autoFixRetries === 'number' ? parsed.autoFixRetries : undefined,
       autoFixAgent: typeof parsed.autoFixAgent === 'string' ? parsed.autoFixAgent : undefined,
+      externalWorkers: Array.isArray(parsed.externalWorkers)
+        ? parsed.externalWorkers as ExternalWorkerConfig[]
+        : undefined,
     };
   } catch {
     return {};
@@ -465,12 +488,44 @@ function workerDisplayName(kind: string): string {
   return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind;
 }
 
-function printWorkerKinds(): void {
-  const registry = registerAutoFixWorker(createWorkerRegistry());
+function printWorkerKinds(registry: WorkerRegistry): void {
   process.stdout.write('Worker kinds\n');
   for (const worker of registry.list()) {
     process.stdout.write(`  ${worker.kind} — available (${worker.note})\n`);
   }
+}
+
+function waitForShutdownSignal(): Promise<void> {
+  return new Promise<void>((resolveShutdown) => {
+    const shutdown = (): void => resolveShutdown();
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+  });
+}
+
+async function waitForExternalWorkerShutdown(worker: ExternalWorkerRuntime): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => {
+      process.removeListener('SIGINT', shutdown);
+      process.removeListener('SIGTERM', shutdown);
+    };
+    const shutdown = (): void => {
+      cleanup();
+      resolve();
+    };
+    worker.waitForExit().then(
+      () => {
+        cleanup();
+        resolve();
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+  });
 }
 
 /**
@@ -481,10 +536,14 @@ function printWorkerKinds(): void {
  * foreground lifetime — owner discovery, connect message, the SIGINT/SIGTERM
  * block, and a deterministic stop.
  */
-async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise<number> {
+async function runWorker(
+  definition: WorkerDefinition,
+  bus: MessageBus,
+  workerConfig: ReturnType<typeof readWorkerConfig>,
+): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
-  const { autoFixRetries, autoFixAgent } = readAutoFixWorkerConfig(homeRoot);
+  const { autoFixRetries, autoFixAgent } = workerConfig;
 
   // Single-instance guard: refuse if another worker of this kind (this door or
   // the dev `--headless worker <kind>` door) already holds the cross-process
@@ -526,11 +585,11 @@ async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise
     const ownerSuffix = owner?.ownerId ? ` to owner ${owner.ownerId}` : '';
     process.stdout.write(`${workerDisplayName(definition.kind)} worker connected${ownerSuffix}.\n`);
 
-    await new Promise<void>((resolveShutdown) => {
-      const shutdown = (): void => resolveShutdown();
-      process.once('SIGINT', shutdown);
-      process.once('SIGTERM', shutdown);
-    });
+    if (isExternalWorkerRuntime(worker)) {
+      await waitForExternalWorkerShutdown(worker);
+    } else {
+      await waitForShutdownSignal();
+    }
     await worker.stop();
   } finally {
     // Release deterministically so a clean shutdown never leaves a stale lock
@@ -557,9 +616,14 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     }
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';
-      const registry = registerAutoFixWorker(createWorkerRegistry());
+      const homeRoot = resolveInvokerHomeRoot();
+      const workerConfig = readWorkerConfig(homeRoot);
+      const registry = registerExternalWorkers(
+        registerAutoFixWorker(createWorkerRegistry()),
+        workerConfig.externalWorkers,
+      );
       if (subcommand === 'list') {
-        printWorkerKinds();
+        printWorkerKinds(registry);
         return 0;
       }
       const definition = registry.get(subcommand);
@@ -568,7 +632,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
         throw new Error(`Unknown worker kind: "${subcommand}". Usage: invoker-cli worker <${knownKinds}|list>`);
       }
       bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());
-      return await runWorker(definition, bus);
+      return await runWorker(definition, bus, workerConfig);
     }
     const parsed = parseArgs(argv);
     if (!parsed.command || parsed.command === '--help') {


### PR DESCRIPTION
## Summary

A loader reads the declared external workers and registers each one into the worker registry as a supervised external process.

Both worker doors call the loader when they build the registry, so a declared worker becomes first-class alongside the built-in one.

The external process talks to Invoker only over the existing owner channel and the normal action path, so no third-party code runs inside Invoker.

<details>
<summary>Review metadata</summary>

Review Claim: A loader reads the external-worker config and registers each one into the worker registry as a supervised external process.

Review Lane: behavior

Review Unit: routing

Safety Invariant: A registered external worker runs only when its kind is started, lives and dies with that foreground process, and is released on stop under the per-kind lock, like the built-in worker.

Slice Rationale: Bridging config to the registry is one claim, kept separate from the config fields and from the end-to-end proof.

</details>

## Non-goals

- Does not add a sample worker or end-to-end proof; that is the next slice.
- Does not change built-in worker behavior.
- Does not run third-party code inside Invoker.

## Test Plan

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/cli && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
