### PR TITLE
[Slack Lobby Routing](6) Add workflow-op progress contract

### DIFF
--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -47,6 +47,20 @@ export interface WorkflowOpResult {
   summary: string;
 }
 
+/** Incremental progress for a bulk workflow op, streamed to the surface while it runs. */
+export interface WorkflowOpProgress {
+  /** Workflows processed so far (ok + failed). */
+  done: number;
+  /** Total workflows in this op. */
+  total: number;
+  /** Succeeded so far. */
+  ok: number;
+  /** Failed so far. */
+  failed: number;
+  /** The workflow currently being processed, when known. */
+  current?: string;
+}
+
 // ── Events (Orchestrator → Surface) ────────────────────────
 
 export interface WorkflowStatus {


### PR DESCRIPTION
## Summary

Adds the `WorkflowOpProgress` type — the shared shape a bulk workflow op uses to report incremental progress (done, total, ok, failed, current) to a surface.

Nothing produces or consumes it yet, so this slice is dormant and changes no behavior.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the new `WorkflowOpProgress` type as a dormant contract.

Review Lane: refactor

Review Unit: contract

Safety Invariant: Pure addition — one exported interface; no existing code path is touched.

Slice Rationale: Lands first so the host and surface slices that produce and render this type review cleanly.

</details>

## Non-goals

No behavior change. No producer and no consumer — the host emits it (slice 7) and the thread renders it (slice 8).

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/surfaces build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live progress reporting for bulk workflow operations, including completed/total counts, successful/failed counts, and optional current item details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->