### PR TITLE
[UI Test Isolation](2) Keep test windows hidden

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -137,6 +137,7 @@ exit 64
         ...(breakTerminalSpawn ? { INVOKER_E2E_BREAK_TERMINAL_SPAWN: '1' } : {}),
         ...(forceReadOnlyStatus ? { INVOKER_E2E_FORCE_READ_ONLY_STATUS: '1' } : {}),
         PATH: pathEnv,
+        INVOKER_USER_DATA_DIR: electronUserDataDir,
       },
     });
     await use(app);

--- a/packages/app/e2e/gap-recovery-bench.spec.ts
+++ b/packages/app/e2e/gap-recovery-bench.spec.ts
@@ -54,6 +54,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
       INVOKER_CLAUDE_FIX_COMMAND: claudeMarker,
       PATH: `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`,
       ...(extraEnv ?? {}),
+      INVOKER_USER_DATA_DIR: electronUserDataDir,
     },
   });
 }

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -174,6 +174,7 @@ test.describe('Headless thundering herd', () => {
         ...headlessTestEnv(testDir),
         INVOKER_HEADLESS_STANDALONE: '1',
         INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS: '60000',
+        INVOKER_USER_DATA_DIR: userDataDir,
       },
     });
 

--- a/packages/app/e2e/launching-stall-watchdog.spec.ts
+++ b/packages/app/e2e/launching-stall-watchdog.spec.ts
@@ -62,6 +62,7 @@ base.describe('Launch stall watchdog', () => {
           INVOKER_REPO_CONFIG_PATH: configPath,
           INVOKER_EXECUTING_STALL_TIMEOUT_MS: '3000',
           INVOKER_STARTUP_POLL_DELAY_MS: '0',
+          INVOKER_USER_DATA_DIR: electronUserDataDir,
         },
       });
       const page = await app.firstWindow();
@@ -170,6 +171,7 @@ base.describe('Launch stall watchdog', () => {
           INVOKER_REPO_CONFIG_PATH: configPath,
           INVOKER_EXECUTING_STALL_TIMEOUT_MS: '3000',
           INVOKER_STARTUP_POLL_DELAY_MS: '0',
+          INVOKER_USER_DATA_DIR: electronUserDataDir,
         },
       });
       const page = await app.firstWindow();

--- a/packages/app/e2e/orphan-relaunch.spec.ts
+++ b/packages/app/e2e/orphan-relaunch.spec.ts
@@ -75,6 +75,7 @@ base.describe('Orphan task relaunch on restart', () => {
           INVOKER_ALLOW_DELETE_ALL: '1',
           INVOKER_E2E_ENABLE_COMPOSITOR: '1',
           INVOKER_REPO_CONFIG_PATH: configPath,
+          INVOKER_USER_DATA_DIR: electronUserDataDir,
         },
       });
       const page1 = await app1.firstWindow();

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -51,6 +51,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
       INVOKER_CLAUDE_FIX_COMMAND: claudeMarker,
       PATH: `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`,
       ...(extraEnv ?? {}),
+      INVOKER_USER_DATA_DIR: electronUserDataDir,
     },
   });
 }

--- a/packages/app/e2e/startup-window-liveness.spec.ts
+++ b/packages/app/e2e/startup-window-liveness.spec.ts
@@ -9,7 +9,7 @@ import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-re
 const repoRoot = resolveRepoRoot(__dirname);
 const STARTUP_BUDGET_MS = 12000;
 
-test('GUI window appears before delayed workflow mutation recovery finishes', async () => {
+test('GUI renderer becomes ready while the test window stays invisible', async () => {
   const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-startup-liveness-'));
   try {
     const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
@@ -59,6 +59,12 @@ test('GUI window appears before delayed workflow mutation recovery finishes', as
       const elapsedMs = Date.now() - startedAt;
       expect(elapsedMs).toBeLessThan(STARTUP_BUDGET_MS);
       await page.waitForLoadState('domcontentloaded');
+      const windowVisible = await electronApp.evaluate(({ BrowserWindow }) => {
+        const win = BrowserWindow.getAllWindows()[0];
+        if (!win) throw new Error('no BrowserWindow found');
+        return win.isVisible();
+      });
+      expect(windowVisible).toBe(false);
       await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 5000 });
     } finally {
       await electronApp.close();

--- a/packages/app/e2e/startup-window-liveness.spec.ts
+++ b/packages/app/e2e/startup-window-liveness.spec.ts
@@ -50,6 +50,7 @@ test('GUI window appears before delayed workflow mutation recovery finishes', as
         INVOKER_E2E_MARKER_ROOT: markerRoot,
         INVOKER_CLAUDE_FIX_COMMAND: claudeMarker,
         INVOKER_TEST_RESUME_PENDING_DELAY_MS: '15000',
+        INVOKER_USER_DATA_DIR: electronUserDataDir,
         PATH: `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`,
       },
     });

--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -87,6 +87,7 @@ async function launchApp(testDir: string, configPath: string): Promise<{ app: El
         process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '5000',
       INVOKER_EMBEDDED_TERMINAL_BACKEND:
         process.env.INVOKER_E2E_EMBEDDED_TERMINAL_BACKEND ?? 'pty',
+      INVOKER_USER_DATA_DIR: electronUserDataDir,
     },
   });
   const page = await app.firstWindow();

