### PR TITLE
[Repo Target Branch](2) Add target branch commands

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
+  getRepoTargetBranch,
   loadConfig,
   resolveEmbeddedTerminalBackendConfig,
+  setRepoTargetBranch,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -39,6 +41,25 @@ describe('loadConfig', () => {
     );
     const config = loadConfig();
     expect(config.defaultBranch).toBe('main');
+  });
+
+  it('stores repo target branch overrides', () => {
+    const configPath = join(fakeHome, '.invoker', 'config.json');
+
+    const config = setRepoTargetBranch('https://example.com/repo.git', 'main', configPath);
+
+    expect(config.repoTargetBranches?.['https://example.com/repo.git']).toBe('main');
+    expect(loadConfig().repoTargetBranches?.['https://example.com/repo.git']).toBe('main');
+  });
+
+  it('reads configured repo target branch by repo URL', () => {
+    const config = {
+      repoTargetBranches: {
+        'https://example.com/repo.git': 'release',
+      },
+    };
+
+    expect(getRepoTargetBranch(config, 'https://example.com/repo.git')).toBe('release');
   });
 
   it('throws on malformed JSON', () => {

--- a/packages/app/src/__tests__/repo-target-branch.test.ts
+++ b/packages/app/src/__tests__/repo-target-branch.test.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { loadConfig } from '../config.js';
+import { resolveRepoTargetBranch, saveRepoTargetBranch } from '../repo-target-branch.js';
+
+let testDir: string;
+let previousConfigPath: string | undefined;
+
+function git(args: string[], cwd: string): void {
+  execFileSync('git', args, {
+    cwd,
+    stdio: ['ignore', 'ignore', 'ignore'],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Invoker Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Invoker Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  });
+}
+
+function createBareRepo(defaultBranch: string): string {
+  const bareRepo = join(testDir, 'repo.git');
+  const worktree = join(testDir, 'worktree');
+  git(['init', '--bare', bareRepo], testDir);
+  git(['init', worktree], testDir);
+  writeFileSync(join(worktree, 'README.md'), 'test\n');
+  git(['add', 'README.md'], worktree);
+  git(['commit', '-m', 'init'], worktree);
+  git(['branch', '-M', defaultBranch], worktree);
+  git(['remote', 'add', 'origin', bareRepo], worktree);
+  git(['push', 'origin', defaultBranch], worktree);
+  git(['symbolic-ref', 'HEAD', `refs/heads/${defaultBranch}`], bareRepo);
+  return bareRepo;
+}
+
+describe('repo target branch config', () => {
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'invoker-repo-target-'));
+    previousConfigPath = process.env.INVOKER_REPO_CONFIG_PATH;
+    process.env.INVOKER_REPO_CONFIG_PATH = join(testDir, 'config.json');
+  });
+
+  afterEach(() => {
+    if (previousConfigPath === undefined) {
+      delete process.env.INVOKER_REPO_CONFIG_PATH;
+    } else {
+      process.env.INVOKER_REPO_CONFIG_PATH = previousConfigPath;
+    }
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('saves a repo target branch only when it exists on the remote', () => {
+    const repoUrl = createBareRepo('main');
+
+    expect(saveRepoTargetBranch(repoUrl, 'main')).toBe('main');
+    expect(loadConfig().repoTargetBranches?.[repoUrl]).toBe('main');
+    expect(() => saveRepoTargetBranch(repoUrl, 'missing')).toThrow(/does not exist/);
+  });
+
+  it('resolves configured repo branch before remote HEAD', () => {
+    const repoUrl = createBareRepo('main');
+    git(['--git-dir', repoUrl, 'branch', 'release', 'main'], testDir);
+    saveRepoTargetBranch(repoUrl, 'release');
+
+    expect(resolveRepoTargetBranch(repoUrl)).toBe('release');
+  });
+
+  it('resolves remote HEAD when no repo override exists', () => {
+    const repoUrl = createBareRepo('main');
+
+    expect(resolveRepoTargetBranch(repoUrl)).toBe('main');
+  });
+});

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -5,12 +5,14 @@
  * Override with INVOKER_REPO_CONFIG_PATH env var (for tests).
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 
 export interface InvokerConfig {
   defaultBranch?: string;
+  /** Repo URL → target branch override used for new workflows and detach retargeting. */
+  repoTargetBranches?: Record<string, string>;
   /**
    * Web surface (browser mirror of the desktop app) shared-secret token.
    * When set (or via INVOKER_WEB_TOKEN), the owner process serves the UI at
@@ -254,10 +256,37 @@ function readJsonSafe(path: string): InvokerConfig {
   return parsed as InvokerConfig;
 }
 
-export function loadConfig(): InvokerConfig {
+export function resolveConfigPath(): string {
   return process.env.INVOKER_REPO_CONFIG_PATH
-    ? readJsonSafe(process.env.INVOKER_REPO_CONFIG_PATH)
-    : readJsonSafe(join(homedir(), '.invoker', 'config.json'));
+    ? resolve(process.env.INVOKER_REPO_CONFIG_PATH)
+    : join(homedir(), '.invoker', 'config.json');
+}
+
+export function loadConfig(): InvokerConfig {
+  return readJsonSafe(resolveConfigPath());
+}
+
+export function saveConfig(config: InvokerConfig, path = resolveConfigPath()): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+export function setRepoTargetBranch(repoUrl: string, branch: string, path = resolveConfigPath()): InvokerConfig {
+  const trimmedRepoUrl = repoUrl.trim();
+  const trimmedBranch = branch.trim();
+  if (trimmedRepoUrl === '') throw new Error('Repo URL is required.');
+  if (trimmedBranch === '') throw new Error('Target branch is required.');
+  const config = readJsonSafe(path);
+  const repoTargetBranches = { ...(config.repoTargetBranches ?? {}) };
+  repoTargetBranches[trimmedRepoUrl] = trimmedBranch;
+  const next = { ...config, repoTargetBranches };
+  saveConfig(next, path);
+  return next;
+}
+
+export function getRepoTargetBranch(config: InvokerConfig, repoUrl: string): string | undefined {
+  const configured = config.repoTargetBranches?.[repoUrl]?.trim();
+  return configured && configured !== '' ? configured : undefined;
 }
 
 

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -13,6 +13,8 @@ export const HEADLESS_SET_SUBCOMMANDS = [
   'executor',
   'agent',
   'merge-mode',
+  'target-branch',
+  'repo-target-branch',
   'fix-prompt',
   'fix-context',
   'gate-policy',

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -11,7 +11,7 @@
 
 import type { BundledSkillsInstallMode } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
-import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+import { requireRemoteBranch, type Orchestrator, type TaskState } from '@invoker/workflow-core';
 import {
   TaskRunner,
   acquireWorkerLock,
@@ -40,6 +40,7 @@ import {
   collectRecoveryWorkerStatus,
   type RecoveryWorkerStatus,
 } from './recovery-worker-observability.js';
+import { saveRepoTargetBranch } from './repo-target-branch.js';
 
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
@@ -181,6 +182,12 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
       break;
     case 'merge-mode':
       await headlessSetMergeMode(args[1], args[2], deps);
+      break;
+    case 'target-branch':
+      await headlessSetTargetBranch(args[1], args[2], deps);
+      break;
+    case 'repo-target-branch':
+      await headlessSetRepoTargetBranch(args[1], args[2], deps);
       break;
     case 'fix-prompt':
       await headlessSetFixContext(args[1], { fixPrompt: args.slice(2).join(' ') }, deps);
@@ -594,6 +601,9 @@ ${BOLD}Configure:${RESET}
   set pool <taskId> <type> [poolMemberId]           Change execution pool (worktree|docker|ssh)
   set agent <taskId> <agent>                          Change execution agent (claude|codex|omp)
   set merge-mode <workflowId> <mode>                  manual | automatic | external_review
+  set target-branch <workflowId> <branch>             Change one workflow target branch and rerun merge gate
+  set repo-target-branch <repoUrl|workflowId> <branch>
+                                                      Save repo target branch override after remote validation
   set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
   set fix-context <taskId> <text>                     Update fix-session context and retry
   set gate-policy <taskId> <wfId> [depTaskId] <policy>
@@ -821,6 +831,52 @@ async function headlessSetMergeMode(
   }
   const wf = deps.persistence.loadWorkflow(workflowId);
   process.stdout.write(`Merge mode updated for ${workflowId}: ${wf?.mergeMode ?? '?'}\n`);
+}
+
+async function headlessSetTargetBranch(
+  workflowId: string,
+  branch: string,
+  deps: HeadlessDeps,
+): Promise<void> {
+  if (!workflowId || !branch) {
+    throw new Error('Missing arguments. Usage: --headless set target-branch <workflowId> <branch>');
+  }
+  const workflow = deps.persistence.loadWorkflow(workflowId);
+  if (!workflow) throw new Error(`Workflow not found: ${workflowId}`);
+  const repoUrl = workflow.repoUrl?.trim();
+  if (!repoUrl) throw new Error(`Workflow ${workflowId} has no repo URL; cannot validate target branch.`);
+  const targetBranch = requireRemoteBranch(repoUrl, branch);
+
+  deps.persistence.updateWorkflow(workflowId, { baseBranch: targetBranch });
+  deps.orchestrator.syncFromDb(workflowId);
+
+  const mergeTask = deps.persistence.loadTasks(workflowId).find((task) => task.config.isMergeNode);
+  if (mergeTask) {
+    const taskExecutor = createHeadlessExecutor(deps);
+    const envelope = makeEnvelope('set-target-branch', 'headless', 'task', { taskId: mergeTask.id });
+    const result = await deps.commandService.retryTask(envelope);
+    if (!result.ok) throw new Error(result.error.message);
+    const runnable = result.data.filter(isDispatchableLaunch);
+    if (runnable.length > 0) {
+      await taskExecutor.executeTasks(runnable);
+    }
+  }
+
+  process.stdout.write(`Target branch updated for ${workflowId}: ${targetBranch}\n`);
+}
+
+async function headlessSetRepoTargetBranch(
+  repoRef: string,
+  branch: string,
+  deps: HeadlessDeps,
+): Promise<void> {
+  if (!repoRef || !branch) {
+    throw new Error('Missing arguments. Usage: --headless set repo-target-branch <repoUrl|workflowId> <branch>');
+  }
+  const workflow = deps.persistence.loadWorkflow(repoRef);
+  const repoUrl = workflow?.repoUrl ?? repoRef;
+  const targetBranch = saveRepoTargetBranch(repoUrl, branch);
+  process.stdout.write(`Repo target branch updated for ${repoUrl}: ${targetBranch}\n`);
 }
 
 /**

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -109,6 +109,7 @@ import {
   type EmbeddedTerminalBackendConfig,
   type InvokerConfig,
 } from './config.js';
+import { resolveRepoTargetBranch } from './repo-target-branch.js';
 import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
   assertExecutionCapacityInvariant,
@@ -744,6 +745,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     defaultPoolId: invokerConfig.defaultPoolId,
     availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
     deferRunningUntilLaunch: true,
+    resolveRepoTargetBranch,
   });
   commandService = new CommandService(
     orchestrator,
@@ -1283,6 +1285,7 @@ function startHeadlessMode(): void {
               defaultPoolId: invokerConfig.defaultPoolId,
               availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
               deferRunningUntilLaunch: true,
+              resolveRepoTargetBranch,
             });
             commandService = new CommandService(
               orchestrator,
@@ -1442,6 +1445,7 @@ function startHeadlessMode(): void {
               switch (subCommand) {
                 case 'workflow':
                 case 'merge-mode':
+                case 'target-branch':
                   return {
                     workflowId: targetArg === undefined ? undefined : String(targetArg),
                     priority: 'high',
@@ -2643,6 +2647,7 @@ function createEmbeddedTerminalBackendFromConfig(
         switch (subCommand) {
           case 'workflow':
           case 'merge-mode':
+          case 'target-branch':
             return { workflowId: targetArg === undefined ? undefined : String(targetArg), priority: 'high' };
           case 'command':
           case 'prompt':
@@ -3784,6 +3789,7 @@ function createEmbeddedTerminalBackendFromConfig(
         defaultPoolId: invokerConfig.defaultPoolId,
         availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
         deferRunningUntilLaunch: true,
+        resolveRepoTargetBranch,
       });
       commandService = new CommandService(
         orchestrator,

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -7,15 +7,22 @@
 
 import { execSync } from 'node:child_process';
 import { parse as parseYaml } from 'yaml';
-import type { PlanDefinition } from '@invoker/workflow-core';
-import { loadConfig } from './config.js';
+import { detectDefaultBranchRemote as detectRemoteDefaultBranch, type PlanDefinition } from '@invoker/workflow-core';
+import { getRepoTargetBranch, loadConfig } from './config.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 
 /** Empty / whitespace `baseBranch` in YAML (`baseBranch:`) must fall through to config + remote detection like a missing key. */
 function resolveDefaultBaseBranch(plan: PlanDefinition): string {
   const b = plan.baseBranch;
   if (typeof b === 'string' && b.trim() !== '') return b.trim();
-  return loadConfig().defaultBranch ?? (plan.repoUrl ? detectDefaultBranchRemote(plan.repoUrl) : 'main');
+  const config = loadConfig();
+  if (plan.repoUrl) {
+    return getRepoTargetBranch(config, plan.repoUrl)
+      ?? config.defaultBranch
+      ?? detectRemoteDefaultBranch(plan.repoUrl)
+      ?? 'main';
+  }
+  return config.defaultBranch ?? 'main';
 }
 
 /**
@@ -111,17 +118,7 @@ export function detectDefaultBranch(cwd?: string): string {
  * Falls back to 'main' if detection fails.
  */
 export function detectDefaultBranchRemote(repoUrl: string): string {
-  try {
-    const output = execSync(`git ls-remote --symref ${repoUrl} HEAD`, {
-      encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 10000,
-    }).trim();
-    // Output format: "ref: refs/heads/main\tHEAD"
-    const match = output.match(/ref:\s+refs\/heads\/(\S+)\s+HEAD/);
-    if (match) return match[1];
-  } catch {
-    // Network error or timeout
-  }
-  return 'main';
+  return detectRemoteDefaultBranch(repoUrl) ?? 'main';
 }
 
 export class PlanParseError extends Error {

--- a/packages/app/src/repo-target-branch.ts
+++ b/packages/app/src/repo-target-branch.ts
@@ -1,0 +1,27 @@
+import {
+  detectDefaultBranchRemote,
+  requireRemoteBranch,
+} from '@invoker/workflow-core';
+import { getRepoTargetBranch, loadConfig, setRepoTargetBranch } from './config.js';
+
+export function resolveRepoTargetBranch(repoUrl: string): string {
+  const trimmedRepoUrl = repoUrl.trim();
+  if (trimmedRepoUrl === '') throw new Error('Repo URL is required.');
+
+  const config = loadConfig();
+  const configuredBranch = getRepoTargetBranch(config, trimmedRepoUrl) ?? config.defaultBranch?.trim();
+  if (configuredBranch && configuredBranch !== '') {
+    return requireRemoteBranch(trimmedRepoUrl, configuredBranch);
+  }
+
+  const detectedBranch = detectDefaultBranchRemote(trimmedRepoUrl);
+  if (detectedBranch) return detectedBranch;
+  throw new Error(`Unable to resolve default branch for repo ${trimmedRepoUrl}. Set a repo target branch or make the remote HEAD readable.`);
+}
+
+export function saveRepoTargetBranch(repoUrl: string, branch: string): string {
+  const trimmedRepoUrl = repoUrl.trim();
+  const targetBranch = requireRemoteBranch(trimmedRepoUrl, branch);
+  setRepoTargetBranch(trimmedRepoUrl, targetBranch);
+  return targetBranch;
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,8 @@ import {
 import {
   Orchestrator,
   parsePlanFile,
+  requireRemoteBranch,
+  detectDefaultBranchRemote,
   type OrchestratorMessageBus,
   type PlanDefinition,
   type TaskState,
@@ -65,6 +67,7 @@ type CliDeps = {
 
 type CliRuntimeConfig = {
   defaultBranch?: string;
+  repoTargetBranches?: Record<string, string>;
   maxConcurrency?: number;
   docker?: {
     imageName?: string;
@@ -283,6 +286,18 @@ function loadRuntimeConfig(configPath?: string): CliRuntimeConfig {
   return parsed as CliRuntimeConfig;
 }
 
+function resolveRepoTargetBranchFromConfig(config: CliRuntimeConfig, repoUrl: string): string {
+  const trimmedRepoUrl = repoUrl.trim();
+  if (trimmedRepoUrl === '') throw new Error('Repo URL is required.');
+  const configuredBranch = config.repoTargetBranches?.[trimmedRepoUrl]?.trim() ?? config.defaultBranch?.trim();
+  if (configuredBranch && configuredBranch !== '') {
+    return requireRemoteBranch(trimmedRepoUrl, configuredBranch);
+  }
+  const detectedBranch = detectDefaultBranchRemote(trimmedRepoUrl);
+  if (detectedBranch) return detectedBranch;
+  throw new Error(`Unable to resolve default branch for repo ${trimmedRepoUrl}. Set a repo target branch or make the remote HEAD readable.`);
+}
+
 function isTerminalTaskStatus(status: TaskState['status']): boolean {
   return status === 'completed'
     || status === 'failed'
@@ -372,6 +387,7 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
       executorRoutingRules: runtimeConfig.executorRoutingRules ?? [],
       defaultPoolId: runtimeConfig.defaultPoolId,
       availablePoolIds: Object.keys(runtimeConfig.executionPools ?? {}),
+      resolveRepoTargetBranch: (repoUrl) => resolveRepoTargetBranchFromConfig(loadRuntimeConfig(options.config), repoUrl),
     });
     const taskRunner = new TaskRunner({
       orchestrator,

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -13,3 +13,4 @@ export * from './task-repository.js';
 export * from './invalidation-policy.js';
 export * from './invalidation-plan.js';
 export * from './attempt-policy.js';
+export * from './repo-default-branch.js';

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -34,6 +34,7 @@ import {
   type ExecutorRoutingRule,
   type HeavyweightCommandRoutingPolicy,
 } from './executor-routing.js';
+import { requireDefaultBranchRemote } from './repo-default-branch.js';
 
 const MERGE_TRACE_LOG = resolve(homedir(), '.invoker', 'merge-trace.log');
 function mergeTrace(tag: string, data: Record<string, unknown>): void {
@@ -261,6 +262,7 @@ export interface OrchestratorPersistence {
     createdAt: string;
     updatedAt: string;
     baseBranch?: string;
+    repoUrl?: string;
     onFinish?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
     externalDependencies?: ExternalDependency[];
@@ -277,6 +279,7 @@ export interface OrchestratorPersistence {
       createdAt: string;
       updatedAt: string;
       baseBranch?: string;
+      repoUrl?: string;
       onFinish?: string;
       mergeMode?: 'manual' | 'automatic' | 'external_review';
       externalDependencies?: ExternalDependency[];
@@ -598,6 +601,8 @@ export interface OrchestratorConfig {
    * scheduler dequeue time).
    */
   deferRunningUntilLaunch?: boolean;
+  /** Resolve the target branch for a repo URL. Must throw when no safe branch is known. */
+  resolveRepoTargetBranch?: (repoUrl: string) => string;
   /**
    * When the persistence layer implements `enqueueLaunchDispatch`,
    * `drainScheduler` writes a durable `task_launch_dispatch` row for each
@@ -629,6 +634,7 @@ export class Orchestrator {
   private readonly defaultPoolId: string | undefined;
   private readonly defaultAutoFixRetries: number;
   private readonly deferRunningUntilLaunch: boolean;
+  private readonly resolveRepoTargetBranch: (repoUrl: string) => string;
 
   private activeWorkflowIds = new Set<string>();
   private deferredTaskIds = new Set<string>();
@@ -701,6 +707,7 @@ export class Orchestrator {
     this.defaultPoolId = config.defaultPoolId;
     this.defaultAutoFixRetries = Math.min(Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0)), 10);
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
+    this.resolveRepoTargetBranch = config.resolveRepoTargetBranch ?? requireDefaultBranchRemote;
 
     this.stateMachine = new TaskStateMachine(new ActionGraph());
     this.responseHandler = new ResponseHandler();

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -1,6 +1,6 @@
-import { execFileSync } from 'node:child_process';
 import { parse as parseYaml } from 'yaml';
 import type { PlanDefinition } from './orchestrator.js';
+import { detectDefaultBranchRemote } from './repo-default-branch.js';
 
 export class PlanParseError extends Error {
   constructor(message: string) {
@@ -58,25 +58,11 @@ export interface RawPlan {
   tasks?: RawPlanTask[];
 }
 
-function detectDefaultBranchRemote(repoUrl: string): string {
-  try {
-    const output = execFileSync('git', ['ls-remote', '--symref', repoUrl, 'HEAD'], {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-      timeout: 10_000,
-    }).trim();
-    const match = output.match(/ref:\s+refs\/heads\/(\S+)\s+HEAD/);
-    if (match) return match[1];
-  } catch {
-    // Network and local-path failures fall back to the common default.
-  }
-  return 'main';
-}
 
 function resolveDefaultBaseBranch(plan: PlanDefinition): string {
   const branch = plan.baseBranch;
   if (typeof branch === 'string' && branch.trim() !== '') return branch.trim();
-  return plan.repoUrl ? detectDefaultBranchRemote(plan.repoUrl) : 'main';
+  return plan.repoUrl ? detectDefaultBranchRemote(plan.repoUrl) ?? 'main' : 'main';
 }
 
 export function applyPlanDefinitionDefaults(plan: PlanDefinition): PlanDefinition {

--- a/packages/workflow-core/src/repo-default-branch.ts
+++ b/packages/workflow-core/src/repo-default-branch.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from 'node:child_process';
+
+
+export function detectDefaultBranchRemote(repoUrl: string): string | undefined {
+  const trimmed = repoUrl.trim();
+  if (trimmed === '') return undefined;
+
+  try {
+    const output = execFileSync('git', ['ls-remote', '--symref', trimmed, 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10_000,
+    }).trim();
+    return output.match(/ref:\s+refs\/heads\/(\S+)\s+HEAD/)?.[1];
+  } catch {
+    return undefined;
+  }
+}
+
+export function requireDefaultBranchRemote(repoUrl: string): string {
+  const branch = detectDefaultBranchRemote(repoUrl);
+  if (branch) return branch;
+  throw new Error(`Unable to resolve default branch for repo ${repoUrl}. Set a repo target branch or make the remote HEAD readable.`);
+}
+
+export function remoteBranchExists(repoUrl: string, branch: string): boolean {
+  const trimmedRepo = repoUrl.trim();
+  const trimmedBranch = branch.trim();
+  if (trimmedRepo === '' || trimmedBranch === '') return false;
+
+  try {
+    execFileSync('git', ['ls-remote', '--exit-code', '--heads', trimmedRepo, trimmedBranch], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function requireRemoteBranch(repoUrl: string, branch: string): string {
+  const trimmedBranch = branch.trim();
+  if (trimmedBranch === '') {
+    throw new Error('Target branch is required.');
+  }
+  if (!remoteBranchExists(repoUrl, trimmedBranch)) {
+    throw new Error(`Branch "${trimmedBranch}" does not exist on repo ${repoUrl}.`);
+  }
+  return trimmedBranch;
+}


### PR DESCRIPTION
## Summary

Invoker can now store a target branch per repo.

The headless `set` command gained workflow and repo target-branch forms. Both check the branch exists on the remote before saving.

New plan loads prefer the saved repo branch over remote HEAD.

<details>
<summary>Review metadata</summary>

Review Claim: The headless activation surface can set workflow and repo target branches safely.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The new commands only write after the target branch exists on the repo remote.

Slice Rationale: This exposes the core resolver seam before detach starts depending on it.

</details>

## Non-goals

This does not change detach behavior, merge checkout rules, or review gate policy.

## Architecture

### Before

Users could edit a workflow base through the GUI path, but there was no repo-level target branch command.

### After

Headless `set target-branch` updates one workflow. Headless `set repo-target-branch` saves a repo override for future plan loading and detach resolution.

## Test Plan

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/config.test.ts src/__tests__/repo-target-branch.test.ts src/__tests__/headless-command-classification.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert c5ad5bdd2`
- Post-revert steps: Revert dependent detach slice first.
- Data migration? No
