### PR TITLE
[Worker Controls](10) Treat autofix budget as worker policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,6 +501,7 @@ jobs:
               e2e/edit-task-prompt.spec.ts
               e2e/fix-with-claude.spec.ts
               e2e/fix-with-agent-transition.spec.ts
+              e2e/autofix-worker-ui.spec.ts
               e2e/orphan-relaunch.spec.ts
               e2e/gap-recovery-bench.spec.ts
               e2e/system-setup-visual-proof.spec.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,7 @@ All notable changes to Invoker will be documented in this file.
 - Stop treating every lobby/DM `@Invoker` mention as a build request. Mentions and a new `/invoker` slash command now recognize explicit verbs — `status`, `recreate`, `rebase`, `retry`, `cancel` (one workflow or `all`), and `submit` — and run the real workflow operation. A fuzzy operational ask falls back to an LLM classifier that proposes the action and waits for confirmation. Destructive all-workflow operations always confirm (Approve/Cancel buttons or a `yes`/`no` reply), and `submit` shows a plain-English, one-line-per-step summary of the plan to approve instead of raw YAML. The Slack app manifest now enables the `/invoker` slash command and Block Kit interactivity.
 - Make Slack lobby mentions normal agent threads by default: plain `@Invoker fix X` now runs a recoverable OMP/Codex-style repo session, `local:` and `run local:` are aliases for that path, workflow count/status questions route to Invoker status directly, `exec local:`/`local command:` run raw shell, and `plan:` is the explicit opt-in for Invoker YAML plus `submit` approval.
 - Stream live progress for bulk lobby workflow operations into the Slack thread: a long `recreate`/`rebase`/`cancel all` now edits one in-thread message with a running `done/total` count (and the workflow being processed) as it works, instead of going silent between the "On it…" acknowledgement and the final summary.
-
-
+- Emit first-class recovery.worker submit/skip audit events from the auto-fix worker and add a mocked browser E2E proving worker-triggered fixes reach the Approve Fix UI.
 - Add task deletion across the desktop app, HTTP API, and headless commands. Deleting a task now kills it first when needed, rewires direct dependents to the deleted task's upstream dependencies, and blocks deleting the last task in a workflow so users delete the whole workflow instead.
 
 ## 0.0.6

--- a/packages/app/e2e/autofix-worker-ui.spec.ts
+++ b/packages/app/e2e/autofix-worker-ui.spec.ts
@@ -1,0 +1,64 @@
+import {
+  test,
+  expect,
+  loadPlan,
+  startPlan,
+  waitForTaskStatus,
+  resolveTaskId,
+  E2E_REPO_URL,
+} from './fixtures/electron-app.js';
+
+test.use({ repoConfig: { autoFixRetries: 1, autoFixAgent: 'claude', autoApproveAIFixes: false } });
+
+const PLAN = {
+  name: 'E2E Autofix Worker UI Plan',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    { id: 'task-pass', description: 'Task that succeeds', command: 'echo ok', dependencies: [] },
+    { id: 'task-fail', description: 'Task that fails', command: 'exit 1', dependencies: ['task-pass'] },
+  ],
+};
+
+test('worker-triggered autofix reaches approval UI with mocked Claude', async ({ page }) => {
+  await loadPlan(page, PLAN);
+  await startPlan(page);
+  await waitForTaskStatus(page, 'task-pass', 'completed');
+  await waitForTaskStatus(page, 'task-fail', 'awaiting_approval', 30000);
+
+  const scopedTaskId = await resolveTaskId(page, 'task-fail');
+  await page.waitForFunction(
+    async (taskId) => {
+      const parsePayload = (payload: unknown): Record<string, unknown> => {
+        if (typeof payload === 'string') {
+          try {
+            return JSON.parse(payload) as Record<string, unknown>;
+          } catch {
+            return {};
+          }
+        }
+        return payload && typeof payload === 'object' ? payload as Record<string, unknown> : {};
+      };
+
+      const events = await window.invoker.getEvents(taskId);
+      return events.some((event: { eventType: string }) => event.eventType === 'task.failed')
+        && events.some((event: { eventType: string; payload?: unknown }) => {
+          const payload = parsePayload(event.payload);
+          return event.eventType === 'debug.auto-fix' && payload.phase === 'worker-autofix-submitted';
+        })
+        && events.some((event: { eventType: string; payload?: unknown }) => {
+          const payload = parsePayload(event.payload);
+          return event.eventType === 'recovery.worker.submit' && payload.action === 'submit';
+        });
+    },
+    scopedTaskId,
+    { timeout: 10000 },
+  );
+
+  const node = page.locator('.react-flow__node[data-testid$="/task-fail"]');
+  await expect(node.locator('text=/APPROVE/')).toBeVisible({ timeout: 5000 });
+  await expect(node.locator('text=FIXING WITH AI')).not.toBeVisible();
+
+  await node.click();
+  await expect(page.getByTestId('inspector-approve-button')).toHaveText('Approve Fix');
+});

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -7,6 +7,7 @@
  */
 
 import type { TaskStateChanges } from '@invoker/workflow-core';
