### PR TITLE
[Read-only Mode](3) Show read-only mode banner

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -4815,6 +4815,22 @@ function createEmbeddedTerminalBackendFromConfig(
       return agentRegistry.listExecution().map(a => a.name);
     });
 
+    ipcMain.handle('invoker:get-runtime-status', () => {
+      if (process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_FORCE_READ_ONLY_STATUS === '1') {
+        return {
+          ownerMode: false,
+          readOnly: true,
+          mode: 'read-only',
+        };
+      }
+      const readOnly = !ownerMode && !guiUsingDaemonOwner;
+      return {
+        ownerMode,
+        readOnly,
+        mode: ownerMode ? 'local-owner' : guiUsingDaemonOwner ? 'daemon-owner' : 'read-only',
+      };
+    });
+
     ipcMain.handle('invoker:get-system-diagnostics', () => {
       return collectSystemDiagnostics({
         appVersion: app.getVersion(),

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -159,6 +159,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
           String(args[0]),
           (args[1] as Parameters<SQLiteAdapter['searchWorkflowsAndTasks']>[1]) ?? undefined,
         );
+      case 'invoker:get-runtime-status':
+        return { ownerMode: true, readOnly: false, mode: 'local-owner' };
       case 'invoker:get-ui-perf-stats':
         return {};
       case 'invoker:report-ui-perf':

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -330,6 +330,15 @@ export interface SystemDiagnostics {
   cliInstaller?: CliInstallerStatus;
 }
 
+export type RuntimeMode = 'local-owner' | 'daemon-owner' | 'read-only';
+
+export interface RuntimeStatus {
+  ownerMode: boolean;
+  readOnly: boolean;
+  mode: RuntimeMode;
+}
+
+
 // ── Embedded terminal session types ─────────────────────────
 
 /**
@@ -639,6 +648,11 @@ export const IpcChannels = {
   'invoker:get-execution-agents': {} as {
     request: [];
     response: string[];
+  },
+
+  'invoker:get-runtime-status': {} as {
+    request: [];
+    response: RuntimeStatus;
   },
 
   // Performance & Activity

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, ReviewGateQueryResponse, TerminalSessionDescriptor } from '@invoker/contracts';
+import type { ActionGraphNode, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
@@ -437,6 +437,7 @@ export function App() {
   const [executionAgents, setExecutionAgents] = useState<string[]>([]);
   const [statusFilters, setStatusFilters] = useState<Set<WorkflowStatus>>(new Set());
   const [systemDiagnostics, setSystemDiagnostics] = useState<SystemDiagnostics | null>(null);
+  const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatus | null>(null);
   const [showSystemSetup, setShowSystemSetup] = useState(false);
   const [showSystemBanner, setShowSystemBanner] = useState(false);
   const [installSkillsPending, setInstallSkillsPending] = useState(false);
@@ -521,6 +522,7 @@ export function App() {
     window.invoker?.getRemoteTargets?.().then(setRemoteTargets).catch(() => {});
     window.invoker?.getExecutionPools?.().then(setExecutionPools).catch(() => {});
     window.invoker?.getExecutionAgents?.().then(setExecutionAgents).catch(() => {});
+    window.invoker?.getRuntimeStatus?.().then(setRuntimeStatus).catch(() => {});
     refreshSystemDiagnostics();
   }, [refreshSystemDiagnostics]);
 
@@ -1886,6 +1888,18 @@ export function App() {
         </div>
       )}
 
+
+      {runtimeStatus?.readOnly && (
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="read-only-mode-banner"
+          className="border-b border-blue-700 bg-blue-950/70 px-4 py-2 text-sm text-blue-100"
+        >
+          <span className="font-semibold text-blue-50">Read-only mode.</span>{' '}
+          This window can browse workflows, but it cannot make changes until the write owner is available.
+        </div>
+      )}
       {/* Main content */}
       <div className="flex-1 flex overflow-hidden">
         <nav className="w-24 border-r border-gray-800 bg-gray-950/60 flex flex-col justify-between py-3">

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -56,6 +56,30 @@ describe('App launch (component)', () => {
     expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
   });
 
+  it('shows a read-only banner when this window is not the write owner', async () => {
+    mock.setRuntimeStatus({
+      ownerMode: false,
+      readOnly: true,
+      mode: 'read-only',
+    });
+
+    render(<App />);
+
+    expect(await screen.findByTestId('read-only-mode-banner')).toHaveTextContent(
+      'Read-only mode. This window can browse workflows, but it cannot make changes until the write owner is available.',
+    );
+  });
+
+  it('hides the read-only banner for the local write owner', async () => {
+    render(<App />);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.queryByTestId('read-only-mode-banner')).not.toBeInTheDocument();
+  });
+
   it('warns when no Claude or Codex CLI is installed', async () => {
     mock.api.getSystemDiagnostics = vi.fn(async () => ({
       platform: 'darwin',

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -16,7 +16,7 @@ import type {
   TaskConfig,
   TaskExecution,
 } from '../../types.js';
-import type { ActionGraphResponse, TerminalOutputEvent, WorkflowMutationAcceptedResult } from '@invoker/contracts';
+import type { ActionGraphResponse, RuntimeStatus, TerminalOutputEvent, WorkflowMutationAcceptedResult } from '@invoker/contracts';
 
 export interface MockInvoker {
   /** The mock InvokerAPI object installed on window.invoker. */
@@ -33,6 +33,8 @@ export interface MockInvoker {
   fireTerminalOutput: (event: TerminalOutputEvent) => void;
   /** Replace the action graph snapshot returned by getActionGraph. */
   setActionGraph: (response: ActionGraphResponse) => void;
+  /** Replace the runtime status returned by getRuntimeStatus. */
+  setRuntimeStatus: (status: RuntimeStatus) => void;
   /** Install the mock on window.invoker. */
   install: () => void;
   /** Remove window.invoker. */
@@ -53,6 +55,11 @@ export function createMockInvoker(
     stallThresholdMs: 60_000,
     nodes: [],
     edges: [],
+  };
+  let runtimeStatus: RuntimeStatus = {
+    ownerMode: true,
+    readOnly: false,
+    mode: 'local-owner',
   };
 
   const accepted = (channel: string, workflowId = 'wf-1'): WorkflowMutationAcceptedResult => ({
@@ -121,6 +128,7 @@ export function createMockInvoker(
     getRemoteTargets: vi.fn(async () => []),
     getExecutionPools: vi.fn(async () => ['mixed-local-ssh', 'pnpm-ssh']),
     getExecutionAgents: vi.fn(async () => ['claude', 'codex']),
+    getRuntimeStatus: vi.fn(async () => runtimeStatus),
     getSystemDiagnostics: vi.fn(async () => ({
       platform: 'linux',
       arch: 'x64',
@@ -245,6 +253,10 @@ export function createMockInvoker(
   function setActionGraph(response: ActionGraphResponse) {
     actionGraphSnapshot = response;
   }
+  function setRuntimeStatus(status: RuntimeStatus) {
+    runtimeStatus = status;
+  }
+
 
   function fireDelta(delta: TaskDelta) {
     graphEventCallback?.({ type: 'delta', delta, workflowRollups: [] });
@@ -283,6 +295,7 @@ export function createMockInvoker(
     api,
     setTasks,
     setActionGraph,
+    setRuntimeStatus,
     fireDelta,
     fireGraphEvent,
     fireWorkflowsChanged,


### PR DESCRIPTION
## Summary

Shows a blue banner when the desktop window is running as a read-only viewer.

This makes read-only state visible before users click a change button and get a confusing failure.

<details>
<summary>Review metadata</summary>

Review Claim: Read-only GUI windows now show a persistent visible warning.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice only reads runtime status and renders a banner when `readOnly` is true.

Slice Rationale: The lower stack slices provide the status query, so this slice stays focused on display behavior.

</details>

## Non-goals

No change to mutation routing.

No automatic recovery.

No change to daemon-backed writable windows.

## Test Plan

- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/app-launch.test.tsx`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/ipc-registration.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 npx playwright test visual-proof.spec.ts -g "read-only mode banner|empty state"`

## Visual Proof

Before, the empty app had no read-only warning.

![Before empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260629-0a40e1/empty-state.png)

After, read-only mode shows a clear banner across the top of the app.

![After read-only banner](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260629-0a40e1/read-only-mode-banner.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

## Files (3)

- packages/ui/src/App.tsx [MODIFIED] (+15 -1)
- packages/ui/src/__tests__/app-launch.test.tsx [MODIFIED] (+24 -0)
- packages/ui/src/__tests__/helpers/mock-invoker.ts [MODIFIED] (+14 -1)
