### PR TITLE
[Worker Registration Step 2: Registry, Auto-Fix, and Auto-Approve](4) Route main auto-fix model

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1369,15 +1369,20 @@ function startHeadlessMode(): void {
             });
             return;
           }
-          const configuredAgent = loadConfig().autoFixAgent?.trim();
+          const autoFixConfig = loadConfig();
+          const configuredAgent = autoFixConfig.autoFixAgent?.trim();
           const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
+          const configuredExecutionModel = autoFixConfig.autoFixExecutionModel?.trim();
+          const executionModel = configuredExecutionModel && configuredExecutionModel.length > 0
+            ? configuredExecutionModel
+            : undefined;
           logStandaloneAutoFixDebug(taskId, 'schedule-enqueue');
           logStandaloneAutoFixDebug(taskId, 'schedule-enqueued');
           void workflowMutationCoordinator.enqueue(
             workflowId,
             'normal',
             'invoker:fix-with-agent',
-            buildFixWithAgentMutationArgs(taskId, selectedAgent, { autoFix: true }),
+            buildFixWithAgentMutationArgs(taskId, selectedAgent, { autoFix: true, executionModel }),
           )
             .then(() => {
               logStandaloneAutoFixDebug(taskId, 'schedule-dispatch-finished');
@@ -2007,6 +2012,7 @@ function createEmbeddedTerminalBackendFromConfig(
     taskId: string,
     agentName?: string,
     source: 'ipc' | 'auto-fix' = 'ipc',
+    executionModel?: string,
   ): Promise<TaskState[]> => {
     const task = orchestrator.getTask(taskId);
     if (!task) {
@@ -2045,6 +2051,7 @@ function createEmbeddedTerminalBackendFromConfig(
         recoveryRoute,
         recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
         failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`,
+        executionModel,
         signal: activeMutationContext?.signal,
       },
     );
@@ -2083,16 +2090,21 @@ function createEmbeddedTerminalBackendFromConfig(
       });
       return;
     }
-    const configuredAgent = loadConfig().autoFixAgent?.trim();
+    const autoFixConfig = loadConfig();
+    const configuredAgent = autoFixConfig.autoFixAgent?.trim();
     const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
+    const configuredExecutionModel = autoFixConfig.autoFixExecutionModel?.trim();
+    const executionModel = configuredExecutionModel && configuredExecutionModel.length > 0
+      ? configuredExecutionModel
+      : undefined;
     logAutoFixDebug(taskId, 'schedule-enqueue');
     logAutoFixDebug(taskId, 'schedule-enqueued');
     void runWorkflowMutation(
       workflowId,
       'normal',
       'invoker:fix-with-agent',
-      [taskId, selectedAgent],
-      async () => executeFixWithAgentMutation(taskId, selectedAgent, 'auto-fix'),
+      buildFixWithAgentMutationArgs(taskId, selectedAgent, { autoFix: true, executionModel }),
+      async () => executeFixWithAgentMutation(taskId, selectedAgent, 'auto-fix', executionModel),
     )
       .then(() => {
         logAutoFixDebug(taskId, 'schedule-dispatch-finished');


### PR DESCRIPTION
## Summary

The main process now routes standalone auto-fix requests with execution model metadata.

This keeps UI-owner auto-fix behavior aligned with the other auto-fix paths.

<details>
<summary>Review metadata</summary>

Review Claim: Main-process routing preserves configured model metadata for standalone auto-fix requests.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The routing only adds optional metadata to the existing fix-with-agent mutation path.

Slice Rationale: Main-process routing lands after the shared action path understands execution models.

</details>

## Non-goals

- Do not change renderer UI behavior.
- Do not change worker registration or CLI behavior in this slice.
- Do not change default model selection.

## Architecture

### Before

```mermaid
graph TD
    A["Main-process auto-fix"] --> B["Fix-with-agent mutation"]
    B --> C["Agent selection"]
```

### After

```mermaid
graph TD
    A["Main-process auto-fix"] --> B["Fix-with-agent mutation"]
    B --> C["Agent selection plus execution model"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/workflow-actions.test.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/worker-registration-step-2-4.md --require-visual-proof`

## Visual Proof

![Stacked workflows after main-process routing](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-dd5bd5/stacked-workflows.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No