### PR TITLE
Speed up long CI shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,10 +192,11 @@ jobs:
       - name: Run INV-117 required proof contract
         env:
           INVOKER_TEST_ALL_PROOF: '1'
-          INVOKER_TEST_ALL_JOBS: '1'
+          INVOKER_TEST_ALL_JOBS: '3'
           INVOKER_TEST_ALL_EXCLUDE: >-
             required/20-e2e-dry-run.sh,
-            required/21-e2e-dry-run-downstream.sh,
+            required/21a-e2e-dry-run-downstream-early.sh,
+            required/21b-e2e-dry-run-downstream-late.sh,
             required/22-e2e-dry-run-github.sh
           TMPDIR: /tmp/invoker-tmp
         run: |
@@ -396,8 +397,12 @@ jobs:
       - name: Install Playwright system dependencies
         run: pnpm --filter @invoker/app exec playwright install-deps chromium
 
-      - name: Run fix-intent repro bundle
-        run: bash scripts/test-suites/required/23-fix-intent-repros.sh
+      - name: Run fix-intent repro shards
+        run: |
+          bash scripts/test-suites/required/23a-recreate-task-queue-authority.sh
+          bash scripts/test-suites/required/23b-fix-intent-cancellation-stale-ssh-metadata.sh
+          bash scripts/test-suites/required/23c-stale-late-completion-after-reset.sh
+          bash scripts/test-suites/required/23d-same-workflow-tracked-fix-vs-recreate.sh
 
   dry-run:
     needs: build-artifacts
@@ -411,8 +416,10 @@ jobs:
         include:
           - name: case-1
             suite: scripts/test-suites/required/20-e2e-dry-run.sh
-          - name: case-2
-            suite: scripts/test-suites/required/21-e2e-dry-run-downstream.sh
+          - name: case-2a
+            suite: scripts/test-suites/required/21a-e2e-dry-run-downstream-early.sh
+          - name: case-2b
+            suite: scripts/test-suites/required/21b-e2e-dry-run-downstream-late.sh
           - name: case-4
             suite: scripts/test-suites/required/22-e2e-dry-run-github.sh
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,7 +27,8 @@ queue_rules:
       - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
       - check-success = dry-run / case-1
-      - check-success = dry-run / case-2
+      - check-success = dry-run / case-2a
+      - check-success = dry-run / case-2b
       - check-success = dry-run / case-4
       - check-success = playwright / 1-of-3
       - check-success = playwright / 2-of-3
@@ -57,7 +58,8 @@ queue_rules:
       - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
       - check-success = dry-run / case-1
-      - check-success = dry-run / case-2
+      - check-success = dry-run / case-2a
+      - check-success = dry-run / case-2b
       - check-success = dry-run / case-4
       - check-success = playwright / 1-of-3
       - check-success = playwright / 2-of-3

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -91,13 +91,13 @@ expected_executed_for_mode() {
 expected_discovered_for_mode() {
   case "$MODE_KEY" in
     required)
-      printf '19'
+      printf '23'
       ;;
     extended)
-      printf '26'
+      printf '30'
       ;;
     dangerous)
-      printf '27'
+      printf '31'
       ;;
   esac
 }
