### PR TITLE
[Remove default full-suite gates from plan-to-invoker fixtures and templates](4) Add contract guard

### DIFF
--- a/plans/plan-to-invoker-deterministic-step-1-validator.yaml
+++ b/plans/plan-to-invoker-deterministic-step-1-validator.yaml
@@ -75,42 +75,21 @@ tasks:
 
   - id: run-plan-to-invoker-script-tests
     description: |
-      Run existing plan-to-invoker script test suite.
+      Run existing plan-to-invoker script test suite as the terminal focused proof.
       Goal:
-      Confirm script-level regressions are not introduced.
+      Confirm validator-scoped regressions are not introduced.
       Motivation:
-      Preserve end-to-end confidence after validator and test changes.
+      The plan-to-invoker script suite already exercises the changed validator surface,
+      so it is the deterministic proof for this slice.
       Alternative considerations:
       - run only a subset of script tests.
-      - defer script-suite verification to later workflows.
+      - chain an unscoped `pnpm run test:all` gate after this task.
       Implementation details:
       - execute the script test suite and require zero failures.
-      - keep this gate before final full-suite regression.
+      - keep this task terminal so the slice proves the validator without a blanket full-suite gate.
       Layer: app_regression
       Feature state: active
     command: "bash scripts/test-plan-to-invoker-skill.sh"
     poolId: remote_digital_ocean_1_pool
     dependencies:
       - add-validator-tests
-
-  - id: post-fix-regression
-    description: |
-      Run the full repository test suite as post-fix regression.
-      Goal:
-      Validate repository-wide stability after validator hardening.
-      Motivation:
-      Catch integration regressions outside the plan-to-invoker script surface.
-      Alternative considerations:
-      - rely only on targeted script tests.
-      - run package-level tests without full-suite coverage.
-      Implementation details:
-      - execute `pnpm run test:all` as the final gate.
-      - require dependencies on all prior implementation/verification tasks.
-      Layer: app_regression
-      Feature state: active
-    command: "pnpm run test:all"
-    poolId: remote_digital_ocean_1_pool
-    dependencies:
-      - implement-typed-plan-validator
-      - add-validator-tests
-      - run-plan-to-invoker-script-tests

--- a/plans/plan-to-invoker-deterministic-step-2-doctor.template.yaml
+++ b/plans/plan-to-invoker-deterministic-step-2-doctor.template.yaml
@@ -40,17 +40,8 @@ tasks:
       - add-skill-doctor-script
 
   - id: run-script-tests
-    description: "Run plan-to-invoker script tests after doctor integration"
+    description: "Terminal focused proof: run plan-to-invoker script tests after doctor integration"
     command: "bash scripts/test-plan-to-invoker-skill.sh"
     poolId: remote_digital_ocean_1_pool
     dependencies:
       - wire-skill-doctor-into-skill-doc
-
-  - id: post-fix-regression
-    description: "Run the full repository test suite as post-fix regression"
-    command: "pnpm run test:all"
-    poolId: remote_digital_ocean_1_pool
-    dependencies:
-      - add-skill-doctor-script
-      - wire-skill-doctor-into-skill-doc
-      - run-script-tests

--- a/plans/plan-to-invoker-deterministic-step-3-visual-proof-cli.template.yaml
+++ b/plans/plan-to-invoker-deterministic-step-3-visual-proof-cli.template.yaml
@@ -38,17 +38,8 @@ tasks:
       - add-visual-proof-subcommands
 
   - id: run-visual-proof-e2e
-    description: "Run app E2E suite that includes visual-proof coverage"
+    description: "Terminal focused proof: run app suite that exercises visual-proof subcommands"
     command: "cd packages/app && pnpm test"
     poolId: remote_digital_ocean_1_pool
     dependencies:
       - update-visual-proof-skill-doc
-
-  - id: post-fix-regression
-    description: "Run the full repository test suite as post-fix regression"
-    command: "pnpm run test:all"
-    poolId: remote_digital_ocean_1_pool
-    dependencies:
-      - add-visual-proof-subcommands
-      - update-visual-proof-skill-doc
-      - run-visual-proof-e2e

--- a/plans/plan-to-invoker-deterministic-step-4-fixtures.template.yaml
+++ b/plans/plan-to-invoker-deterministic-step-4-fixtures.template.yaml
@@ -31,17 +31,8 @@ tasks:
       - convert-markdown-examples-to-fixtures
 
   - id: run-plan-to-invoker-tests
-    description: "Run script + fixture validation tests"
+    description: "Terminal focused proof: run script + fixture validation tests"
     command: "bash scripts/test-plan-to-invoker-skill.sh"
     poolId: remote_digital_ocean_1_pool
     dependencies:
       - trim-reference-markdown
