### PR TITLE
[Invoker UI Reskin](3) Activate reskinned Invoker shell

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -76,6 +76,7 @@
     "@invoker/execution-engine": "workspace:*",
     "@invoker/runtime-adapters": "workspace:*",
     "@invoker/runtime-service": "workspace:*",
+    "@invoker/surfaces": "workspace:*",
     "@invoker/transport": "workspace:*",
     "@invoker/workflow-core": "workspace:*",
     "dockerode": "^4.0.0",

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { PlanConversation } from '../../../surfaces/src/index.ts';
+import { planFromGoal } from '../in-app-planner.js';
+
+const VALID_PLAN = `Here is the plan.
+
+\`\`\`yaml
+name: Mock Plan
+onFinish: none
+tasks:
+  - id: first
+    description: First task
+    command: echo first
+\`\`\``;
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('planFromGoal', () => {
+  it('asks for a goal before planning', async () => {
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: '   ' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: 'Describe a goal first.' });
+
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown planner presets before planning', async () => {
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: 'Add README', presetKey: 'bad' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: 'Unknown planner preset "bad".' });
+
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+
+  it('loads generated YAML as a preview without starting execution', async () => {
+    const sendMessage = vi.spyOn(PlanConversation.prototype, 'sendMessage').mockResolvedValue(VALID_PLAN);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({ planName: 'Mock Plan', workflowId: 'wf-1' });
+
+    await expect(planFromGoal({ goal: '  Add README  ' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
+
+    expect(sendMessage).toHaveBeenCalledWith('Add README');
+    expect(loadGeneratedPlan).toHaveBeenCalledTimes(1);
+    expect(loadGeneratedPlan.mock.calls[0]?.[0]).toContain('name: Mock Plan');
+  });
+
+  it('does not load invalid planner output', async () => {
+    vi.spyOn(PlanConversation.prototype, 'sendMessage').mockResolvedValue('No YAML here.');
+    const loadGeneratedPlan = vi.fn();
+
+    await expect(planFromGoal({ goal: 'Add README' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: false, error: 'Planner did not return a valid YAML plan.' });
+
+    expect(loadGeneratedPlan).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -1,0 +1,83 @@
+import type { InAppPlanRequest, InAppPlanResponse } from '@invoker/contracts';
+import type { HarnessPreset, PlanningCommandBuilder } from '@invoker/surfaces';
+import type { InvokerConfig } from './config.js';
+
+export interface LoadedGeneratedPlan {
+  planName: string;
+  workflowId: string;
+}
+
+export interface InAppPlannerDeps {
+  config: InvokerConfig;
+  loadGeneratedPlan: (planText: string) => LoadedGeneratedPlan | Promise<LoadedGeneratedPlan>;
+  workingDir?: string;
+  planningCommandBuilder?: PlanningCommandBuilder;
+}
+type PlannerSurfacesModule = typeof import('@invoker/surfaces');
+
+async function loadPlannerSurfaces(): Promise<PlannerSurfacesModule> {
+  try {
+    return await import('@invoker/surfaces');
+  } catch {
+    return await import('../../surfaces/src/index.ts');
+  }
+}
+
+
+async function resolveHarnessPresets(config: InvokerConfig): Promise<Record<string, HarnessPreset>> {
+  const { BUILTIN_HARNESS_PRESETS } = await loadPlannerSurfaces();
+  return {
+    ...BUILTIN_HARNESS_PRESETS,
+    ...(config.slackHarnessPresets ?? {}),
+  };
+}
+
+async function resolveDefaultPresetKey(config: InvokerConfig): Promise<string> {
+  const { DEFAULT_HARNESS_PRESET } = await loadPlannerSurfaces();
+  return config.defaultSlackHarnessPreset ?? DEFAULT_HARNESS_PRESET;
+}
+
+export async function planFromGoal(
+  request: InAppPlanRequest,
+  deps: InAppPlannerDeps,
+): Promise<InAppPlanResponse> {
+  const rawRequest = request as Partial<InAppPlanRequest> | null | undefined;
+  const goal = typeof rawRequest?.goal === 'string' ? rawRequest.goal.trim() : '';
+  if (!goal) {
+    return { ok: false, error: 'Describe a goal first.' };
+  }
+
+  const presets = await resolveHarnessPresets(deps.config);
+  const presetKey = request.presetKey ?? await resolveDefaultPresetKey(deps.config);
+  const preset = presets[presetKey];
+  if (!preset) {
+    return { ok: false, error: `Unknown planner preset "${presetKey}".` };
+  }
+
+  try {
+    const { PlanConversation, extractYamlPlan } = await loadPlannerSurfaces();
+    const conversation = new PlanConversation({
+      tool: preset.tool,
+      model: preset.model,
+      workingDir: deps.workingDir,
+      timeoutMs: (deps.config.planningTimeoutSeconds ?? 7200) * 1000,
+      defaultBranch: deps.config.defaultBranch,
+      repoUrl: deps.config.defaultRepoUrl,
+      experimentalPlanner: deps.config.experimentalPlanner,
+      planningCommandBuilder: deps.planningCommandBuilder,
+    });
+    const plannerOutput = await conversation.sendMessage(goal);
+    const planText = extractYamlPlan(plannerOutput);
+    if (!planText) {
+      return { ok: false, error: 'Planner did not return a valid YAML plan.' };
+    }
+
+    const loaded = await deps.loadGeneratedPlan(planText);
+    return { ok: true, planName: loaded.planName, workflowId: loaded.workflowId };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -78,7 +78,7 @@ import {
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
 } from '@invoker/contracts';
-import type { ActionGraphResponse, BundledSkillsInstallMode, Logger, WorkflowMeta, WorkflowMutationAcceptedResult, WorkResponse } from '@invoker/contracts';
+import type { ActionGraphResponse, BundledSkillsInstallMode, InAppPlanRequest, Logger, WorkflowMeta, WorkflowMutationAcceptedResult, WorkResponse } from '@invoker/contracts';
 import { SqliteTaskRepository } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
@@ -243,6 +243,7 @@ import {
   spawnDetachedStandaloneOwner,
   tryAcquireOwnerBootstrapLock,
 } from './headless-owner-bootstrap.js';
+import { planFromGoal as planFromGoalInApp } from './in-app-planner.js';
 import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
 import {
   killRunningTaskExecution,
@@ -877,7 +878,6 @@ function startHeadlessMode(): void {
         if (!standaloneMode) {
           process.stderr.write(
             `${RED}Error:${RESET} Mutation command "${command}" requires a running owner process.\n` +
-            `The headless command is only a submitter. Scheduler drain runs inside the long-lived owner process.\n` +
             `\n${BOLD}Options:${RESET}\n` +
             `  1. Start the interactive process: ${BOLD}electron dist/main.js${RESET}\n` +
             `  2. Run in standalone mode: ${BOLD}INVOKER_HEADLESS_STANDALONE=1 electron dist/main.js --headless ${cliArgs.join(' ')}${RESET}\n` +
@@ -1006,6 +1006,24 @@ function startHeadlessMode(): void {
               buildCommandServiceInvalidationDeps(),
             );
             return undefined;
+          }
+          case 'invoker:plan-from-goal': {
+            return planFromGoalInApp(payload.args[0] as InAppPlanRequest, {
+              config: invokerConfig,
+              workingDir: repoRoot,
+              loadGeneratedPlan: async (planText) => {
+                const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
+                const plan = applyConfiguredPlanDefaults(parsePlan(planText));
+                const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
+                backupPlan(plan, undefined, logger);
+                orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+                const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
+                if (!workflow) {
+                  throw new Error('Loaded plan did not create a workflow.');
+                }
+                return { planName: plan.name, workflowId: workflow.id };
+              },
+            });
           }
           case 'invoker:load-plan': {
             const planText = String(payload.args[0] ?? '');
@@ -2502,6 +2520,8 @@ function createEmbeddedTerminalBackendFromConfig(
     | null {
     const [arg0, arg1, arg2] = payload.args;
     switch (payload.channel) {
+      case 'invoker:plan-from-goal':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:load-plan':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:start':
@@ -3328,10 +3348,7 @@ function createEmbeddedTerminalBackendFromConfig(
         });
         return results;
       });
-      logger.info(
-        `owner-ipc-ready ownerId=${workflowMutationOwnerId} pid=${process.pid} mode=gui handlers=headless.owner-ping,headless.exec,headless.query`,
-        { module: 'ipc-delegate' },
-      );
+      logger.info(`owner-ipc-ready ownerId=${workflowMutationOwnerId}`, { module: 'ipc-delegate' });
       recordStartupMark('owner-ipc-ready');
     }
 
@@ -3397,6 +3414,7 @@ function createEmbeddedTerminalBackendFromConfig(
       };
       try {
         persistence.writeActivityLog('ui-perf-main', 'info', JSON.stringify(snapshot));
+
       } catch {
         // DB might be locked
       }
@@ -3409,15 +3427,55 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     // Register IPC handlers
+    const computeRuntimeStatus = () => (
+      process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_FORCE_READ_ONLY_STATUS === '1'
+        ? { ownerMode: false, readOnly: true, mode: 'read-only' as const }
+        : {
+            ownerMode,
+            readOnly: !ownerMode && !guiUsingDaemonOwner,
+            mode: ownerMode ? 'local-owner' as const : guiUsingDaemonOwner ? 'daemon-owner' as const : 'read-only' as const,
+          }
+    );
+
     registerBootstrapStateIpc({
       ipcMain,
       getTasks: () => (ownerMode ? orchestrator.getAllTasks() : detachedViewerTasks()),
       getWorkflows: () => detachedViewerWorkflows ?? listWorkflowsByStartupRecency(),
       getInitialWorkflowId: () => startupWorkflowId,
+      getRuntimeStatus: computeRuntimeStatus,
       appStartedAtEpochMs: appProcessStartedAt,
       getTaskDeltaStreamSequence,
       recordStartupDuration,
     });
+    async function loadGeneratedPlanPreview(planText: string): Promise<{ planName: string; workflowId: string }> {
+      const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
+      const plan = applyConfiguredPlanDefaults(parsePlan(planText));
+      const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
+      logger.info(`plan-from-goal: loading "${plan.name}" (${plan.tasks.length} tasks)`, { module: 'ipc' });
+      taskHandles.clear();
+      backupPlan(plan, undefined, logger);
+      orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+      const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
+      if (!workflow) {
+        throw new Error('Loaded plan did not create a workflow.');
+      }
+      return { planName: plan.name, workflowId: workflow.id };
+    }
+    let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
+
+
+    registerGuiMutationHandler('invoker:plan-from-goal', async (...args: unknown[]) => {
+      if (process.env.NODE_ENV === 'test' && testPlanFromGoalResponse) {
+        const loaded = await loadGeneratedPlanPreview(testPlanFromGoalResponse.planYaml);
+        return { ok: true, planName: testPlanFromGoalResponse.planName, workflowId: loaded.workflowId };
+      }
+      return planFromGoalInApp(args[0] as InAppPlanRequest, {
+        config: invokerConfig,
+        workingDir: repoRoot,
+        loadGeneratedPlan: loadGeneratedPlanPreview,
+      });
+    });
+
     registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
       const planText = String(planTextArg);
       const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
@@ -3462,6 +3520,12 @@ function createEmbeddedTerminalBackendFromConfig(
             return;
           }
           await injectTaskStates(updates);
+        },
+      );
+      ipcMain.handle(
+        'invoker:set-test-plan-from-goal-response',
+        async (_event, response: { planYaml: string; planName: string } | null) => {
+          testPlanFromGoalResponse = response;
         },
       );
     }
@@ -4558,21 +4622,7 @@ function createEmbeddedTerminalBackendFromConfig(
       return resolveDefaultTaskExecutionSettings(loadConfig());
     });
 
-    ipcMain.handle('invoker:get-runtime-status', () => {
-      if (process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_FORCE_READ_ONLY_STATUS === '1') {
-        return {
-          ownerMode: false,
-          readOnly: true,
-          mode: 'read-only',
-        };
-      }
-      const readOnly = !ownerMode && !guiUsingDaemonOwner;
-      return {
-        ownerMode,
-        readOnly,
-        mode: ownerMode ? 'local-owner' : guiUsingDaemonOwner ? 'daemon-owner' : 'read-only',
-      };
-    });
+    ipcMain.handle('invoker:get-runtime-status', () => computeRuntimeStatus());
 
     ipcMain.handle('invoker:get-system-diagnostics', () => {
       return collectSystemDiagnostics({

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -1,7 +1,16 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig, mergeConfig } from 'vitest/config';
 import sharedConfig from '../../vitest.shared.ts';
 
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
+
 export default mergeConfig(sharedConfig, defineConfig({
+  resolve: {
+    alias: {
+      '@invoker/surfaces': path.resolve(rootDir, '../surfaces/src/index.ts'),
+    },
+  },
   test: {
     exclude: ['e2e/**', 'node_modules/**', 'dist/**'],
   },

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -224,6 +224,22 @@ export interface ResumeWorkflowResult {
   taskCount: number;
   startedCount: number;
 }
+export interface InAppPlanRequest {
+  goal: string;
+  presetKey?: string;
+}
+
+export type InAppPlanResponse =
+  | {
+      ok: true;
+      planName: string;
+      workflowId: string;
+    }
+  | {
+      ok: false;
+      error: string;
+    };
+
 
 export interface WorkflowListEntry {
   id: string;
@@ -424,6 +440,10 @@ export interface SearchOptions {
 
 export const IpcChannels = {
   // Plan & Workflow Management
+  'invoker:plan-from-goal': {} as {
+    request: [request: InAppPlanRequest];
+    response: InAppPlanResponse;
+  },
   'invoker:load-plan': {} as {
     request: [planText: string];
     response: void;
@@ -753,6 +773,10 @@ export const IpcChannels = {
 export const IpcTestOnlyChannels = {
   'invoker:inject-task-states': {} as {
     request: [updates: Array<{ taskId: string; changes: TaskStateChanges }>];
+    response: void;
+  },
+  'invoker:set-test-plan-from-goal-response': {} as {
+    request: [response: { planYaml: string; planName: string } | null];
     response: void;
   },
 } as const;

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -236,6 +236,11 @@ export function resolveDefaultSocketPath(): string {
 export const DEFAULT_SOCKET_PATH = resolveDefaultSocketPath();
 
 /** Default request deadline in milliseconds (30 s). */
+/** Requests that can legitimately run much longer than the default transport round-trip.
+ *  Until request cancellation is threaded through the bus, these channels get a longer
+ *  caller deadline so the responder is less likely to finish after the requester has given up. */
+const LONG_REQUEST_DEADLINE_CHANNELS = new Set(['invoker:plan-from-goal']);
+export const LONG_REQUEST_DEADLINE_MS = 2 * 60 * 60 * 1000;
 export const DEFAULT_REQUEST_DEADLINE_MS = 30_000;
 
 export interface IpcBusOptions {
@@ -652,14 +657,17 @@ export class IpcBus implements MessageBus {
     const env: ReqEnvelope = { kind: 'req', channel, body: message, reqId };
 
     return new Promise<Res>((resolve, reject) => {
+      const effectiveDeadlineMs = LONG_REQUEST_DEADLINE_CHANNELS.has(channel)
+        ? Math.max(this.requestDeadlineMs, LONG_REQUEST_DEADLINE_MS)
+        : this.requestDeadlineMs;
       const timer = setTimeout(() => {
         if (this.pendingRequests.delete(reqId)) {
           reject(new TransportError(
             TransportErrorCode.REQUEST_TIMEOUT,
-            `Request on channel "${channel}" timed out after ${this.requestDeadlineMs}ms`,
+            `Request on channel "${channel}" timed out after ${effectiveDeadlineMs}ms`,
           ));
         }
-      }, this.requestDeadlineMs);
+      }, effectiveDeadlineMs);
       timer.unref?.();
 
       this.pendingRequests.set(reqId, {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -34,6 +34,8 @@ import { groupWorkflowCoreActivity } from './lib/workflow-core-activity.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
 import { WorkflowStatusChips } from './components/WorkflowStatusChips.js';
 import { TerminalDrawer, type TerminalDrawerState } from './components/TerminalDrawer.js';
+import { LeftStatusColumn } from './components/LeftStatusColumn.js';
+import { InvokerTerminal, type InvokerTerminalLine } from './components/InvokerTerminal.js';
 import {
   isExperimentSpawnPivotTask,
   EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE,
@@ -426,6 +428,12 @@ export function App() {
   const [hasLoadedPlan, setHasLoadedPlan] = useState(false);
   const [hasStarted, setHasStarted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
+  const [terminalLines, setTerminalLines] = useState<InvokerTerminalLine[]>([
+    { id: 1, text: 'Start with a goal.', tone: 'muted' },
+  ]);
+  const nextTerminalLineIdRef = useRef(2);
+  const [plannerBusy, setPlannerBusy] = useState(false);
+  const [graphMaximized, setGraphMaximized] = useState(false);
   const [selectedActionNodeId, setSelectedActionNodeId] = useState<string | null>(null);
   const selectedActionNode = useMemo(
     () => actionGraph?.nodes.find((node) => node.id === selectedActionNodeId) ?? null,
@@ -533,6 +541,17 @@ export function App() {
       }
     }).catch(() => {});
   }, []);
+  useEffect(() => {
+    if (!graphMaximized) return;
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setGraphMaximized(false);
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [graphMaximized]);
+
 
   useEffect(() => {
     const unsubscribe = window.invoker?.onTerminalExit?.((event) => {
@@ -1564,6 +1583,11 @@ export function App() {
     void invoker?.checkPrStatuses?.();
     issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason: 'manual-refresh' });
   }, [invoker, issueCameraCommand, refreshTaskGraph]);
+  const appendTerminalLine = useCallback((text: string, tone: InvokerTerminalLine['tone'] = 'muted') => {
+    const id = nextTerminalLineIdRef.current;
+    nextTerminalLineIdRef.current += 1;
+    setTerminalLines((prev) => [...prev, { id, text, tone }]);
+  }, []);
 
   // ── Plan loading ──────────────────────────────────────────
   const handleLoadPlan = useCallback(
@@ -1617,6 +1641,49 @@ export function App() {
       console.error('Failed to start:', err);
     }
   }, [invoker]);
+  const handleTerminalSubmit = useCallback(async (command: string) => {
+    appendTerminalLine(`$ ${command}`);
+    const planMatch = command.match(/^plan\s+"([^"]+)"$/i);
+    if (planMatch) {
+      if (!invoker?.planFromGoal) {
+        appendTerminalLine('Planner is not available.', 'error');
+        return;
+      }
+      setPlannerBusy(true);
+      try {
+        const result = await invoker.planFromGoal({ goal: planMatch[1] });
+        if (result.ok) {
+          setHasLoadedPlan(true);
+          setHasStarted(false);
+          setWorkflowSelectionDismissed(false);
+          setPlanName(result.planName);
+          setSelectedWorkflowId(result.workflowId);
+          await refreshTaskGraph();
+          appendTerminalLine(`Plan \"${result.planName}\" loaded. Use run to execute.`, 'success');
+        } else {
+          appendTerminalLine(result.error, 'error');
+        }
+      } catch (err) {
+        appendTerminalLine(err instanceof Error ? err.message : 'Failed to generate plan.', 'error');
+      } finally {
+        setPlannerBusy(false);
+      }
+      return;
+    }
+
+    if (command.toLowerCase() === 'run') {
+      if (!hasLoadedPlan) {
+        appendTerminalLine('Load or generate a plan before running.', 'error');
+        return;
+      }
+      await handleStart();
+      appendTerminalLine('Run started.', 'success');
+      return;
+    }
+
+    appendTerminalLine('Unknown command. Try plan \"Add README\" or run.', 'error');
+  }, [appendTerminalLine, handleStart, hasLoadedPlan, invoker, refreshTaskGraph]);
+
 
   const handleStop = useCallback(async () => {
     if (!invoker) return;
@@ -2051,152 +2118,244 @@ export function App() {
         </nav>
 
         <div className="flex-1 flex overflow-hidden">
-          <div className="flex-1 flex flex-col overflow-hidden">
-            <div
-              ref={graphSurfaceRef}
-              data-testid="workflow-graph-surface"
-              data-keyboard-region="workflowGraph"
-              tabIndex={0}
-              data-keyboard-active={keyboardRegion === 'workflowGraph' ? 'true' : 'false'}
-              className={`flex-1 relative overflow-hidden border-r border-gray-800 bg-gray-900 outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
-              onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
-            >
-              {viewMode === 'queue' ? (
-                <QueueView
-                  tasks={tasks}
-                  queueStatus={queueStatus}
-                  onTaskClick={handleTaskClick}
-                  onCancel={handleCancelTask}
-                  selectedTaskId={selectedTaskId}
-                />
-              ) : viewMode === 'history' ? (
-                <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
-              ) : viewMode === 'timeline' ? (
-                <TimelineView tasks={tasks} onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
-              ) : viewMode === 'actionGraph' ? (
-                <ActionGraphView
-                  graph={actionGraph}
-                  error={actionGraphError}
-                  selectedNodeId={selectedActionNodeId}
-                  onSelectNode={(node) => {
-                    setSelectedActionNodeId(node?.id ?? null);
-                    if (node?.taskId) setSelectedTaskId(node.taskId);
-                    if (node?.workflowId) setSelectedWorkflowId(node.workflowId);
-                  }}
-                />
-              ) : (
-                <>
-                  <WorkflowGraph
-                    workflows={workflows}
-                    selectedWorkflowId={selectedWorkflow?.id ?? null}
-                    cameraCommand={cameraCommand}
-                    statusFilters={statusFilters}
-                    coreActivityByWorkflow={coreActivityByWorkflow}
-                    onSelectWorkflow={handleWorkflowClick}
-                    onWorkflowContextMenu={handleWorkflowContextMenu}
-                    onManualViewport={handleManualViewport}
-                  />
-                  {displayedSelectedWorkflowGraph !== null && (
-                    <FloatingGraphPanel
-                      key={displayedSelectedWorkflowGraph.workflow.id}
-                      testId="selected-workflow-mini-dag"
-                      dragHandleTestId="selected-workflow-mini-dag-drag-handle"
-                      title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
-                      boundsRef={graphSurfaceRef}
-                      contentClassName="h-[250px]"
-                    >
-                      <div
-                        data-keyboard-region="taskGraph"
-                        tabIndex={0}
-                        data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
-                        className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
-                      >
-                        {isSelectedWorkflowGraphRefreshing && (
-                          <div data-testid="selected-workflow-mini-dag-refreshing" className="px-2 py-1 text-xs text-amber-200">
-                            Refreshing graph…
-                          </div>
-                        )}
-                        <TaskDAG
-                          tasks={displayedSelectedWorkflowGraph.tasks}
-                          workflows={selectedTaskDagWorkflows}
-                          selectedTaskId={selectedTaskId}
-                          cameraCommand={cameraCommand}
-                          onTaskClick={handleTaskClick}
-                          onTaskDoubleClick={handleTaskDoubleClick}
-                          onTaskContextMenu={handleTaskContextMenu}
-                          onManualViewport={handleManualViewport}
-                          statusFilters={new Set()}
-                          runningTaskIds={runningTaskIds}
-                        />
-                      </div>
-                    </FloatingGraphPanel>
-                  )}
-                </>
-              )}
+          <LeftStatusColumn
+            workflows={workflows}
+            tasks={tasks}
+            queueStatus={queueStatus}
+            planName={planName}
+            plannerBusy={plannerBusy}
+            hasStarted={hasStarted}
+            onTaskClick={handleTaskClick}
+          />
+          <main className="flex-1 flex flex-col overflow-hidden bg-gray-900">
+            <div className="space-y-3 border-b border-gray-800 bg-gray-900/80 p-4">
+              <InvokerTerminal
+                lines={terminalLines}
+                busy={plannerBusy}
+                onSubmit={(command) => void handleTerminalSubmit(command)}
+              />
+              <section className="rounded-xl border border-gray-800 bg-gray-950/70 p-4">
+                <h2 className="text-sm font-semibold text-gray-100">What to expect</h2>
+                <p className="mt-2 text-sm text-gray-400">
+                  Type a planning goal, review the graph, then run when the plan is ready.
+                </p>
+              </section>
             </div>
 
-            {viewMode === 'dag' && (
+            <div className="flex-1 flex overflow-hidden">
+              <div className="flex-1 flex flex-col overflow-hidden">
+                <div className="flex items-center justify-between border-b border-gray-800 bg-gray-950/50 px-4 py-2">
+                  <div>
+                    <h2 className="text-sm font-semibold text-gray-100">Plan graph</h2>
+                    <p className="text-xs text-gray-500">Your plan will appear here.</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setGraphMaximized(true)}
+                    className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+                  >
+                    View full graph
+                  </button>
+                </div>
+                <div
+                  ref={graphSurfaceRef}
+                  data-testid="workflow-graph-surface"
+                  data-keyboard-region="workflowGraph"
+                  tabIndex={0}
+                  data-keyboard-active={keyboardRegion === 'workflowGraph' ? 'true' : 'false'}
+                  className={`flex-1 relative overflow-hidden border-r border-gray-800 bg-gray-900 outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+                  onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
+                >
+                  {viewMode === 'queue' ? (
+                    <QueueView
+                      tasks={tasks}
+                      queueStatus={queueStatus}
+                      onTaskClick={handleTaskClick}
+                      onCancel={handleCancelTask}
+                      selectedTaskId={selectedTaskId}
+                    />
+                  ) : viewMode === 'history' ? (
+                    <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
+                  ) : viewMode === 'timeline' ? (
+                    <TimelineView tasks={tasks} onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
+                  ) : viewMode === 'actionGraph' ? (
+                    <ActionGraphView
+                      graph={actionGraph}
+                      error={actionGraphError}
+                      selectedNodeId={selectedActionNodeId}
+                      onSelectNode={(node) => {
+                        setSelectedActionNodeId(node?.id ?? null);
+                        if (node?.taskId) setSelectedTaskId(node.taskId);
+                        if (node?.workflowId) setSelectedWorkflowId(node.workflowId);
+                      }}
+                    />
+                  ) : (
+                    <>
+                      <WorkflowGraph
+                        workflows={workflows}
+                        selectedWorkflowId={selectedWorkflow?.id ?? null}
+                        cameraCommand={cameraCommand}
+                        statusFilters={statusFilters}
+                        coreActivityByWorkflow={coreActivityByWorkflow}
+                        onSelectWorkflow={handleWorkflowClick}
+                        onWorkflowContextMenu={handleWorkflowContextMenu}
+                        onManualViewport={handleManualViewport}
+                      />
+                      {displayedSelectedWorkflowGraph !== null && (
+                        <FloatingGraphPanel
+                          key={displayedSelectedWorkflowGraph.workflow.id}
+                          testId="selected-workflow-mini-dag"
+                          dragHandleTestId="selected-workflow-mini-dag-drag-handle"
+                          title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
+                          boundsRef={graphSurfaceRef}
+                          contentClassName="h-[250px]"
+                        >
+                          <div
+                            data-keyboard-region="taskGraph"
+                            tabIndex={0}
+                            data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
+                            className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
+                          >
+                            {isSelectedWorkflowGraphRefreshing && (
+                              <div data-testid="selected-workflow-mini-dag-refreshing" className="px-2 py-1 text-xs text-amber-200">
+                                Refreshing graph…
+                              </div>
+                            )}
+                            <TaskDAG
+                              tasks={displayedSelectedWorkflowGraph.tasks}
+                              workflows={selectedTaskDagWorkflows}
+                              selectedTaskId={selectedTaskId}
+                              cameraCommand={cameraCommand}
+                              onTaskClick={handleTaskClick}
+                              onTaskDoubleClick={handleTaskDoubleClick}
+                              onTaskContextMenu={handleTaskContextMenu}
+                              onManualViewport={handleManualViewport}
+                              statusFilters={new Set()}
+                              runningTaskIds={runningTaskIds}
+                            />
+                          </div>
+                        </FloatingGraphPanel>
+                      )}
+                    </>
+                  )}
+                </div>
+
+                {viewMode === 'dag' && (
+                  <div
+                    data-keyboard-region="bottomBar"
+                    tabIndex={0}
+                    data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
+                    className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+                  >
+                    <WorkflowStatusChips
+                      workflows={workflows}
+                      activeFilters={statusFilters}
+                      keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
+                      onStatusClick={handleStatusClick}
+                    />
+                    <TerminalDrawer
+                      state={terminalDrawerState}
+                      onCycle={() =>
+                        setTerminalDrawerState((prev) =>
+                          prev === 'minimized' ? 'partial' : prev === 'partial' ? 'maximized' : 'minimized',
+                        )
+                      }
+                      sessions={terminalSessions}
+                      activeSessionId={activeTerminalSessionId}
+                      onSelectSession={setActiveTerminalSessionId}
+                      onCloseSession={(sessionId) => void handleCloseTerminalSession(sessionId)}
+                      taskLabels={terminalTaskLabels}
+                    />
+                  </div>
+                )}
+              </div>
+
               <div
-                data-keyboard-region="bottomBar"
+                data-keyboard-region="inspector"
                 tabIndex={0}
-                data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
-                className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+                data-keyboard-active={keyboardRegion === 'inspector' ? 'true' : 'false'}
+                className={`${inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
               >
-                <WorkflowStatusChips
-                  workflows={workflows}
-                  activeFilters={statusFilters}
-                  keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
-                  onStatusClick={handleStatusClick}
-                />
-                <TerminalDrawer
-                  state={terminalDrawerState}
-                  onCycle={() =>
-                    setTerminalDrawerState((prev) =>
-                      prev === 'minimized' ? 'partial' : prev === 'partial' ? 'maximized' : 'minimized',
-                    )
-                  }
-                  sessions={terminalSessions}
-                  activeSessionId={activeTerminalSessionId}
-                  onSelectSession={setActiveTerminalSessionId}
-                  onCloseSession={(sessionId) => void handleCloseTerminalSession(sessionId)}
-                  taskLabels={terminalTaskLabels}
+                <WorkflowInspector
+                  workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
+                  task={selectedTask}
+                  workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
+                  reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
+                  remoteTargets={remoteTargets}
+                  executionPools={executionPools}
+                  executionAgents={executionAgents}
+                  collapsed={inspectorCollapsed}
+                  advancedExpanded={advancedMetadataExpanded}
+                  actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
+                  onEditType={handleEditType}
+                  onEditPool={handleEditPool}
+                  onEditAgent={handleEditAgent}
+                  onEditPrompt={handleEditPrompt}
+                  onEditCommand={handleEditCommand}
+                  onApprove={openApprovalModal}
+                  onReject={openRejectModal}
+                  onSetMergeBranch={handleSetMergeBranch}
+                  onSetMergeMode={handleSetMergeMode}
+                  onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
+                  onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}
                 />
               </div>
-            )}
-          </div>
-
-          <div
-            data-keyboard-region="inspector"
-            tabIndex={0}
-            data-keyboard-active={keyboardRegion === 'inspector' ? 'true' : 'false'}
-            className={`${inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
-          >
-            <WorkflowInspector
-              workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
-              task={selectedTask}
-              workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
-              reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
-              remoteTargets={remoteTargets}
-              executionPools={executionPools}
-              executionAgents={executionAgents}
-              collapsed={inspectorCollapsed}
-              advancedExpanded={advancedMetadataExpanded}
-              actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
-              onEditType={handleEditType}
-              onEditPool={handleEditPool}
-              onEditAgent={handleEditAgent}
-              onEditPrompt={handleEditPrompt}
-              onEditCommand={handleEditCommand}
-              onApprove={openApprovalModal}
-              onReject={openRejectModal}
-              onSetMergeBranch={handleSetMergeBranch}
-              onSetMergeMode={handleSetMergeMode}
-              onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
-              onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}
-            />
-          </div>
+            </div>
+          </main>
         </div>
       </div>
+
+
+      {graphMaximized && (
+        <div
+          data-testid="graph-maximized-overlay"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Full graph"
+          className="fixed inset-0 z-50 flex flex-col bg-gray-950"
+        >
+          <div className="flex items-center justify-between border-b border-gray-800 px-4 py-3">
+            <div>
+              <h2 className="text-sm font-semibold text-gray-100">Full graph</h2>
+              <p className="text-xs text-gray-500">Press Escape to return.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setGraphMaximized(false)}
+              className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+            >
+              Close
+            </button>
+          </div>
+          <div className="min-h-0 flex-1">
+            {displayedSelectedWorkflowGraph !== null ? (
+              <TaskDAG
+                tasks={displayedSelectedWorkflowGraph.tasks}
+                workflows={selectedTaskDagWorkflows}
+                selectedTaskId={selectedTaskId}
+                cameraCommand={cameraCommand}
+                onTaskClick={handleTaskClick}
+                onTaskDoubleClick={handleTaskDoubleClick}
+                onTaskContextMenu={handleTaskContextMenu}
+                onManualViewport={handleManualViewport}
+                statusFilters={new Set()}
+                runningTaskIds={runningTaskIds}
+              />
+            ) : (
+              <WorkflowGraph
+                workflows={workflows}
+                selectedWorkflowId={selectedWorkflow?.id ?? null}
+                cameraCommand={cameraCommand}
+                statusFilters={statusFilters}
+                coreActivityByWorkflow={coreActivityByWorkflow}
+                onSelectWorkflow={handleWorkflowClick}
+                onWorkflowContextMenu={handleWorkflowContextMenu}
+                onManualViewport={handleManualViewport}
+              />
+            )}
+          </div>
+        </div>
+      )}
 
       {searchOpen && (
         <div

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -33,9 +33,15 @@ describe('App launch (component)', () => {
     mock.cleanup();
   });
 
-  it('shows empty state prompt when no plan is loaded', () => {
+  it('shows the reskinned empty shell when no plan is loaded', () => {
     render(<App />);
-    expect(screen.getByText('Load a plan to render workflow graph')).toBeInTheDocument();
+    expect(screen.getByText('Start with a goal.')).toBeInTheDocument();
+    expect(screen.getByText('Invoker Terminal')).toBeInTheDocument();
+    expect(screen.getByText('What to expect')).toBeInTheDocument();
+    expect(screen.getAllByText('Your plan will appear here.').length).toBeGreaterThan(0);
+    expect(screen.getByText('No runs yet')).toBeInTheDocument();
+    expect(screen.getByText('All clear')).toBeInTheDocument();
+    expect(screen.getByText('No tasks running')).toBeInTheDocument();
   });
 
   it('renders left rail navigation and workflow controls', () => {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -111,6 +111,11 @@ export function createMockInvoker(
     onTaskOutput: vi.fn(() => () => {}),
     onActivityLog: vi.fn(() => () => {}),
     loadPlan: vi.fn(async () => {}),
+    planFromGoal: vi.fn(async () => ({
+      ok: true,
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+    })),
     start: vi.fn(async () => taskSnapshot),
     stop: vi.fn(async () => {}),
     clear: vi.fn(async () => {}),

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+vi.mock('@xyflow/react', async () => {
+  // Dynamic import is required because Vitest hoists mock factories before test imports.
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+// Dynamic import is required so App sees the hoisted @xyflow/react mock.
+const { App } = await import('../App.js');
+
+describe('Invoker terminal (component)', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('generates a plan from a quoted goal command', async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'plan "Add README"' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(mock.api.planFromGoal).toHaveBeenCalledWith({ goal: 'Add README' });
+      expect(screen.getByText('Plan "Mock Plan" loaded. Use run to execute.')).toBeInTheDocument();
+    });
+  });
+
+  it('explains that run needs a loaded plan first', async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'run' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    expect(await screen.findByText('Load or generate a plan before running.')).toBeInTheDocument();
+    expect(mock.api.start).not.toHaveBeenCalled();
+  });
+
+  it('starts execution after a generated plan is loaded', async () => {
+    render(<App />);
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'plan "Add README"' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+    await screen.findByText('Plan "Mock Plan" loaded. Use run to execute.');
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'run' } });
+    fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(mock.api.start).toHaveBeenCalled();
+      expect(screen.getByText('Run started.')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/ui/src/__tests__/plan-loading.test.tsx
+++ b/packages/ui/src/__tests__/plan-loading.test.tsx
@@ -66,12 +66,12 @@ describe('Plan loading (component)', () => {
 
   it('empty state disappears after tasks are loaded', async () => {
     render(<App />);
-    expect(screen.getByText('Load a plan to render workflow graph')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-graph-surface')).toHaveTextContent('Your plan will appear here.');
 
     act(() => mock.setTasks([alpha, beta], workflows));
 
     await waitFor(() => {
-      expect(screen.queryByText('Load a plan to render workflow graph')).not.toBeInTheDocument();
+      expect(screen.getByTestId('workflow-graph-surface')).not.toHaveTextContent('Your plan will appear here.');
     });
   });
 

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -223,4 +223,28 @@ describe('Task interaction (component)', () => {
 
     expect(panel).toHaveStyle({ left: '468px', top: '308px' });
   });
+
+  it('opens and closes the maximized graph without clearing selection', async () => {
+    render(<App />);
+    act(() => mock.setTasks([alpha, beta], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'View full graph' }));
+    expect(screen.getByTestId('graph-maximized-overlay')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('graph-maximized-overlay')).not.toBeInTheDocument();
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+    });
+  });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useRef, useState } from 'react';
+
+export interface InvokerTerminalLine {
+  id: number;
+  text: string;
+  tone?: 'muted' | 'error' | 'success';
+}
+
+interface InvokerTerminalProps {
+  lines: InvokerTerminalLine[];
+  busy: boolean;
+  onSubmit: (command: string) => void;
+}
+
+export function InvokerTerminal({ lines, busy, onSubmit }: InvokerTerminalProps): JSX.Element {
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <section className="rounded-xl border border-gray-800 bg-gray-950 shadow-inner">
+      <div className="flex items-center justify-between border-b border-gray-800 px-4 py-2">
+        <div>
+          <h1 className="text-sm font-semibold text-gray-100">Invoker Terminal</h1>
+          <p className="text-xs text-gray-500">Plan from a goal, then run it.</p>
+        </div>
+        {busy && <span className="text-xs text-blue-300">Working…</span>}
+      </div>
+      <div data-testid="invoker-terminal-transcript" className="max-h-36 space-y-1 overflow-y-auto px-4 py-3 font-mono text-xs">
+        {lines.map((line) => {
+          const toneClass = line.tone === 'error'
+            ? 'text-red-300'
+            : line.tone === 'success'
+              ? 'text-emerald-300'
+              : 'text-gray-300';
+          return (
+            <div key={line.id} className={toneClass}>
+              {line.text}
+            </div>
+          );
+        })}
+      </div>
+      <form
+        className="flex items-center gap-2 border-t border-gray-800 px-4 py-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          const command = value.trim();
+          if (!command || busy) return;
+          onSubmit(command);
+          setValue('');
+        }}
+      >
+        <span className="font-mono text-xs text-gray-500">$</span>
+        <input
+          ref={inputRef}
+          data-testid="invoker-terminal-input"
+          value={value}
+          disabled={busy}
+          onChange={(event) => setValue(event.target.value)}
+          placeholder='plan "Add README" or run'
+          className="min-w-0 flex-1 bg-transparent font-mono text-sm text-gray-100 outline-none placeholder:text-gray-600 disabled:cursor-wait"
+        />
+      </form>
+    </section>
+  );
+}

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -1,0 +1,101 @@
+import type { QueueStatus } from '@invoker/contracts';
+import type { TaskState, WorkflowMeta } from '../types.js';
+
+interface LeftStatusColumnProps {
+  workflows: Map<string, WorkflowMeta>;
+  tasks: Map<string, TaskState>;
+  queueStatus: QueueStatus | null;
+  planName: string | null;
+  plannerBusy: boolean;
+  hasStarted: boolean;
+  onTaskClick: (taskId: string) => void;
+}
+
+const ATTENTION_STATUS: Record<string, true> = {
+  failed: true,
+  blocked: true,
+  needs_input: true,
+  awaiting_approval: true,
+  review_ready: true,
+};
+
+export function LeftStatusColumn({
+  workflows,
+  tasks,
+  queueStatus,
+  planName,
+  plannerBusy,
+  hasStarted,
+  onTaskClick,
+}: LeftStatusColumnProps): JSX.Element {
+  const workflowCount = workflows.size;
+  const taskCount = tasks.size;
+  const attentionTasks = [...tasks.values()].filter((task) => ATTENTION_STATUS[task.status]);
+  const runningTasks = queueStatus?.running.length
+    ? queueStatus.running
+    : [...tasks.values()]
+      .filter((task) => task.status === 'running' || task.status === 'fixing_with_ai')
+      .map((task) => ({ taskId: task.id, description: task.description }));
+
+  return (
+    <aside className="w-64 shrink-0 overflow-y-auto border-r border-gray-800 bg-gray-950/80 p-3 text-sm text-gray-200">
+      <section className="rounded-lg border border-gray-800 bg-gray-900/80 p-3">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Run</div>
+        {taskCount === 0 && !planName ? (
+          <p className="mt-3 text-sm text-gray-500">No runs yet</p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            <div className="truncate text-sm font-medium text-gray-100" title={planName ?? undefined}>
+              {planName ?? `${workflowCount} workflow${workflowCount === 1 ? '' : 's'}`}
+            </div>
+            <div className="text-xs text-gray-400">
+              {plannerBusy ? 'Planning…' : hasStarted ? 'Run started' : `${taskCount} task${taskCount === 1 ? '' : 's'} ready`}
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className="mt-3 rounded-lg border border-gray-800 bg-gray-900/80 p-3">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Needs attention</div>
+        {attentionTasks.length === 0 ? (
+          <p className="mt-3 text-sm text-emerald-300">All clear</p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            {attentionTasks.slice(0, 6).map((task) => (
+              <button
+                key={task.id}
+                type="button"
+                onClick={() => onTaskClick(task.id)}
+                className="block w-full rounded border border-amber-700/40 bg-amber-950/30 px-2 py-1.5 text-left hover:bg-amber-950/50"
+              >
+                <div className="truncate text-xs font-medium text-amber-100">{task.description || task.id}</div>
+                <div className="mt-0.5 text-[11px] text-amber-300">{task.status.replaceAll('_', ' ')}</div>
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="mt-3 rounded-lg border border-gray-800 bg-gray-900/80 p-3">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Running task</div>
+        {runningTasks.length === 0 ? (
+          <p className="mt-3 text-sm text-gray-500">No tasks running</p>
+        ) : (
+          <div className="mt-3 space-y-2">
+            {runningTasks.slice(0, 6).map((task) => (
+              <button
+                key={task.taskId}
+                type="button"
+                onClick={() => onTaskClick(task.taskId)}
+                className="block w-full rounded border border-blue-700/40 bg-blue-950/30 px-2 py-1.5 text-left hover:bg-blue-950/50"
+              >
+                <div className="truncate text-xs font-medium text-blue-100">{task.description || task.taskId}</div>
+                <div className="mt-0.5 text-[11px] text-blue-300">Running</div>
+              </button>
+            ))}
+          </div>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -588,8 +588,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     return (
       <div className="h-full w-full flex items-center justify-center text-gray-500">
         <div className="text-center">
-          <p>No tasks yet</p>
-          <p className="text-sm mt-1">Load a plan to create a task graph</p>
+          <p>Your plan will appear here.</p>
         </div>
       </div>
     );

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -310,7 +310,7 @@ function WorkflowGraphInner({
   if (graph.nodes.length === 0) {
     return (
       <div className="h-full flex items-center justify-center text-gray-500 text-sm">
-        Load a plan to render workflow graph
+        Your plan will appear here.
       </div>
     );
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@invoker/runtime-service':
         specifier: workspace:*
         version: link:../runtime-service
+      '@invoker/surfaces':
+        specifier: workspace:*
+        version: link:../surfaces
       '@invoker/transport':
         specifier: workspace:*
         version: link:../transport


### PR DESCRIPTION
## Summary

The desktop home view now opens as a clearer Invoker workspace. Users get first-run guidance, goal planning, and a full-screen view option.

The existing execution details stay owned by their current components. This slice wires the new workspace around them.

<details>
<summary>Review metadata</summary>

Review Claim: The renderer activates the new workspace around the existing execution views.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Existing execution components still own their behavior; this slice adds workspace state and layout around them.

Slice Rationale: The goal command flow, empty state, status column, and full-screen overlay are one surface activation change.

</details>

## Non-goals

- No task execution semantics change.
- No removal of History, Timeline, Queue, or Action Graph views.
- No planner subprocess logic in the renderer.

## Visual Proof

![Reskinned empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-1db11b/empty-state.png)

![Graph maximize overlay](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-1db11b/graph-maximized-overlay.png)

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx src/__tests__/invoker-terminal.test.tsx src/__tests__/task-interaction.test.tsx src/__tests__/terminal-drawer.test.tsx && pnpm --filter @invoker/ui build`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
