### PR TITLE
[Worker Registration: External Worker Plugins](1) Add external worker runtime

### DIFF
--- a/packages/app/src/__tests__/external-worker-loader.test.ts
+++ b/packages/app/src/__tests__/external-worker-loader.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { createWorkerRegistry } from '@invoker/execution-engine';
+
+import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
+
+const externalWorkers = [
+  {
+    kind: 'preview',
+    launch: {
+      executable: '/usr/local/bin/invoker-preview-worker',
+      args: ['--stdio'],
+    },
+  },
+];
+
+describe('external worker loader', () => {
+  it('registers configured external workers by kind', () => {
+    const registry = registerExternalWorkersFromConfig(externalWorkers, createWorkerRegistry());
+
+    const definition = registry.get('preview');
+
+    expect(definition).toBeDefined();
+    expect(definition?.kind).toBe('preview');
+    expect(registry.list().map((worker) => worker.kind)).toEqual(['preview']);
+  });
+
+  it('defaults to no external workers when config is absent', () => {
+    const registry = registerExternalWorkersFromConfig(undefined, createWorkerRegistry());
+
+    expect(registry.list()).toEqual([]);
+  });
+});

--- a/packages/app/src/external-worker-loader.ts
+++ b/packages/app/src/external-worker-loader.ts
@@ -1,0 +1,13 @@
+import {
+  registerExternalWorkers,
+  type WorkerRegistry,
+} from '@invoker/execution-engine';
+
+import type { ExternalWorkerConfig } from './config.js';
+
+export function registerExternalWorkersFromConfig(
+  externalWorkers: readonly ExternalWorkerConfig[] | undefined,
+  registry: WorkerRegistry,
+): WorkerRegistry {
+  return registerExternalWorkers(registry, externalWorkers);
+}

--- a/packages/execution-engine/src/__tests__/external-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/external-worker.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { registerExternalWorkers, type ExternalWorkerRuntime } from '../external-worker.js';
+import { createWorkerRegistry, type WorkerRuntimeDependencies } from '../worker-registry.js';
+
+const externalWorkers = [
+  {
+    kind: 'preview',
+    launch: {
+      executable: '/usr/local/bin/invoker-preview-worker',
+      args: ['--stdio'],
+    },
+  },
+];
+
+function createSleepingExternalWorker(): ExternalWorkerRuntime {
+  const registry = createWorkerRegistry();
+  registerExternalWorkers(registry, [
+    {
+      kind: 'external-sleep',
+      launch: {
+        executable: 'sleep',
+        args: ['30'],
+      },
+    },
+  ]);
+
+  const definition = registry.get('external-sleep');
+  expect(definition).toBeDefined();
+  return definition!.factory({} as WorkerRuntimeDependencies) as ExternalWorkerRuntime;
+}
+
+describe('external worker registration', () => {
+  it('registers configured external workers by kind', () => {
+    const registry = registerExternalWorkers(createWorkerRegistry(), externalWorkers);
+
+    const definition = registry.get('preview');
+
+    expect(definition).toBeDefined();
+    expect(definition?.kind).toBe('preview');
+    expect(registry.list().map((worker) => worker.kind)).toEqual(['preview']);
+  });
+
+  it('defaults to no external workers when config is absent', () => {
+    const registry = registerExternalWorkers(createWorkerRegistry(), undefined);
+
+    expect(registry.list()).toEqual([]);
+  });
+});
+
+describe('external worker runtime', () => {
+  it('returns from a manual tick after spawning the external process', async () => {
+    const runtime = createSleepingExternalWorker();
+
+    await runtime.tick();
+    await runtime.stop();
+    await runtime.finished;
+  });
+});

