### PR TITLE
[Task Logs](2) Log make-pr publisher progress events

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1243,12 +1243,13 @@ describe('TaskRunner', () => {
           },
           buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
         };
+        const logEvent = vi.fn().mockImplementationOnce(() => { throw new Error('telemetry down'); });
         const executor = new TaskRunner({
           orchestrator: {
             getTask: () => null,
             getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-1', executionAgent: 'claude' } })],
           } as any,
-          persistence: {} as any,
+          persistence: { logEvent } as any,
           executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
           executionAgentRegistry: {
             get: (name: string) => (name === 'claude' ? claudeAgent : name === 'codex' ? codexAgent : undefined),
@@ -1266,11 +1267,38 @@ describe('TaskRunner', () => {
           featureBranch: 'plan/feature',
           workflowSummary: 'summary',
           cwd: '/tmp',
+          mergeNodeTaskId: '__merge__wf-1',
         });
 
         expect(attempts).toEqual(['claude', 'codex']);
         expect(result.agentName).toBe('codex');
         expect(result.artifacts[1].dependsOn).toEqual(['contracts']);
+        expect(logEvent).toHaveBeenCalledWith(
+          '__merge__wf-1',
+          'task.log',
+          expect.objectContaining({
+            level: 'info',
+            message: 'Preparing make-pr review stack publisher',
+            agentCount: 2,
+          }),
+        );
+        expect(logEvent).toHaveBeenCalledWith(
+          '__merge__wf-1',
+          'task.log',
+          expect.objectContaining({
+            level: 'warn',
+            message: 'claude make-pr agent failed',
+          }),
+        );
+        expect(logEvent).toHaveBeenCalledWith(
+          '__merge__wf-1',
+          'task.log',
+          expect.objectContaining({
+            level: 'info',
+            message: 'Review stack body validated',
+            artifactCount: 2,
+          }),
+        );
       } finally {
         if (originalHome === undefined) delete process.env.HOME;
         else process.env.HOME = originalHome;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -2238,6 +2238,33 @@ export class TaskRunner {
     const preferredName = this.resolvePrAuthoringAgentName(args.workflowId, args.mergeNodeTaskId);
     const prCapableAgents = this.executionAgentRegistry.listWithCapability('make-pr');
     const orderedAgents = this.buildAgentFallbackOrder(preferredName, prCapableAgents);
+    const logProgress = (
+      level: 'debug' | 'info' | 'warn' | 'error',
+      message: string,
+      detail: Record<string, unknown> = {},
+    ) => {
+      if (!args.mergeNodeTaskId) return;
+      try {
+        const persistence = this.persistence as { logEvent?: (taskId: string, eventType: string, payload?: unknown) => void };
+        persistence.logEvent?.(args.mergeNodeTaskId, 'task.log', {
+          level,
+          message,
+          ...detail,
+        });
+      } catch (error) {
+        this.logger.warn('[pr-authoring] failed to persist task progress event', {
+          taskId: args.mergeNodeTaskId,
+          error,
+        });
+      }
+    };
+
+    logProgress('info', 'Preparing make-pr review stack publisher', {
+      featureBranch: args.featureBranch,
+      baseBranch: args.baseBranch,
+      agentCount: orderedAgents.length,
+    });
+
     const errors: string[] = [];
 
     for (const agent of orderedAgents) {
@@ -2259,11 +2286,19 @@ export class TaskRunner {
       });
 
       try {
+        logProgress('info', `Starting ${agent.name} make-pr agent`, {
+          agentName: agent.name,
+          cwd: args.cwd,
+        });
         this.logger.info(
           `[pr-authoring] review-stack publish starting agent=${agent.name} `
             + `workflow=${args.workflowId ?? 'unknown'} skill=invoker-make-pr cwd=${args.cwd}`,
         );
         const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
+        logProgress('info', `${agent.name} make-pr agent finished; validating output`, {
+          agentName: agent.name,
+          sessionId: result.sessionId,
+        });
         const parsedArtifacts = parseMakePrStackPublishResult(result.body);
 
         // Enforce the make-pr review-stack schema on every published body. Prefer
@@ -2300,6 +2335,10 @@ export class TaskRunner {
             `[pr-authoring] review-stack body validation failed agent=${agent.name} `
               + `errors=${bodyErrors.join('; ')}`,
           );
+          logProgress('warn', `${agent.name} published review stack failed validation`, {
+            agentName: agent.name,
+            errors: bodyErrors,
+          });
           errors.push(`${agent.name}: invalid PR body — ${bodyErrors.join('; ')}`);
           continue;
         }
@@ -2315,13 +2354,22 @@ export class TaskRunner {
           generation,
           createdAt: nowIso,
         }));
+        logProgress('info', 'Review stack body validated', {
+          agentName: agent.name,
+          artifactCount: artifacts.length,
+        });
         this.logger.info(
           `[pr-authoring] review-stack published agent=${agent.name} artifacts=${artifacts.length} `
             + 'bodies validated against make-pr schema',
         );
         return { artifacts, sessionId: result.sessionId, agentName: agent.name };
       } catch (err) {
-        errors.push(`${agent.name}: ${err instanceof Error ? err.message : String(err)}`);
+        const message = err instanceof Error ? err.message : String(err);
+        logProgress('warn', `${agent.name} make-pr agent failed`, {
+          agentName: agent.name,
+          error: message,
+        });
+        errors.push(`${agent.name}: ${message}`);
       }
     }
 


### PR DESCRIPTION
## Summary

The make-pr publisher now records what its agent is doing.

It logs publisher setup, agent start, body check success, body check failure, and agent failure. Slow PR creation now has visible breadcrumbs.

<details>
<summary>Review metadata</summary>

Review Claim: The make-pr review stack publisher emits levelled task log events during agent publication.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The publisher still uses the same agent order and body check flow; this only records progress events.

Slice Rationale: This is its own slice because make-pr publication has its own agent path.

</details>

## Non-goals

This does not change make-pr prompts, body check rules, agent order, or stack publication results.

## Architecture

### Before

```mermaid
graph TD
    A["make-pr publisher"] --> B["agent process"]
    B --> C["body checks"]
```

### After

```mermaid
graph TD
    A["make-pr publisher"] --> B["agent process"]
    B --> C["body checks"]
    A --> D["task.log events"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- task-runner-fix-publish-and-ssh.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 215947058`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publishing progress updates for review stacks, with clearer status messages during execution.
  * Added warnings when an agent fails or when validation detects issues, making problems easier to spot.
  * Added success updates after validation, including a count of validated artifacts for better visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2705