### PR TITLE
[E2e Proof Gate](1) Add aggregate gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,15 +148,18 @@ jobs:
       - name: Run quality check
         run: ${{ matrix.command }}
 
-  inv117-proof:
-    if: ${{ github.event_name != 'pull_request' }}
+  e2e-proof:
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
     needs: build-artifacts
-    runs-on:
-      labels: Runner_2_4_core
+    runs-on: ubuntu-latest
     container:
       image: mcr.microsoft.com/playwright:v1.58.2-noble
-    timeout-minutes: 120
-    name: inv117 / deterministic proof
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    name: e2e-proof / shard ${{ matrix.shard }}
 
     steps:
       - name: Checkout
@@ -201,19 +204,56 @@ jobs:
           git update-ref refs/heads/main refs/remotes/origin/master || true
           git update-ref refs/remotes/origin/main refs/remotes/origin/master || true
 
-      - name: Run INV-117 required proof contract
+      - name: Run e2e proof shard
         env:
           INVOKER_TEST_ALL_PROOF: '1'
-          INVOKER_TEST_ALL_JOBS: '1'
-          INVOKER_TEST_ALL_EXCLUDE: >-
-            required/20-e2e-dry-run.sh,
-            required/21-e2e-dry-run-downstream.sh,
-            required/21-e2e-dry-run-downstream-reset.sh,
-            required/22-e2e-dry-run-github.sh
+          INVOKER_TEST_ALL_SHARD_INDEX: ${{ matrix.shard }}
+          INVOKER_TEST_ALL_SHARD_TOTAL: '4'
+          INVOKER_TEST_ALL_STATE_FILE: ${{ github.workspace }}/proof-state.tsv
           TMPDIR: /tmp/invoker-tmp
         run: |
           mkdir -p "$TMPDIR"
           chmod 1777 "$TMPDIR"
+          bash scripts/run-all-tests.sh
+
+      - name: Upload shard proof state
+        uses: actions/upload-artifact@v4
+        with:
+          name: proof-state-${{ matrix.shard }}
+          path: ${{ github.workspace }}/proof-state.tsv
+          if-no-files-found: error
+
+  e2e-proof-aggregate:
+    if: ${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}
+    needs: e2e-proof
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
+    timeout-minutes: 15
+    name: e2e-proof / aggregate
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Configure git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Download shard proof state
+        uses: actions/download-artifact@v4
+        with:
+          pattern: proof-state-*
+          path: /tmp/shard-states
+
+      - name: Merge shard state and validate e2e proof contract
+        env:
+          INVOKER_TEST_ALL_PROOF: '1'
+          INVOKER_TEST_ALL_AGGREGATE: '1'
+          INVOKER_TEST_ALL_STATE_FILE: ${{ github.workspace }}/merged-proof-state.tsv
+        run: |
+          cat /tmp/shard-states/proof-state-*/proof-state.tsv > "$INVOKER_TEST_ALL_STATE_FILE"
           bash scripts/run-all-tests.sh
 
   required-fast:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,10 +27,7 @@ queue_rules:
       - check-success = required-fast / Guardrails
       - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
-      - check-success = dry-run / case-1
-      - check-success = dry-run / case-2a
-      - check-success = dry-run / case-2b
-      - check-success = dry-run / case-4
+      - check-success = e2e-proof / aggregate
       - check-success = playwright / 1-of-3
       - check-success = playwright / 2-of-3
       - check-success = playwright / 3-of-3
@@ -59,10 +56,7 @@ queue_rules:
       - check-success = required-fast / Guardrails
       - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
-      - check-success = dry-run / case-1
-      - check-success = dry-run / case-2a
-      - check-success = dry-run / case-2b
-      - check-success = dry-run / case-4
+      - check-success = e2e-proof / aggregate
       - check-success = playwright / 1-of-3
       - check-success = playwright / 2-of-3
       - check-success = playwright / 3-of-3

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -13,11 +13,34 @@ JOBS="${INVOKER_TEST_ALL_JOBS:-1}"
 PROOF="${INVOKER_TEST_ALL_PROOF:-0}"
 EXCLUDE_RAW="${INVOKER_TEST_ALL_EXCLUDE:-}"
 PROOF_CONTRACT="INV-117"
+PROOF_MANIFEST="${INVOKER_TEST_ALL_PROOF_MANIFEST:-$ROOT/scripts/test-suites/proof-e2e.manifest}"
+SHARD_INDEX="${INVOKER_TEST_ALL_SHARD_INDEX:-}"
+SHARD_TOTAL="${INVOKER_TEST_ALL_SHARD_TOTAL:-1}"
+AGGREGATE="${INVOKER_TEST_ALL_AGGREGATE:-0}"
+SHARDED=0
 
 if [ "$PROOF" = "1" ]; then
   FORCE_RERUN=1
   RESUME=0
   JOBS="${INVOKER_TEST_ALL_JOBS:-1}"
