### PR TITLE
[PR Status Workers](6) Start CI failure worker in owner mode

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -99,6 +99,7 @@ import {
   remoteFetchForPool,
   registerBuiltinAgents,
   createPrStatusWorker,
+  createCiFailureWorker,
   type AgentRegistry,
   type WorkerRuntime,
 } from '@invoker/execution-engine';
@@ -208,6 +209,7 @@ import {
   buildHeadlessFixArgs,
   listOpenFixIntentsForTask,
   parseFixWithAgentMutationArgs,
+  type ReviewGateCiContext,
 } from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
@@ -913,6 +915,7 @@ function startHeadlessMode(): void {
 
     let exitCode = 0;
     let prStatusWorker: WorkerRuntime | null = null;
+    let ciFailureWorker: WorkerRuntime | null = null;
     let lifecycleEventBridge: LifecycleEventBridge | null = null;
     let standaloneLaunchDispatcherController: StandaloneLaunchDispatcherController | null = null;
     try {
@@ -1592,6 +1595,16 @@ function startHeadlessMode(): void {
             logger,
           });
           prStatusWorker.start();
+          if (invokerConfig.autoFixCi && workflowMutationCoordinator) {
+            ciFailureWorker = createCiFailureWorker({
+              store: persistence,
+              submitter: workflowMutationCoordinator,
+              messageBus,
+              logger,
+              getAutoFixAgent: () => loadConfig().autoFixAgent,
+            });
+            ciFailureWorker.start();
+          }
         }
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
@@ -1612,6 +1625,7 @@ function startHeadlessMode(): void {
     } finally {
       standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
+      await ciFailureWorker?.stop();
       await prStatusWorker?.stop();
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
@@ -1700,6 +1714,7 @@ function createEmbeddedTerminalBackendFromConfig(
   let mainWindow: BrowserWindow | null = null;
   let taskExecutor: TaskRunner | null = null;
   let prStatusWorker: WorkerRuntime | null = null;
+  let ciFailureWorker: WorkerRuntime | null = null;
   let apiServer: ApiServer | null = null;
   let webBridge: WebBridge | null = null;
   let ownerMode = true;
@@ -2012,6 +2027,7 @@ function createEmbeddedTerminalBackendFromConfig(
     taskId: string,
     agentName?: string,
     source: 'ipc' | 'auto-fix' = 'ipc',
+    reviewGateContext?: ReviewGateCiContext,
   ): Promise<TaskState[]> => {
     const task = orchestrator.getTask(taskId);
     if (!task) {
@@ -2050,6 +2066,7 @@ function createEmbeddedTerminalBackendFromConfig(
         recoveryRoute,
         recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
         failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`,
+        reviewGateContext,
         signal: activeMutationContext?.signal,
       },
     );
@@ -3319,6 +3336,16 @@ function createEmbeddedTerminalBackendFromConfig(
         logger,
       });
       prStatusWorker.start();
+      if (invokerConfig.autoFixCi && workflowMutationCoordinator) {
+        ciFailureWorker = createCiFailureWorker({
+          store: persistence,
+          submitter: workflowMutationCoordinator,
+          messageBus,
+          logger,
+          getAutoFixAgent: () => loadConfig().autoFixAgent,
+        });
+        ciFailureWorker.start();
+      }
     }
 
     // Relaunch orphaned running tasks and start any pending-but-ready tasks.
@@ -4282,7 +4309,7 @@ function createEmbeddedTerminalBackendFromConfig(
       const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
       try {
         const source = context.autoFix ? 'auto-fix' : 'ipc';
-        const started = await executeFixWithAgentMutation(taskId, agentName, source);
+        const started = await executeFixWithAgentMutation(taskId, agentName, source, context.reviewGateContext);
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
@@ -4704,6 +4731,8 @@ function createEmbeddedTerminalBackendFromConfig(
       try {
         if (apiServer) await apiServer.close().catch(() => {});
         if (webBridge) await webBridge.close().catch(() => {});
+        await ciFailureWorker?.stop();
+        ciFailureWorker = null;
         await prStatusWorker?.stop();
         prStatusWorker = null;
         if (dbPollInterval) clearInterval(dbPollInterval);


### PR DESCRIPTION
## Summary

Owner mode now routes CI failure handling into the registered worker.

Repair context from that worker follows the existing fix mutation route.

<details>
<summary>Review metadata</summary>

Review Claim: Owner startup now routes CI failure repair through the registered worker and existing mutation route.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Repair still uses the same `invoker:fix-with-agent` mutation handler.

Slice Rationale: This final routing slice wires the worker after its dependencies and action context are present.

</details>

## Non-goals

No new repair route.

No worker-to-worker relay messages.

No live GitHub tests.

## Architecture

### Before

```mermaid
graph TD
    A["Owner startup"] --> B["pr-status worker only"]
```

### After

```mermaid
graph TD
    A["Owner startup"] --> B["pr-status worker"]
    A --> C["ci-failure worker"]
    C --> D["existing fix-with-agent mutation handler"]
```

## Test Plan

- [x] `pnpm run check:types`

## Visual Proof

No user-visible UI changed. These screenshots are the UI smoke proof for the main-process-only startup change.

![Before empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-e993a9/empty-state.png)

![After empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-e993a9/empty-state.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert cf8b7b0be`
- Post-revert steps: Restart the owner process.
- Data migration? No
