### PR TITLE
[Worker Registration Step 2: Registry, Auto-Fix, and Auto-Approve](2) Route built-in worker runtimes

### DIFF
--- a/packages/app/src/__tests__/auto-fix-intents.test.ts
+++ b/packages/app/src/__tests__/auto-fix-intents.test.ts
@@ -96,6 +96,7 @@ describe('parseHeadlessFixArgs', () => {
       agentName: 'codex',
       autoFix: false,
       reviewGateContext: undefined,
+      executionModel: undefined,
     });
   });
 
@@ -105,6 +106,7 @@ describe('parseHeadlessFixArgs', () => {
       agentName: 'claude',
       autoFix: true,
       reviewGateContext: undefined,
+      executionModel: undefined,
     });
   });
 
@@ -146,6 +148,23 @@ describe('buildHeadlessFixArgs', () => {
       agentName: 'codex',
       autoFix: true,
       reviewGateContext: ctx,
+      executionModel: undefined,
+    });
+  });
+
+  it('appends execution model context that round-trips through parsing', () => {
+    const args = buildHeadlessFixArgs('wf-1/task-1', 'omp', {
+      autoFix: true,
+      executionModel: 'openai/gpt-5.2',
+    });
+
+    expect(args).toEqual(['fix', 'wf-1/task-1', 'omp', '--auto-fix', '--execution-model', 'openai/gpt-5.2']);
+    expect(parseHeadlessFixArgs(args)).toEqual({
+      taskId: 'wf-1/task-1',
+      agentName: 'omp',
+      autoFix: true,
+      reviewGateContext: undefined,
+      executionModel: 'openai/gpt-5.2',
     });
   });
 });
@@ -161,7 +180,19 @@ describe('fix-with-agent mutation options', () => {
     expect(parseFixWithAgentMutationArgs(args)).toEqual({
       taskId: 'wf-1/task-1',
       agentName: 'codex',
-      context: { autoFix: true, reviewGateContext: ctx },
+      context: { autoFix: true, reviewGateContext: ctx, executionModel: undefined },
+    });
+  });
+
+  it('round-trips execution model through structured mutation options', () => {
+    const args = buildFixWithAgentMutationArgs('wf-1/task-1', 'omp', {
+      autoFix: true,
+      executionModel: 'openai/gpt-5.2',
+    });
+    expect(parseFixWithAgentMutationArgs(args)).toEqual({
+      taskId: 'wf-1/task-1',
+      agentName: 'omp',
+      context: { autoFix: true, reviewGateContext: undefined, executionModel: 'openai/gpt-5.2' },
     });
   });
 
@@ -169,12 +200,12 @@ describe('fix-with-agent mutation options', () => {
     expect(parseFixWithAgentMutationArgs(['wf-1/task-1', 'claude'])).toEqual({
       taskId: 'wf-1/task-1',
       agentName: 'claude',
-      context: { autoFix: false, reviewGateContext: undefined },
+      context: { autoFix: false, reviewGateContext: undefined, executionModel: undefined },
     });
     expect(parseFixWithAgentMutationArgs(['wf-1/task-1'])).toEqual({
       taskId: 'wf-1/task-1',
       agentName: undefined,
-      context: { autoFix: false, reviewGateContext: undefined },
+      context: { autoFix: false, reviewGateContext: undefined, executionModel: undefined },
     });
   });
 });
@@ -231,4 +262,3 @@ describe('review-gate CI context encode/decode', () => {
     expect(decodeReviewGateCiContext(JSON.stringify({ reviewId: 'r' }))).toBeUndefined();
   });
 });
-

--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -322,4 +322,40 @@ describe('auto-fix recovery scan submission', () => {
       buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', { autoFix: true }),
     );
   });
+
+  it('passes configured execution model through the queued command and worker action', async () => {
+    const harness = makeRecoveryPolicyHarness();
+    const actions: any[] = [];
+    (harness.options as any).getAutoFixExecutionModel = () => 'openai/gpt-5.2';
+    (harness.options.store as any).getWorkerAction = vi.fn(() => undefined);
+    (harness.options.store as any).upsertWorkerAction = vi.fn((action: any) => {
+      actions.push(action);
+      return action;
+    });
+    const tick = createAutoFixRecoveryTick(harness.options);
+
+    await tick({
+      identity: { kind: 'recovery', instanceId: 'test' },
+      reason: 'startup',
+      tickNumber: 1,
+    });
+
+    expect(harness.submit).toHaveBeenCalledWith(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', {
+        autoFix: true,
+        executionModel: 'openai/gpt-5.2',
+      }),
+    );
+    expect(actions[0]).toMatchObject({
+      workerKind: 'autofix',
+      actionType: 'fix-task',
+      status: 'queued',
+      intentId: '1',
+      agentName: 'codex',
+      executionModel: 'openai/gpt-5.2',
+    });
+  });
 });

