### PR TITLE
[Slack ELI5 40-word responses](1) Direct-answer prompt brevity guidance

### DIFF
--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import * as child_process from 'node:child_process';
-import { SlackSurface, parsePlanningRequest, parseLobbyClassification, BUILTIN_HARNESS_PRESETS } from '../slack/slack-surface.js';
+import { SlackSurface, parsePlanningRequest, parseLobbyClassification, BUILTIN_HARNESS_PRESETS, buildLobbyQuestionPrompt } from '../slack/slack-surface.js';
 import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import type { SurfaceCommand } from '../surface.js';
 import type { WorkflowContext } from '../slack/workflow-assistant.js';
@@ -413,6 +413,14 @@ describe('lobby verb routing', () => {
       ...extra,
     });
   }
+
+  it('asks lobby question answers to be short ELI5 Slack prose except for clearly technical questions', () => {
+    const prompt = buildLobbyQuestionPrompt('how many workflows are running?');
+    expect(prompt).toContain('ELI5 Slack prose');
+    expect(prompt).toContain('40 words or fewer');
+    expect(prompt).toContain('clearly technical');
+    expect(prompt).toContain('Do NOT generate a YAML plan');
+  });
 
   it('stages a bulk verb for confirmation, then runs it on a plain `yes`', async () => {
     runWorkflowOp.mockResolvedValue({ ok: true, summary: 'recreate: 3 ok' });

--- a/packages/surfaces/src/__tests__/workflow-assistant.test.ts
+++ b/packages/surfaces/src/__tests__/workflow-assistant.test.ts
@@ -46,4 +46,11 @@ describe('buildAssistantPrompt', () => {
     expect(prompt).toContain('what changed?');
     expect(prompt).toContain('Answer ONLY from');
   });
+
+  it('asks workflow question answers to be short ELI5 Slack prose except for clearly technical questions', () => {
+    const prompt = buildAssistantPrompt('what changed?', ctx);
+    expect(prompt).toContain('ELI5 Slack prose');
+    expect(prompt).toContain('40 words or fewer');
+    expect(prompt).toContain('clearly technical');
+  });
 });

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -19,7 +19,7 @@ import { parseLobbyControl } from './lobby-control.js';
 import type { LobbyControl } from './lobby-control.js';
 import { summarizePlanText } from './plan-summary.js';
 import { SessionManager, SessionIdentifier } from './thread-session-manager.js';
-import { buildAssistantPrompt, parseWorkflowControl } from './workflow-assistant.js';
+import { buildAssistantPrompt, parseWorkflowControl, SLACK_DIRECT_ANSWER_GUIDANCE } from './workflow-assistant.js';
 import type { WorkflowContext, WorkflowControl } from './workflow-assistant.js';
 import type { ConversationRepository, WorkflowChannelRepository, WorkflowChannel } from '@invoker/data-store';
 
@@ -198,8 +198,8 @@ ${text}
 }
 
 /** Q&A prompt for a lobby question: answer directly, never emit a plan. */
-function buildLobbyQuestionPrompt(text: string): string {
-  return `Answer the user's question about this repository and Invoker. Explore the codebase if needed. Do NOT generate a YAML plan and do NOT create a workflow. Question:\n${text}`;
+export function buildLobbyQuestionPrompt(text: string): string {
+  return `Answer the user's question about this repository and Invoker. Explore the codebase if needed. ${SLACK_DIRECT_ANSWER_GUIDANCE} Do NOT generate a YAML plan and do NOT create a workflow. Question:\n${text}`;
 }
 
 /** Parse the classifier's raw stdout into a validated classification; never throws. */

--- a/packages/surfaces/src/slack/workflow-assistant.ts
+++ b/packages/surfaces/src/slack/workflow-assistant.ts
@@ -14,11 +14,15 @@ export interface WorkflowContext {
 
 // ── Q&A prompt ───────────────────────────────────────────────
 
+export const SLACK_DIRECT_ANSWER_GUIDANCE =
+  'Answer in simple ELI5 Slack prose. By default, keep the answer to 40 words or fewer. If the question is clearly technical, include the necessary technical detail even if that exceeds 40 words.';
+
 export function buildAssistantPrompt(question: string, ctx: WorkflowContext): string {
   const lines: string[] = [
     `You are answering questions about Invoker workflow \`${ctx.workflowId}\`.`,
     "Answer ONLY from this workflow's planning conversation and task transcripts below.",
     'If the answer is not present in this context, say you do not know — never guess or use outside knowledge.',
+    SLACK_DIRECT_ANSWER_GUIDANCE,
     '',
     '=== Planning conversation ===',
   ];


### PR DESCRIPTION
## Summary

Update the Slack lobby-question prompt and the workflow-question prompt to ask for ELI5 prose capped near forty words. Keep the technical-question exception so deep questions still get long answers.

This is the direct-answer pair only. Planner system prompts and the post-approval recap message land in later PRs of this stack.

<details>
<summary>Review metadata</summary>

Review Claim: Lobby and workflow Slack prompts now request ELI5 prose with a forty-word default budget and an explicit exception for clearly technical questions.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice stays inside two prompt builders and their focused tests; Slack message wiring and workflow mutation behavior stay unchanged.

Slice Rationale: The lobby prompt and the workflow prompt are the two direct-answer Slack seams, so they form one reviewable activation-surface unit; planner system prompt and approval recap land in later PRs.

</details>

## Non-goals

- Do not change the planning-thread system prompt.
- Do not change the post-approval recap rendering.
- Do not change Slack message wiring or workflow mutation behavior.
- Do not truncate output after generation; prompt guidance preserves the technical-question exception.

## Test Plan

- [ ] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/slack-surface-workflows.test.ts src/__tests__/workflow-assistant.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack question answers now follow clearer, shorter guidance: more direct ELI5-style prose, a tighter word limit, and better handling for clearly technical questions.
  * Lobby question routing now avoids generating workflow-style YAML plans and stays focused on answering the question directly.

* **Tests**
  * Expanded coverage to verify the updated Slack prompt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->