### PR TITLE
[Task Delete](5) Add task delete control to the UI

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -98,6 +98,7 @@ function createMocks() {
       setFixAwaitingApproval: vi.fn(),
       retryTask: vi.fn(() => [makeTask()]),
       recreateTask: vi.fn(() => [makeTask()]),
+      deleteTask: vi.fn(() => [makeTask()]),
       recreateDownstream: vi.fn(() => [makeTask()]),
       retryWorkflow: vi.fn(() => [makeTask()]),
       recreateWorkflow: vi.fn(() => [makeTask()]),
@@ -163,6 +164,14 @@ function createMocks() {
           return { ok: true, data: mocks.orchestrator.recreateTask(envelope.payload.taskId) };
         } catch (err) {
           return { ok: false, error: { code: 'RECREATE_TASK_FAILED', message: (err as Error).message } };
+        }
+      }),
+      deleteTask: vi.fn(async (envelope: { payload: { taskId: string } }) => {
+        try {
+          return { ok: true, data: mocks.orchestrator.deleteTask(envelope.payload.taskId) };
+        } catch (err) {
+          const code = err instanceof OrchestratorError ? err.code : 'DELETE_TASK_FAILED';
+          return { ok: false, error: { code, message: (err as Error).message } };
         }
       }),
       recreateDownstream: vi.fn(async (envelope: { payload: { taskId: string } }) => {
@@ -1163,6 +1172,30 @@ describe('POST /api/workflows/:id/rebase-recreate', () => {
     const res = await request(port, 'POST', '/api/workflows/wf-missing/rebase-recreate');
     expect(res.status).toBe(404);
     expect(res.body.error).toContain('Could not resolve workflow');
+  });
+});
+
+describe('DELETE /api/tasks/:id', () => {
+  it('deletes task via facade and returns concrete action', async () => {
+    const res = await request(port, 'DELETE', '/api/tasks/task-1');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.taskId).toBe('task-1');
+    expect(res.body.action).toBe('deleted');
+    expect(typeof res.body.tasksStarted).toBe('number');
+    expect(mocks.commandService.deleteTask).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { taskId: 'task-1' } }),
+    );
+    expect(mocks.orchestrator.deleteTask).toHaveBeenCalledWith('task-1');
+  });
+
+  it('maps task-not-found to HTTP 404', async () => {
+    mocks.orchestrator.deleteTask.mockImplementation(() => {
+      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, 'Task "missing" not found');
+    });
+    const res = await request(port, 'DELETE', '/api/tasks/missing');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Task "missing" not found');
   });
 });
 

--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -59,6 +59,7 @@ describe('GUI mutation translation', () => {
   it.each([
     ['invoker:restart-task', 'retry-task'],
     ['invoker:cancel-task', 'cancel'],
+    ['invoker:delete-task', 'delete-task'],
     ['invoker:cancel-workflow', 'cancel-workflow'],
     ['invoker:delete-workflow', 'delete'],
     ['invoker:recreate-workflow', 'recreate'],

--- a/packages/app/src/__tests__/workflow-mutation-facade.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-facade.test.ts
@@ -33,6 +33,7 @@ function makeDeps(overrides: Partial<WorkflowMutationFacadeDeps> = {}): Workflow
   const orchestrator = {
     retryTask: vi.fn(() => [makeRunningTask()]),
     recreateTask: vi.fn(() => [makeRunningTask()]),
+    deleteTask: vi.fn(() => [makeRunningTask({ id: 'task-b' })]),
     recreateDownstream: vi.fn(() => [makeRunningTask({ id: 'task-b' })]),
     cancelTask: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: [] })),
     cancelWorkflow: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: ['task-a'] })),
@@ -74,6 +75,7 @@ function makeDeps(overrides: Partial<WorkflowMutationFacadeDeps> = {}): Workflow
   const commandService = {
     retryTask: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: orchestrator.retryTask(envelope.payload.taskId) })),
     recreateTask: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: orchestrator.recreateTask(envelope.payload.taskId) })),
