### PR TITLE
[Task Delete](1) Add core task deletion support

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -132,6 +132,26 @@ describe('SQLiteAdapter', () => {
       });
     });
 
+    it('deleteTask removes one task and leaves the workflow and sibling tasks', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      adapter.saveTask('wf-1', makeTask('t2'));
+      adapter.saveAttempt(createAttempt('t1', { generation: 1 }));
+      adapter.logEvent('t1', 'task.created');
+      (adapter as any).db.run('INSERT INTO task_output (task_id, data) VALUES (?, ?)', ['t1', 'out']);
+      (adapter as any).db.run('INSERT INTO output_spool (task_id, offset, data) VALUES (?, ?, ?)', ['t1', 0, 'out']);
+
+      adapter.deleteTask('t1');
+
+      expect(adapter.loadWorkflow('wf-1')).toBeDefined();
+      expect(adapter.loadTask('t1')).toBeUndefined();
+      expect(adapter.loadTask('t2')).toBeDefined();
+      expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM attempts WHERE node_id = 't1'")).toBe(0);
+      expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM events WHERE task_id = 't1'")).toBe(0);
+      expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM task_output WHERE task_id = 't1'")).toBe(0);
+      expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM output_spool WHERE task_id = 't1'")).toBe(0);
+    });
+
     it('loads all workflows and tasks in one startup snapshot', () => {
       const wf2: Workflow = {
         ...testWorkflow,

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -144,6 +144,8 @@ export interface PersistenceAdapter {
   loadWorkflowTaskSnapshot?(): WorkflowTaskSnapshot;
   /** Authoritative single-task read by ID, suitable for recovery workflows. */
   loadTask(taskId: string): TaskState | undefined;
+  /** Delete one task and its task-owned rows. */
+  deleteTask(taskId: string): void;
   getAllTaskIds(): string[];
   getAllTaskBranches(): string[];
   deleteAllTasks(workflowId: string): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1687,6 +1687,19 @@ export class SQLiteAdapter implements PersistenceAdapter {
     }));
   }
 
+  deleteTask(taskId: string): void {
+    this.runTransaction(() => {
+      this.db.run('DELETE FROM task_launch_dispatch WHERE task_id = ?', [taskId]);
+      this.db.run('DELETE FROM execution_resource_leases WHERE task_id = ?', [taskId]);
+      this.db.run('DELETE FROM events WHERE task_id = ?', [taskId]);
+      this.db.run('DELETE FROM task_output WHERE task_id = ?', [taskId]);
+      this.db.run('DELETE FROM attempts WHERE node_id = ?', [taskId]);
+      this.db.run('DELETE FROM output_spool WHERE task_id = ?', [taskId]);
+      this.db.run('DELETE FROM tasks WHERE id = ?', [taskId]);
+    });
+    this.removeOutputFiles([taskId]);
+  }
+
   deleteAllTasks(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
     this.runTransaction(() => {

--- a/packages/data-store/src/sqlite-task-repository.ts
+++ b/packages/data-store/src/sqlite-task-repository.ts
@@ -50,6 +50,10 @@ export class SqliteTaskRepository implements TaskRepository {
     this.adapter.updateTask(taskId, changes);
   }
 
+  deleteTask(taskId: string): void {
+    this.adapter.deleteTask(taskId);
+  }
+
   logEvent(taskId: string, eventType: string, payload?: unknown): void {
     this.adapter.logEvent(taskId, eventType, payload);
   }

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -30,6 +30,7 @@ function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
     provideInput: vi.fn(),
     retryTask: vi.fn().mockReturnValue([]),
     recreateTask: vi.fn().mockReturnValue([]),
+    deleteTask: vi.fn().mockReturnValue([]),
     selectExperiment: vi.fn().mockReturnValue([]),
     editTaskCommand: vi.fn().mockReturnValue([]),
     editTaskAgent: vi.fn().mockReturnValue([]),
@@ -286,6 +287,24 @@ describe('CommandService', () => {
       });
       const result = await service.cancelTask(makeEnvelope({ taskId: 'bad' }));
       expect(result).toEqual({ ok: false, error: { code: 'CANCEL_TASK_FAILED', message: 'unexpected' } });
+    });
+  });
+
+  // ── deleteTask ───────────────────────────────────────────
+
+  describe('deleteTask', () => {
+    it('delegates to orchestrator.deleteTask', async () => {
+      const result = await service.deleteTask(makeEnvelope({ taskId: 't-1' }));
+      expect(result).toEqual({ ok: true, data: [] });
+      expect(orchestrator.deleteTask).toHaveBeenCalledWith('t-1');
+    });
+
+    it('returns typed error code from OrchestratorError', async () => {
+      (orchestrator.deleteTask as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new OrchestratorError('TASK_NOT_FOUND', 'Task "bad" not found');
+      });
+      const result = await service.deleteTask(makeEnvelope({ taskId: 'bad' }));
+      expect(result).toEqual({ ok: false, error: { code: 'TASK_NOT_FOUND', message: 'Task "bad" not found' } });
     });
   });
 

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -219,6 +219,13 @@ class InMemoryPersistence implements OrchestratorPersistence {
     }
   }
 
