### PR TITLE
[Planning Chat](5b) Show planner errors in chat

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -526,6 +526,7 @@ export function App() {
   const nextTerminalLineIdRef = useRef(2);
   const [planningPresetOptions, setPlanningPresetOptions] = useState<Array<{ key: string; label: string; isDefault?: boolean }>>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
+  const [planningSubmitError, setPlanningSubmitError] = useState<{ title: string; message: string } | null>(null);
   const [planningTerminalExpanded, setPlanningTerminalExpanded] = useState(false);
   const activePlanningSession = useMemo(
     () => planningSessions.find((session) => session.id === activePlanningSessionId) ?? planningSessions[0] ?? makeInitialPlanningSession(),
@@ -1850,17 +1851,20 @@ export function App() {
 
   const handlePlanningSubmitDraft = useCallback(async () => {
     if (!planningSessionId) {
-      appendTerminalLine('No planning conversation yet.', 'system', 'error');
+      setPlanningSubmitError({ title: 'Plan could not be submitted', message: 'No planning conversation yet.' });
+      appendTerminalLine('Plan could not be submitted:\nNo planning conversation yet.', 'system', 'error');
       return;
     }
     if (!invoker?.planningChatSubmit) {
-      appendTerminalLine('Planner is not available.', 'system', 'error');
+      setPlanningSubmitError({ title: 'Plan could not be submitted', message: 'Planner is not available.' });
+      appendTerminalLine('Plan could not be submitted:\nPlanner is not available.', 'system', 'error');
       return;
     }
     updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: true }));
     try {
       const result = await invoker.planningChatSubmit({ sessionId: planningSessionId });
       if (result.ok) {
+        setPlanningSubmitError(null);
         setHasLoadedPlan(true);
         setHasStarted(false);
         setSidebarSurface('home');
@@ -1883,11 +1887,14 @@ export function App() {
         appendTerminalLine(`Plan "${result.planName}" submitted to Invoker. Review it, then Run.`, 'system', 'success');
       } else {
         updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: false }));
-        appendTerminalLine(result.error, 'system', 'error');
+        setPlanningSubmitError({ title: 'Plan could not be submitted', message: result.error });
+        appendTerminalLine(`Plan could not be submitted:\n${result.error}`, 'system', 'error');
       }
     } catch (err) {
       updatePlanningSessionById(planningSessionId, (session) => ({ ...session, busy: false }));
-      appendTerminalLine(err instanceof Error ? err.message : 'Failed to submit the plan.', 'system', 'error');
+      const message = err instanceof Error ? err.message : 'Failed to submit the plan.';
+      setPlanningSubmitError({ title: 'Plan could not be submitted', message });
+      appendTerminalLine(`Plan could not be submitted:\n${message}`, 'system', 'error');
     }
   }, [appendTerminalLine, invoker, planningSessionId, refreshTaskGraph, updatePlanningSessionById]);
 
