### PR TITLE
[Web Startup](3) Defer startup graph and PR checks

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -392,11 +392,12 @@ export function App() {
   const { tasks, workflows, clearTasks, refreshTaskGraph } = useTasks({
     onTaskGraphSnapshotApplied: handleTaskGraphSnapshotApplied,
   });
+  const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
   const {
     graph: actionGraph,
     error: actionGraphError,
     refreshActionGraph,
-  } = useActionGraphSnapshot();
+  } = useActionGraphSnapshot(2_000, viewMode === 'actionGraph');
   const trackAcceptedMutation = useCallback((result: unknown) => {
     if (result && typeof result === 'object' && (result as { accepted?: unknown }).accepted === true) {
       void refreshActionGraph();
@@ -426,7 +427,6 @@ export function App() {
   const [hasStarted, setHasStarted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
   const [selectedActionNodeId, setSelectedActionNodeId] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
   const selectedActionNode = useMemo(
     () => actionGraph?.nodes.find((node) => node.id === selectedActionNodeId) ?? null,
     [actionGraph, selectedActionNodeId],
@@ -1543,8 +1543,9 @@ export function App() {
 
   const handleRefresh = useCallback(async () => {
     await refreshTaskGraph();
+    void invoker?.checkPrStatuses?.();
     issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason: 'manual-refresh' });
-  }, [issueCameraCommand, refreshTaskGraph]);
+  }, [invoker, issueCameraCommand, refreshTaskGraph]);
 
   // ── Plan loading ──────────────────────────────────────────
   const handleLoadPlan = useCallback(

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -233,6 +233,24 @@ describe('useTasks', () => {
     });
   });
 
+  it('does not check PR statuses during startup snapshot loading', async () => {
+    const getTasks = vi.fn().mockResolvedValue({ tasks: [], workflows: [] });
+    const checkPrStatuses = vi.fn().mockResolvedValue(undefined);
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks,
+      checkPrStatuses,
+      onTaskGraphEvent: vi.fn(() => () => {}),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+
+    renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(getTasks).toHaveBeenCalledTimes(1);
+    });
+    expect(checkPrStatuses).not.toHaveBeenCalled();
+  });
+
   it('ignores a stale startup snapshot after a graph event arrives first', async () => {
     let releaseStartupSnapshot: (value: { tasks: ReturnType<typeof makeUITask>[]; workflows: unknown[]; streamSequence: number }) => void;
     let taskGraphEventHandler: ((event: unknown) => void) | undefined;

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -177,7 +177,6 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
         });
       }
     });
-    window.invoker.checkPrStatuses?.();
     return request.then(() => undefined);
   }, []);
   const refreshWorkflowMetadata = useCallback((): Promise<void> => {


### PR DESCRIPTION
## Summary

The browser startup path no longer activates the Action Graph or PR status checks right away.

The Home view still loads tasks immediately. The graph loads when its tab opens, and PR checks run from manual Refresh.

<details>
<summary>Review metadata</summary>

Review Claim: App startup only loads data needed for the initial Home view.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Opening Action Graph still fetches graph data, and manual Refresh still updates task graph state and PR status state.

Slice Rationale: This wires the dormant hook support into the App without mixing in server transport changes.

</details>

## Non-goals

- Does not change Action Graph rendering.
- Does not change task snapshot hydration.
- Does not remove PR status checks.

## Architecture

### Before

```mermaid
graph TD
    A["Open browser URL"] --> B["Load task snapshot"]
    A --> C["Fetch Action Graph"]
    A --> D["Run PR checks"]
```

### After

```mermaid
graph TD
    A["Open browser URL"] --> B["Load task snapshot"]
    A --> C["Home view only"]
    D["Open Action Graph"] --> E["Fetch Action Graph"]
    F["Manual Refresh"] --> G["Run PR checks"]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run use-action-graph-snapshot use-tasks`
- [x] `pnpm run check:types`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Visual Proof

Before Action Graph diagnostics:

![Before Action Graph diagnostics](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-495826/before-action-graph-diagnostics-view.png)

After Action Graph diagnostics:

![After Action Graph diagnostics](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-495826/after-action-graph-diagnostics-view.png)

After walkthrough video:

[After visual proof walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-495826/after-web-startup-walkthrough.webm)

Note: `capture-before` captured the Action Graph screenshot, but one unrelated SSH terminal proof case failed on the base branch. `capture-after` passed all 46 visual proof cases.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e21046590`
- Post-revert steps: None
- Data migration? No
