### PR TITLE
[CI Runners](1) Route Playwright and SSH to DO2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,7 @@ jobs:
 
   playwright:
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, do2]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 45
@@ -544,7 +544,7 @@ jobs:
 
   ssh:
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, do2]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60


### PR DESCRIPTION
## Summary

This routes the queued Playwright and SSH CI jobs to the DO2 self-hosted runner.

Those five required jobs are the main queue pressure in the current merge path.

<details>
<summary>Review metadata</summary>

Review Claim: Playwright and SSH merge-gate checks now use the dedicated DO2 runner instead of shared hosted Linux capacity.

Review Lane: policy

Review Unit: tooling-policy
Safety Invariant: Only `runs-on` changes for existing jobs. Job names, scripts, containers, and merge requirements stay the same.

Slice Rationale: This is the smallest useful CI routing slice. It moves the worst queue contributors first without changing the rest of the workflow.

</details>

## Non-goals

This does not move dry-run or other required jobs.

This does not add more runners or change runner size.

This does not change any test commands.

## Test Plan

- [x] `node -e "const fs=require('fs'); const yaml=require('yaml'); const doc=yaml.parse(fs.readFileSync('.github/workflows/ci.yml','utf8')); console.log(JSON.stringify({playwright: doc.jobs.playwright['runs-on'], ssh: doc.jobs.ssh['runs-on']}, null, 2));"`
- [x] `gh api repos/Neko-Catpital-Labs/Invoker/actions/runners --jq '.runners[] | select(.name=="invoker-do2-gha-1") | {name,status,labels:[.labels[].name]}'`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 592ddef8d`
- Post-revert steps: None
- Data migration? No
