### PR TITLE
[Mergify Queue Timeout](1) Raise checks_timeout to 60min

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -12,6 +12,7 @@ queue_rules:
     merge_method: squash
     batch_size: 5
     batch_max_wait_time: 5min
+    checks_timeout: 60min
     queue_conditions:
       - base=master
       - -draft
@@ -42,6 +43,7 @@ queue_rules:
     merge_method: squash
     batch_size: 1
     batch_max_wait_time: 5min
+    checks_timeout: 60min
     queue_conditions:
       - base=master
       - -draft


### PR DESCRIPTION
## Summary

Mergify was kicking passing PRs out of the merge queue before they could land.

The queue gives each batch a fixed window for all required checks to go green. The heavy checks — ssh shards, three playwright shards, the docker job — run cold and routinely finish past the old 35-minute default.

When that window expired, Mergify dequeued the PR even though its checks were on track. The author then had to manually requeue and beat the clock.

This raises the per-queue `checks_timeout` to 60 minutes on both the `default` and `admin-bypass` queue rules, so a slow-but-passing batch lands instead of getting evicted.

<details>
<summary>Review metadata</summary>

Review Claim: Raising `checks_timeout` to 60min on both queue rules is the right window for this repo's check suite.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This only widens how long Mergify waits for required checks before giving up. It changes no check, no merge condition, and no approval rule, so nothing can merge that could not merge before.

Slice Rationale: The timeout lives in `.mergify.yml`, which Mergify reads from `master`, so it must land as its own change and cannot ride inside an unrelated feature stack.

</details>

## Non-goals

- Does not change which checks are required.
- Does not change merge method, batch size, or queue conditions.
- Does not touch approval or review-thread requirements.

## Test Plan

- [ ] `python3 -c "import yaml; d=yaml.safe_load(open('.mergify.yml')); assert all(q.get('checks_timeout')=='60min' for q in d['queue_rules']); print('ok')"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
