### PR TITLE
[Invoker UI Reskin](3) Refine shell layout

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2,9 +2,9 @@
  * App — Main layout for Invoker UI.
  *
  * Layout:
- * - Left rail: workflow controls and navigation
- * - Main: workflow graph / task DAG
- * - Right: workflow inspector
+ * - Left: run/status column
+ * - Main: terminal and graph
+ * - Right: empty-state tutorial or inspector
  * - Bottom: status chips and terminal drawer
  * - Modals overlay when needed
  */
@@ -349,21 +349,39 @@ function WorkflowContextMenu({
   );
 }
 
-function GearIcon(): JSX.Element {
+function EmptyGraphTutorial(): JSX.Element {
   return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 16 16"
-      className="h-4 w-4"
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.6"
-    >
-      <path d="M6.9 2.2h2.2l.4 1.6a4.7 4.7 0 0 1 1.1.6l1.6-.5 1.1 1.9-1.2 1.1a4.8 4.8 0 0 1 0 1.3l1.2 1.1-1.1 1.9-1.6-.5a4.7 4.7 0 0 1-1.1.6l-.4 1.6H6.9l-.4-1.6a4.7 4.7 0 0 1-1.1-.6l-1.6.5-1.1-1.9 1.2-1.1a4.8 4.8 0 0 1 0-1.3L2.7 5.8l1.1-1.9 1.6.5a4.7 4.7 0 0 1 1.1-.6l.4-1.6Z" />
-      <circle cx="8" cy="7.5" r="1.7" />
-    </svg>
+    <aside className="h-full w-full border-l border-gray-800 bg-gray-900/90 p-4">
+      <div className="rounded-xl border border-gray-800 bg-gray-950/70 p-4">
+        <h2 className="text-sm font-semibold text-gray-100">What to expect</h2>
+        <ol className="mt-3 space-y-3 text-sm text-gray-400">
+          <li>
+            <div className="font-medium text-gray-200">1. Type a goal</div>
+            <div className="mt-1 text-xs text-gray-500">Describe the change in the terminal to generate a plan.</div>
+          </li>
+          <li>
+            <div className="font-medium text-gray-200">2. Review the plan</div>
+            <div className="mt-1 text-xs text-gray-500">Check the graph before starting work.</div>
+          </li>
+          <li>
+            <div className="font-medium text-gray-200">3. Run it</div>
+            <div className="mt-1 text-xs text-gray-500">Start the workflow when the plan looks right.</div>
+          </li>
+        </ol>
+      </div>
+    </aside>
+  );
+}
+
+function EmptyInspectorPlaceholder(): JSX.Element {
+  return (
+    <aside className="h-full w-full border-l border-gray-800 bg-gray-900/90 p-4">
+      <div className="rounded-xl border border-dashed border-gray-800 bg-gray-950/50 p-4">
+        <h2 className="text-sm font-semibold text-gray-100">No task selected</h2>
+        <p className="mt-2 text-sm text-gray-400">Select a task in the graph to see details.</p>
+        <p className="mt-2 text-xs text-gray-500">Status, logs, and actions will appear here.</p>
+      </div>
+    </aside>
   );
 }
 
@@ -417,6 +435,7 @@ export function App() {
   );
   const fileInputRef = useRef<HTMLInputElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
+  const graphActionsMenuRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
@@ -458,6 +477,7 @@ export function App() {
   const [terminalSessions, setTerminalSessions] = useState<TerminalSessionDescriptor[]>([]);
   const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null);
   const [workflowContextMenu, setWorkflowContextMenu] = useState<WorkflowContextMenuState | null>(null);
+  const [graphActionsMenuOpen, setGraphActionsMenuOpen] = useState(false);
   // Transient, user-visible outcome line for a confirmed workflow detach.
   const [detachNotice, setDetachNotice] = useState<string | null>(null);
   const [keyboardRegion, setKeyboardRegion] = useState<KeyboardRegion>('workflowGraph');
@@ -1725,6 +1745,42 @@ export function App() {
   }, [tasks]);
   const showStart = hasLoadedPlan && !hasStarted;
   const showStop = hasStarted && !allSettled;
