### PR TITLE
[Prevent PR empty commits](2) Mirror the guard in make-pr guidance

### DIFF
--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -37,4 +37,11 @@ must_contain "$SKILL_MD" "Ordering Rules" "make-pr skill must point at review-co
 must_contain "$REVIEW_COMPRESSION_MD" "## Ordering Rules" "review-compression must expose the referenced Ordering Rules section"
 must_contain "$REVIEW_COMPRESSION_MD" "Evidence before change" "review-compression Ordering Rules must state evidence before change"
 
-echo "OK: make-pr skill stack-ordering contract checks passed"
+# The publication checklist must stop empty PR slices before create/update/stack publish.
+must_contain "$SKILL_MD" "has no file changes against its selected base" "make-pr skill must reject branches with no reviewable file diff"
+must_contain "$SKILL_MD" "contains an empty commit slice" "make-pr skill must reject empty commit slices"
+must_contain "$SKILL_MD" 'node scripts/create-pr.mjs`' "make-pr skill must apply the empty-slice rule to normal PR creation"
+must_contain "$SKILL_MD" "node scripts/create-pr.mjs --update-existing" "make-pr skill must apply the empty-slice rule to PR updates"
+must_contain "$SKILL_MD" "mergify stack push" "make-pr skill must apply the empty-slice rule to Mergify stack publication"
+
+echo "OK: make-pr skill contract checks passed"

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -193,6 +193,7 @@ Manual `gh pr edit` is a last-resort escape hatch only when `create-pr` itself i
 - ensure the body sections are present and concrete
 - ensure test commands are real commands that were actually run when possible
 - ensure revert guidance is honest
+- do not create, update, or Mergify-publish a PR when the branch has no file changes against its selected base or contains an empty commit slice; fix the branch history before using `node scripts/create-pr.mjs`, `node scripts/create-pr.mjs --update-existing ...`, or `mergify stack push`
 - validate the body with `node scripts/validate-pr-body.mjs --body-file <file>`
 - for stacked PRs, update title/body through `node scripts/create-pr.mjs --update-existing ...`, not `gh pr edit`
 - for UI-impacting diffs, include `## Visual Proof` with screenshot or video proof before `node scripts/create-pr.mjs`; classify by user-visible behavior, not by path alone


### PR DESCRIPTION
## Summary

make-pr guidance now names the same empty-slice publication rule that create-pr enforces.

A focused shell test fails if that rule is removed.

<details>
<summary>Review metadata</summary>

Review Claim: make-pr guidance requires an empty-commit guard before PR publication.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This slice changes guidance and its guardrail test only; runtime behavior stays in create-pr.

Slice Rationale: The agent instruction surface needs its own reviewer-visible rule after the script enforces it.

</details>

## Non-goals

- Does not change the PR body schema or review-compression slicing rules.
- Does not add another runtime publication gate outside create-pr.

## Test Plan

- [x] `bash scripts/test-make-pr-skill.sh`
- [x] `node scripts/test-create-pr-stack-workflow.mjs`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert HEAD`
- Post-revert steps: Rerun `bash scripts/test-make-pr-skill.sh`.
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added stricter checks to stop PR creation, updates, and publishing when the branch has no file changes versus its selected base or when the commit slice is empty.
  * Improves early failure messaging to prompt fixing branch history before continuing.

* **Documentation**
  * Updated the PR skill checklist with the new “no file changes / empty slice” publication rule and its expected remediation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->