### PR TITLE
[Execution Defaults](2) Add configurable task execution defaults

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   loadConfig,
   resolveDefaultExecutionAgent,
+  resolveDefaultTaskExecutionSettings,
   resolveEmbeddedTerminalBackendConfig,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
@@ -23,7 +24,7 @@ vi.mock('node:os', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:os')>();
   return {
     ...actual,
-    homedir: () => fakeHome,
+    homedir: () => `${actual.tmpdir()}/invoker-config-test-${process.pid}/home`,
   };
 });
 
@@ -138,6 +139,26 @@ describe('loadConfig', () => {
     expect(resolveDefaultExecutionAgent({ defaultExecutionAgent: '   ' })).toBe('codex');
   });
 
+
+  it('reads default execution settings from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ defaultExecutionAgent: 'omp', defaultExecutionModel: 'chatgpt-5.4' }),
+    );
+    const config = loadConfig();
+    expect(config.defaultExecutionAgent).toBe('omp');
+    expect(config.defaultExecutionModel).toBe('chatgpt-5.4');
+  });
+
+  it('resolves built-in task execution defaults when config values are blank', () => {
+    expect(resolveDefaultTaskExecutionSettings({ defaultExecutionAgent: '  ', defaultExecutionModel: '   ' })).toEqual({
+      executionAgent: 'codex',
+    });
+    expect(resolveDefaultTaskExecutionSettings({ defaultExecutionAgent: 'omp', defaultExecutionModel: 'chatgpt-5.4' })).toEqual({
+      executionAgent: 'omp',
+      executionModel: 'chatgpt-5.4',
+    });
+  });
 
   it('reads autoFixCi from user config', () => {
     writeFileSync(

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -64,10 +64,6 @@ export interface InvokerConfig {
    */
   autoFixRetries?: number;
   /**
-   * Default execution agent for plan tasks that omit executionAgent.
-   */
-  defaultExecutionAgent?: string;
-  /**
    * When true, successful AI-applied fixes are automatically approved.
    * This skips the manual "Approve Fix" step for fix-with-agent and
    * resolve-conflict flows.
@@ -88,6 +84,10 @@ export interface InvokerConfig {
    * then to the built-in default agent.
    */
   autoFixAgent?: string;
+  /** Default execution harness for prompt-backed tasks when the task does not override it. */
+  defaultExecutionAgent?: string;
+  /** Default execution model for prompt-backed tasks when the task does not override it. */
+  defaultExecutionModel?: string;
   /**
    * When true, failed CI checks on Invoker-created review-gate PRs can
    * trigger the same auto-fix recovery flow used for task failures.
@@ -297,6 +297,20 @@ export function resolveDefaultExecutionAgent(config: InvokerConfig): string {
   return configured && configured.length > 0 ? configured : BUILT_IN_DEFAULT_EXECUTION_AGENT;
 }
 
+
+export interface DefaultTaskExecutionSettings {
+  executionAgent: string;
+  executionModel?: string;
+}
+
+export function resolveDefaultTaskExecutionSettings(config: InvokerConfig): DefaultTaskExecutionSettings {
+  const configuredAgent = config.defaultExecutionAgent?.trim();
+  const configuredModel = config.defaultExecutionModel?.trim();
+  return {
+    executionAgent: configuredAgent && configuredAgent.length > 0 ? configuredAgent : BUILT_IN_DEFAULT_EXECUTION_AGENT,
+    ...(configuredModel && configuredModel.length > 0 ? { executionModel: configuredModel } : {}),
+  };
+}
 
 
 export type EmbeddedTerminalBackendConfig = 'bash' | 'pty';


### PR DESCRIPTION
## Summary

Invoker had no config keys for the default task harness or model.

This slice adds `defaultExecutionAgent` and `defaultExecutionModel` to config parsing and normalizes them through one helper.

<details>
<summary>Review metadata</summary>

Review Claim: Config now accepts and normalizes task execution default settings.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: This slice only changes config parsing and normalization. Nothing consumes the new defaults until later slices land.

Slice Rationale: The config surface has to exist before runtime and UI slices can rely on it.

</details>

## Non-goals

- No runtime task execution changes yet.
- No task-settings behavior changes yet.
- No documentation changes yet.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 03e1729d9`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for setting default execution agent and model values in app configuration.
  * Blank or whitespace-only values now fall back to built-in defaults, improving consistency for task execution.
  * When a model is not configured, the app now uses the agent default without forcing a model value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->