### PR TITLE
Fix Slack gate-policy routing: wire Slack gate-policy op through the app

### DIFF
--- a/packages/app/src/__tests__/slack-gate-policy-op.test.ts
+++ b/packages/app/src/__tests__/slack-gate-policy-op.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+import { executeSlackGatePolicyOp } from '../slack-gate-policy-op.js';
+
+function makePersistence() {
+  const workflows = [
+    {
+      id: 'wf-down',
+      name: 'Downstream',
+      externalDependencies: [
+        { workflowId: 'wf-up', gatePolicy: 'completed' as const },
+        { workflowId: 'wf-other', taskId: 'api', gatePolicy: 'completed' as const },
+      ],
+    },
+    {
+      id: 'wf-skip',
+      name: 'Skip Me',
+      externalDependencies: [{ workflowId: 'wf-other', gatePolicy: 'completed' as const }],
+    },
+    {
+      id: 'wf-up',
+      name: 'Upstream',
+      externalDependencies: [],
+    },
+  ];
+  return {
+    listWorkflows: vi.fn(() => workflows),
+    loadWorkflow: vi.fn((workflowId: string) => workflows.find((workflow) => workflow.id === workflowId)),
+  };
+}
+
+describe('executeSlackGatePolicyOp', () => {
+  it('resolves workflow names and updates matching external dependency policies through the facade', async () => {
+    const persistence = makePersistence();
+    const mutations = {
+      setWorkflowExternalGatePolicies: vi.fn(async () => ({ runnable: [{ id: 'task-a' }] })),
+      retryWorkflow: vi.fn(),
+      recreateWorkflow: vi.fn(),
+      cancelWorkflow: vi.fn(),
+    };
+
+    const result = await executeSlackGatePolicyOp({
+      operation: 'gate-policy',
+      target: { workflow: 'Downstream' },
+      updates: [{ workflowId: 'Upstream', gatePolicy: 'review_ready' }],
+    }, { persistence, mutations });
+
+    expect(result.ok).toBe(true);
+    expect(result.summary).toContain('1 updated');
+    expect(mutations.setWorkflowExternalGatePolicies).toHaveBeenCalledWith(
+      'wf-down',
+      [{ workflowId: 'wf-up', gatePolicy: 'review_ready' }],
+    );
+    expect(mutations.retryWorkflow).not.toHaveBeenCalled();
+    expect(mutations.recreateWorkflow).not.toHaveBeenCalled();
+    expect(mutations.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('expands all targets but only mutates workflows with the requested dependency', async () => {
+    const persistence = makePersistence();
+    const mutations = {
+      setWorkflowExternalGatePolicies: vi.fn(async () => ({ runnable: [] })),
+    };
+
+    const result = await executeSlackGatePolicyOp({
+      operation: 'gate-policy',
+      target: { all: true },
+      updates: [{ workflowId: 'wf-up', gatePolicy: 'review_ready' }],
+    }, { persistence, mutations });
+
+    expect(result.ok).toBe(true);
+    expect(result.summary).toContain('1 updated');
+    expect(result.summary).toContain('2 skipped');
+    expect(mutations.setWorkflowExternalGatePolicies).toHaveBeenCalledTimes(1);
+    expect(mutations.setWorkflowExternalGatePolicies).toHaveBeenCalledWith(
+      'wf-down',
+      [{ workflowId: 'wf-up', gatePolicy: 'review_ready' }],
+    );
+  });
+
+  it('reports unmatched upstream workflows without mutating', async () => {
+    const persistence = makePersistence();
+    const mutations = {
+      setWorkflowExternalGatePolicies: vi.fn(),
+    };
+
+    const result = await executeSlackGatePolicyOp({
+      operation: 'gate-policy',
+      target: { workflow: 'wf-down' },
+      updates: [{ workflowId: 'missing-upstream', gatePolicy: 'review_ready' }],
+    }, { persistence, mutations });
+
+    expect(result.ok).toBe(false);
+    expect(result.summary).toContain('No upstream workflow matching');
+    expect(mutations.setWorkflowExternalGatePolicies).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -16,6 +16,7 @@ export const HEADLESS_SET_SUBCOMMANDS = [
   'fix-prompt',
   'fix-context',
   'gate-policy',
+  'workflow-gate-policy',
   'workflow',
   'task',
 ] as const;

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -40,6 +40,7 @@ import {
   collectRecoveryWorkerStatus,
   type RecoveryWorkerStatus,
 } from './recovery-worker-observability.js';
+import { executeSlackGatePolicyOp } from './slack-gate-policy-op.js';
 
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
@@ -67,6 +68,7 @@ import {
   restoreWorkflowForTask,
   restoreWorkflowForTaskUnlessDeleteAllWon,
   withRestoredTaskUnlessDeleteAllWon,
+  buildHeadlessApiServerDeps,
 } from './headless-shared.js';
 
 export { createHeadlessExecutor, wireHeadlessApproveHook, parseQueryFlags };
@@ -189,6 +191,9 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
       break;
     case 'gate-policy':
       await headlessSetGatePolicy(args.slice(1), deps);
+      break;
+    case 'workflow-gate-policy':
+      await headlessSetWorkflowGatePolicy(args.slice(1), deps);
       break;
     case 'workflow':
       await headlessSetWorkflowMetadata(args[1], args[2], args.slice(3).join(' '), deps);
@@ -583,6 +588,8 @@ ${BOLD}Configure:${RESET}
   set fix-context <taskId> <text>                     Update fix-session context and retry
   set gate-policy <taskId> <wfId> [depTaskId] <policy>
                                                       policy: completed | review_ready
+  set workflow-gate-policy <workflowId> <wfId> [depTaskId] <policy>
+                                                      policy: completed | review_ready
   set workflow <workflowId> <fieldPath> <value>      Safely update workflow metadata/config
   set task <taskId> <fieldPath> <value>              Safely update task metadata/config
   migrate-compat                                     Normalize persisted compatibility workflow/task state
@@ -908,6 +915,35 @@ async function headlessSetGatePolicy(args: string[], deps: HeadlessDeps): Promis
   });
 }
 
+async function headlessSetWorkflowGatePolicy(args: string[], deps: HeadlessDeps): Promise<void> {
+  const [workflowId, upstreamWorkflowId, arg3, arg4] = args;
+  if (!workflowId || !upstreamWorkflowId || !arg3) {
+    throw new Error(
+      'Missing arguments. Usage: --headless set workflow-gate-policy <workflowId> <upstreamWorkflowId> [depTaskId] <completed|review_ready>',
+    );
+  }
+
+  const hasDepTaskId = arg4 !== undefined;
+  const depTaskId = hasDepTaskId ? arg3 : undefined;
+  const gatePolicy = (hasDepTaskId ? arg4 : arg3) as 'completed' | 'review_ready';
+  if (gatePolicy !== 'completed' && gatePolicy !== 'review_ready') {
+    throw new Error(`Invalid gate policy "${String(gatePolicy)}". Expected completed|review_ready`);
+  }
+
+  const taskExecutor = createHeadlessExecutor(deps);
+  const { mutations } = buildHeadlessApiServerDeps(deps, taskExecutor);
+  const result = await executeSlackGatePolicyOp({
+    operation: 'gate-policy',
+    target: { workflow: workflowId },
+    updates: [{ workflowId: upstreamWorkflowId, ...(depTaskId ? { taskId: depTaskId } : {}), gatePolicy }],
+  }, {
+    persistence: deps.persistence,
+    mutations,
+  });
+  if (!result.ok) throw new Error(result.summary);
+  process.stdout.write(`${result.summary}\n`);
+}
+
 async function headlessSetWorkflowMetadata(
   workflowId: string,
   fieldPath: string,
@@ -951,4 +987,3 @@ async function headlessSetTaskMetadata(
   );
   process.stdout.write(`Updated task "${result.id}" ${result.fieldPath} → ${JSON.stringify(result.value)}\n`);
 }
-

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1154,6 +1154,7 @@ function startHeadlessMode(): void {
               switch (subCommand) {
                 case 'workflow':
                 case 'merge-mode':
+                case 'workflow-gate-policy':
                   return {
                     workflowId: targetArg === undefined ? undefined : String(targetArg),
                     priority: 'high',
@@ -2368,6 +2369,7 @@ function createEmbeddedTerminalBackendFromConfig(
         switch (subCommand) {
           case 'workflow':
           case 'merge-mode':
+          case 'workflow-gate-policy':
             return { workflowId: targetArg === undefined ? undefined : String(targetArg), priority: 'high' };
           case 'command':
           case 'prompt':

--- a/packages/app/src/slack-gate-policy-op.ts
+++ b/packages/app/src/slack-gate-policy-op.ts
@@ -1,0 +1,128 @@
+import type { ExternalDependency, ExternalGatePolicyUpdate, TaskState } from '@invoker/workflow-core';
+
+export type SlackGatePolicy = 'completed' | 'review_ready';
+
+export interface SlackGatePolicyUpdate {
+  workflowId: string;
+  taskId?: string;
+  gatePolicy: SlackGatePolicy;
+}
+
+export interface SlackGatePolicyOp {
+  operation: 'gate-policy';
+  target: { all: true } | { workflow: string };
+  updates: SlackGatePolicyUpdate[];
+}
+
+export interface SlackGatePolicyWorkflow {
+  id: string;
+  name?: string;
+  externalDependencies?: ExternalDependency[];
+}
+
+export interface SlackGatePolicyPersistence {
+  listWorkflows(): SlackGatePolicyWorkflow[];
+  loadWorkflow(workflowId: string): SlackGatePolicyWorkflow | undefined;
+}
+
+export interface SlackGatePolicyMutations {
+  setWorkflowExternalGatePolicies(
+    workflowId: string,
+    updates: ExternalGatePolicyUpdate[],
+  ): Promise<{ runnable: TaskState[] } | { started?: TaskState[] } | { data?: TaskState[] } | unknown>;
+}
+
+export interface SlackGatePolicyOpDeps {
+  persistence: SlackGatePolicyPersistence;
+  mutations: SlackGatePolicyMutations;
+}
+
+export interface SlackGatePolicyOpResult {
+  ok: boolean;
+  summary: string;
+}
+
+function dependencyKey(workflowId: string, taskId?: string): string {
+  return `${workflowId}::${taskId?.trim() || '__merge__'}`;
+}
+
+function workflowLabel(workflow: SlackGatePolicyWorkflow): string {
+  return workflow.name ? `${workflow.id} (${workflow.name})` : workflow.id;
+}
+
+function resolveWorkflowId(input: string, workflows: SlackGatePolicyWorkflow[]): string | undefined {
+  return workflows.find((workflow) => workflow.id === input || workflow.name === input)?.id;
+}
+
+function countStarted(result: Awaited<ReturnType<SlackGatePolicyMutations['setWorkflowExternalGatePolicies']>>): number {
+  if (result && typeof result === 'object') {
+    const value = result as { runnable?: unknown; started?: unknown; data?: unknown };
+    if (Array.isArray(value.runnable)) return value.runnable.length;
+    if (Array.isArray(value.started)) return value.started.length;
+    if (Array.isArray(value.data)) return value.data.length;
+  }
+  return 0;
+}
+
+export async function executeSlackGatePolicyOp(
+  op: SlackGatePolicyOp,
+  deps: SlackGatePolicyOpDeps,
+): Promise<SlackGatePolicyOpResult> {
+  if (op.updates.length === 0) {
+    return { ok: false, summary: 'No gate-policy updates provided.' };
+  }
+
+  const workflows = deps.persistence.listWorkflows();
+  const targets = 'all' in op.target
+    ? workflows
+    : (() => {
+        const workflowId = resolveWorkflowId(op.target.workflow, workflows);
+        if (!workflowId) return undefined;
+        const workflow = deps.persistence.loadWorkflow(workflowId) ?? workflows.find((candidate) => candidate.id === workflowId);
+        return workflow ? [workflow] : undefined;
+      })();
+
+  if (!targets) return { ok: false, summary: `No workflow matching \`${op.target.workflow}\`.` };
+  if (targets.length === 0) return { ok: false, summary: 'No workflows found.' };
+
+  const normalizedUpdates: ExternalGatePolicyUpdate[] = [];
+  for (const update of op.updates) {
+    const workflowId = resolveWorkflowId(update.workflowId, workflows);
+    if (!workflowId) {
+      return { ok: false, summary: `No upstream workflow matching \`${update.workflowId}\`.` };
+    }
+    normalizedUpdates.push({ ...update, workflowId });
+  }
+
+  let ok = 0;
+  let started = 0;
+  const skipped: string[] = [];
+  const failed: string[] = [];
+
+  for (const target of targets) {
+    const workflow = deps.persistence.loadWorkflow(target.id) ?? target;
+    const depsByKey = new Set(
+      (workflow.externalDependencies ?? []).map((dep) => dependencyKey(dep.workflowId, dep.taskId)),
+    );
+    const applicable = normalizedUpdates.filter((update) => depsByKey.has(dependencyKey(update.workflowId, update.taskId)));
+    if (applicable.length === 0) {
+      skipped.push(workflowLabel(workflow));
+      continue;
+    }
+
+    try {
+      const result = await deps.mutations.setWorkflowExternalGatePolicies(workflow.id, applicable);
+      ok++;
+      started += countStarted(result);
+    } catch (err) {
+      failed.push(`${workflowLabel(workflow)}: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  const parts = [`gate-policy: ${ok} updated`];
+  if (started > 0) parts.push(`${started} task(s) started`);
+  if (skipped.length > 0) parts.push(`${skipped.length} skipped without matching dependency`);
+  if (failed.length > 0) parts.push(`${failed.length} failed\n${failed.join('\n')}`);
+
+  return { ok: failed.length === 0 && ok > 0, summary: parts.join(', ') };
+}

--- a/packages/slack-manager/src/__tests__/workflow-ops.test.ts
+++ b/packages/slack-manager/src/__tests__/workflow-ops.test.ts
@@ -63,6 +63,25 @@ describe('createRunWorkflowOp', () => {
     expect(client.exec).toHaveBeenCalledWith(['retry', 'wf-1']);
   });
 
+  it('delegates gate-policy through the workflow-scoped owner command', async () => {
+    const client = makeClient({
+      listWorkflows: vi.fn(async () => [{ id: 'wf-down', name: 'downstream' }, { id: 'wf-up', name: 'upstream' }]),
+      getWorkflowBundle: vi.fn(async () => ({
+        workflow: { externalDependencies: [{ workflowId: 'wf-up', gatePolicy: 'completed' }] },
+        tasks: [],
+      })),
+    });
+
+    const res = await createRunWorkflowOp(client, noop)({
+      operation: 'gate-policy',
+      target: { workflow: 'downstream' },
+      updates: [{ workflowId: 'upstream', gatePolicy: 'review_ready' }],
+    });
+
+    expect(res.ok).toBe(true);
+    expect(client.exec).toHaveBeenCalledWith(['set', 'workflow-gate-policy', 'wf-down', 'wf-up', 'review_ready']);
+  });
+
   it('returns a not-found result for an unknown target', async () => {
     const client = makeClient({ listWorkflows: vi.fn(async () => [{ id: 'wf-1' }]) });
     const res = await createRunWorkflowOp(client, noop)({ operation: 'recreate', target: { workflow: 'nope' } });

--- a/packages/slack-manager/src/invoker-client.ts
+++ b/packages/slack-manager/src/invoker-client.ts
@@ -24,7 +24,7 @@ import {
   type Unsubscribe,
 } from '@invoker/transport';
 import { resolveInvokerIpcSocketPath } from '@invoker/contracts';
-import type { TaskState } from '@invoker/workflow-core';
+import type { ExternalDependency, TaskState } from '@invoker/workflow-core';
 import type { WorkflowStatus } from '@invoker/surfaces';
 
 /** A MessageBus that exposes connection readiness — i.e. an IpcBus client. */
@@ -48,7 +48,7 @@ export interface WorkflowSummary {
 
 /** A workflow's persisted record plus its tasks, as returned by `headless.query` `{kind:'workflow'}`. */
 export interface WorkflowBundle {
-  workflow: { name?: string } | undefined;
+  workflow: { name?: string; externalDependencies?: ExternalDependency[] } | undefined;
   tasks: TaskState[];
 }
 

--- a/packages/slack-manager/src/workflow-ops.ts
+++ b/packages/slack-manager/src/workflow-ops.ts
@@ -60,6 +60,10 @@ async function runOnce(
   }
   if (ids.length === 0) return { ok: false, summary: 'No workflows found.' };
 
+  if (op.operation === 'gate-policy') {
+    return runGatePolicy(client, op, all, ids, onProgress);
+  }
+
   if (op.operation === 'status') {
     const lines = await Promise.all(ids.map(async (id) => {
       const s = await client.getWorkflowStatus(id);
@@ -87,4 +91,55 @@ async function runOnce(
   onProgress?.({ done: total, total, ok, failed: failed.length });
   const summary = `${op.operation}: ${ok} ok${failed.length ? `, ${failed.length} failed\n${failed.join('\n')}` : ''}`;
   return { ok: failed.length === 0, summary };
+}
+
+async function runGatePolicy(
+  client: InvokerClient,
+  op: Extract<WorkflowOp, { operation: 'gate-policy' }>,
+  all: Awaited<ReturnType<InvokerClient['listWorkflows']>>,
+  ids: string[],
+  onProgress?: (p: WorkflowOpProgress) => void,
+): Promise<WorkflowOpResult> {
+  const normalized: typeof op.updates = [];
+  for (const update of op.updates) {
+    const upstream = all.find((w) => w.id === update.workflowId || w.name === update.workflowId);
+    if (!upstream) return { ok: false, summary: `No upstream workflow matching \`${update.workflowId}\`.` };
+    normalized.push({ ...update, workflowId: upstream.id });
+  }
+
+  let ok = 0;
+  let changed = 0;
+  const skipped: string[] = [];
+  const failed: string[] = [];
+  const total = ids.length;
+
+  for (const id of ids) {
+    onProgress?.({ done: ok + skipped.length + failed.length, total, ok, failed: failed.length, current: id });
+    try {
+      const bundle = await client.getWorkflowBundle(id);
+      const deps = bundle.workflow?.externalDependencies ?? [];
+      const applicable = normalized.filter((update) => deps.some((dep) => (
+        dep.workflowId === update.workflowId && (dep.taskId ?? '__merge__') === (update.taskId ?? '__merge__')
+      )));
+      if (applicable.length === 0) {
+        skipped.push(id);
+        continue;
+      }
+      for (const update of applicable) {
+        const args = ['set', 'workflow-gate-policy', id, update.workflowId];
+        if (update.taskId) args.push(update.taskId);
+        args.push(update.gatePolicy);
+        await client.exec(args);
+      }
+      ok++;
+      changed += applicable.length;
+    } catch (err) {
+      if (err instanceof InvokerDownError) throw err;
+      failed.push(`${id}: ${errMessage(err)}`);
+    }
+  }
+
+  onProgress?.({ done: total, total, ok, failed: failed.length });
+  const summary = `gate-policy: ${ok} updated${changed ? `, ${changed} change(s)` : ''}${skipped.length ? `, ${skipped.length} skipped without matching dependency` : ''}${failed.length ? `, ${failed.length} failed\n${failed.join('\n')}` : ''}`;
+  return { ok: failed.length === 0 && ok > 0, summary };
 }

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -591,6 +591,27 @@ describe('lobby verb routing', () => {
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
+  it('runs a deterministic lobby gate-policy op through workflow operations', async () => {
+    runWorkflowOp.mockResolvedValue({ ok: true, summary: 'gate-policy: 1 updated' });
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+
+    await mentionHandler(surface)({
+      event: { text: '<@BOT> gate-policy wf-down wf-upstream review_ready', ts: 't1', user: 'U1' },
+      say,
+    });
+
+    expect(runWorkflowOp.mock.calls[0][0]).toEqual({
+      operation: 'gate-policy',
+      target: { workflow: 'wf-down' },
+      updates: [{ workflowId: 'wf-upstream', gatePolicy: 'review_ready' }],
+    });
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: 'gate-policy: 1 updated' }));
+    expect(planConversationConfigs).toHaveLength(0);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
   it('uses the classifier only for fuzzy operational text, and always confirms before running', async () => {
     mockSpawn.mockImplementationOnce(() => mockProcess('{"intent":"command","operation":"recreate","target":"all"}'));
     runWorkflowOp.mockResolvedValue({ ok: true, summary: 'recreate: 2 ok' });

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -80,7 +80,7 @@ export interface SlackSurfaceConfig {
   workflowChannelRepo?: WorkflowChannelRepository;
   /** Gathers a workflow's planning convo + task transcripts for the in-channel assistant. */
   gatherWorkflowContext?: (workflowId: string) => Promise<WorkflowContext>;
-  /** Executes a workflow operation (recreate/rebase/retry/status/cancel) and returns a summary. Injected by main.ts. */
+  /** Executes a workflow operation (recreate/rebase/retry/status/cancel/gate-policy) and returns a summary. Injected by the host. */
   runWorkflowOp?: (op: WorkflowOp, onProgress?: (p: WorkflowOpProgress) => void) => Promise<WorkflowOpResult>;
   /** Relaunches Invoker (host-owned). Enables the `restart` lobby verb. */
   onRestartInvoker?: () => Promise<void>;
@@ -678,7 +678,7 @@ export class SlackSurface implements Surface {
       return;
     }
     if (ctrl?.kind === 'gate-policy') {
-      await say({ text: 'Gate-policy routing is not available in this deployment yet.', thread_ts: threadTs });
+      await this.handleLobbyGatePolicy(ctrl, threadTs, channel, say);
       return;
     }
 
@@ -785,6 +785,19 @@ export class SlackSurface implements Surface {
     await this.runConfirmedOp(op, threadTs, say, channel);
   }
 
+  private async handleLobbyGatePolicy(
+    ctrl: Extract<LobbyControl, { kind: 'gate-policy' }>,
+    threadTs: string,
+    channel: string,
+    say: SayFn,
+  ): Promise<void> {
+    if (!this.runWorkflowOp) {
+      await say({ text: 'Workflow operations are not available in this deployment.', thread_ts: threadTs });
+      return;
+    }
+    await this.runConfirmedOp({ operation: 'gate-policy', target: ctrl.target, updates: ctrl.updates }, threadTs, say, channel);
+  }
+
   /** A classifier-inferred op is fuzzy, so always confirm before running it. */
   private async proposeLobbyOp(
     cls: Extract<LobbyClassification, { intent: 'command' }>,
@@ -850,7 +863,11 @@ export class SlackSurface implements Surface {
 
   private describeOp(op: WorkflowOp): string {
     const target = 'all' in op.target ? 'ALL workflows' : `\`${op.target.workflow}\``;
-    return `${op.operation} ${target}`;
+    if (op.operation !== 'gate-policy') return `${op.operation} ${target}`;
+    const updates = op.updates
+      .map((update) => `${update.workflowId}${update.taskId ? `/${update.taskId}` : ''} -> ${update.gatePolicy}`)
+      .join(', ');
+    return `gate-policy ${target}${updates ? ` (${updates})` : ''}`;
   }
 
   /** Submit the plan drafted in this thread, after an explicit, summarized confirmation. */
@@ -1021,7 +1038,16 @@ export class SlackSurface implements Surface {
       return;
     }
     if (ctrl.kind === 'gate-policy') {
-      await respond({ text: 'Gate-policy routing is not available in this deployment yet.', response_type: 'ephemeral' });
+      if (!this.runWorkflowOp) {
+        await respond({ text: 'Workflow operations are not available in this deployment.', response_type: 'ephemeral' });
+        return;
+      }
+      try {
+        const result = await this.runWorkflowOp({ operation: 'gate-policy', target: ctrl.target, updates: ctrl.updates });
+        await respond({ text: result.summary, response_type: 'ephemeral' });
+      } catch (err) {
+        await respond({ text: `Operation failed: ${err instanceof Error ? err.message : String(err)}`, response_type: 'ephemeral' });
+      }
       return;
     }
 
@@ -1172,7 +1198,15 @@ export class SlackSurface implements Surface {
         await say({ text: `Sent input to \`${scoped(ctrl.task)}\`.`, thread_ts: threadTs });
         return;
       case 'gate-policy':
-        await say({ text: 'Gate-policy routing is not available in this deployment yet.', thread_ts: threadTs });
+        if (!this.runWorkflowOp) {
+          await say({ text: 'Workflow operations are not available in this deployment.', thread_ts: threadTs });
+          return;
+        }
+        await this.runConfirmedOp({
+          operation: 'gate-policy',
+          target: { workflow: mapping.workflowId },
+          updates: ctrl.updates,
+        }, threadTs, say);
         return;
     }
   }

--- a/packages/surfaces/src/surface.ts
+++ b/packages/surfaces/src/surface.ts
@@ -37,7 +37,7 @@ export type WorkflowOpName =
   | 'status'
   | 'cancel';
 
-export interface WorkflowOp {
+export interface WorkflowControlOp {
   operation: WorkflowOpName;
   target: { all: true } | { workflow: string };
 }
@@ -55,9 +55,11 @@ export interface WorkflowGatePolicyUpdate {
 export interface WorkflowGatePolicyOp {
   operation: 'gate-policy';
   /** Downstream workflow whose external dependency gate policy is edited. */
-  target: { workflow: string };
+  target: { all: true } | { workflow: string };
   updates: WorkflowGatePolicyUpdate[];
 }
+
+export type WorkflowOp = WorkflowControlOp | WorkflowGatePolicyOp;
 
 export interface WorkflowOpResult {
   ok: boolean;


### PR DESCRIPTION
## Summary

The new Slack gate-policy op needs to flow through the existing workflow gate-policy primitives instead of inventing a parallel control plane.

This slice routes the Slack gate-policy op through a focused bridge in `packages/app/src/main.ts` and `packages/app/src/slack-gate-policy-op.ts`, plus the corresponding Slack manager and surface routing in `packages/slack-manager/src/workflow-ops.ts` and `packages/surfaces/src/slack/slack-surface.ts`.

Selection by id, name, or `all` keeps the existing operational ops working. The fuzzy slack-surface router also routes gate-policy phrasing onto the operational op.

<details>
<summary>Review metadata</summary>

Review Claim: Slack gate-policy intent routes through existing workflow gate-policy primitives via a focused bridge.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Existing Slack op routing stays intact; the new bridge reuses the existing workflow mutation primitives.

Slice Rationale: Once the contact surface can express the op, the routing wiring should be reviewed as its own slice because it changes the main-process control plane.

</details>

## Non-goals

- Do not broaden the Slack surface to unrelated new workflow operations.
- Do not update docs or repro proof in this slice.

## Test Plan

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/slack-manager && pnpm test`
- [ ] `cd packages/surfaces && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #2733