### PR TITLE
[Invoker UI Reskin](10) Add source-list workflow browser

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1897,6 +1897,7 @@ test.describe('Visual proof capture', () => {
 
     const actionRow = page.locator('[data-row-id$="task-alpha"]');
     await expect(actionRow).toBeVisible();
+    // Assert the action queue row renders the compact cancel affordance
     const cancelButton = actionRow.getByRole('button', { name: 'Cancel task-alpha' });
     await expect(cancelButton).toBeVisible();
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3447,7 +3447,6 @@ function createEmbeddedTerminalBackendFromConfig(
         loadGeneratedPlan: loadGeneratedPlanPreview,
       });
     });
-
     registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
       const planText = String(planTextArg);
       const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -9,10 +9,11 @@
  * - Modals overlay when needed
  */
 
-import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
+import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
 import type { ActionGraphNode, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
+import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
 import { useActionGraphSnapshot } from './hooks/useActionGraphSnapshot.js';
@@ -37,10 +38,16 @@ import { TerminalDrawer, type TerminalDrawerState } from './components/TerminalD
 import { LeftStatusColumn } from './components/LeftStatusColumn.js';
 import { InvokerTerminal, type InvokerTerminalLine } from './components/InvokerTerminal.js';
 import {
+  getAttentionTaskEntries,
+  getRunningTaskEntries,
+  getSortedWorkflows,
+  formatTaskStatus,
+  formatWorkflowStatus,
+} from './lib/workflow-progress-surfaces.js';
+import {
   isExperimentSpawnPivotTask,
   EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE,
 } from './isExperimentSpawnPivot.js';
-import { parsePlanText } from './lib/plan-parser.js';
 import {
   createGraphCameraCommandIssuer,
   loadCameraLockPreference,
@@ -434,10 +441,10 @@ export function App() {
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
     [queueStatus],
   );
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const graphActionsMenuRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
+  const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [reviewGateByWorkflowId, setReviewGateByWorkflowId] = useState<Record<string, ReviewGateQueryResponse | null>>({});
@@ -826,6 +833,9 @@ export function App() {
     }
     return STATUS_KEY_ORDER.filter((key) => key === 'completed' || key === 'running' || key === 'failed' || key === 'pending' || (counts.get(key) ?? 0) > 0);
   }, [workflows]);