+  deleteTask(taskId: string): void {
+    const resolvedId = this.resolveBareTaskKey(taskId);
+    this.tasks.delete(resolvedId);
+    this.attempts.delete(resolvedId);
+    this.events = this.events.filter((event) => event.taskId !== resolvedId);
+  }
+
   deleteWorkflow(workflowId: string): void {
     this.workflows.delete(workflowId);
     for (const [taskId, entry] of this.tasks) {
@@ -1099,6 +1106,45 @@ describe('Orchestrator', () => {
       expect(hookSpy).toHaveBeenCalledTimes(1);
       expect(hookSpy.mock.calls[0][0].id).toBe(mergeId);
       expect(orchestrator.getTask(mergeId)!.status).toBe('completed');
+    });
+  });
+
+  describe('deleteTask', () => {
+    it('removes one task and retargets dependents to the deleted task upstreams', () => {
+      orchestrator.loadPlan({
+        name: 'task-delete-retarget',
+        tasks: [
+          { id: 'a', description: 'A' },
+          { id: 'b', description: 'B', dependencies: ['a'] },
+          { id: 'c', description: 'C', dependencies: ['b'] },
+        ],
+      });
+      const bId = sid(orchestrator, 0, 'b');
+      const cId = sid(orchestrator, 0, 'c');
+      publishedDeltas = [];
+
+      orchestrator.deleteTask(bId);
+
+      expect(orchestrator.getTask(bId)).toBeUndefined();
+      expect(persistence.getTaskEntry(bId)).toBeUndefined();
+      expect(orchestrator.getTask(cId)?.dependencies).toEqual([sid(orchestrator, 0, 'a')]);
+      expect(publishedDeltas).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'removed', taskId: bId }),
+          expect.objectContaining({ type: 'updated', taskId: cId }),
+        ]),
+      );
+    });
+
+    it('blocks deleting the last non-merge task in a workflow', () => {
+      orchestrator.loadPlan({
+        name: 'task-delete-last',
+        tasks: [{ id: 'only', description: 'Only task' }],
+      });
+      const onlyId = sid(orchestrator, 0, 'only');
+
+      expect(() => orchestrator.deleteTask(onlyId)).toThrow(/last task/);
+      expect(orchestrator.getTask(onlyId)).toBeDefined();
     });
   });
 

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -422,6 +422,16 @@ export class CommandService {
     );
   }
 
