### PR TITLE
[Recovery Lifecycle 2i Step 4: External worker plugin loader](2) Load external workers into the registry

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -132,6 +132,32 @@ describe('loadConfig', () => {
     expect(config.browser).toBe('firefox');
   });
 
+  it('defaults externalWorkers to none when absent', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ defaultBranch: 'main' }),
+    );
+    const config = loadConfig();
+    expect(config.externalWorkers).toBeUndefined();
+  });
+
+  it('reads external worker launch config from user config', () => {
+    const externalWorkers = [{
+      kind: 'preview',
+      launch: {
+        executable: '/usr/local/bin/invoker-preview-worker',
+        args: ['--stdio', '--log-level=info'],
+        cwd: '/srv/invoker',
+      },
+    }];
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ externalWorkers }),
+    );
+    const config = loadConfig();
+    expect(config.externalWorkers).toEqual(externalWorkers);
+  });
+
   it('reads imageStorage from user config', () => {
     const imageStorage = {
       provider: 'r2',

--- a/packages/app/src/__tests__/external-worker-loader.test.ts
+++ b/packages/app/src/__tests__/external-worker-loader.test.ts
@@ -1,0 +1,133 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createWorkerRegistry, type WorkerRuntimeDependencies } from '@invoker/execution-engine';
+
+import { isExternalWorkerRuntime, registerExternalWorkers } from '../external-worker-loader.js';
+
+vi.mock('node:child_process', () => ({ spawn: vi.fn() }));
+
+const externalWorkers = [{
+  kind: 'preview',
+  launch: {
+    executable: '/usr/local/bin/invoker-preview-worker',
+    args: ['--stdio'],
+  },
+}];
+
+const spawnMock = vi.mocked(spawn);
+
+type FakeChildProcess = EventEmitter & Pick<ChildProcess, 'exitCode' | 'killed' | 'kill'>;
+
+function createFakeChildProcess(): FakeChildProcess {
+  const child = new EventEmitter() as FakeChildProcess;
+  child.exitCode = null;
+  child.killed = false;
+  child.kill = vi.fn((signal?: NodeJS.Signals | number) => {
+    child.killed = true;
+    child.exitCode = 0;
+    queueMicrotask(() => child.emit('exit', 0, signal));
+    return true;
+  });
+  return child;
+}
+
+function makeLogger() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger;
+}
+
+function makeDeps(logger = makeLogger()): WorkerRuntimeDependencies {
+  return { store: {} as never, submitter: {} as never, logger };
+}
+
+beforeEach(() => {
+  spawnMock.mockReset();
+});
+
+describe('registerExternalWorkers', () => {
+  it('registers configured external workers by kind', () => {
+    const registry = registerExternalWorkers(createWorkerRegistry(), externalWorkers);
+
+    const definition = registry.get('preview');
+    expect(definition).toBeDefined();
+    expect(definition?.kind).toBe('preview');
+    expect(definition?.note).toContain('/usr/local/bin/invoker-preview-worker');
+    expect(registry.list().map((worker) => worker.kind)).toEqual(['preview']);
+  });
+
+  it('defaults to no registered external workers when config is absent', () => {
+    const registry = registerExternalWorkers(createWorkerRegistry(), undefined);
+
+    expect(registry.list()).toEqual([]);
+    expect(registry.get('preview')).toBeUndefined();
+  });
+
+  it('rejects duplicate external worker kinds', () => {
+    const registry = createWorkerRegistry();
+
+    expect(() => registerExternalWorkers(registry, [externalWorkers[0], externalWorkers[0]])).toThrow(
+      'External worker kind is already registered: preview',
+    );
+  });
+
+  it('starts, waits for, and stops the spawned process without leaking args or env', async () => {
+    const logger = makeLogger();
+    const child = createFakeChildProcess();
+    spawnMock.mockReturnValue(child as unknown as ChildProcess);
+    const previousSecret = process.env.EXTERNAL_WORKER_TEST_SECRET;
+    process.env.EXTERNAL_WORKER_TEST_SECRET = 'secret-value';
+
+    try {
+      const registry = registerExternalWorkers(createWorkerRegistry(), [{
+        kind: 'preview',
+        launch: {
+          executable: '/usr/local/bin/invoker-preview-worker',
+          args: ['--token=secret-value'],
+          cwd: '/srv/invoker',
+        },
+      }]);
+      const runtime = registry.get('preview')!.factory(makeDeps(logger));
+      expect(isExternalWorkerRuntime(runtime)).toBe(true);
+      if (!isExternalWorkerRuntime(runtime)) throw new Error('Expected external worker runtime');
+
+      runtime.start();
+
+      expect(runtime.isRunning()).toBe(true);
+      expect(logger.info).toHaveBeenCalledWith('Starting external worker process', {
+        executable: '/usr/local/bin/invoker-preview-worker',
+        argCount: 1,
+        cwd: '/srv/invoker',
+      });
+      const loggedFields = logger.info.mock.calls[0]?.[1] as Record<string, unknown>;
+      expect(loggedFields.args).toBeUndefined();
+      expect(spawnMock).toHaveBeenCalledWith('/usr/local/bin/invoker-preview-worker', ['--token=secret-value'], {
+        cwd: '/srv/invoker',
+        env: expect.not.objectContaining({ EXTERNAL_WORKER_TEST_SECRET: 'secret-value' }),
+        stdio: ['ignore', 'inherit', 'inherit'],
+      });
+      const spawnOptions = spawnMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
+      expect(spawnOptions.env).not.toBe(process.env);
+
+      const waitForExit = runtime.waitForExit();
+      await runtime.stop();
+      await waitForExit;
+
+      expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+      expect(runtime.isRunning()).toBe(false);
+    } finally {
+      if (previousSecret === undefined) {
+        delete process.env.EXTERNAL_WORKER_TEST_SECRET;
+      } else {
+        process.env.EXTERNAL_WORKER_TEST_SECRET = previousSecret;
+      }
+    }
+  });
+});

--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -86,4 +86,27 @@ describe('headless worker autofix', () => {
       'normal',
     );
   });