@@ -148,7 +148,7 @@ suite_name() {
 
 is_parallel_safe() {
   case "$(suite_relpath "$1")" in
-    required/05-delete-all-prod-db-guard.sh|required/06-large-file-guardrail.sh|required/07-invalid-config-json.sh|required/10-vitest-workspace.sh|required/11-pr-authoring-guardrails.sh|required/15-owner-boundary-policy.sh|required/15-submit-workflow-chain.sh|required/20-e2e-dry-run.sh|required/21-e2e-dry-run-downstream.sh|required/22-e2e-dry-run-github.sh|required/50-verify-executor-routing.sh|optional/40-playwright-app.sh|optional/60-worktree-provisioning.sh|optional/70-ui-visual-proof-validate.sh)
+    required/05-delete-all-prod-db-guard.sh|required/06-large-file-guardrail.sh|required/07-invalid-config-json.sh|required/10-vitest-workspace.sh|required/11-pr-authoring-guardrails.sh|required/15-owner-boundary-policy.sh|required/15-submit-workflow-chain.sh|required/20-e2e-dry-run.sh|required/21a-e2e-dry-run-downstream-early.sh|required/21b-e2e-dry-run-downstream-late.sh|required/22-e2e-dry-run-github.sh|required/23a-recreate-task-queue-authority.sh|required/23b-fix-intent-cancellation-stale-ssh-metadata.sh|required/23c-stale-late-completion-after-reset.sh|required/23d-same-workflow-tracked-fix-vs-recreate.sh|required/50-verify-executor-routing.sh|optional/40-playwright-app.sh|optional/60-worktree-provisioning.sh|optional/70-ui-visual-proof-validate.sh)
       return 0
       ;;
     *)

--- a/scripts/test-suites/required/21-e2e-dry-run-downstream.sh
+++ b/scripts/test-suites/required/21-e2e-dry-run-downstream.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# Headless Electron case scripts, shard 2 (case-2.*).
-set -euo pipefail
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-cd "$ROOT"
-exec bash "$ROOT/scripts/e2e-dry-run/run-all.sh" 'case-2.*.sh'

--- a/scripts/test-suites/required/21a-e2e-dry-run-downstream-early.sh
+++ b/scripts/test-suites/required/21a-e2e-dry-run-downstream-early.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Headless Electron case scripts, shard 2a (case-2.1 through case-2.9).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+exec bash "$ROOT/scripts/e2e-dry-run/run-all.sh" 'case-2.[1-9]-*.sh'

--- a/scripts/test-suites/required/21b-e2e-dry-run-downstream-late.sh
+++ b/scripts/test-suites/required/21b-e2e-dry-run-downstream-late.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Headless Electron case scripts, shard 2b (case-2.10 through case-2.17).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+exec bash "$ROOT/scripts/e2e-dry-run/run-all.sh" 'case-2.1[0-7]-*.sh'

--- a/scripts/test-suites/required/23a-recreate-task-queue-authority.sh
+++ b/scripts/test-suites/required/23a-recreate-task-queue-authority.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Blocking repro for recreate task queue authority.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+export REPRO_TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-180}"
+export INVOKER_REPRO_TIMEOUT_SECONDS="${INVOKER_REPRO_TIMEOUT_SECONDS:-600}"
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec xvfb-run --auto-servernum \
+    bash "$ROOT/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh" --expect-fixed
+fi
+
+exec bash "$ROOT/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh" --expect-fixed

--- a/scripts/test-suites/required/23b-fix-intent-cancellation-stale-ssh-metadata.sh
+++ b/scripts/test-suites/required/23b-fix-intent-cancellation-stale-ssh-metadata.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Blocking repro bundle for the fix-intent cancellation / stale-lineage stack.
+# Blocking repro for fix-intent cancellation and stale SSH metadata.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
@@ -9,7 +9,7 @@ export INVOKER_REPRO_TIMEOUT_SECONDS="${INVOKER_REPRO_TIMEOUT_SECONDS:-600}"
 
 if command -v xvfb-run >/dev/null 2>&1; then
   exec xvfb-run --auto-servernum \
-    bash "$ROOT/scripts/repro/repro-fix-intent-cancellation-stack.sh" --expect fixed
+    bash "$ROOT/scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh" --expect fixed
 fi
 
-exec bash "$ROOT/scripts/repro/repro-fix-intent-cancellation-stack.sh" --expect fixed
+exec bash "$ROOT/scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh" --expect fixed

