### PR TITLE
[Slack Agent Mode](1) Route mentions to agent sessions

### DIFF
--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -8,12 +8,15 @@
 import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-core';
 import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 
+
+export type ConversationMode = 'agent' | 'plan';
 // ── Conversation Types ─────────────────────────────────────
 
 export interface Conversation {
   threadTs: string;
   channelId: string;
   userId: string;
+  mode?: ConversationMode;
   extractedPlan: string | null;   // JSON-serialized PlanDefinition
   planSubmitted: boolean;
   createdAt: string;
@@ -230,7 +233,7 @@ export interface PersistenceAdapter {
   // Conversations (Slack thread-based)
   saveConversation(conversation: Conversation): void;
   loadConversation(threadTs: string): Conversation | undefined;
-  updateConversation(threadTs: string, changes: Partial<Pick<Conversation, 'extractedPlan' | 'planSubmitted' | 'updatedAt'>>): void;
+  updateConversation(threadTs: string, changes: Partial<Pick<Conversation, 'mode' | 'extractedPlan' | 'planSubmitted' | 'updatedAt'>>): void;
   deleteConversation(threadTs: string): void;
 
   // Conversation queries

--- a/packages/data-store/src/conversation-repository.ts
+++ b/packages/data-store/src/conversation-repository.ts
@@ -7,7 +7,7 @@
  */
 
 import type { PlanDefinition } from '@invoker/workflow-core';
-import type { PersistenceAdapter, Conversation, ConversationMessage } from './adapter.js';
+import type { PersistenceAdapter, Conversation, ConversationMessage, ConversationMode } from './adapter.js';
 
 // ── Public Types ─────────────────────────────────────────────
 
@@ -15,6 +15,7 @@ export interface ConversationEntry {
   threadTs: string;
   channelId: string;
   userId: string;
+  mode: ConversationMode;
   messages: ConversationMessageEntry[];
   extractedPlan: PlanDefinition | null;
   planSubmitted: boolean;
@@ -63,6 +64,7 @@ export class ConversationRepository {
     planSubmitted?: boolean,
     channelId?: string,
     userId?: string,
+    mode?: ConversationMode,
   ): void {
     const now = new Date().toISOString();
 
@@ -72,6 +74,7 @@ export class ConversationRepository {
 
     if (existing) {
       this.adapter.updateConversation(threadTs, {
+        mode: mode ?? existing.mode ?? 'plan',
         extractedPlan: planJson ?? existing.extractedPlan,
         planSubmitted: planSubmitted ?? existing.planSubmitted,
         updatedAt: now,
@@ -81,6 +84,7 @@ export class ConversationRepository {
         threadTs,
         channelId: channelId ?? '',
         userId: userId ?? '',
+        mode: mode ?? 'plan',
         extractedPlan: planJson,
         planSubmitted: planSubmitted ?? false,
         createdAt: now,
@@ -118,6 +122,7 @@ export class ConversationRepository {
       threadTs: conv.threadTs,
       channelId: conv.channelId,
       userId: conv.userId,
+      mode: conv.mode ?? 'plan',
       messages: rawMessages.map((m) => ({
         role: m.role,
         content: this.parseJson(m.content, `message seq=${m.seq} in ${threadTs}`),
@@ -147,6 +152,7 @@ export class ConversationRepository {
       threadTs: conv.threadTs,
       channelId: conv.channelId,
       userId: conv.userId,
+      mode: conv.mode ?? 'plan',
       extractedPlan: this.parsePlan(conv.extractedPlan),
       planSubmitted: conv.planSubmitted,
       createdAt: conv.createdAt,

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -8,10 +8,8 @@
 import {
   appendFileSync,
   closeSync,
-  copyFileSync,
   existsSync,
   mkdirSync,
-  mkdtempSync,
   openSync,
   readFileSync,
   readSync,
@@ -389,15 +387,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private readonly activityLogMaxRows: number;
   private activityLogWritesSincePrune = 0;
   private readonly exclusiveLocking: boolean;
-  private readonly readOnlySnapshotPath: string | null;
 
   /** Use SQLiteAdapter.create() instead. */
-  private constructor(
-    db: DatabaseSync,
-    dbPath: string | null,
-    options?: SQLiteAdapterOptions,
-    readOnlySnapshotPath: string | null = null,
-  ) {
+  private constructor(db: DatabaseSync, dbPath: string | null, options?: SQLiteAdapterOptions) {
     this.nativeDb = db;
     this.db = new NativeDatabaseCompat(db);
     this.dbPath = dbPath;
@@ -406,12 +398,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.outputDir = options?.outputDir ?? this.resolveOutputDir(dbPath);
     this.activityLogMaxRows = options?.activityLogMaxRows ?? DEFAULT_ACTIVITY_LOG_MAX_ROWS;
     this.exclusiveLocking = options?.exclusiveLocking === true;
-    this.readOnlySnapshotPath = readOnlySnapshotPath;
-    this.configureConnection(dbPath !== null, this.readOnly);
+    this.configureConnection(dbPath !== null);
     if (!this.readOnly) {
       this.initSchema();
       this.migrate();
     }
+  }
+
+  private normalizeConversationMode(value: unknown): Conversation['mode'] {
+    return value === 'agent' ? 'agent' : 'plan';
   }
 
   /**
@@ -457,21 +452,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
       );
     }
 
-    let readOnlySnapshotPath: string | null = null;
-    if (isFile && options?.readOnly === true) {
-      readOnlySnapshotPath = SQLiteAdapter.createReadOnlySnapshot(dbPath);
-    } else if (isFile) {
+    if (isFile) {
       mkdirSync(dirname(dbPath), { recursive: true });
     }
+
     try {
       const { DatabaseSync } = await loadNativeSqlite();
-      const openPath = readOnlySnapshotPath ?? dbPath;
-      const db = new DatabaseSync(openPath, { readOnly: options?.readOnly === true });
-      return new SQLiteAdapter(db, isFile ? dbPath : null, options, readOnlySnapshotPath);
+      const db = new DatabaseSync(dbPath, { readOnly: options?.readOnly === true });
+      return new SQLiteAdapter(db, isFile ? dbPath : null, options);
     } catch (err) {
-      if (readOnlySnapshotPath) {
-        rmSync(dirname(readOnlySnapshotPath), { recursive: true, force: true });
-      }
       if (!isFile || options?.readOnly === true || !existsSync(dbPath) || !isDatabaseCorruptionError(err)) {
         throw err;
       }
@@ -491,31 +480,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
     }
   }
 
-  private static createReadOnlySnapshot(dbPath: string): string {
-    SQLiteAdapter.assertNoWalSidecars(dbPath);
-    const snapshotDir = mkdtempSync(join(tmpdir(), 'invoker-readonly-snapshot-'));
-    const snapshotPath = join(snapshotDir, 'invoker.db');
-    try {
-      copyFileSync(dbPath, snapshotPath);
-      SQLiteAdapter.assertNoWalSidecars(dbPath);
-      return snapshotPath;
-    } catch (err) {
-      rmSync(snapshotDir, { recursive: true, force: true });
-      throw err;
-    }
-  }
-
-  private static assertNoWalSidecars(dbPath: string): void {
-    const walPath = `${dbPath}-wal`;
-    const shmPath = `${dbPath}-shm`;
-    if (existsSync(walPath) || existsSync(shmPath)) {
-      throw new Error(
-        'Read-only file open refused while WAL sidecars exist. ' +
-        'Route the query through the owner process or start a standalone owner.',
-      );
-    }
-  }
-
   private resolveOutputDir(dbPath: string | null): string {
     const invokerHome = process.env.INVOKER_DB_DIR ?? (dbPath ? dirname(dbPath) : join(homedir(), '.invoker'));
     if (!dbPath && !process.env.INVOKER_DB_DIR) {
@@ -524,10 +488,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return join(invokerHome, 'task-output');
   }
 
-  private configureConnection(fileBacked: boolean, readOnly: boolean): void {
+  private configureConnection(fileBacked: boolean): void {
     this.nativeDb.exec('PRAGMA busy_timeout = 5000');
     this.nativeDb.exec('PRAGMA foreign_keys = ON');
-    if (fileBacked && !readOnly) {
+    if (fileBacked) {
       if (this.exclusiveLocking) {
         // Heap wal-index (no -shm file). MUST precede `journal_mode = WAL`.
         this.nativeDb.exec('PRAGMA locking_mode = EXCLUSIVE');
@@ -2185,12 +2149,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   saveConversation(conversation: Conversation): void {
     this.execRun(`
-      INSERT OR REPLACE INTO conversations (thread_ts, channel_id, user_id, extracted_plan, plan_submitted, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO conversations (thread_ts, channel_id, user_id, mode, extracted_plan, plan_submitted, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       conversation.threadTs,
       conversation.channelId,
       conversation.userId,
+      conversation.mode ?? 'plan',
       conversation.extractedPlan,
       conversation.planSubmitted ? 1 : 0,
       conversation.createdAt,
@@ -2205,6 +2170,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       threadTs: row.thread_ts as string,
       channelId: row.channel_id as string,
       userId: row.user_id as string,
+      mode: this.normalizeConversationMode(row.mode),
       extractedPlan: (row.extracted_plan as string) ?? null,
       planSubmitted: row.plan_submitted === 1,
       createdAt: row.created_at as string,
@@ -2212,10 +2178,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
     };
   }
 
-  updateConversation(threadTs: string, changes: Partial<Pick<Conversation, 'extractedPlan' | 'planSubmitted' | 'updatedAt'>>): void {
+  updateConversation(threadTs: string, changes: Partial<Pick<Conversation, 'mode' | 'extractedPlan' | 'planSubmitted' | 'updatedAt'>>): void {
     const setClauses: string[] = [];
     const values: any[] = [];
 
+    if ('mode' in changes) {
+      setClauses.push('mode = ?');
+      values.push(changes.mode ?? 'plan');
+    }
     if ('extractedPlan' in changes) {
       setClauses.push('extracted_plan = ?');
       values.push(changes.extractedPlan ?? null);
@@ -2247,6 +2217,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       threadTs: row.thread_ts as string,
       channelId: row.channel_id as string,
       userId: row.user_id as string,
+      mode: this.normalizeConversationMode(row.mode),
       extractedPlan: (row.extracted_plan as string) ?? null,
       planSubmitted: row.plan_submitted === 1,
       createdAt: row.created_at as string,
@@ -2766,16 +2737,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Lifecycle ─────────────────────────────────────────
 
   close(): void {
-    try {
-      if (this.dbPath && !this.readOnly) {
-        this.checkpointWal('PASSIVE');
-      }
-      this.db.close();
-    } finally {
-      if (this.readOnlySnapshotPath) {
-        rmSync(dirname(this.readOnlySnapshotPath), { recursive: true, force: true });
-      }
+    if (this.dbPath && !this.readOnly) {
+      this.checkpointWal('PASSIVE');
     }
+    this.db.close();
   }
 
   // ── Helpers ───────────────────────────────────────────

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -121,6 +121,7 @@ export const SCHEMA_DDL = `
         thread_ts TEXT PRIMARY KEY,
         channel_id TEXT NOT NULL,
         user_id TEXT NOT NULL,
+        mode TEXT DEFAULT 'plan',
         extracted_plan TEXT,
         plan_submitted INTEGER DEFAULT 0,
         created_at TEXT DEFAULT (datetime('now')),
@@ -346,6 +347,7 @@ export const SCHEMA_DDL = `
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */
 export const COLUMN_MIGRATIONS = [
+  "ALTER TABLE conversations ADD COLUMN mode TEXT DEFAULT 'plan'",
   'ALTER TABLE tasks ADD COLUMN claude_session_id TEXT',
   'ALTER TABLE tasks ADD COLUMN workspace_path TEXT',
   'ALTER TABLE tasks ADD COLUMN container_id TEXT',

--- a/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation-persistence.test.ts
@@ -82,10 +82,11 @@ describe('PlanConversation persistence', () => {
     adapter.close();
   });
 
-  function createConversation(threadTs: string): PlanConversation {
+  function createConversation(threadTs: string, mode: 'agent' | 'plan' = 'plan'): PlanConversation {
     return new PlanConversation({
       threadTs,
       conversationRepo: repo,
+      mode,
     });
   }
 
@@ -100,6 +101,19 @@ describe('PlanConversation persistence', () => {
       const saved = repo.loadConversation('ts-1');
       expect(saved).not.toBeNull();
       expect(saved!.messages.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('persists conversation mode for recovery', async () => {
+      const conv = createConversation('ts-agent-mode', 'agent');
+      mockCursorResponse('Done locally.');
+      await conv.sendMessage('Fix the local docs');
+
+      const saved = repo.loadConversation('ts-agent-mode');
+      expect(saved?.mode).toBe('agent');
+
+      const recovered = createConversation('ts-agent-mode');
+      await recovered.init();
+      expect(recovered.conversationMode).toBe('agent');
     });
 
     it('no longer persists extractedPlan (plan is scanned on demand)', async () => {

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -659,6 +659,25 @@ describe('PlanConversation prompt construction', () => {
     expect(prompt).toContain('"manual" (default)');
     expect(prompt).toContain('"automatic"');
   });
+
+  it('agent mode refuses Invoker YAML and redirects to plan:', () => {
+    // Agent threads can never submit a plan — handleLobbySubmit rejects a submit
+    // unless conversationMode === 'plan'. So the agent prompt must not offer to
+    // draft Invoker YAML (which would be an un-submittable dead end); it must
+    // steer the user to a `plan:` thread instead.
+    const conv = new PlanConversation({ mode: 'agent' });
+    (conv as any).messages.push({ role: 'user', content: 'Make me an Invoker plan to add a REST API' });
+    const prompt = conv.buildCursorPrompt();
+
+    // Never the plan-mode system prompt in an agent thread.
+    expect(prompt).not.toContain('Invoker orchestrator');
+    // Agent mode must refuse YAML unconditionally and point at `plan:`.
+    expect(prompt).toContain('Do NOT generate Invoker YAML');
+    expect(prompt).toContain('plan:');
+    // The old loophole permitted YAML "unless the user explicitly asks" — that
+    // produced drafts Slack silently rejects on submit.
+    expect(prompt).not.toContain('unless the user explicitly asks');
+  });
 });
 
 describe('isDangerousCommand', () => {

--- a/packages/surfaces/src/__tests__/slack-surface-heartbeat.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-heartbeat.integration.test.ts
@@ -70,6 +70,7 @@ const mockPlanConversation = {
   sendMessage: mockSendMessage,
   submittedPlanText: null as any,
   planSubmitted: false,
+  conversationMode: 'plan' as const,
   init: vi.fn().mockResolvedValue(undefined),
 };
 

--- a/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-immediate-response.integration.test.ts
@@ -109,6 +109,7 @@ const mockPlanConversation = {
   getDraftedPlan: () => mockDraftedPlan,
   submittedPlanText: null as any,
   planSubmitted: false,
+  conversationMode: 'plan' as const,
   init: vi.fn().mockResolvedValue(undefined),
 };
 

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'node:events';
 import * as child_process from 'node:child_process';
-import { SlackSurface, parsePlanningRequest, parseLobbyClassification, BUILTIN_HARNESS_PRESETS, buildLobbyQuestionPrompt } from '../slack/slack-surface.js';
+import { SlackSurface, parsePlanningRequest, parseLobbyClassification, parseLocalRequest, parseThreadRequest, parseWorkflowStatusQuery, BUILTIN_HARNESS_PRESETS, buildLobbyQuestionPrompt } from '../slack/slack-surface.js';
 import { SQLiteAdapter, ConversationRepository, WorkflowChannelRepository } from '@invoker/data-store';
 import type { SurfaceCommand } from '../surface.js';
 import type { WorkflowContext } from '../slack/workflow-assistant.js';
@@ -54,6 +54,7 @@ vi.mock('../slack/plan-conversation.js', async (importOriginal) => {
         getDraftedPlan: vi.fn(() => draftedPlanForMock),
         submittedPlanText: null,
         planSubmitted: false,
+        conversationMode: config?.mode ?? 'plan',
         init: vi.fn().mockResolvedValue(undefined),
       };
     }),
@@ -124,6 +125,7 @@ describe('parsePlanningRequest', () => {
     });
   });
 
+
   it('normalizes a "plain <tool>" tag and stops at unknown tags', () => {
     expect(parsePlanningRequest('[plain codex] go', keys, 'cursor+claude')).toEqual({
       presetKey: 'codex',
@@ -158,6 +160,35 @@ describe('parsePlanningRequest', () => {
       text: 'go',
       unknownPreset: 'omp+gpt5',
     });
+  });
+});
+
+describe('parseLocalRequest', () => {
+  it('requires explicit local prefixes', () => {
+    expect(parseLocalRequest('run local: report back how many workflows are running')).toEqual({ kind: 'agent', text: 'report back how many workflows are running' });
+    expect(parseLocalRequest('exec local: pnpm test')).toEqual({ kind: 'command', text: 'pnpm test' });
+    expect(parseLocalRequest('local command: git status')).toEqual({ kind: 'command', text: 'git status' });
+    expect(parseLocalRequest('local: fix the Slack typo')).toEqual({ kind: 'change', text: 'fix the Slack typo' });
+    expect(parseLocalRequest('patch locally: update the docs')).toEqual({ kind: 'change', text: 'update the docs' });
+    expect(parseLocalRequest('fix the Slack typo')).toBeNull();
+  });
+});
+
+
+describe('parseWorkflowStatusQuery', () => {
+  it('detects workflow count and status questions without an LLM classifier', () => {
+    expect(parseWorkflowStatusQuery('report back how many workflows we are running')).toEqual({ intent: 'command', operation: 'status', target: { all: true } });
+    expect(parseWorkflowStatusQuery('what is the status of workflows')).toEqual({ intent: 'command', operation: 'status', target: { all: true } });
+    expect(parseWorkflowStatusQuery('fix the Slack workflow docs')).toBeNull();
+  });
+});
+describe('parseThreadRequest', () => {
+  it('defaults to a normal agent thread and requires an explicit plan prefix for Invoker YAML', () => {
+    expect(parseThreadRequest('fix the Slack routing bug')).toEqual({ mode: 'agent', text: 'fix the Slack routing bug' });
+    expect(parseThreadRequest('local: fix the Slack routing bug')).toEqual({ mode: 'agent', text: 'fix the Slack routing bug' });
+    expect(parseThreadRequest('run local: report back how many workflows are running')).toEqual({ mode: 'agent', text: 'report back how many workflows are running' });
+    expect(parseThreadRequest('plan: fix the Slack routing bug')).toEqual({ mode: 'plan', text: 'fix the Slack routing bug' });
+    expect(parseThreadRequest('draft an Invoker plan: fix the Slack routing bug')).toEqual({ mode: 'plan', text: 'fix the Slack routing bug' });
   });
 });
 
@@ -640,37 +671,92 @@ describe('lobby verb routing', () => {
     expect(say).not.toHaveBeenCalledWith(expect.objectContaining({ text: 'Processing your request...' }));
   });
 
-  it('answers a question with no session, workflow, or start_plan', async () => {
-    mockSpawn
-      .mockImplementationOnce(() => mockProcess('{"intent":"question","operation":"none","target":"none"}'))
-      .mockImplementationOnce(() => mockProcess('There are 3 workflows running.'));
+  it('answers a workflow count question with deterministic status', async () => {
+    runWorkflowOp.mockResolvedValue({ ok: true, summary: '`wf-1`: 3 running, 0 pending, 0 done, 0 failed' });
     const surface = lobbySurface();
     await surface.start(async (cmd) => { received.push(cmd); });
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> how many workflows are running?', ts: 't1', user: 'U1' }, say });
-    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('3 workflows running') }));
+    expect(runWorkflowOp.mock.calls[0][0]).toEqual({ operation: 'status', target: { all: true } });
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('3 running') }));
     expect(planConversationConfigs).toHaveLength(0);
-    expect(runWorkflowOp).not.toHaveBeenCalled();
+    expect(mockSpawn).not.toHaveBeenCalled();
     expect(received).toHaveLength(0);
   });
 
-  it('routes a build request to a planning conversation without classifying', async () => {
+  it('routes a build request to a normal agent thread without classifying', async () => {
     const surface = lobbySurface();
     await surface.start(async () => {});
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> add a /health endpoint', ts: 't1', user: 'U1' }, say });
     expect(planConversationConfigs).toHaveLength(1);
+    expect(planConversationConfigs[0].mode).toBe('agent');
     expect(mockSpawn).not.toHaveBeenCalled();
     expect(runWorkflowOp).not.toHaveBeenCalled();
   });
 
+  it('routes an explicit plan request to an Invoker plan thread', async () => {
+    const surface = lobbySurface();
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> plan: add a /health endpoint', ts: 't1', user: 'U1' }, say });
+    expect(planConversationConfigs).toHaveLength(1);
+    expect(planConversationConfigs[0].mode).toBe('plan');
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+  });
+
+
+  it('runs an explicit shell command without creating a plan conversation', async () => {
+    mockSpawn.mockImplementationOnce(() => mockProcess('ok'));
+    const surface = lobbySurface();
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> exec local: pnpm test -- --run', ts: 't1', user: 'U1' }, say });
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      '/bin/bash',
+      ['-lc', 'pnpm test -- --run'],
+      expect.objectContaining({ cwd: expect.any(String) }),
+    );
+    expect(planConversationConfigs).toHaveLength(0);
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+    expect(received).toHaveLength(0);
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Local command finished: exit 0') }));
+  });
+
+  it('routes run local workflow-count questions to deterministic status', async () => {
+    runWorkflowOp.mockResolvedValue({ ok: true, summary: '`wf-1`: 1 running, 0 pending, 2 done, 0 failed' });
+    const surface = lobbySurface();
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> run local: report back how many workflows we are running', ts: 't1', user: 'U1' }, say });
+
+    expect(runWorkflowOp.mock.calls[0][0]).toEqual({ operation: 'status', target: { all: true } });
+    expect(planConversationConfigs).toHaveLength(0);
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(received).toHaveLength(0);
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('running') }));
+  });
+
+  it('routes an explicit local change into a recoverable agent thread', async () => {
+    const surface = lobbySurface();
+    await surface.start(async (cmd) => { received.push(cmd); });
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> local: fix the Slack routing bug', ts: 't1', user: 'U1' }, say });
+
+    expect(planConversationConfigs).toHaveLength(1);
+    expect(planConversationConfigs[0].mode).toBe('agent');
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(runWorkflowOp).not.toHaveBeenCalled();
+    expect(received).toHaveLength(0);
+  });
   it('submit with no drafted plan asks the user to describe one', async () => {
     const surface = lobbySurface();
     await surface.start(async () => {});
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> submit', ts: 't1', user: 'U1' }, say });
     expect(received).toHaveLength(0);
-    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('No planning conversation') }));
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('No Invoker plan draft') }));
   });
 
   it('submit shows a short plain-English plan summary and emits start_plan on confirmation', async () => {
@@ -678,7 +764,7 @@ describe('lobby verb routing', () => {
     await surface.start(async (cmd) => { received.push(cmd); });
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     // Open a planning conversation in the thread, then arm its drafted plan.
-    await mentionHandler(surface)({ event: { text: '<@BOT> add a /health endpoint', ts: 't1', user: 'U1' }, say });
+    await mentionHandler(surface)({ event: { text: '<@BOT> plan: add a /health endpoint', ts: 't1', user: 'U1' }, say });
     draftedPlanForMock = `
 name: "Health API rollout with several detailed implementation tasks"
 tasks:

--- a/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface-workflows.test.ts
@@ -708,7 +708,7 @@ describe('lobby verb routing', () => {
 
   it('runs an explicit shell command without creating a plan conversation', async () => {
     mockSpawn.mockImplementationOnce(() => mockProcess('ok'));
-    const surface = lobbySurface();
+    const surface = lobbySurface(true, { adminUserIds: ['U1'] });
     await surface.start(async (cmd) => { received.push(cmd); });
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> exec local: pnpm test -- --run', ts: 't1', user: 'U1' }, say });
@@ -807,5 +807,76 @@ tasks:
     const say = vi.fn().mockResolvedValue({ ts: 'a' });
     await mentionHandler(surface)({ event: { text: '<@BOT> status', ts: 't1', user: 'U1' }, say });
     expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('not available') }));
+  });
+});
+
+// ── Local shell command safety (CodeRabbit PR #3028) ─────────
+
+describe('local shell command safety', () => {
+  beforeEach(() => {
+    planConversationConfigs.length = 0;
+    mockSpawn.mockReset();
+  });
+
+  it('refuses `exec local:` from a non-admin user (no shell spawn)', async () => {
+    const surface = new SlackSurface({ ...baseConfig(), adminUserIds: ['U_ADMIN'] });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> exec local: cat /etc/passwd', ts: 't1', user: 'U_ATTACKER' }, say });
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Permission denied') }));
+  });
+
+  it('refuses `exec local:` when no admins are configured', async () => {
+    const surface = new SlackSurface({ ...baseConfig() });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> exec local: rm -rf /', ts: 't1', user: 'U1' }, say });
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(say).toHaveBeenCalledWith(expect.objectContaining({ text: expect.stringContaining('Permission denied') }));
+  });
+
+  it('runs `[repo:foo] exec local:` in the resolved repo checkout, not the default dir', async () => {
+    mockSpawn.mockImplementationOnce(() => mockProcess('ok'));
+    const prepareRepoCheckout = vi.fn().mockResolvedValue('/checkouts/foo');
+    const surface = new SlackSurface({
+      ...baseConfig(),
+      adminUserIds: ['U1'],
+      workingDir: '/default/dir',
+      prepareRepoCheckout,
+      repoAliases: { foo: 'git@github.com:me/foo.git' },
+    });
+    await surface.start(async () => {});
+    const say = vi.fn().mockResolvedValue({ ts: 'a' });
+    await mentionHandler(surface)({ event: { text: '<@BOT> [repo:foo] exec local: pnpm test', ts: 't1', user: 'U1' }, say });
+
+    expect(prepareRepoCheckout).toHaveBeenCalledWith('git@github.com:me/foo.git');
+    expect(mockSpawn).toHaveBeenCalledWith(
+      '/bin/bash',
+      ['-lc', 'pnpm test'],
+      expect.objectContaining({ cwd: '/checkouts/foo' }),
+    );
+  });
+
+  it('caps captured stdout while streaming, before formatting', async () => {
+    const surface = new SlackSurface({ ...baseConfig(), adminUserIds: ['U1'] });
+    const proc = new EventEmitter() as any;
+    proc.stdout = new EventEmitter();
+    proc.stderr = new EventEmitter();
+    proc.kill = vi.fn();
+    mockSpawn.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        const chunk = 'x'.repeat(100_000);
+        for (let i = 0; i < 20; i++) proc.stdout.emit('data', Buffer.from(chunk)); // 2,000,000 chars emitted
+        proc.emit('close', 0);
+      });
+      return proc;
+    });
+
+    const result = await (surface as any).runLocalCommand('noisy');
+    // The fix bounds retained output; the buggy version keeps all 2,000,000 chars.
+    expect(result.stdout.length).toBeLessThan(200_000);
   });
 });

--- a/packages/surfaces/src/__tests__/slack-surface.test.ts
+++ b/packages/surfaces/src/__tests__/slack-surface.test.ts
@@ -53,6 +53,7 @@ const mockPlanConversation = {
   getDraftedPlan: () => mockDraftedPlan,
   submittedPlanText: null as any,
   planSubmitted: false,
+  conversationMode: 'plan' as const,
 };
 
 vi.mock('../slack/plan-conversation.js', async (importOriginal) => ({
@@ -517,9 +518,9 @@ describe('SlackSurface', () => {
       const mentionHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'app_mention')?.handler;
       const messageHandler = app._eventHandlers.find((h: MockHandler) => h.pattern === 'message')?.handler;
 
-      // Build request → a planning conversation in the thread; nothing submitted.
+      // Explicit plan request → a planning conversation in the thread; nothing submitted.
       const say1 = vi.fn().mockResolvedValue({ ts: '1111.001' });
-      await mentionHandler({ event: { text: '<@U_BOT> build me a REST API', ts: '1111', thread_ts: undefined }, say: say1 });
+      await mentionHandler({ event: { text: '<@U_BOT> plan: build me a REST API', ts: '1111', thread_ts: undefined }, say: say1 });
       expect(receivedCommands).toHaveLength(0);
 
       // Explicit submit → plain-English summary + confirmation, still no start_plan.

--- a/packages/surfaces/src/__tests__/slack-thread-isolation.test.ts
+++ b/packages/surfaces/src/__tests__/slack-thread-isolation.test.ts
@@ -56,6 +56,7 @@ vi.mock('../slack/plan-conversation.js', async (importOriginal) => ({
       submittedPlanText: null as any,
       getDraftedPlan: () => instance.submittedPlanText,
       planSubmitted: false,
+      conversationMode: config?.mode ?? 'plan',
       init: vi.fn().mockResolvedValue(undefined),
       sendMessage: vi.fn().mockImplementation(async (text: string) => {
         instance._messages.push({ role: 'user', content: text });
@@ -320,7 +321,7 @@ describe('Slack thread isolation', () => {
       const say = vi.fn();
 
       await mentionHandler({
-        event: { text: '<@U_BOT> build something', ts: 'thread-submit', thread_ts: undefined, user: 'U1' },
+        event: { text: '<@U_BOT> plan: build something', ts: 'thread-submit', thread_ts: undefined, user: 'U1' },
         say,
       });
 
@@ -617,9 +618,9 @@ Want me to execute this?`;
     const messageHandler = getMessageHandler(surface);
     const say = vi.fn();
 
-    // Step 1: User @mentions with a request → planning conversation.
+    // Step 1: User explicitly asks for an Invoker plan.
     await mentionHandler({
-      event: { text: '<@U_BOT> build a REST API', ts: 'thread-e2e', thread_ts: undefined, user: 'U1' },
+      event: { text: '<@U_BOT> plan: build a REST API', ts: 'thread-e2e', thread_ts: undefined, user: 'U1' },
       say,
     });
     const conv = conversationInstances.get('thread-e2e');

--- a/packages/surfaces/src/__tests__/thread-session-manager.test.ts
+++ b/packages/surfaces/src/__tests__/thread-session-manager.test.ts
@@ -210,6 +210,7 @@ describe('SessionManager', () => {
       false,
       'C123',
       'U001',
+      'agent',
     );
   });
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -117,8 +117,8 @@ function buildAgentSystemPrompt(): string {
 Default behavior:
 - Treat the thread like an ordinary OMP/Codex coding session.
 - Answer questions, run local commands, inspect files, edit code, and run focused verification when useful.
-- Do NOT generate Invoker YAML unless the user explicitly asks for an Invoker plan in this thread.
-- Do NOT submit or start an Invoker workflow. The Slack surface handles submission only after the user runs \`submit\`.
+- Do NOT generate Invoker YAML in this thread. If the user asks for an Invoker plan, tell them to start a new plan thread with \`plan: <request>\` — plan drafts from an agent thread cannot be submitted.
+- Do NOT submit or start an Invoker workflow. Agent threads reject \`submit\`; only a \`plan:\` thread can be submitted.
 - Keep Slack replies short and concrete: changed files, verification, and any remaining risk.`;
 }
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -22,6 +22,8 @@ export interface ConversationMessage {
   content: string;
 }
 
+export type ConversationMode = 'agent' | 'plan';
+
 export type PlanningCommandBuilder = (opts: {
   tool: string;
   model?: string;
@@ -45,6 +47,8 @@ export interface PlanConversationConfig {
   tool?: string;
   /** Model to use (e.g. 'auto', 'sonnet-4'). Omit to use the CLI default. */
   model?: string;
+  /** Agent prompt mode. `agent` is a normal coding session; `plan` drafts Invoker YAML. */
+  mode?: ConversationMode;
   /** Injected builder that maps {tool, model, prompt} → CLI command + args. */
   planningCommandBuilder?: PlanningCommandBuilder;
   /** Root directory for codebase exploration. */
@@ -107,17 +111,24 @@ export function isNegation(text: string): boolean {
 
 // ── System Prompt ───────────────────────────────────────────
 
-function buildSystemPrompt(defaultBranch: string, repoUrl?: string): string {
+function buildAgentSystemPrompt(): string {
+  return `You are a normal coding agent running in a git worktree for a Slack thread.
+
+Default behavior:
+- Treat the thread like an ordinary OMP/Codex coding session.
+- Answer questions, run local commands, inspect files, edit code, and run focused verification when useful.
+- Do NOT generate Invoker YAML unless the user explicitly asks for an Invoker plan in this thread.
+- Do NOT submit or start an Invoker workflow. The Slack surface handles submission only after the user runs \`submit\`.
+- Keep Slack replies short and concrete: changed files, verification, and any remaining risk.`;
+}
+
+function buildPlanSystemPrompt(defaultBranch: string, repoUrl?: string): string {
   const repoUrlLine = repoUrl
     ? `repoUrl: "${repoUrl}"          # git clone URL for the repository`
     : `repoUrl: "git@github.com:user/repo.git"  # git clone URL for the repository`;
-  return `You are an assistant for the Invoker orchestrator. You have two modes:
+  return `You are an assistant for the Invoker orchestrator. The user explicitly requested an Invoker plan.
 
-**Direct answer mode** — For simple, self-contained requests (counting lines of code, checking versions, running a quick command, answering questions about the codebase). Explore the codebase as needed and report the result directly. Do NOT generate a YAML plan for these.
-
-**Plan mode** — For multi-step implementation tasks (adding features, fixing bugs, refactoring code). Generate a YAML task plan as described below.
-
-Use your judgment: if the request can be answered with 1-2 commands or a short explanation, use direct answer mode. If it requires coordinated changes across multiple files, use plan mode.
+Generate a YAML task plan as described below. Answer simple follow-up questions directly only when they are about the plan being drafted.
 
 A plan has this structure:
 \`\`\`yaml
@@ -163,8 +174,8 @@ Rules:
 7. Use meaningful task IDs (kebab-case).
 8. When ready, output the plan inside a \`\`\`yaml code block.
 9. Always include \`dependencies\` (even if empty array).
-10. After generating a plan, tell the user they can confirm execution by replying with "yes", "go", "execute", etc.
-11. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically when the user confirms.
+10. After generating a plan, tell the user they can submit it by replying with \`submit\`.
+11. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically after explicit Slack approval.
 12. Choose \`mergeMode\` deliberately. For reviewable implementation plans, set \`mergeMode: external_review\` so changes land through the canonical GitHub-backed review gate. Keep \`mergeMode: manual\` (the default) for verification-only plans that should not open a review, and use \`mergeMode: automatic\` only when the user explicitly wants changes merged without review.`;
 }
 
@@ -202,6 +213,7 @@ export class PlanConversation {
   private cursorCommand: string;
   private tool?: string;
   private model?: string;
+  private mode: ConversationMode;
   private planningCommandBuilder?: PlanningCommandBuilder;
   private messages: ConversationMessage[] = [];
   private _submittedPlanText: string | null = null;
@@ -220,6 +232,7 @@ export class PlanConversation {
     this.cursorCommand = config.cursorCommand ?? 'agent';
     this.tool = config.tool;
     this.model = config.model;
+    this.mode = config.mode ?? 'plan';
     this.planningCommandBuilder = config.planningCommandBuilder;
     this.workingDir = config.workingDir;
     this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -263,6 +276,7 @@ export class PlanConversation {
               .join(''),
       })).filter((m) => m.content.length > 0);
       this._planSubmitted = saved.planSubmitted;
+      this.mode = saved.mode ?? this.mode;
 
       this.log('plan-conversation', 'info', `Restored conversation ${this.threadTs}: ${saved.messages.length} messages`);
     } catch (err) {
@@ -311,6 +325,10 @@ export class PlanConversation {
     return this._planSubmitted;
   }
 
+  get conversationMode(): ConversationMode {
+    return this.mode;
+  }
+
   /** Returns the last complete YAML plan drafted in this conversation, or null. */
   getDraftedPlan(): string | null {
     return this.extractLastPlanFromMessages();
@@ -338,7 +356,9 @@ export class PlanConversation {
    * and the complete conversation history.
    */
   buildCursorPrompt(): string {
-    const systemPrompt = buildSystemPrompt(this.defaultBranch ?? 'main', this.repoUrl);
+    const systemPrompt = this.mode === 'plan'
+      ? buildPlanSystemPrompt(this.defaultBranch ?? 'main', this.repoUrl)
+      : buildAgentSystemPrompt();
     const parts: string[] = [systemPrompt];
 
     if (this.messages.length > 1) {
@@ -353,7 +373,9 @@ export class PlanConversation {
     const lastMessage = this.messages[this.messages.length - 1];
     if (lastMessage) {
       parts.push(`\nUser's latest message:\n${lastMessage.content}`);
-      parts.push('\nRespond to the latest message. If it requires a plan, explore the codebase and generate one.');
+      parts.push(this.mode === 'plan'
+        ? '\nRespond to the latest message. If it requires a plan, explore the codebase and generate one.'
+        : '\nRespond to the latest message as a normal coding agent in this worktree.');
     }
 
     if (this.experimentalPlanner) {
@@ -449,12 +471,14 @@ export class PlanConversation {
         role: m.role,
         content: m.content,
       }));
-
       this.conversationRepo.saveConversation(
         this.threadTs,
         messages,
         null,
         this._planSubmitted,
+        undefined,
+        undefined,
+        this.mode,
       );
     } catch (err) {
       this.log('plan-conversation', 'error', `Failed to save conversation ${this.threadTs}: ${err}`);

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -14,7 +14,7 @@ import { formatSurfaceEvent, formatWorkflowStatus } from './slack-formatter.js';
 import { splitForSlack, sanitizeSlashCommands } from './slack-message-helpers.js';
 import type { SlackMessage } from './slack-formatter.js';
 import { PlanConversation, defaultPlanningCommand, isConfirmation, isNegation } from './plan-conversation.js';
-import type { PlanningCommandBuilder } from './plan-conversation.js';
+import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
 import { parseLobbyControl } from './lobby-control.js';
 import type { LobbyControl } from './lobby-control.js';
 import { summarizePlanText } from './plan-summary.js';
@@ -119,6 +119,15 @@ interface PlanningContext {
   lobbyChannel?: string;
 }
 
+export type LocalRequest =
+  | { kind: 'command'; text: string }
+  | { kind: 'agent'; text: string }
+  | { kind: 'change'; text: string };
+
+export type ThreadRequest =
+  | { mode: 'agent'; text: string }
+  | { mode: 'plan'; text: string };
+
 // ── Planning request parsing ─────────────────────────────────
 
 const PRESET_TOOL_HINTS = ['cursor', 'omp', 'codex', 'claude'];
@@ -134,7 +143,7 @@ export function parsePlanningRequest(
   presetKeys: string[],
   defaultPresetKey: string,
 ): { presetKey: string; repo?: string; text: string; unknownPreset?: string } {
-  let rest = text.replace(/<@[A-Z0-9]+>/g, '').trim();
+  let rest = text.replace(/<@[^>]+>/g, '').trim();
   let presetKey = defaultPresetKey;
   let repo: string | undefined;
   let unknownPreset: string | undefined;
@@ -244,9 +253,82 @@ export function parseLobbyClassification(raw: string): LobbyClassification {
 
 const OPERATIONAL_HINT = /\b(recreate|rebase|retry|retries|cancel|status|workflows?)\b/i;
 
+export function parseWorkflowStatusQuery(text: string): LobbyClassification | null {
+  const trimmed = text.trim();
+  if (!/\bworkflows?\b/i.test(trimmed)) return null;
+  if (!/\b(status|how many|count|running|active|in progress|progress)\b/i.test(trimmed)) return null;
+  return { intent: 'command', operation: 'status', target: { all: true } };
+}
+
 /** Cheap pre-filter: does a non-verb message look operational enough to spend an LLM classify? */
 export function looksOperational(text: string): boolean {
   return OPERATIONAL_HINT.test(text);
+}
+
+/** Explicit local-mode prefixes. `run local:` means “use the local agent”; `exec local:` means raw shell. */
+export function parseLocalRequest(text: string): LocalRequest | null {
+  const trimmed = text.trim();
+  const commandPatterns = [
+    /^(?:exec|execute)\s+local(?:ly)?\s*:\s*/i,
+    /^local\s+(?:command|cmd)\s*:\s*/i,
+  ];
+  for (const pattern of commandPatterns) {
+    const match = pattern.exec(trimmed);
+    if (match) {
+      const rest = trimmed.slice(match[0].length).trim();
+      return rest ? { kind: 'command', text: rest } : null;
+    }
+  }
+
+  const agentPatterns = [
+    /^run\s+local(?:ly)?\s*:\s*/i,
+    /^local\s+run\s*:\s*/i,
+  ];
+  for (const pattern of agentPatterns) {
+    const match = pattern.exec(trimmed);
+    if (match) {
+      const rest = trimmed.slice(match[0].length).trim();
+      return rest ? { kind: 'agent', text: rest } : null;
+    }
+  }
+
+  const changePatterns = [
+    /^local\s*:\s*/i,
+    /^local\s+(?:change|edit|patch)\s*:\s*/i,
+    /^(?:change|edit|patch)\s+local(?:ly)?\s*:\s*/i,
+    /^locally\s*:\s*/i,
+  ];
+  for (const pattern of changePatterns) {
+    const match = pattern.exec(trimmed);
+    if (match) {
+      const rest = trimmed.slice(match[0].length).trim();
+      return rest ? { kind: 'change', text: rest } : null;
+    }
+  }
+
+  return null;
+}
+
+export function parseThreadRequest(text: string): ThreadRequest | null {
+  const trimmed = text.trim();
+  const planPatterns = [
+    /^(?:invoker\s+)?plan\s*:\s*/i,
+    /^draft\s+(?:an?\s+)?invoker\s+plan\s*:\s*/i,
+  ];
+  for (const pattern of planPatterns) {
+    const match = pattern.exec(trimmed);
+    if (match) {
+      const rest = trimmed.slice(match[0].length).trim();
+      return rest ? { mode: 'plan', text: rest } : null;
+    }
+  }
+
+  const localRequest = parseLocalRequest(trimmed);
+  if (localRequest?.kind === 'agent' || localRequest?.kind === 'change') {
+    return { mode: 'agent', text: localRequest.text };
+  }
+
+  return trimmed ? { mode: 'agent', text: trimmed } : null;
 }
 
 // ── ConversationLike ─────────────────────────────────────────
@@ -255,6 +337,7 @@ export function looksOperational(text: string): boolean {
 interface ConversationLike {
   sendMessage(message: string): Promise<string>;
   getDraftedPlan(): string | null;
+  readonly conversationMode: ConversationMode;
   readonly planSubmitted: boolean;
   readonly submittedPlanText: string | null;
 }
@@ -673,7 +756,7 @@ export class SlackSurface implements Surface {
     // Confirm/cancel a staged action first (plain yes/no in-thread).
     if (await this.resolveConfirm(threadTs, parsed.text, say, channel)) return;
 
-    // Deterministic verb commands respond instantly and take priority over the planner.
+    // Deterministic verb commands respond instantly and take priority over agent sessions.
     const ctrl = parseLobbyControl(parsed.text);
     if (ctrl?.kind === 'op') {
       await this.handleLobbyOp(ctrl, threadTs, channel, say);
@@ -688,12 +771,25 @@ export class SlackSurface implements Surface {
       return;
     }
 
-    // Slower paths (LLM classifier, repo checkout, planner) acknowledge receipt up front.
+    const localRequest = parseLocalRequest(parsed.text);
+    if (localRequest?.kind === 'command') {
+      await this.handleLocalRequest(localRequest, preset, threadTs, say, channel);
+      return;
+    }
+
+    const workflowStatusQuery = parseWorkflowStatusQuery(localRequest?.kind === 'agent' ? localRequest.text : parsed.text);
+    if (workflowStatusQuery?.intent === 'command') {
+      await this.handleLobbyOp({ kind: 'op', operation: workflowStatusQuery.operation, target: workflowStatusQuery.target }, threadTs, channel, say);
+      return;
+    }
+
+    const explicitLocalAgent = localRequest?.kind === 'agent' || localRequest?.kind === 'change';
+
+    // Slower paths (LLM classifier, repo checkout, agent) acknowledge receipt up front.
     if (this.enableImmediateAck) await this.sendImmediateAck(threadTs, say);
 
-
     // Fallback classifier: only when a non-verb message looks operational.
-    if (looksOperational(parsed.text)) {
+    if (!explicitLocalAgent && looksOperational(parsed.text)) {
       const cls = await this.classifyLobbyIntent(parsed.text, preset);
       this.log('slack', 'info', `[CLASSIFY] thread_ts=${threadTs} intent=${cls.intent}`);
       if (cls.intent === 'command') {
@@ -709,8 +805,10 @@ export class SlackSurface implements Surface {
       // invalid-command / plan → fall through to a planning conversation.
     }
 
-    // Default: a plain planning conversation (drafts a plan, never auto-submits).
+    const threadRequest = parseThreadRequest(parsed.text);
+    if (!threadRequest) return;
 
+    // Default: a normal agent conversation. `plan:` opts into an Invoker YAML draft.
     let workingDir = this.workingDir;
     if (repoUrl && this.prepareRepoCheckout) {
       try {
@@ -726,20 +824,23 @@ export class SlackSurface implements Surface {
       tool: preset.tool,
       model: preset.model,
       workingDir,
+      mode: threadRequest.mode,
     });
     if (!conversation) {
       await say({ text: 'Too many active conversations. Please wait.', thread_ts: threadTs });
       return;
     }
 
-    this.planningContexts.set(threadTs, {
-      repoUrl,
-      presetKey: parsed.presetKey,
-      requestedBy: event.user,
-      lobbyChannel: channel,
-    });
+    if (threadRequest.mode === 'plan') {
+      this.planningContexts.set(threadTs, {
+        repoUrl,
+        presetKey: parsed.presetKey,
+        requestedBy: event.user,
+        lobbyChannel: channel,
+      });
+    }
 
-    await this.handleConversationMessage(conversation, parsed.text, threadTs, say, channel);
+    await this.handleConversationMessage(conversation, threadRequest.text, threadTs, say, channel);
   }
 
   /** Post the immediate "received it" acknowledgment and track it for in-place replacement. */
@@ -862,13 +963,13 @@ export class SlackSurface implements Surface {
   /** Submit the plan drafted in this thread, after an explicit, summarized confirmation. */
   private async handleLobbySubmit(channel: string, threadTs: string, userId: string, say: SayFn): Promise<void> {
     const conversation = await this.getSession(channel, threadTs, userId, false);
-    if (!conversation) {
-      await say({ text: "No planning conversation here yet. Tell me what you want to build and I'll draft a plan.", thread_ts: threadTs });
+    if (!conversation || conversation.conversationMode !== 'plan') {
+      await say({ text: "No Invoker plan draft here yet. Start one with `@Invoker plan: ...`, then run `submit`.", thread_ts: threadTs });
       return;
     }
     const planText = conversation.getDraftedPlan();
     if (!planText) {
-      await say({ text: "I don't see a complete plan drafted yet — describe what you want and I'll put one together.", thread_ts: threadTs });
+      await say({ text: "I don't see a complete plan drafted yet — use `plan:` to ask for an Invoker plan, then submit again.", thread_ts: threadTs });
       return;
     }
     const summary = summarizePlanText(planText);
@@ -1092,6 +1193,110 @@ export class SlackSurface implements Surface {
         thread_ts: threadTs,
       });
     }
+  }
+
+  private async handleLocalRequest(
+    request: LocalRequest,
+    harness: HarnessPreset,
+    threadTs: string,
+    say: SayFn,
+    channel: string,
+  ): Promise<void> {
+    if (request.kind === 'command') {
+      await say({ text: `Running locally on DO1: \`${truncateWords(request.text, 12)}\``, thread_ts: threadTs });
+      try {
+        const result = await this.runLocalCommand(request.text);
+        const reply = this.formatLocalCommandResult(result);
+        const chunks = splitForSlack(sanitizeSlashCommands(reply));
+        for (let i = 0; i < chunks.length; i++) {
+          if (i > 0) await this.sleep(this.messagePacingMs);
+          await this.sayWithRateLimitRetry(say, { text: chunks[i], thread_ts: threadTs });
+        }
+      } catch (err) {
+        await this.sayWithRateLimitRetry(say, {
+          text: `Local command failed to start: ${err instanceof Error ? err.message : String(err)}`,
+          thread_ts: threadTs,
+        });
+      }
+      return;
+    }
+
+    await say({ text: 'Making that local change on DO1. I will not create or submit an Invoker plan.', thread_ts: threadTs });
+    try {
+      const reply = await this.runOneShotPlanner(harness, this.buildLocalChangePrompt(request.text));
+      const chunks = splitForSlack(sanitizeSlashCommands(reply));
+      for (let i = 0; i < chunks.length; i++) {
+        if (i > 0) await this.sleep(this.messagePacingMs);
+        await this.sayWithRateLimitRetry(say, { text: chunks[i], thread_ts: threadTs });
+      }
+    } catch (err) {
+      await this.sayWithRateLimitRetry(say, {
+        text: `Local change failed: ${err instanceof Error ? err.message : String(err)}`,
+        thread_ts: threadTs,
+      });
+    }
+  }
+
+  private buildLocalChangePrompt(text: string): string {
+    const cwd = this.workingDir ?? process.cwd();
+    return `Make this request directly in the local checkout on DO1.
+
+Working directory: ${cwd}
+
+Rules:
+- Do NOT generate Invoker YAML.
+- Do NOT create, submit, start, or mention an Invoker workflow.
+- Edit files only when the request needs a local change.
+- Run the focused command or test that verifies the local change when practical.
+- Reply with changed files, verification, and any remaining risk in short Slack prose.
+
+Request:
+${text}`;
+  }
+
+  private runLocalCommand(commandText: string): Promise<{ code: number | null; stdout: string; stderr: string; timedOut: boolean }> {
+    const timeoutMs = (this.planningTimeoutSeconds ?? 7_200) * 1_000;
+    return new Promise((resolve, reject) => {
+      const child = spawn('/bin/bash', ['-lc', commandText], {
+        cwd: this.workingDir ?? process.cwd(),
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: { ...process.env },
+      });
+      let stdout = '';
+      let stderr = '';
+      let settled = false;
+      child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+      child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+      const timer = setTimeout(() => {
+        settled = true;
+        try { child.kill('SIGTERM'); } catch { /* already dead */ }
+        resolve({ code: null, stdout, stderr, timedOut: true });
+      }, timeoutMs);
+      child.on('close', (code) => {
+        if (settled) return;
+        clearTimeout(timer);
+        resolve({ code, stdout, stderr, timedOut: false });
+      });
+      child.on('error', (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+  }
+
+  private formatLocalCommandResult(result: { code: number | null; stdout: string; stderr: string; timedOut: boolean }): string {
+    const status = result.timedOut ? 'timed out' : `exit ${result.code ?? 'unknown'}`;
+    const output = [result.stdout.trim(), result.stderr.trim()].filter(Boolean).join('\n\n');
+    const safeOutput = output.replace(/```/g, '`\u200b``');
+    const maxChars = 12_000;
+    const body = safeOutput.length > maxChars
+      ? `[showing last ${maxChars} chars]\n${safeOutput.slice(-maxChars)}`
+      : safeOutput;
+    return body
+      ? `Local command finished: ${status}\n\`\`\`\n${body}\n\`\`\``
+      : `Local command finished: ${status}`;
   }
 
   private resolveHarnessPreset(presetKey: string): HarnessPreset {
@@ -1320,6 +1525,13 @@ export class SlackSurface implements Surface {
 
       const text = (msg.text ?? '').replace(/<@[A-Z0-9]+>/g, '').trim();
       if (text && (await this.resolveConfirm(msg.thread_ts, text, say, channel))) return;
+
+      const localRequest = parseLocalRequest(text);
+      if (localRequest?.kind === 'command') {
+        const preset = this.resolveHarnessPreset(this.defaultHarnessPreset);
+        await this.handleLocalRequest(localRequest, preset, msg.thread_ts, say, channel);
+        return;
+      }
 
       // Look up or recover session (don't create new sessions for random thread replies in fallback mode)
       const conversation = await this.getSession(channel, msg.thread_ts, msg.user ?? 'unknown', false);
@@ -1647,7 +1859,7 @@ export class SlackSurface implements Surface {
     threadTs: string,
     userId: string,
     create = true,
-    opts?: { tool?: string; model?: string; workingDir?: string },
+    opts?: { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode },
   ): Promise<ConversationLike | null> {
     this.log('slack', 'info', `[TRACE] getSession (channelId=${channelId}, threadTs=${threadTs}, userId=${userId}, create=${create}, hasSessionManager=${!!this.sessionManager})`);
     if (this.sessionManager) {
@@ -1680,6 +1892,7 @@ export class SlackSurface implements Surface {
         cursorCommand: this.cursorCommand,
         tool: opts?.tool,
         model: opts?.model ?? this.model,
+        mode: opts?.mode ?? 'agent',
         planningCommandBuilder: this.planningCommandBuilder,
         workingDir: opts?.workingDir ?? this.workingDir,
         threadTs,
@@ -1746,6 +1959,7 @@ export class SlackSurface implements Surface {
           const conversation = new PlanConversation({
             cursorCommand: this.cursorCommand,
             model: this.model,
+            mode: entry.mode ?? 'plan',
             workingDir: this.workingDir,
             threadTs: entry.threadTs,
             conversationRepo: this.conversationRepo,

--- a/packages/surfaces/src/slack/slack-surface.ts
+++ b/packages/surfaces/src/slack/slack-surface.ts
@@ -128,6 +128,18 @@ export type ThreadRequest =
   | { mode: 'agent'; text: string }
   | { mode: 'plan'; text: string };
 
+/**
+ * Upper bound on stdout/stderr retained per stream while a local command runs.
+ * Bounds process memory against noisy commands; only the tail is kept because
+ * `formatLocalCommandResult` shows the last chars anyway.
+ */
+const MAX_LOCAL_CAPTURE_CHARS = 65_536;
+
+/** Keep only the last `max` chars of a growing buffer. */
+function capTailChars(value: string, max: number): string {
+  return value.length > max ? value.slice(-max) : value;
+}
+
 // ── Planning request parsing ─────────────────────────────────
 
 const PRESET_TOOL_HINTS = ['cursor', 'omp', 'codex', 'claude'];
@@ -773,7 +785,7 @@ export class SlackSurface implements Surface {
 
     const localRequest = parseLocalRequest(parsed.text);
     if (localRequest?.kind === 'command') {
-      await this.handleLocalRequest(localRequest, preset, threadTs, say, channel);
+      await this.handleLocalRequest(localRequest, preset, threadTs, say, channel, { userId: event.user, repoUrl });
       return;
     }
 
@@ -1201,11 +1213,20 @@ export class SlackSurface implements Surface {
     threadTs: string,
     say: SayFn,
     channel: string,
+    opts: { userId?: string; repoUrl?: string } = {},
   ): Promise<void> {
     if (request.kind === 'command') {
+      // Raw shell on the host is admin-only: this runs `/bin/bash -lc` with the
+      // full inherited environment, so anyone else must be refused before execution.
+      if (!this.isLocalCommandAuthorized(opts.userId)) {
+        await say({ text: 'Permission denied. Raw local shell commands (`exec local:`) require admin access.', thread_ts: threadTs });
+        return;
+      }
+      const dir = await this.resolveLocalWorkingDir(opts.repoUrl, threadTs, say);
+      if (!dir.ok) return;
       await say({ text: `Running locally on DO1: \`${truncateWords(request.text, 12)}\``, thread_ts: threadTs });
       try {
-        const result = await this.runLocalCommand(request.text);
+        const result = await this.runLocalCommand(request.text, dir.workingDir);
         const reply = this.formatLocalCommandResult(result);
         const chunks = splitForSlack(sanitizeSlashCommands(reply));
         for (let i = 0; i < chunks.length; i++) {
@@ -1221,9 +1242,11 @@ export class SlackSurface implements Surface {
       return;
     }
 
+    const dir = await this.resolveLocalWorkingDir(opts.repoUrl, threadTs, say);
+    if (!dir.ok) return;
     await say({ text: 'Making that local change on DO1. I will not create or submit an Invoker plan.', thread_ts: threadTs });
     try {
-      const reply = await this.runOneShotPlanner(harness, this.buildLocalChangePrompt(request.text));
+      const reply = await this.runOneShotPlanner(harness, this.buildLocalChangePrompt(request.text, dir.workingDir));
       const chunks = splitForSlack(sanitizeSlashCommands(reply));
       for (let i = 0; i < chunks.length; i++) {
         if (i > 0) await this.sleep(this.messagePacingMs);
@@ -1237,8 +1260,31 @@ export class SlackSurface implements Surface {
     }
   }
 
-  private buildLocalChangePrompt(text: string): string {
-    const cwd = this.workingDir ?? process.cwd();
+  /** Only configured admins may run raw local shell. Empty admin set = nobody. */
+  private isLocalCommandAuthorized(userId?: string): boolean {
+    return !!userId && this.adminUserIds.has(userId);
+  }
+
+  /** Resolve the working dir for a local request, honoring an explicit `[repo:…]` checkout. */
+  private async resolveLocalWorkingDir(
+    repoUrl: string | undefined,
+    threadTs: string,
+    say: SayFn,
+  ): Promise<{ ok: true; workingDir?: string } | { ok: false }> {
+    let workingDir = this.workingDir;
+    if (repoUrl && this.prepareRepoCheckout) {
+      try {
+        workingDir = await this.prepareRepoCheckout(repoUrl);
+      } catch (err) {
+        await say({ text: `Failed to check out repo: ${err instanceof Error ? err.message : String(err)}`, thread_ts: threadTs });
+        return { ok: false };
+      }
+    }
+    return { ok: true, workingDir };
+  }
+
+  private buildLocalChangePrompt(text: string, workingDir?: string): string {
+    const cwd = workingDir ?? this.workingDir ?? process.cwd();
     return `Make this request directly in the local checkout on DO1.
 
 Working directory: ${cwd}
@@ -1254,19 +1300,22 @@ Request:
 ${text}`;
   }
 
-  private runLocalCommand(commandText: string): Promise<{ code: number | null; stdout: string; stderr: string; timedOut: boolean }> {
+  private runLocalCommand(commandText: string, workingDir?: string): Promise<{ code: number | null; stdout: string; stderr: string; timedOut: boolean }> {
     const timeoutMs = (this.planningTimeoutSeconds ?? 7_200) * 1_000;
+    const cwd = workingDir ?? this.workingDir ?? process.cwd();
     return new Promise((resolve, reject) => {
       const child = spawn('/bin/bash', ['-lc', commandText], {
-        cwd: this.workingDir ?? process.cwd(),
+        cwd,
         stdio: ['ignore', 'pipe', 'pipe'],
         env: { ...process.env },
       });
       let stdout = '';
       let stderr = '';
       let settled = false;
-      child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
-      child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+      // Bound the buffers as data arrives so a noisy command cannot exhaust memory
+      // before formatting runs; only the tail is kept, which is all the reply shows.
+      child.stdout?.on('data', (chunk: Buffer) => { stdout = capTailChars(stdout + chunk.toString(), MAX_LOCAL_CAPTURE_CHARS); });
+      child.stderr?.on('data', (chunk: Buffer) => { stderr = capTailChars(stderr + chunk.toString(), MAX_LOCAL_CAPTURE_CHARS); });
       const timer = setTimeout(() => {
         settled = true;
         try { child.kill('SIGTERM'); } catch { /* already dead */ }
@@ -1529,7 +1578,7 @@ ${text}`;
       const localRequest = parseLocalRequest(text);
       if (localRequest?.kind === 'command') {
         const preset = this.resolveHarnessPreset(this.defaultHarnessPreset);
-        await this.handleLocalRequest(localRequest, preset, msg.thread_ts, say, channel);
+        await this.handleLocalRequest(localRequest, preset, msg.thread_ts, say, channel, { userId: msg.user });
         return;
       }
 

--- a/packages/surfaces/src/slack/thread-session-manager.ts
+++ b/packages/surfaces/src/slack/thread-session-manager.ts
@@ -14,7 +14,7 @@
  */
 
 import { PlanConversation } from './plan-conversation.js';
-import type { PlanningCommandBuilder } from './plan-conversation.js';
+import type { ConversationMode, PlanningCommandBuilder } from './plan-conversation.js';
 import type { ConversationRepository } from '@invoker/data-store';
 import type { LogFn } from '../surface.js';
 
@@ -65,6 +65,8 @@ export interface SessionMetadata {
   readonly userId: string;
   /** Whether the plan has been submitted (terminal state) */
   planSubmitted: boolean;
+  /** Whether this thread is a normal agent session or an Invoker plan draft. */
+  mode: ConversationMode;
 }
 
 /**
@@ -113,6 +115,10 @@ export class SessionHandle {
     return this.conversation.planSubmitted;
   }
 
+
+  get conversationMode(): ConversationMode {
+    return this.conversation.conversationMode;
+  }
   /** Returns the last complete YAML plan drafted in this conversation, or null. */
   getDraftedPlan(): string | null {
     return this.conversation.getDraftedPlan();
@@ -168,6 +174,7 @@ export interface SessionManagerConfig {
   log?: LogFn;
   timeoutMs?: number;
   planningCommandBuilder?: PlanningCommandBuilder;
+  mode?: ConversationMode;
 }
 
 export interface SessionMetrics {
@@ -205,6 +212,7 @@ export class SessionManager {
   private readonly maxActiveSessions: number;
   private readonly timeoutMs?: number;
   private readonly planningCommandBuilder?: PlanningCommandBuilder;
+  private readonly mode: ConversationMode;
 
   constructor(config: SessionManagerConfig) {
     this.cursorCommand = config.cursorCommand ?? 'agent';
@@ -219,6 +227,7 @@ export class SessionManager {
     this.maxActiveSessions = config.maxActiveSessions ?? 100;
     this.timeoutMs = config.timeoutMs;
     this.planningCommandBuilder = config.planningCommandBuilder;
+    this.mode = config.mode ?? 'agent';
   }
 
   /**
@@ -254,7 +263,7 @@ export class SessionManager {
   async getOrCreateSession(
     id: SessionIdentifier,
     userId: string,
-    opts?: { tool?: string; model?: string; workingDir?: string },
+    opts?: { tool?: string; model?: string; workingDir?: string; mode?: ConversationMode },
   ): Promise<SessionHandle | null> {
     const key = id.toString();
 
@@ -299,6 +308,7 @@ export class SessionManager {
         cursorCommand: this.cursorCommand,
         tool: opts?.tool,
         model: opts?.model ?? this.model,
+        mode: loaded.mode ?? opts?.mode ?? this.mode ?? 'plan',
         planningCommandBuilder: this.planningCommandBuilder,
         workingDir: opts?.workingDir ?? this.workingDir,
         threadTs: id.threadTs,
@@ -316,6 +326,7 @@ export class SessionManager {
         lastAccessedAt: new Date(loaded.updatedAt),
         userId: loaded.userId,
         planSubmitted: loaded.planSubmitted,
+        mode: loaded.mode ?? opts?.mode ?? this.mode ?? 'plan',
       };
 
       handle = new SessionHandle(id, metadata, conversation);
@@ -328,6 +339,7 @@ export class SessionManager {
         cursorCommand: this.cursorCommand,
         tool: opts?.tool,
         model: opts?.model ?? this.model,
+        mode: opts?.mode ?? this.mode ?? 'agent',
         planningCommandBuilder: this.planningCommandBuilder,
         workingDir: opts?.workingDir ?? this.workingDir,
         threadTs: id.threadTs,
@@ -344,6 +356,7 @@ export class SessionManager {
         lastAccessedAt: new Date(),
         userId,
         planSubmitted: false,
+        mode: opts?.mode ?? this.mode ?? 'agent',
       };
 
       handle = new SessionHandle(id, metadata, conversation);
@@ -357,6 +370,7 @@ export class SessionManager {
         false, // Not submitted
         id.channelId,
         userId,
+        opts?.mode ?? this.mode ?? 'agent',
       );
     }
 

--- a/scripts/repro/repro-coderabbit-pr3028-agent-mode-no-yaml.sh
+++ b/scripts/repro/repro-coderabbit-pr3028-agent-mode-no-yaml.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Repro: CodeRabbit PR #3028 (Functional Correctness, Major) — agent mode must not
+# offer to generate Invoker YAML. Plan threads are only created via `plan:`, and
+# `handleLobbySubmit` rejects `submit` unless conversationMode === 'plan'. The
+# agent system prompt previously allowed YAML "unless the user explicitly asks",
+# so an agent thread could draft a plan Slack silently refuses on submit — a
+# dead end. The agent prompt must refuse YAML and redirect the user to `plan:`.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] problem: agent-mode system prompt let the agent draft un-submittable Invoker YAML"
+if pnpm --filter @invoker/surfaces exec vitest run \
+  src/__tests__/plan-conversation.test.ts \
+  -t "refuses Invoker YAML" --reporter=verbose; then
+  echo "[repro] PASS: agent mode refuses Invoker YAML and redirects to plan:"
+  exit 0
+fi
+
+echo "[repro] FAIL: agent mode still offers to generate Invoker YAML (un-submittable dead end)"
+exit 1

--- a/scripts/repro/repro-coderabbit-pr3028-exec-local-authz.sh
+++ b/scripts/repro/repro-coderabbit-pr3028-exec-local-authz.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Repro: CodeRabbit PR #3028 (Security, Critical) — raw `exec local:` shell must be
+# gated behind adminUserIds. Before the fix, any Slack user who can mention the bot
+# reaches `runLocalCommand()` -> `/bin/bash -lc <text>` with the full inherited
+# environment (host RCE + secret exfiltration via echoed stdout/stderr).
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] problem: non-admin (and no-admin) users could run raw local shell via 'exec local:'"
+if pnpm --filter @invoker/surfaces exec vitest run \
+  src/__tests__/slack-surface-workflows.test.ts \
+  -t "refuses" --reporter=verbose; then
+  echo "[repro] PASS: raw 'exec local:' is refused for non-admins and when no admins are configured"
+  exit 0
+fi
+
+echo "[repro] FAIL: raw 'exec local:' still spawns /bin/bash for unauthorized users"
+exit 1

--- a/scripts/repro/repro-coderabbit-pr3028-local-output-cap.sh
+++ b/scripts/repro/repro-coderabbit-pr3028-local-output-cap.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Repro: CodeRabbit PR #3028 (Stability, Major) — cap local command output while
+# streaming, not only when formatting. Before the fix, `runLocalCommand()` concatenated
+# the full stdout/stderr in memory; `formatLocalCommandResult()` only trimmed to 12k
+# afterward, so a noisy command could exhaust the process before formatting ran.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] problem: runLocalCommand buffered unbounded stdout/stderr before formatting"
+if pnpm --filter @invoker/surfaces exec vitest run \
+  src/__tests__/slack-surface-workflows.test.ts \
+  -t "caps captured stdout" --reporter=verbose; then
+  echo "[repro] PASS: streamed stdout is bounded while the command runs"
+  exit 0
+fi
+
+echo "[repro] FAIL: streamed stdout still grows unbounded in memory"
+exit 1

--- a/scripts/repro/repro-coderabbit-pr3028-local-repo-checkout.sh
+++ b/scripts/repro/repro-coderabbit-pr3028-local-repo-checkout.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Repro: CodeRabbit PR #3028 (Data Integrity, Major) — `[repo:foo] exec local:` must
+# run inside the resolved repo checkout. Before the fix, the raw-command path returned
+# before the repo checkout prep and `runLocalCommand()` fell back to `this.workingDir`/
+# `process.cwd()`, so a repo-tagged command ran against the wrong checkout.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] problem: '[repo:foo] exec local:' ignored the resolved repo checkout"
+if pnpm --filter @invoker/surfaces exec vitest run \
+  src/__tests__/slack-surface-workflows.test.ts \
+  -t "resolved repo checkout" --reporter=verbose; then
+  echo "[repro] PASS: raw local commands run in the resolved repo checkout dir"
+  exit 0
+fi
+
+echo "[repro] FAIL: raw local command still runs against the default working dir"
+exit 1


### PR DESCRIPTION
## Summary

Slack mentions now start a normal agent thread by default. Invoker plan drafting only starts when the user says `plan:`.

`run local:` uses deterministic Invoker status for workflow count questions. Raw shell requires `exec local:` or `local cmd:` so natural language is not sent to bash.

<details>
<summary>Review metadata</summary>

Review Claim: Slack routing now separates normal agent work from explicit Invoker plan drafts, workflow status queries, and raw shell routing.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Existing saved plan conversations load as plan mode, and submit still rejects threads that are not plan drafts.

Slice Rationale: This is one Slack routing change with the small persistence field needed for safe recovery.

</details>

## Non-goals

- Does not remove approval buttons.
- Does not remove workflow channel handling.
- Does not remove raw shell support.
- Does not submit Invoker plans from normal agent threads.

## Architecture

### Before

```mermaid
graph TD
    A["Slack mention"] --> B["PlanConversation"]
    B --> C["Invoker YAML prompt"]
    C --> D["submit can enqueue plan"]
    E["run local: workflow count"] --> F["agent needs API key"]
```

### After

```mermaid
graph TD
    A["Slack mention"] --> B{"Requested mode?"}
    B -->|"plain, local:, or run local:"| C["Agent session"]
    B -->|"workflow count/status"| D["Invoker status path"]
    B -->|"plan:"| E["Invoker plan session"]
    B -->|"exec local:"| F["Raw shell path"]
    C --> G["submit rejects without plan draft"]
    E --> H["submit can enqueue plan"]
```

## Test Plan

- [x] `pnpm --filter @invoker/surfaces exec vitest run src/__tests__/plan-conversation-persistence.test.ts src/__tests__/slack-surface-workflows.test.ts src/__tests__/slack-thread-isolation.test.ts src/__tests__/thread-session-manager.test.ts src/__tests__/plan-conversation.test.ts src/__tests__/slack-surface.test.ts`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/conversation-repository.test.ts src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/data-store build && pnpm --filter @invoker/surfaces build && pnpm --filter @invoker/slack-manager build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 9ef90a254`
- Post-revert steps: Restart `slack-manager.service` after deploy.
- Data migration? Yes. Reverting stops reading the optional `conversations.mode` column; old rows fall back to plan behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conversation modes (agent/plan) and persist them in storage, so Slack thread behavior stays consistent after restart.
  * Introduced explicit Slack “local” command support, including safer parsing and routing for local commands vs local changes.
* **Bug Fixes**
  * Ensure conversation mode is correctly loaded, listed, and updated (defaulting to plan when unspecified).
  * Tightened plan submission and thread routing so `plan:` and agent flows behave predictably.
  * Added safeguards for local command execution and bounded output.
* **Tests**
  * Expanded integration/unit coverage for mode persistence and local routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->