### PR TITLE
[Invoker UI Reskin](1) Add planner bridge

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -76,6 +76,7 @@
     "@invoker/execution-engine": "workspace:*",
     "@invoker/runtime-adapters": "workspace:*",
     "@invoker/runtime-service": "workspace:*",
+    "@invoker/surfaces": "workspace:*",
     "@invoker/transport": "workspace:*",
     "@invoker/workflow-core": "workspace:*",
     "dockerode": "^4.0.0",

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlanConversation } from '@invoker/surfaces';
+import { planFromGoal } from '../in-app-planner.js';
+
+const VALID_PLAN = `Here is the plan.
+
+\`\`\`yaml
+name: Mock Plan
+onFinish: none
+tasks:
+  - id: first
+    description: First task
+    command: echo first
+\`\`\``;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('planFromGoal', () => {
+  it('asks for a goal before planning', async () => {
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: '   ' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: 'Describe a goal first.' });
+
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown planner presets before planning', async () => {
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: 'Add README', presetKey: 'bad' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: 'Unknown planner preset "bad".' });
+
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('loads generated YAML as a preview without starting execution', async () => {
+    const sendMessage = vi.spyOn(PlanConversation.prototype, 'sendMessage').mockResolvedValue(VALID_PLAN);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({ planName: 'Mock Plan', workflowId: 'wf-1' });
+
+    await expect(planFromGoal({ goal: '  Add README  ' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
+
+    expect(sendMessage).toHaveBeenCalledWith('Add README');
+    expect(loadGeneratedPlan).toHaveBeenCalledTimes(1);
+    expect(loadGeneratedPlan.mock.calls[0]?.[0]).toContain('name: Mock Plan');
+  });
+
+  it('does not load invalid planner output', async () => {
+    vi.spyOn(PlanConversation.prototype, 'sendMessage').mockResolvedValue('No YAML here.');
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: 'Add README' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: 'Planner did not return a valid YAML plan.' });
+
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -109,6 +109,8 @@ export interface InvokerConfig {
   planningHeartbeatIntervalSeconds?: number;
   /** Named Slack planning harness presets: preset key → {tool, model}; built-ins apply when omitted. */
   slackHarnessPresets?: Record<string, { tool: 'cursor' | 'omp' | 'codex'; model?: string }>;
+  plannerHarnessPresets?: Record<string, { tool: 'cursor' | 'omp' | 'codex'; model?: string }>;
+  defaultPlannerHarnessPreset?: string;
   /** Default harness preset key when the message carries no `[preset]` tag. Default: 'cursor+claude'. */
   defaultSlackHarnessPreset?: string;
   /** Slack repo aliases: alias → git URL, resolved from a `[repo:<alias>]` tag. */

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1,0 +1,79 @@
+import type { InAppPlanRequest, InAppPlanResponse } from '@invoker/contracts';
+import {
+  BUILTIN_HARNESS_PRESETS,
+  DEFAULT_HARNESS_PRESET,
+  extractYamlPlan,
+  PlanConversation,
+  type HarnessPreset,
+  type PlanningCommandBuilder,
+} from '@invoker/surfaces';
+import type { InvokerConfig } from './config.js';
+
+export interface LoadedGeneratedPlan {
+  planName: string;
+  workflowId: string;
+}
+
+export interface InAppPlannerDeps {
+  config: InvokerConfig;
+  loadGeneratedPlan: (planText: string) => LoadedGeneratedPlan | Promise<LoadedGeneratedPlan>;
+  workingDir?: string;
+  planningCommandBuilder?: PlanningCommandBuilder;
+}
+
+function resolveHarnessPresets(config: InvokerConfig): Record<string, HarnessPreset> {
+  return {
+    ...BUILTIN_HARNESS_PRESETS,
+    ...(config.slackHarnessPresets ?? {}),
+    ...(config.plannerHarnessPresets ?? {}),
+  };
+}
+
+function resolveDefaultPresetKey(config: InvokerConfig): string {
+  return config.defaultPlannerHarnessPreset
+    ?? config.defaultSlackHarnessPreset
+    ?? DEFAULT_HARNESS_PRESET;
+}
+
+export async function planFromGoal(
+  request: InAppPlanRequest,
+  deps: InAppPlannerDeps,
+): Promise<InAppPlanResponse> {
+  const goal = request.goal.trim();
+  if (!goal) {
+    return { ok: false, error: 'Describe a goal first.' };
+  }
+
+  const presets = resolveHarnessPresets(deps.config);
+  const presetKey = request.presetKey ?? resolveDefaultPresetKey(deps.config);
+  const preset = presets[presetKey];
+  if (!preset) {
+    return { ok: false, error: `Unknown planner preset "${presetKey}".` };
+  }
+
+  try {
+    const conversation = new PlanConversation({
+      tool: preset.tool,
+      model: preset.model,
+      workingDir: deps.workingDir,
+      timeoutMs: (deps.config.planningTimeoutSeconds ?? 7200) * 1000,
+      defaultBranch: deps.config.defaultBranch,
+      repoUrl: deps.config.defaultRepoUrl,
+      experimentalPlanner: deps.config.experimentalPlanner,
+      planningCommandBuilder: deps.planningCommandBuilder,
+    });
+    const plannerOutput = await conversation.sendMessage(goal);
+    const planText = extractYamlPlan(plannerOutput);
+    if (!planText) {
+      return { ok: false, error: 'Planner did not return a valid YAML plan.' };
+    }
+
+    const loaded = await deps.loadGeneratedPlan(planText);
+    return { ok: true, planName: loaded.planName, workflowId: loaded.workflowId };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3399,7 +3399,6 @@ function createEmbeddedTerminalBackendFromConfig(
       const plan = parsePlan(planText);
       const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
       logger.info(`plan-from-goal: loading "${plan.name}" (${plan.tasks.length} tasks)`, { module: 'ipc' });
-      taskHandles.clear();
       backupPlan(plan, undefined, logger);
       orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
       const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
@@ -3409,8 +3408,8 @@ function createEmbeddedTerminalBackendFromConfig(
       return { planName: plan.name, workflowId: workflow.id };
     }
 
-    registerGuiMutationHandler('invoker:plan-from-goal', async (request: InAppPlanRequest) => (
-      planFromGoalInApp(request, {
+    registerGuiMutationHandler('invoker:plan-from-goal', async (request: unknown) => (
+      planFromGoalInApp(request as InAppPlanRequest, {
         config: invokerConfig,
         workingDir: repoRoot,
         loadGeneratedPlan: loadGeneratedPlanPreview,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -78,7 +78,7 @@ import {
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { ActionGraphResponse, BundledSkillsInstallMode, Logger, WorkflowMeta, WorkflowMutationAcceptedResult, WorkResponse } from '@invoker/contracts';
+import type { ActionGraphResponse, BundledSkillsInstallMode, InAppPlanRequest, Logger, WorkflowMeta, WorkflowMutationAcceptedResult, WorkResponse } from '@invoker/contracts';
 import { SqliteTaskRepository } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
@@ -239,6 +239,7 @@ import {
   spawnDetachedStandaloneOwner,
   tryAcquireOwnerBootstrapLock,
 } from './headless-owner-bootstrap.js';
+import { planFromGoal as planFromGoalInApp } from './in-app-planner.js';
 import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
 import {
   killRunningTaskExecution,
@@ -1001,6 +1002,24 @@ function startHeadlessMode(): void {
               buildCommandServiceInvalidationDeps(),
             );
             return undefined;
+          }
+          case 'invoker:plan-from-goal': {
+            return planFromGoalInApp(payload.args[0] as InAppPlanRequest, {
+              config: invokerConfig,
+              workingDir: repoRoot,
+              loadGeneratedPlan: async (planText) => {
+                const { parsePlan } = await import('./plan-parser.js');
+                const plan = parsePlan(planText);
+                const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
+                backupPlan(plan, undefined, logger);
+                orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+                const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
+                if (!workflow) {
+                  throw new Error('Loaded plan did not create a workflow.');
+                }
+                return { planName: plan.name, workflowId: workflow.id };
+              },
+            });
           }
           case 'invoker:load-plan': {
             const planText = String(payload.args[0] ?? '');
@@ -2464,6 +2483,8 @@ function createEmbeddedTerminalBackendFromConfig(
     | null {
     const [arg0, arg1, arg2] = payload.args;
     switch (payload.channel) {
+      case 'invoker:plan-from-goal':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:load-plan':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:start':
@@ -3351,6 +3372,7 @@ function createEmbeddedTerminalBackendFromConfig(
       };
       try {
         persistence.writeActivityLog('ui-perf-main', 'info', JSON.stringify(snapshot));
+
       } catch {
         // DB might be locked
       }
@@ -3372,6 +3394,29 @@ function createEmbeddedTerminalBackendFromConfig(
       getTaskDeltaStreamSequence,
       recordStartupDuration,
     });
+    async function loadGeneratedPlanPreview(planText: string): Promise<{ planName: string; workflowId: string }> {
+      const { parsePlan } = await import('./plan-parser.js');
+      const plan = parsePlan(planText);
+      const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
+      logger.info(`plan-from-goal: loading "${plan.name}" (${plan.tasks.length} tasks)`, { module: 'ipc' });
+      taskHandles.clear();
+      backupPlan(plan, undefined, logger);
+      orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+      const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
+      if (!workflow) {
+        throw new Error('Loaded plan did not create a workflow.');
+      }
+      return { planName: plan.name, workflowId: workflow.id };
+    }
+
+    registerGuiMutationHandler('invoker:plan-from-goal', async (request: InAppPlanRequest) => (
+      planFromGoalInApp(request, {
+        config: invokerConfig,
+        workingDir: repoRoot,
+        loadGeneratedPlan: loadGeneratedPlanPreview,
+      })
+    ));
+
     registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
       const planText = String(planTextArg);
       const { parsePlan } = await import('./plan-parser.js');

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -224,6 +224,22 @@ export interface ResumeWorkflowResult {
   taskCount: number;
   startedCount: number;
 }
+export interface InAppPlanRequest {
+  goal: string;
+  presetKey?: string;
+}
+
+export type InAppPlanResponse =
+  | {
+      ok: true;
+      planName: string;
+      workflowId: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
 
 export interface WorkflowListEntry {
   id: string;
@@ -424,6 +440,10 @@ export interface SearchOptions {
 
 export const IpcChannels = {
   // Plan & Workflow Management
+  'invoker:plan-from-goal': {} as {
+    request: [request: InAppPlanRequest];
+    response: InAppPlanResponse;
+  },
   'invoker:load-plan': {} as {
     request: [planText: string];
     response: void;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@invoker/runtime-service':
         specifier: workspace:*
         version: link:../runtime-service
+      '@invoker/surfaces':
+        specifier: workspace:*
+        version: link:../surfaces
       '@invoker/transport':
         specifier: workspace:*
         version: link:../transport

--- a/scripts/repro/repro-coderabbit-pr2662-gui-handler-unknown.sh
+++ b/scripts/repro/repro-coderabbit-pr2662-gui-handler-unknown.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+python3 - <<'PY'
+from pathlib import Path
+import re
+import sys
+
+main_ts = Path('packages/app/src/main.ts')
+text = main_ts.read_text()
+match = re.search(r"registerGuiMutationHandler\('invoker:plan-from-goal',\s*async \(([^)]*)\)", text)
+if not match:
+    print('FAIL: could not locate invoker:plan-from-goal GUI mutation handler')
+    sys.exit(1)
+params = match.group(1).strip()
+if params != 'request: unknown':
+    print(f'FAIL: invoker:plan-from-goal handler parameter is too narrow: ({params})')
+    sys.exit(1)
+if 'planFromGoalInApp(request as InAppPlanRequest' not in text:
+    print('FAIL: handler does not narrow/cast unknown request before calling planFromGoalInApp')
+    sys.exit(1)
+print('PASS: invoker:plan-from-goal handler accepts unknown input and narrows locally')
+PY

--- a/scripts/repro/repro-coderabbit-pr2662-preview-task-handles.sh
+++ b/scripts/repro/repro-coderabbit-pr2662-preview-task-handles.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+python3 - <<'PY'
+from pathlib import Path
+import sys
+
+main_ts = Path('packages/app/src/main.ts')
+text = main_ts.read_text()
+start_marker = 'async function loadGeneratedPlanPreview(planText: string)'
+end_marker = "registerGuiMutationHandler('invoker:plan-from-goal'"
+start = text.find(start_marker)
+end = text.find(end_marker, start)
+if start == -1 or end == -1:
+    print('FAIL: could not locate plan-from-goal preview loader in packages/app/src/main.ts')
+    sys.exit(1)
+body = text[start:end]
+if 'taskHandles.clear()' in body:
+    print('FAIL: plan-from-goal preview loader clears live task handles')
+    sys.exit(1)
+print('PASS: plan-from-goal preview loader leaves live task handles intact')
+PY


### PR DESCRIPTION
## Summary

The app now has one desktop planning bridge. The renderer can ask main to turn a goal into a loaded plan preview.

The bridge reuses the existing planner and YAML extraction. It loads the generated plan but does not start execution.

<details>
<summary>Review metadata</summary>

Review Claim: The app exposes a typed `planFromGoal` IPC path that previews generated plans without running tasks.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Success stops after `orchestrator.loadPlan`; no task execution path is called.

Slice Rationale: This app bridge lands before the renderer shell so the UI consumes a real API instead of inventing planner logic.

</details>

## Non-goals

- No renderer shell changes.
- No automatic task execution after planning.
- No Slack planning behavior changes.

## Test Plan

- [x] `pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts && pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