+  const workflowEntries = useMemo(() => getSortedWorkflows(workflows, tasks), [workflows, tasks]);
+  const attentionEntries = useMemo(() => getAttentionTaskEntries(tasks, workflows), [tasks, workflows]);
+  const runningEntries = useMemo(() => getRunningTaskEntries(tasks, workflows, queueStatus), [tasks, workflows, queueStatus]);
 
   const searchResults = useMemo<SearchResult[]>(() => {
     const query = normalizedSearchText(searchQuery.trim());
@@ -1306,7 +1316,7 @@ export function App() {
     recenterForSelection('workflow', workflowId);
   }, [recenterForSelection]);
 
-  const handleWorkflowContextMenu = useCallback((event: React.MouseEvent<HTMLDivElement>, workflowId: string) => {
+  const handleWorkflowContextMenu = useCallback((event: React.MouseEvent<Element>, workflowId: string) => {
     event.preventDefault();
     setWorkflowSelectionDismissed(false);
     setSelectedWorkflowId(workflowId);
@@ -1314,6 +1324,41 @@ export function App() {
     setContextMenu(null);
     setWorkflowContextMenu({ x: event.clientX, y: event.clientY, workflowId });
   }, []);
+  useEffect(() => {
+    if (sidebarSurface === 'workflows') {
+      const activeWorkflowId = selectedWorkflow?.id ?? selectedWorkflowId;
+      if (!workflowEntries.length || workflowEntries.some((entry) => entry.workflow.id === activeWorkflowId)) {
+        return;
+      }
+      selectWorkflowById(workflowEntries[0].workflow.id);
+      return;
+    }
+
+    if (sidebarSurface === 'attention') {
+      if (!attentionEntries.length || attentionEntries.some((entry) => entry.task.id === selectedTaskId)) {
+        return;
+      }
+      selectTaskById(attentionEntries[0].task.id);
+      return;
+    }
+
+    if (sidebarSurface === 'running') {
+      if (!runningEntries.length || runningEntries.some((entry) => entry.task.id === selectedTaskId)) {
+        return;
+      }
+      selectTaskById(runningEntries[0].task.id);
+    }
+  }, [
+    attentionEntries,
+    runningEntries,
+    selectTaskById,
+    selectWorkflowById,
+    selectedTaskId,
+    selectedWorkflow?.id,
+    selectedWorkflowId,
+    sidebarSurface,
+    workflowEntries,
+  ]);
 
   const handleDagSurfaceClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     if (contextMenu || workflowContextMenu) {
@@ -1611,49 +1656,6 @@ export function App() {
     setTerminalLines((prev) => [...prev, { id, text, tone }]);
   }, []);
 
-  // ── Plan loading ──────────────────────────────────────────
-  const handleLoadPlan = useCallback(
-    async (planText: string) => {
-      if (!invoker) return;
-      try {
-        await invoker.loadPlan(planText);
-        setWorkflowSelectionDismissed(false);
-        setHasLoadedPlan(true);
-        // Parse locally just for UI display state
-        const parsed = yaml.load(planText) as any;
-        setPlanName(parsed?.name ?? 'Untitled Plan');
-        setOnFinish(parsed?.onFinish ?? 'merge');
-        refreshTaskGraph();
-      } catch (err) {
-        console.error('Failed to load plan:', err);
-      }
-    },
-    [invoker, refreshTaskGraph],
-  );
-
-  const handleFileSelect = useCallback(
-    async (event: React.ChangeEvent<HTMLInputElement>) => {
-      const file = event.target.files?.[0];
-      if (!file) return;
-
-      const text = await file.text();
-      const dotIndex = file.name.lastIndexOf('.');
-      const ext = dotIndex >= 0 ? file.name.slice(dotIndex).toLowerCase() : undefined;
-
-      try {
-        parsePlanText(text, ext);
-        await handleLoadPlan(text);
-      } catch (err) {
-        console.error('Failed to parse plan file:', err);
-      }
-
-      if (fileInputRef.current) {
-        fileInputRef.current.value = '';
-      }
-    },
-    [handleLoadPlan],
-  );
-
   const handleStart = useCallback(async () => {
     if (!invoker) return;
     try {
@@ -1663,6 +1665,7 @@ export function App() {
       console.error('Failed to start:', err);
     }
   }, [invoker]);
+
   const handleTerminalSubmit = useCallback(async (command: string) => {
     appendTerminalLine(`$ ${command}`);
     const planMatch = command.match(/^plan\s+"([^"]+)"$/i);
@@ -1677,7 +1680,10 @@ export function App() {
         if (result.ok) {
           setHasLoadedPlan(true);
           setHasStarted(false);
+          setSidebarSurface('home');
           setWorkflowSelectionDismissed(false);
+          setViewMode('dag');
+          setGraphActionsMenuOpen(false);
           setPlanName(result.planName);
           setSelectedWorkflowId(result.workflowId);
           await refreshTaskGraph();
@@ -1695,7 +1701,7 @@ export function App() {
 
     if (command.toLowerCase() === 'run') {
       if (!hasLoadedPlan) {
-        appendTerminalLine('Load or generate a plan before running.', 'error');
+        appendTerminalLine('Create a plan before running.', 'error');
         return;
       }
       await handleStart();
@@ -1724,7 +1730,9 @@ export function App() {
       setHasLoadedPlan(false);
       setHasStarted(false);
       setPlanName(null);
-      setOnFinish('merge');
+      setSidebarSurface('home');
+      setViewMode('dag');
+      setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
       setSelectedWorkflowId(null);
       setModal({ type: 'none' });
@@ -1732,7 +1740,7 @@ export function App() {
     } catch (err) {
       console.error('Failed to clear:', err);
     }
-  }, [invoker, clearTasks]);
+  }, [clearTasks, invoker]);
 
   const handleDeleteDB = useCallback(async () => {
     if (!invoker) return;
@@ -1746,13 +1754,16 @@ export function App() {
       setHasLoadedPlan(false);
       setHasStarted(false);
       setPlanName(null);
+      setSidebarSurface('home');
+      setViewMode('dag');
+      setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
       setSelectedWorkflowId(null);
       setModal({ type: 'none' });
     } catch (err) {
       console.error('Failed to delete workflows:', err);
     }
-  }, [invoker, clearTasks]);
+  }, [clearTasks, invoker]);
 
   // True when all tasks have reached a terminal state.
   const allSettled = useMemo(() => {
@@ -1764,10 +1775,11 @@ export function App() {
     }
     return true;
   }, [tasks]);
+
   const showStart = hasLoadedPlan && !hasStarted;
   const showStop = hasStarted && !allSettled;
-  const showEmptyGraphTutorial = !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
-  const showInspectorPlaceholder = !showEmptyGraphTutorial && !selectedTask && !selectedWorkflow && !selectedActionNode;
+  const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
+  const showInspectorPlaceholder = !showEmptyGraphTutorial && !selectedTask && !selectedWorkflow && !(viewMode === 'actionGraph' && selectedActionNode);
 
   useEffect(() => {
     if (!graphActionsMenuOpen) return undefined;
@@ -1791,6 +1803,7 @@ export function App() {
   const selectViewMode = useCallback((nextView: 'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph') => {
     setGraphActionsMenuOpen(false);
     if (nextView === 'actionGraph') {
+      setSidebarSurface('home');
       setViewMode('actionGraph');
       setWorkflowSelectionDismissed(true);
       setSelectedTaskId(null);
@@ -1800,7 +1813,14 @@ export function App() {
       setViewMode('dag');
       return;
     }
+    setSidebarSurface('home');
     setViewMode(nextView);
+  }, []);
+
+  const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
+    setGraphActionsMenuOpen(false);
+    setSidebarSurface(nextSurface);
+    setViewMode('dag');
   }, []);
 
   // ── Task actions ──────────────────────────────────────────
@@ -2022,6 +2042,320 @@ export function App() {
   }, [refreshSystemDiagnostics]);
 
 
+  const selectedWorkflowEntry = selectedWorkflow
+    ? workflowEntries.find((entry) => entry.workflow.id === selectedWorkflow.id) ?? null
+    : null;
+  const selectedTaskWorkflowName = selectedWorkflow?.name ?? (selectedTask?.config.workflowId ? workflows.get(selectedTask.config.workflowId)?.name ?? selectedTask.config.workflowId : null);
+
+  const renderGraphActions = (showMoreMenu: boolean): JSX.Element => (
+    <div className="flex items-center gap-2">
+      {showStart && (
+        <button
+          type="button"
+          data-testid="rail-start"
+          onClick={handleStart}
+          className="rounded bg-green-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-600"
+        >
+          Run
+        </button>
+      )}
+      {showStop && (
+        <button
+          type="button"
+          data-testid="rail-stop"
+          onClick={handleStop}
+          className="rounded bg-red-700 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-600"
+        >
+          Stop
+        </button>
+      )}
+      <button
+        type="button"
+        data-testid="rail-refresh"
+        onClick={handleRefresh}
+        className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+      >
+        Refresh
+      </button>
+      <button
+        type="button"
+        onClick={() => setGraphMaximized(true)}
+        className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+      >
+        Full graph ⤢
+      </button>
+      {showMoreMenu && (
+        <div ref={graphActionsMenuRef} className="relative">
+          <button
+            type="button"
+            data-testid="graph-more-button"
+            onClick={() => setGraphActionsMenuOpen((open) => !open)}
+            className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+          >
+            More ▾
+          </button>
+          {graphActionsMenuOpen && (
+            <div
+              data-testid="graph-more-menu"
+              className="absolute right-0 top-10 z-20 w-48 rounded-lg border border-gray-700 bg-gray-950 p-1 shadow-xl"
+            >
+              <button
+                type="button"
+                data-testid="rail-home"
+                onClick={() => {
+                  handleSelectSidebarSurface('home');
+                  selectViewMode('dag');
+                }}
+                className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+              >
+                Home
+              </button>
+              <button
+                type="button"
+                data-testid="rail-timeline"
+                onClick={() => selectViewMode('timeline')}
+                className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+              >
+                Timeline
+              </button>
+              <button
+                type="button"
+                data-testid="rail-history"
+                onClick={() => selectViewMode('history')}
+                className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+              >
+                History
+              </button>
+              <button
+                type="button"
+                data-testid="rail-action-graph"
+                onClick={() => selectViewMode('actionGraph')}
+                className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+              >
+                Action Graph
+              </button>
+              <button
+                type="button"
+                data-testid="rail-queue"
+                onClick={() => selectViewMode('queue')}
+                className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+              >
+                Queue
+              </button>
+              <div className="my-1 border-t border-gray-800" />
+              <button
+                type="button"
+                data-testid="rail-clear"
+                onClick={async () => {
+                  setGraphActionsMenuOpen(false);
+                  await handleClear();
+                }}
+                className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
+              >
+                Clear
+              </button>
+              <button
+                type="button"
+                data-testid="rail-delete-history"
+                onClick={async () => {
+                  setGraphActionsMenuOpen(false);
+                  await handleDeleteDB();
+                }}
+                className="block w-full rounded px-3 py-2 text-left text-xs text-red-300 hover:bg-red-950/50"
+              >
+                Delete history
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  const renderGraphCanvas = (): JSX.Element => (
+    <div
+      ref={graphSurfaceRef}
+      data-testid="workflow-graph-surface"
+      data-keyboard-region="workflowGraph"
+      tabIndex={0}
+      data-keyboard-active={keyboardRegion === 'workflowGraph' ? 'true' : 'false'}
+      className={`flex-1 relative overflow-hidden border-r border-gray-800 bg-gray-900 outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+      onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
+    >
+      {viewMode === 'queue' ? (
+        <QueueView
+          tasks={tasks}
+          queueStatus={queueStatus}
+          onTaskClick={handleTaskClick}
+          onCancel={handleCancelTask}
+          selectedTaskId={selectedTaskId}
+        />
+      ) : viewMode === 'history' ? (
+        <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
+      ) : viewMode === 'timeline' ? (
+        <TimelineView tasks={tasks} onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
+      ) : viewMode === 'actionGraph' ? (
+        <ActionGraphView
+          graph={actionGraph}
+          error={actionGraphError}
+          selectedNodeId={selectedActionNodeId}
+          onSelectNode={(node) => {
+            setSelectedActionNodeId(node?.id ?? null);
+            if (node?.taskId) setSelectedTaskId(node.taskId);
+            if (node?.workflowId) setSelectedWorkflowId(node.workflowId);
+          }}
+        />
+      ) : (
+        <>
+          <WorkflowGraph
+            workflows={workflows}
+            selectedWorkflowId={selectedWorkflow?.id ?? null}
+            cameraCommand={cameraCommand}
+            statusFilters={statusFilters}
+            coreActivityByWorkflow={coreActivityByWorkflow}
+            onSelectWorkflow={handleWorkflowClick}
+            onWorkflowContextMenu={handleWorkflowContextMenu}
+            onManualViewport={handleManualViewport}
+          />
+          {displayedSelectedWorkflowGraph !== null && (
+            <FloatingGraphPanel
+              key={displayedSelectedWorkflowGraph.workflow.id}
+              testId="selected-workflow-mini-dag"
+              dragHandleTestId="selected-workflow-mini-dag-drag-handle"
+              title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
+              boundsRef={graphSurfaceRef as unknown as RefObject<HTMLElement>}
+              contentClassName="h-[250px]"
+            >
+              <div
+                data-keyboard-region="taskGraph"
+                tabIndex={0}
+                data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
+                className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
+              >
+                {isSelectedWorkflowGraphRefreshing && (
+                  <div data-testid="selected-workflow-mini-dag-refreshing" className="px-2 py-1 text-xs text-amber-200">
+                    Refreshing graph…
+                  </div>
+                )}
+                <TaskDAG
+                  tasks={displayedSelectedWorkflowGraph.tasks}
+                  workflows={selectedTaskDagWorkflows}
+                  selectedTaskId={selectedTaskId}
+                  cameraCommand={cameraCommand}
+                  onTaskClick={handleTaskClick}
+                  onTaskDoubleClick={handleTaskDoubleClick}
+                  onTaskContextMenu={handleTaskContextMenu}
+                  onManualViewport={handleManualViewport}
+                  statusFilters={new Set<string>()}
+                  runningTaskIds={runningTaskIds}
+                />
+              </div>
+            </FloatingGraphPanel>
+          )}
+        </>
+      )}
+    </div>
+  );
+
+  const renderGraphWorkspace = (title: string, subtitle: string, showMoreMenu: boolean): JSX.Element => (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="flex items-center justify-between border-b border-gray-800 bg-gray-950/50 px-4 py-2">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-100">{title}</h2>
+          <p className="text-xs text-gray-500">{subtitle}</p>
+        </div>
+        {renderGraphActions(showMoreMenu)}
+      </div>
+      {renderGraphCanvas()}
+    </div>
+  );
+
+  const renderBrowserEmptyState = (title: string, copy: string): JSX.Element => (
+    <div className="flex h-full items-center justify-center px-6 text-center">
+      <div>
+        <div className="text-sm font-medium text-gray-200">{title}</div>
+        <div className="mt-2 text-sm text-gray-500">{copy}</div>
+      </div>
+    </div>
+  );
+
+  const renderWorkflowsList = (): JSX.Element => (
+    workflowEntries.length === 0 ? renderBrowserEmptyState('No workflows yet', 'Use the terminal to plan your first run.') : (
+      <div className="overflow-y-auto p-3">
+        <div className="space-y-1">
+          {workflowEntries.map((entry) => {
+            const selected = selectedWorkflow?.id === entry.workflow.id;
+            return (
+              <button
+                key={entry.workflow.id}
+                type="button"
+                onClick={() => handleWorkflowClick(entry.workflow.id)}
+                className={`block w-full rounded-xl px-3 py-2 text-left transition-colors ${selected ? 'bg-gray-800 text-white' : 'text-gray-200 hover:bg-gray-900/80'}`}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div className="truncate font-medium">{entry.workflow.name}</div>
+                  <div className="text-[11px] text-gray-500">{entry.taskCount}</div>
+                </div>
+                <div className="mt-1 text-xs text-gray-500">{formatWorkflowStatus(entry.workflow.status)}</div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    )
+  );
+
+  const renderTaskList = (entries: typeof attentionEntries, emptyTitle: string, emptyCopy: string, tone: 'attention' | 'running'): JSX.Element => (
+    entries.length === 0 ? renderBrowserEmptyState(emptyTitle, emptyCopy) : (
+      <div className="overflow-y-auto p-3">
+        <div className="space-y-1">
+          {entries.map((entry) => {
+            const selected = selectedTask?.id === entry.task.id;
+            const accent = tone === 'attention'
+              ? selected ? 'bg-amber-950/50 text-amber-50 ring-1 ring-amber-800/60' : 'text-gray-200 hover:bg-gray-900/80'
+              : selected ? 'bg-blue-950/50 text-blue-50 ring-1 ring-blue-800/60' : 'text-gray-200 hover:bg-gray-900/80';
+            return (
+              <button
+                key={entry.task.id}
+                type="button"
+                onClick={() => handleTaskClick(entry.task)}
+                className={`block w-full rounded-xl px-3 py-2 text-left transition-colors ${accent}`}
+              >
+                <div className="truncate font-medium">{entry.task.description || entry.task.id}</div>
+                <div className="mt-1 text-xs text-gray-500">{entry.workflow?.name ?? 'No workflow'} · {formatTaskStatus(entry.task.status)}</div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+    )
+  );
+
+  const homeSubtitle = workflows.size === 0
+    ? 'Your plan will appear here.'
+    : selectedWorkflow
+      ? `${selectedWorkflow.name} · ${formatWorkflowStatus(selectedWorkflow.status)}`
+      : `${workflowEntries.length} workflow${workflowEntries.length === 1 ? '' : 's'} ready`;
+  const workflowsSubtitle = `${workflowEntries.length} workflow${workflowEntries.length === 1 ? '' : 's'}`;
+  const attentionSubtitle = attentionEntries.length === 0
+    ? 'Nothing needs a decision right now.'
+    : `${attentionEntries.length} item${attentionEntries.length === 1 ? '' : 's'} need attention.`;
+  const runningSubtitle = runningEntries.length === 0
+    ? 'No active tasks right now.'
+    : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`;
+
+  const browserGraphTitle = sidebarSurface === 'workflows'
+    ? selectedWorkflow?.name ?? 'Workflows'
+    : selectedTask?.description || selectedTask?.id || 'Plan graph';
+  const browserGraphSubtitle = sidebarSurface === 'workflows'
+    ? selectedWorkflowEntry
+      ? `${selectedWorkflowEntry.taskCount} task${selectedWorkflowEntry.taskCount === 1 ? '' : 's'} · ${formatWorkflowStatus(selectedWorkflowEntry.workflow.status)}`
+      : workflowsSubtitle
+    : selectedTask
+      ? `${selectedTaskWorkflowName ?? 'No workflow'} · ${formatTaskStatus(selectedTask.status)}`
+      : sidebarSurface === 'attention'
+        ? attentionSubtitle
+        : runningSubtitle;
   return (
     <div className="h-screen flex flex-col bg-gray-900 text-gray-100" onClick={() => closeContextMenu()}>
       {showSystemBanner && (
@@ -2066,31 +2400,16 @@ export function App() {
       )}
       {/* Main content */}
       <div className="flex-1 flex overflow-hidden">
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".json,.yaml,.yml"
-          onChange={handleFileSelect}
-          className="hidden"
-        />
-
         <LeftStatusColumn
           workflows={workflows}
           tasks={tasks}
           queueStatus={queueStatus}
-          planName={planName}
-          plannerBusy={plannerBusy}
-          hasStarted={hasStarted}
-          showStart={showStart}
-          showStop={showStop}
-          onOpenPlan={() => fileInputRef.current?.click()}
-          onStart={handleStart}
-          onStop={handleStop}
+          selectedSurface={sidebarSurface}
+          onSelectSurface={handleSelectSidebarSurface}
           onOpenSettings={() => {
             cancelPendingSystemSetupAutoOpen();
             setShowSystemSetup(true);
           }}
-          onTaskClick={handleTaskClick}
         />
 
         <div className="flex-1 flex overflow-hidden">
@@ -2103,262 +2422,95 @@ export function App() {
               />
             </div>
 
-            <div className="flex-1 flex overflow-hidden">
-              <div className="flex-1 flex flex-col overflow-hidden">
-                <div className="flex items-center justify-between border-b border-gray-800 bg-gray-950/50 px-4 py-2">
-                  <div>
-                    <h2 className="text-sm font-semibold text-gray-100">Plan graph</h2>
-                    <p className="text-xs text-gray-500">Your plan will appear here.</p>
+            {sidebarSurface === 'home' ? (
+              renderGraphWorkspace('Plan graph', homeSubtitle, true)
+            ) : (
+              <div className="flex-1 flex overflow-hidden">
+                <div className="w-80 shrink-0 border-r border-gray-800 bg-gray-950/35">
+                  <div className="border-b border-gray-800 px-4 py-3">
+                    <h2 className="text-sm font-semibold text-gray-100">
+                      {sidebarSurface === 'workflows' ? 'Workflows' : sidebarSurface === 'attention' ? 'Needs Attention' : 'Running'}
+                    </h2>
+                    <p className="mt-1 text-xs text-gray-500">
+                      {sidebarSurface === 'workflows' ? workflowsSubtitle : sidebarSurface === 'attention' ? attentionSubtitle : runningSubtitle}
+                    </p>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <button
-                      type="button"
-                      data-testid="rail-refresh"
-                      onClick={handleRefresh}
-                      className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
-                    >
-                      Refresh
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => setGraphMaximized(true)}
-                      className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
-                    >
-                      Full graph ⤢
-                    </button>
-                    <div ref={graphActionsMenuRef} className="relative">
-                      <button
-                        type="button"
-                        data-testid="graph-more-button"
-                        onClick={() => setGraphActionsMenuOpen((open) => !open)}
-                        className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
-                      >
-                        More ▾
-                      </button>
-                      {graphActionsMenuOpen && (
-                        <div
-                          data-testid="graph-more-menu"
-                          className="absolute right-0 top-10 z-20 w-48 rounded-lg border border-gray-700 bg-gray-950 p-1 shadow-xl"
-                        >
-                          <button
-                            type="button"
-                            data-testid="rail-home"
-                            onClick={() => selectViewMode('dag')}
-                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
-                          >
-                            Plan graph
-                          </button>
-                          <button
-                            type="button"
-                            data-testid="rail-timeline"
-                            onClick={() => selectViewMode('timeline')}
-                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
-                          >
-                            Timeline
-                          </button>
-                          <button
-                            type="button"
-                            data-testid="rail-history"
-                            onClick={() => selectViewMode('history')}
-                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
-                          >
-                            History
-                          </button>
-                          <button
-                            type="button"
-                            data-testid="rail-action-graph"
-                            onClick={() => selectViewMode('actionGraph')}
-                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
-                          >
-                            Action Graph
-                          </button>
-                          <button
-                            type="button"
-                            data-testid="rail-queue"
-                            onClick={() => selectViewMode('queue')}
-                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
-                          >
-                            Queue
-                          </button>
-                          <div className="my-1 border-t border-gray-800" />
-                          <button
-                            type="button"
-                            data-testid="rail-clear"
-                            onClick={async () => {
-                              setGraphActionsMenuOpen(false);
-                              await handleClear();
-                            }}
-                            className="block w-full rounded px-3 py-2 text-left text-xs text-gray-200 hover:bg-gray-800"
-                          >
-                            Clear
-                          </button>
-                          <button
-                            type="button"
-                            data-testid="rail-delete-history"
-                            onClick={async () => {
-                              setGraphActionsMenuOpen(false);
-                              await handleDeleteDB();
-                            }}
-                            className="block w-full rounded px-3 py-2 text-left text-xs text-red-300 hover:bg-red-950/50"
-                          >
-                            Delete history
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  </div>
+                  {sidebarSurface === 'workflows'
+                    ? renderWorkflowsList()
+                    : sidebarSurface === 'attention'
+                      ? renderTaskList(attentionEntries, 'All clear', 'Nothing needs a decision right now.', 'attention')
+                      : renderTaskList(runningEntries, 'No tasks running', 'Start a run to watch live work here.', 'running')}
                 </div>
-                <div
-                  ref={graphSurfaceRef}
-                  data-testid="workflow-graph-surface"
-                  data-keyboard-region="workflowGraph"
-                  tabIndex={0}
-                  data-keyboard-active={keyboardRegion === 'workflowGraph' ? 'true' : 'false'}
-                  className={`flex-1 relative overflow-hidden border-r border-gray-800 bg-gray-900 outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
-                  onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
-                >
-                  {viewMode === 'queue' ? (
-                    <QueueView
-                      tasks={tasks}
-                      queueStatus={queueStatus}
-                      onTaskClick={handleTaskClick}
-                      onCancel={handleCancelTask}
-                      selectedTaskId={selectedTaskId}
-                    />
-                  ) : viewMode === 'history' ? (
-                    <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
-                  ) : viewMode === 'timeline' ? (
-                    <TimelineView tasks={tasks} onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
-                  ) : viewMode === 'actionGraph' ? (
-                    <ActionGraphView
-                      graph={actionGraph}
-                      error={actionGraphError}
-                      selectedNodeId={selectedActionNodeId}
-                      onSelectNode={(node) => {
-                        setSelectedActionNodeId(node?.id ?? null);
-                        if (node?.taskId) setSelectedTaskId(node.taskId);
-                        if (node?.workflowId) setSelectedWorkflowId(node.workflowId);
-                      }}
-                    />
-                  ) : (
-                    <>
-                      <WorkflowGraph
-                        workflows={workflows}
-                        selectedWorkflowId={selectedWorkflow?.id ?? null}
-                        cameraCommand={cameraCommand}
-                        statusFilters={statusFilters}
-                        coreActivityByWorkflow={coreActivityByWorkflow}
-                        onSelectWorkflow={handleWorkflowClick}
-                        onWorkflowContextMenu={handleWorkflowContextMenu}
-                        onManualViewport={handleManualViewport}
-                      />
-                      {displayedSelectedWorkflowGraph !== null && (
-                        <FloatingGraphPanel
-                          key={displayedSelectedWorkflowGraph.workflow.id}
-                          testId="selected-workflow-mini-dag"
-                          dragHandleTestId="selected-workflow-mini-dag-drag-handle"
-                          title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
-                          boundsRef={graphSurfaceRef}
-                          contentClassName="h-[250px]"
-                        >
-                          <div
-                            data-keyboard-region="taskGraph"
-                            tabIndex={0}
-                            data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
-                            className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
-                          >
-                            {isSelectedWorkflowGraphRefreshing && (
-                              <div data-testid="selected-workflow-mini-dag-refreshing" className="px-2 py-1 text-xs text-amber-200">
-                                Refreshing graph…
-                              </div>
-                            )}
-                            <TaskDAG
-                              tasks={displayedSelectedWorkflowGraph.tasks}
-                              workflows={selectedTaskDagWorkflows}
-                              selectedTaskId={selectedTaskId}
-                              cameraCommand={cameraCommand}
-                              onTaskClick={handleTaskClick}
-                              onTaskDoubleClick={handleTaskDoubleClick}
-                              onTaskContextMenu={handleTaskContextMenu}
-                              onManualViewport={handleManualViewport}
-                              statusFilters={new Set()}
-                              runningTaskIds={runningTaskIds}
-                            />
-                          </div>
-                        </FloatingGraphPanel>
-                      )}
-                    </>
-                  )}
-                </div>
-
-                {viewMode === 'dag' && (
-                  <div
-                    data-keyboard-region="bottomBar"
-                    tabIndex={0}
-                    data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
-                    className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
-                  >
-                    <WorkflowStatusChips
-                      workflows={workflows}
-                      activeFilters={statusFilters}
-                      keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
-                      onStatusClick={handleStatusClick}
-                    />
-                    <TerminalDrawer
-                      state={terminalDrawerState}
-                      onCycle={() =>
-                        setTerminalDrawerState((prev) =>
-                          prev === 'minimized' ? 'partial' : prev === 'partial' ? 'maximized' : 'minimized',
-                        )
-                      }
-                      sessions={terminalSessions}
-                      activeSessionId={activeTerminalSessionId}
-                      onSelectSession={setActiveTerminalSessionId}
-                      onCloseSession={(sessionId) => void handleCloseTerminalSession(sessionId)}
-                      taskLabels={terminalTaskLabels}
-                    />
-                  </div>
-                )}
+                {renderGraphWorkspace(browserGraphTitle, browserGraphSubtitle, false)}
               </div>
+            )}
 
+            {viewMode === 'dag' && sidebarSurface === 'home' && (
               <div
-                data-keyboard-region="inspector"
+                data-keyboard-region="bottomBar"
                 tabIndex={0}
-                data-keyboard-active={keyboardRegion === 'inspector' ? 'true' : 'false'}
-                className={`${showEmptyGraphTutorial || showInspectorPlaceholder ? 'w-96' : inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+                data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
+                className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
               >
-                {showEmptyGraphTutorial ? (
-                  <EmptyGraphTutorial />
-                ) : showInspectorPlaceholder ? (
-                  <EmptyInspectorPlaceholder />
-                ) : (
-                  <WorkflowInspector
-                    workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
-                    task={selectedTask}
-                    workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
-                    reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
-                    remoteTargets={remoteTargets}
-                    executionPools={executionPools}
-                    executionAgents={executionAgents}
-                    collapsed={inspectorCollapsed}
-                    advancedExpanded={advancedMetadataExpanded}
-                    actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
-                    onEditType={handleEditType}
-                    onEditPool={handleEditPool}
-                    onEditAgent={handleEditAgent}
-                    onEditPrompt={handleEditPrompt}
-                    onEditCommand={handleEditCommand}
-                    onApprove={openApprovalModal}
-                    onReject={openRejectModal}
-                    onSetMergeBranch={handleSetMergeBranch}
-                    onSetMergeMode={handleSetMergeMode}
-                    onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
-                    onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}
-                  />
-                )}
+                <WorkflowStatusChips
+                  workflows={workflows}
+                  activeFilters={statusFilters}
+                  keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
+                  onStatusClick={handleStatusClick}
+                />
+                <TerminalDrawer
+                  state={terminalDrawerState}
+                  onCycle={() =>
+                    setTerminalDrawerState((prev) =>
+                      prev === 'minimized' ? 'partial' : prev === 'partial' ? 'maximized' : 'minimized',
+                    )
+                  }
+                  sessions={terminalSessions}
+                  activeSessionId={activeTerminalSessionId}
+                  onSelectSession={setActiveTerminalSessionId}
+                  onCloseSession={(sessionId) => void handleCloseTerminalSession(sessionId)}
+                  taskLabels={terminalTaskLabels}
+                />
               </div>
-            </div>
+            )}
           </main>
+
+          <div
+            data-keyboard-region="inspector"
+            tabIndex={0}
+            data-keyboard-active={keyboardRegion === 'inspector' ? 'true' : 'false'}
+            className={`${showEmptyGraphTutorial || showInspectorPlaceholder ? 'w-96' : inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+          >
+            {showEmptyGraphTutorial ? (
+              <EmptyGraphTutorial />
+            ) : showInspectorPlaceholder ? (
+              <EmptyInspectorPlaceholder />
+            ) : (
+              <WorkflowInspector
+                workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}
+                task={selectedTask}
+                workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
+                reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
+                remoteTargets={remoteTargets}
+                executionPools={executionPools}
+                executionAgents={executionAgents}
+                collapsed={inspectorCollapsed}
+                advancedExpanded={advancedMetadataExpanded}
+                actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
+                onEditType={handleEditType}
+                onEditPool={handleEditPool}
+                onEditAgent={handleEditAgent}
+                onEditPrompt={handleEditPrompt}
+                onEditCommand={handleEditCommand}
+                onApprove={openApprovalModal}
+                onReject={openRejectModal}
+                onSetMergeBranch={handleSetMergeBranch}
+                onSetMergeMode={handleSetMergeMode}
+                onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
+                onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}
+              />
+            )}
+          </div>
         </div>
       </div>
 
@@ -2395,7 +2547,7 @@ export function App() {
                 onTaskDoubleClick={handleTaskDoubleClick}
                 onTaskContextMenu={handleTaskContextMenu}
                 onManualViewport={handleManualViewport}
-                statusFilters={new Set()}
+                statusFilters={new Set<string>()}
                 runningTaskIds={runningTaskIds}
               />
             ) : (

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -9,7 +9,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { vi } from 'vitest';
-import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
 
 vi.mock('@xyflow/react', async () => {
   // Dynamic import is required because Vitest hoists mock factories before test imports.
@@ -39,20 +40,38 @@ describe('App launch (component)', () => {
     expect(screen.getByText('Invoker Terminal')).toBeInTheDocument();
     expect(screen.getByText('What to expect')).toBeInTheDocument();
     expect(screen.getAllByText('Your plan will appear here.').length).toBeGreaterThan(0);
-    expect(screen.getByText('No runs yet')).toBeInTheDocument();
-    expect(screen.getByText('All clear')).toBeInTheDocument();
-    expect(screen.getByText('No tasks running')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-home')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
+    expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
+    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
   });
 
-  it('renders the left status column controls without the old nav rail', () => {
+  it('renders the Apple-like source list without manual plan loading', () => {
     render(<App />);
-    expect(screen.getByTestId('rail-open-file')).toBeInTheDocument();
+    expect(screen.queryByTestId('rail-open-file')).not.toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
-    expect(screen.getByText('Run')).toBeInTheDocument();
-    expect(screen.getByText('Needs attention')).toBeInTheDocument();
-    expect(screen.getByText('Running task')).toBeInTheDocument();
+    expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
+    expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
+    expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
+    expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Timeline' })).not.toBeInTheDocument();
+  });
+
+  it('returns home when Invoker is selected at the top', async () => {
+    const workflows: WorkflowMeta[] = [
+      { id: 'wf-alpha', name: 'Alpha', status: 'running' },
+    ];
+    const alpha = makeUITask({ id: 'task-alpha', description: 'First test task', status: 'running', workflowId: 'wf-alpha' });
+
+    render(<App />);
+    act(() => mock.setTasks([alpha], workflows));
+
+    fireEvent.click(await screen.findByTestId('sidebar-workflows'));
+    expect(await screen.findByText('1 workflow')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    expect(await screen.findByText('Plan graph')).toBeInTheDocument();
+    expect(screen.getByText('Alpha · running')).toBeInTheDocument();
   });
 
   it('shows workflow status chips and terminal drawer controls in home view', () => {

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -83,7 +83,7 @@ describe('Invoker terminal (component)', () => {
     fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'run' } });
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
 
-    expect(await screen.findByText('Load or generate a plan before running.')).toBeInTheDocument();
+    expect(await screen.findByText('Create a plan before running.')).toBeInTheDocument();
     expect(mock.api.start).not.toHaveBeenCalled();
   });
 

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -1,152 +1,116 @@
 import type { QueueStatus } from '@invoker/contracts';
 import type { TaskState, WorkflowMeta } from '../types.js';
+import type { SidebarSurface } from '../lib/workflow-progress-surfaces.js';
+import { getAttentionTaskEntries, getRunningTaskEntries, getSortedWorkflows } from '../lib/workflow-progress-surfaces.js';
 
 interface LeftStatusColumnProps {
   workflows: Map<string, WorkflowMeta>;
   tasks: Map<string, TaskState>;
   queueStatus: QueueStatus | null;
-  planName: string | null;
-  plannerBusy: boolean;
-  hasStarted: boolean;
-  showStart: boolean;
-  showStop: boolean;
-  onOpenPlan: () => void;
-  onStart: () => void;
-  onStop: () => void;
+  selectedSurface: SidebarSurface;
+  onSelectSurface: (surface: SidebarSurface) => void;
   onOpenSettings: () => void;
-  onTaskClick: (taskId: string) => void;
 }
 
-const ATTENTION_STATUS: Record<string, true> = {
-  failed: true,
-  blocked: true,
-  needs_input: true,
-  awaiting_approval: true,
-  review_ready: true,
-};
+function navButtonClass(selected: boolean): string {
+  return [
+    'flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition-colors',
+    selected
+      ? 'bg-gray-800/90 text-white shadow-sm'
+      : 'text-gray-300 hover:bg-gray-900/80 hover:text-white',
+  ].join(' ');
+}
 
 export function LeftStatusColumn({
   workflows,
   tasks,
   queueStatus,
-  planName,
-  plannerBusy,
-  hasStarted,
-  showStart,
-  showStop,
-  onOpenPlan,
-  onStart,
-  onStop,
+  selectedSurface,
+  onSelectSurface,
   onOpenSettings,
-  onTaskClick,
 }: LeftStatusColumnProps): JSX.Element {
-  const workflowCount = workflows.size;
-  const taskCount = tasks.size;
-  const attentionTasks = [...tasks.values()].filter((task) => ATTENTION_STATUS[task.status]);
-  const runningTasks = queueStatus?.running.length
-    ? queueStatus.running
-    : [...tasks.values()]
-      .filter((task) => task.status === 'running' || task.status === 'fixing_with_ai')
-      .map((task) => ({ taskId: task.id, description: task.description }));
+  const workflowEntries = getSortedWorkflows(workflows, tasks);
+  const attentionEntries = getAttentionTaskEntries(tasks, workflows);
+  const runningEntries = getRunningTaskEntries(tasks, workflows, queueStatus);
 
   return (
-    <aside className="flex h-full w-72 shrink-0 flex-col border-r border-gray-800 bg-gray-950/80 p-3 text-sm text-gray-200">
-      <div className="flex-1 space-y-3 overflow-y-auto pr-1">
-        <section className="rounded-lg border border-gray-800 bg-gray-900/80 p-3">
-          <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Run</div>
-          {taskCount === 0 && !planName ? (
-            <p className="mt-3 text-sm text-gray-500">No runs yet</p>
-          ) : (
-            <div className="mt-3 space-y-2">
-              <div className="truncate text-sm font-medium text-gray-100" title={planName ?? undefined}>
-                {planName ?? `${workflowCount} workflow${workflowCount === 1 ? '' : 's'}`}
-              </div>
-              <div className="text-xs text-gray-400">
-                {plannerBusy ? 'Planning…' : hasStarted ? 'Run started' : `${taskCount} task${taskCount === 1 ? '' : 's'} ready`}
-              </div>
-            </div>
-          )}
-          <div className="mt-3 space-y-2">
-            <button
-              type="button"
-              data-testid="rail-open-file"
-              onClick={onOpenPlan}
-              className="w-full rounded bg-gray-700 px-3 py-2 text-left text-xs font-medium text-gray-100 hover:bg-gray-600"
-            >
-              Load plan
-            </button>
-            {showStart && (
-              <button
-                type="button"
-                data-testid="rail-start"
-                onClick={onStart}
-                className="w-full rounded bg-green-700 px-3 py-2 text-left text-xs font-medium text-white hover:bg-green-600"
-              >
-                Run
-              </button>
-            )}
-            {showStop && (
-              <button
-                type="button"
-                data-testid="rail-stop"
-                onClick={onStop}
-                className="w-full rounded bg-red-700 px-3 py-2 text-left text-xs font-medium text-white hover:bg-red-600"
-              >
-                Stop
-              </button>
-            )}
-          </div>
-        </section>
+    <aside className="flex h-full w-72 shrink-0 flex-col border-r border-gray-800 bg-gray-950/85 px-3 py-4 text-sm text-gray-200">
+      <button
+        type="button"
+        data-testid="sidebar-home"
+        data-sidebar-nav-item
+        data-sidebar-nav-order="1"
+        onClick={() => onSelectSurface('home')}
+        className="rounded-xl px-3 py-2 text-left hover:bg-gray-900/80"
+      >
+        <div className={`text-base font-semibold ${selectedSurface === 'home' ? 'text-white' : 'text-gray-100'}`}>Invoker</div>
+        <div className="mt-1 text-xs text-gray-500">Home</div>
+      </button>
 
-        <section className="rounded-lg border border-gray-800 bg-gray-900/80 p-3">
-          <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Needs attention</div>
-          {attentionTasks.length === 0 ? (
-            <p className="mt-3 text-sm text-emerald-300">All clear</p>
-          ) : (
-            <div className="mt-3 space-y-2">
-              {attentionTasks.slice(0, 6).map((task) => (
-                <button
-                  key={task.id}
-                  type="button"
-                  onClick={() => onTaskClick(task.id)}
-                  className="block w-full rounded border border-amber-700/40 bg-amber-950/30 px-2 py-1.5 text-left hover:bg-amber-950/50"
-                >
-                  <div className="truncate text-xs font-medium text-amber-100">{task.description || task.id}</div>
-                  <div className="mt-0.5 text-[11px] text-amber-300">{task.status.replaceAll('_', ' ')}</div>
-                </button>
-              ))}
-            </div>
-          )}
-        </section>
+      <div className="mt-6 px-3 text-[11px] font-semibold uppercase tracking-[0.24em] text-gray-500">Library</div>
+      <nav className="mt-2 space-y-1">
+        <button
+          type="button"
+          data-testid="sidebar-workflows"
+          data-sidebar-nav-item
+          data-sidebar-nav-order="2"
+          onClick={() => onSelectSurface('workflows')}
+          className={navButtonClass(selectedSurface === 'workflows')}
+        >
+          <span>Workflows</span>
+          <span className="text-xs text-gray-500">{workflowEntries.length}</span>
+        </button>
+        <button
+          type="button"
+          data-testid="sidebar-attention"
+          data-sidebar-nav-item
+          data-sidebar-nav-order="3"
+          onClick={() => onSelectSurface('attention')}
+          className={navButtonClass(selectedSurface === 'attention')}
+        >
+          <span>Needs Attention</span>
+          <span className="text-xs text-gray-500">{attentionEntries.length}</span>
+        </button>
+        <button
+          type="button"
+          data-testid="sidebar-running"
+          data-sidebar-nav-item
+          data-sidebar-nav-order="4"
+          onClick={() => onSelectSurface('running')}
+          className={navButtonClass(selectedSurface === 'running')}
+        >
+          <span>Running</span>
+          <span className="text-xs text-gray-500">{runningEntries.length}</span>
+        </button>
+      </nav>
 
-        <section className="rounded-lg border border-gray-800 bg-gray-900/80 p-3">
-          <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Running task</div>
-          {runningTasks.length === 0 ? (
-            <p className="mt-3 text-sm text-gray-500">No tasks running</p>
-          ) : (
-            <div className="mt-3 space-y-2">
-              {runningTasks.slice(0, 6).map((task) => (
-                <button
-                  key={task.taskId}
-                  type="button"
-                  onClick={() => onTaskClick(task.taskId)}
-                  className="block w-full rounded border border-blue-700/40 bg-blue-950/30 px-2 py-1.5 text-left hover:bg-blue-950/50"
-                >
-                  <div className="truncate text-xs font-medium text-blue-100">{task.description || task.taskId}</div>
-                  <div className="mt-0.5 text-[11px] text-blue-300">Running</div>
-                </button>
-              ))}
-            </div>
-          )}
-        </section>
+      <div className="mt-6 flex-1 overflow-y-auto px-3 text-xs text-gray-500">
+        {selectedSurface === 'workflows' && (
+          workflowEntries.length === 0
+            ? 'No workflows yet'
+            : `${workflowEntries.length} workflow${workflowEntries.length === 1 ? '' : 's'} ready to browse.`
+        )}
+        {selectedSurface === 'attention' && (
+          attentionEntries.length === 0
+            ? 'Nothing needs a decision right now.'
+            : `${attentionEntries.length} item${attentionEntries.length === 1 ? '' : 's'} need attention.`
+        )}
+        {selectedSurface === 'running' && (
+          runningEntries.length === 0
+            ? 'No tasks are running right now.'
+            : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`
+        )}
+        {selectedSurface === 'home' && 'Terminal planning and graph details live here.'}
       </div>
 
-      <div className="mt-3 border-t border-gray-800 pt-3">
+      <div className="border-t border-gray-800 px-3 pt-3">
         <button
           type="button"
           data-testid="rail-settings"
+          data-sidebar-nav-item
+          data-sidebar-nav-order="5"
           onClick={onOpenSettings}
-          className="flex w-full items-center justify-center rounded border border-gray-700 px-3 py-2 text-xs font-medium text-gray-200 hover:bg-gray-800"
+          className="flex w-full items-center justify-center rounded-lg border border-gray-700 px-3 py-2 text-xs font-medium text-gray-200 hover:bg-gray-800"
         >
           Settings
         </button>

--- a/packages/ui/src/lib/workflow-progress-surfaces.ts
+++ b/packages/ui/src/lib/workflow-progress-surfaces.ts
@@ -1,0 +1,148 @@
+import type { QueueStatus } from '@invoker/contracts';
+import type { TaskState, TaskStatus, WorkflowMeta, WorkflowStatus } from '../types.js';
+
+export type SidebarSurface = 'home' | 'workflows' | 'attention' | 'running';
+
+export interface WorkflowListEntry {
+  workflow: WorkflowMeta;
+  taskCount: number;
+}
+
+export interface WorkflowTaskEntry {
+  task: TaskState;
+  workflow: WorkflowMeta | null;
+}
+
+const WORKFLOW_STATUS_PRIORITY: Record<WorkflowStatus, number> = {
+  failed: 0,
+  blocked: 1,
+  awaiting_approval: 2,
+  review_ready: 3,
+  running: 4,
+  fixing_with_ai: 5,
+  pending: 6,
+  stale: 7,
+  completed: 8,
+  closed: 9,
+};
+
+const ATTENTION_STATUS_PRIORITY: Partial<Record<TaskStatus, number>> = {
+  failed: 0,
+  awaiting_approval: 1,
+  review_ready: 2,
+  blocked: 3,
+  needs_input: 4,
+};
+
+const RUNNING_TASK_STATUS: Partial<Record<TaskStatus, true>> = {
+  running: true,
+  fixing_with_ai: true,
+};
+
+const ATTENTION_TASK_STATUS: Partial<Record<TaskStatus, true>> = {
+  failed: true,
+  blocked: true,
+  needs_input: true,
+  awaiting_approval: true,
+  review_ready: true,
+};
+
+function compareTimestamps(a?: string, b?: string): number {
+  const aTime = a ? Date.parse(a) : Number.NaN;
+  const bTime = b ? Date.parse(b) : Number.NaN;
+  if (Number.isFinite(aTime) && Number.isFinite(bTime) && aTime !== bTime) {
+    return bTime - aTime;
+  }
+  if (Number.isFinite(aTime)) return -1;
+  if (Number.isFinite(bTime)) return 1;
+  return 0;
+}
+
+export function formatWorkflowStatus(status: WorkflowStatus): string {
+  return status.replaceAll('_', ' ');
+}
+
+export function formatTaskStatus(status: TaskStatus): string {
+  return status.replaceAll('_', ' ');
+}
+
+export function isAttentionTask(task: TaskState): boolean {
+  return ATTENTION_TASK_STATUS[task.status] === true;
+}
+
+export function isRunningTask(task: TaskState): boolean {
+  return RUNNING_TASK_STATUS[task.status] === true;
+}
+
+export function getWorkflowTaskCounts(tasks: Map<string, TaskState>): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const task of tasks.values()) {
+    const workflowId = task.config.workflowId;
+    if (!workflowId) continue;
+    counts.set(workflowId, (counts.get(workflowId) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export function getSortedWorkflows(
+  workflows: Map<string, WorkflowMeta>,
+  tasks: Map<string, TaskState>,
+): WorkflowListEntry[] {
+  const taskCounts = getWorkflowTaskCounts(tasks);
+  return [...workflows.values()]
+    .sort((a, b) => {
+      const priority = (WORKFLOW_STATUS_PRIORITY[a.status] ?? 99) - (WORKFLOW_STATUS_PRIORITY[b.status] ?? 99);
+      if (priority !== 0) return priority;
+      const timestampOrder = compareTimestamps(a.updatedAt ?? a.createdAt, b.updatedAt ?? b.createdAt);
+      if (timestampOrder !== 0) return timestampOrder;
+      return a.name.localeCompare(b.name);
+    })
+    .map((workflow) => ({
+      workflow,
+      taskCount: taskCounts.get(workflow.id) ?? 0,
+    }));
+}
+
+export function getAttentionTaskEntries(
+  tasks: Map<string, TaskState>,
+  workflows: Map<string, WorkflowMeta>,
+): WorkflowTaskEntry[] {
+  return [...tasks.values()]
+    .filter(isAttentionTask)
+    .sort((a, b) => {
+      const priority = (ATTENTION_STATUS_PRIORITY[a.status] ?? 99) - (ATTENTION_STATUS_PRIORITY[b.status] ?? 99);
+      if (priority !== 0) return priority;
+      const workflowA = a.config.workflowId ? workflows.get(a.config.workflowId)?.name ?? a.config.workflowId : '';
+      const workflowB = b.config.workflowId ? workflows.get(b.config.workflowId)?.name ?? b.config.workflowId : '';
+      if (workflowA !== workflowB) return workflowA.localeCompare(workflowB);
+      return (a.description || a.id).localeCompare(b.description || b.id);
+    })
+    .map((task) => ({
+      task,
+      workflow: task.config.workflowId ? workflows.get(task.config.workflowId) ?? null : null,
+    }));
+}
+
+export function getRunningTaskEntries(
+  tasks: Map<string, TaskState>,
+  workflows: Map<string, WorkflowMeta>,
+  queueStatus: QueueStatus | null,
+): WorkflowTaskEntry[] {
+  if (queueStatus?.running.length) {
+    return queueStatus.running
+      .map(({ taskId }) => tasks.get(taskId))
+      .filter((task): task is TaskState => Boolean(task))
+      .map((task) => ({
+        task,
+        workflow: task.config.workflowId ? workflows.get(task.config.workflowId) ?? null : null,
+      }));
+  }
+
+  return [...tasks.values()]
+    .filter(isRunningTask)
+    .sort((a, b) => (a.description || a.id).localeCompare(b.description || b.id))
+    .map((task) => ({
+      task,
+      workflow: task.config.workflowId ? workflows.get(task.config.workflowId) ?? null : null,
+    }));
+}


### PR DESCRIPTION
## Summary

The shell now uses a Finder-like source rail on the left. Home, Workflows, Needs Attention, and Running each open their own browser surface.

The main pane now behaves like a Mac browser surface, with a dedicated workflows panel beside graph context and a clear path back to Home.

<details>
<summary>Review metadata</summary>

Review Claim: The renderer now uses a source-rail shell that treats workflows, running tasks, and attention items as first-class browser surfaces.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice reorganizes shell navigation only. It reuses the existing graph, terminal, and inspector actions underneath.

Slice Rationale: The earlier shell refinement still behaved like a dashboard. This follow-up makes the UI read like a real browser for many workflows.

</details>

## Non-goals

- No planner bridge changes.
- No queue logic changes.
- No approval rule changes.

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx src/__tests__/visual-proof-snapshots.test.tsx src/__tests__/timeline-view-e2e.test.tsx src/__tests__/task-interaction.test.tsx src/__tests__/context-menu-e2e.test.tsx src/__tests__/invoker-terminal.test.tsx`
- [x] `pnpm --filter @invoker/app test:e2e -- e2e/visual-proof.spec.ts`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Visual Proof

![Source-list empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260701-a4ff71/empty-state.png)

![Workflows browser panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260701-a4ff71/workflows-browser.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sidebar workspace switcher with Home, Workflows, Needs Attention, and Running views.
  * The main content area now changes based on the selected workspace, including updated empty-state behavior.

* **Bug Fixes**
  * After clearing, deleting database items, or successfully creating a plan, navigation and view state now reliably return to the Home/DAG layout.
  * Updated the “run” error prompt to “Create a plan before running.” when no plan is available.

* **Tests**
  * Expanded app launch and navigation test coverage for the new sidebar workspace and empty-plan state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->