### PR TITLE
[PR Status Workers](1) Harden review-gate PR status lineage

### DIFF
--- a/packages/app/src/__tests__/auto-fix-intents.test.ts
+++ b/packages/app/src/__tests__/auto-fix-intents.test.ts
@@ -196,11 +196,12 @@ describe('review-gate CI context staleness', () => {
     })).toBe(false);
   });
 
-  it('flags a moved selected attempt, generation, review, or branch as stale', () => {
+  it('flags a moved selected attempt, generation, review, branch, or head SHA as stale', () => {
     expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-1', generation: 2, selectedAttemptId: 'attempt-2', branch: 'experiment/foo' })).toBe(true);
     expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-1', generation: 3, selectedAttemptId: 'attempt-1', branch: 'experiment/foo' })).toBe(true);
     expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-2', generation: 2, selectedAttemptId: 'attempt-1', branch: 'experiment/foo' })).toBe(true);
     expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-1', generation: 2, selectedAttemptId: 'attempt-1', branch: 'experiment/bar' })).toBe(true);
+    expect(isReviewGateCiContextStale({ ...ctx, headSha: 'sha-1' }, { reviewId: 'review-1', generation: 2, selectedAttemptId: 'attempt-1', branch: 'experiment/foo', headSha: 'sha-2' })).toBe(true);
   });
 
   it('defaults a missing generation to 0 when comparing', () => {
@@ -217,6 +218,7 @@ describe('review-gate CI context encode/decode', () => {
       selectedAttemptId: 'a1',
       branch: 'b1',
       headSha: 'deadbeef',
+      dedupeKey: 'ci-failure:wf-1/merge:r1:deadbeef:fingerprint',
       fixContext: 'fix the failing checks',
     };
     expect(decodeReviewGateCiContext(encodeReviewGateCiContext(ctx))).toEqual(ctx);

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -5214,10 +5214,10 @@ console.log(JSON.stringify(out));
         };
         const mergeGateProvider = {
           checkApproval: vi.fn()
-            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved one' })
-            .mockResolvedValueOnce({ lifecycle: 'open', rejected: false, statusText: 'Pending second' })
-            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Still approved' })
-            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved both' })
+            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved one', headSha: 'sha-one' })
+            .mockResolvedValueOnce({ lifecycle: 'open', rejected: false, statusText: 'Pending second', headSha: 'sha-two' })
+            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Still approved', headSha: 'sha-one' })
+            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved both', headSha: 'sha-two' })
         };
 
         const executor = new TaskRunner({
@@ -5241,8 +5241,8 @@ console.log(JSON.stringify(out));
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(task.execution.reviewGate?.artifacts).toEqual([
-          expect.objectContaining({ id: 'contracts', status: 'approved' }),
-          expect.objectContaining({ id: 'runtime', status: 'open', rawStatus: 'Pending second' }),
+          expect.objectContaining({ id: 'contracts', status: 'approved', headSha: 'sha-one' }),
+          expect.objectContaining({ id: 'runtime', status: 'open', rawStatus: 'Pending second', headSha: 'sha-two' }),
         ]);
 
         await executor.checkMergeGateStatuses();
@@ -5251,9 +5251,11 @@ console.log(JSON.stringify(out));
         expect(orchestrator.approve).toHaveBeenCalledWith('merge-stack');
         expect(executeTasks).toHaveBeenCalledWith([downstream]);
         expect(task.execution.reviewGate?.artifacts).toEqual([
-          expect.objectContaining({ id: 'contracts', status: 'approved' }),
-          expect.objectContaining({ id: 'runtime', status: 'approved' }),
+          expect.objectContaining({ id: 'contracts', status: 'approved', headSha: 'sha-one' }),
+          expect.objectContaining({ id: 'runtime', status: 'approved', headSha: 'sha-two' }),
         ]);
+        const runtimeArtifact = task.execution.reviewGate?.artifacts.find((artifact) => artifact.id === 'runtime');
+        expect(Object.prototype.hasOwnProperty.call(runtimeArtifact, 'rawStatus')).toBe(false);
       });
 
       it('marks a structured reviewGate task closed when a required artifact PR is closed', async () => {

--- a/packages/execution-engine/src/auto-fix-intents.ts
+++ b/packages/execution-engine/src/auto-fix-intents.ts
@@ -43,6 +43,7 @@ export interface ReviewGateCiContext {
   branch?: string;
   headSha?: string;
   fixContext?: string;
+  dedupeKey?: string;
 }
 
 export interface ReviewGateLineageFields {
@@ -50,6 +51,36 @@ export interface ReviewGateLineageFields {
   reviewId?: string;
   selectedAttemptId?: string;
   branch?: string;
+  headSha?: string;
+}
+
+export interface ReviewGateArtifactCurrencyState {
+  readonly activeGeneration: number;
+}
+
+export interface ReviewGateArtifactCurrencyFields {
+  readonly generation: number;
+  readonly status?: string;
+  readonly discardedAt?: string;
+  readonly providerId?: string;
+}
+
+export function isCurrentReviewGateArtifact(
+  gate: ReviewGateArtifactCurrencyState,
+  artifact: ReviewGateArtifactCurrencyFields,
+): boolean {
+  return artifact.generation === gate.activeGeneration
+    && artifact.status !== 'discarded'
+    && !artifact.discardedAt;
+}
+
+export function isCurrentReviewGateArtifactForProvider(
+  gate: ReviewGateArtifactCurrencyState,
+  artifact: ReviewGateArtifactCurrencyFields,
+  providerId: string,
+): boolean {
+  return isCurrentReviewGateArtifact(gate, artifact)
+    && artifact.providerId === providerId;
 }
 
 export function encodeReviewGateCiContext(context: ReviewGateCiContext): string {
@@ -80,6 +111,7 @@ export function decodeReviewGateCiContext(encoded: unknown): ReviewGateCiContext
     branch: typeof candidate.branch === 'string' ? candidate.branch : undefined,
     headSha: typeof candidate.headSha === 'string' ? candidate.headSha : undefined,
     fixContext: typeof candidate.fixContext === 'string' ? candidate.fixContext : undefined,
+    dedupeKey: typeof candidate.dedupeKey === 'string' ? candidate.dedupeKey : undefined,
   };
 }
 
@@ -91,7 +123,8 @@ export function isReviewGateCiContextStale(
     current.selectedAttemptId !== context.selectedAttemptId ||
     (current.generation ?? 0) !== context.generation ||
     current.reviewId !== context.reviewId ||
-    current.branch !== context.branch
+    current.branch !== context.branch ||
+    current.headSha !== context.headSha
   );
 }
 

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -9,8 +9,22 @@ import type {
 } from './merge-gate-provider.js';
 import { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
 import { isGitRefLockRace, retryTransientGitHubCli } from './git-utils.js';
+import { killProcessGroup, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 
 type ExistingPullRequest = { url: string; number: number };
+
+const DEFAULT_GITHUB_CLI_TIMEOUT_MS = 60_000;
+
+function getGitHubCliTimeoutMs(): number {
+  const raw = process.env.INVOKER_GITHUB_CLI_TIMEOUT_MS?.trim();
+  if (!raw) return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+  if (!/^\d+$/.test(raw)) return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > 2_147_483_647) {
+    return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+  }
+  return parsed;
+}
 
 export class GitHubMergeGateProvider implements MergeGateProvider {
   readonly name = 'github';
@@ -238,15 +252,78 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
 
   private async exec(cmd: string, args: string[], cwd: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const child = spawn(cmd, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+      const child = spawn(cmd, args, {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: process.platform !== 'win32',
+      });
+      const timeoutMs = getGitHubCliTimeoutMs();
       let stdout = '';
       let stderr = '';
+      let settled = false;
+      let childClosed = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      let forceKill: ReturnType<typeof setTimeout> | undefined;
+
+      const clearTimeoutTimer = (): void => {
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = undefined;
+        }
+      };
+
+      const clearForceKillTimer = (): void => {
+        if (forceKill) {
+          clearTimeout(forceKill);
+          forceKill = undefined;
+        }
+      };
+
+      const settle = (fn: () => void): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeoutTimer();
+        fn();
+      };
+
+      if (timeoutMs > 0) {
+        timeout = setTimeout(() => {
+          if (settled) return;
+          killProcessGroup(child, 'SIGTERM');
+          forceKill = setTimeout(() => {
+            if (!childClosed) {
+              killProcessGroup(child, 'SIGKILL');
+            }
+          }, SIGKILL_TIMEOUT_MS);
+          forceKill.unref?.();
+          settle(() => reject(new Error(
+            `${cmd} ${args.join(' ')} exceeded GitHub CLI timeout (${timeoutMs}ms) in ${cwd}. ` +
+            'Set INVOKER_GITHUB_CLI_TIMEOUT_MS to adjust (0 = unbounded).',
+          )));
+        }, timeoutMs);
+        timeout.unref?.();
+      }
+
       child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
       child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
-      child.on('error', reject);
-      child.on('close', (code) => {
-        if (code === 0) resolve(stdout.trim());
-        else reject(new Error(`${cmd} ${args.join(' ')} failed (code ${code}): ${stderr.trim()}`));
+      child.on('error', (err) => {
+        childClosed = true;
+        clearForceKillTimer();
+        settle(() => reject(err));
+      });
+      child.on('close', (code, signal) => {
+        childClosed = true;
+        clearForceKillTimer();
+        if (settled) return;
+        settled = true;
+        clearTimeoutTimer();
+        if (code === 0) {
+          resolve(stdout.trim());
+          return;
+        }
+        reject(new Error(
+          `${cmd} ${args.join(' ')} failed (code ${code ?? 'null'}${signal ? ` signal ${signal}` : ''}): ${stderr.trim()}`,
+        ));
       });
     });
   }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -29,6 +29,7 @@ import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
 import { MergeGateExecutor } from './merge-gate-executor.js';
 import { isInvokerManagedPoolBranch } from './plan-base-remote.js';
+import { isCurrentReviewGateArtifact } from './auto-fix-intents.js';
 import { SshExecutor } from './ssh-executor.js';
 
 import {
@@ -1875,11 +1876,6 @@ export class TaskRunner {
       }
     }
   }
-  private isCurrentReviewGateArtifact(gate: ReviewGateState, artifact: ReviewGateArtifact): boolean {
-    return artifact.generation === gate.activeGeneration
-      && artifact.status !== 'discarded'
-      && !artifact.discardedAt;
-  }
 
 
   private getCurrentReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
@@ -1897,7 +1893,7 @@ export class TaskRunner {
       }];
     }
 
-    return gate.artifacts.filter((artifact) => this.isCurrentReviewGateArtifact(gate, artifact));
+    return gate.artifacts.filter((artifact) => isCurrentReviewGateArtifact(gate, artifact));
   }
 
   private getCurrentRequiredReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
@@ -1938,7 +1934,7 @@ export class TaskRunner {
       return false;
     }
     return currentGate.artifacts.some((artifact) =>
-      this.isCurrentReviewGateArtifact(currentGate, artifact)
+      isCurrentReviewGateArtifact(currentGate, artifact)
       && artifact.required
       && artifact.providerId === providerId,
     );
@@ -1954,27 +1950,27 @@ export class TaskRunner {
       ...gate,
       artifacts: gate.artifacts.map((artifact) => {
         if (
-          !this.isCurrentReviewGateArtifact(gate, artifact)
+          !isCurrentReviewGateArtifact(gate, artifact)
           || artifact.providerId !== providerId
         ) {
           return artifact;
         }
+        const { rawStatus, ...artifactWithoutRawStatus } = artifact;
+        void rawStatus;
         const next: ReviewGateArtifact = {
-          ...artifact,
+          ...artifactWithoutRawStatus,
           status: mappedStatus,
           updatedAt: new Date().toISOString(),
+          ...(mappedStatus === 'open' ? { rawStatus: status.statusText } : {}),
         };
-        if (mappedStatus === 'open') {
-          return { ...next, rawStatus: status.statusText };
-        }
-        return next;
+        return status.headSha ? { ...next, headSha: status.headSha } : next;
       }),
     };
   }
 
   private reviewGateIsApproved(gate: ReviewGateState): boolean {
     const currentRequired = gate.artifacts.filter((artifact) =>
-      this.isCurrentReviewGateArtifact(gate, artifact) && artifact.required,
+      isCurrentReviewGateArtifact(gate, artifact) && artifact.required,
     );
     return currentRequired.length > 0
       && currentRequired.every((artifact) => artifact.status === 'approved');

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -158,6 +158,7 @@ export interface ReviewGateArtifact {
   readonly updatedAt?: string;
   readonly discardedAt?: string;
   readonly discardReason?: string;
+  readonly headSha?: string;
 }
 
 export interface ReviewGateState {


### PR DESCRIPTION
## Summary

Review-gate artifacts now include the current PR head SHA from GitHub.

The GitHub process runner also has a bounded timeout, so a stuck `gh` call cannot block status checks forever.

<details>
<summary>Review metadata</summary>

Review Claim: Review-gate routing now carries the PR head SHA needed by later repair work.

Review Lane: behavior

Review Unit: routing

Safety Invariant: TaskRunner still owns all review-gate status decisions and writes.

Slice Rationale: This base slice adds the lineage value before any worker consumes it.

</details>

## Non-goals

No live GitHub tests.

No worker registration changes.

No CI repair path.

## Architecture

### Before

```mermaid
graph TD
    A["GitHub status"] --> B["ReviewGateArtifact without headSha"]
```

### After

```mermaid
graph TD
    A["GitHub status with head SHA"] --> B["ReviewGateArtifact.headSha"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts src/__tests__/github-merge-gate-provider.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/auto-fix-intents.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert bf4873a2b`
- Post-revert steps: None
- Data migration? No
