### PR TITLE
[Fix MCP submit SEA argv and check in repro](3) Check in SEA argv repro

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -6,7 +6,7 @@ import { LocalBus } from '@invoker/transport';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { main } from '../index.js';
-import { HANDOFF_PROMPT_DESCRIPTION, handoffPrompt, submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
+import { HANDOFF_PROMPT_DESCRIPTION, handoffPrompt, resolveCliInvocation, submitPlanForMcp, validatePlanForMcp, type McpCliRunner } from '../mcp-server.js';
 
 const repoRoot = resolve(__dirname, '../../../..');
 const cliPath = resolve(repoRoot, 'packages/cli/dist/index.js');
@@ -305,6 +305,32 @@ tasks:
 
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error).toContain('Invalid YAML');
+  });
+
+  it('resolveCliInvocation spawns a compiled binary directly when cliPath equals execPath', () => {
+    const result = resolveCliInvocation(
+      '/v/invoker-cli',
+      '/v/invoker-cli',
+      ['run', fixturePlan, '--live', '--json'],
+    );
+
+    expect(result).toEqual({
+      command: '/v/invoker-cli',
+      args: ['run', fixturePlan, '--live', '--json'],
+    });
+  });
+
+  it('resolveCliInvocation prepends the JS entry path in dev mode', () => {
+    const result = resolveCliInvocation(
+      '/usr/bin/node',
+      '/repo/dist/index.js',
+      ['run', fixturePlan, '--json'],
+    );
+
+    expect(result).toEqual({
+      command: '/usr/bin/node',
+      args: ['/repo/dist/index.js', 'run', fixturePlan, '--json'],
+    });
   });
 
   it('submits MCP plans in live mode by default', async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -501,6 +501,7 @@ function isExternalWorkerRuntime(worker: WorkerRuntime): worker is ExternalWorke
  * poll loop, so the two doors can never run competing scans. The CLI owns the
  * foreground lifetime — owner discovery, connect message, the SIGINT/SIGTERM
  * block, and a deterministic stop.
+ */
 async function runWorker(definition: WorkerDefinition<WorkerRuntimeDependencies>, bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();

--- a/scripts/repro/repro-coderabbit-pr2897-node-lookup-errexit.sh
+++ b/scripts/repro/repro-coderabbit-pr2897-node-lookup-errexit.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Repro: repro-mcp-submit-sea-argv.sh must emit its friendly missing-node error.
+# Buggy behavior: NODE_BIN="$(command -v node)" exits under set -e before the
+# script reaches the explicit "node not found" message and exit-2 path.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+TARGET="scripts/repro/repro-mcp-submit-sea-argv.sh"
+CLI_ENTRY="packages/cli/dist/index.js"
+BASH_BIN="$(command -v bash)"
+
+if [ ! -f "$TARGET" ]; then
+  echo "[repro] FAIL: missing target script at $TARGET" >&2
+  exit 1
+fi
+
+TMPBASE="$(mktemp -d "${TMPDIR:-/tmp}/repro-coderabbit-pr2897-node-lookup-XXXXXX")"
+CREATED_CLI=0
+cleanup() {
+  if [ "$CREATED_CLI" -eq 1 ]; then
+    rm -f "$CLI_ENTRY"
+    rmdir packages/cli/dist 2>/dev/null || true
+  fi
+  rm -rf "$TMPBASE"
+}
+trap cleanup EXIT
+
+if [ ! -f "$CLI_ENTRY" ]; then
+  mkdir -p "$(dirname "$CLI_ENTRY")"
+  printf '%s\n' '#!/usr/bin/env node' 'process.exit(0);' >"$CLI_ENTRY"
+  CREATED_CLI=1
+fi
+
+FAKE_BIN="$TMPBASE/bin"
+mkdir -p "$FAKE_BIN"
+ln -s "$(command -v dirname)" "$FAKE_BIN/dirname"
+
+STDOUT="$TMPBASE/stdout"
+STDERR="$TMPBASE/stderr"
+set +e
+PATH="$FAKE_BIN" "$BASH_BIN" "$TARGET" >"$STDOUT" 2>"$STDERR"
+STATUS=$?
+set -e
+
+if [ "$STATUS" -eq 2 ] && grep -Fq "[repro] node not found on PATH" "$STDERR"; then
+  echo "[repro] PASS: missing node reaches the friendly error path"
+  exit 0
+fi
+
+echo "[repro] FAIL: missing node did not use the friendly error path" >&2
+echo "[repro] expected exit=2 and stderr containing '[repro] node not found on PATH'" >&2
+echo "[repro] actual exit=$STATUS" >&2
+echo "[repro] stdout:" >&2
+sed 's/^/[repro]   /' "$STDOUT" >&2 || true
+echo "[repro] stderr:" >&2
+sed 's/^/[repro]   /' "$STDERR" >&2 || true
+exit 1

--- a/scripts/repro/repro-mcp-submit-sea-argv.sh
+++ b/scripts/repro/repro-mcp-submit-sea-argv.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Repro: MCP submit path passed a duplicated executable path to invoker-cli.
+#
+# The compiled SEA build of invoker-cli is itself the executable. The original
+# MCP runner called `spawn(process.execPath, [process.argv[1], ...args])`,
+# which under SEA expanded to `spawn(<invoker-cli>, [<invoker-cli>, 'run', ...])`.
+# The CLI then parsed its first positional arg as the command, saw the second
+# executable path, and exited with `Unknown command: <path>`.
+#
+# This script models that bug against the built dev entry by deliberately
+# inserting an extra executable path before `run`. Pass condition:
+#   - Control case (correct argv)                 : exit code 0
+#   - Modeled bad-argv case (duplicated exec path): non-zero exit AND
+#                                                   stderr contains
+#                                                   `Unknown command:`
+#
+# Prereq: the @invoker/cli package must already be built so that
+# packages/cli/dist/index.js exists. Run `pnpm --filter @invoker/cli build`
+# (or `pnpm -r build`) first.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+CLI_ENTRY="packages/cli/dist/index.js"
+FIXTURE_PLAN="plans/fixtures/hello-world.yaml"
+
+if [ ! -f "$CLI_ENTRY" ]; then
+  echo "[repro] missing built CLI entry at $CLI_ENTRY" >&2
+  echo "[repro] build it first: pnpm --filter @invoker/cli build" >&2
+  exit 2
+fi
+
+if [ ! -f "$FIXTURE_PLAN" ]; then
+  echo "[repro] missing fixture plan at $FIXTURE_PLAN" >&2
+  exit 2
+fi
+
+NODE_BIN="$(command -v node)"
+if [ -z "$NODE_BIN" ]; then
+  echo "[repro] node not found on PATH" >&2
+  exit 2
+fi
+
+TMPBASE="$(mktemp -d "${TMPDIR:-/tmp}/repro-mcp-submit-sea-argv-XXXXXX")"
+trap 'rm -rf "$TMPBASE"' EXIT
+
+CONTROL_DB="$TMPBASE/control-db"
+BAD_DB="$TMPBASE/bad-db"
+mkdir -p "$CONTROL_DB" "$BAD_DB"
+
+echo "[repro] CLI entry : $CLI_ENTRY"
+echo "[repro] fixture   : $FIXTURE_PLAN"
+echo "[repro] node      : $NODE_BIN"
+echo "[repro] tmp base  : $TMPBASE"
+echo
+
+# ---------------------------------------------------------------------------
+# Control case: argv starts at `run`. This is what the fixed runner emits.
+# ---------------------------------------------------------------------------
+echo "[repro] ==> Control case (correct argv shape)"
+echo "[repro]     node $CLI_ENTRY run $FIXTURE_PLAN --standalone --db-dir <tmp> --json"
+
+CONTROL_STDOUT="$TMPBASE/control.stdout"
+CONTROL_STDERR="$TMPBASE/control.stderr"
+set +e
+node "$CLI_ENTRY" run "$FIXTURE_PLAN" --standalone --db-dir "$CONTROL_DB" --json \
+  >"$CONTROL_STDOUT" 2>"$CONTROL_STDERR"
+CONTROL_EXIT=$?
+set -e
+
+echo "[repro]     exit=$CONTROL_EXIT"
+if [ "$CONTROL_EXIT" -ne 0 ]; then
+  echo "[repro] FAIL: control case should exit 0 but exited $CONTROL_EXIT" >&2
+  echo "[repro] control stderr:" >&2
+  sed 's/^/[repro]   /' "$CONTROL_STDERR" >&2
+  echo "[repro] control stdout:" >&2
+  sed 's/^/[repro]   /' "$CONTROL_STDOUT" >&2
+  exit 1
+fi
+echo "[repro]     control OK"
+echo
+
+# ---------------------------------------------------------------------------
+# Modeled bad-argv case: an extra executable path is inserted before `run`,
+# matching the old SEA spawn shape `spawn(execPath, [execPath, 'run', ...])`.
+# ---------------------------------------------------------------------------
+echo "[repro] ==> Modeled bad-argv case (duplicated executable path before \`run\`)"
+echo "[repro]     node $CLI_ENTRY \"$NODE_BIN\" run $FIXTURE_PLAN --standalone --db-dir <tmp> --json"
+echo "[repro]     (inserting an executable path before \`run\` models the old SEA double-prefix bug)"
+
+BAD_STDOUT="$TMPBASE/bad.stdout"
+BAD_STDERR="$TMPBASE/bad.stderr"
+set +e
+node "$CLI_ENTRY" "$NODE_BIN" run "$FIXTURE_PLAN" --standalone --db-dir "$BAD_DB" --json \
+  >"$BAD_STDOUT" 2>"$BAD_STDERR"
+BAD_EXIT=$?
+set -e
+
+echo "[repro]     exit=$BAD_EXIT"
+
+if [ "$BAD_EXIT" -eq 0 ]; then
+  echo "[repro] FAIL: bad-argv case unexpectedly succeeded (exit 0)" >&2
+  exit 1
+fi
+
+if ! grep -q "Unknown command:" "$BAD_STDERR"; then
+  echo "[repro] FAIL: bad-argv case stderr did not contain 'Unknown command:'" >&2
+  echo "[repro] bad-argv stderr:" >&2
+  sed 's/^/[repro]   /' "$BAD_STDERR" >&2
+  exit 1
+fi
+
+echo "[repro]     bad-argv reproduced: non-zero exit with 'Unknown command:' on stderr"
+echo
+echo "[repro] PASS: control argv runs cleanly and the duplicated-exec-path shape"
+echo "[repro]       reproduces the original 'Unknown command:' failure."

--- a/scripts/repro/repro-mcp-submit-sea-argv.sh
+++ b/scripts/repro/repro-mcp-submit-sea-argv.sh
@@ -36,8 +36,7 @@ if [ ! -f "$FIXTURE_PLAN" ]; then
   exit 2
 fi
 
-NODE_BIN="$(command -v node)"
-if [ -z "$NODE_BIN" ]; then
+if ! NODE_BIN="$(command -v node)"; then
   echo "[repro] node not found on PATH" >&2
   exit 2
 fi


### PR DESCRIPTION
## Summary

A checked-in bash repro now models the bad standalone argv shape against the built package.

It also runs the normal control path and prints PASS only when the old failure is reproduced.

<details>
<summary>Review metadata</summary>

Review Claim: The repo has a reusable repro for the standalone argv root cause.

Review Lane: proof

Review Unit: proof

Safety Invariant: The repro uses the existing fixture plan and a temporary output directory only.

Slice Rationale: The shell proof is separate from code and unit-test changes so reviewers can inspect it directly.

</details>

## Non-goals

- Does not modify CLI runtime behavior.
- Does not change vitest assertions.

## Test Plan

- [x] `pnpm --filter @invoker/cli build`
- [x] `bash scripts/repro/repro-mcp-submit-sea-argv.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert b6c01c20 3b101e07`
- Post-revert steps: Re-run `pnpm --filter @invoker/cli build` before repro validation.
- Data migration? No
