### PR TITLE
[Normalize GitHub review gates for Invoker tasks](2) Plan-to-invoker skill docs and fixtures

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -649,6 +649,19 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).toContain('do not impose Invoker-specific commands on external repos');
     expect(prompt).toContain('reserve broad/full-suite commands for the final gate only when the target repo documents such a command');
   });
+
+  it('system prompt advertises external_review as the GitHub-backed review gate', () => {
+    const conv = new PlanConversation({});
+    (conv as any).messages.push({ role: 'user', content: 'Implement a small feature' });
+    const prompt = conv.buildCursorPrompt();
+
+    // The canonical GitHub review gate must be named explicitly for reviewable plans.
+    expect(prompt).toContain('mergeMode: external_review');
+    expect(prompt).toContain('GitHub-backed review gate');
+    // Manual remains the verification-only default; automatic still documented.
+    expect(prompt).toContain('"manual" (default)');
+    expect(prompt).toContain('"automatic"');
+  });
 });
 
 describe('isDangerousCommand', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -108,7 +108,7 @@ A plan has this structure:
 name: "Plan Name"
 ${repoUrlLine}
 onFinish: pull_request  # "pull_request" (default), "merge", or "none"
-mergeMode: manual       # "manual" (default) or "automatic"
+mergeMode: external_review  # "external_review" = GitHub-backed review gate for reviewable implementation work; "manual" (default) = verification-only, no review; "automatic" = merge without review
 baseBranch: ${defaultBranch}        # base git branch
 featureBranch: plan/my-feature  # auto-generated from plan name if omitted
 tasks:
@@ -148,7 +148,8 @@ Rules:
 8. When ready, output the plan inside a \`\`\`yaml code block.
 9. Always include \`dependencies\` (even if empty array).
 10. After generating a plan, tell the user they can confirm execution by replying with "yes", "go", "execute", etc.
-11. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically when the user confirms.`;
+11. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically when the user confirms.
+12. Choose \`mergeMode\` deliberately. For reviewable implementation plans, set \`mergeMode: external_review\` so changes land through the canonical GitHub-backed review gate. Keep \`mergeMode: manual\` (the default) for verification-only plans that should not open a review, and use \`mergeMode: automatic\` only when the user explicitly wants changes merged without review.`;
 }
 
 // ── Dangerous Command Detection ─────────────────────────────

--- a/skills/plan-to-invoker/playbooks/verify-then-build.md
+++ b/skills/plan-to-invoker/playbooks/verify-then-build.md
@@ -145,7 +145,7 @@ Remove verification workflows before submitting the **implementation** plan if y
 
 Use verified facts + `references/task-patterns.md` to generate the implementation plan.
 
-Set `mergeMode: github` (GitHub PR / **GithubPR** merge gate) on the implementation YAML unless the user explicitly asked for `manual` or `automatic`.
+Set `mergeMode: external_review` (the GitHub-backed PR review gate) on the implementation YAML unless the user explicitly asked for `manual` or `automatic`.
 
 For prompt tasks in implementation plans, write instructions as if the remote executor has no chat history:
 

--- a/skills/plan-to-invoker/references/examples.md
+++ b/skills/plan-to-invoker/references/examples.md
@@ -84,7 +84,7 @@ description: |
 When the target repo is Invoker itself, keep the plan shape normal:
 
 - `onFinish: pull_request`
-- `mergeMode: github`
+- `mergeMode: external_review`
 
 Then make the repo-specific publication step explicit: once the branch's commit stack is ready, publish/update it with `mergify stack push`.
 
@@ -137,7 +137,7 @@ Use this pattern when a change is too large for a single reviewable workflow. Fo
 - Feature implementation → implement → focused proof → verify, `onFinish: merge`
 - Multi-step refactors → omit routing fields for default worktree execution, chained dependencies
 - Large refactors → `onFinish: pull_request`, diamond DAGs
-- Invoker-on-Invoker PR publication → keep `mergeMode: github`, then use `mergify stack push` as the repo-specific publication step
+- Invoker-on-Invoker PR publication → keep `mergeMode: external_review`, then use `mergify stack push` as the repo-specific publication step
 - Policy matrix / architecture docs → preserve row-level coverage with `coverage-map.json` and `stack-manifest.json`
 - Dependency-first layered decomposition → enforce `Layer:` + `Feature state:` metadata, preserve dependency direction, allow explicit dormant tasks
 

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -21,7 +21,7 @@ Source of truth: `packages/surfaces/src/slack/plan-conversation.ts:100-116`
 | "Modify UI component" / "Fix layout" / "Change Electron window UI" | `prompt` + `visualProof: true` | Set `visualProof: true` at plan level; include `description` |
 | **Add visual proof E2E test case** | `prompt` | Add a test to `packages/app/e2e/visual-proof.spec.ts` that sets up the exact UI state being changed and calls `captureScreenshot(page, '<plan-slug>-<state>')`. See `skills/visual-proof/SKILL.md`. |
 | **Capture visual proof (after)** | `command` | `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after` — depends on **all** implementation tasks |
