### PR TITLE
[Web Startup](1) Reduce diagnostic payloads

### DIFF
--- a/packages/app/src/__tests__/action-graph-diagnostics.test.ts
+++ b/packages/app/src/__tests__/action-graph-diagnostics.test.ts
@@ -293,6 +293,54 @@ describe('buildActionGraphDiagnostics', () => {
     );
   });
 
+  it('caps verbose diagnostic text in action graph nodes', () => {
+    const longText = 'x'.repeat(20_000);
+    const selectedAttempt = attempt({
+      id: 'attempt-a1',
+      nodeId: 'task-a',
+      error: longText,
+    });
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [task({
+        id: 'task-a',
+        description: longText,
+        execution: { selectedAttemptId: selectedAttempt.id },
+      })],
+      attemptsByTaskId: new Map([['task-a', [selectedAttempt]]]),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [{
+        id: 9,
+        workflowId: 'wf-1',
+        channel: 'invoker:fix-with-agent',
+        args: [],
+        priority: 'high',
+        status: 'failed',
+        createdAt: '2026-05-14T11:55:00.000Z',
+        error: longText,
+      }],
+      mutationLeases: [],
+      eventsByTaskId: new Map([['task-a', [{
+        id: 1,
+        taskId: 'task-a',
+        eventType: 'output',
+        payload: longText,
+        createdAt: '2026-05-14T11:59:00.000Z',
+      }]]]),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    const attemptNode = graph.nodes.find((node) => node.id === 'attempt:attempt-a1');
+    const intentNode = graph.nodes.find((node) => node.id === 'intent:9');
+    expect(attemptNode?.label.length).toBeLessThan(2_100);
+    expect(attemptNode?.latestError?.length).toBeLessThan(8_300);
+    expect(attemptNode?.history?.[0]?.message.length).toBeLessThan(2_100);
+    expect(intentNode?.latestError?.length).toBeLessThan(8_300);
+    expect(attemptNode?.latestError).toContain('truncated');
+  });
+
   it('skips upstream attempt edges whose source attempts are omitted', () => {
     const upstream = task({ id: 'upstream', status: 'failed' });
     const downstream = task({ id: 'downstream', status: 'pending', dependencies: ['upstream'] });

--- a/packages/app/src/__tests__/web-bridge-server.test.ts
+++ b/packages/app/src/__tests__/web-bridge-server.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import http from 'node:http';
+import { gunzipSync } from 'node:zlib';
 import { tmpdir } from 'node:os';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -29,6 +30,7 @@ interface RequestResult {
   status: number;
   headers: http.IncomingHttpHeaders;
   body: string;
+  rawBody: Buffer;
 }
 
 function request(
@@ -42,9 +44,10 @@ function request(
     (res) => {
       const chunks: Buffer[] = [];
       res.on('data', (c) => chunks.push(c as Buffer));
-      res.on('end', () =>
-        resolve({ status: res.statusCode ?? 0, headers: res.headers, body: Buffer.concat(chunks).toString('utf8') }),
-      );
+      res.on('end', () => {
+        const rawBody = Buffer.concat(chunks);
+        resolve({ status: res.statusCode ?? 0, headers: res.headers, body: rawBody.toString('utf8'), rawBody });
+      });
     },
   );
   req.on('error', reject);
@@ -111,6 +114,27 @@ describe('startWebBridge', () => {
     expect(res.status).toBe(200);
     expect(JSON.parse(res.body)).toEqual({ ok: true, result: { value: 42 } });
     expect(dispatch).toHaveBeenCalledWith('invoker:get-status', []);
+  });
+
+  it('compresses large /invoke JSON responses when the browser accepts gzip', async () => {
+    const dispatch = vi.fn(async () => ({ value: 'x'.repeat(8_000) }));
+    const { port } = await startBridge(dispatch);
+    const res = await request(port, '/invoke', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        cookie: `invoker_web=${TOKEN}`,
+        'accept-encoding': 'gzip',
+      },
+      body: JSON.stringify({ channel: 'invoker:get-action-graph', args: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBe('gzip');
+    expect(JSON.parse(gunzipSync(res.rawBody).toString('utf8'))).toEqual({
+      ok: true,
+      result: { value: 'x'.repeat(8_000) },
+    });
   });
 
   it('reports dispatch failures as { ok: false, error }', async () => {

--- a/packages/app/src/action-graph-diagnostics.ts
+++ b/packages/app/src/action-graph-diagnostics.ts
@@ -23,6 +23,19 @@ export function resolveActionDiagnosticsStallThresholdMs(config: InvokerConfig, 
   const parsed = raw ? Number(raw) : NaN;
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_STALL_THRESHOLD_MS;
 }
+const ACTION_GRAPH_TEXT_LIMITS = {
+  label: 2_048,
+  latestError: 8_192,
+  historyMessage: 2_048,
+} as const;
+
+function truncateActionGraphText(value: string, maxLength: number): string;
+function truncateActionGraphText(value: string | undefined, maxLength: number): string | undefined;
+function truncateActionGraphText(value: string | undefined, maxLength: number): string | undefined {
+  if (value === undefined || value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}… [truncated ${value.length - maxLength} chars]`;
+}
+
 
 export interface ActionGraphDiagnosticsInput {
   workflows: Workflow[];
@@ -95,14 +108,14 @@ function compactHistory(events: TaskEvent[], activityLogs: ActivityLogEntry[]): 
     id: `event:${event.id}`,
     timestamp: event.createdAt,
     source: event.eventType,
-    message: event.payload ?? event.eventType,
+    message: truncateActionGraphText(event.payload ?? event.eventType, ACTION_GRAPH_TEXT_LIMITS.historyMessage),
   }));
   const logs = activityLogs.slice(-10).map((entry) => ({
     id: `activity:${entry.id}`,
     timestamp: entry.timestamp,
     source: entry.source,
     level: entry.level,
-    message: entry.message,
+    message: truncateActionGraphText(entry.message, ACTION_GRAPH_TEXT_LIMITS.historyMessage),
   }));
   return [...taskEvents, ...logs].sort((a, b) => a.timestamp.localeCompare(b.timestamp)).slice(-25);
 }
@@ -140,7 +153,7 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
     nodes.push({
       id: actionId,
       type: 'user-action',
-      label: workflow.name || workflow.id,
+      label: truncateActionGraphText(workflow.name || workflow.id, ACTION_GRAPH_TEXT_LIMITS.label) ?? workflow.id,
       status: taskStatusToActionStatus(workflow.status as TaskState['status']),
       workflowId: workflow.id,
       createdAt: workflow.createdAt,
@@ -176,7 +189,7 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
       createdAt: intent.createdAt,
       startedAt: intent.startedAt,
       completedAt: intent.completedAt,
-      latestError: intent.error,
+      latestError: truncateActionGraphText(intent.error, ACTION_GRAPH_TEXT_LIMITS.latestError),
       durations: {
         queuedMs: intent.status === 'queued' ? ageMs(nowMs, intent.createdAt) : undefined,
         runningMs: intent.status === 'running' ? ageMs(nowMs, intent.startedAt) : undefined,
@@ -302,7 +315,7 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
       nodes.push({
         id: nodeId,
         type: 'task-attempt',
-        label: task.description,
+        label: truncateActionGraphText(task.description, ACTION_GRAPH_TEXT_LIMITS.label) ?? task.id,
         status: stalled ? 'stalled' : attemptStatusToActionStatus(attempt.status),
         workflowId,
         taskId: task.id,
@@ -313,7 +326,7 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
         completedAt: iso(attempt.completedAt),
         heartbeatAt: iso(attempt.lastHeartbeatAt),
         leaseExpiresAt: iso(attempt.leaseExpiresAt),
-        latestError: attempt.error ?? task.execution.error,
+        latestError: truncateActionGraphText(attempt.error ?? task.execution.error, ACTION_GRAPH_TEXT_LIMITS.latestError),
         history: attempt.id === selectedAttemptId ? compactHistory(taskEvents, input.activityLogs) : undefined,
         durations: {
           queuedMs: queuedQueueIds.has(task.id) ? ageMs(nowMs, attempt.createdAt) : undefined,

--- a/packages/app/src/web/web-bridge-server.ts
+++ b/packages/app/src/web/web-bridge-server.ts
@@ -17,6 +17,7 @@
  */
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
+import { brotliCompressSync, gzipSync } from 'node:zlib';
 import { createReadStream, existsSync, statSync } from 'node:fs';
 import { join, normalize, sep, extname } from 'node:path';
 import { timingSafeEqual } from 'node:crypto';
@@ -32,6 +33,7 @@ const SSE_PING_INTERVAL_MS = 20_000;
 const ACTIVITY_POLL_INTERVAL_MS = 2_000;
 const WORKFLOWS_POLL_INTERVAL_MS = 2_000;
 const SSE_DROP_BUFFER_BYTES = 8 * 1024 * 1024; // drop a client whose backlog exceeds this
+const JSON_COMPRESSION_MIN_BYTES = 1024;
 
 export interface WebBridgeDeps {
   logger?: Logger;
@@ -95,10 +97,26 @@ function contentTypeFor(filePath: string): string {
   return CONTENT_TYPES[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
 }
 
-function sendJson(res: ServerResponse, status: number, body: unknown): void {
-  const payload = JSON.stringify(body);
-  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' });
-  res.end(payload);
+function sendJson(res: ServerResponse, status: number, body: unknown, req?: IncomingMessage): void {
+  const payload = Buffer.from(JSON.stringify(body), 'utf8');
+  const headers: Record<string, string> = {
+    'content-type': 'application/json; charset=utf-8',
+    vary: 'Accept-Encoding',
+  };
+  const accepted = typeof req?.headers['accept-encoding'] === 'string' ? req.headers['accept-encoding'] : '';
+  let responseBody = payload;
+  if (payload.length >= JSON_COMPRESSION_MIN_BYTES) {
+    if (accepted.includes('br')) {
+      responseBody = brotliCompressSync(payload);
+      headers['content-encoding'] = 'br';
+    } else if (accepted.includes('gzip')) {
+      responseBody = gzipSync(payload);
+      headers['content-encoding'] = 'gzip';
+    }
+  }
+  headers['content-length'] = String(responseBody.length);
+  res.writeHead(status, headers);
+  res.end(responseBody);
 }
 
 /**
@@ -173,7 +191,7 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
       total += (chunk as Buffer).length;
       if (total > MAX_INVOKE_BODY_BYTES) {
         aborted = true;
-        sendJson(res, 413, { ok: false, error: { message: 'request body too large' } });
+        sendJson(res, 413, { ok: false, error: { message: 'request body too large' } }, req);
         req.destroy();
         return;
       }
@@ -185,21 +203,21 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
     try {
       parsed = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
     } catch {
-      sendJson(res, 400, { ok: false, error: { message: 'invalid JSON body' } });
+      sendJson(res, 400, { ok: false, error: { message: 'invalid JSON body' } }, req);
       return;
     }
     if (typeof parsed.channel !== 'string') {
-      sendJson(res, 400, { ok: false, error: { message: 'missing "channel"' } });
+      sendJson(res, 400, { ok: false, error: { message: 'missing "channel"' } }, req);
       return;
     }
     const args = Array.isArray(parsed.args) ? parsed.args : [];
     try {
       const result = await dispatch(parsed.channel, args);
-      sendJson(res, 200, { ok: true, result });
+      sendJson(res, 200, { ok: true, result }, req);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       const code = (err as { code?: string }).code;
-      sendJson(res, 200, { ok: false, error: code ? { message, code } : { message } });
+      sendJson(res, 200, { ok: false, error: code ? { message, code } : { message } }, req);
     }
   };
 


### PR DESCRIPTION
## Summary

The web bridge now sends smaller diagnostic responses.

Large Action Graph strings are capped before serialization. Large `/invoke` JSON responses use browser-supported compression.

<details>
<summary>Review metadata</summary>

Review Claim: The web bridge no longer sends unbounded diagnostic text or uncompressed large JSON responses.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The same graph nodes and invoke envelope are returned; only oversized text fields are shortened and transport encoding changes when the client accepts it.

Slice Rationale: This server-side payload fix stands alone from the UI lazy-loading change that consumes it.

</details>

## Non-goals

- Does not change Action Graph layout.
- Does not change web authentication.
- Does not change when the UI asks for graph data.

## Architecture

### Before

```mermaid
graph TD
    A["/invoke"] --> B["JSON response"]
    C["Action Graph"] --> D["Full labels, errors, and history text"]
```

### After

```mermaid
graph TD
    A["/invoke"] --> B["Compressed JSON when accepted"]
    C["Action Graph"] --> D["Capped labels, errors, and history text"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run action-graph-diagnostics web-bridge-server`
- [x] `pnpm run check:types`
- [x] Browser GET to `http://157.230.133.215:4200/?token=…` redirected to the Invoker page.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert cce0d30be`
- Post-revert steps: None
- Data migration? No
