### PR TITLE
[Slack Manager](2) Add a confirm-gated restart verb to the Slack surface

### DIFF
--- a/packages/surfaces/src/__tests__/lobby-control.test.ts
+++ b/packages/surfaces/src/__tests__/lobby-control.test.ts
@@ -8,6 +8,15 @@ describe('parseLobbyControl', () => {
     expect(parseLobbyControl('  Submit!  ')).toEqual({ kind: 'submit' });
   });
 
+  it('parses the restart verb (with optional target words and trailing punctuation)', () => {
+    expect(parseLobbyControl('restart')).toEqual({ kind: 'restart' });
+    expect(parseLobbyControl('restart invoker')).toEqual({ kind: 'restart' });
+    expect(parseLobbyControl('  Restart!  ')).toEqual({ kind: 'restart' });
+    expect(parseLobbyControl('restart the app')).toEqual({ kind: 'restart' });
+    // Prose that merely starts with "restart" is not the verb.
+    expect(parseLobbyControl('restart the login workflow')).toBeNull();
+  });
+
   it('parses bulk ops via "all" and "all workflows"', () => {
     expect(parseLobbyControl('recreate all')).toEqual({ kind: 'op', operation: 'recreate', target: { all: true } });
     expect(parseLobbyControl('recreate all workflows')).toEqual({ kind: 'op', operation: 'recreate', target: { all: true } });

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -540,6 +540,35 @@ describe('lobby verb routing', () => {
     );
   });
 
+  it('confirms a restart before relaunching Invoker, then reports health', async () => {
+    const onRestartInvoker = vi.fn().mockResolvedValue(undefined);
+    const surface = lobbySurface(true, { onRestartInvoker });
+    await surface.start(async () => {});
+
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> restart', ts: 't1', user: 'U1' }, say });
+    // Destructive — staged for confirmation, nothing relaunched yet.
+    expect(onRestartInvoker).not.toHaveBeenCalled();
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('restart Invoker') }));
+
+    const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
+    await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'yes' }, say: say2 });
+    expect(onRestartInvoker).toHaveBeenCalledTimes(1);
+    expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Invoker is back') }));
+  });
+
+  it('reports a restart failure when the relaunch throws', async () => {
+    const onRestartInvoker = vi.fn().mockRejectedValue(new Error('no display'));
+    const surface = lobbySurface(true, { onRestartInvoker });
+    await surface.start(async () => {});
+
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> restart', ts: 't1', user: 'U1' }, say });
+    const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
+    await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'yes' }, say: say2 });
+    expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Restart failed') }));
+  });
+
   it('runs a single-workflow verb immediately (no confirmation)', async () => {
     runWorkflowOp.mockResolvedValue({ ok: true, summary: 'retry: 1 ok' });
     const surface = lobbySurface();

--- a/packages/surfaces/src/slack/lobby-control.ts
+++ b/packages/surfaces/src/slack/lobby-control.ts
@@ -11,7 +11,8 @@ import type { WorkflowOpName } from '../surface.js';
 
 export type LobbyControl =
   | { kind: 'op'; operation: WorkflowOpName; target: { all: true } | { workflow: string } }
-  | { kind: 'submit' };
+  | { kind: 'submit' }
+  | { kind: 'restart' };
 
 // Verb spellings → canonical operation. Bare `rebase` means recreate-after-rebase.
 const OP_ALIASES: Record<string, WorkflowOpName> = {
@@ -30,6 +31,7 @@ const TARGET_TOKEN = /^[\w./-]+$/;
 /**
  * Parse a lobby command. Recognizes:
  *   - `submit` / `submit to invoker`
+ *   - `restart` / `restart invoker`
  *   - `<op> all` / `<op> <workflow-id-or-name>`  (op ∈ recreate|rebase|rebase-recreate|rebase-retry|retry|cancel|status)
  *   - `status` with no target → all workflows
  * Returns null for missing/ambiguous targets and for prose, so the message is
@@ -39,6 +41,7 @@ export function parseLobbyControl(text: string): LobbyControl | null {
   const trimmed = text.trim();
 
   if (/^submit(\s+to\s+invoker)?\s*[.!?]*$/i.test(trimmed)) return { kind: 'submit' };
+  if (/^restart(\s+(invoker|the\s+invoker|app|the\s+app|gui|the\s+gui))?\s*[.!?]*$/i.test(trimmed)) return { kind: 'restart' };
 
   const match = VERB_PATTERN.exec(trimmed);
   if (!match) return null;

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -82,6 +82,8 @@ export interface SlackSurfaceConfig {
   gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
   /** Executes a workflow operation (recreate/rebase/retry/status/cancel) and returns a summary. Injected by main.ts. */
   runWorkflowOp?: (op: WorkflowOp, onProgress?: (p: WorkflowOpProgress) => void) => Promise<WorkflowOpResult>;
+  /** Relaunches Invoker (host-owned). Enables the `restart` lobby verb. */
+  onRestartInvoker?: () => Promise<void>;
 }
 
 export interface HarnessPreset {
@@ -250,7 +252,8 @@ interface ConversationLike {
 /** An action staged for a thread, awaiting a yes/no (text or button) confirmation. */
 type PendingConfirm =
   | { kind: 'op'; op: WorkflowOp }
-  | { kind: 'submit'; planText: string; ctx?: PlanningContext; channel: string; lobbyThreadTs: string };
+  | { kind: 'submit'; planText: string; ctx?: PlanningContext; channel: string; lobbyThreadTs: string }
+  | { kind: 'restart' };
 
 interface SayResult {
   ts?: string;
@@ -323,6 +326,7 @@ export class SlackSurface implements Surface {
   private workflowChannelRepo?: WorkflowChannelRepository;
   private gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
   private runWorkflowOp?: (op: WorkflowOp, onProgress?: (p: WorkflowOpProgress) => void) => Promise<WorkflowOpResult>;
+  private onRestartInvoker?: () => Promise<void>;
 
   constructor(config: SlackSurfaceConfig) {
     this.app = new App({
@@ -356,6 +360,7 @@ export class SlackSurface implements Surface {
     this.workflowChannelRepo = config.workflowChannelRepo;
     this.gatherWorkflowContext = config.gatherWorkflowContext;
     this.runWorkflowOp = config.runWorkflowOp;
+    this.onRestartInvoker = config.onRestartInvoker;
     this.log = config.log ?? ((source, level, msg) => {
       const fn = level === 'error' ? console.error : console.log;
       fn(`[${source}] ${msg}`);
@@ -668,6 +673,10 @@ export class SlackSurface implements Surface {
       await this.handleLobbySubmit(channel, threadTs, event.user ?? 'unknown', say);
       return;
     }
+    if (ctrl?.kind === 'restart') {
+      await this.handleLobbyRestart(threadTs, channel, say);
+      return;
+    }
 
     // Slower paths (LLM classifier, repo checkout, planner) acknowledge receipt up front.
     if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
@@ -925,6 +934,10 @@ export class SlackSurface implements Surface {
       await this.runConfirmedOp(pending.op, threadTs, say, channel);
       return;
     }
+    if (pending.kind === 'restart') {
+      await this.runConfirmedRestart(threadTs, say);
+      return;
+    }
     await say({ text: 'Starting plan execution…', thread_ts: threadTs });
     const ctx = pending.ctx;
     await this.onCommand?.({
@@ -938,6 +951,30 @@ export class SlackSurface implements Surface {
     });
     this.planningContexts.delete(pending.lobbyThreadTs);
     this.cleanupSession(pending.lobbyThreadTs, 'plan_submitted');
+  }
+
+  /** Restart Invoker on request — always confirm first (it interrupts the running app). */
+  private async handleLobbyRestart(threadTs: string, channel: string, say: SayFn): Promise<void> {
+    if (!this.onRestartInvoker) {
+      await say({ text: 'Restarting Invoker is not available in this deployment.', thread_ts: threadTs });
+      return;
+    }
+    await this.stageConfirm(threadTs, channel, { kind: 'restart' }, 'This will restart Invoker.', say);
+  }
+
+  /** Run a confirmed restart: relaunch Invoker, then report health. */
+  private async runConfirmedRestart(threadTs: string, say: SayFn): Promise<void> {
+    if (!this.onRestartInvoker) {
+      await say({ text: 'Restarting Invoker is not available in this deployment.', thread_ts: threadTs });
+      return;
+    }
+    await say({ text: 'Bringing Invoker back… :hourglass_flowing_sand:', thread_ts: threadTs });
+    try {
+      await this.onRestartInvoker();
+      await say({ text: 'Invoker is back ✅', thread_ts: threadTs });
+    } catch (err) {
+      await say({ text: `Restart failed: ${err instanceof Error ? err.message : String(err)}`, thread_ts: threadTs });
+    }
   }
 
   /** Route a deterministic verb from `/invoker` (channel-level — slash can't run in a thread). */
@@ -968,6 +1005,13 @@ export class SlackSurface implements Surface {
       const key = `slash:${channel}:${command.user_id}:${Date.now()}`;
       this.pendingConfirms.set(key, { kind: 'submit', planText, ctx, channel, lobbyThreadTs: resolved });
       const prompt = this.renderPlanSummary(summary);
+      await respond({ text: prompt, response_type: 'ephemeral', blocks: this.buildConfirmBlocks(prompt, key) as never });
+      return;
+    }
+    if (ctrl.kind === 'restart') {
+      const key = `slash:${channel}:${command.user_id}:${Date.now()}`;
+      this.pendingConfirms.set(key, { kind: 'restart' });
+      const prompt = 'This will restart Invoker.';
       await respond({ text: prompt, response_type: 'ephemeral', blocks: this.buildConfirmBlocks(prompt, key) as never });
       return;
     }


### PR DESCRIPTION
## Summary

This teaches the Slack lobby a `restart` verb (`restart` or `restart invoker`).

A restart interrupts the running app, so it always asks for confirmation first (Approve/Cancel buttons or a yes/no reply).

On approval it routes to a new optional `onRestartInvoker` host seam, posts "Bringing Invoker back…", then reports health or the failure.

The seam keeps the surface host-agnostic: the host performs the relaunch, while the surface only parses the verb, stages the confirmation, and reports the outcome.

<details>
<summary>Review metadata</summary>

Review Claim: Add the `restart` verb and the optional `onRestartInvoker` seam to the Slack surface.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Additive — the verb is inert unless a host provides `onRestartInvoker`, and it reuses the existing confirm-staging path.

Slice Rationale: A self-contained surface capability, kept apart from the manager package so the surface change reviews on its own.

</details>

## Non-goals

This does not relaunch Invoker itself (the host seam does that) and does not change any other lobby verb.

## Test Plan

- [ ] `pnpm --filter @invoker/surfaces test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
