### PR TITLE
[CLI/UI Setup Parity Step 2: Drive GUI diagnostics from shared readiness](1) Wire GUI diagnostics to shared readiness

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   loadConfig,
+  resolveConfigFilePath,
   resolveDefaultExecutionAgent,
   resolveEmbeddedTerminalBackendConfig,
 } from '../config.js';
@@ -10,12 +11,13 @@ import { tmpdir } from 'node:os';
 
 const testDir = join(tmpdir(), `invoker-config-test-${process.pid}`);
 const fakeHome = join(testDir, 'home');
-
 beforeEach(() => {
+  delete process.env.INVOKER_REPO_CONFIG_PATH;
   mkdirSync(join(fakeHome, '.invoker'), { recursive: true });
 });
 
 afterEach(() => {
+  delete process.env.INVOKER_REPO_CONFIG_PATH;
   rmSync(testDir, { recursive: true, force: true });
 });
 
@@ -270,6 +272,16 @@ describe('loadConfig', () => {
     expect(config.defaultPoolId).toBe('mixed-local-ssh');
   });
 
+
+  it('treats a blank env config path override as unset', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ defaultBranch: 'main' }),
+    );
+    process.env.INVOKER_REPO_CONFIG_PATH = '   ';
+    expect(resolveConfigFilePath()).toBe(join(fakeHome, '.invoker', 'config.json'));
+    expect(loadConfig().defaultBranch).toBe('main');
+  });
 });
 
 describe('resolveEmbeddedTerminalBackendConfig', () => {

--- a/packages/app/src/__tests__/system-diagnostics.test.ts
+++ b/packages/app/src/__tests__/system-diagnostics.test.ts
@@ -3,7 +3,9 @@ import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, expect, it, afterAll, beforeAll } from 'vitest';
 
-import { detectTool } from '../system-diagnostics.js';
+import { DEFAULT_TOOL_REQUIREMENTS } from '@invoker/contracts';
+
+import { collectSystemDiagnostics, commandIsOnPath, detectTool } from '../system-diagnostics.js';
 
 /**
  * Regression for the deterministic Electron main-thread wedge observed
@@ -65,4 +67,57 @@ describe('detectTool — main-thread hang protection', () => {
     expect(result.installed).toBe(true);
     expect(result.version).toMatch(/^v\d+/);
   }, 5000);
+});
+
+const baseArgs = {
+  appVersion: '0.0.0-test',
+  isPackaged: false,
+  platform: 'linux' as NodeJS.Platform,
+  arch: 'x64',
+};
+
+describe('commandIsOnPath — non-spawning PATH probe', () => {
+  it('resolves a binary present on PATH and rejects a missing one', () => {
+    // `node` is always on PATH while the test runner executes.
+    expect(commandIsOnPath('node')).toBe(true);
+    expect(commandIsOnPath('definitely-not-a-real-binary-xyz')).toBe(false);
+  });
+
+  it('honors an injected PATH and finds nothing when PATH is empty', () => {
+    expect(commandIsOnPath('node', { PATH: '' })).toBe(false);
+  });
+});
+
+describe('collectSystemDiagnostics — shared canonical contract', () => {
+  it('builds the tools array from DEFAULT_TOOL_REQUIREMENTS', () => {
+    const diag = collectSystemDiagnostics(baseArgs);
+    expect(diag.tools.map((t) => t.id)).toEqual(DEFAULT_TOOL_REQUIREMENTS.map((r) => r.id));
+    expect(diag.tools.map((t) => t.name)).toEqual(DEFAULT_TOOL_REQUIREMENTS.map((r) => r.name));
+  });
+
+  it('assembles a config-aware readiness report with config, planning-tools, and default-preset checks', () => {
+    const diag = collectSystemDiagnostics({
+      ...baseArgs,
+      config: { path: '/tmp/invoker-nonexistent/config.json', exists: false },
+      presets: { 'cursor+claude': { tool: 'cursor', model: 'claude' } },
+      defaultPreset: 'cursor+claude',
+    });
+    const ids = diag.readiness.map((c) => c.id);
+    expect(ids).toContain('config');
+    expect(ids).toContain('planning-tools');
+    expect(ids).toContain('default-preset');
+    // Readiness tool checks mirror the same canonical contract as the tools array.
+    for (const req of DEFAULT_TOOL_REQUIREMENTS) expect(ids).toContain(req.id);
+  });
+
+  it('skips the preset checks when no presets are configured', () => {
+    const diag = collectSystemDiagnostics({
+      ...baseArgs,
+      config: { path: '/tmp/invoker-nonexistent/config.json', exists: false },
+    });
+    const ids = diag.readiness.map((c) => c.id);
+    expect(ids).toContain('config');
+    expect(ids).not.toContain('planning-tools');
+    expect(ids).not.toContain('default-preset');
+  });
 });

--- a/packages/app/src/__tests__/system-diagnostics.test.ts
+++ b/packages/app/src/__tests__/system-diagnostics.test.ts
@@ -77,27 +77,60 @@ const baseArgs = {
 };
 
 describe('commandIsOnPath — non-spawning PATH probe', () => {
-  it('resolves a binary present on PATH and rejects a missing one', () => {
-    // `node` is always on PATH while the test runner executes.
-    expect(commandIsOnPath('node')).toBe(true);
-    expect(commandIsOnPath('definitely-not-a-real-binary-xyz')).toBe(false);
+  let scratchDir: string;
+  let presentCli: string;
+
+  beforeAll(() => {
+    scratchDir = mkdtempSync(path.join(tmpdir(), 'invoker-path-diag-'));
+    presentCli = path.join(scratchDir, 'fake-present-cli');
+    writeFileSync(presentCli, '#!/usr/bin/env bash\nexit 0\n', 'utf8');
+    chmodSync(presentCli, 0o755);
+  });
+
+  afterAll(() => {
+    rmSync(scratchDir, { recursive: true, force: true });
+  });
+
+  it('resolves a binary present on an injected PATH and rejects a missing one', () => {
+    expect(commandIsOnPath('fake-present-cli', { PATH: scratchDir })).toBe(true);
+    expect(commandIsOnPath('definitely-not-a-real-binary-xyz', { PATH: scratchDir })).toBe(false);
   });
 
   it('honors an injected PATH and finds nothing when PATH is empty', () => {
-    expect(commandIsOnPath('node', { PATH: '' })).toBe(false);
+    expect(commandIsOnPath('fake-present-cli', { PATH: '' })).toBe(false);
   });
+});
+
+type CollectSystemDiagnosticsArgs = Parameters<typeof collectSystemDiagnostics>[0];
+
+const stubToolDetector: NonNullable<CollectSystemDiagnosticsArgs['toolDetector']> = (
+  id,
+  name,
+  _command,
+  _versionArgs,
+  installHint,
+  required = false,
+) => ({ id, name, required, installed: true, version: `${id}-test`, installHint });
+
+const collectWithStubbedTools = (
+  overrides: Partial<CollectSystemDiagnosticsArgs> = {},
+) => collectSystemDiagnostics({
+  ...baseArgs,
+  toolDetector: stubToolDetector,
+  isInstalled: () => true,
+  ...overrides,
 });
 
 describe('collectSystemDiagnostics — shared canonical contract', () => {
   it('builds the tools array from DEFAULT_TOOL_REQUIREMENTS', () => {
-    const diag = collectSystemDiagnostics(baseArgs);
+    const diag = collectWithStubbedTools();
     expect(diag.tools.map((t) => t.id)).toEqual(DEFAULT_TOOL_REQUIREMENTS.map((r) => r.id));
     expect(diag.tools.map((t) => t.name)).toEqual(DEFAULT_TOOL_REQUIREMENTS.map((r) => r.name));
+    expect(diag.tools.map((t) => t.version)).toEqual(DEFAULT_TOOL_REQUIREMENTS.map((r) => `${r.id}-test`));
   });
 
   it('assembles a config-aware readiness report with config, planning-tools, and default-preset checks', () => {
-    const diag = collectSystemDiagnostics({
-      ...baseArgs,
+    const diag = collectWithStubbedTools({
       config: { path: '/tmp/invoker-nonexistent/config.json', exists: false },
       presets: { 'cursor+claude': { tool: 'cursor', model: 'claude' } },
       defaultPreset: 'cursor+claude',
@@ -111,8 +144,7 @@ describe('collectSystemDiagnostics — shared canonical contract', () => {
   });
 
   it('skips the preset checks when no presets are configured', () => {
-    const diag = collectSystemDiagnostics({
-      ...baseArgs,
+    const diag = collectWithStubbedTools({
       config: { path: '/tmp/invoker-nonexistent/config.json', exists: false },
     });
     const ids = diag.readiness.map((c) => c.id);

--- a/packages/app/src/__tests__/system-diagnostics.test.ts
+++ b/packages/app/src/__tests__/system-diagnostics.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
-import { describe, expect, it, afterAll, beforeAll } from 'vitest';
+import { describe, expect, it, afterAll, beforeAll, beforeEach } from 'vitest';
 
 import { DEFAULT_TOOL_REQUIREMENTS } from '@invoker/contracts';
 
@@ -103,14 +103,19 @@ describe('commandIsOnPath — non-spawning PATH probe', () => {
 
 type CollectSystemDiagnosticsArgs = Parameters<typeof collectSystemDiagnostics>[0];
 
+const observedToolDetections: Array<{ id: string; versionArgs: string[] }> = [];
+
 const stubToolDetector: NonNullable<CollectSystemDiagnosticsArgs['toolDetector']> = (
   id,
   name,
   _command,
-  _versionArgs,
+  versionArgs,
   installHint,
   required = false,
-) => ({ id, name, required, installed: true, version: `${id}-test`, installHint });
+) => {
+  observedToolDetections.push({ id, versionArgs });
+  return { id, name, required, installed: true, version: `${id}-test`, installHint };
+};
 
 const collectWithStubbedTools = (
   overrides: Partial<CollectSystemDiagnosticsArgs> = {},
@@ -122,11 +127,18 @@ const collectWithStubbedTools = (
 });
 
 describe('collectSystemDiagnostics — shared canonical contract', () => {
+  beforeEach(() => {
+    observedToolDetections.length = 0;
+  });
   it('builds the tools array from DEFAULT_TOOL_REQUIREMENTS', () => {
     const diag = collectWithStubbedTools();
     expect(diag.tools.map((t) => t.id)).toEqual(DEFAULT_TOOL_REQUIREMENTS.map((r) => r.id));
     expect(diag.tools.map((t) => t.name)).toEqual(DEFAULT_TOOL_REQUIREMENTS.map((r) => r.name));
     expect(diag.tools.map((t) => t.version)).toEqual(DEFAULT_TOOL_REQUIREMENTS.map((r) => `${r.id}-test`));
+    expect(observedToolDetections.find((entry) => entry.id === 'ssh')?.versionArgs).toEqual(['-V']);
+    expect(observedToolDetections.filter((entry) => entry.id !== 'ssh').map((entry) => entry.versionArgs)).toEqual(
+      DEFAULT_TOOL_REQUIREMENTS.filter((req) => req.id !== 'ssh').map(() => ['--version']),
+    );
   });
 
   it('assembles a config-aware readiness report with config, planning-tools, and default-preset checks', () => {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -287,10 +287,17 @@ function readJsonSafe(path: string): InvokerConfig {
   return parsed as InvokerConfig;
 }
 
+export function resolveConfigFilePath(): string {
+  return process.env.INVOKER_REPO_CONFIG_PATH ?? join(homedir(), '.invoker', 'config.json');
+}
+
+export function resolveConfigFileState(): { path: string; exists: boolean } {
+  const path = resolveConfigFilePath();
+  return { path, exists: existsSync(path) };
+}
+
 export function loadConfig(): InvokerConfig {
-  return process.env.INVOKER_REPO_CONFIG_PATH
-    ? readJsonSafe(process.env.INVOKER_REPO_CONFIG_PATH)
-    : readJsonSafe(join(homedir(), '.invoker', 'config.json'));
+  return readJsonSafe(resolveConfigFilePath());
 }
 export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
   const configured = config.defaultExecutionAgent?.trim();

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -265,6 +265,14 @@ export interface InvokerConfig {
    */
   externalWorkers?: ExternalWorkerConfig[];
 }
