### PR TITLE
[Blocked] [PR Status Workers](2) Register PR status worker

### DIFF
--- a/packages/app/src/__tests__/review-gate-status-worker.test.ts
+++ b/packages/app/src/__tests__/review-gate-status-worker.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { startReviewGateStatusWorker } from '../review-gate-status-worker.js';
+import { createPrStatusWorker } from '../review-gate-status-worker.js';
 
 const logger = {
   info: vi.fn(),
@@ -8,62 +8,49 @@ const logger = {
   error: vi.fn(),
   debug: vi.fn(),
   trace: vi.fn(),
+  child: vi.fn(() => logger),
 };
 
-describe('review-gate status worker', () => {
+describe('pr-status worker', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
   });
 
-  it('starts in owner mode', async () => {
+  it('polls review-gate status in owner mode', async () => {
     vi.useFakeTimers();
     const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
 
-    const worker = startReviewGateStatusWorker({
-      ownerMode: true,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+    const worker = createPrStatusWorker({
+      reviewGate: { checkMergeGateStatuses },
       logger,
       intervalMs: 1000,
+      installSignalHandlers: false,
     });
-
-    expect(worker).not.toBeNull();
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(checkMergeGateStatuses).toHaveBeenCalledTimes(1);
-    worker?.stop();
-  });
-
-  it('starts in owner mode even when startup auto-run is disabled', async () => {
-    vi.useFakeTimers();
-    const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
-
-    const worker = startReviewGateStatusWorker({
-      ownerMode: true,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
-      logger,
-      intervalMs: 1000,
-    });
+    worker.start();
 
     await vi.advanceTimersByTimeAsync(1000);
     expect(checkMergeGateStatuses).toHaveBeenCalledTimes(1);
-    worker?.stop();
+    await worker.stop();
   });
 
-  it('does not start in follower or read-only mode', async () => {
+  it('starts even when startup auto-run is disabled', async () => {
     vi.useFakeTimers();
     const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
 
-    const worker = startReviewGateStatusWorker({
-      ownerMode: false,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+    const worker = createPrStatusWorker({
+      reviewGate: { checkMergeGateStatuses },
       logger,
       intervalMs: 1000,
+      installSignalHandlers: false,
     });
+    worker.start();
 
-    expect(worker).toBeNull();
-    await vi.advanceTimersByTimeAsync(3000);
-    expect(checkMergeGateStatuses).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(checkMergeGateStatuses).toHaveBeenCalledTimes(1);
+    await worker.stop();
   });
+
 
   it('does not overlap ticks', async () => {
     vi.useFakeTimers();
@@ -75,12 +62,13 @@ describe('review-gate status worker', () => {
       .mockReturnValueOnce(firstTick)
       .mockResolvedValue(undefined);
 
-    const worker = startReviewGateStatusWorker({
-      ownerMode: true,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+    const worker = createPrStatusWorker({
+      reviewGate: { checkMergeGateStatuses },
       logger,
       intervalMs: 1000,
+      installSignalHandlers: false,
     });
+    worker.start();
 
     await vi.advanceTimersByTimeAsync(1000);
     await vi.advanceTimersByTimeAsync(1000);
@@ -88,9 +76,9 @@ describe('review-gate status worker', () => {
 
     resolveFirst();
     await firstTick;
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(0);
     expect(checkMergeGateStatuses).toHaveBeenCalledTimes(2);
-    worker?.stop();
+    await worker.stop();
   });
 
   it('continues after a tick error', async () => {
@@ -99,33 +87,35 @@ describe('review-gate status worker', () => {
       .mockRejectedValueOnce(new Error('temporary failure'))
       .mockResolvedValue(undefined);
 
-    const worker = startReviewGateStatusWorker({
-      ownerMode: true,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+    const worker = createPrStatusWorker({
+      reviewGate: { checkMergeGateStatuses },
       logger,
       intervalMs: 1000,
+      installSignalHandlers: false,
     });
+    worker.start();
 
     await vi.advanceTimersByTimeAsync(1000);
     await vi.advanceTimersByTimeAsync(1000);
 
     expect(checkMergeGateStatuses).toHaveBeenCalledTimes(2);
-    expect(logger.error).toHaveBeenCalledWith('review-gate status worker tick failed', expect.any(Object));
-    worker?.stop();
+    expect(logger.error).toHaveBeenCalledWith('[worker:pr-status] tick failed', expect.any(Object));
+    await worker.stop();
   });
 
   it('clears the interval on shutdown', async () => {
     vi.useFakeTimers();
     const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
 
-    const worker = startReviewGateStatusWorker({
-      ownerMode: true,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+    const worker = createPrStatusWorker({
+      reviewGate: { checkMergeGateStatuses },
       logger,
       intervalMs: 1000,
+      installSignalHandlers: false,
     });
+    worker.start();
 
-    worker?.stop();
+    await worker.stop();
     await vi.advanceTimersByTimeAsync(3000);
     expect(checkMergeGateStatuses).not.toHaveBeenCalled();
   });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -98,7 +98,9 @@ import {
   RESTART_TO_BRANCH_TRACE,
   remoteFetchForPool,
   registerBuiltinAgents,
+  createPrStatusWorker,
   type AgentRegistry,
+  type WorkerRuntime,
 } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
 import type { TaskOutputData } from './types.js';
@@ -226,7 +228,6 @@ import {
 } from './ipc/ipc-registration.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import { startLifecycleEventBridge, type LifecycleEventBridge } from './lifecycle-event-bridge.js';
-import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
 import {
   buildRecoveryWorkerAuditPayload,
   classifyAutoFixRecoveryPhase,
@@ -911,7 +912,7 @@ function startHeadlessMode(): void {
     }
 
     let exitCode = 0;
-    let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
+    let prStatusWorker: WorkerRuntime | null = null;
     let lifecycleEventBridge: LifecycleEventBridge | null = null;
     let standaloneLaunchDispatcherController: StandaloneLaunchDispatcherController | null = null;
     try {
@@ -1585,11 +1586,13 @@ function startHeadlessMode(): void {
           logWarn: (message) => logger.warn(message, { module: 'surface-relay' }),
         });
 
-        reviewGateStatusWorker = startReviewGateStatusWorker({
-          ownerMode: true,
-          getTaskExecutor: createStandaloneTaskExecutor,
-          logger,
-        });
+        if (!readOnlyMode) {
+          prStatusWorker = createPrStatusWorker({
+            reviewGate: { checkMergeGateStatuses: () => createStandaloneTaskExecutor().checkMergeGateStatuses() },
+            logger,
+          });
+          prStatusWorker.start();
+        }
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
@@ -1609,7 +1612,7 @@ function startHeadlessMode(): void {
     } finally {
       standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
-      reviewGateStatusWorker?.stop();
+      await prStatusWorker?.stop();
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
       }
@@ -1696,7 +1699,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const agentRegistry = registerBuiltinAgents();
   let mainWindow: BrowserWindow | null = null;
   let taskExecutor: TaskRunner | null = null;
-  let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
+  let prStatusWorker: WorkerRuntime | null = null;
   let apiServer: ApiServer | null = null;
   let webBridge: WebBridge | null = null;
   let ownerMode = true;
@@ -3310,11 +3313,13 @@ function createEmbeddedTerminalBackendFromConfig(
       });
     }
 
-    reviewGateStatusWorker = startReviewGateStatusWorker({
-      ownerMode,
-      getTaskExecutor: requireTaskExecutor,
-      logger,
-    });
+    if (ownerMode) {
+      prStatusWorker = createPrStatusWorker({
+        reviewGate: { checkMergeGateStatuses: () => requireTaskExecutor().checkMergeGateStatuses() },
+        logger,
+      });
+      prStatusWorker.start();
+    }
 
     // Relaunch orphaned running tasks and start any pending-but-ready tasks.
     if (!ownerMode) {
@@ -4273,11 +4278,11 @@ function createEmbeddedTerminalBackendFromConfig(
       'invoker:fix-with-agent',
       (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
       'normal',
-      async (taskIdArg: unknown, agentNameArg?: unknown) => {
-      const taskId = String(taskIdArg);
-      const agentName = agentNameArg === undefined ? undefined : String(agentNameArg);
+      async (...fixArgs: unknown[]) => {
+      const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
       try {
-        const started = await executeFixWithAgentMutation(taskId, agentName, 'ipc');
+        const source = context.autoFix ? 'auto-fix' : 'ipc';
+        const started = await executeFixWithAgentMutation(taskId, agentName, source);
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
@@ -4699,8 +4704,8 @@ function createEmbeddedTerminalBackendFromConfig(
       try {
         if (apiServer) await apiServer.close().catch(() => {});
         if (webBridge) await webBridge.close().catch(() => {});
-        reviewGateStatusWorker?.stop();
-        reviewGateStatusWorker = null;
+        await prStatusWorker?.stop();
+        prStatusWorker = null;
         if (dbPollInterval) clearInterval(dbPollInterval);
         if (activityPollInterval) clearInterval(activityPollInterval);
         if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);

--- a/packages/app/src/review-gate-status-worker.ts
+++ b/packages/app/src/review-gate-status-worker.ts
@@ -1,64 +1,11 @@
-import type { Logger } from '@invoker/contracts';
-import type { TaskRunner } from '@invoker/execution-engine';
-
-export interface ReviewGateStatusWorker {
-  tick(): Promise<void>;
-  stop(): void;
-}
-
-export interface ReviewGateStatusWorkerOptions {
-  ownerMode: boolean;
-  getTaskExecutor: () => Pick<TaskRunner, 'checkMergeGateStatuses'>;
-  logger: Logger;
-  intervalMs?: number;
-}
-
-const DEFAULT_REVIEW_GATE_STATUS_WORKER_INTERVAL_MS = 60_000;
-
-export function startReviewGateStatusWorker(
-  options: ReviewGateStatusWorkerOptions,
-): ReviewGateStatusWorker | null {
-  if (!options.ownerMode) {
-    options.logger.info('review-gate status worker disabled outside owner mode', { module: 'merge-gate' });
-    return null;
-  }
-
-  const intervalMs = options.intervalMs ?? DEFAULT_REVIEW_GATE_STATUS_WORKER_INTERVAL_MS;
-  let stopped = false;
-  let inFlight = false;
-
-  const tick = async (): Promise<void> => {
-    if (stopped) return;
-    if (inFlight) {
-      options.logger.info('review-gate status worker tick skipped because previous tick is still running', {
-        module: 'merge-gate',
-      });
-      return;
-    }
-    inFlight = true;
-    try {
-      await options.getTaskExecutor().checkMergeGateStatuses();
-    } catch (err) {
-      options.logger.error('review-gate status worker tick failed', { module: 'merge-gate', err });
-    } finally {
-      inFlight = false;
-    }
-  };
-
-  const interval = setInterval(() => {
-    void tick();
-  }, intervalMs);
-  interval.unref?.();
-
-  options.logger.info(`review-gate status worker started intervalMs=${intervalMs}`, { module: 'merge-gate' });
-
-  return {
-    tick,
-    stop: () => {
-      if (stopped) return;
-      stopped = true;
-      clearInterval(interval);
-      options.logger.info('review-gate status worker stopped', { module: 'merge-gate' });
-    },
-  };
-}
+/**
+ * Compatibility shim. Review-gate PR status polling is now the pr-status
+ * worker in `@invoker/execution-engine`.
+ */
+export {
+  createPrStatusWorker,
+  DEFAULT_PR_STATUS_WORKER_INTERVAL_MS,
+  PR_STATUS_WORKER_KIND,
+  type PrStatusWorkerOptions,
+  type PrStatusWorkerReviewGateDeps,
+} from '@invoker/execution-engine';

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { RECOVERY_WORKER_KIND, type AutoFixRecoveryStore, type AutoFixRecoverySubmitter } from '../auto-fix-recovery.js';
 import {
   AUTO_FIX_WORKER_KIND,
+  PR_STATUS_WORKER_KIND,
   createWorkerRegistry,
   registerAutoFixWorker,
   type WorkerRuntimeDependencies,
@@ -27,7 +28,12 @@ const noopSubmitter: AutoFixRecoverySubmitter = {
 };
 
 function deps(): WorkerRuntimeDependencies {
-  return { store: emptyStore, submitter: noopSubmitter, logger: silentLogger };
+  return {
+    store: emptyStore,
+    submitter: noopSubmitter,
+    logger: silentLogger,
+    reviewGate: { checkMergeGateStatuses: () => {} },
+  };
 }
 
 describe('worker registry', () => {
@@ -37,16 +43,21 @@ describe('worker registry', () => {
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeUndefined();
   });
 
-  it('returns the auto-fix definition by its kind once registered', () => {
+  it('returns the built-in worker definitions by kind once registered', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry());
 
-    const definition = registry.get(AUTO_FIX_WORKER_KIND);
-    expect(definition).toBeDefined();
-    expect(definition?.kind).toBe(AUTO_FIX_WORKER_KIND);
-    expect(definition?.note.length).toBeGreaterThan(0);
-    expect(typeof definition?.factory).toBe('function');
+    for (const kind of [AUTO_FIX_WORKER_KIND, PR_STATUS_WORKER_KIND]) {
+      const definition = registry.get(kind);
+      expect(definition).toBeDefined();
+      expect(definition?.kind).toBe(kind);
+      expect(definition?.note.length).toBeGreaterThan(0);
+      expect(typeof definition?.factory).toBe('function');
+    }
 
-    expect(registry.list().map((d) => d.kind)).toEqual([AUTO_FIX_WORKER_KIND]);
+    expect(registry.list().map((d) => d.kind)).toEqual([
+      AUTO_FIX_WORKER_KIND,
+      PR_STATUS_WORKER_KIND,
+    ]);
   });
 
   it('returns nothing for an unknown kind', () => {
@@ -64,5 +75,11 @@ describe('worker registry', () => {
     // runtime identity keeps the underlying recovery kind.
     expect(runtime.identity.kind).toBe(RECOVERY_WORKER_KIND);
     expect(runtime.isRunning()).toBe(false);
+  });
+
+  it('builds registered pr-status runtime', () => {
+    const registry = registerAutoFixWorker(createWorkerRegistry());
+
+    expect(registry.get(PR_STATUS_WORKER_KIND)!.factory(deps()).identity.kind).toBe(PR_STATUS_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -37,6 +37,7 @@ export * from './worker-registry.js';
 export * from './worker-types.js';
 export * from './worker-lock.js';
 export * from './auto-fix-recovery.js';
+export * from './workers/pr-status-worker.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -4,9 +4,8 @@
  *
  * Each worker is declared once as a {@link WorkerDefinition} — its `kind`, an
  * operator-facing `note`, and a `factory` that builds the worker runtime from
- * injected dependencies. Today the only built-in is the auto-fix recovery
- * worker; centralizing worker knowledge here lets future workers be declared
- * uniformly instead of being implied by a single hard-coded auto-fix branch.
+ * injected dependencies. Centralizing worker knowledge here keeps owner-mode
+ * polling and external worker commands on the same registry surface.
  */
 
 import type { Logger } from '@invoker/contracts';
@@ -17,10 +16,12 @@ import {
   type AutoFixRecoveryStore,
   type AutoFixRecoverySubmitter,
 } from './auto-fix-recovery.js';
+import { createPrStatusWorker, PR_STATUS_WORKER_KIND } from './workers/pr-status-worker.js';
 import type { WorkerRuntime } from './worker-runtime.js';
 
 /** Registry kind for the built-in auto-fix recovery worker. */
 export const AUTO_FIX_WORKER_KIND = 'autofix';
+export { PR_STATUS_WORKER_KIND };
 
 /** Auto-fix tuning handed to a worker factory. */
 export interface AutoFixWorkerConfig {
@@ -42,6 +43,8 @@ export interface WorkerRuntimeDependencies {
   messageBus?: MessageBus;
   /** Auto-fix tuning. */
   autoFix?: AutoFixWorkerConfig;
+  /** Review-gate polling surface for the PR status worker. */
+  reviewGate?: { checkMergeGateStatuses(): void | Promise<void> };
 }
 
 /** Builds a worker runtime from injected dependencies. */
@@ -84,10 +87,9 @@ export function createWorkerRegistry(): WorkerRegistry {
 }
 
 /**
- * Register the built-in auto-fix worker under {@link AUTO_FIX_WORKER_KIND},
- * reusing the existing recovery worker factory ({@link createRecoveryWorker})
- * so the runtime it builds behaves exactly as the auto-fix path always has.
- * Returns the registry so calls can be chained with {@link createWorkerRegistry}.
+ * Register the built-in workers. The legacy function name is kept so existing
+ * headless code and tests keep the same import path while the registry now
+ * includes auto-fix and pr-status entries.
  */
 export function registerAutoFixWorker(registry: WorkerRegistry): WorkerRegistry {
   registry.register({
@@ -104,6 +106,14 @@ export function registerAutoFixWorker(registry: WorkerRegistry): WorkerRegistry 
           getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
         },
       }),
+  });
+  registry.register({
+    kind: PR_STATUS_WORKER_KIND,
+    note: 'Polls review-gate PR statuses through the registered merge-gate provider.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => {
+      if (!deps.reviewGate) throw new Error('pr-status worker requires reviewGate deps');
+      return createPrStatusWorker({ logger: deps.logger, reviewGate: deps.reviewGate });
+    },
   });
   return registry;
 }

--- a/packages/execution-engine/src/workers/pr-status-worker.ts
+++ b/packages/execution-engine/src/workers/pr-status-worker.ts
@@ -1,0 +1,33 @@
+import type { Logger } from '@invoker/contracts';
+
+import { createWorkerRuntime, type WorkerRuntime } from '../worker-runtime.js';
+
+export const PR_STATUS_WORKER_KIND = 'pr-status';
+export const DEFAULT_PR_STATUS_WORKER_INTERVAL_MS = 60_000;
+
+export interface PrStatusWorkerReviewGateDeps {
+  checkMergeGateStatuses(): void | Promise<void>;
+}
+
+export interface PrStatusWorkerOptions {
+  logger: Logger;
+  reviewGate: PrStatusWorkerReviewGateDeps;
+  instanceId?: string;
+  intervalMs?: number;
+  tickOnStart?: boolean;
+  installSignalHandlers?: boolean;
+}
+
+export function createPrStatusWorker(options: PrStatusWorkerOptions): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: PR_STATUS_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_PR_STATUS_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: async () => {
+      await options.reviewGate.checkMergeGateStatuses();
+    },
+  });
+}


### PR DESCRIPTION
## Summary

Review-gate polling now routes through the registered `pr-status` worker.

The old app worker file remains as a compatibility export, but startup now creates the execution-engine worker directly.

<details>
<summary>Review metadata</summary>

Review Claim: PR status polling now uses the shared worker registry route.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The worker only calls the existing TaskRunner review-gate status check.

Slice Rationale: This puts polling on the worker route before CI failure handling uses the same model.

</details>

## Non-goals

No CI repair worker.

No worker-to-worker relay messages.

No live GitHub tests.

## Architecture

### Before

```mermaid
graph TD
    A["App bespoke review-gate worker"] --> B["TaskRunner.checkMergeGateStatuses"]
```

### After

```mermaid
graph TD
    A["Registered pr-status worker"] --> B["TaskRunner.checkMergeGateStatuses"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/worker-registry.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/review-gate-status-worker.test.ts`
- [x] `pnpm run check:types`

## Visual Proof

No user-visible UI changed. These screenshots are the UI smoke proof for the main-process-only startup change.

![Before empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-9c93f1/empty-state.png)

![After empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-9c93f1/empty-state.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 21c6097da`
- Post-revert steps: Restart the owner process.
- Data migration? No
