### PR TITLE
[Worker Registration Step 3: PR Status and CI Failure Workers](2) Check CI repair lineage against active artifacts

### DIFF
--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -102,12 +102,29 @@ export function assertLineageCurrent(
   }
 }
 
+function currentReviewGateLineage(task: TaskState, reviewId: string): ReviewGateLineageFields {
+  const gate = task.execution.reviewGate;
+  const artifact = gate?.artifacts.find((candidate) =>
+    candidate.generation === gate.activeGeneration
+    && candidate.status !== 'discarded'
+    && !candidate.discardedAt
+    && candidate.providerId === reviewId,
+  );
+  return {
+    reviewId: artifact?.providerId ?? task.execution.reviewId,
+    generation: task.execution.generation ?? 0,
+    selectedAttemptId: task.execution.selectedAttemptId,
+    branch: task.execution.branch,
+    headSha: artifact?.headSha,
+  };
+}
+
 function assertReviewGateCiContextCurrent(
   taskId: string,
   context: ReviewGateCiContext,
-  current: ReviewGateLineageFields,
+  task: TaskState,
 ): void {
-  if (!isReviewGateCiContextStale(context, current)) return;
+  if (!isReviewGateCiContextStale(context, currentReviewGateLineage(task, context.reviewId))) return;
   throw new StaleLineageError(
     `Review-gate CI auto-fix for ${taskId} is stale (review=${context.reviewId})`,
   );
@@ -842,7 +859,7 @@ export async function fixWithAgentAction(
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
   if (options.reviewGateContext) {
-    assertReviewGateCiContextCurrent(taskId, options.reviewGateContext, task.execution);
+    assertReviewGateCiContextCurrent(taskId, options.reviewGateContext, task);
   }
 
   const savedError = task.execution.error ?? '';


### PR DESCRIPTION
## Summary

The review-gate CI fix path now reads the task's current review-gate artifact instead of a captured snapshot.

It compares the incoming CI fix context against that live artifact, including its head SHA, before the fix proceeds.

A CI fix tied to an older artifact no longer proceeds against a newer one.

<details>
<summary>Review metadata</summary>

Review Claim: The CI auto-fix path checks its context against the task's current review-gate artifact before the fix proceeds.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The comparison only decides whether an already-requested CI fix proceeds; it never starts new work on its own.

Slice Rationale: This lineage check is a one-file change to the CI fix action and is kept apart from the worker definitions and the app startup wiring.

</details>

## Non-goals

- Do not add new worker definitions in this slice.
- Do not change app startup or worker lifecycle here.
- Do not change live GitHub test coverage.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- src/__tests__/workflow-actions.test.ts`
- [x] Invoker workflow verification task `wf-1782763617781-4/verify-pr-status-ci-workers` completed with focused PR worker tests passing.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 5cb8820fb`
- Post-revert steps: Revert the dependent slice 3 PR first.
- Data migration? No