+export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {
+  'cursor+claude': { tool: 'cursor', model: 'claude' },
+  'cursor+codex': { tool: 'cursor', model: 'codex' },
+  'omp+claude': { tool: 'omp', model: 'claude' },
+  'omp+codex': { tool: 'omp', model: 'codex' },
+  omp: { tool: 'omp' },
+  codex: { tool: 'codex' },
+};
 
 function readJsonSafe(path: string): InvokerConfig {
   if (!existsSync(path)) {
@@ -288,7 +296,8 @@ function readJsonSafe(path: string): InvokerConfig {
 }
 
 export function resolveConfigFilePath(): string {
-  return process.env.INVOKER_REPO_CONFIG_PATH ?? join(homedir(), '.invoker', 'config.json');
+  const override = process.env.INVOKER_REPO_CONFIG_PATH?.trim();
+  return override || join(homedir(), '.invoker', 'config.json');
 }
 
 export function resolveConfigFileState(): { path: string; exists: boolean } {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -103,6 +103,7 @@ import {
 import { FileAndDbLogger } from './logger.js';
 import type { TaskOutputData } from './types.js';
 import {
+  DEFAULT_SLACK_HARNESS_PRESETS,
   loadConfig,
   resolveConfigFileState,
   resolveEmbeddedTerminalBackendConfig,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -104,6 +104,7 @@ import { FileAndDbLogger } from './logger.js';
 import type { TaskOutputData } from './types.js';
 import {
   loadConfig,
+  resolveConfigFileState,
   resolveEmbeddedTerminalBackendConfig,
   type EmbeddedTerminalBackendConfig,
   type InvokerConfig,
@@ -2893,6 +2894,9 @@ function createEmbeddedTerminalBackendFromConfig(
             isPackaged: app.isPackaged,
             platform: process.platform,
             arch: process.arch,
+            config: resolveConfigFileState(),
+            presets: invokerConfig.slackHarnessPresets ?? DEFAULT_SLACK_HARNESS_PRESETS,
+            defaultPreset: invokerConfig.defaultSlackHarnessPreset ?? 'cursor+claude',
           }),
           logger,
         });
@@ -4516,6 +4520,9 @@ function createEmbeddedTerminalBackendFromConfig(
         arch: process.arch,
         bundledSkills: getBundledSkillsStatus(),
         cliInstaller: resolveCliInstallerStatus(buildCliInstallerContext()),
+        config: resolveConfigFileState(),
+        presets: invokerConfig.slackHarnessPresets ?? DEFAULT_SLACK_HARNESS_PRESETS,
+        defaultPreset: invokerConfig.defaultSlackHarnessPreset ?? 'cursor+claude',
       });
     });
 

