### PR TITLE
[Worker Registration Step 3: PR Status and CI Failure Workers](2) Guard CI fixes with review-gate head SHA

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1072,6 +1072,44 @@ describe('headless delegation enforcement', () => {
         expect(mockDeps.commandService.recreateWorkflow).toHaveBeenCalled();
       });
 
+      it('headless recreate with deps.noTrack=true defers runnable execution to the caller', async () => {
+        const deferRunnableTasks = vi.fn();
+        const preemptWorkflowExecution = vi.fn(async () => ({ cancelled: ['wf-1/task-1'], runningCancelled: ['wf-1/task-1'] }));
+        (mockDeps.commandService as any).recreateWorkflow = vi.fn(async () => ({
+          ok: true as const,
+          data: [
+            {
+              id: 'wf-1/task-1',
+              status: 'running',
+              config: { workflowId: 'wf-1' },
+              execution: { selectedAttemptId: 'attempt-2' },
+            } as any,
+          ],
+        }));
+        mockDeps.orchestrator.startExecution = vi.fn(() => []);
+        const executeTasksSpy = vi.spyOn(TaskRunner.prototype, 'executeTasks').mockResolvedValue(undefined);
+
+        const depsWithNoTrack: HeadlessDeps = {
+          ...mockDeps,
+          noTrack: true,
+          deferRunnableTasks,
+          preemptWorkflowExecution,
+        } as HeadlessDeps;
+
+        await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
+
+        expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+        expect(mockDeps.commandService.recreateWorkflow).toHaveBeenCalled();
+        expect(deferRunnableTasks).toHaveBeenCalledTimes(1);
+        expect(deferRunnableTasks.mock.calls[0]?.[1]).toBe('wf-1');
+        const [runnable] = deferRunnableTasks.mock.calls[0] ?? [];
+        expect(runnable).toHaveLength(1);
+        expect(runnable[0]?.id).toBe('wf-1/task-1');
+        expect(executeTasksSpy).not.toHaveBeenCalled();
+
+        executeTasksSpy.mockRestore();
+      });
+
       it('headless recreate dispatches runnable tasks before waiting for completion', async () => {
         let taskStatus: 'running' | 'completed' = 'running';
         (mockDeps.commandService as any).recreateWorkflow = vi.fn(async () => ({

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -71,6 +71,19 @@ export async function headlessWatch(workflowId: string | undefined, deps: Headle
   });
   process.stdout.write(`\n[watch] done — ${result.status.completed} completed, ${result.status.failed} failed, ${result.status.closed} closed\n`);
 }
+function runningExecutionKey(task: TaskState): string {
+  const attemptId = task.execution.selectedAttemptId?.trim();
+  return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
+}
+
+function collectDispatchableTopup(orchestrator: HeadlessDeps['orchestrator'], alreadyDispatchable: TaskState[]): TaskState[] {
+  const scopedKeys = new Set(alreadyDispatchable.map((task) => runningExecutionKey(task)));
+  return orchestrator
+    .startExecution()
+    .filter(isDispatchableLaunch)
+    .filter((task) => !scopedKeys.has(runningExecutionKey(task)));
+}
+
 
 export async function headlessRun(
   planPath: string,
@@ -238,16 +251,7 @@ export async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Pro
     process.stdout.write(`Restarted task "${taskId}" — ${runnable.length} task(s) to execute\n`);
 
     if (deps.noTrack) {
-      const runningKey = (task: TaskState): string => {
-        const attemptId = task.execution.selectedAttemptId?.trim();
-        return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
-      };
-      const scopedKeys = new Set(runnable.map((task) => runningKey(task)));
-      const globalTopup = deps.orchestrator
-        .startExecution()
-        .filter(isDispatchableLaunch)
-        .filter((task) => !scopedKeys.has(runningKey(task)));
-      const dispatchable = [...runnable, ...globalTopup];
+      const dispatchable = [...runnable, ...collectDispatchableTopup(deps.orchestrator, runnable)];
       if (dispatchable.length > 0) {
         if (deps.deferRunnableTasks) {
           deps.deferRunnableTasks(dispatchable, restored.workflowId);
@@ -508,6 +512,28 @@ export async function headlessRecreateWorkflow(workflowId: string, deps: Headles
   const started = recreateWfResult.data;
   const runnable = started.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
+    if (deps.noTrack) {
+      const dispatchable = [...runnable, ...collectDispatchableTopup(deps.orchestrator, runnable)];
+      if (dispatchable.length > 0) {
+        if (deps.deferRunnableTasks) {
+          deps.deferRunnableTasks(dispatchable, workflowId);
+        } else {
+          const te = createHeadlessExecutor(deps);
+          const launch = setTimeout(() => {
+            void te.executeTasks(dispatchable).catch((err) => {
+              deps.logger.error(
+                `background no-track workflow recreate failed for ${workflowId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+                { module: 'headless' },
+              );
+            });
+          }, 25);
+          launch.unref?.();
+        }
+      }
+      process.stdout.write('[headless] --no-track enabled: recreate accepted; exiting without tracking.\n');
+      return;
+    }
+
     const te = createHeadlessExecutor(deps);
     remoteFetchForPool.enabled = false;
     let topup: TaskState[] = [];
@@ -523,13 +549,6 @@ export async function headlessRecreateWorkflow(workflowId: string, deps: Headles
       });
     } finally {
       remoteFetchForPool.enabled = true;
-    }
-    if (runnable.length + topup.length === 0) {
-      return;
-    }
-    if (deps.noTrack) {
-      process.stdout.write('[headless] --no-track enabled: recreate accepted; exiting without tracking.\n');
-      return;
     }
     await trackHeadlessWorkflow(workflowId, deps, {
       printSummary: false,
@@ -740,15 +759,7 @@ export async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDe
     module: 'headless',
   });
 
-  const runningKey = (task: TaskState): string => {
-    const attemptId = task.execution.selectedAttemptId?.trim();
-    return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
-  };
-  const scopedKeys = new Set(runnable.map((task) => runningKey(task)));
-  const globalTopup = deps.orchestrator
-    .startExecution()
-    .filter(isDispatchableLaunch)
-    .filter((task) => !scopedKeys.has(runningKey(task)));
+  const globalTopup = collectDispatchableTopup(deps.orchestrator, runnable);
   deps.logger.info(
     `headlessRetryWorkflow trace workflow="${workflowId}" postStartExecution globalTopup=${globalTopup.length}`,
     { module: 'headless' },

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -102,12 +102,29 @@ export function assertLineageCurrent(
   }
 }
 
+function currentReviewGateLineage(task: TaskState, reviewId: string): ReviewGateLineageFields {
+  const gate = task.execution.reviewGate;
+  const artifact = gate?.artifacts.find((candidate) =>
+    candidate.generation === gate.activeGeneration
+    && candidate.status !== 'discarded'
+    && !candidate.discardedAt
+    && candidate.providerId === reviewId,
+  );
+  return {
+    reviewId: artifact?.providerId ?? task.execution.reviewId,
+    generation: task.execution.generation ?? 0,
+    selectedAttemptId: task.execution.selectedAttemptId,
+    branch: task.execution.branch,
+    headSha: artifact?.headSha,
+  };
+}
+
 function assertReviewGateCiContextCurrent(
   taskId: string,
   context: ReviewGateCiContext,
-  current: ReviewGateLineageFields,
+  task: TaskState,
 ): void {
-  if (!isReviewGateCiContextStale(context, current)) return;
+  if (!isReviewGateCiContextStale(context, currentReviewGateLineage(task, context.reviewId))) return;
   throw new StaleLineageError(
     `Review-gate CI auto-fix for ${taskId} is stale (review=${context.reviewId})`,
   );
@@ -842,7 +859,7 @@ export async function fixWithAgentAction(
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
   if (options.reviewGateContext) {
-    assertReviewGateCiContextCurrent(taskId, options.reviewGateContext, task.execution);
+    assertReviewGateCiContextCurrent(taskId, options.reviewGateContext, task);
   }
 
   const savedError = task.execution.error ?? '';


### PR DESCRIPTION
## Summary

App repair actions now read the active review-gate artifact before checking CI repair requests.

No-track workflow recreate now returns after the reset is accepted. It no longer waits for the relaunched command and turns a successful reset into a failed task.

<details>
<summary>Review metadata</summary>

Review Claim: App repair action context uses the active review-gate artifact, and no-track recreate leaves relaunched work to the background path.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The action keeps the existing lineage comparison and the recreate change only affects no-track dispatch timing after preemption succeeds.

Slice Rationale: This lands after the worker slice because it consumes recorded review-gate artifact data and fixes the same activation surface CI exercises.

</details>

## Non-goals

- Do not change worker registration order.
- Do not change retry limits or provider polling.
- Do not add live GitHub tests.

## Architecture

### Before

```mermaid
graph TD
    A["CI repair context uses task execution fields"]
    B["App repair action"]
    C["No-track recreate waits for relaunched command"]
    A --> B
    C --> D["Command failure can overwrite reset state"]
```

### After

```mermaid
graph TD
    A["CI repair context uses active review-gate artifact"]
    B["App repair action"]
    C["No-track recreate defers relaunched work"]
    A --> B
    C --> D["Reset state is observable immediately"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-delegation.test.ts`
- [x] `pnpm --filter @invoker/app build`
- [x] `bash scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh`
- [x] `node scripts/validate-pr-body.mjs --body "$BODY" --changed-files-file <(git diff --name-only pr-2900-worker-step3-base d08d625be) --diff-file <(git diff --find-renames --unified=200000 --diff-filter=ACMRTD pr-2900-worker-step3-base d08d625be --)`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert d08d625be 19f14eb4d`
- Post-revert steps: Re-run the app workflow-actions and no-track recreate tests.
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved headless workflow retry/recreate handling so no-track runs dispatch the right work immediately and avoid duplicate execution.
  * Fixed review-gate validation to use the current workflow state, reducing false stale-context errors during automated fixes.
  * Added coverage for the updated headless recreation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->