### PR TITLE
[Slack Manager](1) Add IPC surface-event channel + progress relay

### DIFF
--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -27,7 +27,7 @@ export interface OwnerReadQueryHandlers {
   getUiPerfStats: () => Record<string, unknown>;
   resetUiPerfStats: () => void;
   getQueueStatus: () => Record<string, unknown>;
-  getWorkflowStatus: () => Record<string, unknown>;
+  getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
   getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
   getActionGraphSnapshot: () => Record<string, unknown>;
   listWorkflows: () => unknown[];
@@ -76,7 +76,7 @@ export function answerOwnerReadQuery(
     case 'queue':
       return handlers.getQueueStatus();
     case 'workflow-status':
-      return handlers.getWorkflowStatus();
+      return handlers.getWorkflowStatus(body.workflowId);
     case 'tasks':
       return handlers.getTasksSnapshot({ refresh: false });
     case 'task-graph-refresh':
@@ -172,7 +172,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     getUiPerfStats: deps.getUiPerfStats,
     resetUiPerfStats: deps.resetUiPerfStats,
     getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
-    getWorkflowStatus: () => orchestrator.getWorkflowStatus() as unknown as Record<string, unknown>,
+    getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
     getTasksSnapshot: ({ refresh }) => {
       if (refresh) orchestrator.syncAllFromDb();
       return {

--- a/packages/app/src/surface-event-relay.ts
+++ b/packages/app/src/surface-event-relay.ts
@@ -1,0 +1,121 @@
+/**
+ * Surface-event relay — publishes workflow-progress cards on the IPC bus so an
+ * out-of-process surface (the Slack manager) can render live progress without
+ * opening the database or living inside the Electron app.
+ *
+ * This mirrors the in-process progress path the embedded Slack bot formerly ran
+ * (`emitWorkflowProgress` + the debounced `task.delta` subscription), but instead
+ * of calling `slack.handleEvent` directly it publishes a `Channels.SURFACE_EVENT`
+ * message. Publishing with no subscriber is a harmless no-op (IpcBus only
+ * delivers to connected peers), so this can run in every owner process whether
+ * or not any surface is listening.
+ *
+ * Unlike the in-process path, the relay does NOT gate on a workflow→channel map
+ * (that mapping now lives in the manager's own store). It emits for every
+ * workflow that produces task deltas; the surface filters to mapped channels.
+ */
+
+import { Channels, type MessageBus } from '@invoker/transport';
+import type { Orchestrator, TaskDelta, TaskState } from '@invoker/workflow-core';
+import type { PersistenceAdapter } from '@invoker/data-store';
+import { buildReviewGateQueryResponse } from './review-gate-query.js';
+
+export interface SurfaceEventRelayDeps {
+  messageBus: MessageBus;
+  persistence: Pick<PersistenceAdapter, 'loadTasks' | 'loadWorkflow'>;
+  orchestrator: Pick<Orchestrator, 'getWorkflowStatus'>;
+  /** Logs a warning when a progress emit fails. */
+  logWarn: (message: string) => void;
+}
+
+const PROGRESS_DEBOUNCE_MS = 2500;
+const TERMINAL_DERIVED_STATUSES = new Set(['completed', 'failed', 'closed']);
+
+/** Derive the owning workflow id from a task id (`wf-…/task` or `__merge__wf-…`). */
+function workflowIdFromTaskId(taskId: string): string | undefined {
+  if (taskId.startsWith('__merge__')) return taskId.slice('__merge__'.length);
+  const slash = taskId.indexOf('/');
+  return slash <= 0 ? undefined : taskId.slice(0, slash);
+}
+
+/**
+ * Start relaying workflow-progress surface events on the IPC bus.
+ * Returns a stop function that unsubscribes and clears pending timers.
+ */
+export function startSurfaceEventRelay(deps: SurfaceEventRelayDeps): () => void {
+  const { messageBus, persistence, orchestrator } = deps;
+  const progressTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const emitWorkflowProgress = (workflowId: string): void => {
+    const tasks = persistence.loadTasks(workflowId);
+    const workflow = persistence.loadWorkflow(workflowId);
+    const counts = orchestrator.getWorkflowStatus(workflowId);
+    const percentComplete = counts.total > 0 ? Math.round((counts.completed / counts.total) * 100) : 0;
+    const gate = buildReviewGateQueryResponse({ workflowId, workflow, tasks });
+    const prUrl = gate.artifacts.find((artifact) => artifact.url)?.url;
+    const reviewState = gate.mergeTaskId
+      ? (gate.ready ? 'review ready' : (gate.status ?? undefined))
+      : undefined;
+    const event = {
+      type: 'workflow_progress' as const,
+      progress: {
+        workflowId,
+        name: (workflow as { name?: string } | undefined)?.name ?? workflowId,
+        counts,
+        percentComplete,
+        tasks: tasks.map((task: TaskState) => ({
+          id: task.id,
+          name: task.description,
+          status: task.status,
+          phase: task.execution.phase,
+          reviewUrl: task.execution.reviewUrl,
+        })),
+        prUrl,
+        reviewState,
+      },
+    };
+    messageBus.publish(Channels.SURFACE_EVENT, event);
+  };
+
+  const scheduleWorkflowProgress = (workflowId: string, flushNow: boolean): void => {
+    clearTimeout(progressTimers.get(workflowId));
+    const fire = (): void => {
+      progressTimers.delete(workflowId);
+      try {
+        emitWorkflowProgress(workflowId);
+      } catch (err) {
+        deps.logWarn(`surface-event relay emit failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    };
+    if (flushNow) {
+      fire();
+      return;
+    }
+    const timer = setTimeout(fire, PROGRESS_DEBOUNCE_MS);
+    timer.unref?.();
+    progressTimers.set(workflowId, timer);
+  };
+
+  const unsubscribe = messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
+    const d = delta as TaskDelta;
+    const taskId = d.type === 'created' ? d.task.id : d.taskId;
+    const workflowId = workflowIdFromTaskId(taskId);
+    if (!workflowId) return;
+    const status = d.type === 'updated'
+      ? (d.changes.status as string | undefined)
+      : d.type === 'created' ? d.task.status : undefined;
+    // Flush immediately when this delta drives the workflow to a terminal state.
+    let flushNow = false;
+    if (status && TERMINAL_DERIVED_STATUSES.has(status)) {
+      const counts = orchestrator.getWorkflowStatus(workflowId);
+      flushNow = counts.running === 0 && counts.pending === 0;
+    }
+    scheduleWorkflowProgress(workflowId, flushNow);
+  });
+
+  return () => {
+    unsubscribe();
+    for (const timer of progressTimers.values()) clearTimeout(timer);
+    progressTimers.clear();
+  };
+}

--- a/packages/transport/src/message-bus.ts
+++ b/packages/transport/src/message-bus.ts
@@ -45,4 +45,6 @@ export const Channels = {
   WORKFLOW_LOADED: 'workflow.loaded',
   EXPERIMENT_SPAWNED: 'experiment.spawned',
   EXPERIMENT_SELECTED: 'experiment.selected',
+  /** Orchestrator → surface events (workflow progress cards, etc.) for out-of-process surfaces. */
+  SURFACE_EVENT: 'surface.event',
 } as const;


### PR DESCRIPTION
## Summary

This adds an IPC `surface.event` channel and an owner-side relay that publishes the live workflow-progress card onto the message bus.

A surface running in a separate process can then render progress without opening the database or living inside Electron.

It also lets the owner status query take an optional workflow id, so one workflow's counts can be returned instead of the global total.

Nothing consumes the channel yet. This is dormant foundation for the out-of-process Slack surface added later in the stack.

<details>
<summary>Review metadata</summary>

Review Claim: Introduce the cross-process surface-event channel, its progress relay, and a per-workflow status read — consumed by nothing yet.

Review Lane: refactor

Review Unit: routing

Safety Invariant: Additive only — a new channel constant, a new unused module, and a backward-compatible optional query parameter. No existing runtime path changes.

Slice Rationale: Foundation lands before the package and the cutover that depend on it, keeping each later slice small.

</details>

## Non-goals

This does not wire the relay into the owner, does not add any subscriber, and does not change existing behavior; the progress path stays unchanged.

## Test Plan

- [ ] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
