### PR TITLE
[Task Diagnostics](2) Tighten legacy diagnostic row filtering

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2599,6 +2599,13 @@ describe('SQLiteAdapter', () => {
           'INSERT INTO task_output (task_id, data) VALUES (?, ?)',
           [
             't-legacy-diag-tail',
+            'Executor startup failed (ssh) on pool member remote-1; retrying another SSH pool member: connection reset\n',
+          ],
+        );
+        (db as any).db.run(
+          'INSERT INTO task_output (task_id, data) VALUES (?, ?)',
+          [
+            't-legacy-diag-tail',
             '\n[Startup Failure Diagnostic]\nmessage=concrete startup stderr\n--- end startup failure diagnostic ---\n',
           ],
         );
@@ -2617,6 +2624,7 @@ describe('SQLiteAdapter', () => {
         expect(output).toContain('[Shutdown Diagnostic]');
         expect(output).toContain('Application quit');
         expect(output).not.toContain('duplicate stream row');
+        expect(output).not.toContain('retrying another SSH pool member');
 
         db.close();
       } finally {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2399,8 +2399,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   private isDiagnosticTaskOutput(data: string): boolean {
     return data.includes('[Shutdown Diagnostic]')
-      || data.includes('[Startup Failure Diagnostic]')
-      || data.includes('Executor startup failed');
+      || data.includes('[Startup Failure Diagnostic]');
   }
 
   /**


### PR DESCRIPTION
## Summary

Legacy task output now keeps only real diagnostic blocks beside spool output.

CodeRabbit found that the old check also matched retry messages that merely said startup failed. Those rows could appear twice.

The fix narrows the check to the two diagnostic block headers and adds a regression case.

<details>
<summary>Review metadata</summary>

Review Claim: Legacy output readback no longer treats generic startup failure text as a diagnostic block.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: Spool output remains the source of stream text. Only diagnostic block headers qualify for extra readback.

Slice Rationale: This is the single CodeRabbit nit from #3024/#3025, kept separate after the main diagnostics PR merged.

</details>

## Non-goals

No startup diagnostic format changes.

No spool storage changes.

No output cleanup changes.

## Test Plan

- [x] `pnpm --filter @invoker/data-store test -- sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/data-store build`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