+
+  it('lists worker kinds from the registry', async () => {
+    let stdout = '';
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+      stdout += chunk.toString();
+      return true;
+    });
+
+    try {
+      await runHeadless(['worker', 'list'], {} as any);
+    } finally {
+      write.mockRestore();
+    }
+
+    expect(stdout).toContain('Worker kinds');
+    expect(stdout).toContain('autofix');
+  });
+
+  it('rejects unknown worker kinds with a clear error', async () => {
+    await expect(runHeadless(['worker', 'missing-kind'], {} as any)).rejects.toThrow(
+      'Unknown worker kind: "missing-kind"',
+    );
+  });
 });

--- a/packages/app/src/cli-installer.ts
+++ b/packages/app/src/cli-installer.ts
@@ -116,6 +116,10 @@ function isWritableDir(dir: string): boolean {
   }
 }
 
+function canWriteCliTarget(cliPath: string): boolean {
+  return isWritableDir(dirname(cliPath));
+}
+
 export function selectInstallDir(
   context: CliInstallerContext,
 ): { dir: string; warning?: string } | null {
@@ -209,10 +213,11 @@ export function updateInvokerCli(context: CliInstallerContext): CliInstallResult
     if (installed?.version === context.appVersion) {
       return { ok: true, updated: false, installedTo: installed.path, status: resolveCliInstallerStatus(context) };
     }
-    // Prefer updating an existing install in place — its dir is already on
-    // the user's effective PATH.
+    // Prefer updating an existing install in place when the app can replace
+    // it. If PATH exposes a system-level install, fall back to a writable
+    // candidate instead of failing the whole install.
     let targetPath: string;
-    if (installed) {
+    if (installed && canWriteCliTarget(installed.path)) {
       targetPath = installed.path;
     } else {
       const selection = selectInstallDir(context);

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -9,6 +9,22 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 
+export interface ExternalWorkerLaunchConfig {
+  /** Executable used to start the external worker process. */
+  executable: string;
+  /** Optional argv passed after the executable. */
+  args?: string[];
+  /** Optional process working directory for the worker launch. */
+  cwd?: string;
+}
+
+export interface ExternalWorkerConfig {
+  /** Stable worker registry kind declared by the operator. */
+  kind: string;
+  /** Process invocation used by the loader to start the external worker. */
+  launch: ExternalWorkerLaunchConfig;
+}
+
 export interface InvokerConfig {
   defaultBranch?: string;
   /**
@@ -231,6 +247,11 @@ export interface InvokerConfig {
     /** Routing strategy. Defaults to "enforce". */
     strategy?: 'enforce' | 'route';
   }>;
+  /**
+   * Operator-declared external worker list, with each worker identified by registry kind.
+   * The loader consumes this later; absent means no external workers.
+   */
+  externalWorkers?: ExternalWorkerConfig[];
 }
 
 function readJsonSafe(path: string): InvokerConfig {

--- a/packages/app/src/external-worker-loader.ts
+++ b/packages/app/src/external-worker-loader.ts
@@ -1,0 +1,188 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import type {
+  WorkerDefinition,
+  WorkerRegistry,
+  WorkerRuntime,
+  WorkerRuntimeDependencies,
+  WorkerTickReason,
+} from '@invoker/execution-engine';
+
+import type { ExternalWorkerConfig } from './config.js';
+
+const EXTERNAL_WORKER_RUNTIME = Symbol('externalWorkerRuntime');
+const EXTERNAL_WORKER_SHUTDOWN_GRACE_MS = 5_000;
+
+let externalWorkerInstanceCounter = 0;
+
+const EXTERNAL_WORKER_ENV_ALLOWLIST = [
+  'HOME',
+  'PATH',
+  'TMPDIR',
+  'TEMP',
+  'TMP',
+  'USER',
+  'LOGNAME',
+  'SHELL',
+  'LANG',
+  'LC_ALL',
+] as const;
+
+function createExternalWorkerEnvironment(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const name of EXTERNAL_WORKER_ENV_ALLOWLIST) {
+    const value = source[name];
+    if (value !== undefined) env[name] = value;
+  }
+  return env;
+}
+
+export interface ExternalWorkerRuntime extends WorkerRuntime {
+  readonly [EXTERNAL_WORKER_RUNTIME]: true;
+  waitForExit(): Promise<void>;
+}
+
+export function isExternalWorkerRuntime(runtime: WorkerRuntime): runtime is ExternalWorkerRuntime {
+  return (runtime as Partial<ExternalWorkerRuntime>)[EXTERNAL_WORKER_RUNTIME] === true;
+}
+
+export function registerExternalWorkers(
+  registry: WorkerRegistry,
+  externalWorkers: readonly ExternalWorkerConfig[] | undefined,
+): WorkerRegistry {
+  if (!externalWorkers || externalWorkers.length === 0) return registry;
+
+  for (const worker of externalWorkers) {
+    if (registry.get(worker.kind)) {
+      throw new Error(`External worker kind is already registered: ${worker.kind}`);
+    }
+
+    registry.register(createExternalWorkerDefinition(worker));
+  }
+
+  return registry;
+}
+
+function createExternalWorkerDefinition(config: ExternalWorkerConfig): WorkerDefinition {
+  return {
+    kind: config.kind,
+    note: `External process: ${config.launch.executable}`,
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => createExternalWorkerRuntime(config, deps),
+  };
+}
+
+function createExternalWorkerRuntime(
+  config: ExternalWorkerConfig,
+  deps: WorkerRuntimeDependencies,
+): ExternalWorkerRuntime {
+  const identity = {
+    kind: config.kind,
+    instanceId: `external-${++externalWorkerInstanceCounter}`,
+  };
+  const logger = deps.logger.child({ module: 'external-worker-loader', kind: config.kind });
+
+  let child: ChildProcess | undefined;
+  let exitPromise: Promise<void> | undefined;
+  let stopping = false;
+
+  const launch = (): Promise<void> => {
+    if (exitPromise) return exitPromise;
+
+    const args = config.launch.args ?? [];
+    const env = createExternalWorkerEnvironment();
+    logger.info('Starting external worker process', {
+      executable: config.launch.executable,
+      argCount: args.length,
+      cwd: config.launch.cwd,
+    });
+
+    const spawned = spawn(config.launch.executable, args, {
+      cwd: config.launch.cwd,
+      env,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    child = spawned;
+
+    const currentExitPromise = new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const finish = (error?: Error): void => {
+        if (settled) return;
+        settled = true;
+        if (child === spawned) child = undefined;
+        if (error) reject(error);
+        else resolve();
+      };
+
+      spawned.once('error', (error) => {
+        logger.error('External worker process failed to start', { error });
+        finish(error);
+      });
+
+      spawned.once('exit', (code, signal) => {
+        const fields = { code, signal };
+        if (stopping || code === 0) {
+          logger.info('External worker process exited', fields);
+          finish();
+          return;
+        }
+
+        const reason = signal ? `signal ${signal}` : `exit code ${code ?? 'unknown'}`;
+        const error = new Error(`External worker "${config.kind}" exited with ${reason}`);
+        logger.error(error.message, fields);
+        finish(error);
+      });
+    });
+
+    const trackedExitPromise = currentExitPromise.finally(() => {
+      if (exitPromise === trackedExitPromise) exitPromise = undefined;
+      stopping = false;
+    });
+    exitPromise = trackedExitPromise;
+    return trackedExitPromise;
+  };
+
+  const stop = async (): Promise<void> => {
+    const runningChild = child;
+    const runningExit = exitPromise;
+    if (!runningChild || !runningExit) return;
+
+    stopping = true;
+    if (runningChild.exitCode === null && !runningChild.killed) {
+      runningChild.kill('SIGTERM');
+    }
+
+    const killTimer = setTimeout(() => {
+      if (child === runningChild && runningChild.exitCode === null) {
+        runningChild.kill('SIGKILL');
+      }
+    }, EXTERNAL_WORKER_SHUTDOWN_GRACE_MS);
+    killTimer.unref?.();
+
+    try {
+      await runningExit.catch(() => undefined);
+    } finally {
+      clearTimeout(killTimer);
+    }
+  };
+
+  return {
+    [EXTERNAL_WORKER_RUNTIME]: true,
+    identity,
+    start(): void {
+      void launch().catch(() => undefined);
+    },
+    wake(_reason?: WorkerTickReason): void {
+      // External workers do their own work in their process; Invoker only owns lifecycle.
+    },
+    tick(_reason?: WorkerTickReason): Promise<void> {
+      return launch();
+    },
+    stop,
+    isRunning(): boolean {
+      return child !== undefined;
+    },
+    waitForExit(): Promise<void> {
+      return exitPromise ?? Promise.resolve();
+    },
+  };
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -42,6 +42,11 @@ import {
   collectRecoveryWorkerStatus,
   type RecoveryWorkerStatus,
 } from './recovery-worker-observability.js';
+import {
+  isExternalWorkerRuntime,
+  registerExternalWorkers,
+  type ExternalWorkerRuntime,
+} from './external-worker-loader.js';
 
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
@@ -421,7 +426,10 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
 
 async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0] ?? 'list';
-  const registry = registerAutoFixWorker(createWorkerRegistry());
+  const registry = registerExternalWorkers(
+    registerAutoFixWorker(createWorkerRegistry()),
+    deps.invokerConfig?.externalWorkers,
+  );
 
   if (subCommand === 'list') {
     process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);
@@ -482,7 +490,12 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
     });
