### PR TITLE
Set patched guard in CI repro wrapper

### DIFF
--- a/scripts/test-suites/required/28-sqlite-live-wal-repro.sh
+++ b/scripts/test-suites/required/28-sqlite-live-wal-repro.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
 
-exec bash scripts/repro/repro-readonly-follower-live-wal.sh
+EXPECT_PATCHED_GUARD=1 exec bash scripts/repro/repro-readonly-follower-live-wal.sh

--- a/scripts/test-suites/required/28-sqlite-live-wal-repro.sh
+++ b/scripts/test-suites/required/28-sqlite-live-wal-repro.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Required proof coverage for the live SQLite WAL follower hazard.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+exec bash scripts/repro/repro-readonly-follower-live-wal.sh


### PR DESCRIPTION


Depends-On: #2851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a test repro run to use the expected guard setting, improving consistency for the live WAL SQLite check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->