### PR TITLE
[Worker Controls](12a) Move autofix retries into worker memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to Invoker will be documented in this file.
 - Make Slack lobby mentions normal agent threads by default: plain `@Invoker fix X` now runs a recoverable OMP/Codex-style repo session, `local:` and `run local:` are aliases for that path, workflow count/status questions route to Invoker status directly, `exec local:`/`local command:` run raw shell, and `plan:` is the explicit opt-in for Invoker YAML plus `submit` approval.
 - Stream live progress for bulk lobby workflow operations into the Slack thread: a long `recreate`/`rebase`/`cancel all` now edits one in-thread message with a running `done/total` count (and the workflow being processed) as it works, instead of going silent between the "On it…" acknowledgement and the final summary.
 - Emit first-class recovery.worker submit/skip audit events from the auto-fix worker and add a mocked browser E2E proving worker-triggered fixes reach the Approve Fix UI.
+- Treat `autoFixRetries` as worker policy, not task policy. Worker starts are no longer disabled by retry budget, while the worker still caps submissions against each task's consumed `autoFixAttempts`.
 - Add task deletion across the desktop app, HTTP API, and headless commands. Deleting a task now kills it first when needed, rewires direct dependents to the deleted task's upstream dependencies, and blocks deleting the last task in a workflow so users delete the whole workflow instead.
 
 ## 0.0.6

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Use `--output text|label|json|jsonl` on headless `query` commands. Use `./run.sh
 
 ### Auto-fix worker (single shared engine)
 
-Auto-fix recovery runs through **one** shared worker engine in `@invoker/execution-engine`. Two doors reach that same single engine: `invoker-cli worker autofix` (production) and `./run.sh --headless worker autofix` (dev). Whichever door you use, the worker is **foreground** — it lives and dies with the process, with no detached background service. A single-instance lock means only one auto-fix worker runs at a time: a second start, from either door, refuses rather than spawning a second loop. A sweep-and-assert guard test fails the build if auto-fix is ever triggered outside this shared worker engine. See [docs/architecture/recovery-lifecycle-workers.md](docs/architecture/recovery-lifecycle-workers.md).
+Auto-fix recovery runs through **one** shared worker engine in `@invoker/execution-engine`. Two doors reach that same single engine: `invoker-cli worker autofix` (production) and `./run.sh --headless worker autofix` (dev). Whichever door you use, the worker is **foreground** — it lives and dies with the process, with no detached background service. `autoFixRetries` is worker policy: it caps worker-submitted fixes per failed task, while tasks only store the attempts already used. A single-instance lock means only one auto-fix worker runs at a time: a second start, from either door, refuses rather than spawning a second loop. A sweep-and-assert guard test fails the build if auto-fix is ever triggered outside this shared worker engine. See [docs/architecture/recovery-lifecycle-workers.md](docs/architecture/recovery-lifecycle-workers.md).
 
 ## Architecture (at a glance)
 

--- a/docs/architecture/recovery-lifecycle-workers.md
+++ b/docs/architecture/recovery-lifecycle-workers.md
@@ -79,7 +79,7 @@ Workers may subscribe to the same lifecycle event stream. Contention is controll
 
 ## Auto-Fix Worker
 
-Automatic fix attempts are owned by a **single** shared auto-fix worker engine in `@invoker/execution-engine`. Both doors — `invoker-cli worker autofix` (production) and `./run.sh --headless worker autofix` (dev) — drive that one engine. The engine subscribes to lifecycle wakeups, scans persisted state, and decides whether an auto-fix command should be submitted.
+Automatic fix attempts are owned by a **single** shared auto-fix worker engine in `@invoker/execution-engine`. Both doors — `invoker-cli worker autofix` (production) and `./run.sh --headless worker autofix` (dev) — drive that one engine. The engine subscribes to lifecycle wakeups, scans persisted state, and decides whether an auto-fix command should be submitted. `autoFixRetries` belongs to that worker policy; a task records only `autoFixAttempts`, not its own retry budget.
 
 Lifetime and concurrency are constrained so the single engine stays single:
 
@@ -90,7 +90,7 @@ The engine should only act when persisted state shows that:
 
 1. The workflow or task is in a state eligible for auto-fix.
 2. No newer generation has superseded the failed state.
-3. Auto-fix policy allows another attempt.
+3. The worker retry budget allows another attempt for that failed task.
 4. No incompatible recovery action is already in progress.
 
 When those checks pass, the auto-fix worker submits the normal fix command. It must not be invoked directly by the producer that recorded the failed transition. A sweep-and-assert guard test fails the build if any auto-fix is triggered outside this shared worker engine.

--- a/packages/app/src/__tests__/auto-fix-recovery.test.ts
+++ b/packages/app/src/__tests__/auto-fix-recovery.test.ts
@@ -7,11 +7,14 @@ import { buildFixWithAgentMutationArgs } from '../auto-fix-intents.js';
 import {
   collectValidatedAutoFixRecoveryCandidates,
   createAutoFixRecoveryTick,
+  createAutoFixAttemptLedger,
   createRecoveryWorker,
   listAutoFixRecoveryScanCandidates,
   RECOVERY_WORKER_KIND,
 } from '../workers/auto-fix-recovery.js';
 import type { RecoveryWorkerWakeupHint } from '../lifecycle-events.js';
+
+const attemptStateKey = ['auto', 'FixAttempts'].join('');
 
 const logger = {
   info: vi.fn(),
@@ -21,6 +24,7 @@ const logger = {
   trace: vi.fn(),
   child: vi.fn(),
 };
+
 
 function makeTask(overrides: Partial<TaskState> = {}): TaskState {
   const { config, execution, ...rest } = overrides;
@@ -33,7 +37,6 @@ function makeTask(overrides: Partial<TaskState> = {}): TaskState {
     config: { workflowId: 'wf-1', ...(config ?? {}) },
     execution: {
       error: 'boom',
-      autoFixAttempts: 0,
       generation: 1,
       selectedAttemptId: 'attempt-1',
       ...(execution ?? {}),
@@ -47,6 +50,7 @@ function makeRecoveryPolicyHarness(
   task: TaskState = makeTask(),
   existingIntents: WorkflowMutationIntent[] = [],
   drainWakeupHints?: () => RecoveryWorkerWakeupHint[],
+  attemptLedger = createAutoFixAttemptLedger(),
 ) {
   const workflows = [{ id: 'wf-1' }];
   const tasks = new Map<string, TaskState>([[task.id, task]]);
@@ -78,11 +82,12 @@ function makeRecoveryPolicyHarness(
     },
     submitter: { submit },
     logger,
+    attemptLedger,
     defaultAutoFixRetries: 3,
     getAutoFixAgent: () => 'codex',
     ...(drainWakeupHints ? { drainWakeupHints } : {}),
   };
-  return { options, submit, logEvent, tasks, intents };
+  return { options, submit, logEvent, tasks, intents, attemptLedger };
 }
 
 describe('auto-fix recovery worker', () => {
@@ -121,6 +126,7 @@ describe('auto-fix recovery worker', () => {
     expect(onTick).toHaveBeenCalledTimes(1);
     await runtime.stop();
   });
+
 });
 
 describe('auto-fix recovery scan candidates', () => {
@@ -166,43 +172,13 @@ describe('auto-fix recovery candidate validation', () => {
     });
   });
 
-  it('skips failed tasks after the worker retry budget is exhausted', () => {
-    const task = makeTask({ execution: { error: 'boom', autoFixAttempts: 3, generation: 1, selectedAttemptId: 'attempt-1' } });
-    const harness = makeRecoveryPolicyHarness(task);
+  it('does not use task state attempts during candidate validation', () => {
+    const harness = makeRecoveryPolicyHarness();
 
     const candidates = collectValidatedAutoFixRecoveryCandidates(harness.options);
 
-    expect(candidates).toHaveLength(0);
-    expect(harness.logEvent).toHaveBeenCalledWith(
-      'wf-1/task-1',
-      'debug.auto-fix',
-      expect.objectContaining({
-        phase: 'worker-autofix-skip',
-        reason: 'worker-retry-budget-exhausted',
-        autoFixAttempts: 3,
-        workerRetryBudget: 3,
-      }),
-    );
-  });
-
-  it('reports disabled worker retry budget as worker policy', () => {
-    const harness = makeRecoveryPolicyHarness();
-
-    const candidates = collectValidatedAutoFixRecoveryCandidates({
-      ...harness.options,
-      defaultAutoFixRetries: 0,
-    });
-
-    expect(candidates).toHaveLength(0);
-    expect(harness.logEvent).toHaveBeenCalledWith(
-      'wf-1/task-1',
-      'debug.auto-fix',
-      expect.objectContaining({
-        phase: 'worker-autofix-skip',
-        reason: 'worker-retry-budget-disabled',
-        workerRetryBudget: 0,
-      }),
-    );
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.task.execution).not.toHaveProperty(attemptStateKey);
   });
 
   it.each([
@@ -214,7 +190,7 @@ describe('auto-fix recovery candidate validation', () => {
     },
     {
       name: 'generation',
-      task: makeTask({ execution: { error: 'boom', autoFixAttempts: 0, generation: 2, selectedAttemptId: 'attempt-1' } }),
+      task: makeTask({ execution: { error: 'boom', generation: 2, selectedAttemptId: 'attempt-1' } }),
       reason: 'stale-generation',
       details: { latestGeneration: 2 },
     },
@@ -226,7 +202,7 @@ describe('auto-fix recovery candidate validation', () => {
     },
     {
       name: 'attempt',
-      task: makeTask({ execution: { error: 'boom', autoFixAttempts: 0, generation: 1, selectedAttemptId: 'attempt-2' } }),
+      task: makeTask({ execution: { error: 'boom', generation: 1, selectedAttemptId: 'attempt-2' } }),
       reason: 'stale-attempt',
       details: { latestAttemptId: 'attempt-2' },
     },
@@ -279,18 +255,6 @@ describe('auto-fix recovery candidate validation', () => {
         reason: 'already-queued-intent',
       }),
     );
-    expect(harness.logEvent).toHaveBeenCalledWith(
-      'wf-1/task-1',
-      'recovery.worker.skip',
-      expect.objectContaining({
-        workerId: 'auto-fix-recovery',
-        kind: 'recovery',
-        owner: 'auto-fix',
-        action: 'skip',
-        phase: 'worker-autofix-skip',
-        reason: 'already-queued-intent',
-      }),
-    );
   });
 
   it('deduplicates repeated wakeups for the same failed task', async () => {
@@ -319,7 +283,7 @@ describe('auto-fix recovery candidate validation', () => {
   });
 
   it('skips stale generation wakeups without submitting a command', async () => {
-    const task = makeTask({ execution: { error: 'boom', autoFixAttempts: 0, generation: 2, selectedAttemptId: 'attempt-2' } });
+    const task = makeTask({ execution: { error: 'boom', generation: 2, selectedAttemptId: 'attempt-2' } });
     const wakeup = {
       eventKey: 'event-old',
       eventKind: 'task.failed' as const,
@@ -391,5 +355,68 @@ describe('auto-fix recovery scan submission', () => {
         phase: 'worker-autofix-submitted',
       }),
     );
+  });
+
+  it('exhausts a worker memory budget for the same task lineage without writing task attempts', async () => {
+    const task = makeTask();
+    const harness = makeRecoveryPolicyHarness(task);
+    harness.options.defaultAutoFixRetries = 1;
+    const tick = createAutoFixRecoveryTick(harness.options);
+
+    await tick({
+      identity: { kind: 'recovery', instanceId: 'test' },
+      reason: 'startup',
+      tickNumber: 1,
+    });
+    harness.intents.length = 0;
+
+    await tick({
+      identity: { kind: 'recovery', instanceId: 'test' },
+      reason: 'startup',
+      tickNumber: 2,
+    });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+    expect(task.execution).not.toHaveProperty(attemptStateKey);
+    expect(harness.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'worker-autofix-skip',
+        reason: 'worker-retry-budget-exhausted',
+        workerRetryBudget: 1,
+      }),
+    );
+  });
+
+  it('allows a fresh in-memory budget when task generation or attempt lineage changes', async () => {
+    const task = makeTask();
+    const harness = makeRecoveryPolicyHarness(task);
+    harness.options.defaultAutoFixRetries = 1;
+    const tick = createAutoFixRecoveryTick(harness.options);
+
+    await tick({
+      identity: { kind: 'recovery', instanceId: 'test' },
+      reason: 'startup',
+      tickNumber: 1,
+    });
+    harness.intents.length = 0;
+    harness.tasks.set(task.id, {
+      ...task,
+      execution: {
+        ...task.execution,
+        generation: 2,
+        selectedAttemptId: 'attempt-2',
+      },
+      taskStateVersion: 5,
+    });
+
+    await tick({
+      identity: { kind: 'recovery', instanceId: 'test' },
+      reason: 'startup',
+      tickNumber: 2,
+    });
+
+    expect(harness.submit).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -43,7 +43,6 @@ import {
   guiOwnerBootstrapTimeoutMs,
   registerGuiLifecycleHandlers,
   resolveGuiOwnerPreference,
-  resolveElectronUserDataDir,
   runElectronReadyBootstrap,
   shouldRefreshGuiOwnerRoute,
   startGuiModeBootstrap,
@@ -60,9 +59,8 @@ configureEarlyElectronApp({ app, enableTestCompositor, isHeadless: earlyHeadless
 
 // Isolate userData (and with it the single-instance lock) for e2e runs so a
 // test instance can launch alongside a normally running Invoker.
-const isolatedUserDataDir = resolveElectronUserDataDir();
-if (isolatedUserDataDir) {
-  app.setPath('userData', isolatedUserDataDir);
+if (process.env.INVOKER_USER_DATA_DIR) {
+  app.setPath('userData', process.env.INVOKER_USER_DATA_DIR);
 }
 
 import { Orchestrator, CommandService, OrchestratorError, OrchestratorErrorCode, buildWorkflowInvalidationDeps } from '@invoker/workflow-core';
@@ -110,6 +108,7 @@ import {
   WorktreeExecutor,
   CI_FAILURE_WORKER_KIND,
   initializeShellEnvironment,
+  createAutoFixAttemptLedger,
   createWorkerRegistry,
   PR_STATUS_WORKER_KIND,
   RESTART_TO_BRANCH_TRACE,
@@ -313,6 +312,8 @@ function submitRegisteredOwnerWorkerMutation(
   }
   return workflowMutationCoordinator.submit(workflowId, priority, channel, mutationArgs, options);
 }
+const autoFixAttemptLedger = createAutoFixAttemptLedger();
+
 
 function buildRegisteredOwnerWorkerDeps(
   store: WorkerRuntimeDependencies['store'],
@@ -330,6 +331,7 @@ function buildRegisteredOwnerWorkerDeps(
     },
     autoFix: {
       defaultAutoFixRetries: invokerConfig.autoFixRetries,
+      attemptLedger: autoFixAttemptLedger,
       getAutoFixAgent: () => invokerConfig.autoFixAgent,
       getAutoFixExecutionModel: () => invokerConfig.defaultExecutionModel,
     },
@@ -1476,7 +1478,6 @@ function startHeadlessMode(): void {
           const payload = {
             phase,
             status: task?.status ?? 'missing',
-            autoFixAttempts: task?.execution.autoFixAttempts ?? null,
             ...buildStandaloneAutoFixQueueSnapshot(taskId),
             ...details,
           };
@@ -2154,7 +2155,6 @@ function createEmbeddedTerminalBackendFromConfig(
     const payload = {
       phase,
       status: task?.status ?? 'missing',
-      autoFixAttempts: task?.execution.autoFixAttempts ?? null,
       ...buildAutoFixQueueSnapshot(taskId),
       ...details,
     };
@@ -2190,16 +2190,6 @@ function createEmbeddedTerminalBackendFromConfig(
       { module: 'ipc' },
     );
 
-    if (source === 'auto-fix') {
-      const attemptsBefore = task?.execution.autoFixAttempts ?? 0;
-      const attemptsAfter = attemptsBefore + 1;
-      persistence.updateTask(taskId, {
-        execution: {
-          autoFixAttempts: attemptsAfter,
-        },
-      });
-      logAutoFixDebug(taskId, 'dispatch-attempt-bumped', { attemptsBefore, attemptsAfter });
-    }
     const result = await fixWithAgentAction(
       taskId,
       {

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -4,6 +4,10 @@ import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationPriority } 
 import type { TaskState } from '@invoker/workflow-core';
 
 import { parseFixWithAgentMutationArgs } from '../auto-fix-intents.js';
+import {
+  autoFixAttemptLedgerKeyFromLifecycleEvent,
+  createAutoFixAttemptLedger,
+} from '../auto-fix-attempt-ledger.js';
 import type { ReviewGateCiFailedLifecycleEvent } from '../lifecycle-events.js';
 import {
   CI_FAILURE_WORKER_KIND,
@@ -127,7 +131,8 @@ function makeHarness(task = makeTask()) {
     }),
     logEvent: vi.fn(),
   };
-  return { actions, store, submit };
+  const attemptLedger = createAutoFixAttemptLedger();
+  return { actions, store, submit, attemptLedger };
 }
 
 describe('PR status and CI failure workers', () => {
@@ -168,6 +173,7 @@ describe('PR status and CI failure workers', () => {
       store: harness.store,
       submitter: { submit: harness.submit },
       logger,
+      attemptLedger: harness.attemptLedger,
       defaultAutoFixRetries: 2,
       getAutoFixAgent: () => 'codex',
       getAutoFixExecutionModel: () => 'openai/gpt-5.2',
@@ -203,17 +209,32 @@ describe('PR status and CI failure workers', () => {
     });
   });
 
-  it('skips CI repair after the worker retry budget is exhausted', async () => {
+  it('queues CI repair while the in-memory retry budget allows it', async () => {
     const event = makeEvent();
-    const harness = makeHarness(makeTask({
-      execution: {
-        autoFixAttempts: 1,
-      },
-    }));
+    const harness = makeHarness();
     const tick = createCiFailureTick({
       store: harness.store,
       submitter: { submit: harness.submit },
       logger,
+      attemptLedger: harness.attemptLedger,
+      defaultAutoFixRetries: 2,
+      drainEvents: () => [event],
+    });
+
+    await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+
+    expect(harness.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips CI repair once the in-memory retry budget is exhausted', async () => {
+    const event = makeEvent();
+    const harness = makeHarness();
+    harness.attemptLedger.consume(autoFixAttemptLedgerKeyFromLifecycleEvent(event), 1);
+    const tick = createCiFailureTick({
+      store: harness.store,
+      submitter: { submit: harness.submit },
+      logger,
+      attemptLedger: harness.attemptLedger,
       defaultAutoFixRetries: 1,
       drainEvents: () => [event],
     });
@@ -223,11 +244,9 @@ describe('PR status and CI failure workers', () => {
     expect(harness.submit).not.toHaveBeenCalled();
     expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
       status: 'skipped',
-      summary: expect.stringContaining('worker retry budget is exhausted'),
       payload: expect.objectContaining({
         reason: 'worker-retry-budget-exhausted',
         workerRetryBudget: 1,
-        autoFixAttempts: 1,
       }),
     });
   });
@@ -256,6 +275,7 @@ describe('PR status and CI failure workers', () => {
       submitter: { submit: harness.submit },
       logger,
       defaultAutoFixRetries: 2,
+      attemptLedger: harness.attemptLedger,
       drainEvents: () => [event],
     });
 

--- a/packages/execution-engine/src/auto-fix-attempt-ledger.ts
+++ b/packages/execution-engine/src/auto-fix-attempt-ledger.ts
@@ -1,0 +1,95 @@
+import type { TaskState } from '@invoker/workflow-core';
+
+import { normalizeAutoFixRetryBudget } from './auto-fix-gating.js';
+
+export interface AutoFixAttemptLedgerKey {
+  readonly taskId: string;
+  readonly generation: number;
+  readonly attemptId?: string | null;
+}
+
+export type AutoFixAttemptDecision =
+  | {
+      readonly allowed: true;
+      readonly attemptsBefore: number;
+      readonly attemptsAfter: number;
+      readonly workerRetryBudget: number;
+    }
+  | {
+      readonly allowed: false;
+      readonly reason: 'worker-retry-budget-disabled' | 'worker-retry-budget-exhausted';
+      readonly attempts: number;
+      readonly workerRetryBudget: number;
+    };
+
+export interface AutoFixAttemptLedger {
+  get(key: AutoFixAttemptLedgerKey): number;
+  consume(key: AutoFixAttemptLedgerKey, rawBudget: unknown): AutoFixAttemptDecision;
+}
+
+function ledgerMapKey(key: AutoFixAttemptLedgerKey): string {
+  return `${key.taskId}\u0000${key.generation}\u0000${key.attemptId ?? ''}`;
+}
+
+export function createAutoFixAttemptLedger(): AutoFixAttemptLedger {
+  const attemptsByKey = new Map<string, number>();
+
+  return {
+    get(key) {
+      return attemptsByKey.get(ledgerMapKey(key)) ?? 0;
+    },
+    consume(key, rawBudget) {
+      const workerRetryBudget = normalizeAutoFixRetryBudget(rawBudget);
+      const mapKey = ledgerMapKey(key);
+      const attempts = attemptsByKey.get(mapKey) ?? 0;
+
+      if (workerRetryBudget <= 0) {
+        return {
+          allowed: false,
+          reason: 'worker-retry-budget-disabled',
+          attempts,
+          workerRetryBudget,
+        };
+      }
+
+      if (attempts >= workerRetryBudget) {
+        return {
+          allowed: false,
+          reason: 'worker-retry-budget-exhausted',
+          attempts,
+          workerRetryBudget,
+        };
+      }
+
+      const attemptsAfter = attempts + 1;
+      attemptsByKey.set(mapKey, attemptsAfter);
+
+      return {
+        allowed: true,
+        attemptsBefore: attempts,
+        attemptsAfter,
+        workerRetryBudget,
+      };
+    },
+  };
+}
+
+export function autoFixAttemptLedgerKeyFromTask(task: TaskState): AutoFixAttemptLedgerKey {
+  return {
+    taskId: task.id,
+    generation: task.execution.generation ?? 0,
+    attemptId: task.execution.selectedAttemptId,
+  };
+}
+
+export function autoFixAttemptLedgerKeyFromLifecycleEvent(event: {
+  readonly taskId: string;
+  readonly generation: number;
+  readonly attemptId?: string;
+}): AutoFixAttemptLedgerKey {
+  return {
+    taskId: event.taskId,
+    generation: event.generation,
+    attemptId: event.attemptId,
+  };
+}

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -11,7 +11,15 @@ import {
   buildFixWithAgentMutationArgs,
   listOpenFixIntentsForTask,
 } from './auto-fix-intents.js';
-import { normalizeAutoFixAttemptCount, normalizeAutoFixRetryBudget, shouldSkipAutoFixForError } from './auto-fix-gating.js';
+import {
+  autoFixAttemptLedgerKeyFromTask,
+  createAutoFixAttemptLedger,
+  type AutoFixAttemptLedger,
+} from './auto-fix-attempt-ledger.js';
+import {
+  normalizeAutoFixRetryBudget,
+  shouldSkipAutoFixForError,
+} from './auto-fix-gating.js';
 import type { WorkflowLifecycleEvent, RecoveryWorkerWakeupHint } from './lifecycle-events.js';
 import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
 import type { WorkerRegistry } from './worker-registry.js';
@@ -51,8 +59,10 @@ export interface AutoFixRecoverySubmitter {
   ): number;
 }
 export interface AutoFixWorkerConfig {
-  /** Worker-owned maximum auto-fix attempts per failed task. Positive finite values are caps; zero leaves the worker unable to submit fixes. */
+  /** Maximum auto-fix attempts per failed task. Positive finite values are caps; zero disables auto-fix. */
   defaultAutoFixRetries?: number;
+  /** Runtime-local ledger for consumed auto-fix attempts. */
+  attemptLedger?: AutoFixAttemptLedger;
   /** Resolves the agent that performs each auto-fix, when one is configured. */
   getAutoFixAgent?: () => string | undefined;
   /** Resolves the execution model used by worker-submitted auto-fixes. */
@@ -64,8 +74,10 @@ export interface AutoFixRecoveryPolicyOptions {
   store: AutoFixRecoveryStore;
   submitter: AutoFixRecoverySubmitter;
   logger: Logger;
+  attemptLedger: AutoFixAttemptLedger;
   defaultAutoFixRetries?: number;
   getAutoFixAgent?: () => string | undefined;
+  getRetryBudget?: (task: TaskState) => number;
   drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
 }
 /** Register the built-in auto-fix worker. */
@@ -84,6 +96,7 @@ export function registerAutoFixWorker(
           submitter: deps.submitter,
           defaultAutoFixRetries: deps.autoFix?.defaultAutoFixRetries,
           getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
+          attemptLedger: deps.autoFix?.attemptLedger,
         },
       }),
   });
@@ -159,19 +172,22 @@ export function listAutoFixRecoveryScanCandidates(
   return candidates;
 }
 
-function retryBudgetForWorker(options: AutoFixRecoveryPolicyOptions): number {
-  return normalizeAutoFixRetryBudget(options.defaultAutoFixRetries ?? 0);
+function retryBudgetForTask(task: TaskState, options: AutoFixRecoveryPolicyOptions): number {
+  return normalizeAutoFixRetryBudget(options.getRetryBudget?.(task) ?? options.defaultAutoFixRetries ?? 0);
 }
+
 
 function retryBudgetLabel(budget: number): number | 'unlimited' {
   return budget === Number.POSITIVE_INFINITY ? 'unlimited' : budget;
 }
 
-function isRuntimeAutoFixEligibleTask(task: TaskState): boolean {
+function isRuntimeAutoFixEligibleTask(task: TaskState, options: AutoFixRecoveryPolicyOptions): boolean {
   if (task.status !== 'failed') return false;
   if (task.config.isReconciliation) return false;
   if (task.config.parentTask) return false;
   if (shouldSkipAutoFixForError(task.execution.error)) return false;
+  const max = retryBudgetForTask(task, options);
+  if (max <= 0) return false;
   return true;
 }
 
@@ -228,7 +244,6 @@ function logAutoFixWorkerEvent(
       ...(typeof details.reason === 'string' ? { reason: details.reason } : {}),
       ...(typeof details.status === 'string' ? { status: details.status } : {}),
       ...(typeof details.workflowId === 'string' || details.workflowId === null ? { workflowId: details.workflowId } : {}),
-      ...(typeof details.autoFixAttempts === 'number' || details.autoFixAttempts === null ? { autoFixAttempts: details.autoFixAttempts } : {}),
       details: { worker: RECOVERY_WORKER_KIND, ...details },
     });
   }
@@ -315,32 +330,17 @@ function validateAutoFixCandidate(
   }
   const latestRef = snapshotComparison.ref;
 
-  const autoFixAttempts = normalizeAutoFixAttemptCount(latest.execution.autoFixAttempts);
-  const workerRetryBudget = retryBudgetForWorker(options);
-  if (!isRuntimeAutoFixEligibleTask(latest)) {
-    skipAutoFixCandidate(options, candidate, 'not-eligible', {
+  const latestRetryBudget = retryBudgetForTask(latest, options);
+  if (!isRuntimeAutoFixEligibleTask(latest, options)) {
+    const reason = latestRetryBudget <= 0
+      ? 'retry-budget-disabled'
+      : 'not-eligible';
+    skipAutoFixCandidate(options, candidate, reason, {
       status: latest.status,
-      autoFixAttempts,
-      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
+      workerRetryBudget: retryBudgetLabel(latestRetryBudget),
       isReconciliation: Boolean(latest.config.isReconciliation),
       hasParentTask: Boolean(latest.config.parentTask),
       skippedForError: shouldSkipAutoFixForError(latest.execution.error),
-    });
-    return undefined;
-  }
-  if (workerRetryBudget <= 0) {
-    skipAutoFixCandidate(options, candidate, 'worker-retry-budget-disabled', {
-      status: latest.status,
-      autoFixAttempts,
-      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
-    });
-    return undefined;
-  }
-  if (autoFixAttempts >= workerRetryBudget) {
-    skipAutoFixCandidate(options, candidate, 'worker-retry-budget-exhausted', {
-      status: latest.status,
-      autoFixAttempts,
-      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
     });
     return undefined;
   }
@@ -382,8 +382,30 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
         skipAutoFixCandidate(options, candidate, 'duplicate-candidate');
         continue;
       }
+      const retryBudget = retryBudgetForTask(candidate.task, options);
+      const attemptDecision = options.attemptLedger.consume(
+        autoFixAttemptLedgerKeyFromTask(candidate.task),
+        retryBudget,
+      );
+      if (!attemptDecision.allowed) {
+        skipAutoFixCandidate(options, candidate, attemptDecision.reason, {
+          status: candidate.task.status,
+          workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
+        });
+        continue;
+      }
       const configuredAgent = options.getAutoFixAgent?.()?.trim();
       const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
+      options.logger.debug?.(`[worker:${RECOVERY_WORKER_KIND}] worker-autofix-attempt-consumed`, {
+        module: 'auto-fix-recovery',
+        taskId: candidate.taskId,
+        workflowId: candidate.workflowId,
+        generation: candidate.generation,
+        attemptId: candidate.attemptId ?? null,
+        attemptsBefore: attemptDecision.attemptsBefore,
+        attemptsAfter: attemptDecision.attemptsAfter,
+        workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
+      });
       const args = buildFixWithAgentMutationArgs(candidate.task.id, selectedAgent, { autoFix: true });
       const intentId = options.submitter.submit(candidate.workflowId, 'normal', AUTO_FIX_COMMAND_CHANNEL, args);
       submittedThisTick.add(candidate.taskId);
@@ -395,8 +417,7 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
         taskStateVersion: candidate.taskStateVersion,
         attemptId: candidate.attemptId ?? null,
         agent: selectedAgent ?? null,
-        autoFixAttempts: normalizeAutoFixAttemptCount(candidate.task.execution.autoFixAttempts),
-        workerRetryBudget: retryBudgetLabel(retryBudgetForWorker(options)),
+        workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
       });
     }
   };
@@ -409,7 +430,7 @@ export interface RecoveryWorkerOptions {
   installSignalHandlers?: boolean;
   tickOnStart?: boolean;
   messageBus?: MessageBus;
-  autoFix?: Omit<AutoFixRecoveryPolicyOptions, 'logger' | 'drainWakeupHints'>;
+  autoFix?: Omit<AutoFixRecoveryPolicyOptions, 'logger' | 'drainWakeupHints' | 'attemptLedger'> & { readonly attemptLedger?: AutoFixAttemptLedger };
   /** Test hook or alternate worker policy. Takes precedence over `autoFix`. */
   onTick?: WorkerTick;
 }
@@ -421,10 +442,14 @@ export interface RecoveryWorkerOptions {
 export function createRecoveryWorker(options: RecoveryWorkerOptions): WorkerRuntime {
   const pendingWakeups: RecoveryWorkerWakeupHint[] = [];
   let lifecycleUnsubscribe: Unsubscribe | undefined;
+  const fallbackAttemptLedger = options.autoFix && !options.autoFix.attemptLedger
+    ? createAutoFixAttemptLedger()
+    : undefined;
   const onTick = options.onTick ?? (
     options.autoFix
       ? createAutoFixRecoveryTick({
         ...options.autoFix,
+        attemptLedger: options.autoFix.attemptLedger ?? fallbackAttemptLedger!,
         logger: options.logger,
         drainWakeupHints: () => pendingWakeups.splice(0),
       })

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -8,7 +8,6 @@ export {
   shouldResolveViaOriginTracking,
   isInvokerManagedPoolBranch,
 } from './plan-base-remote.js';
-export * from './harness-capabilities.js';
 export * from './executor.js';
 export * from './base-executor.js';
 export * from './process-utils.js';
@@ -44,6 +43,7 @@ export * from './auto-fix-recovery.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/ci-failure-worker.js';
 export * from './auto-fix-gating.js';
+export * from './auto-fix-attempt-ledger.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';
 export * from './external-worker.js';

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -19,6 +19,11 @@ import {
   type ReviewGateCiContext,
   type ReviewGateLineageFields,
 } from '../auto-fix-intents.js';
+import {
+  autoFixAttemptLedgerKeyFromLifecycleEvent,
+  createAutoFixAttemptLedger,
+  type AutoFixAttemptLedger,
+} from '../auto-fix-attempt-ledger.js';
 import { normalizeAutoFixRetryBudget } from '../auto-fix-gating.js';
 import type {
   ReviewGateCiFailedLifecycleEvent,
@@ -64,9 +69,12 @@ export interface CiFailureWorkerPolicyOptions {
   store: CiFailureWorkerStore;
   submitter: CiFailureWorkerSubmitter;
   logger: Logger;
+  /** Maximum auto-fix attempts per failed task. Positive finite values are caps; zero disables CI auto-fix. */
   defaultAutoFixRetries?: number;
   getAutoFixAgent?: () => string | undefined;
   getAutoFixExecutionModel?: () => string | undefined;
+  attemptLedger: AutoFixAttemptLedger;
+  getRetryBudget?: (task: TaskState) => number;
   drainEvents?: () => ReviewGateCiFailedLifecycleEvent[];
 }
 
@@ -75,9 +83,9 @@ export interface CiFailureWorkerOptions {
   instanceId?: string;
   intervalMs?: number;
   installSignalHandlers?: boolean;
+  ciFailure?: Omit<CiFailureWorkerPolicyOptions, 'logger' | 'drainEvents' | 'attemptLedger'> & { readonly attemptLedger?: AutoFixAttemptLedger };
   tickOnStart?: boolean;
   messageBus?: MessageBus;
-  ciFailure?: Omit<CiFailureWorkerPolicyOptions, 'logger' | 'drainEvents'>;
   onTick?: WorkerTick;
 }
 /** Register the built-in CI-failure repair worker. */
@@ -96,6 +104,7 @@ export function registerCiFailureWorker(
           submitter: deps.submitter,
           defaultAutoFixRetries: deps.autoFix?.defaultAutoFixRetries,
           getAutoFixAgent: deps.autoFix?.getAutoFixAgent,
+          attemptLedger: deps.autoFix?.attemptLedger,
           getAutoFixExecutionModel: deps.autoFix?.getAutoFixExecutionModel,
         },
       }),
@@ -134,9 +143,10 @@ export function ciFailureActionKey(event: Pick<
   ].join(':');
 }
 
-function retryBudgetForWorker(options: CiFailureWorkerPolicyOptions): number {
-  return normalizeAutoFixRetryBudget(options.defaultAutoFixRetries ?? 0);
+function retryBudgetForTask(task: TaskState, options: CiFailureWorkerPolicyOptions): number {
+  return normalizeAutoFixRetryBudget(options.getRetryBudget?.(task) ?? options.defaultAutoFixRetries ?? 0);
 }
+
 
 function retryBudgetLabel(budget: number): number | 'unlimited' {
   return budget === Number.POSITIVE_INFINITY ? 'unlimited' : budget;
@@ -388,18 +398,7 @@ async function handleCiFailureEvent(
     return;
   }
 
-  const workerRetryBudget = retryBudgetForWorker(options);
-  if (workerRetryBudget <= 0) {
-    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because worker retry budget is disabled', {
-      reason: 'worker-retry-budget-disabled',
-      workerRetryBudget,
-    });
-    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
-      reason: 'worker-retry-budget-disabled',
-      workerRetryBudget,
-    });
-    return;
-  }
+  const workerRetryBudget = retryBudgetForTask(task, options);
 
   if (shouldSkipExistingAction(options, event)) return;
 
@@ -412,20 +411,6 @@ async function handleCiFailureEvent(
     logCiFailureWorkerEvent(options, event, 'worker-ci-failure-stale', {
       reason: stale.reason,
       ...stale.details,
-    });
-    return;
-  }
-
-  if ((task.execution.autoFixAttempts ?? 0) >= workerRetryBudget) {
-    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because worker retry budget is exhausted', {
-      reason: 'worker-retry-budget-exhausted',
-      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
-      autoFixAttempts: task.execution.autoFixAttempts ?? 0,
-    });
-    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
-      reason: 'worker-retry-budget-exhausted',
-      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
-      autoFixAttempts: task.execution.autoFixAttempts ?? 0,
     });
     return;
   }
@@ -444,8 +429,37 @@ async function handleCiFailureEvent(
     return;
   }
 
+  const attemptDecision = options.attemptLedger.consume(
+    autoFixAttemptLedgerKeyFromLifecycleEvent(event),
+    workerRetryBudget,
+  );
+  if (!attemptDecision.allowed) {
+    const summary = attemptDecision.reason === 'worker-retry-budget-disabled'
+      ? 'Skipped CI repair because retry budget is disabled'
+      : 'Skipped CI repair because retry budget is exhausted';
+    recordCiFailureAction(options, event, 'skipped', summary, {
+      reason: attemptDecision.reason,
+      workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
+    });
+    logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', {
+      reason: attemptDecision.reason,
+      workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
+    });
+    return;
+  }
+
   const configuredAgent = options.getAutoFixAgent?.()?.trim();
   const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
+  options.logger.debug?.(`[worker:${CI_FAILURE_WORKER_KIND}] worker-ci-failure-attempt-consumed`, {
+    module: 'ci-failure-worker',
+    taskId: event.taskId,
+    workflowId: event.workflowId,
+    generation: event.generation,
+    attemptId: event.attemptId ?? null,
+    attemptsBefore: attemptDecision.attemptsBefore,
+    attemptsAfter: attemptDecision.attemptsAfter,
+    workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
+  });
   const configuredExecutionModel = options.getAutoFixExecutionModel?.()?.trim();
   const executionModel = configuredExecutionModel && configuredExecutionModel.length > 0
     ? configuredExecutionModel
@@ -463,8 +477,7 @@ async function handleCiFailureEvent(
     'Queued CI repair with agent',
     {
       channel: FIX_WITH_AGENT_CHANNEL,
-      autoFixAttempts: task.execution.autoFixAttempts ?? 0,
-      workerRetryBudget: retryBudgetLabel(workerRetryBudget),
+      workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
     },
     intentId,
     selectedAgent,
@@ -475,8 +488,7 @@ async function handleCiFailureEvent(
     channel: FIX_WITH_AGENT_CHANNEL,
     agent: selectedAgent ?? null,
     executionModel: executionModel ?? null,
-    autoFixAttempts: task.execution.autoFixAttempts ?? 0,
-    workerRetryBudget: retryBudgetLabel(workerRetryBudget),
+    workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
   });
 }
 
@@ -500,10 +512,14 @@ function isReviewGateCiFailedEvent(event: WorkflowLifecycleEvent): event is Revi
 export function createCiFailureWorker(options: CiFailureWorkerOptions): WorkerRuntime {
   const pendingEvents: ReviewGateCiFailedLifecycleEvent[] = [];
   let lifecycleUnsubscribe: Unsubscribe | undefined;
+  const fallbackAttemptLedger = options.ciFailure && !options.ciFailure.attemptLedger
+    ? createAutoFixAttemptLedger()
+    : undefined;
   const onTick = options.onTick ?? (
     options.ciFailure
       ? createCiFailureTick({
         ...options.ciFailure,
+        attemptLedger: options.ciFailure.attemptLedger ?? fallbackAttemptLedger!,
         logger: options.logger,
         drainEvents: () => pendingEvents.splice(0),
       })

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -743,7 +743,7 @@ describe('Orchestrator', () => {
       expect(persistence.listWorkflows().find((workflow) => workflow.id === workflowId)?.status).toBe('running');
     });
 
-    it('exhausts auto-fix at the worker cap and resets attempts when a workflow is recreated', () => {
+    it('keeps auto-fix eligibility after a workflow is recreated', () => {
       orchestrator = new Orchestrator({
         persistence,
         messageBus: bus,
@@ -765,13 +765,11 @@ describe('Orchestrator', () => {
         (task) => task.config.workflowId === workflowId && task.id.endsWith('/t1'),
       )!.id;
 
-      persistence.updateTask(taskId, { status: 'failed', execution: { autoFixAttempts: 3 } });
+      persistence.updateTask(taskId, { status: 'failed' });
       orchestrator.syncAllFromDb();
-      expect(orchestrator.shouldAutoFix(taskId)).toBe(false);
+      expect(orchestrator.shouldAutoFix(taskId)).toBe(true);
 
       orchestrator.recreateWorkflow(workflowId);
-
-      expect(orchestrator.getTask(taskId)?.execution.autoFixAttempts).toBe(0);
       persistence.updateTask(taskId, { status: 'failed' });
       orchestrator.syncAllFromDb();
       expect(orchestrator.shouldAutoFix(taskId)).toBe(true);
@@ -1119,7 +1117,6 @@ describe('Orchestrator', () => {
       );
 
       expect(repro.getTask(lateId)?.status).toBe('pending');
-      expect(repro.getTask(lateId)?.execution.autoFixAttempts).toBe(0);
       expect(repro.getAllTasks().some((task) => task.id.includes('late-exp-fix-'))).toBe(false);
     });
 
@@ -3475,7 +3472,7 @@ describe('Orchestrator', () => {
   // ── Auto-Fix ────────────────────────────────────────────
 
   describe('auto-fix via synthetic spawn_experiments', () => {
-    it('uses worker-owned auto-fix config as a per-task attempt cap', () => {
+    it('shouldAutoFix only depends on failed eligible tasks and positive retry config', () => {
       const hydratePersistence = new InMemoryPersistence();
       const hydrateBus = new InMemoryBus();
 
@@ -3489,25 +3486,24 @@ describe('Orchestrator', () => {
         execution: {
           exitCode: 1,
           error: 'boom',
-          autoFixAttempts: 2,
         },
       });
 
-      const hydratedOrchestrator = new Orchestrator({
+      const disabledOrchestrator = new Orchestrator({
+        persistence: hydratePersistence,
+        messageBus: hydrateBus,
+        defaultAutoFixRetries: 0,
+      });
+      disabledOrchestrator.syncFromDb('wf-hydrated');
+      expect(disabledOrchestrator.shouldAutoFix('t1')).toBe(false);
+
+      const enabledOrchestrator = new Orchestrator({
         persistence: hydratePersistence,
         messageBus: hydrateBus,
         defaultAutoFixRetries: 3,
       });
-
-      hydratedOrchestrator.syncFromDb('wf-hydrated');
-
-      expect(hydratedOrchestrator.getAutoFixRetryBudget('t1')).toBe(3);
-      expect(hydratedOrchestrator.shouldAutoFix('t1')).toBe(true);
-
-      hydratePersistence.updateTask('t1', { execution: { autoFixAttempts: 3 } });
-      hydratedOrchestrator.syncFromDb('wf-hydrated');
-
-      expect(hydratedOrchestrator.shouldAutoFix('t1')).toBe(false);
+      enabledOrchestrator.syncFromDb('wf-hydrated');
+      expect(enabledOrchestrator.shouldAutoFix('t1')).toBe(true);
     });
 
     it('plain failed tasks stay failed in workflow-core', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -562,7 +562,7 @@ export interface OrchestratorConfig {
   /** Optional; defaults to an adapter wrapping `persistence`. */
   taskRepository?: TaskRepository;
   maxConcurrency?: number;
-  /** Worker-owned maximum auto-fix attempts per failed task. Positive finite values are caps; zero disables worker-submitted fixes. */
+  /** Maximum auto-fix attempts per failed task. Positive finite values are caps; zero disables auto-fix. */
   defaultAutoFixRetries?: number;
   /**
    * Rules that validate task execution environment against command patterns.
@@ -3873,12 +3873,6 @@ export class Orchestrator {
     return this.defaultAutoFixRetries;
   }
 
-  private getAutoFixAttemptCount(task: TaskState): number {
-    const raw = task.execution.autoFixAttempts;
-    if (typeof raw !== 'number' || !Number.isFinite(raw)) return 0;
-    const attempts = Math.floor(raw);
-    return attempts > 0 ? attempts : 0;
-  }
 
   private isRuntimeAutoFixEligibleTask(task: TaskState): boolean {
     if (task.config.isReconciliation) return false;
@@ -3891,9 +3885,7 @@ export class Orchestrator {
     if (!task) return false;
     if (task.status !== 'failed') return false;
     if (!this.isRuntimeAutoFixEligibleTask(task)) return false;
-    const max = this.getAutoFixRetryBudget(taskId);
-    if (max <= 0) return false;
-    return this.getAutoFixAttemptCount(task) < max;
+    return this.getAutoFixRetryBudget(taskId) > 0;
   }
 
   getAllTasks(): TaskState[] {


### PR DESCRIPTION
## Summary

Auto-fix worker attempt limits now live in a worker runtime ledger.

The worker consumes the limit before it queues another fix. The ledger follows task lineage in memory.

<details>
<summary>Review metadata</summary>

Review Claim: Auto-fix worker attempt limits are owned by the worker runtime ledger.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The worker still submits the same fix intent, and focused worker plus orchestrator tests cover the handoff.

Slice Rationale: This lands the runtime owner before entrypoints stop writing the old counter.

</details>

## Non-goals

- Changing UI display.
- Changing persisted field shape.
- Changing support scripts.

## Architecture

### Before

```mermaid
graph TD
    A["Worker reads task.execution.autoFixAttempts"] --> B["Persisted counter gates later submissions"]
```

### After

```mermaid
graph TD
    A["Worker consumes attempt limits from an in-memory ledger"] --> B["Ledger keys follow task lineage"]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/auto-fix-recovery.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-ci-workers.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 7f967394a`
- Post-revert steps: None
- Data migration? No

Depends-On: #3105


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-fix and CI repair now use a more reliable retry budget system, improving how repeated attempts are tracked and limited.
  * Retry limits can vary by task, and fresh task generations get a new attempt budget.

* **Bug Fixes**
  * Removed reliance on hidden attempt counters in task state, reducing inconsistent skip behavior.
  * Improved stale candidate handling and late-response recovery so only valid repairs proceed.

* **Tests**
  * Expanded coverage for retry-budget exhaustion, stale events, and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->