### PR TITLE
[Task Logs](3) Show level-filtered task logs in side panel

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1243,12 +1243,13 @@ describe('TaskRunner', () => {
           },
           buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
         };
+        const logEvent = vi.fn().mockImplementationOnce(() => { throw new Error('telemetry down'); });
         const executor = new TaskRunner({
           orchestrator: {
             getTask: () => null,
             getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-1', executionAgent: 'claude' } })],
           } as any,
-          persistence: {} as any,
+          persistence: { logEvent } as any,
           executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
           executionAgentRegistry: {
             get: (name: string) => (name === 'claude' ? claudeAgent : name === 'codex' ? codexAgent : undefined),
@@ -1266,11 +1267,38 @@ describe('TaskRunner', () => {
           featureBranch: 'plan/feature',
           workflowSummary: 'summary',
           cwd: '/tmp',
+          mergeNodeTaskId: '__merge__wf-1',
         });
 
         expect(attempts).toEqual(['claude', 'codex']);
         expect(result.agentName).toBe('codex');
         expect(result.artifacts[1].dependsOn).toEqual(['contracts']);
+        expect(logEvent).toHaveBeenCalledWith(
+          '__merge__wf-1',
+          'task.log',
+          expect.objectContaining({
+            level: 'info',
+            message: 'Preparing make-pr review stack publisher',
+            agentCount: 2,
+          }),
+        );
+        expect(logEvent).toHaveBeenCalledWith(
+          '__merge__wf-1',
+          'task.log',
+          expect.objectContaining({
+            level: 'warn',
+            message: 'claude make-pr agent failed',
+          }),
+        );
+        expect(logEvent).toHaveBeenCalledWith(
+          '__merge__wf-1',
+          'task.log',
+          expect.objectContaining({
+            level: 'info',
+            message: 'Review stack body validated',
+            artifactCount: 2,
+          }),
+        );
       } finally {
         if (originalHome === undefined) delete process.env.HOME;
         else process.env.HOME = originalHome;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -2238,6 +2238,33 @@ export class TaskRunner {
     const preferredName = this.resolvePrAuthoringAgentName(args.workflowId, args.mergeNodeTaskId);
     const prCapableAgents = this.executionAgentRegistry.listWithCapability('make-pr');
     const orderedAgents = this.buildAgentFallbackOrder(preferredName, prCapableAgents);
+    const logProgress = (
+      level: 'debug' | 'info' | 'warn' | 'error',
+      message: string,
+      detail: Record<string, unknown> = {},
+    ) => {
+      if (!args.mergeNodeTaskId) return;
+      try {
+        const persistence = this.persistence as { logEvent?: (taskId: string, eventType: string, payload?: unknown) => void };
+        persistence.logEvent?.(args.mergeNodeTaskId, 'task.log', {
+          level,
+          message,
+          ...detail,
+        });
+      } catch (error) {
+        this.logger.warn('[pr-authoring] failed to persist task progress event', {
+          taskId: args.mergeNodeTaskId,
+          error,
+        });
+      }
+    };
+
+    logProgress('info', 'Preparing make-pr review stack publisher', {
+      featureBranch: args.featureBranch,
+      baseBranch: args.baseBranch,
+      agentCount: orderedAgents.length,
+    });
+
     const errors: string[] = [];
 
     for (const agent of orderedAgents) {
@@ -2259,11 +2286,19 @@ export class TaskRunner {
       });
 
       try {
+        logProgress('info', `Starting ${agent.name} make-pr agent`, {
+          agentName: agent.name,
+          cwd: args.cwd,
+        });
         this.logger.info(
           `[pr-authoring] review-stack publish starting agent=${agent.name} `
             + `workflow=${args.workflowId ?? 'unknown'} skill=invoker-make-pr cwd=${args.cwd}`,
         );
         const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
+        logProgress('info', `${agent.name} make-pr agent finished; validating output`, {
+          agentName: agent.name,
+          sessionId: result.sessionId,
+        });
         const parsedArtifacts = parseMakePrStackPublishResult(result.body);
 
         // Enforce the make-pr review-stack schema on every published body. Prefer
@@ -2300,6 +2335,10 @@ export class TaskRunner {
             `[pr-authoring] review-stack body validation failed agent=${agent.name} `
               + `errors=${bodyErrors.join('; ')}`,
           );
+          logProgress('warn', `${agent.name} published review stack failed validation`, {
+            agentName: agent.name,
+            errors: bodyErrors,
+          });
           errors.push(`${agent.name}: invalid PR body — ${bodyErrors.join('; ')}`);
           continue;
         }
@@ -2315,13 +2354,22 @@ export class TaskRunner {
           generation,
           createdAt: nowIso,
         }));
+        logProgress('info', 'Review stack body validated', {
+          agentName: agent.name,
+          artifactCount: artifacts.length,
+        });
         this.logger.info(
           `[pr-authoring] review-stack published agent=${agent.name} artifacts=${artifacts.length} `
             + 'bodies validated against make-pr schema',
         );
         return { artifacts, sessionId: result.sessionId, agentName: agent.name };
       } catch (err) {
-        errors.push(`${agent.name}: ${err instanceof Error ? err.message : String(err)}`);
+        const message = err instanceof Error ? err.message : String(err);
+        logProgress('warn', `${agent.name} make-pr agent failed`, {
+          agentName: agent.name,
+          error: message,
+        });
+        errors.push(`${agent.name}: ${message}`);
       }
     }
 

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { WorkflowInspector } from '../components/WorkflowInspector.js';
 import type { TaskState, WorkflowMeta } from '../types.js';
