### PR TITLE
[Planning Chat](5a) Strip legacy planner auto-fix fields

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -289,6 +289,48 @@ describe('planning chat', () => {
     await expect(second).resolves.toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
   });
 
+
+  it('submits planner drafts after stripping legacy auto-fix fields', async () => {
+    const legacyPlan = `Here is the plan.
+
+\`\`\`yaml
+name: Legacy AutoFix Draft
+onFinish: none
+autoFixRetries: 2
+tasks:
+  - id: make-selected-lists-scroll
+    description: Make selected lists scroll
+    command: pnpm test
+    dependencies: []
+    autoFix: false
+\`\`\``;
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(legacyPlan);
+    const sessions = createInAppPlanningChatSessions();
+    const sent = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!sent.ok) throw new Error(sent.error);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({ planName: 'Legacy AutoFix Draft', workflowId: 'wf-1' });
+
+    await expect(submitPlanningChatDraft({
+      sessionId: sent.sessionId,
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({ ok: true, planName: 'Legacy AutoFix Draft', workflowId: 'wf-1' });
+
+    const submittedPlan = loadGeneratedPlan.mock.calls[0]?.[0] as string;
+    expect(submittedPlan).toContain('id: make-selected-lists-scroll');
+    expect(submittedPlan).not.toContain('autoFix');
+    expect(submittedPlan).not.toContain('autoFixRetries');
+  });
+
   it('rejects submit for an unknown session', async () => {
     await expect(submitPlanningChatDraft({
       sessionId: 'missing',

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -134,13 +134,14 @@ describe('extractYamlPlan', () => {
     expect(plan.onFinish).toBeUndefined();
   });
 
-  it('preserves explicit fields from YAML', () => {
+  it('preserves explicit supported fields and strips legacy auto-fix fields from planner YAML', () => {
     const text = `\`\`\`yaml
 name: "Full"
 onFinish: merge
 baseBranch: develop
 featureBranch: feature/test
 mergeMode: automatic
+autoFixRetries: 3
 tasks:
   - id: t1
     description: "test"
@@ -148,6 +149,7 @@ tasks:
     dependencies: []
     pivot: true
     autoFix: true
+    autoFixRetries: 2
     requiresManualApproval: true
 \`\`\``;
     const result = extractYamlPlan(text);
@@ -156,8 +158,10 @@ tasks:
     expect(plan.baseBranch).toBe('develop');
     expect(plan.featureBranch).toBe('feature/test');
     expect(plan.mergeMode).toBe('automatic');
+    expect(plan.autoFixRetries).toBeUndefined();
     expect(plan.tasks[0].pivot).toBe(true);
-    expect(plan.tasks[0].autoFix).toBe(true);
+    expect(plan.tasks[0].autoFix).toBeUndefined();
+    expect(plan.tasks[0].autoFixRetries).toBeUndefined();
     expect(plan.tasks[0].requiresManualApproval).toBe(true);
   });
 

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -150,7 +150,7 @@ tasks:
         description: "Approach A"
         prompt: "Try approach A"
     requiresManualApproval: false
-    autoFix: false               # auto-retry with experiments on failure
+
 \`\`\`
 
 Rules:
@@ -161,7 +161,7 @@ Rules:
    - Ask at most 1-2 clarifying questions only when the answer would materially change the plan. If the assumptions are safe, continue to YAML in the same response after the preview.
 3. Keep plans focused — 3-8 tasks maximum. For small nits, prefer one reviewable implementation slice plus focused verification instead of a large workflow.
 4. File-count guidance is a soft heuristic, not a hard validator gate. Prefer small reviewable slices (for example around 10 files per implementation task when practical), but exceed this when correctness or shared wiring requires broader edits.
-5. Each task should have either a \`command\` or a \`prompt\`, not both.
+5. Each task should have either a \`command\` or a \`prompt\`, not both. Do not include legacy \`autoFix\` or \`autoFixRetries\` fields anywhere in the YAML; auto-fix retries are configured only in ~/.invoker/config.json.
 6. Every step MUST be testable. Every implementation task MUST have a corresponding test task that verifies it works using a concrete, executable \`command\` discovered from the target repo (e.g. that repo's package scripts, build commands, or focused checks such as \`git diff --name-only\`). The test command must produce a clear pass/fail exit code. Do NOT skip tests for any step. Do NOT use prompts for test tasks — use commands only.
    Test command rules:
    - Inspect repo manifests and existing docs/scripts before choosing commands.
@@ -548,7 +548,14 @@ export function extractYamlPlan(text: string): string | null {
       }
     }
 
-    // Return serialized YAML as provided — no defaulting or repo-specific command rewriting.
+    // Return serialized YAML with planner-only legacy fields stripped. The parser still
+    // rejects these fields in user-authored plan files so stale plans fail loudly there.
+    delete plan.autoFix;
+    delete plan.autoFixRetries;
+    for (const task of plan.tasks) {
+      delete task.autoFix;
+      delete task.autoFixRetries;
+    }
     return stringifyYaml(plan);
   } catch (err) {
     console.warn(`extractYamlPlan: YAML parse error: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Summary

Planner draft extraction now normalizes legacy `autoFix` fields out of AI-generated YAML.

This keeps older planner examples compatible with the current draft-validation rules.

<details>
<summary>Review metadata</summary>

Review Claim: Approve normalizing legacy planner-only `autoFix` and `autoFixRetries` fields out of AI-drafted YAML during draft extraction.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: This only changes AI-drafted YAML normalization inside planner extraction. User-authored plan files on disk still fail if they contain the legacy fields.

Slice Rationale: Draft normalization lands before the visible error surface so stale planner examples are made valid at extraction time.

</details>

## Non-goals

- Changing the visible planning terminal UI.
- Changing successful plan execution behavior beyond planner draft normalization.
- Changing parser rules for user-authored YAML files on disk.

## Test Plan

- [x] `pnpm --filter @invoker/surfaces test -- src/__tests__/plan-conversation.test.ts`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Planning chat submission now removes legacy auto-fix fields from drafted YAML before loading the generated plan.
  * Imported/pasted planner YAML is cleaned so unsupported legacy auto-fix settings (`autoFix`, `autoFixRetries`) are no longer retained in parsed plans.
  * On-screen plan guidance and embedded YAML examples were updated to exclude legacy auto-fix options.
* **Tests**
  * Added/expanded coverage to verify legacy auto-fix fields are stripped while supported fields remain preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->