### PR TITLE
[Remove default full-suite gates](3) Normalize plan-to-invoker hardening templates

### DIFF
--- a/plans/plan-to-invoker-deterministic-step-1-validator.yaml
+++ b/plans/plan-to-invoker-deterministic-step-1-validator.yaml
@@ -75,42 +75,21 @@ tasks:
 
   - id: run-plan-to-invoker-script-tests
     description: |
-      Run existing plan-to-invoker script test suite.
+      Run existing plan-to-invoker script test suite as the terminal focused proof.
       Goal:
-      Confirm script-level regressions are not introduced.
+      Confirm validator-scoped regressions are not introduced.
       Motivation:
-      Preserve end-to-end confidence after validator and test changes.
+      The plan-to-invoker script suite already exercises the changed validator surface,
+      so it is the deterministic proof for this slice.
       Alternative considerations:
       - run only a subset of script tests.
-      - defer script-suite verification to later workflows.
+      - chain an unscoped `pnpm run test:all` gate after this task.
       Implementation details:
       - execute the script test suite and require zero failures.
-      - keep this gate before final full-suite regression.
+      - keep this task terminal so the slice proves the validator without a blanket full-suite gate.
       Layer: app_regression
       Feature state: active
     command: "bash scripts/test-plan-to-invoker-skill.sh"
     poolId: remote_digital_ocean_1_pool
     dependencies:
       - add-validator-tests
-
-  - id: post-fix-regression
-    description: |
-      Run the full repository test suite as post-fix regression.
-      Goal:
-      Validate repository-wide stability after validator hardening.
-      Motivation:
-      Catch integration regressions outside the plan-to-invoker script surface.
-      Alternative considerations:
-      - rely only on targeted script tests.
-      - run package-level tests without full-suite coverage.
-      Implementation details:
-      - execute `pnpm run test:all` as the final gate.
-      - require dependencies on all prior implementation/verification tasks.
-      Layer: app_regression
-      Feature state: active
-    command: "pnpm run test:all"
-    poolId: remote_digital_ocean_1_pool
-    dependencies:
-      - implement-typed-plan-validator
-      - add-validator-tests
-      - run-plan-to-invoker-script-tests

--- a/plans/plan-to-invoker-deterministic-step-2-doctor.template.yaml
+++ b/plans/plan-to-invoker-deterministic-step-2-doctor.template.yaml
@@ -40,17 +40,8 @@ tasks:
       - add-skill-doctor-script
 
   - id: run-script-tests
-    description: "Run plan-to-invoker script tests after doctor integration"
+    description: "Terminal focused proof: run plan-to-invoker script tests after doctor integration"
     command: "bash scripts/test-plan-to-invoker-skill.sh"
     poolId: remote_digital_ocean_1_pool
     dependencies:
       - wire-skill-doctor-into-skill-doc
-
-  - id: post-fix-regression
-    description: "Run the full repository test suite as post-fix regression"
-    command: "pnpm run test:all"
-    poolId: remote_digital_ocean_1_pool
-    dependencies:
-      - add-skill-doctor-script
-      - wire-skill-doctor-into-skill-doc
-      - run-script-tests

--- a/plans/plan-to-invoker-deterministic-step-3-visual-proof-cli.template.yaml
+++ b/plans/plan-to-invoker-deterministic-step-3-visual-proof-cli.template.yaml
@@ -38,17 +38,8 @@ tasks:
       - add-visual-proof-subcommands
 
   - id: run-visual-proof-e2e
-    description: "Run app E2E suite that includes visual-proof coverage"
+    description: "Terminal focused proof: run app suite that exercises visual-proof subcommands"
     command: "cd packages/app && pnpm test"
     poolId: remote_digital_ocean_1_pool
     dependencies:
       - update-visual-proof-skill-doc
-
-  - id: post-fix-regression
-    description: "Run the full repository test suite as post-fix regression"
-    command: "pnpm run test:all"
-    poolId: remote_digital_ocean_1_pool
-    dependencies:
-      - add-visual-proof-subcommands
-      - update-visual-proof-skill-doc
-      - run-visual-proof-e2e

--- a/plans/plan-to-invoker-deterministic-step-4-fixtures.template.yaml
+++ b/plans/plan-to-invoker-deterministic-step-4-fixtures.template.yaml
@@ -31,17 +31,8 @@ tasks:
       - convert-markdown-examples-to-fixtures
 
   - id: run-plan-to-invoker-tests
-    description: "Run script + fixture validation tests"
+    description: "Terminal focused proof: run script + fixture validation tests"
     command: "bash scripts/test-plan-to-invoker-skill.sh"
     poolId: remote_digital_ocean_1_pool
     dependencies:
       - trim-reference-markdown
-
-  - id: post-fix-regression
-    description: "Run the full repository test suite as post-fix regression"
-    command: "pnpm run test:all"
-    poolId: remote_digital_ocean_1_pool
-    dependencies:
-      - convert-markdown-examples-to-fixtures
-      - trim-reference-markdown
-      - run-plan-to-invoker-tests


### PR DESCRIPTION
## Summary

The checked-in plan-to-invoker hardening templates under `plans/` no longer encode a blanket `pnpm run test:all` ending.

These templates are executable planning artifacts and have to model the same focused-proof policy the fixture corpus now demonstrates.

Otherwise the templates re-teach the obsolete shape every time a planner reuses them.

Each template now finishes on its existing focused proof task instead of a universal repo-wide check.

<details>
<summary>Review metadata</summary>

Review Claim: The plan-to-invoker hardening templates stop encoding a blanket `pnpm run test:all` ending and reuse their existing focused proof tasks as the honest terminal step.

Review Lane: docs

Review Unit: docs

Safety Invariant: This slice edits only the four checked-in plan-to-invoker hardening templates under `plans/`; no fixture, harness, or guard script moves.

Slice Rationale: These templates are a third normative source of plan-to-invoker shape and need the same fix as the fixture corpus, but the corrected fixtures land first so the templates align with them.

</details>

## Non-goals

- Do not edit unrelated workflow plans outside the plan-to-invoker hardening set.
- Do not change the focused suite under `scripts/test-plan-to-invoker-skill.sh`.
- Do not modify the positive fixture corpus or the inline fixture YAML.

## Test Plan

- [ ] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated several workflow/task descriptions to be clearer and more terminal-focused.
  * Improved the wording of test and proof-related steps for easier readability in CI and planning templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->