### PR TITLE
[Invoker UI Reskin](14) Address CodeRabbit followups

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -484,6 +484,7 @@ export function App() {
   const [setupResult, setSetupResult] = useState<InvokerSetupResult | null>(null);
   const [updateCliError, setUpdateCliError] = useState<string | null>(null);
   const [inspectorCollapsed, setInspectorCollapsed] = useState(false);
+  const [inspectorManualOpen, setInspectorManualOpen] = useState(false);
   const [viewportWidth, setViewportWidth] = useState(() => (typeof window === 'undefined' ? 1600 : window.innerWidth));
   const [advancedMetadataExpanded, setAdvancedMetadataExpanded] = useState(false);
   const [terminalDrawerState, setTerminalDrawerState] = useState<TerminalDrawerState>('minimized');
@@ -575,9 +576,9 @@ export function App() {
     }).catch(() => {});
   }, []);
   useEffect(() => {
-    if (!graphMaximized) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
+        event.stopPropagation();
         setGraphMaximized(false);
       }
     };
@@ -1091,6 +1092,9 @@ export function App() {
         return;
       }
 
+      if (graphMaximized && event.key === 'Escape') {
+        return;
+      }
       if (isEditableKeyboardTarget(event.target) || modal.type !== 'none') return;
 
       // F1 is the keyboard-only camera lock control. It is already ignored for
