### PR TITLE
[Worker Registration Step 3: PR Status and CI Failure Workers](3) Start registered owner workers in app surfaces

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -94,11 +94,17 @@ import type { MessageBus } from '@invoker/transport';
 import {
   ExecutorRegistry, TaskRunner,
   WorktreeExecutor,
+  CI_FAILURE_WORKER_KIND,
   initializeShellEnvironment,
+  createWorkerRegistry,
+  PR_STATUS_WORKER_KIND,
   RESTART_TO_BRANCH_TRACE,
   remoteFetchForPool,
   registerBuiltinAgents,
+  registerBuiltinWorkers,
   type AgentRegistry,
+  type WorkerRuntime,
+  type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
 import type { TaskOutputData } from './types.js';
@@ -204,6 +210,7 @@ import {
   buildHeadlessFixArgs,
   listOpenFixIntentsForTask,
   parseFixWithAgentMutationArgs,
+  type ReviewGateCiContext,
 } from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
@@ -224,7 +231,6 @@ import {
 } from './ipc/ipc-registration.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import { startLifecycleEventBridge, type LifecycleEventBridge } from './lifecycle-event-bridge.js';
-import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
 import {
   buildRecoveryWorkerAuditPayload,
   classifyAutoFixRecoveryPhase,
@@ -254,6 +260,31 @@ import {
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
 
+const REGISTERED_OWNER_WORKER_KINDS = [
+  PR_STATUS_WORKER_KIND,
+  CI_FAILURE_WORKER_KIND,
+] as const;
+
+function startRegisteredOwnerWorkers(deps: WorkerRuntimeDependencies): WorkerRuntime[] {
+  const registry = registerBuiltinWorkers(createWorkerRegistry());
+  const workers: WorkerRuntime[] = [];
+  for (const kind of REGISTERED_OWNER_WORKER_KINDS) {
+    const definition = registry.get(kind);
+    if (!definition) {
+      deps.logger.warn(`registered owner worker "${kind}" is unavailable`, { module: 'worker-registry' });
+      continue;
+    }
+    const worker = definition.factory(deps);
+    worker.start();
+    workers.push(worker);
+  }
+  return workers;
+}
+
+async function stopRegisteredOwnerWorkers(workers: WorkerRuntime[]): Promise<void> {
+  const stopping = workers.splice(0).map((worker) => worker.stop().catch(() => undefined));
+  await Promise.all(stopping);
+}
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -909,7 +940,7 @@ function startHeadlessMode(): void {
     }
 
     let exitCode = 0;
-    let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
+    const registeredOwnerWorkers: WorkerRuntime[] = [];
     let lifecycleEventBridge: LifecycleEventBridge | null = null;
     let standaloneLaunchDispatcherController: StandaloneLaunchDispatcherController | null = null;
     try {
@@ -1588,11 +1619,35 @@ function startHeadlessMode(): void {
           logWarn: (message) => logger.warn(message, { module: 'surface-relay' }),
         });
 
-        reviewGateStatusWorker = startReviewGateStatusWorker({
-          ownerMode: true,
-          getTaskExecutor: createStandaloneTaskExecutor,
+        registeredOwnerWorkers.push(...startRegisteredOwnerWorkers({
+          store: persistence,
+          submitter: {
+            submit: (workflowId, priority, channel, mutationArgs, options) => {
+              if (!workflowMutationCoordinator) {
+                throw new Error('Workflow mutation coordinator is unavailable');
+              }
+              if (!workflowMutationDispatcher.has(channel)) {
+                throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
+              }
+              return workflowMutationCoordinator.submit(workflowId, priority, channel, mutationArgs, options);
+            },
+          },
           logger,
-        });
+          messageBus,
+          reviewGate: {
+            checkMergeGateStatuses: async () => {
+              await createStandaloneTaskExecutor().checkMergeGateStatuses();
+            },
+          },
+          autoFix: {
+            defaultAutoFixRetries: invokerConfig.autoFixRetries,
+            getAutoFixAgent: () => invokerConfig.autoFixAgent,
+            getAutoFixExecutionModel: () => invokerConfig.autoFixExecutionModel,
+          },
+          autoApprove: {
+            getAutoApproveAIFixes: () => invokerConfig.autoApproveAIFixes,
+          },
+        }));
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
@@ -1612,7 +1667,7 @@ function startHeadlessMode(): void {
     } finally {
       standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
-      reviewGateStatusWorker?.stop();
+      await stopRegisteredOwnerWorkers(registeredOwnerWorkers);
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
       }
@@ -1699,7 +1754,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const agentRegistry = registerBuiltinAgents();
   let mainWindow: BrowserWindow | null = null;
   let taskExecutor: TaskRunner | null = null;
-  let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
+  const registeredOwnerWorkers: WorkerRuntime[] = [];
   let apiServer: ApiServer | null = null;
   let webBridge: WebBridge | null = null;
   let ownerMode = true;
@@ -2013,6 +2068,7 @@ function createEmbeddedTerminalBackendFromConfig(
     agentName?: string,
     source: 'ipc' | 'auto-fix' = 'ipc',
     executionModel?: string,
+    reviewGateContext?: ReviewGateCiContext,
   ): Promise<TaskState[]> => {
     const task = orchestrator.getTask(taskId);
     if (!task) {
@@ -2051,6 +2107,7 @@ function createEmbeddedTerminalBackendFromConfig(
         recoveryRoute,
         recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
         failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`,
+        reviewGateContext,
         executionModel,
         signal: activeMutationContext?.signal,
       },
@@ -3315,11 +3372,37 @@ function createEmbeddedTerminalBackendFromConfig(
       });
     }
 
-    reviewGateStatusWorker = startReviewGateStatusWorker({
-      ownerMode,
-      getTaskExecutor: requireTaskExecutor,
-      logger,
-    });
+    if (ownerMode) {
+      registeredOwnerWorkers.push(...startRegisteredOwnerWorkers({
+        store: persistence,
+        submitter: {
+          submit: (workflowId, priority, channel, args, options) => {
+            if (!workflowMutationCoordinator) {
+              throw new Error('Workflow mutation coordinator is unavailable');
+            }
+            if (!workflowMutationDispatcher.has(channel)) {
+              throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
+            }
+            return workflowMutationCoordinator.submit(workflowId, priority, channel, args, options);
+          },
+        },
+        logger,
+        messageBus,
+        reviewGate: {
+          checkMergeGateStatuses: async () => {
+            await requireTaskExecutor().checkMergeGateStatuses();
+          },
+        },
+        autoFix: {
+          defaultAutoFixRetries: invokerConfig.autoFixRetries,
+          getAutoFixAgent: () => invokerConfig.autoFixAgent,
+          getAutoFixExecutionModel: () => invokerConfig.autoFixExecutionModel,
+        },
+        autoApprove: {
+          getAutoApproveAIFixes: () => invokerConfig.autoApproveAIFixes,
+        },
+      }));
+    }
 
     // Relaunch orphaned running tasks and start any pending-but-ready tasks.
     if (!ownerMode) {
@@ -4278,16 +4361,22 @@ function createEmbeddedTerminalBackendFromConfig(
       'invoker:fix-with-agent',
       (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
       'normal',
-      async (taskIdArg: unknown, agentNameArg?: unknown) => {
-      const taskId = String(taskIdArg);
-      const agentName = agentNameArg === undefined ? undefined : String(agentNameArg);
+      async (...fixArgs: unknown[]) => {
+      const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
+      const source = context.autoFix ? 'auto-fix' : 'ipc';
       try {
-        const started = await executeFixWithAgentMutation(taskId, agentName, 'ipc');
+        const started = await executeFixWithAgentMutation(
+          taskId,
+          agentName,
+          source,
+          context.executionModel,
+          context.reviewGateContext,
+        );
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
           logger,
-          context: 'ipc.fix-with-agent',
+          context: source === 'auto-fix' ? 'ipc.fix-with-agent.auto-fix' : 'ipc.fix-with-agent',
           started,
           mutationTiming: activeMutationContext?.mutationTiming,
           scopedTaskIds: [taskId],
@@ -4675,8 +4764,7 @@ function createEmbeddedTerminalBackendFromConfig(
       try {
         if (apiServer) await apiServer.close().catch(() => {});
         if (webBridge) await webBridge.close().catch(() => {});
-        reviewGateStatusWorker?.stop();
-        reviewGateStatusWorker = null;
+        await stopRegisteredOwnerWorkers(registeredOwnerWorkers);
         if (dbPollInterval) clearInterval(dbPollInterval);
         if (activityPollInterval) clearInterval(activityPollInterval);
         if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);


### PR DESCRIPTION
## Summary

App startup now builds the worker registry and starts the PR status and CI failure workers as owner-mode workers.

The earlier bespoke review-gate status worker startup path is gone.

On shutdown, the app stops these registered owner workers together.

<details>
<summary>Review metadata</summary>

Review Claim: App startup starts the registered PR status and CI failure owner workers instead of the earlier bespoke status worker.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The workers only start in owner mode and stop on shutdown, so read-only surfaces keep their prior startup behavior.

Slice Rationale: This app-startup wiring lands last because it depends on the worker definitions and the lineage check from the earlier slices.

</details>

## Non-goals

- Do not add new worker definitions in this slice.
- Do not change the CI fix lineage check here.
- Do not change read-only surface startup.

## Test Plan

- [x] `pnpm --filter @invoker/app build`
- [x] Invoker workflow verification task `wf-1782763617781-4/verify-pr-status-ci-workers` completed with focused PR worker tests passing.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 81811905f`
- Post-revert steps: None beyond restoring the earlier status worker startup path.
- Data migration? No
