### PR TITLE
[Fix Slack gate-policy routing](2) Route Slack gate-policy phrasing

### DIFF
--- a/packages/surfaces/src/__tests__/lobby-control.test.ts
+++ b/packages/surfaces/src/__tests__/lobby-control.test.ts
@@ -25,6 +25,23 @@ describe('parseLobbyControl', () => {
     expect(parseLobbyControl('status my-flow')).toEqual({ kind: 'op', operation: 'status', target: { workflow: 'my-flow' } });
   });
 
+  it('parses gate-policy updates from the headless command form', () => {
+    expect(parseLobbyControl('set gate-policy wf-1/task-a wf-upstream review_ready')).toEqual({
+      kind: 'op',
+      operation: 'gate-policy',
+      target: { workflow: 'wf-1' },
+      ownerTaskId: 'wf-1/task-a',
+      updates: [{ workflowId: 'wf-upstream', taskId: '__merge__', gatePolicy: 'review_ready' }],
+    });
+    expect(parseLobbyControl('set gate-policy wf-1/task-a wf-upstream verify completed')).toEqual({
+      kind: 'op',
+      operation: 'gate-policy',
+      target: { workflow: 'wf-1' },
+      ownerTaskId: 'wf-1/task-a',
+      updates: [{ workflowId: 'wf-upstream', taskId: 'verify', gatePolicy: 'completed' }],
+    });
+  });
+
   it('defaults bare status to all; a bare mutation verb is ambiguous (null)', () => {
     expect(parseLobbyControl('status')).toEqual({ kind: 'op', operation: 'status', target: { all: true } });
     expect(parseLobbyControl('recreate')).toBeNull();
@@ -36,6 +53,7 @@ describe('parseLobbyControl', () => {
     expect(parseLobbyControl('how many workflows are running?')).toBeNull();
     expect(parseLobbyControl('add a /health endpoint')).toBeNull();
     expect(parseLobbyControl('recreate + rebase all workflows')).toBeNull();
+    expect(parseLobbyControl('set gate-policy task-a wf-upstream review_ready')).toBeNull();
     expect(parseLobbyControl('')).toBeNull();
   });
 });

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events';
 import * as child_process from 'node:child_process';
 import { SlackSurface, parsePlanningRequest, parseLobbyClassification, BUILTIN_HARNESS_PRESETS } from '../slack/slack-surface.js';
 import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
-import type { SurfaceCommand } from '../surface.js';
+import type { SurfaceCommand, WorkflowOp, WorkflowOpResult } from '../surface.js';
 import type { WorkflowContext } from '../slack/workflow-assistant.js';
 
 // ── Mocks ────────────────────────────────────────────────────
@@ -286,13 +286,14 @@ describe('in-channel workflow assistant', () => {
     mockSpawn.mockReset();
   });
 
-  function assistantSurface(gather?: (id: string) => Promise<WorkflowContext>) {
+  function assistantSurface(gather?: (id: string) => Promise<WorkflowContext>, runWorkflowOp?: (op: WorkflowOp) => Promise<WorkflowOpResult>) {
     const surface = new SlackSurface({
       ...baseConfig(),
       conversationRepo: convoRepo,
       workflowChannelRepo: repo,
       planningCommandBuilder: () => ({ command: 'cursor', args: ['--print', 'x'] }),
       gatherWorkflowContext: gather,
+      ...(runWorkflowOp ? { runWorkflowOp } : {}),
     });
     return surface;
   }
@@ -315,6 +316,27 @@ describe('in-channel workflow assistant', () => {
       say: vi.fn().mockResolvedValue({ ts: 'a' }),
     });
     expect(received).toContainEqual({ type: 'approve', taskId: 'wf-1-2/api' });
+  });
+
+  it('routes workflow-channel gate-policy commands to workflow ops', async () => {
+    const runWorkflowOp = vi.fn().mockResolvedValue({ ok: true, summary: 'gate policy updated' });
+    const surface = assistantSurface(undefined, runWorkflowOp);
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> set gate-policy api wf-upstream review_ready', ts: 't1', user: 'U1', channel: 'C123' },
+      say,
+    });
+
+    expect(runWorkflowOp).toHaveBeenCalledWith({
+      operation: 'gate-policy',
+      target: { workflow: 'wf-1-2' },
+      ownerTaskId: 'wf-1-2/api',
+      updates: [{ workflowId: 'wf-upstream', taskId: '__merge__', gatePolicy: 'review_ready' }],
+    });
+    expect(received).toHaveLength(0);
+    expect(mockSpawn).not.toHaveBeenCalled();
   });
 
   it('answers a free-form question only from the gathered workflow context', async () => {

--- a/packages/surfaces/src/__tests__/workflow-assistant.test.ts
+++ b/packages/surfaces/src/__tests__/workflow-assistant.test.ts
@@ -22,9 +22,27 @@ describe('parseWorkflowControl', () => {
     });
   });
 