@@ -1235,6 +1239,7 @@ export function App() {
     bottomStatusIndex,
     contextMenu,
     focusKeyboardRegion,
+    graphMaximized,
     handleStatusClick,
     issueCameraCommand,
     keyboardRegion,
@@ -1331,7 +1336,15 @@ export function App() {
   useEffect(() => {
     if (sidebarSurface === 'workflows') {
       const activeWorkflowId = selectedWorkflow?.id ?? selectedWorkflowId;
-      if (!workflowEntries.length || workflowEntries.some((entry) => entry.workflow.id === activeWorkflowId)) {
+      if (!workflowEntries.length) {
+        if (selectedTaskId !== null || activeWorkflowId !== null) {
+          setSelectedTaskId(null);
+          setSelectedWorkflowId(null);
+          setWorkflowSelectionDismissed(false);
+        }
+        return;
+      }
+      if (workflowEntries.some((entry) => entry.workflow.id === activeWorkflowId)) {
         return;
       }
       selectWorkflowById(workflowEntries[0].workflow.id);
@@ -1339,7 +1352,15 @@ export function App() {
     }
 
     if (sidebarSurface === 'attention') {
-      if (!attentionEntries.length || attentionEntries.some((entry) => entry.task.id === selectedTaskId)) {
+      if (!attentionEntries.length) {
+        if (selectedTaskId !== null || selectedWorkflowId !== null) {
+          setSelectedTaskId(null);
+          setSelectedWorkflowId(null);
+          setWorkflowSelectionDismissed(false);
+        }
+        return;
+      }
+      if (attentionEntries.some((entry) => entry.task.id === selectedTaskId)) {
         return;
       }
       selectTaskById(attentionEntries[0].task.id);
@@ -1347,7 +1368,15 @@ export function App() {
     }
 
     if (sidebarSurface === 'running') {
-      if (!runningEntries.length || runningEntries.some((entry) => entry.task.id === selectedTaskId)) {
+      if (!runningEntries.length) {
+        if (selectedTaskId !== null || selectedWorkflowId !== null) {
+          setSelectedTaskId(null);
+          setSelectedWorkflowId(null);
+          setWorkflowSelectionDismissed(false);
+        }
+        return;
+      }
+      if (runningEntries.some((entry) => entry.task.id === selectedTaskId)) {
         return;
       }
       selectTaskById(runningEntries[0].task.id);
@@ -1692,13 +1721,15 @@ export function App() {
     setTerminalLines((prev) => [...prev, { id, text, tone }]);
   }, []);
 
-  const handleStart = useCallback(async () => {
-    if (!invoker) return;
+  const handleStart = useCallback(async (): Promise<boolean> => {
+    if (!invoker) return false;
     try {
       await invoker.start();
       setHasStarted(true);
+      return true;
     } catch (err) {
       console.error('Failed to start:', err);
+      return false;
     }
   }, [invoker]);
 
@@ -1740,8 +1771,8 @@ export function App() {
         appendTerminalLine('Create a plan before running.', 'error');
         return;
       }
-      await handleStart();
-      appendTerminalLine('Run started.', 'success');
+      const started = await handleStart();
+      appendTerminalLine(started ? 'Run started.' : 'Run failed to start.', started ? 'success' : 'error');
       return;
     }
 
@@ -1798,6 +1829,7 @@ export function App() {
       setSelectedTaskId(null);
       setSelectedWorkflowId(null);
       setModal({ type: 'none' });
+      setStatusFilters(new Set<WorkflowStatus>());
     } catch (err) {
       console.error('Failed to delete workflows:', err);
     }
@@ -1818,14 +1850,14 @@ export function App() {
   const showStop = hasStarted && !allSettled;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
   const autoCollapseInspector = sidebarSurface !== 'home' && viewportWidth < 1440;
-  const effectiveInspectorCollapsed = inspectorCollapsed || autoCollapseInspector;
+  const effectiveInspectorCollapsed = inspectorCollapsed || (autoCollapseInspector && !inspectorManualOpen);
   const showInspectorPlaceholder = !showEmptyGraphTutorial && !selectedTask && !selectedWorkflow && !(viewMode === 'actionGraph' && selectedActionNode);
 
   useEffect(() => {
-    const handleResize = () => setViewportWidth(window.innerWidth);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
+    if (sidebarSurface === 'home' || !autoCollapseInspector) {
+      setInspectorManualOpen(false);
+    }
+  }, [autoCollapseInspector, sidebarSurface]);
   useEffect(() => {
     if (!graphActionsMenuOpen) return undefined;
     const handlePointerDown = (event: PointerEvent) => {
@@ -1847,6 +1879,9 @@ export function App() {
 
   const selectViewMode = useCallback((nextView: 'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph') => {
     setGraphActionsMenuOpen(false);
+    if (nextView !== 'actionGraph' && selectedActionNodeId !== null) {
+      setSelectedActionNodeId(null);
+    }
     if (nextView === 'actionGraph') {
       setSidebarSurface('home');
       setViewMode('actionGraph');
@@ -1860,7 +1895,17 @@ export function App() {
     }
     setSidebarSurface('home');
     setViewMode(nextView);
-  }, []);
+  }, [selectedActionNodeId]);
+
+  const handleToggleInspectorCollapsed = useCallback(() => {
+    if (autoCollapseInspector) {
+      setInspectorCollapsed(false);
+      setInspectorManualOpen((prev) => !prev);
+      return;
+    }
+    setInspectorManualOpen(false);
+    setInspectorCollapsed((prev) => !prev);
+  }, [autoCollapseInspector]);
 
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
@@ -1868,16 +1913,20 @@ export function App() {
     if (nextSurface === 'home') {
       setSidebarSurface('home');
       setSidebarCollapsed(false);
+      setInspectorManualOpen(false);
       return;
     }
     setSidebarSurface(nextSurface);
     setSidebarCollapsed(true);
+    setInspectorManualOpen(false);
+    setStatusFilters(new Set<WorkflowStatus>());
   }, []);
 
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
     setSidebarSurface('home');
     setSidebarCollapsed(false);
+    setInspectorManualOpen(false);
     setViewMode('dag');
   }, []);
 
@@ -2498,12 +2547,14 @@ export function App() {
       data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
       className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
     >
-      <WorkflowStatusChips
-        workflows={workflows}
-        activeFilters={statusFilters}
-        keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
-        onStatusClick={handleStatusClick}
-      />
+      {sidebarSurface === 'home' && (
+        <WorkflowStatusChips
+          workflows={workflows}
+          activeFilters={statusFilters}
+          keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
+          onStatusClick={handleStatusClick}
+        />
+      )}
       <TerminalDrawer
         state={terminalDrawerState}
         onCycle={() =>
@@ -2656,22 +2707,17 @@ export function App() {
                 task={selectedTask}
                 workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
                 reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
+                actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
+                collapsed={effectiveInspectorCollapsed}
+                advancedExpanded={advancedMetadataExpanded}
                 remoteTargets={remoteTargets}
                 executionPools={executionPools}
                 executionAgents={executionAgents}
-                collapsed={effectiveInspectorCollapsed}
-                advancedExpanded={advancedMetadataExpanded}
-                actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
-                onEditType={handleEditType}
-                onEditPool={handleEditPool}
-                onEditAgent={handleEditAgent}
-                onEditPrompt={handleEditPrompt}
-                onEditCommand={handleEditCommand}
-                onApprove={openApprovalModal}
-                onReject={openRejectModal}
+                onApprove={(task) => void handleApprove(task.id)}
+                onReject={(task) => void handleReject(task.id)}
                 onSetMergeBranch={handleSetMergeBranch}
                 onSetMergeMode={handleSetMergeMode}
-                onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
+                onToggleCollapsed={handleToggleInspectorCollapsed}
                 onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}
               />
             )}

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -120,6 +120,7 @@ describe('App launch (component)', () => {
     });
 
     expect(mock.api.getRuntimeStatus).toHaveBeenCalled();
+    expect(screen.getByTestId('read-only-mode-banner')).toBeInTheDocument();
   });
 
   it('hides the read-only banner for the local write owner', async () => {

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -17,8 +17,10 @@ export function InvokerTerminal({ lines, busy, onSubmit }: InvokerTerminalProps)
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
+    if (!busy) {
+      inputRef.current?.focus();
+    }
+  }, [busy]);
 
   return (
     <section className="rounded-xl border border-gray-800 bg-gray-950 shadow-inner">

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -162,6 +162,7 @@ export function LeftStatusColumn({
         data-testid="sidebar-home"
         data-sidebar-nav-item
         data-sidebar-nav-order="1"
+        aria-current={selectedSurface === 'home' ? 'page' : undefined}
         onClick={() => onSelectSurface('home')}
         className={[
           'rounded-xl text-left hover:bg-gray-900/80',
@@ -196,7 +197,7 @@ export function LeftStatusColumn({
               aria-label={source.label}
               data-testid={`sidebar-${source.key}`}
               data-sidebar-nav-item
-              data-sidebar-nav-order={String(index + 2)}
+              aria-current={selected ? 'page' : undefined}
               onClick={() => onSelectSurface(source.key)}
               className={navButtonClass(selected, collapsed)}
             >
@@ -237,7 +238,7 @@ export function LeftStatusColumn({
           {selectedSurface === 'attention' && (
             attentionEntries.length === 0
               ? 'Nothing needs a decision right now.'
-              : `${attentionEntries.length} item${attentionEntries.length === 1 ? '' : 's'} need attention.`
+              : `${attentionEntries.length} item${attentionEntries.length === 1 ? ' needs' : 's need'} attention.`
           )}
           {selectedSurface === 'running' && (
             runningEntries.length === 0
@@ -277,13 +278,10 @@ export function LeftStatusColumn({
           {collapsed ? (
             <CollapseIcon collapsed={collapsed} />
           ) : (
-            <>
-              <span className="flex items-center gap-2">
-                <CollapseIcon collapsed={collapsed} />
-                <span>Collapse</span>
-              </span>
-              <span>◂</span>
-            </>
+            <span className="flex items-center gap-2">
+              <CollapseIcon collapsed={collapsed} />
+              <span>Collapse</span>
+            </span>
           )}
         </button>
       </div>

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -164,6 +164,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   const lastHandledCameraSeqRef = useRef(0);
   const browserRemountDoneRef = useRef(false);
   const initFitFrameRef = useRef(0);
+  const nodesRef = useRef<typeof nodes>([]);
   const [layoutState, setLayoutState] = useState<LayoutState | null>(null);
   const [flowInstanceKey, setFlowInstanceKey] = useState(0);
   const onInitHandler = useCallback(() => {
@@ -174,9 +175,6 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   // torn-down graph after the component has gone away.
   useEffect(() => () => cancelAnimationFrame(initFitFrameRef.current), []);
 
-  useEffect(() => {
-    browserRemountDoneRef.current = false;
-  }, [surfaceMode, tasks.size]);
 
   const rawGraph = useMemo(() => {
     const taskArray = [...tasks.values()];
@@ -248,6 +246,9 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       layoutKey: layoutKeyFor(layoutTasks, rawEdges),
     };
   }, [runningTaskIds, tasks, statusFilters]);
+  useEffect(() => {
+    browserRemountDoneRef.current = false;
+  }, [rawGraph.layoutKey, surfaceMode]);
 
   useEffect(() => {
     if (rawGraph.taskArray.length === 0) return;
@@ -452,6 +453,9 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     },
     [onManualViewport],
   );
+  useEffect(() => {
+    nodesRef.current = nodes;
+  }, [nodes]);
 
   // Consume each task-scoped camera command exactly once, by sequence. Centering
   // preserves the current zoom so ordinary refreshes never zoom the graph; only
@@ -484,14 +488,14 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   }, [cameraCommand, fitView, getZoom, nodes, setCenter]);
 
   useEffect(() => {
-    if (surfaceMode !== 'browser' || nodes.length === 0) return;
+    if (surfaceMode !== 'browser' || nodesRef.current.length === 0) return;
 
     let cancelled = false;
     const frame = requestAnimationFrame(() => {
       if (cancelled) return;
       fitView({ padding: 0.2 });
       if (!selectedTaskId) return;
-      const node = nodes.find((candidate) => candidate.id === selectedTaskId);
+      const node = nodesRef.current.find((candidate) => candidate.id === selectedTaskId);
       if (!node) return;
       requestAnimationFrame(() => {
         if (cancelled) return;
@@ -504,10 +508,10 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       cancelled = true;
       cancelAnimationFrame(frame);
     };
-  }, [fitView, getZoom, nodes, selectedTaskId, setCenter, surfaceMode]);
+  }, [fitView, getZoom, rawGraph.layoutKey, selectedTaskId, setCenter, surfaceMode]);
 
   useEffect(() => {
-    if (surfaceMode !== 'browser' || nodes.length === 0 || browserRemountDoneRef.current) return;
+    if (surfaceMode !== 'browser' || nodesRef.current.length === 0 || browserRemountDoneRef.current) return;
 
     let cancelled = false;
     const frame = requestAnimationFrame(() => {
@@ -523,7 +527,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       cancelled = true;
       cancelAnimationFrame(frame);
     };
-  }, [nodes.length, surfaceMode]);
+  }, [rawGraph.layoutKey, surfaceMode]);
 
   useEffect(() => {
     if (reportedGraphVisibleRef.current || nodes.length === 0 || typeof window === 'undefined') {


### PR DESCRIPTION
## Summary

This follow-up tightens the reskinned browser surfaces without reopening the earlier stack slices.

The UI now clears old browser selections when a surface empties, lets the narrow-window inspector reopen on demand, recenters the browser task DAG more predictably, returns terminal focus after commands finish, and keeps the sidebar labels and counts aligned with the selected view.

<details>
<summary>Review metadata</summary>

Review Claim: The reskinned browser surfaces now keep selection, inspector, terminal focus, and sidebar state in sync while staying inside the existing UI entry points.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice only adjusts browser-surface selection and presentation behavior; it does not change planner routing, workflow execution, or proof thresholds.

Slice Rationale: The remaining review feedback all sat on the reskinned browser UI, so one final top slice can finish that surface without reopening the routing slices below.
</details>

## Non-goals

- No planner bridge or main-process request changes.
- No new proof-only thresholds or benchmark updates.
- No new workflow mutations or execution policy changes.

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx src/__tests__/task-interaction.test.tsx src/__tests__/keyboard-controls.test.tsx src/__tests__/visual-proof-snapshots.test.tsx src/__tests__/app-launch.test.tsx -t "requests runtime status for read-only windows"`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts --grep "read-only mode banner|terminal planning loads graph|needs attention browser focuses the selected task|queue-action-wording"`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None.
- Data migration required? No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal run flow now reports success/failure and keeps input focus consistent when not busy.
  * Workflow status chips are shown only on the home view.

* **Bug Fixes**
  * Inspector collapsing now respects manual toggles and resets appropriately across sidebar and browser surface changes.
  * Escape handling for the full graph overlay is safer; dismissal won’t occur while the graph is maximized.
  * Sidebar selections and stale action-node selections clear when switching surfaces or when related lists become empty.
  * Browser graph viewport actions no longer use stale node data.

* **Tests**
  * Added coverage for the read-only mode banner when runtime reports read-only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->