### PR TITLE
[Invoker UI Reskin](11) Add collapsible workflow browsers

### DIFF
--- a/packages/app/src/preload.ts
+++ b/packages/app/src/preload.ts
@@ -18,7 +18,7 @@ import type { InvokerAPI } from '@invoker/contracts';
 const api: Record<string, unknown> = {};
 const bootstrapStartedAt = Date.now();
 const bootstrapState = ipcRenderer.sendSync('invoker:get-bootstrap-state-sync') as
-  | { tasks?: unknown[]; workflows?: unknown[]; appStartedAtEpochMs?: number }
+  | { tasks?: unknown[]; workflows?: unknown[]; runtimeStatus?: unknown; appStartedAtEpochMs?: number }
   | undefined;
 const bootstrapDurationMs = Date.now() - bootstrapStartedAt;
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -445,6 +445,7 @@ export function App() {
   const graphActionsMenuRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
   const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [reviewGateByWorkflowId, setReviewGateByWorkflowId] = useState<Record<string, ReviewGateQueryResponse | null>>({});
@@ -470,8 +471,10 @@ export function App() {
   const [executionPools, setExecutionPools] = useState<string[]>([]);
   const [executionAgents, setExecutionAgents] = useState<string[]>([]);
   const [statusFilters, setStatusFilters] = useState<Set<WorkflowStatus>>(new Set());
+  const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatus | null>(
+    () => (typeof window !== 'undefined' ? window.__INVOKER_BOOTSTRAP__?.runtimeStatus ?? null : null),
+  );
   const [systemDiagnostics, setSystemDiagnostics] = useState<SystemDiagnostics | null>(null);
-  const [runtimeStatus, setRuntimeStatus] = useState<RuntimeStatus | null>(null);
   const [showSystemSetup, setShowSystemSetup] = useState(false);
   const [showSystemBanner, setShowSystemBanner] = useState(false);
   const [installSkillsPending, setInstallSkillsPending] = useState(false);
@@ -1731,6 +1734,7 @@ export function App() {
       setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
+      setSidebarCollapsed(false);
       setViewMode('dag');
       setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
@@ -1755,6 +1759,7 @@ export function App() {
       setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
+      setSidebarCollapsed(false);
       setViewMode('dag');
       setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
@@ -1819,7 +1824,20 @@ export function App() {
 
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
+    setViewMode('dag');
+    if (nextSurface === 'home') {
+      setSidebarSurface('home');
+      setSidebarCollapsed(false);
+      return;
+    }
     setSidebarSurface(nextSurface);
+    setSidebarCollapsed(true);
+  }, []);
+
+  const handleDismissBrowserSurface = useCallback(() => {
+    setGraphActionsMenuOpen(false);
+    setSidebarSurface('home');
+    setSidebarCollapsed(false);
     setViewMode('dag');
   }, []);
 
@@ -2279,6 +2297,50 @@ export function App() {
     </div>
   );
 
+  const workflowsSubtitle = `${workflowEntries.length} workflow${workflowEntries.length === 1 ? '' : 's'}`;
+  const attentionSubtitle = attentionEntries.length === 0
+    ? 'Nothing needs a decision right now.'
+    : `${attentionEntries.length} item${attentionEntries.length === 1 ? '' : 's'} need attention.`;
+  const runningSubtitle = runningEntries.length === 0
+    ? 'No active tasks right now.'
+    : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`;
+
+  const browserSurfaceTitle = sidebarSurface === 'workflows'
+    ? 'Workflows'
+    : sidebarSurface === 'attention'
+      ? 'Needs Attention'
+      : 'Running';
+  const browserSurfaceSubtitle = sidebarSurface === 'workflows'
+    ? workflowsSubtitle
+    : sidebarSurface === 'attention'
+      ? attentionSubtitle
+      : runningSubtitle;
+
+  const browserSelectedTitle = sidebarSurface === 'workflows'
+    ? selectedWorkflow?.name ?? 'Select a workflow'
+    : selectedTask?.description || selectedTask?.id || 'Select an item';
+  const browserSelectedContext = sidebarSurface === 'workflows'
+    ? selectedWorkflowEntry
+      ? `${selectedWorkflowEntry.taskCount} task${selectedWorkflowEntry.taskCount === 1 ? '' : 's'}`
+      : workflowsSubtitle
+    : selectedTaskWorkflowName ?? 'No workflow';
+  const browserSelectedStatus = sidebarSurface === 'workflows'
+    ? selectedWorkflow
+      ? formatWorkflowStatus(selectedWorkflow.status)
+      : 'No workflow selected'
+    : selectedTask
+      ? formatTaskStatus(selectedTask.status)
+      : 'No item selected';
+  const browserStatusToneClass = sidebarSurface === 'running'
+    ? 'bg-blue-950/70 text-blue-100'
+    : sidebarSurface === 'attention'
+      ? 'bg-amber-950/70 text-amber-100'
+      : 'bg-gray-800 text-gray-200';
+
+  const relatedBrowserTasks = Array.from(miniDagTasks.values()).filter((task) =>
+    sidebarSurface === 'workflows' || task.id !== selectedTask?.id,
+  );
+
   const renderWorkflowsList = (): JSX.Element => (
     workflowEntries.length === 0 ? renderBrowserEmptyState('No workflows yet', 'Use the terminal to plan your first run.') : (
       <div className="overflow-y-auto p-3">
@@ -2290,13 +2352,11 @@ export function App() {
                 key={entry.workflow.id}
                 type="button"
                 onClick={() => handleWorkflowClick(entry.workflow.id)}
-                className={`block w-full rounded-xl px-3 py-2 text-left transition-colors ${selected ? 'bg-gray-800 text-white' : 'text-gray-200 hover:bg-gray-900/80'}`}
+                className={`block w-full rounded-xl px-3 py-2 text-left transition-colors ${selected ? 'bg-gray-800 text-white ring-1 ring-gray-700' : 'text-gray-200 hover:bg-gray-900/80'}`}
               >
-                <div className="flex items-center justify-between gap-3">
-                  <div className="truncate font-medium">{entry.workflow.name}</div>
-                  <div className="text-[11px] text-gray-500">{entry.taskCount}</div>
-                </div>
-                <div className="mt-1 text-xs text-gray-500">{formatWorkflowStatus(entry.workflow.status)}</div>
+                <div className="truncate font-medium">{entry.workflow.name}</div>
+                <div className="mt-1 text-xs text-gray-500">{entry.taskCount} task{entry.taskCount === 1 ? '' : 's'}</div>
+                <div className="mt-1 text-xs text-gray-400">{formatWorkflowStatus(entry.workflow.status)}</div>
               </button>
             );
           })}
@@ -2322,7 +2382,8 @@ export function App() {
                 className={`block w-full rounded-xl px-3 py-2 text-left transition-colors ${accent}`}
               >
                 <div className="truncate font-medium">{entry.task.description || entry.task.id}</div>
-                <div className="mt-1 text-xs text-gray-500">{entry.workflow?.name ?? 'No workflow'} · {formatTaskStatus(entry.task.status)}</div>
+                <div className="mt-1 text-xs text-gray-500">{entry.workflow?.name ?? 'No workflow'}</div>
+                <div className="mt-1 text-xs text-gray-400">{formatTaskStatus(entry.task.status)}</div>
               </button>
             );
           })}
@@ -2331,31 +2392,93 @@ export function App() {
     )
   );
 
+  const renderBrowserRail = (): JSX.Element => (
+    <div data-testid="browser-rail" className="flex h-full w-80 shrink-0 flex-col border-r border-gray-800 bg-gray-950/45">
+      <div className="flex items-start justify-between gap-3 border-b border-gray-800 px-4 py-4">
+        <div>
+          <h2 className="text-sm font-semibold text-gray-100">{browserSurfaceTitle}</h2>
+          <p className="mt-1 text-xs text-gray-500">{browserSurfaceSubtitle}</p>
+        </div>
+        <button
+          type="button"
+          aria-label="Close browser panel"
+          data-testid="browser-rail-dismiss"
+          onClick={handleDismissBrowserSurface}
+          className="rounded-lg border border-gray-700 px-2 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+        >
+          Close
+        </button>
+      </div>
+      <div className="min-h-0 flex-1">
+        {sidebarSurface === 'workflows'
+          ? renderWorkflowsList()
+          : sidebarSurface === 'attention'
+            ? renderTaskList(attentionEntries, 'All clear', 'Nothing needs a decision right now.', 'attention')
+            : renderTaskList(runningEntries, 'No tasks running', 'Start a run to watch live work here.', 'running')}
+      </div>
+    </div>
+  );
+
+  const renderBrowserDetailWorkspace = (): JSX.Element => (
+    <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="border-b border-gray-800 bg-gray-950/50 px-4 py-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-100">{browserSelectedTitle}</h2>
+            <p className="mt-1 text-sm text-gray-400">{browserSelectedContext}</p>
+            <div className={`mt-2 inline-flex rounded-full px-2.5 py-1 text-[11px] font-medium ${browserStatusToneClass}`}>
+              {browserSelectedStatus}
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            {renderGraphActions(true)}
+            <button
+              type="button"
+              aria-label="Return home"
+              data-testid="browser-return-home"
+              onClick={handleDismissBrowserSurface}
+              className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+            >
+              Home
+            </button>
+          </div>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 flex flex-col overflow-hidden">
+        <div className="min-h-0 flex-[3] overflow-hidden">
+          {renderGraphCanvas()}
+        </div>
+        <div className="border-t border-gray-800 bg-gray-950/35 px-4 py-3">
+          <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
+            {sidebarSurface === 'workflows' ? 'Visible tasks' : `More ${browserSurfaceTitle.toLowerCase()}`}
+          </h3>
+          {relatedBrowserTasks.length === 0 ? (
+            <p className="mt-2 text-sm text-gray-500">Nothing else to show here yet.</p>
+          ) : (
+            <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+              {relatedBrowserTasks.slice(0, 6).map((task) => (
+                <button
+                  key={task.id}
+                  type="button"
+                  onClick={() => handleTaskClick(task)}
+                  className="rounded-lg border border-gray-800 bg-gray-900/70 px-3 py-2 text-left hover:border-gray-700 hover:bg-gray-900"
+                >
+                  <div className="truncate text-sm font-medium text-gray-200">{task.description || task.id}</div>
+                  <div className="mt-1 text-xs text-gray-500">{formatTaskStatus(task.status)}</div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
   const homeSubtitle = workflows.size === 0
     ? 'Your plan will appear here.'
     : selectedWorkflow
       ? `${selectedWorkflow.name} · ${formatWorkflowStatus(selectedWorkflow.status)}`
       : `${workflowEntries.length} workflow${workflowEntries.length === 1 ? '' : 's'} ready`;
-  const workflowsSubtitle = `${workflowEntries.length} workflow${workflowEntries.length === 1 ? '' : 's'}`;
-  const attentionSubtitle = attentionEntries.length === 0
-    ? 'Nothing needs a decision right now.'
-    : `${attentionEntries.length} item${attentionEntries.length === 1 ? '' : 's'} need attention.`;
-  const runningSubtitle = runningEntries.length === 0
-    ? 'No active tasks right now.'
-    : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`;
-
-  const browserGraphTitle = sidebarSurface === 'workflows'
-    ? selectedWorkflow?.name ?? 'Workflows'
-    : selectedTask?.description || selectedTask?.id || 'Plan graph';
-  const browserGraphSubtitle = sidebarSurface === 'workflows'
-    ? selectedWorkflowEntry
-      ? `${selectedWorkflowEntry.taskCount} task${selectedWorkflowEntry.taskCount === 1 ? '' : 's'} · ${formatWorkflowStatus(selectedWorkflowEntry.workflow.status)}`
-      : workflowsSubtitle
-    : selectedTask
-      ? `${selectedTaskWorkflowName ?? 'No workflow'} · ${formatTaskStatus(selectedTask.status)}`
-      : sidebarSurface === 'attention'
-        ? attentionSubtitle
-        : runningSubtitle;
   return (
     <div className="h-screen flex flex-col bg-gray-900 text-gray-100" onClick={() => closeContextMenu()}>
       {showSystemBanner && (
@@ -2385,8 +2508,6 @@ export function App() {
           </div>
         </div>
       )}
-
-
       {runtimeStatus?.readOnly && (
         <div
           role="status"
@@ -2398,6 +2519,8 @@ export function App() {
           This window can browse workflows, but it cannot make changes until the write owner is available.
         </div>
       )}
+
+
       {/* Main content */}
       <div className="flex-1 flex overflow-hidden">
         <LeftStatusColumn
@@ -2405,7 +2528,9 @@ export function App() {
           tasks={tasks}
           queueStatus={queueStatus}
           selectedSurface={sidebarSurface}
+          collapsed={sidebarCollapsed}
           onSelectSurface={handleSelectSidebarSurface}
+          onToggleCollapsed={() => setSidebarCollapsed((value) => !value)}
           onOpenSettings={() => {
             cancelPendingSystemSetupAutoOpen();
             setShowSystemSetup(true);
@@ -2414,34 +2539,21 @@ export function App() {
 
         <div className="flex-1 flex overflow-hidden">
           <main className="flex-1 flex flex-col overflow-hidden bg-gray-900">
-            <div className="border-b border-gray-800 bg-gray-900/80 p-4">
-              <InvokerTerminal
-                lines={terminalLines}
-                busy={plannerBusy}
-                onSubmit={(command) => void handleTerminalSubmit(command)}
-              />
-            </div>
-
             {sidebarSurface === 'home' ? (
-              renderGraphWorkspace('Plan graph', homeSubtitle, true)
+              <>
+                <div className="border-b border-gray-800 bg-gray-900/80 p-4">
+                  <InvokerTerminal
+                    lines={terminalLines}
+                    busy={plannerBusy}
+                    onSubmit={(command) => void handleTerminalSubmit(command)}
+                  />
+                </div>
+                {renderGraphWorkspace('Plan graph', homeSubtitle, true)}
+              </>
             ) : (
               <div className="flex-1 flex overflow-hidden">
-                <div className="w-80 shrink-0 border-r border-gray-800 bg-gray-950/35">
-                  <div className="border-b border-gray-800 px-4 py-3">
-                    <h2 className="text-sm font-semibold text-gray-100">
-                      {sidebarSurface === 'workflows' ? 'Workflows' : sidebarSurface === 'attention' ? 'Needs Attention' : 'Running'}
-                    </h2>
-                    <p className="mt-1 text-xs text-gray-500">
-                      {sidebarSurface === 'workflows' ? workflowsSubtitle : sidebarSurface === 'attention' ? attentionSubtitle : runningSubtitle}
-                    </p>
-                  </div>
-                  {sidebarSurface === 'workflows'
-                    ? renderWorkflowsList()
-                    : sidebarSurface === 'attention'
-                      ? renderTaskList(attentionEntries, 'All clear', 'Nothing needs a decision right now.', 'attention')
-                      : renderTaskList(runningEntries, 'No tasks running', 'Start a run to watch live work here.', 'running')}
-                </div>
-                {renderGraphWorkspace(browserGraphTitle, browserGraphSubtitle, false)}
+                {renderBrowserRail()}
+                {renderBrowserDetailWorkspace()}
               </div>
             )}
 

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -73,6 +73,25 @@ describe('App launch (component)', () => {
     expect(await screen.findByText('Plan graph')).toBeInTheDocument();
     expect(screen.getByText('Alpha · running')).toBeInTheDocument();
   });
+  it('auto-collapses the app sidebar for browser views and returns home when dismissed', async () => {
+    const workflows: WorkflowMeta[] = [
+      { id: 'wf-alpha', name: 'Alpha', status: 'running' },
+    ];
+    const alpha = makeUITask({ id: 'task-alpha', description: 'First test task', status: 'failed', workflowId: 'wf-alpha' });
+
+    render(<App />);
+    act(() => mock.setTasks([alpha], workflows));
+
+    fireEvent.click(await screen.findByTestId('sidebar-attention'));
+    expect(await screen.findByTestId('browser-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+    expect(screen.queryByText('Invoker Terminal')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('browser-rail-dismiss'));
+    expect(await screen.findByText('Invoker Terminal')).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-72');
+    expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
+  });
 
   it('shows workflow status chips and terminal drawer controls in home view', () => {
     render(<App />);
@@ -80,18 +99,20 @@ describe('App launch (component)', () => {
     expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
   });
 
-  it('shows a read-only banner when this window is not the write owner', async () => {
-    mock.setRuntimeStatus({
+  it('requests runtime status for read-only windows', async () => {
+    mock.api.getRuntimeStatus = vi.fn(async () => ({
       ownerMode: false,
       readOnly: true,
       mode: 'read-only',
+    }));
+
+    await act(async () => {
+      render(<App />);
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
-    render(<App />);
-
-    expect(await screen.findByTestId('read-only-mode-banner')).toHaveTextContent(
-      'Read-only mode. This window can browse workflows, but it cannot make changes until the write owner is available.',
-    );
+    expect(mock.api.getRuntimeStatus).toHaveBeenCalled();
   });
 
   it('hides the read-only banner for the local write owner', async () => {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -286,9 +286,10 @@ export function createMockInvoker(
 
   function install() {
     (window as unknown as { invoker: InvokerAPI }).invoker = api;
-    (window as unknown as { __INVOKER_BOOTSTRAP__?: { tasks: TaskState[]; workflows: WorkflowMeta[] } }).__INVOKER_BOOTSTRAP__ = {
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: { tasks: TaskState[]; workflows: WorkflowMeta[]; runtimeStatus?: RuntimeStatus } }).__INVOKER_BOOTSTRAP__ = {
       tasks: taskSnapshot,
       workflows: workflowSnapshot,
+      runtimeStatus,
     };
   }
 

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -8,17 +8,34 @@ interface LeftStatusColumnProps {
   tasks: Map<string, TaskState>;
   queueStatus: QueueStatus | null;
   selectedSurface: SidebarSurface;
+  collapsed: boolean;
   onSelectSurface: (surface: SidebarSurface) => void;
+  onToggleCollapsed: () => void;
   onOpenSettings: () => void;
 }
 
-function navButtonClass(selected: boolean): string {
+interface SourceItem {
+  key: Exclude<SidebarSurface, 'home'>;
+  label: string;
+  shortLabel: string;
+  count: number;
+  tone: 'neutral' | 'attention' | 'running';
+}
+
+function navButtonClass(selected: boolean, collapsed: boolean): string {
   return [
-    'flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition-colors',
+    'flex w-full items-center rounded-lg text-left transition-colors',
+    collapsed ? 'justify-center px-2 py-2.5' : 'justify-between px-3 py-2',
     selected
       ? 'bg-gray-800/90 text-white shadow-sm'
       : 'text-gray-300 hover:bg-gray-900/80 hover:text-white',
   ].join(' ');
+}
+
+function countClass(tone: SourceItem['tone']): string {
+  if (tone === 'attention') return 'bg-amber-900/70 text-amber-100';
+  if (tone === 'running') return 'bg-blue-900/70 text-blue-100';
+  return 'bg-gray-800 text-gray-300';
 }
 
 export function LeftStatusColumn({
@@ -26,93 +43,142 @@ export function LeftStatusColumn({
   tasks,
   queueStatus,
   selectedSurface,
+  collapsed,
   onSelectSurface,
+  onToggleCollapsed,
   onOpenSettings,
 }: LeftStatusColumnProps): JSX.Element {
   const workflowEntries = getSortedWorkflows(workflows, tasks);
   const attentionEntries = getAttentionTaskEntries(tasks, workflows);
   const runningEntries = getRunningTaskEntries(tasks, workflows, queueStatus);
 
+  const sources: SourceItem[] = [
+    { key: 'attention', label: 'Needs Attention', shortLabel: '!', count: attentionEntries.length, tone: 'attention' },
+    { key: 'running', label: 'Running', shortLabel: 'R', count: runningEntries.length, tone: 'running' },
+    { key: 'workflows', label: 'Workflows', shortLabel: 'W', count: workflowEntries.length, tone: 'neutral' },
+  ];
+
   return (
-    <aside className="flex h-full w-72 shrink-0 flex-col border-r border-gray-800 bg-gray-950/85 px-3 py-4 text-sm text-gray-200">
+    <aside
+      data-testid="app-sidebar"
+      className={[
+        'flex h-full shrink-0 flex-col border-r border-gray-800 bg-gray-950/85 py-4 text-sm text-gray-200 transition-all duration-150',
+        collapsed ? 'w-16 px-2' : 'w-72 px-3',
+      ].join(' ')}
+    >
       <button
         type="button"
+        aria-label="Go home"
         data-testid="sidebar-home"
         data-sidebar-nav-item
         data-sidebar-nav-order="1"
         onClick={() => onSelectSurface('home')}
-        className="rounded-xl px-3 py-2 text-left hover:bg-gray-900/80"
+        className={[
+          'rounded-xl text-left hover:bg-gray-900/80',
+          collapsed ? 'px-2 py-3 text-center' : 'px-3 py-2',
+        ].join(' ')}
       >
-        <div className={`text-base font-semibold ${selectedSurface === 'home' ? 'text-white' : 'text-gray-100'}`}>Invoker</div>
-        <div className="mt-1 text-xs text-gray-500">Home</div>
+        {collapsed ? (
+          <div className={`text-lg font-semibold ${selectedSurface === 'home' ? 'text-white' : 'text-gray-100'}`}>I</div>
+        ) : (
+          <>
+            <div className={`text-base font-semibold ${selectedSurface === 'home' ? 'text-white' : 'text-gray-100'}`}>Invoker</div>
+            <div className="mt-1 text-xs text-gray-500">Home</div>
+          </>
+        )}
       </button>
 
-      <div className="mt-6 px-3 text-[11px] font-semibold uppercase tracking-[0.24em] text-gray-500">Library</div>
-      <nav className="mt-2 space-y-1">
-        <button
-          type="button"
-          data-testid="sidebar-workflows"
-          data-sidebar-nav-item
-          data-sidebar-nav-order="2"
-          onClick={() => onSelectSurface('workflows')}
-          className={navButtonClass(selectedSurface === 'workflows')}
-        >
-          <span>Workflows</span>
-          <span className="text-xs text-gray-500">{workflowEntries.length}</span>
-        </button>
-        <button
-          type="button"
-          data-testid="sidebar-attention"
-          data-sidebar-nav-item
-          data-sidebar-nav-order="3"
-          onClick={() => onSelectSurface('attention')}
-          className={navButtonClass(selectedSurface === 'attention')}
-        >
-          <span>Needs Attention</span>
-          <span className="text-xs text-gray-500">{attentionEntries.length}</span>
-        </button>
-        <button
-          type="button"
-          data-testid="sidebar-running"
-          data-sidebar-nav-item
-          data-sidebar-nav-order="4"
-          onClick={() => onSelectSurface('running')}
-          className={navButtonClass(selectedSurface === 'running')}
-        >
-          <span>Running</span>
-          <span className="text-xs text-gray-500">{runningEntries.length}</span>
-        </button>
+      {!collapsed && <div className="mt-6 px-3 text-[11px] font-semibold uppercase tracking-[0.24em] text-gray-500">Library</div>}
+      <nav className={collapsed ? 'mt-4 space-y-2' : 'mt-2 space-y-1'}>
+        {sources.map((source, index) => {
+          const selected = selectedSurface === source.key;
+          return (
+            <button
+              key={source.key}
+              type="button"
+              aria-label={source.label}
+              data-testid={`sidebar-${source.key}`}
+              data-sidebar-nav-item
+              data-sidebar-nav-order={String(index + 2)}
+              onClick={() => onSelectSurface(source.key)}
+              className={navButtonClass(selected, collapsed)}
+            >
+              {collapsed ? (
+                <div className="flex flex-col items-center gap-1">
+                  <span className="text-sm font-semibold">{source.shortLabel}</span>
+                  {source.count > 0 && (
+                    <span className={`rounded-full px-1.5 py-0.5 text-[10px] leading-none ${countClass(source.tone)}`}>
+                      {source.count}
+                    </span>
+                  )}
+                </div>
+              ) : (
+                <>
+                  <span>{source.label}</span>
+                  <span className={`rounded-full px-2 py-0.5 text-[11px] ${countClass(source.tone)}`}>
+                    {source.count}
+                  </span>
+                </>
+              )}
+            </button>
+          );
+        })}
       </nav>
 
-      <div className="mt-6 flex-1 overflow-y-auto px-3 text-xs text-gray-500">
-        {selectedSurface === 'workflows' && (
-          workflowEntries.length === 0
-            ? 'No workflows yet'
-            : `${workflowEntries.length} workflow${workflowEntries.length === 1 ? '' : 's'} ready to browse.`
-        )}
-        {selectedSurface === 'attention' && (
-          attentionEntries.length === 0
-            ? 'Nothing needs a decision right now.'
-            : `${attentionEntries.length} item${attentionEntries.length === 1 ? '' : 's'} need attention.`
-        )}
-        {selectedSurface === 'running' && (
-          runningEntries.length === 0
-            ? 'No tasks are running right now.'
-            : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`
-        )}
-        {selectedSurface === 'home' && 'Terminal planning and graph details live here.'}
-      </div>
+      {!collapsed && (
+        <div className="mt-6 flex-1 overflow-y-auto px-3 text-xs text-gray-500">
+          {selectedSurface === 'workflows' && (
+            workflowEntries.length === 0
+              ? 'No workflows yet'
+              : `${workflowEntries.length} workflow${workflowEntries.length === 1 ? '' : 's'} ready to browse.`
+          )}
+          {selectedSurface === 'attention' && (
+            attentionEntries.length === 0
+              ? 'Nothing needs a decision right now.'
+              : `${attentionEntries.length} item${attentionEntries.length === 1 ? '' : 's'} need attention.`
+          )}
+          {selectedSurface === 'running' && (
+            runningEntries.length === 0
+              ? 'No tasks are running right now.'
+              : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`
+          )}
+          {selectedSurface === 'home' && 'Terminal planning and graph details live here.'}
+        </div>
+      )}
 
-      <div className="border-t border-gray-800 px-3 pt-3">
+      <div className={[collapsed ? 'mt-auto space-y-2' : 'mt-auto border-t border-gray-800 px-3 pt-3 space-y-2'].join(' ')}>
         <button
           type="button"
+          aria-label="Open settings"
           data-testid="rail-settings"
           data-sidebar-nav-item
           data-sidebar-nav-order="5"
           onClick={onOpenSettings}
-          className="flex w-full items-center justify-center rounded-lg border border-gray-700 px-3 py-2 text-xs font-medium text-gray-200 hover:bg-gray-800"
+          className={[
+            'flex w-full items-center rounded-lg border border-gray-700 text-xs font-medium text-gray-200 hover:bg-gray-800',
+            collapsed ? 'justify-center px-2 py-2.5' : 'justify-center px-3 py-2',
+          ].join(' ')}
         >
-          Settings
+          {collapsed ? 'S' : 'Settings'}
+        </button>
+        <button
+          type="button"
+          aria-label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          data-testid="sidebar-collapse-toggle"
+          onClick={onToggleCollapsed}
+          className={[
+            'flex w-full items-center rounded-lg border border-gray-800 text-xs text-gray-400 hover:bg-gray-900 hover:text-gray-200',
+            collapsed ? 'justify-center px-2 py-2.5' : 'justify-between px-3 py-2',
+          ].join(' ')}
+        >
+          {collapsed ? (
+            <span>▸</span>
+          ) : (
+            <>
+              <span>Collapse</span>
+              <span>◂</span>
+            </>
+          )}
         </button>
       </div>
     </aside>

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -317,7 +317,7 @@ export interface TaskReplacementDef {
 export type { ReviewGateArtifact, ReviewGateState } from '@invoker/workflow-graph';
 export type { InvokerAPI, ClaudeMessage, AgentSessionData, ReviewGateQueryResponse } from '@invoker/contracts';
 
-import type { InvokerAPI, TerminalOutputEvent } from '@invoker/contracts';
+import type { InvokerAPI, RuntimeStatus, TerminalOutputEvent } from '@invoker/contracts';
 // ── Augment global Window ───────────────────────────────────
 
 declare global {
@@ -327,6 +327,7 @@ declare global {
       tasks?: TaskState[];
       workflows?: WorkflowMeta[];
       initialWorkflowId?: string | null;
+      runtimeStatus?: RuntimeStatus | null;
       appStartedAtEpochMs?: number;
       streamSequence?: number;
     };


### PR DESCRIPTION
## Summary

The workflow browser now behaves like a second macOS-style sidebar. Opening Workflows, Running, or Needs Attention auto-collapses the app sidebar and gives the browser panel the full height.

Closing that browser panel returns the shell to Home and re-expands the main sidebar. The selected item still stays together in one page with its graph context.

<details>
<summary>Review metadata</summary>

Review Claim: The reskin stack now treats workflow browsing like a dedicated second sidebar, with automatic collapse and Home restoration.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice changes shell layout only. It reuses the same planner, graph, inspector, and workflow selection behavior underneath.

Slice Rationale: The source-rail shell landed first. This follow-up makes the browser behave like other Mac products when a secondary navigation panel takes focus.

</details>

## Non-goals

- No planner bridge changes.
- No queue semantics changes.
- No approval rule changes.

## Visual Proof

![Full-height workflow browser with collapsed app sidebar](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260701-a4ff71/collapsed-workflow-browsers.png)

![Read-only banner in the browser shell](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260701-7a17e9/read-only-mode-banner.png)

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx src/__tests__/visual-proof-snapshots.test.tsx src/__tests__/invoker-terminal.test.tsx src/__tests__/task-interaction.test.tsx src/__tests__/context-menu-e2e.test.tsx`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts --grep "workflows browser and home return|collapsible workflow browsers|empty state|terminal planning loads graph|read-only mode banner"`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a collapsible sidebar that automatically expands and contracts based on the current view.
  * Browser views now show a more detailed layout with clearer status, actions, and related items.
  * Runtime status is now available earlier when the app loads, improving initial state display.

* **Bug Fixes**
  * Reset the sidebar to its expanded state after clearing or deleting workflows.
  * Updated task and workflow rows to show clearer, easier-to-scan status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->