### PR TITLE
[PR Status Workers](4) Register CI failure worker

### DIFF
--- a/packages/execution-engine/src/__tests__/ci-failure-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/ci-failure-worker.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkflowMutationIntent } from '@invoker/data-store';
+import { Channels, LocalBus } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { buildFixWithAgentMutationArgs, parseFixWithAgentMutationArgs } from '../auto-fix-intents.js';
+import type { ReviewGateCiFailedLifecycleEvent } from '../lifecycle-events.js';
+import {
+  buildCiFailureDedupeKey,
+  createCiFailureWorker,
+} from '../workers/ci-failure-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+};
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id: 'wf-1/merge',
+    description: 'merge gate',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-06-03T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', isMergeNode: true },
+    execution: {
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'feature/ci-red',
+      reviewGate: {
+        activeGeneration: 2,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [
+          {
+            id: 'runtime',
+            providerId: '123',
+            required: true,
+            status: 'open',
+            generation: 2,
+            headSha: 'head-1',
+          },
+        ],
+      },
+    },
+    taskStateVersion: 8,
+    ...overrides,
+  } as TaskState;
+}
+
+function makeEvent(overrides: Partial<ReviewGateCiFailedLifecycleEvent> = {}): ReviewGateCiFailedLifecycleEvent {
+  return {
+    eventKey: 'event-1',
+    kind: 'review_gate.ci_failed',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/merge',
+    status: 'review_ready',
+    taskStateVersion: 8,
+    generation: 2,
+    attemptId: 'attempt-1',
+    createdAt: '2026-06-04T00:00:00.000Z',
+    recoveryWakeup: {
+      eventKey: 'event-1',
+      eventKind: 'review_gate.ci_failed',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      taskStateVersion: 8,
+      generation: 2,
+      attemptId: 'attempt-1',
+      createdAt: '2026-06-04T00:00:00.000Z',
+      reason: 'review_gate_failure',
+      authoritative: false,
+    },
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    headSha: 'head-1',
+    headRef: 'feature/ci-red',
+    branch: 'feature/ci-red',
+    failedChecks: [
+      { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
+    ],
+    statusText: 'CI failed',
+    ...overrides,
+  };
+}
+
+function makeIntent(overrides: Partial<WorkflowMutationIntent>): WorkflowMutationIntent {
+  return {
+    id: 1,
+    workflowId: 'wf-1',
+    channel: 'invoker:fix-with-agent',
+    args: [],
+    priority: 'normal',
+    status: 'completed',
+    createdAt: '2026-06-04T00:00:00.000Z',
+    ...overrides,
+  } as WorkflowMutationIntent;
+}
+
+describe('ci-failure worker', () => {
+  it('submits a review-gate CI fix intent with the stable dedupe key', async () => {
+    const bus = new LocalBus();
+    const task = makeTask();
+    const submit = vi.fn(() => 7);
+    const event = makeEvent();
+    const worker = createCiFailureWorker({
+      logger,
+      messageBus: bus,
+      store: {
+        loadTasks: () => [task],
+        listWorkflowMutationIntents: () => [],
+      },
+      submitter: { submit },
+      getAutoFixAgent: () => 'codex',
+      installSignalHandlers: false,
+    });
+    worker.start();
+
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, event);
+    await worker.tick();
+
+    const expectedDedupeKey = buildCiFailureDedupeKey({
+      taskId: event.taskId,
+      reviewId: event.reviewId,
+      headSha: event.headSha,
+      failedChecks: event.failedChecks,
+    });
+    expect(submit).toHaveBeenCalledWith(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      expect.any(Array),
+    );
+    const args = submit.mock.calls[0][3] as unknown[];
+    const parsed = parseFixWithAgentMutationArgs(args);
+    expect(parsed).toMatchObject({ taskId: 'wf-1/merge', agentName: 'codex' });
+    expect(parsed.context.reviewGateContext).toMatchObject({
+      reviewId: '123',
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      headSha: 'head-1',
+      dedupeKey: expectedDedupeKey,
+    });
+    await worker.stop();
+  });
+
+  it('accepts failures for a later review-gate artifact in a PR stack', async () => {
+    const bus = new LocalBus();
+    const task = makeTask({
+      execution: {
+        ...makeTask().execution,
+        reviewId: '111',
+        reviewGate: {
+          activeGeneration: 2,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [
+            { id: 'contracts', providerId: '111', required: true, status: 'approved', generation: 2, headSha: 'head-a' },
+            { id: 'runtime', providerId: '123', required: true, status: 'open', generation: 2, headSha: 'head-1' },
+          ],
+        },
+      },
+    });
+    const submit = vi.fn(() => 7);
+    const worker = createCiFailureWorker({
+      logger,
+      messageBus: bus,
+      store: {
+        loadTasks: () => [task],
+        listWorkflowMutationIntents: () => [],
+      },
+      submitter: { submit },
+      installSignalHandlers: false,
+    });
+    worker.start();
+
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, makeEvent({ reviewId: '123' }));
+    await worker.tick();
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    await worker.stop();
+  });
+
+  it('rejects stale head SHA before submitting a fix', async () => {
+    const bus = new LocalBus();
+    const task = makeTask({
+      execution: {
+        ...makeTask().execution,
+        reviewGate: {
+          activeGeneration: 2,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [
+            { id: 'runtime', providerId: '123', required: true, status: 'open', generation: 2, headSha: 'head-2' },
+          ],
+        },
+      },
+    });
+    const submit = vi.fn(() => 7);
+    const worker = createCiFailureWorker({
+      logger,
+      messageBus: bus,
+      store: {
+        loadTasks: () => [task],
+        listWorkflowMutationIntents: () => [],
+      },
+      submitter: { submit },
+      installSignalHandlers: false,
+    });
+    worker.start();
+
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, makeEvent());
+    await worker.tick();
+
+    expect(submit).not.toHaveBeenCalled();
+    await worker.stop();
+  });
+
+  it('rejects stale task status before submitting a fix', async () => {
+    const bus = new LocalBus();
+    const task = makeTask({ status: 'running' });
+    const submit = vi.fn(() => 7);
+    const worker = createCiFailureWorker({
+      logger,
+      messageBus: bus,
+      store: {
+        loadTasks: () => [task],
+        listWorkflowMutationIntents: () => [],
+      },
+      submitter: { submit },
+      installSignalHandlers: false,
+    });
+    worker.start();
+
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, makeEvent());
+    await worker.tick();
+
+    expect(submit).not.toHaveBeenCalled();
+    await worker.stop();
+  });
+
+  it('dedupes completed fixes for the same review head and failed-check fingerprint', async () => {
+    const event = makeEvent();
+    const dedupeKey = buildCiFailureDedupeKey({
+      taskId: event.taskId,
+      reviewId: event.reviewId,
+      headSha: event.headSha,
+      failedChecks: event.failedChecks,
+    });
+    const existing = makeIntent({
+      args: buildFixWithAgentMutationArgs('wf-1/merge', 'codex', {
+        autoFix: true,
+        reviewGateContext: {
+          reviewId: '123',
+          generation: 2,
+          selectedAttemptId: 'attempt-1',
+          headSha: 'head-1',
+          dedupeKey,
+        },
+      }),
+    });
+    const bus = new LocalBus();
+    const submit = vi.fn(() => 7);
+    const worker = createCiFailureWorker({
+      logger,
+      messageBus: bus,
+      store: {
+        loadTasks: () => [makeTask()],
+        listWorkflowMutationIntents: () => [existing],
+      },
+      submitter: { submit },
+      installSignalHandlers: false,
+    });
+    worker.start();
+
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, event);
+    await worker.tick();
+
+    expect(submit).not.toHaveBeenCalled();
+    await worker.stop();
+  });
+
+  it('subscribes before manual ticks', async () => {
+    const bus = new LocalBus();
+    const submit = vi.fn(() => 7);
+    const worker = createCiFailureWorker({
+      logger,
+      messageBus: bus,
+      store: {
+        loadTasks: () => [makeTask()],
+        listWorkflowMutationIntents: () => [],
+      },
+      submitter: { submit },
+      installSignalHandlers: false,
+    });
+
+    await worker.tick('manual');
+    bus.publish(Channels.WORKFLOW_LIFECYCLE, makeEvent());
+    await worker.tick('manual');
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    await worker.stop();
+  });
+});

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { RECOVERY_WORKER_KIND, type AutoFixRecoveryStore, type AutoFixRecoverySubmitter } from '../auto-fix-recovery.js';
 import {
   AUTO_FIX_WORKER_KIND,
+  CI_FAILURE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   createWorkerRegistry,
   registerAutoFixWorker,
@@ -46,7 +47,7 @@ describe('worker registry', () => {
   it('returns the built-in worker definitions by kind once registered', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry());
 
-    for (const kind of [AUTO_FIX_WORKER_KIND, PR_STATUS_WORKER_KIND]) {
+    for (const kind of [AUTO_FIX_WORKER_KIND, PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND]) {
       const definition = registry.get(kind);
       expect(definition).toBeDefined();
       expect(definition?.kind).toBe(kind);
@@ -57,6 +58,7 @@ describe('worker registry', () => {
     expect(registry.list().map((d) => d.kind)).toEqual([
       AUTO_FIX_WORKER_KIND,
       PR_STATUS_WORKER_KIND,
+      CI_FAILURE_WORKER_KIND,
     ]);
   });
 
@@ -77,9 +79,10 @@ describe('worker registry', () => {
     expect(runtime.isRunning()).toBe(false);
   });
 
-  it('builds registered pr-status runtime', () => {
+  it('builds registered pr-status and ci-failure runtimes', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry());
 
     expect(registry.get(PR_STATUS_WORKER_KIND)!.factory(deps()).identity.kind).toBe(PR_STATUS_WORKER_KIND);
+    expect(registry.get(CI_FAILURE_WORKER_KIND)!.factory(deps()).identity.kind).toBe(CI_FAILURE_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -38,6 +38,7 @@ export * from './worker-types.js';
 export * from './worker-lock.js';
 export * from './auto-fix-recovery.js';
 export * from './workers/pr-status-worker.js';
+export * from './workers/ci-failure-worker.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -17,11 +17,12 @@ import {
   type AutoFixRecoverySubmitter,
 } from './auto-fix-recovery.js';
 import { createPrStatusWorker, PR_STATUS_WORKER_KIND } from './workers/pr-status-worker.js';
+import { createCiFailureWorker, CI_FAILURE_WORKER_KIND } from './workers/ci-failure-worker.js';
 import type { WorkerRuntime } from './worker-runtime.js';
 
 /** Registry kind for the built-in auto-fix recovery worker. */
 export const AUTO_FIX_WORKER_KIND = 'autofix';
-export { PR_STATUS_WORKER_KIND };
+export { PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND };
 
 /** Auto-fix tuning handed to a worker factory. */
 export interface AutoFixWorkerConfig {
@@ -89,7 +90,7 @@ export function createWorkerRegistry(): WorkerRegistry {
 /**
  * Register the built-in workers. The legacy function name is kept so existing
  * headless code and tests keep the same import path while the registry now
- * includes auto-fix and pr-status entries.
+ * includes auto-fix, pr-status, and ci-failure entries.
  */
 export function registerAutoFixWorker(registry: WorkerRegistry): WorkerRegistry {
   registry.register({
@@ -114,6 +115,18 @@ export function registerAutoFixWorker(registry: WorkerRegistry): WorkerRegistry 
       if (!deps.reviewGate) throw new Error('pr-status worker requires reviewGate deps');
       return createPrStatusWorker({ logger: deps.logger, reviewGate: deps.reviewGate });
     },
+  });
+  registry.register({
+    kind: CI_FAILURE_WORKER_KIND,
+    note: 'Submits deduped fix-with-agent intents for current review-gate CI failures.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createCiFailureWorker({
+        logger: deps.logger,
+        store: deps.store,
+        submitter: deps.submitter,
+        messageBus: deps.messageBus,
+        getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
+      }),
   });
   return registry;
 }

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -1,0 +1,236 @@
+import { createHash } from 'node:crypto';
+
+import type {
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import type { Logger } from '@invoker/contracts';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+import {
+  buildFixWithAgentMutationArgs,
+  isCurrentReviewGateArtifactForProvider,
+  parseFixWithAgentMutationArgs,
+  parseHeadlessFixArgs,
+  type ReviewGateCiContext,
+} from '../auto-fix-intents.js';
+import type { ReviewGateCiFailedLifecycleEvent, ReviewGateFailedCheck, WorkflowLifecycleEvent } from '../lifecycle-events.js';
+import { createWorkerRuntime, type WorkerRuntime } from '../worker-runtime.js';
+
+export const CI_FAILURE_WORKER_KIND = 'ci-failure';
+const FIX_WITH_AGENT_CHANNEL = 'invoker:fix-with-agent';
+
+export interface CiFailureWorkerStore {
+  loadTask?(taskId: string): TaskState | undefined;
+  loadTasks(workflowId: string): TaskState[];
+  listWorkflowMutationIntents(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[];
+  logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+}
+
+export interface CiFailureWorkerSubmitter {
+  submit(
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: typeof FIX_WITH_AGENT_CHANNEL,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number;
+}
+
+export interface CiFailureWorkerOptions {
+  logger: Logger;
+  store: CiFailureWorkerStore;
+  submitter: CiFailureWorkerSubmitter;
+  messageBus?: MessageBus;
+  getAutoFixAgent?: () => string | undefined;
+  instanceId?: string;
+  tickOnStart?: boolean;
+  installSignalHandlers?: boolean;
+}
+
+function checkFingerprint(checks: readonly ReviewGateFailedCheck[]): string {
+  const sorted = checks
+    .map((check) => [check.name, check.conclusion ?? '', check.detailsUrl ?? ''].join('\0'))
+    .sort();
+  return createHash('sha256').update(sorted.join('\n')).digest('hex');
+}
+
+export function buildCiFailureDedupeKey(input: {
+  taskId: string;
+  reviewId: string;
+  headSha?: string;
+  failedChecks: readonly ReviewGateFailedCheck[];
+}): string {
+  return [
+    'ci-failure',
+    input.taskId,
+    input.reviewId,
+    input.headSha ?? 'no-head',
+    checkFingerprint(input.failedChecks),
+  ].join(':');
+}
+
+function loadLatestTask(store: CiFailureWorkerStore, workflowId: string, taskId: string): TaskState | undefined {
+  return store.loadTask?.(taskId) ?? store.loadTasks(workflowId).find((task) => task.id === taskId);
+}
+
+function currentReviewGateArtifact(task: TaskState, reviewId: string) {
+  const gate = task.execution.reviewGate;
+  if (!gate) return undefined;
+  return gate.artifacts.find((candidate) => (
+    isCurrentReviewGateArtifactForProvider(gate, candidate, reviewId)
+  ));
+}
+
+function eventStillMatchesTask(event: ReviewGateCiFailedLifecycleEvent, task: TaskState): boolean {
+  if (task.config.workflowId && task.config.workflowId !== event.workflowId) return false;
+  if (task.status !== event.status) return false;
+  if ((task.execution.generation ?? 0) !== event.generation) return false;
+  if ((task.execution.selectedAttemptId ?? undefined) !== (event.attemptId ?? undefined)) return false;
+  const artifact = currentReviewGateArtifact(task, event.reviewId);
+  const currentReviewId = artifact?.providerId ?? task.execution.reviewId ?? task.execution.reviewProviderId;
+  if (currentReviewId !== event.reviewId) return false;
+  if ((artifact?.headSha ?? undefined) !== (event.headSha ?? undefined)) return false;
+  return true;
+}
+
+function findExistingCiFailureIntent(
+  intents: readonly WorkflowMutationIntent[],
+  taskId: string,
+  dedupeKey: string,
+): WorkflowMutationIntent | undefined {
+  return intents.find((intent) => {
+    if (intent.channel !== FIX_WITH_AGENT_CHANNEL && intent.channel !== 'headless.exec') return false;
+    if (intent.channel === 'headless.exec') {
+      const parsed = parseHeadlessFixArgs((intent.args[0] as { args?: unknown[] } | undefined)?.args?.filter((arg): arg is string => typeof arg === 'string') ?? []);
+      return parsed.taskId === taskId && parsed.reviewGateContext?.dedupeKey === dedupeKey;
+    }
+    const parsed = parseFixWithAgentMutationArgs(intent.args);
+    if (parsed.taskId !== taskId) return false;
+    return parsed.context.reviewGateContext?.dedupeKey === dedupeKey;
+  });
+}
+
+function formatFixContext(event: ReviewGateCiFailedLifecycleEvent): string {
+  const checks = event.failedChecks
+    .map((check) => `- ${check.name}${check.conclusion ? ` (${check.conclusion})` : ''}${check.detailsUrl ? `: ${check.detailsUrl}` : ''}`)
+    .join('\n');
+  return [
+    `Review-gate PR ${event.reviewId} has failing CI checks.`,
+    `PR: ${event.reviewUrl}`,
+    event.headSha ? `Head SHA: ${event.headSha}` : undefined,
+    `Status: ${event.statusText}`,
+    'Failed checks:',
+    checks,
+  ].filter((line): line is string => Boolean(line)).join('\n');
+}
+
+export function createCiFailureWorker(options: CiFailureWorkerOptions): WorkerRuntime {
+  const pendingEvents: ReviewGateCiFailedLifecycleEvent[] = [];
+  let lifecycleUnsubscribe: Unsubscribe | undefined;
+
+  const runtime = createWorkerRuntime({
+    kind: CI_FAILURE_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: 0,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: async () => {
+      const events = pendingEvents.splice(0);
+      for (const event of events) {
+        const task = loadLatestTask(options.store, event.workflowId, event.taskId);
+        if (!task) {
+          options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', { phase: 'skip', reason: 'task-not-found' });
+          continue;
+        }
+        if (!eventStillMatchesTask(event, task)) {
+          options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', { phase: 'skip', reason: 'stale-event' });
+          continue;
+        }
+
+        const dedupeKey = buildCiFailureDedupeKey({
+          taskId: event.taskId,
+          reviewId: event.reviewId,
+          headSha: event.headSha,
+          failedChecks: event.failedChecks,
+        });
+        const existing = findExistingCiFailureIntent(
+          options.store.listWorkflowMutationIntents(event.workflowId),
+          event.taskId,
+          dedupeKey,
+        );
+        if (existing) {
+          options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', {
+            phase: 'skip',
+            reason: 'duplicate-intent',
+            dedupeKey,
+            existingIntentId: existing.id,
+          });
+          continue;
+        }
+
+        const configuredAgent = options.getAutoFixAgent?.()?.trim();
+        const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
+        const context: ReviewGateCiContext = {
+          reviewId: event.reviewId,
+          generation: event.generation,
+          selectedAttemptId: event.attemptId,
+          branch: event.branch,
+          headSha: event.headSha,
+          dedupeKey,
+          fixContext: formatFixContext(event),
+        };
+        const intentId = options.submitter.submit(
+          event.workflowId,
+          'normal',
+          FIX_WITH_AGENT_CHANNEL,
+          buildFixWithAgentMutationArgs(event.taskId, selectedAgent, { autoFix: true, reviewGateContext: context }),
+        );
+        options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', {
+          phase: 'submitted',
+          dedupeKey,
+          intentId,
+          agent: selectedAgent ?? null,
+        });
+      }
+    },
+  });
+
+  if (!options.messageBus) return runtime;
+
+
+  const subscribeToLifecycle = (): void => {
+    if (lifecycleUnsubscribe) return;
+    lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
+      Channels.WORKFLOW_LIFECYCLE,
+      (event) => {
+        if (event.kind !== 'review_gate.ci_failed') return;
+        pendingEvents.push(event);
+        runtime.wake('wake');
+      },
+    );
+  };
+  return {
+    identity: runtime.identity,
+    start: (): void => {
+      subscribeToLifecycle();
+      runtime.start();
+    },
+    wake: runtime.wake,
+    tick: async (reason): Promise<void> => {
+      subscribeToLifecycle();
+      await runtime.tick(reason);
+    },
+    stop: async (): Promise<void> => {
+      lifecycleUnsubscribe?.();
+      lifecycleUnsubscribe = undefined;
+      await runtime.stop();
+    },
+    isRunning: runtime.isRunning,
+  };
+}


### PR DESCRIPTION
## Summary

The execution engine now has a registered `ci-failure` worker.

It listens to workflow lifecycle events, builds a stable repair fingerprint, and hands the request to the existing mutation queue.

<details>
<summary>Review metadata</summary>

Review Claim: CI failure routing is now represented as an execution-engine worker.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The worker only enqueues through the existing mutation queue interface.

Slice Rationale: This adds the worker route before the app starts it in owner mode.

</details>

## Non-goals

No owner startup changes.

No live GitHub tests.

No worker-to-worker relay messages.

## Architecture

### Before

```mermaid
graph TD
    A["review_gate.ci_failed event"] --> B["No CI worker route"]
```

### After

```mermaid
graph TD
    A["review_gate.ci_failed event"] --> B["ci-failure worker"]
    B --> C["workflow mutation queue"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ci-failure-worker.test.ts src/__tests__/worker-registry.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 7837e66da`
- Post-revert steps: None
- Data migration? No
