### PR TITLE
[PR Policy](1) Require visual proof for user-visible changes

### DIFF
--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -105,7 +105,7 @@ Required when the diff changes UI-impacting files. Include before/after screensh
 
 If the change is small and has no architectural impact, omit `## Architecture` rather than forcing filler.
 
-If the change touches UI-impacting files, use `skills/visual-proof/SKILL.md` first and include its screenshot/video markdown in `## Visual Proof`. UI-impacting files include `packages/ui/**`, Electron window lifecycle files, preload, main process window wiring, and app menu changes.
+If the change is UI-impacting, use `skills/visual-proof/SKILL.md` first and include its screenshot/video markdown in `## Visual Proof`. UI-impacting means the user-visible experience changes, even when no file under `packages/ui/**` changes. This includes `packages/ui/**`, Electron window lifecycle files, preload, main process window wiring, app menu changes, task status changes, task error or output text shown in panels, approval/reject behavior, workflow state shown in the DAG or inspector, and web-surface output.
 
 Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Review Claim / ## Review Lane / ## Safety Invariant / ## Slice Rationale / ## Non-goals / ## Test Plan / ## Revert Plan` as the floor, add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.
 
@@ -189,7 +189,7 @@ Manual `gh pr edit` is a last-resort escape hatch only when `create-pr` itself i
 - ensure revert guidance is honest
 - validate the body with `node scripts/validate-pr-body.mjs --body-file <file>`
 - for stacked PRs, update title/body through `node scripts/create-pr.mjs --update-existing ...`, not `gh pr edit`
-- for UI-impacting diffs, include `## Visual Proof` with screenshot or video proof before `node scripts/create-pr.mjs`
+- for UI-impacting diffs, include `## Visual Proof` with screenshot or video proof before `node scripts/create-pr.mjs`; classify by user-visible behavior, not by path alone
 
 If you include `## Architecture`, keep the diagrams renderable by GitHub Mermaid.
 Always quote labels that contain prose, punctuation, or code-ish text such as `reviewGate.artifacts[]`.


### PR DESCRIPTION
## Summary

Visual proof is now required when a PR changes what users see, not just when it edits UI files.

The old wording let app-side error text and approval flows skip screenshots. The new wording names those cases directly.

This keeps the rule in the make-pr skill, where PR creation already checks visual proof.

<details>
<summary>Review metadata</summary>

Review Claim: The make-pr skill now requires visual proof for user-visible behavior changes regardless of file path.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This changes PR guidance only; no runtime code path changes.

Slice Rationale: The missed screenshot came from a PR workflow rule gap, so the permanent fix belongs in the PR skill.

</details>

## Non-goals

This does not change PR validation code.

This does not add new screenshot capture tooling.

## Test Plan

- [x] `git diff --check HEAD`
- [x] `pnpm run test:make-pr-skill`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/visual-proof-rule-pr.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert ef380aa63`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when visual proof is needed in PR descriptions, basing it on user-visible behavior instead of file paths.
  * Expanded the definition of UI-impacting changes to cover more app surfaces, including window behavior, menus, workflow views, and visible task/status/output updates.
  * Added a checklist item to ensure these changes are categorized and ordered consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->