### PR TITLE
[Read-only Mode](2) Serve runtime owner status

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -4815,6 +4815,22 @@ function createEmbeddedTerminalBackendFromConfig(
       return agentRegistry.listExecution().map(a => a.name);
     });
 
+    ipcMain.handle('invoker:get-runtime-status', () => {
+      if (process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_FORCE_READ_ONLY_STATUS === '1') {
+        return {
+          ownerMode: false,
+          readOnly: true,
+          mode: 'read-only',
+        };
+      }
+      const readOnly = !ownerMode && !guiUsingDaemonOwner;
+      return {
+        ownerMode,
+        readOnly,
+        mode: ownerMode ? 'local-owner' : guiUsingDaemonOwner ? 'daemon-owner' : 'read-only',
+      };
+    });
+
     ipcMain.handle('invoker:get-system-diagnostics', () => {
       return collectSystemDiagnostics({
         appVersion: app.getVersion(),

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -159,6 +159,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
           String(args[0]),
           (args[1] as Parameters<SQLiteAdapter['searchWorkflowsAndTasks']>[1]) ?? undefined,
         );
+      case 'invoker:get-runtime-status':
+        return { ownerMode: true, readOnly: false, mode: 'local-owner' };
       case 'invoker:get-ui-perf-stats':
         return {};
       case 'invoker:report-ui-perf':


### PR DESCRIPTION
## Summary

Serves the runtime status from the desktop and web dispatch paths.

The response marks local writers as writable, daemon-backed clients as mutable through the daemon, and detached viewers as read-only.

<details>
<summary>Review metadata</summary>

Review Claim: The app now reports its current runtime mode through the shared IPC channel.

Review Lane: behavior

Review Unit: routing

Safety Invariant: This slice only adds a read-only status query; it does not change mutation routing.

Slice Rationale: The renderer should consume one app-owned status query instead of guessing from failed mutations.

</details>

## Non-goals

No renderer UI changes.

No mutation ownership changes.

## Test Plan

- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/app-launch.test.tsx`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/ipc-registration.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && cd packages/app && CAPTURE_MODE=route CAPTURE_VIDEO=1 npx playwright test visual-proof.spec.ts -g "empty state"`

## Visual Proof

This slice adds only the status route, so the empty app stays visually unchanged.

![Route slice empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260629-845c3c/empty-state.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Revert dependent UI slice first.
- Data migration? No
