### PR TITLE
[PR Status Workers](5) Guard CI repair action context

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -2465,4 +2465,103 @@ describe('fixWithAgentAction review-gate CI context', () => {
     );
     expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
   });
+
+  it('accepts review-gate context for a later artifact in a PR stack', async () => {
+    const orchestrator = makeReviewGateOrchestrator({
+      selectedAttemptId: 'attempt-1',
+      generation: 3,
+      reviewId: 'review-1',
+      branch: 'experiment/foo',
+      reviewGate: {
+        activeGeneration: 3,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [
+          { id: 'contracts', providerId: 'review-1', required: true, status: 'approved', generation: 3, headSha: 'head-a' },
+          { id: 'runtime', providerId: 'review-2', required: true, status: 'open', generation: 3, headSha: 'head-b' },
+        ],
+      },
+    });
+    const persistence = { getTaskOutput: vi.fn(() => 'output'), appendTaskOutput: vi.fn() };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn(),
+    };
+
+    await fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      agentName: 'claude',
+      reviewGateContext: {
+        reviewId: 'review-2',
+        generation: 3,
+        selectedAttemptId: 'attempt-1',
+        branch: 'experiment/foo',
+        headSha: 'head-b',
+      },
+    });
+
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses persisted review-gate lineage when the orchestrator cache is behind', async () => {
+    const orchestrator = makeReviewGateOrchestrator({
+      selectedAttemptId: 'attempt-1',
+      generation: 3,
+      reviewId: 'review-1',
+      branch: 'experiment/foo',
+      reviewGate: {
+        activeGeneration: 3,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [
+          { id: 'runtime', providerId: 'review-1', required: true, status: 'open', generation: 3, headSha: 'old-head' },
+        ],
+      },
+    });
+    const persisted = makeTask({
+      status: 'failed',
+      config: { workflowId: 'wf-1' },
+      execution: {
+        error: 'ci failed',
+        selectedAttemptId: 'attempt-1',
+        generation: 3,
+        reviewId: 'review-1',
+        branch: 'experiment/foo',
+        reviewGate: {
+          activeGeneration: 3,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [
+            { id: 'runtime', providerId: 'review-1', required: true, status: 'open', generation: 3, headSha: 'new-head' },
+          ],
+        },
+      },
+    });
+    const persistence = {
+      getTaskOutput: vi.fn(() => 'output'),
+      appendTaskOutput: vi.fn(),
+      loadTask: vi.fn(() => persisted),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn(),
+    };
+
+    await fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      agentName: 'claude',
+      reviewGateContext: {
+        reviewId: 'review-1',
+        generation: 3,
+        selectedAttemptId: 'attempt-1',
+        branch: 'experiment/foo',
+        headSha: 'new-head',
+      },
+    });
+
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -25,6 +25,7 @@ import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner, ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import {
+  isCurrentReviewGateArtifactForProvider,
   isReviewGateCiContextStale,
   type ReviewGateCiContext,
   type ReviewGateLineageFields,
@@ -100,6 +101,20 @@ export function assertLineageCurrent(
       + `gen ${snapshot.generation} → ${current.generation})`,
     );
   }
+}
+
+function currentReviewGateCiLineage(task: TaskState, reviewId: string): ReviewGateLineageFields {
+  const gate = task.execution.reviewGate;
+  const artifact = gate?.artifacts.find((candidate) => (
+    isCurrentReviewGateArtifactForProvider(gate, candidate, reviewId)
+  ));
+  return {
+    generation: task.execution.generation,
+    reviewId: artifact?.providerId ?? task.execution.reviewId ?? task.execution.reviewProviderId,
+    selectedAttemptId: task.execution.selectedAttemptId,
+    branch: task.execution.branch,
+    headSha: artifact?.headSha,
+  };
 }
 
 function assertReviewGateCiContextCurrent(
@@ -841,7 +856,12 @@ export async function fixWithAgentAction(
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
   if (options.reviewGateContext) {
-    assertReviewGateCiContextCurrent(taskId, options.reviewGateContext, task.execution);
+    const reviewGateLineageTask = persistence.loadTask?.(taskId) ?? task;
+    assertReviewGateCiContextCurrent(
+      taskId,
+      options.reviewGateContext,
+      currentReviewGateCiLineage(reviewGateLineageTask, options.reviewGateContext.reviewId),
+    );
   }
 
   const savedError = task.execution.error ?? '';

--- a/scripts/repro/repro-coderabbit-pr2767-persisted-review-gate-head-sha.sh
+++ b/scripts/repro/repro-coderabbit-pr2767-persisted-review-gate-head-sha.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TEST_NAME='uses persisted review-gate lineage when the orchestrator cache is behind'
+
+if pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts -t "$TEST_NAME"; then
+  echo "PASS: fixWithAgentAction accepts persisted review-gate headSha when orchestrator cache is behind"
+  exit 0
+fi
+
+echo "FAIL: fixWithAgentAction rejected the fresh persisted review-gate headSha as stale" >&2
+exit 1


### PR DESCRIPTION
## Summary

The fix action path now accepts review-gate context from repair requests.

It compares that context with the current task before any repair work begins.

<details>
<summary>Review metadata</summary>

Review Claim: The fix action surface can carry review-gate context into the existing repair path.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The existing action still chooses the recovery route and starts the same repair flow.

Slice Rationale: This activation surface lands after the worker creates context and before owner startup forwards it.

</details>

## Non-goals

No owner startup changes.

No new repair route.

No live GitHub tests.

## Architecture

### Before

```mermaid
graph TD
    A["fix action"] --> B["task lineage only"]
```

### After

```mermaid
graph TD
    A["fix action"] --> B["task lineage plus review-gate context"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 2c79e7910`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of review-gate context when continuing work from a pull request stack, so the app now uses the correct current artifact information and avoids duplicate agent actions.
  * Better resilience when cached review-gate state is out of date, ensuring the latest persisted lineage is used.

* **Tests**
  * Added coverage for review-gate scenarios involving later artifacts and stale cached state.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->