### PR TITLE
[Fix MCP submit SEA argv and check in repro](2) Cover CLI argv resolution

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -6,7 +6,7 @@ import { LocalBus } from '@invoker/transport';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { main } from '../index.js';
-import { HANDOFF_PROMPT_DESCRIPTION, handoffPrompt, submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
+import { HANDOFF_PROMPT_DESCRIPTION, handoffPrompt, resolveCliInvocation, submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
 
 const repoRoot = resolve(__dirname, '../../../..');
 const cliPath = resolve(repoRoot, 'packages/cli/dist/index.js');
@@ -305,6 +305,32 @@ tasks:
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain('Invalid YAML');
+  });
+
+  it('resolveCliInvocation spawns a compiled binary directly when cliPath equals execPath', () => {
+    const result = resolveCliInvocation(
+      '/v/invoker-cli',
+      '/v/invoker-cli',
+      ['run', fixturePlan, '--live', '--json'],
+    );
+
+    expect(result).toEqual({
+      command: '/v/invoker-cli',
+      args: ['run', fixturePlan, '--live', '--json'],
+    });
+  });
+
+  it('resolveCliInvocation prepends the JS entry path in dev mode', () => {
+    const result = resolveCliInvocation(
+      '/usr/bin/node',
+      '/repo/dist/index.js',
+      ['run', fixturePlan, '--json'],
+    );
+
+    expect(result).toEqual({
+      command: '/usr/bin/node',
+      args: ['/repo/dist/index.js', 'run', fixturePlan, '--json'],
+    });
   });
 
   it('submits MCP plans in live mode by default', async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -501,6 +501,7 @@ function isExternalWorkerRuntime(worker: WorkerRuntime): worker is ExternalWorke
  * poll loop, so the two doors can never run competing scans. The CLI owns the
  * foreground lifetime — owner discovery, connect message, the SIGINT/SIGTERM
  * block, and a deterministic stop.
+ */
 async function runWorker(definition: WorkerDefinition<WorkerRuntimeDependencies>, bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();


### PR DESCRIPTION
## Summary

Regression tests now pin the helper output for compiled and development launches.

The assertions cover the command path and first argv entries that failed before.

This slice also closes a worker comment block that was broken on the rebased base, so the CLI test file can compile.

<details>
<summary>Review metadata</summary>

Review Claim: The CLI test suite locks the two argv shapes directly, and the rebased CLI source parses cleanly.

Review Lane: proof

Review Unit: proof

Safety Invariant: Existing MCP cases stay intact; the new assertions only check helper output. The comment close changes documentation text only.

Slice Rationale: Helper-level assertions prove the bug without running a workflow; the one-line syntax fix keeps current master buildable for this proof slice.

</details>

## Non-goals

- Does not change the production runner.
- Does not add or edit the shell repro script.

## Test Plan

- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/cli.test.ts -t "spawns a compiled binary|prepends the JS entry path|rejects missing MCP cliPath"`
- [x] `pnpm --filter @invoker/cli build`
- [x] `bash scripts/repro/repro-mcp-submit-sea-argv.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 80ba23fd ca748cd2`
- Post-revert steps: Re-run `pnpm --filter @invoker/cli test`.
- Data migration? No
