### PR TITLE
[Worker Controls](6) Prove worker-triggered autofix UI

### DIFF
--- a/packages/app/e2e/autofix-worker-ui.spec.ts
+++ b/packages/app/e2e/autofix-worker-ui.spec.ts
@@ -1,0 +1,64 @@
+import {
+  test,
+  expect,
+  loadPlan,
+  startPlan,
+  waitForTaskStatus,
+  resolveTaskId,
+  E2E_REPO_URL,
+} from './fixtures/electron-app.js';
+
+test.use({ repoConfig: { autoFixRetries: 1, autoFixAgent: 'claude', autoApproveAIFixes: false } });
+
+const PLAN = {
+  name: 'E2E Autofix Worker UI Plan',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    { id: 'task-pass', description: 'Task that succeeds', command: 'echo ok', dependencies: [] },
+    { id: 'task-fail', description: 'Task that fails', command: 'exit 1', dependencies: ['task-pass'] },
+  ],
+};
+
+test('worker-triggered autofix reaches approval UI with mocked Claude', async ({ page }) => {
+  await loadPlan(page, PLAN);
+  await startPlan(page);
+  await waitForTaskStatus(page, 'task-pass', 'completed');
+  await waitForTaskStatus(page, 'task-fail', 'awaiting_approval', 30000);
+
+  const scopedTaskId = await resolveTaskId(page, 'task-fail');
+  await page.waitForFunction(
+    async (taskId) => {
+      const parsePayload = (payload: unknown): Record<string, unknown> => {
+        if (typeof payload === 'string') {
+          try {
+            return JSON.parse(payload) as Record<string, unknown>;
+          } catch {
+            return {};
+          }
+        }
+        return payload && typeof payload === 'object' ? payload as Record<string, unknown> : {};
+      };
+
+      const events = await window.invoker.getEvents(taskId);
+      return events.some((event: { eventType: string }) => event.eventType === 'task.failed')
+        && events.some((event: { eventType: string; payload?: unknown }) => {
+          const payload = parsePayload(event.payload);
+          return event.eventType === 'debug.auto-fix' && payload.phase === 'worker-autofix-submitted';
+        })
+        && events.some((event: { eventType: string; payload?: unknown }) => {
+          const payload = parsePayload(event.payload);
+          return event.eventType === 'recovery.worker.submit' && payload.action === 'submit';
+        });
+    },
+    scopedTaskId,
+    { timeout: 10000 },
+  );
+
+  const node = page.locator('.react-flow__node[data-testid$="/task-fail"]');
+  await expect(node.locator('text=/APPROVE/')).toBeVisible({ timeout: 5000 });
+  await expect(node.locator('text=FIXING WITH AI')).not.toBeVisible();
+
+  await node.click();
+  await expect(page.getByTestId('inspector-approve-button')).toHaveText('Approve Fix');
+});

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -7,6 +7,7 @@
  */
 
 import type { TaskStateChanges } from '@invoker/workflow-core';
+import type { InvokerConfig } from '../../src/config.js';
 import { resolveRepoRoot } from '@invoker/contracts';
 import { test as base, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
 import * as path from 'node:path';
@@ -22,6 +23,7 @@ export type ElectronFixtures = {
   guiOwnerMode: string;
   /** When true, the app's embedded terminal backend throws on spawn (fault injection). */
   breakTerminalSpawn: boolean;
+  repoConfig: Partial<InvokerConfig>;
   page: Page;
   testDir: string;
 };
@@ -49,6 +51,7 @@ async function removeTestDir(dir: string): Promise<void> {
 export const test = base.extend<ElectronFixtures>({
   guiOwnerMode: [process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui', { option: true }],
   breakTerminalSpawn: [false, { option: true }],
+  repoConfig: [{ autoFixRetries: 0 }, { option: true }],
 
   testDir: async ({}, use) => {
     const dir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-'));
@@ -58,7 +61,7 @@ export const test = base.extend<ElectronFixtures>({
     }
   },
 
-  electronApp: async ({ guiOwnerMode, breakTerminalSpawn, testDir }, use) => {
+  electronApp: async ({ guiOwnerMode, breakTerminalSpawn, repoConfig, testDir }, use) => {
     // Dummy `claude` on PATH + fix command — same as scripts/e2e-dry-run (no real CLI).
     const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
     const stubDir = path.join(testDir, 'claude-stub');
@@ -70,7 +73,7 @@ export const test = base.extend<ElectronFixtures>({
     await fs.mkdir(markerRoot, { recursive: true });
     await fs.mkdir(electronUserDataDir, { recursive: true });
     registerTrackedBrowserUserDataDir(electronUserDataDir);
-    writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
+    writeFileSync(configPath, JSON.stringify(repoConfig), 'utf8');
     try {
       await fs.symlink(claudeMarker, path.join(stubDir, 'claude'));
     } catch {
@@ -137,7 +140,6 @@ exit 64
         ...(breakTerminalSpawn ? { INVOKER_E2E_BREAK_TERMINAL_SPAWN: '1' } : {}),
         ...(forceReadOnlyStatus ? { INVOKER_E2E_FORCE_READ_ONLY_STATUS: '1' } : {}),
         PATH: pathEnv,
-        INVOKER_USER_DATA_DIR: electronUserDataDir,
       },
     });
     await use(app);

--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -250,6 +250,18 @@ describe('auto-fix recovery candidate validation', () => {
         reason: 'already-queued-intent',
       }),
     );
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'recovery.worker.skip',
+      expect.objectContaining({
+        workerId: 'auto-fix-recovery',
+        kind: 'recovery',
+        owner: 'auto-fix',
+        action: 'skip',
+        phase: 'worker-autofix-skip',
+        reason: 'already-queued-intent',
+      }),
+    );
   });
 
   it('deduplicates repeated wakeups for the same failed task', async () => {
@@ -330,6 +342,25 @@ describe('auto-fix recovery scan submission', () => {
       'normal',
       'invoker:fix-with-agent',
       buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', { autoFix: true }),
+    );
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'worker-autofix-submitted',
+        channel: 'invoker:fix-with-agent',
+      }),
+    );
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'recovery.worker.submit',
+      expect.objectContaining({
+        workerId: 'auto-fix-recovery',
+        kind: 'recovery',
+        owner: 'auto-fix',
+        action: 'submit',
+        phase: 'worker-autofix-submitted',
+      }),
     );
   });
 });