--- a/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationIntent, WorkflowMutationPriority } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import {
+  AUTO_APPROVE_WORKER_KIND,
+  autoApproveActionKey,
+  createAutoApproveTick,
+  createAutoApproveWorker,
+} from '../workers/auto-approve-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/task-1',
+    description: 'fixed task',
+    status: 'awaiting_approval',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', ...(config ?? {}) },
+    execution: {
+      pendingFixError: 'original failure',
+      generation: 1,
+      selectedAttemptId: 'attempt-1',
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 4,
+    ...rest,
+  };
+}
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? now,
+    updatedAt: write.updatedAt ?? now,
+  };
+}
+
+function makeHarness(task: TaskState = makeTask(), enabled = true) {
+  const workflows = [{ id: 'wf-1' }];
+  const tasks = new Map<string, TaskState>([[task.id, task]]);
+  const intents: WorkflowMutationIntent[] = [];
+  const actions = new Map<string, WorkerActionRecord>();
+  const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
+    const id = intents.length + 1;
+    intents.push({
+      id,
+      workflowId,
+      priority,
+      channel,
+      args,
+      status: 'queued',
+      createdAt: new Date().toISOString(),
+    });
+    return id;
+  });
+  const store = {
+    listWorkflows: vi.fn(() => workflows),
+    loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
+    loadTask: vi.fn((taskId: string) => tasks.get(taskId)),
+    listWorkflowMutationIntents: vi.fn((workflowId?: string, statuses?: string[]) => intents.filter((intent) => (
+      (!workflowId || intent.workflowId === workflowId)
+      && (!statuses || statuses.includes(intent.status))
+    ))),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const existing = actions.get(`${write.workerKind}:${write.externalKey}`);
+      const saved = toRecord({ ...write, id: existing?.id ?? write.id, createdAt: existing?.createdAt });
+      actions.set(`${write.workerKind}:${write.externalKey}`, saved);
+      return saved;
+    }),
+    listWorkerActions: vi.fn((filters?: { workerKind?: string }) => Array.from(actions.values()).filter((action) => (
+      !filters?.workerKind || action.workerKind === filters.workerKind
+    ))),
+    logEvent: vi.fn(),
+  };
+  return {
+    options: {
+      store,
+      submitter: { submit },
+      logger,
+      getAutoApproveAIFixes: () => enabled,
+    },
+    actions,
+    intents,
+    store,
+    submit,
+    tasks,
+  };
+}
+
+describe('auto-approve worker', () => {
+  it('exposes the auto-approve identity', () => {
+    const runtime = createAutoApproveWorker({ logger, instanceId: 'aa-1', installSignalHandlers: false });
+
+    expect(runtime.identity).toEqual({ kind: AUTO_APPROVE_WORKER_KIND, instanceId: 'aa-1' });
+  });
+
+  it('queues headless approve once for an awaiting AI fix and records a queued action', async () => {
+    const task = makeTask();
+    const harness = makeHarness(task, true);
+    const tick = createAutoApproveTick(harness.options);
+
+    await tick({ identity: { kind: AUTO_APPROVE_WORKER_KIND, instanceId: 'test' }, reason: 'manual', tickNumber: 1 });
+    await tick({ identity: { kind: AUTO_APPROVE_WORKER_KIND, instanceId: 'test' }, reason: 'manual', tickNumber: 2 });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.submit).toHaveBeenCalledWith(
+      'wf-1',
+      'normal',
+      'headless.exec',
+      [{ args: ['approve', 'wf-1/task-1'], noTrack: true }],
+    );
+    const action = harness.actions.get(`${AUTO_APPROVE_WORKER_KIND}:${autoApproveActionKey({
+      taskId: task.id,
+      generation: 1,
+      taskStateVersion: 4,
+      attemptId: 'attempt-1',
+    })}`);
+    expect(action).toMatchObject({
+      workerKind: AUTO_APPROVE_WORKER_KIND,
+      actionType: 'approve-ai-fix',
+      status: 'queued',
+      intentId: '1',
+      taskId: 'wf-1/task-1',
+    });
+  });
+
+  it('records skipped when auto approval is disabled', async () => {
+    const harness = makeHarness(makeTask(), false);
+    const tick = createAutoApproveTick(harness.options);
+
+    await tick({ identity: { kind: AUTO_APPROVE_WORKER_KIND, instanceId: 'test' }, reason: 'manual', tickNumber: 1 });
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(Array.from(harness.actions.values())[0]).toMatchObject({
+      status: 'skipped',
+      summary: expect.stringContaining('disabled'),
+    });
+  });
+
+  it('marks queued auto-approval actions stale after the task leaves the approval state', async () => {
+    const task = makeTask({ status: 'completed' });
+    const harness = makeHarness(task, true);
+    const externalKey = autoApproveActionKey({
+      taskId: task.id,
+      generation: 1,
+      taskStateVersion: 4,
+      attemptId: 'attempt-1',
+    });
+    harness.actions.set(`${AUTO_APPROVE_WORKER_KIND}:${externalKey}`, toRecord({
+      id: 'aa-1',
+      workerKind: AUTO_APPROVE_WORKER_KIND,
+      actionType: 'approve-ai-fix',
+      workflowId: 'wf-1',
+      taskId: task.id,
+      subjectType: 'task',
+      subjectId: task.id,
+      externalKey,
+      status: 'queued',
+      attemptCount: 1,
+    }));
+    const tick = createAutoApproveTick(harness.options);
+
+    await tick({ identity: { kind: AUTO_APPROVE_WORKER_KIND, instanceId: 'test' }, reason: 'manual', tickNumber: 1 });
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(harness.actions.get(`${AUTO_APPROVE_WORKER_KIND}:${externalKey}`)).toMatchObject({
+      status: 'stale',
+      summary: expect.stringContaining('status-changed'),
+    });
+  });
+});

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -2,9 +2,11 @@ import { describe, it, expect } from 'vitest';
 
 import { RECOVERY_WORKER_KIND, type AutoFixRecoveryStore, type AutoFixRecoverySubmitter } from '../auto-fix-recovery.js';
 import {
+  AUTO_APPROVE_WORKER_KIND,
   AUTO_FIX_WORKER_KIND,
   createWorkerRegistry,
   registerAutoFixWorker,
+  registerBuiltinWorkers,
   type WorkerRuntimeDependencies,
 } from '../worker-registry.js';
 
@@ -49,6 +51,17 @@ describe('worker registry', () => {
     expect(registry.list().map((d) => d.kind)).toEqual([AUTO_FIX_WORKER_KIND]);
   });
 
+  it('registers every built-in worker in one call', () => {
+    const registry = registerBuiltinWorkers(createWorkerRegistry());
+
+    expect(registry.list().map((d) => d.kind)).toEqual([
+      AUTO_FIX_WORKER_KIND,
+      AUTO_APPROVE_WORKER_KIND,
+    ]);
+    expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();
+    expect(registry.get(AUTO_APPROVE_WORKER_KIND)).toBeDefined();
+  });
+
   it('returns nothing for an unknown kind', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry());
     expect(registry.get('does-not-exist')).toBeUndefined();
@@ -63,6 +76,16 @@ describe('worker registry', () => {
     // The registry kind is `autofix`, but it reuses the recovery worker, whose
     // runtime identity keeps the underlying recovery kind.
     expect(runtime.identity.kind).toBe(RECOVERY_WORKER_KIND);
+    expect(runtime.isRunning()).toBe(false);
+  });
+
+  it('builds an auto-approve worker runtime from the auto-approve factory', () => {
+    const registry = registerBuiltinWorkers(createWorkerRegistry());
+    const definition = registry.get(AUTO_APPROVE_WORKER_KIND);
+    expect(definition).toBeDefined();
+
+    const runtime = definition!.factory(deps());
+    expect(runtime.identity.kind).toBe(AUTO_APPROVE_WORKER_KIND);
     expect(runtime.isRunning()).toBe(false);
   });
 });

