### PR TITLE
[Normalize GitHub review gates for Invoker tasks](1) Slack planner prompt

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -649,6 +649,19 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).toContain('do not impose Invoker-specific commands on external repos');
     expect(prompt).toContain('reserve broad/full-suite commands for the final gate only when the target repo documents such a command');
   });
+
+  it('system prompt advertises external_review as the GitHub-backed review gate', () => {
+    const conv = new PlanConversation({});
+    (conv as any).messages.push({ role: 'user', content: 'Implement a small feature' });
+    const prompt = conv.buildCursorPrompt();
+
+    // The canonical GitHub review gate must be named explicitly for reviewable plans.
+    expect(prompt).toContain('mergeMode: external_review');
+    expect(prompt).toContain('GitHub-backed review gate');
+    // Manual remains the verification-only default; automatic still documented.
+    expect(prompt).toContain('"manual" (default)');
+    expect(prompt).toContain('"automatic"');
+  });
 });
 
 describe('isDangerousCommand', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -108,7 +108,7 @@ A plan has this structure:
 name: "Plan Name"
 ${repoUrlLine}
 onFinish: pull_request  # "pull_request" (default), "merge", or "none"
-mergeMode: manual       # "manual" (default) or "automatic"
+mergeMode: external_review  # "external_review" = GitHub-backed review gate for reviewable implementation work; "manual" (default) = verification-only, no review; "automatic" = merge without review
 baseBranch: ${defaultBranch}        # base git branch
 featureBranch: plan/my-feature  # auto-generated from plan name if omitted
 tasks:
@@ -148,7 +148,8 @@ Rules:
 8. When ready, output the plan inside a \`\`\`yaml code block.
 9. Always include \`dependencies\` (even if empty array).
 10. After generating a plan, tell the user they can confirm execution by replying with "yes", "go", "execute", etc.
-11. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically when the user confirms.`;
+11. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically when the user confirms.
+12. Choose \`mergeMode\` deliberately. For reviewable implementation plans, set \`mergeMode: external_review\` so changes land through the canonical GitHub-backed review gate. Keep \`mergeMode: manual\` (the default) for verification-only plans that should not open a review, and use \`mergeMode: automatic\` only when the user explicitly wants changes merged without review.`;
 }
 
 // ── Dangerous Command Detection ─────────────────────────────


### PR DESCRIPTION
## Summary

The Slack planning prompt now teaches Invoker plan authors that `mergeMode: external_review` is the canonical GitHub-backed review gate.

The parser already treats `external_review` as the live review-gate mode, but the prompt only showed `manual` and `automatic`. Reviewable implementation plans could miss the gate entirely.

This slice changes only the prompt contract and its focused regression. Parser semantics and merge execution stay untouched.

<details>
<summary>Review metadata</summary>

Review Claim: The planner prompt advertises `external_review` as the GitHub-backed review-gate option for reviewable implementation plans.

Review Lane: behavior

Review Unit: contract

Safety Invariant: Only the planning prompt contract and its focused regression test change; parser enums and merge runtime behavior stay untouched.

Slice Rationale: Fix the prompt source first so newly generated plans stop carrying outdated merge-mode guidance before the follow-up slice realigns the skill references.

</details>

## Non-goals

- Do not change parser enums, merge execution, or UI merge-mode behavior.
- Do not realign plan-to-invoker skill references (handled by the next slice).

## Test Plan

- [ ] `cd packages/surfaces && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
