### PR TITLE
[Execution Defaults](6) Document task execution defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Minimal example:
   "maxConcurrency": 6,
   "autoFixRetries": 3,
   "autoFixAgent": "claude",
+  "defaultExecutionAgent": "omp",
+  "defaultExecutionModel": "chatgpt-5.4",
   "autoFixCi": false,
   "remoteTargets": {
     "staging-a": {

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -67,6 +67,8 @@
     }
   },
   "defaultPoolId": "mixed-local-ssh",
+  "defaultExecutionAgent": "omp",
+  "defaultExecutionModel": "chatgpt-5.4",
 
   "executorRoutingRules": [
     {


### PR DESCRIPTION
## Summary

The new task execution defaults need a config example, otherwise operators have to guess the key names.

This slice documents `defaultExecutionAgent` and `defaultExecutionModel` in the README snippet and the example config file.

<details>
<summary>Review metadata</summary>

Review Claim: The docs now show the two config keys needed to set task execution defaults.

Review Lane: docs

Review Unit: docs

Safety Invariant: This slice changes only documentation. It does not touch runtime behavior or task settings.

Slice Rationale: Keeping docs alone avoids mixing reviewer attention between behavior and reference text.

</details>

## Non-goals

- No runtime code changes.
- No renderer changes.
- No config migration logic.

## Test Plan

- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 6b37476ef`
- Post-revert steps: None
- Data migration? No
