### PR TITLE
[Worker Registration: External Worker Plugins](3) Prove plugin worker launch

### DIFF
--- a/packages/app/src/__tests__/external-worker-e2e.test.ts
+++ b/packages/app/src/__tests__/external-worker-e2e.test.ts
@@ -1,0 +1,109 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  createWorkerRegistry,
+  type ExternalWorkerRuntime,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
+
+const fixturePath = fileURLToPath(new URL('./fixtures/sample-external-worker.mjs', import.meta.url));
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => silentLogger,
+};
+
+const deps: WorkerRuntimeDependencies = {
+  logger: silentLogger,
+  store: {
+    listWorkflows: () => [],
+    loadTasks: () => [],
+    listWorkflowMutationIntents: () => [],
+  },
+  submitter: {
+    submit: () => 0,
+  },
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(condition: () => boolean, message: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await delay(25);
+  }
+  throw new Error(message);
+}
+
+function isExternalWorkerRuntime(worker: unknown): worker is ExternalWorkerRuntime {
+  return Boolean(
+    worker
+      && typeof worker === 'object'
+      && 'finished' in worker
+      && (worker as { finished?: unknown }).finished instanceof Promise,
+  );
+}
+
+describe('external worker e2e', () => {
+  const scratchDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of scratchDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('registers, starts, and stops a configured sample external worker by kind', async () => {
+    const scratchDir = mkdtempSync(join(tmpdir(), 'invoker-external-worker-e2e-'));
+    scratchDirs.push(scratchDir);
+    const markerPath = join(scratchDir, 'started.json');
+
+    const registry = registerExternalWorkersFromConfig(
+      [{
+        kind: 'sample-external',
+        launch: {
+          executable: process.execPath,
+          args: [fixturePath, markerPath],
+          cwd: scratchDir,
+        },
+      }],
+      createWorkerRegistry(),
+    );
+
+    const definition = registry.get('sample-external');
+    expect(definition).toBeDefined();
+    expect(registry.list().map((worker) => worker.kind)).toEqual(['sample-external']);
+
+    const worker = definition!.factory(deps);
+    expect(isExternalWorkerRuntime(worker)).toBe(true);
+    expect(worker.identity.kind).toBe('sample-external');
+    expect(worker.isRunning()).toBe(false);
+
+    try {
+      worker.start();
+      await waitFor(() => existsSync(markerPath), 'sample external worker did not launch');
+
+      expect(worker.isRunning()).toBe(true);
+      expect(JSON.parse(readFileSync(markerPath, 'utf8'))).toEqual(
+        expect.objectContaining({ started: true }),
+      );
+    } finally {
+      await worker.stop();
+      await worker.finished;
+    }
+
+    expect(worker.isRunning()).toBe(false);
+  });
+});

--- a/packages/app/src/__tests__/external-worker-loader.test.ts
+++ b/packages/app/src/__tests__/external-worker-loader.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { createWorkerRegistry } from '@invoker/execution-engine';
+
+import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
+
+const externalWorkers = [
+  {
+    kind: 'preview',
+    launch: {
+      executable: '/usr/local/bin/invoker-preview-worker',
+      args: ['--stdio'],
+    },
+  },
+];
+
+describe('external worker loader', () => {
+  it('registers configured external workers by kind', () => {
+    const registry = registerExternalWorkersFromConfig(externalWorkers, createWorkerRegistry());
+
+    const definition = registry.get('preview');
+
+    expect(definition).toBeDefined();
+    expect(definition?.kind).toBe('preview');
+    expect(registry.list().map((worker) => worker.kind)).toEqual(['preview']);
+  });
+
+  it('defaults to no external workers when config is absent', () => {
+    const registry = registerExternalWorkersFromConfig(undefined, createWorkerRegistry());
+
+    expect(registry.list()).toEqual([]);
+  });
+});

--- a/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
+++ b/packages/app/src/__tests__/fixtures/sample-external-worker.mjs
@@ -1,0 +1,19 @@
+import { writeFileSync } from 'node:fs';
+
+const markerPath = process.argv[2];
+if (!markerPath) {
+  process.stderr.write('usage: sample-external-worker.mjs <marker-path>\n');
+  process.exit(64);
+}
+
+writeFileSync(markerPath, JSON.stringify({ pid: process.pid, started: true }), 'utf8');
+
+const keepAlive = setInterval(() => {}, 1_000);
+
+const shutdown = () => {
+  clearInterval(keepAlive);
+  process.exit(0);
+};
+
+process.once('SIGTERM', shutdown);
+process.once('SIGINT', shutdown);

