### PR TITLE
[Fix intent cancellation Step 9](1) launch dispatch generation validation (restacked v3)

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -705,6 +705,150 @@ describe('LaunchDispatcher', () => {
       expect(events.some((event) => event.eventType === 'task.launch_dispatch_invalidated')).toBe(true);
     });
 
+
+    it('does not hand a dispatch row to TaskRunner when only the execution generation changed', () => {
+      const task = seedWorkflowAndTask('wf-a/t-gen-only', 'wf-a', {
+        selectedAttemptId: 'attempt-gen',
+        generation: 0,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-gen',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      const currentTask = {
+        ...task,
+        execution: {
+          ...task.execution,
+          selectedAttemptId: 'attempt-gen',
+          generation: 1,
+        },
+      };
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(currentTask as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/selected attempt or generation changed/);
+      const invalidated = adapter
+        .getEvents(task.id)
+        .find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(invalidated).toBeDefined();
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        reason: 'selected_attempt_changed',
+        dispatchAttemptId: 'attempt-gen',
+        dispatchGeneration: 0,
+        selectedAttemptId: 'attempt-gen',
+        selectedGeneration: 1,
+      });
+    });
+
+    it('does not hand a dispatch row to TaskRunner when only the selected attempt id changed', () => {
+      const task = seedWorkflowAndTask('wf-a/t-attempt-only', 'wf-a', {
+        selectedAttemptId: 'attempt-old',
+        generation: 0,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-old',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      const currentTask = {
+        ...task,
+        execution: {
+          ...task.execution,
+          selectedAttemptId: 'attempt-new',
+          generation: 0,
+        },
+      };
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(currentTask as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/selected attempt or generation changed/);
+      const invalidated = adapter
+        .getEvents(task.id)
+        .find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(invalidated).toBeDefined();
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        reason: 'selected_attempt_changed',
+        dispatchAttemptId: 'attempt-old',
+        dispatchGeneration: 0,
+        selectedAttemptId: 'attempt-new',
+        selectedGeneration: 0,
+      });
+    });
+
+    it('hands a dispatch row whose attempt and generation both match to the TaskRunner with no invalidation', () => {
+      const task = seedWorkflowAndTask('wf-a/t-valid-lineage', 'wf-a', {
+        selectedAttemptId: 'attempt-valid',
+        generation: 3,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-valid',
+        workflowId: 'wf-a',
+        generation: 3,
+      });
+      const currentTask = {
+        ...task,
+        execution: {
+          ...task.execution,
+          selectedAttemptId: 'attempt-valid',
+          generation: 3,
+        },
+      };
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(currentTask as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).toHaveBeenCalledTimes(1);
+      expect(executeTask.mock.calls[0]?.[1]?.dispatchId).toBe(enq.id);
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('leased');
+      expect(
+        adapter
+          .getEvents(task.id)
+          .some((event) => event.eventType === 'task.launch_dispatch_invalidated'),
+      ).toBe(false);
+    });
+
     it('abandons the dispatch when readiness is blocked', () => {
       const task = seedWorkflowAndTask('wf-a/t-blocked', 'wf-a', {
         selectedAttemptId: 'attempt-blocked',


### PR DESCRIPTION
## Summary

This change adds launch dispatcher regression tests. No product code changes.

The tests cover stale rows one field at a time: old generation, old attempt, and a matching happy path.

That proves CodeRabbit picked the right file: this PR only changes `packages/app/src/__tests__/launch-dispatcher.test.ts`.

<details>
<summary>Review metadata</summary>

Review Claim: Approve a proof-only test that pins the launch dispatcher lineage guard, so old-attempt and old-generation rows stay out of the TaskRunner.

Review Lane: proof

Review Unit: proof

Safety Invariant: This slice is proof only. It changes one test file under `__tests__` and touches no runtime code.

Slice Rationale: This is regression proof for an already-merged guard. It lands alone so reviewers approve coverage without re-approving runtime code.

</details>

## Non-goals

This does not change launch dispatcher runtime behavior.

This does not change merge-gate execution or persistence writes.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/launch-dispatcher.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for launch dispatch handling when a task’s lineage changes, ensuring invalid dispatches are not processed and are marked as abandoned.
  * Added verification for matching lineage to confirm valid dispatches continue to be leased and processed normally.
  * Added assertions for correct error messaging and `task.launch_dispatch_invalidated` event payloads when attempt or generation selection changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->