### PR TITLE
Route SSH jobs to DO2 SSH-only runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,7 +621,7 @@ jobs:
 
   ssh:
     needs: build-artifacts
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, do2-ssh-only]
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI configuration to use a self-hosted Linux runner for one automated job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->