### PR TITLE
[Intent Cancel Step 9](1) Fix intent cancellation Step 9: launch dispatch generation validation (restacked v3)

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -705,6 +705,162 @@ describe('LaunchDispatcher', () => {
       expect(events.some((event) => event.eventType === 'task.launch_dispatch_invalidated')).toBe(true);
     });
 
+    // Lineage-validation regression: the combined test above changes both
+    // the selected attempt AND the generation at once. These two cases
+    // isolate each field so a regression that drops one half of the
+    // `dispatchMatchesTask` check (attempt-only or generation-only) is
+    // still caught: a stale row must never reach the TaskRunner.
+
+    it('does not hand a dispatch row to TaskRunner when only the execution generation changed', () => {
+      const task = seedWorkflowAndTask('wf-a/t-gen-only', 'wf-a', {
+        selectedAttemptId: 'attempt-gen',
+        generation: 0,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-gen',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      // Same selected attempt, but the live task advanced to a newer
+      // executionGeneration (e.g. a retry bumped it) after the row was
+      // enqueued. Attempt id alone would still "match" — generation must
+      // catch this.
+      const currentTask = {
+        ...task,
+        execution: {
+          ...task.execution,
+          selectedAttemptId: 'attempt-gen',
+          generation: 1,
+        },
+      };
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(currentTask as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/selected attempt or generation changed/);
+      const invalidated = adapter
+        .getEvents(task.id)
+        .find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(invalidated).toBeDefined();
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        reason: 'selected_attempt_changed',
+        dispatchAttemptId: 'attempt-gen',
+        dispatchGeneration: 0,
+        selectedAttemptId: 'attempt-gen',
+        selectedGeneration: 1,
+      });
+    });
+
+    it('does not hand a dispatch row to TaskRunner when only the selected attempt id changed', () => {
+      const task = seedWorkflowAndTask('wf-a/t-attempt-only', 'wf-a', {
+        selectedAttemptId: 'attempt-old',
+        generation: 0,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-old',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      // Same generation, but the live task now points at a different
+      // selected attempt. Generation alone would still "match" — the
+      // attempt id must catch this.
+      const currentTask = {
+        ...task,
+        execution: {
+          ...task.execution,
+          selectedAttemptId: 'attempt-new',
+          generation: 0,
+        },
+      };
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(currentTask as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/selected attempt or generation changed/);
+      const invalidated = adapter
+        .getEvents(task.id)
+        .find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(invalidated).toBeDefined();
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        reason: 'selected_attempt_changed',
+        dispatchAttemptId: 'attempt-old',
+        dispatchGeneration: 0,
+        selectedAttemptId: 'attempt-new',
+        selectedGeneration: 0,
+      });
+    });
+
+    it('hands a dispatch row whose attempt and generation both match to the TaskRunner with no invalidation', () => {
+      const task = seedWorkflowAndTask('wf-a/t-valid-lineage', 'wf-a', {
+        selectedAttemptId: 'attempt-valid',
+        generation: 3,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-valid',
+        workflowId: 'wf-a',
+        generation: 3,
+      });
+      const currentTask = {
+        ...task,
+        execution: {
+          ...task.execution,
+          selectedAttemptId: 'attempt-valid',
+          generation: 3,
+        },
+      };
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(currentTask as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).toHaveBeenCalledTimes(1);
+      expect(executeTask.mock.calls[0]?.[1]?.dispatchId).toBe(enq.id);
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('leased');
+      expect(
+        adapter
+          .getEvents(task.id)
+          .some((event) => event.eventType === 'task.launch_dispatch_invalidated'),
+      ).toBe(false);
+    });
+
     it('abandons the dispatch when readiness is blocked', () => {
       const task = seedWorkflowAndTask('wf-a/t-blocked', 'wf-a', {
         selectedAttemptId: 'attempt-blocked',


### PR DESCRIPTION
## Summary

Adds regression tests that lock in launch-dispatch lineage checks before a row reaches the TaskRunner.

The tests prove a queued dispatch is abandoned when its selected attempt or its execution generation no longer matches the live task.

They also prove a row whose attempt and generation both still match is handed off, with no false invalidation.

<details>
<summary>Review metadata</summary>

Review Claim: Approve test-only coverage that pins launch-dispatch lineage handling before TaskRunner handoff; no runtime code ships here.

Review Lane: proof

Review Unit: proof

Safety Invariant: This is a single test-only file. It adds no product code and cannot alter runtime behavior, so it is safe to review on its own.

Slice Rationale: Kept as a standalone proof slice so the regression coverage lands separately from any dispatcher behavior change.

</details>

## Non-goals

- Does not change launch dispatcher runtime code or any product behavior.
- Does not touch the TaskRunner, persistence schema, or message routing.

## Test Plan

- [ ] `cd packages/app && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
