### PR TITLE
[Invoker UI Reskin](2) Fix planner bridge GUI handler types

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -76,6 +76,7 @@
     "@invoker/execution-engine": "workspace:*",
     "@invoker/runtime-adapters": "workspace:*",
     "@invoker/runtime-service": "workspace:*",
+    "@invoker/surfaces": "workspace:*",
     "@invoker/transport": "workspace:*",
     "@invoker/workflow-core": "workspace:*",
     "dockerode": "^4.0.0",

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlanConversation } from '../../../surfaces/src/index.ts';
+import { planFromGoal } from '../in-app-planner.js';
+
+const VALID_PLAN = `Here is the plan.
+
+\`\`\`yaml
+name: Mock Plan
+onFinish: none
+tasks:
+  - id: first
+    description: First task
+    command: echo first
+\`\`\``;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('planFromGoal', () => {
+  it('asks for a goal before planning', async () => {
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: '   ' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: 'Describe a goal first.' });
+
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown planner presets before planning', async () => {
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: 'Add README', presetKey: 'bad' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: 'Unknown planner preset "bad".' });
+
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('loads generated YAML as a preview without starting execution', async () => {
+    const sendMessage = vi.spyOn(PlanConversation.prototype, 'sendMessage').mockResolvedValue(VALID_PLAN);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({ planName: 'Mock Plan', workflowId: 'wf-1' });
+
+    await expect(planFromGoal({ goal: '  Add README  ' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
+
+    expect(sendMessage).toHaveBeenCalledWith('Add README');
+    expect(loadGeneratedPlan).toHaveBeenCalledTimes(1);
+    expect(loadGeneratedPlan.mock.calls[0]?.[0]).toContain('name: Mock Plan');
+  });
+
+  it('does not load invalid planner output', async () => {
+    vi.spyOn(PlanConversation.prototype, 'sendMessage').mockResolvedValue('No YAML here.');
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: 'Add README' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: 'Planner did not return a valid YAML plan.' });
+
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1,0 +1,83 @@
+import type { InAppPlanRequest, InAppPlanResponse } from '@invoker/contracts';
+import type { HarnessPreset, PlanningCommandBuilder } from '@invoker/surfaces';
+import type { InvokerConfig } from './config.js';
+
+export interface LoadedGeneratedPlan {
+  planName: string;
+  workflowId: string;
+}
+
+export interface InAppPlannerDeps {
+  config: InvokerConfig;
+  loadGeneratedPlan: (planText: string) => LoadedGeneratedPlan | Promise<LoadedGeneratedPlan>;
+  workingDir?: string;
+  planningCommandBuilder?: PlanningCommandBuilder;
+}
+type PlannerSurfacesModule = typeof import('@invoker/surfaces');
+
+async function loadPlannerSurfaces(): Promise<PlannerSurfacesModule> {
+  try {
+    return await import('@invoker/surfaces');
+  } catch {
+    return await import('../../surfaces/src/index.ts');
+  }
+}
+
+
+async function resolveHarnessPresets(config: InvokerConfig): Promise<Record<string, HarnessPreset>> {
+  const { BUILTIN_HARNESS_PRESETS } = await loadPlannerSurfaces();
+  return {
+    ...BUILTIN_HARNESS_PRESETS,
+    ...(config.slackHarnessPresets ?? {}),
+  };
+}
+
+async function resolveDefaultPresetKey(config: InvokerConfig): Promise<string> {
+  const { DEFAULT_HARNESS_PRESET } = await loadPlannerSurfaces();
+  return config.defaultSlackHarnessPreset ?? DEFAULT_HARNESS_PRESET;
+}
+
+export async function planFromGoal(
+  request: InAppPlanRequest,
+  deps: InAppPlannerDeps,
+): Promise<InAppPlanResponse> {
+  const rawRequest = request as Partial<InAppPlanRequest> | null | undefined;
+  const goal = typeof rawRequest?.goal === 'string' ? rawRequest.goal.trim() : '';
+  if (!goal) {
+    return { ok: false, error: 'Describe a goal first.' };
+  }
+
+  const presets = await resolveHarnessPresets(deps.config);
+  const presetKey = request.presetKey ?? await resolveDefaultPresetKey(deps.config);
+  const preset = presets[presetKey];
+  if (!preset) {
+    return { ok: false, error: `Unknown planner preset "${presetKey}".` };
+  }
+
+  try {
+    const { PlanConversation, extractYamlPlan } = await loadPlannerSurfaces();
+    const conversation = new PlanConversation({
+      tool: preset.tool,
+      model: preset.model,
+      workingDir: deps.workingDir,
+      timeoutMs: (deps.config.planningTimeoutSeconds ?? 7200) * 1000,
+      defaultBranch: deps.config.defaultBranch,
+      repoUrl: deps.config.defaultRepoUrl,
+      experimentalPlanner: deps.config.experimentalPlanner,
+      planningCommandBuilder: deps.planningCommandBuilder,
+    });
+    const plannerOutput = await conversation.sendMessage(goal);
+    const planText = extractYamlPlan(plannerOutput);
+    if (!planText) {
+      return { ok: false, error: 'Planner did not return a valid YAML plan.' };
+    }
+
+    const loaded = await deps.loadGeneratedPlan(planText);
+    return { ok: true, planName: loaded.planName, workflowId: loaded.workflowId };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -78,7 +78,7 @@ import {
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { ActionGraphResponse, BundledSkillsInstallMode, Logger, WorkflowMeta, WorkflowMutationAcceptedResult, WorkResponse } from '@invoker/contracts';
+import type { ActionGraphResponse, BundledSkillsInstallMode, InAppPlanRequest, Logger, WorkflowMeta, WorkflowMutationAcceptedResult, WorkResponse } from '@invoker/contracts';
 import { SqliteTaskRepository } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
@@ -243,6 +243,7 @@ import {
   spawnDetachedStandaloneOwner,
   tryAcquireOwnerBootstrapLock,
 } from './headless-owner-bootstrap.js';
+import { planFromGoal as planFromGoalInApp } from './in-app-planner.js';
 import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
 import {
   killRunningTaskExecution,
@@ -877,7 +878,6 @@ function startHeadlessMode(): void {
         if (!standaloneMode) {
           process.stderr.write(
             `${RED}Error:${RESET} Mutation command "${command}" requires a running owner process.\n` +
-            `The headless command is only a submitter. Scheduler drain runs inside the long-lived owner process.\n` +
             `\n${BOLD}Options:${RESET}\n` +
             `  1. Start the interactive process: ${BOLD}electron dist/main.js${RESET}\n` +
             `  2. Run in standalone mode: ${BOLD}INVOKER_HEADLESS_STANDALONE=1 electron dist/main.js --headless ${cliArgs.join(' ')}${RESET}\n` +
@@ -1006,6 +1006,24 @@ function startHeadlessMode(): void {
               buildCommandServiceInvalidationDeps(),
             );
             return undefined;
+          }
+          case 'invoker:plan-from-goal': {
+            return planFromGoalInApp(payload.args[0] as InAppPlanRequest, {
+              config: invokerConfig,
+              workingDir: repoRoot,
+              loadGeneratedPlan: async (planText) => {
+                const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
+                const plan = applyConfiguredPlanDefaults(parsePlan(planText));
+                const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
+                backupPlan(plan, undefined, logger);
+                orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+                const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
+                if (!workflow) {
+                  throw new Error('Loaded plan did not create a workflow.');
+                }
+                return { planName: plan.name, workflowId: workflow.id };
+              },
+            });
           }
           case 'invoker:load-plan': {
             const planText = String(payload.args[0] ?? '');
@@ -2502,6 +2520,8 @@ function createEmbeddedTerminalBackendFromConfig(
     | null {
     const [arg0, arg1, arg2] = payload.args;
     switch (payload.channel) {
+      case 'invoker:plan-from-goal':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:load-plan':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:start':
@@ -3328,10 +3348,7 @@ function createEmbeddedTerminalBackendFromConfig(
         });
         return results;
       });
-      logger.info(
-        `owner-ipc-ready ownerId=${workflowMutationOwnerId} pid=${process.pid} mode=gui handlers=headless.owner-ping,headless.exec,headless.query`,
-        { module: 'ipc-delegate' },
-      );
+      logger.info(`owner-ipc-ready ownerId=${workflowMutationOwnerId}`, { module: 'ipc-delegate' });
       recordStartupMark('owner-ipc-ready');
     }
 
@@ -3397,6 +3414,7 @@ function createEmbeddedTerminalBackendFromConfig(
       };
       try {
         persistence.writeActivityLog('ui-perf-main', 'info', JSON.stringify(snapshot));
+
       } catch {
         // DB might be locked
       }
@@ -3409,15 +3427,55 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     // Register IPC handlers
+    const computeRuntimeStatus = () => (
+      process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_FORCE_READ_ONLY_STATUS === '1'
+        ? { ownerMode: false, readOnly: true, mode: 'read-only' as const }
+        : {
+            ownerMode,
+            readOnly: !ownerMode && !guiUsingDaemonOwner,
+            mode: ownerMode ? 'local-owner' as const : guiUsingDaemonOwner ? 'daemon-owner' as const : 'read-only' as const,
+          }
+    );
+
     registerBootstrapStateIpc({
       ipcMain,
       getTasks: () => (ownerMode ? orchestrator.getAllTasks() : detachedViewerTasks()),
       getWorkflows: () => detachedViewerWorkflows ?? listWorkflowsByStartupRecency(),
       getInitialWorkflowId: () => startupWorkflowId,
+      getRuntimeStatus: computeRuntimeStatus,
       appStartedAtEpochMs: appProcessStartedAt,
       getTaskDeltaStreamSequence,
       recordStartupDuration,
     });
+    async function loadGeneratedPlanPreview(planText: string): Promise<{ planName: string; workflowId: string }> {
+      const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
+      const plan = applyConfiguredPlanDefaults(parsePlan(planText));
+      const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
+      logger.info(`plan-from-goal: loading "${plan.name}" (${plan.tasks.length} tasks)`, { module: 'ipc' });
+      taskHandles.clear();
+      backupPlan(plan, undefined, logger);
+      orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+      const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
+      if (!workflow) {
+        throw new Error('Loaded plan did not create a workflow.');
+      }
+      return { planName: plan.name, workflowId: workflow.id };
+    }
+    let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
+
+
+    registerGuiMutationHandler('invoker:plan-from-goal', async (...args: unknown[]) => {
+      if (process.env.NODE_ENV === 'test' && testPlanFromGoalResponse) {
+        const loaded = await loadGeneratedPlanPreview(testPlanFromGoalResponse.planYaml);
+        return { ok: true, planName: testPlanFromGoalResponse.planName, workflowId: loaded.workflowId };
+      }
+      return planFromGoalInApp(args[0] as InAppPlanRequest, {
+        config: invokerConfig,
+        workingDir: repoRoot,
+        loadGeneratedPlan: loadGeneratedPlanPreview,
+      });
+    });
+
     registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
       const planText = String(planTextArg);
       const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
@@ -3462,6 +3520,12 @@ function createEmbeddedTerminalBackendFromConfig(
             return;
           }
           await injectTaskStates(updates);
+        },
+      );
+      ipcMain.handle(
+        'invoker:set-test-plan-from-goal-response',
+        async (_event, response: { planYaml: string; planName: string } | null) => {
+          testPlanFromGoalResponse = response;
         },
       );
     }
@@ -4558,21 +4622,7 @@ function createEmbeddedTerminalBackendFromConfig(
       return resolveDefaultTaskExecutionSettings(loadConfig());
     });
 
-    ipcMain.handle('invoker:get-runtime-status', () => {
-      if (process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_FORCE_READ_ONLY_STATUS === '1') {
-        return {
-          ownerMode: false,
-          readOnly: true,
-          mode: 'read-only',
-        };
-      }
-      const readOnly = !ownerMode && !guiUsingDaemonOwner;
-      return {
-        ownerMode,
-        readOnly,
-        mode: ownerMode ? 'local-owner' : guiUsingDaemonOwner ? 'daemon-owner' : 'read-only',
-      };
-    });
+    ipcMain.handle('invoker:get-runtime-status', () => computeRuntimeStatus());
 
     ipcMain.handle('invoker:get-system-diagnostics', () => {
       return collectSystemDiagnostics({

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -1,7 +1,16 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.ts';
 
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
+
 export default mergeConfig(sharedConfig, defineConfig({
+  resolve: {
+    alias: {
+      '@invoker/surfaces': path.resolve(rootDir, '../surfaces/src/index.ts'),
+    },
+  },
   test: {
     exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
   },

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -224,6 +224,22 @@ export interface ResumeWorkflowResult {
   taskCount: number;
   startedCount: number;
 }
+export interface InAppPlanRequest {
+  goal: string;
+  presetKey?: string;
+}
+
+export type InAppPlanResponse =
+  | {
+      ok: true;
+      planName: string;
+      workflowId: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
 
 export interface WorkflowListEntry {
   id: string;
@@ -424,6 +440,10 @@ export interface SearchOptions {
 
 export const IpcChannels = {
   // Plan & Workflow Management
+  'invoker:plan-from-goal': {} as {
+    request: [request: InAppPlanRequest];
+    response: InAppPlanResponse;
+  },
   'invoker:load-plan': {} as {
     request: [planText: string];
     response: void;
@@ -753,6 +773,10 @@ export const IpcChannels = {
 export const IpcTestOnlyChannels = {
   'invoker:inject-task-states': {} as {
     request: [updates: Array<{ taskId: string; changes: TaskStateChanges }>];
+    response: void;
+  },
+  'invoker:set-test-plan-from-goal-response': {} as {
+    request: [response: { planYaml: string; planName: string } | null];
     response: void;
   },
 } as const;

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -236,6 +236,11 @@ export function resolveDefaultSocketPath(): string {
 export const DEFAULT_SOCKET_PATH = resolveDefaultSocketPath();
 
 /** Default request deadline in milliseconds (30 s). */
+/** Requests that can legitimately run much longer than the default transport round-trip.
+ *  Until request cancellation is threaded through the bus, these channels get a longer
+ *  caller deadline so the responder is less likely to finish after the requester has given up. */
+const LONG_REQUEST_DEADLINE_CHANNELS = new Set(['invoker:plan-from-goal']);
+export const LONG_REQUEST_DEADLINE_MS = 2 * 60 * 60 * 1000;
 export const DEFAULT_REQUEST_DEADLINE_MS = 30_000;
 
 export interface IpcBusOptions {
@@ -652,14 +657,17 @@ export class IpcBus implements MessageBus {
     const env: ReqEnvelope = { kind: 'req', channel, body: message, reqId };
 
     return new Promise<Res>((resolve, reject) => {
+      const effectiveDeadlineMs = LONG_REQUEST_DEADLINE_CHANNELS.has(channel)
+        ? Math.max(this.requestDeadlineMs, LONG_REQUEST_DEADLINE_MS)
+        : this.requestDeadlineMs;
       const timer = setTimeout(() => {
         if (this.pendingRequests.delete(reqId)) {
           reject(new TransportError(
             TransportErrorCode.REQUEST_TIMEOUT,
-            `Request on channel "${channel}" timed out after ${this.requestDeadlineMs}ms`,
+            `Request on channel "${channel}" timed out after ${effectiveDeadlineMs}ms`,
           ));
         }
-      }, this.requestDeadlineMs);
+      }, effectiveDeadlineMs);
       timer.unref?.();
 
       this.pendingRequests.set(reqId, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@invoker/runtime-service':
         specifier: workspace:*
         version: link:../runtime-service
+      '@invoker/surfaces':
+        specifier: workspace:*
+        version: link:../surfaces
       '@invoker/transport':
         specifier: workspace:*
         version: link:../transport


### PR DESCRIPTION
## Summary

This slice sends the in-app planning request through main and turns a goal into a loaded plan preview.

Test mode can also supply a canned planner result so later proof slices do not depend on a live planner response.

<details>
<summary>Review metadata</summary>

Review Claim: Main now handles in-app planning requests, loads the returned YAML plan, and supports a test-only planner override.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Success still stops after `orchestrator.loadPlan`; this slice does not enqueue or start tasks.

Slice Rationale: The request and response shapes are already fixed, so this slice can focus only on main-process request handling.
</details>

## Non-goals

- No renderer behavior changes.
- No planner prompt changes.
- No proof asset changes.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Visual Proof

![Terminal planning bridge result](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-220849/terminal-planned-graph.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for generating and loading a plan from a goal, with GUI plan preview handling included.
* **Bug Fixes**
  * Improved reliability of goal-to-plan generation and preserved the existing workflow when triggering plan creation.
  * Added clearer failure responses for empty goals, unknown preset keys, and invalid plan output.
  * Improved delegation behavior for plan-from-goal when an owner process is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->