+import type { InvokerConfig } from '../../src/config.js';
 import { resolveRepoRoot } from '@invoker/contracts';
 import { test as base, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
 import * as path from 'node:path';
@@ -22,6 +23,7 @@ export type ElectronFixtures = {
   guiOwnerMode: string;
   /** When true, the app's embedded terminal backend throws on spawn (fault injection). */
   breakTerminalSpawn: boolean;
+  repoConfig: Partial<InvokerConfig>;
   page: Page;
   testDir: string;
 };
@@ -49,6 +51,7 @@ async function removeTestDir(dir: string): Promise<void> {
 export const test = base.extend<ElectronFixtures>({
   guiOwnerMode: [process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui', { option: true }],
   breakTerminalSpawn: [false, { option: true }],
+  repoConfig: [{ autoFixRetries: 0 }, { option: true }],
 
   testDir: async ({}, use) => {
     const dir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-'));
@@ -58,7 +61,7 @@ export const test = base.extend<ElectronFixtures>({
     }
   },
 
-  electronApp: async ({ guiOwnerMode, breakTerminalSpawn, testDir }, use) => {
+  electronApp: async ({ guiOwnerMode, breakTerminalSpawn, repoConfig, testDir }, use) => {
     // Dummy `claude` on PATH + fix command — same as scripts/e2e-dry-run (no real CLI).
     const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
     const stubDir = path.join(testDir, 'claude-stub');
@@ -70,7 +73,7 @@ export const test = base.extend<ElectronFixtures>({
     await fs.mkdir(markerRoot, { recursive: true });
     await fs.mkdir(electronUserDataDir, { recursive: true });
     registerTrackedBrowserUserDataDir(electronUserDataDir);
-    writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
+    writeFileSync(configPath, JSON.stringify(repoConfig), 'utf8');
     try {
       await fs.symlink(claudeMarker, path.join(stubDir, 'claude'));
     } catch {
@@ -137,7 +140,6 @@ exit 64
         ...(breakTerminalSpawn ? { INVOKER_E2E_BREAK_TERMINAL_SPAWN: '1' } : {}),
         ...(forceReadOnlyStatus ? { INVOKER_E2E_FORCE_READ_ONLY_STATUS: '1' } : {}),
         PATH: pathEnv,
-        INVOKER_USER_DATA_DIR: electronUserDataDir,
       },
     });
     await use(app);

--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -166,14 +166,43 @@ describe('auto-fix recovery candidate validation', () => {
     });
   });
 
-  it('keeps failed tasks eligible after previous auto-fix attempts', () => {
-    const task = makeTask({ execution: { error: 'boom', autoFixAttempts: 100, generation: 1, selectedAttemptId: 'attempt-1' } });
+  it('skips failed tasks after the worker retry budget is exhausted', () => {
+    const task = makeTask({ execution: { error: 'boom', autoFixAttempts: 3, generation: 1, selectedAttemptId: 'attempt-1' } });
     const harness = makeRecoveryPolicyHarness(task);
 
     const candidates = collectValidatedAutoFixRecoveryCandidates(harness.options);
 
-    expect(candidates).toHaveLength(1);
-    expect(candidates[0]?.task.execution.autoFixAttempts).toBe(100);
+    expect(candidates).toHaveLength(0);
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'worker-autofix-skip',
+        reason: 'worker-retry-budget-exhausted',
+        autoFixAttempts: 3,
+        workerRetryBudget: 3,
+      }),
+    );
+  });
+
+  it('reports disabled worker retry budget as worker policy', () => {
+    const harness = makeRecoveryPolicyHarness();
+
+    const candidates = collectValidatedAutoFixRecoveryCandidates({
+      ...harness.options,
+      defaultAutoFixRetries: 0,
+    });
+
+    expect(candidates).toHaveLength(0);
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'worker-autofix-skip',
+        reason: 'worker-retry-budget-disabled',
+        workerRetryBudget: 0,
+      }),
+    );
   });
 
   it.each([

--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -250,6 +250,18 @@ describe('auto-fix recovery candidate validation', () => {
         reason: 'already-queued-intent',
       }),
     );
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'recovery.worker.skip',
+      expect.objectContaining({
+        workerId: 'auto-fix-recovery',
+        kind: 'recovery',
+        owner: 'auto-fix',
+        action: 'skip',
+        phase: 'worker-autofix-skip',
+        reason: 'already-queued-intent',
+      }),
+    );
   });
 
   it('deduplicates repeated wakeups for the same failed task', async () => {
@@ -330,6 +342,25 @@ describe('auto-fix recovery scan submission', () => {
       'normal',
       'invoker:fix-with-agent',
       buildFixWithAgentMutationArgs('wf-1/task-1', 'codex', { autoFix: true }),
+    );
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'worker-autofix-submitted',
+        channel: 'invoker:fix-with-agent',
+      }),
+    );
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'recovery.worker.submit',
+      expect.objectContaining({
+        workerId: 'auto-fix-recovery',
+        kind: 'recovery',
+        owner: 'auto-fix',
+        action: 'submit',
+        phase: 'worker-autofix-submitted',
+      }),
     );
   });
 });