+    deleteTask: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: orchestrator.deleteTask(envelope.payload.taskId) })),
     recreateDownstream: vi.fn(async (envelope: { payload: { taskId: string } }) => ({ ok: true as const, data: orchestrator.recreateDownstream(envelope.payload.taskId) })),
     retryWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => ({ ok: true as const, data: orchestrator.retryWorkflow(envelope.payload.workflowId) })),
     recreateWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => {
@@ -149,6 +151,29 @@ describe('WorkflowMutationFacade', () => {
       expect((deps.taskExecutor.closeWorkflowReview as any).mock.invocationCallOrder[0]).toBeLessThan(
         (deps.commandService.recreateTask as any).mock.invocationCallOrder[0],
       );
+    });
+  });
+
+  describe('deleteTask', () => {
+    it('kills an active target and returns accepted runnable tasks', async () => {
+      const killFn = vi.fn();
+      deps = makeDeps({
+        killRunningTask: killFn,
+        orchestrator: {
+          ...deps.orchestrator,
+          getTask: vi.fn(() => makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } })),
+        } as unknown as Orchestrator,
+      });
+      facade = new WorkflowMutationFacade(deps);
+
+      const result = await facade.deleteTask('task-a');
+
+      expect(killFn).toHaveBeenCalledWith('task-a');
+      expect(deps.taskExecutor.closeWorkflowReview).toHaveBeenCalledWith('wf-1');
+      expect(deps.commandService.deleteTask).toHaveBeenCalledWith(
+        expect.objectContaining({ payload: { taskId: 'task-a' } }),
+      );
+      expect(result.started).toHaveLength(1);
     });
   });
 

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -30,6 +30,7 @@
  *   POST   /api/tasks/:id/edit-type    body: { runnerKind, poolMemberId? }
  *   POST   /api/tasks/:id/edit-agent   body: { agent }
  *   POST   /api/tasks/:id/gate-policy  body: { updates: [{ workflowId, taskId?, gatePolicy }] }
+ *   DELETE /api/tasks/:id
  *   POST   /api/workflows/:id/detach  body: { upstreamWorkflowId }
  *   POST   /api/workflows/:id/restart
  *   POST   /api/workflows/:id/rebase-retry
@@ -66,6 +67,7 @@ export interface ApiMutationFacade {
   cancelTask(taskId: string): Promise<CancelMutationResult>;
   retryTask(taskId: string): Promise<MutationResult>;
   recreateTask(taskId: string): Promise<MutationResult>;
+  deleteTask(taskId: string): Promise<MutationResult>;
   recreateDownstream(taskId: string): Promise<MutationResult>;
   resolveConflict(taskId: string, agentName?: string): Promise<ResolveConflictMutationResult>;
   approveTask(taskId: string): Promise<ApproveMutationResult>;
@@ -252,6 +254,19 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           return;
         }
         json(res, 200, serializeTask(task));
+        return;
+      }
+
+      // DELETE /api/tasks/:id
+      const deleteTaskMatch = path.match(/^\/api\/tasks\/([^/]+)$/);
+      if (method === 'DELETE' && deleteTaskMatch) {
+        const taskId = decodeURIComponent(deleteTaskMatch[1]);
+        try {
+          const result = await mutations.deleteTask(taskId);
+          json(res, 200, { ok: true, taskId, action: 'deleted', tasksStarted: result.runnable.length });
+        } catch (err) {
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
+        }
         return;
       }
 

--- a/packages/app/src/headless-approve-delete.ts
+++ b/packages/app/src/headless-approve-delete.ts
@@ -277,6 +277,35 @@ export async function headlessOpenTerminal(taskId: string, deps: HeadlessDeps): 
   }
 }
 
