### PR TITLE
Stabilize shell redesign CI coverage

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1765,13 +1765,24 @@ test.describe('Visual proof capture', () => {
       { taskId: 'task-alpha', changes: { status: 'running', execution: { startedAt: now } } },
     ]);
 
-    // Switch to queue view to verify the compact cancel affordance on task rows
+    await page.evaluate(() => {
+      window.invoker.getQueueStatus = async () => ({
+        maxConcurrency: 5,
+        runningCount: 1,
+        running: [{ taskId: 'task-alpha', description: 'First test task' }],
+        queued: [],
+      });
+    });
+    await page.waitForTimeout(2200);
+
+
+    // Switch to queue view to verify the compact terminate affordance on task rows
     await selectGraphMenuItem(page, 'rail-queue');
     await expect(page.getByRole('heading', { name: /Action Queue/ })).toBeVisible();
-    const cancelButton = page
-      .locator('[data-row-id$="/task-alpha"]')
-      .getByRole('button', { name: 'Cancel task-alpha' });
-    await expect(cancelButton).toBeVisible();
+    const terminateButton = page
+      .locator('[data-row-id$="task-alpha"]')
+      .getByRole('button', { name: 'Terminate' });
+    await expect(terminateButton).toBeVisible();
 
     // Switch back to DAG view and right-click the running task for context menu
     await selectGraphMenuItem(page, 'rail-home');
@@ -1804,15 +1815,17 @@ test.describe('Visual proof capture', () => {
       { taskId: 'task-alpha', changes: { status: 'running', execution: { startedAt: now } } },
     ]);
 
+    await page.waitForTimeout(2200);
+
     // Navigate to queue view
-    await page.getByRole('button', { name: 'Queue' }).click();
+    await selectGraphMenuItem(page, 'rail-queue');
     await expect(page.getByRole('heading', { name: /Action Queue/ })).toBeVisible();
 
-    // Assert the action queue row renders the compact cancel affordance
     const actionRow = page.locator('[data-row-id$="task-alpha"]');
     await expect(actionRow).toBeVisible();
-    const cancelButton = actionRow.getByRole('button', { name: 'Cancel task-alpha' });
-    await expect(cancelButton).toBeVisible();
+    // Assert the action queue row renders the compact terminate affordance
+    const terminateButton = actionRow.getByRole('button', { name: 'Terminate' });
+    await expect(terminateButton).toBeVisible();
 
     // Assert no visible priority metadata line on the row
     await expect(actionRow.locator('text=priority:')).not.toBeVisible();
@@ -1832,6 +1845,19 @@ test.describe('Visual proof capture', () => {
       // qh-downstream stays pending with unmet dep on qh-running → Backlog
     ]);
 
+    await page.evaluate(() => {
+      window.invoker.getQueueStatus = async () => ({
+        maxConcurrency: 5,
+        runningCount: 2,
+        running: [
+          { taskId: 'qh-running', description: 'Running task with downstream' },
+          { taskId: 'qh-fixing', description: 'Fixing task with AI' },
+        ],
+        queued: [],
+      });
+    });
+    await page.waitForTimeout(2200);
+
     // Navigate to queue view
     await selectGraphMenuItem(page, 'rail-queue');
     // Assert canonical Action Queue and Backlog headings
@@ -1841,11 +1867,11 @@ test.describe('Visual proof capture', () => {
     // Assert canonical action queue labels are present
     await expect(page.locator('text=running').first()).toBeVisible();
 
-    // Assert the running task row exposes the compact cancel affordance
-    const cancelButton = page
-      .locator('[data-row-id$="/qh-running"]')
-      .getByRole('button', { name: 'Cancel qh-running' });
-    await expect(cancelButton).toBeVisible();
+    // Assert the running task row exposes the compact terminate affordance
+    const terminateButton = page
+      .locator('[data-row-id$="qh-running"]')
+      .getByRole('button', { name: 'Terminate' });
+    await expect(terminateButton).toBeVisible();
 
     // Assert downstream dependent shows its dependency in Backlog
     await expect(page.getByText('deps: qh-running')).toBeVisible();

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -297,7 +297,8 @@ describe('Context menu (component)', () => {
     await waitFor(() => expect(screen.getByTestId('workflow-node-wf-1-core-activity')).toHaveTextContent('Pending: queued for launch'));
     expect(workflowNode).not.toHaveTextContent(/Rebase|Recreate|invoker:rebase-recreate/);
 
-    fireEvent.click(screen.getByText('Action Graph'));
+    fireEvent.click(screen.getByTestId('graph-more-button'));
+    fireEvent.click(await screen.findByTestId('rail-action-graph'));
     fireEvent.click(await screen.findByTestId('rf__node-intent:77'));
     expect(await screen.findByTestId('workflow-inspector-action-node')).toHaveTextContent('invoker:rebase-recreate');
   });

--- a/packages/ui/src/__tests__/plan-loading.test.tsx
+++ b/packages/ui/src/__tests__/plan-loading.test.tsx
@@ -66,12 +66,12 @@ describe('Plan loading (component)', () => {
 
   it('empty state disappears after tasks are loaded', async () => {
     render(<App />);
-    expect(screen.getByText('Load a plan to render workflow graph')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-graph-surface')).toHaveTextContent('Your plan will appear here.');
 
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
-      expect(screen.queryByText('Load a plan to render workflow graph')).not.toBeInTheDocument();
+      expect(screen.getByTestId('workflow-graph-surface')).not.toHaveTextContent('Your plan will appear here.');
     });
   });
 


### PR DESCRIPTION
## Summary

This slice aligns the shell redesign tests with the new layout. The queue, context-menu, and empty-state tests now look for the graph-header controls and the new empty-state copy.

It keeps the redesign slices green without changing production UI behavior.

<details>
<summary>Review metadata</summary>

Review Claim: The redesign-compatible UI and proof tests now match the shell that already shipped in the earlier slices.

Review Lane: proof

Review Unit: proof

Safety Invariant: This slice changes test and proof files only. Production behavior is unchanged.

Slice Rationale: These compatibility fixes belong after the layout settles and before the later proof-only slices.

</details>

## Non-goals

- No production UI behavior changes.
- No planner bridge changes.
- No new proof screenshots.

## Test Plan

- [x] `bash scripts/workspace-test.sh`
- [x] `pnpm --filter @invoker/app test:e2e -- e2e/action-graph-visual-proof.spec.ts`
- [x] `pnpm --filter @invoker/app test:e2e -- e2e/visual-proof.spec.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
