### PR TITLE
[Task Diagnostics](1) Persist concrete startup diagnostics

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2581,6 +2581,49 @@ describe('SQLiteAdapter', () => {
       }
     });
 
+    it('surfaces legacy diagnostic rows alongside spool stream without duplicating old stream rows', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-output-legacy-diag-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const db = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        db.saveWorkflow(testWorkflow);
+        db.saveTask('wf-1', makeTask('t-legacy-diag-tail'));
+
+        db.appendOutputChunk('t-legacy-diag-tail', 'test output before failure\n');
+        (db as any).db.run(
+          'INSERT INTO task_output (task_id, data) VALUES (?, ?)',
+          ['t-legacy-diag-tail', 'duplicate stream row\n'],
+        );
+        (db as any).db.run(
+          'INSERT INTO task_output (task_id, data) VALUES (?, ?)',
+          [
+            't-legacy-diag-tail',
+            '\n[Startup Failure Diagnostic]\nmessage=concrete startup stderr\n--- end startup failure diagnostic ---\n',
+          ],
+        );
+        (db as any).db.run(
+          'INSERT INTO task_output (task_id, data) VALUES (?, ?)',
+          [
+            't-legacy-diag-tail',
+            '\n[Shutdown Diagnostic]\nforcedStopReason=Application quit\n--- end shutdown diagnostic ---\n',
+          ],
+        );
+
+        const output = db.getTaskOutput('t-legacy-diag-tail');
+        expect(output).toContain('test output before failure');
+        expect(output).toContain('[Startup Failure Diagnostic]');
+        expect(output).toContain('concrete startup stderr');
+        expect(output).toContain('[Shutdown Diagnostic]');
+        expect(output).toContain('Application quit');
+        expect(output).not.toContain('duplicate stream row');
+
+        db.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('falls back to task_output when no output_spool chunks exist', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-output-fallback-'));
       const dbPath = join(dir, 'invoker.db');

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2375,13 +2375,32 @@ export class SQLiteAdapter implements PersistenceAdapter {
     const diagnosticFile = this.readTaskOutputFile(taskId);
     const spoolChunks = this.getOutputChunks(taskId);
     if (spoolChunks.length > 0) {
-      return spoolChunks.map((chunk) => chunk.data).join('') + diagnosticFile;
+      return spoolChunks.map((chunk) => chunk.data).join('')
+        + this.readLegacyDiagnosticTaskOutputRows(taskId)
+        + diagnosticFile;
     }
     const rows = this.queryAll(
       'SELECT data FROM task_output WHERE task_id = ? ORDER BY id ASC',
       [taskId],
     ) as Array<{ data: string }>;
     return rows.map((r) => r.data).join('') + diagnosticFile;
+  }
+
+  private readLegacyDiagnosticTaskOutputRows(taskId: string): string {
+    const rows = this.queryAll(
+      'SELECT data FROM task_output WHERE task_id = ? ORDER BY id ASC',
+      [taskId],
+    ) as Array<{ data: string }>;
+    return rows
+      .map((r) => r.data)
+      .filter((data) => this.isDiagnosticTaskOutput(data))
+      .join('');
+  }
+
+  private isDiagnosticTaskOutput(data: string): boolean {
+    return data.includes('[Shutdown Diagnostic]')
+      || data.includes('[Startup Failure Diagnostic]')
+      || data.includes('Executor startup failed');
   }
 
   /**

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1122,6 +1122,64 @@ describe('TaskRunner', () => {
       expect(onComplete).toHaveBeenCalled();
     });
 
+    it('appends a durable diagnostic block for startup stderr/stdout', async () => {
+      const handleWorkerResponse = vi.fn();
+      const orchestrator = {
+        getTask: () => undefined,
+        handleWorkerResponse,
+      };
+      const startupError = Object.assign(new Error('spawn failed before handle'), {
+        stderr: 'remote setup stderr\nmissing dependency\n',
+        stdout: 'remote setup stdout\n',
+      });
+      const throwingExecutor = {
+        type: 'ssh',
+        start: async () => { throw startupError; },
+        onOutput: () => () => {},
+        onComplete: () => () => {},
+      };
+      const registry = {
+        getDefault: () => throwingExecutor,
+        get: () => throwingExecutor,
+        getAll: () => [throwingExecutor],
+      };
+      const appendTaskOutput = vi.fn();
+      const onOutput = vi.fn();
+
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: { appendTaskOutput } as any,
+        executorRegistry: registry as any,
+        cwd: '/tmp',
+        callbacks: { onOutput },
+      });
+
+      const task = makeTask({ id: 'failing-start', status: 'running', config: { command: 'echo hi' } });
+      await executor.executeTask(task);
+
+      expect(onOutput).toHaveBeenCalledWith(
+        'failing-start',
+        expect.stringContaining('Executor startup failed (ssh): spawn failed before handle'),
+      );
+      expect(appendTaskOutput).toHaveBeenCalledWith(
+        'failing-start',
+        expect.stringContaining('[Startup Failure Diagnostic]'),
+      );
+      const output = appendTaskOutput.mock.calls[0]?.[1] as string;
+      expect(output).toContain('executor=ssh');
+      expect(output).toContain('message=spawn failed before handle');
+      expect(output).toContain('--- startup stderr ---');
+      expect(output).toContain('missing dependency');
+      expect(output).toContain('--- startup stdout ---');
+      expect(output).toContain('remote setup stdout');
+      expect(handleWorkerResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'failed',
+          outputs: expect.objectContaining({ exitCode: 1 }),
+        }),
+      );
+    });
+
     it('startup error includes phase prefix in outputs.error', async () => {
       const handleWorkerResponse = vi.fn();
       const orchestrator = {

--- a/packages/execution-engine/src/task-runner-dispatch.ts
+++ b/packages/execution-engine/src/task-runner-dispatch.ts
@@ -17,6 +17,7 @@ import type { Executor, ExecutorHandle } from './executor.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import {
   PRE_START_HEARTBEAT_INTERVAL_MS,
+  formatStartupFailureDiagnostic,
   getExecutorStartTimeoutMs,
   isRetryableSshStartupTransportError,
   nextLeaseExpiry,
@@ -140,7 +141,7 @@ export async function dispatchExecutor(
       const startupErrorMessage = `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}\n`;
       host.callbacks.onOutput?.(task.id, startupErrorMessage);
       try {
-        host.persistence.appendTaskOutput(task.id, startupErrorMessage);
+        host.persistence.appendTaskOutput(task.id, formatStartupFailureDiagnostic(task, executor.type, err));
       } catch {
         // Preserve the original startup failure if output persistence also fails.
       }

--- a/packages/execution-engine/src/task-runner-launch-support.ts
+++ b/packages/execution-engine/src/task-runner-launch-support.ts
@@ -7,6 +7,7 @@
  */
 
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
 
 /** Keeps launch metadata fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). */
 export const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -18,7 +19,46 @@ export type StartupFailureMetadata = {
   branch?: string;
   agentSessionId?: string;
   containerId?: string;
+  stdout?: unknown;
+  stderr?: unknown;
 };
+
+const STARTUP_DIAGNOSTIC_DETAIL_CHARS = 4_000;
+
+function truncateStartupDiagnosticValue(value: string): string {
+  if (value.length <= STARTUP_DIAGNOSTIC_DETAIL_CHARS) return value;
+  return `...${value.slice(value.length - STARTUP_DIAGNOSTIC_DETAIL_CHARS)}`;
+}
+
+function stringifyStartupDiagnosticValue(value: unknown): string {
+  if (value === undefined || value === null) return '';
+  return Buffer.isBuffer(value) ? value.toString('utf8') : String(value);
+}
+
+export function formatStartupFailureDiagnostic(
+  task: TaskState,
+  executorType: string,
+  err: unknown,
+): string {
+  const meta = err as StartupFailureMetadata;
+  const message = err instanceof Error ? err.message : String(err);
+  const stderr = stringifyStartupDiagnosticValue(meta.stderr);
+  const stdout = stringifyStartupDiagnosticValue(meta.stdout);
+  const parts = [
+    '\n[Startup Failure Diagnostic]',
+    `status=${task.status}`,
+    `executor=${executorType}`,
+    `message=${message}`,
+  ];
+  if (stderr) {
+    parts.push(`--- startup stderr ---\n${truncateStartupDiagnosticValue(stderr)}`);
+  }
+  if (stdout) {
+    parts.push(`--- startup stdout ---\n${truncateStartupDiagnosticValue(stdout)}`);
+  }
+  parts.push('--- end startup failure diagnostic ---\n');
+  return parts.join('\n');
+}
 
 export function nextLeaseExpiry(from: Date): Date {
   return new Date(from.getTime() + ATTEMPT_LEASE_MS);


### PR DESCRIPTION
## Summary

When a task fails before the executor starts, its output now keeps the real setup details.

The bug hid useful stderr and stdout behind a short startup error. Older diagnostic rows could also disappear when newer spool output existed.

The fix writes a durable startup diagnostic block and reads back legacy diagnostic rows without bringing back old stream rows.

<details>
<summary>Review metadata</summary>

Review Claim: Task output keeps concrete startup failure details from both current and older storage paths.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The spool remains the stream source. Extra text is added for diagnostic text, not old stream output.

Slice Rationale: The closed PR included work master already has. This branch keeps the remaining failure-output change.

</details>

## Non-goals

No shutdown flow changes.

No forced-stop state changes.

No output cleanup changes.

## Architecture

### Before

Live startup errors wrote the short failure line to callbacks and durable output. Older diagnostic rows could be hidden when spool output existed.

### After

Live callbacks still get the short failure line. Durable output gets a diagnostic block with stderr and stdout tails.

Task output still uses spool output first. It then appends diagnostic rows from older `task_output` storage.

## Test Plan

- [x] `pnpm --filter @invoker/data-store test -- sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- task-runner.test.ts`
- [x] `pnpm --filter @invoker/data-store build`
- [x] `pnpm --filter @invoker/execution-engine build`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task output so startup/shutdown diagnostics are preserved alongside streamed output.
  * Fixed duplicate legacy stream entries from appearing in combined task logs.
  * Startup failures now include clearer diagnostic details, including standard output and error when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->