### PR TITLE
Use Default runner capacity for CI shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
   quality-required:
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -69,8 +69,10 @@ jobs:
         include:
           - name: Dependency Cruise
             command: pnpm run check:deps
+            runner_group: Invoker managed runners
           - name: TypeScript Types
             command: pnpm run check:types
+            runner_group: Default
 
     name: quality / ${{ matrix.name }}
 
@@ -101,7 +103,7 @@ jobs:
   quality-extra:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -109,10 +111,13 @@ jobs:
         include:
           - name: Required Package Builds
             command: pnpm run check:required-builds
+            runner_group: Invoker managed runners
           - name: Large File Guardrail
             command: pnpm run check:large-files
+            runner_group: Default
           - name: Release Version Sync
             command: pnpm run check:versions
+            runner_group: Invoker managed runners
 
     name: quality / ${{ matrix.name }}
 
@@ -210,7 +215,7 @@ jobs:
   required-fast:
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -223,10 +228,13 @@ jobs:
               bash scripts/test-suites/required/07-invalid-config-json.sh
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh
+            runner_group: Invoker managed runners
           - name: Vitest Workspace
             command: bash scripts/test-suites/required/10-vitest-workspace.sh
+            runner_group: Default
           - name: Submit Workflow Chain
             command: bash scripts/test-suites/required/15-submit-workflow-chain.sh
+            runner_group: Invoker managed runners
 
     name: required-fast / ${{ matrix.name }}
 
@@ -280,7 +288,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -288,16 +296,22 @@ jobs:
         include:
           - name: Branch Carry Forward
             command: bash scripts/test-suites/required/16-branch-carry-forward.sh
+            runner_group: Invoker managed runners
           - name: Merge Gate Concurrency Repro
             command: bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh
+            runner_group: Default
           - name: Start Running MECE Repros
             command: bash scripts/test-suites/required/18-start-running-mece-repros.sh
+            runner_group: Invoker managed runners
           - name: Task New Attempt Reset Repro
             command: bash scripts/test-suites/required/19-task-new-attempt-reset-repro.sh
+            runner_group: Default
           - name: Launch Dispatch Queue Repro
             command: bash scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh
+            runner_group: Invoker managed runners
           - name: Reset Rulebook Repro
             command: bash scripts/test-suites/required/26-reset-rulebook-proof.sh
+            runner_group: Default
 
     name: required-fast / ${{ matrix.name }}
 
@@ -411,7 +425,7 @@ jobs:
   dry-run:
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
@@ -421,10 +435,13 @@ jobs:
         include:
           - name: case-1
             suite: scripts/test-suites/required/20-e2e-dry-run.sh
+            runner_group: Invoker managed runners
           - name: case-2
             suite: scripts/test-suites/required/21-e2e-dry-run-downstream.sh
+            runner_group: Default
           - name: case-4
             suite: scripts/test-suites/required/22-e2e-dry-run-github.sh
+            runner_group: Invoker managed runners
 
     name: dry-run / ${{ matrix.name }}
 
@@ -477,7 +494,7 @@ jobs:
   playwright:
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 45
@@ -487,10 +504,13 @@ jobs:
         include:
           - name: 1-of-3
             shard: 1/3
+            runner_group: Invoker managed runners
           - name: 2-of-3
             shard: 2/3
+            runner_group: Default
           - name: 3-of-3
             shard: 3/3
+            runner_group: Invoker managed runners
 
     name: playwright / ${{ matrix.name }}
 
@@ -554,7 +574,7 @@ jobs:
   ssh:
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
@@ -564,8 +584,10 @@ jobs:
         include:
           - name: shard-30
             suite: scripts/test-suites/optional/30-e2e-ssh.sh
+            runner_group: Invoker managed runners
           - name: shard-31
             suite: scripts/test-suites/optional/31-e2e-ssh-merge.sh
+            runner_group: Default
 
     name: ssh / ${{ matrix.name }}
 
@@ -633,7 +655,7 @@ jobs:
   optional-other:
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -641,8 +663,10 @@ jobs:
         include:
           - name: Worktree Provisioning
             command: bash scripts/test-suites/optional/60-worktree-provisioning.sh
+            runner_group: Invoker managed runners
           - name: Visual Proof Validate
             command: bash scripts/test-suites/optional/70-ui-visual-proof-validate.sh
+            runner_group: Default
 
     name: optional / ${{ matrix.name }}
 

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -17,7 +17,7 @@ jobs:
   validate:
     name: PR Body
     runs-on:
-      labels: Runner_2_4_core
+      group: Default
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Summary

CI now sends some jobs to the Default runner group instead of keeping every check on Runner_2_4_core.

The Mergify-required checks now span the current Invoker managed runner and the Default group, where Runner_1 and Github_Runner are Ready.

GitHub Actions uses the same routing for normal CI events, so PR, manual, and merge-queue runs share the extra pool.

<details>
<summary>Review metadata</summary>

Review Claim: CI routing now uses both runner groups without changing check names or Mergify merge conditions.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Only workflow routing changed. The required check names stay the same, so Mergify still waits for the same gates.

Slice Rationale: This slice is only runner capacity routing. It avoids mixing CI scheduling with test behavior or merge policy changes.

</details>

## Non-goals

This does not change test commands, runner images, branch protection, or Mergify queue rules.

## Architecture

### Before

```mermaid
graph TD
    A["PR, push, workflow_dispatch, or Mergify queue run"] --> B["CI workflow"]
    B --> C["Runner_2_4_core only"]
```

### After

```mermaid
graph TD
    A["PR, push, workflow_dispatch, or Mergify queue run"] --> B["CI workflow"]
    B --> C["Invoker managed runners group"]
    B --> D["Default runner group"]
    D --> E["Runner_1 / Github_Runner capacity"]
```

## Test Plan

- [x] `node -e "const fs=require('fs'); const YAML=require('yaml'); for (const f of ['.github/workflows/ci.yml','.github/workflows/pr-body.yml']) { YAML.parse(fs.readFileSync(f,'utf8')); console.log(f + ' ok'); }"`
- [x] `node <<'NODE' ... NODE` to verify every matrix job using `matrix.runner_group` has either `Invoker managed runners` or `Default`.
- [x] `node <<'NODE' ... NODE` to verify both Mergify queues require checks assigned to both runner groups.
- [x] `gh api orgs/Neko-Catpital-Labs/actions/hosted-runners --jq '.runners[] | [.name,.runner_group_id,.status,.maximum_runners,.platform,.machine_size_details.id] | @tsv'`
- [x] `gh workflow run ci.yml --ref pr/use-github-runner-capacity` created CI jobs for this branch; the manual run was cancelled after routing proof to avoid adding queue load.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 464ce5c32`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and PR validation workflows to use dynamic runner group selection instead of a fixed runner label.
  * Improved job routing across quality, required-fast, E2E/Playwright, SSH, and optional test shards so they can run on the most appropriate available runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->