### PR TITLE
Rebalance e2e proof shards

### DIFF
--- a/scripts/test-suites/proof-e2e.manifest
+++ b/scripts/test-suites/proof-e2e.manifest
@@ -1,11 +1,14 @@
 # True e2e tests on a mock/temp DB — the ONLY suites the e2e proof gate runs.
 # One line per suite, relative to scripts/test-suites/. Blank lines and # comments ignored.
 # Everything else is covered by a dedicated CI job and is NOT run here.
-required/08-electron-preprovision-repro.sh
-required/15-submit-workflow-chain.sh
+required/21-e2e-dry-run-downstream-reset.sh
 required/20-e2e-dry-run.sh
 required/21-e2e-dry-run-downstream.sh
-required/21-e2e-dry-run-downstream-reset.sh
+required/23c-stale-late-completion-after-reset.sh
+required/15-submit-workflow-chain.sh
 required/22-e2e-dry-run-github.sh
-required/23-fix-intent-repros.sh
+required/23d-same-workflow-tracked-fix-vs-recreate.sh
 required/50-verify-executor-routing.sh
+required/23b-fix-intent-cancellation-stale-ssh-metadata.sh
+required/08-electron-preprovision-repro.sh
+required/23a-recreate-task-queue-authority.sh

--- a/scripts/test-suites/required/23a-recreate-task-queue-authority.sh
+++ b/scripts/test-suites/required/23a-recreate-task-queue-authority.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Blocking repro for recreate task queue authority.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+export REPRO_TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-180}"
+export INVOKER_REPRO_TIMEOUT_SECONDS="${INVOKER_REPRO_TIMEOUT_SECONDS:-600}"
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec xvfb-run --auto-servernum \
+    bash "$ROOT/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh" --expect-fixed
+fi
+
+exec bash "$ROOT/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh" --expect-fixed

--- a/scripts/test-suites/required/23b-fix-intent-cancellation-stale-ssh-metadata.sh
+++ b/scripts/test-suites/required/23b-fix-intent-cancellation-stale-ssh-metadata.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Blocking repro for fix-intent cancellation and stale SSH metadata.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+export REPRO_TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-180}"
+export INVOKER_REPRO_TIMEOUT_SECONDS="${INVOKER_REPRO_TIMEOUT_SECONDS:-600}"
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec xvfb-run --auto-servernum \
+    bash "$ROOT/scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh" --expect fixed
+fi
+
+exec bash "$ROOT/scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh" --expect fixed

--- a/scripts/test-suites/required/23c-stale-late-completion-after-reset.sh
+++ b/scripts/test-suites/required/23c-stale-late-completion-after-reset.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Blocking repro for stale late completion after reset.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+export REPRO_TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-180}"
+export INVOKER_REPRO_TIMEOUT_SECONDS="${INVOKER_REPRO_TIMEOUT_SECONDS:-600}"
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec xvfb-run --auto-servernum \
+    bash "$ROOT/scripts/repro/repro-stale-late-completion-after-reset.sh" --mode=both --expect-fixed
+fi
+
+exec bash "$ROOT/scripts/repro/repro-stale-late-completion-after-reset.sh" --mode=both --expect-fixed

--- a/scripts/test-suites/required/23d-same-workflow-tracked-fix-vs-recreate.sh
+++ b/scripts/test-suites/required/23d-same-workflow-tracked-fix-vs-recreate.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Blocking repro for same-workflow tracked-fix vs recreate.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+export REPRO_TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-180}"
+export INVOKER_REPRO_TIMEOUT_SECONDS="${INVOKER_REPRO_TIMEOUT_SECONDS:-600}"
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec xvfb-run --auto-servernum \
+    bash "$ROOT/scripts/repro/repro-same-workflow-tracked-fix-vs-recreate.sh"
+fi
+
+exec bash "$ROOT/scripts/repro/repro-same-workflow-tracked-fix-vs-recreate.sh"


### PR DESCRIPTION
## Summary

This makes the merge-queue e2e proof finish faster by spreading the fix-intent stack across separate shard slots.

The old long pole was shard 2 because it ran `required/20-e2e-dry-run.sh` and the whole `23-fix-intent-repros.sh` bundle together.

On the measured master snapshot, proof wall-clock dropped from 964s to 606s. That is 37% faster without changing any repro implementation.

<details>
<summary>Review metadata</summary>

Review Claim: The e2e proof gate gets materially faster because the proof manifest shards the existing fix-intent repros separately instead of bundling them into one long slot.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: Only proof-suite wrappers and the proof manifest changed. No package source, workflow logic, or repro implementation changed.

Slice Rationale: The speedup comes from test-orchestration shape only, so this stays as one CI-policy slice instead of mixing in runtime changes.

</details>

## Non-goals

- No changes under `scripts/repro/`.
- No changes to app or package source code.
- No changes to the scheduled repro bundle job.

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX=0 INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=$PWD/proof-state.tsv TMPDIR=/tmp/invoker-tmp /usr/bin/time -p bash scripts/run-all-tests.sh`
- [x] `env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX=1 INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=$PWD/proof-state.tsv TMPDIR=/tmp/invoker-tmp /usr/bin/time -p bash scripts/run-all-tests.sh`
- [x] `env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX=2 INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=$PWD/proof-state.tsv TMPDIR=/tmp/invoker-tmp /usr/bin/time -p bash scripts/run-all-tests.sh`
- [x] `env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX=3 INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=$PWD/proof-state.tsv TMPDIR=/tmp/invoker-tmp /usr/bin/time -p bash scripts/run-all-tests.sh`
- [x] `/usr/bin/time -p bash scripts/test-suites/required/23a-recreate-task-queue-authority.sh`
- [x] `/usr/bin/time -p bash scripts/test-suites/required/23b-fix-intent-cancellation-stale-ssh-metadata.sh`
- [x] `/usr/bin/time -p bash scripts/test-suites/required/23c-stale-late-completion-after-reset.sh`
- [x] `/usr/bin/time -p bash scripts/test-suites/required/23d-same-workflow-tracked-fix-vs-recreate.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
