### PR TITLE
[Landing Stack](1) Teach landing skill to suggest PRs

### DIFF
--- a/.cursor/rules/land-stack-precedence.mdc
+++ b/.cursor/rules/land-stack-precedence.mdc
@@ -1,5 +1,5 @@
 ---
-description: Landing or merging a PR stack must go through the land-stack guard; never identify a PR by branch name
+description: Landing or merging a PR stack must go through the land-stack guard; never choose a PR by branch-name lookup
 alwaysApply: true
 ---
 
@@ -9,7 +9,10 @@ When the user asks to **land / merge / ship / queue** a PR or PR stack, treat
 `skills/land-stack/SKILL.md` as the source of truth. Before queueing, labeling
 (`admin-bypass`), resolving review threads, or merging **any** PR:
 
-- **Require explicit PR numbers** from the user (bottom of stack first). Never
+- **Use confirmed PR numbers** (bottom of stack first). If the user does not
+  provide them, make a best-effort read-only discovery pass by broadly listing
+  open PRs, filtering to `stack/` heads, checking local head SHAs, ordering by
+  base/head links, and suggesting the bottom-up numbers for confirmation. Never
   discover the PR to land by branch name — do not use `gh pr list --head <branch>`.
   Two different PRs can share a branch name.
 - **Run the guard, which must exit 0:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@
 ## Landing PR Stacks
 
 - When asked to **land / merge / ship / queue** a PR or PR stack, follow `skills/land-stack/SKILL.md`.
-- **Never identify the PR to land by branch name** (`gh pr list --head <branch>`). Two PRs can share a branch name (a raw workflow branch PR vs the intended `stack/...` PR). Land by **explicit PR number** only.
+- Never choose a PR by branch-name lookup (`gh pr list --head <branch>`). Two PRs can share a branch name (a raw workflow branch PR vs the intended `stack/...` PR). If PR numbers are missing, broadly list open PRs, filter to `stack/` heads, verify local head SHAs, order by base/head links, and suggest bottom-up numbers for confirmation. Land by confirmed PR number only.
 - Verify before any write: `node scripts/land-stack.mjs <pr> [<pr> ...]` must exit 0 (checks head SHA is in the local clone, head branch is a real `stack/` branch, the PRs form a proper stack, all OPEN). Land via `node scripts/land-stack.mjs <pr> ... --execute`. Do not hand-add `admin-bypass` or `gh pr merge` to bypass the guard.
 - See `.cursor/rules/land-stack-precedence.mdc` for the always-on summary.
 

--- a/skills/land-stack/SKILL.md
+++ b/skills/land-stack/SKILL.md
@@ -3,7 +3,7 @@ name: land-stack
 description: >
   Land (queue/merge) a Mergify-managed PR stack safely. Trigger when asked to
   land, merge, ship, or queue a PR or PR stack with Mergify. Enforces that you
-  act on explicit, SHA-verified PR numbers — never a PR found by branch name.
+  act only on confirmed, SHA-verified PR numbers — never a PR found by branch name.
 ---
 
 # land-stack
@@ -14,14 +14,27 @@ Use this skill whenever the user asks to **land / merge / ship / queue** a PR or
 
 **Never identify the PR to land by branch name.** Two different PRs can share a
 branch name (an auto-generated workflow branch PR and the intended `stack/...`
-PR). You must land by **explicit PR number**, and every PR must pass the guard
+PR). You must land by **confirmed PR number**, and every PR must pass the guard
 before any write (label, thread-resolve, queue, merge).
 
 ## Steps
 
-1. **Get explicit PR numbers from the user**, bottom of stack first. If they
-   give a URL, read the number from it. Do not run `gh pr list --head <branch>`
-   to discover what to land.
+1. **Resolve PR numbers, bottom of stack first.** If the user gives numbers or
+   URLs, use those. If they do not, make a best-effort read-only discovery pass
+   and suggest the numbers yourself:
+
+   - Enumerate open PRs broadly, for example with `gh pr list --state open
+     --json number,baseRefName,headRefName,headRefOid,title --limit 100`.
+   - Filter to candidates whose `headRefName` starts with `stack/`.
+   - Prefer candidates whose `headRefOid` exists in the local clone, so the code
+     is actually available for review.
+   - Order the stack by base/head links: the bottom PR targets the trunk; each
+     later PR targets the previous PR's head branch.
+   - Run the guard on the suggested sequence. If it passes, present the exact
+     bottom-up PR numbers and ask the user to confirm them before landing.
+
+   Never discover by branch name. Do not run `gh pr list --head <branch>` to
+   decide what to land; that is the unsafe path this skill exists to prevent.
 
 2. **Verify with the guard — it must exit 0:**
 


### PR DESCRIPTION
## Summary

Landing guidance now helps agents when PR numbers are missing.

The skill and always-on rules now say to find likely stack PRs safely, suggest bottom-up numbers, and ask for confirmation before landing.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the landing guidance that tells agents to suggest likely stack PR numbers before asking for confirmation.

Review Lane: docs

Review Unit: docs

Safety Invariant: This only changes agent guidance; the landing guard still gates every write.

Slice Rationale: This slice changes the human-facing landing instructions before the helper output is adjusted in the next PR.

</details>

## Non-goals

This does not land, queue, or merge any PR.

This does not change the land-stack helper script.

This does not make branch-name PR lookup safe.

## Test Plan

- [x] `node scripts/test-land-stack.mjs`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 9530f3402`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the rules for landing stacked PRs.
  * Allowed a read-only discovery step when PR numbers aren’t provided, then requires confirming the exact bottom-up PR order before proceeding.
  * Reinforced that PRs must not be identified by branch-name lookup and that landing only happens after PR numbers are confirmed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->