### PR TITLE
[Worker Controls](4) Emit auto-fix worker audit events

### DIFF
--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -250,6 +250,18 @@ describe('auto-fix recovery candidate validation', () => {
         reason: 'already-queued-intent',
       }),
     );
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'recovery.worker.skip',
+      expect.objectContaining({
+        workerId: 'auto-fix-recovery',
+        kind: 'recovery',
+        owner: 'auto-fix',
+        action: 'skip',
+        phase: 'worker-autofix-skip',
+        reason: 'already-queued-intent',
+      }),
+    );
   });
 
   it('deduplicates repeated wakeups for the same failed task', async () => {
@@ -330,6 +342,25 @@ describe('auto-fix recovery scan submission', () => {
       'normal',
       'invoker:fix-with-agent',
       buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', { autoFix: true }),
+    );
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'worker-autofix-submitted',
+        channel: 'invoker:fix-with-agent',
+      }),
+    );
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'recovery.worker.submit',
+      expect.objectContaining({
+        workerId: 'auto-fix-recovery',
+        kind: 'recovery',
+        owner: 'auto-fix',
+        action: 'submit',
+        phase: 'worker-autofix-submitted',
+      }),
     );
   });
 });

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -25,6 +25,11 @@ export const RECOVERY_WORKER_KIND = 'recovery';
 const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
 const AUTO_FIX_COMMAND_CHANNEL = 'invoker:fix-with-agent';
 
+const AUTO_FIX_WORKER_AUDIT_EVENTS: Record<string, { eventType: string; action: 'submit' | 'skip' }> = {
+  'worker-autofix-submitted': { eventType: 'recovery.worker.submit', action: 'submit' },
+  'worker-autofix-skip': { eventType: 'recovery.worker.skip', action: 'skip' },
+};
+
 export interface AutoFixRecoveryStore {
   listWorkflows(): ReadonlyArray<{ id: string }>;
   loadTasks(workflowId: string): TaskState[];
@@ -217,6 +222,23 @@ function logAutoFixWorkerEvent(
 ): void {
   const payload = { phase, worker: RECOVERY_WORKER_KIND, ...details };
   options.store.logEvent?.(taskId, 'debug.auto-fix', payload);
+
+  const auditEvent = AUTO_FIX_WORKER_AUDIT_EVENTS[phase];
+  if (auditEvent) {
+    options.store.logEvent?.(taskId, auditEvent.eventType, {
+      workerId: 'auto-fix-recovery',
+      kind: RECOVERY_WORKER_KIND,
+      owner: 'auto-fix',
+      action: auditEvent.action,
+      phase,
+      ...(typeof details.reason === 'string' ? { reason: details.reason } : {}),
+      ...(typeof details.status === 'string' ? { status: details.status } : {}),
+      ...(typeof details.workflowId === 'string' || details.workflowId === null ? { workflowId: details.workflowId } : {}),
+      ...(typeof details.autoFixAttempts === 'number' || details.autoFixAttempts === null ? { autoFixAttempts: details.autoFixAttempts } : {}),
+      details: { worker: RECOVERY_WORKER_KIND, ...details },
+    });
+  }
+
   options.logger.debug?.(`[worker:${RECOVERY_WORKER_KIND}] ${phase}`, {
     module: 'auto-fix-recovery',
     taskId,


### PR DESCRIPTION
## Summary

The auto-fix worker now records a dedicated recovery audit row for each worker handoff and decline decision.

The old debug row remains unchanged, so existing debugging still works while worker status can read a stable audit record.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the worker-owned audit row for handoff and decline decisions.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The worker still writes the existing debug event before the new audit row.

Slice Rationale: This isolates worker event writing before the browser proof consumes the new row.

</details>

## Non-goals

- Does not add wakeup or scan audit rows.
- Does not change agent selection.
- Does not change retry limits.

## Architecture

### Before

The worker only wrote `debug.auto-fix`, so status readers had to infer worker decisions from a debug-only record.

### After

The worker still writes `debug.auto-fix`. For handoff and decline phases, it also writes a `recovery.worker.*` row with worker identity and phase data.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/auto-fix-recovery.test.ts src/__tests__/recovery-worker-observability.test.ts src/__tests__/worker-control.test.ts src/__tests__/lifecycle-event-bridge.test.ts src/__tests__/headless-autofix.test.ts`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app exec playwright test e2e/autofix-worker-ui.spec.ts --reporter=line`
- [x] `bash scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