--- a/packages/app/src/__tests__/recovery-worker-observability.test.ts
+++ b/packages/app/src/__tests__/recovery-worker-observability.test.ts
@@ -39,7 +39,7 @@ describe('recovery-worker-observability', () => {
           id: 4,
           taskId: 'wf-1/task-b',
           eventType: recoveryWorkerEventType('submit'),
-          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('submit', 'schedule-enqueued', { workflowId: 'wf-1' })),
+          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('submit', 'worker-autofix-submitted', { workflowId: 'wf-1' })),
           createdAt: '2026-06-22T10:00:03.000Z',
         },
         {

--- a/packages/app/src/recovery-worker-observability.ts
+++ b/packages/app/src/recovery-worker-observability.ts
@@ -73,7 +73,7 @@ export function classifyAutoFixRecoveryPhase(
 ): RecoveryWorkerAuditAction | undefined {
   if (phase === 'delta-failed') return 'wakeup';
   if (phase === 'poll-failed' || phase === 'schedule-enter') return 'scan';
-  if (phase === 'schedule-enqueued') return 'submit';
+  if (phase === 'schedule-enqueued' || phase === 'worker-autofix-submitted') return 'submit';
   if (phase === 'schedule-skip' || phase.endsWith('-skip')) return 'skip';
   if (details.reason && (phase.includes('skip') || phase.includes('error'))) return 'skip';
   return undefined;

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -25,6 +25,11 @@ export const RECOVERY_WORKER_KIND = 'recovery';
 const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
 const AUTO_FIX_COMMAND_CHANNEL = 'invoker:fix-with-agent';
 
+const AUTO_FIX_WORKER_AUDIT_EVENTS: Record<string, { eventType: string; action: 'submit' | 'skip' }> = {
+  'worker-autofix-submitted': { eventType: 'recovery.worker.submit', action: 'submit' },
+  'worker-autofix-skip': { eventType: 'recovery.worker.skip', action: 'skip' },
+};
+
 export interface AutoFixRecoveryStore {
   listWorkflows(): ReadonlyArray<{ id: string }>;
   loadTasks(workflowId: string): TaskState[];
@@ -217,6 +222,23 @@ function logAutoFixWorkerEvent(
 ): void {
   const payload = { phase, worker: RECOVERY_WORKER_KIND, ...details };
   options.store.logEvent?.(taskId, 'debug.auto-fix', payload);
+
+  const auditEvent = AUTO_FIX_WORKER_AUDIT_EVENTS[phase];
+  if (auditEvent) {
+    options.store.logEvent?.(taskId, auditEvent.eventType, {
+      workerId: 'auto-fix-recovery',
+      kind: RECOVERY_WORKER_KIND,
+      owner: 'auto-fix',
+      action: auditEvent.action,
+      phase,
+      ...(typeof details.reason === 'string' ? { reason: details.reason } : {}),
+      ...(typeof details.status === 'string' ? { status: details.status } : {}),
+      ...(typeof details.workflowId === 'string' || details.workflowId === null ? { workflowId: details.workflowId } : {}),
+      ...(typeof details.autoFixAttempts === 'number' || details.autoFixAttempts === null ? { autoFixAttempts: details.autoFixAttempts } : {}),
+      details: { worker: RECOVERY_WORKER_KIND, ...details },
+    });
+  }
+
   options.logger.debug?.(`[worker:${RECOVERY_WORKER_KIND}] ${phase}`, {
     module: 'auto-fix-recovery',
     taskId,

--- a/scripts/repro/repro-daemon-autofix-persisted-intent.sh
+++ b/scripts/repro/repro-daemon-autofix-persisted-intent.sh
@@ -8,8 +8,8 @@
 #   durable.
 #
 # Fixed behavior:
-#   The failing task records task.failed, debug.auto-fix schedule-enqueued, and
-#   a persisted invoker:fix-with-agent row in workflow_mutation_intents.
+#   The failing task records task.failed, debug.auto-fix worker-autofix-submitted,
+#   and a persisted invoker:fix-with-agent row in workflow_mutation_intents.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"


### PR DESCRIPTION
## Summary

A new browser test starts a real GUI owner, lets the auto-fix worker run mocked Claude, and checks the task reaches Approve Fix.

The shared browser fixture can now opt into a repo config while keeping the default disabled.

The repro note names the worker-owned phase that the browser case observes.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the browser proof for worker-triggered fixes.

Review Lane: proof

Review Unit: proof

Safety Invariant: Existing browser tests keep auto-fix disabled unless they opt in.

Slice Rationale: This proof sits after the worker row and reader support it observes.

</details>

## Non-goals

- Does not auto-approve AI fixes.
- Does not add a Codex browser case.
- Does not replace the broader retry loop.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/auto-fix-recovery.test.ts src/__tests__/recovery-worker-observability.test.ts src/__tests__/worker-control.test.ts src/__tests__/lifecycle-event-bridge.test.ts src/__tests__/headless-autofix.test.ts`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && pnpm --filter @invoker/app exec playwright test e2e/autofix-worker-ui.spec.ts --reporter=line`
- [x] `bash scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
