### PR TITLE
Prove dry-run e2e helper necessity

### DIFF
--- a/scripts/test-e2e-common-helper.sh
+++ b/scripts/test-e2e-common-helper.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMMON_SH="${INVOKER_E2E_COMMON_SH:-$ROOT/scripts/e2e-dry-run/lib/common.sh}"
+source "$COMMON_SH"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+test_retries_wal_guard_once() {
+  local tmp repo stdout_file stderr_file attempts_file output
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  stdout_file="$tmp/stdout"
+  stderr_file="$tmp/stderr"
+  attempts_file="$tmp/attempts"
+  mkdir -p "$repo"
+  : > "$attempts_file"
+  cat > "$repo/run.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+attempt_file="${INVOKER_TEST_ATTEMPT_FILE:?}"
+attempts="$(wc -l < "$attempt_file")"
+if [ "$attempts" -eq 0 ]; then
+  printf 'first\n' >> "$attempt_file"
+  echo 'Read-only file open refused while WAL sidecars exist' >&2
+  exit 1
+fi
+printf 'second\n' >> "$attempt_file"
+printf 'ok\n'
+EOF
+  chmod +x "$repo/run.sh"
+
+  output="$(
+    sleep() { :; }
+    INVOKER_E2E_REPO_ROOT="$repo"
+    INVOKER_TEST_ATTEMPT_FILE="$attempts_file"
+    export INVOKER_E2E_REPO_ROOT INVOKER_TEST_ATTEMPT_FILE
+    invoker_e2e_run_headless query tasks --output json >"$stdout_file" 2>"$stderr_file"
+    cat "$stdout_file"
+  )" || fail "expected WAL-boundary retry to succeed"
+
+  [ "$output" = "ok" ] || fail "expected retried command stdout to be ok"
+  [ "$(wc -l < "$attempts_file")" -eq 2 ] || fail "expected exactly two headless attempts"
+  grep -Fq 'WARN: headless command hit owner-boundary WAL guard, retrying once:' "$stderr_file" \
+    || fail "expected WAL-boundary retry warning"
+
+  rm -rf "$tmp"
+}
+
+test_ignores_electron_helper_processes() {
+  local count
+  count="$(
+    pgrep() { printf '100\n101\n'; }
+    invoker_e2e_pid_cmdline() {
+      case "$1" in
+        100) printf '/Applications/Invoker.app/electron --headless\n' ;;
+        101) printf '/Applications/Invoker.app/Electron Helper --type=renderer --headless\n' ;;
+        *) return 1 ;;
+      esac
+    }
+    invoker_e2e_pid_has_env() { return 0; }
+    INVOKER_DB_DIR='/tmp/invoker-e2e-db'
+    export INVOKER_DB_DIR
+    invoker_e2e_count_owned_headless_processes
+  )"
+  [ "$count" = "1" ] || fail "expected helper process to be ignored, got count=$count"
+}
+
+test_waits_for_owned_process_exit() {
+  local calls_file
+  calls_file="$(mktemp)"
+  printf '0\n' > "$calls_file"
+  (
+    sleep() { :; }
+    invoker_e2e_count_owned_headless_processes() {
+      local calls
+      calls="$(cat "$calls_file")"
+      if [ "$calls" -eq 0 ]; then
+        printf '1\n' > "$calls_file"
+        printf '1'
+        return 0
+      fi
+      printf '0'
+    }
+    invoker_e2e_assert_no_owned_headless_processes 0 2
+  ) || fail "expected helper to wait for a transient owned process to exit"
+  [ "$(cat "$calls_file")" = "1" ] || fail "expected wait loop to poll at least once"
+  rm -f "$calls_file"
+}
+
+run_case() {
+  case "${1:-all}" in
+    wal-guard)
+      test_retries_wal_guard_once
+      ;;
+    helper-count)
+      test_ignores_electron_helper_processes
+      ;;
+    wait-exit)
+      test_waits_for_owned_process_exit
+      ;;
+    all)
+      test_retries_wal_guard_once
+      test_ignores_electron_helper_processes
+      test_waits_for_owned_process_exit
+      ;;
+    *)
+      fail "unknown test case: ${1:-}"
+      ;;
+  esac
+}
+
+run_case "${1:-all}"
+
+echo 'PASS: headless e2e helper retries WAL guard and ignores Electron helpers'


### PR DESCRIPTION
## Summary

This rebuilds the old 2984 justification as one standalone proof slice.

It adds a shell proof script for the dry-run e2e helper. The script covers the WAL-boundary read miss and the Electron helper overcount that 2984 addressed.

The proof passes against the helper that is now in `master`.

The same proof fails against the pre-fix helper from `6c3f29234`. That gives this behavior its own local reason to exist.

<details>
<summary>Review metadata</summary>

Review Claim: The helper behavior that landed with 2984 is still necessary, and this proof script demonstrates the two concrete failure modes it covers.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This slice adds one shell proof script under `scripts/`. It does not change shell behavior, app runtime, workflow state, or product behavior.

Slice Rationale: 2984 merged as part of a much larger stack. This remake isolates the proof and justification without reopening the already-landed helper logic.

</details>

## Non-goals

- No shell behavior changes.
- No app behavior changes.
- No workflow changes.
- No broader CI policy changes.

## Test Plan

- [x] `bash -n scripts/test-e2e-common-helper.sh`
- [x] `bash scripts/test-e2e-common-helper.sh`
- [x] `tmp_common="$(mktemp)" && git show 6c3f29234:scripts/e2e-dry-run/lib/common.sh > "$tmp_common" && ! INVOKER_E2E_COMMON_SH="$tmp_common" bash scripts/test-e2e-common-helper.sh wal-guard && ! INVOKER_E2E_COMMON_SH="$tmp_common" bash scripts/test-e2e-common-helper.sh helper-count && rm -f "$tmp_common"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end helper coverage for headless process handling.
  * Verified retry behavior when WAL sidecars block an initial run, including a successful second attempt.
  * Confirmed Electron helper processes are not counted as owned headless processes.
  * Ensured process-checking polls at least once before reporting success.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->