### PR TITLE
[Detached Workflow Base](1) Prove stale stack base

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -1438,6 +1438,40 @@ describe('Orchestrator', () => {
         },
       ]);
     });
+    it.fails('falls back managed stack base when detached upstream metadata is unavailable', () => {
+      orchestrator.loadPlan({
+        name: 'fallback-upstream',
+        baseBranch: 'master',
+        featureBranch: 'plan/fallback-upstream',
+        tasks: [{ id: 'verify-fallback', description: 'upstream prerequisite' }],
+      });
+      const upstreamWfId = sid(orchestrator, 0, 'verify-fallback').split('/')[0]!;
+
+      orchestrator.loadPlan({
+        name: 'fallback-target',
+        baseBranch: 'plan/fallback-upstream',
+        featureBranch: 'plan/fallback-target',
+        tasks: [
+          {
+            id: 'fallback-leaf',
+            description: 'target waits on upstream',
+            externalDependencies: [{ workflowId: upstreamWfId, gatePolicy: 'review_ready' }],
+          },
+        ],
+      });
+      const targetTaskId = sid(orchestrator, 1, 'fallback-leaf');
+      const targetWfId = targetTaskId.split('/')[0]!;
+      const upstreamWorkflow = persistence.workflows.get(upstreamWfId)!;
+      upstreamWorkflow.baseBranch = undefined;
+      upstreamWorkflow.featureBranch = undefined;
+
+      orchestrator.detachWorkflow(targetWfId, upstreamWfId);
+
+      const targetWorkflow = persistence.loadWorkflow(targetWfId)!;
+      expect(targetWorkflow.externalDependencies).toBeUndefined();
+      expect(targetWorkflow.baseBranch).toBe('master');
+    });
+
 
     it('voids a running target workflow and its descendants back to pending without auto-starting them', () => {
       orchestrator.loadPlan({

--- a/scripts/repro/repro-detached-workflow-stale-stack-base.sh
+++ b/scripts/repro/repro-detached-workflow-stale-stack-base.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Repro script: detach can leave a workflow based on a deleted Invoker stack branch.
+#
+# This runs the workflow-core regression that sets up:
+#   1. an upstream workflow,
+#   2. a downstream workflow whose baseBranch is a plan/* stack branch,
+#   3. missing upstream branch metadata, matching stale/deleted lineage,
+#   4. detachWorkflow(downstream, upstream).
+#
+# Broken behavior:
+#   downstream keeps baseBranch=plan/deleted-upstream and merge checkout later fails.
+#
+# Correct behavior:
+#   downstream clears the dependency and falls back to baseBranch=master.
+#
+# Usage:
+#   bash scripts/repro/repro-detached-workflow-stale-stack-base.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TEST_NAME="falls back managed stack base when detached upstream metadata is unavailable"
+
+cd "$REPO_ROOT/packages/workflow-core"
+pnpm exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts -t "$TEST_NAME"


### PR DESCRIPTION
## Summary

This adds a repro for detached workflows that keep an old stack branch as their base.

The case uses `it.fails`, so this proof slice passes before the behavior fix lands.

A small repro script runs just this case for fast local confirmation.

<details>
<summary>Review metadata</summary>

Review Claim: The managed-base bug is covered by a focused failing regression case.

Review Lane: proof

Review Unit: proof

Safety Invariant: The new case uses `it.fails`, so it proves the current bug without touching runtime code.

Slice Rationale: This lands before the fix so reviewers can see the broken state independently.

</details>

## Non-goals

This does not alter detach behavior, merge behavior, or workflow scheduling.

## Test Plan

- [x] `bash scripts/repro/repro-detached-workflow-stale-stack-base.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 77fbf433a`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for detaching a workflow when upstream branch metadata is missing, confirming the workflow’s external dependency is cleared and a fallback base branch is used.
* **Documentation**
  * Added a reproducible script to run the specific detachment/fallback scenario in isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->