### PR TITLE
[Planning Chat](2b) Harden planning runtime submit flow

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -8,6 +8,7 @@ import {
   resetPlanningChat,
   sendPlanningChatMessage,
   submitPlanningChatDraft,
+  type LoadedGeneratedPlan,
 } from '../in-app-planner.js';
 
 const VALID_PLAN = `Here is the plan.
@@ -257,6 +258,35 @@ describe('planning chat', () => {
       loadGeneratedPlan,
     })).resolves.toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
     expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
+  });
+  it('coalesces concurrent submit requests for one session', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
+    const sessions = createInAppPlanningChatSessions();
+    const sent = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!sent.ok) throw new Error(sent.error);
+
+    let resolveLoad: ((value: LoadedGeneratedPlan) => void) | undefined;
+    const loadGeneratedPlan = vi.fn(() => new Promise<LoadedGeneratedPlan>((resolve) => {
+      resolveLoad = resolve;
+    }));
+
+    const first = submitPlanningChatDraft({ sessionId: sent.sessionId }, { sessions, loadGeneratedPlan });
+    const second = submitPlanningChatDraft({ sessionId: sent.sessionId }, { sessions, loadGeneratedPlan });
+    await vi.dynamicImportSettled();
+
+    expect(loadGeneratedPlan).toHaveBeenCalledTimes(1);
+    resolveLoad?.({ planName: 'Mock Plan', workflowId: 'wf-1' });
+
+    await expect(first).resolves.toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
+    await expect(second).resolves.toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
   });
 
   it('rejects submit for an unknown session', async () => {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -47,6 +47,7 @@ export interface InAppPlanningChatSession {
   updatedAt: string;
   nextMessageId: number;
   pendingSend?: Promise<void>;
+  pendingSubmit?: Promise<InAppPlanningSubmitResponse>;
 }
 
 export type InAppPlanningChatSessions = Map<string, InAppPlanningChatSession>;
@@ -54,6 +55,17 @@ export type InAppPlanningChatSessions = Map<string, InAppPlanningChatSession>;
 export function createInAppPlanningChatSessions(): InAppPlanningChatSessions {
   return new Map();
 }
+
+function isModuleResolutionError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return (
+    error.message.includes('Cannot find module')
+    || error.message.includes('Cannot find package')
+    || error.message.includes('ERR_MODULE_NOT_FOUND')
+    || error.message.includes('ERR_UNKNOWN_FILE_EXTENSION')
+  );
+}
+
 async function loadPlannerSurfaces(): Promise<{
   BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset>;
   DEFAULT_HARNESS_PRESET: string;
@@ -65,8 +77,23 @@ async function loadPlannerSurfaces(): Promise<{
     // Static import cannot work in required-fast CI because that job boots the built app
     // before the workspace @invoker/surfaces package has produced dist/index.js.
     return await import('@invoker/surfaces');
-  } catch {
-    return await import('../../surfaces/src/index.ts');
+  } catch (packageError) {
+    if (!isModuleResolutionError(packageError)) {
+      throw packageError;
+    }
+    const builtSurfacesModulePath = '../../surfaces/dist/index.js';
+    try {
+      return await import(builtSurfacesModulePath);
+    } catch (distError) {
+      if (!isModuleResolutionError(distError)) {
+        throw distError;
+      }
+      if (process.versions.electron) {
+        throw new Error('Unable to load @invoker/surfaces. Build packages/surfaces first so dist/index.js exists.');
+      }
+      const sourceSurfacesModulePath = '../../surfaces/src/index.ts';
+      return await import(sourceSurfacesModulePath);
+    }
   }
 }
 
@@ -415,28 +442,37 @@ export async function submitPlanningChatDraft(
   if (session.status === 'submitted') {
     return { ok: false, error: 'This planning session was already submitted.' };
   }
+  if (session.pendingSubmit) {
+    return session.pendingSubmit;
+  }
 
   const planText = session.conversation.getDraftedPlan();
   if (!planText) {
     return { ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' };
   }
 
-  try {
-    const { summarizePlanText } = await loadPlannerSurfaces();
-    if (!summarizePlanText(planText)) {
-      return { ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' };
-    }
+  const submitAttempt = (async (): Promise<InAppPlanningSubmitResponse> => {
+    try {
+      const { summarizePlanText } = await loadPlannerSurfaces();
+      if (!summarizePlanText(planText)) {
+        return { ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' };
+      }
 
-    const loaded = await deps.loadGeneratedPlan(planText);
-    session.status = 'submitted';
-    session.submittedPlanName = loaded.planName;
-    session.submittedWorkflowId = loaded.workflowId;
-    session.updatedAt = new Date().toISOString();
-    appendSessionMessage(session, 'system', `Plan "${loaded.planName}" submitted to Invoker. Review it, then Run.`, 'success');
-    return { ok: true, planName: loaded.planName, workflowId: loaded.workflowId };
-  } catch (error) {
-    return { ok: false, error: error instanceof Error ? error.message : String(error) };
-  }
+      const loaded = await deps.loadGeneratedPlan(planText);
+      session.status = 'submitted';
+      session.submittedPlanName = loaded.planName;
+      session.submittedWorkflowId = loaded.workflowId;
+      session.updatedAt = new Date().toISOString();
+      appendSessionMessage(session, 'system', `Plan "${loaded.planName}" submitted to Invoker. Review it, then Run.`, 'success');
+      return { ok: true, planName: loaded.planName, workflowId: loaded.workflowId };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    } finally {
+      session.pendingSubmit = undefined;
+    }
+  })();
+  session.pendingSubmit = submitAttempt;
+  return submitAttempt;
 }
 
 export function resetPlanningChat(


### PR DESCRIPTION
## Summary

The planning runtime now serializes one draft handoff at a time for each session.

It also keeps the Electron fallback on a runnable JavaScript surface build instead of reaching for the Slack surfaces TypeScript source directly.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the planning runtime hardening that serializes per-session draft handoffs and keeps the Electron fallback on a runnable JavaScript path.

Review Lane: behavior

Review Unit: routing

Safety Invariant: This stays inside the planning runtime. It does not change the planning terminal layout or the successful workflow graph handoff.

Slice Rationale: These fixes harden the runtime immediately after the base planning channels land, before the UI stack depends on them.

</details>

## Non-goals

- Changing the planning terminal layout.
- Changing planner prompt generation.
- Changing non-planning workflow submission paths.

## Test Plan

- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr3067-body.md --changed-files-file /tmp/3067-files.txt --diff-file /tmp/3067.diff`
- [ ] `pnpm --filter @invoker/app test -- src/__tests__/in-app-planner.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate planning submissions when the same draft is sent multiple times at once; repeated attempts now share the same in-progress result.
  * Improved error messaging when required planner surfaces aren’t available, making setup issues easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->