-    await worker.tick('manual');
+    if (isExternalWorkerRuntime(worker)) {
+      worker.start();
+      await waitForExternalWorkerShutdown(worker);
+    } else {
+      await worker.tick('manual');
+    }
     await worker.stop();
   } finally {
     // Release deterministically so a clean run never leaves a stale lock that
@@ -491,6 +504,31 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   }
   const label = definition.kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : definition.kind;
   process.stdout.write(`${label} worker scan completed.\n`);
+}
+
+async function waitForExternalWorkerShutdown(worker: ExternalWorkerRuntime): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => {
+      process.removeListener('SIGINT', shutdown);
+      process.removeListener('SIGTERM', shutdown);
+    };
+    const shutdown = (): void => {
+      cleanup();
+      resolve();
+    };
+    worker.waitForExit().then(
+      () => {
+        cleanup();
+        resolve();
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+  });
 }
 
 function formatRecoveryWorkerStatus(status: RecoveryWorkerStatus): string {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -13,8 +13,11 @@ import type { BundledSkillsInstallMode } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import {
+  AUTO_FIX_WORKER_KIND,
   TaskRunner,
   acquireWorkerLock,
+  createWorkerRegistry,
+  registerAutoFixWorker,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
 } from '@invoker/execution-engine';
@@ -34,7 +37,6 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
-import { createAutoFixRecoveryTick, RECOVERY_WORKER_KIND } from './workers/auto-fix-recovery.js';
 import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
 import {
   collectRecoveryWorkerStatus,
@@ -417,89 +419,78 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
   }
 }
 
