### PR TITLE
[Temporary Mergify Gates](1) Relax heavy CI blockers

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,22 +19,15 @@ queue_rules:
       - "#approved-reviews-by >= 1"
       - -label=merge-hold
       - "#review-threads-unresolved = 0"
+    # Temporary queue stabilizer: heavy CI still runs on PRs, but does not block
+    # Mergify until the flaky queue-only failures are fixed.
     merge_conditions:
       - check-success = build-artifacts
       - check-success = quality / Dependency Cruise
       - check-success = PR Body
       - check-success = quality / TypeScript Types
       - check-success = required-fast / Guardrails
-      - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
-      - check-success = e2e-proof / aggregate
-      - check-success = playwright / 1-of-3
-      - check-success = playwright / 2-of-3
-      - check-success = playwright / 3-of-3
-      - check-success = ssh / shard-30
-      - check-success = ssh / shard-31
-      - check-success = optional / Worktree Provisioning
-      - check-success = optional / Visual Proof Validate
       - "#review-threads-unresolved = 0"
 
   - name: admin-bypass
@@ -48,22 +41,15 @@ queue_rules:
       - label=admin-bypass
       - -label=merge-hold
       - "#review-threads-unresolved = 0"
+    # Temporary queue stabilizer: heavy CI still runs on PRs, but does not block
+    # Mergify until the flaky queue-only failures are fixed.
     merge_conditions:
       - check-success = build-artifacts
       - check-success = quality / Dependency Cruise
       - check-success = PR Body
       - check-success = quality / TypeScript Types
       - check-success = required-fast / Guardrails
-      - check-success = required-fast / Vitest Workspace
       - check-success = required-fast / Submit Workflow Chain
-      - check-success = e2e-proof / aggregate
-      - check-success = playwright / 1-of-3
-      - check-success = playwright / 2-of-3
-      - check-success = playwright / 3-of-3
-      - check-success = ssh / shard-30
-      - check-success = ssh / shard-31
-      - check-success = optional / Worktree Provisioning
-      - check-success = optional / Visual Proof Validate
       - "#review-threads-unresolved = 0"
 
 pull_request_rules:


### PR DESCRIPTION
## Summary

Temporarily relaxes the Mergify merge queue so heavy checks no longer block merges.

The heavy checks still run in CI. They just stop acting as queue gates while flaky queue-only failures are fixed.

This keeps the queue moving without hiding the failing jobs from PR checks.

<details>
<summary>Review metadata</summary>

Review Claim: Mergify should temporarily require only the lighter queue checks while preserving review-thread and basic CI gates.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This only changes Mergify merge conditions. It does not change application code, test code, or whether heavy CI jobs run.

Slice Rationale: This is isolated to the queue policy so it can be reverted cleanly once the heavy queue failures are stable again.

</details>

## Non-goals

- Does not remove heavy CI jobs.
- Does not change GitHub workflow definitions.
- Does not bypass unresolved review threads.
- Does not change PR approval rules.

## Test Plan

- [x] `ruby -e 'require "yaml"; YAML.load_file(".mergify.yml"); puts "ok"'`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/temporary-mergify-heavy-gates-pr.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * PRs can now enter the merge queue with fewer blocking checks, reducing delays caused by flaky queue-only failures.
  * Heavy validation still runs on pull requests, but it no longer prevents queueing unless the core required checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->