### PR TITLE
[SQLite WAL Read Guard](3) Run the live WAL repro in CI

### DIFF
--- a/scripts/test-suites/required/28-sqlite-live-wal-repro.sh
+++ b/scripts/test-suites/required/28-sqlite-live-wal-repro.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Required proof coverage for the live SQLite WAL follower hazard.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+exec bash scripts/repro/repro-readonly-follower-live-wal.sh


### PR DESCRIPTION
## Summary

This wires the live SQLite WAL repro into the required test suite registry.

CI already runs `bash scripts/run-all-tests.sh`, and that runner executes every `scripts/test-suites/required/*.sh` suite.

This adds a thin required wrapper for the repro script, so the proof now runs on the default CI surface instead of only by hand.

<details>
<summary>Review metadata</summary>

Review Claim: The live WAL repro now runs automatically in the required CI suite.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This only changes test-suite registration. No product or runtime code changes.

Slice Rationale: CI wiring is separate from both the behavior change and the proof script itself.

</details>

## Non-goals

- Change runtime behavior.
- Change the repro script logic.
- Add new merge-queue jobs.

## Test Plan

- [x] `scripts/test-suites/required/28-sqlite-live-wal-repro.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a290763b1`
- Post-revert steps: None
- Data migration? No