+export async function headlessDeleteTask(taskId: string, deps: HeadlessDeps): Promise<void> {
+  if (!taskId) throw new Error('Missing taskId. Usage: --headless delete-task <taskId>');
+  await withRestoredTaskUnlessDeleteAllWon(taskId, deps, 'delete-task', async (restored) => {
+    taskId = restored.resolvedTaskId;
+    const task = deps.orchestrator.getTask(taskId);
+    const workflowId = task?.config.workflowId;
+    const taskExecutor = createHeadlessExecutor(deps);
+    if (task && (task.status === 'running' || task.status === 'fixing_with_ai')) {
+      await taskExecutor.killActiveExecution(task.id);
+    }
+    if (workflowId) {
+      await taskExecutor.closeWorkflowReview(workflowId);
+    }
+    const envelope = makeEnvelope('delete-task', 'headless', 'task', { taskId });
+    const result = await deps.commandService.deleteTask(envelope);
+    if (!result.ok) throw new Error(result.error.message);
+    await finalizeMutationWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor,
+      logger: deps.logger,
+      context: 'headless.delete-task',
+      started: result.data,
+      scopedTaskIds: result.data.map((startedTask) => startedTask.id),
+      mutationTiming: deps.mutationTiming,
+    });
+    process.stdout.write(`Deleted task: ${taskId}\n`);
+  });
+}
+
 export async function headlessDeleteWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {
   if (!workflowId) throw new Error('Missing workflowId. Usage: --headless delete-workflow <workflowId>');
   // Preempt running tasks (kill processes + cancel) — matches owner-mode bridge contract

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -51,6 +51,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'select', kind: 'write' },
   { name: 'cancel', kind: 'write' },
   { name: 'cancel-workflow', kind: 'write' },
+  { name: 'delete-task', kind: 'write' },
   { name: 'delete-workflow', kind: 'write', aliases: ['delete'] },
   { name: 'delete-all', kind: 'write' },
   { name: 'open-terminal', kind: 'read' },

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -96,6 +96,7 @@ import {
   headlessCancel,
   headlessCancelWorkflow,
   headlessDeleteWorkflow,
+  headlessDeleteTask,
   headlessDetachWorkflow,
   headlessOpenTerminal,
 } from './headless-approve-delete.js';
@@ -328,6 +329,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       break;
     case 'cancel-workflow':
       await headlessCancelWorkflow(args[1], deps);
+      break;
+    case 'delete-task':
+      await headlessDeleteTask(args[1], deps);
       break;
     case 'delete':
     case 'delete-workflow':
@@ -590,8 +594,9 @@ ${BOLD}Configure:${RESET}
 ${BOLD}Lifecycle:${RESET}
   cancel <taskId>                                     Cancel task + all downstream
   cancel-workflow <workflowId>                        Cancel all active tasks in a workflow
-  delete <workflowId>                                 Delete a single workflow
-  delete-all                                          Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
+  delete-task <taskId>                                 Delete one task and retarget dependents
+  delete <workflowId>                                  Delete a single workflow
+  delete-all                                           Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
   open-terminal <taskId>                              Open OS terminal for a task
   slack                                               Start Slack bot (long-running)
   worker [kind|list|status]                           Run/list registry worker kinds (autofix scans failed tasks)

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1191,6 +1191,7 @@ function startHeadlessMode(): void {
             case 'cancel':
             case 'retry-task':
             case 'recreate-task':
+            case 'delete-task':
               return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'high' };
             case 'delete':
             case 'delete-workflow':
@@ -2179,6 +2180,37 @@ function createEmbeddedTerminalBackendFromConfig(
     return cmdResult.data;
   }
 
