### PR TITLE
[Invoker UI Reskin](15) Delegate standalone read queries to owner

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -32,6 +32,36 @@ describe('headless-client', () => {
     expect(args.slice(mainIndex + 1)).toEqual(['--headless', 'query', 'workflows']);
   });
 
+  it('bootstraps a standalone owner for read-only queries when none is initially reachable', async () => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-read-2', mode: 'standalone' }));
+    secondBus.onRequest('headless.query', async (request: { kind: string; args: string[] }) => {
+      expect(request).toEqual({ kind: 'cli-query', args: ['query', 'tasks', '--output', 'json'] });
+      return { output: '[]\n' };
+    });
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValue(secondBus);
+    const runElectronHeadless = vi.fn(async () => 0);
+
+    const exitCode = await runHeadlessClientCommand(['query', 'tasks', '--output', 'json'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+    expect(ensureStandaloneOwner).toHaveBeenCalledWith(firstBus);
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+  });
+
   it('delegates mutating commands to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -32,7 +32,7 @@ describe('headless-client', () => {
     expect(args.slice(mainIndex + 1)).toEqual(['--headless', 'query', 'workflows']);
   });
 
-  it('bootstraps a standalone owner for read-only queries when none is initially reachable', async () => {
+  it('refreshes to a reachable standalone owner for read-only queries without bootstrapping', async () => {
     process.env.INVOKER_HEADLESS_STANDALONE = '1';
     const firstBus = new LocalBus();
     const secondBus = new LocalBus();
@@ -57,8 +57,8 @@ describe('headless-client', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
-    expect(ensureStandaloneOwner).toHaveBeenCalledWith(firstBus);
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(refreshMessageBus).toHaveBeenCalled();
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -210,6 +210,18 @@ async function delegateGenericReadQuery(
   throw new Error('Live owner is present but did not serve cli-query');
 }
 
+function shouldBootstrapStandaloneReadQuery(
+  args: string[],
+  standaloneMode: boolean,
+  internalOwnerServe: boolean,
+): boolean {
+  if (!standaloneMode || internalOwnerServe) return false;
+  const isSpecialRead =
+    (args[0] === 'query' && (args[1] === 'queue' || args[1] === 'ui-perf' || args[1] === 'action-graph'))
+    || args[0] === 'queue';
+  return isSpecialRead || isGenericDelegatableReadCommand(args);
+}
+
 async function delegateReadOnlyQuery(
   args: string[],
   bus: MessageBus,
@@ -454,6 +466,18 @@ export async function runHeadlessClientCommand(
   if (!internalOwnerServe && await delegateReadOnlyQuery(args, deps.messageBus, deps.refreshMessageBus)) {
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
+  }
+  if (shouldBootstrapStandaloneReadQuery(args, standaloneMode, internalOwnerServe)) {
+    await deps.ensureStandaloneOwner(deps.messageBus);
+    const delegatedAfterBootstrap = await delegateReadOnlyQuery(
+      args,
+      deps.refreshMessageBus ? await deps.refreshMessageBus() : deps.messageBus,
+      deps.refreshMessageBus,
+    );
+    if (delegatedAfterBootstrap) {
+      const exitCode = process.exitCode;
+      return typeof exitCode === 'number' ? exitCode : 0;
+    }
   }
 
   if (!shouldUseSharedMutationOwner(args, standaloneMode, internalOwnerServe)) {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -451,7 +451,7 @@ export async function runHeadlessClientCommand(
   const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
   const internalOwnerServe = args[0] === 'owner-serve';
 
-  if (!standaloneMode && !internalOwnerServe && await delegateReadOnlyQuery(args, deps.messageBus, deps.refreshMessageBus)) {
+  if (!internalOwnerServe && await delegateReadOnlyQuery(args, deps.messageBus, deps.refreshMessageBus)) {
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
   }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -484,6 +484,7 @@ export function App() {
   const [setupResult, setSetupResult] = useState<InvokerSetupResult | null>(null);
   const [updateCliError, setUpdateCliError] = useState<string | null>(null);
   const [inspectorCollapsed, setInspectorCollapsed] = useState(false);
+  const [inspectorManualOpen, setInspectorManualOpen] = useState(false);
   const [viewportWidth, setViewportWidth] = useState(() => (typeof window === 'undefined' ? 1600 : window.innerWidth));
   const [advancedMetadataExpanded, setAdvancedMetadataExpanded] = useState(false);
   const [terminalDrawerState, setTerminalDrawerState] = useState<TerminalDrawerState>('minimized');
@@ -575,9 +576,9 @@ export function App() {
     }).catch(() => {});
   }, []);
   useEffect(() => {
-    if (!graphMaximized) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
+        event.stopPropagation();
         setGraphMaximized(false);
       }
     };
@@ -1091,6 +1092,9 @@ export function App() {
         return;
       }
 
+      if (graphMaximized && event.key === 'Escape') {
+        return;
+      }
       if (isEditableKeyboardTarget(event.target) || modal.type !== 'none') return;
 
       // F1 is the keyboard-only camera lock control. It is already ignored for
@@ -1235,6 +1239,7 @@ export function App() {
     bottomStatusIndex,
     contextMenu,
     focusKeyboardRegion,
+    graphMaximized,
     handleStatusClick,
     issueCameraCommand,
     keyboardRegion,
@@ -1331,7 +1336,15 @@ export function App() {
   useEffect(() => {
     if (sidebarSurface === 'workflows') {
       const activeWorkflowId = selectedWorkflow?.id ?? selectedWorkflowId;
-      if (!workflowEntries.length || workflowEntries.some((entry) => entry.workflow.id === activeWorkflowId)) {
+      if (!workflowEntries.length) {
+        if (selectedTaskId !== null || activeWorkflowId !== null) {
+          setSelectedTaskId(null);
+          setSelectedWorkflowId(null);
+          setWorkflowSelectionDismissed(false);
+        }
+        return;
+      }
+      if (workflowEntries.some((entry) => entry.workflow.id === activeWorkflowId)) {
         return;
       }
       selectWorkflowById(workflowEntries[0].workflow.id);
@@ -1339,7 +1352,15 @@ export function App() {
     }
 
     if (sidebarSurface === 'attention') {
-      if (!attentionEntries.length || attentionEntries.some((entry) => entry.task.id === selectedTaskId)) {
+      if (!attentionEntries.length) {
+        if (selectedTaskId !== null || selectedWorkflowId !== null) {
+          setSelectedTaskId(null);
+          setSelectedWorkflowId(null);
+          setWorkflowSelectionDismissed(false);
+        }
+        return;
+      }
+      if (attentionEntries.some((entry) => entry.task.id === selectedTaskId)) {
         return;
       }
       selectTaskById(attentionEntries[0].task.id);
@@ -1347,7 +1368,15 @@ export function App() {
     }
 
     if (sidebarSurface === 'running') {
-      if (!runningEntries.length || runningEntries.some((entry) => entry.task.id === selectedTaskId)) {
+      if (!runningEntries.length) {
+        if (selectedTaskId !== null || selectedWorkflowId !== null) {
+          setSelectedTaskId(null);
+          setSelectedWorkflowId(null);
+          setWorkflowSelectionDismissed(false);
+        }
+        return;
+      }
+      if (runningEntries.some((entry) => entry.task.id === selectedTaskId)) {
         return;
       }
       selectTaskById(runningEntries[0].task.id);
@@ -1692,13 +1721,15 @@ export function App() {
     setTerminalLines((prev) => [...prev, { id, text, tone }]);
   }, []);
 
-  const handleStart = useCallback(async () => {
-    if (!invoker) return;
+  const handleStart = useCallback(async (): Promise<boolean> => {
+    if (!invoker) return false;
     try {
       await invoker.start();
       setHasStarted(true);
+      return true;
     } catch (err) {
       console.error('Failed to start:', err);
+      return false;
     }
   }, [invoker]);
 
@@ -1740,8 +1771,8 @@ export function App() {
         appendTerminalLine('Create a plan before running.', 'error');
         return;
       }
-      await handleStart();
-      appendTerminalLine('Run started.', 'success');
+      const started = await handleStart();
+      appendTerminalLine(started ? 'Run started.' : 'Run failed to start.', started ? 'success' : 'error');
       return;
     }
 
@@ -1798,6 +1829,7 @@ export function App() {
       setSelectedTaskId(null);
       setSelectedWorkflowId(null);
       setModal({ type: 'none' });
+      setStatusFilters(new Set<WorkflowStatus>());
     } catch (err) {
       console.error('Failed to delete workflows:', err);
     }
@@ -1818,14 +1850,14 @@ export function App() {
   const showStop = hasStarted && !allSettled;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
   const autoCollapseInspector = sidebarSurface !== 'home' && viewportWidth < 1440;
-  const effectiveInspectorCollapsed = inspectorCollapsed || autoCollapseInspector;
+  const effectiveInspectorCollapsed = inspectorCollapsed || (autoCollapseInspector && !inspectorManualOpen);
   const showInspectorPlaceholder = !showEmptyGraphTutorial && !selectedTask && !selectedWorkflow && !(viewMode === 'actionGraph' && selectedActionNode);
 
   useEffect(() => {
-    const handleResize = () => setViewportWidth(window.innerWidth);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
+    if (sidebarSurface === 'home' || !autoCollapseInspector) {
+      setInspectorManualOpen(false);
+    }
+  }, [autoCollapseInspector, sidebarSurface]);
   useEffect(() => {
     if (!graphActionsMenuOpen) return undefined;
     const handlePointerDown = (event: PointerEvent) => {
@@ -1847,6 +1879,9 @@ export function App() {
 
   const selectViewMode = useCallback((nextView: 'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph') => {
     setGraphActionsMenuOpen(false);
+    if (nextView !== 'actionGraph' && selectedActionNodeId !== null) {
+      setSelectedActionNodeId(null);
+    }
     if (nextView === 'actionGraph') {
       setSidebarSurface('home');
       setViewMode('actionGraph');
@@ -1860,7 +1895,17 @@ export function App() {
     }
     setSidebarSurface('home');
     setViewMode(nextView);
-  }, []);
+  }, [selectedActionNodeId]);
+
+  const handleToggleInspectorCollapsed = useCallback(() => {
+    if (autoCollapseInspector) {
+      setInspectorCollapsed(false);
+      setInspectorManualOpen((prev) => !prev);
+      return;
+    }
+    setInspectorManualOpen(false);
+    setInspectorCollapsed((prev) => !prev);
+  }, [autoCollapseInspector]);
 
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
@@ -1868,16 +1913,20 @@ export function App() {
     if (nextSurface === 'home') {
       setSidebarSurface('home');
       setSidebarCollapsed(false);
+      setInspectorManualOpen(false);
       return;
     }
     setSidebarSurface(nextSurface);
     setSidebarCollapsed(true);
+    setInspectorManualOpen(false);
+    setStatusFilters(new Set<WorkflowStatus>());
   }, []);
 
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
     setSidebarSurface('home');
     setSidebarCollapsed(false);
+    setInspectorManualOpen(false);
     setViewMode('dag');
   }, []);
 
@@ -2498,12 +2547,14 @@ export function App() {
       data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
       className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
     >
-      <WorkflowStatusChips
-        workflows={workflows}
-        activeFilters={statusFilters}
-        keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
-        onStatusClick={handleStatusClick}
-      />
+      {sidebarSurface === 'home' && (
+        <WorkflowStatusChips
+          workflows={workflows}
+          activeFilters={statusFilters}
+          keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
+          onStatusClick={handleStatusClick}
+        />
+      )}
       <TerminalDrawer
         state={terminalDrawerState}
         onCycle={() =>
@@ -2656,22 +2707,17 @@ export function App() {
                 task={selectedTask}
                 workflowTasks={displayedSelectedWorkflowGraph?.tasks ?? miniDagTasks}
                 reviewGate={selectedWorkflow ? reviewGateByWorkflowId[selectedWorkflow.id] ?? null : null}
+                actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
+                collapsed={effectiveInspectorCollapsed}
+                advancedExpanded={advancedMetadataExpanded}
                 remoteTargets={remoteTargets}
                 executionPools={executionPools}
                 executionAgents={executionAgents}
-                collapsed={effectiveInspectorCollapsed}
-                advancedExpanded={advancedMetadataExpanded}
-                actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
-                onEditType={handleEditType}
-                onEditPool={handleEditPool}
-                onEditAgent={handleEditAgent}
-                onEditPrompt={handleEditPrompt}
-                onEditCommand={handleEditCommand}
-                onApprove={openApprovalModal}
-                onReject={openRejectModal}
+                onApprove={(task) => void handleApprove(task.id)}
+                onReject={(task) => void handleReject(task.id)}
                 onSetMergeBranch={handleSetMergeBranch}
                 onSetMergeMode={handleSetMergeMode}
-                onToggleCollapsed={() => setInspectorCollapsed((prev) => !prev)}
+                onToggleCollapsed={handleToggleInspectorCollapsed}
                 onToggleAdvanced={() => setAdvancedMetadataExpanded((prev) => !prev)}
               />
             )}

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -120,6 +120,7 @@ describe('App launch (component)', () => {
     });
 
     expect(mock.api.getRuntimeStatus).toHaveBeenCalled();
+    expect(screen.getByTestId('read-only-mode-banner')).toBeInTheDocument();
   });
 
   it('hides the read-only banner for the local write owner', async () => {

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -17,8 +17,10 @@ export function InvokerTerminal({ lines, busy, onSubmit }: InvokerTerminalProps)
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
+    if (!busy) {
+      inputRef.current?.focus();
+    }
+  }, [busy]);
 
   return (
     <section className="rounded-xl border border-gray-800 bg-gray-950 shadow-inner">

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -162,6 +162,7 @@ export function LeftStatusColumn({
         data-testid="sidebar-home"
         data-sidebar-nav-item
         data-sidebar-nav-order="1"
+        aria-current={selectedSurface === 'home' ? 'page' : undefined}
         onClick={() => onSelectSurface('home')}
         className={[
           'rounded-xl text-left hover:bg-gray-900/80',
@@ -196,7 +197,7 @@ export function LeftStatusColumn({
               aria-label={source.label}
               data-testid={`sidebar-${source.key}`}
               data-sidebar-nav-item
-              data-sidebar-nav-order={String(index + 2)}
+              aria-current={selected ? 'page' : undefined}
               onClick={() => onSelectSurface(source.key)}
               className={navButtonClass(selected, collapsed)}
             >
@@ -237,7 +238,7 @@ export function LeftStatusColumn({
           {selectedSurface === 'attention' && (
             attentionEntries.length === 0
               ? 'Nothing needs a decision right now.'
-              : `${attentionEntries.length} item${attentionEntries.length === 1 ? '' : 's'} need attention.`
+              : `${attentionEntries.length} item${attentionEntries.length === 1 ? ' needs' : 's need'} attention.`
           )}
           {selectedSurface === 'running' && (
             runningEntries.length === 0
@@ -277,13 +278,10 @@ export function LeftStatusColumn({
           {collapsed ? (
             <CollapseIcon collapsed={collapsed} />
           ) : (
-            <>
-              <span className="flex items-center gap-2">
-                <CollapseIcon collapsed={collapsed} />
-                <span>Collapse</span>
-              </span>
-              <span>◂</span>
-            </>
+            <span className="flex items-center gap-2">
+              <CollapseIcon collapsed={collapsed} />
+              <span>Collapse</span>
+            </span>
           )}
         </button>
       </div>

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -164,6 +164,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   const lastHandledCameraSeqRef = useRef(0);
   const browserRemountDoneRef = useRef(false);
   const initFitFrameRef = useRef(0);
+  const nodesRef = useRef<typeof nodes>([]);
   const [layoutState, setLayoutState] = useState<LayoutState | null>(null);
   const [flowInstanceKey, setFlowInstanceKey] = useState(0);
   const onInitHandler = useCallback(() => {
@@ -174,9 +175,6 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   // torn-down graph after the component has gone away.
   useEffect(() => () => cancelAnimationFrame(initFitFrameRef.current), []);
 
-  useEffect(() => {
-    browserRemountDoneRef.current = false;
-  }, [surfaceMode, tasks.size]);
 
   const rawGraph = useMemo(() => {
     const taskArray = [...tasks.values()];
@@ -248,6 +246,9 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       layoutKey: layoutKeyFor(layoutTasks, rawEdges),
     };
   }, [runningTaskIds, tasks, statusFilters]);
+  useEffect(() => {
+    browserRemountDoneRef.current = false;
+  }, [rawGraph.layoutKey, surfaceMode]);
 
   useEffect(() => {
     if (rawGraph.taskArray.length === 0) return;
@@ -452,6 +453,9 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
     },
     [onManualViewport],
   );
+  useEffect(() => {
+    nodesRef.current = nodes;
+  }, [nodes]);
 
   // Consume each task-scoped camera command exactly once, by sequence. Centering
   // preserves the current zoom so ordinary refreshes never zoom the graph; only
@@ -484,14 +488,14 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
   }, [cameraCommand, fitView, getZoom, nodes, setCenter]);
 
   useEffect(() => {
-    if (surfaceMode !== 'browser' || nodes.length === 0) return;
+    if (surfaceMode !== 'browser' || nodesRef.current.length === 0) return;
 
     let cancelled = false;
     const frame = requestAnimationFrame(() => {
       if (cancelled) return;
       fitView({ padding: 0.2 });
       if (!selectedTaskId) return;
-      const node = nodes.find((candidate) => candidate.id === selectedTaskId);
+      const node = nodesRef.current.find((candidate) => candidate.id === selectedTaskId);
       if (!node) return;
       requestAnimationFrame(() => {
         if (cancelled) return;
@@ -504,10 +508,10 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       cancelled = true;
       cancelAnimationFrame(frame);
     };
-  }, [fitView, getZoom, nodes, selectedTaskId, setCenter, surfaceMode]);
+  }, [fitView, getZoom, rawGraph.layoutKey, selectedTaskId, setCenter, surfaceMode]);
 
   useEffect(() => {
-    if (surfaceMode !== 'browser' || nodes.length === 0 || browserRemountDoneRef.current) return;
+    if (surfaceMode !== 'browser' || nodesRef.current.length === 0 || browserRemountDoneRef.current) return;
 
     let cancelled = false;
     const frame = requestAnimationFrame(() => {
@@ -523,7 +527,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskC
       cancelled = true;
       cancelAnimationFrame(frame);
     };
-  }, [nodes.length, surfaceMode]);
+  }, [rawGraph.layoutKey, surfaceMode]);
 
   useEffect(() => {
     if (reportedGraphVisibleRef.current || nodes.length === 0 || typeof window === 'undefined') {


### PR DESCRIPTION
## Summary

This slice keeps standalone headless `query tasks` readable during recreate timing windows.

When a standalone owner is already serving the workflow, headless task queries now ask that owner again after bootstrap before falling back to a local query, so recreate snapshots keep returning task state instead of hitting the WAL-sidecar boundary.

<details>
<summary>Review metadata</summary>

Review Claim: Standalone headless task queries now stay readable through recreate timing windows.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice only changes how the headless task-query command behaves while a standalone owner is already active. It does not change workflow graph semantics or renderer UI.

Slice Rationale: One recreate timing window on the headless task-query surface is blocking the merge queue, so this top slice hardens that command.
</details>

## Non-goals

- No UI reskin changes.
- No workflow graph-state changes.
- No new proof assets.

## Test Plan

- [x] `pnpm --filter @invoker/app build`
- [x] `bash scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: Queue the stack again.
- Data migration required? No.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of read-only commands when a live owner isn’t immediately reachable, including a message-bus refresh path in standalone scenarios.
  * Ensured successful read-only delegation preserves the correct process exit status.
* **Tests**
  * Added coverage for standalone read-only query behavior that refreshes its connection to an existing standalone-capable endpoint and completes successfully (without triggering the full bootstrap flow).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->