### PR TITLE
[Planning Chat Raw Stream Step 1](1) Expose raw planner stdout

### DIFF
--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -29,6 +29,7 @@ export type PlanningCommandBuilder = (opts: {
   model?: string;
   prompt: string;
 }) => { command: string; args: string[] };
+export type RawPlannerOutputHandler = (chunk: string) => void;
 
 export function defaultPlanningCommand(
   cursorCommand: string,
@@ -68,6 +69,8 @@ export interface PlanConversationConfig {
   experimentalPlanner?: boolean;
   /** Prefer top-level `workflows:` stack plans for multi-slice reviewable work. */
   preferStackedWorkflows?: boolean;
+  /** Optional callback for raw stdout chunks emitted by the planner subprocess. */
+  onRawPlannerOutput?: RawPlannerOutputHandler;
   /** Logging callback. Defaults to console.log/console.error. */
   log?: LogFn;
 }
@@ -268,6 +271,7 @@ export class PlanConversation {
   private experimentalPlanner?: boolean;
   private preferStackedWorkflows?: boolean;
   private log: LogFn;
+  private onRawPlannerOutput?: RawPlannerOutputHandler;
   private _initialized = false;
 
   constructor(config: PlanConversationConfig) {
@@ -284,6 +288,7 @@ export class PlanConversation {
     this.repoUrl = config.repoUrl;
     this.experimentalPlanner = config.experimentalPlanner;
     this.preferStackedWorkflows = config.preferStackedWorkflows;
+    this.onRawPlannerOutput = config.onRawPlannerOutput;
     this.log = config.log ?? ((src, lvl, msg) => {
       (lvl === 'error' ? console.error : console.log)(`[${src}] ${msg}`);
     });
@@ -458,6 +463,13 @@ export class PlanConversation {
         const chunkStr = chunk.toString();
         stdout += chunkStr;
         stdoutChunks++;
+        if (this.onRawPlannerOutput) {
+          try {
+            this.onRawPlannerOutput(chunkStr);
+          } catch (err) {
+            this.log('plan-conversation', 'error', `Raw planner output handler failed: ${err}`);
+          }
+        }
         this.log('plan-conversation', 'info', `[PERF] cursor_stdout chunk #${stdoutChunks}: +${chunkStr.length} bytes (total=${stdout.length}, elapsed=${Date.now() - spawnStart}ms)`);
       });
 


### PR DESCRIPTION
## Summary

The in-app planner waits for one full reply, so it cannot show live progress while the model is still working.

This slice exposes each raw stdout chunk from the planner subprocess to an optional listener as the chunk arrives.

The assembled final reply the planner already returns stays the same, and the callback stays off unless a caller opts in.

<details>
<summary>Review metadata</summary>

Review Claim: PlanConversation can hand raw planner stdout to an optional listener as it arrives without changing its final reply.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The change stays inside the surfaces package and only adds an opt-in hook around the existing stdout handler, so callers that do not opt in see identical behavior.

Slice Rationale: The raw stream source must exist before any app or UI code can consume it, so it lands as its own behavior slice ahead of consumer wiring.

</details>

## Non-goals

This does not wire the callback into the app, UI, or Slack surfaces.

It does not persist streamed text, change conversation history, or alter the final reply behavior.

## Test Plan

- [ ] `cd packages/surfaces && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional way to receive live planner output as it is produced.
* **Bug Fixes**
  * Improved stability when handling streamed planner output so callback errors no longer interrupt processing.
  * Logging is now used to record callback failures for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->