--- a/packages/app/src/__tests__/app-bootstrap.test.ts
+++ b/packages/app/src/__tests__/app-bootstrap.test.ts
@@ -5,6 +5,7 @@ import {
   guiOwnerBootstrapTimeoutMs,
   registerGuiLifecycleHandlers,
   resolveGuiOwnerPreference,
+  resolveElectronUserDataDir,
   runElectronReadyBootstrap,
   shouldRefreshGuiOwnerRoute,
   startGuiModeBootstrap,
@@ -102,6 +103,25 @@ describe('app-bootstrap', () => {
 
     expect(setActivationPolicy).not.toHaveBeenCalled();
     expect(hideDock).not.toHaveBeenCalled();
+  });
+
+  it('uses explicit isolated Electron userData when provided', () => {
+    expect(resolveElectronUserDataDir({
+      INVOKER_USER_DATA_DIR: '/tmp/invoker-user-data',
+      INVOKER_DB_DIR: '/tmp/invoker-db',
+      NODE_ENV: 'test',
+    })).toBe('/tmp/invoker-user-data');
+  });
+
+  it('derives isolated Electron userData from the test DB dir', () => {
+    expect(resolveElectronUserDataDir({
+      INVOKER_DB_DIR: '/tmp/invoker-db',
+      NODE_ENV: 'test',
+    })).toBe('/tmp/invoker-db/electron-user-data');
+  });
+
+  it('does not override live Electron userData by default', () => {
+    expect(resolveElectronUserDataDir({})).toBeNull();
   });
 
   it('runs ready bootstrap only after Electron readiness resolves', async () => {

--- a/packages/app/src/__tests__/window-lifecycle.test.ts
+++ b/packages/app/src/__tests__/window-lifecycle.test.ts
@@ -118,6 +118,40 @@ describe('window-lifecycle', () => {
     expect(electronMock.fakeWindow.loadURL).toHaveBeenCalledWith(expect.stringContaining('The UI failed to load'));
   });
 
+  it('keeps e2e compositor windows hidden when they become interactive', () => {
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), child: vi.fn() };
+    const recordStartupMark = vi.fn();
+    const setUiInteractive = vi.fn();
+    const startDeferredStartupWork = vi.fn();
+
+    createMainWindow({
+      appRootDir: '/tmp/app',
+      invokerConfig: {},
+      logger,
+      hideE2eWindow: true,
+      enableTestCompositor: true,
+      recordStartupMark,
+      setUiInteractive,
+      startDeferredStartupWork,
+      setMainWindow: vi.fn(),
+    });
+
+    const options = electronMock.BrowserWindow.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(options.show).toBe(false);
+    expect(options.skipTaskbar).toBe(true);
+
+    const readyHandler = electronMock.fakeWindow.once.mock.calls.find(([eventName]) => eventName === 'ready-to-show')?.[1];
+    expect(readyHandler).toBeDefined();
+    readyHandler?.();
+
+    expect(electronMock.fakeWindow.show).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.showInactive).not.toHaveBeenCalled();
+    expect(electronMock.fakeWindow.focus).not.toHaveBeenCalled();
+    expect(setUiInteractive).toHaveBeenCalledWith(true);
+    expect(startDeferredStartupWork).toHaveBeenCalledTimes(1);
+    expect(recordStartupMark).toHaveBeenCalledWith('window.hidden-ready');
+  });
+
   it('recreates the main window on activate only when no BrowserWindow exists', () => {
     const handlers = new Map<string, (...args: unknown[]) => void>();
     const createWindow = vi.fn();

--- a/packages/app/src/bootstrap/app-bootstrap.ts
+++ b/packages/app/src/bootstrap/app-bootstrap.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import type { App } from 'electron';
 
 export type GuiOwnerPreference = 'auto' | 'daemon' | 'gui';
@@ -34,6 +35,20 @@ export function formatGuiOwnerBootstrapFallbackMessage(message: string): string 
     'Falling back to local GUI owner mode.',
     'Set INVOKER_GUI_OWNER_MODE=daemon to retry daemon/client mode, or INVOKER_GUI_OWNER_MODE=gui to force local ownership.',
   ].join('\n');
+}
+
+export interface ElectronUserDataEnv {
+  INVOKER_USER_DATA_DIR?: string;
+  INVOKER_DB_DIR?: string;
+  NODE_ENV?: string;
+}
+
+export function resolveElectronUserDataDir(env: ElectronUserDataEnv = process.env): string | null {
+  if (env.INVOKER_USER_DATA_DIR) return env.INVOKER_USER_DATA_DIR;
+  if (env.NODE_ENV === 'test' && env.INVOKER_DB_DIR) {
+    return join(env.INVOKER_DB_DIR, 'electron-user-data');
+  }
+  return null;
 }
 
 export interface EarlyElectronAppOptions {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -43,6 +43,7 @@ import {
   guiOwnerBootstrapTimeoutMs,
   registerGuiLifecycleHandlers,
   resolveGuiOwnerPreference,
+  resolveElectronUserDataDir,
   runElectronReadyBootstrap,
   shouldRefreshGuiOwnerRoute,
   startGuiModeBootstrap,
@@ -59,8 +60,9 @@ configureEarlyElectronApp({ app, enableTestCompositor, isHeadless: earlyHeadless
 
 // Isolate userData (and with it the single-instance lock) for e2e runs so a
 // test instance can launch alongside a normally running Invoker.
-if (process.env.INVOKER_USER_DATA_DIR) {
-  app.setPath('userData', process.env.INVOKER_USER_DATA_DIR);
+const isolatedUserDataDir = resolveElectronUserDataDir();
+if (isolatedUserDataDir) {
+  app.setPath('userData', isolatedUserDataDir);
 }
 
 import { Orchestrator, CommandService, OrchestratorError, OrchestratorErrorCode, buildWorkflowInvalidationDeps } from '@invoker/workflow-core';

--- a/packages/app/src/window/window-lifecycle.ts
+++ b/packages/app/src/window/window-lifecycle.ts
@@ -59,7 +59,9 @@ export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
     ...(deps.hideE2eWindow ? { x: -32000, y: -32000, skipTaskbar: true } : {}),
     // Show explicitly after load/timeout rather than relying on Electron's
     // implicit initial map behavior, which has regressed on some Linux/X11
-    // sessions and leaves the BrowserWindow unmapped.
+    // sessions and leaves the BrowserWindow unmapped. E2E windows stay hidden:
+    // Playwright can still drive the renderer, and the test run cannot steal
+    // focus or intercept mouse clicks from a live Invoker session.
     show: false,
     webPreferences: {
       preload: path.join(deps.appRootDir, 'preload.js'),
@@ -128,11 +130,9 @@ export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
     const showWindow = (): void => {
       if (mainWindow.isDestroyed() || showTriggered) return;
       showTriggered = true;
-      deps.logger.info('main window show()', { module: 'window' });
-      deps.recordStartupMark('window.show');
-      if (deps.hideE2eWindow) {
-        mainWindow.showInactive();
-      } else {
+      deps.logger.info(deps.hideE2eWindow ? 'main window ready while hidden' : 'main window show()', { module: 'window' });
+      deps.recordStartupMark(deps.hideE2eWindow ? 'window.hidden-ready' : 'window.show');
+      if (!deps.hideE2eWindow) {
         mainWindow.show();
         mainWindow.focus();
       }


### PR DESCRIPTION
## Summary

Hidden UI tests now stay invisible. They still render for Playwright, but they no longer show, focus, or steal clicks.

The startup e2e test now proves the renderer becomes ready while Electron still reports the test window as not visible.

<details>
<summary>Review metadata</summary>

Review Claim: Hidden e2e compositor windows become interactive without calling `show()`, `showInactive()`, or `focus()`.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The hidden path only applies when `NODE_ENV=test` and hidden mode is enabled. Normal app windows still call `show()` and `focus()`.

Slice Rationale: This depends on the prior profile-isolation slice, then changes only the test window activation behavior.

</details>

## Non-goals

This does not change the visible debug command `test:e2e:visible`.

This does not change production window sizing, focus, or startup flow.

## Architecture

### Before

```mermaid
graph TD
    Test["Hidden e2e compositor window"] --> ShowInactive["showInactive()"]
    ShowInactive --> Desktop["Window can appear and take user attention"]
```

### After

```mermaid
graph TD
    Test["Hidden e2e compositor window"] --> Renderer["Renderer becomes ready"]
    Renderer --> NoShow["No show(), showInactive(), or focus()"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/app-bootstrap.test.ts src/__tests__/window-lifecycle.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app test:e2e -- startup-window-liveness.spec.ts`
- [x] `bash scripts/ui-visual-proof.sh capture-before`
- [x] `bash scripts/ui-visual-proof.sh capture-after`

## Visual Proof

Before and after screenshots show the renderer still paints under Playwright. The e2e assertion now also checks Electron reports the test window as not visible.

Before:

![Before empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260706-2b8b17/before-empty-state.png)

After:

![After empty state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260706-2b8b17/after-empty-state.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup behavior so the app can finish loading while the test window remains hidden.
  * Added stronger checks to ensure the window stays invisible during early launch, including in end-to-end startup scenarios.
  * Refined hidden-window handling so startup readiness is recorded correctly without showing or focusing the window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Depends-On: #3111