### PR TITLE
Fix planner bridge GUI handler types

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3409,8 +3409,8 @@ function createEmbeddedTerminalBackendFromConfig(
       return { planName: plan.name, workflowId: workflow.id };
     }
 
-    registerGuiMutationHandler('invoker:plan-from-goal', async (request: InAppPlanRequest) => (
-      planFromGoalInApp(request, {
+    registerGuiMutationHandler('invoker:plan-from-goal', async (...args: unknown[]) => (
+      planFromGoalInApp(args[0] as InAppPlanRequest, {
         config: invokerConfig,
         workingDir: repoRoot,
         loadGeneratedPlan: loadGeneratedPlanPreview,


### PR DESCRIPTION
## Summary

This slice fixes the main-process type hole in the planner bridge. The GUI mutation registrar now accepts the terminal planning request without fighting the generic IPC handler signature.

It is a narrow safety fix. The bridge behavior stays the same.

<details>
<summary>Review metadata</summary>

Review Claim: The planner bridge now satisfies the app typecheck surface without changing runtime behavior.

Review Lane: behavior

Review Unit: contract

Safety Invariant: Only the handler signature changed. The request still flows to the same `planFromGoalInApp` implementation.

Slice Rationale: The bridge type fix unblocks CI for every downstream UI slice, so it lands before shell and proof work.

</details>

## Non-goals

- No renderer behavior changes.
- No planner prompt changes.
- No proof asset changes.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
