### PR TITLE
[Recovery Lifecycle 2i Step 6: Plan parser execution model field](1) Persist execution model in the task store

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -3247,6 +3247,24 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+
+  describe('executionModel persistence', () => {
+    it('round-trips a saved executionModel and leaves omitted values undefined', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const withModel = makeTask('t-model-1', {
+        config: { workflowId: 'wf-1', executionModel: 'claude' },
+      });
+      const withoutModel = makeTask('t-model-2', {
+        config: { workflowId: 'wf-1' },
+      });
+
+      adapter.saveTask('wf-1', withModel);
+      adapter.saveTask('wf-1', withoutModel);
+
+      expect(adapter.loadTask('t-model-1')?.config.executionModel).toBe('claude');
+      expect(adapter.loadTask('t-model-2')?.config.executionModel).toBeUndefined();
+    });
+  });
   describe('end-to-end: fix-with-codex → open-terminal reads codex', () => {
     it('simulates headless fix codex flow and verifies getExecutionAgent returns codex', () => {
       adapter.saveWorkflow(testWorkflow);

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1283,6 +1283,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         pool_member_id,
         docker_image,
         execution_agent,
+        execution_model,
         agent_name,
         task_state_version
       ) VALUES (
@@ -1300,6 +1301,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ?, ?, ?, ?,
         ?, ?,
         ?, ?, ?, ?, ?,
+        ?,
         ?,
         ?,
         ?,
@@ -1361,6 +1363,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       (cfg as { poolMemberId?: string }).poolMemberId ?? null,
       cfg.dockerImage ?? null,
       cfg.executionAgent ?? null,
+      cfg.executionModel ?? null,
       exec.agentName ?? null,
       task.taskStateVersion ?? 1,
     ]);
@@ -1401,6 +1404,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         poolMemberId: 'pool_member_id',
         dockerImage: 'docker_image',
         executionAgent: 'execution_agent',
+        executionModel: 'execution_model',
         fixPrompt: 'fix_prompt',
         fixContext: 'fix_context',
       };

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -85,6 +85,7 @@ export function mapRowToTask(row: any): TaskState {
       fixPrompt: row.fix_prompt ?? undefined,
       fixContext: row.fix_context ?? undefined,
       executionAgent: row.execution_agent ?? undefined,
+      executionModel: row.execution_model ?? undefined,
     },
     execution: {
       blockedBy: row.blocked_by ?? undefined,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -356,6 +356,7 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE workflows ADD COLUMN detached_external_dependencies TEXT',
   // execution_agent / agent_name: interchangeable agent support
   'ALTER TABLE tasks ADD COLUMN execution_agent TEXT',
+  'ALTER TABLE tasks ADD COLUMN execution_model TEXT',
   'ALTER TABLE tasks ADD COLUMN agent_name TEXT',
   // durable audit pointers for most-recent agent session/name
   'ALTER TABLE tasks ADD COLUMN last_agent_session_id TEXT',


### PR DESCRIPTION
## Summary

A plan task can now keep its pinned execution model after persistence.

The plan-reader path already carries executionModel on this stack.

This slice makes the task store save and load that same value.

That keeps the pinned model available after a save and reload.

The new column is nullable and optional, so tasks that omit executionModel keep loading with undefined.

<details>
<summary>Review metadata</summary>

Review Claim: The task store persists config.executionModel on save and load, so a pinned plan model survives reload.

Review Lane: behavior

Review Unit: write-path

Safety Invariant: executionModel is optional and additive; the new stored column defaults to null, so tasks that omit the model keep loading as undefined.

Slice Rationale: Persistence is the durable home for the plan-level selector, kept separate from the parser and worker slices that produce or consume it.

</details>

## Non-goals

- Does not change executionAgent behavior.
- Does not change how plan readers or harnesses choose a model at runtime.
- Does not change the orchestrator runtime model command.
- Does not run the full repository regression; that belongs to the terminal 2i slice.

## Test Plan

- [x] `cd packages/data-store && pnpm test`
- [x] `cd packages/app && pnpm test`
- [x] `cd packages/workflow-core && pnpm test`
- [x] Round-trip coverage saves a task with `executionModel: "claude"` and reloads it as `claude`; omitted values reload as `undefined`.

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert b7f314c934d2b3445031fc28522778c963a020e3`
- Post-revert steps: None.
- Data migration? Additive nullable `execution_model` column only; reverted code ignores the column, so no rollback step is required.
