### PR TITLE
[Worker Registration Step 3: PR Status and CI Failure Workers](1) Register PR status and CI failure workers

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -94,11 +94,17 @@ import type { MessageBus } from '@invoker/transport';
 import {
   ExecutorRegistry, TaskRunner,
   WorktreeExecutor,
+  CI_FAILURE_WORKER_KIND,
   initializeShellEnvironment,
+  createWorkerRegistry,
+  PR_STATUS_WORKER_KIND,
   RESTART_TO_BRANCH_TRACE,
   remoteFetchForPool,
   registerBuiltinAgents,
+  registerBuiltinWorkers,
   type AgentRegistry,
+  type WorkerRuntime,
+  type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
 import type { TaskOutputData } from './types.js';
@@ -204,6 +210,7 @@ import {
   buildHeadlessFixArgs,
   listOpenFixIntentsForTask,
   parseFixWithAgentMutationArgs,
+  type ReviewGateCiContext,
 } from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
@@ -224,7 +231,6 @@ import {
 } from './ipc/ipc-registration.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import { startLifecycleEventBridge, type LifecycleEventBridge } from './lifecycle-event-bridge.js';
-import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
 import {
   buildRecoveryWorkerAuditPayload,
   classifyAutoFixRecoveryPhase,
@@ -254,6 +260,31 @@ import {
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
 
+const REGISTERED_OWNER_WORKER_KINDS = [
+  PR_STATUS_WORKER_KIND,
+  CI_FAILURE_WORKER_KIND,
+] as const;
+
+function startRegisteredOwnerWorkers(deps: WorkerRuntimeDependencies): WorkerRuntime[] {
+  const registry = registerBuiltinWorkers(createWorkerRegistry());
+  const workers: WorkerRuntime[] = [];
+  for (const kind of REGISTERED_OWNER_WORKER_KINDS) {
+    const definition = registry.get(kind);
+    if (!definition) {
+      deps.logger.warn(`registered owner worker "${kind}" is unavailable`, { module: 'worker-registry' });
+      continue;
+    }
+    const worker = definition.factory(deps);
+    worker.start();
+    workers.push(worker);
+  }
+  return workers;
+}
+
+async function stopRegisteredOwnerWorkers(workers: WorkerRuntime[]): Promise<void> {
+  const stopping = workers.splice(0).map((worker) => worker.stop().catch(() => undefined));
+  await Promise.all(stopping);
+}
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -909,7 +940,7 @@ function startHeadlessMode(): void {
     }
 
     let exitCode = 0;
-    let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
+    const registeredOwnerWorkers: WorkerRuntime[] = [];
     let lifecycleEventBridge: LifecycleEventBridge | null = null;
     let standaloneLaunchDispatcherController: StandaloneLaunchDispatcherController | null = null;
     try {
@@ -1588,11 +1619,35 @@ function startHeadlessMode(): void {
           logWarn: (message) => logger.warn(message, { module: 'surface-relay' }),
         });
 
-        reviewGateStatusWorker = startReviewGateStatusWorker({
-          ownerMode: true,
-          getTaskExecutor: createStandaloneTaskExecutor,
+        registeredOwnerWorkers.push(...startRegisteredOwnerWorkers({
+          store: persistence,
+          submitter: {
+            submit: (workflowId, priority, channel, mutationArgs, options) => {
+              if (!workflowMutationCoordinator) {
+                throw new Error('Workflow mutation coordinator is unavailable');
+              }
+              if (!workflowMutationDispatcher.has(channel)) {
+                throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
+              }
+              return workflowMutationCoordinator.submit(workflowId, priority, channel, mutationArgs, options);
+            },
+          },
           logger,
-        });
+          messageBus,
+          reviewGate: {
+            checkMergeGateStatuses: async () => {
+              await createStandaloneTaskExecutor().checkMergeGateStatuses();
+            },
+          },
+          autoFix: {
+            defaultAutoFixRetries: invokerConfig.autoFixRetries,
+            getAutoFixAgent: () => invokerConfig.autoFixAgent,
+            getAutoFixExecutionModel: () => invokerConfig.autoFixExecutionModel,
+          },
+          autoApprove: {
+            getAutoApproveAIFixes: () => invokerConfig.autoApproveAIFixes,
+          },
+        }));
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
@@ -1612,7 +1667,7 @@ function startHeadlessMode(): void {
     } finally {
       standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
-      reviewGateStatusWorker?.stop();
+      await stopRegisteredOwnerWorkers(registeredOwnerWorkers);
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
       }
@@ -1699,7 +1754,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const agentRegistry = registerBuiltinAgents();
   let mainWindow: BrowserWindow | null = null;
   let taskExecutor: TaskRunner | null = null;
-  let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
+  const registeredOwnerWorkers: WorkerRuntime[] = [];
   let apiServer: ApiServer | null = null;
   let webBridge: WebBridge | null = null;
   let ownerMode = true;
@@ -2013,6 +2068,7 @@ function createEmbeddedTerminalBackendFromConfig(
     agentName?: string,
     source: 'ipc' | 'auto-fix' = 'ipc',
     executionModel?: string,
+    reviewGateContext?: ReviewGateCiContext,
   ): Promise<TaskState[]> => {
     const task = orchestrator.getTask(taskId);
     if (!task) {
@@ -2051,6 +2107,7 @@ function createEmbeddedTerminalBackendFromConfig(
         recoveryRoute,
         recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
         failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`,
+        reviewGateContext,
         executionModel,
         signal: activeMutationContext?.signal,
       },
@@ -3315,11 +3372,37 @@ function createEmbeddedTerminalBackendFromConfig(
       });
     }
 
-    reviewGateStatusWorker = startReviewGateStatusWorker({
-      ownerMode,
-      getTaskExecutor: requireTaskExecutor,
-      logger,
-    });
+    if (ownerMode) {
+      registeredOwnerWorkers.push(...startRegisteredOwnerWorkers({
+        store: persistence,
+        submitter: {
+          submit: (workflowId, priority, channel, args, options) => {
+            if (!workflowMutationCoordinator) {
+              throw new Error('Workflow mutation coordinator is unavailable');
+            }
+            if (!workflowMutationDispatcher.has(channel)) {
+              throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
+            }
+            return workflowMutationCoordinator.submit(workflowId, priority, channel, args, options);
+          },
+        },
+        logger,
+        messageBus,
+        reviewGate: {
+          checkMergeGateStatuses: async () => {
+            await requireTaskExecutor().checkMergeGateStatuses();
+          },
+        },
+        autoFix: {
+          defaultAutoFixRetries: invokerConfig.autoFixRetries,
+          getAutoFixAgent: () => invokerConfig.autoFixAgent,
+          getAutoFixExecutionModel: () => invokerConfig.autoFixExecutionModel,
+        },
+        autoApprove: {
+          getAutoApproveAIFixes: () => invokerConfig.autoApproveAIFixes,
+        },
+      }));
+    }
 
     // Relaunch orphaned running tasks and start any pending-but-ready tasks.
     if (!ownerMode) {
@@ -4278,16 +4361,22 @@ function createEmbeddedTerminalBackendFromConfig(
       'invoker:fix-with-agent',
       (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
       'normal',
-      async (taskIdArg: unknown, agentNameArg?: unknown) => {
-      const taskId = String(taskIdArg);
-      const agentName = agentNameArg === undefined ? undefined : String(agentNameArg);
+      async (...fixArgs: unknown[]) => {
+      const { taskId, agentName, context } = parseFixWithAgentMutationArgs(fixArgs);
+      const source = context.autoFix ? 'auto-fix' : 'ipc';
       try {
-        const started = await executeFixWithAgentMutation(taskId, agentName, 'ipc');
+        const started = await executeFixWithAgentMutation(
+          taskId,
+          agentName,
+          source,
+          context.executionModel,
+          context.reviewGateContext,
+        );
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
           logger,
-          context: 'ipc.fix-with-agent',
+          context: source === 'auto-fix' ? 'ipc.fix-with-agent.auto-fix' : 'ipc.fix-with-agent',
           started,
           mutationTiming: activeMutationContext?.mutationTiming,
           scopedTaskIds: [taskId],
@@ -4675,8 +4764,7 @@ function createEmbeddedTerminalBackendFromConfig(
       try {
         if (apiServer) await apiServer.close().catch(() => {});
         if (webBridge) await webBridge.close().catch(() => {});
-        reviewGateStatusWorker?.stop();
-        reviewGateStatusWorker = null;
+        await stopRegisteredOwnerWorkers(registeredOwnerWorkers);
         if (dbPollInterval) clearInterval(dbPollInterval);
         if (activityPollInterval) clearInterval(activityPollInterval);
         if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationPriority } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { parseFixWithAgentMutationArgs } from '../auto-fix-intents.js';
+import type { ReviewGateCiFailedLifecycleEvent } from '../lifecycle-events.js';
+import {
+  CI_FAILURE_WORKER_KIND,
+  ciFailureActionKey,
+  createCiFailureTick,
+} from '../workers/ci-failure-worker.js';
+import {
+  DEFAULT_PR_STATUS_WORKER_INTERVAL_MS,
+  createPrStatusWorker,
+} from '../workers/pr-status-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/merge',
+    description: 'merge',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', isMergeNode: true, ...(config ?? {}) },
+    execution: {
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'feature/ci',
+      reviewGate: {
+        activeGeneration: 2,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'pr-123',
+          providerId: '123',
+          provider: 'github',
+          required: true,
+          status: 'open',
+          generation: 2,
+          headSha: 'sha-1',
+        }],
+      },
+      ...(execution ?? {}),
+    },
+    taskStateVersion: 10,
+    ...rest,
+  } as TaskState;
+}
+
+function makeEvent(overrides: Partial<ReviewGateCiFailedLifecycleEvent> = {}): ReviewGateCiFailedLifecycleEvent {
+  return {
+    eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge',
+    kind: 'review_gate.ci_failed',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/merge',
+    status: 'review_ready',
+    taskStateVersion: 10,
+    generation: 2,
+    attemptId: 'attempt-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    recoveryWakeup: {
+      eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge',
+      eventKind: 'review_gate.ci_failed',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      taskStateVersion: 10,
+      generation: 2,
+      attemptId: 'attempt-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      reason: 'review_gate_failure',
+      authoritative: false,
+    },
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    headSha: 'sha-1',
+    headRef: 'feature/ci',
+    branch: 'feature/ci',
+    failedChecks: [
+      { name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' },
+      { name: 'lint', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/2' },
+    ],
+    statusText: 'CI failed',
+    ...overrides,
+  };
+}
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? now,
+    updatedAt: write.updatedAt ?? now,
+  };
+}
+
+function makeHarness(task = makeTask()) {
+  const tasks = new Map<string, TaskState>([[task.id, task]]);
+  const actions = new Map<string, WorkerActionRecord>();
+  const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
+    expect(workflowId).toBe('wf-1');
+    expect(priority).toBe('normal');
+    expect(channel).toBe('invoker:fix-with-agent');
+    expect(args).toBeDefined();
+    return 42;
+  });
+  const store = {
+    loadTasks: vi.fn((workflowId: string) => workflowId === 'wf-1' ? Array.from(tasks.values()) : []),
+    loadTask: vi.fn((taskId: string) => tasks.get(taskId)),
+    listWorkflowMutationIntents: vi.fn(() => []),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const existing = actions.get(`${write.workerKind}:${write.externalKey}`);
+      const saved = toRecord({ ...write, id: existing?.id ?? write.id, createdAt: existing?.createdAt });
+      actions.set(`${write.workerKind}:${write.externalKey}`, saved);
+      return saved;
+    }),
+    logEvent: vi.fn(),
+  };
+  return { actions, store, submit };
+}
+
+describe('PR status and CI failure workers', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('polls review-gate status on the 60000ms default interval', async () => {
+    vi.useFakeTimers();
+    const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
+    const worker = createPrStatusWorker({
+      logger,
+      reviewGate: { checkMergeGateStatuses },
+      installSignalHandlers: false,
+    });
+
+    worker.start();
+    expect(checkMergeGateStatuses).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(DEFAULT_PR_STATUS_WORKER_INTERVAL_MS);
+
+    expect(checkMergeGateStatuses).toHaveBeenCalledTimes(1);
+    await worker.stop();
+  });
+
+  it('queues a head-SHA guarded CI repair intent and records its dedupe action', async () => {
+    const event = makeEvent({
+      failedChecks: [
+        { name: 'unit', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/1' },
+        { name: 'lint', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/2' },
+      ],
+    });
+    const sameChecksDifferentOrder = makeEvent({
+      failedChecks: [...event.failedChecks].reverse(),
+    });
+    const harness = makeHarness();
+    const tick = createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      defaultAutoFixRetries: 2,
+      getAutoFixAgent: () => 'codex',
+      getAutoFixExecutionModel: () => 'openai/gpt-5.2',
+      drainEvents: () => [event],
+    });
+
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+
+    expect(ciFailureActionKey(sameChecksDifferentOrder)).toBe(ciFailureActionKey(event));
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    const [, , , args] = harness.submit.mock.calls[0];
+    const parsed = parseFixWithAgentMutationArgs(args);
+    expect(parsed).toMatchObject({
+      taskId: 'wf-1/merge',
+      agentName: 'codex',
+      context: {
+        autoFix: true,
+        executionModel: 'openai/gpt-5.2',
+        reviewGateContext: {
+          reviewId: '123',
+          generation: 2,
+          selectedAttemptId: 'attempt-1',
+          headSha: 'sha-1',
+        },
+      },
+    });
+    expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
+      workerKind: CI_FAILURE_WORKER_KIND,
+      actionType: 'fix-ci-failure',
+      status: 'queued',
+      intentId: '42',
+      externalKey: ciFailureActionKey(event),
+    });
+  });
+
+  it('rejects stale CI failure events when the PR head changed before submit', async () => {
+    const event = makeEvent();
+    const task = makeTask({
+      execution: {
+        reviewGate: {
+          activeGeneration: 2,
+          completion: { required: 'all', status: 'approved' },
+          artifacts: [{
+            id: 'pr-123',
+            providerId: '123',
+            required: true,
+            status: 'open',
+            generation: 2,
+            headSha: 'sha-2',
+          }],
+        },
+      },
+    });
+    const harness = makeHarness(task);
+    const tick = createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      defaultAutoFixRetries: 2,
+      drainEvents: () => [event],
+    });
+
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
+      status: 'skipped',
+      summary: expect.stringContaining('head-sha-changed'),
+    });
+  });
+});

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -5214,8 +5214,8 @@ console.log(JSON.stringify(out));
         };
         const mergeGateProvider = {
           checkApproval: vi.fn()
-            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved one' })
-            .mockResolvedValueOnce({ lifecycle: 'open', rejected: false, statusText: 'Pending second' })
+            .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved one', headSha: 'head-1' })
+            .mockResolvedValueOnce({ lifecycle: 'open', rejected: false, statusText: 'Pending second', headSha: 'head-2' })
             .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Still approved' })
             .mockResolvedValueOnce({ lifecycle: 'merged', rejected: false, statusText: 'Approved both' })
         };
@@ -5241,8 +5241,8 @@ console.log(JSON.stringify(out));
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(task.execution.reviewGate?.artifacts).toEqual([
-          expect.objectContaining({ id: 'contracts', status: 'approved' }),
-          expect.objectContaining({ id: 'runtime', status: 'open', rawStatus: 'Pending second' }),
+          expect.objectContaining({ id: 'contracts', status: 'approved', headSha: 'head-1' }),
+          expect.objectContaining({ id: 'runtime', status: 'open', rawStatus: 'Pending second', headSha: 'head-2' }),
         ]);
 
         await executor.checkMergeGateStatuses();

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -4,7 +4,9 @@ import { RECOVERY_WORKER_KIND, type AutoFixRecoveryStore, type AutoFixRecoverySu
 import {
   AUTO_APPROVE_WORKER_KIND,
   AUTO_FIX_WORKER_KIND,
+  CI_FAILURE_WORKER_KIND,
   createWorkerRegistry,
+  PR_STATUS_WORKER_KIND,
   registerAutoFixWorker,
   registerBuiltinWorkers,
   type WorkerRuntimeDependencies,
@@ -57,9 +59,13 @@ describe('worker registry', () => {
     expect(registry.list().map((d) => d.kind)).toEqual([
       AUTO_FIX_WORKER_KIND,
       AUTO_APPROVE_WORKER_KIND,
+      PR_STATUS_WORKER_KIND,
+      CI_FAILURE_WORKER_KIND,
     ]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();
     expect(registry.get(AUTO_APPROVE_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_STATUS_WORKER_KIND)).toBeDefined();
+    expect(registry.get(CI_FAILURE_WORKER_KIND)).toBeDefined();
   });
 
   it('returns nothing for an unknown kind', () => {
@@ -87,5 +93,12 @@ describe('worker registry', () => {
     const runtime = definition!.factory(deps());
     expect(runtime.identity.kind).toBe(AUTO_APPROVE_WORKER_KIND);
     expect(runtime.isRunning()).toBe(false);
+  });
+
+  it('builds the PR status and CI-failure worker runtimes from the registered factories', () => {
+    const registry = registerBuiltinWorkers(createWorkerRegistry());
+
+    expect(registry.get(PR_STATUS_WORKER_KIND)?.factory(deps()).identity.kind).toBe(PR_STATUS_WORKER_KIND);
+    expect(registry.get(CI_FAILURE_WORKER_KIND)?.factory(deps()).identity.kind).toBe(CI_FAILURE_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/src/auto-fix-intents.ts
+++ b/packages/execution-engine/src/auto-fix-intents.ts
@@ -50,6 +50,7 @@ export interface ReviewGateLineageFields {
   reviewId?: string;
   selectedAttemptId?: string;
   branch?: string;
+  headSha?: string;
 }
 
 export function encodeReviewGateCiContext(context: ReviewGateCiContext): string {
@@ -91,7 +92,8 @@ export function isReviewGateCiContextStale(
     current.selectedAttemptId !== context.selectedAttemptId ||
     (current.generation ?? 0) !== context.generation ||
     current.reviewId !== context.reviewId ||
-    current.branch !== context.branch
+    current.branch !== context.branch ||
+    current.headSha !== context.headSha
   );
 }
 

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
+import { killProcessGroup, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 import type {
   MergeGateProvider,
   MergeGateProviderResult,
@@ -11,6 +12,17 @@ import { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
 import { isGitRefLockRace, retryTransientGitHubCli } from './git-utils.js';
 
 type ExistingPullRequest = { url: string; number: number };
+
+const DEFAULT_GITHUB_CLI_TIMEOUT_MS = 60_000;
+const GITHUB_CLI_TIMEOUT_ENV = 'INVOKER_GITHUB_CLI_TIMEOUT_MS';
+
+function getGitHubCliTimeoutMs(): number {
+  const raw = process.env[GITHUB_CLI_TIMEOUT_ENV]?.trim();
+  if (!raw) return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_GITHUB_CLI_TIMEOUT_MS;
+  return parsed;
+}
 
 export class GitHubMergeGateProvider implements MergeGateProvider {
   readonly name = 'github';
@@ -238,15 +250,49 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
 
   private async exec(cmd: string, args: string[], cwd: string): Promise<string> {
     return new Promise((resolve, reject) => {
-      const child = spawn(cmd, args, { cwd, stdio: ['ignore', 'pipe', 'pipe'] });
+      const child = spawn(cmd, args, {
+        cwd,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: cmd === 'gh' && process.platform !== 'win32',
+      });
+      const timeoutMs = cmd === 'gh' ? getGitHubCliTimeoutMs() : 0;
       let stdout = '';
       let stderr = '';
+      let settled = false;
+      let timeout: ReturnType<typeof setTimeout> | undefined;
+
+      const finish = (fn: () => void): void => {
+        if (settled) return;
+        settled = true;
+        if (timeout) clearTimeout(timeout);
+        fn();
+      };
+
+      if (timeoutMs > 0) {
+        timeout = setTimeout(() => {
+          killProcessGroup(child, 'SIGTERM');
+          const forceKill = setTimeout(() => {
+            killProcessGroup(child, 'SIGKILL');
+          }, SIGKILL_TIMEOUT_MS);
+          forceKill.unref?.();
+          finish(() => reject(new Error(
+            `gh ${args.join(' ')} exceeded GitHub CLI timeout (${timeoutMs}ms) in ${cwd}. ` +
+            `Set ${GITHUB_CLI_TIMEOUT_ENV} to adjust.`,
+          )));
+        }, timeoutMs);
+        timeout.unref?.();
+      }
+
       child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
       child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
-      child.on('error', reject);
+      child.on('error', (err) => {
+        finish(() => reject(err));
+      });
       child.on('close', (code) => {
-        if (code === 0) resolve(stdout.trim());
-        else reject(new Error(`${cmd} ${args.join(' ')} failed (code ${code}): ${stderr.trim()}`));
+        finish(() => {
+          if (code === 0) resolve(stdout.trim());
+          else reject(new Error(`${cmd} ${args.join(' ')} failed (code ${code}): ${stderr.trim()}`));
+        });
       });
     });
   }

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -38,6 +38,8 @@ export * from './worker-types.js';
 export * from './worker-lock.js';
 export * from './auto-fix-recovery.js';
 export * from './workers/auto-approve-worker.js';
+export * from './workers/pr-status-worker.js';
+export * from './workers/ci-failure-worker.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1963,6 +1963,8 @@ export class TaskRunner {
         const next: ReviewGateArtifact = {
           ...artifact,
           status: mappedStatus,
+          ...(status.headSha ? { headSha: status.headSha } : {}),
+          ...(status.headRef ? { headRef: status.headRef } : {}),
           updatedAt: new Date().toISOString(),
         };
         if (mappedStatus === 'open') {

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -23,9 +23,22 @@ import {
   type AutoApproveWorkerSubmitter,
   type AutoApproveWorkerStore,
 } from './workers/auto-approve-worker.js';
+import {
+  PR_STATUS_WORKER_KIND,
+  createPrStatusWorker,
+  type PrStatusReviewGate,
+} from './workers/pr-status-worker.js';
+import {
+  CI_FAILURE_WORKER_KIND,
+  createCiFailureWorker,
+  type CiFailureWorkerStore,
+  type CiFailureWorkerSubmitter,
+} from './workers/ci-failure-worker.js';
 import type { WorkerRuntime } from './worker-runtime.js';
 
 export { AUTO_APPROVE_WORKER_KIND } from './workers/auto-approve-worker.js';
+export { PR_STATUS_WORKER_KIND } from './workers/pr-status-worker.js';
+export { CI_FAILURE_WORKER_KIND } from './workers/ci-failure-worker.js';
 
 /** Registry kind for the built-in auto-fix recovery worker. */
 export const AUTO_FIX_WORKER_KIND = 'autofix';
@@ -49,13 +62,15 @@ export interface AutoApproveWorkerConfig {
 /** Dependencies injected into a worker factory when its runtime is built. */
 export interface WorkerRuntimeDependencies {
   /** Persisted workflow/task state accessor. */
-  store: AutoFixRecoveryStore & AutoApproveWorkerStore;
+  store: AutoFixRecoveryStore & AutoApproveWorkerStore & CiFailureWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
-  submitter: AutoFixRecoverySubmitter & AutoApproveWorkerSubmitter;
+  submitter: AutoFixRecoverySubmitter & AutoApproveWorkerSubmitter & CiFailureWorkerSubmitter;
   /** Operator logger. */
   logger: Logger;
   /** Optional bus that turns lifecycle events into immediate wakeups. */
   messageBus?: MessageBus;
+  /** Review-gate polling surface owned by the task runner. */
+  reviewGate?: PrStatusReviewGate;
   /** Auto-fix tuning. */
   autoFix?: AutoFixWorkerConfig;
   /** Auto-approval tuning. */
@@ -146,9 +161,46 @@ export function registerAutoApproveWorker(registry: WorkerRegistry): WorkerRegis
   return registry;
 }
 
+/** Register the built-in PR status worker. */
+export function registerPrStatusWorker(registry: WorkerRegistry): WorkerRegistry {
+  registry.register({
+    kind: PR_STATUS_WORKER_KIND,
+    note: 'Polls review-gate PR status through the registered TaskRunner review-gate check.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createPrStatusWorker({
+        logger: deps.logger,
+        reviewGate: deps.reviewGate,
+      }),
+  });
+  return registry;
+}
+
+/** Register the built-in CI-failure repair worker. */
+export function registerCiFailureWorker(registry: WorkerRegistry): WorkerRegistry {
+  registry.register({
+    kind: CI_FAILURE_WORKER_KIND,
+    note: 'Submits head-SHA guarded CI repair intents for failed review-gate checks.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createCiFailureWorker({
+        logger: deps.logger,
+        messageBus: deps.messageBus,
+        ciFailure: {
+          store: deps.store,
+          submitter: deps.submitter,
+          defaultAutoFixRetries: deps.autoFix?.defaultAutoFixRetries,
+          getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
+          getAutoFixExecutionModel: deps.autoFix?.getAutoFixExecutionModel,
+        },
+      }),
+  });
+  return registry;
+}
+
 /** Register every built-in worker in the stable built-in order. */
 export function registerBuiltinWorkers(registry: WorkerRegistry): WorkerRegistry {
   registerAutoFixWorker(registry);
   registerAutoApproveWorker(registry);
+  registerPrStatusWorker(registry);
+  registerCiFailureWorker(registry);
   return registry;
 }

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -1,0 +1,541 @@
+import { createHash } from 'node:crypto';
+
+import type { Logger } from '@invoker/contracts';
+import type {
+  WorkerActionRecord,
+  WorkerActionStatus,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+
+import {
+  buildFixWithAgentMutationArgs,
+  isReviewGateCiContextStale,
+  listOpenFixIntentsForTask,
+  type ReviewGateCiContext,
+  type ReviewGateLineageFields,
+} from '../auto-fix-intents.js';
+import type {
+  ReviewGateCiFailedLifecycleEvent,
+  ReviewGateFailedCheck,
+  WorkflowLifecycleEvent,
+} from '../lifecycle-events.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const CI_FAILURE_WORKER_KIND = 'ci-failure';
+export const DEFAULT_CI_FAILURE_WORKER_INTERVAL_MS = 60_000;
+
+const FIX_WITH_AGENT_CHANNEL = 'invoker:fix-with-agent';
+const CI_FAILURE_ACTION_TYPE = 'fix-ci-failure';
+const NO_HEAD_SHA = 'no-head';
+
+type CiFailureActionStatus = WorkerActionStatus;
+
+export interface CiFailureWorkerStore {
+  loadTasks(workflowId: string): TaskState[];
+  loadTask?(taskId: string): TaskState | undefined;
+  listWorkflowMutationIntents?(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[];
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
+  logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+}
+
+export interface CiFailureWorkerSubmitter {
+  submit(
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: typeof FIX_WITH_AGENT_CHANNEL,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number;
+}
+
+export interface CiFailureWorkerPolicyOptions {
+  store: CiFailureWorkerStore;
+  submitter: CiFailureWorkerSubmitter;
+  logger: Logger;
+  defaultAutoFixRetries?: number;
+  getAutoFixAgent?: () => string | undefined;
+  getAutoFixExecutionModel?: () => string | undefined;
+  getRetryBudget?: (task: TaskState) => number;
+  drainEvents?: () => ReviewGateCiFailedLifecycleEvent[];
+}
+
+export interface CiFailureWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  messageBus?: MessageBus;
+  ciFailure?: Omit<CiFailureWorkerPolicyOptions, 'logger' | 'drainEvents'>;
+  onTick?: WorkerTick;
+}
+
+export function ciFailureChecksHash(failedChecks: readonly ReviewGateFailedCheck[]): string {
+  const normalized = failedChecks
+    .map((check) => ({
+      name: check.name,
+      conclusion: check.conclusion ?? '',
+      detailsUrl: check.detailsUrl ?? '',
+    }))
+    .sort((a, b) =>
+      a.name.localeCompare(b.name)
+      || a.conclusion.localeCompare(b.conclusion)
+      || a.detailsUrl.localeCompare(b.detailsUrl),
+    );
+  return createHash('sha256')
+    .update(JSON.stringify(normalized))
+    .digest('hex');
+}
+
+export function ciFailureActionKey(event: Pick<
+  ReviewGateCiFailedLifecycleEvent,
+  'taskId' | 'reviewId' | 'headSha' | 'failedChecks'
+>): string {
+  return [
+    'ci-failure',
+    event.taskId,
+    event.reviewId,
+    event.headSha ?? NO_HEAD_SHA,
+    ciFailureChecksHash(event.failedChecks),
+  ].join(':');
+}
+
+function retryBudgetForTask(task: TaskState, options: CiFailureWorkerPolicyOptions): number {
+  const raw = options.getRetryBudget?.(task) ?? options.defaultAutoFixRetries ?? 0;
+  if (!Number.isFinite(raw)) return 0;
+  return Math.min(Math.max(0, Math.floor(raw)), 10);
+}
+
+function loadTaskForEvent(
+  event: ReviewGateCiFailedLifecycleEvent,
+  options: CiFailureWorkerPolicyOptions,
+): TaskState | undefined {
+  const direct = options.store.loadTask?.(event.taskId);
+  if (direct) return direct;
+  return options.store.loadTasks(event.workflowId).find((task) => task.id === event.taskId);
+}
+
+function currentReviewGateLineage(
+  task: TaskState,
+  reviewId: string,
+): ReviewGateLineageFields {
+  const gate = task.execution.reviewGate;
+  const artifact = gate?.artifacts.find((candidate) =>
+    candidate.generation === gate.activeGeneration
+    && candidate.status !== 'discarded'
+    && !candidate.discardedAt
+    && candidate.providerId === reviewId,
+  );
+  return {
+    reviewId: artifact?.providerId ?? task.execution.reviewId,
+    generation: task.execution.generation ?? 0,
+    selectedAttemptId: task.execution.selectedAttemptId,
+    branch: task.execution.branch,
+    headSha: artifact?.headSha,
+  };
+}
+
+function reviewGateContextFromEvent(event: ReviewGateCiFailedLifecycleEvent): ReviewGateCiContext {
+  return {
+    reviewId: event.reviewId,
+    generation: event.generation,
+    selectedAttemptId: event.attemptId,
+    branch: event.branch,
+    headSha: event.headSha,
+    fixContext: buildCiFailureFixContext(event),
+  };
+}
+
+function staleReasonForEvent(
+  event: ReviewGateCiFailedLifecycleEvent,
+  task: TaskState,
+): { stale: false } | { stale: true; reason: string; details: Record<string, unknown> } {
+  if (task.config.workflowId !== event.workflowId) {
+    return {
+      stale: true,
+      reason: 'workflow-changed',
+      details: { currentWorkflowId: task.config.workflowId ?? null },
+    };
+  }
+  if (task.status !== 'review_ready' && task.status !== 'awaiting_approval') {
+    return {
+      stale: true,
+      reason: 'status-changed',
+      details: { currentStatus: task.status },
+    };
+  }
+
+  const context = reviewGateContextFromEvent(event);
+  const current = currentReviewGateLineage(task, event.reviewId);
+  if (!isReviewGateCiContextStale(context, current)) {
+    return { stale: false };
+  }
+
+  if (current.reviewId !== event.reviewId) {
+    return {
+      stale: true,
+      reason: 'review-changed',
+      details: { currentReviewId: current.reviewId ?? null },
+    };
+  }
+  if ((current.generation ?? 0) !== event.generation) {
+    return {
+      stale: true,
+      reason: 'generation-changed',
+      details: { currentGeneration: current.generation ?? 0 },
+    };
+  }
+  if (current.selectedAttemptId !== event.attemptId) {
+    return {
+      stale: true,
+      reason: 'selected-attempt-changed',
+      details: { currentSelectedAttemptId: current.selectedAttemptId ?? null },
+    };
+  }
+  if (current.headSha !== event.headSha) {
+    return {
+      stale: true,
+      reason: 'head-sha-changed',
+      details: { currentHeadSha: current.headSha ?? null },
+    };
+  }
+  return {
+    stale: true,
+    reason: 'branch-changed',
+    details: { currentBranch: current.branch ?? null },
+  };
+}
+
+function actionIdForKey(externalKey: string): string {
+  return `${CI_FAILURE_WORKER_KIND}:${externalKey}`;
+}
+
+function isOpenOrCompletedActionStatus(status: string): boolean {
+  return status === 'queued'
+    || status === 'pending'
+    || status === 'running'
+    || status === 'needs_input'
+    || status === 'review_ready'
+    || status === 'completed';
+}
+
+function coerceActionStatus(status: CiFailureActionStatus): WorkerActionStatus {
+  return status;
+}
+
+function recordCiFailureAction(
+  options: CiFailureWorkerPolicyOptions,
+  event: ReviewGateCiFailedLifecycleEvent,
+  status: CiFailureActionStatus,
+  summary: string,
+  payload: Record<string, unknown> = {},
+  intentId?: number | string,
+  agentName?: string,
+  executionModel?: string,
+): WorkerActionRecord | undefined {
+  const externalKey = ciFailureActionKey(event);
+  const existing = options.store.getWorkerAction?.(CI_FAILURE_WORKER_KIND, externalKey);
+  const now = new Date().toISOString();
+  return options.store.upsertWorkerAction?.({
+    id: existing?.id ?? actionIdForKey(externalKey),
+    workerKind: CI_FAILURE_WORKER_KIND,
+    actionType: CI_FAILURE_ACTION_TYPE,
+    workflowId: event.workflowId,
+    taskId: event.taskId,
+    subjectType: 'review',
+    subjectId: event.reviewId,
+    externalKey,
+    status: coerceActionStatus(status),
+    attemptCount: status === 'queued' || status === 'failed'
+      ? (existing?.attemptCount ?? 0) + 1
+      : existing?.attemptCount ?? 0,
+    ...(intentId !== undefined ? { intentId: String(intentId) } : {}),
+    agentName,
+    executionModel,
+    summary,
+    payload: {
+      reviewId: event.reviewId,
+      reviewUrl: event.reviewUrl,
+      headSha: event.headSha ?? null,
+      headRef: event.headRef ?? null,
+      branch: event.branch ?? null,
+      generation: event.generation,
+      selectedAttemptId: event.attemptId ?? null,
+      taskStateVersion: event.taskStateVersion ?? null,
+      failedChecksHash: ciFailureChecksHash(event.failedChecks),
+      failedChecks: event.failedChecks.map((check) => ({ ...check })),
+      ...payload,
+    },
+    updatedAt: now,
+    ...(status === 'skipped' || status === 'failed' || status === 'completed' ? { completedAt: now } : {}),
+  });
+}
+
+function logCiFailureWorkerEvent(
+  options: CiFailureWorkerPolicyOptions,
+  event: ReviewGateCiFailedLifecycleEvent,
+  phase: string,
+  details: Record<string, unknown>,
+): void {
+  const payload = {
+    phase,
+    worker: CI_FAILURE_WORKER_KIND,
+    workflowId: event.workflowId,
+    reviewId: event.reviewId,
+    headSha: event.headSha ?? null,
+    generation: event.generation,
+    selectedAttemptId: event.attemptId ?? null,
+    failedChecksHash: ciFailureChecksHash(event.failedChecks),
+    ...details,
+  };
+  options.store.logEvent?.(event.taskId, 'debug.ci-failure-worker', payload);
+  options.logger.debug?.(`[worker:${CI_FAILURE_WORKER_KIND}] ${phase}`, {
+    module: 'ci-failure-worker',
+    taskId: event.taskId,
+    ...payload,
+  });
+}
+
+function listOpenFixIntentsForEvent(
+  options: CiFailureWorkerPolicyOptions,
+  event: ReviewGateCiFailedLifecycleEvent,
+): WorkflowMutationIntent[] {
+  const open = options.store.listWorkflowMutationIntents?.(event.workflowId, ['queued', 'running']) ?? [];
+  return listOpenFixIntentsForTask(open, event.taskId);
+}
+
+function buildCiFailureFixContext(event: ReviewGateCiFailedLifecycleEvent): string {
+  const checks = event.failedChecks
+    .map((check) => {
+      const conclusion = check.conclusion ? ` (${check.conclusion})` : '';
+      const details = check.detailsUrl ? ` - ${check.detailsUrl}` : '';
+      return `- ${check.name}${conclusion}${details}`;
+    })
+    .join('\n');
+  return [
+    `Review-gate CI failed for ${event.reviewUrl}.`,
+    `Head SHA: ${event.headSha ?? 'unknown'}.`,
+    `Status: ${event.statusText}.`,
+    'Failed checks:',
+    checks,
+  ].join('\n');
+}
+
+function shouldSkipExistingAction(
+  options: CiFailureWorkerPolicyOptions,
+  event: ReviewGateCiFailedLifecycleEvent,
+  maxAttempts: number,
+): boolean {
+  const externalKey = ciFailureActionKey(event);
+  const existing = options.store.getWorkerAction?.(CI_FAILURE_WORKER_KIND, externalKey);
+  if (!existing) return false;
+  if (isOpenOrCompletedActionStatus(existing.status)) {
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+      reason: 'already-recorded',
+      existingStatus: existing.status,
+      intentId: existing.intentId ?? null,
+    });
+    return true;
+  }
+  if (existing.attemptCount >= maxAttempts) {
+    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because retry budget is exhausted', {
+      reason: 'retry-budget-exhausted',
+      existingStatus: existing.status,
+      attemptCount: existing.attemptCount,
+      maxAttempts,
+    }, existing.intentId);
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+      reason: 'retry-budget-exhausted',
+      existingStatus: existing.status,
+      attemptCount: existing.attemptCount,
+      maxAttempts,
+    });
+    return true;
+  }
+  return false;
+}
+
+async function handleCiFailureEvent(
+  options: CiFailureWorkerPolicyOptions,
+  event: ReviewGateCiFailedLifecycleEvent,
+): Promise<void> {
+  const task = loadTaskForEvent(event, options);
+  if (!task) {
+    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because task no longer exists', {
+      reason: 'task-not-found',
+    });
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', { reason: 'task-not-found' });
+    return;
+  }
+
+  const maxAttempts = retryBudgetForTask(task, options);
+  if (maxAttempts <= 0) {
+    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because retry budget is disabled', {
+      reason: 'retry-budget-disabled',
+      maxAttempts,
+    });
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+      reason: 'retry-budget-disabled',
+      maxAttempts,
+    });
+    return;
+  }
+  if ((task.execution.autoFixAttempts ?? 0) >= maxAttempts) {
+    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because retry budget is exhausted', {
+      reason: 'retry-budget-exhausted',
+      autoFixAttempts: task.execution.autoFixAttempts ?? 0,
+      maxAttempts,
+    });
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+      reason: 'retry-budget-exhausted',
+      autoFixAttempts: task.execution.autoFixAttempts ?? 0,
+      maxAttempts,
+    });
+    return;
+  }
+
+  if (shouldSkipExistingAction(options, event, maxAttempts)) return;
+
+  const stale = staleReasonForEvent(event, task);
+  if (stale.stale) {
+    recordCiFailureAction(options, event, 'skipped', `Skipped stale CI repair: ${stale.reason}`, {
+      reason: stale.reason,
+      ...stale.details,
+    });
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-stale', {
+      reason: stale.reason,
+      ...stale.details,
+    });
+    return;
+  }
+
+  const openFixIntents = listOpenFixIntentsForEvent(options, event);
+  if (openFixIntents.length > 0) {
+    const intentId = openFixIntents[0]?.id;
+    recordCiFailureAction(options, event, 'queued', 'CI repair already queued for task', {
+      reason: 'already-queued-intent',
+      existingIntentIds: openFixIntents.map((intent) => intent.id),
+    }, intentId);
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+      reason: 'already-queued-intent',
+      existingIntentIds: openFixIntents.map((intent) => intent.id),
+    });
+    return;
+  }
+
+  const configuredAgent = options.getAutoFixAgent?.()?.trim();
+  const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
+  const configuredExecutionModel = options.getAutoFixExecutionModel?.()?.trim();
+  const executionModel = configuredExecutionModel && configuredExecutionModel.length > 0
+    ? configuredExecutionModel
+    : undefined;
+  const args = buildFixWithAgentMutationArgs(event.taskId, selectedAgent, {
+    autoFix: true,
+    reviewGateContext: reviewGateContextFromEvent(event),
+    executionModel,
+  });
+  const intentId = options.submitter.submit(event.workflowId, 'normal', FIX_WITH_AGENT_CHANNEL, args);
+  recordCiFailureAction(
+    options,
+    event,
+    'queued',
+    'Queued CI repair with agent',
+    {
+      channel: FIX_WITH_AGENT_CHANNEL,
+      autoFixAttempts: task.execution.autoFixAttempts ?? 0,
+      maxAttempts,
+    },
+    intentId,
+    selectedAgent,
+    executionModel,
+  );
+  logCiFailureWorkerEvent(options, event, 'worker-ci-failure-submitted', {
+    intentId,
+    channel: FIX_WITH_AGENT_CHANNEL,
+    agent: selectedAgent ?? null,
+    executionModel: executionModel ?? null,
+    autoFixAttempts: task.execution.autoFixAttempts ?? 0,
+    maxAttempts,
+  });
+}
+
+export function createCiFailureTick(options: CiFailureWorkerPolicyOptions): WorkerTick {
+  return async () => {
+    const events = options.drainEvents?.() ?? [];
+    const seen = new Set<string>();
+    for (const event of events) {
+      const externalKey = ciFailureActionKey(event);
+      if (seen.has(externalKey)) continue;
+      seen.add(externalKey);
+      await handleCiFailureEvent(options, event);
+    }
+  };
+}
+
+function isReviewGateCiFailedEvent(event: WorkflowLifecycleEvent): event is ReviewGateCiFailedLifecycleEvent {
+  return event.kind === 'review_gate.ci_failed';
+}
+
+export function createCiFailureWorker(options: CiFailureWorkerOptions): WorkerRuntime {
+  const pendingEvents: ReviewGateCiFailedLifecycleEvent[] = [];
+  let lifecycleUnsubscribe: Unsubscribe | undefined;
+  const onTick = options.onTick ?? (
+    options.ciFailure
+      ? createCiFailureTick({
+        ...options.ciFailure,
+        logger: options.logger,
+        drainEvents: () => pendingEvents.splice(0),
+      })
+      : (() => {})
+  );
+  const runtime = createWorkerRuntime({
+    kind: CI_FAILURE_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_CI_FAILURE_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick,
+  });
+
+  if (!options.messageBus || !options.ciFailure || options.onTick) {
+    return runtime;
+  }
+
+  const start = (): void => {
+    if (!lifecycleUnsubscribe) {
+      lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
+        Channels.WORKFLOW_LIFECYCLE,
+        (event) => {
+          if (!isReviewGateCiFailedEvent(event)) return;
+          pendingEvents.push(event);
+          runtime.wake('wake');
+        },
+      );
+    }
+    runtime.start();
+  };
+  const stop = async (): Promise<void> => {
+    lifecycleUnsubscribe?.();
+    lifecycleUnsubscribe = undefined;
+    await runtime.stop();
+  };
+
+  return {
+    identity: runtime.identity,
+    start,
+    wake: runtime.wake,
+    tick: runtime.tick,
+    stop,
+    isRunning: runtime.isRunning,
+  };
+}

--- a/packages/execution-engine/src/workers/pr-status-worker.ts
+++ b/packages/execution-engine/src/workers/pr-status-worker.ts
@@ -1,0 +1,52 @@
+import type { Logger } from '@invoker/contracts';
+
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const PR_STATUS_WORKER_KIND = 'pr-status';
+export const DEFAULT_PR_STATUS_WORKER_INTERVAL_MS = 60_000;
+
+export interface PrStatusReviewGate {
+  checkMergeGateStatuses(): void | Promise<void>;
+}
+
+export interface PrStatusWorkerPolicyOptions {
+  reviewGate?: PrStatusReviewGate;
+  logger: Logger;
+}
+
+export interface PrStatusWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  reviewGate?: PrStatusReviewGate;
+  onTick?: WorkerTick;
+}
+
+export function createPrStatusTick(options: PrStatusWorkerPolicyOptions): WorkerTick {
+  return async () => {
+    if (!options.reviewGate) {
+      options.logger.debug?.('[worker:pr-status] review gate dependency unavailable', {
+        module: 'pr-status-worker',
+      });
+      return;
+    }
+    await options.reviewGate.checkMergeGateStatuses();
+  };
+}
+
+export function createPrStatusWorker(options: PrStatusWorkerOptions): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: PR_STATUS_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_PR_STATUS_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: options.onTick ?? createPrStatusTick({
+      logger: options.logger,
+      reviewGate: options.reviewGate,
+    }),
+  });
+}

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -149,6 +149,8 @@ export interface ReviewGateArtifact {
   readonly provider?: string;
   readonly branch?: string;
   readonly baseBranch?: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
   readonly required: boolean;
   readonly status: ReviewGateArtifactStatus;
   readonly rawStatus?: string;


### PR DESCRIPTION
## Summary

This registers the PR status and CI failure workers on the owner worker path so their polling and repair work runs through the shared worker runtime.

Before, PR check polling lived on a bespoke app path in the main process. Now the registered workers own it end to end.

<details>
<summary>Review metadata</summary>

Review Claim: PR status polling and CI failure repair run through the registered owner workers.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Existing TaskRunner review-gate checks stay the source of PR status truth. Workers reload persisted task state before acting.

Slice Rationale: The two worker registrations and their wake wiring land together because CI repair consumes the same PR status data. The identity guard is its own follow-up slice.

</details>

## Non-goals

- Do not add live GitHub tests.
- Do not add worker-to-worker relay messages.
- Do not change the CI repair action guard, which lands in slice (2).

## Test Plan

- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `cd packages/app && pnpm test`

## Visual Proof

![Review gate stack side panel](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260702-7b4201/review-gate-stack-side-panel.png)

![Approve-fix task panel actions](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260702-7b4201/approve-fix-task-panel-actions.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
