### PR TITLE
[Recovery Lifecycle 2i Step 4: External worker plugin loader](2b) Wire worker doors to load external workers

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -40,6 +40,7 @@ import {
   collectRecoveryWorkerStatus,
   type RecoveryWorkerStatus,
 } from './recovery-worker-observability.js';
+import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
@@ -415,7 +416,10 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
 
 async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0] ?? 'list';
-  const registry = registerAutoFixWorker(createWorkerRegistry());
+  const registry = registerExternalWorkersFromConfig(
+    deps.invokerConfig?.externalWorkers,
+    registerAutoFixWorker(createWorkerRegistry()),
+  );
 
   if (subCommand === 'list') {
     process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,9 +12,14 @@ import {
   acquireWorkerLock,
   createWorkerRegistry,
   registerAutoFixWorker,
+  registerExternalWorkers,
   WorkerLockHeldError,
   registerBuiltinAgents,
+  type ExternalWorkerConfig,
+  type ExternalWorkerRuntime,
   type WorkerDefinition,
+  type WorkerRegistry,
+  type WorkerRuntime,
 } from '@invoker/execution-engine';
 import {
   IpcBus,
@@ -99,6 +104,7 @@ type CliRuntimeConfig = {
     poolId: string;
     strategy?: 'enforce' | 'route';
   }>;
+  externalWorkers?: ExternalWorkerConfig[];
 };
 
 const silentLogger: Logger = {
@@ -447,14 +453,19 @@ async function createDefaultMessageBus(): Promise<MessageBus> {
  * Read the auto-fix policy knobs from the shared Invoker config so the CLI door
  * drives the engine with the same retry budget / agent the GUI owner uses.
  */
-function readAutoFixWorkerConfig(homeRoot: string): { autoFixRetries?: number; autoFixAgent?: string } {
+function readWorkerConfig(homeRoot: string): {
+  autoFixRetries?: number;
+  autoFixAgent?: string;
+  externalWorkers?: ExternalWorkerConfig[];
+} {
   const configPath = join(homeRoot, 'config.json');
   if (!existsSync(configPath)) return {};
   try {
-    const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>;
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as CliRuntimeConfig;
     return {
       autoFixRetries: typeof parsed.autoFixRetries === 'number' ? parsed.autoFixRetries : undefined,
       autoFixAgent: typeof parsed.autoFixAgent === 'string' ? parsed.autoFixAgent : undefined,
+      externalWorkers: Array.isArray(parsed.externalWorkers) ? parsed.externalWorkers : undefined,
     };
   } catch {
     return {};
@@ -465,12 +476,15 @@ function workerDisplayName(kind: string): string {
   return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind;
 }
 
-function printWorkerKinds(): void {
-  const registry = registerAutoFixWorker(createWorkerRegistry());
+function printWorkerKinds(registry: WorkerRegistry): void {
   process.stdout.write('Worker kinds\n');
   for (const worker of registry.list()) {
     process.stdout.write(`  ${worker.kind} — available (${worker.note})\n`);
   }
+}
+
+function isExternalWorkerRuntime(worker: WorkerRuntime): worker is ExternalWorkerRuntime {
+  return 'finished' in worker && worker.finished instanceof Promise;
 }
 
 /**
@@ -484,7 +498,7 @@ function printWorkerKinds(): void {
 async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
-  const { autoFixRetries, autoFixAgent } = readAutoFixWorkerConfig(homeRoot);
+  const { autoFixRetries, autoFixAgent } = readWorkerConfig(homeRoot);
 
   // Single-instance guard: refuse if another worker of this kind (this door or
   // the dev `--headless worker <kind>` door) already holds the cross-process
@@ -526,11 +540,16 @@ async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise
     const ownerSuffix = owner?.ownerId ? ` to owner ${owner.ownerId}` : '';
     process.stdout.write(`${workerDisplayName(definition.kind)} worker connected${ownerSuffix}.\n`);
 
-    await new Promise<void>((resolveShutdown) => {
-      const shutdown = (): void => resolveShutdown();
-      process.once('SIGINT', shutdown);
-      process.once('SIGTERM', shutdown);
-    });
+    const shutdownGate = Promise.withResolvers<void>();
+    const shutdown = (): void => shutdownGate.resolve();
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+    await Promise.race([
+      shutdownGate.promise,
+      isExternalWorkerRuntime(worker) ? worker.finished : shutdownGate.promise,
+    ]);
+    process.removeListener('SIGINT', shutdown);
+    process.removeListener('SIGTERM', shutdown);
     await worker.stop();
   } finally {
     // Release deterministically so a clean shutdown never leaves a stale lock
@@ -557,9 +576,12 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     }
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';
-      const registry = registerAutoFixWorker(createWorkerRegistry());
+      const registry = registerExternalWorkers(
+        registerAutoFixWorker(createWorkerRegistry()),
+        readWorkerConfig(resolveInvokerHomeRoot()).externalWorkers,
+      );
       if (subcommand === 'list') {
-        printWorkerKinds();
+        printWorkerKinds(registry);
         return 0;
       }
       const definition = registry.get(subcommand);


### PR DESCRIPTION
## Summary

The worker entry points now load configured external workers before they resolve a kind.

Headless and CLI paths both pass operator config into the shared loader, so declared kinds become available beside built-ins.

Existing built-in workers keep the same path when no external workers are configured.

<details>
<summary>Review metadata</summary>

Review Claim: The headless and CLI worker entry points load external-worker config before resolving a requested worker kind.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Absent config produces no registrations, so existing worker commands resolve the same built-in definitions.

Slice Rationale: This keeps entry-point wiring separate from the process runner and the end-to-end proof.

</details>

## Non-goals

This slice does not change the external process runner or add the sample worker proof. It does not change built-in worker behavior.

## Test Plan

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/cli && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
