### PR TITLE
[Worker Registration Step 2: Registry, Auto-Fix, and Auto-Approve](1) Add auto-fix model config

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -106,6 +106,15 @@ describe('loadConfig', () => {
     expect(config.autoApproveAIFixes).toBe(true);
   });
 
+  it('reads autoFixExecutionModel from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ autoFixExecutionModel: 'openai/gpt-5.2' }),
+    );
+    const config = loadConfig();
+    expect(config.autoFixExecutionModel).toBe('openai/gpt-5.2');
+  });
+
   it('reads experimentalPlanner from user config', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),
@@ -304,4 +313,3 @@ describe('resolveEmbeddedTerminalBackendConfig', () => {
     )).toThrow(/Invalid embedded terminal backend/);
   });
 });
-

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -89,6 +89,11 @@ export interface InvokerConfig {
    */
   autoFixAgent?: string;
   /**
+   * Optional execution model passed to automatic fix agent commands.
+   * Agents that do not support model selection ignore this value.
+   */
+  autoFixExecutionModel?: string;
+  /**
    * When true, failed CI checks on Invoker-created review-gate PRs can
    * trigger the same auto-fix recovery flow used for task failures.
    *


### PR DESCRIPTION
## Summary

The Invoker config now carries an optional auto-fix execution model.

This gives later worker paths a typed place to read model selection.

<details>
<summary>Review metadata</summary>

Review Claim: The config schema can store an auto-fix execution model without changing other auto-fix policy.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: The field is optional and existing config files parse the same way.

Slice Rationale: Model policy enters through config before later auto-fix paths consume it.

</details>

## Non-goals

- Do not change the default auto-fix agent.
- Do not enable auto approval or worker execution here.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/config.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/worker-registration-step-2-1.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No