+  it('parses gate-policy updates scoped to the workflow channel', () => {
+    expect(parseWorkflowControl('set gate-policy api wf-upstream review_ready', 'wf-1')).toEqual({
+      kind: 'gate-policy',
+      operation: 'gate-policy',
+      target: { workflow: 'wf-1' },
+      ownerTaskId: 'wf-1/api',
+      updates: [{ workflowId: 'wf-upstream', taskId: '__merge__', gatePolicy: 'review_ready' }],
+    });
+    expect(parseWorkflowControl('set gate-policy wf-1/api wf-upstream verify completed')).toEqual({
+      kind: 'gate-policy',
+      operation: 'gate-policy',
+      target: { workflow: 'wf-1' },
+      ownerTaskId: 'wf-1/api',
+      updates: [{ workflowId: 'wf-upstream', taskId: 'verify', gatePolicy: 'completed' }],
+    });
+  });
+
   it('returns null for free-form questions', () => {
     expect(parseWorkflowControl('what did the api task change?')).toBeNull();
     expect(parseWorkflowControl('approve')).toBeNull(); // verb without a task id
+    expect(parseWorkflowControl('set gate-policy api wf-upstream review_ready')).toBeNull();
   });
 });
 

--- a/packages/surfaces/src/slack/lobby-control.ts
+++ b/packages/surfaces/src/slack/lobby-control.ts
@@ -7,10 +7,11 @@
  * unambiguous command, so the caller falls through to conversation.
  */
 
-import type { WorkflowOpName } from '../surface.js';
+import type { WorkflowGatePolicy, WorkflowGatePolicyOp, WorkflowGatePolicyUpdate, WorkflowOpName, WorkflowOpTarget } from '../surface.js';
 
 export type LobbyControl =
-  | { kind: 'op'; operation: WorkflowOpName; target: { all: true } | { workflow: string } }
+  | { kind: 'op'; operation: WorkflowOpName; target: WorkflowOpTarget }
+  | ({ kind: 'op' } & WorkflowGatePolicyOp)
   | { kind: 'submit' };
 
 // Verb spellings → canonical operation. Bare `rebase` means recreate-after-rebase.
