### PR TITLE
[Recovery Lifecycle 2i Step 4: External worker plugin loader](3) Prove the external worker end to end

### DIFF
--- a/packages/app/src/__tests__/external-worker-e2e.test.ts
+++ b/packages/app/src/__tests__/external-worker-e2e.test.ts
@@ -1,0 +1,109 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createWorkerRegistry,
+  type ExternalWorkerRuntime,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
+
+const fixturePath = fileURLToPath(new URL('./fixtures/sample-external-worker.mjs', import.meta.url));
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => silentLogger,
+};
+
+const deps: WorkerRuntimeDependencies = {
+  logger: silentLogger,
+  store: {
+    listWorkflows: () => [],
+    loadTasks: () => [],
+    listWorkflowMutationIntents: () => [],
+  },
+  submitter: {
+    submit: () => 0,
+  },
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(condition: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await delay(25);
+  }
+  throw new Error(message);
+}
+
+function isExternalWorkerRuntime(worker: unknown): worker is ExternalWorkerRuntime {
+  return Boolean(
+    worker
+      && typeof worker === 'object'
+      && 'finished' in worker
+      && (worker as { finished?: unknown }).finished instanceof Promise,
+  );
+}
+
+describe('external worker e2e', () => {
+  const scratchDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of scratchDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('registers, starts, and stops a configured sample external worker by kind', async () => {
+    const scratchDir = mkdtempSync(join(tmpdir(), 'invoker-external-worker-e2e-'));
+    scratchDirs.push(scratchDir);
+    const markerPath = join(scratchDir, 'started.json');
+
+    const registry = registerExternalWorkersFromConfig(
+      [{
+        kind: 'sample-external',
+        launch: {
+          executable: process.execPath,
+          args: [fixturePath, markerPath],
+          cwd: scratchDir,
+        },
+      }],
+      createWorkerRegistry(),
+    );
+
+    const definition = registry.get('sample-external');
+    expect(definition).toBeDefined();
+    expect(registry.list().map((worker) => worker.kind)).toEqual(['sample-external']);
+
+    const worker = definition!.factory(deps);
+    expect(isExternalWorkerRuntime(worker)).toBe(true);
+    expect(worker.identity.kind).toBe('sample-external');
+    expect(worker.isRunning()).toBe(false);
+
+    try {
+      worker.start();
+      await waitFor(() => existsSync(markerPath), 'sample external worker did not launch');
+
+      expect(worker.isRunning()).toBe(true);
+      expect(JSON.parse(readFileSync(markerPath, 'utf8'))).toEqual(
+        expect.objectContaining({ started: true }),
+      );
+    } finally {
+      await worker.stop();
+      await worker.finished;
+    }
+
+    expect(worker.isRunning()).toBe(false);
+  });
+});

--- a/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
+++ b/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
@@ -1,0 +1,19 @@
+import { writeFileSync } from 'node:fs';
+
+const markerPath = process.argv[2];
+if (!markerPath) {
+  process.stderr.write('usage: sample-external-worker.mjs <marker-path>\n');
+  process.exit(64);
+}
+
+writeFileSync(markerPath, JSON.stringify({ pid: process.pid, started: true }), 'utf8');
+
+const keepAlive = setInterval(() => {}, 1_000);
+
+const shutdown = () => {
+  clearInterval(keepAlive);
+  process.exit(0);
+};
+
+process.once('SIGTERM', shutdown);
+process.once('SIGINT', shutdown);


### PR DESCRIPTION
## Summary

An end-to-end test proves the external-worker path works.

It adds a small sample external worker and points the external-worker config at it.

The test builds the registry through the loader, starts that kind through a worker door, and shows the sample is registered, launches, and stops cleanly.

<details>
<summary>Review metadata</summary>

Review Claim: An end-to-end test proves a configured sample external worker is registered by kind, launches through a worker door, and stops cleanly.

Review Lane: proof

Review Unit: proof

Safety Invariant: The test exercises only a sample worker and changes no product behavior.

Slice Rationale: The end-to-end proof is its own slice so the loader change stays apart from its verification.

</details>

## Non-goals

This slice does not change the loader or the config, and it does not run the full repository regression; that is a later slice.

## Test Plan

- [ ] `cd packages/app && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