+  async deleteTask(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'DELETE_TASK_FAILED',
+      () => this.orchestrator.deleteTask(envelope.payload.taskId),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
   async cancelWorkflow(
     envelope: CommandEnvelope<{ workflowId: string }>,
   ): Promise<CommandResult<CancelResult>> {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -295,6 +295,7 @@ export interface OrchestratorPersistence {
   loadAttempts(nodeId: string): Attempt[];
   loadAttempt(attemptId: string): Attempt | undefined;
   updateAttempt(attemptId: string, changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>): void;
+  deleteTask?(taskId: string): void;
   failTaskAndAttempt?(
     taskId: string,
     taskChanges: TaskStateChanges,
@@ -551,6 +552,10 @@ export function taskRepositoryFromPersistence(p: OrchestratorPersistence): TaskR
     deleteAllWorkflows: () => p.deleteAllWorkflows?.(),
     saveTask: (wfId, t) => p.saveTask(wfId, t),
     updateTask: (id, c) => p.updateTask(id, c),
+    deleteTask: (id) => {
+      if (!p.deleteTask) throw new Error('Persistence adapter does not support deleteTask');
+      p.deleteTask(id);
+    },
     logEvent: (id, et, pl) => p.logEvent?.(id, et, pl),
     saveAttempt: (a) => partial.saveAttempt?.(a),
     updateAttempt: (id, c) => partial.updateAttempt?.(id, c),
@@ -3557,6 +3562,84 @@ export class Orchestrator {
       })
       .map((rt) => scopeLocal(rt.id));
     return this.autoStartReadyTasks(rootIds, 0, { bypassLocalDependencyReadiness: true });
+  }
+
+  deleteTask(taskId: string): TaskState[] {
+    this.refreshFromDb();
+
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task "${taskId}" not found`);
+    if (task.config.isMergeNode) throw new Error(`Cannot delete merge task "${taskId}"`);
+
+    const workflowId = task.config.workflowId;
+    if (!workflowId) throw new Error(`deleteTask: task ${taskId} has no workflowId`);
+
+    const workflowTasks = this.stateMachine
+      .getAllTasks()
+      .filter((candidate) => candidate.config.workflowId === workflowId);
+    const remainingNonMergeTasks = workflowTasks.filter(
+      (candidate) => candidate.id !== task.id && !candidate.config.isMergeNode,
+    );
+    if (remainingNonMergeTasks.length === 0) {
+      throw new Error(`Cannot delete the last task in workflow "${workflowId}"; delete the workflow instead.`);
+    }
+
+    const directDependents = workflowTasks.filter(
+      (candidate) =>
+        candidate.id !== task.id &&
+        !candidate.config.isMergeNode &&
+        candidate.dependencies.includes(task.id),
+    );
+    const upstreamDeps = task.dependencies;
+    const retargetDeltas: TaskDelta[] = [];
+
+    const retargetDependencies = (dependencies: readonly string[]): string[] => {
+      const next: string[] = [];
+      const seen = new Set<string>();
+      const add = (dependencyId: string) => {
+        if (dependencyId === task.id || dependencyId.length === 0 || seen.has(dependencyId)) return;
+        seen.add(dependencyId);
+        next.push(dependencyId);
+      };
+
+      for (const dependencyId of dependencies) {
+        if (dependencyId === task.id) {
+          for (const upstreamId of upstreamDeps) add(upstreamId);
+        } else {
+          add(dependencyId);
+        }
+      }
+      return next;
+    };
+
+    this.taskRepository.runInTransaction(() => {
+      this.invalidateLaunchArtifactsForTasks([task.id], 'task deletion');
+
+      for (const dependent of directDependents) {
+        const dependencies = retargetDependencies(dependent.dependencies);
+        const changes: TaskStateChanges = { dependencies };
+        const updated = this.writeAndSync(dependent.id, changes);
+        retargetDeltas.push(this.buildUpdateDelta(dependent, updated, changes));
+      }
+
+      this.deferredTaskIds.delete(task.id);
+      this.clearQueuedSchedulerEntries(task.id, task.execution.selectedAttemptId);
+      this.taskRepository.deleteTask(task.id);
+      this.touchWorkflow(workflowId);
+    });
+
+    this.syncAllFromDb();
+
+    for (const delta of retargetDeltas) {
+      this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+    }
+    this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildRemoveDelta(task));
+    this.reconcileMergeLeaves(workflowId);
+
+    const readyIds = directDependents
+      .map((dependent) => dependent.id)
+      .filter((id) => this.stateGetTask(id));
+    return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
   }
 
   /**

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -121,6 +121,9 @@ export interface TaskRepository {
   /** Apply a partial update to an existing task. */
   updateTask(taskId: string, changes: TaskStateChanges): void;
 
+  /** Delete one task and its task-owned rows. */
+  deleteTask(taskId: string): void;
+
   /** Persist a task lifecycle event for auditing / replay. */
   logEvent(taskId: string, eventType: string, payload?: unknown): void;
 


### PR DESCRIPTION
## Summary

The core runtime now has one path for pruning a single task.

That path rewires direct dependents, blocks pruning the last task in a workflow, and clears task-owned state from persistence.

<details>
<summary>Review metadata</summary>

Review Claim: The core runtime can prune one task safely and keep the workflow graph valid.

Review Lane: behavior

Review Unit: routing

Safety Invariant: No user-facing entry point is added in this slice. Only the core runtime path changes.

Slice Rationale: The runtime path has to exist before later slices can call it.

</details>

## Non-goals

- This does not add any app, API, headless, or UI entry point.
- This does not change workflow-level pruning.

## Test Plan

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/command-service.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 8bfa7ee98`
- Post-revert steps: None
- Data migration? No
