### PR TITLE
[Planning Chat](4) Add visual proof coverage

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -206,6 +206,11 @@ const MENU_PROOF_PLAN = {
   onFinish: 'pull_request' as const,
   mergeMode: 'external_review',
 };
+const TERMINAL_PLANNED_PLAN = {
+  ...TEST_PLAN,
+  name: 'Terminal Planned Flow',
+};
+
 
 const SSH_TERMINAL_RESUME_PLAN = {
   name: 'SSH Terminal Resume Visual Proof',
@@ -507,15 +512,15 @@ test.describe('Read-only mode visual proof', () => {
 
 test.describe('Visual proof capture', () => {
   test('empty state', async ({ page }) => {
-    await expect(page.getByText('Start with a goal.')).toBeVisible({ timeout: 5000 });
-    await expect(page.getByText('Invoker Terminal')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText('What do you want to build?')).toHaveCount(0);
     await expect(page.getByText('What to expect')).toBeVisible();
     await expect(page.getByTestId('workflow-graph-surface').getByText('Your plan will appear here.')).toBeVisible();
     await expect(page.getByTestId('sidebar-home')).toContainText('Invoker');
+    await expect(page.getByTestId('sidebar-planning')).toContainText('Planning Terminal');
     await expect(page.getByTestId('sidebar-workflows')).toContainText('Workflows');
     await expect(page.getByTestId('sidebar-attention')).toContainText('Needs Attention');
     await expect(page.getByTestId('sidebar-running')).toContainText('Running');
-    await expect(page.getByText('Terminal planning and graph details live here.')).toBeVisible();
     await expect(page.getByTestId('rail-settings')).toBeVisible();
     await expect(page.getByTestId('sidebar-home')).toBeVisible();
     await captureScreenshot(page, 'empty-state');
@@ -524,22 +529,26 @@ test.describe('Visual proof capture', () => {
   });
 
   test('terminal planning loads graph', async ({ page }) => {
-    const plannedYaml = yamlStringify(MENU_PROOF_PLAN);
+    const plannedYaml = yamlStringify(TERMINAL_PLANNED_PLAN);
     await page.evaluate(async ({ planYaml, planName }) => {
-      await window.invoker.setTestPlanFromGoalResponse({ planYaml, planName });
+      await window.invoker.setTestPlanningChatResponse({ planYaml, planName, reply: 'I drafted the plan.' });
     }, { planYaml: plannedYaml, planName: 'Terminal Planned Flow' });
 
-    await page.getByTestId('invoker-terminal-input').fill('plan "Add README"');
-    await page.getByTestId('invoker-terminal-input').press('Enter');
+    await page.getByTestId('sidebar-planning').click();
+    await expect(page.getByRole('heading', { name: 'Planning Terminal' })).toBeVisible();
+    await page.getByTestId('invoker-terminal-input').fill('Add README');
+    await page.getByRole('button', { name: 'Send' }).click();
+    await expect(page.getByTestId('invoker-terminal-ready-bar')).toBeVisible();
+    await page.getByRole('button', { name: 'Submit to Invoker' }).click();
 
-    await expect(page.getByText('Plan "Terminal Planned Flow" loaded. Use run to execute.')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible();
     await expect(page.locator('.react-flow__node[data-testid$="task-alpha"]')).toBeVisible();
-    await expect(page.getByTestId('workflow-inspector-title')).toContainText('Menu Proof Workflow');
+    await expect(page.getByTestId('workflow-inspector-title')).toContainText('Terminal Planned Flow');
     await expect(page.getByText('What to expect')).toHaveCount(0);
     await captureScreenshot(page, 'terminal-planned-graph');
 
     await page.evaluate(async () => {
-      await window.invoker.setTestPlanFromGoalResponse(null);
+      await window.invoker.setTestPlanningChatResponse(null);
     });
   });
 
@@ -553,8 +562,7 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'workflows-browser');
 
     await page.getByTestId('browser-rail-dismiss').click();
-    await expect(page.getByText('Plan graph')).toBeVisible();
-    await expect(page.getByText('Invoker Terminal')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible();
     await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-72/);
   });
   test('needs attention browser focuses the selected task', async ({ page }) => {

--- a/scripts/repro/repro-coderabbit-pr3049-send-preset-resolution-contract.sh
+++ b/scripts/repro/repro-coderabbit-pr3049-send-preset-resolution-contract.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CodeRabbit PR #3049 (packages/app/src/in-app-planner.ts):
+# sendPlanningChatMessage resolves harness presets BEFORE its try/catch:
+#   const presets = await resolveHarnessPresets(deps.config);
+#   const defaultPresetKey = await resolveDefaultPresetKey(deps.config);
+# If either throws (e.g. a malformed `slackHarnessPresets` config), the promise
+# REJECTS instead of returning the declared InAppPlanningChatResponse
+# `{ ok: false, error }` shape — unlike every other failure path in the function.
+# Downstream (main.ts GUI mutation handler) that surfaces as a raw IPC rejection
+# instead of the structured `.ok` response the renderer branches on.
+#
+# This repro drives sendPlanningChatMessage with a config whose
+# `slackHarnessPresets` getter throws:
+#   - Buggy (resolution outside try) -> the call REJECTS -> vitest FAIL -> repro FAIL.
+#   - Fixed (resolution inside try)   -> returns { ok: false, error } -> repro PASS.
+
+REPO_ROOT="$(cd -- "$(dirname -- "$0")/../.." && pwd)"
+APP_DIR="$REPO_ROOT/packages/app"
+VITEST="$APP_DIR/node_modules/.bin/vitest"
+
+if [[ ! -x "$VITEST" ]]; then
+  echo "[repro] FAIL: no vitest binary at $VITEST; run 'pnpm install' at the repo root first."
+  exit 1
+fi
+
+SLUG=".repro-coderabbit-pr3049-send-preset-resolution-contract"
+TEST_DIR="$APP_DIR/$SLUG"
+TEST_FILE="$TEST_DIR/repro.test.ts"
+mkdir -p "$TEST_DIR"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+cat > "$TEST_FILE" <<'TS'
+import { describe, it, expect } from 'vitest';
+import {
+  createInAppPlanningChatSessions,
+  sendPlanningChatMessage,
+} from '../src/in-app-planner.js';
+
+describe('sendPlanningChatMessage preset-resolution contract', () => {
+  it('returns { ok: false } instead of rejecting when preset resolution throws', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const config: Record<string, unknown> = {};
+    // A malformed harness-preset config surfaces here: accessing the field throws.
+    Object.defineProperty(config, 'slackHarnessPresets', {
+      enumerable: true,
+      get() {
+        throw new Error('malformed slackHarnessPresets');
+      },
+    });
+
+    // On the buggy code this rejects (resolution runs before the try), so the
+    // await throws and the test fails. The declared contract is a resolved
+    // { ok: false, error } response for every failure path.
+    const result = await sendPlanningChatMessage(
+      { message: 'plan the feature', presetKey: 'codex' } as never,
+      {
+        config: config as never,
+        loadGeneratedPlan: async () => ({ planName: 'x', workflowId: 'y' }),
+        sessions,
+        planningCommandBuilder: () => ({ command: 'planner', args: [] }),
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('malformed slackHarnessPresets');
+    }
+    // A failed resolution must not have created a session.
+    expect(sessions.size).toBe(0);
+  });
+});
+TS
+
+set +e
+( cd "$APP_DIR" && "$VITEST" run --reporter=dot "$SLUG/repro.test.ts" )
+CODE=$?
+set -e
+
+if [[ "$CODE" -ne 0 ]]; then
+  echo "[repro] FAIL: sendPlanningChatMessage lets preset-resolution failures escape the { ok: false } contract (vitest exit $CODE)."
+  exit 1
+fi
+
+echo "[repro] PASS: sendPlanningChatMessage returns a structured { ok: false, error } response when preset resolution throws."
+exit 0

--- a/scripts/repro/repro-coderabbit-pr3049-serialize-session-sends.sh
+++ b/scripts/repro/repro-coderabbit-pr3049-serialize-session-sends.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CodeRabbit PR #3049 (packages/app/src/in-app-planner.ts):
+# sendPlanningChatMessage reuses one PlanConversation per session, and
+# PlanConversation.sendMessage() mutates this.messages ACROSS an await
+# (push user -> await spawnPlanner -> push assistant). Two overlapping
+# requests for the same sessionId (double-click / retry / multi-tab) interleave
+# turns: both user messages get pushed before either assistant reply lands, so
+# the transcript ordering is corrupted and getDraftedPlan() can read the wrong
+# conversation state.
+#
+# This repro creates a session, then fires two concurrent sends for the same
+# sessionId with controlled planner-resolution order:
+#   - Buggy (no serialization) -> history becomes user,user,assistant,assistant
+#     (two consecutive user turns) -> vitest FAIL -> repro FAIL.
+#   - Fixed (per-session serialization) -> history strictly alternates
+#     user,assistant,user,assistant -> repro PASS.
+
+REPO_ROOT="$(cd -- "$(dirname -- "$0")/../.." && pwd)"
+APP_DIR="$REPO_ROOT/packages/app"
+VITEST="$APP_DIR/node_modules/.bin/vitest"
+
+if [[ ! -x "$VITEST" ]]; then
+  echo "[repro] FAIL: no vitest binary at $VITEST; run 'pnpm install' at the repo root first."
+  exit 1
+fi
+
+SLUG=".repro-coderabbit-pr3049-serialize-session-sends"
+TEST_DIR="$APP_DIR/$SLUG"
+TEST_FILE="$TEST_DIR/repro.test.ts"
+mkdir -p "$TEST_DIR"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+cat > "$TEST_FILE" <<'TS'
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { PlanConversation } from '@invoker/surfaces';
+import {
+  createInAppPlanningChatSessions,
+  sendPlanningChatMessage,
+} from '../src/in-app-planner.js';
+
+const planningCommandBuilder = () => ({ command: 'planner', args: ['prompt'] });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe('sendPlanningChatMessage concurrency', () => {
+  it('serializes concurrent sends for one session so transcripts do not interleave', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const deps = {
+      config: {} as never,
+      loadGeneratedPlan: async () => ({ planName: 'x', workflowId: 'y' }),
+      sessions,
+      planningCommandBuilder,
+    };
+
+    const first = deferred<string>();
+    const second = deferred<string>();
+    // Arrival barriers: resolved the instant each concurrent send actually
+    // reaches its awaited spawnPlanner call. This replaces a wall-clock sleep,
+    // so the repro never races a fixed timeout on a slow machine. Staged (not
+    // "wait for both at once") because the fixed/serialized path only lets send
+    // B reach the planner AFTER send A has completed — a combined barrier would
+    // deadlock the passing case.
+    const arrivedA = deferred<void>();
+    const arrivedB = deferred<void>();
+    let call = 0;
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockImplementation(() => {
+      const idx = call++;
+      if (idx === 0) return Promise.resolve('reply-0'); // session creation
+      if (idx === 1) { arrivedA.resolve(); return first.promise; } // concurrent send A
+      arrivedB.resolve(); // concurrent send B
+      return second.promise;
+    });
+
+    // Create the session with a completed first turn.
+    const created = await sendPlanningChatMessage(
+      { message: 'kick off', presetKey: 'codex' } as never,
+      deps,
+    );
+    if (!created.ok) throw new Error(created.error);
+    const sessionId = created.sessionId;
+
+    // Fire two overlapping sends for the SAME session.
+    const pA = sendPlanningChatMessage({ sessionId, message: 'message A' } as never, deps);
+    const pB = sendPlanningChatMessage({ sessionId, message: 'message B' } as never, deps);
+
+    // Barrier, not sleep: release send A's reply only once it is provably
+    // awaiting the planner, then release send B's reply once it too reaches the
+    // planner. Under serialization send B arrives only after A finishes, so the
+    // awaits proceed in that order; under the buggy interleave both arrive up
+    // front. Either way there is no timing race.
+    await arrivedA.promise;
+    first.resolve('reply-A');
+    await arrivedB.promise;
+    second.resolve('reply-B');
+    await Promise.all([pA, pB]);
+
+    const session = sessions.get(sessionId);
+    expect(session).toBeDefined();
+    const roles = session!.conversation.history.map((m) => m.role);
+
+    // A correctly serialized transcript strictly alternates user/assistant.
+    for (let i = 1; i < roles.length; i++) {
+      expect(roles[i], `roles interleaved: ${roles.join(',')}`).not.toBe(roles[i - 1]);
+    }
+    // Sanity: both concurrent turns landed.
+    expect(roles.filter((r) => r === 'user').length).toBe(3);
+    expect(roles.filter((r) => r === 'assistant').length).toBe(3);
+  });
+});
+TS
+
+set +e
+( cd "$APP_DIR" && "$VITEST" run --reporter=dot "$SLUG/repro.test.ts" )
+CODE=$?
+set -e
+
+if [[ "$CODE" -ne 0 ]]; then
+  echo "[repro] FAIL: concurrent sends for one session interleave the PlanConversation transcript (vitest exit $CODE)."
+  exit 1
+fi
+
+echo "[repro] PASS: concurrent sends for one session are serialized; the transcript stays strictly alternating."
+exit 0

--- a/scripts/repro/repro-coderabbit-pr3049-submit-idempotency-guard.sh
+++ b/scripts/repro/repro-coderabbit-pr3049-submit-idempotency-guard.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CodeRabbit PR #3049 (packages/app/src/in-app-planner.ts):
+# submitPlanningChatDraft has two data-integrity gaps.
+#
+# 1) Missing error handling: loadPlannerSurfaces()/summarizePlanText and
+#    deps.loadGeneratedPlan(planText) run WITHOUT try/catch. Any failure (e.g.
+#    orchestrator.loadPlan throwing on a task-id collision) REJECTS the promise
+#    instead of returning the declared InAppPlanningSubmitResponse
+#    `{ ok: false, error }` shape.
+#
+# 2) No submission guard: the session is never removed after a successful
+#    submit, so a second submitPlanningChatDraft with the same sessionId
+#    (double-click / retry) re-runs loadGeneratedPlan — a non-idempotent write
+#    (orchestrator.loadPlan) — and creates a SECOND workflow from one draft.
+#
+# This repro exercises both:
+#   - Buggy -> loadGeneratedPlan throw rejects, AND a double submit calls
+#     loadGeneratedPlan twice -> vitest FAIL -> repro FAIL.
+#   - Fixed -> throw becomes { ok: false, error }, AND the second submit is
+#     rejected because the session was cleared (loadGeneratedPlan called once)
+#     -> repro PASS.
+
+REPO_ROOT="$(cd -- "$(dirname -- "$0")/../.." && pwd)"
+APP_DIR="$REPO_ROOT/packages/app"
+VITEST="$APP_DIR/node_modules/.bin/vitest"
+
+if [[ ! -x "$VITEST" ]]; then
+  echo "[repro] FAIL: no vitest binary at $VITEST; run 'pnpm install' at the repo root first."
+  exit 1
+fi
+
+SLUG=".repro-coderabbit-pr3049-submit-idempotency-guard"
+TEST_DIR="$APP_DIR/$SLUG"
+TEST_FILE="$TEST_DIR/repro.test.ts"
+mkdir -p "$TEST_DIR"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+cat > "$TEST_FILE" <<'TS'
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { PlanConversation } from '@invoker/surfaces';
+import {
+  createInAppPlanningChatSessions,
+  sendPlanningChatMessage,
+  submitPlanningChatDraft,
+} from '../src/in-app-planner.js';
+
+const VALID_PLAN = `Here is the plan.
+
+\`\`\`yaml
+name: Mock Plan
+onFinish: none
+tasks:
+  - id: first
+    description: First task
+    command: echo first
+  - id: second
+    description: Second task
+    dependencies: [first]
+    command: echo second
+\`\`\``;
+
+const planningCommandBuilder = () => ({ command: 'planner', args: ['prompt'] });
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function draftedSession() {
+  vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
+  const sessions = createInAppPlanningChatSessions();
+  const sent = await sendPlanningChatMessage(
+    { message: 'draft the plan', presetKey: 'codex' } as never,
+    {
+      config: {} as never,
+      loadGeneratedPlan: async () => ({ planName: 'Mock Plan', workflowId: 'wf' }),
+      sessions,
+      planningCommandBuilder,
+    },
+  );
+  if (!sent.ok) throw new Error(sent.error);
+  return { sessions, sessionId: sent.sessionId };
+}
+
+describe('submitPlanningChatDraft', () => {
+  it('returns { ok: false } instead of rejecting when loadGeneratedPlan throws', async () => {
+    const { sessions, sessionId } = await draftedSession();
+
+    const result = await submitPlanningChatDraft(
+      { sessionId } as never,
+      {
+        sessions,
+        loadGeneratedPlan: async () => {
+          throw new Error('task-id collision loading plan');
+        },
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('task-id collision loading plan');
+    }
+  });
+
+  it('does not create a second workflow when the same draft is submitted twice', async () => {
+    const { sessions, sessionId } = await draftedSession();
+    const loadGeneratedPlan = vi
+      .fn()
+      .mockResolvedValue({ planName: 'Mock Plan', workflowId: 'wf-1' });
+
+    const first = await submitPlanningChatDraft({ sessionId } as never, { sessions, loadGeneratedPlan });
+    expect(first).toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
+
+    // Double-click / retry: the same sessionId is submitted again.
+    const second = await submitPlanningChatDraft({ sessionId } as never, { sessions, loadGeneratedPlan });
+
+    // The non-idempotent loadGeneratedPlan (orchestrator.loadPlan) must run once.
+    expect(loadGeneratedPlan).toHaveBeenCalledTimes(1);
+    // The second submit must be rejected, not silently create a duplicate workflow.
+    expect(second.ok).toBe(false);
+  });
+});
+TS
+
+set +e
+( cd "$APP_DIR" && "$VITEST" run --reporter=dot "$SLUG/repro.test.ts" )
+CODE=$?
+set -e
+
+if [[ "$CODE" -ne 0 ]]; then
+  echo "[repro] FAIL: submitPlanningChatDraft rejects on load errors and/or re-submits the same draft into a duplicate workflow (vitest exit $CODE)."
+  exit 1
+fi
+
+echo "[repro] PASS: submitPlanningChatDraft catches load errors as { ok: false } and clears the session so a repeated submit cannot create a duplicate workflow."
+exit 0

--- a/scripts/repro/repro-coderabbit-pr3050-draft-clear.sh
+++ b/scripts/repro/repro-coderabbit-pr3050-draft-clear.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CodeRabbit PR #3050 (discussion r3523490877): after planningChatSubmit succeeds,
+# `draftPlanAvailable` / `draftPlanSummary` were never cleared, so the "Submit to
+# Invoker" ready bar stayed mounted and could resubmit the same planning session.
+#
+# The focused regression submits a ready draft, clicks "Submit to Invoker", then
+# asserts the ready bar is dismissed.
+#   - Buggy code leaves the ready bar visible -> vitest fails -> repro exits non-zero.
+#   - Fixed code clears the draft state -> vitest passes -> repro exits zero.
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-pr3050-draft-clear.XXXXXX.log")"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+echo "[repro] PR #3050: draft state must be cleared after a successful submit."
+
+if pnpm -C "$REPO_ROOT" --filter @invoker/ui exec vitest run \
+  src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx \
+  >"$LOG_FILE" 2>&1; then
+  echo "[repro] PASS: the Submit to Invoker ready bar is dismissed after submit; no resubmit path remains."
+  exit 0
+else
+  status=$?
+  echo "[repro] FAIL: the ready bar stayed mounted after submit, so the same session can be resubmitted."
+  cat "$LOG_FILE"
+  exit "$status"
+fi

--- a/scripts/repro/repro-coderabbit-pr3050-ime-composition.sh
+++ b/scripts/repro/repro-coderabbit-pr3050-ime-composition.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CodeRabbit PR #3050 (discussion r3523490884): the composer's Enter-to-submit
+# handler did not check IME composition, so the Enter that confirms a CJK/IME
+# candidate submitted a half-composed message instead of committing the candidate.
+#
+# The focused regression presses Enter with nativeEvent.isComposing === true and
+# asserts nothing is sent, then confirms a plain Enter still submits.
+#   - Buggy code submits the in-progress text -> vitest fails -> repro exits non-zero.
+#   - Fixed code skips submission during composition -> vitest passes -> repro exits zero.
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-pr3050-ime-composition.XXXXXX.log")"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+echo "[repro] PR #3050: Enter-to-submit must ignore in-progress IME composition."
+
+if pnpm -C "$REPO_ROOT" --filter @invoker/ui exec vitest run \
+  src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx \
+  >"$LOG_FILE" 2>&1; then
+  echo "[repro] PASS: Enter during IME composition does not submit; a plain Enter still does."
+  exit 0
+else
+  status=$?
+  echo "[repro] FAIL: Enter during IME composition submitted a half-composed message."
+  cat "$LOG_FILE"
+  exit "$status"
+fi

--- a/scripts/repro/repro-coderabbit-pr3050-run-guard.sh
+++ b/scripts/repro/repro-coderabbit-pr3050-run-guard.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CodeRabbit PR #3050 (discussion r3523490880): the "run" text command called
+# handleStart() directly, guarded only by `!hasLoadedPlan`. Unlike the Start
+# button (`showStart = hasLoadedPlan && !hasStarted`) it omitted the `hasStarted`
+# check and never engaged `plannerBusy`, so typing "run" again after a run had
+# already started re-invoked invoker.start().
+#
+# The focused regression starts a run, then types "run" again and asserts start()
+# is not called a second time (and that the guard reports "Run already started.").
+#   - Buggy code fires invoker.start() twice -> vitest fails -> repro exits non-zero.
+#   - Fixed code rejects the second run -> vitest passes -> repro exits zero.
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-pr3050-run-guard.XXXXXX.log")"
+trap 'rm -f "$LOG_FILE"' EXIT
+
+echo "[repro] PR #3050: 'run' text command must honor the hasStarted guard."
+
+if pnpm -C "$REPO_ROOT" --filter @invoker/ui exec vitest run \
+  src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx \
+  >"$LOG_FILE" 2>&1; then
+  echo "[repro] PASS: a second 'run' after start is rejected; invoker.start() is invoked exactly once."
+  exit 0
+else
+  status=$?
+  echo "[repro] FAIL: 're-running' after start re-invoked invoker.start(); the busy/hasStarted guard is missing."
+  cat "$LOG_FILE"
+  exit "$status"
+fi


### PR DESCRIPTION
## Summary

Visual proof now opens the Planning Terminal tab before using the planning chat.

The checks cover the new home state, the Planning Terminal handoff into a graph, and the browser return path.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the proof update for the new Planning Terminal location.

Review Lane: proof

Review Unit: proof

Safety Invariant: This slice changes only visual proof expectations. Product behavior lives in earlier slices.

Slice Rationale: Proof stays last so screenshots and assertions match the final UI shape.

</details>

## Non-goals

This does not change runtime planning, sidebar behavior, or workflow execution.

## Test Plan

- [x] `pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts -g "empty state|terminal planning loads graph|workflows browser and home return"`

## Visual Proof

Before:

![Before empty home screen](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260704-f11fc6/empty-state.png)

After:

![After planning graph handoff](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260704-f11fc6/terminal-planned-graph.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0c9ddf088`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated visual-proof assertions for the empty state, ensuring the plan graph is visible while specific prompts/details are not shown.
  * Refined terminal-planning visual coverage to follow the latest send-and-submit interaction flow.
  * Adjusted UI expectations for navigation back to workflows/home, including removal of prior terminal-related checks.
* **Chores**
  * Added Bash repro harnesses for CodeRabbit PR `#3050` scenarios (draft-clear, IME composition, and run-guard).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->