### PR TITLE
[Workflow Lifecycle Refresh](1) Route follower lifecycle actions

### DIFF
--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -12,6 +12,38 @@ function getTranslatorSource(): string {
   return mainSource.slice(start, end);
 }
 
+function getStandaloneClassifierSource(): string {
+  const start = mainSource.indexOf('const classifyStandaloneHeadlessExecMutation =');
+  const end = mainSource.indexOf('        const standaloneWorkflowIdForTaskArg', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return mainSource.slice(start, end);
+}
+
+function getPerformDeleteWorkflowSource(): string {
+  const start = mainSource.indexOf('async function performDeleteWorkflow');
+  const end = mainSource.indexOf('  async function performDetachWorkflow', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return mainSource.slice(start, end);
+}
+
+function getPerformDetachWorkflowSource(): string {
+  const start = mainSource.indexOf('async function performDetachWorkflow');
+  const end = mainSource.indexOf('  /** Orchestrator error codes', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return mainSource.slice(start, end);
+}
+
+function getSetMergeBranchSource(): string {
+  const start = mainSource.lastIndexOf("'invoker:set-merge-branch'");
+  const end = mainSource.indexOf("'invoker:set-merge-mode'", start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return mainSource.slice(start, end);
+}
+
 describe('GUI mutation translation', () => {
   it.each([
     'invoker:check-pr-statuses',
@@ -28,6 +60,7 @@ describe('GUI mutation translation', () => {
     ['invoker:restart-task', 'retry-task'],
     ['invoker:cancel-task', 'cancel'],
     ['invoker:cancel-workflow', 'cancel-workflow'],
+    ['invoker:delete-workflow', 'delete'],
     ['invoker:recreate-workflow', 'recreate'],
     ['invoker:recreate-task', 'recreate-task'],
     ['invoker:recreate-downstream', 'recreate-downstream'],
@@ -43,4 +76,32 @@ describe('GUI mutation translation', () => {
     );
   });
 
+
+  it('classifies delegated standalone workflow delete and detach as workflow-scoped', () => {
+    const classifierSource = getStandaloneClassifierSource();
+    expect(classifierSource).toMatch(
+      /case 'delete':\s*case 'delete-workflow':\s*case 'detach-workflow':\s*return \{ workflowId: arg0 === undefined \? undefined : String\(arg0\), priority: 'high' \};/,
+    );
+  });
+
+  it('publishes workflow metadata after every successful workflow delete', () => {
+    const deleteSource = getPerformDeleteWorkflowSource();
+    expect(deleteSource).toMatch(
+      /if \(!result\.ok\) throw new Error\(result\.error\.message\);\s*requestWorkflowMetadataPublish\('delete-workflow'\);/,
+    );
+  });
+
+  it('publishes workflow metadata after every successful workflow detach', () => {
+    const detachSource = getPerformDetachWorkflowSource();
+    expect(detachSource).toMatch(
+      /if \(!result\.ok\) throw new Error\(result\.error\.message\);\s*logger\.info\(`performDetachWorkflow end workflow="\$\{workflowId\}" upstream="\$\{upstreamWorkflowId\}"`, \{ module: 'kill' \}\);\s*requestWorkflowMetadataPublish\('detach-workflow'\);/,
+    );
+  });
+
+  it('publishes workflow metadata after setting the workflow merge branch', () => {
+    const setMergeBranchSource = getSetMergeBranchSource();
+    expect(setMergeBranchSource).toMatch(
+      /persistence\.updateWorkflow\(workflowId, \{ baseBranch \}\);[\s\S]*requestWorkflowMetadataPublish\('set-merge-branch'\);/,
+    );
+  });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1542,6 +1542,10 @@ function startHeadlessMode(): void {
             case 'retry-task':
             case 'recreate-task':
               return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'high' };
+            case 'delete':
+            case 'delete-workflow':
+            case 'detach-workflow':
+              return { workflowId: arg0 === undefined ? undefined : String(arg0), priority: 'high' };
             case 'approve':
             case 'reject':
             case 'select':
@@ -2553,6 +2557,7 @@ function createEmbeddedTerminalBackendFromConfig(
     const envelope = makeEnvelope('delete-workflow', 'ui', 'workflow', { workflowId });
     const result = await commandService.deleteWorkflow(envelope);
     if (!result.ok) throw new Error(result.error.message);
+    requestWorkflowMetadataPublish('delete-workflow');
     logger.info(`performDeleteWorkflow end workflow="${workflowId}"`, { module: 'kill' });
   }
 
@@ -2562,6 +2567,7 @@ function createEmbeddedTerminalBackendFromConfig(
     const result = await commandService.detachWorkflow(envelope);
     if (!result.ok) throw new Error(result.error.message);
     logger.info(`performDetachWorkflow end workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
+    requestWorkflowMetadataPublish('detach-workflow');
   }
 
   /** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
@@ -2728,6 +2734,7 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'cancel-workflow':
       case 'delete':
       case 'delete-workflow':
+      case 'detach-workflow':
         return { workflowId: arg0, priority: 'high' };
       case 'rebase-retry':
       case 'rebase-recreate':
@@ -3932,10 +3939,6 @@ function createEmbeddedTerminalBackendFromConfig(
         logger.info(`delete-workflow: "${workflowId}"`, { module: 'ipc' });
         try {
           await performDeleteWorkflow(workflowId);
-
-          const workflows = persistence.listWorkflows();
-          lastKnownWorkflowCount = workflows.length;
-          requestWorkflowMetadataPublish('delete-workflow');
         } catch (err) {
           logger.error(`delete-workflow failed: ${err}`, { module: 'ipc' });
           throw err;
@@ -4497,6 +4500,7 @@ function createEmbeddedTerminalBackendFromConfig(
             scopedTaskIds: [mergeTask.id],
           });
         }
+        requestWorkflowMetadataPublish('set-merge-branch');
       } catch (err) {
         logger.error(`set-merge-branch failed: ${err}`, { module: 'ipc' });
         throw err;


### PR DESCRIPTION
## Summary

Follower UI workflow discard, detach, and merge-branch actions now refresh workflow metadata after the owner handles them.

These actions changed workflow-level data, but not every flow told the UI to reload metadata. One delegated flow also did not carry the workflow id.

This routes the delegated lifecycle actions to their target workflow and asks the existing metadata publisher to refresh after each shared workflow-level change succeeds.

<details>
<summary>Review metadata</summary>

Review Claim: Follower UI workflow-level actions reach the owner with the right workflow id and refresh metadata after success.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The actual workflow operations still run through CommandService or the existing storage update. This only changes owner routing metadata and post-success metadata publishing.

Slice Rationale: This is one local UI refresh fix for workflow-level actions that mutate workflow metadata.

</details>

## Non-goals

This does not change workflow contents, task execution, or cancellation rules.

## Architecture

### Before

```mermaid
graph TD
    A["Follower UI sends workflow-level action"] --> B["Owner handles action"]
    B --> C["UI may keep stale workflow metadata"]
```

### After

```mermaid
graph TD
    A["Follower UI sends workflow-level action"] --> B["Owner resolves workflow id"]
    B --> C["Existing operation updates storage"]
    C --> D["Metadata publish updates UI"]
```

## Repro Case Proof

The new classifier test covers the old routing failure: delegated `delete`, `delete-workflow`, and `detach-workflow` must resolve to the workflow id with high priority.

The new publish tests cover the stale UI: shared delete, detach, and merge-branch flows must request workflow metadata after success.

Follow-up architecture ticket: [INV-258](https://linear.app/invokerorchestrator/issue/INV-258/centralize-workflow-metadata-refresh-after-workflow-level-mutations).

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app test -- gui-mutation-translation.test.ts`
- [x] `bash scripts/ui-visual-proof.sh capture-before` captured 46 screenshots; one unrelated existing visual-proof case failed on the base branch after screenshots were collected.
- [x] `bash scripts/ui-visual-proof.sh capture-after` captured 47 screenshots and passed all 44 visual-proof cases.
- [x] `bash scripts/ui-visual-proof.sh embed`

## Visual Proof

Before:
![Before workflow context menu](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260629-21bb47/delete-workflow-before-context-menu.png)

After:
![After workflow context menu](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260629-21bb47/delete-workflow-after-context-menu.png)

After walkthrough:
[visual proof walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260629-21bb47/delete-workflow-after-walkthrough.webm)

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 8768253`
- Post-revert steps: Refresh the UI manually after delegated workflow-level actions.
- Data migration? No.
