### PR TITLE
[Diff atomicity CI and guardrails](1) Wire remote guardrails

### DIFF
--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -65,6 +65,24 @@ jobs:
             const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number });
             fs.writeFileSync('pr-body.md', pull.body || '', 'utf8');
 
+      - name: Fetch PR diff metadata
+        if: steps.rollout.outputs.enabled == 'true'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$BASE_SHA"
+          git fetch --no-tags --depth=1 origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
+          fetched_head_sha="$(git rev-parse "refs/remotes/pull/${PR_NUMBER}/head^{commit}")"
+          if [ "$fetched_head_sha" != "$HEAD_SHA" ]; then
+            echo "Fetched PR head ${fetched_head_sha} did not match event head ${HEAD_SHA}." >&2
+            exit 1
+          fi
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
+          git diff --find-renames --unified=200000 --diff-filter=ACMRTD "$BASE_SHA" "$HEAD_SHA" -- > pr.diff
+
       - name: Validate PR body
         if: steps.rollout.outputs.enabled == 'true'
-        run: node scripts/validate-pr-body.mjs --body-file pr-body.md
+        run: node scripts/validate-pr-body.mjs --body-file pr-body.md --changed-files-file changed-files.txt --diff-file pr.diff

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",
-    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-check-added-comments.mjs && bash scripts/workspace-test.sh",
+    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && bash scripts/workspace-test.sh",
     "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
     "test:low-resource": "pnpm run test",
     "test:low-resource:packages": "bash scripts/workspace-test.sh",
@@ -13,6 +13,7 @@
     "test:plan-to-invoker-skill": "bash scripts/test-plan-to-invoker-skill.sh",
     "test:make-pr-skill": "bash scripts/test-make-pr-skill.sh",
     "test:pr-body-rollout": "node scripts/test-pr-body-rollout.mjs",
+    "test:pr-diff-atomicity": "node scripts/test-pr-diff-atomicity.mjs",
     "test:e2e-dry-run": "bash scripts/e2e-dry-run/run-all.sh",
     "test:e2e": "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app test:e2e",
     "test:e2e:visible": "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app test:e2e:visible",

--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -28,6 +28,8 @@ must_contain "$SKILL_MD" "## Stack ordering" "make-pr skill must document stack 
 must_contain "$SKILL_MD" "Repro/proof comes before the fix." "make-pr skill must land the repro/proof slice before the fix"
 must_contain "$SKILL_MD" "Keep each slice green for CI" "make-pr skill must keep each ordered slice green for CI"
 must_contain "$SKILL_MD" "cleanup and docs come last" "make-pr skill must order foundation before behavior and cleanup/docs last"
+must_contain "$SKILL_MD" "lint-pr-diff-atomicity.mjs" "make-pr skill must mention the diff atomicity gate"
+must_contain "$SKILL_MD" "mixes behavior, refactor, cleanup, or test-harness/proof work" "make-pr skill must tell authors to split mixed work"
 
 # The ordering section delegates the rest of the rules to review-compression,
 # so that referenced section must actually exist.

--- a/scripts/test-suites/required/11-pr-authoring-guardrails.sh
+++ b/scripts/test-suites/required/11-pr-authoring-guardrails.sh
@@ -2,5 +2,6 @@
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
+node scripts/test-pr-diff-atomicity.mjs
 node scripts/test-pr-body-validator.mjs
 node scripts/test-create-pr-visual-proof.mjs

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -109,6 +109,12 @@ If the change is UI-impacting, use `skills/visual-proof/SKILL.md` first and incl
 
 Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Review Claim / ## Review Lane / ## Safety Invariant / ## Slice Rationale / ## Non-goals / ## Test Plan / ## Revert Plan` as the floor, add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.
 
+## Diff atomicity gate
+
+`scripts/create-pr.mjs` computes changed files and a full-context diff, then runs `scripts/lint-pr-diff-atomicity.mjs` through the PR body checker before image upload, push, or GitHub mutation.
+
+If one branch mixes behavior, refactor, cleanup, or test-harness/proof work, split the work into separate PRs. Do not relabel the lane or weaken the checker to make a mixed branch pass.
+
 ## Command surface
 
 Preferred repo-local flow:


### PR DESCRIPTION
## Summary

CI now fetches PR head commit metadata and runs the trusted base-branch diff atomicity checker.

The required guardrail suite and make-pr skill text now point contributors at the same split rule.

<details>
<summary>Review metadata</summary>

Review Claim: The remote PR Body gate and repo guidance enforce the same diff atomicity rule without executing PR head code.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: The workflow only reads GitHub diff and commit metadata and runs scripts from the trusted base checkout.

Slice Rationale: Remote CI and guidance land after the local adapter path exists, so local and remote enforcement stay separable.

</details>

## Non-goals

- Does not change the core diff atomicity engine.
- Does not change local PR adapter behavior.
- Does not execute or check out untrusted PR head code.

## Test Plan

- [x] `bash scripts/test-make-pr-skill.sh`
- [x] `bash scripts/test-suites/required/11-pr-authoring-guardrails.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 76d0c302`
- Post-revert steps: Re-run the focused guardrail commands.
- Data migration? No
