### PR TITLE
[Worker Registration Step 1: Execution Model and Worker State](2) Format worker action records

### DIFF
--- a/packages/app/src/__tests__/formatter.test.ts
+++ b/packages/app/src/__tests__/formatter.test.ts
@@ -3,15 +3,17 @@ import {
   formatTaskStatus,
   formatWorkflowStatus,
   formatEventLog,
+  formatWorkerActions,
   serializeWorkflow,
   serializeTask,
   serializeEvent,
+  serializeWorkerAction,
   formatAsLabel,
   formatAsJson,
   formatAsJsonl,
 } from '../formatter.js';
 import type { TaskState } from '@invoker/workflow-core';
-import type { TaskEvent, Workflow } from '@invoker/data-store';
+import type { TaskEvent, WorkerActionRecord, Workflow } from '@invoker/data-store';
 
 // ── ANSI Code Constants ──────────────────────────────────────
 
@@ -164,6 +166,55 @@ describe('formatEventLog', () => {
   it('handles empty events', () => {
     const output = formatEventLog([]);
     expect(output).toContain('No events recorded');
+  });
+});
+
+// ── formatWorkerActions ─────────────────────────────────────
+
+describe('formatWorkerActions', () => {
+  const action: WorkerActionRecord = {
+    id: 'wa-1',
+    workerKind: 'autofix',
+    actionType: 'fix-task',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/task-1',
+    subjectType: 'task',
+    subjectId: 'wf-1/task-1',
+    externalKey: 'wf-1/task-1:g0:a1',
+    status: 'running',
+    attemptCount: 1,
+    summary: 'Retrying task',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:01:00.000Z',
+  };
+
+  it('formats worker action summaries', () => {
+    const output = formatWorkerActions([action]);
+    expect(output).toContain('Worker actions (1)');
+    expect(output).toContain('wa-1');
+    expect(output).toContain('autofix/fix-task');
+    expect(output).toContain('task=wf-1/task-1');
+    expect(output).toContain('Retrying task');
+  });
+
+  it('handles empty worker actions', () => {
+    expect(formatWorkerActions([])).toContain('No worker actions found');
+  });
+
+  it('escapes terminal control characters in worker action fields', () => {
+    const output = formatWorkerActions([{
+      ...action,
+      id: 'wa-\u001b[31m1',
+      workerKind: 'auto\nfix',
+      actionType: 'fix\ttask',
+      taskId: 'wf-1/task\r1',
+      summary: 'Retry\nnext',
+    }]);
+
+    expect(output).toContain('wa-\\u001b[31m1');
+    expect(output).toContain('auto\\nfix/fix\\ttask');
+    expect(output).toContain('task=wf-1/task\\r1');
+    expect(output).toContain('Retry\\nnext');
   });
 });
 
@@ -331,6 +382,58 @@ describe('serializeEvent', () => {
     };
     const result = serializeEvent(event);
     expect(result).not.toHaveProperty('payload');
+  });
+});
+
+// ── serializeWorkerAction ───────────────────────────────────
+
+describe('serializeWorkerAction', () => {
+  it('returns a JSON-safe worker action object', () => {
+    const action: WorkerActionRecord = {
+      id: 'wa-1',
+      workerKind: 'autofix',
+      actionType: 'fix-task',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-1',
+      subjectType: 'task',
+      subjectId: 'wf-1/task-1',
+      externalKey: 'wf-1/task-1:g0:a1',
+      status: 'completed',
+      attemptCount: 2,
+      intentId: '42',
+      agentName: 'codex',
+      executionModel: 'gpt-5.2',
+      sessionId: 'sess-1',
+      summary: 'Fixed',
+      payload: { result: 'ok' },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:05:00.000Z',
+      completedAt: '2026-01-01T00:05:00.000Z',
+    };
+
+    const result = serializeWorkerAction(action);
+    expect(result).toEqual({
+      id: 'wa-1',
+      workerKind: 'autofix',
+      actionType: 'fix-task',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-1',
+      subjectType: 'task',
+      subjectId: 'wf-1/task-1',
+      externalKey: 'wf-1/task-1:g0:a1',
+      status: 'completed',
+      attemptCount: 2,
+      intentId: '42',
+      agentName: 'codex',
+      executionModel: 'gpt-5.2',
+      sessionId: 'sess-1',
+      summary: 'Fixed',
+      payload: { result: 'ok' },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:05:00.000Z',
+      completedAt: '2026-01-01T00:05:00.000Z',
+    });
+    expect(JSON.stringify(result)).not.toContain('\x1b');
   });
 });
 

--- a/packages/app/src/__tests__/formatter.test.ts
+++ b/packages/app/src/__tests__/formatter.test.ts
@@ -435,6 +435,49 @@ describe('serializeWorkerAction', () => {
     });
     expect(JSON.stringify(result)).not.toContain('\x1b');
   });