--- a/packages/execution-engine/src/external-worker.ts
+++ b/packages/execution-engine/src/external-worker.ts
@@ -1,0 +1,159 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import type { WorkerRegistry } from './worker-registry.js';
+import type { WorkerRuntime } from './worker-runtime.js';
+
+const STOP_TIMEOUT_MS = 5_000;
+
+export interface ExternalWorkerLaunchConfig {
+  /** Executable used to start the external worker process. */
+  executable: string;
+  /** Optional argv passed after the executable. */
+  args?: readonly string[];
+  /** Optional process working directory for the worker launch. */
+  cwd?: string;
+}
+
+export interface ExternalWorkerConfig {
+  /** Stable worker registry kind declared by the operator. */
+  kind: string;
+  /** Process invocation used to start the external worker. */
+  launch: ExternalWorkerLaunchConfig;
+}
+
+export interface ExternalWorkerRuntime extends WorkerRuntime {
+  /** Resolves when the supervised external process exits or the runtime stops before launch. */
+  readonly finished: Promise<void>;
+}
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+  reject(reason?: unknown): void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+
+function delay(ms: number): Promise<void> {
+  const { promise, resolve } = createDeferred<void>();
+  const timer = setTimeout(resolve, ms);
+  timer.unref?.();
+  return promise;
+}
+
+function createExternalWorkerRuntime(config: ExternalWorkerConfig): ExternalWorkerRuntime {
+  const identity = {
+    kind: config.kind,
+    instanceId: `external-${config.kind}-${process.pid}`,
+  };
+  const finishedGate = createDeferred<void>();
+
+  let child: ChildProcess | null = null;
+  let closePromise: Promise<void> | null = null;
+  let started = false;
+  let stopped = false;
+  let finished = false;
+
+  const finish = (): void => {
+    if (finished) return;
+    finished = true;
+    finishedGate.resolve();
+  };
+
+  const launch = (): void => {
+    if (stopped) return;
+    if (closePromise) return;
+
+    const childProcess = spawn(config.launch.executable, [...(config.launch.args ?? [])], {
+      cwd: config.launch.cwd,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    child = childProcess;
+
+    const closeGate = createDeferred<void>();
+    let closed = false;
+    const settle = (): void => {
+      if (closed) return;
+      closed = true;
+      child = null;
+      finish();
+      closeGate.resolve();
+    };
+
+    childProcess.once('error', settle);
+    childProcess.once('close', settle);
+    closePromise = closeGate.promise;
+  };
+
+  const start = (): void => {
+    if (stopped) {
+      throw new Error(`external worker ${identity.kind}/${identity.instanceId} cannot start after stop`);
+    }
+    if (started) return;
+    started = true;
+    void launch();
+  };
+
+  const stop = async (): Promise<void> => {
+    if (stopped) {
+      if (closePromise) await closePromise.catch(() => undefined);
+      return;
+    }
+    stopped = true;
+
+    const activeChild = child;
+    if (!activeChild) {
+      finish();
+      return;
+    }
+
+    if (!activeChild.killed) {
+      activeChild.kill('SIGTERM');
+    }
+
+    await Promise.race([
+      closePromise ?? Promise.resolve(),
+      delay(STOP_TIMEOUT_MS).then(() => {
+        if (child) child.kill('SIGKILL');
+      }),
+    ]).catch(() => undefined);
+  };
+
+  const tick = async (): Promise<void> => {
+    launch();
+  };
+
+  return {
+    identity,
+    finished: finishedGate.promise,
+    start,
+    wake: () => {
+      void launch();
+    },
+    tick,
+    stop,
+    isRunning: () => started && !stopped && child !== null,
+  };
+}
+
+export function registerExternalWorkers(
+  registry: WorkerRegistry,
+  externalWorkers: readonly ExternalWorkerConfig[] | undefined,
+): WorkerRegistry {
+  for (const config of externalWorkers ?? []) {
+    registry.register({
+      kind: config.kind,
+      note: `Supervises external worker process ${config.launch.executable}.`,
+      factory: () => createExternalWorkerRuntime(config),
+    });
+  }
+  return registry;
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -40,3 +40,5 @@ export * from './auto-fix-recovery.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';
+
+export * from './external-worker.js';


### PR DESCRIPTION
## Summary

The execution engine now has an external worker runtime.

A worker definition can supervise one executable as a foreground child process.

The process shares the worker lifetime: start launches it, stop terminates it, and exit marks the runtime finished.

<details>
<summary>Review metadata</summary>

Review Claim: The execution engine can register external worker definitions that supervise foreground child processes.

Review Lane: behavior

Review Unit: routing

Safety Invariant: No product caller registers external workers in this slice, so the runtime is dormant outside direct tests.

Slice Rationale: This lands the lower-level runtime before any later slice loads plugin configuration.

</details>

## Non-goals

- Do not wire headless or CLI worker commands to external worker config.
- Do not change built-in worker registration.
- Do not add a sample end-to-end worker proof.

## Architecture

### Before

```mermaid
graph TD
    A["Execution engine registry"] --> B["Built-in worker definitions"]
```

### After

```mermaid
graph TD
    A["External worker definition"] --> B["Foreground child process"]
    B --> C["Worker runtime lifetime"]
```

## Test Plan

- [x] `pnpm install`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/external-worker.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/external-worker-loader.test.ts src/__tests__/external-worker-e2e.test.ts`
- [x] `pnpm --filter @invoker/cli test`
- [x] `bash scripts/repro/repro-coderabbit-pr2919-manual-tick-launch.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0bfa12239`
- Post-revert steps: Re-run the focused execution-engine tests.
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and running external workers in the app and execution engine.
  * External workers can now be registered by kind and managed through the existing worker system.

* **Bug Fixes**
  * Improved external worker runtime supervision, including orderly shutdown and completion handling.

* **Tests**
  * Added coverage for external worker registration and lifecycle behavior, including enabled and empty configuration cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->