### PR TITLE
[Planning Chat](4) Show planner submit errors

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -259,6 +259,73 @@ describe('planning chat', () => {
     expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
   });
 
+  it('returns load and parse failures as submit errors', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
+    const sessions = createInAppPlanningChatSessions();
+    const sent = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!sent.ok) throw new Error(sent.error);
+    const loadGeneratedPlan = vi.fn().mockRejectedValue(new Error('Task "make-selected-lists-scroll" uses "autoFix", which is no longer supported.'));
+
+    await expect(submitPlanningChatDraft({
+      sessionId: sent.sessionId,
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({
+      ok: false,
+      error: 'Task "make-selected-lists-scroll" uses "autoFix", which is no longer supported.',
+    });
+  });
+
+  it('submits planner drafts after stripping legacy auto-fix fields', async () => {
+    const legacyPlan = `Here is the plan.
+
+\`\`\`yaml
+name: Legacy AutoFix Draft
+onFinish: none
+autoFixRetries: 2
+tasks:
+  - id: make-selected-lists-scroll
+    description: Make selected lists scroll
+    command: pnpm test
+    dependencies: []
+    autoFix: false
+\`\`\``;
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(legacyPlan);
+    const sessions = createInAppPlanningChatSessions();
+    const sent = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!sent.ok) throw new Error(sent.error);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({ planName: 'Legacy AutoFix Draft', workflowId: 'wf-1' });
+
+    await expect(submitPlanningChatDraft({
+      sessionId: sent.sessionId,
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: true, planName: 'Legacy AutoFix Draft', workflowId: 'wf-1' });
+
+    const submittedPlan = loadGeneratedPlan.mock.calls[0]?.[0] as string;
+    expect(submittedPlan).toContain('id: make-selected-lists-scroll');
+    expect(submittedPlan).not.toContain('autoFix');
+    expect(submittedPlan).not.toContain('autoFixRetries');
+  });
+
   it('rejects submit for an unknown session', async () => {
     await expect(submitPlanningChatDraft({
       sessionId: 'missing',

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -134,13 +134,14 @@ describe('extractYamlPlan', () => {
     expect(plan.onFinish).toBeUndefined();
   });
 
-  it('preserves explicit fields from YAML', () => {
+  it('preserves explicit supported fields and strips legacy auto-fix fields from planner YAML', () => {
     const text = `\`\`\`yaml
 name: "Full"
 onFinish: merge
 baseBranch: develop
 featureBranch: feature/test
 mergeMode: automatic
+autoFixRetries: 3
 tasks:
   - id: t1
     description: "test"
@@ -148,6 +149,7 @@ tasks:
     dependencies: []
     pivot: true
     autoFix: true
+    autoFixRetries: 2
     requiresManualApproval: true
 \`\`\``;
     const result = extractYamlPlan(text);
@@ -156,8 +158,10 @@ tasks:
     expect(plan.baseBranch).toBe('develop');
     expect(plan.featureBranch).toBe('feature/test');
     expect(plan.mergeMode).toBe('automatic');
+    expect(plan.autoFixRetries).toBeUndefined();
     expect(plan.tasks[0].pivot).toBe(true);
-    expect(plan.tasks[0].autoFix).toBe(true);
+    expect(plan.tasks[0].autoFix).toBeUndefined();
+    expect(plan.tasks[0].autoFixRetries).toBeUndefined();
     expect(plan.tasks[0].requiresManualApproval).toBe(true);
   });
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -139,7 +139,7 @@ tasks:
         description: "Approach A"
         prompt: "Try approach A"
     requiresManualApproval: false
-    autoFix: false               # auto-retry with experiments on failure
+
 \`\`\`
 
 Rules:
@@ -150,7 +150,7 @@ Rules:
    - Ask at most 1-2 clarifying questions only when the answer would materially change the plan. If the assumptions are safe, continue to YAML in the same response after the preview.
 3. Keep plans focused — 3-8 tasks maximum. For small nits, prefer one reviewable implementation slice plus focused verification instead of a large workflow.
 4. File-count guidance is a soft heuristic, not a hard validator gate. Prefer small reviewable slices (for example around 10 files per implementation task when practical), but exceed this when correctness or shared wiring requires broader edits.
-5. Each task should have either a \`command\` or a \`prompt\`, not both.
+5. Each task should have either a \`command\` or a \`prompt\`, not both. Do not include legacy \`autoFix\` or \`autoFixRetries\` fields anywhere in the YAML; auto-fix retries are configured only in ~/.invoker/config.json.
 6. Every step MUST be testable. Every implementation task MUST have a corresponding test task that verifies it works using a concrete, executable \`command\` discovered from the target repo (e.g. that repo's package scripts, build commands, or focused checks such as \`git diff --name-only\`). The test command must produce a clear pass/fail exit code. Do NOT skip tests for any step. Do NOT use prompts for test tasks — use commands only.
    Test command rules:
    - Inspect repo manifests and existing docs/scripts before choosing commands.
@@ -524,7 +524,14 @@ export function extractYamlPlan(text: string): string | null {
       }
     }
 
-    // Return serialized YAML as provided — no defaulting or repo-specific command rewriting.
+    // Return serialized YAML with planner-only legacy fields stripped. The parser still
+    // rejects these fields in user-authored plan files so stale plans fail loudly there.
+    delete plan.autoFix;
+    delete plan.autoFixRetries;
+    for (const task of plan.tasks) {
+      delete task.autoFix;
+      delete task.autoFixRetries;
+    }
     return stringifyYaml(plan);
   } catch (err) {
     console.warn(`extractYamlPlan: YAML parse error: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -526,6 +526,7 @@ export function App() {
   const nextTerminalLineIdRef = useRef(2);
   const [planningPresetOptions, setPlanningPresetOptions] = useState<Array<{ key: string; label: string; isDefault?: boolean }>>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
+  const [planningSubmitError, setPlanningSubmitError] = useState<{ title: string; message: string } | null>(null);
   const [planningTerminalExpanded, setPlanningTerminalExpanded] = useState(false);
   const activePlanningSession = useMemo(
     () => planningSessions.find((session) => session.id === activePlanningSessionId) ?? planningSessions[0] ?? makeInitialPlanningSession(),
@@ -1850,17 +1851,20 @@ export function App() {
 
   const handlePlanningSubmitDraft = useCallback(async () => {
     if (!planningSessionId) {
-      appendTerminalLine('No planning conversation yet.', 'system', 'error');
+      setPlanningSubmitError({ title: 'Plan could not be submitted', message: 'No planning conversation yet.' });
+      appendTerminalLine('Plan could not be submitted:\nNo planning conversation yet.', 'system', 'error');
       return;
     }
     if (!invoker?.planningChatSubmit) {
-      appendTerminalLine('Planner is not available.', 'system', 'error');
+      setPlanningSubmitError({ title: 'Plan could not be submitted', message: 'Planner is not available.' });
+      appendTerminalLine('Plan could not be submitted:\nPlanner is not available.', 'system', 'error');
       return;
     }
     updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: true }));
     try {
       const result = await invoker.planningChatSubmit({ sessionId: planningSessionId });
       if (result.ok) {
+        setPlanningSubmitError(null);
         setHasLoadedPlan(true);
         setHasStarted(false);
         setSidebarSurface('home');
@@ -1883,11 +1887,14 @@ export function App() {
         appendTerminalLine(`Plan "${result.planName}" submitted to Invoker. Review it, then Run.`, 'system', 'success');
       } else {
         updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: false }));
-        appendTerminalLine(result.error, 'system', 'error');
+        setPlanningSubmitError({ title: 'Plan could not be submitted', message: result.error });
+        appendTerminalLine(`Plan could not be submitted:\n${result.error}`, 'system', 'error');
       }
     } catch (err) {
       updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: false }));
-      appendTerminalLine(err instanceof Error ? err.message : 'Failed to submit the plan.', 'system', 'error');
+      const message = err instanceof Error ? err.message : 'Failed to submit the plan.';
+      setPlanningSubmitError({ title: 'Plan could not be submitted', message });
+      appendTerminalLine(`Plan could not be submitted:\n${message}`, 'system', 'error');
     }
   }, [appendTerminalLine, invoker, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
 
@@ -1896,6 +1903,7 @@ export function App() {
     if (!input || activePlanningSessionBusy || activePlanningSessionSubmitted) return;
     appendTerminalLine(input, 'user');
     setPlanningInput('');
+    setPlanningSubmitError(null);
 
     if (input.toLowerCase() === 'run') {
       if (!hasLoadedPlan || hasStarted) {
@@ -1962,10 +1970,13 @@ export function App() {
       } else {
         updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
         appendTerminalLine(result.error, 'system', 'error');
+        setPlanningSubmitError({ title: 'Planner could not respond', message: result.error });
       }
     } catch (err) {
       updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
-      appendTerminalLine(err instanceof Error ? err.message : 'Failed to reach the planner.', 'system', 'error');
+      const message = err instanceof Error ? err.message : 'Failed to reach the planner.';
+      setPlanningSubmitError({ title: 'Planner could not respond', message });
+      appendTerminalLine(message, 'system', 'error');
     }
   }, [
     activePlanningSessionBusy,
@@ -2813,6 +2824,7 @@ export function App() {
             presetOptions={planningPresetOptions}
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
+            submitError={planningSubmitError}
             readOnly={activePlanningSessionSubmitted}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
@@ -3049,6 +3061,7 @@ export function App() {
             presetOptions={planningPresetOptions}
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
+            submitError={planningSubmitError}
             expanded
             onValueChange={setPlanningInput}
             readOnly={activePlanningSessionSubmitted}

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { vi } from 'vitest';
 import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
 
@@ -121,6 +121,47 @@ describe('Invoker terminal (component)', () => {
     fireEvent.click(screen.getByTestId('sidebar-planning'));
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
     expect(mock.api.start).not.toHaveBeenCalled();
+  });
+
+  it('shows submit errors beside the ready draft and allows retry', async () => {
+    const submitError = 'Task "make-selected-lists-scroll" uses "autoFix", which is no longer supported.';
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-1',
+      reply: 'Here is the plan.',
+      draftPlanAvailable: true,
+      draftPlanSummary: { name: 'Selected lists scroll', taskCount: 4, steps: ['First', 'Second', 'Third', 'Fourth'] },
+    })) as any;
+    mock.api.planningChatSubmit = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, error: submitError })
+      .mockResolvedValueOnce({ ok: true, planName: 'Selected lists scroll', workflowId: 'wf-1' }) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft the full plan');
+    await screen.findByTestId('invoker-terminal-ready-bar');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+
+    const errorPanel = await screen.findByTestId('invoker-terminal-submit-error');
+    expect(errorPanel).toHaveTextContent('Plan could not be submitted');
+    expect(errorPanel).toHaveTextContent(submitError);
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(`Plan could not be submitted: ${submitError}`);
+    expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('Draft plan ready: "Selected lists scroll" (4 steps).');
+    expect(mock.api.refreshTaskGraph).not.toHaveBeenCalled();
+
+    fireEvent.click(within(errorPanel).getByRole('button', { name: 'Retry submit' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(2);
+      expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
+      expect(screen.getByText('Plan graph')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then Run.');
+    expect(screen.queryByTestId('invoker-terminal-submit-error')).not.toBeInTheDocument();
   });
 
   it('explains that run needs a submitted plan first', async () => {

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -20,6 +20,7 @@ interface InvokerTerminalProps {
   presetOptions: PlanningPresetOptionView[];
   draftPlanAvailable: boolean;
   draftPlanSummary?: { name: string; taskCount: number };
+  submitError?: SubmitErrorView | null;
   readOnly?: boolean;
   expanded?: boolean;
   onValueChange: (value: string) => void;
@@ -31,6 +32,11 @@ interface InvokerTerminalProps {
   onCollapse?: () => void;
 }
 
+interface SubmitErrorView {
+  title: string;
+  message: string;
+}
+
 export function InvokerTerminal({
   lines,
   busy,
@@ -39,6 +45,7 @@ export function InvokerTerminal({
   presetOptions,
   draftPlanAvailable,
   draftPlanSummary,
+  submitError,
   readOnly = false,
   expanded = false,
   onValueChange,
@@ -132,30 +139,65 @@ export function InvokerTerminal({
       {draftPlanAvailable && !readOnly && (
         <div
           data-testid="invoker-terminal-ready-bar"
-          className="sticky bottom-0 z-10 mx-4 mb-3 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-emerald-500/30 bg-emerald-950/70 px-4 py-3 text-sm text-emerald-100 shadow-lg"
+          className="sticky bottom-0 z-10 mx-4 mb-3 space-y-3 rounded-2xl border border-emerald-500/30 bg-emerald-950/70 px-4 py-3 text-sm text-emerald-100 shadow-lg"
         >
-          <span>
-            {draftPlanSummary
-              ? `Draft plan ready: "${draftPlanSummary.name}" (${draftPlanSummary.taskCount} steps).`
-              : 'Draft plan ready.'}
-          </span>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={onSubmitDraft}
-              disabled={busy}
-              className="rounded-full bg-emerald-300 px-4 py-2 text-sm font-medium text-emerald-950 hover:bg-emerald-200 disabled:cursor-wait disabled:opacity-50"
-            >
-              Submit to Invoker
-            </button>
-            <button
-              type="button"
-              onClick={focusComposer}
-              className="rounded-full border border-emerald-400/40 px-4 py-2 text-sm text-emerald-100 hover:border-emerald-200"
-            >
-              Keep chatting
-            </button>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span>
+              {draftPlanSummary
+                ? `Draft plan ready: "${draftPlanSummary.name}" (${draftPlanSummary.taskCount} steps).`
+                : 'Draft plan ready.'}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onSubmitDraft}
+                disabled={busy}
+                className="rounded-full bg-emerald-300 px-4 py-2 text-sm font-medium text-emerald-950 hover:bg-emerald-200 disabled:cursor-wait disabled:opacity-50"
+              >
+                {submitError ? 'Retry submit' : 'Submit to Invoker'}
+              </button>
+              <button
+                type="button"
+                onClick={focusComposer}
+                className="rounded-full border border-emerald-400/40 px-4 py-2 text-sm text-emerald-100 hover:border-emerald-200"
+              >
+                Keep chatting
+              </button>
+            </div>
           </div>
+          {submitError && (
+            <div
+              data-testid="invoker-terminal-submit-error"
+              className="rounded-2xl border border-red-500/40 bg-red-950/70 px-4 py-3 text-red-100"
+            >
+              <div className="text-sm font-semibold text-red-100">{submitError.title}</div>
+              <div className="mt-2 whitespace-pre-wrap text-sm leading-6 text-red-200">{submitError.message}</div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={onSubmitDraft}
+                  disabled={busy}
+                  className="rounded-full bg-red-200 px-4 py-2 text-sm font-medium text-red-950 hover:bg-red-100 disabled:cursor-wait disabled:opacity-50"
+                >
+                  Retry submit
+                </button>
+                <button
+                  type="button"
+                  onClick={focusComposer}
+                  className="rounded-full border border-red-300/40 px-4 py-2 text-sm text-red-100 hover:border-red-100"
+                >
+                  Keep chatting
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void navigator.clipboard?.writeText(submitError.message)}
+                  className="rounded-full border border-red-300/40 px-4 py-2 text-sm text-red-100 hover:border-red-100"
+                >
+                  Copy error
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

Planning handoff failures now stay visible in the activation surface instead of disappearing into logs or a failed handler.

The draft remains ready. Users see the exact error, can try again, keep chatting, or copy the message.

Planner-generated YAML also drops legacy auto-fix fields before handoff, so old AI output does not block preview.

<details>
<summary>Review metadata</summary>

Review Claim: The planning activation surface now makes handoff errors visible, recoverable, and safe for users to continue from.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Failed handoffs only update the active planning chat state; successful handoffs still clear draft state and load the graph.

Slice Rationale: This sits on top of the planning chat stack because it only changes the final handoff activation experience.

</details>

## Non-goals

This does not change YAML validation rules for user-authored plan files.

This does not start workflows automatically after a successful submit.

This does not change planner prompt scope beyond removing unsupported auto-fix fields from generated drafts.

## Architecture

### Before

```mermaid
graph TD
    A["User submits draft"] --> B["loadGeneratedPlan throws"]
    B --> C["IPC handler error"]
    C --> D["User loses actionable context"]
```

### After

```mermaid
graph TD
    A["User submits draft"] --> B["submitPlanningChatDraft catches submit error"]
    B --> C["App stores planningSubmitError"]
    C --> D["InvokerTerminal shows retryable error panel"]
```

## Test Plan

- [x] `pnpm --filter @invoker/surfaces test -- plan-conversation.test.ts`
- [x] `pnpm --filter @invoker/app test -- in-app-planner.test.ts`
- [x] `pnpm --dir packages/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`

## Visual Proof

Before: submit failure only left the normal draft-ready chat surface visible.

![Before planning submit error](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260704-854ec7/planning-submit-error-before.png)

After: submit failure keeps the draft ready and adds the retryable error panel with the exact message.

![After planning submit error](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260704-854ec7/planning-submit-error-after.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 5098a3e87`
- Post-revert steps: Restart the app so the rebuilt main process is unloaded.
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer planning submission error handling in the terminal UI, including an error panel with retry, keep chatting, and copy-message actions.
  * Updated the planning draft flow to show a “Retry submit” state when submission fails.

* **Bug Fixes**
  * Improved handling of failed plan generation so users receive a visible error instead of a silent failure.
  * Legacy auto-fix fields are now removed from planning YAML while preserving supported plan details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->