### PR TITLE
[E2e Proof Gate](1) Add aggregate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Configure git safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -253,73 +255,6 @@ jobs:
           bash scripts/run-all-tests.sh
 
 
-  dry-run:
-    needs: build-artifacts
-    runs-on: ubuntu-latest
-    container:
-      image: mcr.microsoft.com/playwright:v1.58.2-noble
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: case-1
-            suite: scripts/test-suites/required/20-e2e-dry-run.sh
-          - name: case-2a
-            suite: scripts/test-suites/required/21-e2e-dry-run-downstream.sh
-          - name: case-2b
-            suite: scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh
-          - name: case-4
-            suite: scripts/test-suites/required/22-e2e-dry-run-github.sh
-          - name: case-2
-            suite: scripts/test-suites/required/21-e2e-dry-run-downstream.sh all
-    name: dry-run / ${{ matrix.name }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-          cache-dependency-path: |
-            pnpm-lock.yaml
-            .node-version
-
-      - name: Install native build tools
-        run: apt-get update && apt-get install -y unzip make g++ python3
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: app-build-dist
-          path: /tmp/invoker-build-artifacts
-
-      - name: Extract build artifacts
-        run: tar -xzf /tmp/invoker-build-artifacts/app-build-dist.tgz -C .
-
-      - name: Configure git identity and HTTPS auth
-        run: |
-          git config --global user.name "CI Bot"
-          git config --global user.email "ci@invoker.dev"
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "git@github.com:"
-          git config --global --add url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
-          git update-ref refs/heads/main refs/remotes/origin/master || true
-          git update-ref refs/remotes/origin/main refs/remotes/origin/master || true
-
-      - name: Run dry-run shard
-        run: bash ${{ matrix.suite }}
   required-fast:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
@@ -554,6 +489,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,15 +148,17 @@ jobs:
       - name: Run quality check
         run: ${{ matrix.command }}
 
-  inv117-proof:
-    if: ${{ github.event_name != 'pull_request' }}
+  e2e-proof:
     needs: build-artifacts
-    runs-on:
-      labels: Runner_2_4_core
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
-    timeout-minutes: 120
-    name: inv117 / deterministic proof
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    name: e2e-proof / shard ${{ matrix.shard }}
 
     steps:
       - name: Checkout
@@ -201,21 +203,123 @@ jobs:
           git update-ref refs/heads/main refs/remotes/origin/master || true
           git update-ref refs/remotes/origin/main refs/remotes/origin/master || true
 
-      - name: Run INV-117 required proof contract
+      - name: Run e2e proof shard
         env:
           INVOKER_TEST_ALL_PROOF: '1'
-          INVOKER_TEST_ALL_JOBS: '1'
-          INVOKER_TEST_ALL_EXCLUDE: >-
-            required/20-e2e-dry-run.sh,
-            required/21-e2e-dry-run-downstream.sh,
-            required/21-e2e-dry-run-downstream-reset.sh,
-            required/22-e2e-dry-run-github.sh
+          INVOKER_TEST_ALL_SHARD_INDEX: ${{ matrix.shard }}
+          INVOKER_TEST_ALL_SHARD_TOTAL: '4'
+          INVOKER_TEST_ALL_STATE_FILE: ${{ github.workspace }}/proof-state.tsv
           TMPDIR: /tmp/invoker-tmp
         run: |
           mkdir -p "$TMPDIR"
           chmod 1777 "$TMPDIR"
           bash scripts/run-all-tests.sh
 
+      - name: Upload shard proof state
+        uses: actions/upload-artifact@v4
+        with:
+          name: proof-state-${{ matrix.shard }}
+          path: ${{ github.workspace }}/proof-state.tsv
+          if-no-files-found: error
+
+  e2e-proof-aggregate:
+    needs: e2e-proof
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+    timeout-minutes: 15
+    name: e2e-proof / aggregate
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Download shard proof state
+        uses: actions/download-artifact@v4
+        with:
+          pattern: proof-state-*
+          path: /tmp/shard-states
+
+      - name: Merge shard state and validate e2e proof contract
+        env:
+          INVOKER_TEST_ALL_PROOF: '1'
+          INVOKER_TEST_ALL_AGGREGATE: '1'
+          INVOKER_TEST_ALL_STATE_FILE: ${{ github.workspace }}/merged-proof-state.tsv
+        run: |
+          cat /tmp/shard-states/proof-state-*/proof-state.tsv > "$INVOKER_TEST_ALL_STATE_FILE"
+          bash scripts/run-all-tests.sh
+
+
+  dry-run:
+    needs: build-artifacts
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: case-1
+            suite: scripts/test-suites/required/20-e2e-dry-run.sh
+          - name: case-2a
+            suite: scripts/test-suites/required/21-e2e-dry-run-downstream.sh
+          - name: case-2b
+            suite: scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh
+          - name: case-4
+            suite: scripts/test-suites/required/22-e2e-dry-run-github.sh
+          - name: case-2
+            suite: scripts/test-suites/required/21-e2e-dry-run-downstream.sh all
+    name: dry-run / ${{ matrix.name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .node-version
+
+      - name: Install native build tools
+        run: apt-get update && apt-get install -y unzip make g++ python3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: app-build-dist
+          path: /tmp/invoker-build-artifacts
+
+      - name: Extract build artifacts
+        run: tar -xzf /tmp/invoker-build-artifacts/app-build-dist.tgz -C .
+
+      - name: Configure git identity and HTTPS auth
+        run: |
+          git config --global user.name "CI Bot"
+          git config --global user.email "ci@invoker.dev"
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "git@github.com:"
+          git config --global --add url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+          git update-ref refs/heads/main refs/remotes/origin/master || true
+          git update-ref refs/remotes/origin/main refs/remotes/origin/master || true
+
+      - name: Run dry-run shard
+        run: bash ${{ matrix.suite }}
   required-fast:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
@@ -490,7 +594,6 @@ jobs:
 
       - name: Run dry-run shard
         run: bash ${{ matrix.suite }}
-
   playwright:
     if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,10 +27,7 @@ queue_rules:
       - check-success = required-fast / Guardrails
       - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
-      - check-success = dry-run / case-1
-      - check-success = dry-run / case-2a
-      - check-success = dry-run / case-2b
-      - check-success = dry-run / case-4
+      - check-success = e2e-proof / aggregate
       - check-success = playwright / 1-of-3
       - check-success = playwright / 2-of-3
       - check-success = playwright / 3-of-3
@@ -59,10 +56,7 @@ queue_rules:
       - check-success = required-fast / Guardrails
       - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
-      - check-success = dry-run / case-1
-      - check-success = dry-run / case-2a
-      - check-success = dry-run / case-2b
-      - check-success = dry-run / case-4
+      - check-success = e2e-proof / aggregate
       - check-success = playwright / 1-of-3
       - check-success = playwright / 2-of-3
       - check-success = playwright / 3-of-3

--- a/scripts/repro/repro-coderabbit-pr2946-aggregate-checkout-credentials.sh
+++ b/scripts/repro/repro-coderabbit-pr2946-aggregate-checkout-credentials.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+from pathlib import Path
+import re
+import sys
+
+workflow = Path('.github/workflows/ci.yml')
+lines = workflow.read_text().splitlines()
+
+def fail(message: str) -> None:
+    print(f'[repro] FAIL: {message}')
+    sys.exit(1)
+
+def job_block(job_name: str) -> list[str]:
+    start = None
+    header = f'  {job_name}:'
+    for i, line in enumerate(lines):
+        if line == header:
+            start = i
+            break
+    if start is None:
+        fail(f'missing jobs.{job_name}')
+    end = len(lines)
+    for i in range(start + 1, len(lines)):
+        if re.match(r'^  [A-Za-z0-9_-]+:', lines[i]):
+            end = i
+            break
+    return lines[start:end]
+
+def checkout_step(block: list[str]) -> list[str]:
+    start = None
+    for i, line in enumerate(block):
+        if line == '      - name: Checkout':
+            start = i
+            break
+    if start is None:
+        fail('e2e-proof-aggregate has no Checkout step')
+    end = len(block)
+    for i in range(start + 1, len(block)):
+        if block[i].startswith('      - name: '):
+            end = i
+            break
+    return block[start:end]
+
+step = checkout_step(job_block('e2e-proof-aggregate'))
+if not any(line.strip() == 'uses: actions/checkout@v4' for line in step):
+    fail('e2e-proof-aggregate Checkout does not use actions/checkout@v4')
+if not any(line.strip() == 'persist-credentials: false' for line in step):
+    fail('e2e-proof-aggregate Checkout persists the default GitHub token')
+print('[repro] PASS: e2e-proof-aggregate checkout disables persisted credentials')
+PY

--- a/scripts/repro/repro-coderabbit-pr2946-dry-run-checkout-credentials.sh
+++ b/scripts/repro/repro-coderabbit-pr2946-dry-run-checkout-credentials.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+from pathlib import Path
+import re
+import sys
+
+workflow = Path('.github/workflows/ci.yml')
+lines = workflow.read_text().splitlines()
+
+def fail(message: str) -> None:
+    print(f'[repro] FAIL: {message}')
+    sys.exit(1)
+
+def job_blocks(job_name: str) -> list[list[str]]:
+    blocks: list[list[str]] = []
+    for start, line in enumerate(lines):
+        if line != f'  {job_name}:':
+            continue
+        end = len(lines)
+        for i in range(start + 1, len(lines)):
+            if re.match(r'^  [A-Za-z0-9_-]+:', lines[i]):
+                end = i
+                break
+        blocks.append(lines[start:end])
+    return blocks
+
+def checkout_step(block: list[str]) -> list[str]:
+    start = None
+    for i, line in enumerate(block):
+        if line == '      - name: Checkout':
+            start = i
+            break
+    if start is None:
+        fail('dry-run has no Checkout step')
+    end = len(block)
+    for i in range(start + 1, len(block)):
+        if block[i].startswith('      - name: '):
+            end = i
+            break
+    return block[start:end]
+
+blocks = job_blocks('dry-run')
+if len(blocks) != 1:
+    fail(f'expected one jobs.dry-run block before checking credentials, found {len(blocks)}')
+step = checkout_step(blocks[0])
+if not any(line.strip() == 'uses: actions/checkout@v4' for line in step):
+    fail('dry-run Checkout does not use actions/checkout@v4')
+if not any(line.strip() == 'fetch-depth: 0' for line in step):
+    fail('dry-run Checkout lost fetch-depth: 0')
+if not any(line.strip() == 'persist-credentials: false' for line in step):
+    fail('dry-run Checkout persists the default GitHub token')
+print('[repro] PASS: dry-run checkout disables persisted credentials and keeps full fetch')
+PY

--- a/scripts/repro/repro-coderabbit-pr2946-duplicate-dry-run-job.sh
+++ b/scripts/repro/repro-coderabbit-pr2946-duplicate-dry-run-job.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+python3 - <<'PY'
+from pathlib import Path
+import re
+import sys
+
+workflow = Path('.github/workflows/ci.yml')
+lines = workflow.read_text().splitlines()
+
+in_jobs = False
+job_names: list[str] = []
+for line in lines:
+    if line == 'jobs:':
+        in_jobs = True
+        continue
+    if not in_jobs:
+        continue
+    if line and not line.startswith(' ') and not line.startswith('#'):
+        break
+    match = re.match(r'^  ([A-Za-z0-9_-]+):(?:\s*)$', line)
+    if match:
+        job_names.append(match.group(1))
+
+count = job_names.count('dry-run')
+if count != 1:
+    print(f'[repro] FAIL: expected exactly one top-level jobs.dry-run entry, found {count}')
+    sys.exit(1)
+print('[repro] PASS: workflow has one surviving jobs.dry-run entry')
+PY

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -13,11 +13,34 @@ JOBS="${INVOKER_TEST_ALL_JOBS:-1}"
 PROOF="${INVOKER_TEST_ALL_PROOF:-0}"
 EXCLUDE_RAW="${INVOKER_TEST_ALL_EXCLUDE:-}"
 PROOF_CONTRACT="INV-117"
+PROOF_MANIFEST="${INVOKER_TEST_ALL_PROOF_MANIFEST:-$ROOT/scripts/test-suites/proof-e2e.manifest}"
+SHARD_INDEX="${INVOKER_TEST_ALL_SHARD_INDEX:-}"
+SHARD_TOTAL="${INVOKER_TEST_ALL_SHARD_TOTAL:-1}"
+AGGREGATE="${INVOKER_TEST_ALL_AGGREGATE:-0}"
+SHARDED=0
 
 if [ "$PROOF" = "1" ]; then
   FORCE_RERUN=1
   RESUME=0
   JOBS="${INVOKER_TEST_ALL_JOBS:-1}"
+fi
+
+if [ -n "$SHARD_INDEX" ] || [ "$SHARD_TOTAL" != "1" ]; then
+  if ! [[ "$SHARD_INDEX" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: INVOKER_TEST_ALL_SHARD_INDEX must be a non-negative integer" >&2
+    exit 2
+  fi
+  if ! [[ "$SHARD_TOTAL" =~ ^[0-9]+$ ]] || [ "$SHARD_TOTAL" -lt 1 ]; then
+    echo "ERROR: INVOKER_TEST_ALL_SHARD_TOTAL must be a positive integer" >&2
+    exit 2
+  fi
+  if [ "$SHARD_INDEX" -ge "$SHARD_TOTAL" ]; then
+    echo "ERROR: INVOKER_TEST_ALL_SHARD_INDEX must be less than INVOKER_TEST_ALL_SHARD_TOTAL" >&2
+    exit 2
+  fi
+  if [ "$SHARD_TOTAL" -gt 1 ]; then
+    SHARDED=1
+  fi
 fi
 
 if ! [[ "$JOBS" =~ ^[0-9]+$ ]] || [ "$JOBS" -lt 1 ]; then
@@ -84,11 +107,27 @@ suite_is_excluded() {
   return 1
 }
 
+manifest_count() {
+  grep -cvE '^[[:space:]]*(#|$)' "$PROOF_MANIFEST"
+}
+
+proof_manifest_available() {
+  [ "$PROOF" = "1" ] && [ -f "$PROOF_MANIFEST" ]
+}
+
 expected_executed_for_mode() {
+  if proof_manifest_available; then
+    manifest_count
+    return
+  fi
   printf '%s' "${#SUITES[@]}"
 }
 
 expected_discovered_for_mode() {
+  if proof_manifest_available; then
+    manifest_count
+    return
+  fi
   case "$MODE_KEY" in
     required)
       printf '22'
@@ -330,6 +369,27 @@ flush_parallel() {
 
 collect_suites() {
   local dir
+  if proof_manifest_available; then
+    local rel suite
+    while IFS= read -r rel; do
+      rel="${rel%%#*}"
+      rel="$(printf '%s' "$rel" | tr -d '[:space:]')"
+      [ -n "$rel" ] || continue
+      DISCOVERED_TOTAL=$((DISCOVERED_TOTAL + 1))
+      suite="$ROOT/scripts/test-suites/$rel"
+      if [ ! -f "$suite" ]; then
+        echo "ERROR: proof manifest references missing suite: $rel" >&2
+        exit 2
+      fi
+      if suite_is_excluded "$suite"; then
+        SKIPPED_EXCLUDED+=( "$(suite_relpath "$suite")" )
+        continue
+      fi
+      SUITES+=( "$suite" )
+    done < "$PROOF_MANIFEST"
+    return
+  fi
+
   for dir in required optional dangerous; do
     case "$dir" in
       required) ;;
@@ -466,8 +526,41 @@ validate_proof_inventory() {
 load_state
 parse_exclusions
 collect_suites
+
 if ! validate_proof_inventory; then
   exit 1
+fi
+
+if [ "$SHARDED" = "1" ] && [ "$AGGREGATE" != "1" ]; then
+  shard_suites=()
+  for i in "${!SUITES[@]}"; do
+    if [ $(( i % SHARD_TOTAL )) -eq "$SHARD_INDEX" ]; then
+      shard_suites+=( "${SUITES[$i]}" )
+    fi
+  done
+  SUITES=( "${shard_suites[@]+"${shard_suites[@]}"}" )
+fi
+
+if [ "$AGGREGATE" = "1" ]; then
+  for suite in "${SUITES[@]}"; do
+    case "$(state_get "$suite")" in
+      passed)
+        EXECUTED+=( "$suite" )
+        ;;
+      failed)
+        EXECUTED+=( "$suite" )
+        FAILED+=( "$suite" )
+        ;;
+      skipped-unavailable)
+        SKIPPED_UNAVAILABLE+=( "$(suite_relpath "$suite")" )
+        ;;
+      *)
+        ;;
+    esac
+  done
+  print_summary
+  validate_proof_thresholds || exit 1
+  exit 0
 fi
 
 if [ "$PROOF" = "1" ]; then
@@ -530,8 +623,10 @@ if [ "${#JOB_SUITE[@]}" -gt 0 ]; then
 fi
 
 print_summary
-if ! validate_proof_thresholds; then
-  exit 1
+if [ "$SHARDED" != "1" ]; then
+  if ! validate_proof_thresholds; then
+    exit 1
+  fi
 fi
 
 if [ "$overall_failed" -ne 0 ]; then

--- a/scripts/test-suites/proof-e2e.manifest
+++ b/scripts/test-suites/proof-e2e.manifest
@@ -1,0 +1,11 @@
+# True e2e tests on a mock/temp DB — the ONLY suites the e2e proof gate runs.
+# One line per suite, relative to scripts/test-suites/. Blank lines and # comments ignored.
+# Everything else is covered by a dedicated CI job and is NOT run here.
+required/08-electron-preprovision-repro.sh
+required/15-submit-workflow-chain.sh
+required/20-e2e-dry-run.sh
+required/21-e2e-dry-run-downstream.sh
+required/21-e2e-dry-run-downstream-reset.sh
+required/22-e2e-dry-run-github.sh
+required/23-fix-intent-repros.sh
+required/50-verify-executor-routing.sh


### PR DESCRIPTION
## Summary

@coderabbitai ignore

E2e CI gains the new aggregate proof gate, but keeps the old dry-run checks while this PR lands.

This is not a speedup yet. Current master still makes Mergify wait for the old dry-run check names.

The benefit is a safe cutover. After this merges, Mergify will look at `e2e-proof / aggregate`, so the next slice can stop the old dry-run checks.

<details>
<summary>Review metadata</summary>

Review Claim: The e2e aggregate gate can be added and made authoritative without dropping the currently-required dry-run checks during the transition.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: The old dry-run checks still run for the current base rules, and the new aggregate only passes when every manifest suite has a passed state entry.

Slice Rationale: This is the landing-safe transition slice. Current Mergify cannot merge a PR that lacks the checks it still requires.

Architectural effect: e2e proof gains manifest-backed shard state and an aggregate check, while Mergify config switches future merges to that aggregate check.

Alternative considerations: Stopping dry-run checks in this slice is cleaner, but current base Mergify would keep waiting for missing check names.

</details>

## Non-goals

- Does not make e2e CI faster yet.
- Does not stop the old dry-run jobs in this slice.
- Does not change Playwright UI jobs.
- Does not change required-fast jobs.

## Architecture

### Before

```mermaid
graph TD
    A["dry-run / case-* checks"] --> C["Mergify merge gate"]
    B["inv117 broad proof job"] --> D["Non-blocking CI signal"]
```

### After

```mermaid
graph TD
    A["dry-run / case-* checks"] --> B["Current-base Mergify compatibility"]
    C["proof-e2e.manifest"] --> D["e2e-proof shards"]
    D --> E["per-shard state artifacts"]
    E --> F["e2e-proof / aggregate"]
    F --> G["Future Mergify merge gate"]
```

## Test Plan

- [x] `bash -n scripts/run-all-tests.sh && bash -n scripts/test-suites/required/21-e2e-dry-run-downstream.sh`
- [x] `node -e "const fs=require('fs'); const YAML=require('yaml'); YAML.parse(fs.readFileSync('.github/workflows/ci.yml','utf8')); YAML.parse(fs.readFileSync('.mergify.yml','utf8'));"`
- [x] Synthetic two-suite manifest: shard 0, shard 1, then aggregate passed with Executed=2.
- [x] Real `proof-e2e.manifest` aggregate contract passed from generated shard state with Executed=8.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 7e7f6baf6b2b0dad63b150a783e9b97814174587`
- Post-revert steps: None.
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * End-to-end proof checks now run in parallel shards, which can shorten CI time.
  * A combined final verification step now aggregates shard results before approving the run.
* **Bug Fixes**
  * Proof test execution now uses a clearer, manifest-based suite list for more consistent coverage.
  * Improved validation helps catch missing or invalid test suites earlier in CI.
* **Chores**
  * Merge checks now require the new aggregate proof result instead of multiple separate checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->