### PR TITLE
[Read-only Mode](4) Add read-only banner visual proof

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -98,6 +98,7 @@ exit 64
 `, 'utf8');
     chmodSync(codexStub, 0o755);
     const pathEnv = `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`;
+    const forceReadOnlyStatus = guiOwnerMode === 'read-only-status';
     // Playwright's `use.video` option only applies to browser contexts, so the
     // Electron walkthrough video must be requested at launch time.
     const recordVideo = process.env.CAPTURE_VIDEO
@@ -116,7 +117,7 @@ exit 64
         ...process.env,
         NODE_ENV: 'test',
         TZ: 'UTC',
-        INVOKER_GUI_OWNER_MODE: guiOwnerMode,
+        INVOKER_GUI_OWNER_MODE: forceReadOnlyStatus ? 'gui' : guiOwnerMode,
         INVOKER_DB_DIR: testDir,
         INVOKER_IPC_SOCKET: ipcSocketPath,
         INVOKER_ALLOW_DELETE_ALL: '1',
@@ -131,6 +132,7 @@ exit 64
         INVOKER_CLAUDE_COMMAND: claudeMarker,
         INVOKER_CLAUDE_FIX_COMMAND: claudeMarker,
         ...(breakTerminalSpawn ? { INVOKER_E2E_BREAK_TERMINAL_SPAWN: '1' } : {}),
+        ...(forceReadOnlyStatus ? { INVOKER_E2E_FORCE_READ_ONLY_STATUS: '1' } : {}),
         PATH: pathEnv,
       },
     });

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -419,6 +419,16 @@ async function seedActiveLaunchAttempt(dbPath: string, taskId: string, attemptId
   }
 }
 
+test.describe('Read-only mode visual proof', () => {
+  test.use({ guiOwnerMode: 'read-only-status' });
+
+  test('read-only mode banner', async ({ page }) => {
+    await expect(page.getByTestId('read-only-mode-banner')).toContainText('Read-only mode.', { timeout: 5000 });
+    await expect(page.getByTestId('read-only-mode-banner')).toContainText('This window can browse workflows');
+    await captureScreenshot(page, 'read-only-mode-banner');
+  });
+});
+
 test.describe('Visual proof capture', () => {
   test('empty state', async ({ page }) => {
     await expect(page.getByText('Load a plan to render workflow graph')).toBeVisible({ timeout: 5000 });


### PR DESCRIPTION
## Summary

Adds the Playwright visual proof path for the read-only banner.

The test-only launch mode makes the app report read-only state without needing a second live process.

<details>
<summary>Review metadata</summary>

Review Claim: Visual proof now covers the read-only banner state.

Review Lane: proof

Review Unit: proof

Safety Invariant: This slice only changes E2E visual proof fixtures and capture coverage.

Slice Rationale: Proof files stay separate from the UI behavior slice so reviewers can assess the visible change locally.

</details>

## Non-goals

No renderer behavior changes.

No production runtime behavior changes.

## Test Plan

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 npx playwright test visual-proof.spec.ts -g "read-only mode banner|empty state"`

## Visual Proof

Before, the empty app had no read-only warning.

![Before empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260629-89ba61/empty-state.png)

After, read-only mode shows a clear banner across the top of the app.

![After read-only banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260629-89ba61/read-only-mode-banner.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
