### PR TITLE
[Planning Chat](5c) Add planner submit failure proof

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -289,6 +289,31 @@ describe('planning chat', () => {
     await expect(second).resolves.toEqual({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
   });
 
+  it('returns load and parse failures as submit errors', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
+    const sessions = createInAppPlanningChatSessions();
+    const sent = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!sent.ok) throw new Error(sent.error);
+    const loadGeneratedPlan = vi.fn().mockRejectedValue(new Error('Task "make-selected-lists-scroll" uses "autoFix", which is no longer supported.'));
+
+    await expect(submitPlanningChatDraft({
+      sessionId: sent.sessionId,
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({
+      ok: false,
+      error: 'Task "make-selected-lists-scroll" uses "autoFix", which is no longer supported.',
+    });
+  });
 
   it('submits planner drafts after stripping legacy auto-fix fields', async () => {
     const legacyPlan = `Here is the plan.


### PR DESCRIPTION
## Summary

This adds a focused regression test for planner submit failures.

The new test proves the helper returns the error text when the submit step fails.

No product code changes.

<details>
<summary>Review metadata</summary>

Review Claim: Planner submit failures stay covered by a focused regression test.

Review Lane: proof

Review Unit: proof

Safety Invariant: Tests only.

Slice Rationale: This is the smallest proof for the planner-side failure case.

</details>

## Non-goals

- Product changes.
- Copy changes.
- Layout changes.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for a planning draft submission flow where generated plan loading fails due to an unsupported legacy field.
  * Verified that the app returns a clear failure response with the original error message after the draft is created successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->