### PR TITLE
[UI Test Isolation](1) Isolate test app profile

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -137,6 +137,7 @@ exit 64
         ...(breakTerminalSpawn ? { INVOKER_E2E_BREAK_TERMINAL_SPAWN: '1' } : {}),
         ...(forceReadOnlyStatus ? { INVOKER_E2E_FORCE_READ_ONLY_STATUS: '1' } : {}),
         PATH: pathEnv,
+        INVOKER_USER_DATA_DIR: electronUserDataDir,
       },
     });
     await use(app);

--- a/packages/app/e2e/gap-recovery-bench.spec.ts
+++ b/packages/app/e2e/gap-recovery-bench.spec.ts
@@ -54,6 +54,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
       INVOKER_CLAUDE_FIX_COMMAND: claudeMarker,
       PATH: `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`,
       ...(extraEnv ?? {}),
+      INVOKER_USER_DATA_DIR: electronUserDataDir,
     },
   });
 }

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -174,6 +174,7 @@ test.describe('Headless thundering herd', () => {
         ...headlessTestEnv(testDir),
         INVOKER_HEADLESS_STANDALONE: '1',
         INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS: '60000',
+        INVOKER_USER_DATA_DIR: userDataDir,
       },
     });
 

--- a/packages/app/e2e/launching-stall-watchdog.spec.ts
+++ b/packages/app/e2e/launching-stall-watchdog.spec.ts
@@ -62,6 +62,7 @@ base.describe('Launch stall watchdog', () => {
           INVOKER_REPO_CONFIG_PATH: configPath,
           INVOKER_EXECUTING_STALL_TIMEOUT_MS: '3000',
           INVOKER_STARTUP_POLL_DELAY_MS: '0',
+          INVOKER_USER_DATA_DIR: electronUserDataDir,
         },
       });
       const page = await app.firstWindow();
@@ -170,6 +171,7 @@ base.describe('Launch stall watchdog', () => {
           INVOKER_REPO_CONFIG_PATH: configPath,
           INVOKER_EXECUTING_STALL_TIMEOUT_MS: '3000',
           INVOKER_STARTUP_POLL_DELAY_MS: '0',
+          INVOKER_USER_DATA_DIR: electronUserDataDir,
         },
       });
       const page = await app.firstWindow();

--- a/packages/app/e2e/orphan-relaunch.spec.ts
+++ b/packages/app/e2e/orphan-relaunch.spec.ts
@@ -75,6 +75,7 @@ base.describe('Orphan task relaunch on restart', () => {
           INVOKER_ALLOW_DELETE_ALL: '1',
           INVOKER_E2E_ENABLE_COMPOSITOR: '1',
           INVOKER_REPO_CONFIG_PATH: configPath,
+          INVOKER_USER_DATA_DIR: electronUserDataDir,
         },
       });
       const page1 = await app1.firstWindow();

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -51,6 +51,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
       INVOKER_CLAUDE_FIX_COMMAND: claudeMarker,
       PATH: `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`,
       ...(extraEnv ?? {}),
+      INVOKER_USER_DATA_DIR: electronUserDataDir,
     },
   });
 }

--- a/packages/app/e2e/startup-window-liveness.spec.ts
+++ b/packages/app/e2e/startup-window-liveness.spec.ts
@@ -50,6 +50,7 @@ test('GUI window appears before delayed workflow mutation recovery finishes', as
         INVOKER_E2E_MARKER_ROOT: markerRoot,
         INVOKER_CLAUDE_FIX_COMMAND: claudeMarker,
         INVOKER_TEST_RESUME_PENDING_DELAY_MS: '15000',
+        INVOKER_USER_DATA_DIR: electronUserDataDir,
         PATH: `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`,
       },
     });

--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -87,6 +87,7 @@ async function launchApp(testDir: string, configPath: string): Promise<{ app: El
         process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '5000',
       INVOKER_EMBEDDED_TERMINAL_BACKEND:
         process.env.INVOKER_E2E_EMBEDDED_TERMINAL_BACKEND ?? 'pty',
+      INVOKER_USER_DATA_DIR: electronUserDataDir,
     },
   });
   const page = await app.firstWindow();

