### PR TITLE
Prefer stacked planner workflow drafts

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -26,6 +26,31 @@ tasks:
     command: echo second
 \`\`\``;
 
+const WORKERS_SURFACE_STACKED_PLAN = `Here is the plan.
+
+\`\`\`yaml
+name: Workers Surface
+repoUrl: git@github.com:test/repo.git
+workflows:
+  - name: Workers Surface Contracts
+    tasks:
+      - id: define-worker-contracts
+        description: Define worker contracts
+        prompt: Update shared contracts for workers
+        dependencies: []
+      - id: verify-worker-contracts
+        description: Verify worker contracts
+        command: pnpm test packages/contracts
+        dependencies: [define-worker-contracts]
+  - name: Workers Surface UI
+    tasks:
+      - id: build-workers-ui
+        description: Build workers UI
+        prompt: Implement the workers surface
+        dependencies: []
+        command: pnpm test packages/ui
+\`\`\``;
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -65,6 +90,30 @@ describe('planFromGoal', () => {
     expect(sendMessage).toHaveBeenCalledWith('Add README');
     expect(loadGeneratedPlan).toHaveBeenCalledTimes(1);
     expect(loadGeneratedPlan.mock.calls[0]?.[0]).toContain('name: Mock Plan');
+  });
+
+  it('returns workflow ids and counts for stacked planner drafts', async () => {
+    const sendMessage = vi.spyOn(PlanConversation.prototype, 'sendMessage').mockResolvedValue(WORKERS_SURFACE_STACKED_PLAN);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Workers Surface',
+      workflowId: 'wf-2',
+      workflowIds: ['wf-1', 'wf-2'],
+      workflowCount: 2,
+    });
+
+    await expect(planFromGoal({ goal: 'Build Workers Surface' }, {
+      config: {},
+      loadGeneratedPlan,
+    })).resolves.toEqual({
+      ok: true,
+      planName: 'Workers Surface',
+      workflowId: 'wf-2',
+      workflowIds: ['wf-1', 'wf-2'],
+      workflowCount: 2,
+    });
+
+    expect(sendMessage).toHaveBeenCalledWith('Build Workers Surface');
+    expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('workflows:'));
   });
 
   it('does not load invalid planner output', async () => {
@@ -236,6 +285,30 @@ describe('planning chat', () => {
     expect(result.ok && result.reply).not.toContain('```yaml');
   });
 
+  it('returns a stacked workflow summary when the assistant drafts workflow bundles', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(WORKERS_SURFACE_STACKED_PLAN);
+    const sessions = createInAppPlanningChatSessions();
+    const result = await sendPlanningChatMessage({
+      message: 'draft the Workers Surface plan',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    expect(result).toMatchObject({
+      ok: true,
+      draftPlanAvailable: true,
+      draftPlanSummary: {
+        name: 'Workers Surface',
+        taskCount: 3,
+        workflowCount: 2,
+        steps: ['Workers Surface Contracts', 'Workers Surface UI'],
+      },
+    });
+  });
+
   it('submits the latest valid draft plan', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
     const sessions = createInAppPlanningChatSessions();
@@ -249,14 +322,25 @@ describe('planning chat', () => {
       planningCommandBuilder,
     });
     if (!sent.ok) throw new Error(sent.error);
-    const loadGeneratedPlan = vi.fn().mockResolvedValue({ planName: 'Mock Plan', workflowId: 'wf-1' });
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+    });
 
     await expect(submitPlanningChatDraft({
       sessionId: sent.sessionId,
     }, {
       sessions,
       loadGeneratedPlan,
-    })).resolves.toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
+    })).resolves.toEqual({
+      ok: true,
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+    });
     expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
   });
   it('coalesces concurrent submit requests for one session', async () => {
@@ -329,6 +413,43 @@ tasks:
     expect(submittedPlan).toContain('id: make-selected-lists-scroll');
     expect(submittedPlan).not.toContain('autoFix');
     expect(submittedPlan).not.toContain('autoFixRetries');
+  });
+
+  it('submits stacked drafts as stacked workflows', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(WORKERS_SURFACE_STACKED_PLAN);
+    const sessions = createInAppPlanningChatSessions();
+    const sent = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!sent.ok) throw new Error(sent.error);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Workers Surface',
+      workflowId: 'wf-2',
+      workflowIds: ['wf-1', 'wf-2'],
+      workflowCount: 2,
+    });
+
+    await expect(submitPlanningChatDraft({
+      sessionId: sent.sessionId,
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({
+      ok: true,
+      planName: 'Workers Surface',
+      workflowId: 'wf-2',
+      workflowIds: ['wf-1', 'wf-2'],
+      workflowCount: 2,
+    });
+    expect(sessions.get(sent.sessionId)?.messages.at(-1)?.text).toBe(
+      'Plan "Workers Surface" submitted as 2 stacked workflows. Review them, then Run.',
+    );
   });
 
   it('rejects submit for an unknown session', async () => {

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { parsePlan, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults } from '../plan-parser.js';
+import { parsePlan, parsePlanSubmissionBundle, PlanParseError, detectDefaultBranch, applyPlanDefinitionDefaults, applyConfiguredPlanDefaults } from '../plan-parser.js';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { writeFileSync } from 'node:fs';
@@ -118,6 +118,76 @@ tasks:
 `;
     const plan = parsePlan(yaml);
     expect(plan.intermediateRepoUrl).toBe('https://github.com/fork/repo.git');
+  });
+
+  it('parses a Workers Surface stacked workflow bundle in order', () => {
+    const yaml = `
+name: Workers Surface
+repoUrl: git@github.com:test/repo.git
+baseBranch: main
+onFinish: pull_request
+mergeMode: external_review
+workflows:
+  - name: Workers Surface Contracts
+    featureBranch: plan/workers-surface-contracts
+    tasks:
+      - id: define-worker-contracts
+        description: Define worker contracts
+        prompt: Update shared contracts for workers
+        dependencies: []
+      - id: verify-worker-contracts
+        description: Verify worker contracts
+        command: pnpm test packages/contracts
+        dependencies: [define-worker-contracts]
+  - name: Workers Surface UI
+    featureBranch: plan/workers-surface-ui
+    tasks:
+      - id: build-workers-ui
+        description: Build workers UI
+        prompt: Implement the workers surface
+        dependencies: []
+      - id: verify-workers-ui
+        description: Verify workers UI
+        command: pnpm test packages/ui
+        dependencies: [build-workers-ui]
+`;
+    const bundle = parsePlanSubmissionBundle(yaml);
+    expect(bundle.name).toBe('Workers Surface');
+    expect(bundle.isStack).toBe(true);
+    expect(bundle.plans.map((plan) => plan.name)).toEqual([
+      'Workers Surface Contracts',
+      'Workers Surface UI',
+    ]);
+    expect(bundle.plans[0].repoUrl).toBe('git@github.com:test/repo.git');
+    expect(bundle.plans[0].mergeMode).toBe('external_review');
+    expect(bundle.plans[0].reviewProvider).toBe('github');
+    expect(bundle.plans[0].featureBranch).toBe('plan/workers-surface-contracts');
+    expect(bundle.plans[1].featureBranch).toBe('plan/workers-surface-ui');
+    expect(bundle.plans[1].tasks.map((task) => task.id)).toEqual([
+      'build-workers-ui',
+      'verify-workers-ui',
+    ]);
+  });
+
+  it('rejects empty or mixed stacked workflow bundles', () => {
+    expect(() => parsePlanSubmissionBundle(`
+name: Empty Stack
+repoUrl: git@github.com:test/repo.git
+workflows: []
+`)).toThrow('Plan stack must have a non-empty "workflows" array');
+
+    expect(() => parsePlanSubmissionBundle(`
+name: Mixed Stack
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: top
+    description: Top task
+workflows:
+  - name: Child
+    tasks:
+      - id: child
+        description: Child task
+`)).toThrow('Plan stack must put tasks inside each workflow');
   });
 
   it('parses plan with dependencies', () => {

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -169,7 +169,7 @@ workflows:
     ]);
   });
 
-  it('rejects empty or mixed stacked workflow bundles', () => {
+  it('rejects invalid stacked workflow bundles', () => {
     expect(() => parsePlanSubmissionBundle(`
 name: Empty Stack
 repoUrl: git@github.com:test/repo.git
@@ -188,6 +188,38 @@ workflows:
       - id: child
         description: Child task
 `)).toThrow('Plan stack must put tasks inside each workflow');
+
+    expect(() => parsePlanSubmissionBundle(`
+name: Legacy Stack
+repoUrl: git@github.com:test/repo.git
+autoFixRetries: 1
+workflows:
+  - name: Child
+    tasks:
+      - id: child
+        description: Child task
+`)).toThrow('Plan stack-level "autoFixRetries" is no longer supported');
+
+    expect(() => parsePlanSubmissionBundle(`
+name: Bad Dependencies
+repoUrl: git@github.com:test/repo.git
+externalDependencies: bad
+workflows:
+  - name: Child
+    tasks:
+      - id: child
+        description: Child task
+`)).toThrow('Plan stack "externalDependencies" must be an array');
+
+    expect(() => parsePlan(`
+name: Legacy Parse Entry
+repoUrl: git@github.com:test/repo.git
+workflows:
+  - name: Child
+    tasks:
+      - id: child
+        description: Child task
+`)).toThrow('Stacked workflow YAML must be loaded with parsePlanSubmissionBundle()');
   });
 
   it('parses plan with dependencies', () => {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -24,6 +24,8 @@ import type { InvokerConfig } from './config.js';
 export interface LoadedGeneratedPlan {
   planName: string;
   workflowId: string;
+  workflowIds?: string[];
+  workflowCount?: number;
 }
 
 export interface InAppPlannerDeps {
@@ -192,6 +194,7 @@ async function createSession(
       defaultBranch: deps.config.defaultBranch,
       repoUrl: deps.config.defaultRepoUrl,
       experimentalPlanner: deps.config.experimentalPlanner,
+      preferStackedWorkflows: true,
       planningCommandBuilder: deps.planningCommandBuilder,
     }),
     createdAt,
@@ -247,6 +250,7 @@ export async function planFromGoal(
       defaultBranch: deps.config.defaultBranch,
       repoUrl: deps.config.defaultRepoUrl,
       experimentalPlanner: deps.config.experimentalPlanner,
+      preferStackedWorkflows: true,
       planningCommandBuilder: deps.planningCommandBuilder,
     });
     const plannerOutput = await conversation.sendMessage(goal);
@@ -256,7 +260,13 @@ export async function planFromGoal(
     }
 
     const loaded = await deps.loadGeneratedPlan(planText);
-    return { ok: true, planName: loaded.planName, workflowId: loaded.workflowId };
+    return {
+      ok: true,
+      planName: loaded.planName,
+      workflowId: loaded.workflowId,
+      workflowIds: loaded.workflowIds,
+      workflowCount: loaded.workflowCount,
+    };
   } catch (error) {
     return {
       ok: false,
@@ -463,8 +473,21 @@ export async function submitPlanningChatDraft(
       session.submittedPlanName = loaded.planName;
       session.submittedWorkflowId = loaded.workflowId;
       session.updatedAt = new Date().toISOString();
-      appendSessionMessage(session, 'system', `Plan "${loaded.planName}" submitted to Invoker. Review it, then Run.`, 'success');
-      return { ok: true, planName: loaded.planName, workflowId: loaded.workflowId };
+      appendSessionMessage(
+        session,
+        'system',
+        loaded.workflowCount && loaded.workflowCount > 1
+          ? `Plan "${loaded.planName}" submitted as ${loaded.workflowCount} stacked workflows. Review them, then Run.`
+          : `Plan "${loaded.planName}" submitted to Invoker. Review it, then Run.`,
+        'success',
+      );
+      return {
+        ok: true,
+        planName: loaded.planName,
+        workflowId: loaded.workflowId,
+        workflowIds: loaded.workflowIds,
+        workflowCount: loaded.workflowCount,
+      };
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : String(error) };
     } finally {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1047,17 +1047,54 @@ function startHeadlessMode(): void {
         return { workflowId, tasks };
       };
 
-      const loadGeneratedPlan = async (planText: string): Promise<{ planName: string; workflowId: string }> => {
-        const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
-        const plan = applyConfiguredPlanDefaults(parsePlan(planText));
+      const loadGeneratedPlan = async (
+        planText: string,
+      ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> => {
+        const { applyConfiguredPlanDefaults, parsePlanSubmissionBundle } = await import('./plan-parser.js');
+        const submission = parsePlanSubmissionBundle(planText);
         const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
-        backupPlan(plan, undefined, logger);
-        orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
-        const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
-        if (!workflow) {
+        const loadedWorkflowIds: string[] = [];
+        let upstream: { workflowId: string; featureBranch: string } | undefined;
+
+        for (const parsedPlan of submission.plans) {
+          let plan = applyConfiguredPlanDefaults(parsedPlan);
+          if (upstream) {
+            plan = {
+              ...plan,
+              baseBranch: upstream.featureBranch,
+              externalDependencies: [
+                ...(plan.externalDependencies ?? []),
+                {
+                  workflowId: upstream.workflowId,
+                  taskId: '__merge__',
+                  requiredStatus: 'completed',
+                  gatePolicy: 'completed',
+                } as const,
+              ],
+            };
+          }
+          backupPlan(plan, undefined, logger);
+          orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+          const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
+          if (!workflow) {
+            throw new Error('Loaded plan did not create a workflow.');
+          }
+          existingWorkflowIds.add(workflow.id);
+          loadedWorkflowIds.push(workflow.id);
+          upstream = { workflowId: workflow.id, featureBranch: workflow.featureBranch ?? plan.featureBranch ?? plan.baseBranch ?? 'main' };
+        }
+
+        const workflowId = loadedWorkflowIds[loadedWorkflowIds.length - 1];
+        if (!workflowId) {
           throw new Error('Loaded plan did not create a workflow.');
         }
-        return { planName: plan.name, workflowId: workflow.id };
+
+        return {
+          planName: submission.name,
+          workflowId,
+          workflowIds: loadedWorkflowIds,
+          workflowCount: loadedWorkflowIds.length,
+        };
       };
 
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
@@ -1123,14 +1160,9 @@ function startHeadlessMode(): void {
           }
           case 'invoker:load-plan': {
             const planText = String(payload.args[0] ?? '');
-            const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
-            const plan = applyConfiguredPlanDefaults(parsePlan(planText));
-            backupPlan(plan, undefined, logger);
-            orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+            await loadGeneratedPlan(planText);
             return undefined;
           }
-          case 'invoker:start':
-            return orchestrator.startExecution();
           case 'invoker:stop': {
             logger.info('stop — destroying all daemon executors', { module: 'ipc-delegate' });
             const failInFlightTasks = (): void => {
@@ -3562,21 +3594,58 @@ function createEmbeddedTerminalBackendFromConfig(
     async function loadGeneratedPlanPreview(
       planText: string,
       options?: { preserveTaskHandles?: boolean; logLabel?: string },
-    ): Promise<{ planName: string; workflowId: string }> {
-      const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
-      const plan = applyConfiguredPlanDefaults(parsePlan(planText));
+    ): Promise<{ planName: string; workflowId: string; workflowIds?: string[]; workflowCount?: number }> {
+      const { applyConfiguredPlanDefaults, parsePlanSubmissionBundle } = await import('./plan-parser.js');
+      const submission = parsePlanSubmissionBundle(planText);
       const existingWorkflowIds = new Set(persistence.listWorkflows().map((workflow) => workflow.id));
-      logger.info(`${options?.logLabel ?? 'plan-from-goal'}: loading "${plan.name}" (${plan.tasks.length} tasks)`, { module: 'ipc' });
+      const loadedWorkflowIds: string[] = [];
+      let upstream: { workflowId: string; featureBranch: string } | undefined;
+      logger.info(
+        `${options?.logLabel ?? 'plan-from-goal'}: loading "${submission.name}" (${submission.plans.length} workflow${submission.plans.length === 1 ? '' : 's'})`,
+        { module: 'ipc' },
+      );
       if (!options?.preserveTaskHandles) {
         taskHandles.clear();
       }
-      backupPlan(plan, undefined, logger);
-      orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
-      const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
-      if (!workflow) {
+
+      for (const parsedPlan of submission.plans) {
+        let plan = applyConfiguredPlanDefaults(parsedPlan);
+        if (upstream) {
+          plan = {
+            ...plan,
+            baseBranch: upstream.featureBranch,
+            externalDependencies: [
+              ...(plan.externalDependencies ?? []),
+              {
+                workflowId: upstream.workflowId,
+                taskId: '__merge__',
+                requiredStatus: 'completed',
+                gatePolicy: 'completed',
+              } as const,
+            ],
+          };
+        }
+        backupPlan(plan, undefined, logger);
+        orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+        const workflow = persistence.listWorkflows().find((candidate) => !existingWorkflowIds.has(candidate.id));
+        if (!workflow) {
+          throw new Error('Loaded plan did not create a workflow.');
+        }
+        existingWorkflowIds.add(workflow.id);
+        loadedWorkflowIds.push(workflow.id);
+        upstream = { workflowId: workflow.id, featureBranch: workflow.featureBranch ?? plan.featureBranch ?? plan.baseBranch ?? 'main' };
+      }
+
+      const workflowId = loadedWorkflowIds[loadedWorkflowIds.length - 1];
+      if (!workflowId) {
         throw new Error('Loaded plan did not create a workflow.');
       }
-      return { planName: plan.name, workflowId: workflow.id };
+      return {
+        planName: submission.name,
+        workflowId,
+        workflowIds: loadedWorkflowIds,
+        workflowCount: loadedWorkflowIds.length,
+      };
     }
     let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
     let testPlanningChatResponse: { planYaml: string; planName: string; reply?: string } | null = null;
@@ -3585,7 +3654,7 @@ function createEmbeddedTerminalBackendFromConfig(
     registerGuiMutationHandler('invoker:plan-from-goal', async (...args: unknown[]) => {
       if (process.env.NODE_ENV === 'test' && testPlanFromGoalResponse) {
         const loaded = await loadGeneratedPlanPreview(testPlanFromGoalResponse.planYaml);
-        return { ok: true, planName: testPlanFromGoalResponse.planName, workflowId: loaded.workflowId };
+        return { ok: true, planName: testPlanFromGoalResponse.planName, workflowId: loaded.workflowId, workflowIds: loaded.workflowIds, workflowCount: loaded.workflowCount };
       }
       return planFromGoalInApp(args[0] as InAppPlanRequest, {
         config: invokerConfig,
@@ -3608,11 +3677,14 @@ function createEmbeddedTerminalBackendFromConfig(
     });
     registerGuiMutationHandler('invoker:planning-chat-send', async (request: unknown) => {
       if (process.env.NODE_ENV === 'test' && testPlanningChatResponse) {
+        const { summarizePlanText } = await import('@invoker/surfaces');
+        const draftPlanSummary = summarizePlanText(testPlanningChatResponse.planYaml) ?? undefined;
         return {
           ok: true,
           sessionId: 'test-session',
           reply: testPlanningChatResponse.reply ?? 'Draft plan ready.',
           draftPlanAvailable: true,
+          draftPlanSummary,
         };
       }
       return sendPlanningChatMessage(request as InAppPlanningChatRequest, {
@@ -3629,7 +3701,7 @@ function createEmbeddedTerminalBackendFromConfig(
           preserveTaskHandles: true,
           logLabel: 'planning-chat-submit',
         });
-        return { ok: true, planName: testPlanningChatResponse.planName, workflowId: loaded.workflowId };
+        return { ok: true, planName: testPlanningChatResponse.planName, workflowId: loaded.workflowId, workflowIds: loaded.workflowIds, workflowCount: loaded.workflowCount };
       }
       return submitPlanningChatDraft(request as InAppPlanningSubmitRequest, {
         sessions: planningChatSessions,
@@ -3644,12 +3716,7 @@ function createEmbeddedTerminalBackendFromConfig(
     });
     registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
       const planText = String(planTextArg);
-      const { applyConfiguredPlanDefaults, parsePlan } = await import('./plan-parser.js');
-      const plan = applyConfiguredPlanDefaults(parsePlan(planText));
-      logger.info(`load-plan: "${plan.name}" (${plan.tasks.length} tasks)`, { module: 'ipc' });
-      taskHandles.clear();
-      backupPlan(plan, undefined, logger);
-      orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+      await loadGeneratedPlanPreview(planText, { logLabel: 'load-plan' });
     });
 
     if (process.env.NODE_ENV === 'test') {

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -414,9 +414,23 @@ function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
 }
 
 function inheritStackWorkflowDefaults(stack: RawPlanBundle, workflow: RawPlan): RawPlan {
+  const stackExternalDependencies = stack.externalDependencies === undefined
+    ? []
+    : Array.isArray(stack.externalDependencies)
+      ? stack.externalDependencies
+      : (() => {
+          throw new PlanParseError('Plan stack "externalDependencies" must be an array when provided.');
+        })();
+  const workflowExternalDependencies = workflow.externalDependencies === undefined
+    ? []
+    : Array.isArray(workflow.externalDependencies)
+      ? workflow.externalDependencies
+      : (() => {
+          throw new PlanParseError(`Workflow "${workflow.name ?? '<unnamed>'}" "externalDependencies" must be an array when provided.`);
+        })();
   const externalDependencies = [
-    ...(stack.externalDependencies ?? []),
-    ...(workflow.externalDependencies ?? []),
+    ...stackExternalDependencies,
+    ...workflowExternalDependencies,
   ];
 
   return {
@@ -453,6 +467,19 @@ export function parsePlanSubmissionBundle(yamlContent: string): PlanSubmissionBu
   if (raw.tasks !== undefined) {
     throw new PlanParseError('Plan stack must put tasks inside each workflow, not at the top level.');
   }
+  const stackHasOwn = (key: string): boolean =>
+    Object.prototype.hasOwnProperty.call(raw as object, key);
+  if (stackHasOwn('autoFix')) {
+    throw new PlanParseError(
+      'Plan stack-level "autoFix" is no longer supported. Configure "~/.invoker/config.json" with "autoFixRetries" instead.',
+    );
+  }
+  if (stackHasOwn('autoFixRetries')) {
+    throw new PlanParseError(
+      'Plan stack-level "autoFixRetries" is no longer supported. Configure "~/.invoker/config.json" with "autoFixRetries" instead.',
+    );
+  }
+  assertNoLegacyRoutingKeys('Plan stack', raw as object);
 
   const plans = raw.workflows.map((workflow, index) => {
     if (!workflow || typeof workflow !== 'object' || Array.isArray(workflow)) {
@@ -465,7 +492,11 @@ export function parsePlanSubmissionBundle(yamlContent: string): PlanSubmissionBu
 }
 
 export function parsePlan(yamlContent: string): PlanDefinition {
-  return parsePlanSubmissionBundle(yamlContent).plans[0];
+  const submission = parsePlanSubmissionBundle(yamlContent);
+  if (submission.isStack) {
+    throw new PlanParseError('Stacked workflow YAML must be loaded with parsePlanSubmissionBundle().');
+  }
+  return submission.plans[0];
 }
 
 /**

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -109,6 +109,16 @@ export interface RawPlan {
   tasks?: RawPlanTask[];
 }
 
+export interface RawPlanBundle extends RawPlan {
+  workflows?: RawPlan[];
+}
+
+export interface PlanSubmissionBundle {
+  name: string;
+  plans: PlanDefinition[];
+  isStack: boolean;
+}
+
 /**
  * Auto-detect the repo's default branch via git.
  * Tries origin/HEAD first, then checks if 'main' exists locally, falls back to 'master'.
@@ -243,19 +253,17 @@ function assertNoLegacyRoutingKeys(ownerLabel: string, value: object): void {
  * Parse a YAML string into a validated PlanDefinition.
  * Throws PlanParseError if validation fails.
  */
-export function parsePlan(yamlContent: string): PlanDefinition {
-  const raw = parseYaml(yamlContent) as RawPlan;
-
+function parseRawPlan(raw: RawPlan, ownerLabel = 'Plan'): PlanDefinition {
   if (!raw || typeof raw !== 'object') {
-    throw new PlanParseError('Plan must be a YAML object');
+    throw new PlanParseError(`${ownerLabel} must be a YAML object`);
   }
 
   if (!raw.name || typeof raw.name !== 'string') {
-    throw new PlanParseError('Plan must have a "name" field');
+    throw new PlanParseError(`${ownerLabel} must have a "name" field`);
   }
 
   if (!raw.tasks || !Array.isArray(raw.tasks) || raw.tasks.length === 0) {
-    throw new PlanParseError('Plan must have a non-empty "tasks" array');
+    throw new PlanParseError(`${ownerLabel} must have a non-empty "tasks" array`);
   }
 
   const hasOwn = (obj: object, key: string): boolean =>
@@ -263,17 +271,16 @@ export function parsePlan(yamlContent: string): PlanDefinition {
 
   if (hasOwn(raw as object, 'autoFix')) {
     throw new PlanParseError(
-      'Plan-level "autoFix" is no longer supported. Configure "~/.invoker/config.json" with "autoFixRetries" instead.',
+      `${ownerLabel}-level "autoFix" is no longer supported. Configure "~/.invoker/config.json" with "autoFixRetries" instead.`,
     );
   }
   if (hasOwn(raw as object, 'autoFixRetries')) {
     throw new PlanParseError(
-      'Plan-level "autoFixRetries" is no longer supported. Configure "~/.invoker/config.json" with "autoFixRetries" instead.',
+      `${ownerLabel}-level "autoFixRetries" is no longer supported. Configure "~/.invoker/config.json" with "autoFixRetries" instead.`,
     );
   }
-  assertNoLegacyRoutingKeys('Plan', raw as object);
+  assertNoLegacyRoutingKeys(ownerLabel, raw as object);
 
-  // Validate onFinish
   const validOnFinishValues = ['none', 'merge', 'pull_request'] as const;
   if (raw.onFinish !== undefined && !validOnFinishValues.includes(raw.onFinish as any)) {
     throw new PlanParseError(
@@ -282,7 +289,6 @@ export function parsePlan(yamlContent: string): PlanDefinition {
   }
   const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
 
-  // Validate mergeMode against canonical values only.
   const validMergeModes = ['manual', 'automatic', 'external_review'] as const;
   if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
     throw new PlanParseError(
@@ -294,32 +300,29 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     ? normalizeMergeModeForPersistence(rawMergeMode)
     : undefined;
 
-  // Default reviewProvider to 'github' for external-review workflows.
   const reviewProvider = raw.reviewProvider
     ?? (rawMergeMode === 'external_review' ? 'github' : undefined);
 
-  // Auto-generate featureBranch from plan name when not explicitly specified
   if (!raw.featureBranch) {
-    const slug = (raw.name as string).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    const slug = raw.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
     raw.featureBranch = `plan/${slug}`;
   }
 
-  // Require plan-level repoUrl
   if (!raw.repoUrl || typeof raw.repoUrl !== 'string') {
     throw new PlanParseError(
-      'Plan must have a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git).',
+      `${ownerLabel} must have a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git).`,
     );
   }
   if (raw.intermediateRepoUrl !== undefined) {
     if (typeof raw.intermediateRepoUrl !== 'string' || raw.intermediateRepoUrl.trim() === '') {
       throw new PlanParseError(
-        'Plan "intermediateRepoUrl" must be a non-empty string when provided.',
+        `${ownerLabel} "intermediateRepoUrl" must be a non-empty string when provided.`,
       );
     }
     raw.intermediateRepoUrl = raw.intermediateRepoUrl.trim();
   }
 
-  const topLevelExternalDependencies = parseExternalDependencies('Plan', raw.externalDependencies);
+  const topLevelExternalDependencies = parseExternalDependencies(ownerLabel, raw.externalDependencies);
 
   const seenTaskIds = new Set<string>();
   const tasks = raw.tasks.map((task, index) => {
@@ -366,7 +369,6 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       );
     }
 
-    // Parse experiment variants if present
     const experimentVariants = task.experimentVariants?.map((v) => ({
       id: v.id ?? '',
       description: v.description ?? '',
@@ -409,6 +411,61 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     externalDependencies: topLevelExternalDependencies,
     tasks,
   });
+}
+
+function inheritStackWorkflowDefaults(stack: RawPlanBundle, workflow: RawPlan): RawPlan {
+  const externalDependencies = [
+    ...(stack.externalDependencies ?? []),
+    ...(workflow.externalDependencies ?? []),
+  ];
+
+  return {
+    ...workflow,
+    repoUrl: workflow.repoUrl ?? stack.repoUrl,
+    intermediateRepoUrl: workflow.intermediateRepoUrl ?? stack.intermediateRepoUrl,
+    onFinish: workflow.onFinish ?? stack.onFinish,
+    baseBranch: workflow.baseBranch ?? stack.baseBranch,
+    mergeMode: workflow.mergeMode ?? stack.mergeMode,
+    reviewProvider: workflow.reviewProvider ?? stack.reviewProvider,
+    visualProof: workflow.visualProof ?? stack.visualProof,
+    externalDependencies: externalDependencies.length > 0 ? externalDependencies : workflow.externalDependencies,
+  };
+}
+
+export function parsePlanSubmissionBundle(yamlContent: string): PlanSubmissionBundle {
+  const raw = parseYaml(yamlContent) as RawPlanBundle;
+
+  if (!raw || typeof raw !== 'object') {
+    throw new PlanParseError('Plan must be a YAML object');
+  }
+
+  if (raw.workflows === undefined) {
+    const plan = parseRawPlan(raw, 'Plan');
+    return { name: plan.name, plans: [plan], isStack: false };
+  }
+
+  if (!raw.name || typeof raw.name !== 'string') {
+    throw new PlanParseError('Plan stack must have a "name" field');
+  }
+  if (!Array.isArray(raw.workflows) || raw.workflows.length === 0) {
+    throw new PlanParseError('Plan stack must have a non-empty "workflows" array');
+  }
+  if (raw.tasks !== undefined) {
+    throw new PlanParseError('Plan stack must put tasks inside each workflow, not at the top level.');
+  }
+
+  const plans = raw.workflows.map((workflow, index) => {
+    if (!workflow || typeof workflow !== 'object' || Array.isArray(workflow)) {
+      throw new PlanParseError(`Workflow at index ${index} must be an object with a "name" field`);
+    }
+    return parseRawPlan(inheritStackWorkflowDefaults(raw, workflow), `Workflow ${index + 1}`);
+  });
+
+  return { name: raw.name, plans, isStack: true };
+}
+
+export function parsePlan(yamlContent: string): PlanDefinition {
+  return parsePlanSubmissionBundle(yamlContent).plans[0];
 }
 
 /**

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -165,6 +165,45 @@ tasks:
     expect(plan.tasks[0].requiresManualApproval).toBe(true);
   });
 
+  it('accepts stacked workflow YAML and strips legacy fields recursively', () => {
+    const text = `\`\`\`yaml
+name: "Workers Surface"
+repoUrl: git@github.com:test/repo.git
+autoFixRetries: 3
+workflows:
+  - name: "Workers Surface Contracts"
+    autoFixRetries: 2
+    tasks:
+      - id: define-worker-contracts
+        description: "Define worker contracts"
+        prompt: "Update shared contracts for workers"
+        dependencies: []
+        autoFix: true
+      - id: verify-worker-contracts
+        description: "Verify worker contracts"
+        command: "pnpm test packages/contracts"
+        dependencies: [define-worker-contracts]
+  - name: "Workers Surface UI"
+    tasks:
+      - id: build-workers-ui
+        description: "Build workers UI"
+        prompt: "Implement the workers surface"
+        dependencies: []
+\`\`\``;
+    const result = extractYamlPlan(text);
+    expect(result).not.toBeNull();
+    const plan = parsePlanText(result!);
+    expect(plan.name).toBe('Workers Surface');
+    expect(plan.tasks).toBeUndefined();
+    expect(plan.workflows.map((workflow: any) => workflow.name)).toEqual([
+      'Workers Surface Contracts',
+      'Workers Surface UI',
+    ]);
+    expect(plan.autoFixRetries).toBeUndefined();
+    expect(plan.workflows[0].autoFixRetries).toBeUndefined();
+    expect(plan.workflows[0].tasks[0].autoFix).toBeUndefined();
+  });
+
   it('preserves discovered repo commands without rewriting them', () => {
     const text = `\`\`\`yaml
 name: "Preserve Commands"
@@ -662,6 +701,20 @@ describe('PlanConversation prompt construction', () => {
     // Manual remains the verification-only default; automatic still documented.
     expect(prompt).toContain('"manual" (default)');
     expect(prompt).toContain('"automatic"');
+  });
+
+  it('buildCursorPrompt can prefer stacked workflows', () => {
+    const conv = new PlanConversation({
+      repoUrl: 'git@github.com:test/repo.git',
+      preferStackedWorkflows: true,
+    });
+    (conv as any).messages.push({ role: 'user', content: 'Build the Workers Surface' });
+    const prompt = conv.buildCursorPrompt();
+
+    expect(prompt).toContain('prefer a workflow stack');
+    expect(prompt).toContain('workflows:');
+    expect(prompt).toContain('Each downstream workflow is based on the previous workflow');
+    expect(prompt).toContain('Build the Workers Surface');
   });
 
   it('agent mode refuses Invoker YAML and redirects to plan:', () => {

--- a/packages/surfaces/src/__tests__/plan-summary.test.ts
+++ b/packages/surfaces/src/__tests__/plan-summary.test.ts
@@ -34,6 +34,33 @@ tasks:
     expect(summary!.taskCount).toBe(2);
   });
 
+  it('summarizes a Workers Surface workflow stack by workflow order', () => {
+    const yaml = `
+name: Workers Surface
+workflows:
+  - name: Workers Surface Contracts
+    tasks:
+      - id: verify-contracts
+        description: Verify contracts
+        dependencies: [define-contracts]
+      - id: define-contracts
+        description: Define contracts
+  - name: Workers Surface UI
+    tasks:
+      - id: build-ui
+        description: Build UI
+      - id: verify-ui
+        description: Verify UI
+        dependencies: [build-ui]
+`;
+    const summary = summarizePlanText(yaml);
+    expect(summary).not.toBeNull();
+    expect(summary!.name).toBe('Workers Surface');
+    expect(summary!.workflowCount).toBe(2);
+    expect(summary!.taskCount).toBe(4);
+    expect(summary!.steps).toEqual(['Workers Surface Contracts', 'Workers Surface UI']);
+  });
+
   it('truncates a description longer than 8 words to 8 words + ellipsis', () => {
     const words = Array.from({ length: 40 }, (_, i) => `word${i + 1}`);
     const yaml = `
@@ -85,6 +112,15 @@ tasks:
   - id: a
     description: Fine
   - id: b
+`;
+    expect(summarizePlanText(yaml)).toBeNull();
+  });
+
+  it('returns null when a stacked child workflow has no tasks', () => {
+    const yaml = `
+name: Bad Workers Surface
+workflows:
+  - name: Missing Tasks
 `;
     expect(summarizePlanText(yaml)).toBeNull();
   });

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -66,6 +66,8 @@ export interface PlanConversationConfig {
   /** EXPERIMENTAL_PLANNER: when true, steer the agent to order the plan via the
    * experimental planner MCP tool (`plan`). The redirect server enforces the gate. */
   experimentalPlanner?: boolean;
+  /** Prefer top-level `workflows:` stack plans for multi-slice reviewable work. */
+  preferStackedWorkflows?: boolean;
   /** Logging callback. Defaults to console.log/console.error. */
   log?: LogFn;
 }
@@ -122,10 +124,49 @@ Default behavior:
 - Keep Slack replies short and concrete: changed files, verification, and any remaining risk.`;
 }
 
-function buildPlanSystemPrompt(defaultBranch: string, repoUrl?: string): string {
+function buildStackedWorkflowPrompt(repoUrlLine: string, defaultBranch: string): string {
+  return `For reviewable multi-slice implementation work, prefer a workflow stack over one workflow with many independent implementation tasks:
+\`\`\`yaml
+name: "Stack Name"
+${repoUrlLine}
+onFinish: pull_request
+mergeMode: external_review
+baseBranch: ${defaultBranch}
+workflows:
+  - name: "Stack Name Step 1"
+    featureBranch: plan/stack-name-step-1
+    tasks:
+      - id: implement-step-1
+        description: "Build the first reviewable slice"
+        prompt: "Specific implementation instructions"
+        dependencies: []
+      - id: verify-step-1
+        description: "Verify the first slice"
+        command: "discovered test command"
+        dependencies: [implement-step-1]
+  - name: "Stack Name Step 2"
+    featureBranch: plan/stack-name-step-2
+    tasks:
+      - id: implement-step-2
+        description: "Build the next reviewable slice"
+        prompt: "Specific implementation instructions"
+        dependencies: []
+      - id: verify-step-2
+        description: "Verify the next slice"
+        command: "discovered test command"
+        dependencies: [implement-step-2]
+\`\`\`
+
+When submitted, Invoker creates one workflow per child in listed order. Each downstream workflow is based on the previous workflow's feature branch and waits on the previous merge gate.`;
+}
+
+function buildPlanSystemPrompt(defaultBranch: string, repoUrl?: string, preferStackedWorkflows = false): string {
   const repoUrlLine = repoUrl
     ? `repoUrl: "${repoUrl}"          # git clone URL for the repository`
     : `repoUrl: "git@github.com:user/repo.git"  # git clone URL for the repository`;
+  const stackedWorkflowSection = preferStackedWorkflows
+    ? `\n${buildStackedWorkflowPrompt(repoUrlLine, defaultBranch)}\n`
+    : '';
   return `You are an assistant for the Invoker orchestrator. The user explicitly requested an Invoker plan.
 
 Generate a YAML task plan as described below. Answer simple follow-up questions directly only when they are about the plan being drafted.
@@ -152,14 +193,14 @@ tasks:
     requiresManualApproval: false
 
 \`\`\`
-
+${stackedWorkflowSection}
 Rules:
 1. Explore the codebase first (list directories, read key files). Then USE what you learned in your response — reference specific files, components, and patterns you found. Do NOT give generic responses that ignore the code you read.
 2. For ambiguous implementation requests, tiny nits, or broad "make this better" requests, do a brief scoping pass before YAML:
    - State concise assumptions based on the repository evidence you found.
    - Show a short plan preview with the likely review slice(s) and verification commands.
    - Ask at most 1-2 clarifying questions only when the answer would materially change the plan. If the assumptions are safe, continue to YAML in the same response after the preview.
-3. Keep plans focused — 3-8 tasks maximum. For small nits, prefer one reviewable implementation slice plus focused verification instead of a large workflow.
+3. Keep plans focused. ${preferStackedWorkflows ? 'For reviewable multi-slice implementation work, prefer 2-6 stacked child workflows with one local implementation-and-verification slice each, instead of one workflow with many independent implementation tasks. ' : ''}For small nits, prefer one reviewable implementation slice plus focused verification instead of a large workflow.
 4. File-count guidance is a soft heuristic, not a hard validator gate. Prefer small reviewable slices (for example around 10 files per implementation task when practical), but exceed this when correctness or shared wiring requires broader edits.
 5. Each task should have either a \`command\` or a \`prompt\`, not both. Do not include legacy \`autoFix\` or \`autoFixRetries\` fields anywhere in the YAML; auto-fix retries are configured only in ~/.invoker/config.json.
 6. Every step MUST be testable. Every implementation task MUST have a corresponding test task that verifies it works using a concrete, executable \`command\` discovered from the target repo (e.g. that repo's package scripts, build commands, or focused checks such as \`git diff --name-only\`). The test command must produce a clear pass/fail exit code. Do NOT skip tests for any step. Do NOT use prompts for test tasks — use commands only.
@@ -225,6 +266,7 @@ export class PlanConversation {
   private defaultBranch?: string;
   private repoUrl?: string;
   private experimentalPlanner?: boolean;
+  private preferStackedWorkflows?: boolean;
   private log: LogFn;
   private _initialized = false;
 
@@ -241,6 +283,7 @@ export class PlanConversation {
     this.defaultBranch = config.defaultBranch;
     this.repoUrl = config.repoUrl;
     this.experimentalPlanner = config.experimentalPlanner;
+    this.preferStackedWorkflows = config.preferStackedWorkflows;
     this.log = config.log ?? ((src, lvl, msg) => {
       (lvl === 'error' ? console.error : console.log)(`[${src}] ${msg}`);
     });
@@ -357,7 +400,7 @@ export class PlanConversation {
    */
   buildCursorPrompt(): string {
     const systemPrompt = this.mode === 'plan'
-      ? buildPlanSystemPrompt(this.defaultBranch ?? 'main', this.repoUrl)
+      ? buildPlanSystemPrompt(this.defaultBranch ?? 'main', this.repoUrl, this.preferStackedWorkflows)
       : buildAgentSystemPrompt();
     const parts: string[] = [systemPrompt];
 
@@ -497,6 +540,40 @@ export function globToRegex(pattern: string): RegExp {
   return new RegExp(`^${escaped}$`);
 }
 
+function isExtractedPlanRecord(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function validateExtractedPlanTasks(tasks: unknown, ownerLabel: string): boolean {
+  if (!Array.isArray(tasks) || tasks.length === 0) {
+    console.warn(`extractYamlPlan: ${ownerLabel} "tasks" missing or empty (got ${typeof tasks})`);
+    return false;
+  }
+
+  for (const task of tasks) {
+    if (!isExtractedPlanRecord(task) || !task.id || !task.description) {
+      console.warn(`extractYamlPlan: ${ownerLabel} task missing id or description: ${JSON.stringify(task).slice(0, 120)}`);
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function stripPlannerOnlyFields(plan: Record<string, any>): void {
+  delete plan.autoFix;
+  delete plan.autoFixRetries;
+  for (const task of Array.isArray(plan.tasks) ? plan.tasks : []) {
+    if (!isExtractedPlanRecord(task)) continue;
+    delete task.autoFix;
+    delete task.autoFixRetries;
+  }
+  for (const workflow of Array.isArray(plan.workflows) ? plan.workflows : []) {
+    if (!isExtractedPlanRecord(workflow)) continue;
+    stripPlannerOnlyFields(workflow);
+  }
+}
+
 // ── YAML Extraction ─────────────────────────────────────────
 
 /**
@@ -531,31 +608,29 @@ export function extractYamlPlan(text: string): string | null {
       return null;
     }
 
-    const plan = raw as Record<string, unknown>;
+    const plan = raw as Record<string, any>;
     if (!plan.name || typeof plan.name !== 'string') {
       console.warn('extractYamlPlan: missing or non-string "name" field');
       return null;
     }
-    if (!Array.isArray(plan.tasks) || plan.tasks.length === 0) {
-      console.warn(`extractYamlPlan: "tasks" missing or empty (got ${typeof plan.tasks})`);
+
+    if (Array.isArray(plan.workflows)) {
+      if (plan.workflows.length === 0) {
+        console.warn('extractYamlPlan: "workflows" is empty');
+        return null;
+      }
+      for (const [index, workflow] of plan.workflows.entries()) {
+        if (!isExtractedPlanRecord(workflow) || !workflow.name || typeof workflow.name !== 'string') {
+          console.warn(`extractYamlPlan: workflow ${index} missing name`);
+          return null;
+        }
+        if (!validateExtractedPlanTasks(workflow.tasks, `workflow ${index}`)) return null;
+      }
+    } else if (!validateExtractedPlanTasks(plan.tasks, 'plan')) {
       return null;
     }
 
-    for (const task of plan.tasks) {
-      if (!task.id || !task.description) {
-        console.warn(`extractYamlPlan: task missing id or description: ${JSON.stringify(task).slice(0, 120)}`);
-        return null;
-      }
-    }
-
-    // Return serialized YAML with planner-only legacy fields stripped. The parser still
-    // rejects these fields in user-authored plan files so stale plans fail loudly there.
-    delete plan.autoFix;
-    delete plan.autoFixRetries;
-    for (const task of plan.tasks) {
-      delete task.autoFix;
-      delete task.autoFixRetries;
-    }
+    stripPlannerOnlyFields(plan);
     return stringifyYaml(plan);
   } catch (err) {
     console.warn(`extractYamlPlan: YAML parse error: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/surfaces/src/slack/plan-summary.ts
+++ b/packages/surfaces/src/slack/plan-summary.ts
@@ -14,6 +14,7 @@ export interface PlanSummary {
   name: string;
   steps: string[];
   taskCount: number;
+  workflowCount?: number;
 }
 
 interface PlanTask {
@@ -39,7 +40,39 @@ export function summarizePlanText(planText: string): PlanSummary | null {
   const name = parsed.name;
   if (typeof name !== 'string' || name.trim().length === 0) return null;
 
-  const rawTasks = parsed.tasks;
+  const rawWorkflows = parsed.workflows;
+  if (Array.isArray(rawWorkflows)) {
+    if (rawWorkflows.length === 0) return null;
+    const workflowNames: string[] = [];
+    let taskCount = 0;
+    for (const rawWorkflow of rawWorkflows) {
+      if (!isRecord(rawWorkflow)) return null;
+      const workflowName = rawWorkflow.name;
+      if (typeof workflowName !== 'string' || workflowName.trim().length === 0) return null;
+      const workflowTasks = parseTasks(rawWorkflow.tasks);
+      if (!workflowTasks) return null;
+      workflowNames.push(summarizeDescription(workflowName));
+      taskCount += workflowTasks.length;
+    }
+    return { name, steps: workflowNames, taskCount, workflowCount: rawWorkflows.length };
+  }
+
+  const tasks = parseTasks(parsed.tasks);
+  if (!tasks) return null;
+
+  const ordered = topoSort(tasks);
+  const steps = ordered.map((t) => summarizeDescription(t.description));
+
+  return { name, steps, taskCount: tasks.length };
+}
+
+// ── Internals ───────────────────────────────────────────────
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseTasks(rawTasks: unknown): PlanTask[] | null {
   if (!Array.isArray(rawTasks) || rawTasks.length === 0) return null;
 
   const tasks: PlanTask[] = [];
@@ -55,16 +88,7 @@ export function summarizePlanText(planText: string): PlanSummary | null {
     tasks.push({ id, description, dependencies });
   }
 
-  const ordered = topoSort(tasks);
-  const steps = ordered.map((t) => summarizeDescription(t.description));
-
-  return { name, steps, taskCount: tasks.length };
-}
-
-// ── Internals ───────────────────────────────────────────────
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
+  return tasks;
 }
 
 /**
@@ -74,47 +98,50 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  */
 function topoSort(tasks: PlanTask[]): PlanTask[] {
   const byId = new Map<string, PlanTask>();
-  for (const task of tasks) byId.set(task.id, task);
-
   const indegree = new Map<string, number>();
-  const dependents = new Map<string, string[]>();
-  for (const task of tasks) {
-    indegree.set(task.id, 0);
-    dependents.set(task.id, []);
+  const outgoing = new Map<string, string[]>();
+
+  for (const t of tasks) {
+    byId.set(t.id, t);
+    indegree.set(t.id, 0);
+    outgoing.set(t.id, []);
   }
 
-  for (const task of tasks) {
-    for (const dep of task.dependencies) {
-      if (!byId.has(dep)) return tasks; // unknown dependency → original order
-      indegree.set(task.id, (indegree.get(task.id) ?? 0) + 1);
-      dependents.get(dep)!.push(task.id);
+  for (const t of tasks) {
+    for (const dep of t.dependencies) {
+      if (!byId.has(dep)) {
+        return tasks; // unknown dep: preserve listed order
+      }
+      indegree.set(t.id, (indegree.get(t.id) ?? 0) + 1);
+      outgoing.get(dep)!.push(t.id);
     }
   }
 
-  // Ready queue, seeded in original listed order for stability.
-  const ready: string[] = [];
-  for (const task of tasks) {
-    if ((indegree.get(task.id) ?? 0) === 0) ready.push(task.id);
-  }
+  const queue: string[] = tasks.filter((t) => (indegree.get(t.id) ?? 0) === 0).map((t) => t.id);
+  const ordered: PlanTask[] = [];
 
-  const result: PlanTask[] = [];
-  while (ready.length > 0) {
-    const id = ready.shift()!;
-    result.push(byId.get(id)!);
-    for (const next of dependents.get(id)!) {
-      const remaining = (indegree.get(next) ?? 0) - 1;
-      indegree.set(next, remaining);
-      if (remaining === 0) ready.push(next);
+  while (queue.length > 0) {
+    const id = queue.shift()!;
+    const task = byId.get(id)!;
+    ordered.push(task);
+
+    for (const nextId of outgoing.get(id) ?? []) {
+      const next = (indegree.get(nextId) ?? 0) - 1;
+      indegree.set(nextId, next);
+      if (next === 0) queue.push(nextId);
     }
   }
 
-  if (result.length !== tasks.length) return tasks; // cycle → original order
-  return result;
+  if (ordered.length !== tasks.length) {
+    return tasks; // cycle: preserve listed order
+  }
+
+  return ordered;
 }
 
 function summarizeDescription(description: string): string {
   const normalized = description.replace(/\s+/g, ' ').trim();
-  const words = normalized.split(' ');
+  const words = normalized.split(' ').filter(Boolean);
   if (words.length <= MAX_STEP_WORDS) return normalized;
-  return words.slice(0, MAX_STEP_WORDS).join(' ') + ' …';
+  return `${words.slice(0, MAX_STEP_WORDS).join(' ')} …`;
 }


### PR DESCRIPTION
## Summary

Top-level `workflows:` planner drafts now take the stack route.

The planner draft path now keeps stack order all the way to downstream workflow dependency wiring.

<details>
<summary>Review metadata</summary>

Review Claim: Top-level `workflows:` planner drafts now take the stack route.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Existing single-workflow drafts still follow the old path. The stack route only runs when the draft uses top-level `workflows:`.

Slice Rationale: The planner draft path has to agree on one routing shape or the draft cannot produce the intended workflow stack.

</details>

## Non-goals

- Changing terminal copy.
- Changing screenshot proof.
- Changing non-planner workflow submission paths.

## Test Plan

- [x] `pnpm --filter @invoker/surfaces test -- src/__tests__/plan-summary.test.ts src/__tests__/plan-conversation.test.ts`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/plan-parser.test.ts src/__tests__/in-app-planner.test.ts`
- [x] `pnpm --filter @invoker/surfaces build`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for stacked workflow plans, including goal planning, draft previewing, and submission.
  * Planner responses and plan summaries now include workflow count and preserve workflow order for stacked plans.
* **Bug Fixes**
  * Strengthened plan parsing/validation to reject empty or mixed legacy workflow bundle shapes and legacy auto-fix fields.
  * Improved guidance generation and YAML extraction for stacked workflow drafts.
* **Tests**
  * Expanded coverage for stacked workflow planning, parsing, summarization, and submission behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->