### PR TITLE
[Worker Registration Step 2: Registry, Auto-Fix, and Auto-Approve](3) Use built-in worker doors

### DIFF
--- a/packages/app/src/__tests__/resolve-conflict-action.test.ts
+++ b/packages/app/src/__tests__/resolve-conflict-action.test.ts
@@ -56,7 +56,7 @@ describe('resolveConflictAction', () => {
     expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
 
-  it('auto-approves after conflict resolution when configured', async () => {
+  it('leaves conflict resolution awaiting worker approval when auto approval is configured', async () => {
     const approve = vi.fn(async () => [{ id: 'task-a', status: 'completed', config: {}, execution: {} }]);
     const getTask = orchestrator.getTask;
     orchestrator = {
@@ -78,7 +78,7 @@ describe('resolveConflictAction', () => {
     });
 
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');
-    expect(approve).toHaveBeenCalledWith('task-a');
+    expect(approve).not.toHaveBeenCalled();
     expect(taskExecutorWithApprove.executeTasks).not.toHaveBeenCalled();
     expect(taskExecutorWithApprove.publishAfterFix).not.toHaveBeenCalled();
   });

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -492,7 +492,7 @@ describe('finalizeAppliedFix', () => {
     expect(orchestrator.approve).not.toHaveBeenCalled();
   });
 
-  it('auto-approves and returns runnable tasks when enabled', async () => {
+  it('leaves task awaiting approval even when autoApproveAIFixes is enabled', async () => {
     const started = [
       makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } }),
     ];
@@ -518,16 +518,15 @@ describe('finalizeAppliedFix', () => {
       autoApproveAIFixes: true,
     });
 
-    expect(result).toEqual({ autoApproved: true, started });
-    expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
-    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'task-a' }),
-    );
+    expect(result).toEqual({ autoApproved: false, started: [] });
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-error');
+    expect(orchestrator.approve).not.toHaveBeenCalled();
+    expect(taskExecutor.commitApprovedFix).not.toHaveBeenCalled();
     expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
   });
 
-  it('auto-approves and publishes post-fix merge gates when enabled', async () => {
+  it('does not inline publish post-fix merge gates when autoApproveAIFixes is enabled', async () => {
     const started = [
       makeRunningTask({ id: 'merge-a', config: { workflowId: 'wf-1', isMergeNode: true } }),
     ];
@@ -548,16 +547,16 @@ describe('finalizeAppliedFix', () => {
       executeTasks: vi.fn(),
     };
 
-    await finalizeAppliedFix('merge-a', 'saved-error', {
+    const result = await finalizeAppliedFix('merge-a', 'saved-error', {
       orchestrator: orchestrator as unknown as Orchestrator,
       taskExecutor: taskExecutor as unknown as TaskRunner,
       autoApproveAIFixes: true,
     });
 
-    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'merge-a' }),
-    );
-    expect(taskExecutor.publishAfterFix).toHaveBeenCalledWith(started[0]);
+    expect(result).toEqual({ autoApproved: false, started: [] });
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('merge-a', 'saved-error');
+    expect(taskExecutor.commitApprovedFix).not.toHaveBeenCalled();
+    expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
     expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
@@ -859,10 +858,11 @@ describe('autoFixOnFailure', () => {
       }),
     );
     expect(orchestrator.retryTask).not.toHaveBeenCalled();
-    expect(taskExecutor.publishAfterFix).toHaveBeenCalledWith(started[0]);
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('merge-a', 'boom');
+    expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
   });
 
-  it('retries inline when merge post-fix publish fails during auto-fix dispatch', async () => {
+  it('does not inline publish or retry merge post-fix approval during auto-fix dispatch', async () => {
     const started = [
       makeRunningTask({ id: 'merge-a', config: { workflowId: 'wf-1', isMergeNode: true } }),
     ];
@@ -878,8 +878,8 @@ describe('autoFixOnFailure', () => {
       { status: 'failed', execution: { autoFixAttempts: 0, workspacePath: '/tmp/merge-a', selectedAttemptId: 'att-1', generation: 1 } },
       // Phase 1: after fix returns, lineage check + finalize + approveTask (cycle 1)
       { status: 'awaiting_approval', execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a', pendingFixError: 'boom', selectedAttemptId: 'att-1', generation: 1 } },
-      // Phase 2: post-finalize check — task re-failed after publish
-      { status: 'failed', execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a', error: 'Post-fix PR prep failed: conflict', selectedAttemptId: 'att-1', generation: 1 } },
+      // Phase 2: post-finalize check — approval is now owned by the auto-approve worker.
+      { status: 'awaiting_approval', execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a', pendingFixError: 'boom', selectedAttemptId: 'att-1', generation: 1 } },
       // Phase 3: inline retry entry + lineage capture (cycle 2)
       { status: 'failed', execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a', selectedAttemptId: 'att-3', generation: 3 } },
       // Phase 4: after fix returns, lineage check + finalize + approveTask (cycle 2)
@@ -942,10 +942,10 @@ describe('autoFixOnFailure', () => {
       getAutoApproveAIFixes: () => true,
     });
 
-    expect(taskExecutor.fixWithAgent).toHaveBeenCalledTimes(2);
-    expect(taskExecutor.execGitIn).toHaveBeenCalledTimes(2);
-    expect(taskExecutor.publishAfterFix).toHaveBeenCalledTimes(2);
-    expect(persistence.logEvent).toHaveBeenCalledWith(
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledTimes(1);
+    expect(taskExecutor.execGitIn).toHaveBeenCalledTimes(1);
+    expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
+    expect(persistence.logEvent).not.toHaveBeenCalledWith(
       'merge-a',
       'debug.auto-fix',
       expect.objectContaining({

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -319,6 +319,7 @@ export async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promis
       recreateOutputLabel: 'Fix with AI',
       failureOutputLabel: 'Fix with AI',
       reviewGateContext: parsed.reviewGateContext,
+      executionModel: parsed.executionModel,
       signal: deps.signal,
     });
     await finalizeMutationWithGlobalTopup({

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -17,7 +17,7 @@ import {
   TaskRunner,
   acquireWorkerLock,
   createWorkerRegistry,
-  registerAutoFixWorker,
+  registerBuiltinWorkers,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
 } from '@invoker/execution-engine';
@@ -415,7 +415,7 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
 
 async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0] ?? 'list';
-  const registry = registerAutoFixWorker(createWorkerRegistry());
+  const registry = registerBuiltinWorkers(createWorkerRegistry());
 
   if (subCommand === 'list') {
     process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);
@@ -474,6 +474,10 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
       autoFix: {
         defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
+        getAutoFixExecutionModel: () => deps.invokerConfig.autoFixExecutionModel,
+      },
+      autoApprove: {
+        getAutoApproveAIFixes: () => deps.invokerConfig.autoApproveAIFixes,
       },
     });
     await worker.tick('manual');
@@ -483,7 +487,11 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
     // blocks the next legitimate start.
     lock.release();
   }
-  const label = definition.kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : definition.kind;
+  const label = definition.kind === AUTO_FIX_WORKER_KIND
+    ? 'Auto-fix'
+    : definition.kind === 'autoapprove'
+      ? 'Auto-approve'
+      : definition.kind;
   process.stdout.write(`${label} worker scan completed.\n`);
 }
 
@@ -594,7 +602,7 @@ ${BOLD}Lifecycle:${RESET}
   delete-all                                          Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
   open-terminal <taskId>                              Open OS terminal for a task
   slack                                               Start Slack bot (long-running)
-  worker [kind|list|status]                           Run/list registry worker kinds (autofix scans failed tasks)
+  worker [kind|list|status]                           Run/list registry worker kinds
 
 ${BOLD}Deprecated${RESET} (use new names above):
   list → query workflows       status → query tasks       task-status → query task
@@ -951,4 +959,3 @@ async function headlessSetTaskMetadata(
   );
   process.stdout.write(`Updated task "${result.id}" ${result.fieldPath} → ${JSON.stringify(result.value)}\n`);
 }
-

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -833,6 +833,7 @@ export async function fixWithAgentAction(
     recreateOutputLabel?: string;
     failureOutputLabel?: string;
     reviewGateContext?: ReviewGateCiContext;
+    executionModel?: string;
     signal?: AbortSignal;
   } = {},
 ): Promise<FixWithAgentActionResult> {
@@ -875,11 +876,17 @@ export async function fixWithAgentAction(
   try {
     assertLineageCurrent(lineage, orchestrator, options.signal);
     if (recoveryRoute.kind === 'resolveConflict') {
-      await taskExecutor.resolveConflict(taskId, persistedSavedError, options.agentName);
+      if (options.executionModel !== undefined) {
+        await taskExecutor.resolveConflict(taskId, persistedSavedError, options.agentName, options.executionModel);
+      } else {
+        await taskExecutor.resolveConflict(taskId, persistedSavedError, options.agentName);
+      }
     } else {
       const output = persistence.getTaskOutput(taskId);
       const fixContext = options.reviewGateContext?.fixContext;
-      if (fixContext !== undefined) {
+      if (options.executionModel !== undefined) {
+        await taskExecutor.fixWithAgent(taskId, output, options.agentName, persistedSavedError, fixContext, options.executionModel);
+      } else if (fixContext !== undefined) {
         await taskExecutor.fixWithAgent(taskId, output, options.agentName, persistedSavedError, fixContext);
       } else {
         await taskExecutor.fixWithAgent(taskId, output, options.agentName, persistedSavedError);
@@ -919,13 +926,7 @@ export async function finalizeAppliedFix(
   }
   if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
   deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
-  if (!deps.autoApproveAIFixes) {
-    return { autoApproved: false, started: [] };
-  }
-
-  if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
-  const { started } = await approveTask(taskId, deps);
-  return { autoApproved: true, started };
+  return { autoApproved: false, started: [] };
 }
 
 // ── Auto-fix helpers ─────────────────────────────────────────
@@ -1122,6 +1123,7 @@ export async function autoFixOnFailure(
     taskExecutor: TaskRunner;
     mutationTiming?: WorkflowMutationTiming;
     getAutoFixAgent?: () => string | undefined;
+    getAutoFixExecutionModel?: () => string | undefined;
     getAutoApproveAIFixes?: () => boolean | undefined;
     signal?: AbortSignal;
   },
@@ -1154,6 +1156,10 @@ export async function autoFixOnFailure(
   persistence.updateTask(taskId, { execution: { autoFixAttempts: attempts } });
 
   const agentSelection = resolveAutoFixAgent(deps.getAutoFixAgent?.());
+  const configuredExecutionModel = deps.getAutoFixExecutionModel?.()?.trim();
+  const executionModel = configuredExecutionModel && configuredExecutionModel.length > 0
+    ? configuredExecutionModel
+    : undefined;
   let persistedSavedError: string | undefined;
   let lineage: TaskLineageSnapshot | undefined;
   try {
@@ -1163,6 +1169,7 @@ export async function autoFixOnFailure(
       selectedAgent: agentSelection.selectedAgent,
       selectedAgentSource: agentSelection.selectedAgentSource,
       fallbackChain: agentSelection.fallbackChain,
+      executionModel: executionModel ?? null,
     });
     persistence.appendTaskOutput(
       taskId,
@@ -1231,10 +1238,18 @@ export async function autoFixOnFailure(
       savedErrorLength: persistedSavedError.length,
     });
     if (recoveryRoute.kind === 'resolveConflict') {
-      await taskExecutor.resolveConflict(taskId, persistedSavedError, agentSelection.selectedAgent);
+      if (executionModel !== undefined) {
+        await taskExecutor.resolveConflict(taskId, persistedSavedError, agentSelection.selectedAgent, executionModel);
+      } else {
+        await taskExecutor.resolveConflict(taskId, persistedSavedError, agentSelection.selectedAgent);
+      }
     } else {
       const output = persistence.getTaskOutput(taskId);
-      await taskExecutor.fixWithAgent(taskId, output, agentSelection.selectedAgent, persistedSavedError);
+      if (executionModel !== undefined) {
+        await taskExecutor.fixWithAgent(taskId, output, agentSelection.selectedAgent, persistedSavedError, undefined, executionModel);
+      } else {
+        await taskExecutor.fixWithAgent(taskId, output, agentSelection.selectedAgent, persistedSavedError);
+      }
     }
     assertLineageCurrent(lineage, orchestrator, deps.signal);
     const postRouteStrategy = selectAutoFixPostRouteStrategy(task);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -11,7 +11,7 @@ import {
   WorktreeExecutor,
   acquireWorkerLock,
   createWorkerRegistry,
-  registerAutoFixWorker,
+  registerBuiltinWorkers,
   WorkerLockHeldError,
   registerBuiltinAgents,
   type WorkerDefinition,
@@ -129,7 +129,7 @@ function usage(): string {
     '  doctor          Validate tools, config, and your default planning preset.',
     '  setup [slack]    Validate the environment, then optionally configure Slack.',
     '  mcp             Start the Invoker MCP stdio server.',
-    '  worker [kind|list]  Run a registry-selected worker or list available worker kinds.',
+    '  worker [kind|list]  Run a built-in worker or list available worker kinds.',
     '',
     'Options:',
     '  --live           Require a running Invoker UI owner and submit over IPC.',
@@ -447,7 +447,12 @@ async function createDefaultMessageBus(): Promise<MessageBus> {
  * Read the auto-fix policy knobs from the shared Invoker config so the CLI door
  * drives the engine with the same retry budget / agent the GUI owner uses.
  */
-function readAutoFixWorkerConfig(homeRoot: string): { autoFixRetries?: number; autoFixAgent?: string } {
+function readAutoFixWorkerConfig(homeRoot: string): {
+  autoFixRetries?: number;
+  autoFixAgent?: string;
+  autoFixExecutionModel?: string;
+  autoApproveAIFixes?: boolean;
+} {
   const configPath = join(homeRoot, 'config.json');
   if (!existsSync(configPath)) return {};
   try {
@@ -455,6 +460,8 @@ function readAutoFixWorkerConfig(homeRoot: string): { autoFixRetries?: number; a
     return {
       autoFixRetries: typeof parsed.autoFixRetries === 'number' ? parsed.autoFixRetries : undefined,
       autoFixAgent: typeof parsed.autoFixAgent === 'string' ? parsed.autoFixAgent : undefined,
+      autoFixExecutionModel: typeof parsed.autoFixExecutionModel === 'string' ? parsed.autoFixExecutionModel : undefined,
+      autoApproveAIFixes: typeof parsed.autoApproveAIFixes === 'boolean' ? parsed.autoApproveAIFixes : undefined,
     };
   } catch {
     return {};
@@ -462,11 +469,12 @@ function readAutoFixWorkerConfig(homeRoot: string): { autoFixRetries?: number; a
 }
 
 function workerDisplayName(kind: string): string {
+  if (kind === 'autoapprove') return 'Auto-approve';
   return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind;
 }
 
 function printWorkerKinds(): void {
-  const registry = registerAutoFixWorker(createWorkerRegistry());
+  const registry = registerBuiltinWorkers(createWorkerRegistry());
   process.stdout.write('Worker kinds\n');
   for (const worker of registry.list()) {
     process.stdout.write(`  ${worker.kind} — available (${worker.note})\n`);
@@ -484,7 +492,7 @@ function printWorkerKinds(): void {
 async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
-  const { autoFixRetries, autoFixAgent } = readAutoFixWorkerConfig(homeRoot);
+  const { autoFixRetries, autoFixAgent, autoFixExecutionModel, autoApproveAIFixes } = readAutoFixWorkerConfig(homeRoot);
 
   // Single-instance guard: refuse if another worker of this kind (this door or
   // the dev `--headless worker <kind>` door) already holds the cross-process
@@ -519,6 +527,10 @@ async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise
       autoFix: {
         defaultAutoFixRetries: autoFixRetries,
         getAutoFixAgent: () => autoFixAgent,
+        getAutoFixExecutionModel: () => autoFixExecutionModel,
+      },
+      autoApprove: {
+        getAutoApproveAIFixes: () => autoApproveAIFixes,
       },
     });
 
@@ -557,7 +569,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     }
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';
-      const registry = registerAutoFixWorker(createWorkerRegistry());
+      const registry = registerBuiltinWorkers(createWorkerRegistry());
       if (subcommand === 'list') {
         printWorkerKinds();
         return 0;


### PR DESCRIPTION
## Summary

Headless and CLI worker commands now use built-in worker registration.

The app action path passes model metadata and leaves AI approval for the worker.

<details>
<summary>Review metadata</summary>

Review Claim: Headless and CLI command surfaces use the built-in worker registry with the new policy knobs.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The surfaces call existing mutation paths and only pass optional model and approval settings.

Slice Rationale: Command activation waits until config and engine worker pieces exist.

</details>

## Non-goals

- Do not change the main-process standalone auto-fix scheduling path here.
- Do not change worker registry internals in this slice.
- Do not auto-approve inline after fix finalization.

## Architecture

### Before

```mermaid
graph TD
    A["Headless and CLI worker commands"] --> B["Auto-fix-only registration"]
    C["Fix finalization"] --> D["Inline approval path"]
```

### After

```mermaid
graph TD
    A["Headless and CLI worker commands"] --> B["Built-in worker registry"]
    C["Fix finalization"] --> D["Awaiting worker approval"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/resolve-conflict-action.test.ts src/__tests__/workflow-actions.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/worker-registration-step-2-3.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No