### PR TITLE
Suggest PR stack numbers before landing

### DIFF
--- a/.cursor/rules/land-stack-precedence.mdc
+++ b/.cursor/rules/land-stack-precedence.mdc
@@ -1,5 +1,5 @@
 ---
-description: Landing or merging a PR stack must go through the land-stack guard; never identify a PR by branch name
+description: Landing or merging a PR stack must go through the land-stack guard; never choose a PR by branch-name lookup
 alwaysApply: true
 ---
 
@@ -9,7 +9,10 @@ When the user asks to **land / merge / ship / queue** a PR or PR stack, treat
 `skills/land-stack/SKILL.md` as the source of truth. Before queueing, labeling
 (`admin-bypass`), resolving review threads, or merging **any** PR:
 
-- **Require explicit PR numbers** from the user (bottom of stack first). Never
+- **Use confirmed PR numbers** (bottom of stack first). If the user does not
+  provide them, make a best-effort read-only discovery pass by broadly listing
+  open PRs, filtering to `stack/` heads, checking local head SHAs, ordering by
+  base/head links, and suggesting the bottom-up numbers for confirmation. Never
   discover the PR to land by branch name — do not use `gh pr list --head <branch>`.
   Two different PRs can share a branch name.
 - **Run the guard, which must exit 0:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 ## Landing PR Stacks
 
 - When asked to **land / merge / ship / queue** a PR or PR stack, follow `skills/land-stack/SKILL.md`.
-- **Never identify the PR to land by branch name** (`gh pr list --head <branch>`). Two PRs can share a branch name (a raw workflow branch PR vs the intended `stack/...` PR). Land by **explicit PR number** only.
+- Never choose a PR by branch-name lookup (`gh pr list --head <branch>`). Two PRs can share a branch name (a raw workflow branch PR vs the intended `stack/...` PR). If PR numbers are missing, broadly list open PRs, filter to `stack/` heads, verify local head SHAs, order by base/head links, and suggest bottom-up numbers for confirmation. Land by confirmed PR number only.
 - Verify before any write: `node scripts/land-stack.mjs <pr> [<pr> ...]` must exit 0 (checks head SHA is in the local clone, head branch is a real `stack/` branch, the PRs form a proper stack, all OPEN). Land via `node scripts/land-stack.mjs <pr> ... --execute`. Do not hand-add `admin-bypass` or `gh pr merge` to bypass the guard.
 - See `.cursor/rules/land-stack-precedence.mdc` for the always-on summary.
 

--- a/scripts/land-stack.mjs
+++ b/scripts/land-stack.mjs
@@ -4,7 +4,7 @@
  * Safely land a Mergify-managed PR stack.
  *
  * The hard rule this enforces: never act on a PR identified by branch name.
- * You pass explicit PR numbers, bottom-of-stack first. Every PR is verified
+ * You pass confirmed PR numbers, bottom-of-stack first. Every PR is verified
  * before any write happens:
  *   - its head commit SHA exists in the local clone (so it is the code you reviewed),
  *   - its head branch is a real `stack/` branch (refuses raw workflow branches),
@@ -21,8 +21,8 @@
  * PR. This guard makes that class of mistake impossible to commit by accident.
  *
  * Usage:
- *   node scripts/land-stack.mjs <pr> [<pr> ...]              # verify only (safe default)
- *   node scripts/land-stack.mjs <pr> [<pr> ...] --execute    # verify, then queue the bottom PR
+ *   node scripts/land-stack.mjs <pr> [<pr> ...]              # verify confirmed numbers (safe default)
+ *   node scripts/land-stack.mjs <pr> [<pr> ...] --execute    # re-verify, then queue the bottom PR
  *   node scripts/land-stack.mjs <pr> ... --base main         # trunk branch (default: master)
  *   node scripts/land-stack.mjs <pr> ... --stack-prefix s/   # required head-branch prefix
  *   node scripts/land-stack.mjs --help
