### PR TITLE
[Invoker UI Reskin Step 2: Shell and Terminal Experience](1) Activate shell workspace

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -32,8 +32,9 @@ import { FloatingGraphPanel } from './components/FloatingGraphPanel.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
 import { groupWorkflowCoreActivity } from './lib/workflow-core-activity.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
-import { WorkflowStatusChips } from './components/WorkflowStatusChips.js';
 import { TerminalDrawer, type TerminalDrawerState } from './components/TerminalDrawer.js';
+import { InvokerTerminal, type InvokerTerminalLine, type InvokerTerminalLineKind } from './components/InvokerTerminal.js';
+import { LeftStatusColumn, type ShellViewMode, type StatusColumnItem } from './components/LeftStatusColumn.js';
 import {
   isExperimentSpawnPivotTask,
   EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE,
@@ -66,6 +67,7 @@ type WorkflowContextMenuState = { x: number; y: number; workflowId: string; retu
 type SearchResult =
   | { kind: 'workflow'; id: string; title: string; subtitle: string }
   | { kind: 'task'; id: string; workflowId: string | null; title: string; subtitle: string };
+type GraphPresentation = 'normal' | 'maximized';
 
 const KEYBOARD_REGION_ORDER: readonly KeyboardRegion[] = ['workflowGraph', 'taskGraph', 'inspector', 'bottomBar'];
 const SIDEBAR_NAV_ITEM_SELECTOR = '[data-sidebar-nav-item]';
@@ -91,6 +93,28 @@ const EDITABLE_SELECTOR = [
   '[role="dialog"] textarea',
 ].join(',');
 const SYSTEM_SETUP_AUTO_OPEN_DELAY_MS = 1200;
+const ATTENTION_STATUSES = new Set<TaskState['status']>([
+  'failed',
+  'blocked',
+  'needs_input',
+  'review_ready',
+  'awaiting_approval',
+]);
+const INITIAL_TERMINAL_LINES: InvokerTerminalLine[] = [
+  {
+    id: 'welcome',
+    kind: 'system',
+    text: 'Start with a goal.',
+  },
+];
+
+function parsePlanGoal(command: string): string | null {
+  const trimmed = command.trim();
+  const quoted = /^plan\s+"([^"]+)"\s*$/i.exec(trimmed);
+  if (quoted) return quoted[1].trim();
+  const unquoted = /^plan\s+(.+)$/i.exec(trimmed);
+  return unquoted?.[1].trim() || null;
+}
 
 function sidebarNavOrder(item: HTMLElement): number {
   const order = Number(item.dataset.sidebarNavOrder);
@@ -365,6 +389,39 @@ function GearIcon(): JSX.Element {
   );
 }
 
