### PR TITLE
[Delete Workflow](1) Handle stale workflow deletes

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-submit.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-submit.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import { submitWorkflowMutationOrAcknowledgeDeleted } from '../workflow-mutation-submit.js';
+
+function makeForeignKeyError(): Error {
+  const error = new Error('FOREIGN KEY constraint failed') as Error & { errcode?: number; errstr?: string };
+  error.errcode = 787;
+  error.errstr = 'constraint failed';
+  return error;
+}
+
+describe('submitWorkflowMutationOrAcknowledgeDeleted', () => {
+  it('treats delete-workflow for an already deleted workflow as accepted without queueing', () => {
+    const submit = vi.fn(() => 42);
+
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(
+      'wf-deleted',
+      'high',
+      'invoker:delete-workflow',
+      ['wf-deleted'],
+      {
+        coordinator: { submit },
+        workflowExists: () => false,
+      },
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      accepted: true,
+      intentId: 0,
+      workflowId: 'wf-deleted',
+      channel: 'invoker:delete-workflow',
+    });
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it('treats headless delete-workflow for an already deleted workflow as accepted without queueing', () => {
+    const submit = vi.fn(() => 42);
+
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(
+      'wf-deleted',
+      'high',
+      'headless.exec',
+      [{ args: ['delete-workflow', 'wf-deleted'] }],
+      {
+        coordinator: { submit },
+        workflowExists: () => false,
+      },
+    );
+
+    expect(result.intentId).toBe(0);
+    expect(result.accepted).toBe(true);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it('treats a delete-workflow foreign-key race as already accepted when the workflow is gone', () => {
+    const submit = vi.fn(() => {
+      throw makeForeignKeyError();
+    });
+    let exists = true;
+
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(
+      'wf-raced',
+      'high',
+      'invoker:delete-workflow',
+      ['wf-raced'],
+      {
+        coordinator: { submit },
+        workflowExists: () => {
+          const current = exists;
+          exists = false;
+          return current;
+        },
+      },
+    );
+
+    expect(result.intentId).toBe(0);
+    expect(result.accepted).toBe(true);
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not treat generic SQLite constraint errors as deleted workflow races', () => {
+    const error = new Error('constraint failed') as Error & { errstr?: string };
+    error.errstr = 'constraint failed';
+    const submit = vi.fn(() => {
+      throw error;
+    });
+    let exists = true;
+
+    expect(() => submitWorkflowMutationOrAcknowledgeDeleted(
+      'wf-raced',
+      'high',
+      'invoker:delete-workflow',
+      ['wf-raced'],
+      {
+        coordinator: { submit },
+        workflowExists: () => {
+          const current = exists;
+          exists = false;
+          return current;
+        },
+      },
+    )).toThrow(error);
+  });
+
+  it('still propagates foreign-key failures for non-delete mutations', () => {
+    const error = makeForeignKeyError();
+    const submit = vi.fn(() => {
+      throw error;
+    });
+
+    expect(() => submitWorkflowMutationOrAcknowledgeDeleted(
+      'wf-missing',
+      'high',
+      'invoker:retry-workflow',
+      ['wf-missing'],
+      {
+        coordinator: { submit },
+        workflowExists: () => false,
+      },
+    )).toThrow(error);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -192,6 +192,7 @@ import { seedTaskCachesFromSnapshot } from './viewer-cache-hydration.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
+import { submitWorkflowMutationOrAcknowledgeDeleted } from './workflow-mutation-submit.js';
 import type { WorkflowMutationContext } from './persisted-workflow-mutation-coordinator.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
@@ -435,14 +436,17 @@ function acknowledgeNoTrackHeadlessExec(
   if (!payload.noTrack) return undefined;
 
   if (workflowId && workflowMutationCoordinator) {
-    const intentId = workflowMutationCoordinator.submit(workflowId, priority, 'headless.exec', [payload], {
+    const result = submitWorkflowMutationOrAcknowledgeDeleted(workflowId, priority, 'headless.exec', [payload], {
+      coordinator: workflowMutationCoordinator,
+      workflowExists: (id) => Boolean(persistence.loadWorkflow(id)),
+      logger,
       deferDrain: true,
     });
     logger.info(
-      `headless.exec accepted ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId}"`, intent: intentId, priority })}`,
+      `headless.exec accepted ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId}"`, intent: result.intentId, priority })}`,
       { module: 'ipc-delegate' },
     );
-    return { ok: true, accepted: true, intentId, workflowId, channel: 'headless.exec' };
+    return result;
   }
 
   const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
@@ -2771,8 +2775,11 @@ function createEmbeddedTerminalBackendFromConfig(
     if (!workflowMutationDispatcher.has(channel)) {
       throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
     }
-    const intentId = workflowMutationCoordinator.submit(workflowId, priority, channel, args);
-    return { ok: true, accepted: true, intentId, workflowId, channel };
+    return submitWorkflowMutationOrAcknowledgeDeleted(workflowId, priority, channel, args, {
+      coordinator: workflowMutationCoordinator,
+      workflowExists: (id) => Boolean(persistence.loadWorkflow(id)),
+      logger,
+    });
   }
 
   function registerTaskScopedGuiMutationHandler<TResult = unknown>(

--- a/packages/app/src/workflow-mutation-submit.ts
+++ b/packages/app/src/workflow-mutation-submit.ts
@@ -1,0 +1,77 @@
+import type { Logger, WorkflowMutationAcceptedResult } from '@invoker/contracts';
+import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
+
+export interface WorkflowMutationSubmitter {
+  submit(
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number;
+}
+
+export interface SubmitWorkflowMutationOptions {
+  workflowExists: (workflowId: string) => boolean;
+  coordinator: WorkflowMutationSubmitter;
+  logger?: Pick<Logger, 'info'>;
+  deferDrain?: boolean;
+}
+
+function isMissingWorkflowDelete(channel: string, workflowId: string, args: unknown[]): boolean {
+  if (channel === 'invoker:delete-workflow') {
+    return args[0] === workflowId;
+  }
+  if (channel !== 'headless.exec') {
+    return false;
+  }
+  const payload = args[0] as { args?: unknown[] } | undefined;
+  const command = payload?.args?.[0];
+  return Array.isArray(payload?.args)
+    && (command === 'delete' || command === 'delete-workflow')
+    && payload.args[1] === workflowId;
+}
+
+function isForeignKeyConstraintError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const sqliteError = error as Error & { code?: unknown; errcode?: unknown; errstr?: unknown };
+  return sqliteError.errcode === 787
+    || sqliteError.message.includes('FOREIGN KEY constraint failed');
+}
+
+function acceptedAlreadyDeleted(
+  workflowId: string,
+  channel: string,
+  logger?: Pick<Logger, 'info'>,
+): WorkflowMutationAcceptedResult {
+  logger?.info(`delete-workflow ignored missing workflow="${workflowId}"`, { module: 'workflow-mutation' });
+  return { ok: true, accepted: true, intentId: 0, workflowId, channel };
+}
+
+export function submitWorkflowMutationOrAcknowledgeDeleted(
+  workflowId: string,
+  priority: WorkflowMutationPriority,
+  channel: string,
+  args: unknown[],
+  options: SubmitWorkflowMutationOptions,
+): WorkflowMutationAcceptedResult {
+  if (isMissingWorkflowDelete(channel, workflowId, args) && !options.workflowExists(workflowId)) {
+    return acceptedAlreadyDeleted(workflowId, channel, options.logger);
+  }
+
+  try {
+    const intentId = options.coordinator.submit(workflowId, priority, channel, args, {
+      deferDrain: options.deferDrain,
+    });
+    return { ok: true, accepted: true, intentId, workflowId, channel };
+  } catch (error) {
+    if (
+      isMissingWorkflowDelete(channel, workflowId, args)
+      && isForeignKeyConstraintError(error)
+      && !options.workflowExists(workflowId)
+    ) {
+      return acceptedAlreadyDeleted(workflowId, channel, options.logger);
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary

Using an out-of-date workflow card is now safe. If the workflow is already gone, Invoker returns the normal accepted result instead of a database error.

The bug happened before work reached the removal handler. The GUI routed the request through the owner path even when the workflow was gone.

The fix routes only missing workflow removal requests to the existing accepted response shape. The normal persisted path remains for live workflows.

<details>
<summary>Review metadata</summary>

Review Claim: Missing workflow removals return accepted results, while other owner-route errors still throw.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Only the workflow removal submission route can become a synthetic accepted result.

Slice Rationale: This fixes one local owner-route bug without changing workflow removal itself.

</details>

## Non-goals

This does not change workflow removal or task removal.

This does not hide database errors outside missing workflow removal submissions.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/workflow-mutation-submit.test.ts`
- [x] `pnpm run check:types`
- [x] `bash scripts/ui-visual-proof.sh capture-after`
- [ ] `bash scripts/ui-visual-proof.sh capture-before` exited 1 on current `origin/master`; it still captured before screenshots. Failures were `workflow-status-all-states` hidden node and `completed SSH task` missing output label.
- [ ] `bash scripts/ui-visual-proof.sh compare` could not run because `ffmpeg` is not installed.

## Visual Proof

Before:

![Before empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260629-5b625a/before-empty-state.png)

After:

![After empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260629-5b625a/after-empty-state.png)

After walkthrough:

[After walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260629-5b625a/after-walkthrough.webm)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added smarter handling for workflow delete requests so they can be immediately acknowledged when the target workflow is already missing.
  * Unified headless and GUI mutation submission flows to use the same “acknowledge missing delete” logic.

* **Bug Fixes**
  * Improved reliability when a delete races with concurrent removal by treating foreign-key constraint failures as an accepted “already deleted” outcome for delete-workflow requests.
  * Ensured non-delete mutations still report real constraint errors instead of being suppressed.

* **Tests**
  * Added coverage for foreign-key constraint scenarios related to delete-workflow mutations and concurrent deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->