### PR TITLE
[Slack Lobby Routing](8) Stream bulk-op progress to the lobby thread

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -876,6 +876,7 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
 
   const runWorkflowOp = async (
     op: { operation: string; target: { all: true } | { workflow: string } },
+    onProgress?: (p: { done: number; total: number; ok: number; failed: number; current?: string }) => void,
   ): Promise<{ ok: boolean; summary: string }> => {
     const all = persistence.listWorkflows();
     let workflowIds: { id: string }[];
@@ -909,7 +910,9 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
 
     let ok = 0;
     const failed: string[] = [];
+    const total = workflowIds.length;
     for (const t of workflowIds) {
+      onProgress?.({ done: ok + failed.length, total, ok, failed: failed.length, current: t.id });
       try {
         await run(t.id);
         ok++;
@@ -917,6 +920,7 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
         failed.push(`${t.id}: ${err instanceof Error ? err.message : String(err)}`);
       }
     }
+    onProgress?.({ done: total, total, ok, failed: failed.length });
     const summary = `${op.operation}: ${ok} ok${failed.length ? `, ${failed.length} failed\n${failed.join('\n')}` : ''}`;
     return { ok: failed.length === 0, summary };
   };

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -430,7 +430,7 @@ describe('lobby verb routing', () => {
     const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
     await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'yes' }, say: say2 });
     expect(runWorkflowOp).toHaveBeenCalledTimes(1);
-    expect(runWorkflowOp).toHaveBeenCalledWith({ operation: 'recreate', target: { all: true } });
+    expect(runWorkflowOp.mock.calls[0][0]).toEqual({ operation: 'recreate', target: { all: true } });
     expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: 'recreate: 3 ok' }));
   });
 
@@ -468,7 +468,7 @@ describe('lobby verb routing', () => {
     expect(ack).toHaveBeenCalled();
     // Buttons are replaced immediately so the click is visibly acknowledged.
     expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: '✅ Approved.', replace_original: true }));
-    expect(runWorkflowOp).toHaveBeenCalledWith({ operation: 'recreate', target: { all: true } });
+    expect(runWorkflowOp.mock.calls[0][0]).toEqual({ operation: 'recreate', target: { all: true } });
     // The result posts durably in-thread via the bot client, not the expiring response_url.
     expect(app.client.chat.postMessage).toHaveBeenCalledWith(
       expect.objectContaining({ channel: 'C1', thread_ts: 't1', text: 'recreate: 3 ok' }),
@@ -506,13 +506,46 @@ describe('lobby verb routing', () => {
     expect(respond).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('expired'), replace_original: true }));
   });
 
+  it('streams live progress into the thread during a bulk op (edits one message)', async () => {
+    // Drive onProgress like the host would, then resolve with a summary.
+    runWorkflowOp.mockImplementation(async (_op: unknown, onProgress?: (p: unknown) => void) => {
+      onProgress?.({ done: 0, total: 3, ok: 0, failed: 0, current: 'wf-a' });
+      onProgress?.({ done: 3, total: 3, ok: 3, failed: 0 });
+      return { ok: true, summary: 'recreate: 3 ok' };
+    });
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const app = surface.getApp() as any;
+
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> recreate all', ts: 't1', user: 'U1' }, say });
+
+    app.client.chat.update.mockClear();
+    app.client.chat.postMessage.mockResolvedValue({ ts: 'onit-ts' });
+    await actionHandler(surface, 'lobby_confirm')({
+      action: { type: 'button', value: 't1' },
+      body: { channel: { id: 'C1' }, message: { thread_ts: 't1' } },
+      ack: vi.fn().mockResolvedValue(undefined),
+      respond: vi.fn().mockResolvedValue(undefined),
+    });
+
+    // The "On it" message is edited in place with the running count, in-thread.
+    expect(app.client.chat.update).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'C1', ts: 'onit-ts', text: expect.stringContaining('3/3') }),
+    );
+    // And the final summary still posts.
+    expect(app.client.chat.postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'C1', thread_ts: 't1', text: 'recreate: 3 ok' }),
+    );
+  });
+
   it('runs a single-workflow verb immediately (no confirmation)', async () => {
     runWorkflowOp.mockResolvedValue({ ok: true, summary: 'retry: 1 ok' });
     const surface = lobbySurface();
     await surface.start(async () => {});
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> retry wf-123', ts: 't1', user: 'U1' }, say });
-    expect(runWorkflowOp).toHaveBeenCalledWith({ operation: 'retry', target: { workflow: 'wf-123' } });
+    expect(runWorkflowOp.mock.calls[0][0]).toEqual({ operation: 'retry', target: { workflow: 'wf-123' } });
     expect(planConversationConfigs).toHaveLength(0);
     expect(mockSpawn).not.toHaveBeenCalled();
   });
@@ -523,7 +556,7 @@ describe('lobby verb routing', () => {
     await surface.start(async () => {});
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> status', ts: 't1', user: 'U1' }, say });
-    expect(runWorkflowOp).toHaveBeenCalledWith({ operation: 'status', target: { all: true } });
+    expect(runWorkflowOp.mock.calls[0][0]).toEqual({ operation: 'status', target: { all: true } });
     expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('running') }));
     expect(mockSpawn).not.toHaveBeenCalled();
   });
