### PR TITLE
[Planner MCP Setup](1) Add planner MCP setup command

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -95,6 +95,14 @@ describe('invoker-cli', () => {
     expect(result.stdout).toContain('Emit only a machine-readable result summary on stdout.');
   });
 
+  it('--help lists the planner setup command', async () => {
+    const result = await runCli(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('invoker-cli setup [planner|slack]');
+    expect(result.stdout).toContain('--planner-url <url>');
+    expect(result.stdout).toContain('Required unless INVOKER_MCP_CONFIG_PATH is set');
+  });
+
   it('lists worker kinds from the registry', async () => {
     const output = captureProcessOutput();
 
@@ -250,6 +258,7 @@ tasks:
 
     expect(code).toBe(0);
     expect(output.stdout).toContain('hello-from-invoker-cli');
+    expect(output.stderr).toContain('Live owner discovery has no handler; falling back to standalone mode');
     output.restore();
   }, 60_000);
 

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import {
   buildDoctorChecks,
   generateSlackManifest,
+  installExperimentalPlannerMcp,
   loadInvokerEnv,
+  readExperimentalPlannerSetup,
   REQUIRED_BOT_SCOPES,
   slackCredsFromEnv,
   runSetup,
@@ -14,6 +16,7 @@ import {
   validateSlackCredentials,
   type CliConfigState,
 } from '../onboarding.js';
+import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES } from '../external-dependencies.js';
 
 describe('generateSlackManifest', () => {
   it('requests the required bot scopes, socket mode, and app_mention events', () => {
@@ -200,6 +203,126 @@ describe('loadInvokerEnv', () => {
       restoreEnv('SLACK_SIGNING_SECRET', saved.sign);
       restoreEnv('SLACK_CHANNEL_ID', saved.chan);
       rmSync(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('experimental planner MCP setup', () => {
+  it('installs the redirect server and enables the Invoker flag', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-planner-setup-'));
+    const targetPath = join(dir, 'mcp.json');
+    const configPath = join(dir, 'config.json');
+    try {
+      writeFileSync(targetPath, JSON.stringify({ mcpServers: { invoker: { type: 'stdio', command: 'invoker-cli', args: ['mcp'] } } }));
+      writeFileSync(configPath, JSON.stringify({ defaultSlackHarnessPreset: 'omp' }));
+
+      const state = installExperimentalPlannerMcp({
+        targetPath,
+        configPath,
+        plannerUrl: 'http://planner.test',
+        accessToken: 'sek',
+      });
+
+      expect(state).toEqual({ targetPath, configPath, installed: true, experimentalPlanner: true });
+      const mcpConfig = JSON.parse(readFileSync(targetPath, 'utf8'));
+      expect(mcpConfig.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
+      expect(mcpConfig.mcpServers['experimental-planner']).toEqual({
+        type: 'stdio',
+        command: 'uvx',
+        args: ['--from', DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES.drafterMcp.commandName],
+        env: { PLANNER_URL: 'http://planner.test', PLANNER_ACCESS_TOKEN: 'sek' },
+      });
+      expect(JSON.parse(readFileSync(configPath, 'utf8')).experimentalPlanner).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+  it('can pin a different planner package without changing Invoker', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-planner-setup-'));
+    const targetPath = join(dir, 'mcp.json');
+    const configPath = join(dir, 'config.json');
+    try {
+      installExperimentalPlannerMcp({
+        targetPath,
+        configPath,
+        plannerPackage: `${EXTERNAL_DEPENDENCIES.drafterMcp.packageName}==0.1.1`,
+      });
+
+      const mcpConfig = JSON.parse(readFileSync(targetPath, 'utf8'));
+      expect(mcpConfig.mcpServers['experimental-planner'].args).toEqual([
+        '--from',
+        `${EXTERNAL_DEPENDENCIES.drafterMcp.packageName}==0.1.1`,
+        EXTERNAL_DEPENDENCIES.drafterMcp.commandName,
+      ]);
+      expect(readExperimentalPlannerSetup({ targetPath, configPath }).installed).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uses INVOKER_MCP_CONFIG_PATH when no target is passed', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-planner-setup-'));
+    const targetPath = join(dir, 'mcp.json');
+    const configPath = join(dir, 'config.json');
+    const savedTarget = process.env.INVOKER_MCP_CONFIG_PATH;
+    try {
+      process.env.INVOKER_MCP_CONFIG_PATH = targetPath;
+
+      const state = installExperimentalPlannerMcp({ configPath });
+
+      expect(state.targetPath).toBe(targetPath);
+      expect(readExperimentalPlannerSetup({ configPath }).installed).toBe(true);
+    } finally {
+      restoreEnv('INVOKER_MCP_CONFIG_PATH', savedTarget);
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('requires an MCP target instead of assuming OMP is installed', () => {
+    const savedTarget = process.env.INVOKER_MCP_CONFIG_PATH;
+    try {
+      delete process.env.INVOKER_MCP_CONFIG_PATH;
+
+      expect(() => installExperimentalPlannerMcp({ configPath: join(tmpdir(), 'invoker-config.json') })).toThrow(
+        'Missing MCP config path. Pass --target <path> or set INVOKER_MCP_CONFIG_PATH.',
+      );
+    } finally {
+      restoreEnv('INVOKER_MCP_CONFIG_PATH', savedTarget);
+    }
+  });
+
+  it('logs malformed MCP config parse failures before throwing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-planner-setup-'));
+    const targetPath = join(dir, 'mcp.json');
+    const configPath = join(dir, 'config.json');
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      writeFileSync(targetPath, '{broken', 'utf8');
+
+      expect(() => installExperimentalPlannerMcp({ targetPath, configPath })).toThrow('Invalid JSON object');
+      expect(stderrSpy).toHaveBeenCalledWith(expect.stringContaining(`Failed to parse JSON object at ${targetPath}`));
+    } finally {
+      stderrSpy.mockRestore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('uninstalls the redirect server and disables the Invoker flag', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-planner-setup-'));
+    const targetPath = join(dir, 'mcp.json');
+    const configPath = join(dir, 'config.json');
+    try {
+      installExperimentalPlannerMcp({ targetPath, configPath });
+
+      const state = installExperimentalPlannerMcp({ targetPath, configPath, uninstall: true });
+
+      expect(state).toEqual({ targetPath, configPath, installed: false, experimentalPlanner: false });
+      const mcpConfig = JSON.parse(readFileSync(targetPath, 'utf8'));
+      expect(mcpConfig.mcpServers['experimental-planner']).toBeUndefined();
+      expect(readExperimentalPlannerSetup({ targetPath, configPath }).installed).toBe(false);
+      expect(JSON.parse(readFileSync(configPath, 'utf8')).experimentalPlanner).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 });

--- a/packages/cli/src/external-dependencies.ts
+++ b/packages/cli/src/external-dependencies.ts
@@ -1,0 +1,9 @@
+export const EXTERNAL_DEPENDENCIES = {
+  drafterMcp: {
+    packageName: 'drafter-mcp',
+    version: '0.1.0',
+    commandName: 'drafter-mcp',
+  },
+} as const;
+
+export const DEFAULT_DRAFTER_MCP_PACKAGE_SPEC = `${EXTERNAL_DEPENDENCIES.drafterMcp.packageName}==${EXTERNAL_DEPENDENCIES.drafterMcp.version}`;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -36,6 +36,8 @@ import {
   type PlanDefinition,
   type TaskState,
 } from '@invoker/workflow-core';
+import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.js';
+import { logCaughtException } from './logging.js';
 import { runMcpServer } from './mcp-server.js';
 import { runDoctor, runSetup } from './onboarding.js';
 
@@ -130,7 +132,7 @@ function usage(): string {
     'Usage:',
     '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
     '  invoker-cli doctor [--fix] [--json]',
-    '  invoker-cli setup [slack] [--check|--from-env]',
+    '  invoker-cli setup [planner|slack] [--check|--from-env] [--json]',
     '  invoker-cli mcp',
     '  invoker-cli worker [autofix|list]',
     '  invoker-cli --help',
@@ -139,11 +141,16 @@ function usage(): string {
     'Commands:',
     '  run <plan.yaml>  Submit to a live Invoker UI when available, otherwise run standalone.',
     '  doctor          Validate tools, config, and your default planning preset.',
-    '  setup [slack]    Validate the environment, then optionally configure Slack.',
+    '  setup [planner|slack]  Run the setup wizard, or directly configure planner MCP or Slack.',
     '  mcp             Start the Invoker MCP stdio server.',
     '  worker [kind|list]  Run a registry-selected worker or list available worker kinds.',
     '',
     'Options:',
+    '  --planner-url <url>   Planner service URL for `setup planner`.',
+    '  --access-token <tok>  Planner service access token for `setup planner`.',
+    `  --planner-package <spec>  Planner MCP package spec for \`setup planner\`. Defaults to ${DEFAULT_DRAFTER_MCP_PACKAGE_SPEC}.`,
+    '  --target <path>       MCP config path for `setup planner`. Required unless INVOKER_MCP_CONFIG_PATH is set.',
+    '  --uninstall           Remove the experimental planner MCP entry and disable its Invoker flag.',
     '  --live           Require a running Invoker UI owner and submit over IPC.',
     '  --standalone     Skip IPC and run with an isolated CLI database.',
     '  --db-dir <path>  Runtime database directory. Defaults to ~/.invoker-cli',
@@ -233,11 +240,14 @@ async function discoverLiveOwner(bus: MessageBus, timeoutMs = 1_000): Promise<Li
     };
   } catch (err) {
     if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
+      logCaughtException('Live owner discovery has no handler; falling back to standalone mode', err);
       return null;
     }
     if (err instanceof Error && err.message.startsWith('Timed out after ')) {
+      logCaughtException('Live owner discovery timed out; falling back to standalone mode', err);
       return null;
     }
+    logCaughtException('Live owner discovery failed; falling back to standalone mode', err);
     return null;
   }
 }
@@ -406,8 +416,8 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
           if (!options.json) process.stdout.write(data);
           try {
             persistence.appendTaskOutput(taskId, data);
-          } catch {
-            // Output is best effort for standalone CLI summaries.
+          } catch (err) {
+            logCaughtException(`Failed to persist standalone output for ${taskId}`, err);
           }
         },
       },
@@ -474,7 +484,8 @@ function readWorkerConfig(homeRoot: string): {
       autoFixAgent: typeof parsed.autoFixAgent === 'string' ? parsed.autoFixAgent : undefined,
       externalWorkers: Array.isArray(parsed.externalWorkers) ? parsed.externalWorkers : undefined,
     };
-  } catch {
+  } catch (err) {
+    logCaughtException(`Failed to read worker config at ${configPath}`, err);
     return {};
   }
 }

--- a/packages/cli/src/logging.ts
+++ b/packages/cli/src/logging.ts
@@ -1,0 +1,8 @@
+export function formatCaughtException(err: unknown): string {
+  if (err instanceof Error) return err.stack ?? err.message;
+  return String(err);
+}
+
+export function logCaughtException(context: string, err: unknown): void {
+  process.stderr.write(`[invoker-cli] ${context}: ${formatCaughtException(err)}\n`);
+}

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { createInterface } from 'node:readline/promises';
@@ -12,8 +12,23 @@ import {
   type PlanningPresetSpec,
   type PrerequisiteCheck,
 } from '@invoker/contracts';
+import { formatCaughtException, logCaughtException } from './logging.js';
+import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES } from './external-dependencies.js';
 
 // ── Paths ────────────────────────────────────────────────────
+
+type JsonRecord = Record<string, unknown>;
+
+const EXPERIMENTAL_PLANNER_SERVER_KEY = 'experimental-planner';
+const EXPERIMENTAL_PLANNER_PACKAGE_NAME = DEFAULT_DRAFTER_MCP_PACKAGE_SPEC;
+const EXPERIMENTAL_PLANNER_COMMAND_NAME = EXTERNAL_DEPENDENCIES.drafterMcp.commandName;
+function experimentalPlannerServerSpec(packageSpec: string = EXPERIMENTAL_PLANNER_PACKAGE_NAME): JsonRecord {
+  return {
+    type: 'stdio',
+    command: 'uvx',
+    args: ['--from', packageSpec, EXPERIMENTAL_PLANNER_COMMAND_NAME],
+  };
+}
 
 export function invokerHomeDir(): string {
   return join(homedir(), '.invoker');
@@ -26,6 +41,15 @@ export function envFilePath(): string {
 }
 export function manifestFilePath(): string {
   return join(invokerHomeDir(), 'slack-app-manifest.json');
+}
+export function experimentalPlannerMcpPath(): string | undefined {
+  return process.env.INVOKER_MCP_CONFIG_PATH;
+}
+
+function requireExperimentalPlannerMcpPath(targetPath?: string): string {
+  const resolvedPath = targetPath ?? experimentalPlannerMcpPath();
+  if (resolvedPath) return resolvedPath;
+  throw new Error('Missing MCP config path. Pass --target <path> or set INVOKER_MCP_CONFIG_PATH.');
 }
 
 // ── Tool probing & install ───────────────────────────────────
@@ -81,8 +105,110 @@ export function loadCliConfig(configPath: string = defaultConfigPath()): CliConf
     };
     return { path: configPath, exists: true, presets: cfg.slackHarnessPresets ?? {}, defaultPreset: cfg.defaultSlackHarnessPreset };
   } catch (err) {
+    logCaughtException(`Failed to read Invoker config at ${configPath}`, err);
     return { path: configPath, exists: true, error: err instanceof Error ? err.message : String(err), presets: {} };
   }
+}
+
+function isJsonRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readMutableJson(filePath: string, fallback: JsonRecord): JsonRecord {
+  if (!existsSync(filePath)) return { ...fallback };
+  try {
+    const parsed = JSON.parse(readFileSync(filePath, 'utf8')) as unknown;
+    if (isJsonRecord(parsed)) return parsed;
+  } catch (err) {
+    logCaughtException(`Failed to parse JSON object at ${filePath}`, err);
+    throw new Error(`Invalid JSON object at ${filePath}: ${formatCaughtException(err)}`);
+  }
+  throw new Error(`Invalid JSON object at ${filePath}`);
+}
+
+function mutableMcpServers(mcpConfig: JsonRecord, targetPath: string): JsonRecord {
+  if (mcpConfig.mcpServers === undefined) return {};
+  if (!isJsonRecord(mcpConfig.mcpServers)) {
+    throw new Error(`Invalid mcpServers object at ${targetPath}`);
+  }
+  return mcpConfig.mcpServers;
+}
+
+function isExperimentalPlannerServer(value: unknown): boolean {
+  if (!isJsonRecord(value)) return false;
+  const args = value.args;
+  return value.type === 'stdio'
+    && value.command === 'uvx'
+    && Array.isArray(args)
+    && args.length === 3
+    && args[0] === '--from'
+    && typeof args[1] === 'string'
+    && args[2] === EXPERIMENTAL_PLANNER_COMMAND_NAME;
+}
+
+export interface ExperimentalPlannerSetupOptions {
+  targetPath?: string;
+  configPath?: string;
+  plannerUrl?: string;
+  accessToken?: string;
+  uninstall?: boolean;
+  plannerPackage?: string;
+}
+
+export interface ExperimentalPlannerSetupState {
+  targetPath: string;
+  configPath: string;
+  installed: boolean;
+  experimentalPlanner: boolean;
+}
+
+export function setExperimentalPlannerFlag(enabled: boolean, configPath: string = defaultConfigPath()): string {
+  const config = readMutableJson(configPath, {});
+  config.experimentalPlanner = enabled;
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+  return configPath;
+}
+
+export function readExperimentalPlannerSetup(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
+  const targetPath = requireExperimentalPlannerMcpPath(options.targetPath);
+  const configPath = options.configPath ?? defaultConfigPath();
+  const invokerConfig = existsSync(configPath) ? readMutableJson(configPath, {}) : {};
+  const mcpConfig = existsSync(targetPath) ? readMutableJson(targetPath, {}) : {};
+  const servers = isJsonRecord(mcpConfig.mcpServers) ? mcpConfig.mcpServers : {};
+  return {
+    targetPath,
+    configPath,
+    installed: isExperimentalPlannerServer(servers[EXPERIMENTAL_PLANNER_SERVER_KEY]),
+    experimentalPlanner: Boolean(invokerConfig.experimentalPlanner),
+  };
+}
+
+export function installExperimentalPlannerMcp(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
+  const targetPath = requireExperimentalPlannerMcpPath(options.targetPath);
+  const configPath = options.configPath ?? defaultConfigPath();
+  const mcpConfig = readMutableJson(targetPath, { $schema: 'https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json' });
+  const existingServers = mutableMcpServers(mcpConfig, targetPath);
+  const servers: JsonRecord = { ...existingServers };
+
+  if (options.uninstall) {
+    delete servers[EXPERIMENTAL_PLANNER_SERVER_KEY];
+  } else {
+    const env: JsonRecord = {};
+    if (options.plannerUrl) env.PLANNER_URL = options.plannerUrl;
+    if (options.accessToken) env.PLANNER_ACCESS_TOKEN = options.accessToken;
+    const spec = experimentalPlannerServerSpec(options.plannerPackage);
+    servers[EXPERIMENTAL_PLANNER_SERVER_KEY] = Object.keys(env).length > 0 ? { ...spec, env } : spec;
+  }
+
+  mcpConfig.mcpServers = servers;
+  mkdirSync(dirname(targetPath), { recursive: true });
+  const writesPlannerAccessToken = Boolean(options.accessToken);
+  if (writesPlannerAccessToken && existsSync(targetPath)) chmodSync(targetPath, 0o600);
+  writeFileSync(targetPath, `${JSON.stringify(mcpConfig, null, 2)}\n`, writesPlannerAccessToken ? { mode: 0o600 } : undefined);
+  if (writesPlannerAccessToken) chmodSync(targetPath, 0o600);
+  setExperimentalPlannerFlag(!options.uninstall, configPath);
+  return readExperimentalPlannerSetup({ targetPath, configPath });
 }
 
 export function buildDoctorChecks(cfg: CliConfigState, isInstalled: IsInstalled = commandExists): PrerequisiteCheck[] {
@@ -117,7 +243,7 @@ export function runDoctor(argv: string[]): number {
   const report = buildReport(checks);
   process.stdout.write(`${formatReport(report, { json })}\n`);
   if (!json && !report.ok) {
-    process.stdout.write('\nFix the items above, then re-run `invoker-cli doctor`. For Slack, run `invoker-cli setup slack`.\n');
+    process.stdout.write('\nFix the items above, then re-run `invoker-cli doctor`. For planner MCP, run `invoker-cli setup planner`; for Slack, run `invoker-cli setup slack`.\n');
   }
   return report.ok ? 0 : 1;
 }
@@ -339,22 +465,115 @@ export function loadInvokerEnv(): void {
   loadEnvFile(join(process.cwd(), '.env'));
 }
 
-export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promise<number> {
-  const wantSlack = argv[0] === 'slack';
-  const checkOnly = argv.includes('--check');
-  const json = argv.includes('--json');
-  const fromEnv = argv.includes('--from-env');
-  for (const arg of argv) {
-    if (arg === 'slack' || arg === '--check' || arg === '--json' || arg === '--from-env') continue;
-    throw new Error(`Unknown setup option: ${arg}`);
+type SetupSubcommand = 'slack' | 'planner';
+
+interface ParsedSetupArgs {
+  subcommand?: SetupSubcommand;
+  checkOnly: boolean;
+  json: boolean;
+  uninstall: boolean;
+  targetPath?: string;
+  plannerUrl?: string;
+  accessToken?: string;
+  plannerPackage?: string;
+  fromEnv: boolean;
+}
+
+function parseSetupArgs(argv: string[]): ParsedSetupArgs {
+  const parsed: ParsedSetupArgs = { checkOnly: false, json: false, uninstall: false, fromEnv: false };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === 'slack' || arg === 'planner') {
+      if (parsed.subcommand) throw new Error(`Unexpected setup argument: ${arg}`);
+      parsed.subcommand = arg;
+    } else if (arg === '--check') {
+      parsed.checkOnly = true;
+    } else if (arg === '--json') {
+      parsed.json = true;
+    } else if (arg === '--from-env') {
+      parsed.fromEnv = true;
+    } else if (arg === '--uninstall') {
+      parsed.uninstall = true;
+    } else if (arg === '--target') {
+      const value = argv[++i];
+      if (!value) throw new Error('Missing value for --target');
+      parsed.targetPath = value;
+    } else if (arg === '--planner-url') {
+      const value = argv[++i];
+      if (!value) throw new Error('Missing value for --planner-url');
+      parsed.plannerUrl = value;
+    } else if (arg === '--access-token') {
+      const value = argv[++i];
+      if (!value) throw new Error('Missing value for --access-token');
+      parsed.accessToken = value;
+    } else if (arg === '--planner-package') {
+      const value = argv[++i];
+      if (!value) throw new Error('Missing value for --planner-package');
+      parsed.plannerPackage = value;
+    } else {
+      throw new Error(`Unknown setup option: ${arg}`);
+    }
   }
+  return parsed;
+}
+
+function formatExperimentalPlannerState(state: ExperimentalPlannerSetupState, json: boolean): string {
+  if (json) return JSON.stringify(state);
+  return [
+    `Experimental planner MCP: ${state.installed ? 'installed' : 'missing'}`,
+    `MCP config: ${state.targetPath}`,
+    `experimentalPlanner flag: ${state.experimentalPlanner ? 'on' : 'off'}`,
+    `Invoker config: ${state.configPath}`,
+  ].join('\n');
+}
+
+async function maybeInstallPlanner(parsed: ParsedSetupArgs, io: SetupIO): Promise<number> {
+  if (parsed.checkOnly) {
+    const state = readExperimentalPlannerSetup({ targetPath: parsed.targetPath });
+    io.print(formatExperimentalPlannerState(state, parsed.json));
+    return state.installed && state.experimentalPlanner ? 0 : 1;
+  }
+
+  const state = installExperimentalPlannerMcp({
+    targetPath: parsed.targetPath,
+    plannerUrl: parsed.plannerUrl,
+    accessToken: parsed.accessToken ?? process.env.PLANNER_ACCESS_TOKEN,
+    plannerPackage: parsed.plannerPackage ?? process.env.INVOKER_PLANNER_PACKAGE,
+    uninstall: parsed.uninstall,
+  });
+  if (parsed.json) {
+    io.print(JSON.stringify(state));
+  } else if (parsed.uninstall) {
+    io.print(`Removed experimental planner MCP from ${state.targetPath}.`);
+    io.print(`Disabled experimentalPlanner in ${state.configPath}.`);
+  } else {
+    io.print(`Installed experimental planner MCP into ${state.targetPath}.`);
+    io.print(`Enabled experimentalPlanner in ${state.configPath}.`);
+    io.print('Restart any running planning agent sessions so they reload MCP tools.');
+  }
+  return 0;
+}
+
+async function promptYes(io: SetupIO, question: string): Promise<boolean> {
+  const answer = (await io.prompt(question)).toLowerCase();
+  return answer === 'y' || answer === 'yes';
+}
+
+export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promise<number> {
+  const parsed = parseSetupArgs(argv);
+  const wantSlack = parsed.subcommand === 'slack';
+  const fromEnv = parsed.fromEnv;
   const rl = (io as { rl?: { close: () => void } }).rl;
   try {
-    if (checkOnly) {
+    if (parsed.subcommand === 'planner') {
+      return await maybeInstallPlanner(parsed, io);
+    }
+
+    if (parsed.checkOnly) {
       loadInvokerEnv();
       const checks = await validateSlackCredentials(slackCredsFromEnv());
       const report = buildReport(checks);
-      io.print(formatReport(report, { json }));
+      io.print(formatReport(report, { json: parsed.json }));
       return report.ok ? 0 : 1;
     }
 
@@ -363,13 +582,17 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
     io.print(formatReport(core));
     io.print('');
 
+    if (!wantSlack && !fromEnv && await promptYes(io, 'Set up the experimental planner MCP now? [y/N] ')) {
+      await maybeInstallPlanner(parsed, io);
+      io.print('');
+    }
+
     let doSlack = wantSlack || fromEnv;
     if (!wantSlack && !fromEnv) {
-      const answer = (await io.prompt('Set up the Slack integration now? [Y/n] ')).toLowerCase();
-      doSlack = answer === '' || answer === 'y' || answer === 'yes';
+      doSlack = await promptYes(io, 'Set up the Slack integration now? [y/N] ');
     }
     if (!doSlack) {
-      io.print('\nYou are good to go for CLI and UI workflows. Run `invoker-cli setup slack` later to add Slack.');
+      io.print('\nYou are good to go for CLI and UI workflows. Run `invoker-cli setup planner` later to add the experimental planner. Run `invoker-cli setup slack` later to add Slack.');
       return core.ok ? 0 : 1;
     }
 
@@ -378,7 +601,7 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
       const creds = slackCredsFromEnv();
       const checks = await validateSlackCredentials(creds);
       const report = buildReport(checks);
-      io.print(`\n${formatReport(report, { json })}`);
+      io.print(`\n${formatReport(report, { json: parsed.json })}`);
       if (!creds.botToken || !creds.appToken || !creds.signingSecret || !creds.channelId || !report.ok) {
         io.print('Nothing written. Fix the items above and re-run setup.');
         return 1;
@@ -408,8 +631,8 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
     io.print(`\n${formatReport(report)}`);
 
     if (!report.ok) {
-      const proceed = (await io.prompt('\nSome checks failed. Save these values anyway? [y/N] ')).toLowerCase();
-      if (proceed !== 'y' && proceed !== 'yes') {
+      const proceed = await promptYes(io, '\nSome checks failed. Save these values anyway? [y/N] ');
+      if (!proceed) {
         io.print('Nothing written. Fix the items above and re-run `invoker-cli setup slack`.');
         return 1;
       }


### PR DESCRIPTION
## Summary

`invoker-cli setup planner` now wires the pinned Drafter MCP and enables `experimentalPlanner`.

`packages/cli/src/external-dependencies.ts` owns the default package pin. `--planner-package` and `INVOKER_PLANNER_PACKAGE` still allow explicit overrides.

`setup planner --check --json` reports readiness. Setup no longer assumes OMP exists: pass `--target`, or set `INVOKER_MCP_CONFIG_PATH`. Caught setup and fallback errors now write explicit stderr logs before continuing.

<details>
<summary>Review metadata</summary>

Review Claim:

- Approve the CLI setup path for installing and checking the experimental planner MCP server.

Review Lane:

- behavior

Review Unit:

- activation-surface

Safety Invariant:

- The new setup path only writes the chosen MCP config file and the Invoker config flag. Existing MCP servers are preserved.

Slice Rationale:

- This is one local setup change: command parsing, config writing, help text, and tests for that path.

</details>

## Non-goals

This does not install Drafter during normal Invoker install, change planner ordering behavior, change hosted planner behavior, change Slack token setup, or change the `invoker-cli mcp` server.

## Test Plan

- [x] `pnpm --filter @invoker/cli test`
- [x] `INVOKER_REPO_CONFIG_PATH="$tmpdir/config.json" node packages/cli/dist/index.js setup planner --target "$tmpdir/mcp.json" --json`
- [x] `node packages/cli/dist/index.js setup planner --check` exits 1 with “Missing MCP config path...”
- [x] `INVOKER_MCP_CONFIG_PATH="$tmpdir/mcp.json" INVOKER_REPO_CONFIG_PATH="$tmpdir/config.json" node packages/cli/dist/index.js setup planner --json`
- [x] `uvx --from drafter-mcp==0.1.0 drafter-mcp --help`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f7f9c41a`
- Post-revert steps: None
- Data migration? No
