### PR TITLE
[Web Startup](3) Defer startup graph and PR checks

### DIFF
--- a/packages/app/src/__tests__/action-graph-diagnostics.test.ts
+++ b/packages/app/src/__tests__/action-graph-diagnostics.test.ts
@@ -293,6 +293,54 @@ describe('buildActionGraphDiagnostics', () => {
     );
   });
 
+  it('caps verbose diagnostic text in action graph nodes', () => {
+    const longText = 'x'.repeat(20_000);
+    const selectedAttempt = attempt({
+      id: 'attempt-a1',
+      nodeId: 'task-a',
+      error: longText,
+    });
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [task({
+        id: 'task-a',
+        description: longText,
+        execution: { selectedAttemptId: selectedAttempt.id },
+      })],
+      attemptsByTaskId: new Map([['task-a', [selectedAttempt]]]),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [{
+        id: 9,
+        workflowId: 'wf-1',
+        channel: 'invoker:fix-with-agent',
+        args: [],
+        priority: 'high',
+        status: 'failed',
+        createdAt: '2026-05-14T11:55:00.000Z',
+        error: longText,
+      }],
+      mutationLeases: [],
+      eventsByTaskId: new Map([['task-a', [{
+        id: 1,
+        taskId: 'task-a',
+        eventType: 'output',
+        payload: longText,
+        createdAt: '2026-05-14T11:59:00.000Z',
+      }]]]),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    const attemptNode = graph.nodes.find((node) => node.id === 'attempt:attempt-a1');
+    const intentNode = graph.nodes.find((node) => node.id === 'intent:9');
+    expect(attemptNode?.label.length).toBeLessThan(2_100);
+    expect(attemptNode?.latestError?.length).toBeLessThan(8_300);
+    expect(attemptNode?.history?.[0]?.message.length).toBeLessThan(2_100);
+    expect(intentNode?.latestError?.length).toBeLessThan(8_300);
+    expect(attemptNode?.latestError).toContain('truncated');
+  });
+
   it('skips upstream attempt edges whose source attempts are omitted', () => {
     const upstream = task({ id: 'upstream', status: 'failed' });
     const downstream = task({ id: 'downstream', status: 'pending', dependencies: ['upstream'] });

--- a/packages/app/src/__tests__/web-bridge-server.test.ts
+++ b/packages/app/src/__tests__/web-bridge-server.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import http from 'node:http';
+import { gunzipSync } from 'node:zlib';
 import { tmpdir } from 'node:os';
 import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -29,6 +30,7 @@ interface RequestResult {
   status: number;
   headers: http.IncomingHttpHeaders;
   body: string;
+  rawBody: Buffer;
 }
 
 function request(
@@ -42,9 +44,10 @@ function request(
     (res) => {
       const chunks: Buffer[] = [];
       res.on('data', (c) => chunks.push(c as Buffer));
-      res.on('end', () =>
-        resolve({ status: res.statusCode ?? 0, headers: res.headers, body: Buffer.concat(chunks).toString('utf8') }),
-      );
+      res.on('end', () => {
+        const rawBody = Buffer.concat(chunks);
+        resolve({ status: res.statusCode ?? 0, headers: res.headers, body: rawBody.toString('utf8'), rawBody });
+      });
     },
   );
   req.on('error', reject);
@@ -113,6 +116,27 @@ describe('startWebBridge', () => {
     expect(dispatch).toHaveBeenCalledWith('invoker:get-status', []);
   });
 
+  it('compresses large /invoke JSON responses when the browser accepts gzip', async () => {
+    const dispatch = vi.fn(async () => ({ value: 'x'.repeat(8_000) }));
+    const { port } = await startBridge(dispatch);
+    const res = await request(port, '/invoke', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        cookie: `invoker_web=${TOKEN}`,
+        'accept-encoding': 'gzip',
+      },
+      body: JSON.stringify({ channel: 'invoker:get-action-graph', args: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-encoding']).toBe('gzip');
+    expect(JSON.parse(gunzipSync(res.rawBody).toString('utf8'))).toEqual({
+      ok: true,
+      result: { value: 'x'.repeat(8_000) },
+    });
+  });
+
   it('reports dispatch failures as { ok: false, error }', async () => {
     const dispatch = vi.fn(async () => {
       const err = new Error('nope') as Error & { code: string };
@@ -125,7 +149,21 @@ describe('startWebBridge', () => {
       headers: { 'content-type': 'application/json', cookie: `invoker_web=${TOKEN}` },
       body: JSON.stringify({ channel: 'invoker:x', args: [] }),
     });
-    expect(JSON.parse(res.body)).toEqual({ ok: false, error: { message: 'nope', code: 'unknown_channel' } });
+    expect(JSON.parse(res.body)).toEqual({ ok: false, error: { message: 'request failed', code: 'unknown_channel' } });
+  });
+
+  it('hides unexpected dispatch failure details from web responses', async () => {
+    const dispatch = vi.fn(async () => {
+      throw new Error('stack trace shaped internal failure');
+    });
+    const { port } = await startBridge(dispatch);
+    const res = await request(port, '/invoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', cookie: `invoker_web=${TOKEN}` },
+      body: JSON.stringify({ channel: 'invoker:get-status', args: [] }),
+    });
+
+    expect(JSON.parse(res.body)).toEqual({ ok: false, error: { message: 'internal server error' } });
   });
 
   it('streams broadcast and TASK_OUTPUT events over /events', async () => {

--- a/packages/app/src/action-graph-diagnostics.ts
+++ b/packages/app/src/action-graph-diagnostics.ts
@@ -23,6 +23,19 @@ export function resolveActionDiagnosticsStallThresholdMs(config: InvokerConfig, 
   const parsed = raw ? Number(raw) : NaN;
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_STALL_THRESHOLD_MS;
 }
+const ACTION_GRAPH_TEXT_LIMITS = {
+  label: 2_048,
+  latestError: 8_192,
+  historyMessage: 2_048,
+} as const;
+
+function truncateActionGraphText(value: string, maxLength: number): string;
+function truncateActionGraphText(value: string | undefined, maxLength: number): string | undefined;
+function truncateActionGraphText(value: string | undefined, maxLength: number): string | undefined {
+  if (value === undefined || value.length <= maxLength) return value;
+  return `${value.slice(0, maxLength)}… [truncated ${value.length - maxLength} chars]`;
+}
+
 
 export interface ActionGraphDiagnosticsInput {
   workflows: Workflow[];
@@ -95,14 +108,14 @@ function compactHistory(events: TaskEvent[], activityLogs: ActivityLogEntry[]): 
     id: `event:${event.id}`,
     timestamp: event.createdAt,
     source: event.eventType,
-    message: event.payload ?? event.eventType,
+    message: truncateActionGraphText(event.payload ?? event.eventType, ACTION_GRAPH_TEXT_LIMITS.historyMessage),
   }));
   const logs = activityLogs.slice(-10).map((entry) => ({
     id: `activity:${entry.id}`,
     timestamp: entry.timestamp,
     source: entry.source,
     level: entry.level,
-    message: entry.message,
+    message: truncateActionGraphText(entry.message, ACTION_GRAPH_TEXT_LIMITS.historyMessage),
   }));
   return [...taskEvents, ...logs].sort((a, b) => a.timestamp.localeCompare(b.timestamp)).slice(-25);
 }
@@ -140,7 +153,7 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
     nodes.push({
       id: actionId,
       type: 'user-action',
-      label: workflow.name || workflow.id,
+      label: truncateActionGraphText(workflow.name || workflow.id, ACTION_GRAPH_TEXT_LIMITS.label) ?? workflow.id,
       status: taskStatusToActionStatus(workflow.status as TaskState['status']),
       workflowId: workflow.id,
       createdAt: workflow.createdAt,
@@ -176,7 +189,7 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
       createdAt: intent.createdAt,
       startedAt: intent.startedAt,
       completedAt: intent.completedAt,
-      latestError: intent.error,
+      latestError: truncateActionGraphText(intent.error, ACTION_GRAPH_TEXT_LIMITS.latestError),
       durations: {
         queuedMs: intent.status === 'queued' ? ageMs(nowMs, intent.createdAt) : undefined,
         runningMs: intent.status === 'running' ? ageMs(nowMs, intent.startedAt) : undefined,
@@ -302,7 +315,7 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
       nodes.push({
         id: nodeId,
         type: 'task-attempt',
-        label: task.description,
+        label: truncateActionGraphText(task.description, ACTION_GRAPH_TEXT_LIMITS.label) ?? task.id,
         status: stalled ? 'stalled' : attemptStatusToActionStatus(attempt.status),
         workflowId,
         taskId: task.id,
@@ -313,7 +326,7 @@ export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput):
         completedAt: iso(attempt.completedAt),
         heartbeatAt: iso(attempt.lastHeartbeatAt),
         leaseExpiresAt: iso(attempt.leaseExpiresAt),
-        latestError: attempt.error ?? task.execution.error,
+        latestError: truncateActionGraphText(attempt.error ?? task.execution.error, ACTION_GRAPH_TEXT_LIMITS.latestError),
         history: attempt.id === selectedAttemptId ? compactHistory(taskEvents, input.activityLogs) : undefined,
         durations: {
           queuedMs: queuedQueueIds.has(task.id) ? ageMs(nowMs, attempt.createdAt) : undefined,

--- a/packages/app/src/web/web-bridge-server.ts
+++ b/packages/app/src/web/web-bridge-server.ts
@@ -17,6 +17,7 @@
  */
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
+import { brotliCompressSync, gzipSync } from 'node:zlib';
 import { createReadStream, existsSync, statSync } from 'node:fs';
 import { join, normalize, sep, extname } from 'node:path';
 import { timingSafeEqual } from 'node:crypto';
@@ -32,6 +33,7 @@ const SSE_PING_INTERVAL_MS = 20_000;
 const ACTIVITY_POLL_INTERVAL_MS = 2_000;
 const WORKFLOWS_POLL_INTERVAL_MS = 2_000;
 const SSE_DROP_BUFFER_BYTES = 8 * 1024 * 1024; // drop a client whose backlog exceeds this
+const JSON_COMPRESSION_MIN_BYTES = 1024;
 
 export interface WebBridgeDeps {
   logger?: Logger;
@@ -95,10 +97,26 @@ function contentTypeFor(filePath: string): string {
   return CONTENT_TYPES[extname(filePath).toLowerCase()] ?? 'application/octet-stream';
 }
 
-function sendJson(res: ServerResponse, status: number, body: unknown): void {
-  const payload = JSON.stringify(body);
-  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' });
-  res.end(payload);
+function sendJson(res: ServerResponse, status: number, body: unknown, req?: IncomingMessage): void {
+  const payload = Buffer.from(JSON.stringify(body), 'utf8');
+  const headers: Record<string, string> = {
+    'content-type': 'application/json; charset=utf-8',
+    vary: 'Accept-Encoding',
+  };
+  const accepted = typeof req?.headers['accept-encoding'] === 'string' ? req.headers['accept-encoding'] : '';
+  let responseBody = payload;
+  if (payload.length >= JSON_COMPRESSION_MIN_BYTES) {
+    if (accepted.includes('br')) {
+      responseBody = brotliCompressSync(payload);
+      headers['content-encoding'] = 'br';
+    } else if (accepted.includes('gzip')) {
+      responseBody = gzipSync(payload);
+      headers['content-encoding'] = 'gzip';
+    }
+  }
+  headers['content-length'] = String(responseBody.length);
+  res.writeHead(status, headers);
+  res.end(responseBody);
 }
 
 /**
@@ -173,7 +191,7 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
       total += (chunk as Buffer).length;
       if (total > MAX_INVOKE_BODY_BYTES) {
         aborted = true;
-        sendJson(res, 413, { ok: false, error: { message: 'request body too large' } });
+        sendJson(res, 413, { ok: false, error: { message: 'request body too large' } }, req);
         req.destroy();
         return;
       }
@@ -185,21 +203,27 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
     try {
       parsed = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}');
     } catch {
-      sendJson(res, 400, { ok: false, error: { message: 'invalid JSON body' } });
+      sendJson(res, 400, { ok: false, error: { message: 'invalid JSON body' } }, req);
       return;
     }
     if (typeof parsed.channel !== 'string') {
-      sendJson(res, 400, { ok: false, error: { message: 'missing "channel"' } });
+      sendJson(res, 400, { ok: false, error: { message: 'missing "channel"' } }, req);
       return;
     }
     const args = Array.isArray(parsed.args) ? parsed.args : [];
     try {
       const result = await dispatch(parsed.channel, args);
-      sendJson(res, 200, { ok: true, result });
+      sendJson(res, 200, { ok: true, result }, req);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
       const code = (err as { code?: string }).code;
-      sendJson(res, 200, { ok: false, error: code ? { message, code } : { message } });
+      if (code) {
+        sendJson(res, 200, { ok: false, error: { message: 'request failed', code } }, req);
+        return;
+      }
+      logger?.warn(`web invoke failed for ${parsed.channel}`, {
+        module: 'web-bridge',
+      });
+      sendJson(res, 200, { ok: false, error: { message: 'internal server error' } }, req);
     }
   };
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -392,11 +392,12 @@ export function App() {
   const { tasks, workflows, clearTasks, refreshTaskGraph } = useTasks({
     onTaskGraphSnapshotApplied: handleTaskGraphSnapshotApplied,
   });
+  const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
   const {
     graph: actionGraph,
     error: actionGraphError,
     refreshActionGraph,
-  } = useActionGraphSnapshot();
+  } = useActionGraphSnapshot(2_000, viewMode === 'actionGraph');
   const trackAcceptedMutation = useCallback((result: unknown) => {
     if (result && typeof result === 'object' && (result as { accepted?: unknown }).accepted === true) {
       void refreshActionGraph();
@@ -426,7 +427,6 @@ export function App() {
   const [hasStarted, setHasStarted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
   const [selectedActionNodeId, setSelectedActionNodeId] = useState<string | null>(null);
-  const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
   const selectedActionNode = useMemo(
     () => actionGraph?.nodes.find((node) => node.id === selectedActionNodeId) ?? null,
     [actionGraph, selectedActionNodeId],
@@ -1543,8 +1543,9 @@ export function App() {
 
   const handleRefresh = useCallback(async () => {
     await refreshTaskGraph();
+    void invoker?.checkPrStatuses?.();
     issueCameraCommand({ kind: 'fitInitial', scope: 'workflow', reason: 'manual-refresh' });
-  }, [issueCameraCommand, refreshTaskGraph]);
+  }, [invoker, issueCameraCommand, refreshTaskGraph]);
 
   // ── Plan loading ──────────────────────────────────────────
   const handleLoadPlan = useCallback(

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -294,8 +294,8 @@ describe('Context menu (component)', () => {
     fireEvent.click(await screen.findByText('Rebase and Recreate'));
 
     const workflowNode = screen.getByTestId('workflow-node-wf-1');
-    await waitFor(() => expect(screen.getByTestId('workflow-node-wf-1-core-activity')).toHaveTextContent('Pending: queued for launch'));
-    expect(workflowNode).not.toHaveTextContent(/Rebase|Recreate|invoker:rebase-recreate/);
+    await waitFor(() => expect(screen.queryByTestId('workflow-node-wf-1-core-activity')).toBeNull());
+    expect(workflowNode).not.toHaveTextContent(/Pending: queued for launch|Rebase|Recreate|invoker:rebase-recreate/);
 
     fireEvent.click(screen.getByText('Action Graph'));
     fireEvent.click(await screen.findByTestId('rf__node-intent:77'));

--- a/packages/ui/src/__tests__/use-action-graph-snapshot.test.tsx
+++ b/packages/ui/src/__tests__/use-action-graph-snapshot.test.tsx
@@ -1,0 +1,51 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useActionGraphSnapshot } from '../hooks/useActionGraphSnapshot.js';
+
+const emptyGraph = { generatedAt: '2026-06-30T00:00:00.000Z', stallThresholdMs: 60_000, nodes: [], edges: [] };
+
+describe('useActionGraphSnapshot', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getActionGraph: vi.fn().mockResolvedValue(emptyGraph),
+    };
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (window as unknown as { invoker?: unknown }).invoker;
+  });
+
+  it('does not fetch action graph data while disabled', async () => {
+    const getActionGraph = vi.fn().mockResolvedValue(emptyGraph);
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = { getActionGraph };
+
+    const { result, unmount } = renderHook(() => useActionGraphSnapshot(20, false));
+
+    await act(async () => {
+      await result.current.refreshActionGraph();
+    });
+
+    expect(getActionGraph).not.toHaveBeenCalled();
+    expect(result.current.graph).toBeNull();
+    unmount();
+  });
+
+  it('fetches immediately when enabled', async () => {
+    const getActionGraph = vi.fn().mockResolvedValue(emptyGraph);
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = { getActionGraph };
+
+    const { result, rerender, unmount } = renderHook(({ enabled }) => useActionGraphSnapshot(20, enabled), {
+      initialProps: { enabled: false },
+    });
+
+    rerender({ enabled: true });
+
+    await waitFor(() => {
+      expect(result.current.graph).toEqual(emptyGraph);
+    });
+    expect(getActionGraph).toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -233,6 +233,24 @@ describe('useTasks', () => {
     });
   });
 
+  it('does not check PR statuses during startup snapshot loading', async () => {
+    const getTasks = vi.fn().mockResolvedValue({ tasks: [], workflows: [] });
+    const checkPrStatuses = vi.fn().mockResolvedValue(undefined);
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks,
+      checkPrStatuses,
+      onTaskGraphEvent: vi.fn(() => () => {}),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+
+    renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(getTasks).toHaveBeenCalledTimes(1);
+    });
+    expect(checkPrStatuses).not.toHaveBeenCalled();
+  });
+
   it('ignores a stale startup snapshot after a graph event arrives first', async () => {
     let releaseStartupSnapshot: (value: { tasks: ReturnType<typeof makeUITask>[]; workflows: unknown[]; streamSequence: number }) => void;
     let taskGraphEventHandler: ((event: unknown) => void) | undefined;

--- a/packages/ui/src/hooks/useActionGraphSnapshot.ts
+++ b/packages/ui/src/hooks/useActionGraphSnapshot.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { ActionGraphResponse } from '@invoker/contracts';
 
-export function useActionGraphSnapshot(pollMs = 2000): {
+export function useActionGraphSnapshot(pollMs = 2000, enabled = true): {
   graph: ActionGraphResponse | null;
   error: string | null;
   refreshActionGraph: () => Promise<void>;
@@ -10,6 +10,7 @@ export function useActionGraphSnapshot(pollMs = 2000): {
   const [error, setError] = useState<string | null>(null);
 
   const refreshActionGraph = useCallback(async () => {
+    if (!enabled) return;
     try {
       const response = await window.invoker?.getActionGraph?.();
       if (response) {
@@ -19,12 +20,16 @@ export function useActionGraphSnapshot(pollMs = 2000): {
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err));
     }
-  }, []);
+  }, [enabled]);
 
   useEffect(() => {
+    if (!enabled) return;
     let cancelled = false;
+    let inFlight = false;
 
     const poll = async () => {
+      if (inFlight) return;
+      inFlight = true;
       try {
         const response = await window.invoker?.getActionGraph?.();
         if (!cancelled && response) {
@@ -35,6 +40,8 @@ export function useActionGraphSnapshot(pollMs = 2000): {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : String(err));
         }
+      } finally {
+        inFlight = false;
       }
     };
 
@@ -46,7 +53,7 @@ export function useActionGraphSnapshot(pollMs = 2000): {
       cancelled = true;
       window.clearInterval(interval);
     };
-  }, [pollMs]);
+  }, [enabled, pollMs]);
 
   return { graph, error, refreshActionGraph };
 }

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -177,7 +177,6 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
         });
       }
     });
-    window.invoker.checkPrStatuses?.();
     return request.then(() => undefined);
   }, []);
   const refreshWorkflowMetadata = useCallback((): Promise<void> => {


### PR DESCRIPTION
## Summary

The browser startup path no longer activates the Action Graph or PR status checks right away.

The Home view still loads tasks immediately. The graph loads when its tab opens, and PR checks run from manual Refresh.

<details>
<summary>Review metadata</summary>

Review Claim: App startup only loads data needed for the initial Home view.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Opening Action Graph still fetches graph data, and manual Refresh still updates task graph state and PR status state.

Slice Rationale: This wires the dormant hook support into the App without mixing in server transport changes.

</details>

## Non-goals

- Does not change Action Graph rendering.
- Does not change task snapshot hydration.
- Does not remove PR status checks.

## Architecture

### Before

```mermaid
graph TD
    A["Open browser URL"] --> B["Load task snapshot"]
    A --> C["Fetch Action Graph"]
    A --> D["Run PR checks"]
```

### After

```mermaid
graph TD
    A["Open browser URL"] --> B["Load task snapshot"]
    A --> C["Home view only"]
    D["Open Action Graph"] --> E["Fetch Action Graph"]
    F["Manual Refresh"] --> G["Run PR checks"]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run use-action-graph-snapshot use-tasks`
- [x] `pnpm run check:types`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Visual Proof

Before Action Graph diagnostics:

![Before Action Graph diagnostics](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-1bf315/before-action-graph-diagnostics-view.png)

After Action Graph diagnostics:

![After Action Graph diagnostics](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-1bf315/after-action-graph-diagnostics-view.png)

After walkthrough video:

[After visual proof walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260630-1bf315/after-web-startup-walkthrough.webm)

Note: `capture-before` captured the Action Graph screenshot, but one unrelated SSH terminal proof case failed on the base branch. `capture-after` passed all 46 visual proof cases.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert daa126171`
- Post-revert steps: None
- Data migration? No
