### PR TITLE
Fix shard 0 proof readback

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -803,43 +803,6 @@ function startHeadlessMode(): void {
     const mutatingMode = isHeadlessMutatingCommand(cliArgs);
     const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1' || command === 'owner-serve';
     const ownsHeadlessShutdown = standaloneMode && !readOnlyMode && command === 'owner-serve';
-    const queueQueryMode = command === 'queue' || (command === 'query' && cliArgs[1] === 'queue');
-
-    const delegatedQueueOutputFormat = (): 'json' | 'jsonl' | 'label' | 'text' => {
-      const outputIndex = cliArgs.indexOf('--output');
-      const value = outputIndex >= 0 ? cliArgs[outputIndex + 1] : undefined;
-      if (value === 'json' || value === 'jsonl' || value === 'label') return value;
-      return 'text';
-    };
-
-    const writeDelegatedQueueStatus = (status: Record<string, unknown>): void => {
-      const format = delegatedQueueOutputFormat();
-      const running = Array.isArray(status.running) ? status.running as Array<Record<string, unknown>> : [];
-      const queued = Array.isArray(status.queued) ? status.queued as Array<Record<string, unknown>> : [];
-      if (format === 'json') {
-        process.stdout.write(JSON.stringify(status) + '\n');
-        return;
-      }
-      if (format === 'jsonl') {
-        for (const task of running) {
-          process.stdout.write(JSON.stringify({ ...task, state: 'running' }) + '\n');
-        }
-        for (const task of queued) {
-          process.stdout.write(JSON.stringify({ ...task, state: 'queued' }) + '\n');
-        }
-        return;
-      }
-      if (format === 'label') {
-        const ids = [...running, ...queued]
-          .map((task) => String(task.taskId ?? ''))
-          .filter(Boolean);
-        process.stdout.write(ids.join('\n') + '\n');
-        return;
-      }
-      const runningCount = Number(status.runningCount ?? running.length);
-      const maxConcurrency = Number(status.maxConcurrency ?? 0);
-      process.stdout.write(`running=${runningCount}/${maxConcurrency} queued=${queued.length}\n`);
-    };
 
     // Try delegation for mutating commands first (owner mode).
     // In standalone mode we skip delegation and run locally.
@@ -894,14 +857,14 @@ function startHeadlessMode(): void {
       }
     }
 
