### PR TITLE
[Slack ELI5 40-word responses](3) Approval preview renderer trimming

### DIFF
--- a/packages/surfaces/src/__tests__/plan-summary.test.ts
+++ b/packages/surfaces/src/__tests__/plan-summary.test.ts
@@ -34,7 +34,7 @@ tasks:
     expect(summary!.taskCount).toBe(2);
   });
 
-  it('truncates a description longer than 30 words to 30 words + ellipsis', () => {
+  it('truncates a description longer than 8 words to 8 words + ellipsis', () => {
     const words = Array.from({ length: 40 }, (_, i) => `word${i + 1}`);
     const yaml = `
 name: Long plan
@@ -44,9 +44,9 @@ tasks:
 `;
     const summary = summarizePlanText(yaml);
     expect(summary).not.toBeNull();
-    const expected = words.slice(0, 30).join(' ') + ' …';
+    const expected = words.slice(0, 8).join(' ') + ' …';
     expect(summary!.steps[0]).toBe(expected);
-    expect(summary!.steps[0].split(' ')).toHaveLength(31); // 30 words + the ellipsis token
+    expect(summary!.steps[0].split(' ')).toHaveLength(9); // 8 words + the ellipsis token
   });
 
   it('collapses whitespace and newlines in descriptions', () => {

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import * as child_process from 'node:child_process';
-import { SlackSurface, parsePlanningRequest, parseLobbyClassification, BUILTIN_HARNESS_PRESETS } from '../slack/slack-surface.js';
+import { SlackSurface, parsePlanningRequest, parseLobbyClassification, BUILTIN_HARNESS_PRESETS, buildLobbyQuestionPrompt } from '../slack/slack-surface.js';
 import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import type { SurfaceCommand } from '../surface.js';
 import type { WorkflowContext } from '../slack/workflow-assistant.js';
@@ -413,6 +413,14 @@ describe('lobby verb routing', () => {
       ...extra,
     });
   }
+
+  it('asks lobby question answers to be short ELI5 Slack prose except for clearly technical questions', () => {
+    const prompt = buildLobbyQuestionPrompt('how many workflows are running?');
+    expect(prompt).toContain('ELI5 Slack prose');
+    expect(prompt).toContain('40 words or fewer');
+    expect(prompt).toContain('clearly technical');
+    expect(prompt).toContain('Do NOT generate a YAML plan');
+  });
 
   it('stages a bulk verb for confirmation, then runs it on a plain `yes`', async () => {
     runWorkflowOp.mockResolvedValue({ ok: true, summary: 'recreate: 3 ok' });

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -87,6 +87,10 @@ function baseConfig() {
   };
 }
 
+function wordCount(text: string): number {
+  return text.replace(/[`*_"]/g, '').trim().split(/\s+/).filter(Boolean).length;
+}
+
 function mentionHandler(surface: SlackSurface): Function {
   const app = surface.getApp() as any;
   return app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')!.handler;
@@ -669,18 +673,39 @@ describe('lobby verb routing', () => {
     expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('No planning conversation') }));
   });
 
-  it('submit shows a plain-English plan summary and emits start_plan on confirmation', async () => {
+  it('submit shows a short plain-English plan summary and emits start_plan on confirmation', async () => {
     const surface = lobbySurface();
     await surface.start(async (cmd) => { received.push(cmd); });
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     // Open a planning conversation in the thread, then arm its drafted plan.
     await mentionHandler(surface)({ event: { text: '<@BOT> add a /health endpoint', ts: 't1', user: 'U1' }, say });
-    draftedPlanForMock = 'name: "Health API"\ntasks:\n  - id: t1\n    description: "Add the /health endpoint to the API"\n    dependencies: []\n';
+    draftedPlanForMock = `
+name: "Health API rollout with several detailed implementation tasks"
+tasks:
+  - id: second
+    description: "Wire the new /health route through the HTTP server without changing unrelated endpoints or middleware"
+    dependencies: [first]
+  - id: first
+    description: "Add a simple /health endpoint for uptime checks"
+    dependencies: []
+  - id: third
+    description: "Add regression coverage for healthy and unhealthy responses"
+    dependencies: [second]
+  - id: fourth
+    description: "Run the focused surface test suite and record the result"
+    dependencies: [third]
+`;
 
     const say2 = vi.fn().mockResolvedValue({ ts: 'b' });
     await mentionHandler(surface)({ event: { text: '<@BOT> submit', thread_ts: 't1', ts: 't2', user: 'U1' }, say: say2 });
     // Shows the ELI5 step summary, does not submit yet.
-    expect(say2).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Add the /health endpoint') }));
+    const confirmationText = say2.mock.calls[0][0].text as string;
+    expect(confirmationText).toContain('steps in order');
+    expect(confirmationText).toContain('First: Add a simple /health endpoint for ...');
+    expect(confirmationText).toContain('Then: Wire the new /health route through ...');
+    expect(confirmationText).toContain('Then 2 more.');
+    expect(confirmationText).not.toContain('without changing unrelated endpoints');
+    expect(wordCount(confirmationText)).toBeLessThanOrEqual(40);
     expect(received.some((c) => c.type === 'start_plan')).toBe(false);
 
     const say3 = vi.fn().mockResolvedValue({ ts: 'c' });

--- a/packages/surfaces/src/__tests__/workflow-assistant.test.ts
+++ b/packages/surfaces/src/__tests__/workflow-assistant.test.ts
@@ -46,4 +46,11 @@ describe('buildAssistantPrompt', () => {
     expect(prompt).toContain('what changed?');
     expect(prompt).toContain('Answer ONLY from');
   });
+
+  it('asks workflow question answers to be short ELI5 Slack prose except for clearly technical questions', () => {
+    const prompt = buildAssistantPrompt('what changed?', ctx);
+    expect(prompt).toContain('ELI5 Slack prose');
+    expect(prompt).toContain('40 words or fewer');
+    expect(prompt).toContain('clearly technical');
+  });
 });

--- a/packages/surfaces/src/slack/plan-summary.ts
+++ b/packages/surfaces/src/slack/plan-summary.ts
@@ -22,7 +22,7 @@ interface PlanTask {
   dependencies: string[];
 }
 
-const MAX_WORDS = 30;
+const MAX_STEP_WORDS = 8;
 
 // ── Public API ──────────────────────────────────────────────
 
@@ -115,6 +115,6 @@ function topoSort(tasks: PlanTask[]): PlanTask[] {
 function summarizeDescription(description: string): string {
   const normalized = description.replace(/\s+/g, ' ').trim();
   const words = normalized.split(' ');
-  if (words.length <= MAX_WORDS) return normalized;
-  return words.slice(0, MAX_WORDS).join(' ') + ' …';
+  if (words.length <= MAX_STEP_WORDS) return normalized;
+  return words.slice(0, MAX_STEP_WORDS).join(' ') + ' …';
 }

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -19,7 +19,7 @@ import { parseLobbyControl } from './lobby-control.js';
 import type { LobbyControl } from './lobby-control.js';
 import { summarizePlanText } from './plan-summary.js';
 import { SessionManager, SessionIdentifier } from './thread-session-manager.js';
-import { buildAssistantPrompt, parseWorkflowControl } from './workflow-assistant.js';
+import { buildAssistantPrompt, parseWorkflowControl, SLACK_DIRECT_ANSWER_GUIDANCE } from './workflow-assistant.js';
 import type { WorkflowContext, WorkflowControl } from './workflow-assistant.js';
 import type { ConversationRepository, WorkflowChannelRepository, WorkflowChannel } from '@invoker/data-store';
 
@@ -198,8 +198,8 @@ ${text}
 }
 
 /** Q&A prompt for a lobby question: answer directly, never emit a plan. */
-function buildLobbyQuestionPrompt(text: string): string {
-  return `Answer the user's question about this repository and Invoker. Explore the codebase if needed. Do NOT generate a YAML plan and do NOT create a workflow. Question:\n${text}`;
+export function buildLobbyQuestionPrompt(text: string): string {
+  return `Answer the user's question about this repository and Invoker. Explore the codebase if needed. ${SLACK_DIRECT_ANSWER_GUIDANCE} Do NOT generate a YAML plan and do NOT create a workflow. Question:\n${text}`;
 }
 
 /** Parse the classifier's raw stdout into a validated classification; never throws. */

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -23,6 +23,16 @@ import { buildAssistantPrompt, parseWorkflowControl, SLACK_DIRECT_ANSWER_GUIDANC
 import type { WorkflowContext, WorkflowControl } from './workflow-assistant.js';
 import type { ConversationRepository, WorkflowChannelRepository, WorkflowChannel } from '@invoker/data-store';
 
+function truncateWords(text: string, maxWords: number): string {
+  const words = text.replace(/\s+/g, ' ').trim().split(' ').filter(Boolean);
+  if (words.length <= maxWords) return words.join(' ');
+  return `${words.slice(0, maxWords).join(' ')} ...`;
+}
+
+function asSentence(text: string): string {
+  return text.endsWith('...') || text.endsWith('…') ? text : `${text}.`;
+}
+
 // ── Config ──────────────────────────────────────────────────
 
 export interface SlackSurfaceConfig {
@@ -870,10 +880,23 @@ export class SlackSurface implements Surface {
     await this.stageConfirm(threadTs, channel, { kind: 'submit', planText, ctx, channel, lobbyThreadTs: threadTs }, this.renderPlanSummary(summary), say);
   }
 
-  /** Plain-English plan view: one numbered sentence per step — the user approves this, not YAML. */
+  /** Short plain-English plan view: the user approves this, not YAML. */
   private renderPlanSummary(summary: { name: string; steps: string[]; taskCount: number }): string {
-    const lines = summary.steps.map((step, i) => `${i + 1}. ${step}`);
-    return [`*${summary.name}* — ${summary.taskCount} step${summary.taskCount === 1 ? '' : 's'}:`, ...lines].join('\n');
+    const title = truncateWords(summary.name, 5);
+    const first = truncateWords(summary.steps[0] ?? 'Run the plan', 6);
+    const parts = [
+      `I'll start "${title}": ${summary.taskCount} step${summary.taskCount === 1 ? '' : 's'} in order.`,
+      `First: ${asSentence(first)}`,
+    ];
+
+    if (summary.steps.length > 1) {
+      parts.push(`Then: ${asSentence(truncateWords(summary.steps[1], 6))}`);
+    }
+    if (summary.steps.length > 2) {
+      parts.push(`Then ${summary.steps.length - 2} more.`);
+    }
+
+    return parts.join(' ');
   }
 
   private buildConfirmBlocks(prompt: string, confirmKey: string): unknown[] {

--- a/packages/surfaces/src/slack/workflow-assistant.ts
+++ b/packages/surfaces/src/slack/workflow-assistant.ts
@@ -14,11 +14,15 @@ export interface WorkflowContext {
 
 // ── Q&A prompt ───────────────────────────────────────────────
 
+export const SLACK_DIRECT_ANSWER_GUIDANCE =
+  'Answer in simple ELI5 Slack prose. By default, keep the answer to 40 words or fewer. If the question is clearly technical, include the necessary technical detail even if that exceeds 40 words.';
+
 export function buildAssistantPrompt(question: string, ctx: WorkflowContext): string {
   const lines: string[] = [
     `You are answering questions about Invoker workflow \`${ctx.workflowId}\`.`,
     "Answer ONLY from this workflow's planning conversation and task transcripts below.",
     'If the answer is not present in this context, say you do not know — never guess or use outside knowledge.',
+    SLACK_DIRECT_ANSWER_GUIDANCE,
     '',
     '=== Planning conversation ===',
   ];


### PR DESCRIPTION
## Summary

Shorten the deterministic Slack approval preview shown after a plan is staged for confirmation. Cap each plan-step description near eight words and render the preview as one short paragraph.

Planner prompts are untouched here; this slice is just renderer trimming, separated from the direct-answer prompt PR earlier in this stack.

<details>
<summary>Review metadata</summary>

Review Claim: The Slack approval preview renders an ELI5 plan summary under forty words instead of echoing long step text.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice stays inside `summarizePlanText()` and `renderPlanSummary()`; planner prompts and the workflow approval pipeline stay unchanged.

Slice Rationale: The deterministic approval preview is local rendering, not prompt guidance, so it ships in its own activation-surface PR after the direct-answer prompt slice.

</details>

## Non-goals

- Do not change planner prompts or planner system text.
- Do not change YAML payloads written to disk.
- Do not change how approval inputs flow into the workflow approval pipeline.

## Test Plan

- [ ] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-summary.test.ts src/__tests__/slack-surface-workflows.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shortened plan summaries and step descriptions in Slack to keep confirmation messages concise and easier to scan.
  * Updated confirmation previews to show a clearer “First / Then” style flow while avoiding overly long text.
  * Improved truncation behavior so long task descriptions are consistently shortened across plan summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->