+  async function performDeleteTask(taskId: string): Promise<void> {
+    logger.info(`performDeleteTask begin task="${taskId}"`, { module: 'kill' });
+    const task = orchestrator.getTask(taskId);
+    const workflowId = task?.config.workflowId;
+    if (task && (task.status === 'running' || task.status === 'fixing_with_ai')) {
+      await killRunningTask(task.id);
+    }
+    if (workflowId) {
+      await requireTaskExecutor().closeWorkflowReview(workflowId);
+    }
+    const envelope = makeEnvelope('delete-task', 'ui', 'task', { taskId });
+    const result = await commandService.deleteTask(envelope);
+    if (!result.ok) throw CommandError.fromResult(result.error);
+    remoteFetchForPool.enabled = false;
+    try {
+      await dispatchStartedTasksWithGlobalTopup({
+        orchestrator,
+        taskExecutor: requireTaskExecutor(),
+        logger,
+        context: 'ipc.delete-task',
+        started: result.data,
+        scopedTaskIds: result.data.map((startedTask) => startedTask.id),
+        mutationTiming: activeMutationContext?.mutationTiming,
+      });
+    } finally {
+      remoteFetchForPool.enabled = true;
+    }
+    requestWorkflowMetadataPublish('delete-task');
+    logger.info(`performDeleteTask end task="${taskId}"`, { module: 'kill' });
+  }
+
   /** Cancel all active tasks in a workflow and kill any running processes. */
   async function performCancelWorkflow(workflowId: string): Promise<{ cancelled: string[]; runningCancelled: string[] }> {
     logger.info(`performCancelWorkflow begin workflow="${workflowId}"`, { module: 'kill' });
@@ -2399,6 +2431,7 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'cancel':
       case 'retry-task':
       case 'recreate-task':
+      case 'delete-task':
         return { workflowId: workflowIdForTaskArg(arg0), priority: 'high' };
       case 'approve':
       case 'reject':
@@ -2486,6 +2519,8 @@ function createEmbeddedTerminalBackendFromConfig(
         return { channel: 'headless.exec', request: { args: ['delete-all'] } };
       case 'invoker:delete-all-workflows-bulk':
         return { channel: 'headless.exec', request: { args: ['delete-all'] } };
+      case 'invoker:delete-task':
+        return { channel: 'headless.exec', request: { args: ['delete-task', String(arg0)], noTrack: true } };
       case 'invoker:delete-workflow':
         return { channel: 'headless.exec', request: { args: ['delete', String(arg0)], noTrack: true } };
       case 'invoker:detach-workflow':
@@ -3581,6 +3616,22 @@ function createEmbeddedTerminalBackendFromConfig(
       lastKnownWorkflowCount = 0;
       requestWorkflowMetadataPublish('delete-all-workflows-bulk');
     });
+
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:delete-task',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'high',
+      async (taskIdArg: unknown) => {
+        const taskId = String(taskIdArg);
+        logger.info(`delete-task: "${taskId}"`, { module: 'ipc' });
+        try {
+          await performDeleteTask(taskId);
+        } catch (err) {
+          logger.error(`delete-task failed: ${err}`, { module: 'ipc' });
+          throw err;
+        }
+      },
+    );
 
     registerWorkflowScopedGuiMutationHandler(
       'invoker:delete-workflow',

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -443,7 +443,12 @@ export class PersistedWorkflowMutationCoordinator {
     ) {
       return 'recreate';
     }
-    if (channel === 'invoker:delete-workflow' || channel === 'invoker:delete-all-workflows' || channel === 'invoker:delete-all-workflows-bulk') {
+    if (
+      channel === 'invoker:delete-workflow'
+      || channel === 'invoker:delete-task'
+      || channel === 'invoker:delete-all-workflows'
+      || channel === 'invoker:delete-all-workflows-bulk'
+    ) {
       return 'delete';
     }
     if (channel !== 'headless.exec') {
@@ -454,7 +459,7 @@ export class PersistedWorkflowMutationCoordinator {
     if (rawArgs[0] === 'recreate' || rawArgs[0] === 'recreate-task' || rawArgs[0] === 'rebase-recreate') {
       return 'recreate';
     }
-    if (rawArgs[0] === 'delete' || rawArgs[0] === 'delete-workflow' || rawArgs[0] === 'delete-all') {
+    if (rawArgs[0] === 'delete' || rawArgs[0] === 'delete-workflow' || rawArgs[0] === 'delete-task' || rawArgs[0] === 'delete-all') {
       return 'delete';
     }
     return null;
@@ -467,6 +472,7 @@ export class PersistedWorkflowMutationCoordinator {
       || intent.channel === 'invoker:recreate-task'
       || intent.channel === 'invoker:rebase-retry'
       || intent.channel === 'invoker:rebase-recreate'
+      || intent.channel === 'invoker:delete-task'
       || intent.channel === 'invoker:delete-workflow'
       || intent.channel === 'invoker:delete-all-workflows'
       || intent.channel === 'invoker:delete-all-workflows-bulk'
@@ -483,7 +489,7 @@ export class PersistedWorkflowMutationCoordinator {
     if (command === 'recreate-task') {
       return true;
     }
-    if (command === 'delete' || command === 'delete-workflow' || command === 'delete-all') {
+    if (command === 'delete' || command === 'delete-workflow' || command === 'delete-task' || command === 'delete-all') {
       return true;
     }
     const isWorkflowId = /^wf-[^/]+$/.test(target);

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -185,6 +185,8 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return mutations.recreateDownstream(String(args[0]));
       case 'invoker:cancel-task':
         return mutations.cancelTask(String(args[0]));
+      case 'invoker:delete-task':
+        return mutations.deleteTask(String(args[0]));
       case 'invoker:recreate-workflow':
         return mutations.recreateWorkflow(String(args[0]));
       case 'invoker:retry-workflow':

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -166,6 +166,20 @@ export class WorkflowMutationFacade {
     return this.finalizeWithTopup(started, 'facade.recreate-task', { scopedTaskIds: [taskId] });
   }
 
+  async deleteTask(taskId: string): Promise<MutationResult> {
+    await this.closeReviewForTask(taskId);
+    if (this.deps.killRunningTask) {
+      const task = this.deps.orchestrator.getTask(taskId);
+      if (task && (task.status === 'running' || task.status === 'fixing_with_ai')) {
+        await this.deps.killRunningTask(task.id);
+      }
+    }
+    const started = await this.runViaCommandService(
+      (cs) => cs.deleteTask(makeEnvelope('facade.delete-task', 'surface', 'task', { taskId })),
+    );
+    return this.finalizeWithTopup(started, 'facade.delete-task', { scopedTaskIds: started.map((task) => task.id) });
+  }
+
   async recreateDownstream(taskId: string): Promise<MutationResult> {
     await this.closeReviewForTask(taskId);
     const started = await this.runViaCommandService(

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1412,6 +1412,24 @@ export function App() {
     }
   }, [trackAcceptedMutation]);
 
+  const handleDeleteTask = useCallback(async (taskId: string) => {
+    setContextMenu(null);
+    const confirmed = window.confirm(
+      `Delete task "${taskId}"? Its dependents will use this task's upstream dependencies.`
+    );
+    if (!confirmed) return;
+    try {
+      const result = await window.invoker?.deleteTask(taskId);
+      trackAcceptedMutation(result);
+      if (selectedTaskId === taskId) {
+        setSelectedTaskId(null);
+      }
+      refreshTaskGraph();
+    } catch (err) {
+      console.error('Delete Task failed:', err);
+    }
+  }, [refreshTaskGraph, selectedTaskId, trackAcceptedMutation]);
+
   const handleDeleteWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     const confirmed = window.confirm(
@@ -2324,6 +2342,7 @@ export function App() {
           onRecreateDownstream={handleRecreateDownstream}
           onFix={handleFix}
           onCancel={handleCancelTask}
+          onDelete={handleDeleteTask}
           onClose={closeContextMenu}
           autoFocus={Boolean(contextMenu.returnFocusRegion)}
         />

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -168,6 +168,7 @@ describe('Context menu (component)', () => {
     expect(await screen.findByText('Recreate from Task')).toBeInTheDocument();
     expect(screen.getByText('Recreate Downstream')).toBeInTheDocument();
     expect(screen.getByText('Terminate Task')).toBeInTheDocument();
+    expect(screen.getByText('Delete Task')).toBeInTheDocument();
   });
 
   it('task context menu calls recreateDownstream for workflow-owned tasks', async () => {
@@ -224,6 +225,21 @@ describe('Context menu (component)', () => {
     await waitFor(() => expect(mock.api.recreateTask).toHaveBeenCalledWith('task-alpha'));
     expect(mock.api.recreateDownstream).not.toHaveBeenCalled();
     expect(mock.api.recreateWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('task context menu deletes task', async () => {
+    await setup();
+    fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    fireEvent.click(await screen.findByText('More'));
+    fireEvent.click(await screen.findByText('Delete Task'));
+
+    await waitFor(() => expect(mock.api.deleteTask).toHaveBeenCalledWith('task-alpha'));
+    expect(mock.api.deleteWorkflow).not.toHaveBeenCalled();
   });
 
   it('workflow context menu retries workflow', async () => {

--- a/packages/ui/src/__tests__/context-menu.test.ts
+++ b/packages/ui/src/__tests__/context-menu.test.ts
@@ -256,7 +256,7 @@ describe('ContextMenu getMenuItems', () => {
       const task = makeTask({ status: 'failed', workflowId: 'wf-1' });
       const items = getMenuItems(task);
 
-      const dangerIds = ['cancel-task', 'recreate-task', 'recreate-downstream'];
+      const dangerIds = ['cancel-task', 'recreate-task', 'recreate-downstream', 'delete-task'];
       dangerIds.forEach((id) => {
         const item = items.find((i) => i.id === id);
         expect(item?.variant).toBe('danger');

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -205,6 +205,7 @@ export function createMockInvoker(
     deleteAllWorkflows: vi.fn(async () => {}),
     deleteAllWorkflowsBulk: vi.fn(async () => {}),
     deleteWorkflow: vi.fn(async () => accepted('invoker:delete-workflow')),
+    deleteTask: vi.fn(async () => accepted('invoker:delete-task')),
     detachWorkflow: vi.fn(async () => {}),
     cleanupWorktrees: vi.fn(async () => ({ removed: [], errors: [] })),
     recreateWorkflow: vi.fn(async () => accepted('invoker:recreate-workflow')),

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -26,6 +26,7 @@ interface ContextMenuProps {
   onRecreateDownstream?: (taskId: string) => void;
   onFix?: (taskId: string, agentName: string) => void;
   onCancel?: (taskId: string) => void;
+  onDelete?: (taskId: string) => void;
   onClose: (options?: { restoreFocus?: boolean }) => void;
   autoFocus?: boolean;
 }
@@ -51,6 +52,7 @@ export function ContextMenu({
   onRecreateDownstream,
   onFix,
   onCancel,
+  onDelete,
   onClose,
   autoFocus = false,
 }: ContextMenuProps) {
@@ -70,6 +72,7 @@ export function ContextMenu({
     if (item.action === 'onRecreateDownstream' && !onRecreateDownstream) return false;
     if (item.action === 'onFix' && !onFix) return false;
     if (item.action === 'onCancel' && !onCancel) return false;
+    if (item.action === 'onDelete' && !onDelete) return false;
     return true;
   });
 
@@ -245,6 +248,9 @@ export function ContextMenu({
         break;
       case 'onCancel':
         onCancel?.(task.id);
+        break;
+      case 'onDelete':
+        onDelete?.(task.id);
         break;
     }
     onClose({ restoreFocus: autoFocus });

--- a/packages/ui/src/lib/context-menu-items.ts
+++ b/packages/ui/src/lib/context-menu-items.ts
@@ -136,6 +136,14 @@ export function getMenuItems(
       action: 'onRecreateDownstream',
       variant: 'danger',
     });
+
+    items.push({
+      id: 'delete-task',
+      label: 'Delete Task',
+      enabled: true,
+      action: 'onDelete',
+      variant: 'danger',
+    });
   }
 
   return items;


### PR DESCRIPTION
## Summary

The task context menu now shows a new destructive action for pruning one task.

That action uses the existing mutation flow from the earlier slices, so the UI only adds the control and confirmation text.

<details>
<summary>Review metadata</summary>

Review Claim: The desktop UI exposes task pruning without changing the underlying mutation behavior.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice is UI-only on top of an already-tested mutation path.

Slice Rationale: The visible control is easier to review after the lower layers already exist.

</details>

## Non-goals

- This does not change task semantics.
- This does not add any new non-UI surface.

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu.test.ts src/__tests__/context-menu-e2e.test.tsx`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Visual Proof

Before:

![Before task context menu](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-53b725/task-context-menu-recreate-downstream.png)

After:

![After task context menu](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-53b725/task-context-menu-recreate-downstream.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 69457a435`
- Post-revert steps: None
- Data migration? No

Depends-On: #2674