### PR TITLE
[Prevent PR empty commits](1) Guard create-pr against empty slices

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -371,6 +371,11 @@ function revList(range) {
   return out ? out.split('\n').filter(Boolean) : [];
 }
 
+function revListStrict(args) {
+  const out = gitText(['rev-list', ...args]);
+  return out ? out.split('\n').filter(Boolean) : [];
+}
+
 function shortOneLine(sha) {
   return gitTextOrEmpty(['show', '--no-patch', '--oneline', '--no-abbrev-commit', sha]) || sha;
 }
@@ -381,6 +386,16 @@ function resolveRev(ref) {
 
 function fetchBranch(remote, branch) {
   runGit(['fetch', '--quiet', remote, branch], { stdio: 'ignore' });
+}
+
+function gitExitStatus(args) {
+  try {
+    execFileSync('git', args, { stdio: 'ignore' });
+    return 0;
+  } catch (error) {
+    if (typeof error.status === 'number') return error.status;
+    throw error;
+  }
 }
 
 export function isUiImpactingPath(filePath) {
@@ -421,6 +436,63 @@ function fullContextDiffSinceBase(baseBranch) {
       `Unable to compute diff atomicity context against ${DEFAULT_BASE_REMOTE}/${baseBranch}. Fetch the base ref and retry.\n${error.message}`,
     );
   }
+}
+
+function commitHasTreeDiffFromFirstParent(sha) {
+  const parentsLine = gitText(['rev-list', '--parents', '-n', '1', sha]);
+  const [, firstParent] = parentsLine.split(/\s+/);
+  const diffArgs = firstParent
+    ? ['diff-tree', '--quiet', '--exit-code', '-r', firstParent, sha, '--']
+    : ['diff-tree', '--quiet', '--exit-code', '--root', '-r', sha, '--'];
+  const status = gitExitStatus(diffArgs);
+
+  if (status === 0) return false;
+  if (status === 1) return true;
+
+  throw new Error(`Unable to inspect tree diff for commit ${sha}.`);
+}
+
+function emptyCommitsSinceBase(baseBranch) {
+  const baseRef = `${DEFAULT_BASE_REMOTE}/${baseBranch}`;
+  const commits = revListStrict(['--reverse', `${baseRef}..HEAD`]);
+  return commits.filter((sha) => !commitHasTreeDiffFromFirstParent(sha));
+}
+
+function assertBranchHasReviewableChanges(baseBranch, changedFiles) {
+  const baseRef = `${DEFAULT_BASE_REMOTE}/${baseBranch}`;
+  const emptyCommits = emptyCommitsSinceBase(baseBranch);
+  const failures = [];
+
+  if (changedFiles.length === 0) {
+    failures.push(`Current branch has no file changes versus ${baseRef}.`);
+  }
+
+  if (emptyCommits.length > 0) {
+    const lines = emptyCommits.slice(0, 12).map((sha) => `  - ${shortOneLine(sha)}`);
+    if (emptyCommits.length > 12) {
+      lines.push(`  ... and ${emptyCommits.length - 12} more`);
+    }
+    failures.push(
+      [
+        'Current branch contains commits with no tree diff from their first parent:',
+        ...lines,
+      ].join('\n'),
+    );
+  }
+
+  if (failures.length === 0) return;
+
+  throw new Error(
+    [
+      'Refusing to create/update PR: branch has no reviewable file changes or contains empty commits.',
+      ...failures,
+      '',
+      'Recovery:',
+      '  Add a real file change before publishing, or do not create a PR for this branch.',
+      `  Drop empty commits with: git rebase -i ${baseRef}`,
+      '  Or squash each empty commit into a neighboring commit that contains real file changes.',
+    ].join('\n'),
+  );
 }
 
 function assertCleanPrBase(baseBranch) {
@@ -677,6 +749,7 @@ async function main() {
 
   const changedFiles = changedFilesSinceBase(args.base);
   const diffText = fullContextDiffSinceBase(args.base);
+  assertBranchHasReviewableChanges(args.base, changedFiles);
   const uiImpactingFiles = getUiImpactingFiles(changedFiles);
   if (uiImpactingFiles.length > 0) {
     console.error(`UI-impacting files changed; requiring visual proof: ${uiImpactingFiles.join(', ')}`);

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -254,6 +254,10 @@ function commitFile(work, fileName, content, message) {
   gitQuiet(work, 'commit', '-m', message);
 }
 
+function commitEmpty(work, message) {
+  gitQuiet(work, 'commit', '--allow-empty', '-m', message);
+}
+
 function createTrackedBranch(work, branch, startPoint = 'origin/master') {
   gitQuiet(work, 'switch', '-c', branch, '--track', startPoint);
 }
@@ -298,6 +302,10 @@ function expectNoPush(harness, label) {
   assert(readLogLines(harness.pushLog).length === 0, `${label}: expected no git push attempt`);
 }
 
+function expectNoGhCalls(harness, label) {
+  assert(readGhCalls(harness.ghLog).length === 0, `${label}: expected no gh invocation`);
+}
+
 function testStaleBaseDetection() {
   const harness = createHarness();
   try {
@@ -311,6 +319,73 @@ function testStaleBaseDetection() {
     assert(result.stderr.includes('not based on the latest origin/master'), 'stale base error should name origin/master');
     assert(result.stderr.includes('git cherry-pick <commit> [<commit> ...]'), 'stale base error should include cherry-pick recovery');
     expectNoPush(harness, 'stale base detection');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testNoFileChangesBlockPrCreation() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    createTrackedBranch(work, 'feature/no-file-changes');
+
+    const result = runCreatePr(work, harness, baseArgs());
+
+    assert(result.status === 1, `no file changes should block PR creation\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(
+      result.stderr.includes('no file changes versus origin/master'),
+      `no file changes error should name the selected base\nstderr:\n${result.stderr}`,
+    );
+    expectNoPush(harness, 'no file changes');
+    expectNoGhCalls(harness, 'no file changes');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testEmptyCommitAloneBlocksPrCreation() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    createTrackedBranch(work, 'feature/empty-only');
+    commitEmpty(work, 'empty slice');
+
+    const result = runCreatePr(work, harness, baseArgs());
+
+    assert(result.status === 1, `empty commit should block PR creation\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(
+      result.stderr.includes('commits with no tree diff from their first parent'),
+      `empty commit error should explain the tree-diff check\nstderr:\n${result.stderr}`,
+    );
+    assert(result.stderr.includes('empty slice'), `empty commit error should list the offending commit\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('Drop empty commits'), `empty commit error should explain drop recovery\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('squash each empty commit'), `empty commit error should explain squash recovery\nstderr:\n${result.stderr}`);
+    expectNoPush(harness, 'empty commit alone');
+    expectNoGhCalls(harness, 'empty commit alone');
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testEmptyCommitMixedWithRealChangeBlocksPrCreation() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    createTrackedBranch(work, 'feature/empty-mixed');
+    commitFile(work, 'feature.txt', 'feature\n', 'feature change');
+    commitEmpty(work, 'empty follow-up');
+
+    const result = runCreatePr(work, harness, baseArgs());
+
+    assert(result.status === 1, `mixed empty commit should block PR creation\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(
+      result.stderr.includes('commits with no tree diff from their first parent'),
+      `mixed empty commit error should explain the tree-diff check\nstderr:\n${result.stderr}`,
+    );
+    assert(result.stderr.includes('empty follow-up'), `mixed empty commit error should list the offending commit\nstderr:\n${result.stderr}`);
+    expectNoPush(harness, 'empty commit mixed with real change');
+    expectNoGhCalls(harness, 'empty commit mixed with real change');
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }
@@ -632,6 +707,9 @@ function testHelpMentionsStackUpdateFlow() {
 
 const tests = [
   testStaleBaseDetection,
+  testNoFileChangesBlockPrCreation,
+  testEmptyCommitAloneBlocksPrCreation,
+  testEmptyCommitMixedWithRealChangeBlocksPrCreation,
   testMergifyManagedCreateRefusal,
   testMergifyManagedUpdateSkipsPush,
   testMergifyManagedUpdateAcceptsLetteredTitle,


### PR DESCRIPTION
## Summary

create-pr now checks the selected base range before it mutates any remote state.

It rejects branches with no file changes and commits whose tree matches their first parent.

<details>
<summary>Review metadata</summary>

Review Claim: create-pr refuses no-diff branches and empty commit slices before publication.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: The guard runs inside the PR publication script before push or GitHub API calls.

Slice Rationale: PR publication is the source of truth for rejecting empty review slices.

</details>

## Non-goals

- Does not change the PR body schema, visual proof requirements, title rules, or Mergify commands.
- Does not alter non-empty PR publication behavior.

## Architecture

### Before

```mermaid
graph TD
    A["create-pr validates the PR body"] --> B["git push runs"]
    B --> C["GitHub PR create or update runs"]
```

### After

```mermaid
graph TD
    A["create-pr inspects the base range"] --> B["empty slices stop locally"]
    B --> C["reviewable branches continue to PR validation"]
    C --> D["git push and GitHub mutation run"]
```

## Test Plan

- [x] `node scripts/test-create-pr-stack-workflow.mjs`
- [x] `bash scripts/test-make-pr-skill.sh`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: Rerun `node scripts/test-create-pr-stack-workflow.mjs`.
- Data migration? No
