### PR TITLE
[Slack Lobby Routing](10) Acknowledge lobby mentions immediately before slow routing

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -404,12 +404,13 @@ describe('lobby verb routing', () => {
     draftedPlanForMock = null;
   });
 
-  function lobbySurface(withOp = true) {
+  function lobbySurface(withOp = true, extra: Partial<ConstructorParameters<typeof SlackSurface>[0]> = {}) {
     return new SlackSurface({
       ...baseConfig(),
       enableImmediateAck: false,
       planningCommandBuilder: () => ({ command: 'cursor', args: ['--print', 'x'] }),
       ...(withOp ? { runWorkflowOp } : {}),
+      ...extra,
     });
   }
 
@@ -576,6 +577,26 @@ describe('lobby verb routing', () => {
     const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
     await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'yes' }, say: say2 });
     expect(runWorkflowOp.mock.calls[0][0]).toEqual({ operation: 'recreate', target: { all: true } });
+  });
+
+  it('acknowledges a fuzzy operational mention immediately, before the classifier returns', async () => {
+    mockSpawn.mockImplementationOnce(() => mockProcess('{"intent":"command","operation":"recreate","target":"all"}'));
+    const surface = lobbySurface(true, { enableImmediateAck: true });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'ack-1' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> can you recreate everything please', ts: 't1', user: 'U1' }, say });
+    // Immediate "processing" receipt posts up front (then is cleared once the confirm is ready).
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: 'Processing your request...', thread_ts: 't1' }));
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not post a processing ack for an instant verb', async () => {
+    runWorkflowOp.mockResolvedValue({ ok: true, summary: '`wf-1`: 1 running, 0 pending, 0 done, 0 failed' });
+    const surface = lobbySurface(true, { enableImmediateAck: true });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> status', ts: 't1', user: 'U1' }, say });
+    expect(say).not.toHaveBeenCalledWith(expect.objectContaining({ text: 'Processing your request...' }));
   });
 
   it('answers a question with no session, workflow, or start_plan', async () => {

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -658,7 +658,7 @@ export class SlackSurface implements Surface {
     // Confirm/cancel a staged action first (plain yes/no in-thread).
     if (await this.resolveConfirm(threadTs, parsed.text, say, channel)) return;
 
-    // Deterministic verb commands take priority over the planning/LLM path.
+    // Deterministic verb commands respond instantly and take priority over the planner.
     const ctrl = parseLobbyControl(parsed.text);
     if (ctrl?.kind === 'op') {
       await this.handleLobbyOp(ctrl, threadTs, channel, say);
@@ -669,15 +669,20 @@ export class SlackSurface implements Surface {
       return;
     }
 
+    // Slower paths (LLM classifier, repo checkout, planner) acknowledge receipt up front.
+    if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
+
     // Fallback classifier: only when a non-verb message looks operational.
     if (looksOperational(parsed.text)) {
       const cls = await this.classifyLobbyIntent(parsed.text, preset);
       this.log('slack', 'info', `[CLASSIFY] thread_ts=${threadTs} intent=${cls.intent}`);
       if (cls.intent === 'command') {
+        await this.clearImmediateAck(channel, threadTs);
         await this.proposeLobbyOp(cls, threadTs, channel, say);
         return;
       }
       if (cls.intent === 'question') {
+        await this.clearImmediateAck(channel, threadTs);
         await this.answerLobbyQuestion(parsed.text, preset, threadTs, say);
         return;
       }
@@ -685,16 +690,6 @@ export class SlackSurface implements Surface {
     }
 
     // Default: a plain planning conversation (drafts a plan, never auto-submits).
-
-    if (this.enableImmediateAck) {
-      try {
-        const ackResult = await say({ text: this.immediateAckMessage, thread_ts: threadTs });
-        if (ackResult?.ts) this.ackMessages.set(threadTs, ackResult.ts);
-        this.log('slack', 'info', `[ACK] Sent immediate acknowledgment (thread_ts=${threadTs})`);
-      } catch (err) {
-        this.log('slack', 'error', `[ACK] Failed to send immediate acknowledgment: ${err}`);
-      }
-    }
 
     let workingDir = this.workingDir;
     if (repoUrl && this.prepareRepoCheckout) {
@@ -725,6 +720,25 @@ export class SlackSurface implements Surface {
     });
 
     await this.handleConversationMessage(conversation, parsed.text, threadTs, say, channel);
+  }
+
+  /** Post the immediate "received it" acknowledgment and track it for in-place replacement. */
+  private async sendImmediateAck(threadTs: string, say: SayFn): Promise<void> {
+    try {
+      const res = await say({ text: this.immediateAckMessage, thread_ts: threadTs });
+      if (res?.ts) this.ackMessages.set(threadTs, res.ts);
+      this.log('slack', 'info', `[ACK] Sent immediate acknowledgment (thread_ts=${threadTs})`);
+    } catch (err) {
+      this.log('slack', 'error', `[ACK] Failed to send immediate acknowledgment: ${err}`);
+    }
+  }
+
+  /** Drop the immediate ack — used by paths that post their own reply instead of replacing it. */
+  private async clearImmediateAck(channel: string, threadTs: string): Promise<void> {
+    const ts = this.ackMessages.get(threadTs);
+    if (!ts) return;
+    this.ackMessages.delete(threadTs);
+    await this.deleteMessage(channel, ts);
   }
 
   private async classifyLobbyIntent(text: string, harness: HarnessPreset): Promise<LobbyClassification> {


### PR DESCRIPTION
## Summary

Reorders the lobby mention routing so the "Processing your request…" receipt posts right after a mention is parsed.

It now fires before the slow LLM classifier, repo checkout, or planner — not only on the plain-conversation path.

A fuzzy operational mention is acknowledged instantly instead of looking dead while the classifier runs.

Instant verb replies need no receipt; the classifier and conversation paths clear or replace it.

<details>
<summary>Review metadata</summary>

Review Claim: Approve posting the immediate mention receipt before the slow routing branches.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Reuses the existing ack message and replacement path; instant verb ops are unchanged; failures to post or remove the receipt are caught and non-fatal.

Slice Rationale: A small routing-order fix on top of the verb model; reviews on its own apart from the host and manifest slices.

</details>

## Non-goals

Does not change which path handles a mention — only when the receipt posts. Verb, classifier, and conversation handling are otherwise identical.

## Test Plan

- [x] `CI=1 pnpm --filter @invoker/surfaces test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved immediate acknowledgements for planning requests so “Processing your request...” appears sooner for slower, classifier-based paths.
  * Removed the acknowledgement when a message is recognized as a direct command or question, reducing confusing extra messages.

* **Tests**
  * Added coverage for immediate acknowledgement behavior in both fuzzy operational mentions and instant command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->