### PR TITLE
[AI Harness Model Split](2) Persist and execute task model overrides

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2898,6 +2898,8 @@ function createEmbeddedTerminalBackendFromConfig(
         return null;
       case 'invoker:edit-task-agent':
         return { channel: 'headless.exec', request: { args: ['set', 'agent', String(arg0), String(arg1)], noTrack: true } };
+      case 'invoker:edit-task-model':
+        return { channel: 'headless.exec', request: { args: ['set', 'model', String(arg0), arg1 == null ? '' : String(arg1)], noTrack: true } };
       case 'invoker:set-task-external-gate-policies': {
         const taskId = String(arg0);
         const updates = Array.isArray(arg1) ? arg1 as Array<{ workflowId: string; taskId?: string; gatePolicy: 'completed' | 'review_ready' }> : [];
@@ -4787,6 +4789,32 @@ function createEmbeddedTerminalBackendFromConfig(
         throw err;
       }
     });
+    registerTaskScopedGuiMutationHandler(
+      'invoker:edit-task-model',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown, executionModelArg: unknown) => {
+      const taskId = String(taskIdArg);
+      const executionModel = typeof executionModelArg === 'string' ? executionModelArg : null;
+      logger.info(`edit-task-model: "${taskId}" → "${executionModel ?? ''}"`, { module: 'ipc' });
+      try {
+        const envelope = makeEnvelope('edit-task-model', 'ui', 'task', { taskId, executionModel });
+        const result = await commandService.editTaskModel(envelope);
+        if (!result.ok) throw new Error(result.error.message);
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.edit-task-model',
+          started: result.data,
+          scopedTaskIds: [taskId],
+        });
+      } catch (err) {
+        logger.error(`edit-task-model failed: ${err}`, { module: 'ipc' });
+        throw err;
+      }
+    });
+
 
     registerTaskScopedGuiMutationHandler(
       'invoker:set-task-external-gate-policies',

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -544,6 +544,10 @@ export const IpcChannels = {
     request: [taskId: string, agentName: string];
     response: WorkflowMutationAcceptedResult;
   },
+  'invoker:edit-task-model': {} as {
+    request: [taskId: string, executionModel: string | null];
+    response: WorkflowMutationAcceptedResult;
+  },
   'invoker:edit-task-prompt': {} as {
     request: [taskId: string, newPrompt: string];
     response: WorkflowMutationAcceptedResult;

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1396,6 +1396,7 @@ describe('SQLiteAdapter', () => {
         description: 'Updated task',
         config: {
           poolId: 'some-pool',
+          executionModel: 'openai/gpt-5.2',
           fixPrompt: 'fix this',
         },
       });
@@ -1404,6 +1405,7 @@ describe('SQLiteAdapter', () => {
         description: 'Updated task',
         config: {
           poolId: 'some-pool',
+          executionModel: 'openai/gpt-5.2',
           fixPrompt: 'fix this',
         },
       });
@@ -1611,12 +1613,14 @@ describe('SQLiteAdapter', () => {
         config: {
           runnerKind: 'docker',
           dockerImage: 'node:20',
+          executionModel: 'claude-sonnet-4',
         },
       }));
 
       let [loaded] = adapter.loadTasks('wf-1');
       expect(loaded.config.runnerKind).toBe('docker');
       expect(loaded.config.dockerImage).toBe('node:20');
+      expect(loaded.config.executionModel).toBe('claude-sonnet-4');
 
       adapter.updateTask('t1', {
         config: {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1303,6 +1303,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         pool_member_id,
         docker_image,
         execution_agent,
+        execution_model,
         agent_name,
         task_state_version
       ) VALUES (
@@ -1320,6 +1321,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ?, ?, ?, ?,
         ?, ?,
         ?, ?, ?, ?, ?,
+        ?,
         ?,
         ?,
         ?,
@@ -1381,6 +1383,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       (cfg as { poolMemberId?: string }).poolMemberId ?? null,
       cfg.dockerImage ?? null,
       cfg.executionAgent ?? null,
+      cfg.executionModel ?? null,
       exec.agentName ?? null,
       task.taskStateVersion ?? 1,
     ]);
@@ -1421,6 +1424,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         poolMemberId: 'pool_member_id',
         dockerImage: 'docker_image',
         executionAgent: 'execution_agent',
+        executionModel: 'execution_model',
         fixPrompt: 'fix_prompt',
         fixContext: 'fix_context',
       };

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -85,6 +85,7 @@ export function mapRowToTask(row: any): TaskState {
       fixPrompt: row.fix_prompt ?? undefined,
       fixContext: row.fix_context ?? undefined,
       executionAgent: row.execution_agent ?? undefined,
+      executionModel: row.execution_model ?? undefined,
     },
     execution: {
       blockedBy: row.blocked_by ?? undefined,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -355,6 +355,7 @@ export const COLUMN_MIGRATIONS = [
   // detached_external_dependencies: read-only provenance for deps removed by detachWorkflow
   'ALTER TABLE workflows ADD COLUMN detached_external_dependencies TEXT',
   // execution_agent / agent_name: interchangeable agent support
+  'ALTER TABLE tasks ADD COLUMN execution_model TEXT',
   'ALTER TABLE tasks ADD COLUMN execution_agent TEXT',
   'ALTER TABLE tasks ADD COLUMN agent_name TEXT',
   // durable audit pointers for most-recent agent session/name

--- a/packages/execution-engine/src/__tests__/claude-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/claude-execution-agent.test.ts
@@ -51,6 +51,21 @@ describe('ClaudeExecutionAgent', () => {
       expect(spec.args[3]).toBe('-p');
       expect(spec.args[4]).toBe('my prompt');
     });
+    it('passes executionModel through as --model', () => {
+      const agent = new ClaudeExecutionAgent();
+      const spec = agent.buildCommand('my prompt', { executionModel: 'opus' });
+
+      expect(spec.args).toEqual([
+        '--session-id',
+        spec.sessionId,
+        '--dangerously-skip-permissions',
+        '--model',
+        'opus',
+        '-p',
+        'my prompt',
+      ]);
+    });
+
   });
 
   describe('buildFixCommand', () => {
@@ -106,6 +121,21 @@ describe('ClaudeExecutionAgent', () => {
       expect(spec.args[0]).toBe('--session-id');
       expect(spec.args[1]).toBe(spec.sessionId);
     });
+    it('passes executionModel through for fix flows', () => {
+      const agent = new ClaudeExecutionAgent();
+      const spec = agent.buildFixCommand('my prompt', { executionModel: 'sonnet' });
+
+      expect(spec.args).toEqual([
+        '--session-id',
+        spec.sessionId,
+        '--model',
+        'sonnet',
+        '-p',
+        'my prompt',
+        '--dangerously-skip-permissions',
+      ]);
+    });
+
 
     it('stored sessionId matches the CLI --session-id value', () => {
       const agent = new ClaudeExecutionAgent();

--- a/packages/execution-engine/src/__tests__/codex-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-execution-agent.test.ts
@@ -14,6 +14,19 @@ describe('CodexExecutionAgent', () => {
     const spec = agent.buildCommand('test prompt');
     expect(spec.args).toEqual(['exec', '--json', '--full-auto', 'test prompt']);
   });
+  it('passes executionModel through as --model', () => {
+    const agent = new CodexExecutionAgent();
+    const spec = agent.buildCommand('test prompt', { executionModel: 'gpt-5.2' });
+    expect(spec.args).toEqual([
+      'exec',
+      '--json',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--model',
+      'gpt-5.2',
+      'test prompt',
+    ]);
+  });
+
 
   it('respects custom command', () => {
     const agent = new CodexExecutionAgent({ command: '/usr/bin/codex' });
@@ -54,6 +67,19 @@ describe('CodexExecutionAgent', () => {
     expect(spec.args).toEqual(['exec', '--json', '--dangerously-bypass-approvals-and-sandbox', 'fix the bug']);
     expect(spec.sessionId).toBeDefined();
   });
+  it('buildFixCommand passes executionModel through', () => {
+    const agent = new CodexExecutionAgent();
+    const spec = agent.buildFixCommand('fix the bug', { executionModel: 'gpt-5.2' });
+    expect(spec.args).toEqual([
+      'exec',
+      '--json',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--model',
+      'gpt-5.2',
+      'fix the bug',
+    ]);
+  });
+
 
   it('buildFixCommand generates unique session IDs', () => {
     const agent = new CodexExecutionAgent();

--- a/packages/execution-engine/src/agents/claude-execution-agent.ts
+++ b/packages/execution-engine/src/agents/claude-execution-agent.ts
@@ -8,7 +8,7 @@
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { ExecutionAgent, AgentCommandSpec } from '../agent.js';
+import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions } from '../agent.js';
 
 export interface ClaudeExecutionAgentConfig {
   /** Command to invoke the Claude CLI. Default: 'claude'. */
@@ -45,23 +45,27 @@ export class ClaudeExecutionAgent implements ExecutionAgent {
     this.bundledSkillRoot = join(this.configDir, 'skills');
   }
 
-  buildCommand(fullPrompt: string): AgentCommandSpec {
+  buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
     const sessionId = randomUUID();
     return {
       cmd: this.command,
-      args: ['--session-id', sessionId, '--dangerously-skip-permissions', '-p', fullPrompt],
+      args: ['--session-id', sessionId, '--dangerously-skip-permissions', ...this.buildModelArgs(options.executionModel), '-p', fullPrompt],
       sessionId,
       fullPrompt,
     };
   }
 
-  buildFixCommand(prompt: string): AgentCommandSpec {
+  buildFixCommand(prompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
     const sessionId = randomUUID();
     return {
       cmd: this.fixCommand,
-      args: ['--session-id', sessionId, '-p', prompt, '--dangerously-skip-permissions'],
+      args: ['--session-id', sessionId, ...this.buildModelArgs(options.executionModel), '-p', prompt, '--dangerously-skip-permissions'],
       sessionId,
     };
+  }
+
+  private buildModelArgs(executionModel?: string): string[] {
+    return executionModel ? ['--model', executionModel] : [];
   }
 
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -12,7 +12,7 @@
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { ExecutionAgent, AgentCommandSpec } from '../agent.js';
+import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions } from '../agent.js';
 
 export interface CodexExecutionAgentConfig {
   /** Command to invoke the Codex CLI. Default: 'codex'. */
@@ -47,12 +47,12 @@ export class CodexExecutionAgent implements ExecutionAgent {
     this.bundledSkillRoot = join(homedir(), '.codex', 'skills');
   }
 
-  buildCommand(fullPrompt: string): AgentCommandSpec {
+  buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
     const sessionId = randomUUID();
     const args = ['exec', '--json'];
     if (this.bypassApprovalsAndSandbox) args.push(...this.buildBypassArgs());
     else if (this.fullAuto) args.push('--full-auto');
-    args.push(fullPrompt);
+    args.push(...this.buildModelArgs(options.executionModel), fullPrompt);
     return { cmd: this.command, args, sessionId, fullPrompt };
   }
 
@@ -63,13 +63,17 @@ export class CodexExecutionAgent implements ExecutionAgent {
     };
   }
 
-  buildFixCommand(prompt: string): AgentCommandSpec {
+  buildFixCommand(prompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
     const sessionId = randomUUID();
     const args = ['exec', '--json'];
     if (this.bypassApprovalsAndSandbox) args.push(...this.buildBypassArgs());
     else if (this.fullAuto) args.push('--full-auto');
-    args.push(prompt);
+    args.push(...this.buildModelArgs(options.executionModel), prompt);
     return { cmd: this.command, args, sessionId };
+  }
+
+  private buildModelArgs(executionModel?: string): string[] {
+    return executionModel ? ['--model', executionModel] : [];
   }
 
   private buildBypassArgs(): string[] {

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -908,7 +908,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         const agentName = request.inputs.executionAgent ?? 'claude';
         const agent = opts.agentRegistry.getOrThrow(agentName);
         const fullPrompt = this.buildFullPrompt(request);
-        const spec = agent.buildCommand(fullPrompt);
+        const spec = agent.buildCommand(fullPrompt, { executionModel: request.inputs.executionModel });
         return { cmd: spec.cmd, args: spec.args, agentSessionId: spec.sessionId, fullPrompt: spec.fullPrompt };
       }
       // Fallback: use prepareClaudeSession when no agent registry is available
@@ -1097,8 +1097,15 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
   /**
    * Build CLI args for invoking `claude` with a session ID and prompt.
    */
-  protected buildClaudeArgs(sessionId: string, fullPrompt: string): string[] {
-    return ['--session-id', sessionId, '--dangerously-skip-permissions', '-p', fullPrompt];
+  protected buildClaudeArgs(sessionId: string, fullPrompt: string, executionModel?: string): string[] {
+    return [
+      '--session-id',
+      sessionId,
+      '--dangerously-skip-permissions',
+      ...(executionModel ? ['--model', executionModel] : []),
+      '-p',
+      fullPrompt,
+    ];
   }
 
   /**
@@ -1108,7 +1115,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
   protected prepareClaudeSession(request: WorkRequest): ClaudeSessionParams {
     const sessionId = randomUUID();
     const fullPrompt = this.buildFullPrompt(request);
-    const cliArgs = this.buildClaudeArgs(sessionId, fullPrompt);
+    const cliArgs = this.buildClaudeArgs(sessionId, fullPrompt, request.inputs.executionModel);
     return { sessionId, cliArgs, fullPrompt };
   }
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -421,7 +421,7 @@ ${runProvisionSection}stop_bootstrap_heartbeat
       if (this.agentRegistry) {
         const agent = this.agentRegistry.getOrThrow(executionAgent);
         const fullPrompt = this.buildFullPrompt(request);
-        const spec = agent.buildCommand(fullPrompt);
+        const spec = agent.buildCommand(fullPrompt, { executionModel: request.inputs.executionModel });
         agentSessionId = spec.sessionId;
         payload = `${spec.cmd} ${spec.args.map(a => this.shellQuote(a)).join(' ')}`;
         bench('SshExecutor.payload.built', {

--- a/packages/workflow-core/src/__tests__/edit-task-agent-invalidation.test.ts
+++ b/packages/workflow-core/src/__tests__/edit-task-agent-invalidation.test.ts
@@ -36,6 +36,12 @@ describe('agent-mutation invalidation contract', () => {
     expect(MUTATION_POLICIES.executionAgent.invalidateIfActive).toBe(true);
   });
 
+  it('MUTATION_POLICIES.executionModel is recreate-class and invalidates active attempts', () => {
+    expect(MUTATION_POLICIES.executionModel.action).toBe('recreateTask');
+    expect(MUTATION_POLICIES.executionModel.invalidatesExecutionSpec).toBe(true);
+    expect(MUTATION_POLICIES.executionModel.invalidateIfActive).toBe(true);
+  });
+
   it('routes through applyInvalidation with cancelInFlight invoked BEFORE recreateTask dep', async () => {
     const deps = makeDeps();
     const policy = MUTATION_POLICIES.executionAgent;
@@ -105,6 +111,7 @@ function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
   return {
     getTask: vi.fn().mockReturnValue({ config: { workflowId: 'wf-1' } }),
     editTaskAgent: vi.fn().mockReturnValue([] as TaskState[]),
+    editTaskModel: vi.fn().mockReturnValue([] as TaskState[]),
     ...overrides,
   } as unknown as Orchestrator;
 }
@@ -132,6 +139,22 @@ describe('CommandService.editTaskAgent (headless integration seam)', () => {
     expect(result).toEqual({ ok: true, data: [] });
     expect(orchestrator.editTaskAgent).toHaveBeenCalledWith('wf-1/t1', 'codex');
     expect(orchestrator.editTaskAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates a model-edit envelope to orchestrator.editTaskModel with the expected payload', async () => {
+    const envelope: CommandEnvelope<{ taskId: string; executionModel: string | null }> = {
+      commandId: 'cmd-model-1',
+      source: 'headless',
+      scope: 'task',
+      idempotencyKey: 'idem-model-1',
+      payload: { taskId: 'wf-1/t1', executionModel: 'openai/gpt-5.2' },
+    };
+
+    const result = await service.editTaskModel(envelope);
+
+    expect(result).toEqual({ ok: true, data: [] });
+    expect(orchestrator.editTaskModel).toHaveBeenCalledWith('wf-1/t1', 'openai/gpt-5.2');
+    expect(orchestrator.editTaskModel).toHaveBeenCalledTimes(1);
   });
 
   it('wraps orchestrator errors in CommandResult instead of throwing', async () => {


### PR DESCRIPTION
## Summary

Task model edits can already exist in task state, but they were not saved to SQLite and did not reach Claude or Codex process invocations.

This slice persists `executionModel`, threads it through task recreation, and appends `--model` for Claude and Codex when a task override exists.

It also teaches the owner process about the new task-model mutation so later entry points can reuse one backend path.

<details>
<summary>Review metadata</summary>

Review Claim: Task model overrides now survive persistence and reach execution invocations through the normal recreate path.

Review Lane: behavior

Review Unit: routing

Safety Invariant: This slice only changes owner/runtime flow, persistence, and executor assembly. No user-facing controls are added yet.

Slice Rationale: Persistence and execution wiring must be proven before exposing a new control. Landing the backend path first avoids a dead setting.

</details>

## Non-goals

- No label or layout changes.
- No central validation of model names.
- No new entry-point controls.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/claude-execution-agent.test.ts src/__tests__/codex-execution-agent.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/edit-task-agent-invalidation.test.ts`

## Visual Proof

No visible change in this slice. Owner-process routing changed, but task surfaces stay the same until the next slice.

![Unchanged task panel in routing slice](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-2ca6dc/ai-task-panel.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 5f05e8532`
- Post-revert steps: None
- Data migration? No