--- a/packages/app/src/__tests__/recovery-worker-observability.test.ts
+++ b/packages/app/src/__tests__/recovery-worker-observability.test.ts
@@ -39,7 +39,7 @@ describe('recovery-worker-observability', () => {
           id: 4,
           taskId: 'wf-1/task-b',
           eventType: recoveryWorkerEventType('submit'),
-          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('submit', 'schedule-enqueued', { workflowId: 'wf-1' })),
+          payload: JSON.stringify(buildRecoveryWorkerAuditPayload('submit', 'worker-autofix-submitted', { workflowId: 'wf-1' })),
           createdAt: '2026-06-22T10:00:03.000Z',
         },
         {

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -64,7 +64,7 @@ function deps(): WorkerRuntimeDependencies {
   } as WorkerRuntimeDependencies;
 }
 
-function controller(options: { autoFixRetries?: number } = {}) {
+function controller() {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
   const runtimes = new Map<string, TestWorkerRuntime[]>();
   const register = (kind: string, note: string, runtimeKind = kind) => {
@@ -93,14 +93,13 @@ function controller(options: { autoFixRetries?: number } = {}) {
       autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
       persistence: persistence() as never,
       canControl: () => true,
-      autoFixRetries: options.autoFixRetries,
     }),
   };
 }
 
 describe('createWorkerRuntimeController', () => {
   it('auto-start starts only pr-status and ci-failure', () => {
-    const setup = controller({ autoFixRetries: 3 });
+    const setup = controller();
 
     setup.controller.startAutoStartedWorkers();
     const snapshot = setup.controller.snapshot();
@@ -112,7 +111,7 @@ describe('createWorkerRuntimeController', () => {
   });
 
   it('autofix remains stopped until explicitly started', () => {
-    const setup = controller({ autoFixRetries: 3 });
+    const setup = controller();
 
     setup.controller.startAutoStartedWorkers();
     expect(setup.runtimes.get(AUTO_FIX_WORKER_KIND)).toBeUndefined();
@@ -124,7 +123,7 @@ describe('createWorkerRuntimeController', () => {
   });
 
   it('duplicate start is idempotent', () => {
-    const setup = controller({ autoFixRetries: 3 });
+    const setup = controller();
 
     setup.controller.start(PR_STATUS_WORKER_KIND);
     setup.controller.start(PR_STATUS_WORKER_KIND);
@@ -133,7 +132,7 @@ describe('createWorkerRuntimeController', () => {
   });
 
   it('stop is idempotent', async () => {
-    const setup = controller({ autoFixRetries: 3 });
+    const setup = controller();
 
     const stoppedBeforeStart = await setup.controller.stop(PR_STATUS_WORKER_KIND);
     expect(stoppedBeforeStart.lifecycle).toBe('stopped');
@@ -147,31 +146,26 @@ describe('createWorkerRuntimeController', () => {
     expect(setup.runtimes.get(PR_STATUS_WORKER_KIND)?.[0]?.stops).toBe(1);
   });
 
-  it('autoFixRetries=0 disables autofix and ci-failure starts', () => {
-    const setup = controller({ autoFixRetries: 0 });
+  it('retry budget policy does not disable worker starts', () => {
+    const setup = controller();
 
-    expect(() => setup.controller.start(AUTO_FIX_WORKER_KIND)).toThrow('Worker "autofix" is disabled by autoFixRetries=0');
-    expect(() => setup.controller.start(CI_FAILURE_WORKER_KIND)).toThrow('Worker "ci-failure" is disabled by autoFixRetries=0');
-    setup.controller.startAutoStartedWorkers();
-    expect(setup.controller.snapshot().workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
-    expect(setup.runtimes.get(CI_FAILURE_WORKER_KIND)).toBeUndefined();
+    const autoFix = setup.controller.start(AUTO_FIX_WORKER_KIND);
+    const ciFailure = setup.controller.start(CI_FAILURE_WORKER_KIND);
 
-
-    const snapshot = setup.controller.snapshot();
-    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
-      policy: 'disabled',
-      policyReason: 'autoFixRetries=0',
+    expect(autoFix).toMatchObject({
+      lifecycle: 'running',
+      policy: 'enabled',
       startable: false,
     });
-    expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)).toMatchObject({
-      policy: 'disabled',
-      policyReason: 'autoFixRetries=0',
+    expect(ciFailure).toMatchObject({
+      lifecycle: 'running',
+      policy: 'enabled',
       startable: false,
     });
   });
 
   it('an exited external worker row reports exited', () => {
-    const setup = controller({ autoFixRetries: 3 });
+    const setup = controller();
 
     setup.controller.start('external-preview');
     setup.runtimes.get('external-preview')?.[0]?.forceExit();

--- a/packages/app/src/recovery-worker-observability.ts
+++ b/packages/app/src/recovery-worker-observability.ts
@@ -73,7 +73,7 @@ export function classifyAutoFixRecoveryPhase(
 ): RecoveryWorkerAuditAction | undefined {
   if (phase === 'delta-failed') return 'wakeup';
   if (phase === 'poll-failed' || phase === 'schedule-enter') return 'scan';
-  if (phase === 'schedule-enqueued') return 'submit';
+  if (phase === 'schedule-enqueued' || phase === 'worker-autofix-submitted') return 'submit';
   if (phase === 'schedule-skip' || phase.endsWith('-skip')) return 'skip';
   if (details.reason && (phase.includes('skip') || phase.includes('error'))) return 'skip';
   return undefined;

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -46,6 +46,7 @@ export function createWorkerRuntimeController(options: {
   deps: WorkerRuntimeDependencies;
   autoStartKinds: readonly string[];
   persistence: WorkerStatusPersistence;
+  /** Compatibility input; retry budget is enforced inside worker policy, not by controller start gating. */
   autoFixRetries?: number;
   canControl: () => boolean;
 }): WorkerRuntimeController {
@@ -60,11 +61,6 @@ export function createWorkerRuntimeController(options: {
     return definition;
   };
 
-  const assertStartAllowed = (kind: string): void => {
-    if (isDisabledByAutoFixRetries(kind, options.autoFixRetries)) {
-      throw new Error(`Worker "${kind}" is disabled by autoFixRetries=0`);
-    }
-  };
 
   const rowForKind = (kind: string): WorkerStatusEntry => {
     const definition = options.registry.get(kind);
@@ -77,7 +73,7 @@ export function createWorkerRuntimeController(options: {
       handle: handles.get(kind),
       stoppedAt: stoppedAtByKind.get(kind),
       autoStarts: options.autoStartKinds.includes(kind),
-      policy: policyForKind(kind, options.autoFixRetries),
+      policy: policyForKind(kind),
       persistence: options.persistence,
       canControl: options.canControl(),
     });
@@ -94,14 +90,12 @@ export function createWorkerRuntimeController(options: {
     startAutoStartedWorkers(): void {
       for (const kind of options.autoStartKinds) {
         if (!options.registry.get(kind)) continue;
-        if (isDisabledByAutoFixRetries(kind, options.autoFixRetries)) continue;
         this.start(kind);
       }
     },
 
     start(kind: string): WorkerStatusEntry {
       const definition = requireDefinition(kind);
-      assertStartAllowed(kind);
 
       const existing = handles.get(kind);
       if (existing) {
@@ -121,7 +115,6 @@ export function createWorkerRuntimeController(options: {
       stoppedAtByKind.delete(kind);
       return rowForKind(kind);
     },
-
     async stop(kind: string): Promise<WorkerStatusEntry> {
       requireDefinition(kind);
       const handle = handles.get(kind);
@@ -177,11 +170,7 @@ function buildWorkerStatusEntry(args: {
   const lifecycle = args.handle
     ? args.handle.runtime.isRunning() ? 'running' : 'exited'
     : 'stopped';
-  const policyReason = args.policy === 'disabled' ? 'autoFixRetries=0' : undefined;
-  const controlDisabledReason = getControlDisabledReason({
-    canControl: args.canControl,
-    policyReason,
-  });
+  const controlDisabledReason = getControlDisabledReason(args.canControl);
   const runtime = args.handle?.runtime;
   return {
     kind: args.definitionKind,
@@ -189,7 +178,6 @@ function buildWorkerStatusEntry(args: {
     ...(runtime ? { runtimeKind: runtime.identity.kind, instanceId: runtime.identity.instanceId } : {}),
     lifecycle,
     policy: args.policy,
-    ...(policyReason ? { policyReason } : {}),
     autoStarts: args.autoStarts,
     startable: lifecycle !== 'running' && args.policy !== 'disabled' && args.canControl,
     stoppable: lifecycle === 'running' && args.canControl,
@@ -201,21 +189,13 @@ function buildWorkerStatusEntry(args: {
   };
 }
 
-function policyForKind(kind: string, autoFixRetries: number | undefined): WorkerPolicyStatus {
-  if (isDisabledByAutoFixRetries(kind, autoFixRetries)) return 'disabled';
+function policyForKind(kind: string): WorkerPolicyStatus {
   if (BUILT_IN_WORKER_KINDS.has(kind)) return 'enabled';
   return 'unknown';
 }
 
-function isDisabledByAutoFixRetries(kind: string, autoFixRetries: number | undefined): boolean {
-  return (kind === AUTO_FIX_WORKER_KIND || kind === CI_FAILURE_WORKER_KIND)
-    && autoFixRetries !== undefined
-    && autoFixRetries <= 0;
-}
-
-function getControlDisabledReason(args: { canControl: boolean; policyReason?: string }): string | undefined {
-  if (args.policyReason) return args.policyReason;
-  if (!args.canControl) return 'Controls unavailable';
+function getControlDisabledReason(canControl: boolean): string | undefined {
+  if (!canControl) return 'Controls unavailable';
   return undefined;
 }
 

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -203,11 +203,11 @@ describe('PR status and CI failure workers', () => {
     });
   });
 
-  it('queues CI repair even after previous auto-fix attempts', async () => {
+  it('skips CI repair after the worker retry budget is exhausted', async () => {
     const event = makeEvent();
     const harness = makeHarness(makeTask({
       execution: {
-        autoFixAttempts: 100,
+        autoFixAttempts: 1,
       },
     }));
     const tick = createCiFailureTick({
@@ -220,7 +220,16 @@ describe('PR status and CI failure workers', () => {
 
     await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
 
-    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(harness.submit).not.toHaveBeenCalled();
+    expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
+      status: 'skipped',
+      summary: expect.stringContaining('worker retry budget is exhausted'),
+      payload: expect.objectContaining({
+        reason: 'worker-retry-budget-exhausted',
+        workerRetryBudget: 1,
+        autoFixAttempts: 1,
+      }),
+    });
   });
 
   it('rejects stale CI failure events when the PR head changed before submit', async () => {

--- a/packages/execution-engine/src/auto-fix-gating.ts
+++ b/packages/execution-engine/src/auto-fix-gating.ts
@@ -1,3 +1,22 @@
+export function normalizeAutoFixRetryBudget(raw: unknown): number {
+  if (raw === Number.POSITIVE_INFINITY) {
+    return Number.POSITIVE_INFINITY;
+  }
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    return 0;
+  }
+  const budget = Math.floor(raw);
+  return budget > 0 ? budget : 0;
+}
+
+export function normalizeAutoFixAttemptCount(raw: unknown): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+    return 0;
+  }
+  const attempts = Math.floor(raw);
+  return attempts > 0 ? attempts : 0;
+}
+
 export function shouldSkipAutoFixForError(errorText: unknown): boolean {
   if (typeof errorText !== 'string') {
     return false;

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -25,6 +25,11 @@ export const RECOVERY_WORKER_KIND = 'recovery';
 const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
 const AUTO_FIX_COMMAND_CHANNEL = 'invoker:fix-with-agent';
 
+const AUTO_FIX_WORKER_AUDIT_EVENTS: Record<string, { eventType: string; action: 'submit' | 'skip' }> = {
+  'worker-autofix-submitted': { eventType: 'recovery.worker.submit', action: 'submit' },
+  'worker-autofix-skip': { eventType: 'recovery.worker.skip', action: 'skip' },
+};
+
 export interface AutoFixRecoveryStore {
   listWorkflows(): ReadonlyArray<{ id: string }>;
   loadTasks(workflowId: string): TaskState[];
@@ -217,6 +222,23 @@ function logAutoFixWorkerEvent(
 ): void {
   const payload = { phase, worker: RECOVERY_WORKER_KIND, ...details };
   options.store.logEvent?.(taskId, 'debug.auto-fix', payload);
+
+  const auditEvent = AUTO_FIX_WORKER_AUDIT_EVENTS[phase];
+  if (auditEvent) {
+    options.store.logEvent?.(taskId, auditEvent.eventType, {
+      workerId: 'auto-fix-recovery',
+      kind: RECOVERY_WORKER_KIND,
+      owner: 'auto-fix',
+      action: auditEvent.action,
+      phase,
+      ...(typeof details.reason === 'string' ? { reason: details.reason } : {}),
+      ...(typeof details.status === 'string' ? { status: details.status } : {}),
+      ...(typeof details.workflowId === 'string' || details.workflowId === null ? { workflowId: details.workflowId } : {}),
+      ...(typeof details.autoFixAttempts === 'number' || details.autoFixAttempts === null ? { autoFixAttempts: details.autoFixAttempts } : {}),
+      details: { worker: RECOVERY_WORKER_KIND, ...details },
+    });
+  }
+
   options.logger.debug?.(`[worker:${RECOVERY_WORKER_KIND}] ${phase}`, {
     module: 'auto-fix-recovery',
     taskId,

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -11,7 +11,7 @@ import {
   buildFixWithAgentMutationArgs,
   listOpenFixIntentsForTask,
 } from './auto-fix-intents.js';
-import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
+import { normalizeAutoFixAttemptCount, normalizeAutoFixRetryBudget, shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowLifecycleEvent, RecoveryWorkerWakeupHint } from './lifecycle-events.js';
 import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
 import type { WorkerRegistry } from './worker-registry.js';
@@ -51,7 +51,7 @@ export interface AutoFixRecoverySubmitter {
   ): number;
 }
 export interface AutoFixWorkerConfig {
-  /** Positive config enables auto-fix; attempts are not capped. */
+  /** Worker-owned maximum auto-fix attempts per failed task. Positive finite values are caps; zero leaves the worker unable to submit fixes. */
   defaultAutoFixRetries?: number;
   /** Resolves the agent that performs each auto-fix, when one is configured. */
   getAutoFixAgent?: () => string | undefined;
@@ -66,7 +66,6 @@ export interface AutoFixRecoveryPolicyOptions {
   logger: Logger;
   defaultAutoFixRetries?: number;
   getAutoFixAgent?: () => string | undefined;
-  getRetryBudget?: (task: TaskState) => number;
   drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
 }
 /** Register the built-in auto-fix worker. */
@@ -160,24 +159,19 @@ export function listAutoFixRecoveryScanCandidates(
   return candidates;
 }
 
-function retryBudgetForTask(task: TaskState, options: AutoFixRecoveryPolicyOptions): number {
-  const raw = options.getRetryBudget?.(task) ?? options.defaultAutoFixRetries ?? 0;
-  if (raw === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
-  if (!Number.isFinite(raw)) return 0;
-  return Math.floor(raw) > 0 ? Number.POSITIVE_INFINITY : 0;
+function retryBudgetForWorker(options: AutoFixRecoveryPolicyOptions): number {
+  return normalizeAutoFixRetryBudget(options.defaultAutoFixRetries ?? 0);
 }
 
 function retryBudgetLabel(budget: number): number | 'unlimited' {
   return budget === Number.POSITIVE_INFINITY ? 'unlimited' : budget;
 }
 
-function isRuntimeAutoFixEligibleTask(task: TaskState, options: AutoFixRecoveryPolicyOptions): boolean {
+function isRuntimeAutoFixEligibleTask(task: TaskState): boolean {
   if (task.status !== 'failed') return false;
   if (task.config.isReconciliation) return false;
   if (task.config.parentTask) return false;
   if (shouldSkipAutoFixForError(task.execution.error)) return false;
-  const max = retryBudgetForTask(task, options);
-  if (max <= 0) return false;
   return true;
 }
 
@@ -321,14 +315,32 @@ function validateAutoFixCandidate(
   }
   const latestRef = snapshotComparison.ref;
 
-  if (!isRuntimeAutoFixEligibleTask(latest, options)) {
+  const autoFixAttempts = normalizeAutoFixAttemptCount(latest.execution.autoFixAttempts);
+  const workerRetryBudget = retryBudgetForWorker(options);
+  if (!isRuntimeAutoFixEligibleTask(latest)) {
     skipAutoFixCandidate(options, candidate, 'not-eligible', {
       status: latest.status,
-      autoFixAttempts: latest.execution.autoFixAttempts ?? 0,
-      maxRetries: retryBudgetLabel(retryBudgetForTask(latest, options)),
+      autoFixAttempts,
+      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
       isReconciliation: Boolean(latest.config.isReconciliation),
       hasParentTask: Boolean(latest.config.parentTask),
       skippedForError: shouldSkipAutoFixForError(latest.execution.error),
+    });
+    return undefined;
+  }
+  if (workerRetryBudget <= 0) {
+    skipAutoFixCandidate(options, candidate, 'worker-retry-budget-disabled', {
+      status: latest.status,
+      autoFixAttempts,
+      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
+    });
+    return undefined;
+  }
+  if (autoFixAttempts >= workerRetryBudget) {
+    skipAutoFixCandidate(options, candidate, 'worker-retry-budget-exhausted', {
+      status: latest.status,
+      autoFixAttempts,
+      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
     });
     return undefined;
   }
@@ -383,8 +395,8 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
         taskStateVersion: candidate.taskStateVersion,
         attemptId: candidate.attemptId ?? null,
         agent: selectedAgent ?? null,
-        autoFixAttempts: candidate.task.execution.autoFixAttempts ?? 0,
-        maxRetries: retryBudgetLabel(retryBudgetForTask(candidate.task, options)),
+        autoFixAttempts: normalizeAutoFixAttemptCount(candidate.task.execution.autoFixAttempts),
+        workerRetryBudget: retryBudgetLabel(retryBudgetForWorker(options)),
       });
     }
   };

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -19,6 +19,7 @@ export * from './ssh-executor.js';
 export * from './repo-pool.js';
 export * from './registry.js';
 export * from './task-runner.js';
+export * from './harness-capabilities.js';
 export * from './merge-runner.js';
 export * from './conflict-resolver.js';
 export * from './merge-gate-provider.js';

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -19,6 +19,7 @@ import {
   type ReviewGateCiContext,
   type ReviewGateLineageFields,
 } from '../auto-fix-intents.js';
+import { normalizeAutoFixRetryBudget } from '../auto-fix-gating.js';
 import type {
   ReviewGateCiFailedLifecycleEvent,
   ReviewGateFailedCheck,
@@ -66,7 +67,6 @@ export interface CiFailureWorkerPolicyOptions {
   defaultAutoFixRetries?: number;
   getAutoFixAgent?: () => string | undefined;
   getAutoFixExecutionModel?: () => string | undefined;
-  getRetryBudget?: (task: TaskState) => number;
   drainEvents?: () => ReviewGateCiFailedLifecycleEvent[];
 }
 
@@ -134,11 +134,8 @@ export function ciFailureActionKey(event: Pick<
   ].join(':');
 }
 
-function retryBudgetForTask(task: TaskState, options: CiFailureWorkerPolicyOptions): number {
-  const raw = options.getRetryBudget?.(task) ?? options.defaultAutoFixRetries ?? 0;
-  if (raw === Number.POSITIVE_INFINITY) return Number.POSITIVE_INFINITY;
-  if (!Number.isFinite(raw)) return 0;
-  return Math.floor(raw) > 0 ? Number.POSITIVE_INFINITY : 0;
+function retryBudgetForWorker(options: CiFailureWorkerPolicyOptions): number {
+  return normalizeAutoFixRetryBudget(options.defaultAutoFixRetries ?? 0);
 }
 
 function retryBudgetLabel(budget: number): number | 'unlimited' {
@@ -391,15 +388,15 @@ async function handleCiFailureEvent(
     return;
   }
 
-  const maxAttempts = retryBudgetForTask(task, options);
-  if (maxAttempts <= 0) {
-    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because retry budget is disabled', {
-      reason: 'retry-budget-disabled',
-      maxAttempts,
+  const workerRetryBudget = retryBudgetForWorker(options);
+  if (workerRetryBudget <= 0) {
+    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because worker retry budget is disabled', {
+      reason: 'worker-retry-budget-disabled',
+      workerRetryBudget,
     });
     logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
-      reason: 'retry-budget-disabled',
-      maxAttempts,
+      reason: 'worker-retry-budget-disabled',
+      workerRetryBudget,
     });
     return;
   }
@@ -415,6 +412,20 @@ async function handleCiFailureEvent(
     logCiFailureWorkerEvent(options, event, 'worker-ci-failure-stale', {
       reason: stale.reason,
       ...stale.details,
+    });
+    return;
+  }
+
+  if ((task.execution.autoFixAttempts ?? 0) >= workerRetryBudget) {
+    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because worker retry budget is exhausted', {
+      reason: 'worker-retry-budget-exhausted',
+      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
+      autoFixAttempts: task.execution.autoFixAttempts ?? 0,
+    });
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+      reason: 'worker-retry-budget-exhausted',
+      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
+      autoFixAttempts: task.execution.autoFixAttempts ?? 0,
     });
     return;
   }
@@ -453,7 +464,7 @@ async function handleCiFailureEvent(
     {
       channel: FIX_WITH_AGENT_CHANNEL,
       autoFixAttempts: task.execution.autoFixAttempts ?? 0,
-      maxAttempts: retryBudgetLabel(maxAttempts),
+      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
     },
     intentId,
     selectedAgent,
@@ -465,7 +476,7 @@ async function handleCiFailureEvent(
     agent: selectedAgent ?? null,
     executionModel: executionModel ?? null,
     autoFixAttempts: task.execution.autoFixAttempts ?? 0,
-    maxAttempts: retryBudgetLabel(maxAttempts),
+    workerRetryBudget: retryBudgetLabel(workerRetryBudget),
   });
 }
 

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -743,7 +743,7 @@ describe('Orchestrator', () => {
       expect(persistence.listWorkflows().find((workflow) => workflow.id === workflowId)?.status).toBe('running');
     });
 
-    it('keeps auto-fix eligible after prior attempts and resets attempts when a workflow is recreated', () => {
+    it('exhausts auto-fix at the worker cap and resets attempts when a workflow is recreated', () => {
       orchestrator = new Orchestrator({
         persistence,
         messageBus: bus,
@@ -767,7 +767,7 @@ describe('Orchestrator', () => {
 
       persistence.updateTask(taskId, { status: 'failed', execution: { autoFixAttempts: 3 } });
       orchestrator.syncAllFromDb();
-      expect(orchestrator.shouldAutoFix(taskId)).toBe(true);
+      expect(orchestrator.shouldAutoFix(taskId)).toBe(false);
 
       orchestrator.recreateWorkflow(workflowId);
 
@@ -3475,7 +3475,7 @@ describe('Orchestrator', () => {
   // ── Auto-Fix ────────────────────────────────────────────
 
   describe('auto-fix via synthetic spawn_experiments', () => {
-    it('uses positive default auto-fix config as an uncapped enable switch for older failed tasks', () => {
+    it('uses worker-owned auto-fix config as a per-task attempt cap', () => {
       const hydratePersistence = new InMemoryPersistence();
       const hydrateBus = new InMemoryBus();
 
@@ -3496,18 +3496,18 @@ describe('Orchestrator', () => {
       const hydratedOrchestrator = new Orchestrator({
         persistence: hydratePersistence,
         messageBus: hydrateBus,
-        defaultAutoFixRetries: 1,
+        defaultAutoFixRetries: 3,
       });
 
       hydratedOrchestrator.syncFromDb('wf-hydrated');
 
-      expect(hydratedOrchestrator.getAutoFixRetryBudget('t1')).toBe(Number.POSITIVE_INFINITY);
+      expect(hydratedOrchestrator.getAutoFixRetryBudget('t1')).toBe(3);
       expect(hydratedOrchestrator.shouldAutoFix('t1')).toBe(true);
 
-      hydratePersistence.updateTask('t1', { execution: { autoFixAttempts: 100 } });
+      hydratePersistence.updateTask('t1', { execution: { autoFixAttempts: 3 } });
       hydratedOrchestrator.syncFromDb('wf-hydrated');
 
-      expect(hydratedOrchestrator.shouldAutoFix('t1')).toBe(true);
+      expect(hydratedOrchestrator.shouldAutoFix('t1')).toBe(false);
     });
 
     it('plain failed tasks stay failed in workflow-core', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -562,7 +562,7 @@ export interface OrchestratorConfig {
   /** Optional; defaults to an adapter wrapping `persistence`. */
   taskRepository?: TaskRepository;
   maxConcurrency?: number;
-  /** Positive values enable auto-fix; attempts are not capped by workflow-core. */
+  /** Worker-owned maximum auto-fix attempts per failed task. Positive finite values are caps; zero disables worker-submitted fixes. */
   defaultAutoFixRetries?: number;
   /**
    * Rules that validate task execution environment against command patterns.
@@ -3870,7 +3870,14 @@ export class Orchestrator {
   }
 
   getAutoFixRetryBudget(taskId: string): number {
-    return this.defaultAutoFixRetries > 0 ? Number.POSITIVE_INFINITY : 0;
+    return this.defaultAutoFixRetries;
+  }
+
+  private getAutoFixAttemptCount(task: TaskState): number {
+    const raw = task.execution.autoFixAttempts;
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) return 0;
+    const attempts = Math.floor(raw);
+    return attempts > 0 ? attempts : 0;
   }
 
   private isRuntimeAutoFixEligibleTask(task: TaskState): boolean {
@@ -3885,7 +3892,8 @@ export class Orchestrator {
     if (task.status !== 'failed') return false;
     if (!this.isRuntimeAutoFixEligibleTask(task)) return false;
     const max = this.getAutoFixRetryBudget(taskId);
-    return max > 0;
+    if (max <= 0) return false;
+    return this.getAutoFixAttemptCount(task) < max;
   }
 
   getAllTasks(): TaskState[] {

--- a/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
+++ b/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
@@ -101,6 +101,20 @@ import sqlite3
 import sys
 
 db_path, task_id = sys.argv[1], sys.argv[2]
+
+def parse_payload(raw):
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    if isinstance(parsed, str):
+        try:
+            parsed = json.loads(parsed)
+        except json.JSONDecodeError:
+            return {}
+    return parsed if isinstance(parsed, dict) else {}
 conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
 conn.row_factory = sqlite3.Row
 
@@ -110,13 +124,14 @@ events = conn.execute(
 ).fetchall()
 
 has_failed = any(row["event_type"] == "task.failed" for row in events)
-has_schedule_enqueued = False
+has_worker_submit = False
 for row in events:
-    if row["event_type"] != "debug.auto-fix":
-        continue
-    payload = json.loads(row["payload"]) if row["payload"] else {}
-    if payload.get("phase") == "schedule-enqueued":
-        has_schedule_enqueued = True
+    payload = parse_payload(row["payload"])
+    if row["event_type"] == "debug.auto-fix" and payload.get("phase") == "worker-autofix-submitted":
+        has_worker_submit = True
+        break
+    if row["event_type"] == "recovery.worker.submit" and payload.get("action") == "submit":
+        has_worker_submit = True
         break
 
 intents = conn.execute(
@@ -132,7 +147,7 @@ for row in intents:
         has_fix_intent = True
         break
 
-raise SystemExit(0 if (has_failed and has_schedule_enqueued and has_fix_intent) else 1)
+raise SystemExit(0 if (has_failed and has_worker_submit and has_fix_intent) else 1)
 PY
   then
     FOUND=1
@@ -142,7 +157,7 @@ PY
 done
 
 if [ "$FOUND" -ne 1 ]; then
-  echo "FAIL case 2.17: expected task.failed + debug.auto-fix schedule-enqueued + persisted invoker:fix-with-agent intent"
+  echo "FAIL case 2.17: expected task.failed + worker-autofix-submitted/recovery.worker.submit + persisted invoker:fix-with-agent intent"
   python3 - <<'PY' "$DB_PATH" "$TASK_ID"
 import sqlite3, sys
 db_path, task_id = sys.argv[1], sys.argv[2]

--- a/scripts/repro/repro-daemon-autofix-persisted-intent.sh
+++ b/scripts/repro/repro-daemon-autofix-persisted-intent.sh
@@ -8,8 +8,8 @@
 #   durable.
 #
 # Fixed behavior:
-#   The failing task records task.failed, debug.auto-fix schedule-enqueued, and
-#   a persisted invoker:fix-with-agent row in workflow_mutation_intents.
+#   The failing task records task.failed, debug.auto-fix worker-autofix-submitted,
+#   and a persisted invoker:fix-with-agent row in workflow_mutation_intents.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"


### PR DESCRIPTION
## Summary

The auto-fix budget now belongs to worker policy. Tasks only carry the number of attempts already consumed.

Worker controls no longer block starting auto-fix or CI-failure workers when the budget is zero. The workers decide whether to submit.

The old uncapped behavior is gone. The worker cap is checked before each auto-fix or CI repair intent.

<details>
<summary>Review metadata</summary>

Review Claim: Worker-owned budget routing gates auto-fix submissions without letting tasks define budget policy.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The change only narrows worker eligibility; submission still uses the existing mutation path.

Slice Rationale: Runtime worker ownership is separate from the follow-up documentation-only slice.

</details>

## Non-goals

- No change to task YAML shape.
- No new user-facing command.
- No docs updates in this slice.

## Architecture

### Before

```mermaid
graph TD
    T["Task state looked like budget policy"] --> W["Worker start could be blocked"]
    W --> F["Auto-fix intent"]
```

### After

```mermaid
graph TD
    W["Worker budget policy"] --> C["Check task autoFixAttempts"]
    C --> F["Auto-fix intent"]
    C --> S["Worker skip event"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/worker-control.test.ts src/__tests__/auto-fix-recovery.test.ts src/__tests__/workflow-actions.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-ci-workers.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
