### PR TITLE
[Worker Registration Step 3: PR Status and CI Failure Workers](2a) Make worker registry generic

### DIFF
--- a/packages/app/src/external-worker-loader.ts
+++ b/packages/app/src/external-worker-loader.ts
@@ -5,9 +5,9 @@ import {
 
 import type { ExternalWorkerConfig } from './config.js';
 
-export function registerExternalWorkersFromConfig(
+export function registerExternalWorkersFromConfig<TDeps>(
   externalWorkers: readonly ExternalWorkerConfig[] | undefined,
-  registry: WorkerRegistry,
-): WorkerRegistry {
+  registry: WorkerRegistry<TDeps>,
+): WorkerRegistry<TDeps> {
   return registerExternalWorkers(registry, externalWorkers);
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -20,6 +20,7 @@ import {
   registerAutoFixWorker,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
+  type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import {
   parseMetadataValue,
@@ -422,7 +423,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
     deps.invokerConfig?.externalWorkers,
-    registerAutoFixWorker(createWorkerRegistry()),
+    registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
   );
 
   if (subCommand === 'list') {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -272,7 +272,7 @@ const REGISTERED_OWNER_WORKER_KINDS = [
 ] as const;
 
 function startRegisteredOwnerWorkers(deps: WorkerRuntimeDependencies): WorkerRuntime[] {
-  const registry = registerBuiltinWorkers(createWorkerRegistry());
+  const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
   const workers: WorkerRuntime[] = [];
   for (const kind of REGISTERED_OWNER_WORKER_KINDS) {
     const definition = registry.get(kind);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -20,6 +20,7 @@ import {
   type WorkerDefinition,
   type WorkerRegistry,
   type WorkerRuntime,
+  type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import {
   IpcBus,
@@ -481,7 +482,7 @@ function workerDisplayName(kind: string): string {
   return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind;
 }
 
-function printWorkerKinds(registry: WorkerRegistry): void {
+function printWorkerKinds<TDeps>(registry: WorkerRegistry<TDeps>): void {
   process.stdout.write('Worker kinds\n');
   for (const worker of registry.list()) {
     process.stdout.write(`  ${worker.kind} — available (${worker.note})\n`);
@@ -499,8 +500,7 @@ function isExternalWorkerRuntime(worker: WorkerRuntime): worker is ExternalWorke
  * poll loop, so the two doors can never run competing scans. The CLI owns the
  * foreground lifetime — owner discovery, connect message, the SIGINT/SIGTERM
  * block, and a deterministic stop.
- */
-async function runWorker(definition: WorkerDefinition, bus: MessageBus): Promise<number> {
+async function runWorker(definition: WorkerDefinition<WorkerRuntimeDependencies>, bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
   const { autoFixRetries, autoFixAgent } = readWorkerConfig(homeRoot);
@@ -582,7 +582,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';
       const registry = registerExternalWorkers(
-        registerAutoFixWorker(createWorkerRegistry()),
+        registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
         readWorkerConfig(resolveInvokerHomeRoot()).externalWorkers,
       );
       if (subcommand === 'list') {

--- a/packages/execution-engine/src/__tests__/external-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/external-worker.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
 import { registerExternalWorkers, type ExternalWorkerRuntime } from '../external-worker.js';
-import { createWorkerRegistry, type WorkerRuntimeDependencies } from '../worker-registry.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import { createWorkerRegistry } from '../worker-registry.js';
 
 const externalWorkers = [
   {
@@ -14,7 +15,7 @@ const externalWorkers = [
 ];
 
 function createSleepingExternalWorker(): ExternalWorkerRuntime {
-  const registry = createWorkerRegistry();
+  const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
   registerExternalWorkers(registry, [
     {
       kind: 'external-sleep',

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -1,15 +1,17 @@
 import { describe, it, expect } from 'vitest';
 
-import { RECOVERY_WORKER_KIND, type AutoFixRecoveryStore, type AutoFixRecoverySubmitter } from '../auto-fix-recovery.js';
 import {
   AUTO_FIX_WORKER_KIND,
-  CI_FAILURE_WORKER_KIND,
-  createWorkerRegistry,
-  PR_STATUS_WORKER_KIND,
+  RECOVERY_WORKER_KIND,
   registerAutoFixWorker,
-  registerBuiltinWorkers,
-  type WorkerRuntimeDependencies,
-} from '../worker-registry.js';
+  type AutoFixRecoveryStore,
+  type AutoFixRecoverySubmitter,
+} from '../auto-fix-recovery.js';
+import { registerBuiltinWorkers } from '../builtin-workers.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import { createWorkerRegistry } from '../worker-registry.js';
+import { CI_FAILURE_WORKER_KIND } from '../workers/ci-failure-worker.js';
+import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
 
 const silentLogger = {
   debug: () => {},
@@ -35,13 +37,13 @@ function deps(): WorkerRuntimeDependencies {
 
 describe('worker registry', () => {
   it('starts empty before anything is registered', () => {
-    const registry = createWorkerRegistry();
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
     expect(registry.list()).toEqual([]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeUndefined();
   });
 
   it('returns the auto-fix definition by its kind once registered', () => {
-    const registry = registerAutoFixWorker(createWorkerRegistry());
+    const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());
 
     const definition = registry.get(AUTO_FIX_WORKER_KIND);
     expect(definition).toBeDefined();
@@ -53,7 +55,7 @@ describe('worker registry', () => {
   });
 
   it('registers every built-in worker in one call', () => {
-    const registry = registerBuiltinWorkers(createWorkerRegistry());
+    const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
 
     expect(registry.list().map((d) => d.kind)).toEqual([
       AUTO_FIX_WORKER_KIND,
@@ -65,12 +67,12 @@ describe('worker registry', () => {
     expect(registry.get(CI_FAILURE_WORKER_KIND)).toBeDefined();
   });
   it('returns nothing for an unknown kind', () => {
-    const registry = registerAutoFixWorker(createWorkerRegistry());
+    const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());
     expect(registry.get('does-not-exist')).toBeUndefined();
   });
 
   it('builds a recovery worker runtime from the auto-fix factory', () => {
-    const registry = registerAutoFixWorker(createWorkerRegistry());
+    const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());
     const definition = registry.get(AUTO_FIX_WORKER_KIND);
     expect(definition).toBeDefined();
 
@@ -83,7 +85,7 @@ describe('worker registry', () => {
 
 
   it('builds the PR status and CI-failure worker runtimes from the registered factories', () => {
-    const registry = registerBuiltinWorkers(createWorkerRegistry());
+    const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
 
     expect(registry.get(PR_STATUS_WORKER_KIND)?.factory(deps()).identity.kind).toBe(PR_STATUS_WORKER_KIND);
     expect(registry.get(CI_FAILURE_WORKER_KIND)?.factory(deps()).identity.kind).toBe(CI_FAILURE_WORKER_KIND);

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -12,10 +12,14 @@ import {
   listOpenFixIntentsForTask,
 } from './auto-fix-intents.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
-import type { RecoveryWorkerWakeupHint, WorkflowLifecycleEvent } from './lifecycle-events.js';
+import type { WorkflowLifecycleEvent, RecoveryWorkerWakeupHint } from './lifecycle-events.js';
+import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
+import type { WorkerRegistry } from './worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from './worker-runtime.js';
 
-/** Public worker kind for the auto-fix recovery worker. */
+/** Registry kind for the built-in auto-fix recovery worker. */
+export const AUTO_FIX_WORKER_KIND = 'autofix';
+/** Public runtime kind for the underlying auto-fix recovery worker. */
 export const RECOVERY_WORKER_KIND = 'recovery';
 
 const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
@@ -41,6 +45,15 @@ export interface AutoFixRecoverySubmitter {
     options?: { deferDrain?: boolean },
   ): number;
 }
+export interface AutoFixWorkerConfig {
+  /** Default attempt budget when a task does not override it. */
+  defaultAutoFixRetries?: number;
+  /** Resolves the agent that performs each auto-fix, when one is configured. */
+  getAutoFixAgent?: () => string | undefined;
+  /** Resolves the execution model used by worker-submitted auto-fixes. */
+  getAutoFixExecutionModel?: () => string | undefined;
+}
+
 
 export interface AutoFixRecoveryPolicyOptions {
   store: AutoFixRecoveryStore;
@@ -50,6 +63,27 @@ export interface AutoFixRecoveryPolicyOptions {
   getAutoFixAgent?: () => string | undefined;
   getRetryBudget?: (task: TaskState) => number;
   drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
+}
+/** Register the built-in auto-fix worker. */
+export function registerAutoFixWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: AUTO_FIX_WORKER_KIND,
+    note: 'Auto-fixes failed tasks by submitting fix-with-agent recovery intents.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createRecoveryWorker({
+        logger: deps.logger,
+        messageBus: deps.messageBus,
+        autoFix: {
+          store: deps.store,
+          submitter: deps.submitter,
+          defaultAutoFixRetries: deps.autoFix?.defaultAutoFixRetries,
+          getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
+        },
+      }),
+  });
+  return registry;
 }
 
 export type AutoFixRecoveryCandidate = {

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -1,0 +1,15 @@
+import { registerAutoFixWorker } from './auto-fix-recovery.js';
+import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
+import type { WorkerRegistry } from './worker-registry.js';
+import { registerCiFailureWorker } from './workers/ci-failure-worker.js';
+import { registerPrStatusWorker } from './workers/pr-status-worker.js';
+
+/** Register every built-in worker in the stable built-in order. */
+export function registerBuiltinWorkers(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registerAutoFixWorker(registry);
+  registerPrStatusWorker(registry);
+  registerCiFailureWorker(registry);
+  return registry;
+}

--- a/packages/execution-engine/src/external-worker.ts
+++ b/packages/execution-engine/src/external-worker.ts
@@ -144,15 +144,15 @@ function createExternalWorkerRuntime(config: ExternalWorkerConfig): ExternalWork
   };
 }
 
-export function registerExternalWorkers(
-  registry: WorkerRegistry,
+export function registerExternalWorkers<TDeps>(
+  registry: WorkerRegistry<TDeps>,
   externalWorkers: readonly ExternalWorkerConfig[] | undefined,
-): WorkerRegistry {
+): WorkerRegistry<TDeps> {
   for (const config of externalWorkers ?? []) {
     registry.register({
       kind: config.kind,
       note: `Supervises external worker process ${config.launch.executable}.`,
-      factory: () => createExternalWorkerRuntime(config),
+      factory: (_deps: TDeps) => createExternalWorkerRuntime(config),
     });
   }
   return registry;

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -34,13 +34,14 @@ export * from './claude-session-driver.js';
 export * from './omp-session-driver.js';
 export * from './worker-runtime.js';
 export * from './worker-registry.js';
+export * from './worker-runtime-dependencies.js';
 export * from './worker-types.js';
 export * from './worker-lock.js';
+export * from './builtin-workers.js';
 export * from './auto-fix-recovery.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/ci-failure-worker.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';
-
 export * from './external-worker.js';

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -1,169 +1,48 @@
-/**
- * Worker registry: a single declaration surface for the long-running workers
- * Invoker can run.
- *
- * Each worker is declared once as a {@link WorkerDefinition} — its `kind`, an
- * operator-facing `note`, and a `factory` that builds the worker runtime from
- * injected dependencies. Today the only built-in is the auto-fix recovery
- * worker; centralizing worker knowledge here lets future workers be declared
- * uniformly instead of being implied by a single hard-coded auto-fix branch.
- */
-
-import type { Logger } from '@invoker/contracts';
-import type { MessageBus } from '@invoker/transport';
-
-import {
-  createRecoveryWorker,
-  type AutoFixRecoveryStore,
-  type AutoFixRecoverySubmitter,
-} from './auto-fix-recovery.js';
-import {
-  PR_STATUS_WORKER_KIND,
-  createPrStatusWorker,
-  type PrStatusReviewGate,
-} from './workers/pr-status-worker.js';
-import {
-  CI_FAILURE_WORKER_KIND,
-  createCiFailureWorker,
-  type CiFailureWorkerStore,
-  type CiFailureWorkerSubmitter,
-} from './workers/ci-failure-worker.js';
 import type { WorkerRuntime } from './worker-runtime.js';
 
-export { PR_STATUS_WORKER_KIND } from './workers/pr-status-worker.js';
-export { CI_FAILURE_WORKER_KIND } from './workers/ci-failure-worker.js';
-/** Registry kind for the built-in auto-fix recovery worker. */
-export const AUTO_FIX_WORKER_KIND = 'autofix';
-
-export interface AutoFixWorkerConfig {
-  /** Default attempt budget when a task does not override it. */
-  defaultAutoFixRetries?: number;
-  /** Resolves the agent that performs each auto-fix, when one is configured. */
-  getAutoFixAgent?: () => string | undefined;
-  /** Resolves the execution model used by worker-submitted auto-fixes. */
-  getAutoFixExecutionModel?: () => string | undefined;
-}
-
-/** Dependencies injected into a worker factory when its runtime is built. */
-export interface WorkerRuntimeDependencies {
-  /** Persisted workflow/task state accessor. */
-  store: AutoFixRecoveryStore & CiFailureWorkerStore;
-  /** Action-output channel used to submit follow-up mutation intents. */
-  submitter: AutoFixRecoverySubmitter & CiFailureWorkerSubmitter;
-  /** Operator logger. */
-  logger: Logger;
-  /** Optional bus that turns lifecycle events into immediate wakeups. */
-  messageBus?: MessageBus;
-  /** Review-gate polling surface owned by the task runner. */
-  reviewGate?: PrStatusReviewGate;
-  /** Auto-fix tuning. */
-  autoFix?: AutoFixWorkerConfig;
-}
+/**
+ * Worker registry: a generic catalog of long-running worker definitions.
+ *
+ * The registry itself is intentionally worker-agnostic. Built-in worker wiring
+ * lives beside each worker implementation, while this file only manages lookup
+ * and registration by stable kind.
+ */
 
 /** Builds a worker runtime from injected dependencies. */
-export type WorkerFactory = (deps: WorkerRuntimeDependencies) => WorkerRuntime;
+export type WorkerFactory<TDeps = unknown> = (deps: TDeps) => WorkerRuntime;
 
 /** A single worker declared in the registry. */
-export interface WorkerDefinition {
+export interface WorkerDefinition<TDeps = unknown> {
   /** Stable registry kind, e.g. `'autofix'`. */
   readonly kind: string;
   /** Human-readable note surfaced in operator output. */
   readonly note: string;
   /** Builds the worker runtime from injected dependencies. */
-  readonly factory: WorkerFactory;
+  readonly factory: WorkerFactory<TDeps>;
 }
 
 /** Mutable collection of worker definitions keyed by kind. */
-export interface WorkerRegistry {
+export interface WorkerRegistry<TDeps = unknown> {
   /** Register (or replace) a definition by its kind. */
-  register(definition: WorkerDefinition): void;
+  register(definition: WorkerDefinition<TDeps>): void;
   /** Look up a definition by kind, or `undefined` when none is registered. */
-  get(kind: string): WorkerDefinition | undefined;
+  get(kind: string): WorkerDefinition<TDeps> | undefined;
   /** Every registered definition, in registration order. */
-  list(): WorkerDefinition[];
+  list(): WorkerDefinition<TDeps>[];
 }
 
 /** Create an empty worker registry. */
-export function createWorkerRegistry(): WorkerRegistry {
-  const byKind = new Map<string, WorkerDefinition>();
+export function createWorkerRegistry<TDeps = unknown>(): WorkerRegistry<TDeps> {
+  const byKind = new Map<string, WorkerDefinition<TDeps>>();
   return {
-    register(definition: WorkerDefinition): void {
+    register(definition: WorkerDefinition<TDeps>): void {
       byKind.set(definition.kind, definition);
     },
-    get(kind: string): WorkerDefinition | undefined {
+    get(kind: string): WorkerDefinition<TDeps> | undefined {
       return byKind.get(kind);
     },
-    list(): WorkerDefinition[] {
+    list(): WorkerDefinition<TDeps>[] {
       return [...byKind.values()];
     },
   };
-}
-
-/**
- * Register the built-in auto-fix worker under {@link AUTO_FIX_WORKER_KIND},
- * reusing the existing recovery worker factory ({@link createRecoveryWorker})
- * so the runtime it builds behaves exactly as the auto-fix path always has.
- * Returns the registry so calls can be chained with {@link createWorkerRegistry}.
- */
-export function registerAutoFixWorker(registry: WorkerRegistry): WorkerRegistry {
-  registry.register({
-    kind: AUTO_FIX_WORKER_KIND,
-    note: 'Auto-fixes failed tasks by submitting fix-with-agent recovery intents.',
-    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
-      createRecoveryWorker({
-        logger: deps.logger,
-        messageBus: deps.messageBus,
-        autoFix: {
-          store: deps.store,
-          submitter: deps.submitter,
-          defaultAutoFixRetries: deps.autoFix?.defaultAutoFixRetries,
-          getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
-        },
-      }),
-  });
-  return registry;
-}
-
-
-/** Register the built-in PR status worker. */
-export function registerPrStatusWorker(registry: WorkerRegistry): WorkerRegistry {
-  registry.register({
-    kind: PR_STATUS_WORKER_KIND,
-    note: 'Polls review-gate PR status through the registered TaskRunner review-gate check.',
-    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
-      createPrStatusWorker({
-        logger: deps.logger,
-        reviewGate: deps.reviewGate,
-      }),
-  });
-  return registry;
-}
-
-/** Register the built-in CI-failure repair worker. */
-export function registerCiFailureWorker(registry: WorkerRegistry): WorkerRegistry {
-  registry.register({
-    kind: CI_FAILURE_WORKER_KIND,
-    note: 'Submits head-SHA guarded CI repair intents for failed review-gate checks.',
-    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
-      createCiFailureWorker({
-        logger: deps.logger,
-        messageBus: deps.messageBus,
-        ciFailure: {
-          store: deps.store,
-          submitter: deps.submitter,
-          defaultAutoFixRetries: deps.autoFix?.defaultAutoFixRetries,
-          getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
-          getAutoFixExecutionModel: deps.autoFix?.getAutoFixExecutionModel,
-        },
-      }),
-  });
-  return registry;
-}
-
-/** Register every built-in worker in the stable built-in order. */
-export function registerBuiltinWorkers(registry: WorkerRegistry): WorkerRegistry {
-  registerAutoFixWorker(registry);
-  registerPrStatusWorker(registry);
-  registerCiFailureWorker(registry);
-  return registry;
 }

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -1,0 +1,26 @@
+import type { Logger } from '@invoker/contracts';
+import type { MessageBus } from '@invoker/transport';
+
+import type {
+  AutoFixRecoveryStore,
+  AutoFixRecoverySubmitter,
+  AutoFixWorkerConfig,
+} from './auto-fix-recovery.js';
+import type { CiFailureWorkerStore, CiFailureWorkerSubmitter } from './workers/ci-failure-worker.js';
+import type { PrStatusReviewGate } from './workers/pr-status-worker.js';
+
+/** Dependencies injected into a built-in worker factory when its runtime is built. */
+export interface WorkerRuntimeDependencies {
+  /** Persisted workflow/task state accessor. */
+  store: AutoFixRecoveryStore & CiFailureWorkerStore;
+  /** Action-output channel used to submit follow-up mutation intents. */
+  submitter: AutoFixRecoverySubmitter & CiFailureWorkerSubmitter;
+  /** Operator logger. */
+  logger: Logger;
+  /** Optional bus that turns lifecycle events into immediate wakeups. */
+  messageBus?: MessageBus;
+  /** Review-gate polling surface owned by the task runner. */
+  reviewGate?: PrStatusReviewGate;
+  /** Auto-fix tuning shared by workers that submit fix intents. */
+  autoFix?: AutoFixWorkerConfig;
+}

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -24,6 +24,8 @@ import type {
   ReviewGateFailedCheck,
   WorkflowLifecycleEvent,
 } from '../lifecycle-events.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
 
 export const CI_FAILURE_WORKER_KIND = 'ci-failure';
@@ -78,6 +80,29 @@ export interface CiFailureWorkerOptions {
   ciFailure?: Omit<CiFailureWorkerPolicyOptions, 'logger' | 'drainEvents'>;
   onTick?: WorkerTick;
 }
+/** Register the built-in CI-failure repair worker. */
+export function registerCiFailureWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: CI_FAILURE_WORKER_KIND,
+    note: 'Submits head-SHA guarded CI repair intents for failed review-gate checks.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createCiFailureWorker({
+        logger: deps.logger,
+        messageBus: deps.messageBus,
+        ciFailure: {
+          store: deps.store,
+          submitter: deps.submitter,
+          defaultAutoFixRetries: deps.autoFix?.defaultAutoFixRetries,
+          getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
+          getAutoFixExecutionModel: deps.autoFix?.getAutoFixExecutionModel,
+        },
+      }),
+  });
+  return registry;
+}
+
 
 export function ciFailureChecksHash(failedChecks: readonly ReviewGateFailedCheck[]): string {
   const normalized = failedChecks

--- a/packages/execution-engine/src/workers/pr-status-worker.ts
+++ b/packages/execution-engine/src/workers/pr-status-worker.ts
@@ -1,7 +1,8 @@
 import type { Logger } from '@invoker/contracts';
 
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
-
 export const PR_STATUS_WORKER_KIND = 'pr-status';
 export const DEFAULT_PR_STATUS_WORKER_INTERVAL_MS = 60_000;
 
@@ -23,6 +24,22 @@ export interface PrStatusWorkerOptions {
   reviewGate?: PrStatusReviewGate;
   onTick?: WorkerTick;
 }
+/** Register the built-in PR status worker. */
+export function registerPrStatusWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: PR_STATUS_WORKER_KIND,
+    note: 'Polls review-gate PR status through the registered TaskRunner review-gate check.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createPrStatusWorker({
+        logger: deps.logger,
+        reviewGate: deps.reviewGate,
+      }),
+  });
+  return registry;
+}
+
 
 export function createPrStatusTick(options: PrStatusWorkerPolicyOptions): WorkerTick {
   return async () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering built-in workers through a unified worker setup path, including auto-fix recovery and other existing worker types.
  * Improved worker handling so configured workers can use typed runtime dependencies more reliably.
* **Bug Fixes**
  * Strengthened worker registration and loading so built-in and external workers are registered consistently.
  * Updated worker-related behavior to better preserve compatibility across app and CLI flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->