-/**
- * Worker kinds exposed to the CLI.
- */
-const HEADLESS_WORKER_KINDS: ReadonlyArray<{ kind: string; available: boolean; note: string }> = [
-  {
-    kind: 'autofix',
-    available: true,
-    note: 'scans persisted failed tasks and submits normal auto-fix command intents',
-  },
-];
-
 async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0] ?? 'list';
-  if (subCommand === 'autofix') {
-    // Single-instance guard across both doors (this dev door and the production
-    // `invoker-cli worker autofix`): refuse rather than run a recovery scan that
-    // competes with a worker already holding the cross-process lock.
-    let lock;
-    try {
-      lock = acquireWorkerLock({ kind: RECOVERY_WORKER_KIND, homeRoot: resolveInvokerHomeRoot(), logger: deps.logger });
-    } catch (err) {
-      if (err instanceof WorkerLockHeldError) {
-        // Surface via the app's throw-based error convention.
-        throw new Error(err.message);
-      }
-      throw err;
-    }
-    try {
-      const tick = createAutoFixRecoveryTick({
-        store: deps.persistence,
-        submitter: {
-          submit: (workflowId, priority, channel, mutationArgs) => (
-            deps.persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority)
-          ),
-        },
-        logger: deps.logger,
-        defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
-        getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
-      });
-      await tick({
-        identity: { kind: RECOVERY_WORKER_KIND, instanceId: 'headless-worker-autofix' },
-        reason: 'manual',
-        tickNumber: 1,
-      });
-    } finally {
-      // Release deterministically so a clean run never leaves a stale lock that
-      // blocks the next legitimate start.
-      lock.release();
-    }
-    process.stdout.write('Auto-fix worker scan completed.\n');
-    return;
-  }
-
-  if (subCommand !== 'list' && subCommand !== 'status') {
-    throw new Error(`Unknown worker sub-command: "${subCommand}". Use: autofix, list, status`);
-  }
+  const registry = registerAutoFixWorker(createWorkerRegistry());
 
   if (subCommand === 'list') {
     process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);
-    for (const worker of HEADLESS_WORKER_KINDS) {
-      const status = worker.available ? 'available' : 'unavailable';
-      process.stdout.write(`  ${worker.kind} — ${status} (${worker.note})\n`);
+    for (const worker of registry.list()) {
+      process.stdout.write(`  ${worker.kind} — available (${worker.note})\n`);
     }
     return;
   }
 
