### PR TITLE
[AI Harness Model Split](1) Add task model IPC channel

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -544,6 +544,10 @@ export const IpcChannels = {
     request: [taskId: string, agentName: string];
     response: WorkflowMutationAcceptedResult;
   },
+  'invoker:edit-task-model': {} as {
+    request: [taskId: string, executionModel: string | null];
+    response: WorkflowMutationAcceptedResult;
+  },
   'invoker:edit-task-prompt': {} as {
     request: [taskId: string, newPrompt: string];
     response: WorkflowMutationAcceptedResult;


### PR DESCRIPTION
## Summary

Invoker already carries `executionModel` in task state, but the IPC channel table still cannot express a task-level model edit.

This slice adds the missing `invoker:edit-task-model` channel so later slices can wire task model edits without stringly typed gaps.

<details>
<summary>Review metadata</summary>

Review Claim: The IPC contract now declares one typed task-model edit channel for downstream slices.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This slice changes one contract file and no runtime handlers. Nothing can call the new channel until later slices land.

Slice Rationale: The shared type boundary has to land before the persistence and entry-point slices. Keeping it alone gives reviewers the boundary first.

</details>

## Non-goals

- No runtime handler changes.
- No persistence changes.
- No entry-point changes.

## Test Plan

- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert cc8bdbfa9`
- Post-revert steps: None
- Data migration? No
