### PR TITLE
Fix Slack gate-policy routing: parse deterministic Slack gate-policy phrasing

### DIFF
--- a/packages/surfaces/src/__tests__/lobby-control.test.ts
+++ b/packages/surfaces/src/__tests__/lobby-control.test.ts
@@ -34,6 +34,32 @@ describe('parseLobbyControl', () => {
     expect(parseLobbyControl('status my-flow')).toEqual({ kind: 'op', operation: 'status', target: { workflow: 'my-flow' } });
   });
 
+  it('parses gate-policy updates with explicit downstream and upstream workflows', () => {
+    expect(parseLobbyControl('gate-policy wf-child wf-parent review_ready')).toEqual({
+      kind: 'gate-policy',
+      target: { workflow: 'wf-child' },
+      updates: [{ workflowId: 'wf-parent', gatePolicy: 'review_ready' }],
+    });
+    expect(parseLobbyControl('set gate policy wf-child wf-parent completed')).toEqual({
+      kind: 'gate-policy',
+      target: { workflow: 'wf-child' },
+      updates: [{ workflowId: 'wf-parent', gatePolicy: 'completed' }],
+    });
+  });
+
+  it('parses gate-policy updates with an upstream task gate', () => {
+    expect(parseLobbyControl('gate-policy wf-child wf-parent/api review ready')).toEqual({
+      kind: 'gate-policy',
+      target: { workflow: 'wf-child' },
+      updates: [{ workflowId: 'wf-parent', taskId: 'api', gatePolicy: 'review_ready' }],
+    });
+    expect(parseLobbyControl('gate-policy wf-child wf-parent api completed')).toEqual({
+      kind: 'gate-policy',
+      target: { workflow: 'wf-child' },
+      updates: [{ workflowId: 'wf-parent', taskId: 'api', gatePolicy: 'completed' }],
+    });
+  });
+
   it('defaults bare status to all; a bare mutation verb is ambiguous (null)', () => {
     expect(parseLobbyControl('status')).toEqual({ kind: 'op', operation: 'status', target: { all: true } });
     expect(parseLobbyControl('recreate')).toBeNull();
@@ -45,6 +71,8 @@ describe('parseLobbyControl', () => {
     expect(parseLobbyControl('how many workflows are running?')).toBeNull();
     expect(parseLobbyControl('add a /health endpoint')).toBeNull();
     expect(parseLobbyControl('recreate + rebase all workflows')).toBeNull();
+    expect(parseLobbyControl('gate-policy wf-child review_ready')).toBeNull();
+    expect(parseLobbyControl('gate-policy wf-child wf-parent api extra completed')).toBeNull();
     expect(parseLobbyControl('')).toBeNull();
   });
 });

--- a/packages/surfaces/src/__tests__/workflow-assistant.test.ts
+++ b/packages/surfaces/src/__tests__/workflow-assistant.test.ts
@@ -22,9 +22,33 @@ describe('parseWorkflowControl', () => {
     });
   });
 
+  it('parses gate-policy updates for the current workflow channel', () => {
+    expect(parseWorkflowControl('gate-policy wf-parent review_ready')).toEqual({
+      kind: 'gate-policy',
+      updates: [{ workflowId: 'wf-parent', gatePolicy: 'review_ready' }],
+    });
+    expect(parseWorkflowControl('set gate policy wf-parent completed')).toEqual({
+      kind: 'gate-policy',
+      updates: [{ workflowId: 'wf-parent', gatePolicy: 'completed' }],
+    });
+  });
+
+  it('parses gate-policy updates with an upstream task gate', () => {
+    expect(parseWorkflowControl('gate-policy wf-parent/api review ready')).toEqual({
+      kind: 'gate-policy',
+      updates: [{ workflowId: 'wf-parent', taskId: 'api', gatePolicy: 'review_ready' }],
+    });
+    expect(parseWorkflowControl('gate-policy wf-parent api completed')).toEqual({
+      kind: 'gate-policy',
+      updates: [{ workflowId: 'wf-parent', taskId: 'api', gatePolicy: 'completed' }],
+    });
+  });
+
   it('returns null for free-form questions', () => {
     expect(parseWorkflowControl('what did the api task change?')).toBeNull();
     expect(parseWorkflowControl('approve')).toBeNull(); // verb without a task id
+    expect(parseWorkflowControl('gate-policy review_ready')).toBeNull();
+    expect(parseWorkflowControl('gate-policy wf-parent api extra completed')).toBeNull();
   });
 });
 

