### PR TITLE
[Remove default full-suite gates](1) Rewrite positive plan-to-invoker fixture corpus

### DIFF
--- a/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml
@@ -1,7 +1,9 @@
 # Feature Implementation Plan
 # Source: examples.md Section 2
 # Description: A plan that adds a feature using prompt tasks for implementation and command tasks for verification.
-# Shows the standard pattern: implement → focused verification → final full-suite gate.
+# Shows the standard pattern: implement → focused verification.
+# Focused proof tasks (`cd packages/utils && pnpm test`, `cd packages/utils && pnpm build`) are the
+# terminal verification; a final `pnpm run test:all` gate is intentionally omitted.
 #
 # Uses `onFinish: merge` (the default) to automatically merge changes into the base branch after all tasks complete.
 # Critical pattern: Every prompt task that modifies code MUST have a corresponding command task that runs tests to verify the change.
@@ -61,8 +63,3 @@ tasks:
     description: "Verify the package builds without errors"
     command: "cd packages/utils && pnpm build 2>&1"
     dependencies: [verify-tests-pass]
-
-  - id: final-regression
-    description: "Run the full repository test suite as the final regression gate"
-    command: "pnpm run test:all"
-    dependencies: [implement-formatter, write-tests, verify-tests-pass, verify-build]

--- a/skills/plan-to-invoker/fixtures/positive/03-multi-step-refactor-worktrees.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/03-multi-step-refactor-worktrees.yaml
@@ -66,8 +66,3 @@ tasks:
     description: "Run full config package test suite"
     command: "cd packages/config && pnpm test 2>&1"
     dependencies: [add-schema-types]
-
-  - id: final-regression
-    description: "Run the full repository test suite as the final regression gate"
-    command: "pnpm run test:all"
-    dependencies: [extract-validator, add-validator-tests, verify-validator, add-schema-types, verify-all-tests]

--- a/skills/plan-to-invoker/fixtures/positive/04-large-refactor-pull-request.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/04-large-refactor-pull-request.yaml
@@ -157,8 +157,3 @@ tasks:
     description: "Build all packages to verify no breakage"
     command: "pnpm build 2>&1"
     dependencies: [verify-core-tests]
-
-  - id: final-regression
-    description: "Run the full repository test suite as the final regression gate"
-    command: "pnpm run test:all"
-    dependencies: [scaffold-package, move-types, move-dag-utils, extract-action-graph, update-graph-index, refactor-state-machine, write-graph-tests, verify-graph-tests, verify-core-tests, verify-full-build]

--- a/skills/plan-to-invoker/fixtures/positive/05-ui-change-with-visual-proof.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/05-ui-change-with-visual-proof.yaml
@@ -62,8 +62,3 @@ tasks:
     description: "Build UI and app packages then capture after-state screenshots"
     command: "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after"
     dependencies: [fix-sidebar-transition, add-visual-proof-test]
-
-  - id: verify-regression-suite
-    description: "Run the full repository test suite as the final regression gate"
-    command: "pnpm run test:all"
-    dependencies: [add-visual-proof-test, fix-sidebar-transition, run-sidebar-unit-tests, capture-visual-proof]

--- a/skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml
@@ -36,8 +36,3 @@ tasks:
     description: "Run the plan-to-invoker fixture tests"
     command: "bash skills/plan-to-invoker/scripts/test-fixtures.sh"
     dependencies: [update-dogfood-guidance]
-
-  - id: final-regression
-    description: "Run the full repository test suite as the final regression gate"
-    command: "pnpm run test:all"
-    dependencies: [update-dogfood-guidance, verify-skill-fixtures]

--- a/skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml
@@ -215,23 +215,23 @@ tasks:
   - id: final-regression
     description: |
       Review claim:
-      - Run the terminal full-suite regression gate for the layered prompt-edit stack.
+      - Run focused app-package regression proof for the layered prompt-edit stack.
       Safety invariant:
       - The command changes no production code and depends on every earlier task.
       Slice rationale:
-      - Full-suite validation belongs at the terminal workflow layer.
+      - Focused proof for the changed app surface belongs at the terminal workflow layer.
       Architectural effect:
-      - No architecture changes; validates the integrated prompt-edit stack.
-      Run the full repository test suite as the terminal regression gate.
+      - No architecture changes; exercises the integrated prompt-edit stack through the app package tests.
+      Run focused app-package proof as the terminal regression gate.
       Goal:
-      - Run the full repository test suite as the terminal regression gate.
+      - Run focused app-package proof as the terminal regression gate.
       Motivation:
-      - Validate all prompt-edit slices together after focused regressions exist.
+      - Validate all prompt-edit slices together with focused proof that exercises the changed behavior, without invoking a full-suite gate.
       Alternative considerations:
-      - Option A (chosen): one terminal full-suite gate.
-      - Option B: repeat full-suite verification in every slice.
+      - Option A (chosen): focused app-package proof for the prompt-edit path.
+      - Option B: terminal full-suite gate (`pnpm run test:all`).
       Implementation details:
-      - Execute `pnpm run test:all` after every earlier task completes.
+      - Execute `cd packages/app && pnpm test 2>&1` after every earlier task completes.
       Layer: e2e_regression
       Feature state: active
       Files:
@@ -239,6 +239,6 @@ tasks:
       Change types:
       - none
       Acceptance criteria:
-      - Ensure the full repository test suite passes after all prompt-edit slices land.
-    command: "pnpm run test:all"
+      - Ensure the focused app-package regression passes after all prompt-edit slices land.
+    command: "cd packages/app && pnpm test 2>&1"
     dependencies: [prompt-edit-contact-surface, app-bridge-and-owner-delegation, ui-prompt-editing-activation, app-and-e2e-regressions]


### PR DESCRIPTION
## Summary

The positive fixture corpus under `skills/plan-to-invoker/fixtures/positive/` no longer teaches `pnpm run test:all` as the standard ending for a plan.

Each fixture now finishes on its own focused verification step tied to the behavior it changed, matching the focused-proof default the plan-to-invoker skill already documents.

The fixture set stays honest because every implementation task still ships a deterministic check, just one scoped to the actual diff instead of the entire repository.

<details>
<summary>Review metadata</summary>

Review Claim: The positive plan-to-invoker fixture corpus stops modeling a blanket `pnpm run test:all` ending and uses focused proof instead.

Review Lane: docs

Review Unit: docs

Safety Invariant: This slice edits only YAML files under `skills/plan-to-invoker/fixtures/positive/`; no runtime code moves.

Slice Rationale: The fixture corpus is the executable source material for planning guidance, so the corrected policy lands here before the guard script or the hardening templates are touched.

</details>

## Non-goals

- Do not edit the focused suite under `scripts/test-plan-to-invoker-skill.sh`.
- Do not change the checked-in hardening templates under `plans/`.
- Do not touch inline fixture YAML embedded in `skills/plan-to-invoker/scripts/test-fixtures.sh`.

## Test Plan

- [ ] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated several plan fixtures to use narrower verification steps, focusing on package-level tests and build checks.
  * Some workflows now end earlier, after the main verification step, instead of continuing to a full final regression run.

* **Bug Fixes**
  * Aligned one prompt-edit flow with a more focused regression check, replacing broad repository-wide testing with a targeted app test run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->