--- a/packages/app/src/system-diagnostics.ts
+++ b/packages/app/src/system-diagnostics.ts
@@ -1,6 +1,15 @@
 import { spawnSync } from 'node:child_process';
+import { accessSync, constants, statSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
 
-import type { SystemDiagnostics, SystemToolStatus } from '@invoker/contracts';
+import {
+  DEFAULT_TOOL_REQUIREMENTS,
+  assembleReadinessChecks,
+  type PlanningPresetSpec,
+  type PrerequisiteCheck,
+  type SystemDiagnostics,
+  type SystemToolStatus,
+} from '@invoker/contracts';
 
 /**
  * Exported only so the regression test in
@@ -53,6 +62,32 @@ export function detectTool(
   };
 }
 
+export function commandIsOnPath(command: string, env: NodeJS.ProcessEnv = process.env): boolean {
+  if (command.includes('/') || command.includes('\\')) {
+    return isExecutableFile(command);
+  }
+  const pathDirs = (env.PATH ?? '').split(delimiter).filter(Boolean);
+  const extensions = process.platform === 'win32'
+    ? (env.PATHEXT ?? '.EXE;.CMD;.BAT;.COM').split(';').filter(Boolean)
+    : [''];
+  for (const dir of pathDirs) {
+    for (const ext of extensions) {
+      if (isExecutableFile(join(dir, command + ext))) return true;
+    }
+  }
+  return false;
+}
+
+function isExecutableFile(candidate: string): boolean {
+  try {
+    if (!statSync(candidate).isFile()) return false;
+    accessSync(candidate, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function collectSystemDiagnostics(args: {
   appVersion: string;
   isPackaged: boolean;
@@ -60,7 +95,22 @@ export function collectSystemDiagnostics(args: {
   arch: string;
   bundledSkills?: SystemDiagnostics['bundledSkills'];
   cliInstaller?: SystemDiagnostics['cliInstaller'];
-}): SystemDiagnostics {
+  config?: { path: string; exists: boolean; error?: string };
+  presets?: Record<string, PlanningPresetSpec>;
+  defaultPreset?: string;
+}): SystemDiagnostics & { readiness: PrerequisiteCheck[] } {
+  const tools = DEFAULT_TOOL_REQUIREMENTS.map((req) =>
+    detectTool(req.id, req.name, req.command, ['--version'], req.installHint ?? '', req.required ?? false),
+  );
+
+  const readiness = assembleReadinessChecks({
+    tools: DEFAULT_TOOL_REQUIREMENTS,
+    isInstalled: commandIsOnPath,
+    config: args.config,
+    presets: args.presets,
+    defaultPreset: args.defaultPreset,
+  });
+
   return {
     platform: args.platform,
     arch: args.arch,
@@ -68,13 +118,7 @@ export function collectSystemDiagnostics(args: {
     isPackaged: args.isPackaged,
     bundledSkills: args.bundledSkills,
     cliInstaller: args.cliInstaller,
-    tools: [
-      detectTool('git', 'Git', 'git', ['--version'], 'Install Git before running workflows.', true),
-      detectTool('node', 'Node.js', 'node', ['--version'], 'Install Node.js 26 for repo-based workflows.'),
-      detectTool('pnpm', 'pnpm', 'pnpm', ['--version'], 'Install pnpm for repo-based workflows that use the default provision command.'),
-      detectTool('claude', 'Claude CLI', 'claude', ['--version'], 'Install Claude CLI if you want Claude-backed execution or fix flows.'),
-      detectTool('codex', 'Codex CLI', 'codex', ['--version'], 'Install Codex CLI if you want Codex-backed execution or fix flows.'),
-      detectTool('docker', 'Docker', 'docker', ['--version'], 'Install Docker if you want Docker executor support.'),
-    ],
+    tools,
+    readiness,
   };
 }

--- a/packages/app/src/system-diagnostics.ts
+++ b/packages/app/src/system-diagnostics.ts
@@ -98,14 +98,18 @@ export function collectSystemDiagnostics(args: {
   config?: { path: string; exists: boolean; error?: string };
   presets?: Record<string, PlanningPresetSpec>;
   defaultPreset?: string;
+  toolDetector?: typeof detectTool;
+  isInstalled?: (command: string) => boolean;
 }): SystemDiagnostics & { readiness: PrerequisiteCheck[] } {
+  const toolDetector = args.toolDetector ?? detectTool;
+  const isInstalled = args.isInstalled ?? commandIsOnPath;
   const tools = DEFAULT_TOOL_REQUIREMENTS.map((req) =>
-    detectTool(req.id, req.name, req.command, ['--version'], req.installHint ?? '', req.required ?? false),
+    toolDetector(req.id, req.name, req.command, ['--version'], req.installHint ?? '', req.required ?? false),
   );
 
   const readiness = assembleReadinessChecks({
     tools: DEFAULT_TOOL_REQUIREMENTS,
-    isInstalled: commandIsOnPath,
+    isInstalled,
     config: args.config,
     presets: args.presets,
     defaultPreset: args.defaultPreset,

--- a/packages/app/src/system-diagnostics.ts
+++ b/packages/app/src/system-diagnostics.ts
@@ -88,6 +88,10 @@ function isExecutableFile(candidate: string): boolean {
   }
 }
 
+function versionArgsForTool(id: string): string[] {
+  return id === 'ssh' ? ['-V'] : ['--version'];
+}
+
 export function collectSystemDiagnostics(args: {
   appVersion: string;
   isPackaged: boolean;
@@ -104,7 +108,7 @@ export function collectSystemDiagnostics(args: {
   const toolDetector = args.toolDetector ?? detectTool;
   const isInstalled = args.isInstalled ?? commandIsOnPath;
   const tools = DEFAULT_TOOL_REQUIREMENTS.map((req) =>
-    toolDetector(req.id, req.name, req.command, ['--version'], req.installHint ?? '', req.required ?? false),
+    toolDetector(req.id, req.name, req.command, versionArgsForTool(req.id), req.installHint ?? '', req.required ?? false),
   );
 
   const readiness = assembleReadinessChecks({


### PR DESCRIPTION
## Summary

Wire the parsed Invoker config through the GUI diagnostics IPC so the desktop app's diagnostics gather matches the readiness the doctor reports.

The IPC handler now routes the config plus the effective Slack planning preset selections into collectSystemDiagnostics, instead of relying on a hardcoded set of probes.

The tools array is sourced from the shared DEFAULT_TOOL_REQUIREMENTS module, and a config-aware readiness report is attached to SystemDiagnostics.readiness.

<details>
<summary>Review metadata</summary>

Review Claim:

Wire the parsed Invoker config plus planning preset selections through the diagnostics IPC so the GUI route matches the doctor's readiness report.

Review Lane:

- behavior

Review Unit:

- routing

Safety Invariant:

The per-tool spawnSync version probe keeps its 3000ms timeout and SIGKILL guard so a wedged CLI cannot stall the Electron main thread; the readiness presence probe uses a fast command-resolution check that cannot hang.

Slice Rationale:

This is the single routing edit that wires the GUI diagnostics IPC to the shared readiness module. The shared module landed in step 1, and the renderer slice ships in step 3.

</details>

## Non-goals

- Does not change the renderer or any UI components.
- Does not modify the CLI doctor implementation.
- Does not redefine the SystemDiagnostics interface (done in step 1).

## Architecture

### Before

```mermaid
flowchart LR
  handler["ipc: get-system-diagnostics"] --> collect["collectSystemDiagnostics (hardcoded probes)"]
  collect --> tools["6 hardcoded tool rows"]
  tools --> diag["SystemDiagnostics"]
```

### After

```mermaid
flowchart LR
  cfg["parsed Invoker config"] --> handler["ipc: get-system-diagnostics"]
  handler --> collect["collectSystemDiagnostics"]
  collect --> tools["tools from DEFAULT_TOOL_REQUIREMENTS"]
  collect --> readiness["assembleReadinessChecks -> readiness"]
  tools --> diag["SystemDiagnostics"]
  readiness --> diag
```

## Test Plan

- [ ] `pnpm --filter @invoker/app exec vitest run system-diagnostics`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded system diagnostics to include configuration file status plus Slack harness preset metadata and readiness details.
  * Tool availability checks now use a configurable requirements list with readiness computed from detected requirements.

* **Bug Fixes**
  * Improved cross-platform tool detection by probing executable paths (including execute permissions) and PATH (including negative and empty-PATH cases).
  * Configuration path resolution now treats blank/whitespace environment values as unset and cleanly falls back to the default location.

* **Tests**
  * Added/extended coverage for tool-path detection, readiness reporting, preset handling, and config path resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->