### PR TITLE
[Invoker UI Reskin](7) Restore action-graph regression coverage

### DIFF
--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -313,7 +313,8 @@ describe('Context menu (component)', () => {
     await waitFor(() => expect(screen.queryByTestId('workflow-node-wf-1-core-activity')).toBeNull());
     expect(workflowNode).not.toHaveTextContent(/Pending: queued for launch|Rebase|Recreate|invoker:rebase-recreate/);
 
-    fireEvent.click(screen.getByText('Action Graph'));
+    fireEvent.click(screen.getByTestId('graph-more-button'));
+    fireEvent.click(await screen.findByTestId('rail-action-graph'));
     fireEvent.click(await screen.findByTestId('rf__node-intent:77'));
     expect(await screen.findByTestId('workflow-inspector-action-node')).toHaveTextContent('invoker:rebase-recreate');
   });


### PR DESCRIPTION
## Summary

This slice updates the activation-surface regression checks around the reskinned shell and keeps the release-note entry with that same user-facing slice.

Behavior stays the same. The change is only the UI-facing test coverage plus the changelog note.

<details>
<summary>Review metadata</summary>

Review Claim: The reskinned shell now has the matching activation-surface regression coverage and release-note entry.

Review Lane: refactor

Review Unit: activation-surface

Safety Invariant: This slice changes activation-surface test coverage and changelog text only. Runtime behavior stays unchanged.

Slice Rationale: The UI-facing regression check and its release note are easiest to review together after the shell landing.

</details>

## Non-goals

- No runtime behavior changes.
- No planner bridge changes.
- No new screenshot baselines.

## Visual Proof

![Redesigned empty graph state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-95ecec/empty-state.png)

![Graph maximized](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-95ecec/graph-maximized-overlay.png)

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/visual-proof-snapshots.test.tsx`
- [x] `pnpm --filter @invoker/app test:e2e -- e2e/visual-proof.spec.ts`
- [x] `bash scripts/ui-visual-proof.sh capture-after`
- [ ] `pnpm run test:all` failed in existing `e2e/task-new-attempt-reset.spec.ts`; rerunning that file alone reproduced the same timeout waiting for slow-task to resume.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
