### PR TITLE
[SQLite WAL Read Guard](2) Prove the live follower hazard

### DIFF
--- a/scripts/repro/repro-readonly-follower-live-wal.sh
+++ b/scripts/repro/repro-readonly-follower-live-wal.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${ROOT_OVERRIDE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+cd "$ROOT"
+
+EXPECT_PATCHED_GUARD="${EXPECT_PATCHED_GUARD:-1}"
+if [[ "$EXPECT_PATCHED_GUARD" != "0" && "$EXPECT_PATCHED_GUARD" != "1" ]]; then
+  echo "EXPECT_PATCHED_GUARD must be 0 or 1" >&2
+  exit 1
+fi
+
+pnpm --filter @invoker/data-store build >/dev/null
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-live-wal-repro.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+DB_PATH="$TMP_DIR/invoker.db"
+
+export REPRO_DB_PATH="$DB_PATH"
+export ROOT EXPECT_PATCHED_GUARD
+
+node --input-type=module <<'NODE'
+import { existsSync } from 'node:fs';
+import { DatabaseSync } from 'node:sqlite';
+
+const { SQLiteAdapter } = await import(`${process.env.ROOT}/packages/data-store/dist/index.js`);
+const dbPath = process.env.REPRO_DB_PATH;
+const sidecars = () => ({
+  wal: existsSync(`${dbPath}-wal`),
+  shm: existsSync(`${dbPath}-shm`),
+});
+
+const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+owner.saveWorkflow({
+  id: 'wf-live-wal',
+  name: 'wf-live-wal',
+  status: 'running',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+});
+
+const whileOwnerOpen = sidecars();
+if (!whileOwnerOpen.wal || !whileOwnerOpen.shm) {
+  throw new Error(`expected live WAL sidecars while owner is open, got ${JSON.stringify(whileOwnerOpen)}`);
+}
+console.log(`[repro] live owner open sidecars wal=${whileOwnerOpen.wal} shm=${whileOwnerOpen.shm}`);
+
+// This is the old unsafe follower path: a second process opens the live DB directly.
+const unsafeFollower = new DatabaseSync(dbPath, { readOnly: true });
+const rows = unsafeFollower.prepare('SELECT id FROM workflows').all();
+unsafeFollower.close();
+console.log(`[repro] old follower path can read live DB directly rows=${rows.length}`);
+
+const expectPatchedGuard = process.env.EXPECT_PATCHED_GUARD === '1';
+let patchedReaderRows = null;
+let blocked = false;
+try {
+  const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
+  patchedReaderRows = reader.listWorkflows().length;
+  reader.close();
+} catch (error) {
+  blocked = /WAL sidecars exist/i.test(String(error));
+  console.log(`[repro] adapter read-only open result: ${String(error)}`);
+}
+
+if (expectPatchedGuard) {
+  if (!blocked) {
+    throw new Error('patched adapter did not reject read-only open while live WAL sidecars existed');
+  }
+  console.log('[repro] patched guard blocked the live follower path');
+} else {
+  if (blocked || patchedReaderRows !== 1) {
+    throw new Error(`pre-fix branch no longer reproduces the unsafe follower path (blocked=${blocked} rows=${patchedReaderRows})`);
+  }
+  console.log(`[repro] pre-fix branch allowed live follower attach rows=${patchedReaderRows}`);
+}
+
+owner.close();
+const afterOwnerClose = sidecars();
+if (afterOwnerClose.wal || afterOwnerClose.shm) {
+  throw new Error(`expected sidecars gone after owner close, got ${JSON.stringify(afterOwnerClose)}`);
+}
+console.log(`[repro] owner closed sidecars wal=${afterOwnerClose.wal} shm=${afterOwnerClose.shm}`);
+
+const safeReader = await SQLiteAdapter.create(dbPath, { readOnly: true });
+const safeRows = safeReader.listWorkflows();
+safeReader.close();
+console.log(`[repro] offline read-only open still works rows=${safeRows.length}`);
+console.log('[repro] passed');
+NODE


### PR DESCRIPTION
## Summary

This adds a repro script for the live SQLite WAL follower hazard.

The script shows the unsafe old mechanism directly. A second process can open `invoker.db` read-only while the owner still has live WAL sidecars.

It then proves the fix. On the patched branch the adapter rejects that read-only open, and after the owner closes cleanly, offline read-only opens still work.

The same script also runs against a pre-fix checkout with `EXPECT_PATCHED_GUARD=0`, proving the old branch allowed the live follower attach.

<details>
<summary>Review metadata</summary>

Review Claim: The repro script demonstrates the exact live-WAL follower hazard and the new fail-closed behavior.

Review Lane: proof

Review Unit: proof

Safety Invariant: This slice adds proof only. It does not change runtime behavior.

Slice Rationale: The behavior fix is already isolated in the base PR. The repro script is separate so review can judge proof on its own.

</details>

## Non-goals

- Change runtime behavior.
- Add new production guards.
- Reconstruct corrupt databases.

## Test Plan

- [x] `scripts/repro/repro-readonly-follower-live-wal.sh`
- [x] `ROOT_OVERRIDE=/tmp/invoker-prefx-branch.egiKoz EXPECT_PATCHED_GUARD=0 scripts/repro/repro-readonly-follower-live-wal.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 1514699cf`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a new repro script that creates a temporary SQLite database with live WAL sidecar files and verifies guard behavior.
  * Confirms that read-only access is blocked while an owner connection is actively using the database, and allowed again once the owner closes it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->