### PR TITLE
[Invoker UI Reskin](1) Add in-app planner bridge

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -224,6 +224,22 @@ export interface ResumeWorkflowResult {
   taskCount: number;
   startedCount: number;
 }
+export interface InAppPlanRequest {
+  goal: string;
+  presetKey?: string;
+}
+
+export type InAppPlanResponse =
+  | {
+      ok: true;
+      planName: string;
+      workflowId: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
 
 export interface WorkflowListEntry {
   id: string;
@@ -424,6 +440,10 @@ export interface SearchOptions {
 
 export const IpcChannels = {
   // Plan & Workflow Management
+  'invoker:plan-from-goal': {} as {
+    request: [request: InAppPlanRequest];
+    response: InAppPlanResponse;
+  },
   'invoker:load-plan': {} as {
     request: [planText: string];
     response: void;
@@ -753,6 +773,10 @@ export const IpcChannels = {
 export const IpcTestOnlyChannels = {
   'invoker:inject-task-states': {} as {
     request: [updates: Array<{ taskId: string; changes: TaskStateChanges }>];
+    response: void;
+  },
+  'invoker:set-test-plan-from-goal-response': {} as {
+    request: [response: { planYaml: string; planName: string } | null];
     response: void;
   },
 } as const;


### PR DESCRIPTION
## Summary

This slice defines the IPC request and response shapes for in-app planning.

The app now has one stable set of planning channel types, including the test-only response payload used by later proof slices.

<details>
<summary>Review metadata</summary>

Review Claim: In-app planning now has one stable IPC contract for the request, response, and test-only response payload.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This slice defines the IPC shapes only. It does not load plans or run tasks by itself.

Slice Rationale: Later slices need one stable planning contract before they can wire main-process behavior or renderer UI.

</details>

## Non-goals

- No renderer shell changes.
- No automatic task execution after planning.
- No Slack planning behavior changes.

## Test Plan

- [x] `pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts && pnpm --filter @invoker/app build`

## Visual Proof

![Terminal planning bridge result](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-220849/terminal-planned-graph.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new planning option that lets the app generate a plan from a goal, with clear success and error responses.
  * Support now includes returning the generated plan name and workflow ID when planning succeeds.

* **Tests**
  * Added test-only support for setting a plan-from-goal response in development and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->