### PR TITLE
[Recovery Lifecycle 2i Step 4: External worker plugin loader](3) Prove the external-worker path end to end

### DIFF
--- a/packages/app/src/__tests__/external-worker-e2e.test.ts
+++ b/packages/app/src/__tests__/external-worker-e2e.test.ts
@@ -1,0 +1,140 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, watch } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join, resolve } from 'node:path';
+import type { Logger } from '@invoker/contracts';
+import { createWorkerRegistry } from '@invoker/execution-engine';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { registerExternalWorkers } from '../external-worker-loader.js';
+import { runHeadless, type HeadlessDeps } from '../headless.js';
+
+const sampleWorkerPath = resolve(__dirname, 'fixtures/sample-external-worker.mjs');
+
+type Marker = { pid: number; signal?: string; state: string };
+
+const tempRoots: string[] = [];
+let previousInvokerDbDir: string | undefined;
+
+function makeLogger(): Logger {
+  const logger: Logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger;
+}
+
+function makeDeps(homeRoot: string, readyPath: string, stoppedPath: string): HeadlessDeps {
+  return {
+    logger: makeLogger(),
+    orchestrator: {} as never,
+    persistence: {
+      enqueueWorkflowMutationIntent: vi.fn(),
+    } as never,
+    executorRegistry: {} as never,
+    messageBus: {} as never,
+    commandService: {} as never,
+    repoRoot: homeRoot,
+    invokerConfig: {
+      externalWorkers: [{
+        kind: 'sample-external',
+        launch: {
+          executable: process.execPath,
+          args: [sampleWorkerPath, '--ready', readyPath, '--stopped', stoppedPath],
+        },
+      }],
+    },
+    initServices: async () => {},
+    wireSlackBot: async () => ({}),
+  };
+}
+
+function readMarker(path: string): Marker {
+  return JSON.parse(readFileSync(path, 'utf8')) as Marker;
+}
+
+async function waitForMarker(path: string): Promise<Marker> {
+  if (existsSync(path)) return readMarker(path);
+
+  const found = Promise.withResolvers<void>();
+  const watcher = watch(dirname(path), (_event, filename) => {
+    if (filename?.toString() === basename(path) && existsSync(path)) {
+      found.resolve();
+    }
+  });
+  if (existsSync(path)) {
+    watcher.close();
+    return readMarker(path);
+  }
+
+  try {
+    await found.promise;
+    return readMarker(path);
+  } finally {
+    watcher.close();
+  }
+}
+
+describe('external worker loader e2e', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (previousInvokerDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = previousInvokerDbDir;
+    }
+    for (const root of tempRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('registers, starts, and stops a configured external worker through the headless worker door', async () => {
+    const homeRoot = mkdtempSync(join(tmpdir(), 'invoker-external-worker-e2e-'));
+    tempRoots.push(homeRoot);
+    previousInvokerDbDir = process.env.INVOKER_DB_DIR;
+    process.env.INVOKER_DB_DIR = homeRoot;
+
+    const readyPath = join(homeRoot, 'sample-ready.json');
+    const stoppedPath = join(homeRoot, 'sample-stopped.json');
+    const deps = makeDeps(homeRoot, readyPath, stoppedPath);
+    const registry = registerExternalWorkers(createWorkerRegistry(), deps.invokerConfig.externalWorkers);
+    const definition = registry.get('sample-external');
+
+    expect(definition).toBeDefined();
+    expect(definition?.kind).toBe('sample-external');
+
+    let stdout = '';
+    vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+      stdout += chunk.toString();
+      return true;
+    });
+
+    const beforeSigintListeners = process.listenerCount('SIGINT');
+    const beforeSigtermListeners = process.listenerCount('SIGTERM');
+    const doorFinished = Promise.withResolvers<void>();
+    const doorRun = runHeadless(['worker', 'sample-external'], deps);
+    doorRun.then(doorFinished.resolve, doorFinished.reject);
+
+    const ready = await Promise.race([
+      waitForMarker(readyPath),
+      doorFinished.promise.then(() => {
+        throw new Error('External worker door exited before the sample worker started');
+      }),
+    ]);
+    expect(ready.state).toBe('ready');
+    expect(ready.pid).toBeGreaterThan(0);
+    expect(existsSync(join(homeRoot, 'locks', 'worker-sample-external.lock'))).toBe(true);
+
+    process.emit('SIGTERM');
+    await doorRun;
+
+    const stopped = await waitForMarker(stoppedPath);
+    expect(stopped).toEqual({ pid: ready.pid, signal: 'SIGTERM', state: 'stopped' });
+    expect(existsSync(join(homeRoot, 'locks', 'worker-sample-external.lock'))).toBe(false);
+    expect(process.listenerCount('SIGINT')).toBe(beforeSigintListeners);
+    expect(process.listenerCount('SIGTERM')).toBe(beforeSigtermListeners);
+    expect(stdout).toContain('sample-external worker scan completed.');
+  });
+});

--- a/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
+++ b/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+import { writeFileSync } from 'node:fs';
+import { createServer } from 'node:net';
+
+const args = process.argv.slice(2);
+const readFlag = (name) => {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+};
+
+const readyPath = readFlag('--ready');
+const stoppedPath = readFlag('--stopped');
+const listening = Promise.withResolvers();
+const server = createServer();
+server.once('error', listening.reject);
+server.listen(0, '127.0.0.1', listening.resolve);
+await listening.promise;
+
+const shutdown = Promise.withResolvers();
+process.once('SIGTERM', () => shutdown.resolve('SIGTERM'));
+process.once('SIGINT', () => shutdown.resolve('SIGINT'));
+
+if (readyPath) {
+  writeFileSync(readyPath, JSON.stringify({ pid: process.pid, state: 'ready' }), 'utf8');
+}
+
+const signal = await shutdown.promise;
+if (stoppedPath) {
+  writeFileSync(stoppedPath, JSON.stringify({ pid: process.pid, signal, state: 'stopped' }), 'utf8');
+}
+server.close();


### PR DESCRIPTION
## Summary

An end-to-end test proves a configured sample external worker is registered and can be started and stopped through a worker door.

A small sample worker fixture stands in for a real external worker, so the proof exercises the whole declared-to-running path.

This slice also stands as the package gate for the external-worker support; the same app suite run is the verification step for the whole feature.

<details>
<summary>Review metadata</summary>

Review Claim: An end-to-end test proves a configured sample external worker is registered, starts, and stops cleanly through a worker door.

Review Lane: proof

Review Unit: proof

Safety Invariant: The test exercises only a sample worker fixture and changes no product behavior.

Slice Rationale: The end-to-end proof is its own slice, kept separate from the loader change so the proof and the behavior stay independently reviewable.

</details>

## Non-goals

- Does not change the loader or the config.
- Does not run the full repository regression; that is the terminal slice.

## Test Plan

- [ ] `cd packages/app && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
