### PR TITLE
[Merge Queue CI](1) Cancel stale runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.base_ref) || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

This changes merge-queue CI so only the newest queued run for a base branch keeps going.

Older merge-queue runs can pile up even after a newer run replaces them.

This cuts wasted runner time without changing normal pull request CI.

<details>
<summary>Review metadata</summary>

Review Claim: Mergify synthetic pull requests now cancel older in-progress CI runs for the same base branch, while ordinary pull request concurrency stays the same.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Only pull requests whose head ref starts with `mergify/merge-queue/` move to the new concurrency group. Every other ref still uses the existing per-ref workflow key.

Slice Rationale: This keeps the fix to one workflow policy change instead of bundling runner routing, queue labels, or required-check changes.

</details>

## Non-goals

- Changing which checks are required for merge
- Moving jobs onto self-hosted runners
- Speeding up individual job execution

## Test Plan

- [x] `node -e "const fs=require('fs'); const yaml=require('yaml'); yaml.parse(fs.readFileSync('.github/workflows/ci.yml','utf8')); console.log('ci.yml parsed');"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 5575377a0`
- Post-revert steps: None
- Data migration? No