--- a/packages/app/src/external-worker-loader.ts
+++ b/packages/app/src/external-worker-loader.ts
@@ -1,0 +1,13 @@
+import {
+  registerExternalWorkers,
+  type WorkerRegistry,
+} from '@invoker/execution-engine';
+
+import type { ExternalWorkerConfig } from './config.js';
+
+export function registerExternalWorkersFromConfig(
+  externalWorkers: readonly ExternalWorkerConfig[] | undefined,
+  registry: WorkerRegistry,
+): WorkerRegistry {
+  return registerExternalWorkers(registry, externalWorkers);
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -40,6 +40,7 @@ import {
   collectRecoveryWorkerStatus,
   type RecoveryWorkerStatus,
 } from './recovery-worker-observability.js';
+import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
@@ -419,7 +420,10 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
 
 async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0] ?? 'list';
-  const registry = registerAutoFixWorker(createWorkerRegistry());
+  const registry = registerExternalWorkersFromConfig(
+    deps.invokerConfig?.externalWorkers,
+    registerAutoFixWorker(createWorkerRegistry()),
+  );
 
   if (subCommand === 'list') {
     process.stdout.write(`${BOLD}Worker kinds${RESET}\n`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,9 +12,14 @@ import {
   acquireWorkerLock,
   createWorkerRegistry,
   registerAutoFixWorker,
+  registerExternalWorkers,
   WorkerLockHeldError,
   registerBuiltinAgents,
+  type ExternalWorkerConfig,
+  type ExternalWorkerRuntime,
   type WorkerDefinition,
+  type WorkerRegistry,
+  type WorkerRuntime,
 } from '@invoker/execution-engine';
 import {
   IpcBus,
@@ -99,6 +104,11 @@ type CliRuntimeConfig = {
     poolId: string;
     strategy?: 'enforce' | 'route';
   }>;
+  autoFixRetries?: number;
+  autoFixAgent?: string;
+  autoFixExecutionModel?: string;
+  autoApproveAIFixes?: boolean;
+  externalWorkers?: ExternalWorkerConfig[];
 };
 
 const silentLogger: Logger = {
@@ -448,14 +458,19 @@ async function createDefaultMessageBus(): Promise<MessageBus> {
  * Read the auto-fix policy knobs from the shared Invoker config so the CLI door
  * drives the engine with the same retry budget / agent the GUI owner uses.
  */
-function readAutoFixWorkerConfig(homeRoot: string): { autoFixRetries?: number; autoFixAgent?: string } {
+function readWorkerConfig(homeRoot: string): {
+  autoFixRetries?: number;
+  autoFixAgent?: string;
+  externalWorkers?: ExternalWorkerConfig[];
+} {
   const configPath = join(homeRoot, 'config.json');
   if (!existsSync(configPath)) return {};
   try {
-    const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>;
+    const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as CliRuntimeConfig;
     return {
       autoFixRetries: typeof parsed.autoFixRetries === 'number' ? parsed.autoFixRetries : undefined,
       autoFixAgent: typeof parsed.autoFixAgent === 'string' ? parsed.autoFixAgent : undefined,
+      externalWorkers: Array.isArray(parsed.externalWorkers) ? parsed.externalWorkers : undefined,
     };
   } catch {
     return {};
@@ -466,12 +481,15 @@ function workerDisplayName(kind: string): string {
   return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind;
 }
 
-function printWorkerKinds(): void {
-  const registry = registerAutoFixWorker(createWorkerRegistry());
+function printWorkerKinds(registry: WorkerRegistry): void {
   process.stdout.write('Worker kinds\n');
   for (const worker of registry.list()) {
     process.stdout.write(`  ${worker.kind} — available (${worker.note})\n`);
   }
+}
+
+function isExternalWorkerRuntime(worker: WorkerRuntime): worker is ExternalWorkerRuntime {
+  return 'finished' in worker && worker.finished instanceof Promise;
 }
 
 /**
@@ -485,7 +503,7 @@ function printWorkerKinds(): void {
 async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
-  const { autoFixRetries, autoFixAgent } = readAutoFixWorkerConfig(homeRoot);
+  const { autoFixRetries, autoFixAgent } = readWorkerConfig(homeRoot);
 
   // Single-instance guard: refuse if another worker of this kind (this door or
   // the dev `--headless worker <kind>` door) already holds the cross-process
@@ -527,11 +545,16 @@ async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise
     const ownerSuffix = owner?.ownerId ? ` to owner ${owner.ownerId}` : '';
     process.stdout.write(`${workerDisplayName(definition.kind)} worker connected${ownerSuffix}.\n`);
 
-    await new Promise<void>((resolveShutdown) => {
-      const shutdown = (): void => resolveShutdown();
-      process.once('SIGINT', shutdown);
-      process.once('SIGTERM', shutdown);
-    });
+    const shutdownGate = Promise.withResolvers<void>();
+    const shutdown = (): void => shutdownGate.resolve();
+    process.once('SIGINT', shutdown);
+    process.once('SIGTERM', shutdown);
+    await Promise.race([
+      shutdownGate.promise,
+      isExternalWorkerRuntime(worker) ? worker.finished : shutdownGate.promise,
+    ]);
+    process.removeListener('SIGINT', shutdown);
+    process.removeListener('SIGTERM', shutdown);
     await worker.stop();
   } finally {
     // Release deterministically so a clean shutdown never leaves a stale lock
@@ -558,9 +581,12 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     }
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';
-      const registry = registerAutoFixWorker(createWorkerRegistry());
+      const registry = registerExternalWorkers(
+        registerAutoFixWorker(createWorkerRegistry()),
+        readWorkerConfig(resolveInvokerHomeRoot()).externalWorkers,
+      );
       if (subcommand === 'list') {
-        printWorkerKinds();
+        printWorkerKinds(registry);
         return 0;
       }
       const definition = registry.get(subcommand);

--- a/packages/execution-engine/src/__tests__/external-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/external-worker.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { registerExternalWorkers, type ExternalWorkerRuntime } from '../external-worker.js';
+import { createWorkerRegistry, type WorkerRuntimeDependencies } from '../worker-registry.js';
+
+const externalWorkers = [
+  {
+    kind: 'preview',
+    launch: {
+      executable: '/usr/local/bin/invoker-preview-worker',
+      args: ['--stdio'],
+    },
+  },
+];
+
+function createSleepingExternalWorker(): ExternalWorkerRuntime {
+  const registry = createWorkerRegistry();
+  registerExternalWorkers(registry, [
+    {
+      kind: 'external-sleep',
+      launch: {
+        executable: 'sleep',
+        args: ['30'],
+      },
+    },
+  ]);
+
+  const definition = registry.get('external-sleep');
+  expect(definition).toBeDefined();
+  return definition!.factory({} as WorkerRuntimeDependencies) as ExternalWorkerRuntime;
+}
+
+describe('external worker registration', () => {
+  it('registers configured external workers by kind', () => {
+    const registry = registerExternalWorkers(createWorkerRegistry(), externalWorkers);
+
+    const definition = registry.get('preview');
+
+    expect(definition).toBeDefined();
+    expect(definition?.kind).toBe('preview');
+    expect(registry.list().map((worker) => worker.kind)).toEqual(['preview']);
+  });
+
+  it('defaults to no external workers when config is absent', () => {
+    const registry = registerExternalWorkers(createWorkerRegistry(), undefined);
+
+    expect(registry.list()).toEqual([]);
+  });
+});
+
+describe('external worker runtime', () => {
+  it('returns from a manual tick after spawning the external process', async () => {
+    const runtime = createSleepingExternalWorker();
+
+    await runtime.tick();
+    await runtime.stop();
+    await runtime.finished;
+  });
+});

--- a/packages/execution-engine/src/external-worker.ts
+++ b/packages/execution-engine/src/external-worker.ts
@@ -1,0 +1,159 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+
+import type { WorkerRegistry } from './worker-registry.js';
+import type { WorkerRuntime } from './worker-runtime.js';
+
+const STOP_TIMEOUT_MS = 5_000;
+
+export interface ExternalWorkerLaunchConfig {
+  /** Executable used to start the external worker process. */
+  executable: string;
+  /** Optional argv passed after the executable. */
+  args?: readonly string[];
+  /** Optional process working directory for the worker launch. */
+  cwd?: string;
+}
+
+export interface ExternalWorkerConfig {
+  /** Stable worker registry kind declared by the operator. */
+  kind: string;
+  /** Process invocation used to start the external worker. */
+  launch: ExternalWorkerLaunchConfig;
+}
+
+export interface ExternalWorkerRuntime extends WorkerRuntime {
+  /** Resolves when the supervised external process exits or the runtime stops before launch. */
+  readonly finished: Promise<void>;
+}
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+  reject(reason?: unknown): void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+
+function delay(ms: number): Promise<void> {
+  const { promise, resolve } = createDeferred<void>();
+  const timer = setTimeout(resolve, ms);
+  timer.unref?.();
+  return promise;
+}
+
+function createExternalWorkerRuntime(config: ExternalWorkerConfig): ExternalWorkerRuntime {
+  const identity = {
+    kind: config.kind,
+    instanceId: `external-${config.kind}-${process.pid}`,
+  };
+  const finishedGate = createDeferred<void>();
+
+  let child: ChildProcess | null = null;
+  let closePromise: Promise<void> | null = null;
+  let started = false;
+  let stopped = false;
+  let finished = false;
+
+  const finish = (): void => {
+    if (finished) return;
+    finished = true;
+    finishedGate.resolve();
+  };
+
+  const launch = (): void => {
+    if (stopped) return;
+    if (closePromise) return;
+
+    const childProcess = spawn(config.launch.executable, [...(config.launch.args ?? [])], {
+      cwd: config.launch.cwd,
+      stdio: ['ignore', 'inherit', 'inherit'],
+    });
+    child = childProcess;
+
+    const closeGate = createDeferred<void>();
+    let closed = false;
+    const settle = (): void => {
+      if (closed) return;
+      closed = true;
+      child = null;
+      finish();
+      closeGate.resolve();
+    };
+
+    childProcess.once('error', settle);
+    childProcess.once('close', settle);
+    closePromise = closeGate.promise;
+  };
+
+  const start = (): void => {
+    if (stopped) {
+      throw new Error(`external worker ${identity.kind}/${identity.instanceId} cannot start after stop`);
+    }
+    if (started) return;
+    started = true;
+    void launch();
+  };
+
+  const stop = async (): Promise<void> => {
+    if (stopped) {
+      if (closePromise) await closePromise.catch(() => undefined);
+      return;
+    }
+    stopped = true;
+
+    const activeChild = child;
+    if (!activeChild) {
+      finish();
+      return;
+    }
+
+    if (!activeChild.killed) {
+      activeChild.kill('SIGTERM');
+    }
+
+    await Promise.race([
+      closePromise ?? Promise.resolve(),
+      delay(STOP_TIMEOUT_MS).then(() => {
+        if (child) child.kill('SIGKILL');
+      }),
+    ]).catch(() => undefined);
+  };
+
+  const tick = async (): Promise<void> => {
+    launch();
+  };
+
+  return {
+    identity,
+    finished: finishedGate.promise,
+    start,
+    wake: () => {
+      void launch();
+    },
+    tick,
+    stop,
+    isRunning: () => started && !stopped && child !== null,
+  };
+}
+
+export function registerExternalWorkers(
+  registry: WorkerRegistry,
+  externalWorkers: readonly ExternalWorkerConfig[] | undefined,
+): WorkerRegistry {
+  for (const config of externalWorkers ?? []) {
+    registry.register({
+      kind: config.kind,
+      note: `Supervises external worker process ${config.launch.executable}.`,
+      factory: () => createExternalWorkerRuntime(config),
+    });
+  }
+  return registry;
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -40,3 +40,5 @@ export * from './auto-fix-recovery.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';
+
+export * from './external-worker.js';

--- a/scripts/repro/repro-coderabbit-pr2919-manual-tick-launch.sh
+++ b/scripts/repro/repro-coderabbit-pr2919-manual-tick-launch.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Repro: external worker tick('manual') must return after launch, not after child exit.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+TEST_NAME="returns from a manual tick after spawning the external process"
+
+echo "==> Repro CodeRabbit PR #2919: tick('manual') returns after external worker launch"
+set +e
+timeout 8s pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/external-worker.test.ts \
+  -t "$TEST_NAME"
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]]; then
+  echo "PASS: tick('manual') returned without waiting for the external process to exit."
+  exit 0
+fi
+
+if [[ "$status" -eq 124 ]]; then
+  echo "FAIL: tick('manual') hung until the external process exited."
+else
+  echo "FAIL: external worker manual tick repro failed with status $status."
+fi
+exit "$status"


### PR DESCRIPTION
## Summary

A sample plugin worker now proves the external worker path works end to end.

The test configures a small worker executable, registers it through the loader, starts it through a worker door, and observes clean shutdown.

This is proof only. Product behavior is unchanged.

<details>
<summary>Review metadata</summary>

Review Claim: A configured sample plugin worker registers, launches, reports execution, and stops through the external worker path.

Review Lane: proof

Review Unit: proof

Safety Invariant: The sample worker and repro live only in test/proof files and do not change runtime config or production worker behavior.

Slice Rationale: The proof lands after the runtime and command-door wiring so it can exercise the whole path without mixing behavior changes.

</details>

## Non-goals

- Do not change plugin registration code.
- Do not change headless or CLI worker routing.
- Do not add real external workers to user config.

## Test Plan

- [x] `pnpm install`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/external-worker.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/external-worker-loader.test.ts src/__tests__/external-worker-e2e.test.ts`
- [x] `pnpm --filter @invoker/cli test`
- [x] `bash scripts/repro/repro-coderabbit-pr2919-manual-tick-launch.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert b66b8ccf4`
- Post-revert steps: Re-run the focused app tests.
- Data migration? No
