### PR TITLE
[Recovery Lifecycle 2i Step 4: External worker plugin loader](2a) Add the external worker process runner

### DIFF
--- a/packages/app/src/__tests__/external-worker-loader.test.ts
+++ b/packages/app/src/__tests__/external-worker-loader.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { createWorkerRegistry } from '@invoker/execution-engine';
+
+import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
+
+const externalWorkers = [
+  {
+    kind: 'preview',
+    launch: {
+      executable: '/usr/local/bin/invoker-preview-worker',
+      args: ['--stdio'],
+    },
+  },
+];
+
+describe('external worker loader', () => {
+  it('registers configured external workers by kind', () => {
+    const registry = registerExternalWorkersFromConfig(externalWorkers, createWorkerRegistry());
+
+    const definition = registry.get('preview');
+
+    expect(definition).toBeDefined();
+    expect(definition?.kind).toBe('preview');
+    expect(registry.list().map((worker) => worker.kind)).toEqual(['preview']);
+  });
+
+  it('defaults to no external workers when config is absent', () => {
+    const registry = registerExternalWorkersFromConfig(undefined, createWorkerRegistry());
+
+    expect(registry.list()).toEqual([]);
+  });
+});

--- a/packages/app/src/external-worker-loader.ts
+++ b/packages/app/src/external-worker-loader.ts
@@ -1,0 +1,13 @@
+import {
+  registerExternalWorkers,
+  type WorkerRegistry,
+} from '@invoker/execution-engine';
+
+import type { ExternalWorkerConfig } from './config.js';
+
+export function registerExternalWorkersFromConfig(
+  externalWorkers: readonly ExternalWorkerConfig[] | undefined,
+  registry: WorkerRegistry,
+): WorkerRegistry {
+  return registerExternalWorkers(registry, externalWorkers);
+}

--- a/packages/execution-engine/src/external-worker.ts
+++ b/packages/execution-engine/src/external-worker.ts
@@ -1,0 +1,148 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import type { WorkerRegistry } from './worker-registry.js';
+import type { WorkerRuntime, WorkerTickReason } from './worker-runtime.js';
+
+const STOP_TIMEOUT_MS = 5_000;
+
+export interface ExternalWorkerLaunchConfig {
+  /** Executable used to start the external worker process. */
+  executable: string;
+  /** Optional argv passed after the executable. */
+  args?: readonly string[];
+  /** Optional process working directory for the worker launch. */
+  cwd?: string;
+}
+
+export interface ExternalWorkerConfig {
+  /** Stable worker registry kind declared by the operator. */
+  kind: string;
+  /** Process invocation used to start the external worker. */
+  launch: ExternalWorkerLaunchConfig;
+}
+
+export interface ExternalWorkerRuntime extends WorkerRuntime {
+  /** Resolves when the supervised external process exits or the runtime stops before launch. */
+  readonly finished: Promise<void>;
+}
+
+function delay(ms: number): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const timer = setTimeout(resolve, ms);
+  timer.unref?.();
+  return promise;
+}
+
+function createExternalWorkerRuntime(config: ExternalWorkerConfig): ExternalWorkerRuntime {
+  const identity = {
+    kind: config.kind,
+    instanceId: `external-${config.kind}-${process.pid}`,
+  };
+  const finishedGate = Promise.withResolvers<void>();
+
+  let child: ChildProcess | null = null;
+  let closePromise: Promise<void> | null = null;
+  let started = false;
+  let stopped = false;
+  let finished = false;
+
+  const finish = (): void => {
+    if (finished) return;
+    finished = true;
+    finishedGate.resolve();
+  };
+
+  const launch = (): Promise<void> => {
+    if (stopped) return Promise.resolve();
+    if (closePromise) return closePromise;
+
+    const childProcess = spawn(config.launch.executable, [...(config.launch.args ?? [])], {
+      cwd: config.launch.cwd,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    child = childProcess;
+
+    const closeGate = Promise.withResolvers<void>();
+    let closed = false;
+    const settle = (): void => {
+      if (closed) return;
+      closed = true;
+      child = null;
+      finish();
+      closeGate.resolve();
+    };
+
+    childProcess.once('error', settle);
+    childProcess.once('close', settle);
+    closePromise = closeGate.promise;
+    return closePromise;
+  };
+
+  const start = (): void => {
+    if (stopped) {
+      throw new Error(`external worker ${identity.kind}/${identity.instanceId} cannot start after stop`);
+    }
+    if (started) return;
+    started = true;
+    void launch();
+  };
+
+  const stop = async (): Promise<void> => {
+    if (stopped) {
+      if (closePromise) await closePromise.catch(() => undefined);
+      return;
+    }
+    stopped = true;
+
+    const activeChild = child;
+    if (!activeChild) {
+      finish();
+      return;
+    }
+
+    if (!activeChild.killed) {
+      activeChild.kill('SIGTERM');
+    }
+
+    await Promise.race([
+      closePromise ?? Promise.resolve(),
+      delay(STOP_TIMEOUT_MS).then(() => {
+        if (child) child.kill('SIGKILL');
+      }),
+    ]).catch(() => undefined);
+  };
+
+  const tick = async (reason: WorkerTickReason = 'manual'): Promise<void> => {
+    if (reason === 'manual') {
+      await launch();
+      return;
+    }
+    void launch();
+  };
+
+  return {
+    identity,
+    finished: finishedGate.promise,
+    start,
+    wake: () => {
+      void launch();
+    },
+    tick,
+    stop,
+    isRunning: () => started && !stopped && child !== null,
+  };
+}
+
+export function registerExternalWorkers(
+  registry: WorkerRegistry,
+  externalWorkers: readonly ExternalWorkerConfig[] | undefined,
+): WorkerRegistry {
+  for (const config of externalWorkers ?? []) {
+    registry.register({
+      kind: config.kind,
+      note: `Supervises external worker process ${config.launch.executable}.`,
+      factory: () => createExternalWorkerRuntime(config),
+    });
+  }
+  return registry;
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -39,3 +39,5 @@ export * from './auto-fix-recovery.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';
+
+export * from './external-worker.js';


### PR DESCRIPTION
## Summary

Declared external workers now have a runtime boundary.

Invoker builds a registry definition that starts the configured executable as its own foreground process.

The process receives the existing owner-channel environment, exits with the worker, and is stopped when the run is released.

<details>
<summary>Review metadata</summary>

Review Claim: The external-worker loader registers configured workers as registry definitions that start and supervise separate foreground processes.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Each external worker is launched only through its registry definition, runs outside Invoker, and is stopped when that run is released.

Slice Rationale: This isolates the process runner from the later doorway wiring and the end-to-end proof.

</details>

## Non-goals

This slice does not wire headless or CLI entry points to call the loader; that is the next slice. It does not add the sample worker proof.

## Test Plan

- [ ] `cd packages/app && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

