### PR TITLE
[Invoker UI Reskin Step 1: In-App Planner Bridge](2) Wire planner package dependencies

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -76,6 +76,7 @@
     "@invoker/execution-engine": "workspace:*",
     "@invoker/runtime-adapters": "workspace:*",
     "@invoker/runtime-service": "workspace:*",
+    "@invoker/surfaces": "workspace:*",
     "@invoker/transport": "workspace:*",
     "@invoker/workflow-core": "workspace:*",
     "dockerode": "^4.0.0",

--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
     '@invoker/runtime-domain',
     '@invoker/runtime-adapters',
     '@invoker/runtime-service',
+    '@invoker/surfaces',
     '@invoker/transport',
     '@invoker/execution-engine',
     'yaml',

--- a/packages/surfaces/package.json
+++ b/packages/surfaces/package.json
@@ -6,6 +6,8 @@
   "exports": {
     ".": {
       "types": "./src/index.ts",
+      "import": "./src/index.ts",
+      "require": "./dist/index.js",
       "default": "./dist/index.js"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@invoker/runtime-service':
         specifier: workspace:*
         version: link:../runtime-service
+      '@invoker/surfaces':
+        specifier: workspace:*
+        version: link:../surfaces
       '@invoker/transport':
         specifier: workspace:*
         version: link:../transport


### PR DESCRIPTION
## Summary

Adds the workspace dependency and bundle settings needed for the app to import the shared planner surface.

The surfaces package now exposes both ESM and CommonJS entry points for the desktop build.

<details>
<summary>Review metadata</summary>

Review Claim: The desktop package can depend on the existing surfaces planner API without changing runtime behavior.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This slice only updates package metadata and lockfile entries; no app code imports the dependency until a later slice.

Slice Rationale: The dependency wiring lands before the handler so the behavior slice stays focused on runtime control flow.

</details>

## Non-goals

- Do not add planner behavior.
- Do not register an IPC handler.
- Do not change renderer UI.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: None
- Data migration? No
