### PR TITLE
[Execution Defaults](3) Honor configured task execution defaults

### DIFF
--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -54,6 +54,7 @@ vi.mock('../config.js', () => ({
     autoFixAgent: 'codex',
     autoApproveAIFixes: true,
   })),
+  resolveDefaultTaskExecutionSettings: vi.fn(() => ({ executionAgent: 'claude' })),
   resolveSecretsFilePath: vi.fn(() => '/tmp/secrets.env'),
 }));
 
@@ -127,7 +128,8 @@ describe('task-runner-wiring', () => {
     expect(config.dockerConfig).toEqual({ imageName: 'image', secretsFile: '/tmp/secrets.env' });
     expect(config.remoteTargetsProvider()).toEqual({ remote: { host: 'host' } });
     expect(config.executionPoolsProvider()).toEqual({ pool: { members: [] } });
-    expect(loadConfig).toHaveBeenCalledTimes(2);
+    expect(config.executionDefaultsProvider()).toEqual({ executionAgent: 'claude' });
+    expect(loadConfig).toHaveBeenCalledTimes(3);
 
     config.callbacks.onOutput('task-1', 'chunk');
     expect(taskRunnerConstructor.mock.calls[0]?.[0].callbacks.onOutput).toBe(config.callbacks.onOutput);

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -25,7 +25,7 @@ function makeDispatch(overrides: Record<string, unknown> = {}) {
       listWorkflows: () => [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
     },
     mutations: { approveTask },
-    agentRegistry: { listExecution: () => [] },
+    agentRegistry: { listExecutionHarnesses: () => [] },
     loadConfig: () => ({}),
     getStreamSequence: () => 7,
     refreshTaskGraph: vi.fn(async () => {}),
@@ -51,6 +51,16 @@ describe('buildWebInvokerDispatch', () => {
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'pending' }],
       streamSequence: 7,
     });
+  });
+
+  it('get-execution-harnesses returns harness metadata', async () => {
+    const harnesses = [
+      { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
+    ];
+    const { dispatch } = makeDispatch({
+      agentRegistry: { listExecutionHarnesses: () => harnesses },
+    });
+    expect(await dispatch('invoker:get-execution-harnesses', [])).toEqual(harnesses);
   });
 
   it('approve routes to the mutation facade', async () => {

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -63,6 +63,16 @@ describe('buildWebInvokerDispatch', () => {
     expect(await dispatch('invoker:get-execution-harnesses', [])).toEqual(harnesses);
   });
 
+  it('get-execution-defaults returns configured task execution defaults', async () => {
+    const { dispatch } = makeDispatch({
+      loadConfig: () => ({ defaultExecutionAgent: 'omp', defaultExecutionModel: 'chatgpt-5.4' } as any),
+    });
+    expect(await dispatch('invoker:get-execution-defaults', [])).toEqual({
+      executionAgent: 'omp',
+      executionModel: 'chatgpt-5.4',
+    });
+  });
+
   it('approve routes to the mutation facade', async () => {
     const { dispatch, approveTask } = makeDispatch();
     await dispatch('invoker:approve', ['wf/x']);

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -11,7 +11,7 @@ import {
   type ExecutorRegistry,
 } from '@invoker/execution-engine';
 import type { Logger } from '@invoker/contracts';
-import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from '../config.js';
+import { loadConfig, resolveDefaultTaskExecutionSettings, resolveSecretsFilePath, type InvokerConfig } from '../config.js';
 import { publishReviewGateCiFailedLifecycleEvent } from '../lifecycle-event-bridge.js';
 
 export type TaskHandleMap = Map<string, { handle: ExecutorHandle; executor: Executor }>;
@@ -90,6 +90,7 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
     },
     remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
     executionPoolsProvider: () => loadConfig().executionPools ?? {},
+    executionDefaultsProvider: () => resolveDefaultTaskExecutionSettings(loadConfig()),
     reviewGateCiFailurePublisher: {
       publish: (trigger) => {
         publishReviewGateCiFailedLifecycleEvent(trigger, {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -107,6 +107,7 @@ import {
   DEFAULT_SLACK_HARNESS_PRESETS,
   loadConfig,
   resolveConfigFileState,
+  resolveDefaultTaskExecutionSettings,
   resolveEmbeddedTerminalBackendConfig,
   type EmbeddedTerminalBackendConfig,
   type InvokerConfig,
@@ -4547,6 +4548,10 @@ function createEmbeddedTerminalBackendFromConfig(
 
     ipcMain.handle('invoker:get-execution-harnesses', () => {
       return agentRegistry.listExecutionHarnesses();
+    });
+
+    ipcMain.handle('invoker:get-execution-defaults', () => {
+      return resolveDefaultTaskExecutionSettings(loadConfig());
     });
 
     ipcMain.handle('invoker:get-runtime-status', () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -4545,8 +4545,8 @@ function createEmbeddedTerminalBackendFromConfig(
       return Object.keys(loadConfig().remoteTargets ?? {});
     });
 
-    ipcMain.handle('invoker:get-execution-agents', () => {
-      return agentRegistry.listExecution().map(a => a.name);
+    ipcMain.handle('invoker:get-execution-harnesses', () => {
+      return agentRegistry.listExecutionHarnesses();
     });
 
     ipcMain.handle('invoker:get-runtime-status', () => {

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -134,8 +134,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return Object.keys(deps.loadConfig().remoteTargets ?? {});
       case 'invoker:get-execution-pools':
         return Object.keys(deps.loadConfig().executionPools ?? {});
-      case 'invoker:get-execution-agents':
-        return agentRegistry.listExecution().map((a) => a.name);
+      case 'invoker:get-execution-harnesses':
+        return agentRegistry.listExecutionHarnesses();
       case 'invoker:get-system-diagnostics':
         return (
           deps.getSystemDiagnostics?.() ??

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -21,7 +21,7 @@ import type {
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
 import type { ExternalGatePolicyUpdate, Orchestrator } from '@invoker/workflow-core';
-import type { InvokerConfig } from '../config.js';
+import { resolveDefaultTaskExecutionSettings, type InvokerConfig } from '../config.js';
 import type { ApiMutationFacade } from '../api-server.js';
 import { buildReviewGateQueryResponse } from '../review-gate-query.js';
 import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
@@ -136,6 +136,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return Object.keys(deps.loadConfig().executionPools ?? {});
       case 'invoker:get-execution-harnesses':
         return agentRegistry.listExecutionHarnesses();
+      case 'invoker:get-execution-defaults':
+        return resolveDefaultTaskExecutionSettings(deps.loadConfig());
       case 'invoker:get-system-diagnostics':
         return (
           deps.getSystemDiagnostics?.() ??

--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -46,6 +46,7 @@ describe('registerBuiltinAgents', () => {
       expect.objectContaining({
         name: 'omp',
         supportedModels: expect.arrayContaining([
+          { id: 'chatgpt-5.4', label: 'ChatGPT 5.4' },
           { id: 'anthropic/claude-opus-4', label: 'Anthropic Claude Opus 4' },
           { id: 'openai/gpt-5', label: 'OpenAI GPT-5' },
         ]),

--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -106,7 +106,6 @@ describe('AgentRegistry', () => {
     expect(registry.getOrThrow('null')).toBe(codex);
     expect(registry.getOrThrow('undefined')).toBe(codex);
   });
-  });
 
   it('keeps explicit valid execution agent names working', () => {
     expect(registry.getOrThrow('codex')).toBe(codex);

--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -6,6 +6,7 @@ import type { ExecutionAgent } from '../agent.js';
 function makeExecutionAgent(name: string, opts?: {
   bundledSkillRoot?: string;
   bundledSkills?: readonly string[];
+  supportedModels?: readonly { id: string; label: string }[];
 }): ExecutionAgent {
   return {
     name,
@@ -15,6 +16,7 @@ function makeExecutionAgent(name: string, opts?: {
     stdinMode: 'pipe',
     ...(opts?.bundledSkillRoot !== undefined && { bundledSkillRoot: opts.bundledSkillRoot }),
     ...(opts?.bundledSkills !== undefined && { bundledSkills: opts.bundledSkills }),
+    ...(opts?.supportedModels !== undefined && { supportedModels: opts.supportedModels }),
   };
 }
 
@@ -23,6 +25,34 @@ describe('registerBuiltinAgents', () => {
     const names = registerBuiltinAgents().listExecution().map((agent) => agent.name);
     expect(names).toEqual(expect.arrayContaining(['claude', 'codex', 'omp']));
   });
+
+  it('exposes curated built-in model choices per harness', () => {
+    const harnesses = registerBuiltinAgents().listExecutionHarnesses();
+    expect(harnesses).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        name: 'claude',
+        supportedModels: expect.arrayContaining([
+          { id: 'sonnet', label: 'Claude Sonnet' },
+          { id: 'opus', label: 'Claude Opus' },
+        ]),
+      }),
+      expect.objectContaining({
+        name: 'codex',
+        supportedModels: expect.arrayContaining([
+          { id: 'gpt-5', label: 'GPT-5' },
+          { id: 'gpt-5-codex', label: 'GPT-5 Codex' },
+        ]),
+      }),
+      expect.objectContaining({
+        name: 'omp',
+        supportedModels: expect.arrayContaining([
+          { id: 'anthropic/claude-opus-4', label: 'Anthropic Claude Opus 4' },
+          { id: 'openai/gpt-5', label: 'OpenAI GPT-5' },
+        ]),
+      }),
+    ]));
+  });
+
 
   it('registers cursor, omp, and codex planning agents', () => {
     const registry = registerBuiltinAgents();
@@ -53,6 +83,20 @@ describe('AgentRegistry', () => {
     registry.registerExecution(codex);
   });
 
+  it('lists serializable harness metadata for the UI', () => {
+    registry = new AgentRegistry();
+    registry.registerExecution(makeExecutionAgent('claude', {
+      supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }],
+    }));
+
+    expect(registry.listExecutionHarnesses()).toEqual([
+      {
+        name: 'claude',
+        supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }],
+      },
+    ]);
+  });
+
   it('defaults nullish execution agent names to codex', () => {
     expect(registry.getOrThrow(undefined)).toBe(codex);
     expect(registry.getOrThrow(null)).toBe(codex);
@@ -60,6 +104,7 @@ describe('AgentRegistry', () => {
     expect(registry.getOrThrow('   ')).toBe(codex);
     expect(registry.getOrThrow('null')).toBe(codex);
     expect(registry.getOrThrow('undefined')).toBe(codex);
+  });
   });
 
   it('keeps explicit valid execution agent names working', () => {

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -181,6 +181,57 @@ describe('TaskRunner', () => {
 
     expect(closeReview).toHaveBeenCalledWith({ identifier: 'scalar-pr', cwd: '/tmp/review-workspace' });
   });
+  it('uses configured default execution settings when task overrides are absent', async () => {
+    let seenRequest: any;
+    let completeCallback: ((response: WorkResponse) => void) | undefined;
+    const executorImpl = {
+      type: 'worktree',
+      start: vi.fn().mockImplementation(async (request: any) => {
+        seenRequest = request;
+        return {
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/tmp/mock-worktree',
+          branch: `experiment/${request.actionId}-mock`,
+        };
+      }),
+      onComplete: vi.fn().mockImplementation((_handle: any, cb: any) => {
+        completeCallback = cb;
+        return () => {};
+      }),
+      onOutput: vi.fn().mockReturnValue(() => {}),
+      onHeartbeat: vi.fn().mockReturnValue(() => {}),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+    const runner = new TaskRunner({
+      orchestrator: { getTask: () => undefined, handleWorkerResponse: vi.fn() } as any,
+      persistence: { updateTask: vi.fn() } as any,
+      executorRegistry: { getDefault: () => executorImpl, get: () => executorImpl, getAll: () => [executorImpl] } as any,
+      executionDefaultsProvider: () => ({ executionAgent: 'omp', executionModel: 'chatgpt-5.4' }),
+      cwd: '/tmp',
+    });
+
+    const task = makeTask({
+      id: 'default-task',
+      status: 'running',
+      config: { prompt: 'Fix failing tests' },
+      execution: { generation: 2, selectedAttemptId: 'default-task-a1' },
+    });
+
+    const done = runner.executeTask(task);
+    await vi.waitFor(() => expect(seenRequest?.inputs).toMatchObject({ executionAgent: 'omp', executionModel: 'chatgpt-5.4' }));
+    completeCallback?.({
+      requestId: seenRequest.requestId,
+      actionId: task.id,
+      attemptId: seenRequest.attemptId,
+      executionGeneration: seenRequest.executionGeneration,
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    });
+    await done;
+  });
+
   it('sends attemptId and executionGeneration in work requests and preserves them in responses', async () => {
     const handleWorkerResponse = vi.fn();
     let seenRequest: any;

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -221,7 +221,8 @@ describe('TaskRunner', () => {
 
     const done = runner.executeTask(task);
     await vi.waitFor(() => expect(seenRequest?.inputs).toMatchObject({ executionAgent: 'omp', executionModel: 'chatgpt-5.4' }));
-    completeCallback?.({
+    await vi.waitFor(() => expect(completeCallback).toBeTypeOf('function'));
+    completeCallback({
       requestId: seenRequest.requestId,
       actionId: task.id,
       attemptId: seenRequest.attemptId,

--- a/packages/execution-engine/src/agent-registry.ts
+++ b/packages/execution-engine/src/agent-registry.ts
@@ -5,7 +5,7 @@
  * Executors look up agents by name (e.g. 'claude') at task execution time.
  */
 
-import { DEFAULT_EXECUTION_AGENT, type ExecutionAgent, type PlanningAgent } from './agent.js';
+import { DEFAULT_EXECUTION_AGENT, type ExecutionAgent, type ExecutionModelOption, type PlanningAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
 
 function normalizeExecutionAgentName(name: string | null | undefined): string | undefined {
@@ -77,6 +77,13 @@ export class AgentRegistry {
   listExecution(): ExecutionAgent[] {
     return [...this.executionAgents.values()];
   }
+  listExecutionHarnesses(): Array<{ name: string; supportedModels: ExecutionModelOption[] }> {
+    return this.listExecution().map((agent) => ({
+      name: agent.name,
+      supportedModels: [...(agent.supportedModels ?? [])],
+    }));
+  }
+
 
   listPlanning(): PlanningAgent[] {
     return [...this.planningAgents.values()];

--- a/packages/execution-engine/src/agent.ts
+++ b/packages/execution-engine/src/agent.ts
@@ -18,6 +18,11 @@ export interface AgentCommandSpec {
 export interface AgentCommandBuildOptions {
   executionModel?: string;
 }
+export interface ExecutionModelOption {
+  id: string;
+  label: string;
+}
+
 
 export const DEFAULT_EXECUTION_AGENT = 'codex';
 
@@ -40,6 +45,8 @@ export interface ExecutionAgent {
    * Each name corresponds to a subdirectory `invoker-{name}` under bundledSkillRoot.
    */
   readonly bundledSkills?: readonly string[];
+  /** Curated built-in model choices for this harness. Values must be CLI-compatible. */
+  readonly supportedModels?: readonly ExecutionModelOption[];
 
   buildCommand(fullPrompt: string, options?: AgentCommandBuildOptions): AgentCommandSpec;
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] };

--- a/packages/execution-engine/src/agents/claude-execution-agent.ts
+++ b/packages/execution-engine/src/agents/claude-execution-agent.ts
@@ -8,7 +8,7 @@
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions } from '../agent.js';
+import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions, ExecutionModelOption } from '../agent.js';
 
 export interface ClaudeExecutionAgentConfig {
   /** Command to invoke the Claude CLI. Default: 'claude'. */
@@ -23,12 +23,19 @@ export interface ClaudeExecutionAgentConfig {
   apiKey?: string;
 }
 
+const CLAUDE_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
+  { id: 'sonnet', label: 'Claude Sonnet' },
+  { id: 'opus', label: 'Claude Opus' },
+  { id: 'haiku', label: 'Claude Haiku' },
+];
+
 export class ClaudeExecutionAgent implements ExecutionAgent {
   readonly name = 'claude';
   readonly stdinMode = 'ignore' as const;
   readonly linuxTerminalTail = 'exec_bash' as const;
   readonly bundledSkillRoot: string;
   readonly bundledSkills = ['make-pr'] as const;
+  readonly supportedModels = CLAUDE_SUPPORTED_MODELS;
 
   private readonly command: string;
   private readonly fixCommand: string;

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -12,7 +12,7 @@
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions } from '../agent.js';
+import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions, ExecutionModelOption } from '../agent.js';
 
 export interface CodexExecutionAgentConfig {
   /** Command to invoke the Codex CLI. Default: 'codex'. */
@@ -29,12 +29,21 @@ export interface CodexExecutionAgentConfig {
   bypassApprovalsAndSandbox?: boolean;
 }
 
+const CODEX_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
+  { id: 'gpt-5', label: 'GPT-5' },
+  { id: 'gpt-5-codex', label: 'GPT-5 Codex' },
+  { id: 'gpt-5-mini', label: 'GPT-5 Mini' },
+  { id: 'o3', label: 'o3' },
+  { id: 'o4-mini', label: 'o4-mini' },
+];
+
 export class CodexExecutionAgent implements ExecutionAgent {
   readonly name = 'codex';
   readonly stdinMode = 'ignore' as const;
   readonly linuxTerminalTail = 'exec_bash' as const;
   readonly bundledSkillRoot: string;
   readonly bundledSkills = ['make-pr'] as const;
+  readonly supportedModels = CODEX_SUPPORTED_MODELS;
 
   private readonly command: string;
   private readonly fullAuto: boolean;

--- a/packages/execution-engine/src/agents/omp-execution-agent.ts
+++ b/packages/execution-engine/src/agents/omp-execution-agent.ts
@@ -10,6 +10,7 @@ export interface OmpExecutionAgentConfig {
 }
 
 const OMP_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
+  { id: 'chatgpt-5.4', label: 'ChatGPT 5.4' },
   { id: 'anthropic/claude-sonnet-4', label: 'Anthropic Claude Sonnet 4' },
   { id: 'anthropic/claude-opus-4', label: 'Anthropic Claude Opus 4' },
   { id: 'openai/gpt-5', label: 'OpenAI GPT-5' },

--- a/packages/execution-engine/src/agents/omp-execution-agent.ts
+++ b/packages/execution-engine/src/agents/omp-execution-agent.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { AgentCommandBuildOptions, AgentCommandSpec, ExecutionAgent } from '../agent.js';
+import type { AgentCommandBuildOptions, AgentCommandSpec, ExecutionAgent, ExecutionModelOption } from '../agent.js';
 
 export interface OmpExecutionAgentConfig {
   command?: string;
@@ -9,12 +9,21 @@ export interface OmpExecutionAgentConfig {
   containerHomePath?: string;
 }
 
+const OMP_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
+  { id: 'anthropic/claude-sonnet-4', label: 'Anthropic Claude Sonnet 4' },
+  { id: 'anthropic/claude-opus-4', label: 'Anthropic Claude Opus 4' },
+  { id: 'openai/gpt-5', label: 'OpenAI GPT-5' },
+  { id: 'openai/gpt-5-codex', label: 'OpenAI GPT-5 Codex' },
+  { id: 'openai/o3', label: 'OpenAI o3' },
+];
+
 export class OmpExecutionAgent implements ExecutionAgent {
   readonly name = 'omp';
   readonly stdinMode = 'ignore' as const;
   readonly linuxTerminalTail = 'exec_bash' as const;
   readonly bundledSkillRoot: string;
   readonly bundledSkills = ['make-pr'] as const;
+  readonly supportedModels = OMP_SUPPORTED_MODELS;
 
   private readonly command: string;
   private readonly configDir: string;

--- a/packages/execution-engine/src/task-runner-dispatch.ts
+++ b/packages/execution-engine/src/task-runner-dispatch.ts
@@ -15,7 +15,6 @@ import type { WorkRequest } from '@invoker/contracts';
 
 import type { Executor, ExecutorHandle } from './executor.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
-import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import {
   PRE_START_HEARTBEAT_INTERVAL_MS,
   getExecutorStartTimeoutMs,
@@ -39,7 +38,7 @@ export async function dispatchExecutor(
   const { task, attemptId, request, bench, dispatchOpts } = args;
   const startGeneration = task.execution.generation ?? 0;
   const actionType = host.determineActionType(task);
-  const executionAgent = task.config.executionAgent?.trim() || DEFAULT_EXECUTION_AGENT;
+  const executionAgent = task.config.executionAgent?.trim() || host.getDefaultExecutionAgent();
 
   const startT0 = Date.now();
   const attemptedPoolMemberKeys = new Set<string>();

--- a/packages/execution-engine/src/task-runner-phase-host.ts
+++ b/packages/execution-engine/src/task-runner-phase-host.ts
@@ -23,6 +23,8 @@ export type TaskRunnerPhaseHost = Pick<
   | 'pendingPoolSelections'
   | 'activeExecutions'
   | 'getExecutionPools'
+  | 'getDefaultExecutionAgent'
+  | 'getDefaultExecutionModel'
   // Prepare-phase helpers
   | 'buildUpstreamContext'
   | 'collectUpstreamBranches'

--- a/packages/execution-engine/src/task-runner-prepare.ts
+++ b/packages/execution-engine/src/task-runner-prepare.ts
@@ -15,7 +15,6 @@ import type { WorkRequest } from '@invoker/contracts';
 
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import { formatLifecycleTag, extractAttemptSuffix } from './branch-utils.js';
-import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import type { TaskRunnerPhaseHost } from './task-runner-phase-host.js';
 
 export async function buildWorkRequest(
@@ -123,7 +122,8 @@ export async function buildWorkRequest(
   };
 
   const actionType = host.determineActionType(task);
-  const executionAgent = task.config.executionAgent?.trim() || DEFAULT_EXECUTION_AGENT;
+  const executionAgent = task.config.executionAgent?.trim() || host.getDefaultExecutionAgent();
+  const executionModel = task.config.executionModel?.trim() || host.getDefaultExecutionModel();
   const request: WorkRequest = {
     requestId: randomUUID(),
     actionId: task.id,
@@ -135,6 +135,7 @@ export async function buildWorkRequest(
       command: task.config.command,
       prompt: task.config.prompt,
       executionAgent,
+      executionModel,
       repoUrl,
       branchRepoUrl,
       featureBranch: task.config.featureBranch,

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -279,6 +279,10 @@ export interface TaskRunnerConfig {
     selectionStrategy?: 'roundRobin' | 'leastLoaded';
     maxConcurrentTasksPerMember?: number;
   }>;
+  executionDefaultsProvider?: () => {
+    executionAgent?: string;
+    executionModel?: string;
+  };
   /** Docker execution environment configuration from .invoker.json. */
   dockerConfig?: {
     imageName?: string;
@@ -306,6 +310,7 @@ export class TaskRunner {
   private reviewGateCiFailureInFlight = new Set<string>();
   private getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   /** @internal */ getExecutionPools: () => Record<string, ExecutionPoolConfig>;
+  private getExecutionDefaults: () => { executionAgent?: string; executionModel?: string };
   private dockerConfig: { imageName?: string; secretsFile?: string };
   private executionAgentRegistry?: AgentRegistry;
   /** @internal */ logger: Logger;
@@ -326,6 +331,16 @@ export class TaskRunner {
   /** Config default branch (e.g. master) for workflows without baseBranch. */
   getDefaultBranchHint(): string | undefined {
     return this.defaultBranch;
+  }
+
+  /** @internal */ getDefaultExecutionAgent(): string {
+    const configured = this.getExecutionDefaults().executionAgent?.trim();
+    return configured && configured.length > 0 ? configured : DEFAULT_EXECUTION_AGENT;
+  }
+
+  /** @internal */ getDefaultExecutionModel(): string | undefined {
+    const configured = this.getExecutionDefaults().executionModel?.trim();
+    return configured && configured.length > 0 ? configured : undefined;
   }
 
   /**
@@ -409,6 +424,7 @@ export class TaskRunner {
     this.reviewGateCiFailurePublisher = config.reviewGateCiFailurePublisher;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
     this.getExecutionPools = config.executionPoolsProvider ?? (() => ({}));
+    this.getExecutionDefaults = config.executionDefaultsProvider ?? (() => ({}));
     this.dockerConfig = config.dockerConfig ?? {};
     this.executionAgentRegistry = config.executionAgentRegistry;
     this.logger = config.logger ?? NOOP_LOGGER;
@@ -2382,7 +2398,7 @@ export class TaskRunner {
         .filter((agent): agent is string => Boolean(agent)),
     )];
     if (distinctAgents.length === 0) {
-      return DEFAULT_EXECUTION_AGENT;
+      return this.getDefaultExecutionAgent();
     }
     if (distinctAgents.length > 1) {
       console.warn(


### PR DESCRIPTION
## Summary

Invoker had no configurable task execution defaults. Prompt-backed tasks without overrides always fell back to Claude, and the runtime never surfaced a default model.

This slice adds `defaultExecutionAgent` and `defaultExecutionModel`, returns them from the owner/web read path, and makes task execution use them whenever a task leaves harness or model unset.

The built-in OMP menu now includes `chatgpt-5.4`, and the config examples document the new keys.

<details>
<summary>Review metadata</summary>

Review Claim: Configured default harness and model settings now flow into task execution when a task does not override them.

Review Lane: behavior

Review Unit: routing

Safety Invariant: This slice only changes config parsing, owner reads, runtime fallback selection, and docs. The next slice only changes the visible task-settings controls.

Slice Rationale: The effective defaults need to exist before the visible controls can show them.

</details>

## Non-goals

- No new task-settings visuals yet.
- No change to auto-fix agent selection.
- No per-harness validation of config defaults.

## Architecture

### Before

```mermaid
graph TD
    A["task with no executionAgent/executionModel override"] --> B["task runner falls back to Claude only"]
    B --> C["no owner read returns configured defaults"]
```

### After

```mermaid
graph TD
    A["config.json defaultExecutionAgent/defaultExecutionModel"] --> B["resolveDefaultTaskExecutionSettings()"]
    B --> C["owner reads return execution defaults"]
    B --> D["TaskRunner prepare/dispatch fills missing executionAgent/executionModel"]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts src/__tests__/task-runner-wiring.test.ts src/__tests__/web-invoker-dispatch.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts src/__tests__/agent-registry.test.ts`

## Visual Proof

No visible change in this slice. It adds config-backed runtime defaults and owner reads that the next slice consumes.

![Before configured execution defaults UI](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-69b220/default-exec-settings.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 59393f937`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added execution harness discovery in the app, including visible supported model options for built-in and registered agents.
  * Added default execution agent/model information to the web and app interfaces.

* **Bug Fixes**
  * Tasks now use configured execution defaults when no task-specific agent or model is set.
  * Improved fallback behavior so default agent selection is more consistent during task setup and dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->