### PR TITLE
Uncap auto-fix attempts

### DIFF
--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -166,6 +166,16 @@ describe('auto-fix recovery candidate validation', () => {
     });
   });
 
+  it('keeps failed tasks eligible after previous auto-fix attempts', () => {
+    const task = makeTask({ execution: { error: 'boom', autoFixAttempts: 100, generation: 1, selectedAttemptId: 'attempt-1' } });
+    const harness = makeRecoveryPolicyHarness(task);
+
+    const candidates = collectValidatedAutoFixRecoveryCandidates(harness.options);
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.task.execution.autoFixAttempts).toBe(100);
+  });
+
   it.each([
     {
       name: 'workflow',

--- a/packages/app/src/__tests__/headless-fix-autofix-context.test.ts
+++ b/packages/app/src/__tests__/headless-fix-autofix-context.test.ts
@@ -60,7 +60,7 @@ describe('headless fix auto-fix accounting', () => {
     resolveConflictActionMock.mockClear();
   });
 
-  it('does not consume the auto-fix retry budget for a manual fix', async () => {
+  it('does not increment auto-fix attempts for a manual fix', async () => {
     const { runHeadless } = await import('../headless.js');
     const { deps, updateTask } = makeDeps(2);
 

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -203,6 +203,26 @@ describe('PR status and CI failure workers', () => {
     });
   });
 
+  it('queues CI repair even after previous auto-fix attempts', async () => {
+    const event = makeEvent();
+    const harness = makeHarness(makeTask({
+      execution: {
+        autoFixAttempts: 100,
+      },
+    }));
+    const tick = createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      defaultAutoFixRetries: 1,
+      drainEvents: () => [event],
+    });
+
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+  });
+
   it('rejects stale CI failure events when the PR head changed before submit', async () => {
     const event = makeEvent();
     const task = makeTask({

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -46,7 +46,7 @@ export interface AutoFixRecoverySubmitter {
   ): number;
 }
 export interface AutoFixWorkerConfig {
-  /** Default attempt budget when a task does not override it. */
+  /** Positive config enables auto-fix; attempts are not capped. */
   defaultAutoFixRetries?: number;
   /** Resolves the agent that performs each auto-fix, when one is configured. */
   getAutoFixAgent?: () => string | undefined;
@@ -157,8 +157,13 @@ export function listAutoFixRecoveryScanCandidates(
 
 function retryBudgetForTask(task: TaskState, options: AutoFixRecoveryPolicyOptions): number {
   const raw = options.getRetryBudget?.(task) ?? options.defaultAutoFixRetries ?? 0;
+  if (raw === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
   if (!Number.isFinite(raw)) return 0;
-  return Math.min(Math.max(0, Math.floor(raw)), 10);
+  return Math.floor(raw) > 0 ? Number.POSITIVE_INFINITY : 0;
+}
+
+function retryBudgetLabel(budget: number): number | 'unlimited' {
+  return budget === Number.POSITIVE_INFINITY ? 'unlimited' : budget;
 }
 
 function isRuntimeAutoFixEligibleTask(task: TaskState, options: AutoFixRecoveryPolicyOptions): boolean {
@@ -168,7 +173,7 @@ function isRuntimeAutoFixEligibleTask(task: TaskState, options: AutoFixRecoveryP
   if (shouldSkipAutoFixForError(task.execution.error)) return false;
   const max = retryBudgetForTask(task, options);
   if (max <= 0) return false;
-  return (task.execution.autoFixAttempts ?? 0) < max;
+  return true;
 }
 
 function candidateFromWakeup(wakeup: RecoveryWorkerWakeupHint): AutoFixRecoveryCandidate | undefined {
@@ -298,7 +303,7 @@ function validateAutoFixCandidate(
     skipAutoFixCandidate(options, candidate, 'not-eligible', {
       status: latest.status,
       autoFixAttempts: latest.execution.autoFixAttempts ?? 0,
-      maxRetries: retryBudgetForTask(latest, options),
+      maxRetries: retryBudgetLabel(retryBudgetForTask(latest, options)),
       isReconciliation: Boolean(latest.config.isReconciliation),
       hasParentTask: Boolean(latest.config.parentTask),
       skippedForError: shouldSkipAutoFixForError(latest.execution.error),
@@ -357,7 +362,7 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
         attemptId: candidate.attemptId ?? null,
         agent: selectedAgent ?? null,
         autoFixAttempts: candidate.task.execution.autoFixAttempts ?? 0,
-        maxRetries: retryBudgetForTask(candidate.task, options),
+        maxRetries: retryBudgetLabel(retryBudgetForTask(candidate.task, options)),
       });
     }
   };

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -136,8 +136,13 @@ export function ciFailureActionKey(event: Pick<
 
 function retryBudgetForTask(task: TaskState, options: CiFailureWorkerPolicyOptions): number {
   const raw = options.getRetryBudget?.(task) ?? options.defaultAutoFixRetries ?? 0;
+  if (raw === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
   if (!Number.isFinite(raw)) return 0;
-  return Math.min(Math.max(0, Math.floor(raw)), 10);
+  return Math.floor(raw) > 0 ? Number.POSITIVE_INFINITY : 0;
+}
+
+function retryBudgetLabel(budget: number): number | 'unlimited' {
+  return budget === Number.POSITIVE_INFINITY ? 'unlimited' : budget;
 }
 
 function loadTaskForEvent(
@@ -358,7 +363,6 @@ function buildCiFailureFixContext(event: ReviewGateCiFailedLifecycleEvent): stri
 function shouldSkipExistingAction(
   options: CiFailureWorkerPolicyOptions,
   event: ReviewGateCiFailedLifecycleEvent,
-  maxAttempts: number,
 ): boolean {
   const externalKey = ciFailureActionKey(event);
   const existing = options.store.getWorkerAction?.(CI_FAILURE_WORKER_KIND, externalKey);
@@ -368,21 +372,6 @@ function shouldSkipExistingAction(
       reason: 'already-recorded',
       existingStatus: existing.status,
       intentId: existing.intentId ?? null,
-    });
-    return true;
-  }
-  if (existing.attemptCount >= maxAttempts) {
-    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because retry budget is exhausted', {
-      reason: 'retry-budget-exhausted',
-      existingStatus: existing.status,
-      attemptCount: existing.attemptCount,
-      maxAttempts,
-    }, existing.intentId);
-    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
-      reason: 'retry-budget-exhausted',
-      existingStatus: existing.status,
-      attemptCount: existing.attemptCount,
-      maxAttempts,
     });
     return true;
   }
@@ -414,21 +403,8 @@ async function handleCiFailureEvent(
     });
     return;
   }
-  if ((task.execution.autoFixAttempts ?? 0) >= maxAttempts) {
-    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because retry budget is exhausted', {
-      reason: 'retry-budget-exhausted',
-      autoFixAttempts: task.execution.autoFixAttempts ?? 0,
-      maxAttempts,
-    });
-    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
-      reason: 'retry-budget-exhausted',
-      autoFixAttempts: task.execution.autoFixAttempts ?? 0,
-      maxAttempts,
-    });
-    return;
-  }
 
-  if (shouldSkipExistingAction(options, event, maxAttempts)) return;
+  if (shouldSkipExistingAction(options, event)) return;
 
   const stale = staleReasonForEvent(event, task);
   if (stale.stale) {
@@ -477,7 +453,7 @@ async function handleCiFailureEvent(
     {
       channel: FIX_WITH_AGENT_CHANNEL,
       autoFixAttempts: task.execution.autoFixAttempts ?? 0,
-      maxAttempts,
+      maxAttempts: retryBudgetLabel(maxAttempts),
     },
     intentId,
     selectedAgent,
@@ -489,7 +465,7 @@ async function handleCiFailureEvent(
     agent: selectedAgent ?? null,
     executionModel: executionModel ?? null,
     autoFixAttempts: task.execution.autoFixAttempts ?? 0,
-    maxAttempts,
+    maxAttempts: retryBudgetLabel(maxAttempts),
   });
 }
 

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -743,12 +743,12 @@ describe('Orchestrator', () => {
       expect(persistence.listWorkflows().find((workflow) => workflow.id === workflowId)?.status).toBe('running');
     });
 
-    it('resets auto-fix attempts to zero when a workflow is recreated', () => {
+    it('keeps auto-fix eligible after prior attempts and resets attempts when a workflow is recreated', () => {
       orchestrator = new Orchestrator({
         persistence,
         messageBus: bus,
         maxConcurrency: 3,
-        defaultAutoFixRetries: 3,
+        defaultAutoFixRetries: 1,
       });
 
       orchestrator.loadPlan({
@@ -765,9 +765,9 @@ describe('Orchestrator', () => {
         (task) => task.config.workflowId === workflowId && task.id.endsWith('/t1'),
       )!.id;
 
-      persistence.updateTask(taskId, { execution: { autoFixAttempts: 3 } });
+      persistence.updateTask(taskId, { status: 'failed', execution: { autoFixAttempts: 3 } });
       orchestrator.syncAllFromDb();
-      expect(orchestrator.shouldAutoFix(taskId)).toBe(false);
+      expect(orchestrator.shouldAutoFix(taskId)).toBe(true);
 
       orchestrator.recreateWorkflow(workflowId);
 
@@ -3475,7 +3475,7 @@ describe('Orchestrator', () => {
   // ── Auto-Fix ────────────────────────────────────────────
 
   describe('auto-fix via synthetic spawn_experiments', () => {
-    it('falls back to default auto-fix retries for older failed tasks missing per-task config', () => {
+    it('uses positive default auto-fix config as an uncapped enable switch for older failed tasks', () => {
       const hydratePersistence = new InMemoryPersistence();
       const hydrateBus = new InMemoryBus();
 
@@ -3496,18 +3496,18 @@ describe('Orchestrator', () => {
       const hydratedOrchestrator = new Orchestrator({
         persistence: hydratePersistence,
         messageBus: hydrateBus,
-        defaultAutoFixRetries: 3,
+        defaultAutoFixRetries: 1,
       });
 
       hydratedOrchestrator.syncFromDb('wf-hydrated');
 
-      expect(hydratedOrchestrator.getAutoFixRetryBudget('t1')).toBe(3);
+      expect(hydratedOrchestrator.getAutoFixRetryBudget('t1')).toBe(Number.POSITIVE_INFINITY);
       expect(hydratedOrchestrator.shouldAutoFix('t1')).toBe(true);
 
-      hydratePersistence.updateTask('t1', { execution: { autoFixAttempts: 3 } });
+      hydratePersistence.updateTask('t1', { execution: { autoFixAttempts: 100 } });
       hydratedOrchestrator.syncFromDb('wf-hydrated');
 
-      expect(hydratedOrchestrator.shouldAutoFix('t1')).toBe(false);
+      expect(hydratedOrchestrator.shouldAutoFix('t1')).toBe(true);
     });
 
     it('plain failed tasks stay failed in workflow-core', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -562,7 +562,7 @@ export interface OrchestratorConfig {
   /** Optional; defaults to an adapter wrapping `persistence`. */
   taskRepository?: TaskRepository;
   maxConcurrency?: number;
-  /** Default auto-fix retry budget for older tasks missing persisted per-task config. */
+  /** Positive values enable auto-fix; attempts are not capped by workflow-core. */
   defaultAutoFixRetries?: number;
   /**
    * Rules that validate task execution environment against command patterns.
@@ -663,7 +663,7 @@ export class Orchestrator {
     ];
     this.availablePoolIds = new Set(config.availablePoolIds ?? []);
     this.defaultPoolId = config.defaultPoolId;
-    this.defaultAutoFixRetries = Math.min(Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0)), 10);
+    this.defaultAutoFixRetries = Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0));
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
     this.resolveRepoDefaultBranch = config.resolveRepoDefaultBranch ?? requireDefaultBranchRemote;
 
@@ -3870,7 +3870,7 @@ export class Orchestrator {
   }
 
   getAutoFixRetryBudget(taskId: string): number {
-    return this.defaultAutoFixRetries;
+    return this.defaultAutoFixRetries > 0 ? Number.POSITIVE_INFINITY : 0;
   }
 
   private isRuntimeAutoFixEligibleTask(task: TaskState): boolean {
@@ -3885,8 +3885,7 @@ export class Orchestrator {
     if (task.status !== 'failed') return false;
     if (!this.isRuntimeAutoFixEligibleTask(task)) return false;
     const max = this.getAutoFixRetryBudget(taskId);
-    if (max <= 0) return false;
-    return (task.execution.autoFixAttempts ?? 0) < max;
+    return max > 0;
   }
 
   getAllTasks(): TaskState[] {


### PR DESCRIPTION
## Summary

Auto-fix no longer stops after a fixed number of failed repair tries in the runtime paths.

`autoFixRetries` is now only an on/off gate. `0` turns auto-fix off. Any positive value lets runtime routing keep trying another repair.

<details>
<summary>Review metadata</summary>

Review Claim: Runtime auto-fix routing should keep choosing repair after previous repair attempts when the config gate is on.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Auto-fix still requires the same task state, config gate, reconciliation guard, and error skip filters.

Slice Rationale: This slice changes only the runtime routing branch that decides whether another repair should run.

</details>

## Non-goals

This does not change which agent performs fixes.

This does not change helper scripts, documentation, approval handling, or stale task recovery.

## Architecture

### Before

```mermaid
graph TD
    A["failed task"] --> B["autoFixAttempts compared to retry cap"]
    B --> C["skip when cap reached"]
```

### After

```mermaid
graph TD
    A["failed task"] --> B["autoFixRetries greater than zero"]
    B --> C["route to another repair"]
```

## Test Plan

- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/orchestrator.test.ts`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/auto-fix-recovery.test.ts src/__tests__/headless-fix-autofix-context.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/pr-ci-workers.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/workflow-core build && pnpm --filter @invoker/execution-engine build && pnpm --filter @invoker/app build && pnpm --filter @invoker/cli build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Restore the previous retry cap if operators need bounded runtime attempts.
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-fix now stays enabled for eligible failed tasks when a positive retry setting is configured, even if prior attempts are already high.
  * Retry limits are now shown as **unlimited** when auto-fix is enabled, instead of a capped number.

* **Bug Fixes**
  * Fixed recovery behavior so failed tasks can still be considered for auto-fix after resyncing or restoring workflow state.
  * Manual fixes no longer affect auto-fix attempt tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->