### PR TITLE
[CLI/UI Setup Parity Step 4](1) Add setup request IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -334,6 +334,31 @@ export interface CliInstallResult {
   error?: string;
   status: CliInstallerStatus;
 }
+export interface InvokerSetupRequest {
+  updateCli: boolean;
+  installHelpers: boolean;
+  fixTools: boolean;
+  slack: false | {
+    botToken: string;
+    appToken: string;
+    signingSecret: string;
+    channelId: string;
+  };
+}
+
+export interface InvokerSetupStepResult {
+  id: 'invoker-cli' | 'helpers' | 'tools' | 'slack';
+  name: string;
+  ok: boolean;
+  output: string;
+  error?: string;
+}
+
+export interface InvokerSetupResult {
+  ok: boolean;
+  steps: InvokerSetupStepResult[];
+}
+
 
 export interface SystemDiagnostics {
   platform: string;
@@ -742,6 +767,10 @@ export const IpcChannels = {
   'invoker:update-invoker-cli': {} as {
     request: [];
     response: CliInstallResult;
+  },
+  'invoker:run-invoker-cli-setup': {} as {
+    request: [request: InvokerSetupRequest];
+    response: InvokerSetupResult;
   },
 
 } as const;


### PR DESCRIPTION
## Summary

The shared IPC contract now describes a checklist setup request.

It also returns one result per setup step. The UI can show partial success instead of one vague failure.

<details>
<summary>Review metadata</summary>

Review Claim: The contract can carry selected setup steps and return per-step setup results.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This only adds new setup types and a typed request shape for one existing IPC channel.

Slice Rationale: The contract lands first so app and UI code can depend on the same request and result shape.

</details>

## Non-goals

This does not run any setup step.

This does not change Slack validation.

This does not change the diagnostics contract.

## Test Plan

- [x] `pnpm --filter @invoker/contracts build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 452607368`
- Post-revert steps: None
- Data migration? No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Invoker CLI setup flow.
  * Users can now request setup actions such as updating the CLI, installing helper tools, and fixing local tools.
  * The setup flow can optionally include Slack credentials, and returns a step-by-step result summary for better visibility into progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->