### PR TITLE
[Fix Slack gate-policy routing](1) Add workflow-op shape

### DIFF
--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -37,10 +37,29 @@ export type WorkflowOpName =
   | 'status'
   | 'cancel';
 
-export interface WorkflowOp {
-  operation: WorkflowOpName;
-  target: { all: true } | { workflow: string };
+export type WorkflowOpTarget = { all: true } | { workflow: string };
+
+export type WorkflowGatePolicy = 'completed' | 'review_ready';
+
+export interface WorkflowGatePolicyUpdate {
+  workflowId: string;
+  taskId?: string;
+  gatePolicy: WorkflowGatePolicy;
 }
+
+export interface WorkflowControlOp {
+  operation: WorkflowOpName;
+  target: WorkflowOpTarget;
+}
+
+export interface WorkflowGatePolicyOp {
+  operation: 'gate-policy';
+  target: { workflow: string };
+  ownerTaskId?: string;
+  updates: WorkflowGatePolicyUpdate[];
+}
+
+export type WorkflowOp = WorkflowControlOp | WorkflowGatePolicyOp;
 
 export interface WorkflowOpResult {
   ok: boolean;

--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -55,7 +55,7 @@ export interface WorkflowControlOp {
 export interface WorkflowGatePolicyOp {
   operation: 'gate-policy';
   target: { workflow: string };
-  ownerTaskId?: string;
+  ownerTaskId: string;
   updates: WorkflowGatePolicyUpdate[];
 }
 

--- a/scripts/repro/repro-coderabbit-pr2614-owner-task-id.sh
+++ b/scripts/repro/repro-coderabbit-pr2614-owner-task-id.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SURFACE_TS="$ROOT/packages/surfaces/src/surface.ts"
+
+if node - "$SURFACE_TS" <<'NODE'
+const fs = require('node:fs');
+const sourcePath = process.argv[2];
+const source = fs.readFileSync(sourcePath, 'utf8');
+const match = source.match(/export interface WorkflowGatePolicyOp \{(?<body>[\s\S]*?)\n\}/);
+
+if (!match?.groups?.body) {
+  console.error('FAIL: WorkflowGatePolicyOp interface was not found');
+  process.exit(2);
+}
+
+const body = match.groups.body;
+if (/ownerTaskId\?\s*:\s*string\b/.test(body)) {
+  console.error('FAIL: WorkflowGatePolicyOp still accepts payloads without ownerTaskId');
+  process.exit(1);
+}
+
+if (!/ownerTaskId\s*:\s*string\b/.test(body)) {
+  console.error('FAIL: WorkflowGatePolicyOp does not declare a required ownerTaskId string');
+  process.exit(2);
+}
+
+console.log('PASS: WorkflowGatePolicyOp requires ownerTaskId for routing');
+NODE
+then
+  exit 0
+else
+  exit $?
+fi


### PR DESCRIPTION
## Summary

Adds the shared Slack workflow-op type for gate-policy mutations.

This lets later slices carry policy intent without changing behavior here.

<details>
<summary>Review metadata</summary>

Review Claim: Slack surfaces have a gate-policy workflow-op type.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This only extends the shared operation type; parser and execution behavior stay unchanged.

Slice Rationale: The contract lands first so later slices can use a typed payload.

</details>

## Non-goals

- Change Slack parsing or fuzzy matching.
- Execute gate-policy mutations.
- Update documentation.

## Test Plan

- [x] `bash scripts/repro/repro-slack-gate-policy-routing.sh`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <PR commit>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded workflow bulk actions to support both general control actions and gate-policy updates.
  * Added support for per-workflow policy changes, including required ownership details and update lists.

* **Tests**
  * Added a verification check to ensure the new ownership field stays required in workflow gate-policy actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->