### PR TITLE
Rebalance Mergify queue shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           INVOKER_TEST_ALL_EXCLUDE: >-
             required/20-e2e-dry-run.sh,
             required/21-e2e-dry-run-downstream.sh,
+            required/21-e2e-dry-run-downstream-reset.sh,
             required/22-e2e-dry-run-github.sh
           TMPDIR: /tmp/invoker-tmp
         run: |
@@ -413,8 +414,10 @@ jobs:
         include:
           - name: case-1
             suite: scripts/test-suites/required/20-e2e-dry-run.sh
-          - name: case-2
+          - name: case-2a
             suite: scripts/test-suites/required/21-e2e-dry-run-downstream.sh
+          - name: case-2b
+            suite: scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh
           - name: case-4
             suite: scripts/test-suites/required/22-e2e-dry-run-github.sh
 
@@ -477,11 +480,37 @@ jobs:
       matrix:
         include:
           - name: 1-of-3
-            shard: 1/3
+            files: >-
+              e2e/visual-proof.spec.ts
+              e2e/edit-task-command.spec.ts
+              e2e/headless-thundering-herd.spec.ts
+              e2e/launching-stall-watchdog.spec.ts
+              e2e/embedded-terminal-pty.spec.ts
+              e2e/keyboard-navigation.spec.ts
+              e2e/action-graph-visual-proof.spec.ts
+              e2e/invalid-merge-workspace-visual.spec.ts
           - name: 2-of-3
-            shard: 2/3
+            files: >-
+              e2e/persistence-lifecycle.spec.ts
+              e2e/task-death-logs.spec.ts
+              e2e/restart-failed-task.spec.ts
+              e2e/task-new-attempt-reset.spec.ts
+              e2e/ui-graph-drag-performance.spec.ts
+              e2e/pending-review-gate-target-repo.proof.spec.ts
+              e2e/workflow-status-composition.spec.ts
+              e2e/startup-window-liveness.spec.ts
           - name: 3-of-3
-            shard: 3/3
+            files: >-
+              e2e/workflow-lifecycle.spec.ts
+              e2e/persistence-recovery.spec.ts
+              e2e/edit-task-prompt.spec.ts
+              e2e/fix-with-claude.spec.ts
+              e2e/fix-with-agent-transition.spec.ts
+              e2e/orphan-relaunch.spec.ts
+              e2e/gap-recovery-bench.spec.ts
+              e2e/system-setup-visual-proof.spec.ts
+              e2e/startup-nonempty-responsiveness.spec.ts
+              e2e/embedded-terminal-spawn-failure.spec.ts
 
     name: playwright / ${{ matrix.name }}
 
@@ -526,9 +555,9 @@ jobs:
 
       - name: Run Playwright shard
         env:
-          INVOKER_PLAYWRIGHT_SHARD: ${{ matrix.shard }}
-          INVOKER_PLAYWRIGHT_RUN_LABEL: ci-playwright
+          INVOKER_PLAYWRIGHT_RUN_LABEL: ci-playwright-${{ matrix.name }}
           INVOKER_PLAYWRIGHT_WORKERS: '1'
+          INVOKER_PLAYWRIGHT_FILES: ${{ matrix.files }}
           INVOKER_PLAYWRIGHT_ARGS: --reporter=line
         run: bash scripts/test-suites/optional/40-playwright-app.sh
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -28,7 +28,8 @@ queue_rules:
       - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
       - check-success = dry-run / case-1
-      - check-success = dry-run / case-2
+      - check-success = dry-run / case-2a
+      - check-success = dry-run / case-2b
       - check-success = dry-run / case-4
       - check-success = playwright / 1-of-3
       - check-success = playwright / 2-of-3
@@ -59,7 +60,8 @@ queue_rules:
       - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
       - check-success = dry-run / case-1
-      - check-success = dry-run / case-2
+      - check-success = dry-run / case-2a
+      - check-success = dry-run / case-2b
       - check-success = dry-run / case-4
       - check-success = playwright / 1-of-3
       - check-success = playwright / 2-of-3

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -91,13 +91,13 @@ expected_executed_for_mode() {
 expected_discovered_for_mode() {
   case "$MODE_KEY" in
     required)
-      printf '20'
+      printf '21'
       ;;
     extended)
-      printf '27'
+      printf '28'
       ;;
     dangerous)
-      printf '28'
+      printf '29'
       ;;
   esac
 }
@@ -148,7 +148,7 @@ suite_name() {
 
 is_parallel_safe() {
   case "$(suite_relpath "$1")" in
-    required/05-delete-all-prod-db-guard.sh|required/06-large-file-guardrail.sh|required/07-invalid-config-json.sh|required/10-vitest-workspace.sh|required/11-pr-authoring-guardrails.sh|required/15-owner-boundary-policy.sh|required/15-submit-workflow-chain.sh|required/20-e2e-dry-run.sh|required/21-e2e-dry-run-downstream.sh|required/22-e2e-dry-run-github.sh|required/50-verify-executor-routing.sh|optional/40-playwright-app.sh|optional/60-worktree-provisioning.sh|optional/70-ui-visual-proof-validate.sh)
+    required/05-delete-all-prod-db-guard.sh|required/06-large-file-guardrail.sh|required/07-invalid-config-json.sh|required/10-vitest-workspace.sh|required/11-pr-authoring-guardrails.sh|required/15-owner-boundary-policy.sh|required/15-submit-workflow-chain.sh|required/20-e2e-dry-run.sh|required/21-e2e-dry-run-downstream.sh|required/21-e2e-dry-run-downstream-reset.sh|required/22-e2e-dry-run-github.sh|required/50-verify-executor-routing.sh|optional/40-playwright-app.sh|optional/60-worktree-provisioning.sh|optional/70-ui-visual-proof-validate.sh)
       return 0
       ;;
     *)