@@ -633,5 +633,84 @@ describe('WorkflowInspector', () => {
     expect(screen.getByTestId('workflow-inspector-action-node-status')).toHaveTextContent('RUNNING');
     expect(screen.getByTestId('workflow-inspector-action-node')).toHaveTextContent('runningMs');
     expect(screen.getByTestId('workflow-inspector-action-node')).toHaveTextContent('12000');
+  });
+
+  it('shows task logs and filters by minimum level', async () => {
+    (window as unknown as {
+      invoker: { getEvents: (taskId: string) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
+    }).invoker = {
+      getEvents: vi.fn(async () => [
+        {
+          id: 1,
+          eventType: 'debug.auto-fix',
+          payload: JSON.stringify({ message: 'debug detail', attempt: 1, value: 'secret' }),
+          createdAt: '2025-01-01T00:00:01.000Z',
+        },
+        {
+          id: 2,
+          eventType: 'task.log',
+          payload: JSON.stringify({ level: 'info', message: 'Preparing review workspace', branch: 'stack/test' }),
+          createdAt: '2025-01-01T00:00:02.000Z',
+        },
+        {
+          id: 3,
+          eventType: 'task.failed',
+          payload: JSON.stringify({ message: 'Merge gate failed' }),
+          createdAt: '2025-01-01T00:00:03.000Z',
+        },
+      ]),
+    };
+
+    try {
+      render(
+        <WorkflowInspector
+          workflow={workflow}
+          task={makeTask({ status: 'running' })}
+          collapsed={false}
+          advancedExpanded={false}
+          onToggleCollapsed={() => {}}
+          onToggleAdvanced={() => {}}
+        />,
+      );
+
+      await waitFor(() => expect(screen.getByText('Preparing review workspace')).toBeInTheDocument());
+      expect(screen.getByText('Merge gate failed')).toBeInTheDocument();
+      expect(screen.queryByText('debug detail')).not.toBeInTheDocument();
+
+      fireEvent.change(screen.getByTestId('task-log-level-select'), { target: { value: 'debug' } });
+
+      expect(screen.getByText('debug detail')).toBeInTheDocument();
+      expect(screen.getByText('{"attempt":1}')).toBeInTheDocument();
+      expect(screen.queryByText(/secret/)).not.toBeInTheDocument();
+    } finally {
+      delete (window as unknown as { invoker?: unknown }).invoker;
+    }
+  });
+
+  it('shows a retrying log error when task events fail to load', async () => {
+    (window as unknown as {
+      invoker: { getEvents: (taskId: string) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
+    }).invoker = {
+      getEvents: vi.fn(async () => {
+        throw new Error('offline');
+      }),
+    };
+
+    try {
+      render(
+        <WorkflowInspector
+          workflow={workflow}
+          task={makeTask({ status: 'running' })}
+          collapsed={false}
+          advancedExpanded={false}
+          onToggleCollapsed={() => {}}
+          onToggleAdvanced={() => {}}
+        />,
+      );
+
+      await waitFor(() => expect(screen.getByTestId('task-log-error')).toHaveTextContent('Could not load logs. Retrying…'));
+    } finally {
+      delete (window as unknown as { invoker?: unknown }).invoker;
+    }
   });
 });

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -5,6 +5,111 @@ import { workflowStatusVisual } from '../lib/workflow-status.js';
 import type { ActionGraphNode } from '@invoker/contracts';
 
 type MergeMode = 'manual' | 'automatic' | 'external_review';