@@ -26,10 +27,53 @@ const OP_ALIASES: Record<string, WorkflowOpName> = {
 
 const VERB_PATTERN = /^(rebase-recreate|rebase-retry|recreate|rebase|retry|cancel|status)\b([\s\S]*)$/i;
 const TARGET_TOKEN = /^[\w./-]+$/;
+const GATE_POLICY_PATTERN = /^set\s+gate-policy\s+([\s\S]+)$/i;
+
+function normalizeGatePolicy(value: string): WorkflowGatePolicy | null {
+  const normalized = value.toLowerCase().replace(/-/g, '_');
+  if (normalized === 'completed' || normalized === 'review_ready') return normalized;
+  return null;
+}
+
+function ownerWorkflowFromTaskId(taskId: string): string | null {
+  const slash = taskId.indexOf('/');
+  if (slash <= 0 || slash === taskId.length - 1) return null;
+  return taskId.slice(0, slash);
+}
+
+export function parseGatePolicyOp(text: string, defaultOwnerWorkflowId?: string): WorkflowGatePolicyOp | null {
+  const match = GATE_POLICY_PATTERN.exec(text.trim());
+  if (!match) return null;
+
+  const args = match[1].trim().replace(/[.!?]+$/, '').trim().split(/\s+/).filter(Boolean);
+  if (args.length !== 3 && args.length !== 4) return null;
+
+  const [rawOwnerTaskId, workflowId] = args;
+  const policyToken = args[args.length - 1];
+  const gatePolicy = normalizeGatePolicy(policyToken);
+  if (!gatePolicy) return null;
+
+  const depTaskId = args.length === 4 ? args[2] : '__merge__';
+  const tokens = [rawOwnerTaskId, workflowId, depTaskId];
+  if (!tokens.every((token) => TARGET_TOKEN.test(token))) return null;
+
+  const ownerWorkflowId = ownerWorkflowFromTaskId(rawOwnerTaskId) ?? defaultOwnerWorkflowId;
+  if (!ownerWorkflowId) return null;
+
+  const ownerTaskId = ownerWorkflowFromTaskId(rawOwnerTaskId) ? rawOwnerTaskId : `${ownerWorkflowId}/${rawOwnerTaskId}`;
+  const update: WorkflowGatePolicyUpdate = { workflowId, taskId: depTaskId, gatePolicy };
+  return {
+    operation: 'gate-policy',
+    target: { workflow: ownerWorkflowId },
+    ownerTaskId,
+    updates: [update],
+  };
+}
 
 /**
  * Parse a lobby command. Recognizes:
  *   - `submit` / `submit to invoker`
+ *   - `set gate-policy <taskId> <wfId> [depTaskId] <completed|review_ready>`
  *   - `<op> all` / `<op> <workflow-id-or-name>`  (op ∈ recreate|rebase|rebase-recreate|rebase-retry|retry|cancel|status)
  *   - `status` with no target → all workflows
  * Returns null for missing/ambiguous targets and for prose, so the message is
@@ -39,6 +83,9 @@ export function parseLobbyControl(text: string): LobbyControl | null {
   const trimmed = text.trim();
 
   if (/^submit(\s+to\s+invoker)?\s*[.!?]*$/i.test(trimmed)) return { kind: 'submit' };
+
+  const gatePolicyOp = parseGatePolicyOp(trimmed);
+  if (gatePolicyOp) return { kind: 'op', ...gatePolicyOp };
 
   const match = VERB_PATTERN.exec(trimmed);
   if (!match) return null;

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -747,7 +747,7 @@ export class SlackSurface implements Surface {
       await say({ text: 'Workflow operations are not available in this deployment.', thread_ts: threadTs });
       return;
     }
-    const op: WorkflowOp = { operation: ctrl.operation, target: ctrl.target };
+    const op = this.workflowOpFromLobbyControl(ctrl);
     // Destructive bulk mutations require explicit confirmation; status and single-workflow ops run now.
     if (ctrl.operation !== 'status' && 'all' in ctrl.target) {
       await this.stageConfirm(threadTs, channel, { kind: 'op', op }, `This will \`${ctrl.operation}\` ALL workflows.`, say);
@@ -804,8 +804,24 @@ export class SlackSurface implements Surface {
   }
 
   private describeOp(op: WorkflowOp): string {
+    if (op.operation === 'gate-policy') {
+      const updates = op.updates.map((u) => `${u.workflowId}/${u.taskId ?? '__merge__'} -> ${u.gatePolicy}`).join(', ');
+      return `gate-policy ${op.ownerTaskId ?? op.target.workflow}: ${updates}`;
+    }
     const target = 'all' in op.target ? 'ALL workflows' : `\`${op.target.workflow}\``;
     return `${op.operation} ${target}`;
+  }
+
+  private workflowOpFromLobbyControl(ctrl: Extract<LobbyControl, { kind: 'op' }>): WorkflowOp {
+    if (ctrl.operation === 'gate-policy') {
+      return {
+        operation: 'gate-policy',
+        target: ctrl.target,
+        ownerTaskId: ctrl.ownerTaskId,
+        updates: ctrl.updates,
+      };
+    }
+    return { operation: ctrl.operation, target: ctrl.target };
   }
 
   /** Submit the plan drafted in this thread, after an explicit, summarized confirmation. */
@@ -945,7 +961,7 @@ export class SlackSurface implements Surface {
       await respond({ text: 'Workflow operations are not available in this deployment.', response_type: 'ephemeral' });
       return;
     }
-    const op: WorkflowOp = { operation: ctrl.operation, target: ctrl.target };
+    const op = this.workflowOpFromLobbyControl(ctrl);
     if (ctrl.operation !== 'status' && 'all' in ctrl.target) {
       const key = `slash:${channel}:${command.user_id}:${Date.now()}`;
       this.pendingConfirms.set(key, { kind: 'op', op });

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -1046,7 +1046,7 @@ export class SlackSurface implements Surface {
       return;
     }
 
-    const ctrl = parseWorkflowControl(text);
+    const ctrl = parseWorkflowControl(text, mapping.workflowId);
     if (ctrl) {
       await this.dispatchWorkflowControl(mapping, ctrl, say, threadTs);
       return;
@@ -1083,6 +1083,18 @@ export class SlackSurface implements Surface {
   ): Promise<void> {
     const scoped = (task: string): string => `${mapping.workflowId}/${task}`;
     switch (ctrl.kind) {
+      case 'gate-policy':
+        if (!this.runWorkflowOp) {
+          await say({ text: 'Workflow operations are not available in this deployment.', thread_ts: threadTs });
+          return;
+        }
+        await this.runConfirmedOp({
+          operation: 'gate-policy',
+          target: ctrl.target,
+          ownerTaskId: ctrl.ownerTaskId,
+          updates: ctrl.updates,
+        }, threadTs, say);
+        return;
       case 'status':
         await this.onCommand?.({ type: 'get_status', workflowId: mapping.workflowId });
         await say({ text: `Fetching status for \`${mapping.workflowId}\`...`, thread_ts: threadTs });

--- a/packages/surfaces/src/slack/workflow-assistant.ts
+++ b/packages/surfaces/src/slack/workflow-assistant.ts
@@ -1,3 +1,6 @@
+import type { WorkflowGatePolicyOp } from '../surface.js';
+import { parseGatePolicyOp } from './lobby-control.js';
+
 // ── Context ──────────────────────────────────────────────────
 
 export interface WorkflowContext {
@@ -44,11 +47,15 @@ export function buildAssistantPrompt(question: string, ctx: WorkflowContext): st
 export type WorkflowControl =
   | { kind: 'status' }
   | { kind: 'approve' | 'reject' | 'retry'; task: string }
-  | { kind: 'input'; task: string; text: string };
+  | { kind: 'input'; task: string; text: string }
+  | ({ kind: 'gate-policy' } & WorkflowGatePolicyOp);
 
-export function parseWorkflowControl(text: string): WorkflowControl | null {
+export function parseWorkflowControl(text: string, workflowId?: string): WorkflowControl | null {
   const t = text.trim();
   if (/^status\b/i.test(t)) return { kind: 'status' };
+
+  const gatePolicyOp = parseGatePolicyOp(t, workflowId);
+  if (gatePolicyOp) return { kind: 'gate-policy', ...gatePolicyOp };
 
   const input = /^input\s+(\S+)\s*:\s*([\s\S]+)$/i.exec(t);
   if (input) return { kind: 'input', task: input[1], text: input[2].trim() };

--- a/scripts/repro/repro-coderabbit-pr2615-workflow-channel-gate-policy-routing.sh
+++ b/scripts/repro/repro-coderabbit-pr2615-workflow-channel-gate-policy-routing.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] CodeRabbit PR #2615: workflow-channel gate-policy commands route to workflow ops"
+if pnpm --filter @invoker/surfaces exec vitest run \
+  src/__tests__/slack-surface-workflows.test.ts \
+  -t "routes workflow-channel gate-policy commands to workflow ops"; then
+  echo "[repro] PASS: workflow-channel gate-policy command reached runWorkflowOp"
+else
+  echo "[repro] FAIL: workflow-channel gate-policy command did not reach runWorkflowOp"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds deterministic parser coverage and operational matching for Slack gate-policy phrasing.

Gate-policy requests now stay on the workflow operation path instead of falling into YAML planning.

<details>
<summary>Review metadata</summary>

Review Claim: Slack gate-policy phrasing stays on the operational routing path.

Review Lane: behavior

Review Unit: routing

Safety Invariant: This slice stays inside Slack surface parsing, matching, and direct tests.

Slice Rationale: Surface routing is reviewed separately before app-side mutation execution.

</details>

## Non-goals

- Execute gate-policy mutations in the app process.
- Change unrelated Slack workflow operations.
- Update documentation.

## Architecture

### Before

```mermaid
flowchart LR
    User["Slack user"] --> Surface["Slack surface"]
    Surface --> Planner["PlanConversation YAML mode"]
```

### After

```mermaid
flowchart LR
    User["Slack user"] --> Surface["Slack surface"]
    Surface --> Operation["Workflow operation path"]
```

## Test Plan

- [x] `bash scripts/repro/repro-slack-gate-policy-routing.sh`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <PR commit>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for `set gate-policy` commands in workflow and lobby controls.
  * Workflow assistant commands can now update gate policies with workflow/task targeting and policy values.
  * Slack responses now display gate-policy operations with clearer, update-by-update summaries.

* **Bug Fixes**
  * Improved validation so incomplete or malformed `set gate-policy` commands are ignored instead of being parsed.
  * Workflow-channel parsing is now scoped correctly, reducing misrouting of assistant commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->