### PR TITLE
Add configurable default execution agent

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   loadConfig,
+  resolveDefaultExecutionAgent,
   resolveEmbeddedTerminalBackendConfig,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
@@ -122,6 +123,21 @@ describe('loadConfig', () => {
     const config = loadConfig();
     expect(config.autoFixAgent).toBe('codex');
   });
+  it('reads defaultExecutionAgent from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ defaultExecutionAgent: 'claude' }),
+    );
+    const config = loadConfig();
+    expect(config.defaultExecutionAgent).toBe('claude');
+    expect(resolveDefaultExecutionAgent(config)).toBe('claude');
+  });
+
+  it('falls back to the built-in default execution agent', () => {
+    expect(resolveDefaultExecutionAgent({})).toBe('codex');
+    expect(resolveDefaultExecutionAgent({ defaultExecutionAgent: '   ' })).toBe('codex');
+  });
+
 
   it('reads autoFixCi from user config', () => {
     writeFileSync(

--- a/packages/app/src/__tests__/cost-rollup.test.ts
+++ b/packages/app/src/__tests__/cost-rollup.test.ts
@@ -329,10 +329,10 @@ describe('resolveAgentName', () => {
     })).toBe('codex');
   });
 
-  it('defaults to claude', () => {
+  it('defaults to codex', () => {
     expect(resolveAgentName({
       id: 't1', workflowId: 'wf-1', runnerKind: 'worktree',
-    })).toBe('claude');
+    })).toBe('codex');
   });
 });
 

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -1093,7 +1093,7 @@ describe('getRestoredTerminalSpec dispatches codex vs claude session resume', ()
       expect(spec.args).toContain('--dangerously-skip-permissions');
     });
 