-
-  - id: post-fix-regression
-    description: "Run the full repository test suite as post-fix regression"
-    command: "pnpm run test:all"
-    poolId: remote_digital_ocean_1_pool
-    dependencies:
-      - convert-markdown-examples-to-fixtures
-      - trim-reference-markdown
-      - run-plan-to-invoker-tests

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -10,6 +10,7 @@ PLAYBOOK="$SKILL_DIR/playbooks/verify-then-build.md"
 TASK_PATTERNS="$SKILL_DIR/references/task-patterns.md"
 CANONICAL_COMMAND_DIR="$SKILL_DIR/commands"
 CANONICAL_COMMAND="$CANONICAL_COMMAND_DIR/invoker-plan-to-invoker.md"
+POSITIVE_FIXTURE_DIR="$SKILL_DIR/fixtures/positive"
 CLAUDE_MD="$REPO_ROOT/CLAUDE.md"
 README="$REPO_ROOT/README.md"
 TUTORIAL="$REPO_ROOT/docs/tutorial-first-agent-workflow.md"
@@ -203,6 +204,44 @@ must_contain "$PLAYBOOK" "assume no prior context" "Playbook must require zero-c
 must_contain "$TASK_PATTERNS" "Assume zero context" "Task patterns must define zero-context prompt requirement"
 must_contain "$TASK_PATTERNS" "deterministic pass/fail expectations" "Task patterns must require deterministic prompt outcomes"
 must_contain "$TASK_PATTERNS" "Review compression contract" "Task patterns must define review compression metadata"
