### PR TITLE
[CI Runners](1) Route SSH to DO2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,8 +553,7 @@ jobs:
 
   ssh:
     needs: build-artifacts
-    runs-on:
-      labels: Runner_2_4_core
+    runs-on: [self-hosted, Linux, X64, do2-ssh-only]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60


### PR DESCRIPTION
## Summary

This routes the queued SSH CI jobs to a dedicated DO2 self-hosted runner label.

Those two required jobs are a safe first slice for bringing DO2 into the merge path.

<details>
<summary>Review metadata</summary>

Review Claim: The workflow now schedules SSH merge-gate checks on the dedicated DO2 SSH-only runner instead of shared hosted Linux capacity.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Only `runs-on` changes for existing SSH jobs. Job names, scripts, containers, and merge requirements stay the same.

Slice Rationale: This is the safest first DO2 rollout. It adds one dedicated runner label without sharing the slot with older DO2 experiments or forcing a single machine to absorb the whole Playwright fan-out.

</details>

## Non-goals

This does not move Playwright, dry-run, or other required jobs.

This does not add more droplets or change runner size.

This does not change any test commands.

## Test Plan

- [x] `node -e "const fs=require('fs'); const yaml=require('yaml'); const doc=yaml.parse(fs.readFileSync('.github/workflows/ci.yml','utf8')); console.log(JSON.stringify({playwright: doc.jobs.playwright['runs-on'], ssh: doc.jobs.ssh['runs-on']}, null, 2));"`
- [x] `gh api repos/Neko-Catpital-Labs/Invoker/actions/runners --jq '.runners[] | select(.name=="invoker-do2-gha-ssh") | {name,status,labels:[.labels[].name]}'`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 4a2aa164b`
- Post-revert steps: None
- Data migration? No
