### PR TITLE
Add stacked planner response contract fields

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -235,6 +235,8 @@ export type InAppPlanResponse =
       ok: true;
       planName: string;
       workflowId: string;
+      workflowIds?: string[];
+      workflowCount?: number;
     }
   | {
       ok: false;
@@ -252,6 +254,7 @@ export interface PlanningPresetOption {
 export interface InAppPlanningPlanSummary {
   name: string;
   taskCount: number;
+  workflowCount?: number;
   steps: string[];
 }
 export type InAppPlanningSessionStatus =
@@ -332,6 +335,8 @@ export type InAppPlanningSubmitResponse =
       ok: true;
       planName: string;
       workflowId: string;
+      workflowIds?: string[];
+      workflowCount?: number;
     }
   | {
       ok: false;


### PR DESCRIPTION
## Summary

Planning IPC responses now have optional fields for workflow IDs and workflow counts.

These fields describe stack metadata without changing the single-workflow response shape.

<details>
<summary>Review metadata</summary>

Review Claim: Planning IPC responses now include optional workflow ID and workflow count fields.

Review Lane: behavior

Review Unit: contract

Safety Invariant: Existing single-workflow responses still use the same required fields. The new metadata is optional.

Slice Rationale: The shared response types need to land first so later slices can read and return stack metadata safely.

</details>

## Non-goals

- Changing planner behavior.
- Changing workflow loading.
- Changing terminal copy.

## Test Plan

- [x] `pnpm --filter @invoker/contracts build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plan and submission responses may now include workflow IDs and workflow counts when available.
  * Planning summaries can now surface the total number of workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->