+
+  it('normalizes unsafe payload values before JSON output', () => {
+    class PayloadBox {
+      label: string;
+
+      constructor(label: string) {
+        this.label = label;
+      }
+    }
+
+    const circular: Record<string, unknown> = { ok: true };
+    circular.self = circular;
+    const action: WorkerActionRecord = {
+      id: 'wa-unsafe',
+      workerKind: 'autofix',
+      actionType: 'fix-task',
+      subjectType: 'task',
+      subjectId: 'wf-1/task-1',
+      externalKey: 'wf-1/task-1:g0:a1',
+      status: 'completed',
+      attemptCount: 1,
+      payload: {
+        big: BigInt(1),
+        circular,
+        map: new Map([['answer', BigInt(42)]]),
+        box: new PayloadBox('kept'),
+        list: [undefined, Number.NaN],
+      },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:05:00.000Z',
+    };
+
+    const result = serializeWorkerAction(action);
+
+    expect(() => formatAsJson(result)).not.toThrow();
+    expect(JSON.parse(formatAsJson(result)).payload).toEqual({
+      big: '1',
+      circular: { ok: true, self: '[Circular]' },
+      map: { answer: '42' },
+      box: { label: 'kept' },
+      list: [null, null],
+    });
+  });
 });
 
 // ── formatAsLabel ───────────────────────────────────────────

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -22,6 +22,8 @@ const MAGENTA = '\x1b[35m';
 const DIM = '\x1b[2m';
 
 
+type JsonSafeValue = string | number | boolean | null | JsonSafeValue[] | { [key: string]: JsonSafeValue };
+
 function escapeTerminalText(value: string): string {
   return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, (char) => {
     switch (char) {
@@ -35,6 +37,58 @@ function escapeTerminalText(value: string): string {
         return `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`;
     }
   });
+}
+
+function normalizeJsonValue(value: unknown, seen = new WeakSet<object>()): JsonSafeValue {
+  if (value === null) return null;
+
+  switch (typeof value) {
+    case 'string':
+    case 'boolean':
+      return value;
+    case 'number':
+      return Number.isFinite(value) ? value : null;
+    case 'bigint':
+      return value.toString();
+    case 'undefined':
+    case 'function':
+    case 'symbol':
+      return null;
+    case 'object':
+      break;
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (seen.has(value)) {
+    return '[Circular]';
+  }
+
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map(item => normalizeJsonValue(item, seen));
+    }
+    if (value instanceof Map) {
+      const normalized: { [key: string]: JsonSafeValue } = {};
+      for (const [key, item] of value.entries()) {
+        normalized[String(key)] = normalizeJsonValue(item, seen);
+      }
+      return normalized;
+    }
+    if (value instanceof Set) {
+      return Array.from(value, item => normalizeJsonValue(item, seen));
+    }
+
+    const normalized: { [key: string]: JsonSafeValue } = {};
+    for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+      normalized[key] = normalizeJsonValue(item, seen);
+    }
+    return normalized;
+  } finally {
+    seen.delete(value);
+  }
 }
 // ── Status Colors ────────────────────────────────────────────
 
@@ -401,7 +455,7 @@ export function serializeWorkerAction(action: WorkerActionRecord): Record<string
     ...(action.executionModel != null && { executionModel: action.executionModel }),
     ...(action.sessionId != null && { sessionId: action.sessionId }),
     ...(action.summary != null && { summary: action.summary }),
-    ...(action.payload !== undefined && { payload: action.payload }),
+    ...(action.payload !== undefined && { payload: normalizeJsonValue(action.payload) }),
     createdAt: action.createdAt,
     updatedAt: action.updatedAt,
     ...(action.completedAt != null && { completedAt: action.completedAt }),

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -5,7 +5,7 @@
  */
 
 import type { TaskState, TaskStatus } from '@invoker/workflow-core';
-import type { TaskEvent, Workflow } from '@invoker/data-store';
+import type { TaskEvent, WorkerActionRecord, Workflow } from '@invoker/data-store';
 import type { NormalizedCostEvent, CostRollup } from '@invoker/contracts';
 import type { GroupedCostRollup } from './cost-rollup.js';
 
@@ -21,6 +21,21 @@ const CYAN = '\x1b[36m';
 const MAGENTA = '\x1b[35m';
 const DIM = '\x1b[2m';
 
+
+function escapeTerminalText(value: string): string {
+  return value.replace(/[\u0000-\u001f\u007f-\u009f]/g, (char) => {
+    switch (char) {
+      case '\n':
+        return '\\n';
+      case '\r':
+        return '\\r';
+      case '\t':
+        return '\\t';
+      default:
+        return `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`;
+    }
+  });
+}
 // ── Status Colors ────────────────────────────────────────────
 
 const STATUS_COLORS: Record<TaskStatus, string> = {
@@ -141,6 +156,30 @@ export function formatEventLog(events: TaskEvent[]): string {
     return `${DIM}[${timestamp}]${RESET} ${BOLD}${event.taskId}${RESET}: ${event.eventType}${payload}`;
   });
 
