### PR TITLE
[Remove default full-suite gates](2) Rewrite inline fixture YAML in the harness

### DIFF
--- a/skills/plan-to-invoker/scripts/test-fixtures.sh
+++ b/skills/plan-to-invoker/scripts/test-fixtures.sh
@@ -928,32 +928,32 @@ tasks:
       - Verify app tests pass and output remains stable.
       Assume no prior context. Modify packages/app/src/main.ts and packages/app/src/headless.ts only. Pass condition: exits 0 after the bridge tests pass.
     dependencies: []
-  - id: final-regression
+  - id: verify-bridge
     description: |
       Review claim:
-      - Run final full-suite regression gate.
+      - Run focused verification for the app bridge change.
       Review lane:
       - proof
       Safety invariant:
       - This command changes no production code.
       Slice rationale:
-      - Keep the terminal full-suite gate separate from implementation.
+      - Keep terminal proof scoped to the changed package.
       Architectural effect:
       - No architecture change.
       Goal:
-      - Run final full-suite regression gate.
+      - Run focused verification for the app bridge change.
       Motivation:
-      - Ensure bridge changes remain stable.
+      - Prove the bridge wiring stays deterministic without a repo-wide gate.
       Alternative considerations:
-      - Option A (chosen): full repository regression.
-      - Option B: package-only checks.
+      - Option A (chosen): focused package-level verification.
+      - Option B: full repository regression.
       Implementation details:
-      - Execute root-level test gate after implementation task.
+      - Execute a deterministic proof command for packages/app after implementation.
       Non-goals:
       - Do not modify source files.
       Layer: app_regression
       Feature state: active
-    command: "pnpm run test:all"
+    command: "cd packages/app && pnpm test"
     dependencies: [implement-bridge]
 EOF
 
@@ -1097,32 +1097,32 @@ tasks:
       - Verify `cd packages/execution-engine && pnpm test` exits 0.
       - Use exit code 0 as the pass condition.
     dependencies: []
-  - id: final-regression
+  - id: verify-runtime-flow
     description: |
       Review claim:
-      - Run the terminal full-suite regression gate for runtime changes.
+      - Run focused verification for the task-runner change.
       Review lane:
       - proof
       Safety invariant:
       - This command changes no production code and depends on runtime implementation.
       Slice rationale:
-      - Terminal validation is separate from implementation work.
+      - Terminal proof stays scoped to the changed package.
       Architectural effect:
-      - No architecture changes; validates integrated behavior.
+      - No architecture changes; validates the runtime path deterministically.
       Goal:
-      - Run final full-suite regression gate.
+      - Run focused verification for the task-runner change.
       Motivation:
-      - Ensure implementation updates remain stable.
+      - Prove the runtime updates stay deterministic without a repo-wide gate.
       Alternative considerations:
-      - Option A (chosen): full repository regression.
-      - Option B: package-only checks.
+      - Option A (chosen): focused package-level verification.
+      - Option B: full repository regression.
       Implementation details:
-      - Execute root-level test gate after implementation task.
+      - Execute a deterministic proof command for packages/execution-engine after implementation.
       Non-goals:
       - Do not modify source files.
       Layer: app_regression
       Feature state: active
-    command: "pnpm run test:all"
+    command: "cd packages/execution-engine && pnpm test"
     dependencies: [implement-runtime-flow]
 EOF
 


### PR DESCRIPTION
## Summary

The inline fixture YAML embedded in `skills/plan-to-invoker/scripts/test-fixtures.sh` now matches the focused-proof default instead of normalizing `pnpm run test:all` as the standard ending.

This is the second normative source of plan-to-invoker fixture YAML, and it has to agree with the corrected positive fixture files so the test harness stops validating stale shape.

Negative fixtures that intentionally exercise the old anti-pattern stay as-is, so the harness can still prove the guard rejects regressions.

<details>
<summary>Review metadata</summary>

Review Claim: Inline fixture YAML in the plan-to-invoker test harness lines up with the focused-proof default and stops teaching a blanket full-suite ending.

Review Lane: docs

Review Unit: docs

Safety Invariant: This slice edits only the inline YAML strings embedded in `skills/plan-to-invoker/scripts/test-fixtures.sh`; the surrounding shell harness structure is untouched.

Slice Rationale: The fixture harness duplicates the positive-fixture policy, so it has to be repaired right after the positive fixtures and before the hardening templates or the guard script.

</details>

## Non-goals

- Do not change the shell harness structure beyond the embedded fixture YAML it validates.
- Do not edit the checked-in hardening templates under `plans/`.
- Do not modify `scripts/test-plan-to-invoker-skill.sh`.

## Test Plan

- [ ] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated verification steps to use package-scoped test commands instead of a repo-wide test gate in affected scenarios.
  * Improved fixture coverage for prompt-task planning flows by reflecting more targeted validation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->