### PR TITLE
[Slack Manager](3) Add the standalone slack-manager daemon

### DIFF
--- a/packages/slack-manager/deploy/install.sh
+++ b/packages/slack-manager/deploy/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Install the Invoker Slack manager as an independently-supervised daemon.
+#
+# Prereqs:
+#   - Slack owner credentials at ~/.invoker/.slack-owner.env with:
+#       SLACK_BOT_TOKEN, SLACK_APP_TOKEN, SLACK_SIGNING_SECRET, SLACK_CHANNEL_ID
+#       (optionally SLACK_LOBBY_CHANNEL_ID, CURSOR_COMMAND, CURSOR_MODEL,
+#        INVOKER_REPO_URL, INVOKER_DEFAULT_BRANCH)
+#   - `cursor` / `omp` on PATH (the planner subprocess), `xvfb-run` for the GUI.
+#
+# Uses systemd --user when available (Restart=always + linger survives reboots),
+# else falls back to an @reboot cron keepalive loop.
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+NODE_BIN="$(command -v node)"
+SERVICE_SRC="$REPO_ROOT/packages/slack-manager/deploy/slack-manager.service"
+ENV_FILE="$HOME/.invoker/.slack-owner.env"
+
+if [ -z "$NODE_BIN" ]; then echo "node not found on PATH" >&2; exit 1; fi
+if [ ! -f "$ENV_FILE" ]; then
+  echo "Missing $ENV_FILE — create it with SLACK_BOT_TOKEN/APP_TOKEN/SIGNING_SECRET/CHANNEL_ID first." >&2
+  exit 1
+fi
+
+echo "Building @invoker/slack-manager…"
+( cd "$REPO_ROOT" && pnpm --filter @invoker/slack-manager build )
+
+if command -v systemctl >/dev/null 2>&1; then
+  UNIT_DIR="$HOME/.config/systemd/user"
+  mkdir -p "$UNIT_DIR"
+  sed -e "s#__REPO_ROOT__#$REPO_ROOT#g" -e "s#__NODE__#$NODE_BIN#g" \
+    "$SERVICE_SRC" > "$UNIT_DIR/slack-manager.service"
+  systemctl --user daemon-reload
+  systemctl --user enable --now slack-manager.service
+  # Keep the user manager (and the service) alive across logout/reboot.
+  loginctl enable-linger "$USER" || true
+  echo "Installed. Logs: journalctl --user -u slack-manager -f"
+else
+  echo "systemd not available — installing @reboot cron keepalive fallback."
+  KEEPALIVE="$REPO_ROOT/packages/slack-manager/deploy/keepalive.sh"
+  chmod +x "$KEEPALIVE"
+  LINE="@reboot INVOKER_REPO_ROOT=$REPO_ROOT NODE_BIN=$NODE_BIN setsid $KEEPALIVE >> $HOME/.invoker/slack-manager.keepalive.log 2>&1"
+  ( crontab -l 2>/dev/null | grep -v 'slack-manager/deploy/keepalive.sh' || true; echo "$LINE" ) | crontab -
+  echo "Installed cron keepalive. Starting now…"
+  INVOKER_REPO_ROOT="$REPO_ROOT" NODE_BIN="$NODE_BIN" setsid "$KEEPALIVE" >> "$HOME/.invoker/slack-manager.keepalive.log" 2>&1 &
+  echo "Logs: $HOME/.invoker/slack-manager.keepalive.log"
+fi

--- a/packages/slack-manager/deploy/keepalive.sh
+++ b/packages/slack-manager/deploy/keepalive.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Fallback supervisor for hosts without systemd. Restarts the Slack manager if it
+# exits. Installed by install.sh as an @reboot cron job wrapped in setsid.
+#
+#   @reboot setsid /path/to/keepalive.sh >> ~/.invoker/slack-manager.keepalive.log 2>&1
+set -u
+
+REPO_ROOT="${INVOKER_REPO_ROOT:-$(cd "$(dirname "$0")/../../.." && pwd)}"
+NODE_BIN="${NODE_BIN:-$(command -v node)}"
+ENV_FILE="${INVOKER_SLACK_OWNER_ENV:-$HOME/.invoker/.slack-owner.env}"
+RESTART_DELAY="${RESTART_DELAY:-5}"
+
+cd "$REPO_ROOT" || exit 1
+# shellcheck disable=SC1090
+[ -f "$ENV_FILE" ] && set -a && . "$ENV_FILE" && set +a
+
+while true; do
+  echo "[keepalive] $(date -Is) starting slack-manager"
+  "$NODE_BIN" packages/slack-manager/dist/index.js
+  echo "[keepalive] $(date -Is) slack-manager exited ($?); restarting in ${RESTART_DELAY}s"
+  sleep "$RESTART_DELAY"
+done

--- a/packages/slack-manager/deploy/slack-manager.service
+++ b/packages/slack-manager/deploy/slack-manager.service
@@ -1,0 +1,27 @@
+# systemd user unit for the Invoker Slack manager.
+#
+# Install via packages/slack-manager/deploy/install.sh, which substitutes
+# __REPO_ROOT__ / __NODE__ and copies this to ~/.config/systemd/user/.
+#
+# The manager is supervised INDEPENDENTLY of Invoker: Restart=always brings it
+# back if it crashes, and `loginctl enable-linger` keeps it running across
+# reboots and while the user is logged out. It in turn watches Invoker and
+# relaunches the GUI when that dies.
+
+[Unit]
+Description=Invoker Slack manager (out-of-process Slack surface)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=__REPO_ROOT__
+EnvironmentFile=%h/.invoker/.slack-owner.env
+ExecStart=__NODE__ packages/slack-manager/dist/index.js
+Restart=always
+RestartSec=5
+# Give the watchdog room to relaunch the GUI without systemd reaping the manager.
+TimeoutStopSec=20
+
+[Install]
+WantedBy=default.target

--- a/packages/slack-manager/package.json
+++ b/packages/slack-manager/package.json
@@ -1,16 +1,12 @@
 {
-  "name": "@invoker/surfaces",
-  "version": "0.0.4",
+  "name": "@invoker/slack-manager",
+  "version": "0.0.6",
+  "private": true,
   "main": "dist/index.js",
-  "types": "src/index.ts",
-  "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "default": "./dist/index.js"
-    }
-  },
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsup",
+    "start": "node dist/index.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"
@@ -18,9 +14,12 @@
   "dependencies": {
     "@invoker/contracts": "workspace:*",
     "@invoker/data-store": "workspace:*",
+    "@invoker/execution-engine": "workspace:*",
+    "@invoker/surfaces": "workspace:*",
     "@invoker/transport": "workspace:*",
     "@invoker/workflow-core": "workspace:*",
     "@slack/bolt": "^4.6.0",
+    "dotenv": "^16.0.0",
     "yaml": "^2.7.0"
   },
   "devDependencies": {

--- a/packages/slack-manager/src/__tests__/command-handler.test.ts
+++ b/packages/slack-manager/src/__tests__/command-handler.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, readFileSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createCommandHandler } from '../command-handler.js';
+import { InvokerDownError, type InvokerClient } from '../invoker-client.js';
+
+const noop = (): void => {};
+
+function makeClient(overrides: Partial<InvokerClient> = {}): InvokerClient {
+  const base: InvokerClient = {
+    ping: vi.fn(async () => true),
+    isHealthy: vi.fn(async () => true),
+    listWorkflows: vi.fn(async () => []),
+    getWorkflowBundle: vi.fn(async () => ({ workflow: undefined, tasks: [] })),
+    getWorkflowStatus: vi.fn(async () => ({ total: 0, completed: 0, failed: 0, closed: 0, running: 0, pending: 0 })),
+    getTaskOutput: vi.fn(async () => ''),
+    exec: vi.fn(async () => {}),
+    run: vi.fn(async () => 'wf-x'),
+    launch: vi.fn(async () => true),
+    withRecovery: vi.fn(async (fn: () => Promise<unknown>) => fn()) as InvokerClient['withRecovery'],
+    subscribe: vi.fn(() => () => {}),
+    onReconnect: vi.fn(() => () => {}),
+    disconnect: vi.fn(),
+  };
+  return { ...base, ...overrides };
+}
+
+describe('createCommandHandler', () => {
+  let plansDir: string;
+  const slack = { handleEvent: vi.fn(async () => {}) };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    plansDir = mkdtempSync(path.join(tmpdir(), 'slack-mgr-plans-'));
+  });
+
+  it('approve → headless approve', async () => {
+    const client = makeClient();
+    await createCommandHandler({ client, slack, plansDir, log: noop })({ type: 'approve', taskId: 't1' });
+    expect(client.exec).toHaveBeenCalledWith(['approve', 't1']);
+  });
+
+  it('reject carries the reason when present, omits it otherwise', async () => {
+    const client = makeClient();
+    const handler = createCommandHandler({ client, slack, plansDir, log: noop });
+    await handler({ type: 'reject', taskId: 't1', reason: 'no good' });
+    expect(client.exec).toHaveBeenCalledWith(['reject', 't1', 'no good']);
+    await handler({ type: 'reject', taskId: 't2' });
+    expect(client.exec).toHaveBeenCalledWith(['reject', 't2']);
+  });
+
+  it('provide_input → input, select_experiment → select, retry → retry-task', async () => {
+    const client = makeClient();
+    const handler = createCommandHandler({ client, slack, plansDir, log: noop });
+    await handler({ type: 'provide_input', taskId: 't1', input: 'hello' });
+    expect(client.exec).toHaveBeenCalledWith(['input', 't1', 'hello']);
+    await handler({ type: 'select_experiment', taskId: 't1', experimentId: 'exp-a' });
+    expect(client.exec).toHaveBeenCalledWith(['select', 't1', 'exp-a']);
+    await handler({ type: 'retry', taskId: 't1' });
+    expect(client.exec).toHaveBeenCalledWith(['retry-task', 't1']);
+  });
+
+  it('get_status → queries status and emits a workflow_status event', async () => {
+    const status = { total: 2, completed: 1, failed: 0, closed: 0, running: 1, pending: 0 };
+    const client = makeClient({ getWorkflowStatus: vi.fn(async () => status) });
+    await createCommandHandler({ client, slack, plansDir, log: noop })({ type: 'get_status', workflowId: 'wf-1' });
+    expect(client.getWorkflowStatus).toHaveBeenCalledWith('wf-1');
+    expect(slack.handleEvent).toHaveBeenCalledWith({ type: 'workflow_status', status, workflowId: 'wf-1' });
+  });
+
+  it('start_plan → writes plan file, runs it, emits workflow_created', async () => {
+    const client = makeClient({ run: vi.fn(async () => 'wf-new') });
+    await createCommandHandler({ client, slack, plansDir, log: noop })({
+      type: 'start_plan',
+      planText: 'name: Demo\n',
+      requestedBy: 'U1',
+      lobbyChannel: 'C1',
+      lobbyThreadTs: '123.45',
+      harnessPreset: 'cursor+claude',
+      repoUrl: 'git@example:repo.git',
+    });
+
+    const files = readdirSync(plansDir);
+    expect(files).toHaveLength(1);
+    const planPath = path.join(plansDir, files[0]);
+    expect(readFileSync(planPath, 'utf8')).toBe('name: Demo\n');
+    expect(client.run).toHaveBeenCalledWith(planPath);
+    expect(slack.handleEvent).toHaveBeenCalledWith({
+      type: 'workflow_created',
+      workflowId: 'wf-new',
+      requestedBy: 'U1',
+      lobbyChannel: 'C1',
+      lobbyThreadTs: '123.45',
+      harnessPreset: 'cursor+claude',
+      repoUrl: 'git@example:repo.git',
+    });
+  });
+
+  it('posts an error event when Invoker stays down', async () => {
+    const client = makeClient({ withRecovery: vi.fn(async () => { throw new InvokerDownError('down'); }) as InvokerClient['withRecovery'] });
+    await createCommandHandler({ client, slack, plansDir, log: noop })({ type: 'approve', taskId: 't1' });
+    expect(slack.handleEvent).toHaveBeenCalledWith(expect.objectContaining({ type: 'error' }));
+  });
+});