--- a/scripts/test-suites/required/23c-stale-late-completion-after-reset.sh
+++ b/scripts/test-suites/required/23c-stale-late-completion-after-reset.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Blocking repro for stale late completion after reset.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+export REPRO_TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-180}"
+export INVOKER_REPRO_TIMEOUT_SECONDS="${INVOKER_REPRO_TIMEOUT_SECONDS:-600}"
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec xvfb-run --auto-servernum \
+    bash "$ROOT/scripts/repro/repro-stale-late-completion-after-reset.sh" --mode=both --expect-fixed
+fi
+
+exec bash "$ROOT/scripts/repro/repro-stale-late-completion-after-reset.sh" --mode=both --expect-fixed

--- a/scripts/test-suites/required/23d-same-workflow-tracked-fix-vs-recreate.sh
+++ b/scripts/test-suites/required/23d-same-workflow-tracked-fix-vs-recreate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Blocking repro for same-workflow tracked-fix vs recreate.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+export REPRO_TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-180}"
+export INVOKER_REPRO_TIMEOUT_SECONDS="${INVOKER_REPRO_TIMEOUT_SECONDS:-600}"
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec xvfb-run --auto-servernum \
+    bash "$ROOT/scripts/repro/repro-same-workflow-tracked-fix-vs-recreate.sh"
+fi
+
+exec bash "$ROOT/scripts/repro/repro-same-workflow-tracked-fix-vs-recreate.sh"


### PR DESCRIPTION
## Summary

This shortens the two longest CI jobs by sharding existing wrapper entrypoints across more GitHub jobs.

The downstream dry-run gate drops from 1157s to 503s on this branch. INV-117 drops from 1149s to 970s.

Only workflow files, suite wrappers, and suite counts change here. Underlying scenario code stays as-is.

<details>
<summary>Review metadata</summary>

Review Claim: CI wall-clock drops because the workflow fans existing wrapper entrypoints out across more jobs, with no underlying scenario code changes.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Only workflow files, suite wrappers, and suite inventory changed. No package source files changed.

Slice Rationale: The runtime win comes from CI orchestration alone, so this stays as one workflow-policy slice.

</details>

## Non-goals

- No package runtime changes.
- No underlying scenario implementation changes.
- No source changes under `scripts/repro/`.

## Test Plan

- [x] `/usr/bin/time -p bash scripts/test-suites/required/21-e2e-dry-run-downstream.sh`
- [x] `/usr/bin/time -p bash scripts/test-suites/required/21a-e2e-dry-run-downstream-early.sh`
- [x] `/usr/bin/time -p bash scripts/test-suites/required/21b-e2e-dry-run-downstream-late.sh`
- [x] `env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_JOBS=1 INVOKER_TEST_ALL_EXCLUDE='required/20-e2e-dry-run.sh,required/21-e2e-dry-run-downstream.sh,required/22-e2e-dry-run-github.sh' TMPDIR=/tmp/invoker-tmp /usr/bin/time -p bash scripts/run-all-tests.sh`
- [x] `env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_JOBS=3 INVOKER_TEST_ALL_EXCLUDE='required/20-e2e-dry-run.sh,required/21a-e2e-dry-run-downstream-early.sh,required/21b-e2e-dry-run-downstream-late.sh,required/22-e2e-dry-run-github.sh' TMPDIR=/tmp/invoker-tmp /usr/bin/time -p bash scripts/run-all-tests.sh`
- [x] `bash scripts/test-suites/required/23a-recreate-task-queue-authority.sh`
- [x] `bash scripts/test-suites/required/23b-fix-intent-cancellation-stale-ssh-metadata.sh`
- [x] `bash scripts/test-suites/required/23c-stale-late-completion-after-reset.sh`
- [x] `bash scripts/test-suites/required/23d-same-workflow-tracked-fix-vs-recreate.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded test and repro coverage with additional sharded checks for dry-run and scheduled repro scenarios.
  * Added support for several new blocking repro cases to improve validation coverage.

* **Bug Fixes**
  * Split a previously single dry-run path into two separate checks for more reliable validation.
  * Updated required checks so merge gating matches the new test split.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->