### PR TITLE
[Slack Manager](2) Add a confirm-gated restart verb to the Slack surface

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -115,6 +115,7 @@ exit 64
       env: {
         ...process.env,
         NODE_ENV: 'test',
+        INVOKER_DISABLE_SLACK: '1',
         TZ: 'UTC',
         INVOKER_GUI_OWNER_MODE: guiOwnerMode,
         INVOKER_DB_DIR: testDir,

--- a/packages/app/src/__tests__/slack-enablement.test.ts
+++ b/packages/app/src/__tests__/slack-enablement.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { slackDisabledForTests } from '../slack-enablement.js';
+
+describe('slackDisabledForTests', () => {
+  it('is true when NODE_ENV is test', () => {
+    expect(slackDisabledForTests({ NODE_ENV: 'test' } as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  it('is true when INVOKER_DISABLE_SLACK is 1', () => {
+    expect(slackDisabledForTests({ INVOKER_DISABLE_SLACK: '1' } as NodeJS.ProcessEnv)).toBe(true);
+  });
+
+  it('is false for a normal production env with real creds', () => {
+    expect(
+      slackDisabledForTests({ NODE_ENV: 'production', SLACK_BOT_TOKEN: 'xoxb-real' } as NodeJS.ProcessEnv),
+    ).toBe(false);
+  });
+
+  it('is false when the disable flag is not exactly "1"', () => {
+    expect(slackDisabledForTests({ INVOKER_DISABLE_SLACK: '0' } as NodeJS.ProcessEnv)).toBe(false);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -110,6 +110,7 @@ import {
   type EmbeddedTerminalBackendConfig,
   type InvokerConfig,
 } from './config.js';
+import { slackDisabledForTests } from './slack-enablement.js';
 import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
   assertExecutionCapacityInvariant,
@@ -5075,6 +5076,10 @@ function createEmbeddedTerminalBackendFromConfig(
     executor: TaskRunner,
     handles: TaskHandleMap,
   ): Promise<void> {
+    if (slackDisabledForTests()) {
+      logger.info('Slack bot not started — disabled in test mode (NODE_ENV=test or INVOKER_DISABLE_SLACK=1)', { module: 'slack' });
+      return;
+    }
     const logFn = (source: string, level: string, message: string) => {
       const logMethod = level === 'error' ? 'error' : level === 'warn' ? 'warn' : 'info';
       logger[logMethod](message, { module: source });

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -27,7 +27,7 @@ export interface OwnerReadQueryHandlers {
   getUiPerfStats: () => Record<string, unknown>;
   resetUiPerfStats: () => void;
   getQueueStatus: () => Record<string, unknown>;
-  getWorkflowStatus: () => Record<string, unknown>;
+  getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
   getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
   getActionGraphSnapshot: () => Record<string, unknown>;
   listWorkflows: () => unknown[];
@@ -76,7 +76,7 @@ export function answerOwnerReadQuery(
     case 'queue':
       return handlers.getQueueStatus();
     case 'workflow-status':
-      return handlers.getWorkflowStatus();
+      return handlers.getWorkflowStatus(body.workflowId);
     case 'tasks':
       return handlers.getTasksSnapshot({ refresh: false });
     case 'task-graph-refresh':
@@ -172,7 +172,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     getUiPerfStats: deps.getUiPerfStats,
     resetUiPerfStats: deps.resetUiPerfStats,
     getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
-    getWorkflowStatus: () => orchestrator.getWorkflowStatus() as unknown as Record<string, unknown>,
+    getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
     getTasksSnapshot: ({ refresh }) => {
       if (refresh) orchestrator.syncAllFromDb();
       return {

--- a/packages/app/src/slack-enablement.ts
+++ b/packages/app/src/slack-enablement.ts
@@ -1,0 +1,12 @@
+/**
+ * Helpers that decide whether this process should bring the Slack surface online.
+ */
+
+/**
+ * Whether the Slack surface must stay offline because this process is a test/e2e
+ * instance. Prevents test apps (which inherit real Slack creds from the shared
+ * `~/.invoker/.env`) from joining the production workspace and stealing events.
+ */
+export function slackDisabledForTests(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.NODE_ENV === 'test' || env.INVOKER_DISABLE_SLACK === '1';
+}

--- a/packages/app/src/surface-event-relay.ts
+++ b/packages/app/src/surface-event-relay.ts
@@ -1,0 +1,121 @@
+/**
+ * Surface-event relay — publishes workflow-progress cards on the IPC bus so an
+ * out-of-process surface (the Slack manager) can render live progress without
+ * opening the database or living inside the Electron app.
+ *
+ * This mirrors the in-process progress path the embedded Slack bot formerly ran
+ * (`emitWorkflowProgress` + the debounced `task.delta` subscription), but instead
+ * of calling `slack.handleEvent` directly it publishes a `Channels.SURFACE_EVENT`
+ * message. Publishing with no subscriber is a harmless no-op (IpcBus only
+ * delivers to connected peers), so this can run in every owner process whether
+ * or not any surface is listening.
+ *
+ * Unlike the in-process path, the relay does NOT gate on a workflow→channel map
+ * (that mapping now lives in the manager's own store). It emits for every
+ * workflow that produces task deltas; the surface filters to mapped channels.
+ */
+
+import { Channels, type MessageBus } from '@invoker/transport';
+import type { Orchestrator, TaskDelta, TaskState } from '@invoker/workflow-core';
+import type { PersistenceAdapter } from '@invoker/data-store';
+import { buildReviewGateQueryResponse } from './review-gate-query.js';
+
+export interface SurfaceEventRelayDeps {
+  messageBus: MessageBus;
+  persistence: Pick<PersistenceAdapter, 'loadTasks' | 'loadWorkflow'>;
+  orchestrator: Pick<Orchestrator, 'getWorkflowStatus'>;
+  /** Logs a warning when a progress emit fails. */
+  logWarn: (message: string) => void;
+}
+
+const PROGRESS_DEBOUNCE_MS = 2500;
+const TERMINAL_DERIVED_STATUSES = new Set(['completed', 'failed', 'closed']);
+
+/** Derive the owning workflow id from a task id (`wf-…/task` or `__merge__wf-…`). */
+function workflowIdFromTaskId(taskId: string): string | undefined {
+  if (taskId.startsWith('__merge__')) return taskId.slice('__merge__'.length);
+  const slash = taskId.indexOf('/');
+  return slash <= 0 ? undefined : taskId.slice(0, slash);
+}
+
+/**
+ * Start relaying workflow-progress surface events on the IPC bus.
+ * Returns a stop function that unsubscribes and clears pending timers.
+ */
+export function startSurfaceEventRelay(deps: SurfaceEventRelayDeps): () => void {
+  const { messageBus, persistence, orchestrator } = deps;
+  const progressTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+  const emitWorkflowProgress = (workflowId: string): void => {
+    const tasks = persistence.loadTasks(workflowId);
+    const workflow = persistence.loadWorkflow(workflowId);
+    const counts = orchestrator.getWorkflowStatus(workflowId);
+    const percentComplete = counts.total > 0 ? Math.round((counts.completed / counts.total) * 100) : 0;
+    const gate = buildReviewGateQueryResponse({ workflowId, workflow, tasks });
+    const prUrl = gate.artifacts.find((artifact) => artifact.url)?.url;
+    const reviewState = gate.mergeTaskId
+      ? (gate.ready ? 'review ready' : (gate.status ?? undefined))
+      : undefined;
+    const event = {
+      type: 'workflow_progress' as const,
+      progress: {
+        workflowId,
+        name: (workflow as { name?: string } | undefined)?.name ?? workflowId,
+        counts,
+        percentComplete,
+        tasks: tasks.map((task: TaskState) => ({
+          id: task.id,
+          name: task.description,
+          status: task.status,
+          phase: task.execution.phase,
+          reviewUrl: task.execution.reviewUrl,
+        })),
+        prUrl,
+        reviewState,
+      },
+    };
+    messageBus.publish(Channels.SURFACE_EVENT, event);
+  };
+
+  const scheduleWorkflowProgress = (workflowId: string, flushNow: boolean): void => {
+    clearTimeout(progressTimers.get(workflowId));
+    const fire = (): void => {
+      progressTimers.delete(workflowId);
+      try {
+        emitWorkflowProgress(workflowId);
+      } catch (err) {
+        deps.logWarn(`surface-event relay emit failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    };
+    if (flushNow) {
+      fire();
+      return;
+    }
+    const timer = setTimeout(fire, PROGRESS_DEBOUNCE_MS);
+    timer.unref?.();
+    progressTimers.set(workflowId, timer);
+  };
+
+  const unsubscribe = messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
+    const d = delta as TaskDelta;
+    const taskId = d.type === 'created' ? d.task.id : d.taskId;
+    const workflowId = workflowIdFromTaskId(taskId);
+    if (!workflowId) return;
+    const status = d.type === 'updated'
+      ? (d.changes.status as string | undefined)
+      : d.type === 'created' ? d.task.status : undefined;
+    // Flush immediately when this delta drives the workflow to a terminal state.
+    let flushNow = false;
+    if (status && TERMINAL_DERIVED_STATUSES.has(status)) {
+      const counts = orchestrator.getWorkflowStatus(workflowId);
+      flushNow = counts.running === 0 && counts.pending === 0;
+    }
+    scheduleWorkflowProgress(workflowId, flushNow);
+  });
+
+  return () => {
+    unsubscribe();
+    for (const timer of progressTimers.values()) clearTimeout(timer);
+    progressTimers.clear();
+  };
+}

--- a/packages/surfaces/src/__tests__/lobby-control.test.ts
+++ b/packages/surfaces/src/__tests__/lobby-control.test.ts
@@ -8,6 +8,15 @@ describe('parseLobbyControl', () => {
     expect(parseLobbyControl('  Submit!  ')).toEqual({ kind: 'submit' });
   });
 
+  it('parses the restart verb (with optional target words and trailing punctuation)', () => {
+    expect(parseLobbyControl('restart')).toEqual({ kind: 'restart' });
+    expect(parseLobbyControl('restart invoker')).toEqual({ kind: 'restart' });
+    expect(parseLobbyControl('  Restart!  ')).toEqual({ kind: 'restart' });
+    expect(parseLobbyControl('restart the app')).toEqual({ kind: 'restart' });
+    // Prose that merely starts with "restart" is not the verb.
+    expect(parseLobbyControl('restart the login workflow')).toBeNull();
+  });
+
   it('parses bulk ops via "all" and "all workflows"', () => {
     expect(parseLobbyControl('recreate all')).toEqual({ kind: 'op', operation: 'recreate', target: { all: true } });
     expect(parseLobbyControl('recreate all workflows')).toEqual({ kind: 'op', operation: 'recreate', target: { all: true } });

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -404,12 +404,13 @@ describe('lobby verb routing', () => {
     draftedPlanForMock = null;
   });
 
-  function lobbySurface(withOp = true) {
+  function lobbySurface(withOp = true, extra: Partial<ConstructorParameters<typeof SlackSurface>[0]> = {}) {
     return new SlackSurface({
       ...baseConfig(),
       enableImmediateAck: false,
       planningCommandBuilder: () => ({ command: 'cursor', args: ['--print', 'x'] }),
       ...(withOp ? { runWorkflowOp } : {}),
+      ...extra,
     });
   }
 
@@ -576,6 +577,26 @@ describe('lobby verb routing', () => {
     const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
     await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'yes' }, say: say2 });
     expect(runWorkflowOp.mock.calls[0][0]).toEqual({ operation: 'recreate', target: { all: true } });
+  });
+
+  it('acknowledges a fuzzy operational mention immediately, before the classifier returns', async () => {
+    mockSpawn.mockImplementationOnce(() => mockProcess('{"intent":"command","operation":"recreate","target":"all"}'));
+    const surface = lobbySurface(true, { enableImmediateAck: true });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'ack-1' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> can you recreate everything please', ts: 't1', user: 'U1' }, say });
+    // Immediate "processing" receipt posts up front (then is cleared once the confirm is ready).
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: 'Processing your request...', thread_ts: 't1' }));
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not post a processing ack for an instant verb', async () => {
+    runWorkflowOp.mockResolvedValue({ ok: true, summary: '`wf-1`: 1 running, 0 pending, 0 done, 0 failed' });
+    const surface = lobbySurface(true, { enableImmediateAck: true });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> status', ts: 't1', user: 'U1' }, say });
+    expect(say).not.toHaveBeenCalledWith(expect.objectContaining({ text: 'Processing your request...' }));
   });
 
   it('answers a question with no session, workflow, or start_plan', async () => {

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -540,6 +540,35 @@ describe('lobby verb routing', () => {
     );
   });
 
+  it('confirms a restart before relaunching Invoker, then reports health', async () => {
+    const onRestartInvoker = vi.fn().mockResolvedValue(undefined);
+    const surface = lobbySurface(true, { onRestartInvoker });
+    await surface.start(async () => {});
+
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> restart', ts: 't1', user: 'U1' }, say });
+    // Destructive — staged for confirmation, nothing relaunched yet.
+    expect(onRestartInvoker).not.toHaveBeenCalled();
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('restart Invoker') }));
+
+    const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
+    await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'yes' }, say: say2 });
+    expect(onRestartInvoker).toHaveBeenCalledTimes(1);
+    expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Invoker is back') }));
+  });
+
+  it('reports a restart failure when the relaunch throws', async () => {
+    const onRestartInvoker = vi.fn().mockRejectedValue(new Error('no display'));
+    const surface = lobbySurface(true, { onRestartInvoker });
+    await surface.start(async () => {});
+
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> restart', ts: 't1', user: 'U1' }, say });
+    const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
+    await messageHandler(surface)({ event: { thread_ts: 't1', ts: 't2', user: 'U1', text: 'yes' }, say: say2 });
+    expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Restart failed') }));
+  });
+
   it('runs a single-workflow verb immediately (no confirmation)', async () => {
     runWorkflowOp.mockResolvedValue({ ok: true, summary: 'retry: 1 ok' });
     const surface = lobbySurface();

--- a/packages/surfaces/src/slack/lobby-control.ts
+++ b/packages/surfaces/src/slack/lobby-control.ts
@@ -11,7 +11,8 @@ import type { WorkflowOpName } from '../surface.js';
 
 export type LobbyControl =
   | { kind: 'op'; operation: WorkflowOpName; target: { all: true } | { workflow: string } }
-  | { kind: 'submit' };
+  | { kind: 'submit' }
+  | { kind: 'restart' };
 
 // Verb spellings → canonical operation. Bare `rebase` means recreate-after-rebase.
 const OP_ALIASES: Record<string, WorkflowOpName> = {
@@ -30,6 +31,7 @@ const TARGET_TOKEN = /^[\w./-]+$/;
 /**
  * Parse a lobby command. Recognizes:
  *   - `submit` / `submit to invoker`
+ *   - `restart` / `restart invoker`
  *   - `<op> all` / `<op> <workflow-id-or-name>`  (op ∈ recreate|rebase|rebase-recreate|rebase-retry|retry|cancel|status)
  *   - `status` with no target → all workflows
  * Returns null for missing/ambiguous targets and for prose, so the message is
@@ -39,6 +41,7 @@ export function parseLobbyControl(text: string): LobbyControl | null {
   const trimmed = text.trim();
 
   if (/^submit(\s+to\s+invoker)?\s*[.!?]*$/i.test(trimmed)) return { kind: 'submit' };
+  if (/^restart(\s+(invoker|the\s+invoker|app|the\s+app|gui|the\s+gui))?\s*[.!?]*$/i.test(trimmed)) return { kind: 'restart' };
 
   const match = VERB_PATTERN.exec(trimmed);
   if (!match) return null;

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -82,6 +82,8 @@ export interface SlackSurfaceConfig {
   gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
   /** Executes a workflow operation (recreate/rebase/retry/status/cancel) and returns a summary. Injected by main.ts. */
   runWorkflowOp?: (op: WorkflowOp, onProgress?: (p: WorkflowOpProgress) => void) => Promise<WorkflowOpResult>;
+  /** Relaunches Invoker (host-owned). Enables the `restart` lobby verb. */
+  onRestartInvoker?: () => Promise<void>;
 }
 
 export interface HarnessPreset {
@@ -250,7 +252,8 @@ interface ConversationLike {
 /** An action staged for a thread, awaiting a yes/no (text or button) confirmation. */
 type PendingConfirm =
   | { kind: 'op'; op: WorkflowOp }
-  | { kind: 'submit'; planText: string; ctx?: PlanningContext; channel: string; lobbyThreadTs: string };
+  | { kind: 'submit'; planText: string; ctx?: PlanningContext; channel: string; lobbyThreadTs: string }
+  | { kind: 'restart' };
 
 interface SayResult {
   ts?: string;
@@ -323,6 +326,7 @@ export class SlackSurface implements Surface {
   private workflowChannelRepo?: WorkflowChannelRepository;
   private gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
   private runWorkflowOp?: (op: WorkflowOp, onProgress?: (p: WorkflowOpProgress) => void) => Promise<WorkflowOpResult>;
+  private onRestartInvoker?: () => Promise<void>;
 
   constructor(config: SlackSurfaceConfig) {
     this.app = new App({
@@ -356,6 +360,7 @@ export class SlackSurface implements Surface {
     this.workflowChannelRepo = config.workflowChannelRepo;
     this.gatherWorkflowContext = config.gatherWorkflowContext;
     this.runWorkflowOp = config.runWorkflowOp;
+    this.onRestartInvoker = config.onRestartInvoker;
     this.log = config.log ?? ((source, level, msg) => {
       const fn = level === 'error' ? console.error : console.log;
       fn(`[${source}] ${msg}`);
@@ -668,6 +673,10 @@ export class SlackSurface implements Surface {
       await this.handleLobbySubmit(channel, threadTs, event.user ?? 'unknown', say);
       return;
     }
+    if (ctrl?.kind === 'restart') {
+      await this.handleLobbyRestart(threadTs, channel, say);
+      return;
+    }
 
     // Slower paths (LLM classifier, repo checkout, planner) acknowledge receipt up front.
     if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
@@ -925,6 +934,10 @@ export class SlackSurface implements Surface {
       await this.runConfirmedOp(pending.op, threadTs, say, channel);
       return;
     }
+    if (pending.kind === 'restart') {
+      await this.runConfirmedRestart(threadTs, say);
+      return;
+    }
     await say({ text: 'Starting plan execution…', thread_ts: threadTs });
     const ctx = pending.ctx;
     await this.onCommand?.({
@@ -938,6 +951,30 @@ export class SlackSurface implements Surface {
     });
     this.planningContexts.delete(pending.lobbyThreadTs);
     this.cleanupSession(pending.lobbyThreadTs, 'plan_submitted');
+  }
+
+  /** Restart Invoker on request — always confirm first (it interrupts the running app). */
+  private async handleLobbyRestart(threadTs: string, channel: string, say: SayFn): Promise<void> {
+    if (!this.onRestartInvoker) {
+      await say({ text: 'Restarting Invoker is not available in this deployment.', thread_ts: threadTs });
+      return;
+    }
+    await this.stageConfirm(threadTs, channel, { kind: 'restart' }, 'This will restart Invoker.', say);
+  }
+
+  /** Run a confirmed restart: relaunch Invoker, then report health. */
+  private async runConfirmedRestart(threadTs: string, say: SayFn): Promise<void> {
+    if (!this.onRestartInvoker) {
+      await say({ text: 'Restarting Invoker is not available in this deployment.', thread_ts: threadTs });
+      return;
+    }
+    await say({ text: 'Bringing Invoker back… :hourglass_flowing_sand:', thread_ts: threadTs });
+    try {
+      await this.onRestartInvoker();
+      await say({ text: 'Invoker is back ✅', thread_ts: threadTs });
+    } catch (err) {
+      await say({ text: `Restart failed: ${err instanceof Error ? err.message : String(err)}`, thread_ts: threadTs });
+    }
   }
 
   /** Route a deterministic verb from `/invoker` (channel-level — slash can't run in a thread). */
@@ -968,6 +1005,13 @@ export class SlackSurface implements Surface {
       const key = `slash:${channel}:${command.user_id}:${Date.now()}`;
       this.pendingConfirms.set(key, { kind: 'submit', planText, ctx, channel, lobbyThreadTs: resolved });
       const prompt = this.renderPlanSummary(summary);
+      await respond({ text: prompt, response_type: 'ephemeral', blocks: this.buildConfirmBlocks(prompt, key) as never });
+      return;
+    }
+    if (ctrl.kind === 'restart') {
+      const key = `slash:${channel}:${command.user_id}:${Date.now()}`;
+      this.pendingConfirms.set(key, { kind: 'restart' });
+      const prompt = 'This will restart Invoker.';
       await respond({ text: prompt, response_type: 'ephemeral', blocks: this.buildConfirmBlocks(prompt, key) as never });
       return;
     }

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -658,7 +658,7 @@ export class SlackSurface implements Surface {
     // Confirm/cancel a staged action first (plain yes/no in-thread).
     if (await this.resolveConfirm(threadTs, parsed.text, say, channel)) return;
 
-    // Deterministic verb commands take priority over the planning/LLM path.
+    // Deterministic verb commands respond instantly and take priority over the planner.
     const ctrl = parseLobbyControl(parsed.text);
     if (ctrl?.kind === 'op') {
       await this.handleLobbyOp(ctrl, threadTs, channel, say);
@@ -669,15 +669,20 @@ export class SlackSurface implements Surface {
       return;
     }
 
+    // Slower paths (LLM classifier, repo checkout, planner) acknowledge receipt up front.
+    if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
+
     // Fallback classifier: only when a non-verb message looks operational.
     if (looksOperational(parsed.text)) {
       const cls = await this.classifyLobbyIntent(parsed.text, preset);
       this.log('slack', 'info', `[CLASSIFY] thread_ts=${threadTs} intent=${cls.intent}`);
       if (cls.intent === 'command') {
+        await this.clearImmediateAck(channel, threadTs);
         await this.proposeLobbyOp(cls, threadTs, channel, say);
         return;
       }
       if (cls.intent === 'question') {
+        await this.clearImmediateAck(channel, threadTs);
         await this.answerLobbyQuestion(parsed.text, preset, threadTs, say);
         return;
       }
@@ -685,16 +690,6 @@ export class SlackSurface implements Surface {
     }
 
     // Default: a plain planning conversation (drafts a plan, never auto-submits).
-
-    if (this.enableImmediateAck) {
-      try {
-        const ackResult = await say({ text: this.immediateAckMessage, thread_ts: threadTs });
-        if (ackResult?.ts) this.ackMessages.set(threadTs, ackResult.ts);
-        this.log('slack', 'info', `[ACK] Sent immediate acknowledgment (thread_ts=${threadTs})`);
-      } catch (err) {
-        this.log('slack', 'error', `[ACK] Failed to send immediate acknowledgment: ${err}`);
-      }
-    }
 
     let workingDir = this.workingDir;
     if (repoUrl && this.prepareRepoCheckout) {
@@ -725,6 +720,25 @@ export class SlackSurface implements Surface {
     });
 
     await this.handleConversationMessage(conversation, parsed.text, threadTs, say, channel);
+  }
+
+  /** Post the immediate "received it" acknowledgment and track it for in-place replacement. */
+  private async sendImmediateAck(threadTs: string, say: SayFn): Promise<void> {
+    try {
+      const res = await say({ text: this.immediateAckMessage, thread_ts: threadTs });
+      if (res?.ts) this.ackMessages.set(threadTs, res.ts);
+      this.log('slack', 'info', `[ACK] Sent immediate acknowledgment (thread_ts=${threadTs})`);
+    } catch (err) {
+      this.log('slack', 'error', `[ACK] Failed to send immediate acknowledgment: ${err}`);
+    }
+  }
+
+  /** Drop the immediate ack — used by paths that post their own reply instead of replacing it. */
+  private async clearImmediateAck(channel: string, threadTs: string): Promise<void> {
+    const ts = this.ackMessages.get(threadTs);
+    if (!ts) return;
+    this.ackMessages.delete(threadTs);
+    await this.deleteMessage(channel, ts);
   }
 
   private async classifyLobbyIntent(text: string, harness: HarnessPreset): Promise<LobbyClassification> {

--- a/packages/transport/src/message-bus.ts
+++ b/packages/transport/src/message-bus.ts
@@ -45,4 +45,6 @@ export const Channels = {
   WORKFLOW_LOADED: 'workflow.loaded',
   EXPERIMENT_SPAWNED: 'experiment.spawned',
   EXPERIMENT_SELECTED: 'experiment.selected',
+  /** Orchestrator → surface events (workflow progress cards, etc.) for out-of-process surfaces. */
+  SURFACE_EVENT: 'surface.event',
 } as const;


### PR DESCRIPTION
## Summary

This teaches the Slack lobby a `restart` verb (`restart` or `restart invoker`).

A restart interrupts the running app, so it always asks for confirmation first (Approve/Cancel buttons or a yes/no reply).

On approval it routes to a new optional `onRestartInvoker` host seam, posts "Bringing Invoker back…", then reports health or the failure.

The seam keeps the surface host-agnostic: the host performs the relaunch, while the surface only parses the verb, stages the confirmation, and reports the outcome.

<details>
<summary>Review metadata</summary>

Review Claim: Add the `restart` verb and the optional `onRestartInvoker` seam to the Slack surface.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Additive — the verb is inert unless a host provides `onRestartInvoker`, and it reuses the existing confirm-staging path.

Slice Rationale: A self-contained surface capability, kept apart from the manager package so the surface change reviews on its own.

</details>

## Non-goals

This does not relaunch Invoker itself (the host seam does that) and does not change any other lobby verb.

## Test Plan

- [ ] `pnpm --filter @invoker/surfaces test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin **restart** command to Slack, available via lobby mentions and the `/invoker` slash command.
  * Restart requests now require an in-thread approval step before executing.
  * Posts clear success/failure status messages to confirm the outcome.
* **Bug Fixes**
  * Enhanced restart command parsing to tolerate punctuation/extra phrasing and avoid matching invalid “restart” prose.
  * Extended automated coverage for restart routing, confirmation gating, and failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2543