### PR TITLE
[Default Agent Config](1) Add default execution agent config

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   loadConfig,
+  resolveDefaultExecutionAgent,
   resolveEmbeddedTerminalBackendConfig,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
@@ -122,6 +123,21 @@ describe('loadConfig', () => {
     const config = loadConfig();
     expect(config.autoFixAgent).toBe('codex');
   });
+  it('reads defaultExecutionAgent from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ defaultExecutionAgent: 'claude' }),
+    );
+    const config = loadConfig();
+    expect(config.defaultExecutionAgent).toBe('claude');
+    expect(resolveDefaultExecutionAgent(config)).toBe('claude');
+  });
+
+  it('falls back to the built-in default execution agent', () => {
+    expect(resolveDefaultExecutionAgent({})).toBe('codex');
+    expect(resolveDefaultExecutionAgent({ defaultExecutionAgent: '   ' })).toBe('codex');
+  });
+
 
   it('reads autoFixCi from user config', () => {
     writeFileSync(

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -8,6 +8,7 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+const BUILT_IN_DEFAULT_EXECUTION_AGENT = 'codex';
 
 export interface ExternalWorkerLaunchConfig {
   /** Executable used to start the external worker process. */
@@ -62,6 +63,10 @@ export interface InvokerConfig {
    * Default: 0 (disabled).
    */
   autoFixRetries?: number;
+  /**
+   * Default execution agent for plan tasks that omit executionAgent.
+   */
+  defaultExecutionAgent?: string;
   /**
    * When true, successful AI-applied fixes are automatically approved.
    * This skips the manual "Approve Fix" step for fix-with-agent and
@@ -287,6 +292,11 @@ export function loadConfig(): InvokerConfig {
     ? readJsonSafe(process.env.INVOKER_REPO_CONFIG_PATH)
     : readJsonSafe(join(homedir(), '.invoker', 'config.json'));
 }
+export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
+  const configured = config.defaultExecutionAgent?.trim();
+  return configured && configured.length > 0 ? configured : BUILT_IN_DEFAULT_EXECUTION_AGENT;
+}
+
 
 
 export type EmbeddedTerminalBackendConfig = 'bash' | 'pty';


### PR DESCRIPTION
## Summary

The app config now accepts `defaultExecutionAgent`.

The built-in value stays Codex when the key is missing.

<details>
<summary>Review metadata</summary>

Review Claim: The saved app config can name the default agent used when no task value exists.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: Existing config files still load because the new key is optional and has a built-in fallback.

Slice Rationale: This adds the config key before any caller starts using it.

</details>

## Non-goals

This does not change task launch behavior by itself.

This does not remove Claude support.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts src/__tests__/plan-parser.test.ts src/__tests__/open-terminal.test.ts src/__tests__/workflow-actions.test.ts src/__tests__/cost-rollup.test.ts`
- [x] `pnpm --filter @invoker/execution-engine build && pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 71a92eaa1`
- Post-revert steps: Remove `defaultExecutionAgent` from `~/.invoker/config.json` if no longer wanted.
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting a default execution agent in app configuration for tasks that don’t specify one.
  * The app now uses a built-in fallback of `codex` when no valid default is configured.

* **Bug Fixes**
  * Improved handling of blank or missing default agent settings so configuration falls back reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->