### PR TITLE
[SQLite WAL Read Guard](3) Run the live WAL repro in CI

### DIFF
--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -130,13 +130,13 @@ expected_discovered_for_mode() {
   fi
   case "$MODE_KEY" in
     required)
-      printf '22'
+      printf '23'
       ;;
     extended)
-      printf '29'
+      printf '30'
       ;;
     dangerous)
-      printf '30'
+      printf '31'
       ;;
   esac
 }


### PR DESCRIPTION
## Summary

This wires the live SQLite WAL repro into the required test suite registry.

CI already runs `bash scripts/run-all-tests.sh`, and that runner executes every `scripts/test-suites/required/*.sh` suite.

This adds a thin required wrapper for the repro script, so the proof now runs on the default CI surface instead of only by hand.

<details>
<summary>Review metadata</summary>

Review Claim: The live WAL repro now runs automatically in the required CI suite.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This only changes test-suite registration. No product or runtime code changes.

Slice Rationale: CI wiring is separate from both the behavior change and the proof script itself.

</details>

## Non-goals

- Change runtime behavior.
- Change the repro script logic.
- Add new merge-queue jobs.

## Test Plan

- [x] `scripts/test-suites/required/28-sqlite-live-wal-repro.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert bfc26e5d7`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a required test wrapper to cover a live SQLite WAL follower hazard scenario.
  * Executes the existing live-WAL repro flow with stricter error handling and the safety check enabled to ensure the scenario is validated during automated testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->