@@ -1896,6 +1903,7 @@ export function App() {
     if (!input || activePlanningSessionBusy || activePlanningSessionSubmitted) return;
     appendTerminalLine(input, 'user');
     setPlanningInput('');
+    setPlanningSubmitError(null);
 
     if (input.toLowerCase() === 'run') {
       if (!hasLoadedPlan || hasStarted) {
@@ -1962,10 +1970,13 @@ export function App() {
       } else {
         updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
         appendTerminalLine(result.error, 'system', 'error');
+        setPlanningSubmitError({ title: 'Planner could not respond', message: result.error });
       }
     } catch (err) {
       updatePlanningSessionById(previousSessionId, (session) => ({ ...session, busy: false }));
-      appendTerminalLine(err instanceof Error ? err.message : 'Failed to reach the planner.', 'system', 'error');
+      const message = err instanceof Error ? err.message : 'Failed to reach the planner.';
+      setPlanningSubmitError({ title: 'Planner could not respond', message });
+      appendTerminalLine(message, 'system', 'error');
     }
   }, [
     activePlanningSessionBusy,
@@ -2813,6 +2824,7 @@ export function App() {
             presetOptions={planningPresetOptions}
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
+            submitError={planningSubmitError}
             readOnly={activePlanningSessionSubmitted}
             onValueChange={setPlanningInput}
             onSubmit={() => void handlePlanningSubmit()}
@@ -3049,6 +3061,7 @@ export function App() {
             presetOptions={planningPresetOptions}
             draftPlanAvailable={draftPlanAvailable}
             draftPlanSummary={draftPlanSummary}
+            submitError={planningSubmitError}
             expanded
             onValueChange={setPlanningInput}
             readOnly={activePlanningSessionSubmitted}

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { vi } from 'vitest';
 import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
 
@@ -121,6 +121,47 @@ describe('Invoker terminal (component)', () => {
     fireEvent.click(screen.getByTestId('sidebar-planning'));
     expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
     expect(mock.api.start).not.toHaveBeenCalled();
+  });
+
+  it('shows submit errors beside the ready draft and allows retry', async () => {
+    const submitError = 'Task "make-selected-lists-scroll" uses "autoFix", which is no longer supported.';
+    mock.api.planningChatSend = vi.fn(async () => ({
+      ok: true,
+      sessionId: 'session-1',
+      reply: 'Here is the plan.',
+      draftPlanAvailable: true,
+      draftPlanSummary: { name: 'Selected lists scroll', taskCount: 4, steps: ['First', 'Second', 'Third', 'Fourth'] },
+    })) as any;
+    mock.api.planningChatSubmit = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, error: submitError })
+      .mockResolvedValueOnce({ ok: true, planName: 'Selected lists scroll', workflowId: 'wf-1' }) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft the full plan');
+    await screen.findByTestId('invoker-terminal-ready-bar');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+
+    const errorPanel = await screen.findByTestId('invoker-terminal-submit-error');
+    expect(errorPanel).toHaveTextContent('Plan could not be submitted');
+    expect(errorPanel).toHaveTextContent(submitError);
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent(`Plan could not be submitted: ${submitError}`);
+    expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('Draft plan ready: "Selected lists scroll" (4 steps).');
+    expect(mock.api.refreshTaskGraph).not.toHaveBeenCalled();
+
+    fireEvent.click(within(errorPanel).getByRole('button', { name: 'Retry submit' }));
+
+    await waitFor(() => {
+      expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(2);
+      expect(mock.api.refreshTaskGraph).toHaveBeenCalled();
+      expect(screen.getByText('Plan graph')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Plan "Selected lists scroll" submitted to Invoker. Review it, then Run.');
+    expect(screen.queryByTestId('invoker-terminal-submit-error')).not.toBeInTheDocument();
   });
 
   it('explains that run needs a submitted plan first', async () => {

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -20,6 +20,7 @@ interface InvokerTerminalProps {
   presetOptions: PlanningPresetOptionView[];
   draftPlanAvailable: boolean;
   draftPlanSummary?: { name: string; taskCount: number };
+  submitError?: SubmitErrorView | null;
   readOnly?: boolean;
   expanded?: boolean;
   onValueChange: (value: string) => void;
@@ -31,6 +32,11 @@ interface InvokerTerminalProps {
   onCollapse?: () => void;
 }
 
+interface SubmitErrorView {
+  title: string;
+  message: string;
+}
+
 export function InvokerTerminal({
   lines,
   busy,
@@ -39,6 +45,7 @@ export function InvokerTerminal({
   presetOptions,
   draftPlanAvailable,
   draftPlanSummary,
+  submitError,
   readOnly = false,
   expanded = false,
   onValueChange,
@@ -132,30 +139,65 @@ export function InvokerTerminal({
       {draftPlanAvailable && !readOnly && (
         <div
           data-testid="invoker-terminal-ready-bar"
-          className="sticky bottom-0 z-10 mx-4 mb-3 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-emerald-500/30 bg-emerald-950/70 px-4 py-3 text-sm text-emerald-100 shadow-lg"
+          className="sticky bottom-0 z-10 mx-4 mb-3 space-y-3 rounded-2xl border border-emerald-500/30 bg-emerald-950/70 px-4 py-3 text-sm text-emerald-100 shadow-lg"
         >
-          <span>
-            {draftPlanSummary
-              ? `Draft plan ready: "${draftPlanSummary.name}" (${draftPlanSummary.taskCount} steps).`
-              : 'Draft plan ready.'}
-          </span>
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={onSubmitDraft}
-              disabled={busy}
-              className="rounded-full bg-emerald-300 px-4 py-2 text-sm font-medium text-emerald-950 hover:bg-emerald-200 disabled:cursor-wait disabled:opacity-50"
-            >
-              Submit to Invoker
-            </button>
-            <button
-              type="button"
-              onClick={focusComposer}
-              className="rounded-full border border-emerald-400/40 px-4 py-2 text-sm text-emerald-100 hover:border-emerald-200"
-            >
-              Keep chatting
-            </button>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <span>
+              {draftPlanSummary
+                ? `Draft plan ready: "${draftPlanSummary.name}" (${draftPlanSummary.taskCount} steps).`
+                : 'Draft plan ready.'}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={onSubmitDraft}
+                disabled={busy}
+                className="rounded-full bg-emerald-300 px-4 py-2 text-sm font-medium text-emerald-950 hover:bg-emerald-200 disabled:cursor-wait disabled:opacity-50"
+              >
+                {submitError ? 'Retry submit' : 'Submit to Invoker'}
+              </button>
+              <button
+                type="button"
+                onClick={focusComposer}
+                className="rounded-full border border-emerald-400/40 px-4 py-2 text-sm text-emerald-100 hover:border-emerald-200"
+              >
+                Keep chatting
+              </button>
+            </div>
           </div>
+          {submitError && (
+            <div
+              data-testid="invoker-terminal-submit-error"
+              className="rounded-2xl border border-red-500/40 bg-red-950/70 px-4 py-3 text-red-100"
+            >
+              <div className="text-sm font-semibold text-red-100">{submitError.title}</div>
+              <div className="mt-2 whitespace-pre-wrap text-sm leading-6 text-red-200">{submitError.message}</div>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={onSubmitDraft}
+                  disabled={busy}
+                  className="rounded-full bg-red-200 px-4 py-2 text-sm font-medium text-red-950 hover:bg-red-100 disabled:cursor-wait disabled:opacity-50"
+                >
+                  Retry submit
+                </button>
+                <button
+                  type="button"
+                  onClick={focusComposer}
+                  className="rounded-full border border-red-300/40 px-4 py-2 text-sm text-red-100 hover:border-red-100"
+                >
+                  Keep chatting
+                </button>
+                <button
+                  type="button"
+                  onClick={() => void navigator.clipboard?.writeText(submitError.message)}
+                  className="rounded-full border border-red-300/40 px-4 py-2 text-sm text-red-100 hover:border-red-100"
+                >
+                  Copy error
+                </button>
+              </div>
+            </div>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

The planning terminal now keeps the drafted plan visible when the planner action fails.

Instead of only writing a transcript line, the ready area now shows a visible error panel beside the drafted plan.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the visible planning-terminal error panel while keeping the drafted plan available.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This only changes the planning terminal surface after the planner action returns an error. The successful graph handoff is unchanged.

Slice Rationale: Draft normalization lands first. This slice then adds visible terminal feedback for the remaining planner-action errors.

</details>

## Non-goals

- Changing planner prompt generation.
- Changing the successful graph handoff.
- Changing non-planning workflow error panels.

## Test Plan

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/invoker-terminal.test.tsx`
- [x] `CAPTURE_MODE=after pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts -g "terminal planning shows submit errors"`

## Visual Proof

After:

![Planning submit error proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260705-453d08/planning-submit-error.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-facing planning submit error panel to the planning terminal (including the expanded overlay), with title/message and actions to retry, keep chatting, and copy error details.
  * The primary button now switches to **Retry submit** when a submission failure is present.
* **Bug Fixes**
  * Improved planning submission failure handling: errors are surfaced reliably, cleared after a successful retry, and non-OK submission text is no longer appended to the terminal output.
* **Tests**
  * Added coverage for first-attempt failure, ensuring task graph refresh is not triggered, and validating the retry success flow (transcript and UI updates).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->