### PR TITLE
[Worker Registration Step 1: Execution Model and Worker State](3) Expose worker action queries

### DIFF
--- a/packages/app/src/__tests__/headless-query-list.test.ts
+++ b/packages/app/src/__tests__/headless-query-list.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkerActionRecord } from '@invoker/data-store';
+import {
+  runReadOnlyHeadlessQueryToString,
+  type HeadlessQueryDeps,
+} from '../headless-query-list.js';
+
+const workerActions: WorkerActionRecord[] = [
+  {
+    id: 'wa-1',
+    workerKind: 'autofix',
+    actionType: 'fix-task',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/task-1',
+    subjectType: 'task',
+    subjectId: 'wf-1/task-1',
+    externalKey: 'wf-1/task-1:g0:a1',
+    status: 'completed',
+    attemptCount: 2,
+    intentId: '42',
+    agentName: 'codex',
+    executionModel: 'gpt-5.2',
+    sessionId: 'sess-1',
+    summary: 'Fixed failing tests',
+    payload: { result: 'ok' },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:05:00.000Z',
+    completedAt: '2026-01-01T00:05:00.000Z',
+  },
+];
+
+function makeQueryDeps(): HeadlessQueryDeps {
+  return {
+    persistence: {
+      listWorkerActions: (filters?: unknown) => {
+        if (filters && (filters as { workflowId?: string }).workflowId === 'missing') return [];
+        return workerActions;
+      },
+      listWorkflows: () => [],
+    } as unknown as HeadlessQueryDeps['persistence'],
+    orchestrator: {} as unknown as HeadlessQueryDeps['orchestrator'],
+    executionAgentRegistry: undefined,
+    invokerConfig: {} as unknown as HeadlessQueryDeps['invokerConfig'],
+    getUiPerfStats: () => ({}),
+    resetUiPerfStats: () => {},
+  };
+}
+
+describe('headless query worker-actions', () => {
+  it('renders worker actions as JSON', async () => {
+    const output = await runReadOnlyHeadlessQueryToString(
+      ['query', 'worker-actions', '--workflow', 'wf-1', '--output', 'json'],
+      makeQueryDeps(),
+    );
+
+    expect(JSON.parse(output)).toEqual([{
+      id: 'wa-1',
+      workerKind: 'autofix',
+      actionType: 'fix-task',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-1',
+      subjectType: 'task',
+      subjectId: 'wf-1/task-1',
+      externalKey: 'wf-1/task-1:g0:a1',
+      status: 'completed',
+      attemptCount: 2,
+      intentId: '42',
+      agentName: 'codex',
+      executionModel: 'gpt-5.2',
+      sessionId: 'sess-1',
+      summary: 'Fixed failing tests',
+      payload: { result: 'ok' },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:05:00.000Z',
+      completedAt: '2026-01-01T00:05:00.000Z',
+    }]);
+  });
+
+  it('renders worker actions as text and handles an empty result', async () => {
+    const text = await runReadOnlyHeadlessQueryToString(
+      ['query', 'worker-actions'],
+      makeQueryDeps(),
+    );
+    expect(text).toContain('Worker actions (1)');
+    expect(text).toContain('wa-1');
+    expect(text).toContain('autofix/fix-task');
+
+    const empty = await runReadOnlyHeadlessQueryToString(
+      ['query', 'worker-actions', '--workflow', 'missing'],
+      makeQueryDeps(),
+    );
+    expect(empty).toContain('No worker actions found');
+  });
+});

--- a/packages/app/src/headless-query-list.ts
+++ b/packages/app/src/headless-query-list.ts
@@ -1,7 +1,7 @@
 /**
  * Headless "query" command family: the read-only `query <sub>` router
  * (workflows · tasks · task · queue · review-gate · action-graph · audit ·
- * session · cost · cost-events · costs · ui-perf · stats), the cost-event
+ * session · worker-actions · cost · cost-events · costs · ui-perf · stats), the cost-event
  * collection/rollup
  * helpers, agent session resolution, and `query-select`.
  *
@@ -53,14 +53,14 @@ export type HeadlessQueryDeps = Pick<
 export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing query sub-command. Usage: --headless query <workflows|workflow|tasks|task|queue|review-gate|action-graph|audit|session|cost|cost-events|costs|ui-perf|stats>');
+    throw new Error('Missing query sub-command. Usage: --headless query <workflows|workflow|tasks|task|queue|review-gate|action-graph|audit|session|worker-actions|cost|cost-events|costs|ui-perf|stats>');
   }
   const flags = parseQueryFlags(args.slice(1));
 
   const {
     formatWorkflowList, formatTaskStatus, formatWorkflowStatus,
-    formatEventLog, formatQueueStatus, formatWorkflowStats,
-    serializeWorkflow, serializeTask, serializeEvent,
+    formatEventLog, formatQueueStatus, formatWorkflowStats, formatWorkerActions,
+    serializeWorkflow, serializeTask, serializeEvent, serializeWorkerAction,
     formatAsLabel, formatAsJson, formatAsJsonl,
   } = await import('./formatter.js');
 
@@ -244,6 +244,20 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       await headlessSession(taskId, deps);
       break;
     }
+    case 'worker-actions': {
+      const workflowFilter = flags.workflow ?? flags.positional[0];
+      const actions = deps.persistence.listWorkerActions({
+        workflowId: workflowFilter,
+        status: flags.status,
+      });
+      switch (flags.output) {
+        case 'label': writeOut(formatAsLabel(actions) + '\n'); break;
+        case 'json': writeOut(formatAsJson(actions.map(serializeWorkerAction)) + '\n'); break;
+        case 'jsonl': writeOut(formatAsJsonl(actions.map(serializeWorkerAction)) + '\n'); break;
+        default: writeOut(formatWorkerActions(actions) + '\n'); break;
+      }
+      break;
+    }
     case 'ui-perf': {
       if (flags.reset) {
         deps.resetUiPerfStats?.();
@@ -341,7 +355,7 @@ export async function headlessQuery(args: string[], deps: HeadlessQueryDeps): Pr
       break;
     }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, workflow, tasks, task, queue, review-gate, action-graph, audit, session, cost, cost-events, costs, ui-perf, stats`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, workflow, tasks, task, queue, review-gate, action-graph, audit, session, worker-actions, cost, cost-events, costs, ui-perf, stats`);
   }
 }
 


### PR DESCRIPTION
## Summary

The headless query path now exposes worker action records.

It can render text, JSON, or JSONL for workflow-scoped action history.

<details>
<summary>Review metadata</summary>

Review Claim: `--headless query worker-actions` reads durable worker action state through the existing read-only path.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The path is read-only and only runs when the new subcommand is requested.

Slice Rationale: The user-facing query surface lands after storage and formatting are already reviewable.

</details>

## Non-goals

- Do not enable new worker behavior.
- Do not add worker action writes from the app layer.
- Do not change existing query subcommands.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/headless-query-list.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 6ffdcbd8af44ab2b1936bc6cc555bc8cab4fdb13`
- Post-revert steps: Re-run the app headless query test command above.
- Data migration? No

Depends-On: #2653


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `worker-actions` sub-command to the read-only headless query flow.
  * Supports filtering by workflow (and optional status) and exporting results in label, text, JSON, or JSONL formats.
  * Updated headless query help and unknown-command messaging to include `worker-actions`.

* **Tests**
  * Added Vitest coverage for rendering worker-action results in both JSON and text modes, including the “No worker actions found” case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->