### PR TITLE
[Execution Defaults](5) Use harness model dropdowns in task settings

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,7 +12,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
 import yaml from 'js-yaml';
 import type { ActionGraphNode, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor } from '@invoker/contracts';
-import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
+import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, ExecutionHarnessOption, WorkflowMeta, WorkflowStatus } from './types.js';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
 import { useActionGraphSnapshot } from './hooks/useActionGraphSnapshot.js';
@@ -434,7 +434,7 @@ export function App() {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const [remoteTargets, setRemoteTargets] = useState<string[]>([]);
   const [executionPools, setExecutionPools] = useState<string[]>([]);
-  const [executionAgents, setExecutionAgents] = useState<string[]>([]);
+  const [executionHarnesses, setExecutionHarnesses] = useState<ExecutionHarnessOption[]>([]);
   const [statusFilters, setStatusFilters] = useState<Set<WorkflowStatus>>(new Set());
   const [systemDiagnostics, setSystemDiagnostics] = useState<SystemDiagnostics | null>(null);
   const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatus | null>(null);
@@ -521,7 +521,7 @@ export function App() {
   useEffect(() => {
     window.invoker?.getRemoteTargets?.().then(setRemoteTargets).catch(() => {});
     window.invoker?.getExecutionPools?.().then(setExecutionPools).catch(() => {});
-    window.invoker?.getExecutionAgents?.().then(setExecutionAgents).catch(() => {});
+    window.invoker?.getExecutionHarnesses?.().then(setExecutionHarnesses).catch(() => {});
     window.invoker?.getRuntimeStatus?.().then(setRuntimeStatus).catch(() => {});
     refreshSystemDiagnostics();
   }, [refreshSystemDiagnostics]);
@@ -2172,7 +2172,7 @@ export function App() {
               reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
               remoteTargets={remoteTargets}
               executionPools={executionPools}
-              executionAgents={executionAgents}
+              executionHarnesses={executionHarnesses}
               collapsed={inspectorCollapsed}
               advancedExpanded={advancedMetadataExpanded}
               actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,7 +12,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
 import yaml from 'js-yaml';
 import type { ActionGraphNode, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor } from '@invoker/contracts';
-import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, ExecutionHarnessOption, WorkflowMeta, WorkflowStatus } from './types.js';
+import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, ExecutionDefaults, ExecutionHarnessOption, WorkflowMeta, WorkflowStatus } from './types.js';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
 import { useActionGraphSnapshot } from './hooks/useActionGraphSnapshot.js';
@@ -435,6 +435,7 @@ export function App() {
   const [remoteTargets, setRemoteTargets] = useState<string[]>([]);
   const [executionPools, setExecutionPools] = useState<string[]>([]);
   const [executionHarnesses, setExecutionHarnesses] = useState<ExecutionHarnessOption[]>([]);
+  const [executionDefaults, setExecutionDefaults] = useState<ExecutionDefaults>({ executionAgent: 'claude' });
   const [statusFilters, setStatusFilters] = useState<Set<WorkflowStatus>>(new Set());
   const [systemDiagnostics, setSystemDiagnostics] = useState<SystemDiagnostics | null>(null);
   const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatus | null>(null);
@@ -522,6 +523,7 @@ export function App() {
     window.invoker?.getRemoteTargets?.().then(setRemoteTargets).catch(() => {});
     window.invoker?.getExecutionPools?.().then(setExecutionPools).catch(() => {});
     window.invoker?.getExecutionHarnesses?.().then(setExecutionHarnesses).catch(() => {});
+    window.invoker?.getExecutionDefaults?.().then(setExecutionDefaults).catch(() => {});
     window.invoker?.getRuntimeStatus?.().then(setRuntimeStatus).catch(() => {});
     refreshSystemDiagnostics();
   }, [refreshSystemDiagnostics]);
@@ -2173,6 +2175,7 @@ export function App() {
               remoteTargets={remoteTargets}
               executionPools={executionPools}
               executionHarnesses={executionHarnesses}
+              executionDefaults={executionDefaults}
               collapsed={inspectorCollapsed}
               advancedExpanded={advancedMetadataExpanded}
               actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -131,7 +131,9 @@ export function createMockInvoker(
     getExecutionHarnesses: vi.fn(async () => [
       { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
       { name: 'codex', supportedModels: [{ id: 'gpt-5', label: 'GPT-5' }] },
+      { name: 'omp', supportedModels: [{ id: 'chatgpt-5.4', label: 'ChatGPT 5.4' }] },
     ]),
+    getExecutionDefaults: vi.fn(async () => ({ executionAgent: 'omp', executionModel: 'chatgpt-5.4' })),
     getRuntimeStatus: vi.fn(async () => runtimeStatus),
     getSystemDiagnostics: vi.fn(async () => ({
       platform: 'linux',

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -128,7 +128,10 @@ export function createMockInvoker(
     setTaskExternalGatePolicies: vi.fn(async () => accepted('invoker:set-task-external-gate-policies')),
     getRemoteTargets: vi.fn(async () => []),
     getExecutionPools: vi.fn(async () => ['mixed-local-ssh', 'pnpm-ssh']),
-    getExecutionAgents: vi.fn(async () => ['claude', 'codex']),
+    getExecutionHarnesses: vi.fn(async () => [
+      { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
+      { name: 'codex', supportedModels: [{ id: 'gpt-5', label: 'GPT-5' }] },
+    ]),
     getRuntimeStatus: vi.fn(async () => runtimeStatus),
     getSystemDiagnostics: vi.fn(async () => ({
       platform: 'linux',

--- a/packages/ui/src/__tests__/task-panel-double-click.test.tsx
+++ b/packages/ui/src/__tests__/task-panel-double-click.test.tsx
@@ -826,15 +826,19 @@ describe('TaskPanel double-click editing', () => {
     });
   });
 
-  describe('Execution agent selector', () => {
+  describe('Execution harness selector', () => {
     const mockOnEditAgent = vi.fn();
+    const executionHarnesses = [
+      { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
+      { name: 'codex', supportedModels: [{ id: 'gpt-5', label: 'GPT-5' }, { id: 'o3', label: 'o3' }] },
+    ];
 
-    it('renders agent selector for prompt tasks when onEditAgent + executionAgents provided', () => {
+    it('renders harness selector for prompt tasks when onEditAgent + executionHarnesses provided', () => {
       const task = makeTask({ prompt: 'Write a test', status: 'pending' });
       render(
         <TaskPanel
           task={task}
-          executionAgents={['claude', 'codex']}
+          executionHarnesses={executionHarnesses}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -846,12 +850,12 @@ describe('TaskPanel double-click editing', () => {
       expect(screen.getByTestId('execution-agent-select')).toBeInTheDocument();
     });
 
-    it('does not render agent selector for command-only tasks', () => {
+    it('does not render harness selector for command-only tasks', () => {
       const task = makeTask({ command: 'echo test', status: 'pending' });
       render(
         <TaskPanel
           task={task}
-          executionAgents={['claude', 'codex']}
+          executionHarnesses={executionHarnesses}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -863,12 +867,12 @@ describe('TaskPanel double-click editing', () => {
       expect(screen.queryByTestId('execution-agent-select')).not.toBeInTheDocument();
     });
 
-    it('populates options from executionAgents prop with capitalized labels', () => {
+    it('populates options from executionHarnesses prop with capitalized labels', () => {
       const task = makeTask({ prompt: 'Write a test', status: 'pending' });
       render(
         <TaskPanel
           task={task}
-          executionAgents={['claude', 'codex']}
+          executionHarnesses={executionHarnesses}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -889,7 +893,7 @@ describe('TaskPanel double-click editing', () => {
       render(
         <TaskPanel
           task={task}
-          executionAgents={['claude', 'codex']}
+          executionHarnesses={executionHarnesses}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -908,7 +912,7 @@ describe('TaskPanel double-click editing', () => {
       render(
         <TaskPanel
           task={task}
-          executionAgents={['claude', 'codex']}
+          executionHarnesses={executionHarnesses}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -917,8 +921,7 @@ describe('TaskPanel double-click editing', () => {
         />,
       );
 
-      const select = screen.getByTestId('execution-agent-select');
-      expect(select).toBeDisabled();
+      expect(screen.getByTestId('execution-agent-select')).toBeDisabled();
     });
 
     it('defaults to claude when executionAgent config is unset', () => {
@@ -926,7 +929,7 @@ describe('TaskPanel double-click editing', () => {
       render(
         <TaskPanel
           task={task}
-          executionAgents={['claude', 'codex']}
+          executionHarnesses={executionHarnesses}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -935,11 +938,10 @@ describe('TaskPanel double-click editing', () => {
         />,
       );
 
-      const select = screen.getByTestId('execution-agent-select') as HTMLSelectElement;
-      expect(select.value).toBe('claude');
+      expect(screen.getByTestId('execution-agent-select')).toHaveValue('claude');
     });
 
-    it('selects current agent when executionAgent is set', () => {
+    it('selects current harness when executionAgent is set', () => {
       const task = {
         ...makeTask({ prompt: 'Write a test', status: 'pending' }),
         config: { prompt: 'Write a test', executionAgent: 'codex' },
@@ -947,7 +949,7 @@ describe('TaskPanel double-click editing', () => {
       render(
         <TaskPanel
           task={task}
-          executionAgents={['claude', 'codex']}
+          executionHarnesses={executionHarnesses}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -956,8 +958,7 @@ describe('TaskPanel double-click editing', () => {
         />,
       );
 
-      const select = screen.getByTestId('execution-agent-select') as HTMLSelectElement;
-      expect(select.value).toBe('codex');
+      expect(screen.getByTestId('execution-agent-select')).toHaveValue('codex');
     });
 
     it('fallback badge shows capitalized harness name when onEditAgent not provided', () => {
@@ -968,12 +969,11 @@ describe('TaskPanel double-click editing', () => {
       render(
         <TaskPanel
           task={task}
-          executionAgents={['claude', 'codex']}
+          executionHarnesses={executionHarnesses}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
           onSelectExperiment={mockOnSelectExperiment}
-          // no onEditAgent
         />,
       );
 
@@ -990,7 +990,6 @@ describe('TaskPanel double-click editing', () => {
           onApprove={mockOnApprove}
           onReject={mockOnReject}
           onSelectExperiment={mockOnSelectExperiment}
-          // no onEditAgent
         />,
       );
 
@@ -998,12 +997,61 @@ describe('TaskPanel double-click editing', () => {
       expect(screen.getByText('Claude Harness')).toBeInTheDocument();
     });
 
-    it('edits AI model on blur', () => {
-      const mockOnEditModel = vi.fn();
-      const task = makeTask({ prompt: 'Write a test', status: 'pending' });
+    it('renders harness-specific AI model choices', () => {
+      const task = {
+        ...makeTask({ prompt: 'Write a test', status: 'pending' }),
+        config: { prompt: 'Write a test', executionAgent: 'codex', executionModel: 'gpt-5' },
+      } as TaskState;
       render(
         <TaskPanel
           task={task}
+          executionHarnesses={executionHarnesses}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditModel={vi.fn()}
+        />,
+      );
+
+      const select = screen.getByTestId('execution-model-select');
+      const options = select.querySelectorAll('option');
+      expect(options).toHaveLength(3);
+      expect(options[0]).toHaveTextContent('Default');
+      expect(options[1]).toHaveTextContent('GPT-5');
+      expect(options[2]).toHaveTextContent('o3');
+    });
+
+    it('keeps a custom current model in the dropdown', () => {
+      const task = {
+        ...makeTask({ prompt: 'Write a test', status: 'pending' }),
+        config: { prompt: 'Write a test', executionAgent: 'codex', executionModel: 'gpt-5.2-preview' },
+      } as TaskState;
+      render(
+        <TaskPanel
+          task={task}
+          executionHarnesses={executionHarnesses}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditModel={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByRole('option', { name: 'gpt-5.2-preview' })).toBeInTheDocument();
+    });
+
+    it('edits AI model on change', () => {
+      const mockOnEditModel = vi.fn();
+      const task = {
+        ...makeTask({ prompt: 'Write a test', status: 'pending' }),
+        config: { prompt: 'Write a test', executionAgent: 'codex' },
+      } as TaskState;
+      render(
+        <TaskPanel
+          task={task}
+          executionHarnesses={executionHarnesses}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -1012,19 +1060,16 @@ describe('TaskPanel double-click editing', () => {
         />,
       );
 
-      const input = screen.getByTestId('execution-model-input');
-      fireEvent.change(input, { target: { value: 'openai/gpt-5.2' } });
-      fireEvent.blur(input);
-
-      expect(mockOnEditModel).toHaveBeenCalledWith('test-task-1', 'openai/gpt-5.2');
+      fireEvent.change(screen.getByTestId('execution-model-select'), { target: { value: 'o3' } });
+      expect(mockOnEditModel).toHaveBeenCalledWith('test-task-1', 'o3');
     });
 
-    it('renders empty selector gracefully when executionAgents is empty', () => {
+    it('renders the current harness gracefully when registry is empty', () => {
       const task = makeTask({ prompt: 'Write a test', status: 'pending' });
       render(
         <TaskPanel
           task={task}
-          executionAgents={[]}
+          executionHarnesses={[]}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -1035,7 +1080,8 @@ describe('TaskPanel double-click editing', () => {
 
       const select = screen.getByTestId('execution-agent-select');
       const options = select.querySelectorAll('option');
-      expect(options).toHaveLength(0);
+      expect(options).toHaveLength(1);
+      expect(select).toHaveValue('claude');
     });
   });
 

--- a/packages/ui/src/__tests__/task-panel-double-click.test.tsx
+++ b/packages/ui/src/__tests__/task-panel-double-click.test.tsx
@@ -831,7 +831,9 @@ describe('TaskPanel double-click editing', () => {
     const executionHarnesses = [
       { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
       { name: 'codex', supportedModels: [{ id: 'gpt-5', label: 'GPT-5' }, { id: 'o3', label: 'o3' }] },
+      { name: 'omp', supportedModels: [{ id: 'chatgpt-5.4', label: 'ChatGPT 5.4' }] },
     ];
+    const executionDefaults = { executionAgent: 'omp', executionModel: 'chatgpt-5.4' };
 
     it('renders harness selector for prompt tasks when onEditAgent + executionHarnesses provided', () => {
       const task = makeTask({ prompt: 'Write a test', status: 'pending' });
@@ -839,6 +841,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={executionHarnesses}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -856,6 +859,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={executionHarnesses}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -873,6 +877,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={executionHarnesses}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -883,9 +888,10 @@ describe('TaskPanel double-click editing', () => {
 
       const select = screen.getByTestId('execution-agent-select');
       const options = select.querySelectorAll('option');
-      expect(options).toHaveLength(2);
+      expect(options).toHaveLength(3);
       expect(options[0]).toHaveTextContent('Claude');
       expect(options[1]).toHaveTextContent('Codex');
+      expect(options[2]).toHaveTextContent('OMP');
     });
 
     it('calls onEditAgent with selected value on change', () => {
@@ -894,6 +900,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={executionHarnesses}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -913,6 +920,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={executionHarnesses}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -930,6 +938,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={executionHarnesses}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -938,7 +947,7 @@ describe('TaskPanel double-click editing', () => {
         />,
       );
 
-      expect(screen.getByTestId('execution-agent-select')).toHaveValue('claude');
+      expect(screen.getByTestId('execution-agent-select')).toHaveValue('omp');
     });
 
     it('selects current harness when executionAgent is set', () => {
@@ -950,6 +959,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={executionHarnesses}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -970,6 +980,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={executionHarnesses}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -986,6 +997,7 @@ describe('TaskPanel double-click editing', () => {
       render(
         <TaskPanel
           task={task}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -994,7 +1006,7 @@ describe('TaskPanel double-click editing', () => {
       );
 
       expect(screen.queryByTestId('execution-agent-select')).not.toBeInTheDocument();
-      expect(screen.getByText('Claude Harness')).toBeInTheDocument();
+      expect(screen.getByText('OMP Harness')).toBeInTheDocument();
     });
 
     it('renders harness-specific AI model choices', () => {
@@ -1006,6 +1018,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={executionHarnesses}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -1017,7 +1030,7 @@ describe('TaskPanel double-click editing', () => {
       const select = screen.getByTestId('execution-model-select');
       const options = select.querySelectorAll('option');
       expect(options).toHaveLength(3);
-      expect(options[0]).toHaveTextContent('Default');
+      expect(options[0]).toHaveTextContent('Default (chatgpt-5.4)');
       expect(options[1]).toHaveTextContent('GPT-5');
       expect(options[2]).toHaveTextContent('o3');
     });
@@ -1031,6 +1044,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={executionHarnesses}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -1052,6 +1066,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={executionHarnesses}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -1070,6 +1085,7 @@ describe('TaskPanel double-click editing', () => {
         <TaskPanel
           task={task}
           executionHarnesses={[]}
+          executionDefaults={executionDefaults}
           onProvideInput={mockOnProvideInput}
           onApprove={mockOnApprove}
           onReject={mockOnReject}
@@ -1081,7 +1097,7 @@ describe('TaskPanel double-click editing', () => {
       const select = screen.getByTestId('execution-agent-select');
       const options = select.querySelectorAll('option');
       expect(options).toHaveLength(1);
-      expect(select).toHaveValue('claude');
+      expect(select).toHaveValue('omp');
     });
   });
 

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -396,7 +396,7 @@ describe('WorkflowInspector', () => {
     const { rerender } = render(
       <WorkflowInspector
         workflow={workflow}
-        task={makeTask()}
+        task={makeTask({ config: { workflowId: 'wf-1', prompt: 'Fix failing tests' } as TaskState['config'] })}
         collapsed={true}
         advancedExpanded={false}
         onToggleCollapsed={() => {}}
@@ -408,7 +408,7 @@ describe('WorkflowInspector', () => {
     rerender(
       <WorkflowInspector
         workflow={workflow}
-        task={makeTask()}
+        task={makeTask({ config: { workflowId: 'wf-1', prompt: 'Fix failing tests' } as TaskState['config'] })}
         collapsed={false}
         advancedExpanded={false}
         onToggleCollapsed={() => {}}
@@ -505,11 +505,13 @@ describe('WorkflowInspector', () => {
     render(
       <WorkflowInspector
         workflow={workflow}
-        task={makeTask()}
+        task={makeTask({ config: { workflowId: 'wf-1', prompt: 'Fix failing tests' } as TaskState['config'] })}
         executionHarnesses={[
           { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
           { name: 'codex', supportedModels: [{ id: 'gpt-5', label: 'GPT-5' }] },
+          { name: 'omp', supportedModels: [{ id: 'chatgpt-5.4', label: 'ChatGPT 5.4' }] },
         ]}
+        executionDefaults={{ executionAgent: 'omp', executionModel: 'chatgpt-5.4' }}
         collapsed={false}
         advancedExpanded={false}
         onEditAgent={onEditAgent}
@@ -519,6 +521,7 @@ describe('WorkflowInspector', () => {
     );
 
     expect(screen.getByText('AI Harness')).toBeInTheDocument();
+    expect(screen.getByTestId('execution-agent-select')).toHaveValue('omp');
     fireEvent.change(screen.getByTestId('execution-agent-select'), { target: { value: 'codex' } });
     expect(onEditAgent).toHaveBeenCalledWith('task-1', 'codex');
   });
@@ -533,6 +536,7 @@ describe('WorkflowInspector', () => {
           { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
           { name: 'codex', supportedModels: [{ id: 'gpt-5', label: 'GPT-5' }, { id: 'o3', label: 'o3' }] },
         ]}
+        executionDefaults={{ executionAgent: 'omp', executionModel: 'chatgpt-5.4' }}
         collapsed={false}
         advancedExpanded={false}
         onEditModel={onEditModel}
@@ -544,7 +548,7 @@ describe('WorkflowInspector', () => {
     const select = screen.getByTestId('execution-model-select');
     const options = select.querySelectorAll('option');
     expect(options).toHaveLength(3);
-    expect(options[0]).toHaveTextContent('Default');
+    expect(options[0]).toHaveTextContent('Default (chatgpt-5.4)');
     expect(options[1]).toHaveTextContent('GPT-5');
     expect(options[2]).toHaveTextContent('o3');
 
@@ -560,6 +564,7 @@ describe('WorkflowInspector', () => {
         executionHarnesses={[
           { name: 'codex', supportedModels: [{ id: 'gpt-5', label: 'GPT-5' }] },
         ]}
+        executionDefaults={{ executionAgent: 'omp', executionModel: 'chatgpt-5.4' }}
         collapsed={false}
         advancedExpanded={false}
         onEditModel={() => {}}

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -506,7 +506,10 @@ describe('WorkflowInspector', () => {
       <WorkflowInspector
         workflow={workflow}
         task={makeTask()}
-        executionAgents={['claude', 'codex']}
+        executionHarnesses={[
+          { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
+          { name: 'codex', supportedModels: [{ id: 'gpt-5', label: 'GPT-5' }] },
+        ]}
         collapsed={false}
         advancedExpanded={false}
         onEditAgent={onEditAgent}
@@ -516,16 +519,20 @@ describe('WorkflowInspector', () => {
     );
 
     expect(screen.getByText('AI Harness')).toBeInTheDocument();
-    fireEvent.change(screen.getByTestId('execution-agent-select'), { target: { value: 'claude' } });
-    expect(onEditAgent).toHaveBeenCalledWith('task-1', 'claude');
+    fireEvent.change(screen.getByTestId('execution-agent-select'), { target: { value: 'codex' } });
+    expect(onEditAgent).toHaveBeenCalledWith('task-1', 'codex');
   });
 
-  it('edits AI model and clears blank overrides', () => {
+  it('renders harness-specific AI model choices and clears to default', () => {
     const onEditModel = vi.fn();
     render(
       <WorkflowInspector
         workflow={workflow}
-        task={makeTask({ config: { workflowId: 'wf-1', prompt: 'Fix failing tests', executionModel: 'openai/gpt-5' } })}
+        task={makeTask({ config: { workflowId: 'wf-1', prompt: 'Fix failing tests', executionAgent: 'codex', executionModel: 'gpt-5' } })}
+        executionHarnesses={[
+          { name: 'claude', supportedModels: [{ id: 'sonnet', label: 'Claude Sonnet' }] },
+          { name: 'codex', supportedModels: [{ id: 'gpt-5', label: 'GPT-5' }, { id: 'o3', label: 'o3' }] },
+        ]}
         collapsed={false}
         advancedExpanded={false}
         onEditModel={onEditModel}
@@ -534,12 +541,34 @@ describe('WorkflowInspector', () => {
       />,
     );
 
-    expect(screen.getByText('AI Model')).toBeInTheDocument();
-    const input = screen.getByTestId('execution-model-input');
-    fireEvent.change(input, { target: { value: '   ' } });
-    fireEvent.blur(input);
+    const select = screen.getByTestId('execution-model-select');
+    const options = select.querySelectorAll('option');
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveTextContent('Default');
+    expect(options[1]).toHaveTextContent('GPT-5');
+    expect(options[2]).toHaveTextContent('o3');
 
+    fireEvent.change(select, { target: { value: '' } });
     expect(onEditModel).toHaveBeenCalledWith('task-1', null);
+  });
+
+  it('keeps a custom current model in the dropdown', () => {
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ config: { workflowId: 'wf-1', prompt: 'Fix failing tests', executionAgent: 'codex', executionModel: 'gpt-5.2-preview' } })}
+        executionHarnesses={[
+          { name: 'codex', supportedModels: [{ id: 'gpt-5', label: 'GPT-5' }] },
+        ]}
+        collapsed={false}
+        advancedExpanded={false}
+        onEditModel={() => {}}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByRole('option', { name: 'gpt-5.2-preview' })).toBeInTheDocument();
   });
 
   it('double-click edits prompt and saves through callback', () => {

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import type { TaskState, ExternalDependency, ExternalGatePolicyUpdate, TaskStatus } from '../types.js';
+import type { ExecutionHarnessOption, TaskState, ExternalDependency, ExternalGatePolicyUpdate, TaskStatus } from '../types.js';
 import {
   getStatusColor,
   getEffectiveVisualStatus,
@@ -68,6 +68,30 @@ function formatElapsed(dateVal: Date | string | undefined): string {
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
+function getHarnessOptions(
+  executionHarnesses: readonly ExecutionHarnessOption[] | undefined,
+  currentHarness: string,
+): ExecutionHarnessOption[] {
+  const byName = new Map((executionHarnesses ?? []).map((harness) => [harness.name, harness]));
+  if (currentHarness && !byName.has(currentHarness)) {
+    byName.set(currentHarness, { name: currentHarness, supportedModels: [] });
+  }
+  return [...byName.values()];
+}
+
+function getModelOptions(
+  executionHarnesses: readonly ExecutionHarnessOption[] | undefined,
+  harnessName: string,
+  currentModel: string,
+): Array<{ id: string; label: string }> {
+  const selectedHarness = executionHarnesses?.find((harness) => harness.name === harnessName);
+  const byId = new Map((selectedHarness?.supportedModels ?? []).map((model) => [model.id, model]));
+  if (currentModel && !byId.has(currentModel)) {
+    byId.set(currentModel, { id: currentModel, label: currentModel });
+  }
+  return [...byId.values()];
+}
+
 
 function normalizeExternalDepTaskId(dep: Pick<ExternalDependency, 'taskId'>): string {
   return dep.taskId?.trim() || '__merge__';
@@ -102,7 +126,7 @@ interface TaskPanelProps {
   baseBranch?: string;
   workflowRepoUrl?: string;
   remoteTargets?: string[];
-  executionAgents?: string[];
+  executionHarnesses?: ExecutionHarnessOption[];
   onProvideInput: (task: TaskState) => void;
   onApprove: (task: TaskState) => void;
   onReject: (task: TaskState) => void;
@@ -225,7 +249,7 @@ export function TaskPanel({
   baseBranch,
   workflowRepoUrl,
   remoteTargets,
-  executionAgents,
+  executionHarnesses,
   onProvideInput,
   onApprove,
   onReject,
@@ -251,6 +275,7 @@ export function TaskPanel({
   const [isSavingGatePolicies, setIsSavingGatePolicies] = useState(false);
   const [gatePolicyDraft, setGatePolicyDraft] = useState<Record<string, 'completed' | 'review_ready'>>({});
   const [isSatisfiedListExpanded, setIsSatisfiedListExpanded] = useState(false);
+  const [modelValue, setModelValue] = useState(task?.config.executionModel ?? '');
   const [workspaceSetupFailures, setWorkspaceSetupFailures] = useState<string[]>([]);
 
   useEffect(() => {
@@ -258,6 +283,7 @@ export function TaskPanel({
     setEditCommandValue(task?.config.command ?? '');
     setIsEditingPrompt(false);
     setEditPromptValue(task?.config.prompt ?? '');
+    setModelValue(task?.config.executionModel ?? '');
     setBranchValue(baseBranch ?? '');
     setIsEditingGatePolicies(false);
     setIsSavingGatePolicies(false);
@@ -268,6 +294,10 @@ export function TaskPanel({
     }
     setGatePolicyDraft(nextDraft);
   }, [task?.id, baseBranch]);
+  const currentHarness = task?.config.executionAgent ?? task?.execution.agentName ?? 'claude';
+  const harnessOptions = getHarnessOptions(executionHarnesses, currentHarness);
+  const modelOptions = getModelOptions(executionHarnesses, currentHarness, modelValue);
+
 
   useEffect(() => {
     if (!task) {
@@ -522,14 +552,14 @@ export function TaskPanel({
             <div className="flex items-center justify-between">
               <span className="text-sm text-gray-400">AI Harness</span>
               <select
-                value={task.config.executionAgent ?? 'claude'}
+                value={currentHarness}
                 onChange={(e) => onEditAgent(task.id, e.target.value)}
                 disabled={task.status === 'running' || task.status === 'fixing_with_ai'}
                 className="bg-gray-700 text-gray-200 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 data-testid="execution-agent-select"
               >
-                {(executionAgents ?? []).map(name => (
-                  <option key={name} value={name}>{capitalize(name)}</option>
+                {harnessOptions.map((harness) => (
+                  <option key={harness.name} value={harness.name}>{capitalize(harness.name)}</option>
                 ))}
               </select>
             </div>
@@ -537,23 +567,24 @@ export function TaskPanel({
           {onEditModel && (
             <div className="flex items-center justify-between">
               <span className="text-sm text-gray-400">AI Model</span>
-              <input
-                key={`${task.id}:${task.config.executionModel ?? ''}`}
-                defaultValue={task.config.executionModel ?? ''}
-                onBlur={(e) => {
-                  const trimmed = e.currentTarget.value.trim();
-                  if (trimmed !== (task.config.executionModel ?? '')) {
-                    onEditModel(task.id, trimmed || null);
+              <select
+                value={modelValue}
+                onChange={(e) => {
+                  const nextModel = e.target.value;
+                  setModelValue(nextModel);
+                  if (nextModel !== (task.config.executionModel ?? '')) {
+                    onEditModel(task.id, nextModel || null);
                   }
                 }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') e.currentTarget.blur();
-                }}
                 disabled={task.status === 'running' || task.status === 'fixing_with_ai'}
-                placeholder="Default"
-                className="bg-gray-700 text-gray-200 placeholder:text-gray-500 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                data-testid="execution-model-input"
-              />
+                className="bg-gray-700 text-gray-200 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                data-testid="execution-model-select"
+              >
+                <option value="">Default</option>
+                {modelOptions.map((model) => (
+                  <option key={model.id} value={model.id}>{model.label}</option>
+                ))}
+              </select>
             </div>
           )}
         </div>

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -9,7 +9,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import type { ExecutionHarnessOption, TaskState, ExternalDependency, ExternalGatePolicyUpdate, TaskStatus } from '../types.js';
+import type { ExecutionDefaults, ExecutionHarnessOption, TaskState, ExternalDependency, ExternalGatePolicyUpdate, TaskStatus } from '../types.js';
 import {
   getStatusColor,
   getEffectiveVisualStatus,
@@ -66,6 +66,7 @@ function formatElapsed(dateVal: Date | string | undefined): string {
 }
 
 function capitalize(s: string): string {
+  if (s.toLowerCase() === 'omp') return 'OMP';
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 function getHarnessOptions(
@@ -127,6 +128,7 @@ interface TaskPanelProps {
   workflowRepoUrl?: string;
   remoteTargets?: string[];
   executionHarnesses?: ExecutionHarnessOption[];
+  executionDefaults?: ExecutionDefaults;
   onProvideInput: (task: TaskState) => void;
   onApprove: (task: TaskState) => void;
   onReject: (task: TaskState) => void;
@@ -250,6 +252,7 @@ export function TaskPanel({
   workflowRepoUrl,
   remoteTargets,
   executionHarnesses,
+  executionDefaults,
   onProvideInput,
   onApprove,
   onReject,
@@ -294,7 +297,8 @@ export function TaskPanel({
     }
     setGatePolicyDraft(nextDraft);
   }, [task?.id, baseBranch]);
-  const currentHarness = task?.config.executionAgent ?? task?.execution.agentName ?? 'claude';
+  const defaultModelLabel = executionDefaults?.executionModel ? `Default (${executionDefaults.executionModel})` : 'Default';
+  const currentHarness = task?.config.executionAgent ?? task?.execution.agentName ?? executionDefaults?.executionAgent ?? 'claude';
   const harnessOptions = getHarnessOptions(executionHarnesses, currentHarness);
   const modelOptions = getModelOptions(executionHarnesses, currentHarness, modelValue);
 
@@ -580,7 +584,7 @@ export function TaskPanel({
                 className="bg-gray-700 text-gray-200 text-xs rounded px-2 py-1 border border-gray-600 focus:outline-none focus:border-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
                 data-testid="execution-model-select"
               >
-                <option value="">Default</option>
+                <option value="">{defaultModelLabel}</option>
                 {modelOptions.map((model) => (
                   <option key={model.id} value={model.id}>{model.label}</option>
                 ))}
@@ -638,7 +642,7 @@ export function TaskPanel({
                 : 'bg-gray-700 text-gray-300'
             }`}>
               {task.config.prompt
-                ? `${capitalize(task.config.executionAgent ?? 'claude')} Harness`
+                ? `${capitalize(currentHarness)} Harness`
                 : 'Command'}
             </span>
           </div>

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { ExecutionHarnessOption, ReviewGateArtifact, ReviewGateQueryResponse, TaskState, WorkflowMeta } from '../types.js';
+import type { ExecutionDefaults, ExecutionHarnessOption, ReviewGateArtifact, ReviewGateQueryResponse, TaskState, WorkflowMeta } from '../types.js';
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 import type { ActionGraphNode } from '@invoker/contracts';
@@ -14,6 +14,7 @@ interface WorkflowInspectorProps {
   remoteTargets?: string[];
   executionPools?: string[];
   executionHarnesses?: ExecutionHarnessOption[];
+  executionDefaults?: ExecutionDefaults;
   actionNode?: ActionGraphNode | null;
   collapsed: boolean;
   advancedExpanded: boolean;
@@ -36,6 +37,7 @@ function formatStatus(value: string | undefined): string {
 }
 
 function capitalize(value: string): string {
+  if (value.toLowerCase() === 'omp') return 'OMP';
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 function getHarnessOptions(
@@ -144,6 +146,7 @@ export function WorkflowInspector({
   reviewGate,
   executionPools,
   executionHarnesses,
+  executionDefaults,
   actionNode,
   collapsed,
   advancedExpanded,
@@ -193,7 +196,8 @@ export function WorkflowInspector({
   const nodeTitle = task?.description ?? workflowTitle ?? 'No node selected';
   const showsWorkflowMergeDetails = Boolean(!task && workflow?.id && workflow.onFinish === 'pull_request');
   const isMergeNode = Boolean((task?.config.isMergeNode || showsWorkflowMergeDetails) && workflow?.id);
-  const currentAgent = task?.config.executionAgent ?? task?.execution.agentName ?? 'claude';
+  const defaultModelLabel = executionDefaults?.executionModel ? `Default (${executionDefaults.executionModel})` : 'Default';
+  const currentAgent = task?.config.executionAgent ?? task?.execution.agentName ?? executionDefaults?.executionAgent ?? 'claude';
   const harnessOptions = useMemo(
     () => getHarnessOptions(executionHarnesses, currentAgent),
     [currentAgent, executionHarnesses],
@@ -448,7 +452,7 @@ export function WorkflowInspector({
                   className="min-w-0 max-w-[190px] rounded border border-gray-600 bg-gray-700 px-2 py-1 text-xs text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
                   data-testid="execution-model-select"
                 >
-                  <option value="">Default</option>
+                  <option value="">{defaultModelLabel}</option>
                   {modelOptions.map((model) => (
                     <option key={model.id} value={model.id}>{model.label}</option>
                   ))}

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { ReviewGateArtifact, ReviewGateQueryResponse, TaskState, WorkflowMeta } from '../types.js';
+import type { ExecutionHarnessOption, ReviewGateArtifact, ReviewGateQueryResponse, TaskState, WorkflowMeta } from '../types.js';
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 import type { ActionGraphNode } from '@invoker/contracts';
@@ -13,7 +13,7 @@ interface WorkflowInspectorProps {
   reviewGate?: ReviewGateQueryResponse | null;
   remoteTargets?: string[];
   executionPools?: string[];
-  executionAgents?: string[];
+  executionHarnesses?: ExecutionHarnessOption[];
   actionNode?: ActionGraphNode | null;
   collapsed: boolean;
   advancedExpanded: boolean;
@@ -38,6 +38,30 @@ function formatStatus(value: string | undefined): string {
 function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
+function getHarnessOptions(
+  executionHarnesses: readonly ExecutionHarnessOption[] | undefined,
+  currentHarness: string,
+): ExecutionHarnessOption[] {
+  const byName = new Map((executionHarnesses ?? []).map((harness) => [harness.name, harness]));
+  if (currentHarness && !byName.has(currentHarness)) {
+    byName.set(currentHarness, { name: currentHarness, supportedModels: [] });
+  }
+  return [...byName.values()];
+}
+
+function getModelOptions(
+  executionHarnesses: readonly ExecutionHarnessOption[] | undefined,
+  harnessName: string,
+  currentModel: string,
+): Array<{ id: string; label: string }> {
+  const selectedHarness = executionHarnesses?.find((harness) => harness.name === harnessName);
+  const byId = new Map((selectedHarness?.supportedModels ?? []).map((model) => [model.id, model]));
+  if (currentModel && !byId.has(currentModel)) {
+    byId.set(currentModel, { id: currentModel, label: currentModel });
+  }
+  return [...byId.values()];
+}
+
 
 function mergeModeValue(value: string | undefined): MergeMode {
   return value === 'automatic' || value === 'external_review' ? value : 'manual';
@@ -119,7 +143,7 @@ export function WorkflowInspector({
   workflowTasks,
   reviewGate,
   executionPools,
-  executionAgents,
+  executionHarnesses,
   actionNode,
   collapsed,
   advancedExpanded,
@@ -170,11 +194,14 @@ export function WorkflowInspector({
   const showsWorkflowMergeDetails = Boolean(!task && workflow?.id && workflow.onFinish === 'pull_request');
   const isMergeNode = Boolean((task?.config.isMergeNode || showsWorkflowMergeDetails) && workflow?.id);
   const currentAgent = task?.config.executionAgent ?? task?.execution.agentName ?? 'claude';
-  const agentOptions = useMemo(() => {
-    const names = new Set(executionAgents ?? []);
-    names.add(currentAgent);
-    return [...names].filter(Boolean);
-  }, [currentAgent, executionAgents]);
+  const harnessOptions = useMemo(
+    () => getHarnessOptions(executionHarnesses, currentAgent),
+    [currentAgent, executionHarnesses],
+  );
+  const modelOptions = useMemo(
+    () => getModelOptions(executionHarnesses, currentAgent, modelValue),
+    [currentAgent, executionHarnesses, modelValue],
+  );
   const poolOptions = useMemo(() => {
     const ids = new Set(executionPools ?? []);
     if (task?.config.poolId) ids.add(task.config.poolId);
@@ -228,11 +255,11 @@ export function WorkflowInspector({
       void onSetMergeBranch?.(workflow.id, trimmed);
     }
   };
-  const saveModel = () => {
+  const applyModel = (nextModel: string) => {
     if (!task || !onEditModel) return;
-    const trimmed = modelValue.trim();
-    if (trimmed !== (task.config.executionModel ?? '')) {
-      onEditModel(task.id, trimmed || null);
+    setModelValue(nextModel);
+    if (nextModel !== (task.config.executionModel ?? '')) {
+      onEditModel(task.id, nextModel || null);
     }
   };
 
@@ -401,12 +428,12 @@ export function WorkflowInspector({
                 <select
                   value={currentAgent}
                   onChange={(event) => onEditAgent(task.id, event.target.value)}
-                  disabled={isTaskBusy || agentOptions.length === 0}
+                  disabled={isTaskBusy || harnessOptions.length === 0}
                   className="min-w-0 max-w-[190px] rounded border border-gray-600 bg-gray-700 px-2 py-1 text-xs text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
                   data-testid="execution-agent-select"
                 >
-                  {agentOptions.map((agentName) => (
-                    <option key={agentName} value={agentName}>{capitalize(agentName)}</option>
+                  {harnessOptions.map((harness) => (
+                    <option key={harness.name} value={harness.name}>{capitalize(harness.name)}</option>
                   ))}
                 </select>
               </label>
@@ -414,20 +441,18 @@ export function WorkflowInspector({
             {onEditModel && (
               <label className="flex items-center justify-between gap-3">
                 <span className="text-xs uppercase tracking-wide text-gray-400">AI Model</span>
-                <input
+                <select
                   value={modelValue}
-                  onChange={(event) => setModelValue(event.target.value)}
-                  onBlur={saveModel}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter') {
-                      event.currentTarget.blur();
-                    }
-                  }}
+                  onChange={(event) => applyModel(event.target.value)}
                   disabled={isTaskBusy}
-                  placeholder="Default"
-                  className="min-w-0 max-w-[190px] rounded border border-gray-600 bg-gray-700 px-2 py-1 text-xs text-gray-100 placeholder:text-gray-500 disabled:cursor-not-allowed disabled:opacity-50"
-                  data-testid="execution-model-input"
-                />
+                  className="min-w-0 max-w-[190px] rounded border border-gray-600 bg-gray-700 px-2 py-1 text-xs text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                  data-testid="execution-model-select"
+                >
+                  <option value="">Default</option>
+                  {modelOptions.map((model) => (
+                    <option key={model.id} value={model.id}>{model.label}</option>
+                  ))}
+                </select>
               </label>
             )}
           </section>

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -68,6 +68,16 @@ export interface ExternalGatePolicyUpdate {
   taskId?: string;
   gatePolicy: 'completed' | 'review_ready';
 }
+export interface ExecutionModelOption {
+  readonly id: string;
+  readonly label: string;
+}
+
+export interface ExecutionHarnessOption {
+  readonly name: string;
+  readonly supportedModels: readonly ExecutionModelOption[];
+}
+
 
 // ── Task Config (plan-time / static fields) ────────────────
 

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -78,6 +78,10 @@ export interface ExecutionHarnessOption {
   readonly supportedModels: readonly ExecutionModelOption[];
 }
 
+export interface ExecutionDefaults {
+  readonly executionAgent: string;
+  readonly executionModel?: string;
+}
 
 // ── Task Config (plan-time / static fields) ────────────────
 


### PR DESCRIPTION
## Summary

Task settings now use a harness-aware AI Model dropdown instead of a free text box.

Changing the AI Harness swaps the AI Model menu to that harness's built-in options. Older tasks with a saved custom model still keep that value visible so the setting is not lost.

<details>
<summary>Review metadata</summary>

Review Claim: Task settings now expose harness-specific AI model menus while still preserving existing custom task model overrides.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice only changes renderer state, labels, and tests. The harness registry, defaults read path, and execution behavior land in earlier stack slices.

Slice Rationale: The visible dropdown behavior and its tests belong together because they are one user-facing claim.

</details>

## Non-goals

- No execution harness registry changes.
- No task execution runtime changes.
- No config parsing changes.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-inspector.test.tsx src/__tests__/task-panel-double-click.test.tsx src/__tests__/app-launch.test.tsx`

## Visual Proof

OMP uses the AI Model menu with Default, ChatGPT 5.4, Anthropic Claude Sonnet 4, Anthropic Claude Opus 4, OpenAI GPT-5, OpenAI GPT-5 Codex, and OpenAI o3.

![OMP AI model dropdown](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-ea38c8/omp-model-dropdown.png)

Claude uses the AI Model menu with Default, Claude Sonnet, Claude Opus, and Claude Haiku.

![Claude AI model dropdown](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-ea38c8/claude-model-dropdown.png)

Codex uses the AI Model menu with Default, GPT-5, GPT-5 Codex, GPT-5 Mini, o3, and o4-mini.

![Codex AI model dropdown](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-ea38c8/codex-model-dropdown.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 1e567bf94`
- Post-revert steps: None
- Data migration? No
