### PR TITLE
Move heavy CI to merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ env:
   NODE_VERSION: '26'
 
 jobs:
+  # Full CI runs on default-branch pushes, manual/scheduled runs, and Mergify merge-queue refs.
+  # Ordinary PRs keep only cheap quality checks so stacked PR pushes do not fan out heavy jobs.
   build-artifacts:
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     runs-on:
       labels: Runner_2_4_core
     timeout-minutes: 30
@@ -146,7 +149,7 @@ jobs:
         run: ${{ matrix.command }}
 
   inv117-proof:
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
+    if: ${{ github.event_name != 'pull_request' }}
     needs: build-artifacts
     runs-on:
       labels: Runner_2_4_core
@@ -214,6 +217,7 @@ jobs:
           bash scripts/run-all-tests.sh
 
   required-fast:
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -419,6 +423,7 @@ jobs:
         run: bash scripts/test-suites/required/23-fix-intent-repros.sh
 
   dry-run:
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
     runs-on: ubuntu-latest
     container:
@@ -487,6 +492,7 @@ jobs:
         run: bash ${{ matrix.suite }}
 
   playwright:
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
     runs-on: ubuntu-latest
     container:
@@ -620,6 +626,7 @@ jobs:
           if-no-files-found: ignore
 
   ssh:
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
     runs-on: ubuntu-latest
     container:
@@ -697,6 +704,7 @@ jobs:
         run: bash ${{ matrix.suite }}
 
   optional-other:
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
     runs-on:
       labels: ${{ matrix.runner_label }}
@@ -748,7 +756,7 @@ jobs:
         run: ${{ matrix.command }}
 
   docker:
-    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
+    if: ${{ github.event_name != 'pull_request' }}
     needs: build-artifacts
     runs-on:
       labels: Runner_2_4_core

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",
-    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-review-unit-classification.mjs && bash scripts/workspace-test.sh",
+    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-ci-workflow-merge-queue-policy.mjs && node scripts/test-review-unit-classification.mjs && bash scripts/workspace-test.sh",
     "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
     "test:low-resource": "pnpm run test",
     "test:low-resource:packages": "bash scripts/workspace-test.sh",

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import YAML from 'yaml';
+
+const FULL_CI_GATE = "${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}";
+const NON_PR_GATE = "${{ github.event_name != 'pull_request' }}";
+const ORDINARY_PR_GATE = "${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}";
+const FULL_CI_JOBS = new Set(['build-artifacts', 'required-fast', 'dry-run', 'playwright', 'ssh', 'optional-other']);
+
+const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
+const mergify = YAML.parse(readFileSync('.mergify.yml', 'utf8'));
+const jobs = workflow.jobs ?? {};
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function jobForCheck(checkName) {
+  if (checkName === 'PR Body' || checkName.startsWith('quality / ')) {
+    return null;
+  }
+  if (checkName.startsWith('optional / ')) {
+    return 'optional-other';
+  }
+  return checkName.split(' / ')[0];
+}
+
+for (const jobName of FULL_CI_JOBS) {
+  assert(jobs[jobName], `Missing CI job ${jobName}`);
+  assert(jobs[jobName].if === FULL_CI_GATE, `${jobName} must run only for full CI events`);
+}
+
+assert(jobs['quality-required'], 'Missing quality-required job');
+assert(!jobs['quality-required'].if, 'quality-required must run on ordinary PRs');
+
+assert(jobs['quality-extra'], 'Missing quality-extra job');
+assert(jobs['quality-extra'].if === ORDINARY_PR_GATE, 'quality-extra must run on ordinary PRs and skip merge queue refs');
+
+assert(jobs['inv117-proof'], 'Missing inv117-proof job');
+assert(jobs['inv117-proof'].if === NON_PR_GATE, 'inv117-proof must not run on pull_request events');
+
+assert(jobs.docker, 'Missing docker job');
+assert(jobs.docker.if === NON_PR_GATE, 'docker must not run on pull_request events');
+
+const mergeConditions = (mergify.queue_rules ?? []).flatMap((rule) => rule.merge_conditions ?? []);
+const requiredChecks = new Set(
+  mergeConditions
+    .map(String)
+    .filter((condition) => condition.startsWith('check-success = '))
+    .map((condition) => condition.slice('check-success = '.length)),
+);
+
+for (const checkName of requiredChecks) {
+  const jobName = jobForCheck(checkName);
+  if (!jobName) {
+    continue;
+  }
+  assert(jobs[jobName], `Mergify requires missing CI job ${jobName} for ${checkName}`);
+  assert(jobs[jobName].if === FULL_CI_GATE, `Mergify-required job ${jobName} must run on merge queue refs`);
+}
+
+console.log('CI merge-queue policy is valid.');


### PR DESCRIPTION
## Summary

Ordinary PRs now run only cheap CI checks. Heavy gates wait for default-branch, manual, scheduled, or Mergify merge-queue runs.

This keeps stacked PR pushes from starting many full CI copies at once. Mergify still checks the required heavy jobs before merge.

<details>
<summary>Review metadata</summary>

Review Claim: Ordinary PR CI is intentionally lightweight, while Mergify-required heavy jobs still run on merge-queue refs.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: The Mergify-required jobs keep merge-queue conditions that run on `mergify/merge-queue/` refs.

Slice Rationale: This only changes workflow gating, not test commands or merge requirements.

</details>

## Non-goals

This does not change the test suites themselves.

This does not make Docker or inv117 proof required by Mergify.

## Architecture

### Before

Every ordinary PR started the build artifact job, then heavy dependent jobs fanned out across each stack slice.

### After

Ordinary PRs run quality checks only. Merge queue refs run build artifacts, required-fast, dry-run, Playwright, SSH, and optional gates.

## Test Plan

- [x] `node scripts/test-ci-workflow-merge-queue-policy.mjs`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/ci-merge-queue-pr.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated CI workflow job triggers and gating so the correct checks run for pull requests, merge-queue refs, and other event types.
  * Tightened conditions for multiple CI jobs, restricting certain runs to non–pull request events where appropriate.

* **Tests**
  * Added a CI validation script that verifies merge-queue policy consistency with the CI workflow and ensures required jobs are present and correctly gated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->