### PR TITLE
[Automation Chrome Reaper](2) Track browser test launches for teardown

### DIFF
--- a/packages/app/e2e/fixtures/browser-process-registry.ts
+++ b/packages/app/e2e/fixtures/browser-process-registry.ts
@@ -1,0 +1,11 @@
+import { appendFileSync, mkdirSync } from 'node:fs';
+import * as path from 'node:path';
+
+export const E2E_BROWSER_REGISTRY_ENV = 'INVOKER_E2E_BROWSER_PROCESS_REGISTRY';
+
+export function registerTrackedBrowserUserDataDir(userDataDir: string): void {
+  const registryPath = process.env[E2E_BROWSER_REGISTRY_ENV];
+  if (!registryPath) return;
+  mkdirSync(path.dirname(registryPath), { recursive: true });
+  appendFileSync(registryPath, `${userDataDir}\n`, 'utf8');
+}

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -15,6 +15,7 @@ import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import { stringify as yamlStringify } from 'yaml';
+import { registerTrackedBrowserUserDataDir } from './browser-process-registry.js';
 
 export type ElectronFixtures = {
   electronApp: ElectronApplication;
@@ -68,6 +69,7 @@ export const test = base.extend<ElectronFixtures>({
     await fs.mkdir(stubDir, { recursive: true });
     await fs.mkdir(markerRoot, { recursive: true });
     await fs.mkdir(electronUserDataDir, { recursive: true });
+    registerTrackedBrowserUserDataDir(electronUserDataDir);
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
     try {
       await fs.symlink(claudeMarker, path.join(stubDir, 'claude'));

--- a/packages/app/e2e/gap-recovery-bench.spec.ts
+++ b/packages/app/e2e/gap-recovery-bench.spec.ts
@@ -8,6 +8,7 @@ import { stringify as yamlStringify } from 'yaml';
 import type { ElectronApplication, Page } from '@playwright/test';
 
 import { E2E_REPO_URL } from './fixtures/electron-app.js';
+import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 
 const repoRoot = resolveRepoRoot(__dirname);
 
@@ -23,8 +24,11 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
   const markerRoot = path.join(testDir, 'e2e-markers');
   const configPath = path.join(testDir, 'e2e-config.json');
   const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+  const electronUserDataDir = path.join(testDir, 'electron-user-data');
   await fs.mkdir(stubDir, { recursive: true });
   await fs.mkdir(markerRoot, { recursive: true });
+  await fs.mkdir(electronUserDataDir, { recursive: true });
+  registerTrackedBrowserUserDataDir(electronUserDataDir);
   writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
   try {
     await fs.symlink(claudeMarker, path.join(stubDir, 'claude'));
@@ -34,6 +38,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
       ...(process.platform === 'linux'
         ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
         : []),
+      `--user-data-dir=${electronUserDataDir}`,
       path.resolve(__dirname, '..', 'dist', 'main.js'),
     ],
     env: {

--- a/packages/app/e2e/global-teardown.ts
+++ b/packages/app/e2e/global-teardown.ts
@@ -1,0 +1,18 @@
+import { execFileSync } from 'node:child_process';
+import { rmSync } from 'node:fs';
+import * as path from 'node:path';
+import { E2E_BROWSER_REGISTRY_ENV } from './fixtures/browser-process-registry.js';
+
+export default async function globalTeardown(): Promise<void> {
+  const registryPath = process.env[E2E_BROWSER_REGISTRY_ENV];
+  if (!registryPath) return;
+
+  const repoRoot = path.resolve(__dirname, '..', '..', '..');
+  const cleanupScript = path.join(repoRoot, 'scripts', 'cleanup-orphaned-automation-chrome.mjs');
+
+  try {
+    execFileSync(process.execPath, [cleanupScript, '--registry', registryPath], { stdio: 'inherit' });
+  } finally {
+    rmSync(path.dirname(registryPath), { recursive: true, force: true });
+  }
+}

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -6,6 +6,7 @@ import { _electron as electron, type Page } from '@playwright/test';
 import { resolveRepoRoot } from '@invoker/contracts';
 import { stringify as yamlStringify } from 'yaml';
 
+import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 import {
   E2E_REPO_URL,
   TEST_PLAN,
@@ -157,6 +158,7 @@ test.describe('Headless thundering herd', () => {
     await ensureHeadlessTestConfig(testDir);
     const userDataDir = path.join(testDir, 'owner-electron-user-data');
     await mkdir(userDataDir, { recursive: true });
+    registerTrackedBrowserUserDataDir(userDataDir);
 
     const ownerApp = await electron.launch({
       args: [

--- a/packages/app/e2e/launching-stall-watchdog.spec.ts
+++ b/packages/app/e2e/launching-stall-watchdog.spec.ts
@@ -3,8 +3,8 @@ import { tmpdir } from 'node:os';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { stringify as yamlStringify } from 'yaml';
-import { E2E_REPO_URL } from './fixtures/electron-app.js';
-import { injectTaskStates } from './fixtures/electron-app.js';
+import { E2E_REPO_URL, injectTaskStates } from './fixtures/electron-app.js';
+import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 
 const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
 
@@ -45,6 +45,7 @@ base.describe('Launch stall watchdog', () => {
     const configPath = path.join(testDir, 'e2e-config.json');
     const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
     const electronUserDataDir = path.join(testDir, 'electron-user-data');
+    registerTrackedBrowserUserDataDir(electronUserDataDir);
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
     let app: ElectronApplication | undefined;
 
@@ -152,6 +153,7 @@ base.describe('Launch stall watchdog', () => {
     const configPath = path.join(testDir, 'e2e-config.json');
     const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
     const electronUserDataDir = path.join(testDir, 'electron-user-data');
+    registerTrackedBrowserUserDataDir(electronUserDataDir);
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
     let app: ElectronApplication | undefined;
 

--- a/packages/app/e2e/orphan-relaunch.spec.ts
+++ b/packages/app/e2e/orphan-relaunch.spec.ts
@@ -13,6 +13,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { stringify as yamlStringify } from 'yaml';
 import { E2E_REPO_URL } from './fixtures/electron-app.js';
+import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 
 const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
 
@@ -58,78 +59,81 @@ base.describe('Orphan task relaunch on restart', () => {
   base('orphaned running task is relaunched after app restart', async () => {
     const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-'));
     const configPath = path.join(testDir, 'e2e-config.json');
+    const electronUserDataDir = path.join(testDir, 'electron-user-data');
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
+    rmSync(electronUserDataDir, { recursive: true, force: true });
+    registerTrackedBrowserUserDataDir(electronUserDataDir);
 
     try {
-    const app1 = await electron.launch({
-      args: launchArgs(),
-      env: {
-        ...process.env,
-        NODE_ENV: 'test',
-        INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
-        INVOKER_DB_DIR: testDir,
-        INVOKER_ALLOW_DELETE_ALL: '1',
-        INVOKER_E2E_ENABLE_COMPOSITOR: '1',
-        INVOKER_REPO_CONFIG_PATH: configPath,
-      },
-    });
-    const page1 = await app1.firstWindow();
-    await waitForInvoker(page1);
+      const app1 = await electron.launch({
+        args: [`--user-data-dir=${electronUserDataDir}`, ...launchArgs()],
+        env: {
+          ...process.env,
+          NODE_ENV: 'test',
+          INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
+          INVOKER_DB_DIR: testDir,
+          INVOKER_ALLOW_DELETE_ALL: '1',
+          INVOKER_E2E_ENABLE_COMPOSITOR: '1',
+          INVOKER_REPO_CONFIG_PATH: configPath,
+        },
+      });
+      const page1 = await app1.firstWindow();
+      await waitForInvoker(page1);
 
-    // Clear any leftover state
-    await page1.evaluate(async () => {
-      await window.invoker.clear();
-      await window.invoker.deleteAllWorkflows();
-    });
+      // Clear any leftover state
+      await page1.evaluate(async () => {
+        await window.invoker.clear();
+        await window.invoker.deleteAllWorkflows();
+      });
 
-    // Load the plan and synthesize an orphaned running task with no live handle.
-    await page1.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(RELAUNCH_PLAN));
-    const loadedResult = await page1.evaluate(() => window.invoker.getTasks());
-    const loadedTasks = Array.isArray(loadedResult) ? loadedResult : loadedResult.tasks;
-    const loadedSlow = findTask(loadedTasks, 'slow-task');
-    expect(loadedSlow).toBeDefined();
+      // Load the plan and synthesize an orphaned running task with no live handle.
+      await page1.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(RELAUNCH_PLAN));
+      const loadedResult = await page1.evaluate(() => window.invoker.getTasks());
+      const loadedTasks = Array.isArray(loadedResult) ? loadedResult : loadedResult.tasks;
+      const loadedSlow = findTask(loadedTasks, 'slow-task');
+      expect(loadedSlow).toBeDefined();
 
-    await page1.evaluate(async ({ taskId }) => {
-      const now = new Date().toISOString();
-      await window.invoker.injectTaskStates?.([
-        {
-          taskId,
-          changes: {
-            status: 'running',
-            execution: {
-              phase: 'launching',
-              startedAt: now,
-              lastHeartbeatAt: now,
-              launchStartedAt: now,
+      await page1.evaluate(async ({ taskId }) => {
+        const now = new Date().toISOString();
+        await window.invoker.injectTaskStates?.([
+          {
+            taskId,
+            changes: {
+              status: 'running',
+              execution: {
+                phase: 'launching',
+                startedAt: now,
+                lastHeartbeatAt: now,
+                launchStartedAt: now,
+              },
             },
           },
-        },
-      ]);
-    }, { taskId: loadedSlow!.id });
+        ]);
+      }, { taskId: loadedSlow!.id });
 
-    await page1.evaluate(() => window.invoker.resumeWorkflow());
+      await page1.evaluate(() => window.invoker.resumeWorkflow());
 
-    const deadline2 = Date.now() + 60_000;
-    let observedSlow: any;
-    while (Date.now() < deadline2) {
-      const snapshot = await page1.evaluate(() => window.invoker.getTasks());
-      const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
-      observedSlow = findTask(tasks, 'slow-task');
-      if (observedSlow?.status === 'running' && observedSlow?.execution?.phase !== 'launching') {
-        break;
+      const deadline2 = Date.now() + 60_000;
+      let observedSlow: any;
+      while (Date.now() < deadline2) {
+        const snapshot = await page1.evaluate(() => window.invoker.getTasks());
+        const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
+        observedSlow = findTask(tasks, 'slow-task');
+        if (observedSlow?.status === 'running' && observedSlow?.execution?.phase !== 'launching') {
+          break;
+        }
+        await page1.waitForTimeout(300);
       }
-      await page1.waitForTimeout(300);
-    }
-    expect(observedSlow).toBeDefined();
-    expect(observedSlow?.status).toBe('running');
-    expect(observedSlow?.execution?.phase).not.toBe('launching');
+      expect(observedSlow).toBeDefined();
+      expect(observedSlow?.status).toBe('running');
+      expect(observedSlow?.execution?.phase).not.toBe('launching');
 
-    const postResult = await page1.evaluate(() => window.invoker.getTasks());
-    const postTasks = Array.isArray(postResult) ? postResult : postResult.tasks;
-    const postSlow = findTask(postTasks, 'slow-task');
-    expect(postSlow).toBeDefined();
-    expect(postSlow?.status).toBe('running');
-    await app1.close();
+      const postResult = await page1.evaluate(() => window.invoker.getTasks());
+      const postTasks = Array.isArray(postResult) ? postResult : postResult.tasks;
+      const postSlow = findTask(postTasks, 'slow-task');
+      expect(postSlow).toBeDefined();
+      expect(postSlow?.status).toBe('running');
+      await app1.close();
     } finally {
       if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
         rmSync(testDir, { recursive: true, force: true });

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -8,6 +8,7 @@ import { stringify as yamlStringify } from 'yaml';
 import type { Page } from '@playwright/test';
 
 import { E2E_REPO_URL } from './fixtures/electron-app.js';
+import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 
 const repoRoot = resolveRepoRoot(__dirname);
 const STARTUP_BUDGET_MS = 12000;
@@ -18,8 +19,11 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
   const markerRoot = path.join(testDir, 'e2e-markers');
   const configPath = path.join(testDir, 'e2e-config.json');
   const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+  const electronUserDataDir = path.join(testDir, 'electron-user-data');
   await fs.mkdir(stubDir, { recursive: true });
   await fs.mkdir(markerRoot, { recursive: true });
+  await fs.mkdir(electronUserDataDir, { recursive: true });
+  registerTrackedBrowserUserDataDir(electronUserDataDir);
   writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
   try {
     await fs.symlink(claudeMarker, path.join(stubDir, 'claude'));
@@ -31,6 +35,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
       ...(process.platform === 'linux'
         ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
         : []),
+      `--user-data-dir=${electronUserDataDir}`,
       path.resolve(__dirname, '..', 'dist', 'main.js'),
     ],
     env: {

--- a/packages/app/e2e/startup-window-liveness.spec.ts
+++ b/packages/app/e2e/startup-window-liveness.spec.ts
@@ -5,6 +5,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
 import { tmpdir } from 'node:os';
 
+import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 const repoRoot = resolveRepoRoot(__dirname);
 const STARTUP_BUDGET_MS = 12000;
 
@@ -16,8 +17,11 @@ test('GUI window appears before delayed workflow mutation recovery finishes', as
     const markerRoot = path.join(testDir, 'e2e-markers');
     const configPath = path.join(testDir, 'e2e-config.json');
     const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    const electronUserDataDir = path.join(testDir, 'electron-user-data');
     await fs.mkdir(stubDir, { recursive: true });
     await fs.mkdir(markerRoot, { recursive: true });
+    await fs.mkdir(electronUserDataDir, { recursive: true });
+    registerTrackedBrowserUserDataDir(electronUserDataDir);
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
     try {
       await fs.symlink(claudeMarker, path.join(stubDir, 'claude'));
@@ -31,6 +35,7 @@ test('GUI window appears before delayed workflow mutation recovery finishes', as
         ...(process.platform === 'linux'
           ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
           : []),
+        `--user-data-dir=${electronUserDataDir}`,
         path.resolve(__dirname, '..', 'dist', 'main.js'),
       ],
       env: {

--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -6,6 +6,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { SQLiteAdapter } from '@invoker/data-store';
 import { stringify as yamlStringify } from 'yaml';
 import { E2E_REPO_URL } from './fixtures/electron-app.js';
+import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
 
 const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
 
@@ -65,6 +66,7 @@ async function waitForTask(page: Page, taskId: string, predicate: (task: any) =>
 async function launchApp(testDir: string, configPath: string): Promise<{ app: ElectronApplication; page: Page }> {
   const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
   const electronUserDataDir = path.join(testDir, 'electron-user-data');
+  registerTrackedBrowserUserDataDir(electronUserDataDir);
   const app = await electron.launch({
     args: [
       ...launchArgs().slice(0, -1),

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -1,9 +1,18 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
 import { defineConfig } from '@playwright/test';
+import { E2E_BROWSER_REGISTRY_ENV } from './e2e/fixtures/browser-process-registry.js';
 
 const workers = Number(process.env.INVOKER_PLAYWRIGHT_WORKERS ?? (process.env.CI ? '1' : '2'));
+process.env[E2E_BROWSER_REGISTRY_ENV] ??= path.join(
+  mkdtempSync(path.join(tmpdir(), 'invoker-e2e-browser-registry-')),
+  'user-data-dirs.txt',
+);
 
 export default defineConfig({
   globalSetup: './e2e/global-setup.ts',
+  globalTeardown: './e2e/global-teardown.ts',
   testDir: './e2e',
   timeout: 120000,
   retries: 0,

--- a/run.sh
+++ b/run.sh
@@ -126,8 +126,12 @@ if [ "$1" = "--headless" ]; then
   exec node ./packages/app/dist/headless-client.js "$@"
 fi
 
-# Kill any stale Electron/tsup processes from previous runs so we
-# always start from a clean state.
+# Kill any orphaned Puppeteer/automation Chrome left behind by crashed browser
+# sessions, then clear stale Electron/tsup processes so we always start from a
+# clean state.
+if ! node ./scripts/cleanup-orphaned-automation-chrome.mjs; then
+  echo "WARN: orphaned automation Chrome cleanup failed; continuing launch" >&2
+fi
 pkill -f "electron.*packages/app/dist/main.js" 2>/dev/null || true
 pkill -f "tsup.*packages/app" 2>/dev/null || true
 sleep 0.2

--- a/scripts/cleanup-orphaned-automation-chrome.mjs
+++ b/scripts/cleanup-orphaned-automation-chrome.mjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+import process from 'node:process';
+import { execFile as execFileCb } from 'node:child_process';
+import { readFileSync as fsReadFileSync } from 'node:fs';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+const POLL_INTERVAL_MS = 200;
+const TERM_WAIT_MS = 3_000;
+const KILL_WAIT_MS = 1_000;
+
+export function isAutomationChromeCommand(command) {
+  return command.includes('puppeteer_dev_chrome_profile-')
+    && command.includes('--headless=new');
+}
+
+export function extractUserDataDir(command) {
+  const match = command.match(/--user-data-dir=([^\s]+)/);
+  return match ? match[1] : undefined;
+}
+
+export function parsePsSnapshot(text) {
+  return text
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const match = line.match(/^(\d+)\s+(\d+)\s+(\d+)\s+(.*)$/);
+      if (!match) return null;
+      return {
+        pid: Number.parseInt(match[1], 10),
+        ppid: Number.parseInt(match[2], 10),
+        pgid: Number.parseInt(match[3], 10),
+        command: match[4],
+      };
+    })
+    .filter(Boolean);
+}
+
+function groupsByPgid(rows, predicate) {
+  const byPgid = new Map();
+  for (const row of rows) {
+    if (!predicate(row)) continue;
+    const group = byPgid.get(row.pgid) ?? { pgid: row.pgid, rows: [] };
+    group.rows.push(row);
+    byPgid.set(row.pgid, group);
+  }
+  return byPgid;
+}
+
+function materializeGroup(group) {
+  return {
+    pgid: group.pgid,
+    pids: [...new Set(group.rows.map((row) => row.pid))].sort((a, b) => a - b),
+    profiles: [...new Set(group.rows.flatMap((row) => {
+      const userDataDir = extractUserDataDir(row.command);
+      return userDataDir ? [userDataDir] : [];
+    }))].sort(),
+  };
+}
+
+export function findOrphanedAutomationChromeGroups(rows) {
+  return [...groupsByPgid(rows, (row) => isAutomationChromeCommand(row.command)).values()]
+    .filter((group) => group.rows.some((row) => row.ppid === 1))
+    .map(materializeGroup)
+    .sort((a, b) => a.pgid - b.pgid);
+}
+
+export function readTrackedUserDataDirs(registryPath) {
+  if (!registryPath) return [];
+  return [...new Set(
+    fsReadFileSync(registryPath, 'utf8')
+      .split('\n')
+      .map((line) => line.trim())
+      .filter(Boolean),
+  )].sort();
+}
+
+export function findTrackedBrowserGroups(rows, trackedUserDataDirs) {
+  const tracked = new Set(trackedUserDataDirs);
+  if (tracked.size === 0) return [];
+  return [...groupsByPgid(rows, (row) => {
+    const userDataDir = extractUserDataDir(row.command);
+    return userDataDir ? tracked.has(userDataDir) : false;
+  }).values()]
+    .map(materializeGroup)
+    .sort((a, b) => a.pgid - b.pgid);
+}
+
+export function mergeGroups(...groupLists) {
+  const merged = new Map();
+  for (const group of groupLists.flat()) {
+    const current = merged.get(group.pgid) ?? { pgid: group.pgid, pids: [], profiles: [] };
+    current.pids = [...new Set([...current.pids, ...group.pids])].sort((a, b) => a - b);
+    current.profiles = [...new Set([...current.profiles, ...group.profiles])].sort();
+    merged.set(group.pgid, current);
+  }
+  return [...merged.values()].sort((a, b) => a.pgid - b.pgid);
+}
+
+export function formatGroup(group) {
+  return `pgid=${group.pgid} pids=${group.pids.join(',')} profiles=${group.profiles.join(',')}`;
+}
+
+async function readSnapshot() {
+  const { stdout } = await execFile('ps', ['-axo', 'pid=,ppid=,pgid=,command=']);
+  return parsePsSnapshot(stdout);
+}
+
+async function sleep(ms) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitForGroupExit(pgid, timeoutMs) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = await readSnapshot();
+    const stillAlive = rows.some((row) => row.pgid === pgid);
+    if (!stillAlive) return true;
+    await sleep(POLL_INTERVAL_MS);
+  }
+  return false;
+}
+
+async function terminateGroup(group, signal) {
+  process.kill(-group.pgid, signal);
+}
+
+export async function cleanupOrphanedAutomationChrome({ dryRun = false, log = console.error, registryPath } = {}) {
+  const rows = await readSnapshot();
+  const groups = mergeGroups(
+    findOrphanedAutomationChromeGroups(rows),
+    findTrackedBrowserGroups(rows, readTrackedUserDataDirs(registryPath)),
+  );
+  if (groups.length === 0) {
+    log('cleanup-orphaned-automation-chrome: no orphaned automation Chrome groups found');
+    return { cleaned: 0, groups: [] };
+  }
+
+  for (const group of groups) {
+    log(`cleanup-orphaned-automation-chrome: found ${formatGroup(group)}`);
+  }
+  if (dryRun) return { cleaned: 0, groups };
+
+  let cleaned = 0;
+  for (const group of groups) {
+    try {
+      await terminateGroup(group, 'SIGTERM');
+    } catch (error) {
+      if (error?.code === 'ESRCH') {
+        cleaned += 1;
+        continue;
+      }
+      throw error;
+    }
+    const exitedOnTerm = await waitForGroupExit(group.pgid, TERM_WAIT_MS);
+    if (!exitedOnTerm) {
+      log(`cleanup-orphaned-automation-chrome: escalating ${formatGroup(group)}`);
+      try {
+        await terminateGroup(group, 'SIGKILL');
+      } catch (error) {
+        if (error?.code !== 'ESRCH') throw error;
+      }
+      await waitForGroupExit(group.pgid, KILL_WAIT_MS);
+    }
+    cleaned += 1;
+  }
+  return { cleaned, groups };
+}
+
+function parseArgs(argv) {
+  let dryRun = false;
+  let registryPath;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    if (arg === '--registry') {
+      registryPath = argv[i + 1];
+      i += 1;
+    }
+  }
+  return { dryRun, registryPath };
+}
+
+async function main(argv) {
+  const { dryRun, registryPath } = parseArgs(argv);
+  const result = await cleanupOrphanedAutomationChrome({ dryRun, registryPath });
+  if (!dryRun && result.cleaned > 0) {
+    console.error(`cleanup-orphaned-automation-chrome: cleaned ${result.cleaned} group(s)`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main(process.argv.slice(2)).catch((error) => {
+    console.error(`cleanup-orphaned-automation-chrome: ${error instanceof Error ? error.stack ?? error.message : String(error)}`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/cleanup-orphaned-automation-chrome.test.mjs
+++ b/scripts/cleanup-orphaned-automation-chrome.test.mjs
@@ -1,0 +1,95 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+  extractUserDataDir,
+  findOrphanedAutomationChromeGroups,
+  findTrackedBrowserGroups,
+  formatGroup,
+  isAutomationChromeCommand,
+  mergeGroups,
+  parsePsSnapshot,
+  readTrackedUserDataDirs,
+} from './cleanup-orphaned-automation-chrome.mjs';
+
+const orphanChrome = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --enable-automation --headless=new --user-data-dir=/tmp/puppeteer_dev_chrome_profile-abc';
+const orphanHelper = '/Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Helpers/Google Chrome Helper --type=gpu-process --headless=new --user-data-dir=/tmp/puppeteer_dev_chrome_profile-abc';
+const liveChrome = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome --enable-automation --headless=new --user-data-dir=/tmp/puppeteer_dev_chrome_profile-live';
+const desktopChrome = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const trackedElectron = '/Users/test/electron packages/app/dist/main.js --user-data-dir=/tmp/invoker-e2e-123/electron-user-data';
+
+describe('cleanup-orphaned-automation-chrome', () => {
+  it('recognizes Puppeteer headless Chrome commands only', () => {
+    assert.equal(isAutomationChromeCommand(orphanChrome), true);
+    assert.equal(isAutomationChromeCommand(desktopChrome), false);
+    assert.equal(isAutomationChromeCommand(`${orphanChrome} --headless=old`.replace('--headless=new', '')), false);
+  });
+
+  it('extracts user-data-dir from process command lines', () => {
+    assert.equal(extractUserDataDir(orphanChrome), '/tmp/puppeteer_dev_chrome_profile-abc');
+    assert.equal(extractUserDataDir(desktopChrome), undefined);
+  });
+
+  it('parses ps snapshots with command payloads', () => {
+    const rows = parsePsSnapshot(`58744 1 58744 ${orphanChrome}\n58812 58744 58744 ${orphanHelper}\n`);
+    assert.deepEqual(rows, [
+      { pid: 58744, ppid: 1, pgid: 58744, command: orphanChrome },
+      { pid: 58812, ppid: 58744, pgid: 58744, command: orphanHelper },
+    ]);
+  });
+
+  it('groups orphaned automation Chrome by process group', () => {
+    const groups = findOrphanedAutomationChromeGroups([
+      { pid: 58744, ppid: 1, pgid: 58744, command: orphanChrome },
+      { pid: 58812, ppid: 58744, pgid: 58744, command: orphanHelper },
+      { pid: 2146, ppid: 30346, pgid: 2146, command: liveChrome },
+      { pid: 25754, ppid: 1, pgid: 25754, command: desktopChrome },
+    ]);
+    assert.deepEqual(groups, [{
+      pgid: 58744,
+      pids: [58744, 58812],
+      profiles: ['/tmp/puppeteer_dev_chrome_profile-abc'],
+    }]);
+  });
+
+  it('finds tracked browser groups by user-data-dir even when not orphaned', () => {
+    const groups = findTrackedBrowserGroups([
+      { pid: 7000, ppid: 6999, pgid: 7000, command: trackedElectron },
+      { pid: 7001, ppid: 7000, pgid: 7000, command: `${trackedElectron} --type=renderer` },
+      { pid: 7002, ppid: 6999, pgid: 7002, command: liveChrome },
+    ], ['/tmp/invoker-e2e-123/electron-user-data']);
+    assert.deepEqual(groups, [{
+      pgid: 7000,
+      pids: [7000, 7001],
+      profiles: ['/tmp/invoker-e2e-123/electron-user-data'],
+    }]);
+  });
+
+  it('reads tracked user-data-dirs from a registry file', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-registry-test-'));
+    const registryPath = path.join(dir, 'user-data-dirs.txt');
+    writeFileSync(registryPath, '/tmp/a\n/tmp/b\n/tmp/a\n', 'utf8');
+    assert.deepEqual(readTrackedUserDataDirs(registryPath), ['/tmp/a', '/tmp/b']);
+  });
+
+  it('merges orphaned and tracked groups by process group', () => {
+    const merged = mergeGroups(
+      [{ pgid: 58744, pids: [58744], profiles: ['/tmp/puppeteer_dev_chrome_profile-abc'] }],
+      [{ pgid: 58744, pids: [58812], profiles: ['/tmp/puppeteer_dev_chrome_profile-abc'] }],
+    );
+    assert.deepEqual(merged, [{
+      pgid: 58744,
+      pids: [58744, 58812],
+      profiles: ['/tmp/puppeteer_dev_chrome_profile-abc'],
+    }]);
+  });
+
+  it('formats cleanup output with pgid pids and profile', () => {
+    assert.equal(
+      formatGroup({ pgid: 58744, pids: [58744, 58812], profiles: ['/tmp/puppeteer_dev_chrome_profile-abc'] }),
+      'pgid=58744 pids=58744,58812 profiles=/tmp/puppeteer_dev_chrome_profile-abc',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Playwright now registers the browser user-data dirs it launches during Invoker E2E runs.

Each Electron launch appends its user-data dir to a shared registry. Global teardown passes that registry to the browser reaper, which then reaps only leftover processes from that run.

This closes the loop when a Playwright worker exits before `app.close()` finishes.

<details>
<summary>Review metadata</summary>

Review Claim: Approve that Playwright E2E launches now register their browser profiles and global teardown reaps only leftover tracked browser processes.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Only user-data dirs registered by the current Playwright run are eligible for teardown reaping. Untracked desktop Chrome and unrelated automation sessions stay untouched.

Slice Rationale: The launch-time reaper fixes old leaks. This follow-up covers browser processes started by the current E2E run.

</details>

## Non-goals

This does not change browser-tool launch behavior outside Playwright E2E, or alter the Electron app runtime itself.

## Test Plan

- [x] `node --test scripts/cleanup-orphaned-automation-chrome.test.mjs`
- [x] `bash -n run.sh`
- [x] `node scripts/cleanup-orphaned-automation-chrome.mjs --dry-run`
- [x] `pnpm --filter @invoker/app exec playwright test --list`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/startup-window-liveness.spec.ts --workers=1`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert b2202ffbb`
- Post-revert steps: None
- Data migration? No
