### PR TITLE
[PR Status Workers](3) Wire headless worker dependencies

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -463,6 +463,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
     throw err;
   }
   try {
+    const headlessExecutor = createHeadlessExecutor(deps);
     const worker = definition.factory({
       store: deps.persistence,
       submitter: {
@@ -475,6 +476,8 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         defaultAutoFixRetries: deps.invokerConfig.autoFixRetries,
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
+      messageBus: deps.messageBus,
+      reviewGate: { checkMergeGateStatuses: () => headlessExecutor.checkMergeGateStatuses() },
     });
     await worker.tick('manual');
     await worker.stop();


### PR DESCRIPTION
## Summary

The headless worker command now provides worker dependencies for the registered workers.

That lets one-shot worker commands build the same runtimes as owner mode.

<details>
<summary>Review metadata</summary>

Review Claim: The headless worker command can activate registered worker runtimes with their required dependencies.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This only passes existing dependencies into worker factories.

Slice Rationale: This activation surface is separate from the worker definitions it enables.

</details>

## Non-goals

No worker behavior changes.

No owner startup changes.

No new CLI command names.

## Architecture

### Before

```mermaid
graph TD
    A["headless worker command"] --> B["factory without reviewGate/messageBus deps"]
```

### After

```mermaid
graph TD
    A["headless worker command"] --> B["factory with reviewGate/messageBus deps"]
```

## Test Plan

- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 259736f0d`
- Post-revert steps: None
- Data migration? No
