### PR TITLE
[Invoker UI Reskin](13) Refine needs-attention browser

### DIFF
--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -219,10 +219,10 @@ describe('ipc-registration', () => {
       getTasks: () => [{ id: 'task-1' } as any],
       getWorkflows: () => [{ id: 'workflow-1' }],
       getInitialWorkflowId: () => 'workflow-1',
+      getRuntimeStatus: () => ({ ownerMode: true, readOnly: false, mode: 'local-owner' }),
       appStartedAtEpochMs: 123,
       getTaskDeltaStreamSequence: () => 7,
       recordStartupDuration,
-      getRuntimeStatus: () => ({ ownerMode: true, readOnly: false, mode: 'local-owner' }),
     });
 
     const event: { returnValue?: unknown } = {};
@@ -232,9 +232,9 @@ describe('ipc-registration', () => {
       tasks: [{ id: 'task-1' }],
       workflows: [{ id: 'workflow-1' }],
       initialWorkflowId: 'workflow-1',
+      runtimeStatus: { ownerMode: true, readOnly: false, mode: 'local-owner' },
       appStartedAtEpochMs: 123,
       streamSequence: 7,
-      runtimeStatus: { ownerMode: true, readOnly: false, mode: 'local-owner' },
     });
     expect(recordStartupDuration).toHaveBeenCalledWith(
       'bootstrap-ipc.serialize-return',

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -484,6 +484,7 @@ export function App() {
   const [setupResult, setSetupResult] = useState<InvokerSetupResult | null>(null);
   const [updateCliError, setUpdateCliError] = useState<string | null>(null);
   const [inspectorCollapsed, setInspectorCollapsed] = useState(false);
+  const [viewportWidth, setViewportWidth] = useState(() => (typeof window === 'undefined' ? 1600 : window.innerWidth));
   const [advancedMetadataExpanded, setAdvancedMetadataExpanded] = useState(false);
   const [terminalDrawerState, setTerminalDrawerState] = useState<TerminalDrawerState>('minimized');
   const [terminalSessions, setTerminalSessions] = useState<TerminalSessionDescriptor[]>([]);
@@ -1362,6 +1363,38 @@ export function App() {
     sidebarSurface,
     workflowEntries,
   ]);
+  useEffect(() => {
+    if (viewMode !== 'dag' || sidebarSurface === 'home' || displayedSelectedWorkflowGraph === null) {
+      return;
+    }
+
+    let cancelled = false;
+    const fitFrame = requestAnimationFrame(() => {
+      if (cancelled) return;
+      issueCameraCommand({ kind: 'fitInitial', scope: 'task', reason: 'browser-surface' });
+
+      if (!selectedTaskId) return;
+      requestAnimationFrame(() => {
+        if (cancelled) return;
+        requestAnimationFrame(() => {
+          if (cancelled) return;
+          issueCameraCommand({ kind: 'centerSelection', scope: 'task', target: selectedTaskId, reason: 'browser-selection' });
+        });
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(fitFrame);
+    };
+  }, [
+    displayedSelectedWorkflowGraph,
+    issueCameraCommand,
+    selectedTaskId,
+    sidebarSurface,
+    viewMode,
+  ]);
+
 
   const handleDagSurfaceClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
     if (contextMenu || workflowContextMenu) {
@@ -1784,8 +1817,15 @@ export function App() {
   const showStart = hasLoadedPlan && !hasStarted;
   const showStop = hasStarted && !allSettled;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
+  const autoCollapseInspector = sidebarSurface !== 'home' && viewportWidth < 1440;
+  const effectiveInspectorCollapsed = inspectorCollapsed || autoCollapseInspector;
   const showInspectorPlaceholder = !showEmptyGraphTutorial && !selectedTask && !selectedWorkflow && !(viewMode === 'actionGraph' && selectedActionNode);
 
+  useEffect(() => {
+    const handleResize = () => setViewportWidth(window.innerWidth);
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
   useEffect(() => {
     if (!graphActionsMenuOpen) return undefined;
     const handlePointerDown = (event: PointerEvent) => {
@@ -2190,6 +2230,70 @@ export function App() {
     </div>
   );
 
+  const renderSelectedWorkflowTaskGraph = (floating: boolean): JSX.Element | null => {
+    if (displayedSelectedWorkflowGraph === null) return null;
+
+    const graphBody = (
+      <div
+        data-keyboard-region="taskGraph"
+        tabIndex={0}
+        data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
+        className={`flex h-full min-h-0 flex-1 outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
+      >
+        {isSelectedWorkflowGraphRefreshing && (
+          <div data-testid="selected-workflow-mini-dag-refreshing" className="px-2 py-1 text-xs text-amber-200">
+            Refreshing graph…
+          </div>
+        )}
+        <TaskDAG
+          key={`${displayedSelectedWorkflowGraph.workflow.id}-${floating ? 'floating' : 'browser'}`}
+          tasks={displayedSelectedWorkflowGraph.tasks}
+          workflows={selectedTaskDagWorkflows}
+          selectedTaskId={selectedTaskId}
+          cameraCommand={cameraCommand}
+          onTaskClick={handleTaskClick}
+          onTaskDoubleClick={handleTaskDoubleClick}
+          onTaskContextMenu={handleTaskContextMenu}
+          onManualViewport={handleManualViewport}
+          statusFilters={new Set<string>()}
+          runningTaskIds={runningTaskIds}
+          surfaceMode={floating ? 'default' : 'browser'}
+        />
+      </div>
+    );
+
+    if (floating) {
+      return (
+        <FloatingGraphPanel
+          key={displayedSelectedWorkflowGraph.workflow.id}
+          testId="selected-workflow-mini-dag"
+          dragHandleTestId="selected-workflow-mini-dag-drag-handle"
+          title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
+          boundsRef={graphSurfaceRef as unknown as RefObject<HTMLElement>}
+          contentClassName="h-[250px]"
+        >
+          {graphBody}
+        </FloatingGraphPanel>
+      );
+    }
+
+    return (
+      <div className="flex h-full min-h-0 flex-col p-4">
+        <div
+          data-testid="selected-workflow-mini-dag"
+          className="flex min-h-0 flex-1 flex-col overflow-hidden rounded border border-gray-700 bg-gray-900/95 shadow-lg"
+        >
+          <div className="border-b border-gray-700 px-3 py-2 text-[11px] text-gray-300">
+            {displayedSelectedWorkflowGraph.workflow.name} task DAG
+          </div>
+          <div className="flex min-h-0 flex-1 flex-col">
+            {graphBody}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
   const renderGraphCanvas = (): JSX.Element => (
     <div
       ref={graphSurfaceRef}
@@ -2225,51 +2329,19 @@ export function App() {
         />
       ) : (
         <>
-          <WorkflowGraph
-            workflows={workflows}
-            selectedWorkflowId={selectedWorkflow?.id ?? null}
-            cameraCommand={cameraCommand}
-            statusFilters={statusFilters}
-            coreActivityByWorkflow={coreActivityByWorkflow}
-            onSelectWorkflow={handleWorkflowClick}
-            onWorkflowContextMenu={handleWorkflowContextMenu}
-            onManualViewport={handleManualViewport}
-          />
-          {displayedSelectedWorkflowGraph !== null && (
-            <FloatingGraphPanel
-              key={displayedSelectedWorkflowGraph.workflow.id}
-              testId="selected-workflow-mini-dag"
-              dragHandleTestId="selected-workflow-mini-dag-drag-handle"
-              title={`${displayedSelectedWorkflowGraph.workflow.name} task DAG`}
-              boundsRef={graphSurfaceRef as unknown as RefObject<HTMLElement>}
-              contentClassName="h-[250px]"
-            >
-              <div
-                data-keyboard-region="taskGraph"
-                tabIndex={0}
-                data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
-                className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
-              >
-                {isSelectedWorkflowGraphRefreshing && (
-                  <div data-testid="selected-workflow-mini-dag-refreshing" className="px-2 py-1 text-xs text-amber-200">
-                    Refreshing graph…
-                  </div>
-                )}
-                <TaskDAG
-                  tasks={displayedSelectedWorkflowGraph.tasks}
-                  workflows={selectedTaskDagWorkflows}
-                  selectedTaskId={selectedTaskId}
-                  cameraCommand={cameraCommand}
-                  onTaskClick={handleTaskClick}
-                  onTaskDoubleClick={handleTaskDoubleClick}
-                  onTaskContextMenu={handleTaskContextMenu}
-                  onManualViewport={handleManualViewport}
-                  statusFilters={new Set<string>()}
-                  runningTaskIds={runningTaskIds}
-                />
-              </div>
-            </FloatingGraphPanel>
+          {sidebarSurface === 'home' && (
+            <WorkflowGraph
+              workflows={workflows}
+              selectedWorkflowId={selectedWorkflow?.id ?? null}
+              cameraCommand={cameraCommand}
+              statusFilters={statusFilters}
+              coreActivityByWorkflow={coreActivityByWorkflow}
+              onSelectWorkflow={handleWorkflowClick}
+              onWorkflowContextMenu={handleWorkflowContextMenu}
+              onManualViewport={handleManualViewport}
+            />
           )}
+          {renderSelectedWorkflowTaskGraph(sidebarSurface === 'home')}
         </>
       )}
     </div>
@@ -2351,7 +2423,7 @@ export function App() {
               <button
                 key={entry.workflow.id}
                 type="button"
-                onClick={() => handleWorkflowClick(entry.workflow.id)}
+                onClick={() => selectWorkflowById(entry.workflow.id)}
                 className={`block w-full rounded-xl px-3 py-2 text-left transition-colors ${selected ? 'bg-gray-800 text-white ring-1 ring-gray-700' : 'text-gray-200 hover:bg-gray-900/80'}`}
               >
                 <div className="truncate font-medium">{entry.workflow.name}</div>
@@ -2378,7 +2450,7 @@ export function App() {
               <button
                 key={entry.task.id}
                 type="button"
-                onClick={() => handleTaskClick(entry.task)}
+                onClick={() => selectTaskById(entry.task.id)}
                 className={`block w-full rounded-xl px-3 py-2 text-left transition-colors ${accent}`}
               >
                 <div className="truncate font-medium">{entry.task.description || entry.task.id}</div>
@@ -2418,6 +2490,36 @@ export function App() {
       </div>
     </div>
   );
+  const renderGraphTerminalChrome = (): JSX.Element => (
+    <div
+      data-testid="graph-terminal-chrome"
+      data-keyboard-region="bottomBar"
+      tabIndex={0}
+      data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
+      className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+    >
+      <WorkflowStatusChips
+        workflows={workflows}
+        activeFilters={statusFilters}
+        keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
+        onStatusClick={handleStatusClick}
+      />
+      <TerminalDrawer
+        state={terminalDrawerState}
+        onCycle={() =>
+          setTerminalDrawerState((prev) =>
+            prev === 'minimized' ? 'partial' : prev === 'partial' ? 'maximized' : 'minimized',
+          )
+        }
+        sessions={terminalSessions}
+        activeSessionId={activeTerminalSessionId}
+        onSelectSession={setActiveTerminalSessionId}
+        onCloseSession={(sessionId) => void handleCloseTerminalSession(sessionId)}
+        taskLabels={terminalTaskLabels}
+      />
+    </div>
+  );
+
 
   const renderBrowserDetailWorkspace = (): JSX.Element => (
     <div className="flex-1 flex flex-col overflow-hidden">
@@ -2444,33 +2546,10 @@ export function App() {
           </div>
         </div>
       </div>
-      <div className="min-h-0 flex-1 flex flex-col overflow-hidden">
-        <div className="min-h-0 flex-[3] overflow-hidden">
-          {renderGraphCanvas()}
-        </div>
-        <div className="border-t border-gray-800 bg-gray-950/35 px-4 py-3">
-          <h3 className="text-xs font-semibold uppercase tracking-[0.18em] text-gray-500">
-            {sidebarSurface === 'workflows' ? 'Visible tasks' : `More ${browserSurfaceTitle.toLowerCase()}`}
-          </h3>
-          {relatedBrowserTasks.length === 0 ? (
-            <p className="mt-2 text-sm text-gray-500">Nothing else to show here yet.</p>
-          ) : (
-            <div className="mt-3 grid gap-2 md:grid-cols-2 xl:grid-cols-3">
-              {relatedBrowserTasks.slice(0, 6).map((task) => (
-                <button
-                  key={task.id}
-                  type="button"
-                  onClick={() => handleTaskClick(task)}
-                  className="rounded-lg border border-gray-800 bg-gray-900/70 px-3 py-2 text-left hover:border-gray-700 hover:bg-gray-900"
-                >
-                  <div className="truncate text-sm font-medium text-gray-200">{task.description || task.id}</div>
-                  <div className="mt-1 text-xs text-gray-500">{formatTaskStatus(task.status)}</div>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {renderGraphCanvas()}
       </div>
+      {viewMode === 'dag' && renderGraphTerminalChrome()}
     </div>
   );
 
@@ -2557,41 +2636,15 @@ export function App() {
               </div>
             )}
 
-            {viewMode === 'dag' && sidebarSurface === 'home' && (
-              <div
-                data-keyboard-region="bottomBar"
-                tabIndex={0}
-                data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
-                className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
-              >
-                <WorkflowStatusChips
-                  workflows={workflows}
-                  activeFilters={statusFilters}
-                  keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
-                  onStatusClick={handleStatusClick}
-                />
-                <TerminalDrawer
-                  state={terminalDrawerState}
-                  onCycle={() =>
-                    setTerminalDrawerState((prev) =>
-                      prev === 'minimized' ? 'partial' : prev === 'partial' ? 'maximized' : 'minimized',
-                    )
-                  }
-                  sessions={terminalSessions}
-                  activeSessionId={activeTerminalSessionId}
-                  onSelectSession={setActiveTerminalSessionId}
-                  onCloseSession={(sessionId) => void handleCloseTerminalSession(sessionId)}
-                  taskLabels={terminalTaskLabels}
-                />
-              </div>
-            )}
+            {sidebarSurface === 'home' && viewMode === 'dag' && renderGraphTerminalChrome()}
           </main>
 
           <div
+            data-testid="workflow-inspector-shell"
             data-keyboard-region="inspector"
             tabIndex={0}
             data-keyboard-active={keyboardRegion === 'inspector' ? 'true' : 'false'}
-            className={`${showEmptyGraphTutorial || showInspectorPlaceholder ? 'w-96' : inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+            className={`${showEmptyGraphTutorial || showInspectorPlaceholder ? 'w-96' : effectiveInspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
           >
             {showEmptyGraphTutorial ? (
               <EmptyGraphTutorial />
@@ -2606,7 +2659,7 @@ export function App() {
                 remoteTargets={remoteTargets}
                 executionPools={executionPools}
                 executionAgents={executionAgents}
-                collapsed={inspectorCollapsed}
+                collapsed={effectiveInspectorCollapsed}
                 advancedExpanded={advancedMetadataExpanded}
                 actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
                 onEditType={handleEditType}
@@ -2661,6 +2714,7 @@ export function App() {
                 onManualViewport={handleManualViewport}
                 statusFilters={new Set<string>()}
                 runningTaskIds={runningTaskIds}
+                surfaceMode="overlay"
               />
             ) : (
               <WorkflowGraph

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -73,24 +73,31 @@ describe('App launch (component)', () => {
     expect(await screen.findByText('Plan graph')).toBeInTheDocument();
     expect(screen.getByText('Alpha · running')).toBeInTheDocument();
   });
-  it('auto-collapses the app sidebar for browser views and returns home when dismissed', async () => {
+  it('auto-collapses the app sidebar for browser views, focuses attention tasks, and collapses the inspector on narrow windows', async () => {
     const workflows: WorkflowMeta[] = [
       { id: 'wf-alpha', name: 'Alpha', status: 'running' },
     ];
     const alpha = makeUITask({ id: 'task-alpha', description: 'First test task', status: 'failed', workflowId: 'wf-alpha' });
 
+    Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
+
     render(<App />);
     act(() => mock.setTasks([alpha], workflows));
+    act(() => window.dispatchEvent(new Event('resize')));
 
     fireEvent.click(await screen.findByTestId('sidebar-attention'));
     expect(await screen.findByTestId('browser-rail')).toBeInTheDocument();
     expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+    expect(screen.getByTestId('workflow-inspector-shell').className).toContain('w-16');
     expect(screen.queryByText('Invoker Terminal')).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Needs Attention' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
+    expect(screen.queryByText('More needs attention')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByTestId('browser-rail-dismiss'));
     expect(await screen.findByText('Invoker Terminal')).toBeInTheDocument();
-    expect(screen.getByTestId('app-sidebar').className).toContain('w-72');
-    expect(screen.getByTestId('sidebar-home')).toHaveTextContent('Invoker');
+    expect(screen.queryByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
+    Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
   });
 
   it('shows workflow status chips and terminal drawer controls in home view', () => {

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -54,6 +54,7 @@ interface TaskDAGProps {
   onManualViewport?: () => void;
   statusFilters?: Set<string>;
   runningTaskIds?: ReadonlySet<string>;
+  surfaceMode?: 'default' | 'browser' | 'overlay';
 }
 
 const nodeTypes = { taskNode: TaskNode, mergeGateNode: MergeGateNode };
@@ -152,7 +153,7 @@ function mergeMeasuredNodeState(prevNodes: Node[], nextNodes: Node[]): Node[] {
   });
 }
 
-function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskClick, onTaskDoubleClick, onTaskContextMenu, onManualViewport, statusFilters, runningTaskIds }: TaskDAGProps) {
+function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskClick, onTaskDoubleClick, onTaskContextMenu, onManualViewport, statusFilters, runningTaskIds, surfaceMode = 'default' }: TaskDAGProps) {
   const { fitView, setCenter, getZoom } = useReactFlow();
   const graphRootRef = useRef<HTMLDivElement>(null);
   const prevNodeCount = useRef(0);
@@ -161,10 +162,10 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   const watchdogMissCountRef = useRef(0);
   const watchdogRecoveryAttemptedRef = useRef(false);
   const lastHandledCameraSeqRef = useRef(0);
+  const browserRemountDoneRef = useRef(false);
   const initFitFrameRef = useRef(0);
   const [layoutState, setLayoutState] = useState<LayoutState | null>(null);
   const [flowInstanceKey, setFlowInstanceKey] = useState(0);
-
   const onInitHandler = useCallback(() => {
     initFitFrameRef.current = requestAnimationFrame(() => fitView({ padding: 0.2 }));
   }, [fitView]);
@@ -172,6 +173,10 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   // Cancel a pending first-fit frame on unmount so it never fires against a
   // torn-down graph after the component has gone away.
   useEffect(() => () => cancelAnimationFrame(initFitFrameRef.current), []);
+
+  useEffect(() => {
+    browserRemountDoneRef.current = false;
+  }, [surfaceMode, tasks.size]);
 
   const rawGraph = useMemo(() => {
     const taskArray = [...tasks.values()];
@@ -220,7 +225,6 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       }
     }
 
-    // Build dimmed node set for edge opacity
     const dimmedNodeIds = new Set<string>();
     if (statusFilters && statusFilters.size > 0) {
       for (const task of taskArray) {
@@ -480,6 +484,48 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   }, [cameraCommand, fitView, getZoom, nodes, setCenter]);
 
   useEffect(() => {
+    if (surfaceMode !== 'browser' || nodes.length === 0) return;
+
+    let cancelled = false;
+    const frame = requestAnimationFrame(() => {
+      if (cancelled) return;
+      fitView({ padding: 0.2 });
+      if (!selectedTaskId) return;
+      const node = nodes.find((candidate) => candidate.id === selectedTaskId);
+      if (!node) return;
+      requestAnimationFrame(() => {
+        if (cancelled) return;
+        const zoom = Math.max(typeof getZoom === 'function' ? getZoom() : 1, 0.85);
+        setCenter(node.position.x + 132, node.position.y + 55, { zoom, duration: 0 });
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frame);
+    };
+  }, [fitView, getZoom, nodes, selectedTaskId, setCenter, surfaceMode]);
+
+  useEffect(() => {
+    if (surfaceMode !== 'browser' || nodes.length === 0 || browserRemountDoneRef.current) return;
+
+    let cancelled = false;
+    const frame = requestAnimationFrame(() => {
+      if (cancelled) return;
+      requestAnimationFrame(() => {
+        if (cancelled || browserRemountDoneRef.current) return;
+        browserRemountDoneRef.current = true;
+        setFlowInstanceKey((key) => key + 1);
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(frame);
+    };
+  }, [nodes.length, surfaceMode]);
+
+  useEffect(() => {
     if (reportedGraphVisibleRef.current || nodes.length === 0 || typeof window === 'undefined') {
       return;
     }
@@ -594,10 +640,18 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     );
   }
 
+  const browserHeight = surfaceMode === 'browser' ? '300px' : '100%';
+
   return (
-    <div ref={graphRootRef} className="h-full w-full" style={{ minHeight: '300px' }}>
+    <div
+      ref={graphRootRef}
+      className="flex w-full flex-1"
+      style={{ minHeight: '300px', height: browserHeight }}
+    >
       <ReactFlow
         key={flowInstanceKey}
+        className="h-full w-full"
+        style={{ width: '100%', height: browserHeight }}
         nodes={rfNodes}
         edges={edges}
         nodeTypes={nodeTypes}

--- a/packages/ui/src/components/WorkflowStatusChips.tsx
+++ b/packages/ui/src/components/WorkflowStatusChips.tsx
@@ -37,7 +37,7 @@ export function WorkflowStatusChips({
   const hasFilters = activeFilters.size > 0;
 
   return (
-    <div className="flex items-center gap-6 px-4 py-2 bg-gray-800 border-t border-gray-700 text-sm">
+    <div data-testid="workflow-status-chips" className="flex items-center gap-6 px-4 py-2 bg-gray-800 border-t border-gray-700 text-sm">
       {DISPLAY_ORDER.map((status) => {
         const visual = workflowStatusVisual(status);
         const active = activeFilters.has(status);


### PR DESCRIPTION
## Summary

Needs Attention now behaves like a focused Mac browser surface. Selecting an item drives task selection and centers the workflow graph on that task.

The graph fills the available detail space, the extra "More needs attention" footer is gone, and tighter windows auto-collapse the inspector.

<details>
<summary>Review metadata</summary>

Review Claim: The needs-attention browser now focuses the selected task in the workflow graph and protects graph space on narrower windows.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice changes selection and layout behavior in the browser surfaces only. The underlying planner, task state, and inspector actions stay the same.

Slice Rationale: After the browser shell landed, the next risk was losing graph context and window space when triaging many tasks. This slice fixes that behavior directly.

</details>

## Non-goals

- No planner bridge changes.
- No queue semantics changes.
- No approval rule changes.

## Visual Proof

![Needs Attention browser with populated task DAG](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260702-de4d67/needs-attention-browser.png)

![Needs Attention browser on a narrower window](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260702-de4d67/needs-attention-browser-narrow.png)

![Needs Attention full graph with populated task DAG](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260702-de4d67/needs-attention-browser-full-graph.png)


## Test Plan

- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/app-launch.test.tsx src/__tests__/visual-proof-snapshots.test.tsx`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts --grep "needs attention browser focuses the selected task|workflows browser and home return|collapsible workflow browsers"`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
