### PR TITLE
Add CI failure worker fixes

### DIFF
--- a/packages/app/src/__tests__/auto-fix-intents.test.ts
+++ b/packages/app/src/__tests__/auto-fix-intents.test.ts
@@ -196,11 +196,12 @@ describe('review-gate CI context staleness', () => {
     })).toBe(false);
   });
 
-  it('flags a moved selected attempt, generation, review, or branch as stale', () => {
+  it('flags a moved selected attempt, generation, review, branch, or head SHA as stale', () => {
     expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-1', generation: 2, selectedAttemptId: 'attempt-2', branch: 'experiment/foo' })).toBe(true);
     expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-1', generation: 3, selectedAttemptId: 'attempt-1', branch: 'experiment/foo' })).toBe(true);
     expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-2', generation: 2, selectedAttemptId: 'attempt-1', branch: 'experiment/foo' })).toBe(true);
     expect(isReviewGateCiContextStale(ctx, { reviewId: 'review-1', generation: 2, selectedAttemptId: 'attempt-1', branch: 'experiment/bar' })).toBe(true);
+    expect(isReviewGateCiContextStale({ ...ctx, headSha: 'sha-1' }, { reviewId: 'review-1', generation: 2, selectedAttemptId: 'attempt-1', branch: 'experiment/foo', headSha: 'sha-2' })).toBe(true);
   });
 
   it('defaults a missing generation to 0 when comparing', () => {
@@ -217,6 +218,7 @@ describe('review-gate CI context encode/decode', () => {
       selectedAttemptId: 'a1',
       branch: 'b1',
       headSha: 'deadbeef',
+      dedupeKey: 'ci-failure:wf-1/merge:r1:deadbeef:fingerprint',
       fixContext: 'fix the failing checks',
     };
     expect(decodeReviewGateCiContext(encodeReviewGateCiContext(ctx))).toEqual(ctx);

--- a/packages/app/src/__tests__/review-gate-status-worker.test.ts
+++ b/packages/app/src/__tests__/review-gate-status-worker.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { startReviewGateStatusWorker } from '../review-gate-status-worker.js';
+import { createPrStatusWorker } from '../review-gate-status-worker.js';
 
 const logger = {
   info: vi.fn(),
@@ -10,60 +10,46 @@ const logger = {
   trace: vi.fn(),
 };
 
-describe('review-gate status worker', () => {
+describe('pr-status worker', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.clearAllMocks();
   });
 
-  it('starts in owner mode', async () => {
+  it('polls review-gate status in owner mode', async () => {
     vi.useFakeTimers();
     const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
 
-    const worker = startReviewGateStatusWorker({
-      ownerMode: true,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+    const worker = createPrStatusWorker({
+      reviewGate: { checkMergeGateStatuses },
       logger,
       intervalMs: 1000,
+      installSignalHandlers: false,
     });
-
-    expect(worker).not.toBeNull();
-    await vi.advanceTimersByTimeAsync(1000);
-    expect(checkMergeGateStatuses).toHaveBeenCalledTimes(1);
-    worker?.stop();
-  });
-
-  it('starts in owner mode even when startup auto-run is disabled', async () => {
-    vi.useFakeTimers();
-    const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
-
-    const worker = startReviewGateStatusWorker({
-      ownerMode: true,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
-      logger,
-      intervalMs: 1000,
-    });
+    worker.start();
 
     await vi.advanceTimersByTimeAsync(1000);
     expect(checkMergeGateStatuses).toHaveBeenCalledTimes(1);
-    worker?.stop();
+    await worker.stop();
   });
 
-  it('does not start in follower or read-only mode', async () => {
+  it('starts even when startup auto-run is disabled', async () => {
     vi.useFakeTimers();
     const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
 
-    const worker = startReviewGateStatusWorker({
-      ownerMode: false,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+    const worker = createPrStatusWorker({
+      reviewGate: { checkMergeGateStatuses },
       logger,
       intervalMs: 1000,
+      installSignalHandlers: false,
     });
+    worker.start();
 
-    expect(worker).toBeNull();
-    await vi.advanceTimersByTimeAsync(3000);
-    expect(checkMergeGateStatuses).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(checkMergeGateStatuses).toHaveBeenCalledTimes(1);
+    await worker.stop();
   });
+
 
   it('does not overlap ticks', async () => {
     vi.useFakeTimers();
@@ -75,12 +61,13 @@ describe('review-gate status worker', () => {
       .mockReturnValueOnce(firstTick)
       .mockResolvedValue(undefined);
 
-    const worker = startReviewGateStatusWorker({
-      ownerMode: true,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+    const worker = createPrStatusWorker({
+      reviewGate: { checkMergeGateStatuses },
       logger,
       intervalMs: 1000,
+      installSignalHandlers: false,
     });
+    worker.start();
 
     await vi.advanceTimersByTimeAsync(1000);
     await vi.advanceTimersByTimeAsync(1000);
@@ -88,9 +75,9 @@ describe('review-gate status worker', () => {
 
     resolveFirst();
     await firstTick;
-    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(0);
     expect(checkMergeGateStatuses).toHaveBeenCalledTimes(2);
-    worker?.stop();
+    await worker.stop();
   });
 
   it('continues after a tick error', async () => {
@@ -99,33 +86,35 @@ describe('review-gate status worker', () => {
       .mockRejectedValueOnce(new Error('temporary failure'))
       .mockResolvedValue(undefined);
 
-    const worker = startReviewGateStatusWorker({
-      ownerMode: true,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+    const worker = createPrStatusWorker({
+      reviewGate: { checkMergeGateStatuses },
       logger,
       intervalMs: 1000,
+      installSignalHandlers: false,
     });
+    worker.start();
 
     await vi.advanceTimersByTimeAsync(1000);
     await vi.advanceTimersByTimeAsync(1000);
 
     expect(checkMergeGateStatuses).toHaveBeenCalledTimes(2);
-    expect(logger.error).toHaveBeenCalledWith('review-gate status worker tick failed', expect.any(Object));
-    worker?.stop();
+    expect(logger.error).toHaveBeenCalledWith('[worker:pr-status] tick failed', expect.any(Object));
+    await worker.stop();
   });
 
   it('clears the interval on shutdown', async () => {
     vi.useFakeTimers();
     const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
 
-    const worker = startReviewGateStatusWorker({
-      ownerMode: true,
-      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+    const worker = createPrStatusWorker({
+      reviewGate: { checkMergeGateStatuses },
       logger,
       intervalMs: 1000,
+      installSignalHandlers: false,
     });
+    worker.start();
 
-    worker?.stop();
+    await worker.stop();
     await vi.advanceTimersByTimeAsync(3000);
     expect(checkMergeGateStatuses).not.toHaveBeenCalled();
   });

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -2465,4 +2465,43 @@ describe('fixWithAgentAction review-gate CI context', () => {
     );
     expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
   });
+
+  it('accepts review-gate context for a later artifact in a PR stack', async () => {
+    const orchestrator = makeReviewGateOrchestrator({
+      selectedAttemptId: 'attempt-1',
+      generation: 3,
+      reviewId: 'review-1',
+      branch: 'experiment/foo',
+      reviewGate: {
+        activeGeneration: 3,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [
+          { id: 'contracts', providerId: 'review-1', required: true, status: 'approved', generation: 3, headSha: 'head-a' },
+          { id: 'runtime', providerId: 'review-2', required: true, status: 'open', generation: 3, headSha: 'head-b' },
+        ],
+      },
+    });
+    const persistence = { getTaskOutput: vi.fn(() => 'output'), appendTaskOutput: vi.fn() };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn(),
+    };
+
+    await fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      agentName: 'claude',
+      reviewGateContext: {
+        reviewId: 'review-2',
+        generation: 3,
+        selectedAttemptId: 'attempt-1',
+        branch: 'experiment/foo',
+        headSha: 'head-b',
+      },
+    });
+
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -475,6 +475,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
+      messageBus: deps.messageBus,
       reviewGate: { checkMergeGateStatuses: () => createHeadlessExecutor(deps).checkMergeGateStatuses() },
     });
     await worker.tick('manual');

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -475,6 +475,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
+      reviewGate: { checkMergeGateStatuses: () => createHeadlessExecutor(deps).checkMergeGateStatuses() },
     });
     await worker.tick('manual');
     await worker.stop();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -98,7 +98,9 @@ import {
   RESTART_TO_BRANCH_TRACE,
   remoteFetchForPool,
   registerBuiltinAgents,
+  createPrStatusWorker,
   type AgentRegistry,
+  type WorkerRuntime,
 } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
 import type { TaskOutputData } from './types.js';
@@ -224,7 +226,6 @@ import {
 } from './ipc/ipc-registration.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import { startLifecycleEventBridge, type LifecycleEventBridge } from './lifecycle-event-bridge.js';
-import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
 import {
   buildRecoveryWorkerAuditPayload,
   classifyAutoFixRecoveryPhase,
@@ -909,7 +910,7 @@ function startHeadlessMode(): void {
     }
 
     let exitCode = 0;
-    let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
+    let prStatusWorker: WorkerRuntime | null = null;
     let lifecycleEventBridge: LifecycleEventBridge | null = null;
     let standaloneLaunchDispatcherController: StandaloneLaunchDispatcherController | null = null;
     try {
@@ -1583,11 +1584,13 @@ function startHeadlessMode(): void {
           logWarn: (message) => logger.warn(message, { module: 'surface-relay' }),
         });
 
-        reviewGateStatusWorker = startReviewGateStatusWorker({
-          ownerMode: true,
-          getTaskExecutor: createStandaloneTaskExecutor,
-          logger,
-        });
+        if (!readOnlyMode) {
+          prStatusWorker = createPrStatusWorker({
+            reviewGate: { checkMergeGateStatuses: () => createStandaloneTaskExecutor().checkMergeGateStatuses() },
+            logger,
+          });
+          prStatusWorker.start();
+        }
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
@@ -1607,7 +1610,7 @@ function startHeadlessMode(): void {
     } finally {
       standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
-      reviewGateStatusWorker?.stop();
+      await prStatusWorker?.stop();
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
       }
@@ -1694,7 +1697,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const agentRegistry = registerBuiltinAgents();
   let mainWindow: BrowserWindow | null = null;
   let taskExecutor: TaskRunner | null = null;
-  let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
+  let prStatusWorker: WorkerRuntime | null = null;
   let apiServer: ApiServer | null = null;
   let webBridge: WebBridge | null = null;
   let ownerMode = true;
@@ -3305,11 +3308,13 @@ function createEmbeddedTerminalBackendFromConfig(
       });
     }
 
-    reviewGateStatusWorker = startReviewGateStatusWorker({
-      ownerMode,
-      getTaskExecutor: requireTaskExecutor,
-      logger,
-    });
+    if (ownerMode) {
+      prStatusWorker = createPrStatusWorker({
+        reviewGate: { checkMergeGateStatuses: () => requireTaskExecutor().checkMergeGateStatuses() },
+        logger,
+      });
+      prStatusWorker.start();
+    }
 
     // Relaunch orphaned running tasks and start any pending-but-ready tasks.
     if (!ownerMode) {
@@ -4268,11 +4273,11 @@ function createEmbeddedTerminalBackendFromConfig(
       'invoker:fix-with-agent',
       (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
       'normal',
-      async (taskIdArg: unknown, agentNameArg?: unknown) => {
-      const taskId = String(taskIdArg);
-      const agentName = agentNameArg === undefined ? undefined : String(agentNameArg);
+      async (...fixArgs: unknown[]) => {
+      const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
       try {
-        const started = await executeFixWithAgentMutation(taskId, agentName, 'ipc');
+        const source = context.autoFix ? 'auto-fix' : 'ipc';
+        const started = await executeFixWithAgentMutation(taskId, agentName, source);
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
@@ -4691,8 +4696,8 @@ function createEmbeddedTerminalBackendFromConfig(
       try {
         if (apiServer) await apiServer.close().catch(() => {});
         if (webBridge) await webBridge.close().catch(() => {});
-        reviewGateStatusWorker?.stop();
-        reviewGateStatusWorker = null;
+        await prStatusWorker?.stop();
+        prStatusWorker = null;
         if (dbPollInterval) clearInterval(dbPollInterval);
         if (activityPollInterval) clearInterval(activityPollInterval);
         if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -99,6 +99,7 @@ import {
   remoteFetchForPool,
   registerBuiltinAgents,
   createPrStatusWorker,
+  createCiFailureWorker,
   type AgentRegistry,
   type WorkerRuntime,
 } from '@invoker/execution-engine';
@@ -206,6 +207,7 @@ import {
   buildHeadlessFixArgs,
   listOpenFixIntentsForTask,
   parseFixWithAgentMutationArgs,
+  type ReviewGateCiContext,
 } from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
@@ -911,6 +913,7 @@ function startHeadlessMode(): void {
 
     let exitCode = 0;
     let prStatusWorker: WorkerRuntime | null = null;
+    let ciFailureWorker: WorkerRuntime | null = null;
     let lifecycleEventBridge: LifecycleEventBridge | null = null;
     let standaloneLaunchDispatcherController: StandaloneLaunchDispatcherController | null = null;
     try {
@@ -1590,6 +1593,16 @@ function startHeadlessMode(): void {
             logger,
           });
           prStatusWorker.start();
+          if (invokerConfig.autoFixCi && workflowMutationCoordinator) {
+            ciFailureWorker = createCiFailureWorker({
+              store: persistence,
+              submitter: workflowMutationCoordinator,
+              messageBus,
+              logger,
+              getAutoFixAgent: () => loadConfig().autoFixAgent,
+            });
+            ciFailureWorker.start();
+          }
         }
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
@@ -1610,6 +1623,7 @@ function startHeadlessMode(): void {
     } finally {
       standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
+      await ciFailureWorker?.stop();
       await prStatusWorker?.stop();
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
@@ -1698,6 +1712,7 @@ function createEmbeddedTerminalBackendFromConfig(
   let mainWindow: BrowserWindow | null = null;
   let taskExecutor: TaskRunner | null = null;
   let prStatusWorker: WorkerRuntime | null = null;
+  let ciFailureWorker: WorkerRuntime | null = null;
   let apiServer: ApiServer | null = null;
   let webBridge: WebBridge | null = null;
   let ownerMode = true;
@@ -2010,6 +2025,7 @@ function createEmbeddedTerminalBackendFromConfig(
     taskId: string,
     agentName?: string,
     source: 'ipc' | 'auto-fix' = 'ipc',
+    reviewGateContext?: ReviewGateCiContext,
   ): Promise<TaskState[]> => {
     const task = orchestrator.getTask(taskId);
     if (!task) {
@@ -2048,6 +2064,7 @@ function createEmbeddedTerminalBackendFromConfig(
         recoveryRoute,
         recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
         failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`,
+        reviewGateContext,
         signal: activeMutationContext?.signal,
       },
     );
@@ -3314,6 +3331,16 @@ function createEmbeddedTerminalBackendFromConfig(
         logger,
       });
       prStatusWorker.start();
+      if (invokerConfig.autoFixCi && workflowMutationCoordinator) {
+        ciFailureWorker = createCiFailureWorker({
+          store: persistence,
+          submitter: workflowMutationCoordinator,
+          messageBus,
+          logger,
+          getAutoFixAgent: () => loadConfig().autoFixAgent,
+        });
+        ciFailureWorker.start();
+      }
     }
 
     // Relaunch orphaned running tasks and start any pending-but-ready tasks.
@@ -4277,7 +4304,7 @@ function createEmbeddedTerminalBackendFromConfig(
       const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
       try {
         const source = context.autoFix ? 'auto-fix' : 'ipc';
-        const started = await executeFixWithAgentMutation(taskId, agentName, source);
+        const started = await executeFixWithAgentMutation(taskId, agentName, source, context.reviewGateContext);
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
@@ -4696,6 +4723,8 @@ function createEmbeddedTerminalBackendFromConfig(
       try {
         if (apiServer) await apiServer.close().catch(() => {});
         if (webBridge) await webBridge.close().catch(() => {});
+        await ciFailureWorker?.stop();
+        ciFailureWorker = null;
         await prStatusWorker?.stop();
         prStatusWorker = null;
         if (dbPollInterval) clearInterval(dbPollInterval);

--- a/packages/app/src/review-gate-status-worker.ts
+++ b/packages/app/src/review-gate-status-worker.ts
@@ -1,64 +1,11 @@
-import type { Logger } from '@invoker/contracts';
-import type { TaskRunner } from '@invoker/execution-engine';
-
-export interface ReviewGateStatusWorker {
-  tick(): Promise<void>;
-  stop(): void;
-}
-
-export interface ReviewGateStatusWorkerOptions {
-  ownerMode: boolean;
-  getTaskExecutor: () => Pick<TaskRunner, 'checkMergeGateStatuses'>;
-  logger: Logger;
-  intervalMs?: number;
-}
-
-const DEFAULT_REVIEW_GATE_STATUS_WORKER_INTERVAL_MS = 60_000;
-
-export function startReviewGateStatusWorker(
-  options: ReviewGateStatusWorkerOptions,
-): ReviewGateStatusWorker | null {
-  if (!options.ownerMode) {
-    options.logger.info('review-gate status worker disabled outside owner mode', { module: 'merge-gate' });
-    return null;
-  }
-
-  const intervalMs = options.intervalMs ?? DEFAULT_REVIEW_GATE_STATUS_WORKER_INTERVAL_MS;
-  let stopped = false;
-  let inFlight = false;
-
-  const tick = async (): Promise<void> => {
-    if (stopped) return;
-    if (inFlight) {
-      options.logger.info('review-gate status worker tick skipped because previous tick is still running', {
-        module: 'merge-gate',
-      });
-      return;
-    }
-    inFlight = true;
-    try {
-      await options.getTaskExecutor().checkMergeGateStatuses();
-    } catch (err) {
-      options.logger.error('review-gate status worker tick failed', { module: 'merge-gate', err });
-    } finally {
-      inFlight = false;
-    }
-  };
-
-  const interval = setInterval(() => {
-    void tick();
-  }, intervalMs);
-  interval.unref?.();
-
-  options.logger.info(`review-gate status worker started intervalMs=${intervalMs}`, { module: 'merge-gate' });
-
-  return {
-    tick,
-    stop: () => {
-      if (stopped) return;
-      stopped = true;
-      clearInterval(interval);
-      options.logger.info('review-gate status worker stopped', { module: 'merge-gate' });
-    },
-  };
-}
+/**
+ * Compatibility shim. Review-gate PR status polling is now the pr-status
+ * worker in `@invoker/execution-engine`.
+ */
+export {
+  createPrStatusWorker,
+  DEFAULT_PR_STATUS_WORKER_INTERVAL_MS,
+  PR_STATUS_WORKER_KIND,
+  type PrStatusWorkerOptions,
+  type PrStatusWorkerReviewGateDeps,
+} from '@invoker/execution-engine';

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -25,6 +25,7 @@ import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner, ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import {
+  isCurrentReviewGateArtifactForProvider,
   isReviewGateCiContextStale,
   type ReviewGateCiContext,
   type ReviewGateLineageFields,
@@ -100,6 +101,20 @@ export function assertLineageCurrent(
       + `gen ${snapshot.generation} → ${current.generation})`,
     );
   }
+}
+
+function currentReviewGateCiLineage(task: TaskState, reviewId: string): ReviewGateLineageFields {
+  const gate = task.execution.reviewGate;
+  const artifact = gate?.artifacts.find((candidate) => (
+    isCurrentReviewGateArtifactForProvider(gate, candidate, reviewId)
+  ));
+  return {
+    generation: task.execution.generation,
+    reviewId: artifact?.providerId ?? task.execution.reviewId ?? task.execution.reviewProviderId,
+    selectedAttemptId: task.execution.selectedAttemptId,
+    branch: task.execution.branch,
+    headSha: artifact?.headSha,
+  };
 }
 
 function assertReviewGateCiContextCurrent(
@@ -841,7 +856,11 @@ export async function fixWithAgentAction(
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
   if (options.reviewGateContext) {
-    assertReviewGateCiContextCurrent(taskId, options.reviewGateContext, task.execution);
+    assertReviewGateCiContextCurrent(
+      taskId,
+      options.reviewGateContext,
+      currentReviewGateCiLineage(task, options.reviewGateContext.reviewId),
+    );
   }
 
   const savedError = task.execution.error ?? '';

--- a/packages/execution-engine/src/__tests__/ci-failure-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/ci-failure-worker.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkflowMutationIntent } from '@invoker/data-store';
+import { Channels, LocalBus } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { buildFixWithAgentMutationArgs, parseFixWithAgentMutationArgs } from '../auto-fix-intents.js';
+import type { ReviewGateCiFailedLifecycleEvent } from '../lifecycle-events.js';
+import {
+  buildCiFailureDedupeKey,
+  createCiFailureWorker,
+} from '../workers/ci-failure-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+};
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id: 'wf-1/merge',
+    description: 'merge gate',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-06-03T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', isMergeNode: true },
+    execution: {
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'feature/ci-red',
+      reviewGate: {
+        activeGeneration: 2,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [
+          {
+            id: 'runtime',
+            providerId: '123',
+            required: true,
+            status: 'open',
+            generation: 2,
+            headSha: 'head-1',
+          },
+        ],
+      },
+    },
+    taskStateVersion: 8,
+    ...overrides,
+  } as TaskState;
+}
+
+function makeEvent(overrides: Partial<ReviewGateCiFailedLifecycleEvent> = {}): ReviewGateCiFailedLifecycleEvent {
+  return {
+    eventKey: 'event-1',
+    kind: 'review_gate.ci_failed',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/merge',
+    status: 'review_ready',
+    taskStateVersion: 8,
+    generation: 2,
+    attemptId: 'attempt-1',
+    createdAt: '2026-06-04T00:00:00.000Z',
+    recoveryWakeup: {
+      eventKey: 'event-1',
+      eventKind: 'review_gate.ci_failed',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      taskStateVersion: 8,
+      generation: 2,
+      attemptId: 'attempt-1',
+      createdAt: '2026-06-04T00:00:00.000Z',
+      reason: 'review_gate_failure',
+      authoritative: false,
+    },
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    headSha: 'head-1',
+    headRef: 'feature/ci-red',
+    branch: 'feature/ci-red',
+    failedChecks: [
+      { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
+    ],
+    statusText: 'CI failed',
+    ...overrides,
+  };
+}
+
+function makeIntent(overrides: Partial<WorkflowMutationIntent>): WorkflowMutationIntent {
+  return {
+    id: 1,
+    workflowId: 'wf-1',
+    channel: 'invoker:fix-with-agent',
+    args: [],
+    priority: 'normal',
+    status: 'completed',
+    createdAt: '2026-06-04T00:00:00.000Z',
+    ...overrides,
+  } as WorkflowMutationIntent;
+}
+
+describe('ci-failure worker', () => {
+  it('submits a review-gate CI fix intent with the stable dedupe key', async () => {
+    const bus = new LocalBus();
+    const task = makeTask();
+    const submit = vi.fn(() => 7);
+    const event = makeEvent();
+    const worker = createCiFailureWorker({
+      logger,
+      messageBus: bus,
+      store: {
+        loadTasks: () => [task],
+        listWorkflowMutationIntents: () => [],
+      },
+      submitter: { submit },
+      getAutoFixAgent: () => 'codex',
+      installSignalHandlers: false,
+    });
+    worker.start();
+
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, event);
+    await worker.tick();
+
+    const expectedDedupeKey = buildCiFailureDedupeKey({
+      taskId: event.taskId,
+      reviewId: event.reviewId,
+      headSha: event.headSha,
+      failedChecks: event.failedChecks,
+    });
+    expect(submit).toHaveBeenCalledWith(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      expect.any(Array),
+    );
+    const args = submit.mock.calls[0][3] as unknown[];
+    const parsed = parseFixWithAgentMutationArgs(args);
+    expect(parsed).toMatchObject({ taskId: 'wf-1/merge', agentName: 'codex' });
+    expect(parsed.context.reviewGateContext).toMatchObject({
+      reviewId: '123',
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      headSha: 'head-1',
+      dedupeKey: expectedDedupeKey,
+    });
+    await worker.stop();
+  });
+
+  it('accepts failures for a later review-gate artifact in a PR stack', async () => {
+    const bus = new LocalBus();
+    const task = makeTask({
+      execution: {
+        ...makeTask().execution,
+        reviewId: '111',
+        reviewGate: {
+          activeGeneration: 2,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [
+            { id: 'contracts', providerId: '111', required: true, status: 'approved', generation: 2, headSha: 'head-a' },
+            { id: 'runtime', providerId: '123', required: true, status: 'open', generation: 2, headSha: 'head-1' },
+          ],
+        },
+      },
+    });
+    const submit = vi.fn(() => 7);
+    const worker = createCiFailureWorker({
+      logger,
+      messageBus: bus,
+      store: {
+        loadTasks: () => [task],
+        listWorkflowMutationIntents: () => [],
+      },
+      submitter: { submit },
+      installSignalHandlers: false,
+    });
+    worker.start();
+
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, makeEvent({ reviewId: '123' }));
+    await worker.tick();
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    await worker.stop();
+  });
+
+  it('rejects stale head SHA before submitting a fix', async () => {
+    const bus = new LocalBus();
+    const task = makeTask({
+      execution: {
+        ...makeTask().execution,
+        reviewGate: {
+          activeGeneration: 2,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [
+            { id: 'runtime', providerId: '123', required: true, status: 'open', generation: 2, headSha: 'head-2' },
+          ],
+        },
+      },
+    });
+    const submit = vi.fn(() => 7);
+    const worker = createCiFailureWorker({
+      logger,
+      messageBus: bus,
+      store: {
+        loadTasks: () => [task],
+        listWorkflowMutationIntents: () => [],
+      },
+      submitter: { submit },
+      installSignalHandlers: false,
+    });
+    worker.start();
+
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, makeEvent());
+    await worker.tick();
+
+    expect(submit).not.toHaveBeenCalled();
+    await worker.stop();
+  });
+
+  it('dedupes completed fixes for the same review head and failed-check fingerprint', async () => {
+    const event = makeEvent();
+    const dedupeKey = buildCiFailureDedupeKey({
+      taskId: event.taskId,
+      reviewId: event.reviewId,
+      headSha: event.headSha,
+      failedChecks: event.failedChecks,
+    });
+    const existing = makeIntent({
+      args: buildFixWithAgentMutationArgs('wf-1/merge', 'codex', {
+        autoFix: true,
+        reviewGateContext: {
+          reviewId: '123',
+          generation: 2,
+          selectedAttemptId: 'attempt-1',
+          headSha: 'head-1',
+          dedupeKey,
+        },
+      }),
+    });
+    const bus = new LocalBus();
+    const submit = vi.fn(() => 7);
+    const worker = createCiFailureWorker({
+      logger,
+      messageBus: bus,
+      store: {
+        loadTasks: () => [makeTask()],
+        listWorkflowMutationIntents: () => [existing],
+      },
+      submitter: { submit },
+      installSignalHandlers: false,
+    });
+    worker.start();
+
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, event);
+    await worker.tick();
+
+    expect(submit).not.toHaveBeenCalled();
+    await worker.stop();
+  });
+
+  it('subscribes before manual ticks', async () => {
+    const bus = new LocalBus();
+    const submit = vi.fn(() => 7);
+    const worker = createCiFailureWorker({
+      logger,
+      messageBus: bus,
+      store: {
+        loadTasks: () => [makeTask()],
+        listWorkflowMutationIntents: () => [],
+      },
+      submitter: { submit },
+      installSignalHandlers: false,
+    });
+
+    await worker.tick('manual');
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, makeEvent());
+    await worker.tick('manual');
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    await worker.stop();
+  });
+});

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -5214,10 +5214,10 @@ console.log(JSON.stringify(out));
         };
         const mergeGateProvider = {
           checkApproval: vi.fn()
-            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved one' })
-            .mockResolvedValueOnce({ lifecycle: 'open', rejected: false, statusText: 'Pending second' })
-            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Still approved' })
-            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved both' })
+            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved one', headSha: 'sha-one' })
+            .mockResolvedValueOnce({ lifecycle: 'open', rejected: false, statusText: 'Pending second', headSha: 'sha-two' })
+            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Still approved', headSha: 'sha-one' })
+            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved both', headSha: 'sha-two' })
         };
 
         const executor = new TaskRunner({
@@ -5241,8 +5241,8 @@ console.log(JSON.stringify(out));
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(task.execution.reviewGate?.artifacts).toEqual([
-          expect.objectContaining({ id: 'contracts', status: 'approved' }),
-          expect.objectContaining({ id: 'runtime', status: 'open', rawStatus: 'Pending second' }),
+          expect.objectContaining({ id: 'contracts', status: 'approved', headSha: 'sha-one' }),
+          expect.objectContaining({ id: 'runtime', status: 'open', rawStatus: 'Pending second', headSha: 'sha-two' }),
         ]);
 
         await executor.checkMergeGateStatuses();
@@ -5251,8 +5251,8 @@ console.log(JSON.stringify(out));
         expect(orchestrator.approve).toHaveBeenCalledWith('merge-stack');
         expect(executeTasks).toHaveBeenCalledWith([downstream]);
         expect(task.execution.reviewGate?.artifacts).toEqual([
-          expect.objectContaining({ id: 'contracts', status: 'approved' }),
-          expect.objectContaining({ id: 'runtime', status: 'approved' }),
+          expect.objectContaining({ id: 'contracts', status: 'approved', headSha: 'sha-one' }),
+          expect.objectContaining({ id: 'runtime', status: 'approved', headSha: 'sha-two' }),
         ]);
       });
 

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { RECOVERY_WORKER_KIND, type AutoFixRecoveryStore, type AutoFixRecoverySubmitter } from '../auto-fix-recovery.js';
 import {
   AUTO_FIX_WORKER_KIND,
+  PR_STATUS_WORKER_KIND,
   createWorkerRegistry,
   registerAutoFixWorker,
   type WorkerRuntimeDependencies,
@@ -27,7 +28,12 @@ const noopSubmitter: AutoFixRecoverySubmitter = {
 };
 
 function deps(): WorkerRuntimeDependencies {
-  return { store: emptyStore, submitter: noopSubmitter, logger: silentLogger };
+  return {
+    store: emptyStore,
+    submitter: noopSubmitter,
+    logger: silentLogger,
+    reviewGate: { checkMergeGateStatuses: () => {} },
+  };
 }
 
 describe('worker registry', () => {
@@ -37,16 +43,21 @@ describe('worker registry', () => {
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeUndefined();
   });
 
-  it('returns the auto-fix definition by its kind once registered', () => {
+  it('returns the built-in worker definitions by kind once registered', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry());
 
-    const definition = registry.get(AUTO_FIX_WORKER_KIND);
-    expect(definition).toBeDefined();
-    expect(definition?.kind).toBe(AUTO_FIX_WORKER_KIND);
-    expect(definition?.note.length).toBeGreaterThan(0);
-    expect(typeof definition?.factory).toBe('function');
+    for (const kind of [AUTO_FIX_WORKER_KIND, PR_STATUS_WORKER_KIND]) {
+      const definition = registry.get(kind);
+      expect(definition).toBeDefined();
+      expect(definition?.kind).toBe(kind);
+      expect(definition?.note.length).toBeGreaterThan(0);
+      expect(typeof definition?.factory).toBe('function');
+    }
 
-    expect(registry.list().map((d) => d.kind)).toEqual([AUTO_FIX_WORKER_KIND]);
+    expect(registry.list().map((d) => d.kind)).toEqual([
+      AUTO_FIX_WORKER_KIND,
+      PR_STATUS_WORKER_KIND,
+    ]);
   });
 
   it('returns nothing for an unknown kind', () => {
@@ -64,5 +75,11 @@ describe('worker registry', () => {
     // runtime identity keeps the underlying recovery kind.
     expect(runtime.identity.kind).toBe(RECOVERY_WORKER_KIND);
     expect(runtime.isRunning()).toBe(false);
+  });
+
+  it('builds registered pr-status runtime', () => {
+    const registry = registerAutoFixWorker(createWorkerRegistry());
+
+    expect(registry.get(PR_STATUS_WORKER_KIND)!.factory(deps()).identity.kind).toBe(PR_STATUS_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { RECOVERY_WORKER_KIND, type AutoFixRecoveryStore, type AutoFixRecoverySubmitter } from '../auto-fix-recovery.js';
 import {
   AUTO_FIX_WORKER_KIND,
+  CI_FAILURE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   createWorkerRegistry,
   registerAutoFixWorker,
@@ -46,7 +47,7 @@ describe('worker registry', () => {
   it('returns the built-in worker definitions by kind once registered', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry());
 
-    for (const kind of [AUTO_FIX_WORKER_KIND, PR_STATUS_WORKER_KIND]) {
+    for (const kind of [AUTO_FIX_WORKER_KIND, PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND]) {
       const definition = registry.get(kind);
       expect(definition).toBeDefined();
       expect(definition?.kind).toBe(kind);
@@ -57,6 +58,7 @@ describe('worker registry', () => {
     expect(registry.list().map((d) => d.kind)).toEqual([
       AUTO_FIX_WORKER_KIND,
       PR_STATUS_WORKER_KIND,
+      CI_FAILURE_WORKER_KIND,
     ]);
   });
 
@@ -77,9 +79,10 @@ describe('worker registry', () => {
     expect(runtime.isRunning()).toBe(false);
   });
 
-  it('builds registered pr-status runtime', () => {
+  it('builds registered pr-status and ci-failure runtimes', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry());
 
     expect(registry.get(PR_STATUS_WORKER_KIND)!.factory(deps()).identity.kind).toBe(PR_STATUS_WORKER_KIND);
+    expect(registry.get(CI_FAILURE_WORKER_KIND)!.factory(deps()).identity.kind).toBe(CI_FAILURE_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/src/auto-fix-intents.ts
+++ b/packages/execution-engine/src/auto-fix-intents.ts
@@ -43,6 +43,7 @@ export interface ReviewGateCiContext {
   branch?: string;
   headSha?: string;
   fixContext?: string;
+  dedupeKey?: string;
 }
 
 export interface ReviewGateLineageFields {
@@ -50,6 +51,36 @@ export interface ReviewGateLineageFields {
   reviewId?: string;
   selectedAttemptId?: string;
   branch?: string;
+  headSha?: string;
+}
+
+export interface ReviewGateArtifactCurrencyState {
+  readonly activeGeneration: number;
+}
+
+export interface ReviewGateArtifactCurrencyFields {
+  readonly generation: number;
+  readonly status?: string;
+  readonly discardedAt?: string;
+  readonly providerId?: string;
+}
+
+export function isCurrentReviewGateArtifact(
+  gate: ReviewGateArtifactCurrencyState,
+  artifact: ReviewGateArtifactCurrencyFields,
+): boolean {
+  return artifact.generation === gate.activeGeneration
+    && artifact.status !== 'discarded'
+    && !artifact.discardedAt;
+}
+
+export function isCurrentReviewGateArtifactForProvider(
+  gate: ReviewGateArtifactCurrencyState,
+  artifact: ReviewGateArtifactCurrencyFields,
+  providerId: string,
+): boolean {
+  return isCurrentReviewGateArtifact(gate, artifact)
+    && artifact.providerId === providerId;
 }
 
 export function encodeReviewGateCiContext(context: ReviewGateCiContext): string {
@@ -80,6 +111,7 @@ export function decodeReviewGateCiContext(encoded: unknown): ReviewGateCiContext
     branch: typeof candidate.branch === 'string' ? candidate.branch : undefined,
     headSha: typeof candidate.headSha === 'string' ? candidate.headSha : undefined,
     fixContext: typeof candidate.fixContext === 'string' ? candidate.fixContext : undefined,
+    dedupeKey: typeof candidate.dedupeKey === 'string' ? candidate.dedupeKey : undefined,
   };
 }
 
@@ -91,7 +123,8 @@ export function isReviewGateCiContextStale(
     current.selectedAttemptId !== context.selectedAttemptId ||
     (current.generation ?? 0) !== context.generation ||
     current.reviewId !== context.reviewId ||
-    current.branch !== context.branch
+    current.branch !== context.branch ||
+    current.headSha !== context.headSha
   );
 }
 

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -9,8 +9,22 @@ import type {
 } from './merge-gate-provider.js';
 import { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
 import { isGitRefLockRace, retryTransientGitHubCli } from './git-utils.js';
+import { killProcessGroup, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 
 type ExistingPullRequest = { url: string; number: number };
+
+const DEFAULT_GITHUB_CLI_TIMEOUT_MS = 60_000;
+
+function getGitHubCliTimeoutMs(): number {
+  const raw = process.env.INVOKER_GITHUB_CLI_TIMEOUT_MS?.trim();
+  if (!raw) return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+  if (!/^\d+$/.test(raw)) return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 0 || parsed > 2_147_483_647) {
+    return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+  }
+  return parsed;
+}
 
 export class GitHubMergeGateProvider implements MergeGateProvider {
   readonly name = 'github';
@@ -238,15 +252,63 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
 
   private async exec(cmd: string, args: string[], cwd: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const child = spawn(cmd, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+      const child = spawn(cmd, args, {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: process.platform !== 'win32',
+      });
+      const timeoutMs = getGitHubCliTimeoutMs();
       let stdout = '';
       let stderr = '';
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+      let forceKill: ReturnType<typeof setTimeout> | undefined;
+
+      const clearTimers = (): void => {
+        if (timeout) clearTimeout(timeout);
+        if (forceKill) clearTimeout(forceKill);
+      };
+
+      const finish = (fn: () => void): void => {
+        if (settled) return;
+        settled = true;
+        clearTimers();
+        fn();
+      };
+
+      if (timeoutMs > 0) {
+        timeout = setTimeout(() => {
+          if (settled) return;
+          killProcessGroup(child, 'SIGTERM');
+          forceKill = setTimeout(() => {
+            if (!settled) {
+              killProcessGroup(child, 'SIGKILL');
+            }
+          }, SIGKILL_TIMEOUT_MS);
+          forceKill.unref?.();
+          finish(() => reject(new Error(
+            `${cmd} ${args.join(' ')} exceeded GitHub CLI timeout (${timeoutMs}ms) in ${cwd}. ` +
+            'Set INVOKER_GITHUB_CLI_TIMEOUT_MS to adjust (0 = unbounded).',
+          )));
+        }, timeoutMs);
+        timeout.unref?.();
+      }
+
       child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
       child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
-      child.on('error', reject);
-      child.on('close', (code) => {
-        if (code === 0) resolve(stdout.trim());
-        else reject(new Error(`${cmd} ${args.join(' ')} failed (code ${code}): ${stderr.trim()}`));
+      child.on('error', (err) => {
+        finish(() => reject(err));
+      });
+      child.on('close', (code, signal) => {
+        finish(() => {
+          if (code === 0) {
+            resolve(stdout.trim());
+            return;
+          }
+          reject(new Error(
+            `${cmd} ${args.join(' ')} failed (code ${code ?? 'null'}${signal ? ` signal ${signal}` : ''}): ${stderr.trim()}`,
+          ));
+        });
       });
     });
   }

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -36,6 +36,7 @@ export * from './worker-runtime.js';
 export * from './worker-registry.js';
 export * from './worker-lock.js';
 export * from './auto-fix-recovery.js';
+export * from './workers/pr-status-worker.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -37,6 +37,7 @@ export * from './worker-registry.js';
 export * from './worker-lock.js';
 export * from './auto-fix-recovery.js';
 export * from './workers/pr-status-worker.js';
+export * from './workers/ci-failure-worker.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -29,6 +29,7 @@ import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
 import { MergeGateExecutor } from './merge-gate-executor.js';
 import { isInvokerManagedPoolBranch } from './plan-base-remote.js';
+import { isCurrentReviewGateArtifact } from './auto-fix-intents.js';
 import { SshExecutor } from './ssh-executor.js';
 
 import {
@@ -1875,11 +1876,6 @@ export class TaskRunner {
       }
     }
   }
-  private isCurrentReviewGateArtifact(gate: ReviewGateState, artifact: ReviewGateArtifact): boolean {
-    return artifact.generation === gate.activeGeneration
-      && artifact.status !== 'discarded'
-      && !artifact.discardedAt;
-  }
 
 
   private getCurrentReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
@@ -1897,7 +1893,7 @@ export class TaskRunner {
       }];
     }
 
-    return gate.artifacts.filter((artifact) => this.isCurrentReviewGateArtifact(gate, artifact));
+    return gate.artifacts.filter((artifact) => isCurrentReviewGateArtifact(gate, artifact));
   }
 
   private getCurrentRequiredReviewArtifacts(task: TaskState): ReviewGateArtifact[] {
@@ -1938,7 +1934,7 @@ export class TaskRunner {
       return false;
     }
     return currentGate.artifacts.some((artifact) =>
-      this.isCurrentReviewGateArtifact(currentGate, artifact)
+      isCurrentReviewGateArtifact(currentGate, artifact)
       && artifact.required
       && artifact.providerId === providerId,
     );
@@ -1954,7 +1950,7 @@ export class TaskRunner {
       ...gate,
       artifacts: gate.artifacts.map((artifact) => {
         if (
-          !this.isCurrentReviewGateArtifact(gate, artifact)
+          !isCurrentReviewGateArtifact(gate, artifact)
           || artifact.providerId !== providerId
         ) {
           return artifact;
@@ -1964,6 +1960,9 @@ export class TaskRunner {
           status: mappedStatus,
           updatedAt: new Date().toISOString(),
         };
+        if (status.headSha) {
+          return { ...next, headSha: status.headSha, ...(mappedStatus === 'open' ? { rawStatus: status.statusText } : {}) };
+        }
         if (mappedStatus === 'open') {
           return { ...next, rawStatus: status.statusText };
         }
@@ -1974,7 +1973,7 @@ export class TaskRunner {
 
   private reviewGateIsApproved(gate: ReviewGateState): boolean {
     const currentRequired = gate.artifacts.filter((artifact) =>
-      this.isCurrentReviewGateArtifact(gate, artifact) && artifact.required,
+      isCurrentReviewGateArtifact(gate, artifact) && artifact.required,
     );
     return currentRequired.length > 0
       && currentRequired.every((artifact) => artifact.status === 'approved');

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -17,11 +17,12 @@ import {
   type AutoFixRecoverySubmitter,
 } from './auto-fix-recovery.js';
 import { createPrStatusWorker, PR_STATUS_WORKER_KIND } from './workers/pr-status-worker.js';
+import { createCiFailureWorker, CI_FAILURE_WORKER_KIND } from './workers/ci-failure-worker.js';
 import type { WorkerRuntime } from './worker-runtime.js';
 
 /** Registry kind for the built-in auto-fix recovery worker. */
 export const AUTO_FIX_WORKER_KIND = 'autofix';
-export { PR_STATUS_WORKER_KIND };
+export { PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND };
 
 /** Auto-fix tuning handed to a worker factory. */
 export interface AutoFixWorkerConfig {
@@ -89,7 +90,7 @@ export function createWorkerRegistry(): WorkerRegistry {
 /**
  * Register the built-in workers. The legacy function name is kept so existing
  * headless code and tests keep the same import path while the registry now
- * includes auto-fix and pr-status entries.
+ * includes auto-fix, pr-status, and ci-failure entries.
  */
 export function registerAutoFixWorker(registry: WorkerRegistry): WorkerRegistry {
   registry.register({
@@ -114,6 +115,18 @@ export function registerAutoFixWorker(registry: WorkerRegistry): WorkerRegistry 
       if (!deps.reviewGate) throw new Error('pr-status worker requires reviewGate deps');
       return createPrStatusWorker({ logger: deps.logger, reviewGate: deps.reviewGate });
     },
+  });
+  registry.register({
+    kind: CI_FAILURE_WORKER_KIND,
+    note: 'Submits deduped fix-with-agent intents for current review-gate CI failures.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createCiFailureWorker({
+        logger: deps.logger,
+        store: deps.store,
+        submitter: deps.submitter,
+        messageBus: deps.messageBus,
+        getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
+      }),
   });
   return registry;
 }

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -4,9 +4,8 @@
  *
  * Each worker is declared once as a {@link WorkerDefinition} — its `kind`, an
  * operator-facing `note`, and a `factory` that builds the worker runtime from
- * injected dependencies. Today the only built-in is the auto-fix recovery
- * worker; centralizing worker knowledge here lets future workers be declared
- * uniformly instead of being implied by a single hard-coded auto-fix branch.
+ * injected dependencies. Centralizing worker knowledge here keeps owner-mode
+ * polling and external worker commands on the same registry surface.
  */
 
 import type { Logger } from '@invoker/contracts';
@@ -17,10 +16,12 @@ import {
   type AutoFixRecoveryStore,
   type AutoFixRecoverySubmitter,
 } from './auto-fix-recovery.js';
+import { createPrStatusWorker, PR_STATUS_WORKER_KIND } from './workers/pr-status-worker.js';
 import type { WorkerRuntime } from './worker-runtime.js';
 
 /** Registry kind for the built-in auto-fix recovery worker. */
 export const AUTO_FIX_WORKER_KIND = 'autofix';
+export { PR_STATUS_WORKER_KIND };
 
 /** Auto-fix tuning handed to a worker factory. */
 export interface AutoFixWorkerConfig {
@@ -42,6 +43,8 @@ export interface WorkerRuntimeDependencies {
   messageBus?: MessageBus;
   /** Auto-fix tuning. */
   autoFix?: AutoFixWorkerConfig;
+  /** Review-gate polling surface for the PR status worker. */
+  reviewGate?: { checkMergeGateStatuses(): void | Promise<void> };
 }
 
 /** Builds a worker runtime from injected dependencies. */
@@ -84,10 +87,9 @@ export function createWorkerRegistry(): WorkerRegistry {
 }
 
 /**
- * Register the built-in auto-fix worker under {@link AUTO_FIX_WORKER_KIND},
- * reusing the existing recovery worker factory ({@link createRecoveryWorker})
- * so the runtime it builds behaves exactly as the auto-fix path always has.
- * Returns the registry so calls can be chained with {@link createWorkerRegistry}.
+ * Register the built-in workers. The legacy function name is kept so existing
+ * headless code and tests keep the same import path while the registry now
+ * includes auto-fix and pr-status entries.
  */
 export function registerAutoFixWorker(registry: WorkerRegistry): WorkerRegistry {
   registry.register({
@@ -104,6 +106,14 @@ export function registerAutoFixWorker(registry: WorkerRegistry): WorkerRegistry 
           getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
         },
       }),
+  });
+  registry.register({
+    kind: PR_STATUS_WORKER_KIND,
+    note: 'Polls review-gate PR statuses through the registered merge-gate provider.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime => {
+      if (!deps.reviewGate) throw new Error('pr-status worker requires reviewGate deps');
+      return createPrStatusWorker({ logger: deps.logger, reviewGate: deps.reviewGate });
+    },
   });
   return registry;
 }

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -1,0 +1,235 @@
+import { createHash } from 'node:crypto';
+
+import type {
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import type { Logger } from '@invoker/contracts';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+import {
+  buildFixWithAgentMutationArgs,
+  isCurrentReviewGateArtifactForProvider,
+  parseFixWithAgentMutationArgs,
+  parseHeadlessFixArgs,
+  type ReviewGateCiContext,
+} from '../auto-fix-intents.js';
+import type { ReviewGateCiFailedLifecycleEvent, ReviewGateFailedCheck, WorkflowLifecycleEvent } from '../lifecycle-events.js';
+import { createWorkerRuntime, type WorkerRuntime } from '../worker-runtime.js';
+
+export const CI_FAILURE_WORKER_KIND = 'ci-failure';
+const FIX_WITH_AGENT_CHANNEL = 'invoker:fix-with-agent';
+
+export interface CiFailureWorkerStore {
+  loadTask?(taskId: string): TaskState | undefined;
+  loadTasks(workflowId: string): TaskState[];
+  listWorkflowMutationIntents(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[];
+  logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+}
+
+export interface CiFailureWorkerSubmitter {
+  submit(
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: typeof FIX_WITH_AGENT_CHANNEL,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number;
+}
+
+export interface CiFailureWorkerOptions {
+  logger: Logger;
+  store: CiFailureWorkerStore;
+  submitter: CiFailureWorkerSubmitter;
+  messageBus?: MessageBus;
+  getAutoFixAgent?: () => string | undefined;
+  instanceId?: string;
+  tickOnStart?: boolean;
+  installSignalHandlers?: boolean;
+}
+
+function checkFingerprint(checks: readonly ReviewGateFailedCheck[]): string {
+  const sorted = checks
+    .map((check) => [check.name, check.conclusion ?? '', check.detailsUrl ?? ''].join('\0'))
+    .sort();
+  return createHash('sha256').update(sorted.join('\n')).digest('hex');
+}
+
+export function buildCiFailureDedupeKey(input: {
+  taskId: string;
+  reviewId: string;
+  headSha?: string;
+  failedChecks: readonly ReviewGateFailedCheck[];
+}): string {
+  return [
+    'ci-failure',
+    input.taskId,
+    input.reviewId,
+    input.headSha ?? 'no-head',
+    checkFingerprint(input.failedChecks),
+  ].join(':');
+}
+
+function loadLatestTask(store: CiFailureWorkerStore, workflowId: string, taskId: string): TaskState | undefined {
+  return store.loadTask?.(taskId) ?? store.loadTasks(workflowId).find((task) => task.id === taskId);
+}
+
+function currentReviewGateArtifact(task: TaskState, reviewId: string) {
+  const gate = task.execution.reviewGate;
+  if (!gate) return undefined;
+  return gate.artifacts.find((candidate) => (
+    isCurrentReviewGateArtifactForProvider(gate, candidate, reviewId)
+  ));
+}
+
+function eventStillMatchesTask(event: ReviewGateCiFailedLifecycleEvent, task: TaskState): boolean {
+  if (task.config.workflowId && task.config.workflowId !== event.workflowId) return false;
+  if ((task.execution.generation ?? 0) !== event.generation) return false;
+  if ((task.execution.selectedAttemptId ?? undefined) !== (event.attemptId ?? undefined)) return false;
+  const artifact = currentReviewGateArtifact(task, event.reviewId);
+  const currentReviewId = artifact?.providerId ?? task.execution.reviewId ?? task.execution.reviewProviderId;
+  if (currentReviewId !== event.reviewId) return false;
+  if ((artifact?.headSha ?? undefined) !== (event.headSha ?? undefined)) return false;
+  return true;
+}
+
+function findExistingCiFailureIntent(
+  intents: readonly WorkflowMutationIntent[],
+  taskId: string,
+  dedupeKey: string,
+): WorkflowMutationIntent | undefined {
+  return intents.find((intent) => {
+    if (intent.channel !== FIX_WITH_AGENT_CHANNEL && intent.channel !== 'headless.exec') return false;
+    if (intent.channel === 'headless.exec') {
+      const parsed = parseHeadlessFixArgs((intent.args[0] as { args?: unknown[] } | undefined)?.args?.filter((arg): arg is string => typeof arg === 'string') ?? []);
+      return parsed.taskId === taskId && parsed.reviewGateContext?.dedupeKey === dedupeKey;
+    }
+    const parsed = parseFixWithAgentMutationArgs(intent.args);
+    if (parsed.taskId !== taskId) return false;
+    return parsed.context.reviewGateContext?.dedupeKey === dedupeKey;
+  });
+}
+
+function formatFixContext(event: ReviewGateCiFailedLifecycleEvent): string {
+  const checks = event.failedChecks
+    .map((check) => `- ${check.name}${check.conclusion ? ` (${check.conclusion})` : ''}${check.detailsUrl ? `: ${check.detailsUrl}` : ''}`)
+    .join('\n');
+  return [
+    `Review-gate PR ${event.reviewId} has failing CI checks.`,
+    `PR: ${event.reviewUrl}`,
+    event.headSha ? `Head SHA: ${event.headSha}` : undefined,
+    `Status: ${event.statusText}`,
+    'Failed checks:',
+    checks,
+  ].filter((line): line is string => Boolean(line)).join('\n');
+}
+
+export function createCiFailureWorker(options: CiFailureWorkerOptions): WorkerRuntime {
+  const pendingEvents: ReviewGateCiFailedLifecycleEvent[] = [];
+  let lifecycleUnsubscribe: Unsubscribe | undefined;
+
+  const runtime = createWorkerRuntime({
+    kind: CI_FAILURE_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: 0,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: async () => {
+      const events = pendingEvents.splice(0);
+      for (const event of events) {
+        const task = loadLatestTask(options.store, event.workflowId, event.taskId);
+        if (!task) {
+          options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', { phase: 'skip', reason: 'task-not-found' });
+          continue;
+        }
+        if (!eventStillMatchesTask(event, task)) {
+          options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', { phase: 'skip', reason: 'stale-event' });
+          continue;
+        }
+
+        const dedupeKey = buildCiFailureDedupeKey({
+          taskId: event.taskId,
+          reviewId: event.reviewId,
+          headSha: event.headSha,
+          failedChecks: event.failedChecks,
+        });
+        const existing = findExistingCiFailureIntent(
+          options.store.listWorkflowMutationIntents(event.workflowId),
+          event.taskId,
+          dedupeKey,
+        );
+        if (existing) {
+          options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', {
+            phase: 'skip',
+            reason: 'duplicate-intent',
+            dedupeKey,
+            existingIntentId: existing.id,
+          });
+          continue;
+        }
+
+        const configuredAgent = options.getAutoFixAgent?.()?.trim();
+        const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
+        const context: ReviewGateCiContext = {
+          reviewId: event.reviewId,
+          generation: event.generation,
+          selectedAttemptId: event.attemptId,
+          branch: event.branch,
+          headSha: event.headSha,
+          dedupeKey,
+          fixContext: formatFixContext(event),
+        };
+        const intentId = options.submitter.submit(
+          event.workflowId,
+          'normal',
+          FIX_WITH_AGENT_CHANNEL,
+          buildFixWithAgentMutationArgs(event.taskId, selectedAgent, { autoFix: true, reviewGateContext: context }),
+        );
+        options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', {
+          phase: 'submitted',
+          dedupeKey,
+          intentId,
+          agent: selectedAgent ?? null,
+        });
+      }
+    },
+  });
+
+  if (!options.messageBus) return runtime;
+
+
+  const subscribeToLifecycle = (): void => {
+    if (lifecycleUnsubscribe) return;
+    lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
+      Channels.WORKFLOW_LIFECYCLE,
+      (event) => {
+        if (event.kind !== 'review_gate.ci_failed') return;
+        pendingEvents.push(event);
+        runtime.wake('wake');
+      },
+    );
+  };
+  return {
+    identity: runtime.identity,
+    start: (): void => {
+      subscribeToLifecycle();
+      runtime.start();
+    },
+    wake: runtime.wake,
+    tick: async (reason): Promise<void> => {
+      subscribeToLifecycle();
+      await runtime.tick(reason);
+    },
+    stop: async (): Promise<void> => {
+      lifecycleUnsubscribe?.();
+      lifecycleUnsubscribe = undefined;
+      await runtime.stop();
+    },
+    isRunning: runtime.isRunning,
+  };
+}

--- a/packages/execution-engine/src/workers/pr-status-worker.ts
+++ b/packages/execution-engine/src/workers/pr-status-worker.ts
@@ -1,0 +1,33 @@
+import type { Logger } from '@invoker/contracts';
+
+import { createWorkerRuntime, type WorkerRuntime } from '../worker-runtime.js';
+
+export const PR_STATUS_WORKER_KIND = 'pr-status';
+export const DEFAULT_PR_STATUS_WORKER_INTERVAL_MS = 60_000;
+
+export interface PrStatusWorkerReviewGateDeps {
+  checkMergeGateStatuses(): void | Promise<void>;
+}
+
+export interface PrStatusWorkerOptions {
+  logger: Logger;
+  reviewGate: PrStatusWorkerReviewGateDeps;
+  instanceId?: string;
+  intervalMs?: number;
+  tickOnStart?: boolean;
+  installSignalHandlers?: boolean;
+}
+
+export function createPrStatusWorker(options: PrStatusWorkerOptions): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: PR_STATUS_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_PR_STATUS_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: async () => {
+      await options.reviewGate.checkMergeGateStatuses();
+    },
+  });
+}

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -158,6 +158,7 @@ export interface ReviewGateArtifact {
   readonly updatedAt?: string;
   readonly discardedAt?: string;
   readonly discardReason?: string;
+  readonly headSha?: string;
 }
 
 export interface ReviewGateState {


### PR DESCRIPTION




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic handling for CI failures that can trigger a “fix with agent” workflow.
  * Expanded support for review-gate context so fixes can be applied to the correct item in a PR stack.
  * Added the new worker to both headless and GUI app flows.

* **Bug Fixes**
  * Improved stale-context checks to avoid rejecting valid later-artifact updates.
  * Reduced duplicate fix attempts for the same CI failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #2762