### PR TITLE
[Diff atomicity PR gate wiring](1) Wire the diff atomicity engine into local PR authoring

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -237,8 +237,8 @@ async function assertValidPrBody(body, options = {}) {
   );
 }
 
-function printPrBodyWarnings(body, changedFiles = []) {
-  const warnings = getPrBodyWarnings(body, { changedFiles });
+function printPrBodyWarnings(body, changedFiles = [], diffText = '') {
+  const warnings = getPrBodyWarnings(body, { changedFiles, diffText });
   if (warnings.length === 0) return;
 
   console.error('PR body validation warnings:');
@@ -403,6 +403,21 @@ function changedFilesSinceBase(baseBranch) {
     return output ? output.split('\n').filter(Boolean) : [];
   } catch {
     return [];
+  }
+}
+
+function fullContextDiffSinceBase(baseBranch) {
+  try {
+    return runGit([
+      'diff',
+      '--find-renames',
+      '--unified=200000',
+      '--diff-filter=ACMRTD',
+      `${DEFAULT_BASE_REMOTE}/${baseBranch}...HEAD`,
+      '--',
+    ]);
+  } catch {
+    return '';
   }
 }
 
@@ -659,13 +674,14 @@ async function main() {
   }
 
   const changedFiles = changedFilesSinceBase(args.base);
+  const diffText = fullContextDiffSinceBase(args.base);
   const uiImpactingFiles = getUiImpactingFiles(changedFiles);
   if (uiImpactingFiles.length > 0) {
     console.error(`UI-impacting files changed; requiring visual proof: ${uiImpactingFiles.join(', ')}`);
   }
 
-  await assertValidPrBody(body, { requiresVisualProof: uiImpactingFiles.length > 0, changedFiles });
-  printPrBodyWarnings(body, changedFiles);
+  await assertValidPrBody(body, { requiresVisualProof: uiImpactingFiles.length > 0, changedFiles, diffText });
+  printPrBodyWarnings(body, changedFiles, diffText);
   body = await injectImages(body, args.dryRun);
 
   const currentBranch = getCurrentBranch();

--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -416,8 +416,10 @@ function fullContextDiffSinceBase(baseBranch) {
       `${DEFAULT_BASE_REMOTE}/${baseBranch}...HEAD`,
       '--',
     ]);
-  } catch {
-    return '';
+  } catch (error) {
+    throw new Error(
+      `Unable to compute diff atomicity context against ${DEFAULT_BASE_REMOTE}/${baseBranch}. Fetch the base ref and retry.\n${error.message}`,
+    );
   }
 }
 

