### PR TITLE
[Read-only Mode](1) Add runtime status IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -330,6 +330,15 @@ export interface SystemDiagnostics {
   cliInstaller?: CliInstallerStatus;
 }
 
+export type RuntimeMode = 'local-owner' | 'daemon-owner' | 'read-only';
+
+export interface RuntimeStatus {
+  ownerMode: boolean;
+  readOnly: boolean;
+  mode: RuntimeMode;
+}
+
+
 // ── Embedded terminal session types ─────────────────────────
 
 /**
@@ -639,6 +648,11 @@ export const IpcChannels = {
   'invoker:get-execution-agents': {} as {
     request: [];
     response: string[];
+  },
+
+  'invoker:get-runtime-status': {} as {
+    request: [];
+    response: RuntimeStatus;
   },
 
   // Performance & Activity


### PR DESCRIPTION
## Summary

Adds a small runtime status contract so the app can say whether it is the write owner, a daemon-backed client, or a read-only viewer.

This only defines the shared IPC shape. It does not change app behavior by itself.

<details>
<summary>Review metadata</summary>

Review Claim: The shared IPC contract now has a typed runtime status response.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This slice only adds a new IPC channel type and exported status shape.

Slice Rationale: The UI and app wiring need a stable contract before either side can use it.

</details>

## Non-goals

No renderer UI changes.

No owner routing behavior changes.

## Test Plan

- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/app-launch.test.tsx`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/ipc-registration.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Revert dependent runtime status app/UI slices first.
- Data migration? No