+  const showEmptyGraphTutorial = !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
+  const showInspectorPlaceholder = !showEmptyGraphTutorial && !selectedTask && !selectedWorkflow && !selectedActionNode;
+
+  useEffect(() => {
+    if (!graphActionsMenuOpen) return undefined;
+    const handlePointerDown = (event: PointerEvent) => {
+      if (graphActionsMenuRef.current?.contains(event.target as Node)) return;
+      setGraphActionsMenuOpen(false);
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setGraphActionsMenuOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [graphActionsMenuOpen]);
+
+  const selectViewMode = useCallback((nextView: 'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph') => {
+    setGraphActionsMenuOpen(false);
+    if (nextView === 'actionGraph') {
+      setViewMode('actionGraph');
+      setWorkflowSelectionDismissed(true);
+      setSelectedTaskId(null);
+      return;
+    }
+    if (nextView === 'dag') {
+      setViewMode('dag');
+      return;
+    }
+    setViewMode(nextView);
+  }, []);
 
   // ── Task actions ──────────────────────────────────────────
   const handleProvideInput = useCallback(
@@ -1969,158 +2025,41 @@ export function App() {
       )}
       {/* Main content */}
       <div className="flex-1 flex overflow-hidden">
-        <nav className="w-24 border-r border-gray-800 bg-gray-950/60 flex flex-col justify-between py-3">
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".json,.yaml,.yml"
-            onChange={handleFileSelect}
-            className="hidden"
-          />
-          <div className="space-y-3 px-2">
-            <div className="space-y-1">
-              <button
-                data-testid="rail-open-file"
-                onClick={() => fileInputRef.current?.click()}
-                className="w-full rounded bg-gray-700 px-2 py-1.5 text-left text-xs font-medium text-gray-100 hover:bg-gray-600"
-              >
-                Open
-              </button>
-              {showStart && (
-                <button
-                  data-testid="rail-start"
-                  onClick={handleStart}
-                  className="w-full rounded bg-green-700 px-2 py-1.5 text-left text-xs font-medium text-white hover:bg-green-600"
-                >
-                  Start
-                </button>
-              )}
-              {showStop && (
-                <button
-                  data-testid="rail-stop"
-                  onClick={handleStop}
-                  className="w-full rounded bg-red-700 px-2 py-1.5 text-left text-xs font-medium text-white hover:bg-red-600"
-                >
-                  Stop
-                </button>
-              )}
-              {planName && (
-                <div className="truncate px-1 pt-1 text-[10px] leading-tight text-gray-500" title={planName}>
-                  {planName}
-                </div>
-              )}
-            </div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json,.yaml,.yml"
+          onChange={handleFileSelect}
+          className="hidden"
+        />
 
-            <div className="space-y-1">
-            <button
-              data-testid="rail-home"
-              onClick={() => {
-                setViewMode('dag');
-              }}
-              className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'dag' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
-            >
-              Home
-            </button>
-            <button
-              data-testid="rail-timeline"
-              onClick={() => {
-                setViewMode('timeline');
-              }}
-              className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'timeline' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
-            >
-              Timeline
-            </button>
-            <button
-              data-testid="rail-history"
-              onClick={() => {
-                setViewMode('history');
-              }}
-              className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'history' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
-            >
-              History
-            </button>
-            <button
-              data-testid="rail-action-graph"
-              onClick={() => {
-                setViewMode('actionGraph');
-                setWorkflowSelectionDismissed(true);
-                setSelectedTaskId(null);
-              }}
-              className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'actionGraph' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
-            >
-              Action Graph
-            </button>
-            <button
-              data-testid="rail-queue"
-              onClick={() => {
-                setViewMode('queue');
-              }}
-              className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'queue' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
-            >
-              Queue
-            </button>
-            </div>
-
-            <div className="space-y-1 border-t border-gray-800 pt-3">
-              <button
-                data-testid="rail-refresh"
-                onClick={handleRefresh}
-                className="w-full rounded px-2 py-1.5 text-left text-xs text-gray-300 hover:bg-gray-800/70"
-              >
-                Refresh
-              </button>
-              <button
-                data-testid="rail-clear"
-                onClick={handleClear}
-                className="w-full rounded px-2 py-1.5 text-left text-xs text-gray-300 hover:bg-gray-800/70"
-              >
-                Clear
-              </button>
-              <button
-                data-testid="rail-delete-history"
-                onClick={handleDeleteDB}
-                className="w-full rounded px-2 py-1.5 text-left text-xs text-red-300 hover:bg-red-950/50"
-              >
-                Delete
-              </button>
-            </div>
-          </div>
-          <div className="px-2">
-            <button
-              data-testid="rail-settings"
-              onClick={() => { cancelPendingSystemSetupAutoOpen(); setShowSystemSetup(true); }}
-              className="flex h-8 w-full items-center justify-center rounded text-gray-300 hover:bg-gray-800/70 hover:text-white"
-              aria-label="Settings"
-              title="Settings"
-            >
-              <GearIcon />
-            </button>
-          </div>
-        </nav>
+        <LeftStatusColumn
+          workflows={workflows}
+          tasks={tasks}
+          queueStatus={queueStatus}
+          planName={planName}
+          plannerBusy={plannerBusy}
+          hasStarted={hasStarted}
+          showStart={showStart}
+          showStop={showStop}
+          onOpenPlan={() => fileInputRef.current?.click()}
+          onStart={handleStart}
+          onStop={handleStop}
+          onOpenSettings={() => {
+            cancelPendingSystemSetupAutoOpen();
+            setShowSystemSetup(true);
+          }}
+          onTaskClick={handleTaskClick}
+        />
 
         <div className="flex-1 flex overflow-hidden">
-          <LeftStatusColumn
-            workflows={workflows}
-            tasks={tasks}
-            queueStatus={queueStatus}
-            planName={planName}
-            plannerBusy={plannerBusy}
-            hasStarted={hasStarted}
-            onTaskClick={handleTaskClick}
-          />
           <main className="flex-1 flex flex-col overflow-hidden bg-gray-900">
-            <div className="space-y-3 border-b border-gray-800 bg-gray-900/80 p-4">
+            <div className="border-b border-gray-800 bg-gray-900/80 p-4">
               <InvokerTerminal
                 lines={terminalLines}
                 busy={plannerBusy}
                 onSubmit={(command) => void handleTerminalSubmit(command)}
               />
-              <section className="rounded-xl border border-gray-800 bg-gray-950/70 p-4">
-                <h2 className="text-sm font-semibold text-gray-100">What to expect</h2>
-                <p className="mt-2 text-sm text-gray-400">
-                  Type a planning goal, review the graph, then run when the plan is ready.
-                </p>
-              </section>
             </div>
 
             <div className="flex-1 flex overflow-hidden">
@@ -2130,13 +2069,103 @@ export function App() {
                     <h2 className="text-sm font-semibold text-gray-100">Plan graph</h2>
                     <p className="text-xs text-gray-500">Your plan will appear here.</p>
                   </div>
-                  <button
-                    type="button"
-                    onClick={() => setGraphMaximized(true)}
-                    className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
-                  >
-                    View full graph
-                  </button>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      data-testid="rail-refresh"
+                      onClick={handleRefresh}
+                      className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+                    >
+                      Refresh
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setGraphMaximized(true)}
+                      className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+                    >
+                      Full graph ⤢
+                    </button>
+                    <div ref={graphActionsMenuRef} className="relative">
+                      <button
+                        type="button"
+                        data-testid="graph-more-button"
+                        onClick={() => setGraphActionsMenuOpen((open) => !open)}
+                        className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+                      >
+                        More ▾
+                      </button>
+                      {graphActionsMenuOpen && (
+                        <div
+                          data-testid="graph-more-menu"
+                          className="absolute right-0 top-10 z-20 w-48 rounded-lg border border-gray-700 bg-gray-950 p-1 shadow-xl"
+                        >
+                          <button
+                            type="button"
+                            data-testid="rail-home"
+                            onClick={() => selectViewMode('dag')}
+                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+                          >
+                            Plan graph
+                          </button>
+                          <button
+                            type="button"
+                            data-testid="rail-timeline"
+                            onClick={() => selectViewMode('timeline')}
+                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+                          >
+                            Timeline
+                          </button>
+                          <button
+                            type="button"
+                            data-testid="rail-history"
+                            onClick={() => selectViewMode('history')}
+                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+                          >
+                            History
+                          </button>
+                          <button
+                            type="button"
+                            data-testid="rail-action-graph"
+                            onClick={() => selectViewMode('actionGraph')}
+                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+                          >
+                            Action Graph
+                          </button>
+                          <button
+                            type="button"
+                            data-testid="rail-queue"
+                            onClick={() => selectViewMode('queue')}
+                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+                          >
+                            Queue
+                          </button>
+                          <div className="my-1 border-t border-gray-800" />
+                          <button
+                            type="button"
+                            data-testid="rail-clear"
+                            onClick={async () => {
+                              setGraphActionsMenuOpen(false);
+                              await handleClear();
+                            }}
+                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+                          >
+                            Clear
+                          </button>
+                          <button
+                            type="button"
+                            data-testid="rail-delete-history"
+                            onClick={async () => {
+                              setGraphActionsMenuOpen(false);
+                              await handleDeleteDB();
+                            }}
+                            className="block w-full rounded px-3 py-2 text-left text-xs text-red-300 hover:bg-red-950/50"
+                          >
+                            Delete history
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  </div>
                 </div>
                 <div
                   ref={graphSurfaceRef}
@@ -2255,31 +2284,37 @@ export function App() {
                 data-keyboard-region="inspector"
                 tabIndex={0}
                 data-keyboard-active={keyboardRegion === 'inspector' ? 'true' : 'false'}
-                className={`${inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+                className={`${showEmptyGraphTutorial || showInspectorPlaceholder ? 'w-96' : inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
               >
-                <WorkflowInspector
-                  workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
-                  task={selectedTask}
-                  workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
-                  reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
-                  remoteTargets={remoteTargets}
-                  executionPools={executionPools}
-                  executionAgents={executionAgents}
-                  collapsed={inspectorCollapsed}
-                  advancedExpanded={advancedMetadataExpanded}
-                  actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
-                  onEditType={handleEditType}
-                  onEditPool={handleEditPool}
-                  onEditAgent={handleEditAgent}
-                  onEditPrompt={handleEditPrompt}
-                  onEditCommand={handleEditCommand}
-                  onApprove={openApprovalModal}
-                  onReject={openRejectModal}
-                  onSetMergeBranch={handleSetMergeBranch}
-                  onSetMergeMode={handleSetMergeMode}
-                  onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
-                  onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}
-                />
+                {showEmptyGraphTutorial ? (
+                  <EmptyGraphTutorial />
+                ) : showInspectorPlaceholder ? (
+                  <EmptyInspectorPlaceholder />
+                ) : (
+                  <WorkflowInspector
+                    workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
+                    task={selectedTask}
+                    workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
+                    reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
+                    remoteTargets={remoteTargets}
+                    executionPools={executionPools}
+                    executionAgents={executionAgents}
+                    collapsed={inspectorCollapsed}
+                    advancedExpanded={advancedMetadataExpanded}
+                    actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
+                    onEditType={handleEditType}
+                    onEditPool={handleEditPool}
+                    onEditAgent={handleEditAgent}
+                    onEditPrompt={handleEditPrompt}
+                    onEditCommand={handleEditCommand}
+                    onApprove={openApprovalModal}
+                    onReject={openRejectModal}
+                    onSetMergeBranch={handleSetMergeBranch}
+                    onSetMergeMode={handleSetMergeMode}
+                    onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
+                    onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}
+                  />
+                )}
               </div>
             </div>
           </main>

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1598,10 +1598,10 @@ export function App() {
         await invoker.loadPlan(planText);
         setWorkflowSelectionDismissed(false);
         setHasLoadedPlan(true);
+        setHasStarted(false);
         // Parse locally just for UI display state
         const parsed = yaml.load(planText) as any;
         setPlanName(parsed?.name ?? 'Untitled Plan');
-        setOnFinish(parsed?.onFinish ?? 'merge');
         refreshTaskGraph();
       } catch (err) {
         console.error('Failed to load plan:', err);
@@ -1703,7 +1703,6 @@ export function App() {
       setHasLoadedPlan(false);
       setHasStarted(false);
       setPlanName(null);
-      setOnFinish('merge');
       setSelectedTaskId(null);
       setSelectedWorkflowId(null);
       setModal({ type: 'none' });

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
 
@@ -53,6 +53,38 @@ describe('App launch (component)', () => {
     expect(screen.getByText('Running task')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Timeline' })).not.toBeInTheDocument();
+  });
+
+  it('resets run controls when uploading a new plan after start', async () => {
+    const { container } = render(<App />);
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+
+    const uploadPlan = async (name: string) => {
+      const planText = `name: ${name}\nonFinish: merge\n`;
+      const file = new File([planText], `${name}.yaml`, { type: 'application/x-yaml' });
+      Object.defineProperty(file, 'text', {
+        value: async () => planText,
+      });
+      fireEvent.change(fileInput, { target: { files: [file] } });
+      await waitFor(() => {
+        expect(mock.api.loadPlan).toHaveBeenLastCalledWith(expect.stringContaining(`name: ${name}`));
+      });
+    };
+
+    await uploadPlan('First Plan');
+    expect(screen.getByTestId('rail-start')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('rail-start'));
+    await waitFor(() => {
+      expect(mock.api.start).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('rail-stop')).toBeInTheDocument();
+    });
+
+    await uploadPlan('Second Plan');
+    await waitFor(() => {
+      expect(screen.getByTestId('rail-start')).toBeInTheDocument();
+      expect(screen.queryByTestId('rail-stop')).not.toBeInTheDocument();
+    });
   });
 
   it('shows workflow status chips and terminal drawer controls in home view', () => {

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -44,16 +44,15 @@ describe('App launch (component)', () => {
     expect(screen.getByText('No tasks running')).toBeInTheDocument();
   });
 
-  it('renders left rail navigation and workflow controls', () => {
+  it('renders the left status column controls without the old nav rail', () => {
     render(<App />);
     expect(screen.getByTestId('rail-open-file')).toBeInTheDocument();
-    expect(screen.getByTestId('rail-home')).toBeInTheDocument();
-    expect(screen.getByTestId('rail-timeline')).toBeInTheDocument();
-    expect(screen.getByTestId('rail-history')).toBeInTheDocument();
-    expect(screen.getByTestId('rail-queue')).toBeInTheDocument();
-    expect(screen.queryByTestId('rail-attention')).not.toBeInTheDocument();
-    expect(screen.getByTestId('rail-refresh')).toBeInTheDocument();
-    expect(screen.getByTestId('rail-clear')).toBeInTheDocument();
+    expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
+    expect(screen.getByText('Run')).toBeInTheDocument();
+    expect(screen.getByText('Needs attention')).toBeInTheDocument();
+    expect(screen.getByText('Running task')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Timeline' })).not.toBeInTheDocument();
   });
 
   it('shows workflow status chips and terminal drawer controls in home view', () => {

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -106,8 +106,8 @@ describe('Side rail controls (component)', () => {
 
   it('Clear button calls clear', async () => {
     render(<App />);
+    fireEvent.click(screen.getByTestId('graph-more-button'));
     fireEvent.click(screen.getByTestId('rail-clear'));
-
     await waitFor(() => {
       expect(mock.api.clear).toHaveBeenCalled();
     });

--- a/packages/ui/src/__tests__/timeline-view-e2e.test.tsx
+++ b/packages/ui/src/__tests__/timeline-view-e2e.test.tsx
@@ -35,6 +35,14 @@ const beta = makeUITask({
   command: 'echo hello-beta',
 });
 const workflows: WorkflowMeta[] = [{ id: 'wf-timeline', name: 'Timeline WF', status: 'running' }];
+async function chooseGraphMenuItem(testId: string): Promise<void> {
+  fireEvent.click(screen.getByTestId('graph-more-button'));
+  await waitFor(() => {
+    expect(screen.getByTestId('graph-more-menu')).toBeInTheDocument();
+  });
+  fireEvent.click(screen.getByTestId(testId));
+}
+
 
 describe('Timeline view (component)', () => {
   let mock: MockInvoker;
@@ -52,7 +60,7 @@ describe('Timeline view (component)', () => {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));
 
-    fireEvent.click(screen.getByTestId('rail-timeline'));
+    await chooseGraphMenuItem('rail-timeline');
 
     await waitFor(() => {
       expect(screen.getByTestId('timeline-view')).toBeInTheDocument();
@@ -63,7 +71,7 @@ describe('Timeline view (component)', () => {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));
 
-    fireEvent.click(screen.getByTestId('rail-timeline'));
+    await chooseGraphMenuItem('rail-timeline');
 
     await waitFor(() => {
       expect(screen.getByTestId('timeline-bar-task-alpha')).toBeInTheDocument();
@@ -88,7 +96,7 @@ describe('Timeline view (component)', () => {
     render(<App />);
     act(() => mock.setTasks([completedAlpha, beta], workflows));
 
-    fireEvent.click(screen.getByTestId('rail-timeline'));
+    await chooseGraphMenuItem('rail-timeline');
 
     await waitFor(() => {
       const bar = screen.getByTestId('timeline-bar-task-alpha');
@@ -113,7 +121,7 @@ describe('Timeline view (component)', () => {
     render(<App />);
     act(() => mock.setTasks([startedAlpha, beta], workflows));
 
-    fireEvent.click(screen.getByTestId('rail-timeline'));
+    await chooseGraphMenuItem('rail-timeline');
 
     await waitFor(() => {
       expect(screen.getByTestId('timeline-bar-task-alpha')).toBeInTheDocument();
@@ -130,7 +138,7 @@ describe('Timeline view (component)', () => {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));
 
-    fireEvent.click(screen.getByTestId('rail-timeline'));
+    await chooseGraphMenuItem('rail-timeline');
 
     await waitFor(() => {
       expect(screen.getByTestId('timeline-bar-task-alpha')).toBeInTheDocument();
@@ -148,13 +156,13 @@ describe('Timeline view (component)', () => {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));
 
-    fireEvent.click(screen.getByTestId('rail-timeline'));
+    await chooseGraphMenuItem('rail-timeline');
 
     await waitFor(() => {
       expect(screen.getByTestId('timeline-bar-task-alpha')).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByTestId('rail-home'));
+    await chooseGraphMenuItem('rail-home');
 
     await waitFor(() => {
       expect(screen.queryByTestId('timeline-view')).not.toBeInTheDocument();

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -8,6 +8,12 @@ interface LeftStatusColumnProps {
   planName: string | null;
   plannerBusy: boolean;
   hasStarted: boolean;
+  showStart: boolean;
+  showStop: boolean;
+  onOpenPlan: () => void;
+  onStart: () => void;
+  onStop: () => void;
+  onOpenSettings: () => void;
   onTaskClick: (taskId: string) => void;
 }
 
@@ -26,6 +32,12 @@ export function LeftStatusColumn({
   planName,
   plannerBusy,
   hasStarted,
+  showStart,
+  showStop,
+  onOpenPlan,
+  onStart,
+  onStop,
+  onOpenSettings,
   onTaskClick,
 }: LeftStatusColumnProps): JSX.Element {
   const workflowCount = workflows.size;
@@ -38,64 +50,107 @@ export function LeftStatusColumn({
       .map((task) => ({ taskId: task.id, description: task.description }));
 
   return (
-    <aside className="w-64 shrink-0 overflow-y-auto border-r border-gray-800 bg-gray-950/80 p-3 text-sm text-gray-200">
-      <section className="rounded-lg border border-gray-800 bg-gray-900/80 p-3">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Run</div>
-        {taskCount === 0 && !planName ? (
-          <p className="mt-3 text-sm text-gray-500">No runs yet</p>
-        ) : (
-          <div className="mt-3 space-y-2">
-            <div className="truncate text-sm font-medium text-gray-100" title={planName ?? undefined}>
-              {planName ?? `${workflowCount} workflow${workflowCount === 1 ? '' : 's'}`}
+    <aside className="flex h-full w-72 shrink-0 flex-col border-r border-gray-800 bg-gray-950/80 p-3 text-sm text-gray-200">
+      <div className="flex-1 space-y-3 overflow-y-auto pr-1">
+        <section className="rounded-lg border border-gray-800 bg-gray-900/80 p-3">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Run</div>
+          {taskCount === 0 && !planName ? (
+            <p className="mt-3 text-sm text-gray-500">No runs yet</p>
+          ) : (
+            <div className="mt-3 space-y-2">
+              <div className="truncate text-sm font-medium text-gray-100" title={planName ?? undefined}>
+                {planName ?? `${workflowCount} workflow${workflowCount === 1 ? '' : 's'}`}
+              </div>
+              <div className="text-xs text-gray-400">
+                {plannerBusy ? 'Planning…' : hasStarted ? 'Run started' : `${taskCount} task${taskCount === 1 ? '' : 's'} ready`}
+              </div>
             </div>
-            <div className="text-xs text-gray-400">
-              {plannerBusy ? 'Planning…' : hasStarted ? 'Run started' : `${taskCount} task${taskCount === 1 ? '' : 's'} ready`}
+          )}
+          <div className="mt-3 space-y-2">
+            <button
+              type="button"
+              data-testid="rail-open-file"
+              onClick={onOpenPlan}
+              className="w-full rounded bg-gray-700 px-3 py-2 text-left text-xs font-medium text-gray-100 hover:bg-gray-600"
+            >
+              Load plan
+            </button>
+            {showStart && (
+              <button
+                type="button"
+                data-testid="rail-start"
+                onClick={onStart}
+                className="w-full rounded bg-green-700 px-3 py-2 text-left text-xs font-medium text-white hover:bg-green-600"
+              >
+                Run
+              </button>
+            )}
+            {showStop && (
+              <button
+                type="button"
+                data-testid="rail-stop"
+                onClick={onStop}
+                className="w-full rounded bg-red-700 px-3 py-2 text-left text-xs font-medium text-white hover:bg-red-600"
+              >
+                Stop
+              </button>
+            )}
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-gray-800 bg-gray-900/80 p-3">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Needs attention</div>
+          {attentionTasks.length === 0 ? (
+            <p className="mt-3 text-sm text-emerald-300">All clear</p>
+          ) : (
+            <div className="mt-3 space-y-2">
+              {attentionTasks.slice(0, 6).map((task) => (
+                <button
+                  key={task.id}
+                  type="button"
+                  onClick={() => onTaskClick(task.id)}
+                  className="block w-full rounded border border-amber-700/40 bg-amber-950/30 px-2 py-1.5 text-left hover:bg-amber-950/50"
+                >
+                  <div className="truncate text-xs font-medium text-amber-100">{task.description || task.id}</div>
+                  <div className="mt-0.5 text-[11px] text-amber-300">{task.status.replaceAll('_', ' ')}</div>
+                </button>
+              ))}
             </div>
-          </div>
-        )}
-      </section>
+          )}
+        </section>
 
-      <section className="mt-3 rounded-lg border border-gray-800 bg-gray-900/80 p-3">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Needs attention</div>
-        {attentionTasks.length === 0 ? (
-          <p className="mt-3 text-sm text-emerald-300">All clear</p>
-        ) : (
-          <div className="mt-3 space-y-2">
-            {attentionTasks.slice(0, 6).map((task) => (
-              <button
-                key={task.id}
-                type="button"
-                onClick={() => onTaskClick(task.id)}
-                className="block w-full rounded border border-amber-700/40 bg-amber-950/30 px-2 py-1.5 text-left hover:bg-amber-950/50"
-              >
-                <div className="truncate text-xs font-medium text-amber-100">{task.description || task.id}</div>
-                <div className="mt-0.5 text-[11px] text-amber-300">{task.status.replaceAll('_', ' ')}</div>
-              </button>
-            ))}
-          </div>
-        )}
-      </section>
+        <section className="rounded-lg border border-gray-800 bg-gray-900/80 p-3">
+          <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Running task</div>
+          {runningTasks.length === 0 ? (
+            <p className="mt-3 text-sm text-gray-500">No tasks running</p>
+          ) : (
+            <div className="mt-3 space-y-2">
+              {runningTasks.slice(0, 6).map((task) => (
+                <button
+                  key={task.taskId}
+                  type="button"
+                  onClick={() => onTaskClick(task.taskId)}
+                  className="block w-full rounded border border-blue-700/40 bg-blue-950/30 px-2 py-1.5 text-left hover:bg-blue-950/50"
+                >
+                  <div className="truncate text-xs font-medium text-blue-100">{task.description || task.taskId}</div>
+                  <div className="mt-0.5 text-[11px] text-blue-300">Running</div>
+                </button>
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
 
-      <section className="mt-3 rounded-lg border border-gray-800 bg-gray-900/80 p-3">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Running task</div>
-        {runningTasks.length === 0 ? (
-          <p className="mt-3 text-sm text-gray-500">No tasks running</p>
-        ) : (
-          <div className="mt-3 space-y-2">
-            {runningTasks.slice(0, 6).map((task) => (
-              <button
-                key={task.taskId}
-                type="button"
-                onClick={() => onTaskClick(task.taskId)}
-                className="block w-full rounded border border-blue-700/40 bg-blue-950/30 px-2 py-1.5 text-left hover:bg-blue-950/50"
-              >
-                <div className="truncate text-xs font-medium text-blue-100">{task.description || task.taskId}</div>
-                <div className="mt-0.5 text-[11px] text-blue-300">Running</div>
-              </button>
-            ))}
-          </div>
-        )}
-      </section>
+      <div className="mt-3 border-t border-gray-800 pt-3">
+        <button
+          type="button"
+          data-testid="rail-settings"
+          onClick={onOpenSettings}
+          className="flex w-full items-center justify-center rounded border border-gray-700 px-3 py-2 text-xs font-medium text-gray-200 hover:bg-gray-800"
+        >
+          Settings
+        </button>
+      </div>
     </aside>
   );
 }

--- a/scripts/repro/repro-coderabbit-pr2669-reset-run-state-on-plan-load.sh
+++ b/scripts/repro/repro-coderabbit-pr2669-reset-run-state-on-plan-load.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: loading a new plan after starting a previous plan must reset App run controls.
+#
+# The buggy behavior leaves hasStarted=true in the shared plan-load path, so the
+# newly uploaded plan hides Run and keeps Stop visible before it has started.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "==> Running CodeRabbit PR #2669 repro: reset run state on plan load"
+
+if pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx -t 'resets run controls when uploading a new plan after start'; then
+  echo "PASS: loading a new plan resets run controls."
+else
+  echo "FAIL: loading a new plan leaves stale started state; Run is hidden or Stop remains visible." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

The shell now uses one status column on the left. The graph actions live in the graph header, and the right side switches between the empty-state tutorial and task details.

The tutorial now appears only when the graph is empty. Once a plan exists, the right side returns to the detail surface.

<details>
<summary>Review metadata</summary>

Review Claim: The renderer matches the new one-column-left, tutorial-on-empty-right layout while keeping the secondary views available.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Queue, history, timeline, and action-graph views still exist; the graph header menu is their access point in this shell.

Slice Rationale: The layout change is one UI behavior slice on top of the first reskinned shell activation.

</details>

## Non-goals

- No planner bridge changes.
- No task execution semantics changes.
- No proof asset refresh in this slice.

## Visual Proof

![Empty graph state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-95ecec/empty-state.png)

![Loaded graph state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-95ecec/dag-loaded.png)

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx src/__tests__/keyboard-controls.test.tsx src/__tests__/timeline-view-e2e.test.tsx src/__tests__/visual-proof-snapshots.test.tsx`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app test:e2e -- e2e/visual-proof.spec.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2663

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reworked the app layout to use a dedicated status column with clearer plan, run, task, and settings controls.
  * Added a graph “More” menu for switching views and accessing navigation options.

* **Bug Fixes**
  * Improved empty-state handling with clearer guidance when no plan is loaded and a cleaner placeholder when nothing is selected.
  * Loading a new plan now correctly resets the run state and updates the displayed plan name.

* **Tests**
  * Expanded coverage for the new layout, graph menu navigation, and run-state reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->