@@ -56,7 +56,7 @@ export function analyzeStack({ prs, hasLocalCommit, trunk = TRUNK_DEFAULT, stack
   const add = (pr, name, ok, detail) => checks.push({ pr, name, ok, detail });
 
   if (!Array.isArray(prs) || prs.length === 0) {
-    add(0, 'input', false, 'no PR numbers provided — pass explicit PR numbers, bottom of stack first');
+    add(0, 'input', false, 'no PR numbers provided — discover/suggest bottom-up PR numbers, confirm them, then rerun');
     return { ok: false, checks };
   }
 
@@ -127,15 +127,17 @@ function parseArgs(argv) {
   return { prs, execute, trunk, stackPrefix, help };
 }
 
-const HELP = `land-stack — verify and land a Mergify PR stack by explicit PR number
+const HELP = `land-stack — verify and land a Mergify PR stack by confirmed PR number
 
-  node scripts/land-stack.mjs <pr> [<pr> ...]              verify only (safe default)
-  node scripts/land-stack.mjs <pr> [<pr> ...] --execute    verify, then queue the bottom PR
+  node scripts/land-stack.mjs <pr> [<pr> ...]              verify confirmed numbers (safe default)
+  node scripts/land-stack.mjs <pr> [<pr> ...] --execute    re-verify, then queue the bottom PR
   node scripts/land-stack.mjs <pr> ... --base <branch>     trunk branch (default: master)
   node scripts/land-stack.mjs <pr> ... --stack-prefix <p>  required head-branch prefix (default: stack/)
 
-Pass PR numbers bottom-of-stack first. Verification must pass before anything is
-queued. --execute adds the admin-bypass label to the bottom PR (base == trunk).`;
+Pass confirmed PR numbers bottom-of-stack first. If numbers are missing, broadly
+list open PRs, filter to stack heads, order by base/head links, ask the user to
+confirm the suggested numbers, then run this guard. Verification must pass before
+anything is queued. --execute adds the admin-bypass label to the bottom PR.`;
 
 function printReport(result) {
   const byPr = new Map();

--- a/scripts/test-land-stack.mjs
+++ b/scripts/test-land-stack.mjs
@@ -103,6 +103,7 @@ test('closed PR fails open check', () => {
 test('empty input fails', () => {
   const res = analyzeStack({ hasLocalCommit: hasLocal, prs: [] });
   assert.equal(res.ok, false);
+  assert.match(check(res, 0, 'input').detail, /discover\/suggest bottom-up PR numbers/);
 });
 
 test('custom --base trunk is honored', () => {

--- a/skills/land-stack/SKILL.md
+++ b/skills/land-stack/SKILL.md
@@ -3,7 +3,7 @@ name: land-stack
 description: >
   Land (queue/merge) a Mergify-managed PR stack safely. Trigger when asked to
   land, merge, ship, or queue a PR or PR stack with Mergify. Enforces that you
-  act on explicit, SHA-verified PR numbers — never a PR found by branch name.
+  act only on confirmed, SHA-verified PR numbers — never a PR found by branch name.
 ---
 
 # land-stack
@@ -14,14 +14,27 @@ Use this skill whenever the user asks to **land / merge / ship / queue** a PR or
 
 **Never identify the PR to land by branch name.** Two different PRs can share a
 branch name (an auto-generated workflow branch PR and the intended `stack/...`
-PR). You must land by **explicit PR number**, and every PR must pass the guard
+PR). You must land by **confirmed PR number**, and every PR must pass the guard
 before any write (label, thread-resolve, queue, merge).
 
 ## Steps
 
-1. **Get explicit PR numbers from the user**, bottom of stack first. If they
-   give a URL, read the number from it. Do not run `gh pr list --head <branch>`
-   to discover what to land.
+1. **Resolve PR numbers, bottom of stack first.** If the user gives numbers or
+   URLs, use those. If they do not, make a best-effort read-only discovery pass
+   and suggest the numbers yourself:
+
+   - Enumerate open PRs broadly, for example with `gh pr list --state open
+     --json number,baseRefName,headRefName,headRefOid,title --limit 100`.
+   - Filter to candidates whose `headRefName` starts with `stack/`.
+   - Prefer candidates whose `headRefOid` exists in the local clone, so the code
+     is actually available for review.
+   - Order the stack by base/head links: the bottom PR targets the trunk; each
+     later PR targets the previous PR's head branch.
+   - Run the guard on the suggested sequence. If it passes, present the exact
+     bottom-up PR numbers and ask the user to confirm them before landing.
+
+   Never discover by branch name. Do not run `gh pr list --head <branch>` to
+   decide what to land; that is the unsafe path this skill exists to prevent.
 
 2. **Verify with the guard — it must exit 0:**
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened safeguards for landing PR stacks by requiring confirmed PR numbers and SHA verification before taking action.
  * Improved guidance when PR numbers aren’t available by suggesting a read-only discovery flow and asking for confirmation of the bottom-up stack order.
  * Removed branch-name-based PR selection from landing workflows to reduce accidental merges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->