### PR TITLE
Stop dependency manifests from blocking a one-PR package add

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",
-    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && bash scripts/workspace-test.sh",
+    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-review-unit-classification.mjs && bash scripts/workspace-test.sh",
     "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
     "test:low-resource": "pnpm run test",
     "test:low-resource:packages": "bash scripts/workspace-test.sh",

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -280,12 +280,13 @@ export function classifyReviewUnitsForPath(filePath) {
   if (
     path === 'package.json'
     || path === 'pnpm-lock.yaml'
-    || path === 'run.sh'
     || /^tsconfig.*\.json$/.test(path)
     || /^packages\/[^/]+\/package\.json$/.test(path)
+    || /^packages\/[^/]+\/tsconfig.*\.json$/.test(path)
   ) {
-    return ['tooling-policy'];
+    return [];
   }
+  if (path === 'run.sh') return ['tooling-policy'];
   if (path.startsWith('scripts/')) return ['tooling-policy'];
   if (
     path.startsWith('packages/')

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import {
+  classifyReviewUnitsForPath,
+  reviewUnitsForChangedFiles,
+  validateReviewUnitChangedFiles,
+} from './review-unit-rules.mjs';
+
+const neutralManifests = [
+  'package.json',
+  'pnpm-lock.yaml',
+  'tsconfig.json',
+  'tsconfig.typecheck.json',
+  'packages/slack-manager/package.json',
+  'packages/slack-manager/tsconfig.json',
+  'packages/slack-manager/tsconfig.tsup.json',
+];
+for (const path of neutralManifests) {
+  assert.deepEqual(
+    classifyReviewUnitsForPath(path),
+    [],
+    `dependency/build manifest should be review-neutral: ${path}`,
+  );
+}
+
+const stillToolingPolicy = [
+  'run.sh',
+  'scripts/create-pr.mjs',
+  'scripts/review-unit-rules.mjs',
+  '.github/workflows/ci.yml',
+  'skills/make-pr/SKILL.md',
+];
+for (const path of stillToolingPolicy) {
+  assert.deepEqual(
+    classifyReviewUnitsForPath(path),
+    ['tooling-policy'],
+    `genuine policy/automation path should stay tooling-policy: ${path}`,
+  );
+}
+
+const newPackageFiles = [
+  'packages/slack-manager/package.json',
+  'packages/slack-manager/src/index.ts',
+  'packages/slack-manager/tsconfig.json',
+  'pnpm-lock.yaml',
+  'tsconfig.typecheck.json',
+];
+assert.deepEqual(
+  reviewUnitsForChangedFiles(newPackageFiles),
+  [],
+  'adding a package must not be forced into tooling-policy by its own manifests',
+);
+assert.deepEqual(
+  validateReviewUnitChangedFiles({ declaredReviewUnit: 'routing', changedFiles: newPackageFiles, context: 'test' }),
+  [],
+  'a new-package PR may declare its source review unit without colliding with its manifests',
+);
+
+const depBumpFiles = ['package.json', 'pnpm-lock.yaml'];
+assert.deepEqual(
+  reviewUnitsForChangedFiles(depBumpFiles),
+  [],
+  'a manifest-only change carries no review unit of its own',
+);
+
+console.log('review-unit classification: all assertions passed');

--- a/scripts/test-review-unit-classification.mjs
+++ b/scripts/test-review-unit-classification.mjs
@@ -1,9 +1,17 @@
+import { readFileSync } from 'node:fs';
 import assert from 'node:assert/strict';
 import {
   classifyReviewUnitsForPath,
   reviewUnitsForChangedFiles,
   validateReviewUnitChangedFiles,
 } from './review-unit-rules.mjs';
+
+const rootPackage = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+assert.match(
+  rootPackage.scripts.test,
+  /node scripts\/test-review-unit-classification\.mjs && bash scripts\/workspace-test\.sh/,
+  'root test must add review-unit classification before the existing workspace test contract',
+);
 
 const neutralManifests = [
   'package.json',


### PR DESCRIPTION
## Summary

The review-unit classifier labeled `package.json`, the lockfile, and `tsconfig` files as `tooling-policy`.

That blocked adding a new package in one PR: its source is product code, but its manifests forced a `tooling-policy` unit — and the one-unit rule rejects that mix.

This treats dependency and build manifests as review-neutral, so they carry no review unit of their own and may ride along with whatever package or build change they belong to.

Genuine policy and automation paths (`scripts/`, `.github/`, `run.sh`, `skills/`) still classify as `tooling-policy`.

<details>
<summary>Review metadata</summary>

Review Claim: Dependency and build manifests no longer force a tooling-policy review unit.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Only manifest paths change classification; scripts, .github, run.sh, and skills keep tooling-policy, and CI's structural PR-body check is unaffected.

Slice Rationale: A focused validator fix, kept separate from any feature stack.

</details>

## Non-goals

This does not relax the one-review-unit-per-PR rule itself and does not change how CI validates PR bodies.

## Test Plan

- [ ] `node scripts/test-review-unit-classification.mjs`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review-unit handling so common project and package manifest changes are less likely to be misclassified as policy-related work.
  * Package-level config changes now behave more consistently, reducing unnecessary review noise for routine updates.

* **Tests**
  * Added coverage for review-unit classification across multiple file-change scenarios.
  * Expanded automated checks to verify the release’s classification behavior stays consistent over time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->