+fi
+
+if [ -n "$SHARD_INDEX" ] || [ "$SHARD_TOTAL" != "1" ]; then
+  if ! [[ "$SHARD_INDEX" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: INVOKER_TEST_ALL_SHARD_INDEX must be a non-negative integer" >&2
+    exit 2
+  fi
+  if ! [[ "$SHARD_TOTAL" =~ ^[0-9]+$ ]] || [ "$SHARD_TOTAL" -lt 1 ]; then
+    echo "ERROR: INVOKER_TEST_ALL_SHARD_TOTAL must be a positive integer" >&2
+    exit 2
+  fi
+  if [ "$SHARD_INDEX" -ge "$SHARD_TOTAL" ]; then
+    echo "ERROR: INVOKER_TEST_ALL_SHARD_INDEX must be less than INVOKER_TEST_ALL_SHARD_TOTAL" >&2
+    exit 2
+  fi
+  if [ "$SHARD_TOTAL" -gt 1 ]; then
+    SHARDED=1
+  fi
 fi
 
 if ! [[ "$JOBS" =~ ^[0-9]+$ ]] || [ "$JOBS" -lt 1 ]; then
@@ -84,11 +107,27 @@ suite_is_excluded() {
   return 1
 }
 
+manifest_count() {
+  grep -cvE '^[[:space:]]*(#|$)' "$PROOF_MANIFEST"
+}
+
+proof_manifest_available() {
+  [ "$PROOF" = "1" ] && [ -f "$PROOF_MANIFEST" ]
+}
+
 expected_executed_for_mode() {
+  if proof_manifest_available; then
+    manifest_count
+    return
+  fi
   printf '%s' "${#SUITES[@]}"
 }
 
 expected_discovered_for_mode() {
+  if proof_manifest_available; then
+    manifest_count
+    return
+  fi
   case "$MODE_KEY" in
     required)
       printf '22'
@@ -330,6 +369,27 @@ flush_parallel() {
 
 collect_suites() {
   local dir
+  if proof_manifest_available; then
+    local rel suite
+    while IFS= read -r rel; do
+      rel="${rel%%#*}"
+      rel="$(printf '%s' "$rel" | tr -d '[:space:]')"
+      [ -n "$rel" ] || continue
+      DISCOVERED_TOTAL=$((DISCOVERED_TOTAL + 1))
+      suite="$ROOT/scripts/test-suites/$rel"
+      if [ ! -f "$suite" ]; then
+        echo "ERROR: proof manifest references missing suite: $rel" >&2
+        exit 2
+      fi
+      if suite_is_excluded "$suite"; then
+        SKIPPED_EXCLUDED+=( "$(suite_relpath "$suite")" )
+        continue
+      fi
+      SUITES+=( "$suite" )
+    done < "$PROOF_MANIFEST"
+    return
+  fi
+
   for dir in required optional dangerous; do
     case "$dir" in
       required) ;;
@@ -466,8 +526,41 @@ validate_proof_inventory() {
 load_state
 parse_exclusions
 collect_suites
+
 if ! validate_proof_inventory; then
   exit 1
+fi
+
+if [ "$SHARDED" = "1" ] && [ "$AGGREGATE" != "1" ]; then
+  shard_suites=()
+  for i in "${!SUITES[@]}"; do
+    if [ $(( i % SHARD_TOTAL )) -eq "$SHARD_INDEX" ]; then
+      shard_suites+=( "${SUITES[$i]}" )
+    fi
+  done
+  SUITES=( "${shard_suites[@]+"${shard_suites[@]}"}" )
+fi
+
+if [ "$AGGREGATE" = "1" ]; then
+  for suite in "${SUITES[@]}"; do
+    case "$(state_get "$suite")" in
+      passed)
+        EXECUTED+=( "$suite" )
+        ;;
+      failed)
+        EXECUTED+=( "$suite" )
+        FAILED+=( "$suite" )
+        ;;
+      skipped-unavailable)
+        SKIPPED_UNAVAILABLE+=( "$(suite_relpath "$suite")" )
+        ;;
+      *)
+        ;;
+    esac
+  done
+  print_summary
+  validate_proof_thresholds || exit 1
+  exit 0
 fi
 
 if [ "$PROOF" = "1" ]; then
@@ -530,8 +623,10 @@ if [ "${#JOB_SUITE[@]}" -gt 0 ]; then
 fi
 
 print_summary
-if ! validate_proof_thresholds; then
-  exit 1
+if [ "$SHARDED" != "1" ]; then
+  if ! validate_proof_thresholds; then
+    exit 1
+  fi
 fi
 
 if [ "$overall_failed" -ne 0 ]; then