--- a/scripts/test-suites/optional/40-playwright-app.sh
+++ b/scripts/test-suites/optional/40-playwright-app.sh
@@ -22,6 +22,13 @@ if [ -n "${INVOKER_PLAYWRIGHT_ARGS:-}" ]; then
   PLAYWRIGHT_ARGS+=( "${EXTRA_ARGS[@]}" )
 fi
 
+if [ -n "${INVOKER_PLAYWRIGHT_FILES:-}" ]; then
+  # Intentionally split on shell whitespace so CI can pass a static file list.
+  # shellcheck disable=SC2206
+  PLAYWRIGHT_FILES=( ${INVOKER_PLAYWRIGHT_FILES} )
+  PLAYWRIGHT_ARGS+=( "${PLAYWRIGHT_FILES[@]}" )
+fi
+
 RUN_LABEL="${INVOKER_PLAYWRIGHT_RUN_LABEL:-playwright-app}"
 if [ -n "${INVOKER_PLAYWRIGHT_SHARD:-}" ]; then
   RUN_LABEL="${RUN_LABEL}-$(sanitize_label "${INVOKER_PLAYWRIGHT_SHARD}")"

--- a/scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh
+++ b/scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Headless Electron case scripts, shard 2b (balanced case-2 subset).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+exec bash "$ROOT/scripts/e2e-dry-run/run-all.sh" \
+  'case-2.11-edit-restart-downstream.sh' \
+  'case-2.13-rebase-recreate-coalesced.sh' \
+  'case-2.15-recreate-preempt-attempt-refresh.sh' \
+  'case-2.16-retry-vs-recreate-five-second-window.sh' \
+  'case-2.3-parallel-success.sh' \
+  'case-2.5-fan-in-partial-fail.sh' \
+  'case-2.6-diamond-success.sh' \
+  'case-2.8-fix-reject-downstream.sh'

--- a/scripts/test-suites/required/21-e2e-dry-run-downstream.sh
+++ b/scripts/test-suites/required/21-e2e-dry-run-downstream.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
-# Headless Electron case scripts, shard 2 (case-2.*).
+# Headless Electron case scripts, shard 2a (balanced case-2 subset).
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
-exec bash "$ROOT/scripts/e2e-dry-run/run-all.sh" 'case-2.*.sh'
+exec bash "$ROOT/scripts/e2e-dry-run/run-all.sh" \
+  'case-2.1-sequential-success.sh' \
+  'case-2.10-cancel-downstream.sh' \
+  'case-2.12-manual-approve-downstream.sh' \
+  'case-2.14-standalone-timeout-deadlock-guard.sh' \
+  'case-2.17-autofix-persists-fix-intent.sh' \
+  'case-2.2-sequential-upstream-fail.sh' \
+  'case-2.4-fan-in-success.sh' \
+  'case-2.7-fan-in-fix.sh' \
+  'case-2.9-diamond-fail.sh'


### PR DESCRIPTION
## Summary

Mergify queue checks now split the slow dry-run case-2 lane into two required jobs.

Playwright queue jobs now use measured file groups instead of count-only sharding, so one shard should not carry most slow tests.

<details>
<summary>Review metadata</summary>

Review Claim: This PR only changes merge-queue test partitioning and the matching Mergify required checks.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: The dry-run split names every existing `case-2.*.sh` file exactly once. Playwright still runs the same spec files, just grouped by measured cost.

Slice Rationale: This is the smallest queue-speed change: split the known long poles without changing app behavior or test assertions.

</details>

## Non-goals

- Does not remove any merge-queue coverage.
- Does not change app runtime behavior.
- Does not introduce Bazel.

## Test Plan

- [x] `bash -n scripts/test-suites/required/21-e2e-dry-run-downstream.sh scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh scripts/test-suites/optional/40-playwright-app.sh scripts/run-all-tests.sh && node -e "const fs=require('fs'); const YAML=require('yaml'); for (const f of ['.github/workflows/ci.yml','.mergify.yml']) YAML.parse(fs.readFileSync(f,'utf8'));"`
- [x] `node <<'NODE' ... NODE` dry-run shard coverage check: `expected=17 actual=17`
- [x] `INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_EXCLUDE="...all required suites..." bash scripts/run-all-tests.sh`
- [x] `pnpm --filter @invoker/app exec playwright test --list --reporter=line ...` for all three new Playwright file groups

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 6515e0928`
- Post-revert steps: None.
- Data migration? No.