--- a/scripts/lint-pr-diff-atomicity.mjs
+++ b/scripts/lint-pr-diff-atomicity.mjs
@@ -1,0 +1,431 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const CODE_EXTENSIONS = new Set(['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx']);
+const LOCKFILES = new Set(['pnpm-lock.yaml', 'package-lock.json', 'npm-shrinkwrap.json', 'yarn.lock', 'bun.lockb']);
+const MANIFESTS = new Set(['package.json']);
+const GENERATED_DIRS = new Set(['dist', 'out', 'build', 'coverage', '.next', '__generated__']);
+const DOC_EXTENSIONS = new Set(['.md', '.mdx', '.txt']);
+const CONFIG_EXTENSIONS = new Set(['.yml', '.yaml', '.json', '.toml', '.ini']);
+const TEST_FUNCTIONS = new Set(['describe', 'it', 'test', 'context', 'suite']);
+
+const POLICY = {
+  'mixed-generated-and-source': {
+    severity: 'fatal',
+    message: 'Generated or build-output files are mixed with hand-written source in one diff; split them into separate PRs.',
+  },
+  'orphaned-lockfile': {
+    severity: 'fatal',
+    message: 'A dependency lockfile changed without a matching package manifest change; isolate lockfile churn in its own PR.',
+  },
+  'debugger-statement': {
+    severity: 'fatal',
+    message: 'A debugger statement was added to source; remove debug scaffolding before review.',
+  },
+  'focused-test': {
+    severity: 'fatal',
+    message: 'A focused test (.only) was added; it silently skips the rest of the suite.',
+  },
+  'skipped-test': {
+    severity: 'warning',
+    message: 'A skipped test (.skip) was added; confirm the skip is intentional.',
+  },
+  'unrelated-areas': {
+    severity: 'warning',
+    message: 'The diff spans multiple unrelated top-level areas; confirm this is one atomic change.',
+  },
+};
+
+function stripPrefix(marker) {
+  const trimmed = marker.trim();
+  if (trimmed === '/dev/null') {
+    return '/dev/null';
+  }
+  if (trimmed.startsWith('a/') || trimmed.startsWith('b/')) {
+    return trimmed.slice(2);
+  }
+  return trimmed;
+}
+
+function classifyPath(filePath) {
+  const normalized = filePath.split(path.sep).join('/');
+  const basename = path.basename(normalized);
+  const extension = path.extname(basename);
+  const parts = normalized.split('/');
+
+  if (LOCKFILES.has(basename)) {
+    return 'lockfile';
+  }
+  if (MANIFESTS.has(basename)) {
+    return 'manifest';
+  }
+  if (parts.some((part) => GENERATED_DIRS.has(part)) || basename.includes('.generated.') || basename.includes('.gen.') || basename.endsWith('.min.js')) {
+    return 'generated';
+  }
+  if (basename.includes('.test.') || basename.includes('.spec.') || basename.startsWith('test-') || parts.includes('__tests__') || parts.includes('tests')) {
+    return 'test';
+  }
+  if (CODE_EXTENSIONS.has(extension)) {
+    return 'source';
+  }
+  if (DOC_EXTENSIONS.has(extension) || parts.includes('docs')) {
+    return 'docs';
+  }
+  if (CONFIG_EXTENSIONS.has(extension) || parts.includes('.github')) {
+    return 'config';
+  }
+  return 'other';
+}
+
+function scriptKindFor(filePath) {
+  const extension = path.extname(filePath);
+  if (extension === '.tsx') {
+    return ts.ScriptKind.TSX;
+  }
+  if (extension === '.ts') {
+    return ts.ScriptKind.TS;
+  }
+  if (extension === '.jsx') {
+    return ts.ScriptKind.JSX;
+  }
+  return ts.ScriptKind.JS;
+}
+
+function topArea(filePath) {
+  const parts = filePath.split('/');
+  if (parts[0] === 'packages' && parts.length > 1) {
+    return `packages/${parts[1]}`;
+  }
+  return parts[0] || filePath;
+}
+
+function finalizeFile(file) {
+  if (!file) {
+    return null;
+  }
+  const max = file.newLineMap.size > 0 ? Math.max(...file.newLineMap.keys()) : 0;
+  const lines = new Array(max).fill('');
+  for (const [lineNumber, text] of file.newLineMap) {
+    lines[lineNumber - 1] = text;
+  }
+  file.newContent = lines.join('\n');
+  file.category = classifyPath(file.path);
+  delete file.newLineMap;
+  return file;
+}
+
+export function parseUnifiedDiff(diffText, source = 'diff') {
+  const files = [];
+  const lines = (diffText || '').split('\n');
+  let current = null;
+  let counter = 0;
+
+  const start = (header) => {
+    const finalized = finalizeFile(current);
+    if (finalized) {
+      files.push(finalized);
+    }
+    current = {
+      source,
+      header,
+      oldPath: '',
+      newPath: '',
+      path: '',
+      changeType: 'modify',
+      addedLineNumbers: new Set(),
+      removedCount: 0,
+      newLineMap: new Map(),
+      newContent: '',
+      category: 'other',
+    };
+    counter = 0;
+  };
+
+  for (const line of lines) {
+    if (line.startsWith('diff --git ')) {
+      start(line);
+      continue;
+    }
+    if (!current) {
+      continue;
+    }
+    if (line.startsWith('new file mode')) {
+      current.changeType = 'add';
+      continue;
+    }
+    if (line.startsWith('deleted file mode')) {
+      current.changeType = 'delete';
+      continue;
+    }
+    if (line.startsWith('rename from ')) {
+      current.changeType = 'rename';
+      current.oldPath = stripPrefix(line.slice('rename from '.length));
+      continue;
+    }
+    if (line.startsWith('rename to ')) {
+      current.changeType = 'rename';
+      current.newPath = stripPrefix(line.slice('rename to '.length));
+      current.path = current.newPath;
+      continue;
+    }
+    if (line.startsWith('--- ')) {
+      current.oldPath = stripPrefix(line.slice(4));
+      continue;
+    }
+    if (line.startsWith('+++ ')) {
+      current.newPath = stripPrefix(line.slice(4));
+      current.path = current.newPath === '/dev/null' ? current.oldPath : current.newPath;
+      continue;
+    }
+    if (line.startsWith('@@')) {
+      const match = /@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+      counter = match ? Number.parseInt(match[1], 10) : 0;
+      continue;
+    }
+    if (counter < 1) {
+      continue;
+    }
+    if (line.startsWith('+') && !line.startsWith('+++')) {
+      current.newLineMap.set(counter, line.slice(1));
+      current.addedLineNumbers.add(counter);
+      counter += 1;
+      continue;
+    }
+    if (line.startsWith('-') && !line.startsWith('---')) {
+      current.removedCount += 1;
+      continue;
+    }
+    if (line.startsWith(' ')) {
+      current.newLineMap.set(counter, line.slice(1));
+      counter += 1;
+    }
+  }
+
+  const finalized = finalizeFile(current);
+  if (finalized) {
+    files.push(finalized);
+  }
+
+  return files;
+}
+
+function rootIdentifier(node) {
+  let expression = node;
+  while (ts.isPropertyAccessExpression(expression)) {
+    expression = expression.expression;
+  }
+  return ts.isIdentifier(expression) ? expression.text : '';
+}
+
+function collectAstFindings(file) {
+  if (!CODE_EXTENSIONS.has(path.extname(file.path)) || file.category === 'generated') {
+    return [];
+  }
+  const findings = [];
+  const sourceFile = ts.createSourceFile(file.path, file.newContent, ts.ScriptTarget.Latest, true, scriptKindFor(file.path));
+
+  const record = (kind, node) => {
+    const lineNumber = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1;
+    if (file.addedLineNumbers.has(lineNumber)) {
+      findings.push(makeFinding(kind, file.path, lineNumber, file.source));
+    }
+  };
+
+  const walk = (node) => {
+    if (node.kind === ts.SyntaxKind.DebuggerStatement) {
+      record('debugger-statement', node);
+    } else if (ts.isPropertyAccessExpression(node) && ts.isIdentifier(node.name)) {
+      const member = node.name.text;
+      if ((member === 'only' || member === 'skip') && TEST_FUNCTIONS.has(rootIdentifier(node.expression))) {
+        record(member === 'only' ? 'focused-test' : 'skipped-test', node);
+      }
+    }
+    ts.forEachChild(node, walk);
+  };
+
+  walk(sourceFile);
+  return findings;
+}
+
+function makeFinding(kind, filePath, line, source) {
+  const policy = POLICY[kind];
+  return {
+    kind,
+    severity: policy.severity,
+    message: policy.message,
+    path: filePath,
+    line: line ?? null,
+    source: source ?? 'diff',
+  };
+}
+
+export function collectDiffAtomicityFindings(options = {}) {
+  const { diffText, source = 'diff' } = options;
+  const files = Array.isArray(options.files) ? options.files : parseUnifiedDiff(diffText, source);
+  const findings = [];
+
+  const hasGenerated = files.some((file) => file.category === 'generated');
+  const hasHandwritten = files.some((file) => file.category === 'source' || file.category === 'test');
+  if (hasGenerated && hasHandwritten) {
+    for (const file of files) {
+      if (file.category === 'generated') {
+        findings.push(makeFinding('mixed-generated-and-source', file.path, null, file.source));
+      }
+    }
+  }
+
+  const lockfiles = files.filter((file) => file.category === 'lockfile');
+  const hasManifest = files.some((file) => file.category === 'manifest');
+  if (lockfiles.length > 0 && !hasManifest) {
+    for (const file of lockfiles) {
+      findings.push(makeFinding('orphaned-lockfile', file.path, null, file.source));
+    }
+  }
+
+  for (const file of files) {
+    findings.push(...collectAstFindings(file));
+  }
+
+  const areas = new Set();
+  for (const file of files) {
+    if (['source', 'test', 'docs', 'config', 'other'].includes(file.category) && file.path && file.path !== '/dev/null') {
+      areas.add(topArea(file.path));
+    }
+  }
+  if (areas.size >= 3) {
+    const finding = makeFinding('unrelated-areas', '', null, source);
+    finding.message = `${finding.message} (${[...areas].sort().join(', ')})`;
+    findings.push(finding);
+  }
+
+  return findings;
+}
+
+export function formatDiffAtomicityFindings(findings) {
+  return findings.map((finding) => {
+    const location = finding.path
+      ? `${finding.path}${finding.line ? `:${finding.line}` : ''}`
+      : '(diff)';
+    return `${finding.kind} ${location} — ${finding.message}`;
+  });
+}
+
+function runGit(root, args) {
+  return execFileSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+export function lintDiffAtomicityForGit(options = {}) {
+  const root = options.root || process.cwd();
+  const baseRef = options.baseRef;
+  if (!baseRef) {
+    throw new Error('lintDiffAtomicityForGit requires a baseRef');
+  }
+  const diffText = runGit(root, [
+    'diff',
+    '--find-renames',
+    '--unified=200000',
+    '--diff-filter=ACMRTD',
+    `${baseRef}...HEAD`,
+    '--',
+  ]);
+  return collectDiffAtomicityFindings({ diffText, source: `${baseRef}...HEAD` });
+}
+
+function usage() {
+  console.error('Usage: node scripts/lint-pr-diff-atomicity.mjs [--base <ref>] [--root <path>]');
+}
+
+function hasGitRef(root, ref) {
+  try {
+    runGit(root, ['rev-parse', '--verify', `${ref}^{commit}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function defaultBase(root) {
+  const candidates = [];
+  if (process.env.GITHUB_BASE_REF) {
+    candidates.push(`origin/${process.env.GITHUB_BASE_REF}`);
+  }
+  candidates.push('origin/master', 'origin/main', 'master', 'main');
+  for (const candidate of candidates) {
+    if (hasGitRef(root, candidate)) {
+      return candidate;
+    }
+  }
+  return '';
+}
+
+function parseArgs(argv) {
+  const parsed = { base: process.env.INVOKER_DIFF_ATOMICITY_BASE || '', root: process.cwd() };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--base') {
+      parsed.base = argv[index + 1] || '';
+      index += 1;
+    } else if (arg.startsWith('--base=')) {
+      parsed.base = arg.slice('--base='.length);
+    } else if (arg === '--root') {
+      parsed.root = argv[index + 1] || '';
+      index += 1;
+    } else if (arg.startsWith('--root=')) {
+      parsed.root = arg.slice('--root='.length);
+    } else if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    } else {
+      console.error(`[atomicity] Unknown argument: ${arg}`);
+      usage();
+      process.exit(2);
+    }
+  }
+  return { base: parsed.base, root: path.resolve(parsed.root) };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const base = args.base || defaultBase(args.root);
+  if (!base) {
+    console.error('[atomicity] Could not resolve a base ref. Pass --base <ref>.');
+    process.exit(2);
+  }
+
+  const findings = lintDiffAtomicityForGit({ root: args.root, baseRef: base });
+  const fatal = findings.filter((finding) => finding.severity === 'fatal');
+  const warnings = findings.filter((finding) => finding.severity === 'warning');
+
+  if (fatal.length > 0) {
+    console.error('Diff atomicity validation failed:');
+    for (const line of formatDiffAtomicityFindings(fatal)) {
+      console.error(`  ${line}`);
+    }
+    for (const line of formatDiffAtomicityFindings(warnings)) {
+      console.error(`  warning: ${line}`);
+    }
+    process.exit(1);
+  }
+
+  if (warnings.length > 0) {
+    console.error('Diff atomicity warnings:');
+    for (const line of formatDiffAtomicityFindings(warnings)) {
+      console.error(`  ${line}`);
+    }
+    process.exit(0);
+  }
+
+  console.log('Diff atomicity validation passed.');
+}
+
+if (fileURLToPath(import.meta.url) === path.resolve(process.argv[1] || '')) {
+  main();
+}

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -564,6 +564,34 @@ function testStackedDiffTitleRequiredForNonTrunkBase() {
   }
 }
 
+function testDiffAtomicityBlocksMixedDiff() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    createTrackedBranch(work, 'feature/atomicity-lockfile');
+    commitFile(work, 'pnpm-lock.yaml', 'lockfileVersion: 9\npackages: {}\n', 'orphaned lockfile churn');
+
+    const result = runCreatePr(work, harness, baseArgs());
+
+    assert(
+      result.status === 1,
+      `mixed diff should fail diff atomicity gate\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
+    assert(
+      result.stderr.includes('Diff atomicity violation'),
+      `create-pr should report the diff atomicity violation\nstderr:\n${result.stderr}`,
+    );
+    expectNoPush(harness, 'diff atomicity violation');
+    const ghCalls = readGhCalls(harness.ghLog);
+    assert(
+      !ghCalls.some((call) => /\/pulls\/[0-9]+$/.test(call.route)),
+      'diff atomicity violation should fail before any GitHub PATCH',
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
 function testHelpMentionsStackUpdateFlow() {
   const harness = createHarness();
   try {
@@ -586,6 +614,7 @@ const tests = [
   testUnpublishedStackCommitsBlockUpdate,
   testCurrentBranchPrLookupFailure,
   testStackedDiffTitleRequiredForNonTrunkBase,
+  testDiffAtomicityBlocksMixedDiff,
   testHelpMentionsStackUpdateFlow,
 ];
 

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -147,6 +147,10 @@ function createHarness() {
   const realGit = run('which', ['git']).trim();
 
   writeExecutable(join(binDir, 'git'), `#!/bin/sh
+if [ "$1" = "diff" ] && [ -n "$TEST_GIT_DIFF_FAIL" ]; then
+  printf '%s\n' "$TEST_GIT_DIFF_FAIL" >&2
+  exit 1
+fi
 if [ "$1" = "push" ]; then
   printf '%s\n' "$*" >> "$TEST_PUSH_LOG"
   exit 0
@@ -584,9 +588,31 @@ function testDiffAtomicityBlocksMixedDiff() {
     expectNoPush(harness, 'diff atomicity violation');
     const ghCalls = readGhCalls(harness.ghLog);
     assert(
-      !ghCalls.some((call) => /\/pulls\/[0-9]+$/.test(call.route)),
-      'diff atomicity violation should fail before any GitHub PATCH',
+      !ghCalls.some((call) => /\/pulls(?:\/[0-9]+)?$/.test(call.route)),
+      'diff atomicity violation should fail before any GitHub PR mutation',
     );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testDiffComputationFailureBlocksPrCreation() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    createTrackedBranch(work, 'feature/diff-failure');
+    commitFile(work, 'feature.txt', 'feature\n', 'feature change');
+
+    const result = runCreatePr(work, harness, baseArgs(), { TEST_GIT_DIFF_FAIL: 'simulated diff failure' });
+
+    assert(result.status === 1, `diff failure should block PR creation\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(
+      result.stderr.includes('Unable to compute diff atomicity context against origin/master'),
+      `diff failure should explain atomicity context failure\nstderr:\n${result.stderr}`,
+    );
+    assert(result.stderr.includes('simulated diff failure'), `diff failure should include git stderr\nstderr:\n${result.stderr}`);
+    expectNoPush(harness, 'diff computation failure');
+    assert(readGhCalls(harness.ghLog).length === 0, 'diff computation failure should fail before GitHub calls');
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }
@@ -615,6 +641,7 @@ const tests = [
   testCurrentBranchPrLookupFailure,
   testStackedDiffTitleRequiredForNonTrunkBase,
   testDiffAtomicityBlocksMixedDiff,
+  testDiffComputationFailureBlocksPrCreation,
   testHelpMentionsStackUpdateFlow,
 ];
 

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
-import { getPrBodyWarnings, validatePrBody, validatePrScope } from './validate-pr-body.mjs';
+import { getPrBodyWarnings, getReviewMetadata, validatePrBody, validatePrScope } from './validate-pr-body.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -765,5 +766,74 @@ assert(
   directScopeErrors.some((error) => error.includes('Review lane behavior cannot ship with docs files')),
   'direct scope validator should reject product plus docs mixing',
 );
+
+const reviewMetadata = getReviewMetadata(validMinimal);
+assert(reviewMetadata.reviewLane === 'behavior', 'getReviewMetadata should expose the normalized review lane');
+assert(reviewMetadata.reviewUnit === 'routing', 'getReviewMetadata should expose the normalized review unit');
+assert(reviewMetadata.reviewClaim.includes('Keep the owner fallback local.'), 'getReviewMetadata should expose the review claim');
+
+const mixedDiff = `diff --git a/dist/bundle.js b/dist/bundle.js
+new file mode 100644
+--- /dev/null
++++ b/dist/bundle.js
+@@ -0,0 +1,1 @@
++console.log('generated bundle');
+diff --git a/packages/app/src/feature.ts b/packages/app/src/feature.ts
+new file mode 100644
+--- /dev/null
++++ b/packages/app/src/feature.ts
+@@ -0,0 +1,1 @@
++export const feature = true;
+`;
+
+const cleanDiff = `diff --git a/packages/app/src/feature.ts b/packages/app/src/feature.ts
+new file mode 100644
+--- /dev/null
++++ b/packages/app/src/feature.ts
+@@ -0,0 +1,1 @@
++export const feature = true;
+`;
+
+const mixedDiffErrors = await validatePrBody(validMinimal, { diffText: mixedDiff });
+assert(
+  mixedDiffErrors.some((error) => error.includes('Diff atomicity violation')),
+  'mixed generated and hand-written diff should fail diff atomicity validation',
+);
+assert(
+  (await validatePrBody(validMinimal, { diffText: cleanDiff })).length === 0,
+  'an atomic source-only diff should pass diff atomicity validation',
+);
+assert(
+  (await validatePrBody(validMinimal)).length === 0,
+  'omitting diff text should preserve body-only validation',
+);
+
+const diffTmp = mkdtempSync(join(tmpdir(), 'pr-body-validator-diff-'));
+try {
+  const bodyPath = join(diffTmp, 'body.md');
+  const mixedDiffPath = join(diffTmp, 'mixed.diff');
+  const cleanDiffPath = join(diffTmp, 'clean.diff');
+  writeFileSync(bodyPath, validMinimal);
+  writeFileSync(mixedDiffPath, mixedDiff);
+  writeFileSync(cleanDiffPath, cleanDiff);
+
+  const mixedDiffCli = spawnSync(
+    process.execPath,
+    ['scripts/validate-pr-body.mjs', '--body-file', bodyPath, '--diff-file', mixedDiffPath],
+    { cwd: repoRoot, encoding: 'utf8' },
+  );
+  assert(mixedDiffCli.status === 1, 'CLI validator should fail on a mixed diff file');
+  assert(mixedDiffCli.stderr.includes('Diff atomicity violation'), 'CLI validator should report the diff atomicity violation');
+
+  const cleanDiffCli = spawnSync(
+    process.execPath,
+    ['scripts/validate-pr-body.mjs', '--body-file', bodyPath, '--diff-file', cleanDiffPath],
+    { cwd: repoRoot, encoding: 'utf8' },
+  );
+  assert(cleanDiffCli.status === 0, 'CLI validator should pass an atomic source-only diff file');
+  assert(cleanDiffCli.stdout.includes('PR body validation passed.'), 'CLI validator should report success for an atomic diff file');
+} finally {
+  rmSync(diffTmp, { recursive: true, force: true });
+}
 
 console.log('OK: PR body validator checks passed');

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -830,6 +830,27 @@ try {
     ['scripts/validate-pr-body.mjs', '--body-file', bodyPath, '--diff-file', cleanDiffPath],
     { cwd: repoRoot, encoding: 'utf8' },
   );
+  const missingDiffFileCli = spawnSync(
+    process.execPath,
+    ['scripts/validate-pr-body.mjs', '--body-file', bodyPath, '--diff-file'],
+    { cwd: repoRoot, encoding: 'utf8' },
+  );
+  assert(missingDiffFileCli.status === 1, 'CLI validator should reject --diff-file without a path');
+  assert(
+    missingDiffFileCli.stderr.includes('--diff-file requires a file path.'),
+    'CLI validator should explain the missing --diff-file path',
+  );
+
+  const missingChangedFilesCli = spawnSync(
+    process.execPath,
+    ['scripts/validate-pr-body.mjs', '--body-file', bodyPath, '--changed-files-file', '--diff-file', cleanDiffPath],
+    { cwd: repoRoot, encoding: 'utf8' },
+  );
+  assert(missingChangedFilesCli.status === 1, 'CLI validator should reject --changed-files-file without a path');
+  assert(
+    missingChangedFilesCli.stderr.includes('--changed-files-file requires a file path.'),
+    'CLI validator should explain the missing --changed-files-file path',
+  );
   assert(cleanDiffCli.status === 0, 'CLI validator should pass an atomic source-only diff file');
   assert(cleanDiffCli.stdout.includes('PR body validation passed.'), 'CLI validator should report success for an atomic diff file');
 } finally {

--- a/scripts/test-pr-diff-atomicity.mjs
+++ b/scripts/test-pr-diff-atomicity.mjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  parseUnifiedDiff,
+  collectDiffAtomicityFindings,
+  formatDiffAtomicityFindings,
+} from './lint-pr-diff-atomicity.mjs';
+
+const scriptPath = fileURLToPath(new URL('./lint-pr-diff-atomicity.mjs', import.meta.url));
+
+function diff(lines) {
+  return `${lines.join('\n')}\n`;
+}
+
+function kinds(findings) {
+  return findings.map((finding) => finding.kind).sort();
+}
+
+// Case 1: a clean, single-area source + test change is atomic.
+{
+  const text = diff([
+    'diff --git a/packages/core/src/add.ts b/packages/core/src/add.ts',
+    'new file mode 100644',
+    '--- /dev/null',
+    '+++ b/packages/core/src/add.ts',
+    '@@ -0,0 +1,3 @@',
+    '+export function add(a: number, b: number): number {',
+    '+  return a + b;',
+    '+}',
+    'diff --git a/packages/core/src/add.test.ts b/packages/core/src/add.test.ts',
+    'new file mode 100644',
+    '--- /dev/null',
+    '+++ b/packages/core/src/add.test.ts',
+    '@@ -0,0 +1,3 @@',
+    "+import { add } from './add';",
+    "+import { it } from 'vitest';",
+    "+it('adds', () => { add(1, 2); });",
+  ]);
+  const files = parseUnifiedDiff(text);
+  assert.equal(files.length, 2);
+  assert.deepEqual(files.map((file) => file.category).sort(), ['source', 'test']);
+  assert.deepEqual(collectDiffAtomicityFindings({ diffText: text }), []);
+}
+
+// Case 2: hand-written source mixed with a build artifact is fatal.
+{
+  const text = diff([
+    'diff --git a/packages/core/dist/bundle.js b/packages/core/dist/bundle.js',
+    '--- a/packages/core/dist/bundle.js',
+    '+++ b/packages/core/dist/bundle.js',
+    '@@ -1 +1,2 @@',
+    " console.log('built');",
+    "+console.log('rebuilt');",
+    'diff --git a/packages/core/src/index.ts b/packages/core/src/index.ts',
+    '--- a/packages/core/src/index.ts',
+    '+++ b/packages/core/src/index.ts',
+    '@@ -1 +1,2 @@',
+    ' export const x = 1;',
+    '+export const y = 2;',
+  ]);
+  const findings = collectDiffAtomicityFindings({ diffText: text });
+  assert.deepEqual(kinds(findings), ['mixed-generated-and-source']);
+  assert.equal(findings[0].severity, 'fatal');
+  assert.equal(findings[0].path, 'packages/core/dist/bundle.js');
+}
+
+// Case 3: a lockfile changed with no manifest change is fatal.
+{
+  const text = diff([
+    'diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml',
+    '--- a/pnpm-lock.yaml',
+    '+++ b/pnpm-lock.yaml',
+    '@@ -1 +1,2 @@',
+    ' lockfileVersion: 9.0',
+    "+  '/left-pad@1.3.0': {}",
+  ]);
+  const findings = collectDiffAtomicityFindings({ diffText: text });
+  assert.deepEqual(kinds(findings), ['orphaned-lockfile']);
+  assert.equal(findings[0].severity, 'fatal');
+
+  // A lockfile next to its manifest is allowed.
+  const withManifest = diff([
+    'diff --git a/package.json b/package.json',
+    '--- a/package.json',
+    '+++ b/package.json',
+    '@@ -1 +1,2 @@',
+    ' {',
+    '+  "dependencies": { "left-pad": "1.3.0" }',
+    'diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml',
+    '--- a/pnpm-lock.yaml',
+    '+++ b/pnpm-lock.yaml',
+    '@@ -1 +1,2 @@',
+    ' lockfileVersion: 9.0',
+    "+  '/left-pad@1.3.0': {}",
+  ]);
+  assert.deepEqual(collectDiffAtomicityFindings({ diffText: withManifest }), []);
+}
+
+// Case 4: a debugger statement added to source is fatal (AST detected, added-only).
+{
+  const text = diff([
+    'diff --git a/packages/core/src/run.ts b/packages/core/src/run.ts',
+    '--- a/packages/core/src/run.ts',
+    '+++ b/packages/core/src/run.ts',
+    '@@ -1,3 +1,4 @@',
+    ' export function run() {',
+    '+  debugger;',
+    '   return 1;',
+    ' }',
+  ]);
+  const findings = collectDiffAtomicityFindings({ diffText: text });
+  assert.deepEqual(kinds(findings), ['debugger-statement']);
+  assert.equal(findings[0].severity, 'fatal');
+  assert.equal(findings[0].line, 2);
+}
+
+// A pre-existing debugger on a context line is not flagged.
+{
+  const text = diff([
+    'diff --git a/packages/core/src/run.ts b/packages/core/src/run.ts',
+    '--- a/packages/core/src/run.ts',
+    '+++ b/packages/core/src/run.ts',
+    '@@ -1,3 +1,4 @@',
+    ' export function run() {',
+    '   debugger;',
+    '+  return 2;',
+    ' }',
+  ]);
+  assert.deepEqual(collectDiffAtomicityFindings({ diffText: text }), []);
+}
+
+// Case 5: a focused test (.only) is fatal.
+{
+  const text = diff([
+    'diff --git a/packages/core/src/run.test.ts b/packages/core/src/run.test.ts',
+    '--- a/packages/core/src/run.test.ts',
+    '+++ b/packages/core/src/run.test.ts',
+    '@@ -1,2 +1,3 @@',
+    " describe('run', () => {",
+    "+  it.only('focused', () => {});",
+    ' });',
+  ]);
+  const findings = collectDiffAtomicityFindings({ diffText: text });
+  assert.deepEqual(kinds(findings), ['focused-test']);
+  assert.equal(findings[0].severity, 'fatal');
+}
+
+// Case 6: a skipped test (.skip) is a warning, and unrelated areas warn too.
+{
+  const skipped = diff([
+    'diff --git a/packages/core/src/run.test.ts b/packages/core/src/run.test.ts',
+    '--- a/packages/core/src/run.test.ts',
+    '+++ b/packages/core/src/run.test.ts',
+    '@@ -1,2 +1,3 @@',
+    " describe('run', () => {",
+    "+  it.skip('later', () => {});",
+    ' });',
+  ]);
+  const skippedFindings = collectDiffAtomicityFindings({ diffText: skipped });
+  assert.deepEqual(kinds(skippedFindings), ['skipped-test']);
+  assert.equal(skippedFindings[0].severity, 'warning');
+
+  const spread = diff([
+    'diff --git a/packages/core/src/a.ts b/packages/core/src/a.ts',
+    '--- a/packages/core/src/a.ts',
+    '+++ b/packages/core/src/a.ts',
+    '@@ -1 +1,2 @@',
+    ' export const a = 1;',
+    '+export const a2 = 2;',
+    'diff --git a/packages/app/src/b.ts b/packages/app/src/b.ts',
+    '--- a/packages/app/src/b.ts',
+    '+++ b/packages/app/src/b.ts',
+    '@@ -1 +1,2 @@',
+    ' export const b = 1;',
+    '+export const b2 = 2;',
+    'diff --git a/scripts/c.mjs b/scripts/c.mjs',
+    '--- a/scripts/c.mjs',
+    '+++ b/scripts/c.mjs',
+    '@@ -1 +1,2 @@',
+    ' export const c = 1;',
+    '+export const c2 = 2;',
+  ]);
+  const spreadFindings = collectDiffAtomicityFindings({ diffText: spread });
+  assert.deepEqual(kinds(spreadFindings), ['unrelated-areas']);
+  assert.equal(spreadFindings[0].severity, 'warning');
+  assert.match(formatDiffAtomicityFindings(spreadFindings)[0], /packages\/app/);
+}
+
+// Temp git case: the git entry path flags a real added debugger and exits 1,
+// and a clean follow-up change passes with the success message on stdout.
+{
+  const root = mkdtempSync(path.join(tmpdir(), 'invoker-diff-atomicity-'));
+  try {
+    execFileSync('git', ['init', '-q'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: root, stdio: 'ignore' });
+    mkdirSync(path.join(root, 'packages/core/src'), { recursive: true });
+    writeFileSync(path.join(root, 'packages/core/src/thing.ts'), 'export function run() {\n  return 1;\n}\n');
+    execFileSync('git', ['add', '.'], { cwd: root, stdio: 'ignore' });
+    execFileSync('git', ['commit', '-q', '-m', 'base'], { cwd: root, stdio: 'ignore' });
+
+    writeFileSync(path.join(root, 'packages/core/src/thing.ts'), 'export function run() {\n  debugger;\n  return 1;\n}\n');
+    execFileSync('git', ['commit', '-aqm', 'debug'], { cwd: root, stdio: 'ignore' });
+
+    let failed = false;
+    try {
+      execFileSync(process.execPath, [scriptPath, '--root', root, '--base', 'HEAD~1'], { encoding: 'utf8' });
+    } catch (error) {
+      failed = true;
+      assert.equal(error.status, 1);
+      assert.match(String(error.stderr), /Diff atomicity validation failed:/);
+      assert.match(String(error.stderr), /debugger-statement/);
+    }
+    assert.equal(failed, true, 'expected the linter to exit non-zero on an added debugger');
+
+    writeFileSync(path.join(root, 'packages/core/src/thing.ts'), 'export function run() {\n  return 2;\n}\n');
+    execFileSync('git', ['commit', '-aqm', 'clean'], { cwd: root, stdio: 'ignore' });
+    const passOutput = execFileSync(process.execPath, [scriptPath, '--root', root, '--base', 'HEAD~1'], { encoding: 'utf8' });
+    assert.match(passOutput, /Diff atomicity validation passed\./);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+console.log('ok pr diff atomicity');

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -2,6 +2,7 @@
 
 import { readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
+import { collectDiffAtomicityFindings, formatDiffAtomicityFindings } from './lint-pr-diff-atomicity.mjs';
 import {
   formatReviewUnits,
   getLabelSection,
@@ -159,6 +160,17 @@ function getReviewMetadataValue(metadata, label) {
   return getLabelSection(metadata, label);
 }
 
+export function getReviewMetadata(body) {
+  const block = getReviewMetadataBlock(body);
+  return {
+    reviewClaim: getReviewMetadataValue(block.body, 'Review Claim'),
+    reviewLane: normalizeSectionValue(getReviewMetadataValue(block.body, 'Review Lane')),
+    reviewUnit: normalizeReviewUnit(getReviewMetadataValue(block.body, 'Review Unit')),
+    safetyInvariant: getReviewMetadataValue(block.body, 'Safety Invariant'),
+    sliceRationale: getReviewMetadataValue(block.body, 'Slice Rationale'),
+  };
+}
+
 function stripDetailsBlocks(text) {
   return String(text).replace(/<details\b[^>]*>[\s\S]*?<\/details>/gi, '').trim();
 }
@@ -264,6 +276,14 @@ export function getPrBodyWarnings(body, options = {}) {
     warnings.push(`PR spans ${units.length} review units: ${formatReviewUnits(units)}.`);
   }
 
+  if (options.diffText) {
+    const diffWarnings = collectDiffAtomicityFindings({ diffText: options.diffText })
+      .filter((finding) => finding.severity === 'warning');
+    for (const line of formatDiffAtomicityFindings(diffWarnings)) {
+      warnings.push(`Diff atomicity warning: ${line}`);
+    }
+  }
+
   return warnings;
 }
 
@@ -366,16 +386,26 @@ export async function validatePrBody(body, options = {}) {
     }));
   }
 
+  if (options.diffText) {
+    const fatalFindings = collectDiffAtomicityFindings({ diffText: options.diffText })
+      .filter((finding) => finding.severity === 'fatal');
+    for (const line of formatDiffAtomicityFindings(fatalFindings)) {
+      errors.push(`Diff atomicity violation: ${line}`);
+    }
+  }
+
   return errors;
 }
 
 function usage() {
-  console.error(`Usage: node scripts/validate-pr-body.mjs (--body-file <file> | --body <markdown>) [--require-visual-proof]
+  console.error(`Usage: node scripts/validate-pr-body.mjs (--body-file <file> | --body <markdown>) [--require-visual-proof] [--changed-files-file <file>] [--diff-file <file>]
 
 Validates the canonical PR schema:
   Required: ## Summary with a collapsed Review metadata block, ## Non-goals, ## Test Plan, ## Revert Plan
   Optional: ## Architecture (must include ### Before and ### After when present)
-  UI changes: pass --require-visual-proof to require screenshot or video proof.`);
+  UI changes: pass --require-visual-proof to require screenshot or video proof.
+  --changed-files-file <file>  Newline-separated changed file paths for scope checks.
+  --diff-file <file>           Unified diff text to run the diff atomicity engine.`);
   process.exit(1);
 }
 
@@ -383,6 +413,8 @@ function parseArgs(argv) {
   let body = '';
   let bodyFile = '';
   let requiresVisualProof = false;
+  let changedFilesFile = '';
+  let diffFile = '';
 
   for (let i = 0; i < argv.length; i++) {
     switch (argv[i]) {
@@ -394,6 +426,12 @@ function parseArgs(argv) {
         break;
       case '--require-visual-proof':
         requiresVisualProof = true;
+        break;
+      case '--changed-files-file':
+        changedFilesFile = argv[++i] || '';
+        break;
+      case '--diff-file':
+        diffFile = argv[++i] || '';
         break;
       case '--help':
         usage();
@@ -409,14 +447,18 @@ function parseArgs(argv) {
     usage();
   }
 
-  return { body, bodyFile, requiresVisualProof };
+  return { body, bodyFile, requiresVisualProof, changedFilesFile, diffFile };
 }
 
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   const body = args.bodyFile ? readFileSync(args.bodyFile, 'utf-8') : args.body;
-  const errors = await validatePrBody(body, { requiresVisualProof: args.requiresVisualProof });
-  const warnings = getPrBodyWarnings(body);
+  const changedFiles = args.changedFilesFile
+    ? readFileSync(args.changedFilesFile, 'utf-8').split('\n').map((line) => line.trim()).filter(Boolean)
+    : undefined;
+  const diffText = args.diffFile ? readFileSync(args.diffFile, 'utf-8') : undefined;
+  const errors = await validatePrBody(body, { requiresVisualProof: args.requiresVisualProof, changedFiles, diffText });
+  const warnings = getPrBodyWarnings(body, { changedFiles, diffText });
 
   if (errors.length > 0) {
     console.error('PR body validation failed:');

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -428,10 +428,18 @@ function parseArgs(argv) {
         requiresVisualProof = true;
         break;
       case '--changed-files-file':
-        changedFilesFile = argv[++i] || '';
+        changedFilesFile = argv[++i];
+        if (!changedFilesFile || changedFilesFile.startsWith('--')) {
+          console.error('--changed-files-file requires a file path.');
+          usage();
+        }
         break;
       case '--diff-file':
-        diffFile = argv[++i] || '';
+        diffFile = argv[++i];
+        if (!diffFile || diffFile.startsWith('--')) {
+          console.error('--diff-file requires a file path.');
+          usage();
+        }
         break;
       case '--help':
         usage();


### PR DESCRIPTION
## Summary

Wire the proven diff atomicity engine into Invoker's local PR authoring gate and PR body checker.

This slice leaves CI and skill files untouched. It only makes local `create-pr` and the checker shell path stop mixed diffs before they reach push or any GitHub mutation.

The engine already exists in the parent slice. Here the existing PR metadata simply carries diff text into that engine, so no second PR body parser is introduced.

<details>
<summary>Review metadata</summary>

Review Claim: Existing PR metadata now carries diff text into the shared engine, fatal mixed-diff findings block the local gate, and behavior is identical when diff text is absent.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Behavior is unchanged when no diff text is supplied; body-only checks run exactly as before, so the new flags are purely additive.

Slice Rationale: Adapter wiring is kept separate from the engine slice and the later CI slice, so each diff carries one claim and one safety story.

</details>

## Non-goals

- Does not edit any `.github` workflow or CI policy.
- Does not change `package.json` scripts, skills, or docs.
- Does not alter the engine's detection rules, only how diff text reaches it.
- Does not change body-only checking when no diff input is provided.

## Test Plan

- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/test-create-pr-stack-workflow.mjs`
- [ ] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-gate-wiring-body.md --changed-files-file /tmp/pr-changed-files.txt --diff-file /tmp/pr-diff.txt`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>` or close the PR without merge
- Post-revert steps: None; the checker falls back to body-only behavior automatically
- Data migration? No

Supersedes #2564 because the landing guard only queues `stack/` head branches.