### PR TITLE
[Launch Dispatcher](1) Top up ready tasks before polling

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -665,6 +665,43 @@ describe('LaunchDispatcher', () => {
       expect(adapter.loadLaunchDispatchById(1)?.lastError).toBeUndefined();
     });
 
+    it('tops up ready tasks before polling launch dispatch rows', () => {
+      const orchestrator = new Orchestrator({
+        persistence: adapter as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 1,
+        deferRunningUntilLaunch: true,
+      });
+      orchestrator.loadPlan({
+        name: 'poll-topup',
+        tasks: [
+          {
+            id: 'alpha',
+            description: 'alpha',
+            command: 'echo alpha',
+          },
+        ],
+      });
+      expect(adapter.listLaunchDispatchesByState(['enqueued', 'leased'])).toEqual([]);
+
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator,
+        taskRunnerProvider: () => ({ executeTask }),
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).toHaveBeenCalledTimes(1);
+      const task = executeTask.mock.calls[0]?.[0];
+      expect(task?.id).toBe(orchestrator.getAllTasks().find((candidate) => !candidate.config.isMergeNode)?.id);
+      const dispatch = adapter.listLaunchDispatchesByState(['leased'])[0];
+      expect(dispatch?.state).toBe('leased');
+      expect(dispatch?.taskId).toBe(task?.id);
+    });
+
     it('abandons a dispatch row when the selected attempt changed after lease', () => {
       const task = seedWorkflowAndTask('wf-a/t-stale', 'wf-a', {
         selectedAttemptId: 'attempt-old',

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -39,6 +39,7 @@ export interface LaunchDispatcherOrchestrator {
   syncFromDb?(workflowId: string): void;
   getTask?(taskId: string): TaskState | undefined;
   getTaskLaunchReadiness?(taskId: string): TaskLaunchReadiness;
+  startExecution?(): TaskState[];
 }
 
 /**
@@ -103,12 +104,34 @@ export class LaunchDispatcher {
    *
    *   1. Reap any leased rows whose dispatch lease expired.
    *   2. Abandon expired rows that exhausted their retry budget.
-   *   3. Lease and dispatch enqueued rows.
+   *   3. Top up ready tasks into the durable launch outbox.
+   *   4. Lease and dispatch enqueued rows.
    */
   poll(): void {
     this.reapExpiredLeases();
     this.abandonStuckLeases();
+    this.topUpReadyLaunches();
     this.dispatchActive();
+  }
+
+  private topUpReadyLaunches(): void {
+    try {
+      const started = this.orchestrator?.startExecution?.() ?? [];
+      if (started.length > 0) {
+        this.logger?.info?.('[launch-dispatcher] topped up ready launches', {
+          ownerId: this.ownerId,
+          started: started.length,
+          taskIds: started.map((task) => task.id),
+          module: 'launch-dispatcher',
+        });
+      }
+    } catch (err) {
+      this.logger?.warn?.('[launch-dispatcher] ready launch top-up failed', {
+        ownerId: this.ownerId,
+        error: err instanceof Error ? err.message : String(err),
+        module: 'launch-dispatcher',
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Ready tasks no longer get stuck when the launch outbox is empty.

The dispatcher used to only consume existing launch rows. After launch moved fully to the outbox, queued scheduler work could sit idle if no row existed.

This makes each dispatcher poll top up ready work first, then dispatch the new row through the normal durable path.

<details>
<summary>Review metadata</summary>

Review Claim: The launch dispatcher now recovers from an empty outbox with ready scheduler work.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The change only calls the existing scheduler start path before dispatch polling. Existing launch rows still use the same lease and acknowledgement flow.

Slice Rationale: This is one narrow scheduler-liveness fix with one regression test. It does not change task execution or retry policy.

</details>

## Non-goals

- No change to worker retry behavior.
- No change to launch row leasing rules.
- No change to failed workflow accounting.

## Architecture

### Before

The dispatcher only drained `task_launch_dispatch`. If that table had no live row, ready scheduler jobs were invisible to it.

```mermaid
graph TD
    A["dispatcher.poll()"] --> B["claimLaunchDispatchAtomic()"]
    B --> C["no launch row"]
    C --> D["ready scheduler job stays queued"]
```

### After

Each poll asks the orchestrator to create launch rows for ready work before leasing rows.

```mermaid
graph TD
    A["dispatcher.poll()"] --> B["orchestrator.startExecution()"]
    B --> C["task_launch_dispatch row exists"]
    C --> D["claimLaunchDispatchAtomic()"]
    D --> E["TaskRunner.executeTask()"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatcher.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 1af7896cc`
- Post-revert steps: Restart Invoker if the app is running.
- Data migration? No