--- a/packages/slack-manager/src/__tests__/event-subscription.test.ts
+++ b/packages/slack-manager/src/__tests__/event-subscription.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Channels } from '@invoker/transport';
+import { startEventSubscription } from '../event-subscription.js';
+
+function setup() {
+  const handlers = new Map<string, (message: unknown) => void>();
+  const client = {
+    subscribe: vi.fn((channel: string, handler: (message: unknown) => void) => {
+      handlers.set(channel, handler);
+      return () => handlers.delete(channel);
+    }),
+  };
+  const slack = { handleEvent: vi.fn(async () => {}) };
+  const stop = startEventSubscription({ client, slack, log: () => {} });
+  return { handlers, client, slack, stop };
+}
+
+describe('startEventSubscription', () => {
+  it('forwards a surface.event workflow_progress card straight to the surface', () => {
+    const { handlers, slack } = setup();
+    const event = {
+      type: 'workflow_progress',
+      progress: {
+        workflowId: 'wf-1',
+        name: 'demo',
+        counts: { total: 1, completed: 0, failed: 0, closed: 0, running: 1, pending: 0 },
+        percentComplete: 0,
+        tasks: [],
+      },
+    };
+    handlers.get(Channels.SURFACE_EVENT)!(event);
+    expect(slack.handleEvent).toHaveBeenCalledWith(event);
+  });
+
+  it('wraps a raw task.delta into a task_delta event (awaiting_approval → surface renders buttons)', () => {
+    const { handlers, slack } = setup();
+    const delta = { type: 'updated', taskId: 'wf-1/task-a', changes: { status: 'awaiting_approval' } };
+    handlers.get(Channels.TASK_DELTA)!(delta);
+    expect(slack.handleEvent).toHaveBeenCalledWith({ type: 'task_delta', delta });
+  });
+
+  it('subscribes to both channels and tears them down on stop', () => {
+    const { client, handlers, stop } = setup();
+    expect(client.subscribe).toHaveBeenCalledTimes(2);
+    expect(handlers.has(Channels.SURFACE_EVENT)).toBe(true);
+    expect(handlers.has(Channels.TASK_DELTA)).toBe(true);
+    stop();
+    expect(handlers.size).toBe(0);
+  });
+});

--- a/packages/slack-manager/src/__tests__/invoker-client.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-client.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from 'vitest';
+import { TransportError, TransportErrorCode } from '@invoker/transport';
+import { IpcInvokerClient, InvokerDownError, type ConnectableBus } from '../invoker-client.js';
+
+/** A fake IpcBus whose owner-ping succeeds only while `ownerUp()` is true. */
+function makeFakeBus(ownerUp: () => boolean): ConnectableBus & { subscribe: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> } {
+  return {
+    ready: vi.fn(async () => {}),
+    request: vi.fn(async (_channel: string) => {
+      if (!ownerUp()) throw new TransportError(TransportErrorCode.NO_HANDLER, 'no peer');
+      return { ok: true } as never;
+    }),
+    subscribe: vi.fn(() => () => {}),
+    publish: vi.fn(),
+    onRequest: vi.fn(() => () => {}),
+    disconnect: vi.fn(),
+  } as never;
+}
+
+describe('IpcInvokerClient', () => {
+  it('withRecovery relaunches Invoker and retries the operation once', async () => {
+    let ownerUp = false;
+    const spawnInvoker = vi.fn(() => { ownerUp = true; });
+    const client = new IpcInvokerClient({
+      spawnInvoker, log: () => {},
+      busFactory: () => makeFakeBus(() => ownerUp),
+      sleep: async () => {}, healthPollIntervalMs: 1, launchHealthTimeoutMs: 1_000,
+      httpHealthCheck: async () => false,
+    });
+
+    let calls = 0;
+    const result = await client.withRecovery(async () => {
+      calls += 1;
+      if (calls === 1) throw new InvokerDownError('down');
+      return 'recovered';
+    });
+
+    expect(spawnInvoker).toHaveBeenCalledTimes(1);
+    expect(calls).toBe(2);
+    expect(result).toBe('recovered');
+  });
+
+  it('coalesces concurrent launches into a single spawn', async () => {
+    let ownerUp = false;
+    const spawnInvoker = vi.fn(() => { ownerUp = true; });
+    const client = new IpcInvokerClient({
+      spawnInvoker, log: () => {},
+      busFactory: () => makeFakeBus(() => ownerUp),
+      sleep: async () => {}, healthPollIntervalMs: 1, launchHealthTimeoutMs: 1_000,
+      httpHealthCheck: async () => false,
+    });
+
+    const [a, b] = await Promise.all([client.launch(), client.launch()]);
+    expect(spawnInvoker).toHaveBeenCalledTimes(1);
+    expect(a).toBe(true);
+    expect(b).toBe(true);
+  });
+
+  it('throttles a second (non-forced) launch within the min interval', async () => {
+    let ownerUp = false; // never recovers
+    const spawnInvoker = vi.fn();
+    let nowMs = 100_000;
+    const client = new IpcInvokerClient({
+      spawnInvoker, log: () => {},
+      busFactory: () => makeFakeBus(() => ownerUp),
+      now: () => nowMs,
+      sleep: async (ms) => { nowMs += ms; },
+      healthPollIntervalMs: 2, launchHealthTimeoutMs: 10,
+      minLaunchIntervalMs: 60_000, httpHealthCheck: async () => false,
+    });
+
+    expect(await client.launch()).toBe(false);
+    expect(spawnInvoker).toHaveBeenCalledTimes(1);
+
+    nowMs += 1_000; // inside the window
+    expect(await client.launch()).toBe(false);
+    expect(spawnInvoker).toHaveBeenCalledTimes(1);
+
+    nowMs += 60_000; // past the window
+    await client.launch();
+    expect(spawnInvoker).toHaveBeenCalledTimes(2);
+  });
+
+  it('promotes a probe to the live bus, applies subscriptions, and fires onReconnect', async () => {
+    let ownerUp = true;
+    const buses: Array<ReturnType<typeof makeFakeBus>> = [];
+    const client = new IpcInvokerClient({
+      spawnInvoker: vi.fn(), log: () => {},
+      busFactory: () => { const b = makeFakeBus(() => ownerUp); buses.push(b); return b; },
+      httpHealthCheck: async () => false,
+    });
+    const reconnect = vi.fn();
+    client.onReconnect(reconnect);
+    client.subscribe('surface.event', vi.fn());
+
+    expect(await client.ping()).toBe(true);
+    expect(reconnect).toHaveBeenCalledTimes(1);
+    expect(buses).toHaveLength(1);
+    expect(buses[0].subscribe).toHaveBeenCalledWith('surface.event', expect.any(Function));
+  });
+
+  it('re-subscribes on a fresh bus after the owner dies and returns', async () => {
+    let ownerUp = true;
+    const buses: Array<ReturnType<typeof makeFakeBus>> = [];
+    const client = new IpcInvokerClient({
+      spawnInvoker: vi.fn(), log: () => {},
+      busFactory: () => { const b = makeFakeBus(() => ownerUp); buses.push(b); return b; },
+      httpHealthCheck: async () => false,
+    });
+    client.subscribe('task.delta', vi.fn());
+
+    expect(await client.ping()).toBe(true);          // bus0 connects, subscription applied
+    expect(buses[0].subscribe).toHaveBeenCalledTimes(1);
+
+    ownerUp = false;
+    expect(await client.ping()).toBe(false);         // bus0 ping fails → torn down
+    expect(buses[0].disconnect).toHaveBeenCalled();
+
+    ownerUp = true;
+    expect(await client.ping()).toBe(true);          // fresh probe connects + re-subscribes
+    expect(buses).toHaveLength(2);
+    expect(buses[1].subscribe).toHaveBeenCalledWith('task.delta', expect.any(Function));
+  });
+});

