### PR TITLE
[Harness Capability Policy](3) Carry resolved models into executors

### DIFF
--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -186,7 +186,7 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     logger.info(`get-claude-session: "${sessionId}"`, { module: 'ipc' });
     try {
       const orchestrator = getOrchestrator();
-      return await resolveAgentSession(sessionId, 'claude', agentRegistry, orchestrator.getAllTasks());
+      return await resolveAgentSession(sessionId, DEFAULT_EXECUTION_AGENT, agentRegistry, orchestrator.getAllTasks());
     } catch (err) {
       logger.error(`get-claude-session failed: ${err}`, { module: 'ipc' });
       return null;
@@ -194,10 +194,11 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
   });
 
   ipcMain.handle('invoker:get-agent-session', async (_event, sessionId: string, agentName?: string) => {
-    logger.info(`get-agent-session: "${sessionId}" agent="${agentName ?? DEFAULT_EXECUTION_AGENT}"`, { module: 'ipc' });
+    const resolvedAgentName = agentName ?? DEFAULT_EXECUTION_AGENT;
+    logger.info(`get-agent-session: "${sessionId}" agent="${resolvedAgentName}"`, { module: 'ipc' });
     try {
       const orchestrator = getOrchestrator();
-      return await resolveAgentSession(sessionId, agentName ?? DEFAULT_EXECUTION_AGENT, agentRegistry, orchestrator.getAllTasks());
+      return await resolveAgentSession(sessionId, resolvedAgentName, agentRegistry, orchestrator.getAllTasks());
     } catch (err) {
       logger.error(`get-agent-session failed: ${err}`, { module: 'ipc' });
       return null;

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -7,11 +7,11 @@ import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import {
+  DEFAULT_EXECUTION_AGENT,
   DockerExecutor,
   getEffectivePath,
   WorktreeExecutor,
   SshExecutor,
-  DEFAULT_EXECUTION_AGENT,
   type Executor,
   type ExecutorRegistry,
   type AgentRegistry,

--- a/packages/execution-engine/src/__tests__/fix-prompt-transport.test.ts
+++ b/packages/execution-engine/src/__tests__/fix-prompt-transport.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { spawnAgentFixViaRegistry, spawnRemoteAgentFixImpl } from '../conflict-resolver.js';
-import type { ExecutionAgent } from '../agent.js';
+import type { AgentCommandBuildOptions, ExecutionAgent } from '../agent.js';
 import type { AgentRegistry } from '../agent-registry.js';
 
 vi.mock('node:child_process');
@@ -151,6 +151,76 @@ describe('fix prompt transport for oversized prompts', () => {
     expect(stdinScript).toContain('PROMPT_FILE=');
     expect(stdinScript).toContain('base64 -d > "$PROMPT_FILE"');
     expect(stdinScript).toContain("trap 'rm -f \"$PROMPT_FILE\"' EXIT");
+  });
+
+  it('passes resolved executionModel into local OMP fix commands', async () => {
+    const { spawn } = await import('node:child_process');
+    const buildFixCommand = vi.fn((prompt: string, options?: AgentCommandBuildOptions) => ({
+      cmd: 'omp',
+      args: ['--model', options?.executionModel ?? 'missing', '-p', prompt],
+      sessionId: 'omp-local-sess',
+    }));
+    const agent: ExecutionAgent = {
+      name: 'omp',
+      stdinMode: 'ignore',
+      linuxTerminalTail: 'exec_bash',
+      buildCommand: (fullPrompt: string) => ({ cmd: 'omp', args: ['-p', fullPrompt] }),
+      buildResumeArgs: (sessionId: string) => ({ cmd: 'omp', args: ['resume', sessionId] }),
+      buildFixCommand,
+    };
+
+    vi.mocked(spawn).mockReturnValueOnce(mockSpawnChild('ok', 0) as any);
+
+    await spawnAgentFixViaRegistry(
+      'small prompt',
+      '/tmp',
+      agent,
+      undefined,
+      'anthropic/claude-opus-4',
+    );
+
+    expect(buildFixCommand).toHaveBeenCalledWith(
+      'small prompt',
+      { executionModel: 'anthropic/claude-opus-4' },
+    );
+  });
+
+  it('passes resolved executionModel into remote OMP fix commands', async () => {
+    const { spawn } = await import('node:child_process');
+    const buildFixCommand = vi.fn((prompt: string, options?: AgentCommandBuildOptions) => ({
+      cmd: 'omp',
+      args: ['--model', options?.executionModel ?? 'missing', '-p', prompt],
+      sessionId: 'omp-remote-sess',
+    }));
+
+    const child = mockSpawnChild('remote ok', 0) as any;
+    let stdinScript = '';
+    child.stdin.write = vi.fn((chunk: string) => {
+      stdinScript += chunk;
+      return true;
+    });
+    vi.mocked(spawn).mockReturnValueOnce(child);
+
+    const registry = {
+      get: () => ({ name: 'omp', buildFixCommand }),
+      getOrThrow: () => ({ name: 'omp', buildFixCommand }),
+      getSessionDriver: () => undefined,
+    } as unknown as AgentRegistry;
+
+    await spawnRemoteAgentFixImpl(
+      'small prompt',
+      '/home/user/worktree',
+      { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
+      'omp',
+      registry,
+      'anthropic/claude-opus-4',
+    );
+
+    expect(buildFixCommand).toHaveBeenCalledWith(
+      'small prompt',
+      { executionModel: 'anthropic/claude-opus-4' },
+    );
+    expect(stdinScript).toContain('eval "$(echo "');
   });
 });
 

--- a/packages/execution-engine/src/__tests__/remote-fix-process-output.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-fix-process-output.test.ts
@@ -101,6 +101,36 @@ describe('spawnRemoteAgentFixImpl processOutput', () => {
     }
   });
 
+  it('passes executionModel through remote OMP fix commands', async () => {
+    const { spawn } = await import('node:child_process');
+    const buildFixCommand = vi.fn((prompt: string, options?: { executionModel?: string }) => ({
+      cmd: 'omp',
+      args: ['--model', options?.executionModel ?? 'missing', '-p', prompt],
+      sessionId: 'omp-local-uuid',
+    }));
+    const mockRegistry = {
+      get: () => ({ name: 'omp', buildFixCommand }),
+      getOrThrow: () => ({ name: 'omp', buildFixCommand }),
+      getSessionDriver: () => undefined,
+    } as unknown as AgentRegistry;
+
+    vi.mocked(spawn).mockReturnValueOnce(mockSpawnChild('omp output', 0) as any);
+
+    await spawnRemoteAgentFixImpl(
+      'fix the bug',
+      '/home/user/worktree',
+      { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
+      'omp',
+      mockRegistry,
+      'anthropic/claude-opus-4',
+    );
+
+    expect(buildFixCommand).toHaveBeenCalledWith(
+      'fix the bug',
+      { executionModel: 'anthropic/claude-opus-4' },
+    );
+  });
+
   it('calls driver.processOutput with effectiveSessionId and stdout on success', async () => {
     const { spawn } = await import('node:child_process');
     const mockProcessOutput = vi.fn(() => 'display text');

--- a/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
@@ -118,6 +118,60 @@ branch refs/heads/${branch}
     );
   });
 
+  it('uses the resolved OMP model for repaired remote fix sessions', async () => {
+    const { spawn } = await import('node:child_process');
+    const stalePath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-b68b146f';
+    const ownerPath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-bc7a0b71';
+    const branch = 'experiment/wf-1/test-execution-engine-b68b146f';
+    const task = {
+      id: 'wf-1/test-execution-engine-omp',
+      status: 'failed' as const,
+      execution: {
+        error: 'Test failed',
+        workspacePath: stalePath,
+        branch,
+      },
+      config: {
+        command: 'pnpm test',
+        runnerKind: 'ssh' as const,
+        poolMemberId: 'remote-1',
+        executionAgent: 'omp',
+        executionModel: 'anthropic/claude-opus-4',
+      },
+    };
+
+    const { host } = makeHost(task);
+    const buildFixCommand = vi.fn((prompt: string, options?: { executionModel?: string }) => ({
+      cmd: 'omp',
+      args: ['--model', options?.executionModel ?? 'missing', '-p', prompt],
+      sessionId: 'omp-session',
+    }));
+    Object.assign(host, {
+      agentRegistry: {
+        get: () => ({ name: 'omp', buildFixCommand }),
+        getOrThrow: () => ({ name: 'omp', buildFixCommand }),
+        getSessionDriver: () => undefined,
+      },
+    });
+    const firstChild = mockSshChild(
+      `worktree ${ownerPath}
+HEAD deadbeef
+branch refs/heads/${branch}
+`,
+      0,
+    );
+    const secondChild = mockSshChild('OMP session: real-session-123\nremote fix applied', 0);
+    vi.mocked(spawn)
+      .mockReturnValueOnce(firstChild as any)
+      .mockReturnValueOnce(secondChild as any);
+
+    await fixWithAgentImpl(host, task.id, 'error output', 'omp');
+
+    expect(buildFixCommand).toHaveBeenCalledWith(
+      expect.stringContaining('Fix the underlying code issue.'),
+      { executionModel: 'anthropic/claude-opus-4' },
+    );
+  });
   it('repairs the remote workspace path before publishing an approved fix', async () => {
     const { spawn } = await import('node:child_process');
     const stalePath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-b68b146f';

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -245,6 +245,87 @@ describe('TaskRunner launch-dispatch wiring', () => {
     expect(launchOutbox.failCalls).toHaveLength(0);
   });
 
+  it('dispatches the member-resolved OMP model to executor.start', async () => {
+    const task = makeTask({
+      config: { workflowId: 'wf-d', runnerKind: 'ssh', poolId: 'ssh-pool', executionAgent: 'omp' },
+    });
+    let completeCallback: ((response: WorkResponse) => void) | undefined;
+    const executor = {
+      type: 'ssh' as const,
+      start: vi.fn().mockImplementation(async (request: { actionId: string; inputs: { executionAgent?: string; executionModel?: string } }) => ({
+        executionId: `exec-${request.actionId}`,
+        taskId: request.actionId,
+        workspacePath: '/tmp/mock-ws',
+        branch: `experiment/${request.actionId}-mock`,
+      })),
+      onComplete: vi.fn().mockImplementation((_handle: unknown, cb: (response: WorkResponse) => void) => {
+        completeCallback = cb;
+        return () => {};
+      }),
+      onOutput: vi.fn().mockReturnValue(() => {}),
+      onHeartbeat: vi.fn().mockReturnValue(() => {}),
+      kill: vi.fn().mockResolvedValue(undefined),
+      destroyAll: vi.fn().mockResolvedValue(undefined),
+    };
+    const orchestrator = {
+      getTask: vi.fn().mockReturnValue(task),
+      getAllTasks: vi.fn().mockReturnValue([task]),
+      markTaskRunningAfterLaunch: vi.fn().mockReturnValue(true),
+      handleWorkerResponse: vi.fn().mockReturnValue([]),
+      deferTask: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      loadAttempts: vi.fn().mockReturnValue([]),
+      logEvent: vi.fn(),
+    };
+    const runner = new TaskRunner({
+      orchestrator: orchestrator as any,
+      persistence: persistence as any,
+      executorRegistry: {
+        get: vi.fn().mockReturnValue(executor),
+        getAll: vi.fn().mockReturnValue([['ssh', executor]]),
+        getDefault: vi.fn().mockReturnValue(executor),
+      } as any,
+      cwd: '/tmp/test-runner-dispatch',
+      logger: makeLogger(),
+      remoteTargetsProvider: () => ({
+        'remote-a': { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
+      }),
+      executionPoolsProvider: () => ({
+        'ssh-pool': {
+          members: [
+            {
+              type: 'ssh',
+              id: 'remote-a',
+              capabilities: {
+                execution: {
+                  omp: {
+                    modelPolicy: { kind: 'fixed', model: 'anthropic/claude-opus-4' },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    });
+
+    const run = runner.executeTask(task);
+    await vi.waitFor(() => expect(executor.start).toHaveBeenCalled());
+    expect(executor.start.mock.calls[0]?.[0].inputs.executionAgent).toBe('omp');
+    expect(executor.start.mock.calls[0]?.[0].inputs.executionModel).toBe('anthropic/claude-opus-4');
+    completeCallback?.({
+      requestId: 'req',
+      actionId: task.id,
+      attemptId: task.execution.selectedAttemptId,
+      executionGeneration: task.execution.generation ?? 0,
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    });
+    await run;
+  });
+
   it('is a no-op for the outbox when dispatchOpts is omitted', async () => {
     const task = makeTask();
     const env = buildRunnerEnv(task, { startThrows: new Error('start sentinel') });

--- a/packages/execution-engine/src/agents/claude-execution-agent.ts
+++ b/packages/execution-engine/src/agents/claude-execution-agent.ts
@@ -9,7 +9,6 @@ import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions, ExecutionModelOption } from '../agent.js';
-
 export interface ClaudeExecutionAgentConfig {
   /** Command to invoke the Claude CLI. Default: 'claude'. */
   command?: string;

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -13,7 +13,6 @@ import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ExecutionAgent, AgentCommandSpec, AgentCommandBuildOptions, ExecutionModelOption } from '../agent.js';
-
 export interface CodexExecutionAgentConfig {
   /** Command to invoke the Codex CLI. Default: 'codex'. */
   command?: string;

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -351,6 +351,17 @@ export function resolveSelectedRemoteTargetId(host: ConflictResolverHost, taskId
   return undefined;
 }
 
+function resolveExecutionModelForAgent(
+  task: ReturnType<Orchestrator['getTask']> & {},
+  agentName?: string,
+): string | undefined {
+  const taskAgent = task.config.executionAgent?.trim();
+  const effectiveAgent = agentName?.trim() ?? taskAgent;
+  if (!taskAgent || !effectiveAgent || effectiveAgent !== taskAgent) return undefined;
+  const executionModel = task.config.executionModel?.trim();
+  return executionModel || undefined;
+}
+
 async function resolveConflictRemote(
   host: ConflictResolverHost,
   taskId: string,
@@ -490,8 +501,8 @@ export async function fixWithAgentImpl(
     ? `${basePrompt}\n\nAdditional fix context:\n${fixContext.trim()}`
     : basePrompt;
   const workspacePath = task.execution.workspacePath;
+  const executionModel = resolveExecutionModelForAgent(task, agentName);
 
-  // SSH tasks: run agent on the remote host
   const poolMemberId = resolveSelectedRemoteTargetId(host, taskId, task);
   if (task.config.runnerKind === 'ssh' && poolMemberId && workspacePath && !existsSync(workspacePath)) {
     host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
@@ -524,6 +535,7 @@ export async function fixWithAgentImpl(
       target,
       agentName,
       host.agentRegistry,
+      executionModel,
     );
     if (output) {
       host.persistence.appendTaskOutput(taskId, `\n[Fix with ${remoteAgentBin} (remote)] Output:\n${output}`);
@@ -546,7 +558,6 @@ export async function fixWithAgentImpl(
     return;
   }
 
-  // Local tasks: require valid workspace before running agent
   if (!workspacePath) {
     throw new Error(
       `fixWithAgent: task "${taskId}" has no valid workspace ` +
@@ -572,7 +583,7 @@ export async function fixWithAgentImpl(
       workspacePath: cwd,
       agent: agentLabel,
     });
-    const { stdout: output, sessionId } = await host.spawnAgentFix(prompt, cwd, agentName);
+    const { stdout: output, sessionId } = await host.spawnAgentFix(prompt, cwd, agentName, executionModel);
     if (output) {
       host.persistence.appendTaskOutput(taskId, `\n[Fix with ${agentLabel}] Output:\n${output}`);
     }
@@ -591,9 +602,10 @@ export async function fixWithAgentImpl(
       sessionId,
       agent: agentLabel,
     });
-  } catch (err: any) {
-    // Persist session ID even on failure so the session can be audited
-    const failedSessionId = err?.sessionId as string | undefined;
+  } catch (err) {
+    const failedSessionId = err && typeof err === 'object' && 'sessionId' in err && typeof err.sessionId === 'string'
+      ? err.sessionId
+      : undefined;
     if (failedSessionId) {
       host.persistence.updateTask(taskId, {
         execution: {
@@ -605,17 +617,37 @@ export async function fixWithAgentImpl(
       });
       console.log(`[fixWithAgent] Fix failed for ${taskId} via ${agentLabel}, session persisted (session=${failedSessionId})`);
     }
+    const errorRecord = err && typeof err === 'object' ? err : undefined;
+    const exitCode = errorRecord && 'exitCode' in errorRecord && typeof errorRecord.exitCode === 'number'
+      ? errorRecord.exitCode
+      : null;
+    const cmd = errorRecord && 'cmd' in errorRecord && typeof errorRecord.cmd === 'string'
+      ? errorRecord.cmd
+      : null;
+    const args = errorRecord && 'args' in errorRecord && Array.isArray(errorRecord.args)
+      ? errorRecord.args
+      : null;
+    const stdoutTail = errorRecord && 'stdoutTail' in errorRecord
+      ? tailText(errorRecord.stdoutTail)
+      : errorRecord && 'stdout' in errorRecord
+        ? tailText(errorRecord.stdout)
+        : undefined;
+    const stderrTail = errorRecord && 'stderrTail' in errorRecord
+      ? tailText(errorRecord.stderrTail)
+      : errorRecord && 'stderr' in errorRecord
+        ? tailText(errorRecord.stderr)
+        : undefined;
     host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'fix-with-agent-failed',
       agent: agentLabel,
       sessionId: failedSessionId ?? null,
       errorType: err instanceof Error ? err.name : typeof err,
       errorMessage: err instanceof Error ? err.message : String(err),
-      exitCode: typeof err?.exitCode === 'number' ? err.exitCode : null,
-      cmd: typeof err?.cmd === 'string' ? err.cmd : null,
-      args: Array.isArray(err?.args) ? err.args : null,
-      stdoutTail: tailText(err?.stdoutTail ?? err?.stdout),
-      stderrTail: tailText(err?.stderrTail ?? err?.stderr),
+      exitCode,
+      cmd,
+      args,
+      stdoutTail,
+      stderrTail,
     });
     throw err;
   }
@@ -630,12 +662,14 @@ export function spawnRemoteAgentFixImpl(
   target: RemoteTargetConfig,
   agentName?: string,
   agentRegistry?: AgentRegistry,
+  executionModel?: string,
 ): Promise<{ stdout: string; sessionId: string }> {
   const promptTransport = materializeRemotePrompt(prompt);
   const { shellCommand: agentCmd, sessionId } = buildRemoteAgentCommand(
     promptTransport.effectivePrompt,
     agentRegistry,
     agentName,
+    executionModel,
   );
   const agentCmdB64 = Buffer.from(agentCmd).toString('base64');
   const promptWrite = promptTransport.remotePromptFilePath && promptTransport.promptB64
@@ -647,7 +681,7 @@ export function spawnRemoteAgentFixImpl(
     : '';
   const envExports = buildRemoteAgentEnvExports(target.secretsFile, target.use_api_key === true);
 
-const script = `set -euo pipefail
+  const script = `set -euo pipefail
 WT="${remoteCwd}"
 if [[ "$WT" == '~' ]]; then WT="$HOME"; elif [[ "\${WT:0:2}" == '~/' ]]; then WT="$HOME/\${WT:2}"; fi
 cd "$WT"
@@ -697,9 +731,6 @@ eval "$(echo "${agentCmdB64}" | base64 -d)"
 }
 
 /**
- * Execute a bash script on a remote host via SSH. Throws on non-zero exit.
- */
-/**
  * Spawn an agent fix using the registry-backed ExecutionAgent.buildFixCommand().
  */
 export function spawnAgentFixViaRegistry(
@@ -730,8 +761,6 @@ export function spawnAgentFixViaRegistry(
     child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
     child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
     child.on('close', (code) => {
-      // Extract real backend session/thread ID BEFORE writing the file,
-      // so processOutput stores under the real ID (not the local UUID).
       const realId = driver?.extractSessionId?.(stdout);
       const effectiveSessionId = realId ?? sessionId;
       const displayStdout = driver ? driver.processOutput(effectiveSessionId, stdout) : stdout;
@@ -754,7 +783,7 @@ export function spawnAgentFixViaRegistry(
         ));
       }
     });
-    child.on('error', (err: any) => {
+    child.on('error', (err) => {
       promptTransport.cleanup();
       reject(Object.assign(err, {
         cmd: spec.cmd,

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -423,7 +423,8 @@ ${runProvisionSection}stop_bootstrap_heartbeat
       bench('SshExecutor.payload.built', { command: true });
     } else if (request.actionType === 'ai_task') {
       if (this.agentRegistry) {
-        const agent = this.agentRegistry.getOrThrow(executionAgent);
+        const agentName = request.inputs.executionAgent ?? 'claude';
+        const agent = this.agentRegistry.getOrThrow(agentName);
         const fullPrompt = this.buildFullPrompt(request);
         const spec = agent.buildCommand(fullPrompt, { executionModel: request.inputs.executionModel });
         agentSessionId = spec.sessionId;

--- a/packages/execution-engine/src/task-runner-dispatch.ts
+++ b/packages/execution-engine/src/task-runner-dispatch.ts
@@ -39,16 +39,19 @@ export async function dispatchExecutor(
   const { task, attemptId, request, bench, dispatchOpts } = args;
   const startGeneration = task.execution.generation ?? 0;
   const actionType = host.determineActionType(task);
-  const executionAgent = task.config.executionAgent?.trim() || host.getDefaultExecutionAgent();
+
 
   const startT0 = Date.now();
   const attemptedPoolMemberKeys = new Set<string>();
   let executor!: Executor;
   let handle!: ExecutorHandle;
+  let resolvedExecution!: { executionAgent: string; executionModel?: string };
   while (true) {
     bench('selectExecutor.start');
-    executor = host.selectExecutor(task, attemptedPoolMemberKeys).executor;
+    const selectedExecutor = host.selectExecutor(task, attemptedPoolMemberKeys);
+    executor = selectedExecutor.executor;
     const poolSelectionForStart = host.pendingPoolSelections.get(task.id);
+    resolvedExecution = host.takeResolvedExecutionSelection(task.id) ?? selectedExecutor.resolvedExecution;
     if (!host.acquirePoolSelectionLease(task, attemptId, poolSelectionForStart)) {
       if (poolSelectionForStart) {
         attemptedPoolMemberKeys.add(poolSelectionForStart.memberKey);
@@ -81,6 +84,9 @@ export async function dispatchExecutor(
     bench('executor.start.before', {
       executorType: executor.type,
     });
+
+    request.inputs.executionAgent = resolvedExecution.executionAgent;
+    request.inputs.executionModel = resolvedExecution.executionModel;
     const startTimeoutMs = getExecutorStartTimeoutMs();
     const preStartHeartbeatTimer = setInterval(() => {
       const now = new Date();
@@ -268,21 +274,23 @@ export async function dispatchExecutor(
       );
     }
 
+    const poolSelection = host.pendingPoolSelections.get(task.id);
     host.logExecutorSelected(
       task,
       executor,
       handle,
       attemptId,
-      host.pendingPoolSelections.get(task.id),
+      poolSelection,
     );
 
-    const poolSelection = host.pendingPoolSelections.get(task.id);
     const selectedSshTargetId = executor.type === 'ssh'
       ? host.selectedRemoteTargetId(task, poolSelection)
       : undefined;
     const changes = {
       config: {
         runnerKind: executor.type as RunnerKind,
+        executionAgent: resolvedExecution.executionAgent,
+        executionModel: resolvedExecution.executionModel,
         ...(selectedSshTargetId ? { poolMemberId: selectedSshTargetId } : {}),
       },
       execution: {
@@ -290,8 +298,8 @@ export async function dispatchExecutor(
         branch: handle.branch ?? undefined,  // Explicit undefined when branch is not applicable (e.g., BYO mode)
         agentSessionId: handle.agentSessionId ?? undefined,
         lastAgentSessionId: handle.agentSessionId ?? undefined,
-        agentName: actionType === 'ai_task' ? executionAgent : undefined,
-        lastAgentName: actionType === 'ai_task' ? executionAgent : undefined,
+        agentName: actionType === 'ai_task' ? resolvedExecution.executionAgent : undefined,
+        lastAgentName: actionType === 'ai_task' ? resolvedExecution.executionAgent : undefined,
         containerId: handle.containerId ?? undefined,
       },
     };

--- a/packages/execution-engine/src/task-runner-phase-host.ts
+++ b/packages/execution-engine/src/task-runner-phase-host.ts
@@ -32,8 +32,11 @@ export type TaskRunnerPhaseHost = Pick<
   | 'resolveExternalDependencyTask'
   | 'shouldUseFreshWorkspace'
   | 'determineActionType'
+  | 'resolveExecutionAgent'
+  | 'resolveExecutionModel'
   // Dispatch-phase helpers
   | 'selectExecutor'
+  | 'takeResolvedExecutionSelection'
   | 'acquirePoolSelectionLease'
   | 'renewPoolSelectionLease'
   | 'releasePoolSelectionLease'

--- a/packages/execution-engine/src/task-runner-prepare.ts
+++ b/packages/execution-engine/src/task-runner-prepare.ts
@@ -122,8 +122,8 @@ export async function buildWorkRequest(
   };
 
   const actionType = host.determineActionType(task);
-  const executionAgent = task.config.executionAgent?.trim() || host.getDefaultExecutionAgent();
-  const executionModel = task.config.executionModel?.trim() || host.getDefaultExecutionModel();
+  const executionAgent = host.resolveExecutionAgent(task);
+  const executionModel = host.resolveExecutionModel(task);
   const request: WorkRequest = {
     requestId: randomUUID(),
     actionId: task.id,


### PR DESCRIPTION
## Summary

Resolved per-machine execution models now route through dispatch and reach every executor and fix path.

Before this, selection could pick the right machine but still launch with task defaults from the plan. Fixed OMP models could disappear before executor.start and during repair.

This slice routes the chosen harness and model through dispatch, executors, and recovery paths.

<details>
<summary>Review metadata</summary>

Review Claim: Resolved per-machine execution models now route through dispatch and reach every executor and fix path.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Safe because it only changes how an already-chosen selection is propagated into requests/executors.

Slice Rationale: Once machine selection is correct, this routing slice makes the chosen result observable at launch and during repair without reopening the earlier gate.

</details>

## Non-goals

- No config schema changes.
- No new machine-selection rules.
- No planning preset changes.

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-launch-dispatch.test.ts src/__tests__/remote-fix-process-output.test.ts src/__tests__/fix-prompt-transport.test.ts src/__tests__/remote-fix-worktree-repair.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts src/__tests__/open-terminal.test.ts src/__tests__/open-terminal-session-repair.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 9d7526b5f`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Execution runs can now select an execution model (where supported), including Claude and Codex, across local, remote, and headless workflows.
  * Task launching now carries through the resolved agent and execution model, and persists that selection.

* **Bug Fixes**
  * Agent/session default resolution is now consistently aligned with the shared execution default.
  * Conflict resolution and task-fixing flows preserve the chosen execution model for both local and remote operations.

* **Tests**
  * Added regression coverage to verify execution model forwarding through SSH and conflict/fix command generation paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2646
