### PR TITLE
[Worker Controls](2) Route worker controls through the app

### DIFF
--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -12,6 +12,7 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     getUiPerfStats: vi.fn(() => ({ mainDeltaToUi: 7 })),
     resetUiPerfStats: vi.fn(),
     getQueueStatus: vi.fn(() => ({ runningCount: 2 })),
+    getWorkerStatus: vi.fn(() => ({ generatedAt: 'now', workers: [] })),
     getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
     getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
     getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
@@ -41,6 +42,7 @@ describe('answerOwnerReadQuery', () => {
   it('routes the snapshot kinds to their handlers', () => {
     const h = makeHandlers();
     expect(answerOwnerReadQuery({ kind: 'queue' }, h)).toEqual({ runningCount: 2 });
+    expect(answerOwnerReadQuery({ kind: 'worker-status' }, h)).toEqual({ workerStatus: { generatedAt: 'now', workers: [] } });
     expect(answerOwnerReadQuery({ kind: 'workflow-status' }, h)).toEqual({ 'wf-1': 'running' });
     expect(answerOwnerReadQuery({ kind: 'action-graph' }, h)).toEqual({ nodes: [] });
   });
@@ -137,6 +139,7 @@ describe('buildOwnerReadQueryHandlers', () => {
       getUiPerfStats: () => ({}),
       resetUiPerfStats: () => {},
       getStreamSequence: () => 5,
+      getWorkerStatus: () => ({ generatedAt: 'now', workers: [] }),
       resolveInvokerHomeRoot: () => '/home',
       orchestrator: { ...f.orchestrator, ...orch } as never,
       persistence: { ...f.persistence, ...persist } as never,
@@ -153,6 +156,7 @@ describe('buildOwnerReadQueryHandlers', () => {
     expect(h.getOutputChunks('t1')).toEqual([{ c: 1 }]);
     expect(h.replayOutput('t1', 9)).toEqual([{ id: 't1', off: 9 }]);
     expect(h.getAllCompletedTasks()).toEqual([{ id: 'done' }]);
+    expect(h.getWorkerStatus()).toEqual({ generatedAt: 'now', workers: [] });
   });
 
   it('loadWorkflowBundle syncs that workflow first, then returns workflow + tasks', () => {

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AUTO_FIX_WORKER_KIND,
+  CI_FAILURE_WORKER_KIND,
+  createWorkerRegistry,
+  PR_STATUS_WORKER_KIND,
+  type WorkerRuntime,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
+
+import {
+  AUTO_STARTED_OWNER_WORKER_KINDS,
+  createWorkerRuntimeController,
+} from '../worker-control.js';
+
+interface TestWorkerRuntime extends WorkerRuntime {
+  forceExit: () => void;
+  readonly starts: number;
+  readonly stops: number;
+}
+
+function runtime(kind: string): TestWorkerRuntime {
+  let running = false;
+  let starts = 0;
+  let stops = 0;
+  return {
+    identity: { kind, instanceId: `${kind}-instance` },
+    start: vi.fn(() => {
+      starts += 1;
+      running = true;
+    }),
+    wake: vi.fn(),
+    tick: vi.fn(async () => {}),
+    stop: vi.fn(async () => {
+      stops += 1;
+      running = false;
+    }),
+    isRunning: vi.fn(() => running),
+    forceExit: () => { running = false; },
+    get starts() { return starts; },
+    get stops() { return stops; },
+  };
+}
+
+function persistence() {
+  return {
+    listWorkerActions: vi.fn(() => []),
+    listWorkflows: vi.fn(() => []),
+    loadTasks: vi.fn(() => []),
+    getEvents: vi.fn(() => []),
+  };
+}
+
+function deps(): WorkerRuntimeDependencies {
+  return {
+    store: {} as WorkerRuntimeDependencies['store'],
+    submitter: { submit: vi.fn(() => 1) },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  } as WorkerRuntimeDependencies;
+}
+
+function controller(options: { autoFixRetries?: number } = {}) {
+  const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+  const runtimes = new Map<string, TestWorkerRuntime[]>();
+  const register = (kind: string, note: string, runtimeKind = kind) => {
+    registry.register({
+      kind,
+      note,
+      factory: () => {
+        const created = runtime(runtimeKind);
+        const list = runtimes.get(kind) ?? [];
+        list.push(created);
+        runtimes.set(kind, list);
+        return created;
+      },
+    });
+  };
+  register(AUTO_FIX_WORKER_KIND, 'Auto-fixes failed tasks.', 'recovery');
+  register(PR_STATUS_WORKER_KIND, 'Checks pull request status.');
+  register(CI_FAILURE_WORKER_KIND, 'Repairs failed CI.');
+  register('external-preview', 'External preview worker.');
+
+  return {
+    runtimes,
+    controller: createWorkerRuntimeController({
+      registry,
+      deps: deps(),
+      autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      persistence: persistence() as never,
+      canControl: () => true,
+      autoFixRetries: options.autoFixRetries,
+    }),
+  };
+}
+
+describe('createWorkerRuntimeController', () => {
+  it('auto-start starts only pr-status and ci-failure', () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    setup.controller.startAutoStartedWorkers();
+    const snapshot = setup.controller.snapshot();
+
+    expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
+    expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)?.lifecycle).toBe('running');
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
+    expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.lifecycle).toBe('stopped');
+  });
+
+  it('autofix remains stopped until explicitly started', () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    setup.controller.startAutoStartedWorkers();
+    expect(setup.runtimes.get(AUTO_FIX_WORKER_KIND)).toBeUndefined();
+
+    const row = setup.controller.start(AUTO_FIX_WORKER_KIND);
+
+    expect(row.lifecycle).toBe('running');
+    expect(row.runtimeKind).toBe('recovery');
+  });
+
+  it('duplicate start is idempotent', () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    setup.controller.start(PR_STATUS_WORKER_KIND);
+    setup.controller.start(PR_STATUS_WORKER_KIND);
+
+    expect(setup.runtimes.get(PR_STATUS_WORKER_KIND)).toHaveLength(1);
+  });
+
+  it('stop is idempotent', async () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    const stoppedBeforeStart = await setup.controller.stop(PR_STATUS_WORKER_KIND);
+    expect(stoppedBeforeStart.lifecycle).toBe('stopped');
+
+    setup.controller.start(PR_STATUS_WORKER_KIND);
+    const stopped = await setup.controller.stop(PR_STATUS_WORKER_KIND);
+    const stoppedAgain = await setup.controller.stop(PR_STATUS_WORKER_KIND);
+
+    expect(stopped.lifecycle).toBe('stopped');
+    expect(stoppedAgain.lifecycle).toBe('stopped');
+    expect(setup.runtimes.get(PR_STATUS_WORKER_KIND)?.[0]?.stops).toBe(1);
+  });
+
+  it('autoFixRetries=0 disables autofix and ci-failure starts', () => {
+    const setup = controller({ autoFixRetries: 0 });
+
+    expect(() => setup.controller.start(AUTO_FIX_WORKER_KIND)).toThrow('Worker "autofix" is disabled by autoFixRetries=0');
+    expect(() => setup.controller.start(CI_FAILURE_WORKER_KIND)).toThrow('Worker "ci-failure" is disabled by autoFixRetries=0');
+    setup.controller.startAutoStartedWorkers();
+    expect(setup.controller.snapshot().workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
+    expect(setup.runtimes.get(CI_FAILURE_WORKER_KIND)).toBeUndefined();
+
+
+    const snapshot = setup.controller.snapshot();
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
+      policy: 'disabled',
+      policyReason: 'autoFixRetries=0',
+      startable: false,
+    });
+    expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)).toMatchObject({
+      policy: 'disabled',
+      policyReason: 'autoFixRetries=0',
+      startable: false,
+    });
+  });
+
+  it('an exited external worker row reports exited', () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    setup.controller.start('external-preview');
+    setup.runtimes.get('external-preview')?.[0]?.forceExit();
+
+    expect(setup.controller.snapshot().workers.find((worker) => worker.kind === 'external-preview')).toMatchObject({
+      lifecycle: 'exited',
+      policy: 'unknown',
+    });
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -116,7 +116,7 @@ import {
   registerBuiltinAgents,
   registerBuiltinWorkers,
   type AgentRegistry,
-  type WorkerRuntime,
+  type WorkerRegistry,
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
@@ -234,6 +234,13 @@ import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
+import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
+import {
+  AUTO_STARTED_OWNER_WORKER_KINDS,
+  createLocalWorkerStatusSnapshot,
+  createWorkerRuntimeController,
+  type WorkerRuntimeController,
+} from './worker-control.js';
 import { startSurfaceEventRelay } from './surface-event-relay.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import { buildWebInvokerDispatch } from './web/web-invoker-dispatch.js';
@@ -288,16 +295,14 @@ import {
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
 
-const REGISTERED_OWNER_WORKER_KINDS = [
-  PR_STATUS_WORKER_KIND,
-  CI_FAILURE_WORKER_KIND,
-] as const;
-type RegisteredOwnerWorkerSubmit = WorkerRuntimeDependencies['submitter']['submit'];
 
 function submitRegisteredOwnerWorkerMutation(
-  ...args: Parameters<RegisteredOwnerWorkerSubmit>
-): ReturnType<RegisteredOwnerWorkerSubmit> {
-  const [workflowId, priority, channel, mutationArgs, options] = args;
+  workflowId: string,
+  priority: WorkflowMutationPriority,
+  channel: string,
+  mutationArgs: unknown[],
+  options?: { deferDrain?: boolean },
+): number {
   if (!workflowMutationCoordinator) {
     throw new Error('Workflow mutation coordinator is unavailable');
   }
@@ -328,27 +333,14 @@ function buildRegisteredOwnerWorkerDeps(
     },
   };
 }
-
-function startRegisteredOwnerWorkers(deps: WorkerRuntimeDependencies): WorkerRuntime[] {
-  const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
-  const workers: WorkerRuntime[] = [];
-  for (const kind of REGISTERED_OWNER_WORKER_KINDS) {
-    const definition = registry.get(kind);
-    if (!definition) {
-      deps.logger.warn(`registered owner worker "${kind}" is unavailable`, { module: 'worker-registry' });
-      continue;
-    }
-    const worker = definition.factory(deps);
-    worker.start();
-    workers.push(worker);
-  }
-  return workers;
+function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependencies> {
+  return registerExternalWorkersFromConfig(
+    invokerConfig.externalWorkers,
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
+  );
 }
 
-async function stopRegisteredOwnerWorkers(workers: WorkerRuntime[]): Promise<void> {
-  const stopping = workers.splice(0).map((worker) => worker.stop().catch(() => undefined));
-  await Promise.all(stopping);
-}
+
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -977,7 +969,7 @@ function startHeadlessMode(): void {
     }
 
     let exitCode = 0;
-    const registeredOwnerWorkers: WorkerRuntime[] = [];
+    let workerRuntimeController: WorkerRuntimeController | null = null;
     let lifecycleEventBridge: LifecycleEventBridge | null = null;
     let standaloneLaunchDispatcherController: StandaloneLaunchDispatcherController | null = null;
     try {
@@ -1186,6 +1178,18 @@ function startHeadlessMode(): void {
             await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
             failInFlightTasks();
             return undefined;
+          }
+          case 'invoker:start-worker': {
+            if (!workerRuntimeController) {
+              throw new Error('Worker runtime controller is unavailable');
+            }
+            return workerRuntimeController.start(String(payload.args[0]));
+          }
+          case 'invoker:stop-worker': {
+            if (!workerRuntimeController) {
+              throw new Error('Worker runtime controller is unavailable');
+            }
+            return workerRuntimeController.stop(String(payload.args[0]));
           }
           case 'invoker:inject-task-states': {
             if (process.env.NODE_ENV !== 'test') {
@@ -1661,6 +1665,7 @@ function startHeadlessMode(): void {
             getUiPerfStats: () => headlessDeps.getUiPerfStats?.() ?? {},
             resetUiPerfStats: () => headlessDeps.resetUiPerfStats?.(),
             getStreamSequence: () => 0,
+            getWorkerStatus: () => workerRuntimeController?.snapshot() ?? { generatedAt: new Date().toISOString(), workers: [] },
             resolveInvokerHomeRoot,
             orchestrator,
             persistence,
@@ -1735,14 +1740,20 @@ function startHeadlessMode(): void {
           logWarn: (message) => logger.warn(message, { module: 'surface-relay' }),
         });
 
-        registeredOwnerWorkers.push(...startRegisteredOwnerWorkers(
-          buildRegisteredOwnerWorkerDeps(
+        workerRuntimeController = createWorkerRuntimeController({
+          registry: createRegisteredWorkerRegistry(),
+          deps: buildRegisteredOwnerWorkerDeps(
             persistence,
             async () => {
               await createStandaloneTaskExecutor().checkMergeGateStatuses();
             },
           ),
-        ));
+          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          persistence,
+          autoFixRetries: invokerConfig.autoFixRetries,
+          canControl: () => !readOnlyMode,
+        });
+        workerRuntimeController.startAutoStartedWorkers();
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
@@ -1762,7 +1773,7 @@ function startHeadlessMode(): void {
     } finally {
       standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
-      await stopRegisteredOwnerWorkers(registeredOwnerWorkers);
+      await workerRuntimeController?.stopAll();
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
       }
@@ -1851,7 +1862,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const planningCommandBuilder = createPlanningCommandBuilderFromRegistry(agentRegistry);
   let mainWindow: BrowserWindow | null = null;
   let taskExecutor: TaskRunner | null = null;
-  const registeredOwnerWorkers: WorkerRuntime[] = [];
+  let workerRuntimeController: WorkerRuntimeController | null = null;
   let apiServer: ApiServer | null = null;
   let webBridge: WebBridge | null = null;
   let ownerMode = true;
@@ -2670,6 +2681,10 @@ function createEmbeddedTerminalBackendFromConfig(
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:clear':
         return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:start-worker':
+        return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:stop-worker':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
         const workflows = detachedViewerWorkflows ?? persistence.listWorkflows();
         const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
@@ -3407,6 +3422,7 @@ function createEmbeddedTerminalBackendFromConfig(
           ownerModeLabel: 'gui',
           getUiPerfStats: () => getUiPerfStats(),
           resetUiPerfStats: () => resetUiPerfStats(),
+          getWorkerStatus: () => workerRuntimeController?.snapshot() ?? { generatedAt: new Date().toISOString(), workers: [] },
           getStreamSequence: () => getTaskDeltaStreamSequence(),
           resolveInvokerHomeRoot,
           orchestrator,
@@ -3509,14 +3525,20 @@ function createEmbeddedTerminalBackendFromConfig(
     }
 
     if (ownerMode) {
-      registeredOwnerWorkers.push(...startRegisteredOwnerWorkers(
-        buildRegisteredOwnerWorkerDeps(
+      workerRuntimeController = createWorkerRuntimeController({
+        registry: createRegisteredWorkerRegistry(),
+        deps: buildRegisteredOwnerWorkerDeps(
           persistence,
           async () => {
             await requireTaskExecutor().checkMergeGateStatuses();
           },
         ),
-      ));
+        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        persistence,
+        autoFixRetries: invokerConfig.autoFixRetries,
+        canControl: () => ownerMode,
+      });
+      workerRuntimeController.startAutoStartedWorkers();
     }
 
     // Relaunch orphaned running tasks and start any pending-but-ready tasks.
@@ -4146,9 +4168,54 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
+    registerGuiMutationHandler('invoker:start-worker', async (kindArg: unknown) => {
+      if (!workerRuntimeController) {
+        throw new Error('Worker runtime controller is unavailable');
+      }
+      return workerRuntimeController.start(String(kindArg));
+    });
+
+    registerGuiMutationHandler('invoker:stop-worker', async (kindArg: unknown) => {
+      if (!workerRuntimeController) {
+        throw new Error('Worker runtime controller is unavailable');
+      }
+      return workerRuntimeController.stop(String(kindArg));
+    });
+
     ipcMain.handle('invoker:get-queue-status', () => {
       return orchestrator.getQueueStatus();
     });
+    ipcMain.handle('invoker:get-worker-status', async () => {
+      if (!ownerMode) {
+        try {
+          const delegated = await messageBus.request<{ kind: string }, { workerStatus?: unknown }>(
+            'headless.query',
+            { kind: 'worker-status' },
+          );
+          if (delegated && typeof delegated === 'object' && 'workerStatus' in delegated) {
+            return delegated.workerStatus;
+          }
+        } catch (err) {
+          logger.warn(
+            `get-worker-status owner delegation failed; falling back to local read-only snapshot: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            { module: 'ipc' },
+          );
+        }
+        return createLocalWorkerStatusSnapshot({
+          registry: createRegisteredWorkerRegistry(),
+          persistence,
+          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        });
+      }
+      return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+        registry: createRegisteredWorkerRegistry(),
+        persistence,
+        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      });
+    });
+
 
     ipcMain.handle('invoker:get-action-graph', async () => {
       if (!ownerMode) {
@@ -5064,7 +5131,7 @@ function createEmbeddedTerminalBackendFromConfig(
       try {
         if (apiServer) await apiServer.close().catch(() => {});
         if (webBridge) await webBridge.close().catch(() => {});
-        await stopRegisteredOwnerWorkers(registeredOwnerWorkers);
+        await workerRuntimeController?.stopAll();
         if (dbPollInterval) clearInterval(dbPollInterval);
         if (activityPollInterval) clearInterval(activityPollInterval);
         if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -1,5 +1,6 @@
 import type { Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
+import type { WorkerStatusSnapshot } from '@invoker/contracts';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { isHeadlessReadOnlyCommand } from './headless-command-classification.js';
 import { runReadOnlyHeadlessQueryToString, type HeadlessQueryDeps } from './headless-query-list.js';
@@ -27,6 +28,7 @@ export interface OwnerReadQueryHandlers {
   getUiPerfStats: () => Record<string, unknown>;
   resetUiPerfStats: () => void;
   getQueueStatus: () => Record<string, unknown>;
+  getWorkerStatus: () => WorkerStatusSnapshot;
   getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
   getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
   getActionGraphSnapshot: () => Record<string, unknown>;
@@ -75,6 +77,8 @@ export function answerOwnerReadQuery(
       return { ownerMode: handlers.ownerModeLabel, ...handlers.getUiPerfStats() };
     case 'queue':
       return handlers.getQueueStatus();
+    case 'worker-status':
+      return { workerStatus: handlers.getWorkerStatus() };
     case 'workflow-status':
       return handlers.getWorkflowStatus(body.workflowId);
     case 'tasks':
@@ -156,6 +160,7 @@ export interface OwnerReadQueryDeps {
   getUiPerfStats: () => Record<string, unknown>;
   resetUiPerfStats: () => void;
   getStreamSequence: () => number;
+  getWorkerStatus: () => WorkerStatusSnapshot;
   resolveInvokerHomeRoot: () => string;
   orchestrator: ReadOrchestrator;
   persistence: ReadPersistence;
@@ -172,6 +177,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     getUiPerfStats: deps.getUiPerfStats,
     resetUiPerfStats: deps.resetUiPerfStats,
     getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
+    getWorkerStatus: deps.getWorkerStatus,
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
     getTasksSnapshot: ({ refresh }) => {
       if (refresh) orchestrator.syncAllFromDb();

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -1,0 +1,261 @@
+import type {
+  WorkerActionSummary,
+  WorkerPolicyStatus,
+  WorkerRecoverySummary,
+  WorkerStatusEntry,
+  WorkerStatusSnapshot,
+} from '@invoker/contracts';
+import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
+import {
+  AUTO_FIX_WORKER_KIND,
+  CI_FAILURE_WORKER_KIND,
+  PR_STATUS_WORKER_KIND,
+  type WorkerRegistry,
+  type WorkerRuntime,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
+
+import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
+
+export const AUTO_STARTED_OWNER_WORKER_KINDS = [PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND] as const;
+
+export interface WorkerRuntimeController {
+  startAutoStartedWorkers(): void;
+  start(kind: string): WorkerStatusEntry;
+  stop(kind: string): Promise<WorkerStatusEntry>;
+  stopAll(): Promise<void>;
+  snapshot(): WorkerStatusSnapshot;
+}
+
+type WorkerStatusPersistence = Pick<SQLiteAdapter, 'listWorkerActions' | 'listWorkflows' | 'loadTasks' | 'getEvents'>;
+
+interface RuntimeHandle {
+  runtime: WorkerRuntime;
+  startedAt: string;
+  stoppedAt?: string;
+}
+
+const BUILT_IN_WORKER_KINDS = new Set<string>([
+  AUTO_FIX_WORKER_KIND,
+  PR_STATUS_WORKER_KIND,
+  CI_FAILURE_WORKER_KIND,
+]);
+
+export function createWorkerRuntimeController(options: {
+  registry: WorkerRegistry<WorkerRuntimeDependencies>;
+  deps: WorkerRuntimeDependencies;
+  autoStartKinds: readonly string[];
+  persistence: WorkerStatusPersistence;
+  autoFixRetries?: number;
+  canControl: () => boolean;
+}): WorkerRuntimeController {
+  const handles = new Map<string, RuntimeHandle>();
+  const stoppedAtByKind = new Map<string, string>();
+
+  const requireDefinition = (kind: string) => {
+    const definition = options.registry.get(kind);
+    if (!definition) {
+      throw new Error(`Unknown worker kind: "${kind}"`);
+    }
+    return definition;
+  };
+
+  const assertStartAllowed = (kind: string): void => {
+    if (isDisabledByAutoFixRetries(kind, options.autoFixRetries)) {
+      throw new Error(`Worker "${kind}" is disabled by autoFixRetries=0`);
+    }
+  };
+
+  const rowForKind = (kind: string): WorkerStatusEntry => {
+    const definition = options.registry.get(kind);
+    if (!definition) {
+      throw new Error(`Unknown worker kind: "${kind}"`);
+    }
+    return buildWorkerStatusEntry({
+      definitionKind: definition.kind,
+      note: definition.note,
+      handle: handles.get(kind),
+      stoppedAt: stoppedAtByKind.get(kind),
+      autoStarts: options.autoStartKinds.includes(kind),
+      policy: policyForKind(kind, options.autoFixRetries),
+      persistence: options.persistence,
+      canControl: options.canControl(),
+    });
+  };
+
+  const stopHandle = async (kind: string, handle: RuntimeHandle): Promise<void> => {
+    await handle.runtime.stop();
+    const stoppedAt = new Date().toISOString();
+    stoppedAtByKind.set(kind, stoppedAt);
+    handles.delete(kind);
+  };
+
+  return {
+    startAutoStartedWorkers(): void {
+      for (const kind of options.autoStartKinds) {
+        if (!options.registry.get(kind)) continue;
+        if (isDisabledByAutoFixRetries(kind, options.autoFixRetries)) continue;
+        this.start(kind);
+      }
+    },
+
+    start(kind: string): WorkerStatusEntry {
+      const definition = requireDefinition(kind);
+      assertStartAllowed(kind);
+
+      const existing = handles.get(kind);
+      if (existing) {
+        if (existing.runtime.isRunning()) {
+          return rowForKind(kind);
+        }
+        void existing.runtime.stop().catch(() => undefined);
+        handles.delete(kind);
+      }
+
+      const runtime = definition.factory(options.deps);
+      runtime.start();
+      handles.set(kind, {
+        runtime,
+        startedAt: new Date().toISOString(),
+      });
+      stoppedAtByKind.delete(kind);
+      return rowForKind(kind);
+    },
+
+    async stop(kind: string): Promise<WorkerStatusEntry> {
+      requireDefinition(kind);
+      const handle = handles.get(kind);
+      if (!handle) {
+        return rowForKind(kind);
+      }
+      await stopHandle(kind, handle);
+      return rowForKind(kind);
+    },
+
+    async stopAll(): Promise<void> {
+      const stopping = [...handles.entries()].map(([kind, handle]) => stopHandle(kind, handle).catch(() => undefined));
+      await Promise.all(stopping);
+    },
+
+    snapshot(): WorkerStatusSnapshot {
+      return {
+        generatedAt: new Date().toISOString(),
+        workers: options.registry.list().map((definition) => rowForKind(definition.kind)),
+      };
+    },
+  };
+}
+export function createLocalWorkerStatusSnapshot(options: {
+  registry: WorkerRegistry<WorkerRuntimeDependencies>;
+  persistence: WorkerStatusPersistence;
+  autoStartKinds: readonly string[];
+}): WorkerStatusSnapshot {
+  return {
+    generatedAt: new Date().toISOString(),
+    workers: options.registry.list().map((definition) => buildWorkerStatusEntry({
+      definitionKind: definition.kind,
+      note: definition.note,
+      autoStarts: options.autoStartKinds.includes(definition.kind),
+      policy: 'unknown',
+      persistence: options.persistence,
+      canControl: false,
+    })),
+  };
+}
+
+
+function buildWorkerStatusEntry(args: {
+  definitionKind: string;
+  note: string;
+  handle?: RuntimeHandle;
+  stoppedAt?: string;
+  autoStarts: boolean;
+  policy: WorkerPolicyStatus;
+  persistence: WorkerStatusPersistence;
+  canControl: boolean;
+}): WorkerStatusEntry {
+  const lifecycle = args.handle
+    ? args.handle.runtime.isRunning() ? 'running' : 'exited'
+    : 'stopped';
+  const policyReason = args.policy === 'disabled' ? 'autoFixRetries=0' : undefined;
+  const controlDisabledReason = getControlDisabledReason({
+    canControl: args.canControl,
+    policyReason,
+  });
+  const runtime = args.handle?.runtime;
+  return {
+    kind: args.definitionKind,
+    note: args.note,
+    ...(runtime ? { runtimeKind: runtime.identity.kind, instanceId: runtime.identity.instanceId } : {}),
+    lifecycle,
+    policy: args.policy,
+    ...(policyReason ? { policyReason } : {}),
+    autoStarts: args.autoStarts,
+    startable: lifecycle !== 'running' && args.policy !== 'disabled' && args.canControl,
+    stoppable: lifecycle === 'running' && args.canControl,
+    ...(controlDisabledReason ? { controlDisabledReason } : {}),
+    ...(args.handle?.startedAt ? { startedAt: args.handle.startedAt } : {}),
+    ...(args.stoppedAt ? { stoppedAt: args.stoppedAt } : {}),
+    recentActions: args.persistence.listWorkerActions({ workerKind: args.definitionKind, limit: 5 }).map(toWorkerActionSummary),
+    ...(args.definitionKind === AUTO_FIX_WORKER_KIND ? { recovery: toWorkerRecoverySummary(args.persistence) } : {}),
+  };
+}
+
+function policyForKind(kind: string, autoFixRetries: number | undefined): WorkerPolicyStatus {
+  if (isDisabledByAutoFixRetries(kind, autoFixRetries)) return 'disabled';
+  if (BUILT_IN_WORKER_KINDS.has(kind)) return 'enabled';
+  return 'unknown';
+}
+
+function isDisabledByAutoFixRetries(kind: string, autoFixRetries: number | undefined): boolean {
+  return (kind === AUTO_FIX_WORKER_KIND || kind === CI_FAILURE_WORKER_KIND)
+    && autoFixRetries !== undefined
+    && autoFixRetries <= 0;
+}
+
+function getControlDisabledReason(args: { canControl: boolean; policyReason?: string }): string | undefined {
+  if (args.policyReason) return args.policyReason;
+  if (!args.canControl) return 'Controls unavailable';
+  return undefined;
+}
+
+function toWorkerActionSummary(action: WorkerActionRecord): WorkerActionSummary {
+  return {
+    id: action.id,
+    workerKind: action.workerKind,
+    actionType: action.actionType,
+    ...(action.workflowId ? { workflowId: action.workflowId } : {}),
+    ...(action.taskId ? { taskId: action.taskId } : {}),
+    subjectType: action.subjectType,
+    subjectId: action.subjectId,
+    externalKey: action.externalKey,
+    status: action.status,
+    attemptCount: action.attemptCount,
+    ...(action.intentId ? { intentId: action.intentId } : {}),
+    ...(action.agentName ? { agentName: action.agentName } : {}),
+    ...(action.executionModel ? { executionModel: action.executionModel } : {}),
+    ...(action.sessionId ? { sessionId: action.sessionId } : {}),
+    ...(action.summary ? { summary: action.summary } : {}),
+    createdAt: action.createdAt,
+    updatedAt: action.updatedAt,
+    ...(action.completedAt ? { completedAt: action.completedAt } : {}),
+  };
+}
+
+function toWorkerRecoverySummary(persistence: WorkerStatusPersistence): WorkerRecoverySummary {
+  const status = collectRecoveryWorkerStatus(persistence);
+  return {
+    workerId: status.workerId,
+    owner: status.owner,
+    ...(status.lastWakeupAt ? { lastWakeupAt: status.lastWakeupAt } : {}),
+    ...(status.lastScanAt ? { lastScanAt: status.lastScanAt } : {}),
+    ...(status.lastSubmitAt ? { lastSubmitAt: status.lastSubmitAt } : {}),
+    ...(status.lastSkipAt ? { lastSkipAt: status.lastSkipAt } : {}),
+    ...(status.lastSkipReason ? { lastSkipReason: status.lastSkipReason } : {}),
+    ...(status.lastSkipTaskId ? { lastSkipTaskId: status.lastSkipTaskId } : {}),
+    wakeups: status.wakeups,
+    scans: status.scans,
+    submissions: status.submissions,
+    skips: status.skips,
+  };
+}

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -144,6 +144,81 @@ export interface QueueStatus {
   running: Array<{ taskId: string; description: string }>;
   queued: Array<{ taskId: string; priority: number; description: string }>;
 }
+export type WorkerLifecycleStatus = 'running' | 'stopped' | 'exited';
+export type WorkerPolicyStatus = 'enabled' | 'disabled' | 'unknown';
+export type WorkerControlAction = 'start' | 'stop';
+export type WorkerActionStatus =
+  | 'queued'
+  | 'pending'
+  | 'running'
+  | 'needs_input'
+  | 'review_ready'
+  | 'completed'
+  | 'failed'
+  | 'skipped'
+  | 'abandoned'
+  | 'cancelled';
+
+export interface WorkerActionSummary {
+  id: string;
+  workerKind: string;
+  actionType: string;
+  workflowId?: string;
+  taskId?: string;
+  subjectType: string;
+  subjectId: string;
+  externalKey: string;
+  status: WorkerActionStatus;
+  attemptCount: number;
+  intentId?: string;
+  agentName?: string;
+  executionModel?: string;
+  sessionId?: string;
+  summary?: string;
+  createdAt: string;
+  updatedAt: string;
+  completedAt?: string;
+}
+
+export interface WorkerRecoverySummary {
+  workerId: string;
+  owner: string;
+  lastWakeupAt?: string;
+  lastScanAt?: string;
+  lastSubmitAt?: string;
+  lastSkipAt?: string;
+  lastSkipReason?: string;
+  lastSkipTaskId?: string;
+  wakeups: number;
+  scans: number;
+  submissions: number;
+  skips: number;
+}
+
+export interface WorkerStatusEntry {
+  kind: string;
+  note: string;
+  runtimeKind?: string;
+  instanceId?: string;
+  lifecycle: WorkerLifecycleStatus;
+  policy: WorkerPolicyStatus;
+  policyReason?: string;
+  autoStarts: boolean;
+  startable: boolean;
+  stoppable: boolean;
+  controlDisabledReason?: string;
+  startedAt?: string;
+  stoppedAt?: string;
+  lastError?: string;
+  recentActions: WorkerActionSummary[];
+  recovery?: WorkerRecoverySummary;
+}
+
+export interface WorkerStatusSnapshot {
+  generatedAt: string;
+  workers: WorkerStatusEntry[];
+}
+
 
 export type UIActionGraphNodeType =
   | 'user-action'
@@ -835,6 +910,18 @@ export const IpcChannels = {
   'invoker:get-queue-status': {} as {
     request: [];
     response: QueueStatus;
+  },
+  'invoker:get-worker-status': {} as {
+    request: [];
+    response: WorkerStatusSnapshot;
+  },
+  'invoker:start-worker': {} as {
+    request: [kind: string];
+    response: WorkerStatusEntry;
+  },
+  'invoker:stop-worker': {} as {
+    request: [kind: string];
+    response: WorkerStatusEntry;
   },
   'invoker:get-action-graph': {} as {
     request: [];


### PR DESCRIPTION
## Summary

Invoker now routes worker start, stop, and status requests through the owner process.

The owner keeps worker handles in one controller, so repeated start or stop calls stay safe.

<details>
<summary>Review metadata</summary>

Review Claim: Worker control requests now route through the owner process and return current worker state.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Worker startup still skips disabled auto-fix workers, and repeated start or stop calls stay harmless.

Slice Rationale: This routing slice lands before the UI so the next slice has real owner-backed data to call.

</details>

## Non-goals

- Changing worker business logic.
- Changing the worker card layout.
- Changing task scheduling rules.

## Visual Proof

The app wiring supports the worker surface shown in the next slice.

![Worker UI after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260706-6711c9/invoker-worker-ui-after.png)

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/worker-control.test.ts src/__tests__/owner-read-query.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Revert dependent UI slice first.
- Data migration? No

Depends-On: #3087