### PR TITLE
[Harness Capability Policy](2) Validate and route execution by policy

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -30,6 +30,10 @@ vi.mock('node:os', async (importOriginal) => {
   };
 });
 
+function writeUserConfig(value: unknown): void {
+  writeFileSync(join(fakeHome, '.invoker', 'config.json'), JSON.stringify(value));
+}
+
 describe('loadConfig', () => {
   it('returns empty config when no files exist', () => {
     const config = loadConfig();
@@ -237,7 +241,7 @@ describe('loadConfig', () => {
     expect(config.executorRoutingRules).toEqual(executorRoutingRules);
   });
 
-  it('reads remote target maxConcurrentTasks from user config', () => {
+  it('reads remote target capabilities from user config', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),
       JSON.stringify({
@@ -247,24 +251,74 @@ describe('loadConfig', () => {
             user: 'invoker',
             sshKeyPath: '/tmp/key',
             maxConcurrentTasks: 2,
+            capabilities: {
+              execution: {
+                omp: {
+                  modelPolicy: {
+                    kind: 'select',
+                    models: ['anthropic/claude-opus-4', 'openai/gpt-5'],
+                    defaultModel: 'anthropic/claude-opus-4',
+                  },
+                },
+              },
+            },
           },
         },
       }),
     );
     const config = loadConfig();
     expect(config.remoteTargets?.ci1?.maxConcurrentTasks).toBe(2);
+    expect(config.remoteTargets?.ci1?.capabilities).toEqual({
+      execution: {
+        omp: {
+          modelPolicy: {
+            kind: 'select',
+            models: ['anthropic/claude-opus-4', 'openai/gpt-5'],
+            defaultModel: 'anthropic/claude-opus-4',
+          },
+        },
+      },
+    });
   });
 
-  it('reads executionPools from user config', () => {
+  it('reads execution pool member capabilities from user config', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),
       JSON.stringify({
         executionPools: {
           'ssh-light': {
             members: [
-              { type: 'ssh', id: 'remote-1' },
+              {
+                type: 'ssh',
+                id: 'remote-1',
+                capabilities: {
+                  execution: {
+                    codex: { modelPolicy: { kind: 'implicit' } },
+                  },
+                },
+              },
               { type: 'ssh', id: 'remote-2' },
-              { type: 'worktree', id: 'local-fallback', maxConcurrentTasks: 2 },
+              {
+                type: 'worktree',
+                id: 'local-fallback',
+                maxConcurrentTasks: 2,
+                capabilities: {
+                  planning: {
+                    cursor: {
+                      modelPolicy: { kind: 'fixed', model: 'claude' },
+                    },
+                  },
+                  execution: {
+                    omp: {
+                      modelPolicy: {
+                        kind: 'select',
+                        models: ['anthropic/claude-opus-4', 'openai/gpt-5'],
+                        defaultModel: 'anthropic/claude-opus-4',
+                      },
+                    },
+                  },
+                },
+              },
             ],
             selectionStrategy: 'roundRobin',
             maxConcurrentTasksPerMember: 1,
@@ -275,9 +329,37 @@ describe('loadConfig', () => {
     const config = loadConfig();
     expect(config.executionPools?.['ssh-light']).toEqual({
       members: [
-        { type: 'ssh', id: 'remote-1' },
+        {
+          type: 'ssh',
+          id: 'remote-1',
+          capabilities: {
+            execution: {
+              codex: { modelPolicy: { kind: 'implicit' } },
+            },
+          },
+        },
         { type: 'ssh', id: 'remote-2' },
-        { type: 'worktree', id: 'local-fallback', maxConcurrentTasks: 2 },
+        {
+          type: 'worktree',
+          id: 'local-fallback',
+          maxConcurrentTasks: 2,
+          capabilities: {
+            planning: {
+              cursor: {
+                modelPolicy: { kind: 'fixed', model: 'claude' },
+              },
+            },
+            execution: {
+              omp: {
+                modelPolicy: {
+                  kind: 'select',
+                  models: ['anthropic/claude-opus-4', 'openai/gpt-5'],
+                  defaultModel: 'anthropic/claude-opus-4',
+                },
+              },
+            },
+          },
+        },
       ],
       selectionStrategy: 'roundRobin',
       maxConcurrentTasksPerMember: 1,
@@ -291,6 +373,226 @@ describe('loadConfig', () => {
     );
     const config = loadConfig();
     expect(config.defaultPoolId).toBe('mixed-local-ssh');
+  });
+  it('reads defaultExecution from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({
+        defaultExecution: {
+          executionAgent: 'omp',
+          executionModel: 'anthropic/claude-opus-4',
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.defaultExecution).toEqual({
+      executionAgent: 'omp',
+      executionModel: 'anthropic/claude-opus-4',
+    });
+  });
+
+  it('rejects fixed policies without a model', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              omp: {
+                modelPolicy: { kind: 'fixed', model: '' },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow('remoteTargets.ci1.capabilities.execution.omp.modelPolicy.model: expected a non-empty string');
+  });
+
+  it('rejects select policies without model choices', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              omp: {
+                modelPolicy: {
+                  kind: 'select',
+                  models: [],
+                  defaultModel: 'anthropic/claude-opus-4',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'remoteTargets.ci1.capabilities.execution.omp.modelPolicy.models: expected a non-empty array of non-empty strings',
+    );
+  });
+
+  it('rejects select policies with blank model choices', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              omp: {
+                modelPolicy: {
+                  kind: 'select',
+                  models: ['anthropic/claude-opus-4', ''],
+                  defaultModel: 'anthropic/claude-opus-4',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'remoteTargets.ci1.capabilities.execution.omp.modelPolicy.models[1]: expected a non-empty string',
+    );
+  });
+
+  it('rejects select policies whose default is not advertised', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              omp: {
+                modelPolicy: {
+                  kind: 'select',
+                  models: ['anthropic/claude-opus-4'],
+                  defaultModel: 'openai/gpt-5',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'remoteTargets.ci1.capabilities.execution.omp.modelPolicy.defaultModel: expected one of models',
+    );
+  });
+
+  it('rejects cursor under execution capabilities', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              cursor: {
+                modelPolicy: { kind: 'fixed', model: 'claude' },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'remoteTargets.ci1.capabilities.execution.cursor: cursor is planning-only',
+    );
+  });
+
+  it('rejects claude under planning capabilities', () => {
+    writeUserConfig({
+      executionPools: {
+        local: {
+          members: [
+            {
+              type: 'worktree',
+              id: 'local',
+              capabilities: {
+                planning: {
+                  claude: {
+                    modelPolicy: { kind: 'implicit' },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'executionPools.local.members[0].capabilities.planning.claude: claude is execution-only',
+    );
+  });
+
+  it('rejects codex under planning capabilities', () => {
+    writeUserConfig({
+      executionPools: {
+        local: {
+          members: [
+            {
+              type: 'worktree',
+              id: 'local',
+              capabilities: {
+                planning: {
+                  codex: {
+                    modelPolicy: { kind: 'implicit' },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'executionPools.local.members[0].capabilities.planning.codex: codex is execution-only',
+    );
+  });
+
+  it('rejects implicit policies with extra model payload', () => {
+    writeUserConfig({
+      remoteTargets: {
+        ci1: {
+          host: '10.0.0.1',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          capabilities: {
+            execution: {
+              claude: {
+                modelPolicy: {
+                  kind: 'implicit',
+                  model: 'anthropic/claude-opus-4',
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+    expect(() => loadConfig()).toThrow(
+      'remoteTargets.ci1.capabilities.execution.claude.modelPolicy: implicit policies must not include model, models, or defaultModel',
+    );
+  });
+
+  it('rejects defaultExecution model without an agent', () => {
+    writeUserConfig({
+      defaultExecution: {
+        executionModel: 'anthropic/claude-opus-4',
+      },
+    });
+    expect(() => loadConfig()).toThrow('defaultExecution.executionModel requires defaultExecution.executionAgent');
   });
 
 

--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -49,8 +49,31 @@ vi.mock('../lifecycle-event-bridge.js', () => ({
 
 vi.mock('../config.js', () => ({
   loadConfig: vi.fn(() => ({
-    remoteTargets: { remote: { host: 'host' } },
-    executionPools: { pool: { members: [] } },
+    remoteTargets: {
+      remote: {
+        host: 'host',
+        capabilities: {
+          execution: {
+            claude: { modelPolicy: { kind: 'implicit' } },
+          },
+        },
+      },
+    },
+    executionPools: {
+      pool: {
+        members: [
+          {
+            type: 'worktree',
+            id: 'local',
+            capabilities: {
+              planning: {
+                cursor: { modelPolicy: { kind: 'fixed', model: 'claude' } },
+              },
+            },
+          },
+        ],
+      },
+    },
     autoFixAgent: 'codex',
     autoApproveAIFixes: true,
   })),
@@ -104,6 +127,7 @@ describe('task-runner-wiring', () => {
       repoRoot: '/repo',
       invokerConfig: {
         defaultBranch: 'main',
+        defaultExecution: { executionAgent: 'omp', executionModel: 'anthropic/claude-opus-4' },
         docker: { imageName: 'image' },
         autoFixCi: true,
       },
@@ -126,8 +150,31 @@ describe('task-runner-wiring', () => {
     const config = taskRunnerConstructor.mock.calls[0]?.[0] as any;
     expect(config.cwd).toBe('/repo');
     expect(config.dockerConfig).toEqual({ imageName: 'image', secretsFile: '/tmp/secrets.env' });
-    expect(config.remoteTargetsProvider()).toEqual({ remote: { host: 'host' } });
-    expect(config.executionPoolsProvider()).toEqual({ pool: { members: [] } });
+    expect(config.remoteTargetsProvider()).toEqual({
+      remote: {
+        host: 'host',
+        capabilities: {
+          execution: {
+            claude: { modelPolicy: { kind: 'implicit' } },
+          },
+        },
+      },
+    });
+    expect(config.executionPoolsProvider()).toEqual({
+      pool: {
+        members: [
+          {
+            type: 'worktree',
+            id: 'local',
+            capabilities: {
+              planning: {
+                cursor: { modelPolicy: { kind: 'fixed', model: 'claude' } },
+              },
+            },
+          },
+        ],
+      },
+    });
     expect(config.executionDefaultsProvider()).toEqual({ executionAgent: 'claude' });
     expect(loadConfig).toHaveBeenCalledTimes(3);
 

--- a/packages/app/src/config-validation.ts
+++ b/packages/app/src/config-validation.ts
@@ -1,0 +1,122 @@
+import type { InvokerConfig, MachineCapabilities } from './config.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readNonEmptyString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function validateModelPolicy(path: string, policy: unknown): void {
+  if (!isRecord(policy)) {
+    throw new Error(`${path}: expected modelPolicy object`);
+  }
+
+  const kind = policy.kind;
+  if (kind === 'implicit') {
+    if ('model' in policy || 'models' in policy || 'defaultModel' in policy) {
+      throw new Error(`${path}: implicit policies must not include model, models, or defaultModel`);
+    }
+    return;
+  }
+
+  if (kind === 'fixed') {
+    if (!readNonEmptyString(policy.model)) {
+      throw new Error(`${path}.model: expected a non-empty string`);
+    }
+    return;
+  }
+
+  if (kind === 'select') {
+    if (!Array.isArray(policy.models) || policy.models.length === 0) {
+      throw new Error(`${path}.models: expected a non-empty array of non-empty strings`);
+    }
+    const models = policy.models.map((model, index) => {
+      const value = readNonEmptyString(model);
+      if (!value) {
+        throw new Error(`${path}.models[${index}]: expected a non-empty string`);
+      }
+      return value;
+    });
+    const defaultModel = readNonEmptyString(policy.defaultModel);
+    if (!defaultModel) {
+      throw new Error(`${path}.defaultModel: expected a non-empty string`);
+    }
+    if (!models.includes(defaultModel)) {
+      throw new Error(`${path}.defaultModel: expected one of models`);
+    }
+    return;
+  }
+
+  throw new Error(`${path}.kind: expected "implicit", "fixed", or "select"`);
+}
+
+function validateRoleHarnesses(
+  label: string,
+  role: 'planning' | 'execution',
+  harnesses: Record<string, unknown>,
+): void {
+  for (const [harness, capability] of Object.entries(harnesses)) {
+    const harnessPath = `${label}.${role}.${harness}`;
+    if (role === 'execution' && harness === 'cursor') {
+      throw new Error(`${harnessPath}: cursor is planning-only`);
+    }
+    if (role === 'planning' && (harness === 'claude' || harness === 'codex')) {
+      throw new Error(`${harnessPath}: ${harness} is execution-only`);
+    }
+    if (!isRecord(capability)) {
+      throw new Error(`${harnessPath}: expected harness capability object`);
+    }
+    validateModelPolicy(`${harnessPath}.modelPolicy`, capability.modelPolicy);
+  }
+}
+
+function validateMachineCapabilities(label: string, capabilities: MachineCapabilities): void {
+  const rawCapabilities = capabilities as unknown;
+  if (!isRecord(rawCapabilities)) {
+    throw new Error(`${label}: expected capabilities object`);
+  }
+
+  const planning = rawCapabilities.planning;
+  if (planning !== undefined) {
+    if (!isRecord(planning)) {
+      throw new Error(`${label}.planning: expected a harness map`);
+    }
+    validateRoleHarnesses(label, 'planning', planning);
+  }
+
+  const execution = rawCapabilities.execution;
+  if (execution !== undefined) {
+    if (!isRecord(execution)) {
+      throw new Error(`${label}.execution: expected a harness map`);
+    }
+    validateRoleHarnesses(label, 'execution', execution);
+  }
+}
+
+export function validateInvokerConfig(config: InvokerConfig): InvokerConfig {
+  const defaultExecutionAgent = readNonEmptyString(config.defaultExecution?.executionAgent);
+  if (config.defaultExecution?.executionModel !== undefined && !defaultExecutionAgent) {
+    throw new Error('defaultExecution.executionModel requires defaultExecution.executionAgent');
+  }
+
+  for (const [targetId, target] of Object.entries(config.remoteTargets ?? {})) {
+    if (target.capabilities) {
+      validateMachineCapabilities(`remoteTargets.${targetId}.capabilities`, target.capabilities);
+    }
+  }
+
+  for (const [poolId, pool] of Object.entries(config.executionPools ?? {})) {
+    pool.members.forEach((member, index) => {
+      if (member.capabilities) {
+        validateMachineCapabilities(
+          `executionPools.${poolId}.members[${index}].capabilities`,
+          member.capabilities,
+        );
+      }
+    });
+  }
+
+  return config;
+}

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -8,6 +8,21 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { validateInvokerConfig } from './config-validation.js';
+
+export type HarnessModelPolicy =
+  | { kind: 'implicit' }
+  | { kind: 'fixed'; model: string }
+  | { kind: 'select'; models: string[]; defaultModel: string };
+
+export interface HarnessCapability {
+  modelPolicy: HarnessModelPolicy;
+}
+
+export interface MachineCapabilities {
+  planning?: Record<string, HarnessCapability>;
+  execution?: Record<string, HarnessCapability>;
+}
 const BUILT_IN_DEFAULT_EXECUTION_AGENT = 'codex';
 
 export interface ExternalWorkerLaunchConfig {
@@ -24,6 +39,18 @@ export interface ExternalWorkerConfig {
   kind: string;
   /** Process invocation used by the loader to start the external worker. */
   launch: ExternalWorkerLaunchConfig;
+}
+export interface DefaultExecutionConfig {
+  /**
+   * Default task execution harness when a task omits executionAgent.
+   * Falls back to the built-in default agent when unset.
+   */
+  executionAgent?: string;
+  /**
+   * Default task execution model paired with executionAgent.
+   * Only applied when the resolved task executionAgent matches this default agent.
+   */
+  executionModel?: string;
 }
 
 export interface InvokerConfig {
@@ -88,6 +115,11 @@ export interface InvokerConfig {
   defaultExecutionAgent?: string;
   /** Default execution model for prompt-backed tasks when the task does not override it. */
   defaultExecutionModel?: string;
+  /**
+   * Config-owned default execution harness/model for tasks that omit them.
+   * This is separate from Slack planning presets and applies across surfaces.
+   */
+  defaultExecution?: DefaultExecutionConfig;
   /**
    * When true, failed CI checks on Invoker-created review-gate PRs can
    * trigger the same auto-fix recovery flow used for task failures.
@@ -193,6 +225,7 @@ export interface InvokerConfig {
      * Default for pooled SSH members: 1.
      */
     maxConcurrentTasks?: number;
+    capabilities?: MachineCapabilities;
   }>;
   /**
    * Named execution pools used by routing rules.
@@ -201,8 +234,8 @@ export interface InvokerConfig {
   executionPools?: Record<string, {
     /** Pool members can mix substrates under one shared queue. */
     members: Array<
-      | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
-      | { type: 'worktree'; id: string; maxConcurrentTasks?: number }
+      | { type: 'ssh'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities }
+      | { type: 'worktree'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities }
     >;
     /** Member selection strategy for available capacity. Default: roundRobin */
     selectionStrategy?: 'roundRobin' | 'leastLoaded';
@@ -305,7 +338,8 @@ export function resolveConfigFileState(): { path: string; exists: boolean } {
   return { path, exists: existsSync(path) };
 }
 export function loadConfig(): InvokerConfig {
-  return readJsonSafe(resolveConfigFilePath());
+  const config = readJsonSafe(resolveConfigFilePath());
+  return validateInvokerConfig(config);
 }
 export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
   const configured = config.defaultExecutionAgent?.trim();

--- a/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
@@ -182,6 +182,7 @@ describe('resolveConflictImpl', () => {
       expect.stringContaining('Conflicting files: packages/app/src/headless.ts'),
       task.execution.workspacePath,
       'codex',
+      undefined,
     );
   });
 
@@ -223,6 +224,46 @@ describe('resolveConflictImpl', () => {
 
     expect(spawnAgentFix).toHaveBeenCalledTimes(1);
     expect(spawnAgentFix.mock.calls[0][2]).toBe('codex');
+  });
+
+  it('threads resolved executionModel to spawnAgentFix when merge fails', async () => {
+    const spawnAgentFix = vi.fn<
+      (prompt: string, cwd: string, agentName?: string, executionModel?: string) => Promise<{ stdout: string; sessionId: string }>
+    >(async () => ({ stdout: '', sessionId: 'sess-conflict-model' }));
+    const conflictError = JSON.stringify({
+      type: 'merge_conflict',
+      failedBranch: 'invoker/dep-1',
+      conflictFiles: ['src/index.ts'],
+    });
+    const task = {
+      id: 'task-conflict-model',
+      status: 'failed' as const,
+      execution: { error: conflictError, branch: 'invoker/task-conflict-model', workspacePath: createTempWorkspace() },
+      config: {},
+    };
+    const host: ConflictResolverHost = {
+      orchestrator: {
+        getTask: () => task,
+        getAllTasks: () => [],
+      } as unknown as Orchestrator,
+      persistence: {} as any,
+      cwd: '/tmp',
+      execGitReadonly: async () => '',
+      execGitIn: async (args: string[]) => {
+        if (args[0] === 'merge') throw new Error('merge conflict');
+        if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        return '';
+      },
+      createMergeWorktree: async () => '/tmp/wt',
+      removeMergeWorktree: async () => {},
+      spawnAgentFix,
+    };
+
+    await resolveConflictImpl(host, 'task-conflict-model', undefined, 'codex', 'gpt-5.1-codex-max');
+
+    expect(spawnAgentFix).toHaveBeenCalledTimes(1);
+    expect(spawnAgentFix.mock.calls[0][2]).toBe('codex');
+    expect(spawnAgentFix.mock.calls[0][3]).toBe('gpt-5.1-codex-max');
   });
 
   it('threads agentName="claude" to spawnAgentFix by default', async () => {

--- a/packages/execution-engine/src/__tests__/fix-prompt-transport.test.ts
+++ b/packages/execution-engine/src/__tests__/fix-prompt-transport.test.ts
@@ -63,7 +63,7 @@ function mockSpawnChildErrorEvent(err: Error & { code?: string }) {
   return child;
 }
 
-function makeExecutionAgent(buildFixCommand: (prompt: string) => { cmd: string; args: string[]; sessionId?: string }): ExecutionAgent {
+function makeExecutionAgent(buildFixCommand: ExecutionAgent['buildFixCommand']): ExecutionAgent {
   return {
     name: 'codex',
     stdinMode: 'ignore',
@@ -96,6 +96,21 @@ describe('fix prompt transport for oversized prompts', () => {
     expect(captured.prompt).toContain('The full task instructions are in this file:');
     expect(captured.prompt).toContain('invoker-agent-prompt-');
     expect(captured.prompt).not.toContain(hugePrompt.slice(0, 200));
+  });
+  it('passes executionModel to local fix command builders', async () => {
+    const { spawn } = await import('node:child_process');
+    const buildFixCommand = vi.fn((prompt: string, options?: { executionModel?: string }) => ({
+      cmd: 'codex',
+      args: ['exec', '--json', ...(options?.executionModel ? ['--model', options.executionModel] : []), prompt],
+      sessionId: 'local-model-sess',
+    }));
+    const agent = makeExecutionAgent(buildFixCommand);
+
+    vi.mocked(spawn).mockReturnValueOnce(mockSpawnChild('ok', 0) as any);
+
+    const result = await spawnAgentFixViaRegistry('small prompt', '/tmp', agent, undefined, 'gpt-5.1-codex-max');
+    expect(result.sessionId).toBe('local-model-sess');
+    expect(buildFixCommand).toHaveBeenCalledWith('small prompt', { executionModel: 'gpt-5.1-codex-max' });
   });
 
   it('remote fix path writes oversized prompt to remote temp file and passes short bootstrap prompt', async () => {

--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { TaskRunner } from '../task-runner.js';
+import { TaskRunner, type ExecutionPoolMember } from '../task-runner.js';
 import { ResourceLimitError } from '../repo-pool.js';
 import { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
+import type { MachineCapabilities } from '../harness-capabilities.js';
 
 function makeTask(id: string): TaskState {
   return {
@@ -16,12 +17,20 @@ function makeTask(id: string): TaskState {
   } as TaskState;
 }
 
+type RemoteTargetTestConfig = {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  capabilities?: MachineCapabilities;
+};
+
 function makeRunner(overrides: {
-  members?: Array<{ id: string; type: 'ssh'; maxConcurrentTasks?: number }>;
+  members?: ExecutionPoolMember[];
   strategy?: 'roundRobin' | 'leastLoaded';
-  orchestrator?: any;
-  persistence?: any;
-  sshExecutor?: any;
+  orchestrator?: unknown;
+  persistence?: unknown;
+  sshExecutor?: unknown;
+  remoteTargets?: Record<string, RemoteTargetTestConfig>;
 } = {}): TaskRunner {
   const sshExecutor = overrides.sshExecutor ?? {
     type: 'ssh',
@@ -32,7 +41,11 @@ function makeRunner(overrides: {
     kill: vi.fn(),
     destroyAll: vi.fn(),
   };
-  const members = overrides.members ?? [{ id: 'remote-a', type: 'ssh' as const, maxConcurrentTasks: 1 }];
+  const members = overrides.members ?? [{ id: 'remote-a', type: 'ssh', maxConcurrentTasks: 1 }];
+  const remoteTargets = overrides.remoteTargets ?? {
+    'remote-a': { host: 'remote-a.example.com', user: 'invoker', sshKeyPath: '/tmp/fake-a' },
+    'remote-b': { host: 'remote-b.example.com', user: 'invoker', sshKeyPath: '/tmp/fake-b' },
+  };
   return new TaskRunner({
     orchestrator: overrides.orchestrator ?? { getTask: () => null, getAllTasks: () => [], deferTask: vi.fn() },
     persistence: overrides.persistence ?? { logEvent: vi.fn() },
@@ -43,10 +56,7 @@ function makeRunner(overrides: {
       register: vi.fn(),
     } as any,
     cwd: '/tmp',
-    remoteTargetsProvider: () => ({
-      'remote-a': { host: 'remote-a.example.com', user: 'invoker', sshKeyPath: '/tmp/fake-a' },
-      'remote-b': { host: 'remote-b.example.com', user: 'invoker', sshKeyPath: '/tmp/fake-b' },
-    }),
+    remoteTargetsProvider: () => remoteTargets,
     executionPoolsProvider: () => ({
       'ssh-pool': {
         selectionStrategy: overrides.strategy ?? 'leastLoaded',
@@ -55,6 +65,12 @@ function makeRunner(overrides: {
       },
     }),
   });
+}
+
+function getPendingSelection(runner: TaskRunner, taskId: string) {
+  const selection = runner.pendingPoolSelections.get(taskId);
+  if (!selection) throw new Error(`Missing pending selection for ${taskId}`);
+  return selection;
 }
 
 describe('SSH pool member capacity', () => {
@@ -104,6 +120,134 @@ describe('SSH pool member capacity', () => {
     expect(() => runner.selectExecutor(secondTask)).toThrow(/no member capacity/);
     const selections = [...(runner as any).pendingPoolSelections.values()];
     expect(selections.map((selection: any) => selection.member.id)).toEqual(['remote-a']);
+  });
+
+  it('rejects explicit models for implicit codex execution members', () => {
+    const task = makeTask('wf-1/task-codex');
+    task.config = {
+      ...task.config,
+      executionAgent: 'codex',
+      executionModel: 'anthropic/claude-opus-4',
+    };
+    const runner = makeRunner({
+      members: [
+        {
+          id: 'remote-a',
+          type: 'ssh',
+          maxConcurrentTasks: 1,
+          capabilities: {
+            execution: {
+              codex: { modelPolicy: { kind: 'implicit' } },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(() => runner.selectExecutor(task)).toThrow('does not accept an explicit model');
+  });
+
+  it('fills fixed OMP models from member policy when the task omits one', () => {
+    const task = makeTask('wf-1/task-omp-fixed');
+    task.config = {
+      ...task.config,
+      executionAgent: 'omp',
+    };
+    const runner = makeRunner({
+      members: [
+        {
+          id: 'remote-a',
+          type: 'ssh',
+          maxConcurrentTasks: 1,
+          capabilities: {
+            execution: {
+              omp: {
+                modelPolicy: { kind: 'fixed', model: 'anthropic/claude-opus-4' },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    runner.selectExecutor(task);
+    expect(getPendingSelection(runner, task.id).resolvedExecution).toEqual({
+      executionAgent: 'omp',
+      executionModel: 'anthropic/claude-opus-4',
+    });
+  });
+
+  it('rejects OMP models that are not advertised by the member', () => {
+    const task = makeTask('wf-1/task-omp-select');
+    task.config = {
+      ...task.config,
+      executionAgent: 'omp',
+      executionModel: 'openai/gpt-5',
+    };
+    const runner = makeRunner({
+      members: [
+        {
+          id: 'remote-a',
+          type: 'ssh',
+          maxConcurrentTasks: 1,
+          capabilities: {
+            execution: {
+              omp: {
+                modelPolicy: {
+                  kind: 'select',
+                  models: ['anthropic/claude-opus-4'],
+                  defaultModel: 'anthropic/claude-opus-4',
+                },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    expect(() => runner.selectExecutor(task)).toThrow('does not advertise model "openai/gpt-5"');
+  });
+
+  it('picks the pool member whose execution policy matches the task', () => {
+    const task = makeTask('wf-1/task-omp-member');
+    task.config = {
+      ...task.config,
+      executionAgent: 'omp',
+    };
+    const runner = makeRunner({
+      members: [
+        {
+          id: 'remote-a',
+          type: 'ssh',
+          maxConcurrentTasks: 1,
+          capabilities: {
+            execution: {
+              codex: { modelPolicy: { kind: 'implicit' } },
+            },
+          },
+        },
+        {
+          id: 'remote-b',
+          type: 'ssh',
+          maxConcurrentTasks: 1,
+          capabilities: {
+            execution: {
+              omp: {
+                modelPolicy: { kind: 'fixed', model: 'anthropic/claude-opus-4' },
+              },
+            },
+          },
+        },
+      ],
+    });
+
+    runner.selectExecutor(task);
+    const selection = getPendingSelection(runner, task.id);
+    expect(selection.member.id).toBe('remote-b');
+    expect(selection.resolvedExecution).toEqual({
+      executionAgent: 'omp',
+      executionModel: 'anthropic/claude-opus-4',
+    });
   });
 
   it('does not reselect an excluded persisted poolMemberId', () => {

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -170,6 +170,7 @@ export async function resolveConflictImpl(
   taskId: string,
   savedError?: string,
   agentName?: string,
+  resolvedExecutionModel?: string,
 ): Promise<void> {
   host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
     phase: 'resolve-conflict-start',
@@ -216,7 +217,7 @@ export async function resolveConflictImpl(
     if (!target) {
       throw new Error(`No remote target config for "${poolMemberId}" — cannot resolve conflict on remote`);
     }
-    await resolveConflictRemote(host, task, taskBranch, conflictInfo, rawCwd, target, agentName);
+    await resolveConflictRemote(host, task, taskBranch, conflictInfo, rawCwd, target, agentName, resolvedExecutionModel);
     return;
   }
 
@@ -270,8 +271,8 @@ export async function resolveConflictImpl(
         `4. Staging the resolved files with 'git add'`,
         `5. Completing the merge with 'git commit --no-edit'`,
       ].join('\n');
-
-      await host.spawnAgentFix(prompt, cwd, agentName);
+      const executionModel = resolvedExecutionModel ?? resolveExecutionModelForAgent(task, agentName);
+      await host.spawnAgentFix(prompt, cwd, agentName, executionModel);
     }
 
     console.log(`[resolveConflict] Successfully resolved conflict for ${taskId}`);
@@ -358,6 +359,7 @@ async function resolveConflictRemote(
   remoteCwd: string,
   target: RemoteTargetConfig,
   agentName?: string,
+  resolvedExecutionModel?: string,
 ): Promise<void> {
   const conflictFilesList = conflictInfo.conflictFiles.join(', ');
   const prompt = [
@@ -377,7 +379,13 @@ async function resolveConflictRemote(
     ? `Merge upstream ${conflictInfo.failedBranch} — ${depTask.description}`
     : `Merge upstream ${conflictInfo.failedBranch}`;
 
-  const { shellCommand: agentCmd } = buildRemoteAgentCommand(prompt, host.agentRegistry, agentName);
+  const executionModel = resolvedExecutionModel ?? resolveExecutionModelForAgent(task, agentName);
+  const { shellCommand: agentCmd } = buildRemoteAgentCommand(
+    prompt,
+    host.agentRegistry,
+    agentName,
+    executionModel,
+  );
   const agentCmdB64 = Buffer.from(agentCmd).toString('base64');
   const mergeMsgB64 = Buffer.from(conflictMergeMsg).toString('base64');
   const envExports = buildRemoteAgentEnvExports(target.secretsFile, target.use_api_key === true);

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -50,7 +50,7 @@ export interface ConflictResolverHost {
   execGitIn(args: string[], dir: string): Promise<string>;
   createMergeWorktree(ref: string, label: string, repoUrl?: string): Promise<string>;
   removeMergeWorktree(dir: string): Promise<void>;
-  spawnAgentFix(prompt: string, cwd: string, agentName?: string): Promise<{ stdout: string; sessionId: string }>;
+  spawnAgentFix(prompt: string, cwd: string, agentName?: string, executionModel?: string): Promise<{ stdout: string; sessionId: string }>;
   getRemoteTargetConfig?(targetId: string): RemoteTargetConfig | undefined;
 }
 
@@ -217,7 +217,7 @@ export async function resolveConflictImpl(
     if (!target) {
       throw new Error(`No remote target config for "${poolMemberId}" — cannot resolve conflict on remote`);
     }
-    await resolveConflictRemote(host, task, taskBranch, conflictInfo, rawCwd, target, agentName, resolvedExecutionModel);
+    await resolveConflictRemote(host, taskId, taskBranch, conflictInfo, rawCwd, target, agentName, resolvedExecutionModel);
     return;
   }
 
@@ -271,8 +271,7 @@ export async function resolveConflictImpl(
         `4. Staging the resolved files with 'git add'`,
         `5. Completing the merge with 'git commit --no-edit'`,
       ].join('\n');
-      const executionModel = resolvedExecutionModel ?? resolveExecutionModelForAgent(task, agentName);
-      await host.spawnAgentFix(prompt, cwd, agentName, executionModel);
+      await host.spawnAgentFix(prompt, cwd, agentName, resolvedExecutionModel);
     }
 
     console.log(`[resolveConflict] Successfully resolved conflict for ${taskId}`);
@@ -311,12 +310,13 @@ function buildRemoteAgentCommand(
   prompt: string,
   agentRegistry?: AgentRegistry,
   agentName?: string,
+  executionModel?: string,
 ): { shellCommand: string; sessionId: string } {
   const name = agentName ?? DEFAULT_EXECUTION_AGENT;
   if (agentRegistry) {
     const agent = agentRegistry.get(name);
     if (agent?.buildFixCommand) {
-      const spec = agent.buildFixCommand(prompt);
+      const spec = agent.buildFixCommand(prompt, { executionModel });
       const sessionId = spec.sessionId ?? randomUUID();
       const cmd = `${spec.cmd} ${spec.args.map(a => shellQuote(a)).join(' ')}`;
       return { shellCommand: cmd, sessionId };
@@ -353,7 +353,7 @@ export function resolveSelectedRemoteTargetId(host: ConflictResolverHost, taskId
 
 async function resolveConflictRemote(
   host: ConflictResolverHost,
-  task: ReturnType<Orchestrator['getTask']> & {},
+  taskId: string,
   taskBranch: string,
   conflictInfo: { failedBranch: string; conflictFiles: string[] },
   remoteCwd: string,
@@ -379,12 +379,11 @@ async function resolveConflictRemote(
     ? `Merge upstream ${conflictInfo.failedBranch} — ${depTask.description}`
     : `Merge upstream ${conflictInfo.failedBranch}`;
 
-  const executionModel = resolvedExecutionModel ?? resolveExecutionModelForAgent(task, agentName);
   const { shellCommand: agentCmd } = buildRemoteAgentCommand(
     prompt,
     host.agentRegistry,
     agentName,
-    executionModel,
+    resolvedExecutionModel,
   );
   const agentCmdB64 = Buffer.from(agentCmd).toString('base64');
   const mergeMsgB64 = Buffer.from(conflictMergeMsg).toString('base64');
@@ -406,7 +405,7 @@ fi
 `;
 
   await execRemoteSsh(target, script, 'remote_conflict_fix');
-  console.log(`[resolveConflict] Successfully resolved remote conflict for ${task.id}`);
+  console.log(`[resolveConflict] Successfully resolved remote conflict for ${taskId}`);
 }
 
 /**
@@ -708,9 +707,10 @@ export function spawnAgentFixViaRegistry(
   cwd: string,
   agent: ExecutionAgent,
   driver?: SessionDriver,
+  executionModel?: string,
 ): Promise<{ stdout: string; sessionId: string }> {
   const promptTransport = materializeLocalPrompt(prompt);
-  const spec = agent.buildFixCommand?.(promptTransport.effectivePrompt);
+  const spec = agent.buildFixCommand?.(promptTransport.effectivePrompt, { executionModel });
   if (!spec) {
     promptTransport.cleanup();
     throw new Error(`Agent "${agent.name}" does not support fix commands`);

--- a/packages/execution-engine/src/harness-capabilities.ts
+++ b/packages/execution-engine/src/harness-capabilities.ts
@@ -1,0 +1,83 @@
+export type CapabilityRole = 'planning' | 'execution';
+
+export type HarnessModelPolicy =
+  | { kind: 'implicit' }
+  | { kind: 'fixed'; model: string }
+  | { kind: 'select'; models: string[]; defaultModel: string };
+
+export interface HarnessCapability {
+  modelPolicy: HarnessModelPolicy;
+}
+
+export interface MachineCapabilities {
+  planning?: Record<string, HarnessCapability>;
+  execution?: Record<string, HarnessCapability>;
+}
+
+export interface HarnessSelectionRequest {
+  role: CapabilityRole;
+  harness: string;
+  model?: string;
+}
+
+export interface ResolvedHarnessSelection {
+  harness: string;
+  model?: string;
+}
+
+export function resolveHarnessSelection(
+  capabilities: MachineCapabilities | undefined,
+  request: HarnessSelectionRequest,
+): { ok: true; selection: ResolvedHarnessSelection } | { ok: false; reason: string } {
+  if (!capabilities) {
+    return {
+      ok: true,
+      selection: { harness: request.harness, model: request.model },
+    };
+  }
+
+  const roleCapabilities = capabilities[request.role];
+  if (!roleCapabilities) {
+    return { ok: false, reason: `missing ${request.role} capabilities` };
+  }
+
+  const capability = roleCapabilities[request.harness];
+  if (!capability) {
+    return { ok: false, reason: `missing ${request.role} harness "${request.harness}"` };
+  }
+
+  const policy = capability.modelPolicy;
+  if (policy.kind === 'implicit') {
+    if (request.model) {
+      return { ok: false, reason: `harness "${request.harness}" does not accept an explicit model` };
+    }
+    return { ok: true, selection: { harness: request.harness } };
+  }
+
+  if (policy.kind === 'fixed') {
+    if (request.model && request.model !== policy.model) {
+      return { ok: false, reason: `harness "${request.harness}" is fixed to model "${policy.model}"` };
+    }
+    return {
+      ok: true,
+      selection: { harness: request.harness, model: policy.model },
+    };
+  }
+
+  if (policy.models.length === 0) {
+    return { ok: false, reason: `harness "${request.harness}" does not advertise any models` };
+  }
+  if (!request.model) {
+    return {
+      ok: true,
+      selection: { harness: request.harness, model: policy.defaultModel },
+    };
+  }
+  if (!policy.models.includes(request.model)) {
+    return { ok: false, reason: `harness "${request.harness}" does not advertise model "${request.model}"` };
+  }
+  return {
+    ok: true,
+    selection: { harness: request.harness, model: request.model },
+  };
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -8,6 +8,7 @@ export {
   shouldResolveViaOriginTracking,
   isInvokerManagedPoolBranch,
 } from './plan-base-remote.js';
+export * from './harness-capabilities.js';
 export * from './executor.js';
 export * from './base-executor.js';
 export * from './process-utils.js';

--- a/packages/execution-engine/src/task-runner-dispatch.ts
+++ b/packages/execution-engine/src/task-runner-dispatch.ts
@@ -47,7 +47,7 @@ export async function dispatchExecutor(
   let handle!: ExecutorHandle;
   while (true) {
     bench('selectExecutor.start');
-    executor = host.selectExecutor(task, attemptedPoolMemberKeys);
+    executor = host.selectExecutor(task, attemptedPoolMemberKeys).executor;
     const poolSelectionForStart = host.pendingPoolSelections.get(task.id);
     if (!host.acquirePoolSelectionLease(task, attemptId, poolSelectionForStart)) {
       if (poolSelectionForStart) {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -17,6 +17,8 @@ import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
 import type { Executor, ExecutorHandle } from './executor.js';
 import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
+import type { MachineCapabilities } from './harness-capabilities.js';
+import { resolveHarnessSelection } from './harness-capabilities.js';
 import { BaseExecutor } from './base-executor.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import { createExecutionBench } from './execution-bench.js';
@@ -89,8 +91,8 @@ export type ActiveExecutionEntry = {
 };
 
 export type ExecutionPoolMember =
-  | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
-  | { type: 'worktree'; id: string; maxConcurrentTasks?: number };
+  | { type: 'ssh'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities }
+  | { type: 'worktree'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities };
 
 export type ExecutionPoolConfig = {
   members: ExecutionPoolMember[];
@@ -98,15 +100,26 @@ export type ExecutionPoolConfig = {
   maxConcurrentTasksPerMember?: number;
 };
 
+type ResolvedExecutionSelection = {
+  executionAgent: string;
+  executionModel?: string;
+};
+
+
+type SelectedExecutor = {
+  executor: Executor;
+  resolvedExecution: ResolvedExecutionSelection;
+  selectedPoolMemberId?: string;
+};
 export type PoolSelection = {
   poolId: string;
   member: ExecutionPoolMember;
   memberKey: string;
   selectionStrategy: 'roundRobin' | 'leastLoaded';
+  resolvedExecution?: ResolvedExecutionSelection;
   leaseResourceKey?: string;
   leaseHolderId?: string;
 };
-
 export type FreshBaseCommit = {
   branch: string;
   commit: string;
@@ -123,6 +136,8 @@ type RemoteTargetDisplay = {
   use_api_key?: boolean;
   secretsFile?: string;
   remoteHeartbeatIntervalSeconds?: number;
+  maxConcurrentTasks?: number;
+  capabilities?: MachineCapabilities;
 };
 
 export interface ReviewGateCiFailureTrigger {
@@ -270,11 +285,13 @@ export interface TaskRunnerConfig {
     use_api_key?: boolean;
     secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;
+    maxConcurrentTasks?: number;
+    capabilities?: MachineCapabilities;
   }>;
   executionPoolsProvider?: () => Record<string, {
     members: Array<
-      | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
-      | { type: 'worktree'; id: string; maxConcurrentTasks?: number }
+      | { type: 'ssh'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities }
+      | { type: 'worktree'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities }
     >;
     selectionStrategy?: 'roundRobin' | 'leastLoaded';
     maxConcurrentTasksPerMember?: number;
@@ -428,6 +445,47 @@ export class TaskRunner {
     this.dockerConfig = config.dockerConfig ?? {};
     this.executionAgentRegistry = config.executionAgentRegistry;
     this.logger = config.logger ?? NOOP_LOGGER;
+  }
+
+  resolveExecutionAgent(task: Pick<TaskState, 'config'>): string {
+    return task.config.executionAgent?.trim() || this.getDefaultExecutionAgent();
+  }
+
+  resolveExecutionModel(task: Pick<TaskState, 'config'>): string | undefined {
+    const explicitModel = task.config.executionModel?.trim();
+    if (explicitModel) return explicitModel;
+    const defaults = this.getExecutionDefaults();
+    const defaultAgent = this.getDefaultExecutionAgent();
+    const defaultModel = defaults.executionModel?.trim();
+    if (!defaultModel) return undefined;
+    return this.resolveExecutionAgent(task) === defaultAgent ? defaultModel : undefined;
+  }
+
+  private executionRequirementLabel(task: Pick<TaskState, 'config'>): string {
+    const executionAgent = this.resolveExecutionAgent(task);
+    const executionModel = this.resolveExecutionModel(task);
+    return executionModel ? `${executionAgent}/${executionModel}` : executionAgent;
+  }
+
+  private resolveExecutionForMember(
+    task: Pick<TaskState, 'config'>,
+    memberCapabilities: MachineCapabilities | undefined,
+  ): { ok: true; selection: ResolvedExecutionSelection } | { ok: false; reason: string } {
+    const resolvedAgent = this.resolveExecutionAgent(task);
+    const requestedModel = this.resolveExecutionModel(task);
+    const result = resolveHarnessSelection(memberCapabilities, {
+      role: 'execution',
+      harness: resolvedAgent,
+      model: requestedModel,
+    });
+    if (!result.ok) return result;
+    return {
+      ok: true,
+      selection: {
+        executionAgent: result.selection.harness,
+        executionModel: result.selection.model,
+      },
+    };
   }
 
   /**
@@ -802,11 +860,6 @@ export class TaskRunner {
       && task.execution.workspacePath === undefined;
   }
 
-  /**
-   * Select the executor to use for a given task.
-   * Uses task.runnerKind to look up in the registry; falls back to default.
-   * Merge gate tasks use the dedicated merge executor.
-   */
   /** @internal */ poolMemberKey(member: ExecutionPoolMember): string {
     return `${member.type}:${member.id}`;
   }
@@ -830,8 +883,18 @@ export class TaskRunner {
     const limit = this.poolMemberLimit(pool, member);
     return limit === undefined || this.poolMemberLoad(poolId, this.poolMemberKey(member)) < limit;
   }
+  private memberCapabilities(member: ExecutionPoolMember): MachineCapabilities | undefined {
+    if (member.capabilities) return member.capabilities;
+    return member.type === 'ssh' ? this.getRemoteTargets()[member.id]?.capabilities : undefined;
+  }
+
+  private memberCapabilityMismatch(member: ExecutionPoolMember, task: Pick<TaskState, 'config'>): string | undefined {
+    const match = this.resolveExecutionForMember(task, this.memberCapabilities(member));
+    return match.ok ? undefined : match.reason;
+  }
 
   private selectPoolMember(
+    task: Pick<TaskState, 'config'>,
     poolId: string,
     pool: ExecutionPoolConfig,
     excludedMemberKeys: Set<string> = new Set(),
@@ -844,6 +907,7 @@ export class TaskRunner {
         const index = (cursor + offset) % pool.members.length;
         const member = pool.members[index];
         if (excludedMemberKeys.has(this.poolMemberKey(member))) continue;
+        if (this.memberCapabilityMismatch(member, task)) continue;
         if (!this.poolMemberHasCapacity(poolId, pool, member)) continue;
         this.poolRoundRobinCursor.set(poolId, (index + 1) % pool.members.length);
         return member;
@@ -851,22 +915,37 @@ export class TaskRunner {
       return undefined;
     }
 
-    const scored = pool.members.filter((member) => !excludedMemberKeys.has(this.poolMemberKey(member))).map((member, index) => {
-      const memberKey = this.poolMemberKey(member);
-      const load = this.poolMemberLoad(poolId, memberKey);
-      const limit = this.poolMemberLimit(pool, member);
-      return { member, index, load, hasCapacity: limit === undefined || load < limit };
-    });
-    const candidates = scored.filter((entry) => entry.hasCapacity);
+    const scored = pool.members
+      .filter((member) => !excludedMemberKeys.has(this.poolMemberKey(member)))
+      .map((member, index) => {
+        const memberKey = this.poolMemberKey(member);
+        const load = this.poolMemberLoad(poolId, memberKey);
+        const limit = this.poolMemberLimit(pool, member);
+        return {
+          member,
+          index,
+          load,
+          hasCapacity: limit === undefined || load < limit,
+          capabilityMismatch: this.memberCapabilityMismatch(member, task),
+        };
+      });
+    const candidates = scored.filter((entry) => entry.hasCapacity && !entry.capabilityMismatch);
     candidates.sort((a, b) => a.load - b.load || a.index - b.index);
     return candidates[0]?.member;
   }
 
-  private poolCapacitySnapshot(poolId: string, pool: ExecutionPoolConfig): Array<{
+  private poolCapacitySnapshot(
+    task: Pick<TaskState, 'config'>,
+    poolId: string,
+    pool: ExecutionPoolConfig,
+    excludedMemberKeys: Set<string>,
+  ): Array<{
     memberId: string;
     memberType: string;
     load: number;
     limit: number | undefined;
+    excluded: boolean;
+    capabilityMismatch?: string;
   }> {
     return pool.members.map((member) => {
       const memberKey = this.poolMemberKey(member);
@@ -875,23 +954,51 @@ export class TaskRunner {
         memberType: member.type,
         load: this.poolMemberLoad(poolId, memberKey),
         limit: this.poolMemberLimit(pool, member),
+        excluded: excludedMemberKeys.has(memberKey),
+        capabilityMismatch: this.memberCapabilityMismatch(member, task),
       };
     });
   }
 
-  private poolCapacityError(taskId: string, poolId: string, pool: ExecutionPoolConfig, excludedMemberKeys: Set<string>): Error {
-    const snapshot = this.poolCapacitySnapshot(poolId, pool);
-    const message = `Execution pool "${poolId}" has no member capacity available`;
+  private poolCapacityError(
+    task: Pick<TaskState, 'id' | 'config'>,
+    poolId: string,
+    pool: ExecutionPoolConfig,
+    excludedMemberKeys: Set<string>,
+  ): Error {
+    const snapshot = this.poolCapacitySnapshot(task, poolId, pool, excludedMemberKeys);
+    const requirementAgent = this.resolveExecutionAgent(task);
+    const requirementModel = this.resolveExecutionModel(task);
+    const requirementLabel = requirementModel ? `${requirementAgent}/${requirementModel}` : requirementAgent;
+    const reasonSuffix = snapshot
+      .map((member) => {
+        const reasons = [
+          member.excluded ? 'excluded' : undefined,
+          member.capabilityMismatch,
+          member.limit !== undefined && member.load >= member.limit ? `capacity ${member.load}/${member.limit}` : undefined,
+        ].filter((reason): reason is string => Boolean(reason));
+        return `${member.memberType}:${member.memberId}${reasons.length > 0 ? ` (${reasons.join(', ')})` : ''}`;
+      })
+      .join('; ');
+    const message = `Execution pool "${poolId}" has no member capacity available for ${requirementLabel}${reasonSuffix ? `: ${reasonSuffix}` : ''}`;
     const resourceLimit = new ResourceLimitError(message);
-    this.persistence.logEvent?.(taskId, 'task.executor.deferred', {
+    this.persistence.logEvent?.(task.id, 'task.executor.deferred', {
       reason: 'execution-pool-capacity',
       poolId,
       excludedMemberKeys: [...excludedMemberKeys],
+      requirement: {
+        executionAgent: requirementAgent,
+        executionModel: requirementModel,
+      },
       members: snapshot,
     });
     this.logger.info(`[TaskRunner] deferring task: ${message}`, {
       poolId,
       excludedMemberKeys: [...excludedMemberKeys],
+      requirement: {
+        executionAgent: requirementAgent,
+        executionModel: requirementModel,
+      },
       members: snapshot,
     });
     return new Error(message, { cause: resourceLimit });
@@ -1023,45 +1130,76 @@ export class TaskRunner {
       ?? (task.config.poolId && this.getRemoteTargets()[task.config.poolId] ? task.config.poolId : undefined);
   }
 
-  selectExecutor(task: TaskState, excludedPoolMemberKeys: Set<string> = new Set()): Executor {
+  takeResolvedExecutionSelection(taskId: string): ResolvedExecutionSelection | undefined {
+    const selection = this.pendingPoolSelections.get(taskId);
+    const resolvedExecution = selection?.resolvedExecution;
+    if (selection) {
+      selection.resolvedExecution = undefined;
+    }
+    return resolvedExecution;
+  }
+
+  selectExecutor(task: TaskState, excludedPoolMemberKeys: Set<string> = new Set()): SelectedExecutor {
     let effectiveType = task.config.runnerKind ?? (task.config.isMergeNode ? 'merge' : undefined);
     let selectedPoolMemberId: string | undefined;
     const explicitPoolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
+    let resolvedExecution: ResolvedExecutionSelection = {
+      executionAgent: this.resolveExecutionAgent(task),
+      executionModel: this.resolveExecutionModel(task),
+    };
     this.pendingPoolSelections.delete(task.id);
 
     if (task.config.poolId && explicitPoolMemberId) {
       const pool = this.getExecutionPools()[task.config.poolId];
       const member = pool?.members.find((candidate) => candidate.type === 'ssh' && candidate.id === explicitPoolMemberId);
       if (pool && member) {
+        const memberExecution = this.resolveExecutionForMember(task, this.memberCapabilities(member));
+        if (!memberExecution.ok) {
+          throw new Error(
+            `Execution pool "${task.config.poolId}" member "${explicitPoolMemberId}" cannot run ` +
+            `${this.executionRequirementLabel(task)}: ${memberExecution.reason}`,
+          );
+        }
         if (
           excludedPoolMemberKeys.has(this.poolMemberKey(member))
           || !this.poolMemberHasCapacity(task.config.poolId, pool, member)
         ) {
-          throw this.poolCapacityError(task.id, task.config.poolId, pool, excludedPoolMemberKeys);
+          throw this.poolCapacityError(task, task.config.poolId, pool, excludedPoolMemberKeys);
         }
         effectiveType = member.type;
         selectedPoolMemberId = member.id;
+        resolvedExecution = memberExecution.selection;
         this.pendingPoolSelections.set(task.id, {
           poolId: task.config.poolId,
           member,
           memberKey: this.poolMemberKey(member),
           selectionStrategy: pool.selectionStrategy ?? 'roundRobin',
+          resolvedExecution,
         });
       }
     } else if (task.config.poolId) {
       const pool = this.getExecutionPools()[task.config.poolId];
-      const member = pool ? this.selectPoolMember(task.config.poolId, pool, excludedPoolMemberKeys) : undefined;
+      const member = pool ? this.selectPoolMember(task, task.config.poolId, pool, excludedPoolMemberKeys) : undefined;
       if (member) {
+        const memberExecution = this.resolveExecutionForMember(task, this.memberCapabilities(member));
+        if (!memberExecution.ok) {
+          throw new Error(
+            `Execution pool "${task.config.poolId}" member "${member.id}" cannot run ` +
+            `${this.executionRequirementLabel(task)}: ${memberExecution.reason}`,
+          );
+        }
         effectiveType = member.type;
         selectedPoolMemberId = member.type === 'ssh' ? member.id : undefined;
+        resolvedExecution = memberExecution.selection;
         this.pendingPoolSelections.set(task.id, {
           poolId: task.config.poolId,
           member,
           memberKey: this.poolMemberKey(member),
           selectionStrategy: pool.selectionStrategy ?? 'roundRobin',
+          resolvedExecution,
         });
       } else if (pool) {
-        throw this.poolCapacityError(task.id, task.config.poolId, pool, excludedPoolMemberKeys);
+        throw this.poolCapacityError(task, task.config.poolId, pool, excludedPoolMemberKeys);
       }
     }
     if (
@@ -1078,10 +1216,9 @@ export class TaskRunner {
       const registered = this.executorRegistry.get(effectiveType);
       if (registered && (effectiveType !== 'merge' || registered.type === 'merge')) {
         traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=${effectiveType} → ${registered.type}`);
-        return registered;
+        return { executor: registered, resolvedExecution, selectedPoolMemberId };
       }
 
-      // Per-task Docker instance (each task gets its own container + execGitSimple routing)
       if (effectiveType === 'docker') {
         const docker = new DockerExecutor({
           imageName: task.config.dockerImage || this.dockerConfig.imageName,
@@ -1090,10 +1227,9 @@ export class TaskRunner {
         });
         this.executorRegistry.register(`docker:${task.id}`, docker);
         traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=docker → docker (per-task)`);
-        return docker;
+        return { executor: docker, resolvedExecution, selectedPoolMemberId };
       }
 
-      // Lazy registration for Worktree
       if (effectiveType === 'worktree') {
         const invokerHome = resolve(homedir(), '.invoker');
         const worktree = new WorktreeExecutor({
@@ -1104,20 +1240,16 @@ export class TaskRunner {
         });
         this.executorRegistry.register('worktree', worktree);
         traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=worktree → worktree (lazy registered)`);
-        return worktree;
+        return { executor: worktree, resolvedExecution, selectedPoolMemberId };
       }
 
       if (effectiveType === 'merge') {
         const merge = new MergeGateExecutor(this);
         this.executorRegistry.register?.('merge', merge);
         traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=merge → merge (lazy registered)`);
-        return merge;
+        return { executor: merge, resolvedExecution, selectedPoolMemberId };
       }
 
-      // Lazy registration for SSH — resolve poolMemberId from config and cache by targetId.
-      // The cache is config-aware: if the underlying remote target config changes (e.g. via
-      // remoteTargetsProvider returning new values), we replace the cached executor so the
-      // new config takes effect immediately.
       if (effectiveType === 'ssh') {
         const remoteTargets = this.getRemoteTargets();
         const targetId =
@@ -1128,7 +1260,6 @@ export class TaskRunner {
           throw new Error(`Task ${task.id} has runnerKind=ssh but no poolMemberId`);
         }
 
-        // Always re-read targets so dynamic provider updates are picked up.
         const target = remoteTargets[targetId];
         if (!target) {
           throw new Error(
@@ -1136,8 +1267,14 @@ export class TaskRunner {
             `entry exists in remoteTargets config. Available: [${Object.keys(remoteTargets).join(', ')}]`,
           );
         }
+        const directExecution = this.resolveExecutionForMember(task, target.capabilities);
+        if (!directExecution.ok) {
+          throw new Error(
+            `SSH target "${targetId}" cannot run ${this.executionRequirementLabel(task)}: ${directExecution.reason}`,
+          );
+        }
+        resolvedExecution = directExecution.selection;
 
-        // Build a config fingerprint so cache invalidates when target config changes.
         const configFingerprint = JSON.stringify({
           host: target.host,
           user: target.user,
@@ -1152,14 +1289,12 @@ export class TaskRunner {
         });
         const cacheKey = `${targetId}|${configFingerprint}`;
 
-        // Return cached executor if it exists for this target+config combo
         const cached = this.sshExecutorCache.get(cacheKey);
         if (cached) {
           traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (cached)`);
-          return cached;
+          return { executor: cached, resolvedExecution, selectedPoolMemberId: targetId };
         }
 
-        // Drop any stale entries for this targetId so we don't accumulate dead caches.
         for (const key of this.sshExecutorCache.keys()) {
           if (key.startsWith(`${targetId}|`)) {
             this.sshExecutorCache.delete(key);
@@ -1173,22 +1308,21 @@ export class TaskRunner {
           port: target.port,
           agentRegistry: this.executionAgentRegistry,
           managedWorkspaces: target.managedWorkspaces,
-          remoteInvokerHome: target.remoteInvokerHome,
           provisionCommand: target.provisionCommand,
-          useApiKey: target.use_api_key === true,
+          useApiKey: target.use_api_key,
           secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
           remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
         });
-
+        this.executorRegistry.register(`ssh:${targetId}`, ssh);
         this.sshExecutorCache.set(cacheKey, ssh);
-        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (new, cached)`);
-        return ssh;
+        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (lazy registered)`);
+        return { executor: ssh, resolvedExecution, selectedPoolMemberId: targetId };
       }
     }
 
-    const defaultExecutor = this.executorRegistry.getDefault();
-    traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=${effectiveType ?? 'none'} → ${defaultExecutor.type} (default)`);
-    return defaultExecutor;
+    const executor = this.executorRegistry.getDefault();
+    traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=(default) → ${executor.type}`);
+    return { executor, resolvedExecution, selectedPoolMemberId };
   }
 
   /**
@@ -1277,7 +1411,8 @@ export class TaskRunner {
       }
     }
 
-    const executor = this.selectExecutor(task);
+    const selectedExecutor = this.selectExecutor(task);
+    const executor = selectedExecutor.executor;
     let result: { commitHash?: string; error?: string };
     if (executor instanceof SshExecutor) {
       result = await executor.publishApprovedFix(publishWorkspacePath, request, branch);
@@ -1841,7 +1976,9 @@ export class TaskRunner {
    * After resolution, the task is restarted so it can proceed normally.
    */
   async resolveConflict(taskId: string, savedError?: string, agentName?: string): Promise<void> {
-    return this.withAttemptHeartbeat(taskId, () => resolveConflictImpl(this, taskId, savedError, agentName));
+    const task = this.orchestrator.getTask(taskId);
+    const executionModel = task ? this.resolveExecutionModel(task) : undefined;
+    return this.withAttemptHeartbeat(taskId, () => resolveConflictImpl(this, taskId, savedError, agentName, executionModel));
   }
 
   /**
@@ -2157,6 +2294,7 @@ export class TaskRunner {
     prompt: string,
     cwd: string,
     agentName: string = DEFAULT_EXECUTION_AGENT,
+    executionModel?: string,
   ): Promise<{ stdout: string; sessionId: string }> {
     if (!this.executionAgentRegistry) {
       throw new Error('executionAgentRegistry is required for spawnAgentFix');
@@ -2166,7 +2304,7 @@ export class TaskRunner {
       throw new Error(`Agent "${agentName}" does not support fix commands`);
     }
     const driver = this.executionAgentRegistry.getSessionDriver(agentName);
-    return spawnAgentFixViaRegistry(prompt, cwd, agent, driver);
+    return spawnAgentFixViaRegistry(prompt, cwd, agent, driver, executionModel);
   }
 
   async authorPrBodyWithSkill(args: {


### PR DESCRIPTION
## Summary

TaskRunner now routes pool members by advertised harness and model capability before launch.

This slice makes the launch gate choose a capability-compatible member before executor startup.

<details>
<summary>Review metadata</summary>

Review Claim: TaskRunner routes pool members by advertised harness and model capability before launch.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Safe because it changes selection before launch and is covered by pool-selection unit tests.

Slice Rationale: The launch gate had to choose a capability-compatible member before later slices carry the chosen result deeper into execution.

</details>

## Non-goals

- No executor command changes.
- No dispatch-time request rewrite yet.
- No planning preset validation changes.

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-pool-member-capacity.test.ts`
- [x] `pnpm --filter @invoker/execution-engine build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert bb12fafb6`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution selection now respects machine capabilities for SSH/worktree pool members and remote targets.
  * Selected tasks can now resolve both the execution agent and model automatically when the machine policy requires it.
  * Fix-related agent commands can now receive a specific execution model.

* **Bug Fixes**
  * Tasks with incompatible execution settings are now rejected earlier and more clearly.
  * Pool member selection now avoids mismatched machines and reports selection issues more accurately.
  * Explicit pool member requests now fail when the member is not available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2645