+  return lines.join('\n');
+}
+
+export function formatWorkerActions(actions: WorkerActionRecord[]): string {
+  if (actions.length === 0) {
+    return `${DIM}No worker actions found.${RESET}`;
+  }
+
+  const lines: string[] = [];
+  lines.push(`${BOLD}Worker actions (${actions.length})${RESET}`);
+  for (const action of actions) {
+    const id = escapeTerminalText(action.id);
+    const workerKind = escapeTerminalText(action.workerKind);
+    const actionType = escapeTerminalText(action.actionType);
+    const task = action.taskId ? ` task=${escapeTerminalText(action.taskId)}` : '';
+    const workflow = action.workflowId ? ` workflow=${escapeTerminalText(action.workflowId)}` : '';
+    const attempts = ` attempts=${action.attemptCount}`;
+    const completed = action.completedAt ? ` completed=${escapeTerminalText(action.completedAt)}` : '';
+    const summary = action.summary ? ` — ${escapeTerminalText(action.summary)}` : '';
+    lines.push(
+      `  ${BOLD}${id}${RESET} [${action.status}] ${workerKind}/${actionType}` +
+        `${workflow}${task}${attempts}${completed}${summary}`,
+    );
+  }
   return lines.join('\n');
 }
 
@@ -342,6 +381,30 @@ export function serializeEvent(event: TaskEvent): Record<string, unknown> {
     eventType: event.eventType,
     ...(event.payload != null && { payload: event.payload }),
     createdAt: event.createdAt,
+  };
+}
+
+export function serializeWorkerAction(action: WorkerActionRecord): Record<string, unknown> {
+  return {
+    id: action.id,
+    workerKind: action.workerKind,
+    actionType: action.actionType,
+    ...(action.workflowId != null && { workflowId: action.workflowId }),
+    ...(action.taskId != null && { taskId: action.taskId }),
+    subjectType: action.subjectType,
+    subjectId: action.subjectId,
+    externalKey: action.externalKey,
+    status: action.status,
+    attemptCount: action.attemptCount,
+    ...(action.intentId != null && { intentId: action.intentId }),
+    ...(action.agentName != null && { agentName: action.agentName }),
+    ...(action.executionModel != null && { executionModel: action.executionModel }),
+    ...(action.sessionId != null && { sessionId: action.sessionId }),
+    ...(action.summary != null && { summary: action.summary }),
+    ...(action.payload !== undefined && { payload: action.payload }),
+    createdAt: action.createdAt,
+    updatedAt: action.updatedAt,
+    ...(action.completedAt != null && { completedAt: action.completedAt }),
   };
 }
 

--- a/scripts/repro/repro-coderabbit-pr2653-json-safe-payload.sh
+++ b/scripts/repro/repro-coderabbit-pr2653-json-safe-payload.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] problem: serializeWorkerAction forwarded unknown payload values that can break JSON output"
+if pnpm --filter @invoker/app exec vitest run src/__tests__/formatter.test.ts -t "normalizes unsafe payload values before JSON output" --reporter=verbose; then
+  echo "[repro] PASS: worker action payloads are normalized before JSON formatting"
+  exit 0
+fi
+
+echo "[repro] FAIL: worker action payload still breaks JSON formatting"
+exit 1


### PR DESCRIPTION
## Summary

Worker action records now have text, JSON, and JSONL formatting helpers.

This keeps output serialization separate from the reader that will call it.

<details>
<summary>Review metadata</summary>

Review Claim: The app formatter can render and serialize worker action records for later query output.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Formatter helpers are inert until a caller chooses the worker action output path.

Slice Rationale: Formatting lands between storage and query exposure so the final reader change stays small.

</details>

## Non-goals

- Do not add a new headless subcommand.
- Do not change persistence.
- Do not change existing workflow, task, or event formatting.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/formatter.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 78af883747928fa645ccab0c55de7d15767f5014`
- Post-revert steps: Re-run the app formatter test command above.
- Data migration? No

Depends-On: #2652


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a clearer terminal view for worker actions, including totals, action identifiers, status/attempts, and optional details (task/workflow, completion time, and summary).
  * Added JSON-safe serialization for worker actions for easier exporting and downstream use.
* **Bug Fixes**
  * Escaped control characters in worker-action text to prevent unreadable/malformed terminal output.
  * Ensured serialized output is free of ANSI escape sequences and normalizes unsafe payload values for safe JSON.
* **Tests**
  * Expanded formatter/serializer coverage, including empty-state handling, control-character escaping, and unsafe payload normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->