--- a/packages/slack-manager/src/__tests__/watchdog.test.ts
+++ b/packages/slack-manager/src/__tests__/watchdog.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createWatchdog } from '../watchdog.js';
+
+interface HealthLaunch {
+  isHealthy: () => Promise<boolean>;
+  launch: () => Promise<boolean>;
+}
+
+describe('createWatchdog', () => {
+  it('relaunches after the failure threshold and not more than once per backoff window', async () => {
+    let nowMs = 1_000_000;
+    const launch = vi.fn(async () => false); // Invoker stays down
+    const client: HealthLaunch = { isHealthy: vi.fn(async () => false), launch };
+    const wd = createWatchdog({
+      client, log: () => {}, alert: vi.fn(),
+      failuresBeforeRelaunch: 2, maxAttempts: 5,
+      baseBackoffMs: 60_000, maxBackoffMs: 300_000,
+      now: () => nowMs,
+    });
+
+    await wd.tick(); // failure 1 — below threshold
+    expect(launch).toHaveBeenCalledTimes(0);
+    await wd.tick(); // failure 2 — first relaunch
+    expect(launch).toHaveBeenCalledTimes(1);
+    await wd.tick(); // still inside the backoff window
+    await wd.tick();
+    expect(launch).toHaveBeenCalledTimes(1);
+
+    nowMs += 61_000; // past the 60s window
+    await wd.tick();
+    expect(launch).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up and alerts after maxAttempts, then stops auto-restarting', async () => {
+    let nowMs = 0;
+    const launch = vi.fn(async () => false);
+    const alert = vi.fn();
+    const wd = createWatchdog({
+      client: { isHealthy: vi.fn(async () => false), launch },
+      log: () => {}, alert,
+      failuresBeforeRelaunch: 1, maxAttempts: 3, baseBackoffMs: 1_000, maxBackoffMs: 1_000,
+      now: () => nowMs,
+    });
+
+    await wd.tick();
+    expect(launch).toHaveBeenCalledTimes(1);
+    nowMs += 2_000; await wd.tick();
+    expect(launch).toHaveBeenCalledTimes(2);
+    nowMs += 2_000; await wd.tick();
+    expect(launch).toHaveBeenCalledTimes(3);
+    expect(alert).toHaveBeenCalledTimes(1);
+
+    nowMs += 10_000; await wd.tick(); // gave up — no further launches
+    expect(launch).toHaveBeenCalledTimes(3);
+  });
+
+  it('resets after a successful relaunch', async () => {
+    let nowMs = 0;
+    const launch = vi.fn(async () => true); // relaunch succeeds
+    const wd = createWatchdog({
+      client: { isHealthy: vi.fn(async () => false), launch },
+      log: () => {}, alert: vi.fn(),
+      failuresBeforeRelaunch: 1, baseBackoffMs: 60_000,
+      now: () => nowMs,
+    });
+    await wd.tick();
+    expect(launch).toHaveBeenCalledTimes(1);
+    // success reset the window → next failure relaunches again immediately
+    await wd.tick();
+    expect(launch).toHaveBeenCalledTimes(2);
+  });
+
+  it('resets when Invoker recovers on its own', async () => {
+    let nowMs = 0;
+    let healthy = false;
+    const launch = vi.fn(async () => false);
+    const wd = createWatchdog({
+      client: { isHealthy: vi.fn(async () => healthy), launch },
+      log: () => {}, alert: vi.fn(),
+      failuresBeforeRelaunch: 1, baseBackoffMs: 60_000,
+      now: () => nowMs,
+    });
+    await wd.tick();
+    expect(launch).toHaveBeenCalledTimes(1);
+    healthy = true; await wd.tick(); // recovered → reset
+    healthy = false; nowMs += 100; await wd.tick(); // fresh failure relaunches without waiting a window
+    expect(launch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/slack-manager/src/__tests__/workflow-ops.test.ts
+++ b/packages/slack-manager/src/__tests__/workflow-ops.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createRunWorkflowOp } from '../workflow-ops.js';
+import { InvokerDownError, type InvokerClient } from '../invoker-client.js';
+
+const noop = (): void => {};
+
+function makeClient(overrides: Partial<InvokerClient> = {}): InvokerClient {
+  const base: InvokerClient = {
+    ping: vi.fn(async () => true),
+    isHealthy: vi.fn(async () => true),
+    listWorkflows: vi.fn(async () => []),
+    getWorkflowBundle: vi.fn(async () => ({ workflow: undefined, tasks: [] })),
+    getWorkflowStatus: vi.fn(async () => ({ total: 0, completed: 0, failed: 0, closed: 0, running: 0, pending: 0 })),
+    getTaskOutput: vi.fn(async () => ''),
+    exec: vi.fn(async () => {}),
+    run: vi.fn(async () => 'wf-x'),
+    launch: vi.fn(async () => true),
+    withRecovery: vi.fn(async (fn: () => Promise<unknown>) => fn()) as InvokerClient['withRecovery'],
+    subscribe: vi.fn(() => () => {}),
+    onReconnect: vi.fn(() => () => {}),
+    disconnect: vi.fn(),
+  };
+  return { ...base, ...overrides };
+}
+
+describe('createRunWorkflowOp', () => {
+  it('recreate all → lists workflows then exec recreate per id with onProgress', async () => {
+    const client = makeClient({ listWorkflows: vi.fn(async () => [{ id: 'wf-1' }, { id: 'wf-2' }]) });
+    const onProgress = vi.fn();
+    const run = createRunWorkflowOp(client, noop);
+
+    const res = await run({ operation: 'recreate', target: { all: true } }, onProgress);
+
+    expect(client.listWorkflows).toHaveBeenCalledTimes(1);
+    expect(client.exec).toHaveBeenNthCalledWith(1, ['recreate', 'wf-1']);
+    expect(client.exec).toHaveBeenNthCalledWith(2, ['recreate', 'wf-2']);
+    expect(res).toEqual({ ok: true, summary: 'recreate: 2 ok' });
+    // one progress per id plus a final flush
+    expect(onProgress).toHaveBeenCalledWith(expect.objectContaining({ current: 'wf-1', total: 2 }));
+    expect(onProgress).toHaveBeenLastCalledWith(expect.objectContaining({ done: 2, total: 2, ok: 2, failed: 0 }));
+  });
+
+  it('cancel maps to the workflow-scoped cancel-workflow command', async () => {
+    const client = makeClient({ listWorkflows: vi.fn(async () => [{ id: 'wf-9' }]) });
+    await createRunWorkflowOp(client, noop)({ operation: 'cancel', target: { workflow: 'wf-9' } });
+    expect(client.exec).toHaveBeenCalledWith(['cancel-workflow', 'wf-9']);
+  });
+
+  it('status → queries per-workflow status and builds a summary (no mutation)', async () => {
+    const client = makeClient({
+      listWorkflows: vi.fn(async () => [{ id: 'wf-1' }]),
+      getWorkflowStatus: vi.fn(async () => ({ total: 3, completed: 1, failed: 0, closed: 0, running: 1, pending: 1 })),
+    });
+    const res = await createRunWorkflowOp(client, noop)({ operation: 'status', target: { all: true } });
+    expect(client.exec).not.toHaveBeenCalled();
+    expect(res.ok).toBe(true);
+    expect(res.summary).toBe('`wf-1`: 1 running, 1 pending, 1 done, 0 failed');
+  });
+
+  it('resolves a single workflow by name', async () => {
+    const client = makeClient({ listWorkflows: vi.fn(async () => [{ id: 'wf-1', name: 'login' }]) });
+    await createRunWorkflowOp(client, noop)({ operation: 'retry', target: { workflow: 'login' } });
+    expect(client.exec).toHaveBeenCalledWith(['retry', 'wf-1']);
+  });
+
+  it('returns a not-found result for an unknown target', async () => {
+    const client = makeClient({ listWorkflows: vi.fn(async () => [{ id: 'wf-1' }]) });
+    const res = await createRunWorkflowOp(client, noop)({ operation: 'recreate', target: { workflow: 'nope' } });
+    expect(res).toEqual({ ok: false, summary: 'No workflow matching `nope`.' });
+    expect(client.exec).not.toHaveBeenCalled();
+  });
+
+  it('records per-workflow failures without aborting the batch', async () => {
+    const client = makeClient({
+      listWorkflows: vi.fn(async () => [{ id: 'wf-1' }, { id: 'wf-2' }]),
+      exec: vi.fn(async (args: string[]) => { if (args[1] === 'wf-1') throw new Error('boom'); }),
+    });
+    const res = await createRunWorkflowOp(client, noop)({ operation: 'recreate', target: { all: true } });
+    expect(res.ok).toBe(false);
+    expect(res.summary).toContain('recreate: 1 ok, 1 failed');
+    expect(res.summary).toContain('wf-1: boom');
+  });
+
+  it('returns the down summary when Invoker stays down', async () => {
+    const client = makeClient({ withRecovery: vi.fn(async () => { throw new InvokerDownError('down'); }) as InvokerClient['withRecovery'] });
+    const res = await createRunWorkflowOp(client, noop)({ operation: 'recreate', target: { all: true } });
+    expect(res.ok).toBe(false);
+    expect(res.summary).toContain('Invoker is down');
+  });
+});

--- a/packages/slack-manager/src/command-handler.ts
+++ b/packages/slack-manager/src/command-handler.ts
@@ -1,0 +1,78 @@
+/**
+ * CommandHandler — the `onCommand` passed to `slack.start()`. Translates surface
+ * commands into delegated Invoker actions over IPC. Each command is wrapped in
+ * launch-and-retry-once-if-down; if Invoker stays down, an error is posted back.
+ */
+
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import type { CommandHandler, SurfaceCommand, SurfaceEvent } from '@invoker/surfaces';
+import { InvokerDownError, type InvokerClient } from './invoker-client.js';
+import { errMessage } from './util.js';
+
+export interface CommandHandlerDeps {
+  client: InvokerClient;
+  slack: { handleEvent: (event: SurfaceEvent) => Promise<void> };
+  /** Directory plan YAML files are written to before `headless run`. */
+  plansDir: string;
+  log: (level: string, message: string) => void;
+}
+
+const DOWN_MESSAGE = 'Invoker is down and I could not bring it back. Reply `restart` to retry.';
+
+export function createCommandHandler(deps: CommandHandlerDeps): CommandHandler {
+  return async (command: SurfaceCommand): Promise<void> => {
+    try {
+      await deps.client.withRecovery(() => dispatch(deps, command));
+    } catch (err) {
+      const message = err instanceof InvokerDownError
+        ? DOWN_MESSAGE
+        : `Command \`${command.type}\` failed: ${errMessage(err)}`;
+      deps.log('error', message);
+      await deps.slack.handleEvent({ type: 'error', message }).catch(() => {});
+    }
+  };
+}
+
+async function dispatch(deps: CommandHandlerDeps, command: SurfaceCommand): Promise<void> {
+  const { client, slack, plansDir, log } = deps;
+  switch (command.type) {
+    case 'approve':
+      await client.exec(['approve', command.taskId]);
+      return;
+    case 'reject':
+      await client.exec(['reject', command.taskId, ...(command.reason ? [command.reason] : [])]);
+      return;
+    case 'provide_input':
+      await client.exec(['input', command.taskId, command.input]);
+      return;
+    case 'select_experiment':
+      await client.exec(['select', command.taskId, command.experimentId]);
+      return;
+    case 'retry':
+      await client.exec(['retry-task', command.taskId]);
+      return;
+    case 'get_status': {
+      const status = await client.getWorkflowStatus(command.workflowId);
+      await slack.handleEvent({ type: 'workflow_status', status, workflowId: command.workflowId });
+      return;
+    }
+    case 'start_plan': {
+      mkdirSync(plansDir, { recursive: true });
+      const planPath = path.join(plansDir, `manager-${Date.now()}.yaml`);
+      writeFileSync(planPath, command.planText, 'utf8');
+      const workflowId = await client.run(planPath);
+      log('info', `submitted plan → workflow ${workflowId}`);
+      await slack.handleEvent({
+        type: 'workflow_created',
+        workflowId,
+        requestedBy: command.requestedBy,
+        lobbyChannel: command.lobbyChannel,
+        lobbyThreadTs: command.lobbyThreadTs,
+        harnessPreset: command.harnessPreset,
+        repoUrl: command.repoUrl,
+      });
+      return;
+    }
+  }
+}

--- a/packages/slack-manager/src/event-subscription.ts
+++ b/packages/slack-manager/src/event-subscription.ts
@@ -1,0 +1,43 @@
+/**
+ * Event subscription — forwards Invoker's broadcast events to the Slack surface.
+ *
+ * `surface.event` carries a full SurfaceEvent (the workflow-progress card,
+ * published by the owner's surface-event relay). `task.delta` carries a raw
+ * TaskDelta, wrapped into a `task_delta` surface event so the surface renders
+ * per-task messages + Approve/Reject/Provide-Input buttons.
+ *
+ * Subscriptions are registered through the InvokerClient, which re-applies them
+ * on a fresh bus after a reconnect (live-forward only; no replay — the next
+ * delta/progress refreshes the in-place cards).
+ */
+
+import { Channels } from '@invoker/transport';
+import type { SurfaceEvent } from '@invoker/surfaces';
+import type { TaskDelta } from '@invoker/workflow-core';
+import type { InvokerClient } from './invoker-client.js';
+import { errMessage } from './util.js';
+
+export interface EventSubscriptionDeps {
+  client: Pick<InvokerClient, 'subscribe'>;
+  slack: { handleEvent: (event: SurfaceEvent) => Promise<void> };
+  log: (level: string, message: string) => void;
+}
+
+export function startEventSubscription(deps: EventSubscriptionDeps): () => void {
+  const { client, slack, log } = deps;
+  const forward = (event: SurfaceEvent): void => {
+    void slack.handleEvent(event).catch((err) => log('warn', `handleEvent failed: ${errMessage(err)}`));
+  };
+
+  const unsubProgress = client.subscribe(Channels.SURFACE_EVENT, (message) => {
+    forward(message as SurfaceEvent);
+  });
+  const unsubDelta = client.subscribe(Channels.TASK_DELTA, (message) => {
+    forward({ type: 'task_delta', delta: message as TaskDelta });
+  });
+
+  return () => {
+    unsubProgress();
+    unsubDelta();
+  };
+}

--- a/packages/slack-manager/src/host-seams.ts
+++ b/packages/slack-manager/src/host-seams.ts
@@ -1,0 +1,73 @@
+/**
+ * Host seams — the planner/repo/context callbacks the SlackSurface needs,
+ * reconstructed outside Electron.
+ *
+ * `planningCommandBuilder` and `prepareRepoCheckout` reuse @invoker/execution-engine
+ * exactly as `wireSlackBot` does. `gatherWorkflowContext` is the cross-process
+ * (degraded) variant: it reads tasks + task output over IPC and the planning
+ * conversation from the manager's own store. Per-task agent-session transcripts
+ * are not reachable cross-process, so the transcript is empty and task output
+ * carries the per-task detail.
+ */
+
+import { registerBuiltinAgents, RepoPool } from '@invoker/execution-engine';
+import type { ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
+import type { PlanningCommandBuilder, WorkflowContext } from '@invoker/surfaces';
+import type { InvokerClient } from './invoker-client.js';
+import { errMessage } from './util.js';
+
+/** Build the planner command from the built-in agent registry (cursor/omp/codex). */
+export function createPlanningCommandBuilder(): PlanningCommandBuilder {
+  const registry = registerBuiltinAgents();
+  return (opts) => registry.getPlanningOrThrow(opts.tool).buildPlanningCommand(opts.prompt, { model: opts.model });
+}
+
+/** Check out a repo for the planning agent through the shared repo queue; returns the working dir. */
+export function createPrepareRepoCheckout(cacheDir: string): (repoUrl: string) => Promise<string> {
+  const pool = new RepoPool({ cacheDir });
+  return (repoUrl) => pool.ensureCloneThroughRepoQueue(repoUrl);
+}
+
+export interface GatherWorkflowContextDeps {
+  client: Pick<InvokerClient, 'getWorkflowBundle' | 'getTaskOutput'>;
+  conversationRepo: Pick<ConversationRepository, 'loadConversation'>;
+  workflowChannelRepo: Pick<WorkflowChannelRepository, 'getByWorkflowId'>;
+  log: (level: string, message: string) => void;
+}
+
+export function createGatherWorkflowContext(
+  deps: GatherWorkflowContextDeps,
+): (workflowId: string) => Promise<WorkflowContext> {
+  return async (workflowId) => {
+    const { tasks } = await deps.client.getWorkflowBundle(workflowId);
+    const contextTasks: WorkflowContext['tasks'] = [];
+    for (const task of tasks) {
+      if (task.config.isMergeNode) continue;
+      let output = '';
+      try {
+        output = await deps.client.getTaskOutput(task.id);
+      } catch (err) {
+        deps.log('warn', `gatherWorkflowContext: task-output failed for ${task.id}: ${errMessage(err)}`);
+      }
+      contextTasks.push({
+        id: task.id,
+        status: task.status,
+        agentName: task.execution.agentName ?? task.execution.lastAgentName ?? '',
+        transcript: [],
+        output: output || undefined,
+      });
+    }
+
+    let planning: WorkflowContext['planning'] = [];
+    const mapping = deps.workflowChannelRepo.getByWorkflowId(workflowId);
+    if (mapping?.lobbyThreadTs) {
+      const convo = deps.conversationRepo.loadConversation(mapping.lobbyThreadTs);
+      planning = (convo?.messages ?? []).map((m) => ({
+        role: m.role,
+        content: typeof m.content === 'string' ? m.content : JSON.stringify(m.content),
+      }));
+    }
+
+    return { workflowId, planning, tasks: contextTasks };
+  };
+}

--- a/packages/slack-manager/src/index.ts
+++ b/packages/slack-manager/src/index.ts
@@ -1,0 +1,146 @@
+/**
+ * @invoker/slack-manager — a standalone, independently-supervised daemon that
+ * owns the Slack Socket Mode connection and drives a running Invoker over IPC.
+ *
+ * It survives Invoker dying: a watchdog relaunches Invoker when it's down, and
+ * an `@Invoker restart` request relaunches on demand. Sessions and the
+ * workflow→channel map live in the manager's OWN SQLite store so they persist
+ * while Invoker's DB is owned or its process is down.
+ */
+
+import { execSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import dotenv from 'dotenv';
+
+import { SlackSurface, type SlackSurfaceConfig } from '@invoker/surfaces';
+import { ConversationRepository, SQLiteAdapter, WorkflowChannelRepository } from '@invoker/data-store';
+
+import { IpcInvokerClient } from './invoker-client.js';
+import { createInvokerLauncher } from './invoker-launcher.js';
+import { createRunWorkflowOp } from './workflow-ops.js';
+import { createCommandHandler } from './command-handler.js';
+import { startEventSubscription } from './event-subscription.js';
+import { createPlanningCommandBuilder, createPrepareRepoCheckout, createGatherWorkflowContext } from './host-seams.js';
+import { createWatchdog } from './watchdog.js';
+import { errMessage } from './util.js';
+
+const REQUIRED_ENV = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'];
+
+function makeLog(): { log: (level: string, message: string) => void; logFn: (source: string, level: string, message: string) => void } {
+  const log = (level: string, message: string): void => {
+    const line = `[slack-manager] ${new Date().toISOString()} ${level.toUpperCase()} ${message}`;
+    if (level === 'error') console.error(line);
+    else console.log(line);
+  };
+  return { log, logFn: (source, level, message) => log(level, `[${source}] ${message}`) };
+}
+
+function detectRepoUrl(repoRoot: string, log: (level: string, message: string) => void): string | undefined {
+  if (process.env.INVOKER_REPO_URL) return process.env.INVOKER_REPO_URL;
+  try {
+    return execSync('git remote get-url origin', { cwd: repoRoot, encoding: 'utf8', timeout: 5000 }).trim();
+  } catch {
+    log('warn', 'could not detect repoUrl from git remote; plans will require repoUrl in YAML');
+    return undefined;
+  }
+}
+
+async function main(): Promise<void> {
+  const { log, logFn } = makeLog();
+
+  const ownerEnvPath = process.env.INVOKER_SLACK_OWNER_ENV ?? path.join(homedir(), '.invoker', '.slack-owner.env');
+  dotenv.config({ path: ownerEnvPath });
+
+  const missing = REQUIRED_ENV.filter((key) => !process.env[key]);
+  if (missing.length > 0) {
+    log('error', `missing Slack credentials: ${missing.join(', ')} (looked in ${ownerEnvPath})`);
+    process.exit(1);
+  }
+
+  const managerHome = process.env.INVOKER_SLACK_MANAGER_DIR ?? path.join(homedir(), '.invoker', 'slack-manager');
+  mkdirSync(managerHome, { recursive: true });
+  const checkoutsRoot = path.join(managerHome, 'checkouts');
+  const plansDir = path.join(homedir(), '.invoker', 'plans');
+
+  // Manager-owned store — survives while Invoker's DB is owned or its process is down.
+  const adapter = await SQLiteAdapter.create(path.join(managerHome, 'slack-manager.db'), { ownerCapability: true });
+  const conversationRepo = new ConversationRepository(adapter);
+  const workflowChannelRepo = new WorkflowChannelRepository(adapter);
+
+  const repoRoot = process.env.INVOKER_REPO_ROOT ?? process.cwd();
+  const repoUrl = detectRepoUrl(repoRoot, log);
+
+  const launcher = createInvokerLauncher({
+    repoRoot,
+    logPath: path.join(homedir(), '.invoker', 'gui.log'),
+    log,
+  });
+  const client = new IpcInvokerClient({ spawnInvoker: launcher.spawnInvoker, log });
+
+  const runWorkflowOp = createRunWorkflowOp(client, log);
+  const gatherWorkflowContext = createGatherWorkflowContext({ client, conversationRepo, workflowChannelRepo, log });
+
+  const config: SlackSurfaceConfig = {
+    botToken: process.env.SLACK_BOT_TOKEN!,
+    appToken: process.env.SLACK_APP_TOKEN!,
+    signingSecret: process.env.SLACK_SIGNING_SECRET!,
+    channelId: process.env.SLACK_CHANNEL_ID!,
+    lobbyChannelId: process.env.SLACK_LOBBY_CHANNEL_ID ?? process.env.SLACK_CHANNEL_ID,
+    cursorCommand: process.env.CURSOR_COMMAND ?? 'agent',
+    model: process.env.CURSOR_MODEL,
+    defaultHarnessPreset: process.env.INVOKER_SLACK_DEFAULT_PRESET,
+    workingDir: repoRoot,
+    conversationRepo,
+    workflowChannelRepo,
+    planningCommandBuilder: createPlanningCommandBuilder(),
+    prepareRepoCheckout: createPrepareRepoCheckout(path.join(managerHome, 'planning-clones')),
+    defaultBranch: process.env.INVOKER_DEFAULT_BRANCH ?? 'master',
+    repoUrl,
+    defaultRepoUrl: repoUrl,
+    runWorkflowOp,
+    gatherWorkflowContext,
+    onRestartInvoker: async () => {
+      const healthy = await client.launch({ force: true });
+      if (!healthy) throw new Error('Invoker did not become healthy after relaunch');
+    },
+    log: logFn,
+  };
+  void checkoutsRoot; // reserved for future per-workflow checkout root
+
+  const slack = new SlackSurface(config);
+  const commandHandler = createCommandHandler({ client, slack, plansDir, log });
+  const stopEvents = startEventSubscription({ client, slack, log });
+  const watchdog = createWatchdog({
+    client,
+    log,
+    alert: (message) => slack.handleEvent({ type: 'error', message }),
+  });
+
+  await slack.start(commandHandler);
+  watchdog.start();
+  // Establish the IPC connection (and re-apply subscriptions) if Invoker is already up.
+  void client.ping();
+  log('info', `slack-manager started (store=${managerHome})`);
+
+  let shuttingDown = false;
+  const shutdown = async (signal: string): Promise<void> => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    log('info', `received ${signal}, shutting down`);
+    watchdog.stop();
+    stopEvents();
+    await slack.stop().catch((err) => log('warn', `slack.stop failed: ${errMessage(err)}`));
+    client.disconnect();
+    adapter.close();
+    process.exit(0);
+  };
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+}
+
+void main().catch((err) => {
+  console.error(`[slack-manager] fatal: ${errMessage(err)}`);
+  process.exit(1);
+});

--- a/packages/slack-manager/src/invoker-client.ts
+++ b/packages/slack-manager/src/invoker-client.ts
@@ -1,0 +1,412 @@
+/**
+ * InvokerClient — drives a running Invoker over its IPC bus, and (re)launches it
+ * when it's down.
+ *
+ * Invoker exposes an owner socket (`~/.invoker/ipc-transport.sock`). A client
+ * bus (`allowServe:false`) connects to it and uses the `headless.*` request
+ * channels: `owner-ping` (health), `query` (structured reads), `exec`
+ * (mutations), `run` (submit a plan). The client also subscribes to broadcast
+ * channels (`task.delta`, `surface.event`) for live forwarding.
+ *
+ * The IpcBus does NOT auto-reconnect: a client created while the owner is down,
+ * or whose owner dies, stays peerless forever. So this client tears down and
+ * re-probes a fresh bus whenever a request reports the transport is down, and
+ * re-applies subscriptions + fires `onReconnect` the moment a fresh probe
+ * connects to a live owner.
+ */
+
+import {
+  IpcBus,
+  TransportError,
+  TransportErrorCode,
+  type MessageBus,
+  type MessageHandler,
+  type Unsubscribe,
+} from '@invoker/transport';
+import { resolveInvokerIpcSocketPath } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
+import type { WorkflowStatus } from '@invoker/surfaces';
+
+/** A MessageBus that exposes connection readiness — i.e. an IpcBus client. */
+export interface ConnectableBus extends MessageBus {
+  ready(): Promise<void>;
+}
+
+/** Thrown when an operation cannot reach the Invoker owner (transport-level down). */
+export class InvokerDownError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvokerDownError';
+  }
+}
+
+/** Minimal workflow identity used for target resolution. */
+export interface WorkflowSummary {
+  id: string;
+  name?: string;
+}
+
+/** A workflow's persisted record plus its tasks, as returned by `headless.query` `{kind:'workflow'}`. */
+export interface WorkflowBundle {
+  workflow: { name?: string } | undefined;
+  tasks: TaskState[];
+}
+
+export interface InvokerClient {
+  /** True when the owner answers `owner-ping` over IPC. Establishes/repairs the live bus as a side effect. */
+  ping(): Promise<boolean>;
+  /** True when the owner answers IPC ping OR the HTTP `/api/health` endpoint. */
+  isHealthy(): Promise<boolean>;
+  listWorkflows(): Promise<WorkflowSummary[]>;
+  getWorkflowBundle(workflowId: string): Promise<WorkflowBundle>;
+  getWorkflowStatus(workflowId?: string): Promise<WorkflowStatus>;
+  getTaskOutput(taskId: string): Promise<string>;
+  /** Run a delegated headless mutation (`approve`, `recreate`, `cancel-workflow`, …). Fire-and-forget. */
+  exec(args: string[]): Promise<void>;
+  /** Submit a plan file; resolves to the created workflow id. */
+  run(planPath: string): Promise<string>;
+  /** (Re)launch Invoker. Resolves true once healthy over IPC, false on timeout/throttle. */
+  launch(opts?: { force?: boolean }): Promise<boolean>;
+  /** Runs `fn`; on `InvokerDownError`, launches Invoker and retries once. Rethrows if still down. */
+  withRecovery<T>(fn: () => Promise<T>): Promise<T>;
+  /** Subscribe to a broadcast channel; survives reconnects (re-applied on a fresh bus). */
+  subscribe(channel: string, handler: (message: unknown) => void): () => void;
+  /** Register a callback fired whenever a fresh bus connects to a live owner. */
+  onReconnect(handler: () => void): () => void;
+  disconnect(): void;
+}
+
+export interface InvokerClientOptions {
+  /** Starts a fresh detached Invoker GUI process. Owns kill-and-respawn for force restarts. */
+  spawnInvoker: () => void;
+  log: (level: string, message: string) => void;
+  socketPath?: string;
+  /** HTTP health endpoint; defaults to `http://127.0.0.1:${INVOKER_API_PORT ?? 4100}/api/health`. */
+  healthUrl?: string;
+  /** Minimum ms between (non-forced) launches — guards against restart storms. Default 60_000. */
+  minLaunchIntervalMs?: number;
+  /** Max ms to wait for IPC health after a launch. Default 90_000. */
+  launchHealthTimeoutMs?: number;
+  /** Interval between health polls while waiting for launch. Default 2_000. */
+  healthPollIntervalMs?: number;
+  /** Per-ping IPC timeout. Default 1_000. */
+  pingTimeoutMs?: number;
+  // Injection points for tests:
+  busFactory?: (socketPath: string) => ConnectableBus;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  httpHealthCheck?: () => Promise<boolean>;
+}
+
+interface SubscriptionEntry {
+  channel: string;
+  handler: MessageHandler;
+  unsub?: Unsubscribe;
+}
+
+const QUERY_TIMEOUT_MS = 5_000;
+const OUTPUT_QUERY_TIMEOUT_MS = 10_000;
+const EXEC_TIMEOUT_MS = 60_000;
+
+function defaultSleep(ms: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const timer = setTimeout(resolve, ms);
+  timer.unref?.();
+  return promise;
+}
+
+/** Race a promise against a timeout that rejects with `onTimeout()`. */
+async function withTimeout<T>(p: Promise<T>, ms: number, onTimeout: () => Error): Promise<T> {
+  const { promise, resolve, reject } = Promise.withResolvers<T>();
+  const timer = setTimeout(() => reject(onTimeout()), ms);
+  timer.unref?.();
+  p.then(resolve, reject);
+  try {
+    return await promise;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** True for transport-level "owner is unreachable" errors (not owner-side handler failures). */
+function isTransportDown(err: unknown): boolean {
+  return err instanceof TransportError && (
+    err.code === TransportErrorCode.NO_HANDLER
+    || err.code === TransportErrorCode.DISCONNECTED
+    || err.code === TransportErrorCode.REQUEST_TIMEOUT
+  );
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export class IpcInvokerClient implements InvokerClient {
+  private readonly socketPath: string;
+  private readonly healthUrl: string;
+  private readonly spawnInvoker: () => void;
+  private readonly log: (level: string, message: string) => void;
+  private readonly minLaunchIntervalMs: number;
+  private readonly launchHealthTimeoutMs: number;
+  private readonly healthPollIntervalMs: number;
+  private readonly pingTimeoutMs: number;
+  private readonly busFactory: (socketPath: string) => ConnectableBus;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly httpHealthCheck: () => Promise<boolean>;
+
+  private bus: ConnectableBus | null = null;
+  private healthy = false;
+  private lastLaunchAt = 0;
+  private launchInFlight: Promise<boolean> | null = null;
+  private readonly subs = new Set<SubscriptionEntry>();
+  private readonly reconnectHandlers = new Set<() => void>();
+
+  constructor(options: InvokerClientOptions) {
+    this.socketPath = options.socketPath ?? resolveInvokerIpcSocketPath();
+    this.healthUrl = options.healthUrl
+      ?? `http://127.0.0.1:${process.env.INVOKER_API_PORT ?? 4100}/api/health`;
+    this.spawnInvoker = options.spawnInvoker;
+    this.log = options.log;
+    this.minLaunchIntervalMs = options.minLaunchIntervalMs ?? 60_000;
+    this.launchHealthTimeoutMs = options.launchHealthTimeoutMs ?? 90_000;
+    this.healthPollIntervalMs = options.healthPollIntervalMs ?? 2_000;
+    this.pingTimeoutMs = options.pingTimeoutMs ?? 1_000;
+    this.busFactory = options.busFactory ?? ((socketPath) => new IpcBus(socketPath, { allowServe: false }));
+    this.now = options.now ?? (() => Date.now());
+    this.sleep = options.sleep ?? defaultSleep;
+    this.httpHealthCheck = options.httpHealthCheck ?? (() => this.defaultHttpHealth());
+  }
+
+  async ping(): Promise<boolean> {
+    if (!this.bus) {
+      const probe = await this.connectProbe();
+      if (!probe) return false;
+      this.bus = probe;
+      this.healthy = true;
+      this.applySubscriptions(probe);
+      this.fireReconnect();
+      return true;
+    }
+    try {
+      const res = await withTimeout(
+        this.bus.request<Record<string, never>, { ok?: boolean }>('headless.owner-ping', {}),
+        this.pingTimeoutMs,
+        () => new InvokerDownError('owner-ping timed out'),
+      );
+      const ok = !!res?.ok;
+      if (!ok) this.markDown();
+      return ok;
+    } catch {
+      this.markDown();
+      return false;
+    }
+  }
+
+  async isHealthy(): Promise<boolean> {
+    if (await this.ping()) return true;
+    return this.httpHealthCheck();
+  }
+
+  async listWorkflows(): Promise<WorkflowSummary[]> {
+    const res = await this.query<{ workflows?: Array<{ id?: string; name?: string }> }>({ kind: 'workflows' });
+    return (res.workflows ?? [])
+      .filter((w): w is { id: string; name?: string } => typeof w.id === 'string')
+      .map((w) => ({ id: w.id, name: w.name }));
+  }
+
+  async getWorkflowBundle(workflowId: string): Promise<WorkflowBundle> {
+    const res = await this.query<WorkflowBundle>({ kind: 'workflow', workflowId });
+    return { workflow: res.workflow, tasks: Array.isArray(res.tasks) ? res.tasks : [] };
+  }
+
+  async getWorkflowStatus(workflowId?: string): Promise<WorkflowStatus> {
+    return this.query<WorkflowStatus>({ kind: 'workflow-status', ...(workflowId ? { workflowId } : {}) });
+  }
+
+  async getTaskOutput(taskId: string): Promise<string> {
+    const res = await this.query<{ output?: string }>({ kind: 'task-output', taskId }, OUTPUT_QUERY_TIMEOUT_MS);
+    return res.output ?? '';
+  }
+
+  async exec(args: string[]): Promise<void> {
+    await this.ownerRequest('headless.exec', { args, noTrack: true, traceId: this.traceId('exec') }, EXEC_TIMEOUT_MS);
+  }
+
+  async run(planPath: string): Promise<string> {
+    const res = await this.ownerRequest<{ workflowId?: string }>(
+      'headless.run',
+      { planPath, traceId: this.traceId('run') },
+      EXEC_TIMEOUT_MS,
+    );
+    if (!res.workflowId) throw new Error('headless.run did not return a workflowId');
+    return res.workflowId;
+  }
+
+  async withRecovery<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (err) {
+      if (!(err instanceof InvokerDownError)) throw err;
+      this.log('warn', `Invoker appears down (${err.message}); attempting relaunch`);
+      const healthy = await this.launch();
+      if (!healthy) throw new InvokerDownError('Invoker is down and could not be relaunched');
+      return fn();
+    }
+  }
+
+  async launch(opts?: { force?: boolean }): Promise<boolean> {
+    // Coalesce concurrent callers (watchdog + command recovery) onto one launch.
+    if (this.launchInFlight) return this.launchInFlight;
+    this.launchInFlight = this.runLaunch(opts?.force ?? false);
+    try {
+      return await this.launchInFlight;
+    } finally {
+      this.launchInFlight = null;
+    }
+  }
+
+  private async runLaunch(force: boolean): Promise<boolean> {
+    if (!force) {
+      if (await this.ping()) return true;
+      const sinceLast = this.now() - this.lastLaunchAt;
+      if (sinceLast < this.minLaunchIntervalMs) {
+        this.log('warn', `launch throttled — only ${Math.round(sinceLast / 1000)}s since last launch`);
+        return false;
+      }
+    }
+    return this.doLaunch();
+  }
+
+  subscribe(channel: string, handler: (message: unknown) => void): () => void {
+    const entry: SubscriptionEntry = { channel, handler: handler as MessageHandler };
+    this.subs.add(entry);
+    if (this.bus && this.healthy) entry.unsub = this.bus.subscribe(channel, entry.handler);
+    return () => {
+      this.subs.delete(entry);
+      entry.unsub?.();
+    };
+  }
+
+  onReconnect(handler: () => void): () => void {
+    this.reconnectHandlers.add(handler);
+    return () => {
+      this.reconnectHandlers.delete(handler);
+    };
+  }
+
+  disconnect(): void {
+    this.markDown();
+    this.subs.clear();
+    this.reconnectHandlers.clear();
+  }
+
+  // ── internals ───────────────────────────────────────────────
+
+  private async doLaunch(): Promise<boolean> {
+    this.lastLaunchAt = this.now();
+    this.log('info', 'launching Invoker…');
+    this.markDown();
+    this.spawnInvoker();
+    const deadline = this.now() + this.launchHealthTimeoutMs;
+    while (this.now() < deadline) {
+      await this.sleep(this.healthPollIntervalMs);
+      if (await this.ping()) {
+        this.log('info', 'Invoker is healthy');
+        return true;
+      }
+    }
+    this.log('error', `Invoker did not become healthy within ${Math.round(this.launchHealthTimeoutMs / 1000)}s`);
+    return false;
+  }
+
+  private async query<T>(payload: Record<string, unknown>, timeoutMs = QUERY_TIMEOUT_MS): Promise<T> {
+    return this.ownerRequest<T>('headless.query', payload, timeoutMs);
+  }
+
+  private async ownerRequest<T>(channel: string, payload: unknown, timeoutMs: number): Promise<T> {
+    const bus = this.bus;
+    if (!bus || !this.healthy) throw new InvokerDownError(`Invoker is not connected (channel ${channel})`);
+    try {
+      return await withTimeout(
+        bus.request<unknown, T>(channel, payload),
+        timeoutMs,
+        () => new InvokerDownError(`Request ${channel} timed out`),
+      );
+    } catch (err) {
+      if (err instanceof InvokerDownError) {
+        this.markDown();
+        throw err;
+      }
+      if (isTransportDown(err)) {
+        this.markDown();
+        throw new InvokerDownError(`Invoker is down: ${errMessage(err)}`);
+      }
+      throw err;
+    }
+  }
+
+  private async connectProbe(): Promise<ConnectableBus | null> {
+    const bus = this.busFactory(this.socketPath);
+    try {
+      await bus.ready();
+      const res = await withTimeout(
+        bus.request<Record<string, never>, { ok?: boolean }>('headless.owner-ping', {}),
+        this.pingTimeoutMs,
+        () => new InvokerDownError('owner-ping timed out'),
+      );
+      if (res?.ok) return bus;
+    } catch {
+      /* owner unreachable */
+    }
+    bus.disconnect();
+    return null;
+  }
+
+  private applySubscriptions(bus: MessageBus): void {
+    for (const entry of this.subs) {
+      entry.unsub = bus.subscribe(entry.channel, entry.handler);
+    }
+  }
+
+  private fireReconnect(): void {
+    for (const handler of this.reconnectHandlers) {
+      try {
+        handler();
+      } catch (err) {
+        this.log('warn', `onReconnect handler failed: ${errMessage(err)}`);
+      }
+    }
+  }
+
+  private markDown(): void {
+    if (this.bus) {
+      try {
+        this.bus.disconnect();
+      } catch {
+        /* already gone */
+      }
+      this.bus = null;
+    }
+    this.healthy = false;
+  }
+
+  private async defaultHttpHealth(): Promise<boolean> {
+    try {
+      const res = await withTimeout(
+        fetch(this.healthUrl),
+        this.pingTimeoutMs,
+        () => new Error('health request timed out'),
+      );
+      if (!res.ok) return false;
+      const body = (await res.json()) as { ok?: boolean };
+      return body?.ok === true;
+    } catch {
+      return false;
+    }
+  }
+
+  private traceId(prefix: string): string {
+    return `slack-manager.${prefix}:${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2, 8)}`;
+  }
+}

--- a/packages/slack-manager/src/invoker-launcher.ts
+++ b/packages/slack-manager/src/invoker-launcher.ts
@@ -1,0 +1,60 @@
+/**
+ * Invoker GUI launcher — spawns the Slack-free Invoker GUI as a detached process
+ * group, matching `run.sh`'s headless-Linux path. Tracks the spawned child so a
+ * forced restart can tear down a manager-managed instance before respawning.
+ *
+ * Slack credentials are stripped from the child env: post-cutover Invoker has no
+ * Slack surface, and the manager owns the only Slack connection.
+ */
+
+import { spawn, type ChildProcess } from 'node:child_process';
+import { openSync } from 'node:fs';
+
+const SLACK_ENV_VARS = [
+  'SLACK_BOT_TOKEN',
+  'SLACK_APP_TOKEN',
+  'SLACK_SIGNING_SECRET',
+  'SLACK_CHANNEL_ID',
+  'SLACK_LOBBY_CHANNEL_ID',
+];
+
+export interface InvokerLauncherOptions {
+  repoRoot: string;
+  /** Path the GUI's stdout/stderr is appended to. */
+  logPath: string;
+  log: (level: string, message: string) => void;
+}
+
+export interface InvokerLauncher {
+  spawnInvoker: () => void;
+}
+
+export function createInvokerLauncher(options: InvokerLauncherOptions): InvokerLauncher {
+  let child: ChildProcess | undefined;
+
+  return {
+    spawnInvoker: () => {
+      // Tear down a previously manager-spawned GUI (force-restart of a managed instance).
+      if (child?.pid && child.exitCode === null) {
+        try {
+          process.kill(-child.pid, 'SIGTERM');
+          options.log('info', `sent SIGTERM to previous Invoker GUI group (pid=${child.pid})`);
+        } catch {
+          /* already gone */
+        }
+      }
+
+      const env: NodeJS.ProcessEnv = { ...process.env, LIBGL_ALWAYS_SOFTWARE: '1' };
+      for (const key of SLACK_ENV_VARS) delete env[key];
+
+      const out = openSync(options.logPath, 'a');
+      child = spawn(
+        'xvfb-run',
+        ['--auto-servernum', './scripts/electron.cjs', 'packages/app/dist/main.js', '--no-sandbox'],
+        { cwd: options.repoRoot, env, detached: true, stdio: ['ignore', out, out] },
+      );
+      child.unref();
+      options.log('info', `spawned Invoker GUI (pid=${child.pid})`);
+    },
+  };
+}

--- a/packages/slack-manager/src/util.ts
+++ b/packages/slack-manager/src/util.ts
@@ -1,0 +1,3 @@
+export function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/slack-manager/src/watchdog.ts
+++ b/packages/slack-manager/src/watchdog.ts
@@ -1,0 +1,109 @@
+/**
+ * Watchdog — polls Invoker health and relaunches it when it's down.
+ *
+ * Every `intervalMs` it checks `isHealthy()` (IPC ping, HTTP `/api/health`
+ * fallback). After `failuresBeforeRelaunch` consecutive failures it calls
+ * `launch()`. Relaunch attempts are spaced by an exponential backoff
+ * (`baseBackoffMs` → `maxBackoffMs`); after `maxAttempts` it posts an alert and
+ * stops auto-restarting until Invoker is healthy again (e.g. via a manual
+ * `restart`). This backoff is the load-bearing guard against restart storms.
+ */
+
+import type { InvokerClient } from './invoker-client.js';
+import { errMessage } from './util.js';
+
+export interface WatchdogDeps {
+  client: Pick<InvokerClient, 'isHealthy' | 'launch'>;
+  log: (level: string, message: string) => void;
+  /** Posts an operator-visible alert (e.g. to the lobby) when auto-restart gives up. */
+  alert: (message: string) => Promise<void> | void;
+  intervalMs?: number;
+  failuresBeforeRelaunch?: number;
+  maxAttempts?: number;
+  baseBackoffMs?: number;
+  maxBackoffMs?: number;
+  now?: () => number;
+}
+
+export interface Watchdog {
+  start(): void;
+  stop(): void;
+  /** Run one health/relaunch cycle. Exposed for tests. */
+  tick(): Promise<void>;
+}
+
+export function createWatchdog(deps: WatchdogDeps): Watchdog {
+  const intervalMs = deps.intervalMs ?? 15_000;
+  const failuresBeforeRelaunch = deps.failuresBeforeRelaunch ?? 2;
+  const maxAttempts = deps.maxAttempts ?? 5;
+  const baseBackoffMs = deps.baseBackoffMs ?? 60_000;
+  const maxBackoffMs = deps.maxBackoffMs ?? 300_000;
+  const now = deps.now ?? (() => Date.now());
+
+  let consecutiveFailures = 0;
+  let attempts = 0;
+  let backoffMs = baseBackoffMs;
+  let nextAttemptAt = 0;
+  let gaveUp = false;
+  let busy = false;
+  let timer: ReturnType<typeof setInterval> | undefined;
+
+  const reset = (): void => {
+    consecutiveFailures = 0;
+    attempts = 0;
+    backoffMs = baseBackoffMs;
+    nextAttemptAt = 0;
+    gaveUp = false;
+  };
+
+  const tick = async (): Promise<void> => {
+    if (busy) return;
+    busy = true;
+    try {
+      const healthy = await deps.client.isHealthy();
+      if (healthy) {
+        if (consecutiveFailures > 0 || attempts > 0 || gaveUp) deps.log('info', 'Invoker is healthy again');
+        reset();
+        return;
+      }
+      consecutiveFailures++;
+      if (consecutiveFailures < failuresBeforeRelaunch) return;
+      if (gaveUp) return;
+      if (now() < nextAttemptAt) return;
+
+      attempts++;
+      deps.log('warn', `Invoker is down — relaunch attempt ${attempts}/${maxAttempts}`);
+      const ok = await deps.client.launch();
+      if (ok) {
+        deps.log('info', 'watchdog relaunch succeeded');
+        reset();
+        return;
+      }
+      if (attempts >= maxAttempts) {
+        gaveUp = true;
+        await deps.alert(
+          `:rotating_light: Invoker is down and I could not bring it back after ${maxAttempts} attempts. Reply \`restart\` to retry.`,
+        );
+        return;
+      }
+      nextAttemptAt = now() + backoffMs;
+      backoffMs = Math.min(backoffMs * 2, maxBackoffMs);
+    } catch (err) {
+      deps.log('error', `watchdog tick failed: ${errMessage(err)}`);
+    } finally {
+      busy = false;
+    }
+  };
+
+  return {
+    tick,
+    start() {
+      timer = setInterval(() => void tick(), intervalMs);
+      timer.unref?.();
+    },
+    stop() {
+      clearInterval(timer);
+      timer = undefined;
+    },
+  };
+}

--- a/packages/slack-manager/src/workflow-ops.ts
+++ b/packages/slack-manager/src/workflow-ops.ts
@@ -1,0 +1,90 @@
+/**
+ * runWorkflowOp seam — executes lobby workflow operations against a running
+ * Invoker over IPC, mirroring the in-process `wireSlackBot.runWorkflowOp`.
+ *
+ * Reads resolve targets via `headless.query`; mutations delegate via
+ * `headless.exec` so the owner serializes them (no forced-standalone writes).
+ * When Invoker is down, `withRecovery` relaunches and retries once; if it's
+ * still down, a failure result is returned for the surface to post.
+ */
+
+import type { WorkflowOp, WorkflowOpName, WorkflowOpProgress, WorkflowOpResult } from '@invoker/surfaces';
+import { InvokerDownError, type InvokerClient } from './invoker-client.js';
+import { errMessage } from './util.js';
+
+export type RunWorkflowOp = (
+  op: WorkflowOp,
+  onProgress?: (p: WorkflowOpProgress) => void,
+) => Promise<WorkflowOpResult>;
+
+const DOWN_SUMMARY = 'Invoker is down and I could not bring it back. Reply `restart` to retry.';
+
+/** Workflow-op verb → delegated headless `exec` command (workflow id appended). `cancel` is workflow-scoped. */
+const MUTATION_COMMAND: Partial<Record<WorkflowOpName, string>> = {
+  recreate: 'recreate',
+  'rebase-recreate': 'rebase-recreate',
+  'rebase-retry': 'rebase-retry',
+  retry: 'retry',
+  cancel: 'cancel-workflow',
+};
+
+export function createRunWorkflowOp(
+  client: InvokerClient,
+  log: (level: string, message: string) => void,
+): RunWorkflowOp {
+  return async (op, onProgress) => {
+    try {
+      return await client.withRecovery(() => runOnce(client, op, onProgress));
+    } catch (err) {
+      if (err instanceof InvokerDownError) return { ok: false, summary: DOWN_SUMMARY };
+      log('error', `workflow op ${op.operation} failed: ${errMessage(err)}`);
+      return { ok: false, summary: `Operation failed: ${errMessage(err)}` };
+    }
+  };
+}
+
+async function runOnce(
+  client: InvokerClient,
+  op: WorkflowOp,
+  onProgress?: (p: WorkflowOpProgress) => void,
+): Promise<WorkflowOpResult> {
+  const all = await client.listWorkflows();
+  let ids: string[];
+  if ('all' in op.target) {
+    ids = all.map((w) => w.id);
+  } else {
+    const wanted = op.target.workflow;
+    const match = all.find((w) => w.id === wanted || w.name === wanted);
+    if (!match) return { ok: false, summary: `No workflow matching \`${wanted}\`.` };
+    ids = [match.id];
+  }
+  if (ids.length === 0) return { ok: false, summary: 'No workflows found.' };
+
+  if (op.operation === 'status') {
+    const lines = await Promise.all(ids.map(async (id) => {
+      const s = await client.getWorkflowStatus(id);
+      return `\`${id}\`: ${s.running} running, ${s.pending} pending, ${s.completed} done, ${s.failed} failed`;
+    }));
+    return { ok: true, summary: lines.join('\n') };
+  }
+
+  const command = MUTATION_COMMAND[op.operation];
+  if (!command) return { ok: false, summary: `Unsupported operation \`${op.operation}\`.` };
+
+  let ok = 0;
+  const failed: string[] = [];
+  const total = ids.length;
+  for (const id of ids) {
+    onProgress?.({ done: ok + failed.length, total, ok, failed: failed.length, current: id });
+    try {
+      await client.exec([command, id]);
+      ok++;
+    } catch (err) {
+      if (err instanceof InvokerDownError) throw err; // bubble to withRecovery
+      failed.push(`${id}: ${errMessage(err)}`);
+    }
+  }
+  onProgress?.({ done: total, total, ok, failed: failed.length });
+  const summary = `${op.operation}: ${ok} ok${failed.length ? `, ${failed.length} failed\n${failed.join('\n')}` : ''}`;
+  return { ok: failed.length === 0, summary };
+}

--- a/packages/slack-manager/tsconfig.json
+++ b/packages/slack-manager/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    { "path": "../contracts" },
+    { "path": "../data-store" },
+    { "path": "../execution-engine" },
+    { "path": "../transport" },
+    { "path": "../workflow-core" },
+    { "path": "../surfaces" }
+  ]
+}

--- a/packages/slack-manager/tsconfig.tsup.json
+++ b/packages/slack-manager/tsconfig.tsup.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/slack-manager/tsup.config.ts
+++ b/packages/slack-manager/tsup.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs'],
+  outDir: 'dist',
+  tsconfig: 'tsconfig.tsup.json',
+  clean: true,
+  // @invoker/surfaces is consumed as a built artifact at runtime (it bundles
+  // @slack/bolt-bound code); everything else is bundled from TS source.
+  external: ['@invoker/surfaces', '@slack/bolt', 'sql.js', 'dockerode', 'node-pty', 'node:sqlite'],
+  noExternal: [
+    '@invoker/workflow-core',
+    '@invoker/workflow-graph',
+    '@invoker/contracts',
+    '@invoker/data-store',
+    '@invoker/runtime-domain',
+    '@invoker/runtime-adapters',
+    '@invoker/runtime-service',
+    '@invoker/transport',
+    '@invoker/execution-engine',
+    'yaml',
+  ],
+});

--- a/packages/slack-manager/vitest.config.ts
+++ b/packages/slack-manager/vitest.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import sharedConfig from '../../vitest.shared.ts';
+
+export default mergeConfig(sharedConfig, defineConfig({
+  test: {},
+}));

--- a/packages/surfaces/src/slack/index.ts
+++ b/packages/surfaces/src/slack/index.ts
@@ -3,3 +3,4 @@ export * from './slack-formatter.js';
 export * from './slack-surface.js';
 export * from './plan-conversation.js';
 export * from './thread-session-manager.js';
+export * from './workflow-assistant.js';

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -681,8 +681,6 @@ export class SlackSurface implements Surface {
     // Slower paths (LLM classifier, repo checkout, planner) acknowledge receipt up front.
     if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
 
-    // Slower paths (LLM classifier, repo checkout, planner) acknowledge receipt up front.
-    if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
 
     // Fallback classifier: only when a non-verb message looks operational.
     if (looksOperational(parsed.text)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -380,6 +380,49 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
+  packages/slack-manager:
+    dependencies:
+      '@invoker/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      '@invoker/data-store':
+        specifier: workspace:*
+        version: link:../data-store
+      '@invoker/execution-engine':
+        specifier: workspace:*
+        version: link:../execution-engine
+      '@invoker/surfaces':
+        specifier: workspace:*
+        version: link:../surfaces
+      '@invoker/transport':
+        specifier: workspace:*
+        version: link:../transport
+      '@invoker/workflow-core':
+        specifier: workspace:*
+        version: link:../workflow-core
+      '@slack/bolt':
+        specifier: ^4.6.0
+        version: 4.6.0(@types/express@5.0.6)
+      dotenv:
+        specifier: ^16.0.0
+        version: 16.6.1
+      yaml:
+        specifier: ^2.7.0
+        version: 2.8.2
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.3
+        version: 25.3.3
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
+
   packages/surfaces:
     dependencies:
       '@invoker/contracts':

--- a/scripts/check-owner-boundary.sh
+++ b/scripts/check-owner-boundary.sh
@@ -20,6 +20,7 @@ if command -v rg >/dev/null 2>&1; then
     --glob '!packages/app/src/viewer-db-boundary.ts' \
     --glob '!packages/cli/src/index.ts' \
     --glob '!packages/persistence/src/sqlite-adapter.ts' \
+    --glob '!packages/slack-manager/src/index.ts' \
     --glob '!packages/data-store/src/sqlite-adapter.ts' || true)"
 
   # 2) Runtime value-imports of SQLiteAdapter must stay owner-only.
@@ -32,6 +33,7 @@ if command -v rg >/dev/null 2>&1; then
     --glob '!**/e2e/**' \
     --glob '!**/node_modules/**' \
     --glob '!packages/app/src/viewer-db-boundary.ts' \
+    --glob '!packages/slack-manager/src/index.ts' \
     --glob '!packages/cli/src/index.ts' || true)"
 
   raw_memory_violations="$(rg -n "SQLiteAdapter\\.create\\(['\"]:memory:" packages \
@@ -66,6 +68,7 @@ else
     | grep -v '^packages/app/src/viewer-db-boundary.ts:' \
     | grep -v '^packages/cli/src/index.ts:' \
     | grep -v '^packages/persistence/src/sqlite-adapter.ts:' \
+    | grep -v '^packages/slack-manager/src/index.ts:' \
     | grep -v '^packages/data-store/src/sqlite-adapter.ts:' || true)"
 
   value_import_violations="$(grep -RInE "import[[:space:]]+\\{[^}]*SQLiteAdapter[^}]*\\}[[:space:]]+from[[:space:]]+'@invoker/(persistence|data-store)'" packages \
@@ -76,6 +79,7 @@ else
     --exclude="*.d.ts" \
     --exclude="*.test.ts" \
     | grep -v '^packages/app/src/viewer-db-boundary.ts:' \