--- a/packages/execution-engine/src/auto-fix-intents.ts
+++ b/packages/execution-engine/src/auto-fix-intents.ts
@@ -97,10 +97,12 @@ export function isReviewGateCiContextStale(
 
 const AUTO_FIX_FLAG = '--auto-fix';
 const REVIEW_GATE_CI_FLAG = '--review-gate-ci';
+const EXECUTION_MODEL_FLAG = '--execution-model';
 
 export interface AutoFixCommandContext {
   autoFix: boolean;
   reviewGateContext?: ReviewGateCiContext;
+  executionModel?: string;
 }
 
 export interface ParsedHeadlessFixArgs extends AutoFixCommandContext {
@@ -114,6 +116,7 @@ export function parseHeadlessFixArgs(args: readonly string[]): ParsedHeadlessFix
   let agentName: string | undefined;
   let autoFix = false;
   let reviewGateContext: ReviewGateCiContext | undefined;
+  let executionModel: string | undefined;
 
   for (let i = 0; i < rest.length; i += 1) {
     const token = rest[i];
@@ -130,6 +133,14 @@ export function parseHeadlessFixArgs(args: readonly string[]): ParsedHeadlessFix
       i += 1;
       continue;
     }
+    if (token === EXECUTION_MODEL_FLAG) {
+      const model = rest[i + 1]?.trim();
+      if (model) {
+        executionModel = model;
+      }
+      i += 1;
+      continue;
+    }
     if (taskId === undefined) {
       taskId = token;
       continue;
@@ -139,7 +150,7 @@ export function parseHeadlessFixArgs(args: readonly string[]): ParsedHeadlessFix
     }
   }
 
-  return { taskId, agentName, autoFix, reviewGateContext };
+  return { taskId, agentName, autoFix, reviewGateContext, executionModel };
 }
 
 export function buildHeadlessFixArgs(
@@ -157,6 +168,10 @@ export function buildHeadlessFixArgs(
   if (context.reviewGateContext) {
     args.push(REVIEW_GATE_CI_FLAG, encodeReviewGateCiContext(context.reviewGateContext));
   }
+  const executionModel = context.executionModel?.trim();
+  if (executionModel) {
+    args.push(EXECUTION_MODEL_FLAG, executionModel);
+  }
   return args;
 }
 
@@ -164,6 +179,7 @@ export function buildHeadlessFixArgs(
 export interface FixWithAgentMutationOptions {
   autoFix?: boolean;
   reviewGateContext?: ReviewGateCiContext;
+  executionModel?: string;
 }
 
 export interface ParsedFixWithAgentMutationArgs {
@@ -179,9 +195,16 @@ export function buildFixWithAgentMutationArgs(
 ): unknown[] {
   const args: unknown[] = [taskId, agentName];
   if (options && (options.autoFix || options.reviewGateContext)) {
+    const executionModel = options.executionModel?.trim();
     args.push({
       autoFix: Boolean(options.autoFix || options.reviewGateContext),
       ...(options.reviewGateContext ? { reviewGateContext: options.reviewGateContext } : {}),
+      ...(executionModel ? { executionModel } : {}),
+    });
+  } else if (options?.executionModel?.trim()) {
+    args.push({
+      autoFix: false,
+      executionModel: options.executionModel.trim(),
     });
   }
   return args;
@@ -193,10 +216,15 @@ export function parseFixWithAgentMutationArgs(args: unknown[]): ParsedFixWithAge
   const optionsArg = args[2];
   let autoFix = false;
   let reviewGateContext: ReviewGateCiContext | undefined;
+  let executionModel: string | undefined;
 
   if (optionsArg && typeof optionsArg === 'object') {
     const candidate = optionsArg as Record<string, unknown>;
     autoFix = Boolean(candidate.autoFix);
+    if (typeof candidate.executionModel === 'string') {
+      const trimmed = candidate.executionModel.trim();
+      executionModel = trimmed.length > 0 ? trimmed : undefined;
+    }
     if (candidate.reviewGateContext) {
       const ctx = candidate.reviewGateContext;
       reviewGateContext = typeof ctx === 'string'
@@ -208,5 +236,5 @@ export function parseFixWithAgentMutationArgs(args: unknown[]): ParsedFixWithAge
     }
   }
 
-  return { taskId, agentName, context: { autoFix, reviewGateContext } };
+  return { taskId, agentName, context: { autoFix, reviewGateContext, executionModel } };
 }

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -1,5 +1,7 @@
 import type { Logger } from '@invoker/contracts';
 import type {
+  WorkerActionRecord,
+  WorkerActionWrite,
   WorkflowMutationIntent,
   WorkflowMutationIntentStatus,
   WorkflowMutationPriority,
@@ -20,6 +22,7 @@ export const RECOVERY_WORKER_KIND = 'recovery';
 
 const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
 const AUTO_FIX_COMMAND_CHANNEL = 'invoker:fix-with-agent';
+const AUTO_FIX_ACTION_WORKER_KIND = 'autofix';
 
 export interface AutoFixRecoveryStore {
   listWorkflows(): ReadonlyArray<{ id: string }>;
@@ -29,6 +32,8 @@ export interface AutoFixRecoveryStore {
     workflowId?: string,
     statuses?: WorkflowMutationIntentStatus[],
   ): WorkflowMutationIntent[];
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
 }
 
@@ -48,6 +53,7 @@ export interface AutoFixRecoveryPolicyOptions {
   logger: Logger;
   defaultAutoFixRetries?: number;
   getAutoFixAgent?: () => string | undefined;
+  getAutoFixExecutionModel?: () => string | undefined;
   getRetryBudget?: (task: TaskState) => number;
   drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
 }
@@ -96,6 +102,15 @@ function taskRefFromTask(task: TaskState): AutoFixRecoveryTaskRef | undefined {
     taskStateVersion: task.taskStateVersion,
     attemptId: task.execution.selectedAttemptId,
   };
+}
+
+function autoFixActionKey(ref: AutoFixRecoveryTaskRef): string {
+  return [
+    ref.taskId,
+    `g${ref.generation}`,
+    `v${ref.taskStateVersion}`,
+    `a${ref.attemptId ?? 'none'}`,
+  ].join(':');
 }
 
 function candidateFromTask(task: TaskState): AutoFixRecoveryCandidate | undefined {
@@ -182,6 +197,44 @@ function logAutoFixWorkerEvent(
     module: 'auto-fix-recovery',
     taskId,
     ...details,
+  });
+}
+
+function recordAutoFixQueuedAction(
+  options: AutoFixRecoveryPolicyOptions,
+  candidate: ValidatedAutoFixRecoveryCandidate,
+  intentId: number,
+  selectedAgent: string | undefined,
+  executionModel: string | undefined,
+): void {
+  const externalKey = autoFixActionKey(candidate);
+  const existing = options.store.getWorkerAction?.(AUTO_FIX_ACTION_WORKER_KIND, externalKey);
+  const now = new Date().toISOString();
+  options.store.upsertWorkerAction?.({
+    id: existing?.id ?? `${AUTO_FIX_ACTION_WORKER_KIND}:${externalKey}`,
+    workerKind: AUTO_FIX_ACTION_WORKER_KIND,
+    actionType: 'fix-task',
+    workflowId: candidate.workflowId,
+    taskId: candidate.taskId,
+    subjectType: 'task',
+    subjectId: candidate.taskId,
+    externalKey,
+    status: 'queued',
+    attemptCount: (existing?.attemptCount ?? 0) + 1,
+    intentId: String(intentId),
+    agentName: selectedAgent,
+    executionModel,
+    summary: 'Queued auto-fix with agent',
+    payload: {
+      channel: AUTO_FIX_COMMAND_CHANNEL,
+      source: candidate.source,
+      generation: candidate.generation,
+      taskStateVersion: candidate.taskStateVersion,
+      attemptId: candidate.attemptId ?? null,
+      autoFixAttempts: candidate.task.execution.autoFixAttempts ?? 0,
+      maxRetries: retryBudgetForTask(candidate.task, options),
+    },
+    updatedAt: now,
   });
 }
 
@@ -311,8 +364,13 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
       }
       const configuredAgent = options.getAutoFixAgent?.()?.trim();
       const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
-      const args = buildFixWithAgentMutationArgs(candidate.task.id, selectedAgent, { autoFix: true });
+      const configuredExecutionModel = options.getAutoFixExecutionModel?.()?.trim();
+      const executionModel = configuredExecutionModel && configuredExecutionModel.length > 0
+        ? configuredExecutionModel
+        : undefined;
+      const args = buildFixWithAgentMutationArgs(candidate.task.id, selectedAgent, { autoFix: true, executionModel });
       const intentId = options.submitter.submit(candidate.workflowId, 'normal', AUTO_FIX_COMMAND_CHANNEL, args);
+      recordAutoFixQueuedAction(options, candidate, intentId, selectedAgent, executionModel);
       submittedThisTick.add(candidate.taskId);
       logAutoFixWorkerEvent(options, candidate.taskId, 'worker-autofix-submitted', {
         workflowId: candidate.workflowId,
@@ -322,6 +380,7 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
         taskStateVersion: candidate.taskStateVersion,
         attemptId: candidate.attemptId ?? null,
         agent: selectedAgent ?? null,
+        executionModel: executionModel ?? null,
         autoFixAttempts: candidate.task.execution.autoFixAttempts ?? 0,
         maxRetries: retryBudgetForTask(candidate.task, options),
       });

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -50,7 +50,7 @@ export interface ConflictResolverHost {
   execGitIn(args: string[], dir: string): Promise<string>;
   createMergeWorktree(ref: string, label: string, repoUrl?: string): Promise<string>;
   removeMergeWorktree(dir: string): Promise<void>;
-  spawnAgentFix(prompt: string, cwd: string, agentName?: string): Promise<{ stdout: string; sessionId: string }>;
+  spawnAgentFix(prompt: string, cwd: string, agentName?: string, executionModel?: string): Promise<{ stdout: string; sessionId: string }>;
   getRemoteTargetConfig?(targetId: string): RemoteTargetConfig | undefined;
 }
 
@@ -170,6 +170,7 @@ export async function resolveConflictImpl(
   taskId: string,
   savedError?: string,
   agentName?: string,
+  executionModel?: string,
 ): Promise<void> {
   host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
     phase: 'resolve-conflict-start',
@@ -216,7 +217,7 @@ export async function resolveConflictImpl(
     if (!target) {
       throw new Error(`No remote target config for "${poolMemberId}" — cannot resolve conflict on remote`);
     }
-    await resolveConflictRemote(host, task, taskBranch, conflictInfo, rawCwd, target, agentName);
+    await resolveConflictRemote(host, task, taskBranch, conflictInfo, rawCwd, target, agentName, executionModel);
     return;
   }
 
@@ -271,7 +272,11 @@ export async function resolveConflictImpl(
         `5. Completing the merge with 'git commit --no-edit'`,
       ].join('\n');
 
-      await host.spawnAgentFix(prompt, cwd, agentName);
+      if (executionModel !== undefined) {
+        await host.spawnAgentFix(prompt, cwd, agentName, executionModel);
+      } else {
+        await host.spawnAgentFix(prompt, cwd, agentName);
+      }
     }
 
     console.log(`[resolveConflict] Successfully resolved conflict for ${taskId}`);
@@ -310,12 +315,13 @@ function buildRemoteAgentCommand(
   prompt: string,
   agentRegistry?: AgentRegistry,
   agentName?: string,
+  executionModel?: string,
 ): { shellCommand: string; sessionId: string } {
   const name = agentName ?? 'claude';
   if (agentRegistry) {
     const agent = agentRegistry.get(name);
     if (agent?.buildFixCommand) {
-      const spec = agent.buildFixCommand(prompt);
+      const spec = agent.buildFixCommand(prompt, { executionModel });
       const sessionId = spec.sessionId ?? randomUUID();
       const cmd = `${spec.cmd} ${spec.args.map(a => shellQuote(a)).join(' ')}`;
       return { shellCommand: cmd, sessionId };
@@ -358,6 +364,7 @@ async function resolveConflictRemote(
   remoteCwd: string,
   target: RemoteTargetConfig,
   agentName?: string,
+  executionModel?: string,
 ): Promise<void> {
   const conflictFilesList = conflictInfo.conflictFiles.join(', ');
   const prompt = [
@@ -377,7 +384,7 @@ async function resolveConflictRemote(
     ? `Merge upstream ${conflictInfo.failedBranch} — ${depTask.description}`
     : `Merge upstream ${conflictInfo.failedBranch}`;
 
-  const { shellCommand: agentCmd } = buildRemoteAgentCommand(prompt, host.agentRegistry, agentName);
+  const { shellCommand: agentCmd } = buildRemoteAgentCommand(prompt, host.agentRegistry, agentName, executionModel);
   const agentCmdB64 = Buffer.from(agentCmd).toString('base64');
   const mergeMsgB64 = Buffer.from(conflictMergeMsg).toString('base64');
   const envExports = buildRemoteAgentEnvExports(target.secretsFile, target.use_api_key === true);
@@ -462,12 +469,14 @@ export async function fixWithAgentImpl(
   agentName?: string,
   savedError?: string,
   fixContext?: string,
+  executionModel?: string,
 ): Promise<void> {
   host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
     phase: 'fix-with-agent-start',
     agent: agentName ?? 'claude',
     hasSavedError: savedError !== undefined,
     outputLength: taskOutput.length,
+    executionModel: executionModel ?? null,
   });
   const task = host.orchestrator.getTask(taskId);
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
@@ -517,6 +526,7 @@ export async function fixWithAgentImpl(
       target,
       agentName,
       host.agentRegistry,
+      executionModel,
     );
     if (output) {
       host.persistence.appendTaskOutput(taskId, `\n[Fix with ${remoteAgentBin} (remote)] Output:\n${output}`);
@@ -535,6 +545,7 @@ export async function fixWithAgentImpl(
       mode: 'remote',
       sessionId,
       agent: remoteAgentBin,
+      executionModel: executionModel ?? null,
     });
     return;
   }
@@ -564,8 +575,11 @@ export async function fixWithAgentImpl(
       phase: 'fix-with-agent-spawn-local',
       workspacePath: cwd,
       agent: agentLabel,
+      executionModel: executionModel ?? null,
     });
-    const { stdout: output, sessionId } = await host.spawnAgentFix(prompt, cwd, agentName);
+    const { stdout: output, sessionId } = executionModel !== undefined
+      ? await host.spawnAgentFix(prompt, cwd, agentName, executionModel)
+      : await host.spawnAgentFix(prompt, cwd, agentName);
     if (output) {
       host.persistence.appendTaskOutput(taskId, `\n[Fix with ${agentLabel}] Output:\n${output}`);
     }
@@ -583,6 +597,7 @@ export async function fixWithAgentImpl(
       mode: 'local',
       sessionId,
       agent: agentLabel,
+      executionModel: executionModel ?? null,
     });
   } catch (err: any) {
     // Persist session ID even on failure so the session can be audited
@@ -623,12 +638,14 @@ export function spawnRemoteAgentFixImpl(
   target: RemoteTargetConfig,
   agentName?: string,
   agentRegistry?: AgentRegistry,
+  executionModel?: string,
 ): Promise<{ stdout: string; sessionId: string }> {
   const promptTransport = materializeRemotePrompt(prompt);
   const { shellCommand: agentCmd, sessionId } = buildRemoteAgentCommand(
     promptTransport.effectivePrompt,
     agentRegistry,
     agentName,
+    executionModel,
   );
   const agentCmdB64 = Buffer.from(agentCmd).toString('base64');
   const promptWrite = promptTransport.remotePromptFilePath && promptTransport.promptB64
@@ -700,9 +717,10 @@ export function spawnAgentFixViaRegistry(
   cwd: string,
   agent: ExecutionAgent,
   driver?: SessionDriver,
+  executionModel?: string,
 ): Promise<{ stdout: string; sessionId: string }> {
   const promptTransport = materializeLocalPrompt(prompt);
-  const spec = agent.buildFixCommand?.(promptTransport.effectivePrompt);
+  const spec = agent.buildFixCommand?.(promptTransport.effectivePrompt, { executionModel });
   if (!spec) {
     promptTransport.cleanup();
     throw new Error(`Agent "${agent.name}" does not support fix commands`);

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -37,6 +37,7 @@ export * from './worker-registry.js';
 export * from './worker-types.js';
 export * from './worker-lock.js';
 export * from './auto-fix-recovery.js';
+export * from './workers/auto-approve-worker.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1809,8 +1809,8 @@ export class TaskRunner {
    * Resolve a merge conflict by re-creating the merge state and spawning an agent to fix it.
    * After resolution, the task is restarted so it can proceed normally.
    */
-  async resolveConflict(taskId: string, savedError?: string, agentName?: string): Promise<void> {
-    return this.withAttemptHeartbeat(taskId, () => resolveConflictImpl(this, taskId, savedError, agentName));
+  async resolveConflict(taskId: string, savedError?: string, agentName?: string, executionModel?: string): Promise<void> {
+    return this.withAttemptHeartbeat(taskId, () => resolveConflictImpl(this, taskId, savedError, agentName, executionModel));
   }
 
   /**
@@ -1823,10 +1823,11 @@ export class TaskRunner {
     agentName?: string,
     savedError?: string,
     fixContext?: string,
+    executionModel?: string,
   ): Promise<void> {
     return this.withAttemptHeartbeat(
       taskId,
-      () => fixWithAgentImpl(this, taskId, taskOutput, agentName, savedError, fixContext),
+      () => fixWithAgentImpl(this, taskId, taskOutput, agentName, savedError, fixContext, executionModel),
     );
   }
 
@@ -2124,6 +2125,7 @@ export class TaskRunner {
     prompt: string,
     cwd: string,
     agentName: string = DEFAULT_EXECUTION_AGENT,
+    executionModel?: string,
   ): Promise<{ stdout: string; sessionId: string }> {
     if (!this.executionAgentRegistry) {
       throw new Error('executionAgentRegistry is required for spawnAgentFix');
@@ -2133,7 +2135,7 @@ export class TaskRunner {
       throw new Error(`Agent "${agentName}" does not support fix commands`);
     }
     const driver = this.executionAgentRegistry.getSessionDriver(agentName);
-    return spawnAgentFixViaRegistry(prompt, cwd, agent, driver);
+    return spawnAgentFixViaRegistry(prompt, cwd, agent, driver, executionModel);
   }
 
   async authorPrBodyWithSkill(args: {

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -4,9 +4,9 @@
  *
  * Each worker is declared once as a {@link WorkerDefinition} — its `kind`, an
  * operator-facing `note`, and a `factory` that builds the worker runtime from
- * injected dependencies. Today the only built-in is the auto-fix recovery
- * worker; centralizing worker knowledge here lets future workers be declared
- * uniformly instead of being implied by a single hard-coded auto-fix branch.
+ * injected dependencies. Centralizing worker knowledge here keeps all built-in
+ * workers on one declaration path instead of scattering hard-coded branches
+ * across the app and CLI doors.
  */
 
 import type { Logger } from '@invoker/contracts';
@@ -17,7 +17,15 @@ import {
   type AutoFixRecoveryStore,
   type AutoFixRecoverySubmitter,
 } from './auto-fix-recovery.js';
+import {
+  AUTO_APPROVE_WORKER_KIND,
+  createAutoApproveWorker,
+  type AutoApproveWorkerSubmitter,
+  type AutoApproveWorkerStore,
+} from './workers/auto-approve-worker.js';
 import type { WorkerRuntime } from './worker-runtime.js';
+
+export { AUTO_APPROVE_WORKER_KIND } from './workers/auto-approve-worker.js';
 
 /** Registry kind for the built-in auto-fix recovery worker. */
 export const AUTO_FIX_WORKER_KIND = 'autofix';
@@ -28,20 +36,30 @@ export interface AutoFixWorkerConfig {
   defaultAutoFixRetries?: number;
   /** Resolves the agent that performs each auto-fix, when one is configured. */
   getAutoFixAgent?: () => string | undefined;
+  /** Resolves the execution model passed to auto-fix agent commands. */
+  getAutoFixExecutionModel?: () => string | undefined;
+}
+
+/** Auto-approval tuning handed to a worker factory. */
+export interface AutoApproveWorkerConfig {
+  /** Returns true when AI-applied fixes should be approved by the worker. */
+  getAutoApproveAIFixes?: () => boolean | undefined;
 }
 
 /** Dependencies injected into a worker factory when its runtime is built. */
 export interface WorkerRuntimeDependencies {
   /** Persisted workflow/task state accessor. */
-  store: AutoFixRecoveryStore;
+  store: AutoFixRecoveryStore & AutoApproveWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
-  submitter: AutoFixRecoverySubmitter;
+  submitter: AutoFixRecoverySubmitter & AutoApproveWorkerSubmitter;
   /** Operator logger. */
   logger: Logger;
   /** Optional bus that turns lifecycle events into immediate wakeups. */
   messageBus?: MessageBus;
   /** Auto-fix tuning. */
   autoFix?: AutoFixWorkerConfig;
+  /** Auto-approval tuning. */
+  autoApprove?: AutoApproveWorkerConfig;
 }
 
 /** Builds a worker runtime from injected dependencies. */
@@ -102,8 +120,35 @@ export function registerAutoFixWorker(registry: WorkerRegistry): WorkerRegistry 
           submitter: deps.submitter,
           defaultAutoFixRetries: deps.autoFix?.defaultAutoFixRetries,
           getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
+          getAutoFixExecutionModel: deps.autoFix?.getAutoFixExecutionModel,
         },
       }),
   });
+  return registry;
+}
+
+/** Register the built-in auto-approval worker. */
+export function registerAutoApproveWorker(registry: WorkerRegistry): WorkerRegistry {
+  registry.register({
+    kind: AUTO_APPROVE_WORKER_KIND,
+    note: 'Approves AI-applied fixes that are awaiting approval when enabled.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createAutoApproveWorker({
+        logger: deps.logger,
+        messageBus: deps.messageBus,
+        autoApprove: {
+          store: deps.store,
+          submitter: deps.submitter,
+          getAutoApproveAIFixes: deps.autoApprove?.getAutoApproveAIFixes,
+        },
+      }),
+  });
+  return registry;
+}
+
+/** Register every built-in worker in the stable built-in order. */
+export function registerBuiltinWorkers(registry: WorkerRegistry): WorkerRegistry {
+  registerAutoFixWorker(registry);
+  registerAutoApproveWorker(registry);
   return registry;
 }

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -1,0 +1,407 @@
+import type { Logger } from '@invoker/contracts';
+import type {
+  WorkerActionRecord,
+  WorkerActionStatus,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+
+import type { WorkflowLifecycleEvent } from '../lifecycle-events.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const AUTO_APPROVE_WORKER_KIND = 'autoapprove';
+
+const DEFAULT_AUTO_APPROVE_POLL_INTERVAL_MS = 60_000;
+const HEADLESS_EXEC_CHANNEL = 'headless.exec';
+const AUTO_APPROVE_ACTION_TYPE = 'approve-ai-fix';
+
+type AutoApproveActionStatus = WorkerActionStatus | 'stale';
+
+export interface AutoApproveWorkerStore {
+  listWorkflows(): ReadonlyArray<{ id: string }>;
+  loadTasks(workflowId: string): TaskState[];
+  loadTask?(taskId: string): TaskState | undefined;
+  listWorkflowMutationIntents?(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[];
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
+  listWorkerActions?(filters?: { workerKind?: string; status?: string; limit?: number }): WorkerActionRecord[];
+  logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+}
+
+export interface AutoApproveWorkerSubmitter {
+  submit(
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: typeof HEADLESS_EXEC_CHANNEL,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number;
+}
+
+export interface AutoApproveWorkerPolicyOptions {
+  store: AutoApproveWorkerStore;
+  submitter: AutoApproveWorkerSubmitter;
+  logger: Logger;
+  getAutoApproveAIFixes?: () => boolean | undefined;
+}
+
+export interface AutoApproveCandidate {
+  taskId: string;
+  workflowId: string;
+  generation: number;
+  taskStateVersion: number;
+  attemptId?: string;
+  pendingFixError?: string;
+  task: TaskState;
+}
+
+function workflowIdForTask(task: TaskState, fallbackWorkflowId?: string): string | undefined {
+  return task.config.workflowId ?? fallbackWorkflowId ?? task.id.split('/')[0];
+}
+
+export function autoApproveActionKey(candidate: Pick<AutoApproveCandidate, 'taskId' | 'generation' | 'taskStateVersion' | 'attemptId'>): string {
+  return [
+    candidate.taskId,
+    `g${candidate.generation}`,
+    `v${candidate.taskStateVersion}`,
+    `a${candidate.attemptId ?? 'none'}`,
+  ].join(':');
+}
+
+function candidateFromTask(task: TaskState, fallbackWorkflowId?: string): AutoApproveCandidate | undefined {
+  const workflowId = workflowIdForTask(task, fallbackWorkflowId);
+  if (!workflowId) return undefined;
+  return {
+    taskId: task.id,
+    workflowId,
+    generation: task.execution.generation ?? 0,
+    taskStateVersion: task.taskStateVersion,
+    attemptId: task.execution.selectedAttemptId,
+    pendingFixError: task.execution.pendingFixError,
+    task,
+  };
+}
+
+export function listAutoApproveScanCandidates(
+  options: Pick<AutoApproveWorkerPolicyOptions, 'store'>,
+): AutoApproveCandidate[] {
+  const candidates: AutoApproveCandidate[] = [];
+  for (const workflow of options.store.listWorkflows()) {
+    for (const task of options.store.loadTasks(workflow.id)) {
+      if (task.status !== 'awaiting_approval') continue;
+      const candidate = candidateFromTask(task, workflow.id);
+      if (candidate) candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+
+function isOpenActionStatus(status: string): boolean {
+  return status === 'queued' || status === 'pending' || status === 'running';
+}
+
+function isTerminalQueuedActionStatus(status: string): boolean {
+  return isOpenActionStatus(status) || status === 'completed';
+}
+
+function coerceActionStatus(status: AutoApproveActionStatus): WorkerActionStatus {
+  return status as WorkerActionStatus;
+}
+
+function actionIdForKey(externalKey: string): string {
+  return `${AUTO_APPROVE_WORKER_KIND}:${externalKey}`;
+}
+
+function taskPayload(candidate: AutoApproveCandidate, payload: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    generation: candidate.generation,
+    taskStateVersion: candidate.taskStateVersion,
+    attemptId: candidate.attemptId ?? null,
+    hasPendingFixError: candidate.pendingFixError !== undefined,
+    ...payload,
+  };
+}
+
+function recordAutoApproveAction(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+  status: AutoApproveActionStatus,
+  summary: string,
+  payload: Record<string, unknown> = {},
+  intentId?: number | string,
+): WorkerActionRecord | undefined {
+  const externalKey = autoApproveActionKey(candidate);
+  const existing = options.store.getWorkerAction?.(AUTO_APPROVE_WORKER_KIND, externalKey);
+  const now = new Date().toISOString();
+  return options.store.upsertWorkerAction?.({
+    id: existing?.id ?? actionIdForKey(externalKey),
+    workerKind: AUTO_APPROVE_WORKER_KIND,
+    actionType: AUTO_APPROVE_ACTION_TYPE,
+    workflowId: candidate.workflowId,
+    taskId: candidate.taskId,
+    subjectType: 'task',
+    subjectId: candidate.taskId,
+    externalKey,
+    status: coerceActionStatus(status),
+    attemptCount: status === 'queued' ? (existing?.attemptCount ?? 0) + 1 : existing?.attemptCount ?? 0,
+    ...(intentId !== undefined ? { intentId: String(intentId) } : {}),
+    summary,
+    payload: taskPayload(candidate, payload),
+    updatedAt: now,
+    ...(status === 'skipped' || status === 'stale' ? { completedAt: now } : {}),
+  });
+}
+
+function logAutoApproveWorkerEvent(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+  phase: string,
+  details: Record<string, unknown>,
+): void {
+  const payload = {
+    phase,
+    worker: AUTO_APPROVE_WORKER_KIND,
+    workflowId: candidate.workflowId,
+    generation: candidate.generation,
+    taskStateVersion: candidate.taskStateVersion,
+    attemptId: candidate.attemptId ?? null,
+    ...details,
+  };
+  options.store.logEvent?.(candidate.taskId, 'debug.auto-approve', payload);
+  options.logger.debug?.(`[worker:${AUTO_APPROVE_WORKER_KIND}] ${phase}`, {
+    module: 'auto-approve-worker',
+    taskId: candidate.taskId,
+    ...payload,
+  });
+}
+
+type HeadlessExecPayload = {
+  args?: unknown[];
+};
+
+function isApproveIntentForTask(intent: WorkflowMutationIntent, taskId: string): boolean {
+  if (intent.channel !== HEADLESS_EXEC_CHANNEL) return false;
+  const payload = intent.args[0] as HeadlessExecPayload | undefined;
+  const args = Array.isArray(payload?.args) ? payload.args : [];
+  return args[0] === 'approve' && args[1] === taskId;
+}
+
+function listOpenApproveIntentsForTask(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+): WorkflowMutationIntent[] {
+  const open = options.store.listWorkflowMutationIntents?.(candidate.workflowId, ['queued', 'running']) ?? [];
+  return open.filter((intent) => isApproveIntentForTask(intent, candidate.taskId));
+}
+
+function loadTaskForAction(
+  options: AutoApproveWorkerPolicyOptions,
+  action: WorkerActionRecord,
+): TaskState | undefined {
+  if (action.taskId) {
+    const direct = options.store.loadTask?.(action.taskId);
+    if (direct) return direct;
+  }
+  if (!action.workflowId) return undefined;
+  return options.store.loadTasks(action.workflowId).find((task) => task.id === action.taskId);
+}
+
+function staleReasonForAction(
+  action: WorkerActionRecord,
+  task: TaskState | undefined,
+): { stale: true; reason: string; candidate?: AutoApproveCandidate } | { stale: false; candidate?: AutoApproveCandidate } {
+  if (!task) {
+    return { stale: true, reason: 'task-not-found' };
+  }
+  const candidate = candidateFromTask(task, action.workflowId);
+  if (!candidate) {
+    return { stale: true, reason: 'workflow-not-found' };
+  }
+  if (task.status !== 'awaiting_approval') {
+    return { stale: true, reason: 'status-changed', candidate };
+  }
+  if (task.execution.pendingFixError === undefined) {
+    return { stale: true, reason: 'pending-fix-cleared', candidate };
+  }
+  if (autoApproveActionKey(candidate) !== action.externalKey) {
+    return { stale: true, reason: 'lineage-changed', candidate };
+  }
+  return { stale: false, candidate };
+}
+
+function markStaleQueuedActions(options: AutoApproveWorkerPolicyOptions): void {
+  const actions = options.store.listWorkerActions?.({ workerKind: AUTO_APPROVE_WORKER_KIND }) ?? [];
+  for (const action of actions) {
+    if (!isOpenActionStatus(action.status)) continue;
+    const task = loadTaskForAction(options, action);
+    const stale = staleReasonForAction(action, task);
+    if (!stale.stale) continue;
+    const candidate = stale.candidate ?? {
+      taskId: action.taskId ?? action.subjectId,
+      workflowId: action.workflowId ?? '',
+      generation: 0,
+      taskStateVersion: 0,
+      task: task ?? ({
+        id: action.taskId ?? action.subjectId,
+        description: '',
+        status: 'stale',
+        dependencies: [],
+        createdAt: new Date(0),
+        config: {},
+        execution: {},
+        taskStateVersion: 0,
+      } as TaskState),
+    };
+    recordAutoApproveAction(options, candidate, 'stale', `Stale auto-approval: ${stale.reason}`, {
+      reason: stale.reason,
+      previousStatus: action.status,
+      previousExternalKey: action.externalKey,
+      latestStatus: task?.status ?? null,
+    }, action.intentId);
+    logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-stale', {
+      reason: stale.reason,
+      previousExternalKey: action.externalKey,
+      previousStatus: action.status,
+    });
+  }
+}
+
+export function createAutoApproveTick(options: AutoApproveWorkerPolicyOptions): WorkerTick {
+  return async () => {
+    markStaleQueuedActions(options);
+    const enabled = options.getAutoApproveAIFixes?.() === true;
+    const submittedThisTick = new Set<string>();
+
+    for (const candidate of listAutoApproveScanCandidates(options)) {
+      const externalKey = autoApproveActionKey(candidate);
+      if (submittedThisTick.has(externalKey)) {
+        recordAutoApproveAction(options, candidate, 'skipped', 'Skipped duplicate auto-approval candidate', {
+          reason: 'duplicate-candidate',
+        });
+        continue;
+      }
+      if (candidate.pendingFixError === undefined) {
+        recordAutoApproveAction(options, candidate, 'skipped', 'Skipped non-AI approval gate', {
+          reason: 'missing-pending-fix-error',
+        });
+        logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-skip', {
+          reason: 'missing-pending-fix-error',
+        });
+        continue;
+      }
+      if (!enabled) {
+        recordAutoApproveAction(options, candidate, 'skipped', 'Skipped auto-approval because autoApproveAIFixes is disabled', {
+          reason: 'auto-approve-disabled',
+        });
+        logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-skip', {
+          reason: 'auto-approve-disabled',
+        });
+        continue;
+      }
+
+      const existing = options.store.getWorkerAction?.(AUTO_APPROVE_WORKER_KIND, externalKey);
+      if (existing && isTerminalQueuedActionStatus(existing.status)) {
+        logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-skip', {
+          reason: 'already-recorded',
+          existingStatus: existing.status,
+          intentId: existing.intentId ?? null,
+        });
+        continue;
+      }
+
+      const openApproveIntents = listOpenApproveIntentsForTask(options, candidate);
+      if (openApproveIntents.length > 0) {
+        const intentId = openApproveIntents[0]?.id;
+        recordAutoApproveAction(options, candidate, 'queued', 'Auto-approval already queued', {
+          reason: 'already-queued-intent',
+          existingIntentIds: openApproveIntents.map((intent) => intent.id),
+        }, intentId);
+        submittedThisTick.add(externalKey);
+        continue;
+      }
+
+      const intentId = options.submitter.submit(candidate.workflowId, 'normal', HEADLESS_EXEC_CHANNEL, [
+        { args: ['approve', candidate.taskId], noTrack: true },
+      ]);
+      recordAutoApproveAction(options, candidate, 'queued', 'Queued auto-approval for AI fix', {
+        channel: HEADLESS_EXEC_CHANNEL,
+      }, intentId);
+      submittedThisTick.add(externalKey);
+      logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-submitted', {
+        intentId,
+        channel: HEADLESS_EXEC_CHANNEL,
+      });
+    }
+  };
+}
+
+export interface AutoApproveWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  messageBus?: MessageBus;
+  autoApprove?: Omit<AutoApproveWorkerPolicyOptions, 'logger'>;
+  onTick?: WorkerTick;
+}
+
+export function createAutoApproveWorker(options: AutoApproveWorkerOptions): WorkerRuntime {
+  let lifecycleUnsubscribe: Unsubscribe | undefined;
+  const onTick = options.onTick ?? (
+    options.autoApprove
+      ? createAutoApproveTick({
+        ...options.autoApprove,
+        logger: options.logger,
+      })
+      : (() => {})
+  );
+  const runtime = createWorkerRuntime({
+    kind: AUTO_APPROVE_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_AUTO_APPROVE_POLL_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick,
+  });
+
+  if (!options.messageBus || !options.autoApprove || options.onTick) {
+    return runtime;
+  }
+
+  const start = (): void => {
+    if (!lifecycleUnsubscribe) {
+      lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
+        Channels.WORKFLOW_LIFECYCLE,
+        (event) => {
+          if (event.kind === 'task.awaiting_approval') {
+            runtime.wake('wake');
+          }
+        },
+      );
+    }
+    runtime.start();
+  };
+  const stop = async (): Promise<void> => {
+    lifecycleUnsubscribe?.();
+    lifecycleUnsubscribe = undefined;
+    await runtime.stop();
+  };
+
+  return {
+    identity: runtime.identity,
+    start,
+    wake: runtime.wake,
+    tick: runtime.tick,
+    stop,
+    isRunning: runtime.isRunning,
+  };
+}


### PR DESCRIPTION
## Summary

The execution engine now routes auto-fix and auto-approve through the worker registry.

Auto-fix records worker actions, and auto-approve owns AI fix approvals when enabled.

<details>
<summary>Review metadata</summary>

Review Claim: Built-in worker routing covers auto-fix and auto-approve behavior in the execution engine.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Workers reload persisted task state before acting and keep using existing mutation intent channels.

Slice Rationale: The registry route is the shared dependency for action recording and worker-owned approval.

</details>

## Non-goals

- Do not change headless or CLI command entry points in this slice.
- Do not add worker-to-worker relay messages.
- Do not remove the existing auto-fix guard behavior.

## Architecture

### Before

```mermaid
graph TD
    A["Auto-fix worker registration"] --> B["Recovery worker runtime"]
    C["Fix finalization"] --> D["Inline approval"]
```

### After

```mermaid
graph TD
    A["Built-in worker routing"] --> B["Auto-fix worker runtime"]
    A --> C["Auto-approve worker runtime"]
    C --> D["Approval mutation intent"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/worker-registry.test.ts src/__tests__/auto-approve-worker.test.ts`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/auto-fix-intents.test.ts src/__tests__/auto-fix-recovery.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/worker-registration-step-2-2.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No