-| **Invoker-on-Invoker PR publication** | repo-level workflow note | Keep `onFinish: pull_request` + `mergeMode: github`, then publish/update the commit stack with `mergify stack push` once the branch is ready |
+| **Invoker-on-Invoker PR publication** | repo-level workflow note | Keep `onFinish: pull_request` + `mergeMode: external_review`, then publish/update the commit stack with `mergify stack push` once the branch is ready |
 
 Command tasks run under the platform default shell unless the command explicitly invokes another shell. Keep commands POSIX-shell portable by default. If a command needs bash-only options such as `set -o pipefail` or `set -euo pipefail`, wrap it explicitly, for example `bash -lc 'set -euo pipefail; ...'`.
 
@@ -257,7 +257,7 @@ description: |
   Constrains ApprovalModal height to 90vh and adds internal scroll.
   Architecture: uses flex-col + overflow-y-auto pattern.
 onFinish: pull_request
-mergeMode: github
+mergeMode: external_review
 visualProof: true
 tasks:
   - id: add-visual-proof-test

--- a/skills/plan-to-invoker/scripts/test-fixtures.sh
+++ b/skills/plan-to-invoker/scripts/test-fixtures.sh
@@ -463,7 +463,7 @@ test_lint_rejects_multi_prompt_standalone_without_waiver() {
 name: "Invalid multi-prompt standalone workflow"
 description: "Implementation workflow with multiple prompt slices but no stack context."
 onFinish: pull_request
-mergeMode: github
+mergeMode: external_review
 repoUrl: git@github.com:example-org/acme-repo.git
 tasks:
   - id: implement-surface
@@ -565,7 +565,7 @@ test_lint_allows_nonterminal_stack_workflow_without_test_all() {
 name: "Stack step 1 with focused verification"
 description: "First implementation workflow in a stack with focused verification."
 onFinish: pull_request
-mergeMode: github
+mergeMode: external_review
 repoUrl: git@github.com:example-org/acme-repo.git
 featureBranch: plan/stack-step-1
 tasks:
@@ -658,7 +658,7 @@ EOF
 name: "Stack step 2 focused verification"
 description: "Terminal implementation workflow in a stack with focused verification."
 onFinish: pull_request
-mergeMode: github
+mergeMode: external_review
 repoUrl: git@github.com:example-org/acme-repo.git
 baseBranch: plan/stack-step-1
 featureBranch: plan/stack-step-2
@@ -1210,7 +1210,7 @@ test_lint_requires_review_lane() {
 name: "Missing review lane"
 description: "Implementation plan missing review lane metadata."
 onFinish: pull_request
-mergeMode: github
+mergeMode: external_review
 repoUrl: git@github.com:example-org/acme-repo.git
 tasks:
   - id: implement-owner-fallback


### PR DESCRIPTION
## Summary

The plan-to-invoker skill references and fixture inline plans now use `mergeMode: external_review` for reviewable implementation plans.

The repo's parser already treats `external_review` as the canonical GitHub-backed review gate, but the skill examples and fixture inline plans still showed the older `mergeMode: github` wording.

Only docs, examples, and deterministic fixture checks change. Parser behavior and merge execution stay untouched.

<details>
<summary>Review metadata</summary>

Review Claim: Plan-to-invoker skill docs and fixture inline plans describe GitHub review gates with `mergeMode: external_review`.

Review Lane: docs

Review Unit: docs

Safety Invariant: Only docs, examples, and deterministic fixture checks change; parser behavior, merge execution, and unrelated product code stay untouched.

Slice Rationale: After the planner prompt slice fixes the source of new plans, this slice realigns the skill docs and fixture inline plans so the two sources agree on `external_review` wording.

</details>

## Non-goals

- Do not alter parser validation rules or widen merge-mode acceptance.
- Do not change the Slack planner prompt (handled by the preceding slice).

## Test Plan

- [ ] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2529