--- a/packages/app/src/__tests__/app-bootstrap.test.ts
+++ b/packages/app/src/__tests__/app-bootstrap.test.ts
@@ -5,6 +5,7 @@ import {
   guiOwnerBootstrapTimeoutMs,
   registerGuiLifecycleHandlers,
   resolveGuiOwnerPreference,
+  resolveElectronUserDataDir,
   runElectronReadyBootstrap,
   shouldRefreshGuiOwnerRoute,
   startGuiModeBootstrap,
@@ -102,6 +103,25 @@ describe('app-bootstrap', () => {
 
     expect(setActivationPolicy).not.toHaveBeenCalled();
     expect(hideDock).not.toHaveBeenCalled();
+  });
+
+  it('uses explicit isolated Electron userData when provided', () => {
+    expect(resolveElectronUserDataDir({
+      INVOKER_USER_DATA_DIR: '/tmp/invoker-user-data',
+      INVOKER_DB_DIR: '/tmp/invoker-db',
+      NODE_ENV: 'test',
+    })).toBe('/tmp/invoker-user-data');
+  });
+
+  it('derives isolated Electron userData from the test DB dir', () => {
+    expect(resolveElectronUserDataDir({
+      INVOKER_DB_DIR: '/tmp/invoker-db',
+      NODE_ENV: 'test',
+    })).toBe('/tmp/invoker-db/electron-user-data');
+  });
+
+  it('does not override live Electron userData by default', () => {
+    expect(resolveElectronUserDataDir({})).toBeNull();
   });
 
   it('runs ready bootstrap only after Electron readiness resolves', async () => {

--- a/packages/app/src/bootstrap/app-bootstrap.ts
+++ b/packages/app/src/bootstrap/app-bootstrap.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import type { App } from 'electron';
 
 export type GuiOwnerPreference = 'auto' | 'daemon' | 'gui';
@@ -34,6 +35,20 @@ export function formatGuiOwnerBootstrapFallbackMessage(message: string): string 
     'Falling back to local GUI owner mode.',
     'Set INVOKER_GUI_OWNER_MODE=daemon to retry daemon/client mode, or INVOKER_GUI_OWNER_MODE=gui to force local ownership.',
   ].join('\n');
+}
+
+export interface ElectronUserDataEnv {
+  INVOKER_USER_DATA_DIR?: string;
+  INVOKER_DB_DIR?: string;
+  NODE_ENV?: string;
+}
+
+export function resolveElectronUserDataDir(env: ElectronUserDataEnv = process.env): string | null {
+  if (env.INVOKER_USER_DATA_DIR) return env.INVOKER_USER_DATA_DIR;
+  if (env.NODE_ENV === 'test' && env.INVOKER_DB_DIR) {
+    return join(env.INVOKER_DB_DIR, 'electron-user-data');
+  }
+  return null;
 }
 
 export interface EarlyElectronAppOptions {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -43,6 +43,7 @@ import {
   guiOwnerBootstrapTimeoutMs,
   registerGuiLifecycleHandlers,
   resolveGuiOwnerPreference,
+  resolveElectronUserDataDir,
   runElectronReadyBootstrap,
   shouldRefreshGuiOwnerRoute,
   startGuiModeBootstrap,
@@ -59,8 +60,9 @@ configureEarlyElectronApp({ app, enableTestCompositor, isHeadless: earlyHeadless
 
 // Isolate userData (and with it the single-instance lock) for e2e runs so a
 // test instance can launch alongside a normally running Invoker.
-if (process.env.INVOKER_USER_DATA_DIR) {
-  app.setPath('userData', process.env.INVOKER_USER_DATA_DIR);
+const isolatedUserDataDir = resolveElectronUserDataDir();
+if (isolatedUserDataDir) {
+  app.setPath('userData', isolatedUserDataDir);
 }
 
 import { Orchestrator, CommandService, OrchestratorError, OrchestratorErrorCode, buildWorkflowInvalidationDeps } from '@invoker/workflow-core';


### PR DESCRIPTION
## Summary

UI tests now use their own Electron profile. A test run no longer shares the live app profile or single-instance lock.

Each e2e launcher passes the same test-only user data directory through Electron args and app startup env.

<details>
<summary>Review metadata</summary>

Review Claim: E2E Electron launches are routed to a test-only user data directory instead of the live app profile.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Only `NODE_ENV=test` launches derive user data from `INVOKER_DB_DIR`. Normal app launches keep the current Electron profile behavior.

Slice Rationale: This isolates the process profile before the hidden-window behavior changes in the next slice.

</details>

## Non-goals

This does not change production window creation or focus behavior.

This does not change the visible e2e debug command.

## Architecture

### Before

```mermaid
graph TD
    Test["E2E Electron test"] --> SharedProfile["Default Electron userData"]
    SharedProfile --> LiveLock["Live Invoker single-instance lock"]
```

### After

```mermaid
graph TD
    Test["E2E Electron test"] --> TestProfile["Test-only Electron userData"]
    LiveApp["Live Invoker app"] --> LiveProfile["Normal Electron userData"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/app-bootstrap.test.ts src/__tests__/window-lifecycle.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app test:e2e -- startup-window-liveness.spec.ts`
- [x] `bash scripts/ui-visual-proof.sh capture-before`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Visual Proof

The UI still renders under Playwright with an isolated Electron profile.

Before:

![Before empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260706-c97346/before-empty-state.png)

After:

![After empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260706-c97346/after-empty-state.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
