### PR TITLE
[Invoker UI Reskin Step 1: In-App Planner Bridge](3) Add planner config presets

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -111,6 +111,10 @@ export interface InvokerConfig {
   slackHarnessPresets?: Record<string, { tool: 'cursor' | 'omp' | 'codex'; model?: string }>;
   /** Default harness preset key when the message carries no `[preset]` tag. Default: 'cursor+claude'. */
   defaultSlackHarnessPreset?: string;
+  /** Named in-app planning harness presets: preset key → {tool, model}; built-ins apply when omitted. */
+  plannerHarnessPresets?: Record<string, { tool: 'cursor' | 'omp' | 'codex'; model?: string }>;
+  /** Default in-app planner harness preset key. Default: 'cursor+claude'. */
+  defaultPlannerHarnessPreset?: string;
   /** Slack repo aliases: alias → git URL, resolved from a `[repo:<alias>]` tag. */
   slackRepos?: Record<string, string>;
   /** Repo URL used for Slack planning when the message carries no `[repo:]` tag. */


### PR DESCRIPTION
## Summary

Adds config fields for in-app planner presets.

These fields mirror the existing Slack planner preset shape so the bridge can choose a harness deterministically.

<details>
<summary>Review metadata</summary>

Review Claim: The app config can carry named in-app planner harness presets and a default preset key.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: This slice only extends optional config shape; default behavior is unchanged when the fields are absent.

Slice Rationale: Config shape lands before the bridge reads it, keeping preset selection separate from preview handling.

</details>

## Non-goals

- Do not run the planner from the app.
- Do not add an IPC handler.
- Do not change existing Slack planner presets.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: None
- Data migration? No
