### PR TITLE
[Harness Capability Policy](1) Add role-aware capability config

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -30,6 +30,10 @@ vi.mock('node:os', async (importOriginal) => {
   };
 });
 
+function writeUserConfig(value: unknown): void {
+  writeFileSync(join(fakeHome, '.invoker', 'config.json'), JSON.stringify(value));
+}
+
 describe('loadConfig', () => {
   it('returns empty config when no files exist', () => {
     const config = loadConfig();
@@ -237,7 +241,7 @@ describe('loadConfig', () => {
     expect(config.executorRoutingRules).toEqual(executorRoutingRules);
   });
 
-  it('reads remote target maxConcurrentTasks from user config', () => {
+  it('reads remote target capabilities from user config', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),
       JSON.stringify({
@@ -247,24 +251,74 @@ describe('loadConfig', () => {
             user: 'invoker',
             sshKeyPath: '/tmp/key',
             maxConcurrentTasks: 2,
+            capabilities: {
+              execution: {
+                omp: {
+                  modelPolicy: {
+                    kind: 'select',
+                    models: ['anthropic/claude-opus-4', 'openai/gpt-5'],
+                    defaultModel: 'anthropic/claude-opus-4',
+                  },
+                },
+              },
+            },
           },
         },
       }),
     );
     const config = loadConfig();
     expect(config.remoteTargets?.ci1?.maxConcurrentTasks).toBe(2);
+    expect(config.remoteTargets?.ci1?.capabilities).toEqual({
+      execution: {
+        omp: {
+          modelPolicy: {
+            kind: 'select',
+            models: ['anthropic/claude-opus-4', 'openai/gpt-5'],
+            defaultModel: 'anthropic/claude-opus-4',
+          },
+        },
+      },
+    });
   });
 
-  it('reads executionPools from user config', () => {
+  it('reads execution pool member capabilities from user config', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),
       JSON.stringify({
         executionPools: {
           'ssh-light': {
             members: [
-              { type: 'ssh', id: 'remote-1' },
+              {
+                type: 'ssh',
+                id: 'remote-1',
+                capabilities: {
+                  execution: {
+                    codex: { modelPolicy: { kind: 'implicit' } },
+                  },
+                },
+              },
               { type: 'ssh', id: 'remote-2' },
-              { type: 'worktree', id: 'local-fallback', maxConcurrentTasks: 2 },
+              {
+                type: 'worktree',
+                id: 'local-fallback',
+                maxConcurrentTasks: 2,
+                capabilities: {
+                  planning: {
+                    cursor: {
+                      modelPolicy: { kind: 'fixed', model: 'claude' },
+                    },
+                  },
+                  execution: {
+                    omp: {
+                      modelPolicy: {
+                        kind: 'select',
+                        models: ['anthropic/claude-opus-4', 'openai/gpt-5'],
+                        defaultModel: 'anthropic/claude-opus-4',
+                      },
+                    },
+                  },
+                },
+              },
             ],
             selectionStrategy: 'roundRobin',
             maxConcurrentTasksPerMember: 1,
@@ -275,9 +329,37 @@ describe('loadConfig', () => {
     const config = loadConfig();
     expect(config.executionPools?.['ssh-light']).toEqual({
       members: [
-        { type: 'ssh', id: 'remote-1' },
+        {
+          type: 'ssh',
+          id: 'remote-1',
+          capabilities: {
+            execution: {
+              codex: { modelPolicy: { kind: 'implicit' } },
+            },
+          },
+        },
         { type: 'ssh', id: 'remote-2' },
-        { type: 'worktree', id: 'local-fallback', maxConcurrentTasks: 2 },
+        {
+          type: 'worktree',
+          id: 'local-fallback',
+          maxConcurrentTasks: 2,
+          capabilities: {
+            planning: {
+              cursor: {
+                modelPolicy: { kind: 'fixed', model: 'claude' },
+              },
+            },
+            execution: {
+              omp: {
+                modelPolicy: {
+                  kind: 'select',
+                  models: ['anthropic/claude-opus-4', 'openai/gpt-5'],
+                  defaultModel: 'anthropic/claude-opus-4',
+                },
+              },
+            },
+          },
+        },
       ],
       selectionStrategy: 'roundRobin',
       maxConcurrentTasksPerMember: 1,
@@ -291,6 +373,226 @@ describe('loadConfig', () => {
     );
     const config = loadConfig();
     expect(config.defaultPoolId).toBe('mixed-local-ssh');
+  });
+  it('reads defaultExecution from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({
+        defaultExecution: {
+          executionAgent: 'omp',
+          executionModel: 'anthropic/claude-opus-4',
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.defaultExecution).toEqual({
+      executionAgent: 'omp',
+      executionModel: 'anthropic/claude-opus-4',
+    });
+  });
+
+  it('rejects fixed policies without a model', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              omp: {
+                modelPolicy: { kind: 'fixed', model: '' },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow('remoteTargets.ci1.capabilities.execution.omp.modelPolicy.model: expected a non-empty string');
+  });
+
+  it('rejects select policies without model choices', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              omp: {
+                modelPolicy: {
+                  kind: 'select',
+                  models: [],
+                  defaultModel: 'anthropic/claude-opus-4',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'remoteTargets.ci1.capabilities.execution.omp.modelPolicy.models: expected a non-empty array of non-empty strings',
+    );
+  });
+
+  it('rejects select policies with blank model choices', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              omp: {
+                modelPolicy: {
+                  kind: 'select',
+                  models: ['anthropic/claude-opus-4', ''],
+                  defaultModel: 'anthropic/claude-opus-4',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'remoteTargets.ci1.capabilities.execution.omp.modelPolicy.models[1]: expected a non-empty string',
+    );
+  });
+
+  it('rejects select policies whose default is not advertised', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              omp: {
+                modelPolicy: {
+                  kind: 'select',
+                  models: ['anthropic/claude-opus-4'],
+                  defaultModel: 'openai/gpt-5',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'remoteTargets.ci1.capabilities.execution.omp.modelPolicy.defaultModel: expected one of models',
+    );
+  });
+
+  it('rejects cursor under execution capabilities', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              cursor: {
+                modelPolicy: { kind: 'fixed', model: 'claude' },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'remoteTargets.ci1.capabilities.execution.cursor: cursor is planning-only',
+    );
+  });
+
+  it('rejects claude under planning capabilities', () => {
+    writeUserConfig({
+      executionPools: {
+        local: {
+          members: [
+            {
+              type: 'worktree',
+              id: 'local',
+              capabilities: {
+                planning: {
+                  claude: {
+                    modelPolicy: { kind: 'implicit' },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'executionPools.local.members[0].capabilities.planning.claude: claude is execution-only',
+    );
+  });
+
+  it('rejects codex under planning capabilities', () => {
+    writeUserConfig({
+      executionPools: {
+        local: {
+          members: [
+            {
+              type: 'worktree',
+              id: 'local',
+              capabilities: {
+                planning: {
+                  codex: {
+                    modelPolicy: { kind: 'implicit' },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'executionPools.local.members[0].capabilities.planning.codex: codex is execution-only',
+    );
+  });
+
+  it('rejects implicit policies with extra model payload', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              claude: {
+                modelPolicy: {
+                  kind: 'implicit',
+                  model: 'anthropic/claude-opus-4',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'remoteTargets.ci1.capabilities.execution.claude.modelPolicy: implicit policies must not include model, models, or defaultModel',
+    );
+  });
+
+  it('rejects defaultExecution model without an agent', () => {
+    writeUserConfig({
+      defaultExecution: {
+        executionModel: 'anthropic/claude-opus-4',
+      },
+    });
+    expect(() => loadConfig()).toThrow('defaultExecution.executionModel requires defaultExecution.executionAgent');
   });
 
 

--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -49,8 +49,31 @@ vi.mock('../lifecycle-event-bridge.js', () => ({
 
 vi.mock('../config.js', () => ({
   loadConfig: vi.fn(() => ({
-    remoteTargets: { remote: { host: 'host' } },
-    executionPools: { pool: { members: [] } },
+    remoteTargets: {
+      remote: {
+        host: 'host',
+        capabilities: {
+          execution: {
+            claude: { modelPolicy: { kind: 'implicit' } },
+          },
+        },
+      },
+    },
+    executionPools: {
+      pool: {
+        members: [
+          {
+            type: 'worktree',
+            id: 'local',
+            capabilities: {
+              planning: {
+                cursor: { modelPolicy: { kind: 'fixed', model: 'claude' } },
+              },
+            },
+          },
+        ],
+      },
+    },
     autoFixAgent: 'codex',
     autoApproveAIFixes: true,
   })),
@@ -104,6 +127,7 @@ describe('task-runner-wiring', () => {
       repoRoot: '/repo',
       invokerConfig: {
         defaultBranch: 'main',
+        defaultExecution: { executionAgent: 'omp', executionModel: 'anthropic/claude-opus-4' },
         docker: { imageName: 'image' },
         autoFixCi: true,
       },
@@ -126,8 +150,31 @@ describe('task-runner-wiring', () => {
     const config = taskRunnerConstructor.mock.calls[0]?.[0] as any;
     expect(config.cwd).toBe('/repo');
     expect(config.dockerConfig).toEqual({ imageName: 'image', secretsFile: '/tmp/secrets.env' });
-    expect(config.remoteTargetsProvider()).toEqual({ remote: { host: 'host' } });
-    expect(config.executionPoolsProvider()).toEqual({ pool: { members: [] } });
+    expect(config.remoteTargetsProvider()).toEqual({
+      remote: {
+        host: 'host',
+        capabilities: {
+          execution: {
+            claude: { modelPolicy: { kind: 'implicit' } },
+          },
+        },
+      },
+    });
+    expect(config.executionPoolsProvider()).toEqual({
+      pool: {
+        members: [
+          {
+            type: 'worktree',
+            id: 'local',
+            capabilities: {
+              planning: {
+                cursor: { modelPolicy: { kind: 'fixed', model: 'claude' } },
+              },
+            },
+          },
+        ],
+      },
+    });
     expect(config.executionDefaultsProvider()).toEqual({ executionAgent: 'claude' });
     expect(loadConfig).toHaveBeenCalledTimes(3);
 

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -1,0 +1,122 @@
+import type { InvokerConfig, MachineCapabilities } from './config.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function validateModelPolicy(path: string, policy: unknown): void {
+  if (!isRecord(policy)) {
+    throw new Error(`${path}: expected modelPolicy object`);
+  }
+
+  const kind = policy.kind;
+  if (kind === 'implicit') {
+    if ('model' in policy || 'models' in policy || 'defaultModel' in policy) {
+      throw new Error(`${path}: implicit policies must not include model, models, or defaultModel`);
+    }
+    return;
+  }
+
+  if (kind === 'fixed') {
+    if (!readNonEmptyString(policy.model)) {
+      throw new Error(`${path}.model: expected a non-empty string`);
+    }
+    return;
+  }
+
+  if (kind === 'select') {
+    if (!Array.isArray(policy.models) || policy.models.length === 0) {
+      throw new Error(`${path}.models: expected a non-empty array of non-empty strings`);
+    }
+    const models = policy.models.map((model, index) => {
+      const value = readNonEmptyString(model);
+      if (!value) {
+        throw new Error(`${path}.models[${index}]: expected a non-empty string`);
+      }
+      return value;
+    });
+    const defaultModel = readNonEmptyString(policy.defaultModel);
+    if (!defaultModel) {
+      throw new Error(`${path}.defaultModel: expected a non-empty string`);
+    }
+    if (!models.includes(defaultModel)) {
+      throw new Error(`${path}.defaultModel: expected one of models`);
+    }
+    return;
+  }
+
+  throw new Error(`${path}.kind: expected "implicit", "fixed", or "select"`);
+}
+
+function validateRoleHarnesses(
+  label: string,
+  role: 'planning' | 'execution',
+  harnesses: Record<string, unknown>,
+): void {
+  for (const [harness, capability] of Object.entries(harnesses)) {
+    const harnessPath = `${label}.${role}.${harness}`;
+    if (role === 'execution' && harness === 'cursor') {
+      throw new Error(`${harnessPath}: cursor is planning-only`);
+    }
+    if (role === 'planning' && (harness === 'claude' || harness === 'codex')) {
+      throw new Error(`${harnessPath}: ${harness} is execution-only`);
+    }
+    if (!isRecord(capability)) {
+      throw new Error(`${harnessPath}: expected harness capability object`);
+    }
+    validateModelPolicy(`${harnessPath}.modelPolicy`, capability.modelPolicy);
+  }
+}
+
+function validateMachineCapabilities(label: string, capabilities: MachineCapabilities): void {
+  const rawCapabilities = capabilities as unknown;
+  if (!isRecord(rawCapabilities)) {
+    throw new Error(`${label}: expected capabilities object`);
+  }
+
+  const planning = rawCapabilities.planning;
+  if (planning !== undefined) {
+    if (!isRecord(planning)) {
+      throw new Error(`${label}.planning: expected a harness map`);
+    }
+    validateRoleHarnesses(label, 'planning', planning);
+  }
+
+  const execution = rawCapabilities.execution;
+  if (execution !== undefined) {
+    if (!isRecord(execution)) {
+      throw new Error(`${label}.execution: expected a harness map`);
+    }
+    validateRoleHarnesses(label, 'execution', execution);
+  }
+}
+
+export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
+  const defaultExecutionAgent = readNonEmptyString(config.defaultExecution?.executionAgent);
+  if (config.defaultExecution?.executionModel !== undefined && !defaultExecutionAgent) {
+    throw new Error('defaultExecution.executionModel requires defaultExecution.executionAgent');
+  }
+
+  for (const [targetId, target] of Object.entries(config.remoteTargets ?? {})) {
+    if (target.capabilities) {
+      validateMachineCapabilities(`remoteTargets.${targetId}.capabilities`, target.capabilities);
+    }
+  }
+
+  for (const [poolId, pool] of Object.entries(config.executionPools ?? {})) {
+    pool.members.forEach((member, index) => {
+      if (member.capabilities) {
+        validateMachineCapabilities(
+          `executionPools.${poolId}.members[${index}].capabilities`,
+          member.capabilities,
+        );
+      }
+    });
+  }
+
+  return config;
+}

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -8,6 +8,21 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { validateInvokerConfig } from './config-validation.js';
+
+export type HarnessModelPolicy =
+  | { kind: 'implicit' }
+  | { kind: 'fixed'; model: string }
+  | { kind: 'select'; models: string[]; defaultModel: string };
+
+export interface HarnessCapability {
+  modelPolicy: HarnessModelPolicy;
+}
+
+export interface MachineCapabilities {
+  planning?: Record<string, HarnessCapability>;
+  execution?: Record<string, HarnessCapability>;
+}
 const BUILT_IN_DEFAULT_EXECUTION_AGENT = 'codex';
 
 export interface ExternalWorkerLaunchConfig {
@@ -24,6 +39,18 @@ export interface ExternalWorkerConfig {
   kind: string;
   /** Process invocation used by the loader to start the external worker. */
   launch: ExternalWorkerLaunchConfig;
+}
+export interface DefaultExecutionConfig {
+  /**
+   * Default task execution harness when a task omits executionAgent.
+   * Falls back to the built-in default agent when unset.
+   */
+  executionAgent?: string;
+  /**
+   * Default task execution model paired with executionAgent.
+   * Only applied when the resolved task executionAgent matches this default agent.
+   */
+  executionModel?: string;
 }
 
 export interface InvokerConfig {
@@ -88,6 +115,11 @@ export interface InvokerConfig {
   defaultExecutionAgent?: string;
   /** Default execution model for prompt-backed tasks when the task does not override it. */
   defaultExecutionModel?: string;
+  /**
+   * Config-owned default execution harness/model for tasks that omit them.
+   * This is separate from Slack planning presets and applies across surfaces.
+   */
+  defaultExecution?: DefaultExecutionConfig;
   /**
    * When true, failed CI checks on Invoker-created review-gate PRs can
    * trigger the same auto-fix recovery flow used for task failures.
@@ -193,6 +225,7 @@ export interface InvokerConfig {
      * Default for pooled SSH members: 1.
      */
     maxConcurrentTasks?: number;
+    capabilities?: MachineCapabilities;
   }>;
   /**
    * Named execution pools used by routing rules.
@@ -201,8 +234,8 @@ export interface InvokerConfig {
   executionPools?: Record<string, {
     /** Pool members can mix substrates under one shared queue. */
     members: Array<
-      | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
-      | { type: 'worktree'; id: string; maxConcurrentTasks?: number }
+      | { type: 'ssh'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities }
+      | { type: 'worktree'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities }
     >;
     /** Member selection strategy for available capacity. Default: roundRobin */
     selectionStrategy?: 'roundRobin' | 'leastLoaded';
@@ -305,7 +338,8 @@ export function resolveConfigFileState(): { path: string; exists: boolean } {
   return { path, exists: existsSync(path) };
 }
 export function loadConfig(): InvokerConfig {
-  return readJsonSafe(resolveConfigFilePath());
+  const config = readJsonSafe(resolveConfigFilePath());
+  return validateInvokerConfig(config);
 }
 export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
   const configured = config.defaultExecutionAgent?.trim();


### PR DESCRIPTION
## Summary

Config loading now accepts machine capability blocks and rejects role/model-policy mismatches before runtime config is used.

The validator catches planning-only versus execution-only harness placement and malformed modelPolicy shapes.

<details>
<summary>Review metadata</summary>

Review Claim: Config validation now enforces machine capability role and model-policy rules.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: Safe because capability data is parsed without changing executor selection or dispatch behavior.

Slice Rationale: Validation lands first so later runtime enforcement can assume invalid capability config is rejected at load time.

</details>

## Non-goals

- No executor selection changes.
- No dispatch-time model propagation.
- No planning runtime changes.
- No documentation changes in this slice.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts src/__tests__/task-runner-wiring.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 46b9c1864 9964d083c`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for richer configuration options for default execution settings and machine capabilities.
  * Remote targets and execution pool members can now include capability-based model selection details.

* **Bug Fixes**
  * Configuration loading now validates invalid settings early and rejects unsupported capability combinations.
  * Improved error reporting for malformed model policy settings and incomplete execution defaults.

* **Tests**
  * Expanded coverage for config parsing, validation, and task runner wiring with the new configuration shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->