### PR TITLE
[Slack Lobby Routing](7) Emit per-workflow progress from the host op runner

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -876,6 +876,7 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
 
   const runWorkflowOp = async (
     op: { operation: string; target: { all: true } | { workflow: string } },
+    onProgress?: (p: { done: number; total: number; ok: number; failed: number; current?: string }) => void,
   ): Promise<{ ok: boolean; summary: string }> => {
     const all = persistence.listWorkflows();
     let workflowIds: { id: string }[];
@@ -909,7 +910,9 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
 
     let ok = 0;
     const failed: string[] = [];
+    const total = workflowIds.length;
     for (const t of workflowIds) {
+      onProgress?.({ done: ok + failed.length, total, ok, failed: failed.length, current: t.id });
       try {
         await run(t.id);
         ok++;
@@ -917,6 +920,7 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
         failed.push(`${t.id}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
+    onProgress?.({ done: total, total, ok, failed: failed.length });
     const summary = `${op.operation}: ${ok} ok${failed.length ? `, ${failed.length} failed\n${failed.join('\n')}` : ''}`;
     return { ok: failed.length === 0, summary };
   };

--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -47,6 +47,20 @@ export interface WorkflowOpResult {
   summary: string;
 }
 
+/** Incremental progress for a bulk workflow op, streamed to the surface while it runs. */
+export interface WorkflowOpProgress {
+  /** Workflows processed so far (ok + failed). */
+  done: number;
+  /** Total workflows in this op. */
+  total: number;
+  /** Succeeded so far. */
+  ok: number;
+  /** Failed so far. */
+  failed: number;
+  /** The workflow currently being processed, when known. */
+  current?: string;
+}
+
 // ── Events (Orchestrator → Surface) ────────────────────────
 
 export interface WorkflowStatus {


### PR DESCRIPTION
## Summary

The host's workflow-op runner now routes incremental progress to the caller: an optional callback fires before each workflow and once at the end.

When no callback is passed it behaves exactly as before, so existing callers are unaffected.

<details>
<summary>Review metadata</summary>

Review Claim: Approve routing per-workflow progress from the host op runner to an optional callback.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Backward compatible — the callback is optional; the op's result and per-target ok/failed accounting are unchanged.

Slice Rationale: Host wiring lands before the surface change so the routing addition reviews on its own.

</details>

## Non-goals

Renders nothing itself — the Slack thread display lands in slice 8. Status, single-workflow, and recreate/rebase/retry/cancel ops are unchanged apart from the new callback.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live progress updates during workflow runs, showing completed count, total count, success/failure counts, and the current item being processed.
  * Emitted a final progress snapshot when the run completes, reflecting total results.
  * Workflow runs still complete with the same outcome reporting as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2502