### PR TITLE
[Web Startup](2) Gate action graph polling

### DIFF
--- a/packages/ui/src/__tests__/use-action-graph-snapshot.test.tsx
+++ b/packages/ui/src/__tests__/use-action-graph-snapshot.test.tsx
@@ -1,0 +1,51 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useActionGraphSnapshot } from '../hooks/useActionGraphSnapshot.js';
+
+const emptyGraph = { generatedAt: '2026-06-30T00:00:00.000Z', stallThresholdMs: 60_000, nodes: [], edges: [] };
+
+describe('useActionGraphSnapshot', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getActionGraph: vi.fn().mockResolvedValue(emptyGraph),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as { invoker?: unknown }).invoker;
+  });
+
+  it('does not fetch action graph data while disabled', async () => {
+    const getActionGraph = vi.fn().mockResolvedValue(emptyGraph);
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = { getActionGraph };
+
+    const { result, unmount } = renderHook(() => useActionGraphSnapshot(20, false));
+
+    await act(async () => {
+      await result.current.refreshActionGraph();
+    });
+
+    expect(getActionGraph).not.toHaveBeenCalled();
+    expect(result.current.graph).toBeNull();
+    unmount();
+  });
+
+  it('fetches immediately when enabled', async () => {
+    const getActionGraph = vi.fn().mockResolvedValue(emptyGraph);
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = { getActionGraph };
+
+    const { result, rerender, unmount } = renderHook(({ enabled }) => useActionGraphSnapshot(20, enabled), {
+      initialProps: { enabled: false },
+    });
+
+    rerender({ enabled: true });
+
+    await waitFor(() => {
+      expect(result.current.graph).toEqual(emptyGraph);
+    });
+    expect(getActionGraph).toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/packages/ui/src/hooks/useActionGraphSnapshot.ts
+++ b/packages/ui/src/hooks/useActionGraphSnapshot.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { ActionGraphResponse } from '@invoker/contracts';
 
-export function useActionGraphSnapshot(pollMs = 2000): {
+export function useActionGraphSnapshot(pollMs = 2000, enabled = true): {
   graph: ActionGraphResponse | null;
   error: string | null;
   refreshActionGraph: () => Promise<void>;
@@ -10,6 +10,7 @@ export function useActionGraphSnapshot(pollMs = 2000): {
   const [error, setError] = useState<string | null>(null);
 
   const refreshActionGraph = useCallback(async () => {
+    if (!enabled) return;
     try {
       const response = await window.invoker?.getActionGraph?.();
       if (response) {
@@ -19,12 +20,16 @@ export function useActionGraphSnapshot(pollMs = 2000): {
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     }
-  }, []);
+  }, [enabled]);
 
   useEffect(() => {
+    if (!enabled) return;
     let cancelled = false;
+    let inFlight = false;
 
     const poll = async () => {
+      if (inFlight) return;
+      inFlight = true;
       try {
         const response = await window.invoker?.getActionGraph?.();
         if (!cancelled && response) {
@@ -35,6 +40,8 @@ export function useActionGraphSnapshot(pollMs = 2000): {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : String(err));
         }
+      } finally {
+        inFlight = false;
       }
     };
 
@@ -46,7 +53,7 @@ export function useActionGraphSnapshot(pollMs = 2000): {
       cancelled = true;
       window.clearInterval(interval);
     };
-  }, [pollMs]);
+  }, [enabled, pollMs]);
 
   return { graph, error, refreshActionGraph };
 }


### PR DESCRIPTION
## Summary

The Action Graph polling hook can now stay idle until a caller enables it.

This keeps the default behavior for existing callers, while giving the browser startup path a way to avoid the heavy graph read.

<details>
<summary>Review metadata</summary>

Review Claim: `useActionGraphSnapshot` supports a disabled state without fetching or polling graph data.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The hook defaults to enabled, so existing callers keep the old fetch-and-poll behavior unless they opt out.

Slice Rationale: This dormant hook capability is separate from the App wiring that turns it on only for the Action Graph tab.

</details>

## Non-goals

- Does not change App navigation.
- Does not change server responses.
- Does not change Action Graph rendering.

## Architecture

### Before

```mermaid
graph TD
    A["Hook mounts"] --> B["Fetch Action Graph"]
    B --> C["Poll every interval"]
```

### After

```mermaid
graph TD
    A["Hook mounts disabled"] --> B["No graph request"]
    C["Hook enabled"] --> D["Fetch Action Graph"]
    D --> E["Poll every interval"]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run use-action-graph-snapshot use-tasks`
- [x] `pnpm run check:types`

## Visual Proof

Before Action Graph diagnostics:

![Before Action Graph diagnostics](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-be500c/before-action-graph-diagnostics-view.png)

After Action Graph diagnostics:

![After Action Graph diagnostics](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-be500c/after-action-graph-diagnostics-view.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 15cef7b11`
- Post-revert steps: None
- Data migration? No
