### PR TITLE
[Invoker UI Reskin](2) Activate reskinned shell

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1613,13 +1613,15 @@ export function App() {
     [handleLoadPlan],
   );
 
-  const handleStart = useCallback(async () => {
-    if (!invoker) return;
+  const handleStart = useCallback(async (): Promise<boolean> => {
+    if (!invoker) return false;
     try {
       await invoker.start();
       setHasStarted(true);
+      return true;
     } catch (err) {
       console.error('Failed to start:', err);
+      return false;
     }
   }, [invoker]);
   const handleTerminalSubmit = useCallback(async (command: string) => {
@@ -1657,8 +1659,8 @@ export function App() {
         appendTerminalLine('Load or generate a plan before running.', 'error');
         return;
       }
-      await handleStart();
-      appendTerminalLine('Run started.', 'success');
+      const started = await handleStart();
+      appendTerminalLine(started ? 'Run started.' : 'Failed to start run.', started ? 'success' : 'error');
       return;
     }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -34,6 +34,8 @@ import { groupWorkflowCoreActivity } from './lib/workflow-core-activity.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
 import { WorkflowStatusChips } from './components/WorkflowStatusChips.js';
 import { TerminalDrawer, type TerminalDrawerState } from './components/TerminalDrawer.js';
+import { LeftStatusColumn } from './components/LeftStatusColumn.js';
+import { InvokerTerminal, type InvokerTerminalLine } from './components/InvokerTerminal.js';
 import {
   isExperimentSpawnPivotTask,
   EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE,
@@ -425,6 +427,12 @@ export function App() {
   const [hasLoadedPlan, setHasLoadedPlan] = useState(false);
   const [hasStarted, setHasStarted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
+  const [terminalLines, setTerminalLines] = useState<InvokerTerminalLine[]>([
+    { id: 1, text: 'Start with a goal.', tone: 'muted' },
+  ]);
+  const nextTerminalLineIdRef = useRef(2);
+  const [plannerBusy, setPlannerBusy] = useState(false);
+  const [graphMaximized, setGraphMaximized] = useState(false);
   const [selectedActionNodeId, setSelectedActionNodeId] = useState<string | null>(null);
   const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
   const selectedActionNode = useMemo(
@@ -533,6 +541,17 @@ export function App() {
       }
     }).catch(() => {});
   }, []);
+  useEffect(() => {
+    if (!graphMaximized) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setGraphMaximized(false);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [graphMaximized]);
+
 
   useEffect(() => {
     const unsubscribe = window.invoker?.onTerminalExit?.((event) => {
@@ -1545,6 +1564,11 @@ export function App() {
     await refreshTaskGraph();
     issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason: 'manual-refresh' });
   }, [issueCameraCommand, refreshTaskGraph]);
+  const appendTerminalLine = useCallback((text: string, tone: InvokerTerminalLine['tone'] = 'muted') => {
+    const id = nextTerminalLineIdRef.current;
+    nextTerminalLineIdRef.current += 1;
+    setTerminalLines((prev) => [...prev, { id, text, tone }]);
+  }, []);
 
   // ── Plan loading ──────────────────────────────────────────
   const handleLoadPlan = useCallback(
@@ -1598,6 +1622,49 @@ export function App() {
       console.error('Failed to start:', err);
     }
   }, [invoker]);
+  const handleTerminalSubmit = useCallback(async (command: string) => {
+    appendTerminalLine(`$ ${command}`);
+    const planMatch = command.match(/^plan\s+"([^"]+)"$/i);
+    if (planMatch) {
+      if (!invoker?.planFromGoal) {
+        appendTerminalLine('Planner is not available.', 'error');
+        return;
+      }
+      setPlannerBusy(true);
+      try {
+        const result = await invoker.planFromGoal({ goal: planMatch[1] });
+        if (result.ok) {
+          setHasLoadedPlan(true);
+          setHasStarted(false);
+          setWorkflowSelectionDismissed(false);
+          setPlanName(result.planName);
+          setSelectedWorkflowId(result.workflowId);
+          await refreshTaskGraph();
+          appendTerminalLine(`Plan \"${result.planName}\" loaded. Use run to execute.`, 'success');
+        } else {
+          appendTerminalLine(result.error, 'error');
+        }
+      } catch (err) {
+        appendTerminalLine(err instanceof Error ? err.message : 'Failed to generate plan.', 'error');
+      } finally {
+        setPlannerBusy(false);
+      }
+      return;
+    }
+
+    if (command.toLowerCase() === 'run') {
+      if (!hasLoadedPlan) {
+        appendTerminalLine('Load or generate a plan before running.', 'error');
+        return;
+      }
+      await handleStart();
+      appendTerminalLine('Run started.', 'success');
+      return;
+    }
+
+    appendTerminalLine('Unknown command. Try plan \"Add README\" or run.', 'error');
+  }, [appendTerminalLine, handleStart, hasLoadedPlan, invoker, refreshTaskGraph]);
+
 
   const handleStop = useCallback(async () => {
     if (!invoker) return;
@@ -2032,152 +2099,244 @@ export function App() {
         </nav>
 
         <div className="flex-1 flex overflow-hidden">
-          <div className="flex-1 flex flex-col overflow-hidden">
-            <div
-              ref={graphSurfaceRef}
-              data-testid="workflow-graph-surface"
-              data-keyboard-region="workflowGraph"
-              tabIndex={0}
-              data-keyboard-active={keyboardRegion === 'workflowGraph' ? 'true' : 'false'}
-              className={`flex-1 relative overflow-hidden border-r border-gray-800 bg-gray-900 outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
-              onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
-            >
-              {viewMode === 'queue' ? (
-                <QueueView
-                  tasks={tasks}
-                  queueStatus={queueStatus}
-                  onTaskClick={handleTaskClick}
-                  onCancel={handleCancelTask}
-                  selectedTaskId={selectedTaskId}
-                />
-              ) : viewMode === 'history' ? (
-                <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
-              ) : viewMode === 'timeline' ? (
-                <TimelineView tasks={tasks} onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
-              ) : viewMode === 'actionGraph' ? (
-                <ActionGraphView
-                  graph={actionGraph}
-                  error={actionGraphError}
-                  selectedNodeId={selectedActionNodeId}
-                  onSelectNode={(node) => {
-                    setSelectedActionNodeId(node?.id ?? null);
-                    if (node?.taskId) setSelectedTaskId(node.taskId);
-                    if (node?.workflowId) setSelectedWorkflowId(node.workflowId);
-                  }}
-                />
-              ) : (
-                <>
-                  <WorkflowGraph
-                    workflows={workflows}
-                    selectedWorkflowId={selectedWorkflow?.id ?? null}
-                    cameraCommand={cameraCommand}
-                    statusFilters={statusFilters}
-                    coreActivityByWorkflow={coreActivityByWorkflow}
-                    onSelectWorkflow={handleWorkflowClick}
-                    onWorkflowContextMenu={handleWorkflowContextMenu}
-                    onManualViewport={handleManualViewport}
-                  />
-                  {displayedSelectedWorkflowGraph !== null && (
-                    <FloatingGraphPanel
-                      key={displayedSelectedWorkflowGraph.workflow.id}
-                      testId="selected-workflow-mini-dag"
-                      dragHandleTestId="selected-workflow-mini-dag-drag-handle"
-                      title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
-                      boundsRef={graphSurfaceRef}
-                      contentClassName="h-[250px]"
-                    >
-                      <div
-                        data-keyboard-region="taskGraph"
-                        tabIndex={0}
-                        data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
-                        className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
-                      >
-                        {isSelectedWorkflowGraphRefreshing && (
-                          <div data-testid="selected-workflow-mini-dag-refreshing" className="px-2 py-1 text-xs text-amber-200">
-                            Refreshing graph…
-                          </div>
-                        )}
-                        <TaskDAG
-                          tasks={displayedSelectedWorkflowGraph.tasks}
-                          workflows={selectedTaskDagWorkflows}
-                          selectedTaskId={selectedTaskId}
-                          cameraCommand={cameraCommand}
-                          onTaskClick={handleTaskClick}
-                          onTaskDoubleClick={handleTaskDoubleClick}
-                          onTaskContextMenu={handleTaskContextMenu}
-                          onManualViewport={handleManualViewport}
-                          statusFilters={new Set()}
-                          runningTaskIds={runningTaskIds}
-                        />
-                      </div>
-                    </FloatingGraphPanel>
-                  )}
-                </>
-              )}
+          <LeftStatusColumn
+            workflows={workflows}
+            tasks={tasks}
+            queueStatus={queueStatus}
+            planName={planName}
+            plannerBusy={plannerBusy}
+            hasStarted={hasStarted}
+            onTaskClick={handleTaskClick}
+          />
+          <main className="flex-1 flex flex-col overflow-hidden bg-gray-900">
+            <div className="space-y-3 border-b border-gray-800 bg-gray-900/80 p-4">
+              <InvokerTerminal
+                lines={terminalLines}
+                busy={plannerBusy}
+                onSubmit={(command) => void handleTerminalSubmit(command)}
+              />
+              <section className="rounded-xl border border-gray-800 bg-gray-950/70 p-4">
+                <h2 className="text-sm font-semibold text-gray-100">What to expect</h2>
+                <p className="mt-2 text-sm text-gray-400">
+                  Type a planning goal, review the graph, then run when the plan is ready.
+                </p>
+              </section>
             </div>
 
-            {viewMode === 'dag' && (
+            <div className="flex-1 flex overflow-hidden">
+              <div className="flex-1 flex flex-col overflow-hidden">
+                <div className="flex items-center justify-between border-b border-gray-800 bg-gray-950/50 px-4 py-2">
+                  <div>
+                    <h2 className="text-sm font-semibold text-gray-100">Plan graph</h2>
+                    <p className="text-xs text-gray-500">Your plan will appear here.</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setGraphMaximized(true)}
+                    className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+                  >
+                    View full graph
+                  </button>
+                </div>
+                <div
+                  ref={graphSurfaceRef}
+                  data-testid="workflow-graph-surface"
+                  data-keyboard-region="workflowGraph"
+                  tabIndex={0}
+                  data-keyboard-active={keyboardRegion === 'workflowGraph' ? 'true' : 'false'}
+                  className={`flex-1 relative overflow-hidden border-r border-gray-800 bg-gray-900 outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+                  onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
+                >
+                  {viewMode === 'queue' ? (
+                    <QueueView
+                      tasks={tasks}
+                      queueStatus={queueStatus}
+                      onTaskClick={handleTaskClick}
+                      onCancel={handleCancelTask}
+                      selectedTaskId={selectedTaskId}
+                    />
+                  ) : viewMode === 'history' ? (
+                    <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
+                  ) : viewMode === 'timeline' ? (
+                    <TimelineView tasks={tasks} onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
+                  ) : viewMode === 'actionGraph' ? (
+                    <ActionGraphView
+                      graph={actionGraph}
+                      error={actionGraphError}
+                      selectedNodeId={selectedActionNodeId}
+                      onSelectNode={(node) => {
+                        setSelectedActionNodeId(node?.id ?? null);
+                        if (node?.taskId) setSelectedTaskId(node.taskId);
+                        if (node?.workflowId) setSelectedWorkflowId(node.workflowId);
+                      }}
+                    />
+                  ) : (
+                    <>
+                      <WorkflowGraph
+                        workflows={workflows}
+                        selectedWorkflowId={selectedWorkflow?.id ?? null}
+                        cameraCommand={cameraCommand}
+                        statusFilters={statusFilters}
+                        coreActivityByWorkflow={coreActivityByWorkflow}
+                        onSelectWorkflow={handleWorkflowClick}
+                        onWorkflowContextMenu={handleWorkflowContextMenu}
+                        onManualViewport={handleManualViewport}
+                      />
+                      {displayedSelectedWorkflowGraph !== null && (
+                        <FloatingGraphPanel
+                          key={displayedSelectedWorkflowGraph.workflow.id}
+                          testId="selected-workflow-mini-dag"
+                          dragHandleTestId="selected-workflow-mini-dag-drag-handle"
+                          title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
+                          boundsRef={graphSurfaceRef}
+                          contentClassName="h-[250px]"
+                        >
+                          <div
+                            data-keyboard-region="taskGraph"
+                            tabIndex={0}
+                            data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
+                            className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
+                          >
+                            {isSelectedWorkflowGraphRefreshing && (
+                              <div data-testid="selected-workflow-mini-dag-refreshing" className="px-2 py-1 text-xs text-amber-200">
+                                Refreshing graph…
+                              </div>
+                            )}
+                            <TaskDAG
+                              tasks={displayedSelectedWorkflowGraph.tasks}
+                              workflows={selectedTaskDagWorkflows}
+                              selectedTaskId={selectedTaskId}
+                              cameraCommand={cameraCommand}
+                              onTaskClick={handleTaskClick}
+                              onTaskDoubleClick={handleTaskDoubleClick}
+                              onTaskContextMenu={handleTaskContextMenu}
+                              onManualViewport={handleManualViewport}
+                              statusFilters={new Set()}
+                              runningTaskIds={runningTaskIds}
+                            />
+                          </div>
+                        </FloatingGraphPanel>
+                      )}
+                    </>
+                  )}
+                </div>
+
+                {viewMode === 'dag' && (
+                  <div
+                    data-keyboard-region="bottomBar"
+                    tabIndex={0}
+                    data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
+                    className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+                  >
+                    <WorkflowStatusChips
+                      workflows={workflows}
+                      activeFilters={statusFilters}
+                      keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
+                      onStatusClick={handleStatusClick}
+                    />
+                    <TerminalDrawer
+                      state={terminalDrawerState}
+                      onCycle={() =>
+                        setTerminalDrawerState((prev) =>
+                          prev === 'minimized' ? 'partial' : prev === 'partial' ? 'maximized' : 'minimized',
+                        )
+                      }
+                      sessions={terminalSessions}
+                      activeSessionId={activeTerminalSessionId}
+                      onSelectSession={setActiveTerminalSessionId}
+                      onCloseSession={(sessionId) => void handleCloseTerminalSession(sessionId)}
+                      taskLabels={terminalTaskLabels}
+                    />
+                  </div>
+                )}
+              </div>
+
               <div
-                data-keyboard-region="bottomBar"
+                data-keyboard-region="inspector"
                 tabIndex={0}
-                data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
-                className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+                data-keyboard-active={keyboardRegion === 'inspector' ? 'true' : 'false'}
+                className={`${inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
               >
-                <WorkflowStatusChips
-                  workflows={workflows}
-                  activeFilters={statusFilters}
-                  keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
-                  onStatusClick={handleStatusClick}
-                />
-                <TerminalDrawer
-                  state={terminalDrawerState}
-                  onCycle={() =>
-                    setTerminalDrawerState((prev) =>
-                      prev === 'minimized' ? 'partial' : prev === 'partial' ? 'maximized' : 'minimized',
-                    )
-                  }
-                  sessions={terminalSessions}
-                  activeSessionId={activeTerminalSessionId}
-                  onSelectSession={setActiveTerminalSessionId}
-                  onCloseSession={(sessionId) => void handleCloseTerminalSession(sessionId)}
-                  taskLabels={terminalTaskLabels}
+                <WorkflowInspector
+                  workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
+                  task={selectedTask}
+                  workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
+                  reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
+                  remoteTargets={remoteTargets}
+                  executionPools={executionPools}
+                  executionAgents={executionAgents}
+                  collapsed={inspectorCollapsed}
+                  advancedExpanded={advancedMetadataExpanded}
+                  actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
+                  onEditType={handleEditType}
+                  onEditPool={handleEditPool}
+                  onEditAgent={handleEditAgent}
+                  onEditPrompt={handleEditPrompt}
+                  onEditCommand={handleEditCommand}
+                  onApprove={openApprovalModal}
+                  onReject={openRejectModal}
+                  onSetMergeBranch={handleSetMergeBranch}
+                  onSetMergeMode={handleSetMergeMode}
+                  onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
+                  onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}
                 />
               </div>
-            )}
-          </div>
-
-          <div
-            data-keyboard-region="inspector"
-            tabIndex={0}
-            data-keyboard-active={keyboardRegion === 'inspector' ? 'true' : 'false'}
-            className={`${inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
-          >
-            <WorkflowInspector
-              workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
-              task={selectedTask}
-              workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
-              reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
-              remoteTargets={remoteTargets}
-              executionPools={executionPools}
-              executionAgents={executionAgents}
-              collapsed={inspectorCollapsed}
-              advancedExpanded={advancedMetadataExpanded}
-              actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
-              onEditType={handleEditType}
-              onEditPool={handleEditPool}
-              onEditAgent={handleEditAgent}
-              onEditPrompt={handleEditPrompt}
-              onEditCommand={handleEditCommand}
-              onApprove={openApprovalModal}
-              onReject={openRejectModal}
-              onSetMergeBranch={handleSetMergeBranch}
-              onSetMergeMode={handleSetMergeMode}
-              onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
-              onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}
-            />
-          </div>
+            </div>
+          </main>
         </div>
       </div>
+
+
+      {graphMaximized && (
+        <div
+          data-testid="graph-maximized-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Full graph"
+          className="fixed inset-0 z-50 flex flex-col bg-gray-950"
+        >
+          <div className="flex items-center justify-between border-b border-gray-800 px-4 py-3">
+            <div>
+              <h2 className="text-sm font-semibold text-gray-100">Full graph</h2>
+              <p className="text-xs text-gray-500">Press Escape to return.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setGraphMaximized(false)}
+              className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+            >
+              Close
+            </button>
+          </div>
+          <div className="min-h-0 flex-1">
+            {displayedSelectedWorkflowGraph !== null ? (
+              <TaskDAG
+                tasks={displayedSelectedWorkflowGraph.tasks}
+                workflows={selectedTaskDagWorkflows}
+                selectedTaskId={selectedTaskId}
+                cameraCommand={cameraCommand}
+                onTaskClick={handleTaskClick}
+                onTaskDoubleClick={handleTaskDoubleClick}
+                onTaskContextMenu={handleTaskContextMenu}
+                onManualViewport={handleManualViewport}
+                statusFilters={new Set()}
+                runningTaskIds={runningTaskIds}
+              />
+            ) : (
+              <WorkflowGraph
+                workflows={workflows}
+                selectedWorkflowId={selectedWorkflow?.id ?? null}
+                cameraCommand={cameraCommand}
+                statusFilters={statusFilters}
+                coreActivityByWorkflow={coreActivityByWorkflow}
+                onSelectWorkflow={handleWorkflowClick}
+                onWorkflowContextMenu={handleWorkflowContextMenu}
+                onManualViewport={handleManualViewport}
+              />
+            )}
+          </div>
+        </div>
+      )}
 
       {searchOpen && (
         <div

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -33,9 +33,15 @@ describe('App launch (component)', () => {
     mock.cleanup();
   });
 
-  it('shows empty state prompt when no plan is loaded', () => {
+  it('shows the reskinned empty shell when no plan is loaded', () => {
     render(<App />);
-    expect(screen.getByText('Load a plan to render workflow graph')).toBeInTheDocument();
+    expect(screen.getByText('Start with a goal.')).toBeInTheDocument();
+    expect(screen.getByText('Invoker Terminal')).toBeInTheDocument();
+    expect(screen.getByText('What to expect')).toBeInTheDocument();
+    expect(screen.getAllByText('Your plan will appear here.').length).toBeGreaterThan(0);
+    expect(screen.getByText('No runs yet')).toBeInTheDocument();
+    expect(screen.getByText('All clear')).toBeInTheDocument();
+    expect(screen.getByText('No tasks running')).toBeInTheDocument();
   });
 
   it('renders left rail navigation and workflow controls', () => {

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, within } from '@testing-library/react';
 import { vi } from 'vitest';
 import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
 
@@ -38,7 +38,7 @@ describe('App launch (component)', () => {
     expect(screen.getByText('Start with a goal.')).toBeInTheDocument();
     expect(screen.getByText('Invoker Terminal')).toBeInTheDocument();
     expect(screen.getByText('What to expect')).toBeInTheDocument();
-    expect(screen.getAllByText('Your plan will appear here.').length).toBeGreaterThan(0);
+    expect(within(screen.getByTestId('workflow-graph-surface')).getByText('Your plan will appear here.')).toBeInTheDocument();
     expect(screen.getByText('No runs yet')).toBeInTheDocument();
     expect(screen.getByText('All clear')).toBeInTheDocument();
     expect(screen.getByText('No tasks running')).toBeInTheDocument();

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -111,6 +111,11 @@ export function createMockInvoker(
     onTaskOutput: vi.fn(() => () => {}),
     onActivityLog: vi.fn(() => () => {}),
     loadPlan: vi.fn(async () => {}),
+    planFromGoal: vi.fn(async () => ({
+      ok: true,
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+    })),
     start: vi.fn(async () => taskSnapshot),
     stop: vi.fn(async () => {}),
     clear: vi.fn(async () => {}),

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -23,6 +23,12 @@ export interface MockInvoker {
   api: InvokerAPI;
   /** Replace the task snapshot and fire matching 'created' graph events. */
   setTasks: (tasks: TaskState[], workflows?: WorkflowMeta[]) => void;
+  /** Replace the snapshots published after planFromGoal succeeds. */
+  setPlannedGraph: (
+    tasks: TaskState[],
+    workflows: WorkflowMeta[],
+    result?: { planName?: string; workflowId?: string },
+  ) => void;
   /** Directly fire a task delta to subscribers. */
   fireDelta: (delta: TaskDelta) => void;
   /** Directly fire a task graph event to subscribers. */
@@ -47,6 +53,12 @@ export function createMockInvoker(
 ): MockInvoker {
   let taskSnapshot = initialTasks;
   let workflowSnapshot = initialWorkflows;
+  let plannedTaskSnapshot: TaskState[] = [
+    makeUITask({ id: 'planned-task', description: 'Planned task', workflowId: 'wf-1' }),
+  ];
+  let plannedWorkflowSnapshot: WorkflowMeta[] = [{ id: 'wf-1', name: 'Mock Plan', status: 'pending' }];
+  let plannedPlanName = 'Mock Plan';
+  let plannedWorkflowId = 'wf-1';
   let graphEventCallback: ((event: TaskGraphEvent) => void) | undefined;
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
@@ -111,11 +123,15 @@ export function createMockInvoker(
     onTaskOutput: vi.fn(() => () => {}),
     onActivityLog: vi.fn(() => () => {}),
     loadPlan: vi.fn(async () => {}),
-    planFromGoal: vi.fn(async () => ({
-      ok: true,
-      planName: 'Mock Plan',
-      workflowId: 'wf-1',
-    })),
+    planFromGoal: vi.fn(async () => {
+      taskSnapshot = plannedTaskSnapshot;
+      workflowSnapshot = plannedWorkflowSnapshot;
+      return {
+        ok: true,
+        planName: plannedPlanName,
+        workflowId: plannedWorkflowId,
+      };
+    }),
     start: vi.fn(async () => taskSnapshot),
     stop: vi.fn(async () => {}),
     clear: vi.fn(async () => {}),
@@ -255,6 +271,17 @@ export function createMockInvoker(
     });
   }
 
+  function setPlannedGraph(
+    tasks: TaskState[],
+    workflows: WorkflowMeta[],
+    result: { planName?: string; workflowId?: string } = {},
+  ) {
+    plannedTaskSnapshot = tasks;
+    plannedWorkflowSnapshot = workflows;
+    plannedPlanName = result.planName ?? workflows[0]?.name ?? 'Mock Plan';
+    plannedWorkflowId = result.workflowId ?? workflows[0]?.id ?? tasks[0]?.config.workflowId ?? 'wf-1';
+  }
+
   function setActionGraph(response: ActionGraphResponse) {
     actionGraphSnapshot = response;
   }
@@ -299,6 +326,7 @@ export function createMockInvoker(
   return {
     api,
     setTasks,
+    setPlannedGraph,
     setActionGraph,
     setRuntimeStatus,
     fireDelta,

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  // Dynamic import is required because Vitest hoists mock factories before test imports.
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+// Dynamic import is required so App sees the hoisted @xyflow/react mock.
+const { App } = await import('../App.js');
+
+describe('Invoker terminal (component)', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('generates a plan from a quoted goal command', async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'plan "Add README"' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(mock.api.planFromGoal).toHaveBeenCalledWith({ goal: 'Add README' });
+      expect(screen.getByText('Plan "Mock Plan" loaded. Use run to execute.')).toBeInTheDocument();
+    });
+  });
+
+  it('explains that run needs a loaded plan first', async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'run' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    expect(await screen.findByText('Load or generate a plan before running.')).toBeInTheDocument();
+    expect(mock.api.start).not.toHaveBeenCalled();
+  });
+
+  it('starts execution after a generated plan is loaded', async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'plan "Add README"' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+    await screen.findByText('Plan "Mock Plan" loaded. Use run to execute.');
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'run' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(mock.api.start).toHaveBeenCalled();
+      expect(screen.getByText('Run started.')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
-import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 
 vi.mock('@xyflow/react', async () => {
   // Dynamic import is required because Vitest hoists mock factories before test imports.
@@ -36,6 +36,23 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('refreshes the graph from the planned snapshot after plan generation', async () => {
+    mock.setPlannedGraph(
+      [makeUITask({ id: 'planned-task', description: 'Planned task', workflowId: 'wf-planned' })],
+      [{ id: 'wf-planned', name: 'Planned Workflow', status: 'pending' }],
+      { planName: 'Planned Workflow', workflowId: 'wf-planned' },
+    );
+    render(<App />);
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'plan "Add README"' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Plan "Planned Workflow" loaded. Use run to execute.')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-planned')).toBeInTheDocument();
+    });
+  });
+
   it('explains that run needs a loaded plan first', async () => {
     render(<App />);
 
@@ -59,6 +76,27 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(mock.api.start).toHaveBeenCalled();
       expect(screen.getByText('Run started.')).toBeInTheDocument();
+    });
+  });
+
+  it('reports start failures instead of a successful run', async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'plan "Add README"' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+    await screen.findByText('Plan "Mock Plan" loaded. Use run to execute.');
+
+    mock.api.start = vi.fn(async () => {
+      throw new Error('start failed');
+    });
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'run' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(mock.api.start).toHaveBeenCalled();
+      expect(screen.getByText('Failed to start run.')).toBeInTheDocument();
+      expect(screen.queryByText('Run started.')).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -223,4 +223,28 @@ describe('Task interaction (component)', () => {
 
     expect(panel).toHaveStyle({ left: '468px', top: '308px' });
   });
+
+  it('opens and closes the maximized graph without clearing selection', async () => {
+    render(<App />);
+    act(() => mock.setTasks([alpha, beta], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'View full graph' }));
+    expect(screen.getByTestId('graph-maximized-overlay')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('graph-maximized-overlay')).not.toBeInTheDocument();
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+    });
+  });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react';
+
+export interface InvokerTerminalLine {
+  id: number;
+  text: string;
+  tone?: 'muted' | 'error' | 'success';
+}
+
+interface InvokerTerminalProps {
+  lines: InvokerTerminalLine[];
+  busy: boolean;
+  onSubmit: (command: string) => void;
+}
+
+export function InvokerTerminal({ lines, busy, onSubmit }: InvokerTerminalProps): JSX.Element {
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <section className="rounded-xl border border-gray-800 bg-gray-950 shadow-inner">
+      <div className="flex items-center justify-between border-b border-gray-800 px-4 py-2">
+        <div>
+          <h1 className="text-sm font-semibold text-gray-100">Invoker Terminal</h1>
+          <p className="text-xs text-gray-500">Plan from a goal, then run it.</p>
+        </div>
+        {busy && <span className="text-xs text-blue-300">Working…</span>}
+      </div>
+      <div data-testid="invoker-terminal-transcript" className="max-h-36 space-y-1 overflow-y-auto px-4 py-3 font-mono text-xs">
+        {lines.map((line) => {
+          const toneClass = line.tone === 'error'
+            ? 'text-red-300'
+            : line.tone === 'success'
+              ? 'text-emerald-300'
+              : 'text-gray-300';
+          return (
+            <div key={line.id} className={toneClass}>
+              {line.text}
+            </div>
+          );
+        })}
+      </div>
+      <form
+        className="flex items-center gap-2 border-t border-gray-800 px-4 py-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const command = value.trim();
+          if (!command || busy) return;
+          onSubmit(command);
+          setValue('');
+        }}
+      >
+        <span className="font-mono text-xs text-gray-500">$</span>
+        <input
+          ref={inputRef}
+          data-testid="invoker-terminal-input"
+          value={value}
+          disabled={busy}
+          onChange={(event) => setValue(event.target.value)}
+          placeholder='plan "Add README" or run'
+          className="min-w-0 flex-1 bg-transparent font-mono text-sm text-gray-100 outline-none placeholder:text-gray-600 disabled:cursor-wait"
+        />
+      </form>
+    </section>
+  );
+}

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -12,7 +12,7 @@ interface InvokerTerminalProps {
   onSubmit: (command: string) => void;
 }
 
-export function InvokerTerminal({ lines, busy, onSubmit }: InvokerTerminalProps): JSX.Element {
+export function InvokerTerminal({ lines, busy, onSubmit }: InvokerTerminalProps) {
   const [value, setValue] = useState('');
   const inputRef = useRef<HTMLInputElement | null>(null);
 

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -1,0 +1,101 @@
+import type { QueueStatus } from '@invoker/contracts';
+import type { TaskState, WorkflowMeta } from '../types.js';
+
+interface LeftStatusColumnProps {
+  workflows: Map<string, WorkflowMeta>;
+  tasks: Map<string, TaskState>;
+  queueStatus: QueueStatus | null;
+  planName: string | null;
+  plannerBusy: boolean;
+  hasStarted: boolean;
+  onTaskClick: (taskId: string) => void;
+}
+
+const ATTENTION_STATUS: Record<string, true> = {
+  failed: true,
+  blocked: true,
+  needs_input: true,
+  awaiting_approval: true,
+  review_ready: true,
+};
+
+export function LeftStatusColumn({
+  workflows,
+  tasks,
+  queueStatus,
+  planName,
+  plannerBusy,
+  hasStarted,
+  onTaskClick,
+}: LeftStatusColumnProps): JSX.Element {
+  const workflowCount = workflows.size;
+  const taskCount = tasks.size;
+  const attentionTasks = [...tasks.values()].filter((task) => ATTENTION_STATUS[task.status]);
+  const runningTasks = queueStatus?.running.length
+    ? queueStatus.running
+    : [...tasks.values()]
+      .filter((task) => task.status === 'running' || task.status === 'fixing_with_ai')
+      .map((task) => ({ taskId: task.id, description: task.description }));
+
+  return (
+    <aside className="w-64 shrink-0 overflow-y-auto border-r border-gray-800 bg-gray-950/80 p-3 text-sm text-gray-200">
+      <section className="rounded-lg border border-gray-800 bg-gray-900/80 p-3">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Run</div>
+        {taskCount === 0 && !planName ? (
+          <p className="mt-3 text-sm text-gray-500">No runs yet</p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            <div className="truncate text-sm font-medium text-gray-100" title={planName ?? undefined}>
+              {planName ?? `${workflowCount} workflow${workflowCount === 1 ? '' : 's'}`}
+            </div>
+            <div className="text-xs text-gray-400">
+              {plannerBusy ? 'Planning…' : hasStarted ? 'Run started' : `${taskCount} task${taskCount === 1 ? '' : 's'} ready`}
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className="mt-3 rounded-lg border border-gray-800 bg-gray-900/80 p-3">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Needs attention</div>
+        {attentionTasks.length === 0 ? (
+          <p className="mt-3 text-sm text-emerald-300">All clear</p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            {attentionTasks.slice(0, 6).map((task) => (
+              <button
+                key={task.id}
+                type="button"
+                onClick={() => onTaskClick(task.id)}
+                className="block w-full rounded border border-amber-700/40 bg-amber-950/30 px-2 py-1.5 text-left hover:bg-amber-950/50"
+              >
+                <div className="truncate text-xs font-medium text-amber-100">{task.description || task.id}</div>
+                <div className="mt-0.5 text-[11px] text-amber-300">{task.status.replaceAll('_', ' ')}</div>
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="mt-3 rounded-lg border border-gray-800 bg-gray-900/80 p-3">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Running task</div>
+        {runningTasks.length === 0 ? (
+          <p className="mt-3 text-sm text-gray-500">No tasks running</p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            {runningTasks.slice(0, 6).map((task) => (
+              <button
+                key={task.taskId}
+                type="button"
+                onClick={() => onTaskClick(task.taskId)}
+                className="block w-full rounded border border-blue-700/40 bg-blue-950/30 px-2 py-1.5 text-left hover:bg-blue-950/50"
+              >
+                <div className="truncate text-xs font-medium text-blue-100">{task.description || task.taskId}</div>
+                <div className="mt-0.5 text-[11px] text-blue-300">Running</div>
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -27,7 +27,7 @@ export function LeftStatusColumn({
   plannerBusy,
   hasStarted,
   onTaskClick,
-}: LeftStatusColumnProps): JSX.Element {
+}: LeftStatusColumnProps) {
   const workflowCount = workflows.size;
   const taskCount = tasks.size;
   const attentionTasks = [...tasks.values()].filter((task) => ATTENTION_STATUS[task.status]);

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -588,8 +588,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     return (
       <div className="h-full w-full flex items-center justify-center text-gray-500">
         <div className="text-center">
-          <p>No tasks yet</p>
-          <p className="text-sm mt-1">Load a plan to create a task graph</p>
+          <p>Your plan will appear here.</p>
         </div>
       </div>
     );

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -310,7 +310,7 @@ function WorkflowGraphInner({
   if (graph.nodes.length === 0) {
     return (
       <div className="h-full flex items-center justify-center text-gray-500 text-sm">
-        Load a plan to render workflow graph
+        Your plan will appear here.
       </div>
     );
   }

--- a/scripts/repro/repro-coderabbit-pr2663-graph-placeholder-scope.sh
+++ b/scripts/repro/repro-coderabbit-pr2663-graph-placeholder-scope.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-pr2663-graph-placeholder.XXXXXX.log")"
+trap 'rm -f "$log_file"' EXIT
+
+echo "[repro] Running PR #2663 graph placeholder assertion regression."
+
+if pnpm -C "$repo_root" --filter @invoker/ui exec vitest run \
+  src/__tests__/app-launch.test.tsx \
+  -t 'shows the reskinned empty shell when no plan is loaded' \
+  >"$log_file" 2>&1; then
+  echo "[repro] PASS: empty-state copy is asserted inside the workflow graph surface."
+else
+  status=$?
+  echo "[repro] FAIL: empty-state copy is not proven inside the workflow graph surface."
+  cat "$log_file"
+  exit "$status"
+fi

--- a/scripts/repro/repro-coderabbit-pr2663-planned-graph-refresh.sh
+++ b/scripts/repro/repro-coderabbit-pr2663-planned-graph-refresh.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-pr2663-planned-graph.XXXXXX.log")"
+trap 'rm -f "$log_file"' EXIT
+
+echo "[repro] Running PR #2663 planned graph refresh regression."
+
+if pnpm -C "$repo_root" --filter @invoker/ui exec vitest run \
+  src/__tests__/invoker-terminal.test.tsx \
+  -t 'refreshes the graph from the planned snapshot after plan generation' \
+  >"$log_file" 2>&1; then
+  echo "[repro] PASS: planFromGoal refresh publishes the planned graph snapshot."
+else
+  status=$?
+  echo "[repro] FAIL: planFromGoal left the app on a stale graph snapshot."
+  cat "$log_file"
+  exit "$status"
+fi

--- a/scripts/repro/repro-coderabbit-pr2663-react19-jsx-return-type.sh
+++ b/scripts/repro/repro-coderabbit-pr2663-react19-jsx-return-type.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+echo "[repro] Running PR #2663 React 19 JSX namespace regression."
+
+if node - "$repo_root" <<'NODE'
+const fs = require('node:fs');
+const path = require('node:path');
+const root = process.argv[2];
+const files = [
+  'packages/ui/src/components/InvokerTerminal.tsx',
+  'packages/ui/src/components/LeftStatusColumn.tsx',
+];
+let failed = false;
+for (const file of files) {
+  const text = fs.readFileSync(path.join(root, file), 'utf8');
+  if (/:\s*JSX\.Element\b/.test(text)) {
+    console.error(`${file} still uses bare JSX.Element`);
+    failed = true;
+  }
+}
+process.exit(failed ? 1 : 0);
+NODE
+then
+  echo "[repro] PASS: reviewed components no longer use bare JSX.Element return types."
+else
+  status=$?
+  echo "[repro] FAIL: React 19 does not expose global JSX.Element for these component return types."
+  exit "$status"
+fi

--- a/scripts/repro/repro-coderabbit-pr2663-run-start-failure.sh
+++ b/scripts/repro/repro-coderabbit-pr2663-run-start-failure.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-pr2663-run-start.XXXXXX.log")"
+trap 'rm -f "$log_file"' EXIT
+
+echo "[repro] Running PR #2663 run-start failure regression."
+
+if pnpm -C "$repo_root" --filter @invoker/ui exec vitest run \
+  src/__tests__/invoker-terminal.test.tsx \
+  -t 'reports start failures instead of a successful run' \
+  >"$log_file" 2>&1; then
+  echo "[repro] PASS: terminal reports a failed run start as an error."
+else
+  status=$?
+  echo "[repro] FAIL: terminal reported success even though invoker.start failed."
+  cat "$log_file"
+  exit "$status"
+fi


### PR DESCRIPTION
## Summary

The desktop home view now opens as a clearer Invoker workspace. Users get first-run guidance, goal planning, and a full-screen view option.

The existing execution details stay owned by their current components. This slice wires the new workspace around them.

<details>
<summary>Review metadata</summary>

Review Claim: The renderer activates the new workspace around the existing execution views.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Existing execution components still own their behavior; this slice adds workspace state and layout around them.

Slice Rationale: The goal command flow, empty state, status column, and full-screen overlay are one surface activation change.

</details>

## Non-goals

- No task execution semantics change.
- No removal of History, Timeline, Queue, or Action Graph views.
- No planner subprocess logic in the renderer.

## Visual Proof

![Reskinned empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-1db11b/empty-state.png)

![Graph maximize overlay](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-1db11b/graph-maximized-overlay.png)

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx src/__tests__/invoker-terminal.test.tsx src/__tests__/task-interaction.test.tsx src/__tests__/terminal-drawer.test.tsx && pnpm --filter @invoker/ui build`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an inline terminal in the main UI for entering goal and run commands.
  * Added a “View full graph” overlay for an expanded workflow view, closable with Escape.
  * Introduced a refreshed left-side status panel with run summary plus attention/running task lists.
* **Bug Fixes**
  * Updated empty-state text to consistently show “Your plan will appear here.”
  * Improved terminal feedback for success, missing-plan guidance, unknown commands, and run start failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2715