@@ -542,7 +575,7 @@ describe('lobby verb routing', () => {
 
     const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
     await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'yes' }, say: say2 });
-    expect(runWorkflowOp).toHaveBeenCalledWith({ operation: 'recreate', target: { all: true } });
+    expect(runWorkflowOp.mock.calls[0][0]).toEqual({ operation: 'recreate', target: { all: true } });
   });
 
   it('answers a question with no session, workflow, or start_plan', async () => {

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -7,7 +7,7 @@
 
 import { App, type RespondFn } from '@slack/bolt';
 import { spawn } from 'node:child_process';
-import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn, WorkflowOp, WorkflowOpResult, WorkflowOpName } from '../surface.js';
+import type { Surface, CommandHandler, SurfaceCommand, SurfaceEvent, LogFn, WorkflowOp, WorkflowOpResult, WorkflowOpProgress, WorkflowOpName } from '../surface.js';
 import { parseSlackCommand } from './slack-commands.js';
 import type { ConversationCommand } from './slack-commands.js';
 import { formatSurfaceEvent, formatWorkflowStatus } from './slack-formatter.js';
@@ -81,7 +81,7 @@ export interface SlackSurfaceConfig {
   /** Gathers a workflow's planning convo + task transcripts for the in-channel assistant. */
   gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
   /** Executes a workflow operation (recreate/rebase/retry/status/cancel) and returns a summary. Injected by main.ts. */
-  runWorkflowOp?: (op: WorkflowOp) => Promise<WorkflowOpResult>;
+  runWorkflowOp?: (op: WorkflowOp, onProgress?: (p: WorkflowOpProgress) => void) => Promise<WorkflowOpResult>;
 }
 
 export interface HarnessPreset {
@@ -322,7 +322,7 @@ export class SlackSurface implements Surface {
   private defaultRepoUrl?: string;
   private workflowChannelRepo?: WorkflowChannelRepository;
   private gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
-  private runWorkflowOp?: (op: WorkflowOp) => Promise<WorkflowOpResult>;
+  private runWorkflowOp?: (op: WorkflowOp, onProgress?: (p: WorkflowOpProgress) => void) => Promise<WorkflowOpResult>;
 
   constructor(config: SlackSurfaceConfig) {
     this.app = new App({
@@ -582,7 +582,8 @@ export class SlackSurface implements Surface {
       await respond?.({ text: '✅ Approved.', replace_original: true });
       // Follow-ups post in-thread via the bot client: a response_url expires after
       // 30 minutes / 5 uses, which a long bulk op can outlast.
-      await this.executeConfirm(pending, key, this.lobbyButtonSay(body, respond));
+      const opChannel = (body as { channel?: { id?: string } })?.channel?.id;
+      await this.executeConfirm(pending, key, this.lobbyButtonSay(body, respond), opChannel);
     });
 
     this.app.action('lobby_cancel', async ({ action, ack, respond }) => {
@@ -655,7 +656,7 @@ export class SlackSurface implements Surface {
     const threadTs = event.thread_ts ?? event.ts;
 
     // Confirm/cancel a staged action first (plain yes/no in-thread).
-    if (await this.resolveConfirm(threadTs, parsed.text, say)) return;
+    if (await this.resolveConfirm(threadTs, parsed.text, say, channel)) return;
 
     // Deterministic verb commands take priority over the planning/LLM path.
     const ctrl = parseLobbyControl(parsed.text);
@@ -753,7 +754,7 @@ export class SlackSurface implements Surface {
       await this.stageConfirm(threadTs, channel, { kind: 'op', op }, `This will \`${ctrl.operation}\` ALL workflows.`, say);
       return;
     }
-    await this.runConfirmedOp(op, threadTs, say);
+    await this.runConfirmedOp(op, threadTs, say, channel);
   }
 
   /** A classifier-inferred op is fuzzy, so always confirm before running it. */
@@ -772,10 +773,26 @@ export class SlackSurface implements Surface {
     await this.stageConfirm(threadTs, channel, { kind: 'op', op }, `It sounds like you want to \`${cls.operation}\` ${label}.`, say);
   }
 
-  private async runConfirmedOp(op: WorkflowOp, threadTs: string, say: SayFn): Promise<void> {
-    await say({ text: `On it — ${this.describeOp(op)}. I'll post a summary here when it finishes.`, thread_ts: threadTs });
+  private async runConfirmedOp(op: WorkflowOp, threadTs: string, say: SayFn, channel?: string): Promise<void> {
+    const onIt = await say({ text: `On it — ${this.describeOp(op)}. I'll post a summary here when it finishes.`, thread_ts: threadTs });
+    const progressTs = onIt?.ts;
+    let lastEdit = 0;
+    const onProgress = channel && progressTs
+      ? (p: WorkflowOpProgress): void => {
+          if (p.total <= 1) return;
+          const now = Date.now();
+          if (now - lastEdit < 2000 && p.done < p.total) return;
+          lastEdit = now;
+          const icon = p.done >= p.total ? '✅' : '⏳';
+          const tail = p.failed ? `, ${p.failed} failed` : '';
+          const cur = p.current && p.done < p.total ? ` · now \`${p.current}\`` : '';
+          void this.app.client.chat
+            .update({ channel, ts: progressTs, text: `${icon} ${this.describeOp(op)} — ${p.done}/${p.total} (${p.ok} ok${tail})${cur}` })
+            .catch(() => {});
+        }
+      : undefined;
     try {
-      const result = await this.runWorkflowOp!(op);
+      const result = await this.runWorkflowOp!(op, onProgress);
       await say({ text: result.summary, thread_ts: threadTs });
     } catch (err) {
       await say({ text: `Operation failed: ${err instanceof Error ? err.message : String(err)}`, thread_ts: threadTs });
@@ -866,12 +883,12 @@ export class SlackSurface implements Surface {
 
 
   /** Resolve a staged action from a plain-text reply. Returns true if the reply was consumed. */
-  private async resolveConfirm(threadTs: string, text: string, say: SayFn): Promise<boolean> {
+  private async resolveConfirm(threadTs: string, text: string, say: SayFn, channel?: string): Promise<boolean> {
     const pending = this.pendingConfirms.get(threadTs);
     if (!pending) return false;
     if (isConfirmation(text)) {
       this.pendingConfirms.delete(threadTs);
-      await this.executeConfirm(pending, threadTs, say);
+      await this.executeConfirm(pending, threadTs, say, channel);
       return true;
     }
     if (isNegation(text)) {
@@ -885,13 +902,13 @@ export class SlackSurface implements Surface {
   }
 
   /** Run a confirmed action — a workflow op, or a plan submission. */
-  private async executeConfirm(pending: PendingConfirm, threadTs: string, say: SayFn): Promise<void> {
+  private async executeConfirm(pending: PendingConfirm, threadTs: string, say: SayFn, channel?: string): Promise<void> {
     if (pending.kind === 'op') {
       if (!this.runWorkflowOp) {
         await say({ text: 'Workflow operations are not available in this deployment.', thread_ts: threadTs });
         return;
       }
-      await this.runConfirmedOp(pending.op, threadTs, say);
+      await this.runConfirmedOp(pending.op, threadTs, say, channel);
       return;
     }
     await say({ text: 'Starting plan execution…', thread_ts: threadTs });
@@ -1220,7 +1237,7 @@ export class SlackSurface implements Surface {
       if (msg.channel && this.workflowChannelRepo?.getByChannelId(msg.channel)) return;
 
       const text = (msg.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
-      if (text && (await this.resolveConfirm(msg.thread_ts, text, say))) return;
+      if (text && (await this.resolveConfirm(msg.thread_ts, text, say, channel))) return;
 
       // Look up or recover session (don't create new sessions for random thread replies in fallback mode)
       const conversation = await this.getSession(channel, msg.thread_ts, msg.user ?? 'unknown', false);

--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -47,6 +47,20 @@ export interface WorkflowOpResult {
   summary: string;
 }
 
+/** Incremental progress for a bulk workflow op, streamed to the surface while it runs. */
+export interface WorkflowOpProgress {
+  /** Workflows processed so far (ok + failed). */
+  done: number;
+  /** Total workflows in this op. */
+  total: number;
+  /** Succeeded so far. */
+  ok: number;
+  /** Failed so far. */
+  failed: number;
+  /** The workflow currently being processed, when known. */
+  current?: string;
+}
+
 // ── Events (Orchestrator → Surface) ────────────────────────
 
 export interface WorkflowStatus {


### PR DESCRIPTION
## Summary

Routes live progress into the lobby thread: while a bulk op runs, the bot edits one in-thread message with a running done/total count instead of going silent until the summary.

The channel is threaded through the confirm paths so the message can be edited in place; a single-workflow op leaves the progress line off.

<details>
<summary>Review metadata</summary>

Review Claim: Approve routing bulk-op progress into the lobby thread as one edited message.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Throttled to at most one edit every two seconds and only for multi-workflow ops; `chat.update` failures are swallowed; the final summary still posts durably in-thread.

Slice Rationale: The surface change and its coverage review together, after the host emits the progress this slice routes to the thread.

</details>

## Non-goals

No new workflow operations and no host logic — only the thread rendering. The host callback ships in slice 7.

## Test Plan

- [x] `CI=1 pnpm --filter @invoker/surfaces test`
- [x] `pnpm --filter @invoker/surfaces build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Slack workflow operations now show live progress updates in the thread, including completed steps and any failures.
  * Bulk and confirmed actions now post an initial “On it” message and update it as work progresses, then add the final summary in the same thread.

* **Bug Fixes**
  * Progress updates now stay in the correct Slack channel for both button-based and threaded confirmations.
  * Workflow progress messages are throttled to reduce noisy UI updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->