+type TaskLogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+interface TaskAuditEvent {
+  id?: number;
+  eventType: string;
+  payload?: string;
+  createdAt?: string;
+}
+
+interface TaskLogEntry {
+  id: string;
+  level: TaskLogLevel;
+  message: string;
+  detail?: string;
+  createdAt?: string;
+}
+
+const SAFE_LOG_DETAIL_KEYS = new Set([
+  'agentCount',
+  'agentName',
+  'artifactCount',
+  'attempt',
+  'baseBranch',
+  'branch',
+  'featureBranch',
+  'reviewId',
+  'reviewUrl',
+  'status',
+]);
+
+const LOG_LEVELS: readonly TaskLogLevel[] = ['debug', 'info', 'warn', 'error'];
+const LOG_LEVEL_RANK: Record<TaskLogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
+function isTaskLogLevel(value: unknown): value is TaskLogLevel {
+  return typeof value === 'string' && (LOG_LEVELS as readonly string[]).includes(value);
+}
+
+function parseEventPayload(payload: string | undefined): Record<string, unknown> | undefined {
+  if (!payload) return undefined;
+  try {
+    const parsed = JSON.parse(payload);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function inferLogLevel(event: TaskAuditEvent, payload: Record<string, unknown> | undefined): TaskLogLevel {
+  if (isTaskLogLevel(payload?.level)) return payload.level;
+  if (event.eventType.includes('failed') || event.eventType.includes('error')) return 'error';
+  if (event.eventType.includes('warn')) return 'warn';
+  if (event.eventType.startsWith('debug.')) return 'debug';
+  return 'info';
+}
+
+function formatLogDetail(payload: Record<string, unknown> | undefined): string | undefined {
+  if (!payload) return undefined;
+  const detail: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(payload)) {
+    if (!SAFE_LOG_DETAIL_KEYS.has(key)) continue;
+    if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') continue;
+    detail[key] = value;
+  }
+  return Object.keys(detail).length > 0 ? JSON.stringify(detail) : undefined;
+}
+
+function taskEventToLogEntry(event: TaskAuditEvent, index: number): TaskLogEntry {
+  const payload = parseEventPayload(event.payload);
+  const payloadMessage = payload?.message;
+  return {
+    id: String(event.id ?? `${event.eventType}-${event.createdAt ?? index}`),
+    level: inferLogLevel(event, payload),
+    message: typeof payloadMessage === 'string' && payloadMessage.trim()
+      ? payloadMessage
+      : event.eventType,
+    detail: formatLogDetail(payload),
+    createdAt: event.createdAt,
+  };
+}
+
+function logLevelClass(level: TaskLogLevel): string {
+  switch (level) {
+    case 'error':
+      return 'bg-red-900/40 text-red-300 border-red-800';
+    case 'warn':
+      return 'bg-amber-900/40 text-amber-300 border-amber-800';
+    case 'debug':
+      return 'bg-slate-800 text-slate-300 border-slate-700';
+    case 'info':
+    default:
+      return 'bg-blue-900/30 text-blue-300 border-blue-800';
+  }
+}
+
+function formatEventTime(value: string | undefined): string {
+  if (!value) return '';
+  return new Date(value).toLocaleTimeString();
+}
 
 interface WorkflowInspectorProps {
   workflow: WorkflowMeta | null;
@@ -138,6 +243,10 @@ export function WorkflowInspector({
   const [isEditingCommand, setIsEditingCommand] = useState(false);
   const [editCommandValue, setEditCommandValue] = useState('');
   const [branchValue, setBranchValue] = useState('');
+  const [taskLogEvents, setTaskLogEvents] = useState<TaskAuditEvent[]>([]);
+  const [taskLogError, setTaskLogError] = useState<string | null>(null);
+  const [showLogs, setShowLogs] = useState(true);
+  const [logLevelFilter, setLogLevelFilter] = useState<TaskLogLevel>('info');
 
   useEffect(() => {
     setIsEditingPrompt(false);
@@ -149,6 +258,48 @@ export function WorkflowInspector({
   useEffect(() => {
     setBranchValue(workflow?.baseBranch ?? task?.config.featureBranch ?? '');
   }, [workflow?.baseBranch, task?.config.featureBranch, task?.id]);
+
+  useEffect(() => {
+    if (!task) {
+      setTaskLogEvents([]);
+      setTaskLogError(null);
+      return;
+    }
+
+    let cancelled = false;
+    let inFlight = false;
+    const refreshEvents = () => {
+      if (inFlight) return;
+      const eventsPromise = window.invoker?.getEvents(task.id);
+      if (!eventsPromise) return;
+
+      inFlight = true;
+      eventsPromise
+        .then((events) => {
+          if (cancelled) return;
+          setTaskLogEvents(events);
+          setTaskLogError(null);
+        })
+        .catch(() => {
+          if (!cancelled) setTaskLogError('Could not load logs. Retrying…');
+        })
+        .finally(() => {
+          inFlight = false;
+        });
+    };
+
+    setTaskLogEvents([]);
+    setTaskLogError(null);
+    refreshEvents();
+
+    const shouldPoll = task.status === 'running' || task.status === 'fixing_with_ai';
+    const timer = shouldPoll ? window.setInterval(refreshEvents, 2_500) : undefined;
+
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) window.clearInterval(timer);
+    };
+  }, [task?.id, task?.status]);
 
   const taskVisualStatus = task ? getEffectiveVisualStatus(task.status, task.execution) : null;
   const taskColors = taskVisualStatus ? getStatusColor(taskVisualStatus) : null;
@@ -193,6 +344,11 @@ export function WorkflowInspector({
     && onReject,
   );
   const statusHeading = task ? 'Task Status' : 'Status';
+  const logEntries = taskLogEvents.map(taskEventToLogEntry);
+  const visibleLogEntries = logEntries
+    .filter((entry) => LOG_LEVEL_RANK[entry.level] >= LOG_LEVEL_RANK[logLevelFilter])
+    .slice()
+    .reverse();
 
   const savePrompt = () => {
     if (task && onEditPrompt && editPromptValue !== (task.config.prompt ?? '')) {
@@ -533,6 +689,73 @@ export function WorkflowInspector({
             >
               {reviewUrl}
             </a>
+          </section>
+        )}
+
+        {task && (
+          <section className="rounded border border-gray-700 bg-gray-800/70" data-testid="task-logs-section">
+            <div className="flex items-center justify-between gap-3 px-3 py-2">
+              <button
+                onClick={() => setShowLogs(!showLogs)}
+                className="text-left text-[11px] uppercase tracking-wide text-gray-300 hover:text-gray-100"
+                data-testid="task-logs-toggle"
+                data-sidebar-nav-item
+                data-sidebar-nav-order="80"
+                data-sidebar-expandable="true"
+                aria-expanded={showLogs}
+              >
+                Logs {showLogs ? '▲' : '▼'}
+              </button>
+              <label className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-gray-400">
+                Level
+                <select
+                  value={logLevelFilter}
+                  onChange={(event) => setLogLevelFilter(event.target.value as TaskLogLevel)}
+                  className="rounded border border-gray-600 bg-gray-700 px-2 py-1 text-xs normal-case text-gray-100 focus:border-blue-500 focus:outline-none"
+                  data-testid="task-log-level-select"
+                >
+                  <option value="debug">Debug+</option>
+                  <option value="info">Info+</option>
+                  <option value="warn">Warn+</option>
+                  <option value="error">Error</option>
+                </select>
+              </label>
+            </div>
+            {showLogs && (
+              <div className="border-t border-gray-700 px-3 py-2">
+                {taskLogError && (
+                  <p className="mb-2 rounded border border-amber-800 bg-amber-950/30 px-2 py-1 text-xs text-amber-300" data-testid="task-log-error">
+                    {taskLogError}
+                  </p>
+                )}
+                {visibleLogEntries.length === 0 ? (
+                  <p className="text-xs text-gray-500">No logs at this level.</p>
+                ) : (
+                  <div className="space-y-2">
+                    {visibleLogEntries.slice(0, 20).map((entry) => (
+                      <div key={entry.id} className="rounded border border-gray-700 bg-gray-950/60 p-2" data-testid="task-log-entry">
+                        <div className="flex items-start gap-2">
+                          <span className={`shrink-0 rounded border px-1.5 py-0.5 text-[10px] font-semibold uppercase ${logLevelClass(entry.level)}`}>
+                            {entry.level}
+                          </span>
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-baseline justify-between gap-2">
+                              <p className="break-words text-xs text-gray-200">{entry.message}</p>
+                              {entry.createdAt && (
+                                <span className="shrink-0 text-[10px] text-gray-500">{formatEventTime(entry.createdAt)}</span>
+                              )}
+                            </div>
+                            {entry.detail && (
+                              <code className="mt-1 block break-all text-[10px] text-gray-500">{entry.detail}</code>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
           </section>
         )}
 


### PR DESCRIPTION
## Summary

The workflow side panel now has a Logs section with a level filter.

It uses the same task events already saved for audits. Running tasks refresh the panel, so long review gates can show their current step.

<details>
<summary>Review metadata</summary>

Review Claim: The side panel renders task logs and filters them by minimum level.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The section does not mutate task state and only consumes existing task events.

Slice Rationale: This final slice displays the events produced by the lower stack slices.

</details>

## Non-goals

This does not add a new persistence table, change task status, or show raw local log files.

## Architecture

### Before

```mermaid
graph TD
    A["WorkflowInspector"] --> B["task status and metadata"]
```

### After

```mermaid
graph TD
    A["WorkflowInspector"] --> B["task status and metadata"]
    A --> C["level-filtered Logs section"]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-inspector.test.tsx`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && CAPTURE_MODE=after pnpm --filter @invoker/app test:e2e e2e/visual-proof.spec.ts -g "task panel"`

## Visual Proof

![Task panel after capture](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-daa76e/task-panel.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 23d04a126`
- Post-revert steps: None
- Data migration? No

## Files (2)

- packages/ui/src/__tests__/workflow-inspector.test.tsx [MODIFIED]
- packages/ui/src/components/WorkflowInspector.tsx [MODIFIED]

Depends-On: #2710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Logs section to the workflow inspector for running tasks.
  * Logs now refresh automatically while tasks are active, with a severity-level filter and expandable details.
  * Entries show a readable timestamp and message; up to the most recent 20 are displayed.
* **Bug Fixes**
  * Debug-level details are hidden by default and revealed only after selecting the appropriate log level.
  * Improved messaging when log loading fails by showing a retry notice.
  * Clear “no logs at this level” state when nothing matches the filter.
* **Tests**
  * Extended workflow inspector and publish/SSH-related tests to cover log-level rendering, retry behavior, and expanded telemetry expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->