### PR TITLE
[Stack Landing](1) Refuse partial Mergify stack landings

### DIFF
--- a/scripts/land-stack.mjs
+++ b/scripts/land-stack.mjs
@@ -10,11 +10,12 @@
  *   - its head branch is a real `stack/` branch (refuses raw workflow branches),
  *   - the PRs form a proper stack (each PR's base is the previous PR's head branch;
  *     the bottom PR's base is the trunk),
+ *   - the provided PRs are the complete open stack, not a prefix/suffix slice,
  *   - every PR is OPEN.
  *
- * Only after ALL checks pass does `--execute` add the `admin-bypass` label to the
- * bottom-most open PR (the one whose base is the trunk) to trigger the Mergify
- * merge queue. Re-run after that PR merges and the next one re-targets the trunk.
+ * Only after ALL checks pass does `--execute` add the `admin-bypass` label to
+ * every PR in the verified stack, bottom-to-top. That lets Mergify land the
+ * whole stack as one unit of work instead of one PR per manual re-run.
  *
  * Background: a raw workflow branch PR (#505) once shared a branch name with the
  * intended stack (#2174/#2175). Landing "the PR on this branch" queued the wrong
@@ -22,7 +23,7 @@
  *
  * Usage:
  *   node scripts/land-stack.mjs <pr> [<pr> ...]              # verify confirmed numbers (safe default)
- *   node scripts/land-stack.mjs <pr> [<pr> ...] --execute    # re-verify, then queue the bottom PR
+ *   node scripts/land-stack.mjs <pr> [<pr> ...] --execute    # re-verify, then queue the whole stack
  *   node scripts/land-stack.mjs <pr> ... --base main         # trunk branch (default: master)
  *   node scripts/land-stack.mjs <pr> ... --stack-prefix s/   # required head-branch prefix
  *   node scripts/land-stack.mjs --help
@@ -38,19 +39,6 @@ import { fileURLToPath } from 'node:url';
 export const TRUNK_DEFAULT = 'master';
 export const STACK_PREFIX_DEFAULT = 'stack/';
 
-// ----------------------------- pure verification -----------------------------
-// Kept side-effect free so scripts/test-land-stack.mjs can exercise every branch
-// without touching gh or git.
-
-/**
- * @param {object} input
- * @param {Array<{number:number, headRefOid:string, headRefName:string, baseRefName:string, state:string}>} input.prs
- *   ordered bottom -> top of the stack
- * @param {(sha:string)=>boolean} input.hasLocalCommit
- * @param {string} [input.trunk]
- * @param {string} [input.stackPrefix]
- * @returns {{ok:boolean, checks:Array<{pr:number,name:string,ok:boolean,detail:string}>}}
- */
 export function analyzeStack({ prs, hasLocalCommit, trunk = TRUNK_DEFAULT, stackPrefix = STACK_PREFIX_DEFAULT }) {
   const checks = [];
   const add = (pr, name, ok, detail) => checks.push({ pr, name, ok, detail });
@@ -62,10 +50,9 @@ export function analyzeStack({ prs, hasLocalCommit, trunk = TRUNK_DEFAULT, stack
 
   prs.forEach((pr, i) => {
     const n = pr.number;
-
     add(n, 'open', pr.state === 'OPEN', `state=${pr.state}`);
 
-    const shaOk = !!pr.headRefOid && hasLocalCommit(pr.headRefOid);
+    const shaOk = Boolean(pr.headRefOid) && hasLocalCommit(pr.headRefOid);
     add(n, 'sha-local', shaOk,
       `head ${short(pr.headRefOid)} ${shaOk ? 'present in local clone' : 'NOT found locally — refusing a PR whose code you do not have'}`);
 
@@ -82,11 +69,79 @@ export function analyzeStack({ prs, hasLocalCommit, trunk = TRUNK_DEFAULT, stack
   return { ok: checks.every((c) => c.ok), checks };
 }
 
+export function analyzeCompleteOpenStack({ selectedPrs, allOpenPrs, trunk = TRUNK_DEFAULT, stackPrefix = STACK_PREFIX_DEFAULT }) {
+  const selectedNumbers = selectedPrs.map((pr) => pr.number);
+  const fail = (detail, fullStack = []) => ({
+    ok: false,
+    fullStack,
+    checks: [{ pr: 0, name: 'complete-stack', ok: false, detail }],
+  });
+
+  if (selectedPrs.length === 0) return fail('no PR numbers provided');
+
+  const byNumber = new Map();
+  for (const pr of allOpenPrs.concat(selectedPrs)) {
+    if (pr?.state === 'OPEN' && typeof pr.headRefName === 'string' && pr.headRefName.startsWith(stackPrefix)) {
+      byNumber.set(pr.number, pr);
+    }
+  }
+  const openStackPrs = [...byNumber.values()];
+  const byHead = new Map(openStackPrs.map((pr) => [pr.headRefName, pr]));
+  const childrenByBase = new Map();
+  for (const pr of openStackPrs) {
+    const children = childrenByBase.get(pr.baseRefName) ?? [];
+    children.push(pr);
+    childrenByBase.set(pr.baseRefName, children);
+  }
+
+  const fullStack = [selectedPrs[0]];
+  const seen = new Set([selectedPrs[0].number]);
+  let bottom = selectedPrs[0];
+  while (bottom.baseRefName !== trunk) {
+    const parent = byHead.get(bottom.baseRefName);
+    if (!parent) return fail(`missing lower open stack PR whose head branch is '${bottom.baseRefName}'`, fullStack);
+    if (seen.has(parent.number)) return fail(`cycle detected while walking lower stack from PR #${selectedPrs[0].number}`, fullStack);
+    fullStack.unshift(parent);
+    seen.add(parent.number);
+    bottom = parent;
+  }
+
+  let top = fullStack[fullStack.length - 1];
+  while (true) {
+    const children = (childrenByBase.get(top.headRefName) ?? []).filter((pr) => pr.number !== top.number);
+    if (children.length === 0) break;
+    if (children.length > 1) return fail(`ambiguous stack: branch '${top.headRefName}' has ${children.length} open stack children`, fullStack);
+    const child = children[0];
+    if (seen.has(child.number)) return fail(`cycle detected while walking upper stack from PR #${top.number}`, fullStack);
+    fullStack.push(child);
+    seen.add(child.number);
+    top = child;
+  }
+
+  const expectedNumbers = fullStack.map((pr) => pr.number);
+  const ok = expectedNumbers.length === selectedNumbers.length
+    && expectedNumbers.every((number, index) => number === selectedNumbers[index]);
+  return {
+    ok,
+    fullStack,
+    checks: [{
+      pr: 0,
+      name: 'complete-stack',
+      ok,
+      detail: ok
+        ? `provided complete open stack [${expectedNumbers.join(', ')}]`
+        : `provided [${selectedNumbers.join(', ')}], but full open stack is [${expectedNumbers.join(', ')}]`,
+    }],
+  };
+}
+
+export function queueTargets(prs) {
+  return prs.filter((pr) => pr.state === 'OPEN');
+}
+
 export function short(sha) {
   return sha ? String(sha).slice(0, 9) : '(none)';
 }
-
-// --------------------------------- CLI glue ----------------------------------
 
 function gh(args) {
   return execFileSync('gh', args, { encoding: 'utf8' });
@@ -95,6 +150,12 @@ function gh(args) {
 function fetchPr(num) {
   const out = gh(['pr', 'view', String(num), '--json',
     'number,headRefOid,headRefName,baseRefName,state,mergeStateStatus,reviewDecision']);
+  return JSON.parse(out);
+}
+
+function listOpenPrs() {
+  const out = gh(['pr', 'list', '--state', 'open', '--limit', '200', '--json',
+    'number,headRefOid,headRefName,baseRefName,state']);
   return JSON.parse(out);
 }
 
@@ -130,14 +191,14 @@ function parseArgs(argv) {
 const HELP = `land-stack — verify and land a Mergify PR stack by confirmed PR number
 
   node scripts/land-stack.mjs <pr> [<pr> ...]              verify confirmed numbers (safe default)
-  node scripts/land-stack.mjs <pr> [<pr> ...] --execute    re-verify, then queue the bottom PR
+  node scripts/land-stack.mjs <pr> [<pr> ...] --execute    re-verify, then queue the whole stack
   node scripts/land-stack.mjs <pr> ... --base <branch>     trunk branch (default: master)
   node scripts/land-stack.mjs <pr> ... --stack-prefix <p>  required head-branch prefix (default: stack/)
 
 Pass confirmed PR numbers bottom-of-stack first. If numbers are missing, broadly
 list open PRs, filter to stack heads, order by base/head links, ask the user to
 confirm the suggested numbers, then run this guard. Verification must pass before
-anything is queued. --execute adds the admin-bypass label to the bottom PR.`;
+anything is queued. --execute adds the admin-bypass label to every verified PR.`;
 
 function printReport(result) {
   const byPr = new Map();
@@ -146,9 +207,9 @@ function printReport(result) {
     byPr.get(c.pr).push(c);
   }
   for (const [pr, checks] of byPr) {
-    console.log(`\nPR #${pr}`);
+    console.log(`\n${pr === 0 ? 'Stack' : `PR #${pr}`}`);
     for (const c of checks) {
-      console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.name.padEnd(13)} ${c.detail}`);
+      console.log(`  ${c.ok ? 'PASS' : 'FAIL'}  ${c.name.padEnd(14)} ${c.detail}`);
     }
   }
 }
@@ -173,22 +234,33 @@ function main() {
   }
 
   let prData;
+  let openPrData;
   try {
     prData = args.prs.map(fetchPr);
+    openPrData = listOpenPrs();
   } catch (e) {
-    console.error(`error: failed to read PR via gh: ${e.message}`);
+    console.error(`error: failed to read PR data via gh: ${e.message}`);
     process.exit(2);
   }
 
-  const result = analyzeStack({
+  const structureResult = analyzeStack({
     prs: prData,
     hasLocalCommit: localCommitChecker(),
     trunk: args.trunk,
     stackPrefix: args.stackPrefix,
   });
+  const completenessResult = analyzeCompleteOpenStack({
+    selectedPrs: prData,
+    allOpenPrs: openPrData,
+    trunk: args.trunk,
+    stackPrefix: args.stackPrefix,
+  });
+  const result = {
+    ok: structureResult.ok && completenessResult.ok,
+    checks: structureResult.checks.concat(completenessResult.checks),
+  };
   printReport(result);
 
-  // Informational only — Mergify itself blocks the actual merge on these.
   for (const pr of prData) {
     if (pr.reviewDecision && pr.reviewDecision !== 'APPROVED') {
       console.log(`\nnote: PR #${pr.number} reviewDecision=${pr.reviewDecision}, mergeState=${pr.mergeStateStatus}`);
@@ -196,24 +268,28 @@ function main() {
   }
 
   if (!result.ok) {
-    console.error('\nRESULT: FAILED — not touching any PR. Fix the failures above (or confirm you passed the right PR numbers).');
+    console.error('\nRESULT: FAILED — not touching any PR. Fix the failures above (or confirm you passed the full bottom-up PR stack).');
     process.exit(1);
   }
   console.log('\nRESULT: verification passed.');
 
   if (!args.execute) {
-    console.log('Re-run with --execute to queue the bottom PR (base == trunk) via admin-bypass.');
+    console.log('Re-run with --execute to queue the whole verified stack via admin-bypass.');
     return;
   }
 
-  const bottom = prData.find((p) => p.state === 'OPEN' && p.baseRefName === args.trunk);
-  if (!bottom) {
-    console.error(`\nerror: no open PR with base '${args.trunk}' to queue. After the bottom PR merges, re-run with the remaining PR numbers.`);
+  const targets = queueTargets(prData);
+  if (targets.length === 0) {
+    console.error('\nerror: no open PRs to queue.');
     process.exit(1);
   }
-  console.log(`\nExecuting: adding 'admin-bypass' to bottom PR #${bottom.number} (head ${short(bottom.headRefOid)}, base ${bottom.baseRefName}).`);
-  gh(['pr', 'edit', String(bottom.number), '--add-label', 'admin-bypass']);
-  console.log(`Queued PR #${bottom.number}. Once it merges, the next PR re-targets '${args.trunk}'; re-run land-stack with the remaining PR numbers and --execute.`);
+
+  console.log(`\nExecuting: adding 'admin-bypass' to ${targets.length} verified PR(s), bottom-to-top.`);
+  for (const pr of targets) {
+    console.log(`  PR #${pr.number} (head ${short(pr.headRefOid)}, base ${pr.baseRefName})`);
+    gh(['pr', 'edit', String(pr.number), '--add-label', 'admin-bypass']);
+  }
+  console.log(`Queued ${targets.length} PR(s) as one stack unit.`);
 }
 
 const invokedDirectly = (() => {

--- a/scripts/test-land-stack.mjs
+++ b/scripts/test-land-stack.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Unit tests for the land-stack guard's pure verification.
+ * Unit tests for the land-stack guard and its execute path.
  * Run: node scripts/test-land-stack.mjs   (exit 0 = pass, non-zero = fail)
  *
  * Cases are modeled on the real incident: the intended stack (#2174 -> #2175)
@@ -9,7 +9,11 @@
  */
 
 import assert from 'node:assert/strict';
-import { analyzeStack } from './land-stack.mjs';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { analyzeCompleteOpenStack, analyzeStack, queueTargets } from './land-stack.mjs';
 
 const SHA_2174 = 'db05fa18441693b0a51a8f9c2e2e3f0109d8f7a7';
 const SHA_2175 = '1049a6c76c5f788f31ca9cecaf19812c327bd107';
@@ -18,12 +22,13 @@ const SHA_505 = '8f52adfcf94423c55b6b4fc2af95bbd4d6592eb4';
 const STACK_BR_BOTTOM = 'stack/EdbertChan/plan/reduce-large-files-step-3/...--5fb697a6';
 const STACK_BR_TOP = 'stack/EdbertChan/plan/reduce-large-files-step-3/...--8e5f5c84';
 
-// Everything except #505's head is "present locally".
 const localShas = new Set([SHA_2174, SHA_2175]);
 const hasLocal = (sha) => localShas.has(sha);
-
-const check = (res, pr, name) =>
-  res.checks.find((c) => c.pr === pr && c.name === name);
+const check = (res, pr, name) => res.checks.find((c) => c.pr === pr && c.name === name);
+const createExecutable = (path, content) => {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+};
 
 let passed = 0;
 function test(name, fn) {
@@ -32,23 +37,20 @@ function test(name, fn) {
   console.log(`ok - ${name}`);
 }
 
+const fullStack = [
+  { number: 2174, headRefOid: SHA_2174, headRefName: STACK_BR_BOTTOM, baseRefName: 'master', state: 'OPEN' },
+  { number: 2175, headRefOid: SHA_2175, headRefName: STACK_BR_TOP, baseRefName: STACK_BR_BOTTOM, state: 'OPEN' },
+];
+
 test('valid bottom->top stack passes every check', () => {
-  const res = analyzeStack({
-    hasLocalCommit: hasLocal,
-    prs: [
-      { number: 2174, headRefOid: SHA_2174, headRefName: STACK_BR_BOTTOM, baseRefName: 'master', state: 'OPEN' },
-      { number: 2175, headRefOid: SHA_2175, headRefName: STACK_BR_TOP, baseRefName: STACK_BR_BOTTOM, state: 'OPEN' },
-    ],
-  });
+  const res = analyzeStack({ hasLocalCommit: hasLocal, prs: fullStack });
   assert.equal(res.ok, true, 'expected the real stack to pass');
 });
 
 test('raw workflow-branch PR (#505) is rejected', () => {
   const res = analyzeStack({
     hasLocalCommit: hasLocal,
-    prs: [
-      { number: 505, headRefOid: SHA_505, headRefName: 'plan/reduce-large-files-step-3-orchestrator-ts-decomposition', baseRefName: 'master', state: 'OPEN' },
-    ],
+    prs: [{ number: 505, headRefOid: SHA_505, headRefName: 'plan/reduce-large-files-step-3-orchestrator-ts-decomposition', baseRefName: 'master', state: 'OPEN' }],
   });
   assert.equal(res.ok, false, 'expected #505 to fail');
   assert.equal(check(res, 505, 'stack-branch').ok, false, 'non-stack branch must fail');
@@ -58,9 +60,7 @@ test('raw workflow-branch PR (#505) is rejected', () => {
 test('head SHA missing from local clone fails sha-local', () => {
   const res = analyzeStack({
     hasLocalCommit: hasLocal,
-    prs: [
-      { number: 2174, headRefOid: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef', headRefName: STACK_BR_BOTTOM, baseRefName: 'master', state: 'OPEN' },
-    ],
+    prs: [{ number: 2174, headRefOid: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef', headRefName: STACK_BR_BOTTOM, baseRefName: 'master', state: 'OPEN' }],
   });
   assert.equal(res.ok, false);
   assert.equal(check(res, 2174, 'sha-local').ok, false);
@@ -69,10 +69,7 @@ test('head SHA missing from local clone fails sha-local', () => {
 test('broken stack linkage fails base-linkage on the upper PR', () => {
   const res = analyzeStack({
     hasLocalCommit: hasLocal,
-    prs: [
-      { number: 2174, headRefOid: SHA_2174, headRefName: STACK_BR_BOTTOM, baseRefName: 'master', state: 'OPEN' },
-      { number: 2175, headRefOid: SHA_2175, headRefName: STACK_BR_TOP, baseRefName: 'master', state: 'OPEN' }, // should be STACK_BR_BOTTOM
-    ],
+    prs: [fullStack[0], { ...fullStack[1], baseRefName: 'master' }],
   });
   assert.equal(res.ok, false);
   assert.equal(check(res, 2175, 'base-linkage').ok, false);
@@ -81,9 +78,7 @@ test('broken stack linkage fails base-linkage on the upper PR', () => {
 test('bottom PR not based on trunk fails base-linkage', () => {
   const res = analyzeStack({
     hasLocalCommit: hasLocal,
-    prs: [
-      { number: 2174, headRefOid: SHA_2174, headRefName: STACK_BR_BOTTOM, baseRefName: 'some-other-branch', state: 'OPEN' },
-    ],
+    prs: [{ ...fullStack[0], baseRefName: 'some-other-branch' }],
   });
   assert.equal(res.ok, false);
   assert.equal(check(res, 2174, 'base-linkage').ok, false);
@@ -92,9 +87,7 @@ test('bottom PR not based on trunk fails base-linkage', () => {
 test('closed PR fails open check', () => {
   const res = analyzeStack({
     hasLocalCommit: hasLocal,
-    prs: [
-      { number: 2174, headRefOid: SHA_2174, headRefName: STACK_BR_BOTTOM, baseRefName: 'master', state: 'MERGED' },
-    ],
+    prs: [{ ...fullStack[0], state: 'MERGED' }],
   });
   assert.equal(res.ok, false);
   assert.equal(check(res, 2174, 'open').ok, false);
@@ -110,11 +103,89 @@ test('custom --base trunk is honored', () => {
   const res = analyzeStack({
     hasLocalCommit: hasLocal,
     trunk: 'main',
-    prs: [
-      { number: 2174, headRefOid: SHA_2174, headRefName: STACK_BR_BOTTOM, baseRefName: 'main', state: 'OPEN' },
-    ],
+    prs: [{ ...fullStack[0], baseRefName: 'main' }],
   });
   assert.equal(res.ok, true);
+});
+
+test('complete stack check rejects a bottom-only prefix', () => {
+  const res = analyzeCompleteOpenStack({ selectedPrs: [fullStack[0]], allOpenPrs: fullStack });
+  assert.equal(res.ok, false);
+  assert.match(check(res, 0, 'complete-stack').detail, /full open stack is \[2174, 2175\]/);
+});
+
+test('complete stack check rejects a top-only suffix', () => {
+  const res = analyzeCompleteOpenStack({ selectedPrs: [fullStack[1]], allOpenPrs: fullStack });
+  assert.equal(res.ok, false);
+  assert.match(check(res, 0, 'complete-stack').detail, /provided \[2175\]/);
+});
+
+test('complete stack check accepts the full bottom-to-top stack', () => {
+  const res = analyzeCompleteOpenStack({ selectedPrs: fullStack, allOpenPrs: fullStack });
+  assert.equal(res.ok, true);
+  assert.deepEqual(res.fullStack.map((pr) => pr.number), [2174, 2175]);
+});
+
+test('queue targets include the whole open stack in order', () => {
+  const targets = queueTargets(fullStack);
+  assert.deepEqual(targets.map((pr) => pr.number), [2174, 2175]);
+});
+
+function runCli(prNumbers) {
+  const tmp = mkdtempSync(join(tmpdir(), 'land-stack-test-'));
+  const bin = join(tmp, 'bin');
+  const log = join(tmp, 'gh.log');
+  mkdirSync(bin);
+  writeFileSync(log, '');
+  createExecutable(join(bin, 'gh'), `#!/usr/bin/env node
+const fs = require('node:fs');
+const log = ${JSON.stringify(log)};
+const prs = {
+  '2174': { number: 2174, headRefOid: ${JSON.stringify(SHA_2174)}, headRefName: ${JSON.stringify(STACK_BR_BOTTOM)}, baseRefName: 'master', state: 'OPEN', mergeStateStatus: 'CLEAN', reviewDecision: 'APPROVED' },
+  '2175': { number: 2175, headRefOid: ${JSON.stringify(SHA_2175)}, headRefName: ${JSON.stringify(STACK_BR_TOP)}, baseRefName: ${JSON.stringify(STACK_BR_BOTTOM)}, state: 'OPEN', mergeStateStatus: 'CLEAN', reviewDecision: 'APPROVED' },
+};
+if (process.argv[2] === 'pr' && process.argv[3] === 'view') {
+  process.stdout.write(JSON.stringify(prs[process.argv[4]]));
+  process.exit(0);
+}
+if (process.argv[2] === 'pr' && process.argv[3] === 'list') {
+  process.stdout.write(JSON.stringify(Object.values(prs)));
+  process.exit(0);
+}
+if (process.argv[2] === 'pr' && process.argv[3] === 'edit') {
+  fs.appendFileSync(log, process.argv.slice(2).join(' ') + '\\n');
+  process.exit(0);
+}
+process.stderr.write('unexpected gh args: ' + process.argv.slice(2).join(' ') + '\\n');
+process.exit(1);
+`);
+  createExecutable(join(bin, 'git'), `#!/usr/bin/env sh
+if [ "$1" = "cat-file" ]; then exit 0; fi
+echo "unexpected git args: $@" >&2
+exit 1
+`);
+  const res = spawnSync(process.execPath, ['scripts/land-stack.mjs', ...prNumbers, '--execute'], {
+    cwd: process.cwd(),
+    env: { ...process.env, PATH: `${bin}:${process.env.PATH ?? ''}` },
+    encoding: 'utf8',
+  });
+  return { res, edits: readFileSync(log, 'utf8').trim().split('\n').filter(Boolean) };
+}
+
+test('execute refuses to label a partial stack', () => {
+  const { res, edits } = runCli(['2174']);
+  assert.equal(res.status, 1, `${res.stdout}\n${res.stderr}`);
+  assert.match(res.stdout, /complete-stack/);
+  assert.deepEqual(edits, []);
+});
+
+test('execute labels every verified PR bottom-to-top', () => {
+  const { res, edits } = runCli(['2174', '2175']);
+  assert.equal(res.status, 0, `${res.stdout}\n${res.stderr}`);
+  assert.deepEqual(edits, [
+    'pr edit 2174 --add-label admin-bypass',
+    'pr edit 2175 --add-label admin-bypass',
+  ]);
 });
 
 console.log(`\n${passed} tests passed`);


### PR DESCRIPTION
## Summary

Stack landing now fails closed when only part of a Mergify stack is provided.

The old guard checked order, but it could still label only the bottom PR from a larger stack.

The fix discovers the full open stack before labeling anything, then labels every verified PR bottom-to-top.

<details>
<summary>Review metadata</summary>

Review Claim: The land-stack guard now refuses partial stacks and queues the complete verified stack.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: The script still exits before any GitHub write unless all checks pass.

Slice Rationale: This is one focused stack-landing policy change with its guard tests.

</details>

## Non-goals

This does not change Mergify rules, GitHub permissions, or PR review requirements.

## Architecture

### Before

```mermaid
graph TD
    A["User passes PR numbers"] --> B["Guard checks provided order"]
    B --> C["--execute labels bottom PR only"]
```

### After

```mermaid
graph TD
    A["User passes PR numbers"] --> B["Guard checks provided order"]
    B --> C["Guard discovers full open stack"]
    C --> D["Partial stack fails before writes"]
    C --> E["Complete stack labels every PR bottom-to-top"]
```

## Test Plan

- [x] `node scripts/test-land-stack.mjs`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit>`
- Post-revert steps: None
- Data migration? No