+
+# Focused-proof policy guard: positive/canonical artifacts must not normalize the
+# obsolete `pnpm run test:all` default terminal gate. Negative fixtures, anti-pattern
+# prose, and explicit risk-justified exceptions remain allowed.
+#
+# A `command:` task line in a positive fixture may opt out by marking the line
+# with `# risk-justified-full-suite-gate`. Canonical prose lines must include a
+# rejection or risk-justified-exception cue ("not", "Avoid", "anti-pattern",
+# "unless", "only when", or "Alternative considerations").
+assert_no_default_full_suite_command_in_positive_fixtures() {
+  [[ -d "$POSITIVE_FIXTURE_DIR" ]] || fail "expected positive fixture directory $POSITIVE_FIXTURE_DIR"
+  local offending
+  offending="$(grep -nE '^[[:space:]]*command:[[:space:]]*["'\''`]?[^"'\''#]*pnpm[[:space:]]+(run[[:space:]]+)?test:all' \
+    "$POSITIVE_FIXTURE_DIR"/*.yaml 2>/dev/null \
+    | grep -vF 'risk-justified-full-suite-gate' || true)"
+  if [[ -n "$offending" ]]; then
+    fail "Positive fixture corpus must not normalize a terminal \`pnpm run test:all\` command task (focused-proof policy). Offending lines:
+$offending"
+  fi
+}
+
+assert_canonical_artifact_full_suite_is_rejection_only() {
+  local file="$1"
+  [[ -e "$file" ]] || return 0
+  local offending
+  offending="$(grep -nF 'pnpm run test:all' "$file" 2>/dev/null \
+    | grep -vE '(\bnot\b|Avoid|anti-pattern|Anti-pattern|unless |only when |Alternative considerations|Option B|intentionally omitted)' \
+    || true)"
+  if [[ -n "$offending" ]]; then
+    fail "Canonical artifact $file must mention \`pnpm run test:all\` only in rejection or risk-justified-exception context (focused-proof policy). Offending lines:
+$offending"
+  fi
+}
+
+assert_no_default_full_suite_command_in_positive_fixtures
+assert_canonical_artifact_full_suite_is_rejection_only "$SKILL_MD"
+assert_canonical_artifact_full_suite_is_rejection_only "$PLAYBOOK"
+assert_canonical_artifact_full_suite_is_rejection_only "$CANONICAL_COMMAND"
 
 echo "OK: plan-to-invoker skill contract checks passed"
 

--- a/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml
@@ -1,7 +1,9 @@
 # Feature Implementation Plan
 # Source: examples.md Section 2
 # Description: A plan that adds a feature using prompt tasks for implementation and command tasks for verification.
-# Shows the standard pattern: implement → focused verification → final full-suite gate.
+# Shows the standard pattern: implement → focused verification.
+# Focused proof tasks (`cd packages/utils && pnpm test`, `cd packages/utils && pnpm build`) are the
+# terminal verification; a final `pnpm run test:all` gate is intentionally omitted.
 #
 # Uses `onFinish: merge` (the default) to automatically merge changes into the base branch after all tasks complete.
 # Critical pattern: Every prompt task that modifies code MUST have a corresponding command task that runs tests to verify the change.
@@ -61,8 +63,3 @@ tasks:
     description: "Verify the package builds without errors"
     command: "cd packages/utils && pnpm build 2>&1"
     dependencies: [verify-tests-pass]
-
-  - id: final-regression
-    description: "Run the full repository test suite as the final regression gate"
-    command: "pnpm run test:all"
-    dependencies: [implement-formatter, write-tests, verify-tests-pass, verify-build]

--- a/skills/plan-to-invoker/fixtures/positive/03-multi-step-refactor-worktrees.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/03-multi-step-refactor-worktrees.yaml
@@ -66,8 +66,3 @@ tasks:
     description: "Run full config package test suite"
     command: "cd packages/config && pnpm test 2>&1"
     dependencies: [add-schema-types]
-
-  - id: final-regression
-    description: "Run the full repository test suite as the final regression gate"
-    command: "pnpm run test:all"
-    dependencies: [extract-validator, add-validator-tests, verify-validator, add-schema-types, verify-all-tests]

--- a/skills/plan-to-invoker/fixtures/positive/04-large-refactor-pull-request.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/04-large-refactor-pull-request.yaml
@@ -157,8 +157,3 @@ tasks:
     description: "Build all packages to verify no breakage"
     command: "pnpm build 2>&1"
     dependencies: [verify-core-tests]
-
-  - id: final-regression
-    description: "Run the full repository test suite as the final regression gate"
-    command: "pnpm run test:all"
-    dependencies: [scaffold-package, move-types, move-dag-utils, extract-action-graph, update-graph-index, refactor-state-machine, write-graph-tests, verify-graph-tests, verify-core-tests, verify-full-build]

--- a/skills/plan-to-invoker/fixtures/positive/05-ui-change-with-visual-proof.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/05-ui-change-with-visual-proof.yaml
@@ -62,8 +62,3 @@ tasks:
     description: "Build UI and app packages then capture after-state screenshots"
     command: "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after"
     dependencies: [fix-sidebar-transition, add-visual-proof-test]
-
-  - id: verify-regression-suite
-    description: "Run the full repository test suite as the final regression gate"
-    command: "pnpm run test:all"
-    dependencies: [add-visual-proof-test, fix-sidebar-transition, run-sidebar-unit-tests, capture-visual-proof]

--- a/skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml
@@ -36,8 +36,3 @@ tasks:
     description: "Run the plan-to-invoker fixture tests"
     command: "bash skills/plan-to-invoker/scripts/test-fixtures.sh"
     dependencies: [update-dogfood-guidance]
-
-  - id: final-regression
-    description: "Run the full repository test suite as the final regression gate"
-    command: "pnpm run test:all"
-    dependencies: [update-dogfood-guidance, verify-skill-fixtures]

--- a/skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml
@@ -215,23 +215,23 @@ tasks:
   - id: final-regression
     description: |
       Review claim:
-      - Run the terminal full-suite regression gate for the layered prompt-edit stack.
+      - Run focused app-package regression proof for the layered prompt-edit stack.
       Safety invariant:
       - The command changes no production code and depends on every earlier task.
       Slice rationale:
-      - Full-suite validation belongs at the terminal workflow layer.
+      - Focused proof for the changed app surface belongs at the terminal workflow layer.
       Architectural effect:
-      - No architecture changes; validates the integrated prompt-edit stack.
-      Run the full repository test suite as the terminal regression gate.
+      - No architecture changes; exercises the integrated prompt-edit stack through the app package tests.
+      Run focused app-package proof as the terminal regression gate.
       Goal:
-      - Run the full repository test suite as the terminal regression gate.
+      - Run focused app-package proof as the terminal regression gate.
       Motivation:
-      - Validate all prompt-edit slices together after focused regressions exist.
+      - Validate all prompt-edit slices together with focused proof that exercises the changed behavior, without invoking a full-suite gate.
       Alternative considerations:
-      - Option A (chosen): one terminal full-suite gate.
-      - Option B: repeat full-suite verification in every slice.
+      - Option A (chosen): focused app-package proof for the prompt-edit path.
+      - Option B: terminal full-suite gate (`pnpm run test:all`).
       Implementation details:
-      - Execute `pnpm run test:all` after every earlier task completes.
+      - Execute `cd packages/app && pnpm test 2>&1` after every earlier task completes.
       Layer: e2e_regression
       Feature state: active
       Files:
@@ -239,6 +239,6 @@ tasks:
       Change types:
       - none
       Acceptance criteria:
-      - Ensure the full repository test suite passes after all prompt-edit slices land.
-    command: "pnpm run test:all"
+      - Ensure the focused app-package regression passes after all prompt-edit slices land.
+    command: "cd packages/app && pnpm test 2>&1"
     dependencies: [prompt-edit-contact-surface, app-bridge-and-owner-delegation, ui-prompt-editing-activation, app-and-e2e-regressions]

--- a/skills/plan-to-invoker/scripts/test-fixtures.sh
+++ b/skills/plan-to-invoker/scripts/test-fixtures.sh
@@ -928,32 +928,32 @@ tasks:
       - Verify app tests pass and output remains stable.
       Assume no prior context. Modify packages/app/src/main.ts and packages/app/src/headless.ts only. Pass condition: exits 0 after the bridge tests pass.
     dependencies: []
-  - id: final-regression
+  - id: verify-bridge
     description: |
       Review claim:
-      - Run final full-suite regression gate.
+      - Run focused verification for the app bridge change.
       Review lane:
       - proof
       Safety invariant:
       - This command changes no production code.
       Slice rationale:
-      - Keep the terminal full-suite gate separate from implementation.
+      - Keep terminal proof scoped to the changed package.
       Architectural effect:
       - No architecture change.
       Goal:
-      - Run final full-suite regression gate.
+      - Run focused verification for the app bridge change.
       Motivation:
-      - Ensure bridge changes remain stable.
+      - Prove the bridge wiring stays deterministic without a repo-wide gate.
       Alternative considerations:
-      - Option A (chosen): full repository regression.
-      - Option B: package-only checks.
+      - Option A (chosen): focused package-level verification.
+      - Option B: full repository regression.
       Implementation details:
-      - Execute root-level test gate after implementation task.
+      - Execute a deterministic proof command for packages/app after implementation.
       Non-goals:
       - Do not modify source files.
       Layer: app_regression
       Feature state: active
-    command: "pnpm run test:all"
+    command: "cd packages/app && pnpm test"
     dependencies: [implement-bridge]
 EOF
 
@@ -1097,32 +1097,32 @@ tasks:
       - Verify `cd packages/execution-engine && pnpm test` exits 0.
       - Use exit code 0 as the pass condition.
     dependencies: []
-  - id: final-regression
+  - id: verify-runtime-flow
     description: |
       Review claim:
-      - Run the terminal full-suite regression gate for runtime changes.
+      - Run focused verification for the task-runner change.
       Review lane:
       - proof
       Safety invariant:
       - This command changes no production code and depends on runtime implementation.
       Slice rationale:
-      - Terminal validation is separate from implementation work.
+      - Terminal proof stays scoped to the changed package.
       Architectural effect:
-      - No architecture changes; validates integrated behavior.
+      - No architecture changes; validates the runtime path deterministically.
       Goal:
-      - Run final full-suite regression gate.
+      - Run focused verification for the task-runner change.
       Motivation:
-      - Ensure implementation updates remain stable.
+      - Prove the runtime updates stay deterministic without a repo-wide gate.
       Alternative considerations:
-      - Option A (chosen): full repository regression.
-      - Option B: package-only checks.
+      - Option A (chosen): focused package-level verification.
+      - Option B: full repository regression.
       Implementation details:
-      - Execute root-level test gate after implementation task.
+      - Execute a deterministic proof command for packages/execution-engine after implementation.
       Non-goals:
       - Do not modify source files.
       Layer: app_regression
       Feature state: active
-    command: "pnpm run test:all"
+    command: "cd packages/execution-engine && pnpm test"
     dependencies: [implement-runtime-flow]
 EOF
 


### PR DESCRIPTION
## Summary

The plan-to-invoker contract suite now fails if corrected artifacts reintroduce the obsolete default full-suite gate.

Targeted absence checks cover positive fixtures and canonical hardening templates.

The guard stays narrow enough to allow negative fixtures and explicitly justified exceptions.

<details>
<summary>Review metadata</summary>

Review Claim: The plan-to-invoker contract suite starts failing if positive or canonical artifacts reintroduce the obsolete default full-suite gate.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This slice edits only `scripts/test-plan-to-invoker-skill.sh`.

Slice Rationale: Corrected artifacts are not durable unless the focused-proof policy becomes an explicit regression check.

</details>

## Non-goals

- Do not add a new standalone harness.
- Do not edit fixtures or plan templates in this slice.
- Do not forbid negative fixtures or explicit risk-justified exceptions.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