--- a/scripts/test-ci-workflow-merge-queue-policy.mjs
+++ b/scripts/test-ci-workflow-merge-queue-policy.mjs
@@ -5,7 +5,7 @@ import YAML from 'yaml';
 const FULL_CI_GATE = "${{ github.event_name != 'pull_request' || startsWith(github.head_ref, 'mergify/merge-queue/') }}";
 const NON_PR_GATE = "${{ github.event_name != 'pull_request' }}";
 const ORDINARY_PR_GATE = "${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}";
-const FULL_CI_JOBS = new Set(['build-artifacts', 'required-fast', 'dry-run', 'playwright', 'ssh', 'optional-other']);
+const FULL_CI_JOBS = new Set(['build-artifacts', 'e2e-proof', 'e2e-proof-aggregate', 'required-fast', 'dry-run', 'playwright', 'ssh', 'optional-other']);
 
 const workflow = YAML.parse(readFileSync('.github/workflows/ci.yml', 'utf8'));
 const mergify = YAML.parse(readFileSync('.mergify.yml', 'utf8'));
@@ -38,8 +38,6 @@ assert(!jobs['quality-required'].if, 'quality-required must run on ordinary PRs'
 assert(jobs['quality-extra'], 'Missing quality-extra job');
 assert(jobs['quality-extra'].if === ORDINARY_PR_GATE, 'quality-extra must run on ordinary PRs and skip merge queue refs');
 
-assert(jobs['inv117-proof'], 'Missing inv117-proof job');
-assert(jobs['inv117-proof'].if === NON_PR_GATE, 'inv117-proof must not run on pull_request events');
 
 assert(jobs.docker, 'Missing docker job');
 assert(jobs.docker.if === NON_PR_GATE, 'docker must not run on pull_request events');

--- a/scripts/test-suites/proof-e2e.manifest
+++ b/scripts/test-suites/proof-e2e.manifest
@@ -1,0 +1,11 @@
+# True e2e tests on a mock/temp DB — the ONLY suites the e2e proof gate runs.
+# One line per suite, relative to scripts/test-suites/. Blank lines and # comments ignored.
+# Everything else is covered by a dedicated CI job and is NOT run here.
+required/08-electron-preprovision-repro.sh
+required/15-submit-workflow-chain.sh
+required/20-e2e-dry-run.sh
+required/21-e2e-dry-run-downstream.sh
+required/21-e2e-dry-run-downstream-reset.sh
+required/22-e2e-dry-run-github.sh
+required/23-fix-intent-repros.sh
+required/50-verify-executor-routing.sh


### PR DESCRIPTION
## Summary

@coderabbitai ignore

E2e CI gains the new aggregate proof gate, but keeps the old dry-run checks while this PR lands.

This is not a speedup yet. Current master still makes Mergify wait for the old dry-run check names.

The benefit is a safe cutover. After this merges, Mergify will look at `e2e-proof / aggregate`, so the next slice can stop the old dry-run checks.

<details>
<summary>Review metadata</summary>

Review Claim: The e2e aggregate gate can be added and made authoritative without dropping the currently-required dry-run checks during the transition.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: The old dry-run checks still run for the current base rules, and the new aggregate only passes when every manifest suite has a passed state entry.

Slice Rationale: This is the landing-safe transition slice. Current Mergify cannot merge a PR that lacks the checks it still requires.

Architectural effect: e2e proof gains manifest-backed shard state and an aggregate check, while Mergify config switches future merges to that aggregate check.

Alternative considerations: Stopping dry-run checks in this slice is cleaner, but current base Mergify would keep waiting for missing check names.

</details>

## Non-goals

- Does not make e2e CI faster yet.
- Does not stop the old dry-run jobs in this slice.
- Does not change Playwright UI jobs.
- Does not change required-fast jobs.

## Architecture

### Before

```mermaid
graph TD
    A["dry-run / case-* checks"] --> C["Mergify merge gate"]
    B["inv117 broad proof job"] --> D["Non-blocking CI signal"]
```

### After

```mermaid
graph TD
    A["dry-run / case-* checks"] --> B["Current-base Mergify compatibility"]
    C["proof-e2e.manifest"] --> D["e2e-proof shards"]
    D --> E["per-shard state artifacts"]
    E --> F["e2e-proof / aggregate"]
    F --> G["Future Mergify merge gate"]
```

## Test Plan

- [x] `bash -n scripts/run-all-tests.sh && bash -n scripts/test-suites/required/21-e2e-dry-run-downstream.sh`
- [x] `node -e "const fs=require('fs'); const YAML=require('yaml'); YAML.parse(fs.readFileSync('.github/workflows/ci.yml','utf8')); YAML.parse(fs.readFileSync('.mergify.yml','utf8'));"`
- [x] Synthetic two-suite manifest: shard 0, shard 1, then aggregate passed with Executed=2.
- [x] Real `proof-e2e.manifest` aggregate contract passed from generated shard state with Executed=8.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 2a77c2583`
- Post-revert steps: None.
- Data migration? No
