### PR TITLE
[Automation Chrome Reaper](1) Reap orphaned automation Chrome before launch

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -126,8 +126,12 @@ if [ "$1" = "--headless" ]; then
   exec node ./packages/app/dist/headless-client.js "$@"
 fi
 
-# Kill any stale Electron/tsup processes from previous runs so we
-# always start from a clean state.
+# Kill any orphaned Puppeteer/automation Chrome left behind by crashed browser
+# sessions, then clear stale Electron/tsup processes so we always start from a
+# clean state.
+if ! node ./scripts/cleanup-orphaned-automation-chrome.mjs; then
+  echo "WARN: orphaned automation Chrome cleanup failed; continuing launch" >&2
+fi
 pkill -f "electron.*packages/app/dist/main.js" 2>/dev/null || true
 pkill -f "tsup.*packages/app" 2>/dev/null || true
 sleep 0.2

--- a/scripts/cleanup-orphaned-automation-chrome.mjs
+++ b/scripts/cleanup-orphaned-automation-chrome.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import { execFile as execFileCb } from 'node:child_process';
+import { readFileSync as fsReadFileSync } from 'node:fs';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+const POLL_INTERVAL_MS = 200;
+const TERM_WAIT_MS = 3_000;
+const KILL_WAIT_MS = 1_000;
+
+export function isAutomationChromeCommand(command) {
+  return command.includes('puppeteer_dev_chrome_profile-')
+    && command.includes('--headless=new');
+}
+
+export function extractUserDataDir(command) {
+  const match = command.match(/--user-data-dir=([^\s]+)/);
+  return match ? match[1] : undefined;
+}
+
+export function parsePsSnapshot(text) {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.*)$/);
+      if (!match) return null;
+      return {
+        pid: Number.parseInt(match[1], 10),
+        ppid: Number.parseInt(match[2], 10),
+        pgid: Number.parseInt(match[3], 10),
+        command: match[4],
+      };
+    })
+    .filter(Boolean);
+}
+
+function groupsByPgid(rows, predicate) {
+  const byPgid = new Map();
+  for (const row of rows) {
+    if (!predicate(row)) continue;
+    const group = byPgid.get(row.pgid) ?? { pgid: row.pgid, rows: [] };
+    group.rows.push(row);
+    byPgid.set(row.pgid, group);
+  }
+  return byPgid;
+}
+
+function materializeGroup(group) {
+  return {
+    pgid: group.pgid,
+    pids: [...new Set(group.rows.map((row) => row.pid))].sort((a, b) => a - b),
+    profiles: [...new Set(group.rows.flatMap((row) => {
+      const userDataDir = extractUserDataDir(row.command);
+      return userDataDir ? [userDataDir] : [];
+    }))].sort(),
+  };
+}
+
+export function findOrphanedAutomationChromeGroups(rows) {
+  return [...groupsByPgid(rows, (row) => isAutomationChromeCommand(row.command)).values()]
+    .filter((group) => group.rows.some((row) => row.ppid === 1))
+    .map(materializeGroup)
+    .sort((a, b) => a.pgid - b.pgid);
+}
+
+export function readTrackedUserDataDirs(registryPath) {
+  if (!registryPath) return [];
+  return [...new Set(
+    fsReadFileSync(registryPath, 'utf8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean),
+  )].sort();
+}
+
+export function findTrackedBrowserGroups(rows, trackedUserDataDirs) {
+  const tracked = new Set(trackedUserDataDirs);
+  if (tracked.size === 0) return [];
+  return [...groupsByPgid(rows, (row) => {
+    const userDataDir = extractUserDataDir(row.command);
+    return userDataDir ? tracked.has(userDataDir) : false;
+  }).values()]
+    .map(materializeGroup)
+    .sort((a, b) => a.pgid - b.pgid);
+}
+
+export function mergeGroups(...groupLists) {
+  const merged = new Map();
+  for (const group of groupLists.flat()) {
+    const current = merged.get(group.pgid) ?? { pgid: group.pgid, pids: [], profiles: [] };
+    current.pids = [...new Set([...current.pids, ...group.pids])].sort((a, b) => a - b);
+    current.profiles = [...new Set([...current.profiles, ...group.profiles])].sort();
+    merged.set(group.pgid, current);
+  }
+  return [...merged.values()].sort((a, b) => a.pgid - b.pgid);
+}
+
+export function formatGroup(group) {
+  return `pgid=${group.pgid} pids=${group.pids.join(',')} profiles=${group.profiles.join(',')}`;
+}
+
+async function readSnapshot() {
+  const { stdout } = await execFile('ps', ['-axo', 'pid=,ppid=,pgid=,command=']);
+  return parsePsSnapshot(stdout);
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForGroupExit(pgid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = await readSnapshot();
+    const stillAlive = rows.some((row) => row.pgid === pgid);
+    if (!stillAlive) return true;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  return false;
+}
+
+async function terminateGroup(group, signal) {
+  process.kill(-group.pgid, signal);
+}
+
+export async function cleanupOrphanedAutomationChrome({ dryRun = false, log = console.error, registryPath } = {}) {
+  const rows = await readSnapshot();
+  const groups = mergeGroups(
+    findOrphanedAutomationChromeGroups(rows),
+    findTrackedBrowserGroups(rows, readTrackedUserDataDirs(registryPath)),
+  );
+  if (groups.length === 0) {
+    log('cleanup-orphaned-automation-chrome: no orphaned automation Chrome groups found');
+    return { cleaned: 0, groups: [] };
+  }
+
+  for (const group of groups) {
+    log(`cleanup-orphaned-automation-chrome: found ${formatGroup(group)}`);
+  }
+  if (dryRun) return { cleaned: 0, groups };
+
+  let cleaned = 0;
+  for (const group of groups) {
+    try {
+      await terminateGroup(group, 'SIGTERM');
+    } catch (error) {
+      if (error?.code === 'ESRCH') {
+        cleaned += 1;
+        continue;
+      }
+      throw error;
+    }
+    const exitedOnTerm = await waitForGroupExit(group.pgid, TERM_WAIT_MS);
+    if (!exitedOnTerm) {
+      log(`cleanup-orphaned-automation-chrome: escalating ${formatGroup(group)}`);
+      try {
+        await terminateGroup(group, 'SIGKILL');
+      } catch (error) {
+        if (error?.code !== 'ESRCH') throw error;
+      }
+      await waitForGroupExit(group.pgid, KILL_WAIT_MS);
+    }
+    cleaned += 1;
+  }
+  return { cleaned, groups };
+}
+
+function parseArgs(argv) {
+  let dryRun = false;
+  let registryPath;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    if (arg === '--registry') {
+      registryPath = argv[i + 1];
+      i += 1;
+    }
+  }
+  return { dryRun, registryPath };
+}
+
+async function main(argv) {
+  const { dryRun, registryPath } = parseArgs(argv);
+  const result = await cleanupOrphanedAutomationChrome({ dryRun, registryPath });
+  if (!dryRun && result.cleaned > 0) {
+    console.error(`cleanup-orphaned-automation-chrome: cleaned ${result.cleaned} group(s)`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(`cleanup-orphaned-automation-chrome: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/cleanup-orphaned-automation-chrome.test.mjs
+++ b/scripts/cleanup-orphaned-automation-chrome.test.mjs
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+  extractUserDataDir,
+  findOrphanedAutomationChromeGroups,
+  findTrackedBrowserGroups,
+  formatGroup,
+  isAutomationChromeCommand,
+  mergeGroups,
+  parsePsSnapshot,
+  readTrackedUserDataDirs,
+} from './cleanup-orphaned-automation-chrome.mjs';
+
+const orphanChrome = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --enable-automation --headless=new --user-data-dir=/tmp/puppeteer_dev_chrome_profile-abc';
+const orphanHelper = '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Helpers/Google Chrome Helper --type=gpu-process --headless=new --user-data-dir=/tmp/puppeteer_dev_chrome_profile-abc';
+const liveChrome = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --enable-automation --headless=new --user-data-dir=/tmp/puppeteer_dev_chrome_profile-live';
+const desktopChrome = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const trackedElectron = '/Users/test/electron packages/app/dist/main.js --user-data-dir=/tmp/invoker-e2e-123/electron-user-data';
+
+describe('cleanup-orphaned-automation-chrome', () => {
+  it('recognizes Puppeteer headless Chrome commands only', () => {
+    assert.equal(isAutomationChromeCommand(orphanChrome), true);
+    assert.equal(isAutomationChromeCommand(desktopChrome), false);
+    assert.equal(isAutomationChromeCommand(`${orphanChrome} --headless=old`.replace('--headless=new', '')), false);
+  });
+
+  it('extracts user-data-dir from process command lines', () => {
+    assert.equal(extractUserDataDir(orphanChrome), '/tmp/puppeteer_dev_chrome_profile-abc');
+    assert.equal(extractUserDataDir(desktopChrome), undefined);
+  });
+
+  it('parses ps snapshots with command payloads', () => {
+    const rows = parsePsSnapshot(`58744 1 58744 ${orphanChrome}\n58812 58744 58744 ${orphanHelper}\n`);
+    assert.deepEqual(rows, [
+      { pid: 58744, ppid: 1, pgid: 58744, command: orphanChrome },
+      { pid: 58812, ppid: 58744, pgid: 58744, command: orphanHelper },
+    ]);
+  });
+
+  it('groups orphaned automation Chrome by process group', () => {
+    const groups = findOrphanedAutomationChromeGroups([
+      { pid: 58744, ppid: 1, pgid: 58744, command: orphanChrome },
+      { pid: 58812, ppid: 58744, pgid: 58744, command: orphanHelper },
+      { pid: 2146, ppid: 30346, pgid: 2146, command: liveChrome },
+      { pid: 25754, ppid: 1, pgid: 25754, command: desktopChrome },
+    ]);
+    assert.deepEqual(groups, [{
+      pgid: 58744,
+      pids: [58744, 58812],
+      profiles: ['/tmp/puppeteer_dev_chrome_profile-abc'],
+    }]);
+  });
+
+  it('finds tracked browser groups by user-data-dir even when not orphaned', () => {
+    const groups = findTrackedBrowserGroups([
+      { pid: 7000, ppid: 6999, pgid: 7000, command: trackedElectron },
+      { pid: 7001, ppid: 7000, pgid: 7000, command: `${trackedElectron} --type=renderer` },
+      { pid: 7002, ppid: 6999, pgid: 7002, command: liveChrome },
+    ], ['/tmp/invoker-e2e-123/electron-user-data']);
+    assert.deepEqual(groups, [{
+      pgid: 7000,
+      pids: [7000, 7001],
+      profiles: ['/tmp/invoker-e2e-123/electron-user-data'],
+    }]);
+  });
+
+  it('reads tracked user-data-dirs from a registry file', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-registry-test-'));
+    const registryPath = path.join(dir, 'user-data-dirs.txt');
+    writeFileSync(registryPath, '/tmp/a\n/tmp/b\n/tmp/a\n', 'utf8');
+    assert.deepEqual(readTrackedUserDataDirs(registryPath), ['/tmp/a', '/tmp/b']);
+  });
+
+  it('merges orphaned and tracked groups by process group', () => {
+    const merged = mergeGroups(
+      [{ pgid: 58744, pids: [58744], profiles: ['/tmp/puppeteer_dev_chrome_profile-abc'] }],
+      [{ pgid: 58744, pids: [58812], profiles: ['/tmp/puppeteer_dev_chrome_profile-abc'] }],
+    );
+    assert.deepEqual(merged, [{
+      pgid: 58744,
+      pids: [58744, 58812],
+      profiles: ['/tmp/puppeteer_dev_chrome_profile-abc'],
+    }]);
+  });
+
+  it('formats cleanup output with pgid pids and profile', () => {
+    assert.equal(
+      formatGroup({ pgid: 58744, pids: [58744, 58812], profiles: ['/tmp/puppeteer_dev_chrome_profile-abc'] }),
+      'pgid=58744 pids=58744,58812 profiles=/tmp/puppeteer_dev_chrome_profile-abc',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Invoker now reaps orphaned automation Chrome before a normal GUI start.

The stuck browser jobs were Puppeteer Chrome processes with `puppeteer_dev_chrome_profile-*` user-data dirs. Their owner had already died, so the GPU helper kept spinning in the background.

`run.sh` now calls a small reaper first. It targets orphaned automation Chrome groups, then leaves still-owned automation tabs and normal Chrome alone.

<details>
<summary>Review metadata</summary>

Review Claim: Approve that GUI start now reaps orphaned automation Chrome without touching live browser sessions.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: The reaper filter requires both Puppeteer Chrome flags and an orphaned parent (`PPID 1`). Live automation sessions and normal Chrome do not match.

Slice Rationale: This is the smallest local fix that stops leaked browser-tool Chrome from poisoning the next Invoker start.

</details>

## Non-goals

This does not change browser-tool launch behavior, Electron window code, or web-surface rendering.

## Test Plan

- [x] `node --test scripts/cleanup-orphaned-automation-chrome.test.mjs`
- [x] `bash -n run.sh`
- [x] `node scripts/cleanup-orphaned-automation-chrome.mjs --dry-run`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 972fa569c`
- Post-revert steps: None
- Data migration? No
