### PR TITLE
[CI Capacity](2) Scope queue cancellation per branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.base_ref) || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.head_ref) || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, synchronize, reopened, ready_for_review]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.base_ref) || format('pr-{0}', github.event.pull_request.number) }}
+  group: ${{ github.workflow }}-${{ startsWith(github.head_ref, 'mergify/merge-queue/') && format('merge-queue-{0}', github.head_ref) || format('pr-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Summary

Merge-queue workflow runs now cancel only older runs for the same queue branch.

The previous key used the base branch. That let one queued PR cancel another queued PR aimed at the same target.

This fixes the CodeRabbit finding from #2876 without changing runner labels, test commands, or required check names.

<details>
<summary>Review metadata</summary>

Review Claim: CI and PR Body concurrency now use a per-queue branch key for Mergify queue runs.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Only workflow-level concurrency keys changed. Job definitions, commands, runner labels, and permissions stay the same.

Slice Rationale: This is the narrow follow-up to #2876. It fixes the stale-run cancellation key without mixing in runner capacity work.

</details>

## Non-goals

- Changing runner labels
- Changing check names
- Changing Mergify queue rules
- Changing any test command

## Test Plan

- [x] `node <<'NODE' ... NODE` to parse `.github/workflows/ci.yml` and `.github/workflows/pr-body.yml` with `yaml`.
- [x] `node <<'NODE' ... NODE` to assert merge-queue concurrency uses `github.head_ref`, not `github.base_ref`.
- [x] `node <<'NODE' ... NODE` to assert two different merge-queue head refs produce different concurrency keys.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 8b862a565b3d4f2bd6b0820a15f0147afdd1bd08`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how automated checks are grouped and cancelled for pull requests, including merge-queue runs.
  * Reduced the chance of overlapping workflow runs on the same pull request, helping CI behave more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->