--- a/packages/surfaces/src/slack/lobby-control.ts
+++ b/packages/surfaces/src/slack/lobby-control.ts
@@ -7,10 +7,11 @@
  * unambiguous command, so the caller falls through to conversation.
  */
 
-import type { WorkflowOpName } from '../surface.js';
+import type { WorkflowGatePolicy, WorkflowGatePolicyUpdate, WorkflowOpName } from '../surface.js';
 
 export type LobbyControl =
   | { kind: 'op'; operation: WorkflowOpName; target: { all: true } | { workflow: string } }
+  | { kind: 'gate-policy'; target: { workflow: string }; updates: WorkflowGatePolicyUpdate[] }
   | { kind: 'submit' }
   | { kind: 'restart' };
 
@@ -28,11 +29,56 @@ const OP_ALIASES: Record<string, WorkflowOpName> = {
 const VERB_PATTERN = /^(rebase-recreate|rebase-retry|recreate|rebase|retry|cancel|status)\b([\s\S]*)$/i;
 const TARGET_TOKEN = /^[\w./-]+$/;
 
+function parseGatePolicy(rest: string): Extract<LobbyControl, { kind: 'gate-policy' }> | null {
+  const withoutPolicy = rest.trim().replace(/[.!?]+$/, '').trim();
+  let gatePolicy: WorkflowGatePolicy;
+  let argsText: string;
+
+  const reviewReady = /\s+review[-_\s]+ready$/i.exec(withoutPolicy);
+  if (reviewReady) {
+    gatePolicy = 'review_ready';
+    argsText = withoutPolicy.slice(0, reviewReady.index).trim();
+  } else {
+    const completed = /\s+completed$/i.exec(withoutPolicy);
+    if (!completed) return null;
+    gatePolicy = 'completed';
+    argsText = withoutPolicy.slice(0, completed.index).trim();
+  }
+
+  const args = argsText.split(/\s+/).filter(Boolean);
+  if (args.length < 2 || args.length > 3) return null;
+  if (!args.every((arg) => TARGET_TOKEN.test(arg))) return null;
+
+  const [downstreamWorkflow, upstreamWorkflowToken, upstreamTaskToken] = args;
+  const update = parseGatePolicyUpdate(upstreamWorkflowToken, upstreamTaskToken, gatePolicy);
+  if (!update) return null;
+
+  return { kind: 'gate-policy', target: { workflow: downstreamWorkflow }, updates: [update] };
+}
+
+function parseGatePolicyUpdate(
+  upstreamWorkflowToken: string,
+  upstreamTaskToken: string | undefined,
+  gatePolicy: WorkflowGatePolicy,
+): WorkflowGatePolicyUpdate | null {
+  if (upstreamWorkflowToken.includes('/')) {
+    if (upstreamTaskToken) return null;
+    const [workflowId, taskId, ...extra] = upstreamWorkflowToken.split('/');
+    if (!workflowId || !taskId || extra.length > 0) return null;
+    return { workflowId, taskId, gatePolicy };
+  }
+
+  return upstreamTaskToken
+    ? { workflowId: upstreamWorkflowToken, taskId: upstreamTaskToken, gatePolicy }
+    : { workflowId: upstreamWorkflowToken, gatePolicy };
+}
+
 /**
  * Parse a lobby command. Recognizes:
  *   - `submit` / `submit to invoker`
  *   - `restart` / `restart invoker`
  *   - `<op> all` / `<op> <workflow-id-or-name>`  (op ∈ recreate|rebase|rebase-recreate|rebase-retry|retry|cancel|status)
+ *   - `gate-policy <downstream-workflow> <upstream-workflow>[/<upstream-task>] <completed|review_ready>`
  *   - `status` with no target → all workflows
  * Returns null for missing/ambiguous targets and for prose, so the message is
  * treated as conversation (or routed to the classifier fallback).
@@ -42,6 +88,9 @@ export function parseLobbyControl(text: string): LobbyControl | null {
 
   if (/^submit(\s+to\s+invoker)?\s*[.!?]*$/i.test(trimmed)) return { kind: 'submit' };
   if (/^restart(\s+(invoker|the\s+invoker|app|the\s+app|gui|the\s+gui))?\s*[.!?]*$/i.test(trimmed)) return { kind: 'restart' };
+
+  const gatePolicy = /^(?:set\s+)?gate[-\s]+policy\b([\s\S]*)$/i.exec(trimmed);
+  if (gatePolicy) return parseGatePolicy(gatePolicy[1]);
 
   const match = VERB_PATTERN.exec(trimmed);
   if (!match) return null;

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -677,6 +677,10 @@ export class SlackSurface implements Surface {
       await this.handleLobbyRestart(threadTs, channel, say);
       return;
     }
+    if (ctrl?.kind === 'gate-policy') {
+      await say({ text: 'Gate-policy routing is not available in this deployment yet.', thread_ts: threadTs });
+      return;
+    }
 
     // Slower paths (LLM classifier, repo checkout, planner) acknowledge receipt up front.
     if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
@@ -1016,6 +1020,10 @@ export class SlackSurface implements Surface {
       await respond({ text: prompt, response_type: 'ephemeral', blocks: this.buildConfirmBlocks(prompt, key) as never });
       return;
     }
+    if (ctrl.kind === 'gate-policy') {
+      await respond({ text: 'Gate-policy routing is not available in this deployment yet.', response_type: 'ephemeral' });
+      return;
+    }
 
     if (!this.runWorkflowOp) {
       await respond({ text: 'Workflow operations are not available in this deployment.', response_type: 'ephemeral' });
@@ -1162,6 +1170,9 @@ export class SlackSurface implements Surface {
       case 'input':
         await this.onCommand?.({ type: 'provide_input', taskId: scoped(ctrl.task), input: ctrl.text });
         await say({ text: `Sent input to \`${scoped(ctrl.task)}\`.`, thread_ts: threadTs });
+        return;
+      case 'gate-policy':
+        await say({ text: 'Gate-policy routing is not available in this deployment yet.', thread_ts: threadTs });
         return;
     }
   }

--- a/packages/surfaces/src/slack/workflow-assistant.ts
+++ b/packages/surfaces/src/slack/workflow-assistant.ts
@@ -1,3 +1,5 @@
+import type { WorkflowGatePolicy, WorkflowGatePolicyUpdate } from '../surface.js';
+
 // ── Context ──────────────────────────────────────────────────
 
 export interface WorkflowContext {
@@ -44,11 +46,61 @@ export function buildAssistantPrompt(question: string, ctx: WorkflowContext): st
 export type WorkflowControl =
   | { kind: 'status' }
   | { kind: 'approve' | 'reject' | 'retry'; task: string }
-  | { kind: 'input'; task: string; text: string };
+  | { kind: 'input'; task: string; text: string }
+  | { kind: 'gate-policy'; updates: WorkflowGatePolicyUpdate[] };
+
+const TARGET_TOKEN = /^[\w./-]+$/;
+
+function parseGatePolicy(rest: string): Extract<WorkflowControl, { kind: 'gate-policy' }> | null {
+  const withoutPolicy = rest.trim().replace(/[.!?]+$/, '').trim();
+  let gatePolicy: WorkflowGatePolicy;
+  let argsText: string;
+
+  const reviewReady = /\s+review[-_\s]+ready$/i.exec(withoutPolicy);
+  if (reviewReady) {
+    gatePolicy = 'review_ready';
+    argsText = withoutPolicy.slice(0, reviewReady.index).trim();
+  } else {
+    const completed = /\s+completed$/i.exec(withoutPolicy);
+    if (!completed) return null;
+    gatePolicy = 'completed';
+    argsText = withoutPolicy.slice(0, completed.index).trim();
+  }
+
+  const args = argsText.split(/\s+/).filter(Boolean);
+  if (args.length < 1 || args.length > 2) return null;
+  if (!args.every((arg) => TARGET_TOKEN.test(arg))) return null;
+
+  const [upstreamWorkflowToken, upstreamTaskToken] = args;
+  const update = parseGatePolicyUpdate(upstreamWorkflowToken, upstreamTaskToken, gatePolicy);
+  if (!update) return null;
+
+  return { kind: 'gate-policy', updates: [update] };
+}
+
+function parseGatePolicyUpdate(
+  upstreamWorkflowToken: string,
+  upstreamTaskToken: string | undefined,
+  gatePolicy: WorkflowGatePolicy,
+): WorkflowGatePolicyUpdate | null {
+  if (upstreamWorkflowToken.includes('/')) {
+    if (upstreamTaskToken) return null;
+    const [workflowId, taskId, ...extra] = upstreamWorkflowToken.split('/');
+    if (!workflowId || !taskId || extra.length > 0) return null;
+    return { workflowId, taskId, gatePolicy };
+  }
+
+  return upstreamTaskToken
+    ? { workflowId: upstreamWorkflowToken, taskId: upstreamTaskToken, gatePolicy }
+    : { workflowId: upstreamWorkflowToken, gatePolicy };
+}
 
 export function parseWorkflowControl(text: string): WorkflowControl | null {
   const t = text.trim();
   if (/^status\b/i.test(t)) return { kind: 'status' };
+
+  const gatePolicy = /^(?:set\s+)?gate[-\s]+policy\b([\s\S]*)$/i.exec(t);
+  if (gatePolicy) return parseGatePolicy(gatePolicy[1]);
 
   const input = /^input\s+(\S+)\s*:\s*([\s\S]+)$/i.exec(t);
   if (input) return { kind: 'input', task: input[1], text: input[2].trim() };


### PR DESCRIPTION
## Summary

Slack deterministic parsing in lobby and workflow channels did not recognize gate-policy phrasing. Operational gate-policy requests fell through and started YAML planning.

This slice routes deterministic gate-policy phrasing onto the shared op shape from inside `packages/surfaces/src/slack/lobby-control.ts` and `packages/surfaces/src/slack/workflow-assistant.ts`.

Tests in `packages/surfaces/src/__tests__/lobby-control.test.ts` and `packages/surfaces/src/__tests__/workflow-assistant.test.ts` cover the new routing.

<details>
<summary>Review metadata</summary>

Review Claim: Slack deterministic parsing routes gate-policy phrasing onto the shared op shape in lobby and workflow channels.

Review Lane: behavior

Review Unit: routing

Safety Invariant: This slice stays inside deterministic parsing plus directly affected tests; fuzzy classifier behavior and app-side execution stay unchanged.

Slice Rationale: Deterministic parser routing is the narrowest reviewable behavior slice once the shared op shape exists.

</details>

## Non-goals

- Do not change `packages/surfaces/src/slack/slack-surface.ts` fuzzy classifier behavior in this slice.
- Do not wire execution to `packages/app/src/main.ts` in this slice.
- Do not update docs or repro proof in this slice.

## Test Plan

- [ ] `cd packages/surfaces && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for “gate policy” commands in workflow and lobby controls, including downstream workflow targeting and upstream workflow/task references.
  * Improved recognition of multiple command formats, including variants like `gate policy`, `set gate policy`, and related slash/in-channel forms.

* **Bug Fixes**
  * Invalid or incomplete gate policy inputs now fail cleanly instead of being misread as other commands.
  * Requests for unsupported gate-policy routing now return a clear in-context message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->