### PR TITLE
[Fix Slack gate-policy routing](4) Add routing repro script

### DIFF
--- a/scripts/repro/repro-slack-gate-policy-routing.sh
+++ b/scripts/repro/repro-slack-gate-policy-routing.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+pnpm --filter @invoker/surfaces exec vitest run \
+  src/__tests__/lobby-control.test.ts \
+  src/__tests__/workflow-assistant.test.ts \
+  src/__tests__/slack-surface-workflows.test.ts
+
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/slack-gate-policy-op.test.ts


### PR DESCRIPTION
## Summary

Adds a reusable repro script for Slack gate-policy routing.

The script runs the focused Slack surface and app regression checks for this incident.

<details>
<summary>Review metadata</summary>

Review Claim: The Slack gate-policy bug has a canonical executable repro.

Review Lane: proof

Review Unit: proof

Safety Invariant: This slice adds only the repro script and does not change runtime behavior.

Slice Rationale: The proof artifact is isolated so reviewers can inspect the regression harness on its own.

</details>

## Non-goals

- Change production Slack behavior.
- Change app-side mutation behavior.
- Update documentation.

## Test Plan

- [x] `bash scripts/repro/repro-slack-gate-policy-routing.sh`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <PR commit>`
- Post-revert steps: None
- Data migration? No