+function WhatToExpectPanel(): JSX.Element {
+  return (
+    <section className="rounded-lg border border-gray-800 bg-[#10130f] p-4">
+      <h2 className="text-sm font-semibold text-gray-100">What to expect</h2>
+      <div className="mt-3 space-y-3 text-sm text-gray-300">
+        <div>
+          <div className="font-medium text-gray-100">Plan</div>
+          <div className="mt-0.5 text-xs leading-5 text-gray-500">Turn a goal into an Invoker workflow.</div>
+        </div>
+        <div>
+          <div className="font-medium text-gray-100">Review</div>
+          <div className="mt-0.5 text-xs leading-5 text-gray-500">Inspect the graph and task details before execution.</div>
+        </div>
+        <div>
+          <div className="font-medium text-gray-100">Run</div>
+          <div className="mt-0.5 text-xs leading-5 text-gray-500">Use run to execute.</div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function EmptyPlanState(): JSX.Element {
+  return (
+    <div className="flex h-full items-center justify-center px-6 text-center">
+      <div>
+        <h2 className="text-lg font-semibold text-gray-100">Start with a goal.</h2>
+        <p className="mt-2 text-sm text-gray-500">Your plan will appear here.</p>
+      </div>
+    </div>
+  );
+}
+
 export function hasMergeConflictExecution(task: TaskState | undefined): boolean {
   if (!task) return false;
   if (task.execution.mergeConflict) return true;
@@ -426,7 +483,11 @@ export function App() {
   const [hasStarted, setHasStarted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
   const [selectedActionNodeId, setSelectedActionNodeId] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
+  const [viewMode, setViewMode] = useState<ShellViewMode>('dag');
+  const [terminalLines, setTerminalLines] = useState<InvokerTerminalLine[]>(INITIAL_TERMINAL_LINES);
+  const [terminalInput, setTerminalInput] = useState('');
+  const [plannerBusy, setPlannerBusy] = useState(false);
+  const [graphPresentation, setGraphPresentation] = useState<GraphPresentation>('normal');
   const selectedActionNode = useMemo(
     () => actionGraph?.nodes.find((node) => node.id === selectedActionNodeId) ?? null,
     [actionGraph, selectedActionNodeId],
@@ -480,6 +541,7 @@ export function App() {
   const [searchActiveIndex, setSearchActiveIndex] = useState(0);
   const uiPerfThrottleRef = useRef<Record<string, number>>({});
   const systemSetupAutoOpenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const terminalLineSequenceRef = useRef(0);
 
   const cancelPendingSystemSetupAutoOpen = useCallback(() => {
     if (systemSetupAutoOpenTimerRef.current !== null) {
@@ -500,6 +562,17 @@ export function App() {
 
   const lastShiftAtRef = useRef(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const appendTerminalLine = useCallback((kind: InvokerTerminalLineKind, text: string) => {
+    terminalLineSequenceRef.current += 1;
+    setTerminalLines((prev) => [
+      ...prev,
+      {
+        id: `${kind}-${terminalLineSequenceRef.current}`,
+        kind,
+        text,
+      },
+    ]);
+  }, []);
 
   const refreshSystemDiagnostics = useCallback(() => {
     window.invoker?.getSystemDiagnostics?.().then((diagnostics) => {
@@ -785,6 +858,39 @@ export function App() {
     }
     return STATUS_KEY_ORDER.filter((key) => key === 'completed' || key === 'running' || key === 'failed' || key === 'pending' || (counts.get(key) ?? 0) > 0);
   }, [workflows]);
+  const attentionItems = useMemo<StatusColumnItem[]>(
+    () =>
+      [...tasks.values()]
+        .filter((task) => ATTENTION_STATUSES.has(task.status))
+        .slice(0, 5)
+        .map((task) => ({
+          id: task.id,
+          label: task.description || task.id,
+          detail: task.status.replaceAll('_', ' '),
+        })),
+    [tasks],
+  );
+  const runningItems = useMemo<StatusColumnItem[]>(
+    () => {
+      const queueRunning = queueStatus?.running ?? [];
+      if (queueRunning.length > 0) {
+        return queueRunning.slice(0, 5).map((entry) => ({
+          id: entry.taskId,
+          label: entry.description || entry.taskId,
+          detail: entry.taskId,
+        }));
+      }
+      return [...tasks.values()]
+        .filter((task) => task.status === 'running' || task.status === 'fixing_with_ai')
+        .slice(0, 5)
+        .map((task) => ({
+          id: task.id,
+          label: task.description || task.id,
+          detail: task.status.replaceAll('_', ' '),
+        }));
+    },
+    [queueStatus, tasks],
+  );
 
   const searchResults = useMemo<SearchResult[]>(() => {
     const query = normalizedSearchText(searchQuery.trim());
@@ -1038,6 +1144,12 @@ export function App() {
 
       if (isEditableKeyboardTarget(event.target) || modal.type !== 'none') return;
 
+      if (graphPresentation === 'maximized' && event.key === 'Escape') {
+        event.preventDefault();
+        setGraphPresentation('normal');
+        return;
+      }
+
       // F1 is the keyboard-only camera lock control. It is already ignored for
       // input/modal/terminal/editable targets by the guard above.
       if (event.key === 'F1') {
@@ -1180,6 +1292,7 @@ export function App() {
     bottomStatusIndex,
     contextMenu,
     focusKeyboardRegion,
+    graphPresentation,
     handleStatusClick,
     issueCameraCommand,
     keyboardRegion,
@@ -1557,7 +1670,6 @@ export function App() {
         // Parse locally just for UI display state
         const parsed = yaml.load(planText) as any;
         setPlanName(parsed?.name ?? 'Untitled Plan');
-        setOnFinish(parsed?.onFinish ?? 'merge');
         refreshTaskGraph();
       } catch (err) {
         console.error('Failed to load plan:', err);
@@ -1616,15 +1728,87 @@ export function App() {
       setHasLoadedPlan(false);
       setHasStarted(false);
       setPlanName(null);
-      setOnFinish('merge');
       setSelectedTaskId(null);
       setSelectedWorkflowId(null);
       setModal({ type: 'none' });
       setStatusFilters(new Set<WorkflowStatus>());
+      setGraphPresentation('normal');
+      setTerminalInput('');
+      setTerminalLines(INITIAL_TERMINAL_LINES);
     } catch (err) {
       console.error('Failed to clear:', err);
     }
   }, [invoker, clearTasks]);
+
+  const handleTerminalSubmit = useCallback(async () => {
+    const command = terminalInput.trim();
+    if (!command || plannerBusy) return;
+
+    setTerminalInput('');
+    appendTerminalLine('command', command);
+
+    const goal = parsePlanGoal(command);
+    if (goal) {
+      if (!invoker?.planFromGoal) {
+        appendTerminalLine('error', 'Planner is not available in this window.');
+        return;
+      }
+
+      setPlannerBusy(true);
+      try {
+        const result = await invoker.planFromGoal({ goal });
+        if (!result.ok) {
+          appendTerminalLine('error', result.error);
+          return;
+        }
+
+        setWorkflowSelectionDismissed(false);
+        setHasLoadedPlan(true);
+        setHasStarted(false);
+        setPlanName(result.planName);
+        setSelectedTaskId(null);
+        setSelectedWorkflowId(result.workflowId);
+        setViewMode('dag');
+        await refreshTaskGraph();
+        appendTerminalLine('success', `Plan "${result.planName}" loaded. Use run to execute.`);
+      } catch (err) {
+        appendTerminalLine('error', err instanceof Error ? err.message : String(err));
+      } finally {
+        setPlannerBusy(false);
+      }
+      return;
+    }
+
+    if (/^(run|start)$/i.test(command)) {
+      if (!hasLoadedPlan) {
+        appendTerminalLine('error', 'Load a plan before running.');
+        return;
+      }
+      await handleStart();
+      appendTerminalLine('success', 'Run started.');
+      return;
+    }
+
+    if (/^help$/i.test(command)) {
+      appendTerminalLine('system', 'Commands: plan "your goal", run, clear.');
+      return;
+    }
+
+    if (/^clear$/i.test(command)) {
+      setTerminalLines(INITIAL_TERMINAL_LINES);
+      return;
+    }
+
+    appendTerminalLine('error', `Unknown command "${command}".`);
+  }, [
+    appendTerminalLine,
+    handleStart,
+    hasLoadedPlan,
+    invoker,
+    plannerBusy,
+    refreshTaskGraph,
+    terminalInput,
+  ]);
 
   const handleDeleteDB = useCallback(async () => {
     if (!invoker) return;
@@ -1901,234 +2085,192 @@ export function App() {
         </div>
       )}
       {/* Main content */}
-      <div className="flex-1 flex overflow-hidden">
-        <nav className="w-24 border-r border-gray-800 bg-gray-950/60 flex flex-col justify-between py-3">
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept=".json,.yaml,.yml"
-            onChange={handleFileSelect}
-            className="hidden"
-          />
-          <div className="space-y-3 px-2">
-            <div className="space-y-1">
-              <button
-                data-testid="rail-open-file"
-                onClick={() => fileInputRef.current?.click()}
-                className="w-full rounded bg-gray-700 px-2 py-1.5 text-left text-xs font-medium text-gray-100 hover:bg-gray-600"
-              >
-                Open
-              </button>
-              {showStart && (
-                <button
-                  data-testid="rail-start"
-                  onClick={handleStart}
-                  className="w-full rounded bg-green-700 px-2 py-1.5 text-left text-xs font-medium text-white hover:bg-green-600"
-                >
-                  Start
-                </button>
-              )}
-              {showStop && (
-                <button
-                  data-testid="rail-stop"
-                  onClick={handleStop}
-                  className="w-full rounded bg-red-700 px-2 py-1.5 text-left text-xs font-medium text-white hover:bg-red-600"
-                >
-                  Stop
-                </button>
-              )}
-              {planName && (
-                <div className="truncate px-1 pt-1 text-[10px] leading-tight text-gray-500" title={planName}>
-                  {planName}
-                </div>
-              )}
-            </div>
+      <div className="flex min-h-0 flex-1 overflow-hidden bg-[#0b0f14]">
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".json,.yaml,.yml"
+          onChange={handleFileSelect}
+          className="hidden"
+        />
 
-            <div className="space-y-1">
-            <button
-              data-testid="rail-home"
-              onClick={() => {
-                setViewMode('dag');
-              }}
-              className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'dag' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
-            >
-              Home
-            </button>
-            <button
-              data-testid="rail-timeline"
-              onClick={() => {
-                setViewMode('timeline');
-              }}
-              className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'timeline' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
-            >
-              Timeline
-            </button>
-            <button
-              data-testid="rail-history"
-              onClick={() => {
-                setViewMode('history');
-              }}
-              className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'history' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
-            >
-              History
-            </button>
-            <button
-              data-testid="rail-action-graph"
-              onClick={() => {
-                setViewMode('actionGraph');
-                setWorkflowSelectionDismissed(true);
-                setSelectedTaskId(null);
-              }}
-              className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'actionGraph' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
-            >
-              Action Graph
-            </button>
-            <button
-              data-testid="rail-queue"
-              onClick={() => {
-                setViewMode('queue');
-              }}
-              className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'queue' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
-            >
-              Queue
-            </button>
-            </div>
+        <LeftStatusColumn
+          planName={planName}
+          workflowCount={workflows.size}
+          activeView={viewMode}
+          showStart={showStart}
+          showStop={showStop}
+          onOpenFile={() => fileInputRef.current?.click()}
+          onStart={handleStart}
+          onStop={handleStop}
+          onSelectView={(view) => {
+            setViewMode(view);
+            if (view === 'actionGraph') {
+              setWorkflowSelectionDismissed(true);
+              setSelectedTaskId(null);
+            }
+          }}
+          onRefresh={handleRefresh}
+          onClear={handleClear}
+          onDeleteHistory={handleDeleteDB}
+          onOpenSettings={() => { cancelPendingSystemSetupAutoOpen(); setShowSystemSetup(true); }}
+          attentionItems={attentionItems}
+          runningItems={runningItems}
+          visibleStatusKeys={visibleStatusKeys}
+          activeStatusKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
+          onStatusClick={handleStatusClick}
+          settingsIcon={<GearIcon />}
+        />
 
-            <div className="space-y-1 border-t border-gray-800 pt-3">
-              <button
-                data-testid="rail-refresh"
-                onClick={handleRefresh}
-                className="w-full rounded px-2 py-1.5 text-left text-xs text-gray-300 hover:bg-gray-800/70"
-              >
-                Refresh
-              </button>
-              <button
-                data-testid="rail-clear"
-                onClick={handleClear}
-                className="w-full rounded px-2 py-1.5 text-left text-xs text-gray-300 hover:bg-gray-800/70"
-              >
-                Clear
-              </button>
-              <button
-                data-testid="rail-delete-history"
-                onClick={handleDeleteDB}
-                className="w-full rounded px-2 py-1.5 text-left text-xs text-red-300 hover:bg-red-950/50"
-              >
-                Delete
-              </button>
-            </div>
-          </div>
-          <div className="px-2">
-            <button
-              data-testid="rail-settings"
-              onClick={() => { cancelPendingSystemSetupAutoOpen(); setShowSystemSetup(true); }}
-              className="flex h-8 w-full items-center justify-center rounded text-gray-300 hover:bg-gray-800/70 hover:text-white"
-              aria-label="Settings"
-              title="Settings"
-            >
-              <GearIcon />
-            </button>
-          </div>
-        </nav>
-
-        <div className="flex-1 flex overflow-hidden">
-          <div className="flex-1 flex flex-col overflow-hidden">
-            <div
-              ref={graphSurfaceRef}
-              data-testid="workflow-graph-surface"
-              data-keyboard-region="workflowGraph"
-              tabIndex={0}
-              data-keyboard-active={keyboardRegion === 'workflowGraph' ? 'true' : 'false'}
-              className={`flex-1 relative overflow-hidden border-r border-gray-800 bg-gray-900 outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
-              onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
-            >
-              {viewMode === 'queue' ? (
-                <QueueView
-                  tasks={tasks}
-                  queueStatus={queueStatus}
-                  onTaskClick={handleTaskClick}
-                  onCancel={handleCancelTask}
-                  selectedTaskId={selectedTaskId}
+        <div className="flex min-w-0 flex-1 overflow-hidden">
+          <main className="flex min-w-0 flex-1 flex-col gap-3 overflow-hidden px-4 py-4">
+            {viewMode === 'dag' && graphPresentation === 'normal' && (
+              <div className="grid shrink-0 grid-cols-[minmax(0,1fr)_280px] gap-3">
+                <InvokerTerminal
+                  lines={terminalLines}
+                  input={terminalInput}
+                  busy={plannerBusy}
+                  onInputChange={setTerminalInput}
+                  onSubmit={handleTerminalSubmit}
                 />
-              ) : viewMode === 'history' ? (
-                <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
-              ) : viewMode === 'timeline' ? (
-                <TimelineView tasks={tasks} onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
-              ) : viewMode === 'actionGraph' ? (
-                <ActionGraphView
-                  graph={actionGraph}
-                  error={actionGraphError}
-                  selectedNodeId={selectedActionNodeId}
-                  onSelectNode={(node) => {
-                    setSelectedActionNodeId(node?.id ?? null);
-                    if (node?.taskId) setSelectedTaskId(node.taskId);
-                    if (node?.workflowId) setSelectedWorkflowId(node.workflowId);
-                  }}
-                />
-              ) : (
-                <>
-                  <WorkflowGraph
-                    workflows={workflows}
-                    selectedWorkflowId={selectedWorkflow?.id ?? null}
-                    cameraCommand={cameraCommand}
-                    statusFilters={statusFilters}
-                    coreActivityByWorkflow={coreActivityByWorkflow}
-                    onSelectWorkflow={handleWorkflowClick}
-                    onWorkflowContextMenu={handleWorkflowContextMenu}
-                    onManualViewport={handleManualViewport}
-                  />
-                  {displayedSelectedWorkflowGraph !== null && (
-                    <FloatingGraphPanel
-                      key={displayedSelectedWorkflowGraph.workflow.id}
-                      testId="selected-workflow-mini-dag"
-                      dragHandleTestId="selected-workflow-mini-dag-drag-handle"
-                      title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
-                      boundsRef={graphSurfaceRef}
-                      contentClassName="h-[250px]"
-                    >
-                      <div
-                        data-keyboard-region="taskGraph"
-                        tabIndex={0}
-                        data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
-                        className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
-                      >
-                        {isSelectedWorkflowGraphRefreshing && (
-                          <div data-testid="selected-workflow-mini-dag-refreshing" className="px-2 py-1 text-xs text-amber-200">
-                            Refreshing graph…
-                          </div>
-                        )}
-                        <TaskDAG
-                          tasks={displayedSelectedWorkflowGraph.tasks}
-                          workflows={selectedTaskDagWorkflows}
-                          selectedTaskId={selectedTaskId}
-                          cameraCommand={cameraCommand}
-                          onTaskClick={handleTaskClick}
-                          onTaskDoubleClick={handleTaskDoubleClick}
-                          onTaskContextMenu={handleTaskContextMenu}
-                          onManualViewport={handleManualViewport}
-                          statusFilters={new Set()}
-                          runningTaskIds={runningTaskIds}
-                        />
-                      </div>
-                    </FloatingGraphPanel>
+                <WhatToExpectPanel />
+              </div>
+            )}
+
+            <section
+              data-testid={graphPresentation === 'maximized' ? 'graph-maximized-overlay' : 'center-shell'}
+              role={graphPresentation === 'maximized' ? 'dialog' : undefined}
+              aria-modal={graphPresentation === 'maximized' ? true : undefined}
+              aria-label={graphPresentation === 'maximized' ? 'Full workflow graph' : undefined}
+              className={
+                graphPresentation === 'maximized'
+                  ? 'fixed inset-4 z-50 flex flex-col overflow-hidden rounded-lg border border-gray-700 bg-gray-950 shadow-2xl'
+                  : 'flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-gray-800 bg-gray-950/60'
+              }
+            >
+              <div className="flex shrink-0 items-center justify-between gap-3 border-b border-gray-800 px-4 py-3">
+                <div className="min-w-0">
+                  <h2 className="truncate text-sm font-semibold text-gray-100">
+                    {viewMode === 'queue'
+                      ? 'Queue'
+                      : viewMode === 'history'
+                        ? 'History'
+                        : viewMode === 'timeline'
+                          ? 'Timeline'
+                          : viewMode === 'actionGraph'
+                            ? 'Action graph'
+                            : 'Workflow graph'}
+                  </h2>
+                  {viewMode === 'dag' && (
+                    <p className="mt-0.5 text-xs text-gray-500">
+                      {workflows.size === 0 ? 'Your plan will appear here.' : `${workflows.size} active workflow${workflows.size === 1 ? '' : 's'}`}
+                    </p>
                   )}
-                </>
-              )}
-            </div>
+                </div>
+                {viewMode === 'dag' && (
+                  <button
+                    type="button"
+                    onClick={() => setGraphPresentation((prev) => (prev === 'maximized' ? 'normal' : 'maximized'))}
+                    className="shrink-0 rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+                  >
+                    {graphPresentation === 'maximized' ? 'Close full graph' : 'View full graph'}
+                  </button>
+                )}
+              </div>
 
-            {viewMode === 'dag' && (
+              <div
+                ref={graphSurfaceRef}
+                data-testid="workflow-graph-surface"
+                data-keyboard-region="workflowGraph"
+                tabIndex={0}
+                data-keyboard-active={keyboardRegion === 'workflowGraph' ? 'true' : 'false'}
+                className={`relative min-h-0 flex-1 overflow-hidden bg-gray-900 outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+                onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
+              >
+                {viewMode === 'queue' ? (
+                  <QueueView
+                    tasks={tasks}
+                    queueStatus={queueStatus}
+                    onTaskClick={handleTaskClick}
+                    onCancel={handleCancelTask}
+                    selectedTaskId={selectedTaskId}
+                  />
+                ) : viewMode === 'history' ? (
+                  <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
+                ) : viewMode === 'timeline' ? (
+                  <TimelineView tasks={tasks} onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
+                ) : viewMode === 'actionGraph' ? (
+                  <ActionGraphView
+                    graph={actionGraph}
+                    error={actionGraphError}
+                    selectedNodeId={selectedActionNodeId}
+                    onSelectNode={(node) => {
+                      setSelectedActionNodeId(node?.id ?? null);
+                      if (node?.taskId) setSelectedTaskId(node.taskId);
+                      if (node?.workflowId) setSelectedWorkflowId(node.workflowId);
+                    }}
+                  />
+                ) : workflows.size === 0 ? (
+                  <EmptyPlanState />
+                ) : (
+                  <>
+                    <WorkflowGraph
+                      workflows={workflows}
+                      selectedWorkflowId={selectedWorkflow?.id ?? null}
+                      cameraCommand={cameraCommand}
+                      statusFilters={statusFilters}
+                      coreActivityByWorkflow={coreActivityByWorkflow}
+                      onSelectWorkflow={handleWorkflowClick}
+                      onWorkflowContextMenu={handleWorkflowContextMenu}
+                      onManualViewport={handleManualViewport}
+                    />
+                    {displayedSelectedWorkflowGraph !== null && (
+                      <FloatingGraphPanel
+                        key={displayedSelectedWorkflowGraph.workflow.id}
+                        testId="selected-workflow-mini-dag"
+                        dragHandleTestId="selected-workflow-mini-dag-drag-handle"
+                        title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
+                        boundsRef={graphSurfaceRef}
+                        contentClassName="h-[250px]"
+                      >
+                        <div
+                          data-keyboard-region="taskGraph"
+                          tabIndex={0}
+                          data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
+                          className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
+                        >
+                          {isSelectedWorkflowGraphRefreshing && (
+                            <div data-testid="selected-workflow-mini-dag-refreshing" className="px-2 py-1 text-xs text-amber-200">
+                              Refreshing graph...
+                            </div>
+                          )}
+                          <TaskDAG
+                            tasks={displayedSelectedWorkflowGraph.tasks}
+                            workflows={selectedTaskDagWorkflows}
+                            selectedTaskId={selectedTaskId}
+                            cameraCommand={cameraCommand}
+                            onTaskClick={handleTaskClick}
+                            onTaskDoubleClick={handleTaskDoubleClick}
+                            onTaskContextMenu={handleTaskContextMenu}
+                            onManualViewport={handleManualViewport}
+                            statusFilters={new Set()}
+                            runningTaskIds={runningTaskIds}
+                          />
+                        </div>
+                      </FloatingGraphPanel>
+                    )}
+                  </>
+                )}
+              </div>
+            </section>
+
+            {viewMode === 'dag' && graphPresentation === 'normal' && (
               <div
                 data-keyboard-region="bottomBar"
                 tabIndex={0}
                 data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
-                className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+                className={`shrink-0 outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
               >
-                <WorkflowStatusChips
-                  workflows={workflows}
-                  activeFilters={statusFilters}
-                  keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
-                  onStatusClick={handleStatusClick}
-                />
                 <TerminalDrawer
                   state={terminalDrawerState}
                   onCycle={() =>
@@ -2144,13 +2286,13 @@ export function App() {
                 />
               </div>
             )}
-          </div>
+          </main>
 
           <div
             data-keyboard-region="inspector"
             tabIndex={0}
             data-keyboard-active={keyboardRegion === 'inspector' ? 'true' : 'false'}
-            className={`${inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+            className={`${inspectorCollapsed ? 'w-16' : 'w-96'} shrink-0 border-l border-gray-800 bg-gray-950/50 transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
           >
             <WorkflowInspector
               workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
@@ -2331,4 +2473,3 @@ export function App() {
     </div>
   );
 }
-

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -35,7 +35,13 @@ describe('App launch (component)', () => {
 
   it('shows empty state prompt when no plan is loaded', () => {
     render(<App />);
-    expect(screen.getByText('Load a plan to render workflow graph')).toBeInTheDocument();
+    expect(screen.getAllByText('Start with a goal.')[0]).toBeInTheDocument();
+    expect(screen.getByText('Invoker Terminal')).toBeInTheDocument();
+    expect(screen.getByText('What to expect')).toBeInTheDocument();
+    expect(screen.getAllByText('Your plan will appear here.')[0]).toBeInTheDocument();
+    expect(screen.getByText('No runs yet')).toBeInTheDocument();
+    expect(screen.getByText('All clear')).toBeInTheDocument();
+    expect(screen.getByText('No tasks running')).toBeInTheDocument();
   });
 
   it('renders left rail navigation and workflow controls', () => {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -111,6 +111,11 @@ export function createMockInvoker(
     onTaskOutput: vi.fn(() => () => {}),
     onActivityLog: vi.fn(() => () => {}),
     loadPlan: vi.fn(async () => {}),
+    planFromGoal: vi.fn(async () => ({
+      ok: true,
+      planName: 'Mock Plan',
+      workflowId: 'wf-mock',
+    })),
     start: vi.fn(async () => taskSnapshot),
     stop: vi.fn(async () => {}),
     clear: vi.fn(async () => {}),

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+describe('Invoker terminal (component)', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('plans from a quoted goal and then runs the loaded plan', async () => {
+    render(<App />);
+
+    const input = screen.getByLabelText('Invoker terminal input');
+    fireEvent.change(input, { target: { value: 'plan "Add README"' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(mock.api.planFromGoal).toHaveBeenCalledWith({ goal: 'Add README' });
+      expect(screen.getByText('Plan "Mock Plan" loaded. Use run to execute.')).toBeInTheDocument();
+    });
+
+    fireEvent.change(input, { target: { value: 'run' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(mock.api.start).toHaveBeenCalled();
+      expect(screen.getByText('Run started.')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/__tests__/plan-loading.test.tsx
+++ b/packages/ui/src/__tests__/plan-loading.test.tsx
@@ -66,12 +66,12 @@ describe('Plan loading (component)', () => {
 
   it('empty state disappears after tasks are loaded', async () => {
     render(<App />);
-    expect(screen.getByText('Load a plan to render workflow graph')).toBeInTheDocument();
+    expect(screen.getAllByText('Your plan will appear here.')[0]).toBeInTheDocument();
 
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
-      expect(screen.queryByText('Load a plan to render workflow graph')).not.toBeInTheDocument();
+      expect(screen.queryByText('Your plan will appear here.')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -130,6 +130,31 @@ describe('Task interaction (component)', () => {
     expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
   });
 
+  it('maximizes the workflow graph and closes it with Escape without clearing selection', async () => {
+    render(<App />);
+    act(() => mock.setTasks([alpha, beta], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'View full graph' }));
+    expect(screen.getByTestId('graph-maximized-overlay')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('graph-maximized-overlay')).not.toBeInTheDocument();
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+    });
+  });
+
   it('drags the selected workflow mini DAG by its header', async () => {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -142,6 +142,7 @@ describe('Terminal drawer (component)', () => {
       expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
     });
     expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'minimized');
+    expect(screen.getByText('Task terminals')).toBeInTheDocument();
     expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
   });
 

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1,0 +1,96 @@
+import type { FormEvent } from 'react';
+
+export type InvokerTerminalLineKind = 'system' | 'command' | 'success' | 'error';
+
+export interface InvokerTerminalLine {
+  id: string;
+  kind: InvokerTerminalLineKind;
+  text: string;
+}
+
+interface InvokerTerminalProps {
+  lines: InvokerTerminalLine[];
+  input: string;
+  busy: boolean;
+  onInputChange: (value: string) => void;
+  onSubmit: () => void;
+}
+
+const LINE_CLASS_BY_KIND: Record<InvokerTerminalLineKind, string> = {
+  system: 'text-gray-400',
+  command: 'text-cyan-100',
+  success: 'text-emerald-200',
+  error: 'text-red-200',
+};
+
+const PROMPT_BY_KIND: Record<InvokerTerminalLineKind, string> = {
+  system: 'invoker',
+  command: '$',
+  success: 'ok',
+  error: 'error',
+};
+
+export function InvokerTerminal({
+  lines,
+  input,
+  busy,
+  onInputChange,
+  onSubmit,
+}: InvokerTerminalProps): JSX.Element {
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    onSubmit();
+  };
+
+  return (
+    <section
+      data-testid="invoker-terminal"
+      className="flex min-h-[220px] flex-col overflow-hidden rounded-lg border border-gray-800 bg-[#080b10]"
+    >
+      <div className="flex items-center justify-between border-b border-gray-800 px-4 py-3">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-100">Invoker Terminal</h2>
+          <p className="mt-0.5 text-xs text-gray-500">Plan from a goal, then run when ready.</p>
+        </div>
+        {busy && (
+          <div role="status" className="rounded border border-amber-700/60 px-2 py-1 text-[11px] text-amber-200">
+            Planning
+          </div>
+        )}
+      </div>
+
+      <div
+        role="log"
+        aria-live="polite"
+        data-testid="invoker-terminal-transcript"
+        className="min-h-0 flex-1 space-y-1 overflow-auto px-4 py-3 font-mono text-[12px] leading-5"
+      >
+        {lines.map((line) => (
+          <div key={line.id} className={`flex gap-2 ${LINE_CLASS_BY_KIND[line.kind]}`}>
+            <span className="w-12 shrink-0 select-none text-gray-600">{PROMPT_BY_KIND[line.kind]}</span>
+            <span className="min-w-0 flex-1 break-words">{line.text}</span>
+          </div>
+        ))}
+      </div>
+
+      <form onSubmit={handleSubmit} className="flex items-center gap-2 border-t border-gray-800 px-3 py-3">
+        <span className="font-mono text-xs text-gray-500">$</span>
+        <input
+          aria-label="Invoker terminal input"
+          value={input}
+          disabled={busy}
+          onChange={(event) => onInputChange(event.target.value)}
+          placeholder='plan "Add README"'
+          className="min-w-0 flex-1 rounded border border-gray-700 bg-gray-950 px-3 py-2 font-mono text-sm text-gray-100 outline-none placeholder:text-gray-600 focus:border-cyan-500 disabled:cursor-wait disabled:opacity-70"
+        />
+        <button
+          type="submit"
+          disabled={busy || input.trim().length === 0}
+          className="rounded border border-cyan-700 bg-cyan-950 px-3 py-2 text-xs font-medium text-cyan-100 hover:bg-cyan-900 disabled:cursor-not-allowed disabled:border-gray-800 disabled:bg-gray-900 disabled:text-gray-600"
+        >
+          Send
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -1,0 +1,235 @@
+import type { MouseEvent } from 'react';
+import type { WorkflowStatus } from '../types.js';
+
+export type ShellViewMode = 'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph';
+
+export interface StatusColumnItem {
+  id: string;
+  label: string;
+  detail?: string;
+}
+
+interface LeftStatusColumnProps {
+  planName: string | null;
+  workflowCount: number;
+  activeView: ShellViewMode;
+  showStart: boolean;
+  showStop: boolean;
+  onOpenFile: () => void;
+  onStart: () => void;
+  onStop: () => void;
+  onSelectView: (view: ShellViewMode) => void;
+  onRefresh: () => void;
+  onClear: () => void;
+  onDeleteHistory: () => void;
+  onOpenSettings: () => void;
+  attentionItems: StatusColumnItem[];
+  runningItems: StatusColumnItem[];
+  visibleStatusKeys: readonly WorkflowStatus[];
+  activeStatusKey: WorkflowStatus | null;
+  onStatusClick: (status: WorkflowStatus, event: MouseEvent) => void;
+  settingsIcon: JSX.Element;
+}
+
+const NAV_ITEMS: Array<{ view: ShellViewMode; label: string; testId: string }> = [
+  { view: 'dag', label: 'Home', testId: 'rail-home' },
+  { view: 'timeline', label: 'Timeline', testId: 'rail-timeline' },
+  { view: 'history', label: 'History', testId: 'rail-history' },
+  { view: 'actionGraph', label: 'Action Graph', testId: 'rail-action-graph' },
+  { view: 'queue', label: 'Queue', testId: 'rail-queue' },
+];
+
+function sectionTitle(title: string): JSX.Element {
+  return <h2 className="text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-500">{title}</h2>;
+}
+
+export function LeftStatusColumn({
+  planName,
+  workflowCount,
+  activeView,
+  showStart,
+  showStop,
+  onOpenFile,
+  onStart,
+  onStop,
+  onSelectView,
+  onRefresh,
+  onClear,
+  onDeleteHistory,
+  onOpenSettings,
+  attentionItems,
+  runningItems,
+  visibleStatusKeys,
+  activeStatusKey,
+  onStatusClick,
+  settingsIcon,
+}: LeftStatusColumnProps): JSX.Element {
+  return (
+    <aside className="flex w-72 shrink-0 flex-col border-r border-gray-800 bg-[#080b10]">
+      <div className="min-h-0 flex-1 space-y-5 overflow-auto px-4 py-4">
+        <section className="space-y-3">
+          <div className="flex items-center justify-between gap-3">
+            {sectionTitle('Run')}
+            <button
+              data-testid="rail-open-file"
+              type="button"
+              onClick={onOpenFile}
+              className="rounded border border-gray-700 px-2 py-1 text-[11px] text-gray-300 hover:bg-gray-800"
+            >
+              Open
+            </button>
+          </div>
+
+          <div className="rounded-lg border border-gray-800 bg-gray-950/70 p-3">
+            {workflowCount === 0 ? (
+              <div className="text-sm font-medium text-gray-300">No runs yet</div>
+            ) : (
+              <div className="text-sm font-medium text-gray-200">
+                {workflowCount} {workflowCount === 1 ? 'run' : 'runs'}
+              </div>
+            )}
+            <div className="mt-1 truncate text-xs text-gray-500" title={planName ?? undefined}>
+              {planName ?? 'Start with a goal.'}
+            </div>
+            <div className="mt-3 flex gap-2">
+              {showStart && (
+                <button
+                  data-testid="rail-start"
+                  type="button"
+                  onClick={onStart}
+                  className="rounded border border-emerald-700 bg-emerald-950 px-3 py-1.5 text-xs font-medium text-emerald-100 hover:bg-emerald-900"
+                >
+                  Run
+                </button>
+              )}
+              {showStop && (
+                <button
+                  data-testid="rail-stop"
+                  type="button"
+                  onClick={onStop}
+                  className="rounded border border-red-800 bg-red-950 px-3 py-1.5 text-xs font-medium text-red-100 hover:bg-red-900"
+                >
+                  Stop
+                </button>
+              )}
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          {sectionTitle('Views')}
+          <div className="space-y-1">
+            {NAV_ITEMS.map((item) => (
+              <button
+                key={item.view}
+                data-testid={item.testId}
+                type="button"
+                onClick={() => onSelectView(item.view)}
+                className={`w-full rounded px-3 py-2 text-left text-xs ${
+                  activeView === item.view
+                    ? 'bg-gray-800 text-white'
+                    : 'text-gray-300 hover:bg-gray-800/70'
+                }`}
+              >
+                {item.label}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-2">
+          {sectionTitle('Attention')}
+          {attentionItems.length === 0 ? (
+            <div className="rounded-lg border border-gray-800 bg-gray-950/60 px-3 py-2 text-sm text-gray-400">All clear</div>
+          ) : (
+            <div data-testid="rail-attention" className="space-y-1">
+              {attentionItems.map((item) => (
+                <div key={item.id} className="rounded border border-amber-800/60 bg-amber-950/30 px-3 py-2">
+                  <div className="truncate text-sm text-amber-100">{item.label}</div>
+                  {item.detail && <div className="truncate text-xs text-amber-300/70">{item.detail}</div>}
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          {sectionTitle('Running Tasks')}
+          {runningItems.length === 0 ? (
+            <div className="rounded-lg border border-gray-800 bg-gray-950/60 px-3 py-2 text-sm text-gray-400">No tasks running</div>
+          ) : (
+            <div className="space-y-1">
+              {runningItems.map((item) => (
+                <div key={item.id} className="rounded border border-cyan-900/70 bg-cyan-950/20 px-3 py-2">
+                  <div className="truncate text-sm text-cyan-100">{item.label}</div>
+                  {item.detail && <div className="truncate text-xs text-cyan-300/70">{item.detail}</div>}
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
+
+        <section className="space-y-2">
+          {sectionTitle('Workflow Status')}
+          <div className="flex flex-wrap gap-1">
+            {visibleStatusKeys.map((key) => (
+              <button
+                key={key}
+                type="button"
+                data-testid={`workflow-status-pill-${key}`}
+                onClick={(event) => onStatusClick(key, event)}
+                className={`rounded border px-2 py-1 text-[11px] ${
+                  activeStatusKey === key
+                    ? 'border-blue-500 bg-blue-950 text-blue-100'
+                    : 'border-gray-800 bg-gray-950 text-gray-400 hover:bg-gray-800'
+                }`}
+              >
+                {key.replaceAll('_', ' ')}
+              </button>
+            ))}
+          </div>
+        </section>
+
+        <section className="space-y-1 border-t border-gray-800 pt-4">
+          <button
+            data-testid="rail-refresh"
+            type="button"
+            onClick={onRefresh}
+            className="w-full rounded px-3 py-2 text-left text-xs text-gray-300 hover:bg-gray-800/70"
+          >
+            Refresh
+          </button>
+          <button
+            data-testid="rail-clear"
+            type="button"
+            onClick={onClear}
+            className="w-full rounded px-3 py-2 text-left text-xs text-gray-300 hover:bg-gray-800/70"
+          >
+            Clear
+          </button>
+          <button
+            data-testid="rail-delete-history"
+            type="button"
+            onClick={onDeleteHistory}
+            className="w-full rounded px-3 py-2 text-left text-xs text-red-300 hover:bg-red-950/50"
+          >
+            Delete
+          </button>
+        </section>
+      </div>
+
+      <div className="border-t border-gray-800 p-3">
+        <button
+          data-testid="rail-settings"
+          type="button"
+          onClick={onOpenSettings}
+          className="flex h-9 w-full items-center justify-center rounded text-gray-300 hover:bg-gray-800/70 hover:text-white"
+          aria-label="Settings"
+          title="Settings"
+        >
+          {settingsIcon}
+        </button>
+      </div>
+    </aside>
+  );
+}

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -230,10 +230,11 @@ export function TerminalDrawer({
       className={
         isMaximized
           ? 'fixed inset-0 z-40 flex min-h-0 flex-col overflow-hidden border-t border-gray-800 bg-gray-950'
-          : 'border-t border-gray-800 bg-gray-950'
+          : 'overflow-hidden rounded-lg border border-gray-800 bg-gray-950'
       }
     >
-      <div className="flex items-center gap-2 border-b border-gray-800 px-3 py-2">
+      <div className="flex items-center gap-3 border-b border-gray-800 px-3 py-2">
+        <div className="shrink-0 text-xs font-medium text-gray-300">Task terminals</div>
         <div
           role="tablist"
           data-testid="terminal-tab-strip"


### PR DESCRIPTION
## Summary

This change activates the new Invoker shell in the renderer.

A left status column, a top planner terminal, the center graph, bottom task terminals, and an always-visible right rail now frame the workspace.

The planner terminal turns a written goal into a plan preview through window.invoker.planFromGoal.

It builds on the in-app planner bridge slice and adds no planner subprocess work to the renderer.

<details>
<summary>Review metadata</summary>

Review Claim: The renderer activates the new shell and exposes a planner terminal while existing graph and task terminal behavior is unchanged.
Review Lane: behavior
Review Unit: activation-surface
Safety Invariant: Existing App handlers, WorkflowGraph, TaskDAG, WorkflowInspector, and TerminalDrawer stay the behavior owners; the shell wires them without changing task execution.
Slice Rationale: Shell layout, planner terminal input, empty-state copy, and graph maximize are coupled renderer activation work that activates as one surface.

</details>

## Non-goals

- Does not delete HistoryView, TimelineView, QueueView, or ActionGraphView.
- Does not change task execution semantics.
- Does not add planner subprocess logic to the renderer.

## Architecture

### Before

The old side-tab shell kept planner actions behind tabs and showed the graph in a single pane.

### After

```mermaid
flowchart LR
    Left["Runs / Needs attention / Running tasks"] --> Center["Planner terminal, graph, task terminals"]
    Center --> Right["What to expect or WorkflowInspector"]
    Center --> Full["Maximized graph overlay"]
```

## Test Plan

- [ ] `cd packages/ui && pnpm test`
- [ ] `cd packages/ui && pnpm build`

## Visual Proof

Before — old side-tab shell:

![before embedded terminal](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-ec787f/before-shell-embedded-terminal.png)

After — new Invoker shell:

![after embedded terminal](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-ec787f/after-shell-embedded-terminal.png)

![after graph loaded](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-ec787f/after-shell-graph-loaded.png)

![after running task](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-ec787f/after-shell-task-running.png)

Walkthrough video: [shell walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-ec787f/after-shell-walkthrough.webm)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None; the old side-tab shell returns.
- Data migration? No