-    if (readOnlyMode && queueQueryMode && !standaloneMode) {
+    if (readOnlyMode && command !== 'owner-serve') {
       const delegationBus = new IpcBus(undefined, { allowServe: false });
       try {
         await delegationBus.ready();
-        const delegated = await tryDelegateQuery(delegationBus, { kind: 'queue' }, 5_000);
+        const delegated = await tryDelegateQuery(delegationBus, { kind: 'cli-query', args: cliArgs }, 5_000);
         delegationBus.disconnect();
-        if (delegated) {
-          writeDelegatedQueueStatus(delegated);
+        if (delegated && typeof delegated.output === 'string') {
+          process.stdout.write(delegated.output);
           process.exit(0);
           return;
         }

--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -2118,6 +2118,19 @@ describe('BaseExecutor.pushBranchToRemote', () => {
     const remoteBranches = execSync('git branch', { cwd: intermediateDir }).toString();
     expect(remoteBranches).toContain('invoker/task-intermediate');
   });
+  it('pushes HEAD when the branch ref is missing locally', async () => {
+    execSync('git checkout -b invoker/task-detached', { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'detached.txt'), 'task result');
+    execSync('git add -A && git commit -m "task commit detached"', { cwd: cloneDir });
+    execSync('git checkout --detach HEAD', { cwd: cloneDir });
+    execSync('git branch -D invoker/task-detached', { cwd: cloneDir });
+
+    const pushErr = await executor.testPushBranchToRemote(cloneDir, 'invoker/task-detached');
+    expect(pushErr).toBeUndefined();
+
+    const remoteBranches = execSync('git branch', { cwd: originDir }).toString();
+    expect(remoteBranches).toContain('invoker/task-detached');
+  });
 });
 
 describe('BaseExecutor.handleProcessExit push semantics', () => {

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -875,8 +875,10 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         );
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
+        const missingLocalRef = message.includes('src refspec ')
+          && message.includes(' does not match any');
         const currentBranch = (await this.execGitSimple(['branch', '--show-current'], cwd)).trim();
-        if (!/src refspec .* does not match any/i.test(message) || currentBranch.length > 0) {
+        if (!missingLocalRef || currentBranch.length > 0) {
           throw err;
         }
         await this.execGitSimpleWithNetworkTimeout(

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -858,19 +858,31 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         ? this.entries.get(executionId)?.request.inputs.branchRepoUrl
         : undefined);
       const branchRepoUrl = requestBranchRepoUrl?.trim();
+      const remoteName = branchRepoUrl ? BaseExecutor.BRANCH_REMOTE_NAME : 'origin';
       if (branchRepoUrl) {
         await ensureRemoteUrl({
           cwd,
-          remote: BaseExecutor.BRANCH_REMOTE_NAME,
+          remote: remoteName,
           url: branchRepoUrl,
           context: { caller: `${this.type}.pushBranchToRemote`, detail: branch },
         });
+      }
+      const branchRef = `${branch}:refs/heads/${branch}`;
+      try {
         await this.execGitSimpleWithNetworkTimeout(
-          ['push', '--force-with-lease', BaseExecutor.BRANCH_REMOTE_NAME, `${branch}:refs/heads/${branch}`],
+          ['push', '--force-with-lease', remoteName, branchRef],
           cwd,
         );
-      } else {
-        await this.execGitSimpleWithNetworkTimeout(['push', '--force-with-lease', 'origin', `${branch}:refs/heads/${branch}`], cwd);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        const currentBranch = (await this.execGitSimple(['branch', '--show-current'], cwd)).trim();
+        if (!/src refspec .* does not match any/i.test(message) || currentBranch.length > 0) {
+          throw err;
+        }
+        await this.execGitSimpleWithNetworkTimeout(
+          ['push', '--force-with-lease', remoteName, `HEAD:refs/heads/${branch}`],
+          cwd,
+        );
       }
       return undefined;
     } catch (err) {


### PR DESCRIPTION
## Summary

This fixes the two shard-0 queue failures that blocked the proof-shard speedup PR.

One failure came from recreate worktrees finishing successfully but failing the final branch push. The other came from standalone read-only queries opening the database directly while a live process still held WAL sidecars.

The fix routes read-only headless commands through a live standalone process when one is available, and it falls back to pushing `HEAD` when a successful detached worktree no longer has a named local branch ref.

<details>
<summary>Review metadata</summary>

Review Claim: Shard 0 no longer fails on recreate readback or detached-branch push paths in merge-queue proof runs.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The change is limited to headless query routing, task-branch push fallback, and one executor regression test. No repro script implementation changed.

Slice Rationale: The queue failure came from runtime routing, so this lands as one routing slice that unblocks the existing proof-speedup PR.

</details>

## Non-goals

- No changes under `scripts/repro/`.
- No changes to proof manifest layout.
- No changes to scheduled repro jobs.

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --dir packages/execution-engine test -- auto-commit.test.ts`
- [x] `pnpm --dir packages/app build`
- [x] `bash scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh`
- [x] `bash scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh`
- [x] `bash scripts/test-suites/required/21-e2e-dry-run-downstream-reset.sh`
- [x] `env INVOKER_TEST_ALL_PROOF=1 INVOKER_TEST_ALL_SHARD_INDEX=0 INVOKER_TEST_ALL_SHARD_TOTAL=4 INVOKER_TEST_ALL_STATE_FILE=$PWD/proof-state.tsv TMPDIR=/tmp/invoker-tmp bash scripts/run-all-tests.sh`

## Visual Proof

No visible UI change expected. Same read-only banner before and after.

| Before | After |
| --- | --- |
| ![Before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260703-2f5284/read-only-mode-banner-before.png) | ![After](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260703-2f5284/read-only-mode-banner-after.png) |

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In headless mode, CLI queries now delegate more broadly, and when delegated results include output, it’s written directly to stdout.
* **Bug Fixes**
  * Improved branch pushing when the local branch ref is missing (e.g., detached/empty states), including a targeted retry that pushes from `HEAD` to the expected remote branch.
* **Tests**
  * Added coverage for pushing a branch reference that doesn’t exist locally before the push.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->