### PR TITLE
[SQLite WAL Read Guard](4) Route retry-loop reads through owner

### DIFF
--- a/scripts/retry-pending-autofix-failed.sh
+++ b/scripts/retry-pending-autofix-failed.sh
@@ -389,10 +389,18 @@ bounded_headless_query() {
   local output_file="$STATE_DIR/query-output.$$.$RANDOM"
 
   while [ "$attempt" -le "$attempts" ]; do
+    local query_cmd=()
+    if [ -f "$HEADLESS_CLIENT_JS" ] && owner_ping_ready; then
+      query_cmd=(node "$HEADLESS_CLIENT_JS" --no-track "$@")
+    else
+      query_cmd=("$ELECTRON" "$MAIN")
+      if [ -n "$SANDBOX_FLAG" ]; then
+        query_cmd+=("$SANDBOX_FLAG")
+      fi
+      query_cmd+=(--headless "$@")
+    fi
     set +e
-    # shellcheck disable=SC2086
-    run_with_optional_timeout "$QUERY_TIMEOUT_SECONDS" \
-      "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" > "$output_file" 2>/dev/null
+    run_with_optional_timeout "$QUERY_TIMEOUT_SECONDS" "${query_cmd[@]}" > "$output_file" 2>/dev/null
     code=$?
     set -e
     if [ "$code" -eq 0 ]; then


### PR DESCRIPTION
## Summary

The autofix loop now sends live workflow reads through the existing owner when one is up.

Before this, `bounded_headless_query` always launched a separate Electron reader, even when the owner was already serving the same data.

Now the script checks owner reachability first, uses the owner client for that path, and falls back to the old direct reader only when no owner exists.

<details>
<summary>Review metadata</summary>

Review Claim: The autofix loop reads through the owner instead of opening its own reader when the owner is reachable.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Only the read-query transport choice changed. Retry decisions, mutation routing, and the no-owner fallback still use the existing paths.

Slice Rationale: The SQLite adapter guard protects the storage boundary. This companion script change steers one hot caller onto the existing owner path.

</details>

## Non-goals

- Change database repair or recovery.
- Change retry selection rules.
- Remove the direct query fallback when no owner is running.

## Architecture

### Before

```mermaid
graph TD
    A["autofix loop read query"] --> B["direct Electron headless query"]
    B --> C["separate reader can touch the live WAL session"]
```

### After

```mermaid
graph TD
    A["autofix loop read query"] --> B{"owner ping ready?"}
    B -->|yes| C["owner client delegates query to owner"]
    B -->|no| D["direct Electron headless query fallback"]
```

## Test Plan

- [x] `scripts/retry-pending-autofix-failed.sh --self-test`
- [x] Start `node packages/app/dist/headless-client.js --no-track owner-serve`, then run `scripts/retry-pending-autofix-failed.sh --dry-run --once --interval 60`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 7361af15d`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of headless query execution by automatically selecting the best available runtime.
  * When the bundled headless client is available and reachable, queries run through it; otherwise, the system falls back to an alternate headless launch method.
  * Existing timeout and output-to-file behavior are preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->