-  const flags = parseQueryFlags(args.slice(1));
-  const status = collectRecoveryWorkerStatus(deps.persistence);
-  const { formatAsJson, formatAsJsonl } = await import('./formatter.js');
-  switch (flags.output) {
-    case 'label':
-      process.stdout.write(`${status.workerId}\n`);
-      break;
-    case 'json':
-      process.stdout.write(formatAsJson(status) + '\n');
-      break;
-    case 'jsonl':
-      process.stdout.write(formatAsJsonl([status]) + '\n');
-      break;
-    default:
-      process.stdout.write(formatRecoveryWorkerStatus(status) + '\n');
-      break;
+  if (subCommand === 'status') {
+    const flags = parseQueryFlags(args.slice(1));
+    const status = collectRecoveryWorkerStatus(deps.persistence);
+    const { formatAsJson, formatAsJsonl } = await import('./formatter.js');
+    switch (flags.output) {
+      case 'label':
+        process.stdout.write(`${status.workerId}\n`);
+        break;
+      case 'json':
+        process.stdout.write(formatAsJson(status) + '\n');
+        break;
+      case 'jsonl':
+        process.stdout.write(formatAsJsonl([status]) + '\n');
+        break;
+      default:
+        process.stdout.write(formatRecoveryWorkerStatus(status) + '\n');
+        break;
+    }
+    return;
   }
+
+  const definition = registry.get(subCommand);
+  if (!definition) {
+    const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
+    throw new Error(`Unknown worker kind: "${subCommand}". Use: ${knownKinds}, list, status`);
+  }
+
+  let lock;
+  try {
+    lock = acquireWorkerLock({ kind: definition.kind, homeRoot: resolveInvokerHomeRoot(), logger: deps.logger });
+  } catch (err) {
+    if (err instanceof WorkerLockHeldError) {
+      // Surface via the app's throw-based error convention.
+      throw new Error(err.message);
+    }
+    throw err;
+  }
+  try {
+    const worker = definition.factory({
+      store: deps.persistence,
+      submitter: {
+        submit: (workflowId, priority, channel, mutationArgs) => (
+          deps.persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority)
+        ),
+      },
+      logger: deps.logger,
+      autoFix: {
+        defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
+        getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
+      },
+    });
+    await worker.tick('manual');
+    await worker.stop();
+  } finally {
+    // Release deterministically so a clean run never leaves a stale lock that
+    // blocks the next legitimate start.
+    lock.release();
+  }
+  const label = definition.kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : definition.kind;
+  process.stdout.write(`${label} worker scan completed.\n`);
 }
 
 function formatRecoveryWorkerStatus(status: RecoveryWorkerStatus): string {
@@ -609,7 +600,7 @@ ${BOLD}Lifecycle:${RESET}
   delete-all                                          Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
   open-terminal <taskId>                              Open OS terminal for a task
   slack                                               Start Slack bot (long-running)
-  worker [autofix|list|status]                        Run/list worker kinds (autofix scans failed tasks)
+  worker [kind|list|status]                           Run/list registry worker kinds (autofix scans failed tasks)
 
 ${BOLD}Deprecated${RESET} (use new names above):
   list → query workflows       status → query tasks       task-status → query task

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -18,10 +18,26 @@ function writeStandalonePlan(dir: string, body: string): string {
   return planPath;
 }
 
-function runCli(args: string[]) {
-  return spawnSync(process.execPath, [cliPath, ...args], {
-    cwd: repoRoot,
-    encoding: 'utf8',
+function runCli(args: string[]): Promise<{ status: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.once('error', rejectRun);
+    child.once('close', (status) => {
+      resolveRun({ status, stdout, stderr });
+    });
   });
 }
 
@@ -66,17 +82,42 @@ describe('invoker-cli', () => {
     expect(lockfile).toContain('  zod@4.4.3:');
   });
 
-  it('--help exits 0', () => {
-    const result = runCli(['--help']);
+  it('--help exits 0', async () => {
+    const result = await runCli(['--help']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('invoker-cli run <plan.yaml>');
   });
 
-  it('--help lists the MCP server command and JSON-only output contract', () => {
-    const result = runCli(['--help']);
+  it('--help lists the MCP server command and JSON-only output contract', async () => {
+    const result = await runCli(['--help']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('invoker-cli mcp');
     expect(result.stdout).toContain('Emit only a machine-readable result summary on stdout.');
+  });
+
+  it('lists worker kinds from the registry', async () => {
+    const output = captureProcessOutput();
+
+    const code = await main(['worker', 'list'], {
+      createMessageBus: () => {
+        throw new Error('worker list should not open IPC');
+      },
+    });
+
+    expect(code).toBe(0);
+    expect(output.stdout).toContain('Worker kinds');
+    expect(output.stdout).toContain('autofix');
+    output.restore();
+  });
+
+  it('rejects unknown worker kinds with a clear non-zero error', async () => {
+    const output = captureProcessOutput();
+
+    const code = await main(['worker', 'missing-kind']);
+
+    expect(code).toBe(1);
+    expect(output.stderr).toContain('Unknown worker kind: "missing-kind"');
+    output.restore();
   });
 
   it('mcp command starts the MCP server runner', async () => {
@@ -88,16 +129,16 @@ describe('invoker-cli', () => {
     expect(runMcpServer).toHaveBeenCalledTimes(1);
   });
 
-  it('runs the hello-world fixture with an isolated db dir', () => {
+  it('runs the hello-world fixture with an isolated db dir', async () => {
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-test-db-'));
-    const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir]);
+    const result = await runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir]);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('hello-from-invoker-cli');
   });
 
-  it('--json emits only a workflow result object on stdout', () => {
+  it('--json emits only a workflow result object on stdout', async () => {
     const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-json-db-'));
-    const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir, '--json']);
+    const result = await runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir, '--json']);
     expect(result.status).toBe(0);
     const json = JSON.parse(result.stdout);
     expect(json.workflow.status).toBe('success');
@@ -105,11 +146,11 @@ describe('invoker-cli', () => {
     expect(result.stderr).toBe('');
   });
 
-  it('invalid YAML exits non-zero with a validation error', () => {
+  it('invalid YAML exits non-zero with a validation error', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-invalid-'));
     const invalidPlan = join(dir, 'invalid.yaml');
     writeFileSync(invalidPlan, 'name: [broken\n', 'utf8');
-    const result = runCli(['run', invalidPlan, '--standalone', '--db-dir', join(dir, 'db')]);
+    const result = await runCli(['run', invalidPlan, '--standalone', '--db-dir', join(dir, 'db')]);
     expect(result.status).not.toBe(0);
     expect(result.stderr).toContain('Invalid YAML');
   });
@@ -212,7 +253,7 @@ tasks:
     output.restore();
   }, 60_000);
 
-  it('standalone prompt-only plans route through the execution engine', () => {
+  it('standalone prompt-only plans route through the execution engine', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-prompt-'));
     const planPath = writeStandalonePlan(dir, `name: Prompt-only standalone
 repoUrl: __REPO_ROOT__
@@ -224,7 +265,7 @@ tasks:
     executionAgent: missing-agent
 `);
 
-    const result = runCli(['run', planPath, '--standalone', '--db-dir', join(dir, 'db'), '--json']);
+    const result = await runCli(['run', planPath, '--standalone', '--db-dir', join(dir, 'db'), '--json']);
 
     expect(result.status).not.toBe(0);
     const json = JSON.parse(result.stdout);

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -110,6 +110,41 @@ describe('invoker-cli', () => {
     output.restore();
   });
 
+  it('lists only valid external worker config entries', async () => {
+    const previousInvokerDbDir = process.env.INVOKER_DB_DIR;
+    const homeRoot = mkdtempSync(join(tmpdir(), 'invoker-cli-worker-config-'));
+    process.env.INVOKER_DB_DIR = homeRoot;
+    writeFileSync(join(homeRoot, 'config.json'), JSON.stringify({
+      externalWorkers: [
+        { kind: 'valid-external', launch: { executable: '/usr/local/bin/valid-worker', args: ['--stdio'] } },
+        { kind: 'missing-executable', launch: { args: ['--stdio'] } },
+        { kind: 'bad-args', launch: { executable: '/usr/local/bin/bad-worker', args: [1] } },
+        null,
+      ],
+    }), 'utf8');
+    const output = captureProcessOutput();
+
+    try {
+      const code = await main(['worker', 'list'], {
+        createMessageBus: () => {
+          throw new Error('worker list should not open IPC');
+        },
+      });
+
+      expect(code).toBe(0);
+      expect(output.stdout).toContain('valid-external');
+      expect(output.stdout).not.toContain('missing-executable');
+      expect(output.stdout).not.toContain('bad-args');
+    } finally {
+      output.restore();
+      if (previousInvokerDbDir === undefined) {
+        delete process.env.INVOKER_DB_DIR;
+      } else {
+        process.env.INVOKER_DB_DIR = previousInvokerDbDir;
+      }
+    }
+  });
+
   it('rejects unknown worker kinds with a clear non-zero error', async () => {
     const output = captureProcessOutput();
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,13 @@ import {
   WorkerLockHeldError,
   registerBuiltinAgents,
   type WorkerDefinition,
+  type WorkerRegistry,
 } from '@invoker/execution-engine';
+import {
+  isExternalWorkerRuntime,
+  registerExternalWorkers,
+  type ExternalWorkerRuntime,
+} from '../../app/src/external-worker-loader.js';
 import {
   IpcBus,
   TransportError,
@@ -65,6 +71,15 @@ type CliDeps = {
   runMcpServer?: () => Promise<void>;
 };
 
+type ExternalWorkerConfig = {
+  kind: string;
+  launch: {
+    executable: string;
+    args?: string[];
+    cwd?: string;
+  };
+};
+
 type CliRuntimeConfig = {
   defaultBranch?: string;
   maxConcurrency?: number;
@@ -99,6 +114,7 @@ type CliRuntimeConfig = {
     poolId: string;
     strategy?: 'enforce' | 'route';
   }>;
+  externalWorkers?: ExternalWorkerConfig[];
 };
 
 const silentLogger: Logger = {
@@ -120,7 +136,7 @@ function usage(): string {
     '  invoker-cli doctor [--fix] [--json]',
     '  invoker-cli setup [slack] [--check]',
     '  invoker-cli mcp',
-    '  invoker-cli worker [autofix|list]',
+    '  invoker-cli worker [kind|list]',
     '  invoker-cli --help',
     '  invoker-cli --version',
     '',
@@ -443,11 +459,33 @@ async function createDefaultMessageBus(): Promise<MessageBus> {
   return bus;
 }
 
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function isExternalWorkerConfig(value: unknown): value is ExternalWorkerConfig {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const worker = value as { kind?: unknown; launch?: unknown };
+  if (typeof worker.kind !== 'string') return false;
+  if (!worker.launch || typeof worker.launch !== 'object' || Array.isArray(worker.launch)) return false;
+
+  const launch = worker.launch as { executable?: unknown; args?: unknown; cwd?: unknown };
+  return (
+    typeof launch.executable === 'string'
+    && (launch.args === undefined || isStringArray(launch.args))
+    && (launch.cwd === undefined || typeof launch.cwd === 'string')
+  );
+}
+
 /**
  * Read the auto-fix policy knobs from the shared Invoker config so the CLI door
  * drives the engine with the same retry budget / agent the GUI owner uses.
  */
-function readAutoFixWorkerConfig(homeRoot: string): { autoFixRetries?: number; autoFixAgent?: string } {
+function readWorkerConfig(homeRoot: string): {
+  autoFixRetries?: number;
+  autoFixAgent?: string;
+  externalWorkers?: ExternalWorkerConfig[];
+} {
   const configPath = join(homeRoot, 'config.json');
   if (!existsSync(configPath)) return {};
   try {
@@ -455,6 +493,9 @@ function readAutoFixWorkerConfig(homeRoot: string): { autoFixRetries?: number; a
     return {
       autoFixRetries: typeof parsed.autoFixRetries === 'number' ? parsed.autoFixRetries : undefined,
       autoFixAgent: typeof parsed.autoFixAgent === 'string' ? parsed.autoFixAgent : undefined,
+      externalWorkers: Array.isArray(parsed.externalWorkers)
+        ? parsed.externalWorkers.filter(isExternalWorkerConfig)
+        : undefined,
     };
   } catch {
     return {};
@@ -465,12 +506,44 @@ function workerDisplayName(kind: string): string {
   return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind;
 }
 
-function printWorkerKinds(): void {
-  const registry = registerAutoFixWorker(createWorkerRegistry());
+function printWorkerKinds(registry: WorkerRegistry): void {
   process.stdout.write('Worker kinds\n');
   for (const worker of registry.list()) {
     process.stdout.write(`  ${worker.kind} — available (${worker.note})\n`);
   }
+}
+
+function waitForShutdownSignal(): Promise<void> {
+  return new Promise<void>((resolveShutdown) => {
+    const shutdown = (): void => resolveShutdown();
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+  });
+}
+
+async function waitForExternalWorkerShutdown(worker: ExternalWorkerRuntime): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const cleanup = (): void => {
+      process.removeListener('SIGINT', shutdown);
+      process.removeListener('SIGTERM', shutdown);
+    };
+    const shutdown = (): void => {
+      cleanup();
+      resolve();
+    };
+    worker.waitForExit().then(
+      () => {
+        cleanup();
+        resolve();
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+  });
 }
 
 /**
@@ -481,10 +554,14 @@ function printWorkerKinds(): void {
  * foreground lifetime — owner discovery, connect message, the SIGINT/SIGTERM
  * block, and a deterministic stop.
  */
-async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise<number> {
+async function runWorker(
+  definition: WorkerDefinition,
+  bus: MessageBus,
+  workerConfig: ReturnType<typeof readWorkerConfig>,
+): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
-  const { autoFixRetries, autoFixAgent } = readAutoFixWorkerConfig(homeRoot);
+  const { autoFixRetries, autoFixAgent } = workerConfig;
 
   // Single-instance guard: refuse if another worker of this kind (this door or
   // the dev `--headless worker <kind>` door) already holds the cross-process
@@ -526,11 +603,11 @@ async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise
     const ownerSuffix = owner?.ownerId ? ` to owner ${owner.ownerId}` : '';
     process.stdout.write(`${workerDisplayName(definition.kind)} worker connected${ownerSuffix}.\n`);
 
-    await new Promise<void>((resolveShutdown) => {
-      const shutdown = (): void => resolveShutdown();
-      process.once('SIGINT', shutdown);
-      process.once('SIGTERM', shutdown);
-    });
+    if (isExternalWorkerRuntime(worker)) {
+      await waitForExternalWorkerShutdown(worker);
+    } else {
+      await waitForShutdownSignal();
+    }
     await worker.stop();
   } finally {
     // Release deterministically so a clean shutdown never leaves a stale lock
@@ -557,9 +634,14 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     }
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';
-      const registry = registerAutoFixWorker(createWorkerRegistry());
+      const homeRoot = resolveInvokerHomeRoot();
+      const workerConfig = readWorkerConfig(homeRoot);
+      const registry = registerExternalWorkers(
+        registerAutoFixWorker(createWorkerRegistry()),
+        workerConfig.externalWorkers,
+      );
       if (subcommand === 'list') {
-        printWorkerKinds();
+        printWorkerKinds(registry);
         return 0;
       }
       const definition = registry.get(subcommand);
@@ -568,7 +650,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
         throw new Error(`Unknown worker kind: "${subcommand}". Usage: invoker-cli worker <${knownKinds}|list>`);
       }
       bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());
-      return await runWorker(definition, bus);
+      return await runWorker(definition, bus, workerConfig);
     }
     const parsed = parseArgs(argv);
     if (!parsed.command || parsed.command === '--help') {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,14 +5,16 @@ import { pathToFileURL } from 'node:url';
 import { resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
 import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
 import {
+  AUTO_FIX_WORKER_KIND,
   ExecutorRegistry,
   TaskRunner,
   WorktreeExecutor,
-  createRecoveryWorker,
   acquireWorkerLock,
-  RECOVERY_WORKER_KIND,
+  createWorkerRegistry,
+  registerAutoFixWorker,
   WorkerLockHeldError,
   registerBuiltinAgents,
+  type WorkerDefinition,
 } from '@invoker/execution-engine';
 import {
   IpcBus,
@@ -118,7 +120,7 @@ function usage(): string {
     '  invoker-cli doctor [--fix] [--json]',
     '  invoker-cli setup [slack] [--check]',
     '  invoker-cli mcp',
-    '  invoker-cli worker autofix',
+    '  invoker-cli worker [autofix|list]',
     '  invoker-cli --help',
     '  invoker-cli --version',
     '',
@@ -127,7 +129,7 @@ function usage(): string {
     '  doctor          Validate tools, config, and your default planning preset.',
     '  setup [slack]    Validate the environment, then optionally configure Slack.',
     '  mcp             Start the Invoker MCP stdio server.',
-    '  worker autofix  Run the shared auto-fix recovery worker in the foreground.',
+    '  worker [kind|list]  Run a registry-selected worker or list available worker kinds.',
     '',
     'Options:',
     '  --live           Require a running Invoker UI owner and submit over IPC.',
@@ -459,27 +461,38 @@ function readAutoFixWorkerConfig(homeRoot: string): { autoFixRetries?: number; a
   }
 }
 
+function workerDisplayName(kind: string): string {
+  return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind;
+}
+
+function printWorkerKinds(): void {
+  const registry = registerAutoFixWorker(createWorkerRegistry());
+  process.stdout.write('Worker kinds\n');
+  for (const worker of registry.list()) {
+    process.stdout.write(`  ${worker.kind} — available (${worker.note})\n`);
+  }
+}
+
 /**
- * Run the auto-fix recovery worker in the foreground. There is exactly one
- * auto-fix engine: this builds the shared `createRecoveryWorker` from
- * `@invoker/execution-engine` (the same engine the app door uses) instead of a
- * private poll loop, so the two doors can never run competing scans. The shared
- * engine owns the scan, cadence, and lifecycle-wakeup subscription; the CLI owns
- * only the foreground lifetime — owner discovery, connect message, the
- * SIGINT/SIGTERM block, and a deterministic stop.
+ * Run a registry-selected worker in the foreground. There is exactly one
+ * auto-fix engine: the built-in registry entry builds the shared
+ * `createRecoveryWorker` from `@invoker/execution-engine` instead of a private
+ * poll loop, so the two doors can never run competing scans. The CLI owns the
+ * foreground lifetime — owner discovery, connect message, the SIGINT/SIGTERM
+ * block, and a deterministic stop.
  */
-async function runAutoFixWorker(bus: MessageBus): Promise<number> {
+async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
   const { autoFixRetries, autoFixAgent } = readAutoFixWorkerConfig(homeRoot);
 
-  // Single-instance guard: refuse if another auto-fix worker (this door or the
-  // dev `--headless worker autofix` door) already holds the cross-process lock,
-  // rather than spawning a second recovery loop that competes over the same
-  // failed tasks.
+  // Single-instance guard: refuse if another worker of this kind (this door or
+  // the dev `--headless worker <kind>` door) already holds the cross-process
+  // lock, rather than spawning a second recovery loop that competes over the
+  // same failed tasks.
   let lock;
   try {
-    lock = acquireWorkerLock({ kind: RECOVERY_WORKER_KIND, homeRoot, logger: silentLogger });
+    lock = acquireWorkerLock({ kind: definition.kind, homeRoot, logger: silentLogger });
   } catch (err) {
     if (err instanceof WorkerLockHeldError) {
       process.stderr.write(`${err.message}\n`);
@@ -495,19 +508,15 @@ async function runAutoFixWorker(bus: MessageBus): Promise<number> {
   // always closed even if construction or start throws (otherwise the SQLite
   // handle leaks when control unwinds to main()'s catch).
   try {
-    // The CLI owns the foreground signals so shutdown ordering is deterministic
-    // (signal -> unblock -> engine.stop() -> close); the engine does not also
-    // install its own handlers.
-    const worker = createRecoveryWorker({
+    const worker = definition.factory({
       logger: silentLogger,
-      installSignalHandlers: false,
       messageBus: bus,
+      store: persistence,
+      submitter: {
+        submit: (workflowId, priority, channel, mutationArgs) =>
+          persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority),
+      },
       autoFix: {
-        store: persistence,
-        submitter: {
-          submit: (workflowId, priority, channel, mutationArgs) =>
-            persistence.enqueueWorkflowMutationIntent(workflowId, channel, mutationArgs, priority),
-        },
         defaultAutoFixRetries: autoFixRetries,
         getAutoFixAgent: () => autoFixAgent,
       },
@@ -515,7 +524,7 @@ async function runAutoFixWorker(bus: MessageBus): Promise<number> {
 
     worker.start();
     const ownerSuffix = owner?.ownerId ? ` to owner ${owner.ownerId}` : '';
-    process.stdout.write(`Auto-fix worker connected${ownerSuffix}.\n`);
+    process.stdout.write(`${workerDisplayName(definition.kind)} worker connected${ownerSuffix}.\n`);
 
     await new Promise<void>((resolveShutdown) => {
       const shutdown = (): void => resolveShutdown();
@@ -529,7 +538,7 @@ async function runAutoFixWorker(bus: MessageBus): Promise<number> {
     lock.release();
     persistence.close();
   }
-  process.stdout.write('Auto-fix worker stopped.\n');
+  process.stdout.write(`${workerDisplayName(definition.kind)} worker stopped.\n`);
   return 0;
 }
 
@@ -547,12 +556,19 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
       return 0;
     }
     if (argv[0] === 'worker') {
-      const subcommand = argv[1];
-      if (subcommand !== 'autofix') {
-        throw new Error(`Unknown worker subcommand: ${subcommand ?? '(none)'}. Usage: invoker-cli worker autofix`);
+      const subcommand = argv[1] ?? 'list';
+      const registry = registerAutoFixWorker(createWorkerRegistry());
+      if (subcommand === 'list') {
+        printWorkerKinds();
+        return 0;
+      }
+      const definition = registry.get(subcommand);
+      if (!definition) {
+        const knownKinds = registry.list().map((worker) => worker.kind).join(', ');
+        throw new Error(`Unknown worker kind: "${subcommand}". Usage: invoker-cli worker <${knownKinds}|list>`);
       }
       bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());
-      return await runAutoFixWorker(bus);
+      return await runWorker(definition, bus);
     }
     const parsed = parseArgs(argv);
     if (!parsed.command || parsed.command === '--help') {


### PR DESCRIPTION
## Summary

A loader turns declared external workers into supervised processes.

It reads the external-worker config and adds each entry to the worker registry as a definition. Running that definition starts the configured process.

The process lives for the foreground life of the worker door and is released on stop, held under the per-kind lock, just like the built-in worker.

Both worker doors call the loader when they build the registry.

An external worker reaches Invoker only over the existing owner channel and the normal action path. No third-party code runs inside Invoker.

<details>
<summary>Review metadata</summary>

Review Claim: A loader reads the external-worker config and adds each declared worker to the registry as a definition that starts and supervises its own process.

Review Lane: behavior

Review Unit: routing

Safety Invariant: A registered external worker runs only when its kind starts, lives and dies with that foreground process, is released on stop under the per-kind lock, and runs no third-party code inside Invoker.

Slice Rationale: Bridging config to the registry is one claim, kept apart from the config fields it reads and from the end-to-end proof.

</details>

## Non-goals

This slice does not add a sample worker or an end-to-end proof; that is the next slice. It does not change built-in worker behavior.

## Test Plan

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/cli && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for externally configured worker runtimes in worker commands.
  * Worker listing now includes valid external worker kinds from configuration.
  * Headless worker execution now handles both built-in and external runtimes correctly.

* **Bug Fixes**
  * Duplicate external worker kinds are now rejected.
  * Invalid external worker entries are ignored when listing available workers.
  * External workers shut down more reliably, including signal handling and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->