### PR TITLE
[Repo Default Branch](1) Add core resolver

### DIFF
--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -13,3 +13,4 @@ export * from './task-repository.js';
 export * from './invalidation-policy.js';
 export * from './invalidation-plan.js';
 export * from './attempt-policy.js';
+export * from './repo-default-branch.js';

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -34,6 +34,7 @@ import {
   type ExecutorRoutingRule,
   type HeavyweightCommandRoutingPolicy,
 } from './executor-routing.js';
+import { requireDefaultBranchRemote } from './repo-default-branch.js';
 
 const MERGE_TRACE_LOG = resolve(homedir(), '.invoker', 'merge-trace.log');
 function mergeTrace(tag: string, data: Record<string, unknown>): void {
@@ -261,6 +262,7 @@ export interface OrchestratorPersistence {
     createdAt: string;
     updatedAt: string;
     baseBranch?: string;
+    repoUrl?: string;
     onFinish?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
     externalDependencies?: ExternalDependency[];
@@ -277,6 +279,7 @@ export interface OrchestratorPersistence {
       createdAt: string;
       updatedAt: string;
       baseBranch?: string;
+      repoUrl?: string;
       onFinish?: string;
       mergeMode?: 'manual' | 'automatic' | 'external_review';
       externalDependencies?: ExternalDependency[];
@@ -598,6 +601,8 @@ export interface OrchestratorConfig {
    * scheduler dequeue time).
    */
   deferRunningUntilLaunch?: boolean;
+  /** Resolve the repo default branch. Must throw when no safe branch is known. */
+  resolveRepoDefaultBranch?: (repoUrl: string) => string;
   /**
    * When the persistence layer implements `enqueueLaunchDispatch`,
    * `drainScheduler` writes a durable `task_launch_dispatch` row for each
@@ -629,6 +634,7 @@ export class Orchestrator {
   private readonly defaultPoolId: string | undefined;
   private readonly defaultAutoFixRetries: number;
   private readonly deferRunningUntilLaunch: boolean;
+  private readonly resolveRepoDefaultBranch: (repoUrl: string) => string;
 
   private activeWorkflowIds = new Set<string>();
   private deferredTaskIds = new Set<string>();
@@ -701,6 +707,7 @@ export class Orchestrator {
     this.defaultPoolId = config.defaultPoolId;
     this.defaultAutoFixRetries = Math.min(Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0)), 10);
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
+    this.resolveRepoDefaultBranch = config.resolveRepoDefaultBranch ?? requireDefaultBranchRemote;
 
     this.stateMachine = new TaskStateMachine(new ActionGraph());
     this.responseHandler = new ResponseHandler();

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -1,6 +1,6 @@
-import { execFileSync } from 'node:child_process';
 import { parse as parseYaml } from 'yaml';
 import type { PlanDefinition } from './orchestrator.js';
+import { detectDefaultBranchRemote } from './repo-default-branch.js';
 
 export class PlanParseError extends Error {
   constructor(message: string) {
@@ -58,25 +58,11 @@ export interface RawPlan {
   tasks?: RawPlanTask[];
 }
 
-function detectDefaultBranchRemote(repoUrl: string): string {
-  try {
-    const output = execFileSync('git', ['ls-remote', '--symref', repoUrl, 'HEAD'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 10_000,
-    }).trim();
-    const match = output.match(/ref:\s+refs\/heads\/(\S+)\s+HEAD/);
-    if (match) return match[1];
-  } catch {
-    // Network and local-path failures fall back to the common default.
-  }
-  return 'main';
-}
 
 function resolveDefaultBaseBranch(plan: PlanDefinition): string {
   const branch = plan.baseBranch;
   if (typeof branch === 'string' && branch.trim() !== '') return branch.trim();
-  return plan.repoUrl ? detectDefaultBranchRemote(plan.repoUrl) : 'main';
+  return plan.repoUrl ? detectDefaultBranchRemote(plan.repoUrl) ?? 'main' : 'main';
 }
 
 export function applyPlanDefinitionDefaults(plan: PlanDefinition): PlanDefinition {

--- a/packages/workflow-core/src/repo-default-branch.ts
+++ b/packages/workflow-core/src/repo-default-branch.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from 'node:child_process';
+
+
+export function detectDefaultBranchRemote(repoUrl: string): string | undefined {
+  const trimmed = repoUrl.trim();
+  if (trimmed === '') return undefined;
+
+  try {
+    const output = execFileSync('git', ['ls-remote', '--symref', trimmed, 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10_000,
+    }).trim();
+    return output.match(/ref:\s+refs\/heads\/(\S+)\s+HEAD/)?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+export function requireDefaultBranchRemote(repoUrl: string): string {
+  const branch = detectDefaultBranchRemote(repoUrl);
+  if (branch) return branch;
+  throw new Error(`Unable to resolve default branch for repo ${repoUrl}. Make the remote HEAD readable.`);
+}
+
+export function remoteBranchExists(repoUrl: string, branch: string): boolean {
+  const trimmedRepo = repoUrl.trim();
+  const trimmedBranch = branch.trim();
+  if (trimmedRepo === '' || trimmedBranch === '') return false;
+
+  try {
+    execFileSync('git', ['ls-remote', '--exit-code', '--heads', trimmedRepo, trimmedBranch], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function requireRemoteBranch(repoUrl: string, branch: string): string {
+  const trimmedBranch = branch.trim();
+  if (trimmedBranch === '') {
+    throw new Error('Target branch is required.');
+  }
+  if (!remoteBranchExists(repoUrl, trimmedBranch)) {
+    throw new Error(`Branch "${trimmedBranch}" does not exist on repo ${repoUrl}.`);
+  }
+  return trimmedBranch;
+}


### PR DESCRIPTION
## Summary

Repo default branch lookup now lives in one workflow-core helper.

Plan parsing keeps its current fallback, but the remote HEAD lookup is shared with later detach routing.

Orchestrator now accepts an injected repo default branch resolver.

<details>
<summary>Review metadata</summary>

Review Claim: Workflow-core has one branch-default routing seam for repo default branch lookup.

Review Lane: refactor

Review Unit: routing

Safety Invariant: Plan parsing still falls back to `main` when remote HEAD lookup is unavailable.

Slice Rationale: This foundation lets the detach slice use the same default-branch lookup behavior.

</details>

## Non-goals

Behavior unchanged: plan fallback and detach behavior stay the same in this slice.

## Architecture

### Before

Plan parsing owned a private remote HEAD lookup. Orchestrator had no way to receive repo default branch rules from its caller.

### After

Workflow-core owns the remote default-branch helper and Orchestrator accepts a resolver dependency. Callers can supply stricter default-branch rules.

## Test Plan

- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts src/__tests__/orchestrator.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 606d6df5a`
- Post-revert steps: Revert dependent stack slices first.
- Data migration? No
