### PR TITLE
[Invoker UI Reskin Step 1: In-App Planner Bridge](5) Cover planner preview adapter

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlanConversation } from '@invoker/surfaces';
+import { planFromGoal, type InAppPlannerDeps } from '../in-app-planner.js';
+
+const validPlannerReply = `Here is the plan:
+
+\`\`\`yaml
+name: Preview Plan
+tasks:
+  - id: inspect
+    description: Inspect the current implementation
+\`\`\`
+`;
+
+function createDeps(loadGeneratedPlan = vi.fn()): InAppPlannerDeps {
+  return {
+    config: {},
+    loadGeneratedPlan,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('planFromGoal', () => {
+  it('returns an error for an empty goal', async () => {
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: '   ' }, createDeps(loadGeneratedPlan))).resolves.toEqual({
+      ok: false,
+      error: 'Describe a goal first.',
+    });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('returns an error for an unknown preset', async () => {
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: 'Build it', preset: 'bad' }, createDeps(loadGeneratedPlan))).resolves.toEqual({
+      ok: false,
+      error: 'Unknown planner preset "bad".',
+    });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('loads a generated YAML plan preview once', async () => {
+    vi.spyOn(PlanConversation.prototype, 'sendMessage').mockResolvedValue(validPlannerReply);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Preview Plan',
+      workflowId: 'wf-1',
+    });
+
+    await expect(planFromGoal({ goal: 'Build a bridge' }, createDeps(loadGeneratedPlan))).resolves.toEqual({
+      ok: true,
+      planName: 'Preview Plan',
+      workflowId: 'wf-1',
+    });
+    expect(loadGeneratedPlan).toHaveBeenCalledTimes(1);
+    expect(loadGeneratedPlan.mock.calls[0][0]).toContain('name: Preview Plan');
+  });
+
+  it('returns an error when the planner reply has no valid YAML plan', async () => {
+    vi.spyOn(PlanConversation.prototype, 'sendMessage').mockResolvedValue('No plan here.');
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: 'Build a bridge' }, createDeps(loadGeneratedPlan))).resolves.toEqual({
+      ok: false,
+      error: 'Planner did not return a valid YAML plan.',
+    });
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds focused tests for planner preview errors and the successful YAML load path.

The tests mock the planner surface and assert bad replies do not load a preview.

<details>
<summary>Review metadata</summary>

Review Claim: The in-app planner adapter has focused coverage for empty goals, preset misses, bad planner output, and successful preview loads.

Review Lane: proof

Review Unit: proof

Safety Invariant: This slice adds tests only; production behavior is unchanged.

Slice Rationale: Proof follows the runtime bridge so the behavior slices stay readable.

</details>

## Non-goals

- Do not change production code.
- Do not add broad app regression coverage.
- Do not start task execution.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <this-pr-commit>`
- Post-revert steps: None
- Data migration? No
