### PR TITLE
[Invoker UI Reskin](6) Prove terminal planning refreshes graph

### DIFF
--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -36,6 +36,47 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('refreshes the graph after terminal planning succeeds', async () => {
+    mock.api.planFromGoal = vi.fn(async () => {
+      mock.setTasks([
+        {
+          id: 'task-alpha',
+          description: 'Alpha task',
+          status: 'pending',
+          config: {
+            baseBranch: 'main',
+            prompt: 'Do alpha',
+            agent: 'codex',
+            dependencies: [],
+            canRunInParallel: true,
+            requiresReview: true,
+            autoRetry: false,
+            sandboxMode: 'workspace-write',
+            model: 'gpt-5',
+            workflowId: 'wf-graph',
+          },
+        } as any,
+      ], [
+        { id: 'wf-graph', name: 'Mock Plan', status: 'pending' } as any,
+      ]);
+      return { ok: true as const, planName: 'Mock Plan', workflowId: 'wf-graph' };
+    }) as any;
+
+    render(<App />);
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'plan "Add README"' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(mock.api.planFromGoal).toHaveBeenCalledWith({ goal: 'Add README' });
+      expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
+      expect(screen.getByTestId('workflow-node-wf-graph')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('What to expect')).not.toBeInTheDocument();
+    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Mock Plan');
+  });
+
   it('explains that run needs a loaded plan first', async () => {
     render(<App />);
 


### PR DESCRIPTION
## Summary

This slice adds direct proof that planning from the terminal refreshes the Invoker graph. The component test now verifies that a successful `plan "..."` command updates the workflow graph and swaps out the empty tutorial state.

It exists to answer one reviewer question clearly: does terminal planning really land in the graph surface the user sees?

<details>
<summary>Review metadata</summary>

Review Claim: Terminal planning now has an explicit UI proof test that the graph refreshes after a generated plan is loaded.

Review Lane: proof

Review Unit: proof

Safety Invariant: This slice changes a proof-focused UI test only. It does not change production shell behavior.

Slice Rationale: The terminal-to-graph behavior needed its own proof after the shell redesign changed the empty and selected states.

</details>

## Non-goals

- No production UI behavior changes.
- No planner bridge changes.
- No screenshot updates.

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2664