### PR TITLE
[CI Capacity](1) Use spare runners and cancel stale runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.base_ref) || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -61,7 +61,7 @@ jobs:
 
   quality-required:
     runs-on:
-      group: ${{ matrix.runner_group }}
+      labels: ${{ matrix.runner_label }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -69,10 +69,10 @@ jobs:
         include:
           - name: Dependency Cruise
             command: pnpm run check:deps
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
           - name: TypeScript Types
             command: pnpm run check:types
-            runner_group: Default
+            runner_label: Github_Runner
 
     name: quality / ${{ matrix.name }}
 
@@ -103,7 +103,7 @@ jobs:
   quality-extra:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     runs-on:
-      group: ${{ matrix.runner_group }}
+      labels: ${{ matrix.runner_label }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -111,13 +111,13 @@ jobs:
         include:
           - name: Required Package Builds
             command: pnpm run check:required-builds
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
           - name: Large File Guardrail
             command: pnpm run check:large-files
-            runner_group: Default
+            runner_label: Runner_1
           - name: Release Version Sync
             command: pnpm run check:versions
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
 
     name: quality / ${{ matrix.name }}
 
@@ -215,7 +215,7 @@ jobs:
   required-fast:
     needs: build-artifacts
     runs-on:
-      group: ${{ matrix.runner_group }}
+      labels: ${{ matrix.runner_label }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -228,13 +228,13 @@ jobs:
               bash scripts/test-suites/required/07-invalid-config-json.sh
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
           - name: Vitest Workspace
             command: bash scripts/test-suites/required/10-vitest-workspace.sh
-            runner_group: Default
+            runner_label: Github_Runner
           - name: Submit Workflow Chain
             command: bash scripts/test-suites/required/15-submit-workflow-chain.sh
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
 
     name: required-fast / ${{ matrix.name }}
 
@@ -288,7 +288,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
     runs-on:
-      group: ${{ matrix.runner_group }}
+      labels: ${{ matrix.runner_label }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -296,22 +296,22 @@ jobs:
         include:
           - name: Branch Carry Forward
             command: bash scripts/test-suites/required/16-branch-carry-forward.sh
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
           - name: Merge Gate Concurrency Repro
             command: bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh
-            runner_group: Default
+            runner_label: Runner_1
           - name: Start Running MECE Repros
             command: bash scripts/test-suites/required/18-start-running-mece-repros.sh
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
           - name: Task New Attempt Reset Repro
             command: bash scripts/test-suites/required/19-task-new-attempt-reset-repro.sh
-            runner_group: Default
+            runner_label: Github_Runner
           - name: Launch Dispatch Queue Repro
             command: bash scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
           - name: Reset Rulebook Repro
             command: bash scripts/test-suites/required/26-reset-rulebook-proof.sh
-            runner_group: Default
+            runner_label: Runner_1
 
     name: required-fast / ${{ matrix.name }}
 
@@ -425,7 +425,7 @@ jobs:
   dry-run:
     needs: build-artifacts
     runs-on:
-      group: ${{ matrix.runner_group }}
+      labels: ${{ matrix.runner_label }}
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
@@ -435,13 +435,13 @@ jobs:
         include:
           - name: case-1
             suite: scripts/test-suites/required/20-e2e-dry-run.sh
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
           - name: case-2
             suite: scripts/test-suites/required/21-e2e-dry-run-downstream.sh
-            runner_group: Default
+            runner_label: Github_Runner
           - name: case-4
             suite: scripts/test-suites/required/22-e2e-dry-run-github.sh
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
 
     name: dry-run / ${{ matrix.name }}
 
@@ -494,7 +494,7 @@ jobs:
   playwright:
     needs: build-artifacts
     runs-on:
-      group: ${{ matrix.runner_group }}
+      labels: ${{ matrix.runner_label }}
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 45
@@ -504,13 +504,13 @@ jobs:
         include:
           - name: 1-of-3
             shard: 1/3
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
           - name: 2-of-3
             shard: 2/3
-            runner_group: Default
+            runner_label: Runner_1
           - name: 3-of-3
             shard: 3/3
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
 
     name: playwright / ${{ matrix.name }}
 
@@ -574,7 +574,7 @@ jobs:
   ssh:
     needs: build-artifacts
     runs-on:
-      group: ${{ matrix.runner_group }}
+      labels: ${{ matrix.runner_label }}
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
@@ -584,10 +584,10 @@ jobs:
         include:
           - name: shard-30
             suite: scripts/test-suites/optional/30-e2e-ssh.sh
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
           - name: shard-31
             suite: scripts/test-suites/optional/31-e2e-ssh-merge.sh
-            runner_group: Default
+            runner_label: Github_Runner
 
     name: ssh / ${{ matrix.name }}
 
@@ -655,7 +655,7 @@ jobs:
   optional-other:
     needs: build-artifacts
     runs-on:
-      group: ${{ matrix.runner_group }}
+      labels: ${{ matrix.runner_label }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -663,10 +663,10 @@ jobs:
         include:
           - name: Worktree Provisioning
             command: bash scripts/test-suites/optional/60-worktree-provisioning.sh
-            runner_group: Invoker managed runners
+            runner_label: Runner_2_4_core
           - name: Visual Proof Validate
             command: bash scripts/test-suites/optional/70-ui-visual-proof-validate.sh
-            runner_group: Default
+            runner_label: Runner_1
 
     name: optional / ${{ matrix.name }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
   quality-required:
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -69,8 +69,10 @@ jobs:
         include:
           - name: Dependency Cruise
             command: pnpm run check:deps
+            runner_group: Invoker managed runners
           - name: TypeScript Types
             command: pnpm run check:types
+            runner_group: Default
 
     name: quality / ${{ matrix.name }}
 
@@ -101,7 +103,7 @@ jobs:
   quality-extra:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -109,10 +111,13 @@ jobs:
         include:
           - name: Required Package Builds
             command: pnpm run check:required-builds
+            runner_group: Invoker managed runners
           - name: Large File Guardrail
             command: pnpm run check:large-files
+            runner_group: Default
           - name: Release Version Sync
             command: pnpm run check:versions
+            runner_group: Invoker managed runners
 
     name: quality / ${{ matrix.name }}
 
@@ -210,7 +215,7 @@ jobs:
   required-fast:
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -223,10 +228,13 @@ jobs:
               bash scripts/test-suites/required/07-invalid-config-json.sh
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh
+            runner_group: Invoker managed runners
           - name: Vitest Workspace
             command: bash scripts/test-suites/required/10-vitest-workspace.sh
+            runner_group: Default
           - name: Submit Workflow Chain
             command: bash scripts/test-suites/required/15-submit-workflow-chain.sh
+            runner_group: Invoker managed runners
 
     name: required-fast / ${{ matrix.name }}
 
@@ -280,7 +288,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -288,16 +296,22 @@ jobs:
         include:
           - name: Branch Carry Forward
             command: bash scripts/test-suites/required/16-branch-carry-forward.sh
+            runner_group: Invoker managed runners
           - name: Merge Gate Concurrency Repro
             command: bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh
+            runner_group: Default
           - name: Start Running MECE Repros
             command: bash scripts/test-suites/required/18-start-running-mece-repros.sh
+            runner_group: Invoker managed runners
           - name: Task New Attempt Reset Repro
             command: bash scripts/test-suites/required/19-task-new-attempt-reset-repro.sh
+            runner_group: Default
           - name: Launch Dispatch Queue Repro
             command: bash scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh
+            runner_group: Invoker managed runners
           - name: Reset Rulebook Repro
             command: bash scripts/test-suites/required/26-reset-rulebook-proof.sh
+            runner_group: Default
 
     name: required-fast / ${{ matrix.name }}
 
@@ -411,7 +425,7 @@ jobs:
   dry-run:
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
@@ -421,10 +435,13 @@ jobs:
         include:
           - name: case-1
             suite: scripts/test-suites/required/20-e2e-dry-run.sh
+            runner_group: Invoker managed runners
           - name: case-2
             suite: scripts/test-suites/required/21-e2e-dry-run-downstream.sh
+            runner_group: Default
           - name: case-4
             suite: scripts/test-suites/required/22-e2e-dry-run-github.sh
+            runner_group: Invoker managed runners
 
     name: dry-run / ${{ matrix.name }}
 
@@ -477,7 +494,7 @@ jobs:
   playwright:
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 45
@@ -487,10 +504,13 @@ jobs:
         include:
           - name: 1-of-3
             shard: 1/3
+            runner_group: Invoker managed runners
           - name: 2-of-3
             shard: 2/3
+            runner_group: Default
           - name: 3-of-3
             shard: 3/3
+            runner_group: Invoker managed runners
 
     name: playwright / ${{ matrix.name }}
 
@@ -554,7 +574,7 @@ jobs:
   ssh:
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
@@ -564,8 +584,10 @@ jobs:
         include:
           - name: shard-30
             suite: scripts/test-suites/optional/30-e2e-ssh.sh
+            runner_group: Invoker managed runners
           - name: shard-31
             suite: scripts/test-suites/optional/31-e2e-ssh-merge.sh
+            runner_group: Default
 
     name: ssh / ${{ matrix.name }}
 
@@ -633,7 +655,7 @@ jobs:
   optional-other:
     needs: build-artifacts
     runs-on:
-      labels: Runner_2_4_core
+      group: ${{ matrix.runner_group }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -641,8 +663,10 @@ jobs:
         include:
           - name: Worktree Provisioning
             command: bash scripts/test-suites/optional/60-worktree-provisioning.sh
+            runner_group: Invoker managed runners
           - name: Visual Proof Validate
             command: bash scripts/test-suites/optional/70-ui-visual-proof-validate.sh
+            runner_group: Default
 
     name: optional / ${{ matrix.name }}
 

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.base_ref) || format('pr-{0}', github.event.pull_request.number) }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: read
@@ -17,7 +21,7 @@ jobs:
   validate:
     name: PR Body
     runs-on:
-      group: Default
+      labels: Github_Runner
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -17,7 +17,7 @@ jobs:
   validate:
     name: PR Body
     runs-on:
-      labels: Runner_2_4_core
+      group: Default
     timeout-minutes: 10
 
     steps:


### PR DESCRIPTION
## Summary

CI now uses all three hosted runner labels instead of sending every check to `Runner_2_4_core`.

Stale merge-queue runs now cancel each other. PR Body also cancels old queued runs for the same PR once this lands on `master`.

This reduces runner starvation without changing check names or merge rules.

<details>
<summary>Review metadata</summary>

Review Claim: CI scheduling now spreads safe shards across available runner labels and cancels stale queued work before it wastes capacity.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Only workflow routing and workflow-level concurrency changed. The check names and test commands stay the same, so Mergify still waits for the same gates.

Slice Rationale: This keeps the emergency fix focused on CI scheduling pressure instead of bundling test behavior, branch protection, or merge policy.

</details>

## Non-goals

- Changing which checks are required for merge
- Changing test commands or runner images
- Adding or removing Mergify queue rules
- Fixing unrelated CI failures

## Architecture

### Before

```mermaid
graph TD
    A["PR, manual, or Mergify queue run"] --> B["CI workflow"]
    B --> C["Runner_2_4_core only"]
    D["Repeated PR Body events"] --> E["Duplicate queued PR Body runs"]
```

### After

```mermaid
graph TD
    A["PR, manual, or Mergify queue run"] --> B["CI workflow"]
    B --> C["Runner_2_4_core"]
    B --> D["Runner_1"]
    B --> E["Github_Runner"]
    F["Newer run for same PR or queue base"] --> G["Cancels older queued run"]
```

## Test Plan

- [x] `node <<'NODE' ... NODE` to parse `.github/workflows/ci.yml` and `.github/workflows/pr-body.yml` with `yaml`.
- [x] `node <<'NODE' ... NODE` to verify CI and PR Body concurrency groups cancel stale merge-queue and per-PR runs.
- [x] `node <<'NODE' ... NODE` to verify every `matrix.runner_label` value is one of `Runner_2_4_core`, `Runner_1`, or `Github_Runner`.
- [x] `gh api /repos/Neko-Catpital-Labs/Invoker/actions/runs?status=queued&per_page=1 --jq '.total_count'` returned `0` after cancelling stale queued runs.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 48a9d34aa`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI and PR validation workflows to refine run concurrency grouping, including merge-queue-specific handling.
  * Enabled automatic cancellation of older in-progress workflow runs within the same concurrency group.
  * Standardized runner selection for validation and test jobs, using per-matrix runner targets for better consistency across quality checks, required suites, and sharded optional/dry-run jobs.
  * Left build-artifacts and Docker runner settings unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->