### PR TITLE
Fix Slack gate-policy routing: add Slack gate-policy workflow-op shape

### DIFF
--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -42,6 +42,23 @@ export interface WorkflowOp {
   target: { all: true } | { workflow: string };
 }
 
+export type WorkflowGatePolicy = 'completed' | 'review_ready';
+
+export interface WorkflowGatePolicyUpdate {
+  /** Upstream workflow whose gate policy should be changed. */
+  workflowId: string;
+  /** Upstream task gate; omitted means the workflow merge gate. */
+  taskId?: string;
+  gatePolicy: WorkflowGatePolicy;
+}
+
+export interface WorkflowGatePolicyOp {
+  operation: 'gate-policy';
+  /** Downstream workflow whose external dependency gate policy is edited. */
+  target: { workflow: string };
+  updates: WorkflowGatePolicyUpdate[];
+}
+
 export interface WorkflowOpResult {
   ok: boolean;
   summary: string;


### PR DESCRIPTION
## Summary

Slack workflow ops only modeled a fixed set of lifecycle intents and could not represent gate-policy mutation. Adding a gate-policy intent needs a shared type first.

This slice extends the contract in `packages/surfaces/src/surface.ts` so Slack workflow ops can also carry gate-policy intent.

Parser, classifier, and execution semantics stay unchanged here. Later slices build on this shared shape.

<details>
<summary>Review metadata</summary>

Review Claim: Slack surfaces gain a shared gate-policy workflow-op shape for later slices to consume.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This slice only adds the shared Slack gate-policy op shape; parser, classifier, and execution semantics stay unchanged.

Slice Rationale: The shared op shape must land before later slices begin using it.

</details>

## Non-goals

- Do not change deterministic parser behavior in this slice.
- Do not change fuzzy classifier or app-side execution behavior in this slice.
- Do not update docs or repro proof in this slice.

## Test Plan

- [ ] `cd packages/surfaces && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No