-    it('defaults to claude when executionAgent is undefined', () => {
+    it('defaults to codex when executionAgent is undefined', () => {
       const agentRegistry = registerBuiltinAgents();
       const wt = new WorktreeExecutor({
         worktreeBaseDir: '/tmp/wt',
@@ -1109,7 +1109,7 @@ describe('getRestoredTerminalSpec dispatches codex vs claude session resume', ()
         // executionAgent intentionally omitted
       };
       const spec = wt.getRestoredTerminalSpec(meta);
-      expect(spec.command).toBe('claude');
+      expect(spec.command).toBe('codex');
     });
   });
 
@@ -1415,7 +1415,7 @@ describe('fix-with-agent → open-terminal produces correct agent resume command
     expect(resolved.spec.command).not.toBe('claude');
   });
 
-  it('fix with no agent specified → terminal defaults to claude', () => {
+  it('fix with no agent specified → terminal defaults to codex', () => {
     vi.mocked(existsSync).mockReturnValue(true);
     const agentRegistry = registerBuiltinAgents();
     const wt = new WorktreeExecutor({
@@ -1441,10 +1441,10 @@ describe('fix-with-agent → open-terminal produces correct agent resume command
       workspacePath: persistence.getWorkspacePath('task-noagent') ?? undefined,
     };
 
-    // executionAgent is undefined → defaults to claude
+    // executionAgent is undefined → defaults to codex
     expect(meta.executionAgent).toBeUndefined();
     const spec = wt.getRestoredTerminalSpec(meta);
-    expect(spec.command).toBe('claude');
+    expect(spec.command).toBe('codex');
   });
 
   it('openExternalTerminalForTask: refuses fallback when managed workspace has no workspacePath', async () => {

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { parsePlan, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults } from '../plan-parser.js';
+import { parsePlan, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults } from '../plan-parser.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { writeFileSync } from 'node:fs';
@@ -565,6 +565,25 @@ tasks:
     const plan = parsePlan(yaml);
     expect(plan.tasks[0].executionAgent).toBe('codex');
     expect(plan.tasks[1].executionAgent).toBeUndefined();
+  });
+
+  it('applies defaultExecutionAgent from config when task omits executionAgent', () => {
+    writeFileSync(isolatedConfigPath, JSON.stringify({ defaultBranch: 'main', defaultExecutionAgent: 'codex' }));
+    const yaml = `
+name: Config Agent Test
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: default-task
+    description: "No agent specified"
+    command: "echo hi"
+  - id: explicit-task
+    description: "Explicit agent"
+    command: "echo hi"
+    executionAgent: claude
+`;
+    const plan = applyConfiguredPlanDefaults(parsePlan(yaml));
+    expect(plan.tasks[0].executionAgent).toBe('codex');
+    expect(plan.tasks[1].executionAgent).toBe('claude');
   });
 
   it('parses executionModel from task definitions', () => {

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -666,7 +666,7 @@ describe('autoFixOnFailure', () => {
     });
 
     expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
-    expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'claude', 'boom');
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'codex', 'boom');
     expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
@@ -761,7 +761,7 @@ describe('autoFixOnFailure', () => {
     });
 
     expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
-    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
@@ -803,7 +803,7 @@ describe('autoFixOnFailure', () => {
       commandService: makeCommandService(),
     });
 
-    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
   });
 
@@ -1042,13 +1042,13 @@ describe('autoFixOnFailure', () => {
       getAutoFixAgent: () => '   ',
     });
 
-    expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'claude', 'boom');
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'codex', 'boom');
     expect(logEvent).toHaveBeenCalledWith(
       'task-a',
       'debug.auto-fix',
       expect.objectContaining({
         phase: 'auto-fix-agent-selected',
-        selectedAgent: 'claude',
+        selectedAgent: 'codex',
         selectedAgentSource: 'default',
       }),
     );
@@ -1094,13 +1094,13 @@ describe('autoFixOnFailure', () => {
       getAutoFixAgent: () => undefined,
     });
 
-    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex');
     expect(logEvent).toHaveBeenCalledWith(
       'task-a',
       'debug.auto-fix',
       expect.objectContaining({
         phase: 'auto-fix-agent-selected',
-        selectedAgent: 'claude',
+        selectedAgent: 'codex',
         selectedAgentSource: 'default',
       }),
     );

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -8,6 +8,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+const BUILT_IN_DEFAULT_EXECUTION_AGENT = 'codex';
 
 export interface ExternalWorkerLaunchConfig {
   /** Executable used to start the external worker process. */
@@ -62,6 +63,11 @@ export interface InvokerConfig {
    * Default: 0 (disabled).
    */
   autoFixRetries?: number;
+  /**
+   * Default execution agent for plan tasks that omit executionAgent.
+   * Default: built-in DEFAULT_EXECUTION_AGENT.
+   */
+  defaultExecutionAgent?: string;
   /**
    * When true, successful AI-applied fixes are automatically approved.
    * This skips the manual "Approve Fix" step for fix-with-agent and
@@ -287,6 +293,11 @@ export function loadConfig(): InvokerConfig {
     ? readJsonSafe(process.env.INVOKER_REPO_CONFIG_PATH)
     : readJsonSafe(join(homedir(), '.invoker', 'config.json'));
 }
+export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
+  const configured = config.defaultExecutionAgent?.trim();
+  return configured && configured.length > 0 ? configured : BUILT_IN_DEFAULT_EXECUTION_AGENT;
+}
+
 
 
 export type EmbeddedTerminalBackendConfig = 'bash' | 'pty';

--- a/packages/app/src/cost-rollup.ts
+++ b/packages/app/src/cost-rollup.ts
@@ -9,7 +9,7 @@
 
 import type { NormalizedCostEvent, CostRollup } from '@invoker/contracts';
 import { rollUpCostEvents } from '@invoker/contracts';
-import type { SessionUsageEvent } from '@invoker/execution-engine';
+import { DEFAULT_EXECUTION_AGENT, type SessionUsageEvent } from '@invoker/execution-engine';
 
 // ── Attribution Context ────────────────────────────────────
 
@@ -177,7 +177,7 @@ export function resolveSessionId(task: CostTaskInfo): string | undefined {
  * 3. 'claude' (default)
  */
 export function resolveAgentName(task: CostTaskInfo): string {
-  return task.agentName ?? task.lastAgentName ?? 'claude';
+  return task.agentName ?? task.lastAgentName ?? DEFAULT_EXECUTION_AGENT;
 }
 
 /**

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -13,7 +13,7 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Attempt, TaskState } from '@invoker/workflow-core';
 import type { AgentSessionData, NormalizedCostEvent } from '@invoker/contracts';
-import type { AgentRegistry } from '@invoker/execution-engine';
+import { DEFAULT_EXECUTION_AGENT, type AgentRegistry } from '@invoker/execution-engine';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import {
@@ -676,7 +676,7 @@ export async function headlessSession(taskId: string | undefined, deps: Pick<Hea
   if (!task) throw new Error(`Task "${taskId}" not found`);
 
   let sessionId = task.execution.agentSessionId ?? task.execution.lastAgentSessionId;
-  let agentName = task.execution.agentName ?? task.execution.lastAgentName ?? 'claude';
+  let agentName = task.execution.agentName ?? task.execution.lastAgentName ?? DEFAULT_EXECUTION_AGENT;
 
   // Fallback: if current execution dropped agentSessionId, recover the most
   // recent session from task event payloads.

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -12,6 +12,7 @@ import { makeEnvelope } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import {
   remoteFetchForPool,
+  DEFAULT_EXECUTION_AGENT,
   registerBuiltinAgents,
   assertPlanExecutionAgentsRegistered,
 } from '@invoker/execution-engine';
@@ -82,10 +83,10 @@ export async function headlessRun(
   if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
 
   const { readFile } = await import('node:fs/promises');
-  const { parsePlanFile } = await import('./plan-parser.js');
+  const { applyConfiguredPlanDefaults, parsePlanFile } = await import('./plan-parser.js');
 
   const yamlSource = await readFile(planPath, 'utf-8');
-  const plan = await parsePlanFile(planPath);
+  const plan = applyConfiguredPlanDefaults(await parsePlanFile(planPath));
   const execRegistry = deps.executionAgentRegistry ?? registerBuiltinAgents();
   assertPlanExecutionAgentsRegistered(plan, execRegistry);
   backupPlan(plan, yamlSource, deps.logger);
@@ -304,7 +305,7 @@ export async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promis
   }
 
   const te = createHeadlessExecutor(deps);
-  const agent = (parsed.agentName ?? 'claude').toLowerCase();
+  const agent = (parsed.agentName ?? DEFAULT_EXECUTION_AGENT).toLowerCase();
   try {
     const result = await fixWithAgentAction(taskId, {
       logger: deps.logger,
@@ -363,7 +364,7 @@ export async function headlessResolveConflict(taskId: string, deps: HeadlessDeps
   taskId = restored.resolvedTaskId;
 
   const te = createHeadlessExecutor(deps);
-  const agent = (agentArg ?? 'claude').toLowerCase();
+  const agent = (agentArg ?? DEFAULT_EXECUTION_AGENT).toLowerCase();
   try {
     const result = await resolveConflictAction(taskId, {
       ...deps,

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -2,7 +2,7 @@ import type { IpcMain } from 'electron';
 import type { Logger, SearchOptions } from '@invoker/contracts';
 import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { AgentRegistry } from '@invoker/execution-engine';
+import { DEFAULT_EXECUTION_AGENT, type AgentRegistry } from '@invoker/execution-engine';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { MessageBus } from '@invoker/transport';
 import { loadConfig } from './config.js';
@@ -194,10 +194,10 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
   });
 
   ipcMain.handle('invoker:get-agent-session', async (_event, sessionId: string, agentName?: string) => {
-    logger.info(`get-agent-session: "${sessionId}" agent="${agentName ?? 'claude'}"`, { module: 'ipc' });
+    logger.info(`get-agent-session: "${sessionId}" agent="${agentName ?? DEFAULT_EXECUTION_AGENT}"`, { module: 'ipc' });
     try {
       const orchestrator = getOrchestrator();
-      return await resolveAgentSession(sessionId, agentName ?? 'claude', agentRegistry, orchestrator.getAllTasks());
+      return await resolveAgentSession(sessionId, agentName ?? DEFAULT_EXECUTION_AGENT, agentRegistry, orchestrator.getAllTasks());
     } catch (err) {
       logger.error(`get-agent-session failed: ${err}`, { module: 'ipc' });
       return null;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -107,6 +107,7 @@ import type { TaskOutputData } from './types.js';
 import {
   loadConfig,
   resolveEmbeddedTerminalBackendConfig,
+  resolveDefaultExecutionAgent,
   type EmbeddedTerminalBackendConfig,
   type InvokerConfig,
 } from './config.js';
@@ -850,7 +851,7 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
   const defaultHarnessPreset = invokerConfig.defaultSlackHarnessPreset ?? 'cursor+claude';
   const registeredExecutionAgents = new Set(planningRegistry.listExecution().map((a) => a.name));
   const resolveFallbackExecutionAgent = (presetKey?: string): string =>
-    presetToExecutionAgent(presetKey, harnessPresets, registeredExecutionAgents, DEFAULT_EXECUTION_AGENT);
+    presetToExecutionAgent(presetKey, harnessPresets, registeredExecutionAgents, resolveDefaultExecutionAgent(invokerConfig));
 
   const gatherWorkflowContext = (workflowId: string) =>
     gatherWorkflowContextImpl(
@@ -1310,8 +1311,8 @@ function startHeadlessMode(): void {
       };
 
       const executeStandaloneHeadlessRun = async (payload: HeadlessRunMutationPayload): Promise<unknown> => {
-        const { parsePlanFile } = await import('./plan-parser.js');
-        const plan = await parsePlanFile(payload.planPath);
+        const { applyConfiguredPlanDefaults, parsePlanFile } = await import('./plan-parser.js');
+        const plan = applyConfiguredPlanDefaults(await parsePlanFile(payload.planPath));
         backupPlan(plan, undefined, logger);
         const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
         orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
@@ -1360,8 +1361,8 @@ function startHeadlessMode(): void {
           }
           case 'invoker:load-plan': {
             const planText = String(payload.args[0] ?? '');
-            const { parsePlan } = await import('./plan-parser.js');
-            const plan = parsePlan(planText);
+            const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
+            const plan = applyConfiguredPlanDefaults(parsePlan(planText));
             backupPlan(plan, undefined, logger);
             orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
             return undefined;
@@ -1812,8 +1813,8 @@ function startHeadlessMode(): void {
         const executeStandaloneHeadlessRun = async (
           payload: HeadlessRunMutationPayload,
         ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
-          const { parsePlanFile } = await import('./plan-parser.js');
-          const plan = await parsePlanFile(payload.planPath);
+          const { applyConfiguredPlanDefaults, parsePlanFile } = await import('./plan-parser.js');
+          const plan = applyConfiguredPlanDefaults(await parsePlanFile(payload.planPath));
           backupPlan(plan, undefined, logger);
           const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
           orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
@@ -2364,7 +2365,7 @@ function createEmbeddedTerminalBackendFromConfig(
     const savedError = task.execution.error ?? '';
     const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
     logger.info(
-      `fix-with-agent: "${taskId}" agent=${agentName ?? 'claude'} source=${source} route=${recoveryRoute.kind}`,
+      `fix-with-agent: "${taskId}" agent=${agentName ?? DEFAULT_EXECUTION_AGENT} source=${source} route=${recoveryRoute.kind}`,
       { module: 'ipc' },
     );
 
@@ -2393,7 +2394,7 @@ function createEmbeddedTerminalBackendFromConfig(
         agentName,
         recoveryRoute,
         recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
-        failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`,
+        failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Codex'}`,
         signal: activeMutationContext?.signal,
       },
     );
@@ -2614,8 +2615,8 @@ function createEmbeddedTerminalBackendFromConfig(
 
 
   async function executeHeadlessRun(payload: HeadlessRunMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
-    const { parsePlanFile } = await import('./plan-parser.js');
-    const plan = await parsePlanFile(payload.planPath);
+    const { applyConfiguredPlanDefaults, parsePlanFile } = await import('./plan-parser.js');
+    const plan = applyConfiguredPlanDefaults(await parsePlanFile(payload.planPath));
     taskHandles.clear();
     backupPlan(plan, undefined, logger);
     const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
@@ -3731,8 +3732,8 @@ function createEmbeddedTerminalBackendFromConfig(
     });
     registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
       const planText = String(planTextArg);
-      const { parsePlan } = await import('./plan-parser.js');
-      const plan = parsePlan(planText);
+      const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
+      const plan = applyConfiguredPlanDefaults(parsePlan(planText));
       logger.info(`load-plan: "${plan.name}" (${plan.tasks.length} tasks)`, { module: 'ipc' });
       taskHandles.clear();
       backupPlan(plan, undefined, logger);
@@ -4584,7 +4585,7 @@ function createEmbeddedTerminalBackendFromConfig(
       const taskId = String(taskIdArg);
       const agentName = agentNameArg === undefined ? undefined : String(agentNameArg);
       logger.info(
-        `resolve-conflict: "${taskId}" agent=${agentName ?? 'claude'} source=ipc route=resolveConflictAction`,
+        `resolve-conflict: "${taskId}" agent=${agentName ?? DEFAULT_EXECUTION_AGENT} source=ipc route=resolveConflictAction`,
         { module: 'ipc' },
       );
       try {

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -11,6 +11,7 @@ import {
   getEffectivePath,
   WorktreeExecutor,
   SshExecutor,
+  DEFAULT_EXECUTION_AGENT,
   type Executor,
   type ExecutorRegistry,
   type AgentRegistry,
@@ -64,7 +65,7 @@ export function repairCodexResumeSessionMeta(
   persistence: OpenTerminalPersistence,
   executionAgentRegistry?: AgentRegistry,
 ): PersistedTaskMeta {
-  const executionAgent = meta.executionAgent ?? 'claude';
+  const executionAgent = meta.executionAgent ?? DEFAULT_EXECUTION_AGENT;
   const originalSessionId = meta.agentSessionId;
   if (executionAgent !== 'codex' || !originalSessionId) return meta;
 

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -8,7 +8,7 @@
 import { execSync } from 'node:child_process';
 import { parse as parseYaml } from 'yaml';
 import type { PlanDefinition } from '@invoker/workflow-core';
-import { loadConfig } from './config.js';
+import { loadConfig, resolveDefaultExecutionAgent } from './config.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 
 /** Empty / whitespace `baseBranch` in YAML (`baseBranch:`) must fall through to config + remote detection like a missing key. */
@@ -34,6 +34,23 @@ export function applyPlanDefinitionDefaults(plan: PlanDefinition): PlanDefinitio
     featureBranch,
   };
 }
+export function applyPlanExecutionAgentDefault(plan: PlanDefinition, executionAgent: string): PlanDefinition {
+  const defaultExecutionAgent = executionAgent.trim();
+  if (!defaultExecutionAgent) return plan;
+  return {
+    ...plan,
+    tasks: plan.tasks.map((task) => (
+      task.executionAgent?.trim()
+        ? task
+        : { ...task, executionAgent: defaultExecutionAgent }
+    )),
+  };
+}
+
+export function applyConfiguredPlanDefaults(plan: PlanDefinition): PlanDefinition {
+  return applyPlanExecutionAgentDefault(plan, resolveDefaultExecutionAgent(loadConfig()));
+}
+
 
 export interface RawExperimentVariant {
   id?: string;

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -22,7 +22,7 @@ import {
   parseMergeConflictError,
 } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { TaskRunner, ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
+import { DEFAULT_EXECUTION_AGENT, type TaskRunner, type ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import {
   isReviewGateCiContextStale,
@@ -848,7 +848,7 @@ export async function fixWithAgentAction(
   const recoveryRoute = await selectFailureRecoveryRouteForAction(task, savedError, taskExecutor, options.recoveryRoute);
   if (recoveryRoute.kind === 'invalidMergeWorkspace') {
     const msg = invalidMergeWorkspaceMessage(recoveryRoute);
-    const errorLabel = options.failureOutputLabel ?? `Fix with ${options.agentName ?? 'Claude'}`;
+    const errorLabel = options.failureOutputLabel ?? `Fix with ${options.agentName ?? 'Codex'}`;
     persistence.appendTaskOutput(taskId, `\n[${errorLabel}] ${msg}`);
     orchestrator.revertConflictResolution(taskId, savedError, msg);
     throw new Error(msg);
@@ -896,7 +896,7 @@ export async function fixWithAgentAction(
     if (err instanceof StaleLineageError) throw err;
     const msg = err instanceof Error ? err.message : String(err);
     const errorLabel = options.failureOutputLabel
-      ?? (recoveryRoute.kind === 'resolveConflict' ? 'Resolve Conflict' : `Fix with ${options.agentName ?? 'Claude'}`);
+      ?? (recoveryRoute.kind === 'resolveConflict' ? 'Resolve Conflict' : `Fix with ${options.agentName ?? 'Codex'}`);
     assertLineageCurrent(lineage, orchestrator, options.signal);
     persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
     assertLineageCurrent(lineage, orchestrator, options.signal);
@@ -1047,7 +1047,7 @@ function resolveAutoFixAgent(
     };
   }
   return {
-    selectedAgent: 'claude',
+    selectedAgent: DEFAULT_EXECUTION_AGENT,
     selectedAgentSource: 'default',
     configuredAutoFixAgent: undefined,
     fallbackChain: 'config(empty)->default',

--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -53,13 +53,13 @@ describe('AgentRegistry', () => {
     registry.registerExecution(codex);
   });
 
-  it('defaults nullish execution agent names to claude', () => {
-    expect(registry.getOrThrow(undefined)).toBe(claude);
-    expect(registry.getOrThrow(null)).toBe(claude);
-    expect(registry.getOrThrow('')).toBe(claude);
-    expect(registry.getOrThrow('   ')).toBe(claude);
-    expect(registry.getOrThrow('null')).toBe(claude);
-    expect(registry.getOrThrow('undefined')).toBe(claude);
+  it('defaults nullish execution agent names to codex', () => {
+    expect(registry.getOrThrow(undefined)).toBe(codex);
+    expect(registry.getOrThrow(null)).toBe(codex);
+    expect(registry.getOrThrow('')).toBe(codex);
+    expect(registry.getOrThrow('   ')).toBe(codex);
+    expect(registry.getOrThrow('null')).toBe(codex);
+    expect(registry.getOrThrow('undefined')).toBe(codex);
   });
 
   it('keeps explicit valid execution agent names working', () => {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -402,8 +402,8 @@ describe('TaskRunner', () => {
         execution: {
           agentSessionId: 'sess-abc-123',
           lastAgentSessionId: 'sess-abc-123',
-          agentName: 'claude',
-          lastAgentName: 'claude',
+          agentName: 'codex',
+          lastAgentName: 'codex',
         },
       });
     });

--- a/packages/execution-engine/src/agent-registry.ts
+++ b/packages/execution-engine/src/agent-registry.ts
@@ -5,7 +5,7 @@
  * Executors look up agents by name (e.g. 'claude') at task execution time.
  */
 
-import type { ExecutionAgent, PlanningAgent } from './agent.js';
+import { DEFAULT_EXECUTION_AGENT, type ExecutionAgent, type PlanningAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
 
 function normalizeExecutionAgentName(name: string | null | undefined): string | undefined {
@@ -37,13 +37,13 @@ export class AgentRegistry {
 
   get(name: string | null | undefined): ExecutionAgent | undefined {
     const normalized = normalizeExecutionAgentName(name);
-    if (!normalized) return this.executionAgents.get('claude');
+    if (!normalized) return this.executionAgents.get(DEFAULT_EXECUTION_AGENT);
     return this.executionAgents.get(normalized);
   }
 
   getOrThrow(name: string | null | undefined): ExecutionAgent {
     const normalized = normalizeExecutionAgentName(name);
-    const resolvedName = normalized ?? 'claude';
+    const resolvedName = normalized ?? DEFAULT_EXECUTION_AGENT;
     const agent = this.executionAgents.get(resolvedName);
     if (!agent) {
       throw new Error(`No execution agent registered with name "${resolvedName}". Available: [${[...this.executionAgents.keys()].join(', ')}]`);

--- a/packages/execution-engine/src/agent.ts
+++ b/packages/execution-engine/src/agent.ts
@@ -19,7 +19,7 @@ export interface AgentCommandBuildOptions {
   executionModel?: string;
 }
 
-export const DEFAULT_EXECUTION_AGENT = 'claude';
+export const DEFAULT_EXECUTION_AGENT = 'codex';
 
 export interface ExecutionAgent {
   readonly name: string;

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -5,6 +5,7 @@ import type { Executor, ExecutorHandle, PersistedTaskMeta, TerminalSpec, Unsubsc
 import { bashPreserveOrReset, bashMergeUpstreams, bashFetchNodeRemotes, parsePreserveResult, parseMergeError } from './branch-utils.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import type { AgentRegistry } from './agent-registry.js';
+import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import { checkStaleness } from './git-staleness-detector.js';
 import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
 import { childProcessHasExited, terminateChildProcessGroup } from './process-utils.js';
@@ -905,7 +906,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     }
     if (request.actionType === 'ai_task') {
       if (opts?.agentRegistry) {
-        const agentName = request.inputs.executionAgent ?? 'claude';
+        const agentName = request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
         const agent = opts.agentRegistry.getOrThrow(agentName);
         const fullPrompt = this.buildFullPrompt(request);
         const spec = agent.buildCommand(fullPrompt);
@@ -1051,7 +1052,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
   ): SemanticFailure | undefined {
     if (exitCode !== 0) return undefined;
     if (request.actionType !== 'ai_task') return undefined;
-    if ((request.inputs.executionAgent ?? 'claude') !== 'codex') return undefined;
+    if ((request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT) !== 'codex') return undefined;
     const haystack = output.toLowerCase();
     const codexSandboxDenied =
       haystack.includes('codex(sandbox(denied') ||

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -15,7 +15,7 @@ import type { Orchestrator } from '@invoker/workflow-core';
 import { OrchestratorError, OrchestratorErrorCode, parseMergeConflictError } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { cleanElectronEnv, resolveExecutableOnCurrentPath } from './process-utils.js';
-import type { ExecutionAgent } from './agent.js';
+import { DEFAULT_EXECUTION_AGENT, type ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { buildWorktreeListScript, createSshRemoteScriptError } from './ssh-git-exec.js';
@@ -173,7 +173,7 @@ export async function resolveConflictImpl(
 ): Promise<void> {
   host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
     phase: 'resolve-conflict-start',
-    agent: agentName ?? 'claude',
+    agent: agentName ?? DEFAULT_EXECUTION_AGENT,
     hasSavedError: savedError !== undefined,
   });
   const task = host.orchestrator.getTask(taskId);
@@ -311,7 +311,7 @@ function buildRemoteAgentCommand(
   agentRegistry?: AgentRegistry,
   agentName?: string,
 ): { shellCommand: string; sessionId: string } {
-  const name = agentName ?? 'claude';
+  const name = agentName ?? DEFAULT_EXECUTION_AGENT;
   if (agentRegistry) {
     const agent = agentRegistry.get(name);
     if (agent?.buildFixCommand) {
@@ -465,7 +465,7 @@ export async function fixWithAgentImpl(
 ): Promise<void> {
   host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
     phase: 'fix-with-agent-start',
-    agent: agentName ?? 'claude',
+    agent: agentName ?? DEFAULT_EXECUTION_AGENT,
     hasSavedError: savedError !== undefined,
     outputLength: taskOutput.length,
   });
@@ -510,7 +510,7 @@ export async function fixWithAgentImpl(
         repairedWorkspacePath: resolvedWorkspacePath,
       });
     }
-    const remoteAgentBin = agentName ?? 'claude';
+    const remoteAgentBin = agentName ?? DEFAULT_EXECUTION_AGENT;
     const { stdout: output, sessionId } = await spawnRemoteAgentFixImpl(
       prompt,
       resolvedWorkspacePath,
@@ -558,7 +558,7 @@ export async function fixWithAgentImpl(
   }
   const cwd = workspacePath;
 
-  const agentLabel = agentName ?? 'claude';
+  const agentLabel = agentName ?? DEFAULT_EXECUTION_AGENT;
   try {
     host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'fix-with-agent-spawn-local',
@@ -676,7 +676,7 @@ eval "$(echo "${agentCmdB64}" | base64 -d)"
     child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
     child.on('close', (code) => {
       // Replace local UUID with real backend session/thread ID for resume
-      const driver = agentRegistry?.getSessionDriver(agentName ?? 'claude');
+      const driver = agentRegistry?.getSessionDriver(agentName ?? DEFAULT_EXECUTION_AGENT);
       const realId = driver?.extractSessionId?.(stdout);
       const effectiveSessionId = realId ?? sessionId;
       if (driver) {

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -7,6 +7,7 @@ import { loadSecretsFile } from './secrets-loader.js';
 import { killProcessGroup, cleanElectronEnv } from './process-utils.js';
 import { computeContentHash, buildExperimentBranchName } from './branch-utils.js';
 import type { AgentRegistry } from './agent-registry.js';
+import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import { traceExecution } from './exec-trace.js';
 
 const CONTAINER_STOP_TIMEOUT_S = 5;
@@ -316,8 +317,8 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
     }
     log(`${TAG} Container created: ${container.id.slice(0, 12)} image=${this.imageName}`);
 
-    // Determine task command and Claude session before entry registration
-    const executionAgent = request.inputs.executionAgent ?? 'claude';
+    // Determine task command and agent session before entry registration
+    const executionAgent = request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
     const { cmd, args: cmdArgs, agentSessionId } = this.buildCommandAndArgs(request, {
       agentRegistry: this.agentRegistry,
     });
@@ -524,7 +525,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
       // Docker containers (see github.com/anthropics/claude-code/issues/20572,
       // #24068, #25286). The --resume terminal may hang after the trust prompt.
       // The automated -p (pipe) execution path is unaffected.
-      const agentName = entry.request.inputs.executionAgent ?? 'claude';
+      const agentName = entry.request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
       const resume = this.agentRegistry
         ? this.agentRegistry.getOrThrow(agentName).buildResumeArgs(entry.agentSessionId)
         : { cmd: 'claude', args: ['--resume', entry.agentSessionId, '--dangerously-skip-permissions'] };
@@ -554,7 +555,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
       // Docker containers (see github.com/anthropics/claude-code/issues/20572,
       // #24068, #25286). The --resume terminal may hang after the trust prompt.
       const resume = this.agentRegistry
-        ? this.agentRegistry.getOrThrow(meta.executionAgent ?? 'claude').buildResumeArgs(meta.agentSessionId)
+        ? this.agentRegistry.getOrThrow(meta.executionAgent ?? DEFAULT_EXECUTION_AGENT).buildResumeArgs(meta.agentSessionId)
         : { cmd: 'claude', args: ['--resume', meta.agentSessionId, '--dangerously-skip-permissions'] };
       const resumeCmd = [resume.cmd, ...resume.args].join(' ');
       console.log(`[DockerExecutor] getRestoredTerminalSpec task="${meta.taskId}" → docker exec ${resumeCmd}`);

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -11,6 +11,7 @@ import { planManagedWorktree } from './managed-worktree-controller.js';
 import { findManagedWorktreeForBranch, abbrevRefMatchesBranch } from './worktree-discovery.js';
 import { DEFAULT_WORKTREE_PROVISION_COMMAND } from './default-worktree-provision-command.js';
 import type { AgentRegistry } from './agent-registry.js';
+import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import { computeRepoUrlHash, sanitizeBranchForPath } from './git-utils.js';
 import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { buildSshConnectionArgs } from './ssh-transport-options.js';
@@ -410,7 +411,7 @@ ${runProvisionSection}stop_bootstrap_heartbeat
 
     let payload: string;
     let agentSessionId: string | undefined;
-    const executionAgent = request.inputs.executionAgent ?? 'claude';
+    const executionAgent = request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
 
     if (request.actionType === 'command') {
       const command = request.inputs.command;
@@ -772,7 +773,7 @@ ${runProvisionSection}stop_bootstrap_heartbeat
     if (!request.inputs.command && !request.inputs.prompt) {
       await this.handleProcessExit(executionId, request, remoteWt, 0, {
         branch: experimentBranch,
-        agentName: request.actionType === 'ai_task' ? request.inputs.executionAgent ?? 'claude' : undefined,
+        agentName: request.actionType === 'ai_task' ? request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT : undefined,
       });
       bench('SshExecutor.startManagedWorkspace.noCommand.returning', { remoteWt });
       return handle;
@@ -1071,7 +1072,7 @@ ${runProvisionSection}stop_bootstrap_heartbeat
           // Replace local UUID with real backend session/thread ID for resume,
           // then store session locally via driver (matches worktree-executor pattern).
           if (entry.agentSessionId && this.agentRegistry) {
-            const agentName = request.inputs.executionAgent ?? 'claude';
+            const agentName = request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
             const driver = this.agentRegistry.getSessionDriver(agentName);
             const rawOutput = e?.outputBuffer.join('') ?? '';
             const realId = driver?.extractSessionId?.(rawOutput);
@@ -1093,7 +1094,7 @@ ${runProvisionSection}stop_bootstrap_heartbeat
               exitCode: finalExitCode,
               commitHash,
               agentSessionId: entry.agentSessionId,
-              agentName: request.actionType === 'ai_task' ? request.inputs.executionAgent ?? 'claude' : undefined,
+              agentName: request.actionType === 'ai_task' ? request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT : undefined,
               ...(mappedError ? { error: mappedError } : {}),
               ...(finalizeRemote && commitHash
                 ? { summary: `branch=${finalizeRemote.branch} commit=${commitHash}` }
@@ -1147,7 +1148,7 @@ ${runProvisionSection}stop_bootstrap_heartbeat
       const base = this.buildSshArgsInteractive();
       const userAtHost = base[base.length - 1]!;
       const opts = base.slice(0, -1);
-      const executionAgent = entry.request.inputs.executionAgent ?? 'claude';
+      const executionAgent = entry.request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
       const inner = this.buildRemoteTerminalInner(handle.workspacePath, handle.branch, entry.agentSessionId, executionAgent);
       return {
         command: 'ssh',
@@ -1196,7 +1197,7 @@ ${runProvisionSection}stop_bootstrap_heartbeat
     if (agentSessionId) {
       let resumeCmd: string;
       if (this.agentRegistry) {
-        const resume = this.agentRegistry.getOrThrow(executionAgent ?? 'claude').buildResumeArgs(agentSessionId);
+        const resume = this.agentRegistry.getOrThrow(executionAgent ?? DEFAULT_EXECUTION_AGENT).buildResumeArgs(agentSessionId);
         resumeCmd = [resume.cmd, ...resume.args.map(a => sshGitShellQuote(a))].join(' ');
       } else {
         resumeCmd = `claude --resume ${sshGitShellQuote(agentSessionId)} --dangerously-skip-permissions`;

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -22,6 +22,7 @@ import {
   shouldResolveViaOriginTracking,
 } from './plan-base-remote.js';
 import { remoteFetchForPool } from './remote-fetch-policy.js';
+import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import { sanitizeBranchForPath } from './git-utils.js';
 
 // Re-export for backward compatibility
@@ -443,7 +444,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       hasAgentSessionId: !!agentSessionId,
     });
 
-    const executionAgent = request.inputs.executionAgent ?? 'claude';
+    const executionAgent = request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
     const stdinMode = this.agentRegistry && executionAgent
       ? this.agentRegistry.getOrThrow(executionAgent).stdinMode
       : (request.actionType === 'ai_task' ? 'ignore' : 'pipe');
@@ -576,7 +577,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     const entry = this.entries.get(handle.executionId);
     if (!entry) return null;
     if (entry.agentSessionId) {
-      const agentName = entry.request.inputs.executionAgent ?? 'claude';
+      const agentName = entry.request.inputs.executionAgent ?? DEFAULT_EXECUTION_AGENT;
       const resume = this.agentRegistry
         ? this.agentRegistry.getOrThrow(agentName).buildResumeArgs(entry.agentSessionId)
         : { cmd: 'claude', args: ['--resume', entry.agentSessionId, '--dangerously-skip-permissions'] };
@@ -605,7 +606,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     }
     if (meta.agentSessionId) {
       const resume = this.agentRegistry
-        ? this.agentRegistry.getOrThrow(meta.executionAgent ?? 'claude').buildResumeArgs(meta.agentSessionId)
+        ? this.agentRegistry.getOrThrow(meta.executionAgent ?? DEFAULT_EXECUTION_AGENT).buildResumeArgs(meta.agentSessionId)
         : { cmd: 'claude', args: ['--resume', meta.agentSessionId, '--dangerously-skip-permissions'] };
       const spec = {
         command: resume.cmd,


### PR DESCRIPTION
## Summary

Plans can now use `defaultExecutionAgent` from `~/.invoker/config.json` when a task does not name an agent.

The built-in fallback is now Codex. Explicit Claude tasks still run with Claude.

This keeps local, remote, terminal restore, auto-fix, and cost/session lookup paths on the same default.

<details>
<summary>Review metadata</summary>

Review Claim: Missing execution agent values resolve through config first, then Codex.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Explicit `executionAgent` values are preserved. The new default only applies when a task or session has no stored agent.

Slice Rationale: Parser and executor fallbacks move together so one config value owns the default.

</details>

## Non-goals

This does not remove Claude support or change `autoFixAgent` when it is explicitly configured.

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/agent-registry.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts src/__tests__/plan-parser.test.ts src/__tests__/open-terminal.test.ts src/__tests__/workflow-actions.test.ts src/__tests__/cost-rollup.test.ts`
- [x] `pnpm --filter @invoker/execution-engine build && pnpm --filter @invoker/app build`

## Visual Proof

No visible UI control changed. Main-process files changed the plan-loading default only.

![Existing task panel smoke](docs/assets/invoker-ui-load-fallback.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 7dd7e3f`
- Post-revert steps: Remove `defaultExecutionAgent` from `~/.invoker/config.json` if no longer wanted.
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a configurable default execution agent, with a built-in fallback of Codex.
  * Plan files can now automatically fill in a missing execution agent from saved settings.

* **Bug Fixes**
  * Fixed several flows so missing or blank agent values consistently resolve to Codex instead of the previous default.
  * Improved resume, auto-fix, and conflict-resolution behavior when no agent is explicitly set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->