### PR TITLE
[Invoker UI Reskin Step 1: In-App Planner Bridge](4) Route planner previews through IPC

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1,0 +1,97 @@
+import type { InAppPlanRequest, InAppPlanResponse } from '@invoker/contracts';
+import {
+  BUILTIN_HARNESS_PRESETS,
+  DEFAULT_HARNESS_PRESET,
+  PlanConversation,
+  extractYamlPlan,
+  type HarnessPreset,
+} from '@invoker/surfaces';
+import type { InvokerConfig } from './config.js';
+
+export interface GeneratedPlanPreview {
+  planName: string;
+  workflowId: string;
+}
+
+export interface InAppPlannerDeps {
+  config: Pick<
+    InvokerConfig,
+    | 'defaultBranch'
+    | 'defaultRepoUrl'
+    | 'experimentalPlanner'
+    | 'planningTimeoutSeconds'
+    | 'plannerHarnessPresets'
+    | 'defaultPlannerHarnessPreset'
+  >;
+  workingDir?: string;
+  loadGeneratedPlan: (planText: string) => GeneratedPlanPreview | Promise<GeneratedPlanPreview>;
+  log?: (source: string, level: string, message: string) => void;
+}
+
+function plannerPresets(config: InAppPlannerDeps['config']): Record<string, HarnessPreset> {
+  return {
+    ...BUILTIN_HARNESS_PRESETS,
+    ...(config.plannerHarnessPresets ?? {}),
+  };
+}
+
+function plannerError(error: string): InAppPlanResponse {
+  return { ok: false, error };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export async function planFromGoal(
+  request: InAppPlanRequest,
+  deps: InAppPlannerDeps,
+): Promise<InAppPlanResponse> {
+  const goal = String(request?.goal ?? '').trim();
+  if (!goal) {
+    return plannerError('Describe a goal first.');
+  }
+
+  const presets = plannerPresets(deps.config);
+  const presetKey = String(
+    request?.preset?.trim() || deps.config.defaultPlannerHarnessPreset || DEFAULT_HARNESS_PRESET,
+  );
+  const preset = presets[presetKey];
+  if (!preset) {
+    return plannerError(`Unknown planner preset "${presetKey}".`);
+  }
+
+  const conversation = new PlanConversation({
+    tool: preset.tool,
+    model: preset.model,
+    workingDir: deps.workingDir,
+    defaultBranch: deps.config.defaultBranch,
+    repoUrl: deps.config.defaultRepoUrl,
+    experimentalPlanner: deps.config.experimentalPlanner,
+    timeoutMs: (deps.config.planningTimeoutSeconds ?? 7_200) * 1_000,
+    log: deps.log,
+  });
+
+  let reply: string;
+  try {
+    reply = await conversation.sendMessage(goal);
+  } catch (error) {
+    return plannerError(errorMessage(error));
+  }
+
+  const yamlPlan = extractYamlPlan(reply);
+  if (!yamlPlan) {
+    return plannerError('Planner did not return a valid YAML plan.');
+  }
+
+  try {
+    const preview = await deps.loadGeneratedPlan(yamlPlan);
+    return {
+      ok: true,
+      planName: preview.planName,
+      workflowId: preview.workflowId,
+    };
+  } catch (error) {
+    return plannerError(errorMessage(error));
+  }
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -78,7 +78,7 @@ import {
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { ActionGraphResponse, BundledSkillsInstallMode, Logger, WorkflowMeta, WorkflowMutationAcceptedResult, WorkResponse } from '@invoker/contracts';
+import type { ActionGraphResponse, BundledSkillsInstallMode, InAppPlanRequest, Logger, WorkflowMeta, WorkflowMutationAcceptedResult, WorkResponse } from '@invoker/contracts';
 import { SqliteTaskRepository } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
@@ -127,6 +127,7 @@ import {
 } from './headless-command-classification.js';
 import { backupPlan } from './plan-backup.js';
 // applyPlanDefinitionDefaults removed — parsePlan() applies defaults internally
+import { planFromGoal, type GeneratedPlanPreview } from './in-app-planner.js';
 import { startApiServer, type ApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
@@ -953,6 +954,28 @@ function startHeadlessMode(): void {
         return executor;
       };
 
+      const loadStandaloneGeneratedPlanPreview = async (planText: string): Promise<GeneratedPlanPreview> => {
+        const { parsePlan } = await import('./plan-parser.js');
+        const plan = parsePlan(planText);
+        logger.info(`load-plan: "${plan.name}" (${plan.tasks.length} tasks)`, { module: 'ipc-delegate' });
+        backupPlan(plan, undefined, logger);
+        const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
+        orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+        const workflowId = orchestrator.getWorkflowIds().find((id) => !wfIdsBefore.has(id));
+        if (!workflowId) {
+          throw new Error(`Failed to resolve workflow id for generated plan "${plan.name}"`);
+        }
+        return { planName: plan.name, workflowId };
+      };
+
+      const logStandaloneInAppPlannerMessage = (source: string, level: string, message: string): void => {
+        if (level === 'error') {
+          logger.error(message, { module: source });
+          return;
+        }
+        logger.info(message, { module: source });
+      };
+
       const executeStandaloneHeadlessRun = async (payload: HeadlessRunMutationPayload): Promise<unknown> => {
         const { parsePlanFile } = await import('./plan-parser.js');
         const plan = await parsePlanFile(payload.planPath);
@@ -1004,12 +1027,16 @@ function startHeadlessMode(): void {
           }
           case 'invoker:load-plan': {
             const planText = String(payload.args[0] ?? '');
-            const { parsePlan } = await import('./plan-parser.js');
-            const plan = parsePlan(planText);
-            backupPlan(plan, undefined, logger);
-            orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+            await loadStandaloneGeneratedPlanPreview(planText);
             return undefined;
           }
+          case 'invoker:plan-from-goal':
+            return planFromGoal((payload.args[0] ?? {}) as InAppPlanRequest, {
+              config: invokerConfig,
+              workingDir: process.cwd(),
+              loadGeneratedPlan: loadStandaloneGeneratedPlanPreview,
+              log: logStandaloneInAppPlannerMessage,
+            });
           case 'invoker:start':
             return orchestrator.startExecution();
           case 'invoker:stop': {
@@ -2263,6 +2290,32 @@ function createEmbeddedTerminalBackendFromConfig(
     return requireWiredTaskRunner(() => taskExecutor);
   }
 
+  async function loadGeneratedPlanPreview(
+    planText: string,
+    module = 'ipc',
+  ): Promise<GeneratedPlanPreview> {
+    const { parsePlan } = await import('./plan-parser.js');
+    const plan = parsePlan(planText);
+    logger.info(`load-plan: "${plan.name}" (${plan.tasks.length} tasks)`, { module });
+    taskHandles.clear();
+    backupPlan(plan, undefined, logger);
+    const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
+    orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+    const workflowId = orchestrator.getWorkflowIds().find((id) => !wfIdsBefore.has(id));
+    if (!workflowId) {
+      throw new Error(`Failed to resolve workflow id for generated plan "${plan.name}"`);
+    }
+    return { planName: plan.name, workflowId };
+  }
+
+  function logInAppPlannerMessage(source: string, level: string, message: string): void {
+    if (level === 'error') {
+      logger.error(message, { module: source });
+      return;
+    }
+    logger.info(message, { module: source });
+  }
+
 
   async function executeHeadlessRun(payload: HeadlessRunMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
     const { parsePlanFile } = await import('./plan-parser.js');
@@ -2465,6 +2518,8 @@ function createEmbeddedTerminalBackendFromConfig(
     const [arg0, arg1, arg2] = payload.args;
     switch (payload.channel) {
       case 'invoker:load-plan':
+        return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:plan-from-goal':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:start':
         return { channel: 'headless.gui-mutation', request: payload };
@@ -3374,12 +3429,15 @@ function createEmbeddedTerminalBackendFromConfig(
     });
     registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
       const planText = String(planTextArg);
-      const { parsePlan } = await import('./plan-parser.js');
-      const plan = parsePlan(planText);
-      logger.info(`load-plan: "${plan.name}" (${plan.tasks.length} tasks)`, { module: 'ipc' });
-      taskHandles.clear();
-      backupPlan(plan, undefined, logger);
-      orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+      await loadGeneratedPlanPreview(planText);
+    });
+    registerGuiMutationHandler('invoker:plan-from-goal', async (requestArg: unknown) => {
+      return planFromGoal((requestArg ?? {}) as InAppPlanRequest, {
+        config: invokerConfig,
+        workingDir: process.cwd(),
+        loadGeneratedPlan: (planText) => loadGeneratedPlanPreview(planText),
+        log: logInAppPlannerMessage,
+      });
     });
 
     if (process.env.NODE_ENV === 'test') {

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -239,6 +239,7 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
       case 'invoker:edit-task-pool':
       case 'invoker:replace-task':
       case 'invoker:load-plan':
+      case 'invoker:plan-from-goal':
       case 'invoker:start':
       case 'invoker:stop':
       case 'invoker:clear':


### PR DESCRIPTION
## Summary

Routes the typed planner request through the main process.

The handler asks the existing planner for YAML, loads the result as a preview, and returns the new workflow id.

<details>
<summary>Review metadata</summary>

Review Claim: The app routes one planner preview request from IPC to the existing planner and loadPlan path.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The success path ends at loadPlan and never calls startExecution.

Slice Rationale: Runtime routing lands after earlier setup so this slice can focus on the preview path.

</details>

## Non-goals

- Do not start execution after planning.
- Do not add renderer UI consumption.
- Do not edit `packages/app/src/preload.ts`.

## Architecture

### Before

```mermaid
flowchart LR
    Renderer["Renderer has no planner preview IPC"] --> External["Planning stays outside the desktop app"]
```

### After

```mermaid
flowchart LR
    Renderer["Renderer request"] --> IPC["invoker:plan-from-goal"]
    IPC --> Planner["PlanConversation"]
    Planner --> YAML["extractYamlPlan"]
    YAML --> Load["orchestrator.loadPlan"]
    Load --> Preview["Workflow preview"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Visual Proof

The changed file is main-process IPC, so this screenshot checks the existing graph view still renders.

![Planner bridge graph view](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-4cd133/stacked-workflows.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: None
- Data migration? No