+    | grep -v '^packages/slack-manager/src/index.ts:' \
     | grep -v '^packages/cli/src/index.ts:' || true)"
 
   raw_memory_violations="$(grep -RInE "SQLiteAdapter\\.create\\(['\"]:memory:" packages \

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -20,6 +20,7 @@
     "packages/runtime-service/src/**/*.ts",
     "packages/shell/src/**/*.ts",
     "packages/surfaces/src/**/*.ts",
+    "packages/slack-manager/src/**/*.ts",
     "packages/test-kit/src/**/*.ts",
     "packages/transport/src/**/*.ts",
     "packages/workflow-core/src/**/*.ts",


### PR DESCRIPTION
## Summary

This adds `@invoker/slack-manager`, a long-running process that owns the Slack connection and talks to Invoker over IPC instead of running inside it.

It keeps its planning sessions and workflow-to-channel map in its own SQLite store, opened as that store's sole owner, so they survive while Invoker's DB is held or down.

It forwards live progress and task events over the message bus to the Slack surface, and a watchdog relaunches Invoker, with backoff, when it goes down.

Nothing imports this package yet and the embedded bot still runs, so this slice changes no running behavior.

Beyond the new package it adds the build wiring it needs: a `@invoker/surfaces` exports map, a typecheck entry, and an owner-boundary allowlist for the manager's own store.

It also corrects the lobby mention handler so it sends the immediate acknowledgment a single time, keeping the acknowledge-then-replace flow intact.

<details>
<summary>Review metadata</summary>

Review Claim: Add the out-of-process Slack manager package with its build wiring, plus a one-line fix to the lobby mention acknowledgment — not in use yet.

Review Lane: behavior

Review Unit: routing

Safety Invariant: A new package that no running code imports; the only edits outside it are build wiring and a one-line fix to the mention acknowledgment path, so the embedded bot is unaffected until the next slice.

Slice Rationale: Introduce the replacement in full, with tests, before removing what it replaces.

</details>

## Non-goals

This does not remove the embedded bot, does not wire the relay into the owner, and does not change Invoker's startup.

## Test Plan

- [ ] `pnpm --filter @invoker/slack-manager test`
- [ ] `pnpm --filter @invoker/surfaces test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone Slack manager that can run in the background, reconnect automatically, and keep working across restarts.
  * Added support for handling Slack commands, workflow updates, and status updates end to end.

* **Bug Fixes**
  * Improved startup and recovery handling so the app can restart cleanly when the backend is unavailable.
  * Added fallback deployment support for systems without user services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->