### PR TITLE
[Invoker UI Reskin Step 1: In-App Planner Bridge](1) Add planner IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -418,6 +418,24 @@ export interface SearchOptions {
   offset?: number;
 }
 
+// ── In-app planning types ──────────────────────────────────
+
+export interface InAppPlanRequest {
+  goal: string;
+  preset?: string;
+}
+
+export type InAppPlanResponse =
+  | {
+      ok: true;
+      planName: string;
+      workflowId: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
 // ── Invoke Channel Registry ─────────────────────────────────
 // Each key is the channel name string; value is { request, response }.
 // `request` is a tuple of the arguments passed after the channel name.
@@ -427,6 +445,10 @@ export const IpcChannels = {
   'invoker:load-plan': {} as {
     request: [planText: string];
     response: void;
+  },
+  'invoker:plan-from-goal': {} as {
+    request: [request: InAppPlanRequest];
+    response: InAppPlanResponse;
   },
   'invoker:start': {} as {
     request: [];


### PR DESCRIPTION
## Summary

Adds the shared request and response types for renderer-initiated planning.

The channel registry now names one planner preview call without binding it to a UI implementation.

<details>
<summary>Review metadata</summary>

Review Claim: The contracts package declares the typed in-app planner channel and response shape.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This slice only changes shared TypeScript declarations; no handler or renderer behavior uses the channel yet.

Slice Rationale: The contract lands first so downstream app code can use a stable IPC type.

</details>

## Non-goals

- Do not run a planner.
- Do not add a main-process handler.
- Do not add renderer UI.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: None
- Data migration? No
