### PR TITLE
[Runner Routing](1) Route Mergify checks to managed runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ env:
 
 jobs:
   build-artifacts:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     timeout-minutes: 30
 
     steps:
@@ -59,7 +60,8 @@ jobs:
           if-no-files-found: error
 
   quality-required:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -98,7 +100,8 @@ jobs:
 
   quality-extra:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -140,7 +143,8 @@ jobs:
   inv117-proof:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 120
@@ -205,7 +209,8 @@ jobs:
 
   required-fast:
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -274,7 +279,8 @@ jobs:
   required-fast-extra:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -351,7 +357,8 @@ jobs:
   scheduled-repros:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     timeout-minutes: 45
     name: scheduled / Fix Intent Repros
 
@@ -403,7 +410,8 @@ jobs:
 
   dry-run:
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
@@ -468,7 +476,8 @@ jobs:
 
   playwright:
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 45
@@ -544,7 +553,8 @@ jobs:
 
   ssh:
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
@@ -622,7 +632,8 @@ jobs:
 
   optional-other:
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -671,7 +682,8 @@ jobs:
   docker:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     timeout-minutes: 60
     name: docker / comprehensive
 

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -16,7 +16,8 @@ env:
 jobs:
   validate:
     name: PR Body
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: Runner_2_4_core
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Summary

CI now sends the Mergify-required jobs to the new managed runner pool.

The old workflow used `ubuntu-latest`, so merge-queue jobs would keep using GitHub's default runners instead of the pool we created.

This changes the CI and PR body workflows to target `Runner_2_4_core` directly.

<details>
<summary>Review metadata</summary>

Review Claim: Mergify-required CI checks now target the managed runner pool.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Only workflow runner selection changed. Job names, commands, conditions, and Mergify merge conditions stay the same.

Slice Rationale: This is a single CI policy change. Keeping it separate makes any runner issue easy to revert.

</details>

## Non-goals

- Does not change Mergify queue rules.
- Does not change test commands.
- Does not change release workflow runners.

## Test Plan

- [x] `node --input-type=module <<'NODE' ... NODE` verified all 17 Mergify-required checks target `Runner_2_4_core`.

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert <sha>`.
- Post-revert steps: None.
- Data migration? No.
