### PR TITLE
[Worker Controls](3c) Add worker task-data proof

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -581,6 +581,8 @@ test.describe('Visual proof capture', () => {
     }, { planYaml: plannedYaml, planName: 'Terminal Planned Flow' });
 
     await page.getByTestId('sidebar-planning').click();
+    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-16/);
+    await expect(page.getByTestId('planning-session-rail')).toHaveClass(/w-64/);
     await expect(page.getByRole('heading', { name: 'Planning Terminal' })).toBeVisible();
     await page.getByTestId('invoker-terminal-input').fill('Add README');
     await page.getByRole('button', { name: 'Send' }).click();
@@ -661,7 +663,7 @@ test.describe('Visual proof capture', () => {
 
     await page.getByTestId('browser-rail-dismiss').click();
     await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible();
-    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-72/);
+    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-60/);
   });
   test('needs attention browser focuses the selected task', async ({ page }) => {
     await loadPlanAndSelectWorkflow(page, MENU_PROOF_PLAN);
@@ -683,6 +685,7 @@ test.describe('Visual proof capture', () => {
     ]);
 
     await page.getByTestId('sidebar-attention').click();
+    await expect(page.getByTestId('browser-rail')).toHaveClass(/w-64/);
     await expect(page.getByTestId('browser-rail').getByRole('heading', { name: 'Needs Attention' })).toBeVisible();
     await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-16/);
     await expect(page.getByRole('heading', { name: 'First test task' })).toBeVisible();
@@ -723,7 +726,7 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'collapsed-workflow-browsers');
 
     await page.getByTestId('sidebar-collapse-toggle').click();
-    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-72/);
+    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-60/);
   });
   test('dag loaded', async ({ page }) => {
     await loadPlanAndSelectWorkflow(page, MENU_PROOF_PLAN);

--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -12,6 +12,7 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     getUiPerfStats: vi.fn(() => ({ mainDeltaToUi: 7 })),
     resetUiPerfStats: vi.fn(),
     getQueueStatus: vi.fn(() => ({ runningCount: 2 })),
+    getWorkerStatus: vi.fn(() => ({ generatedAt: 'now', workers: [] })),
     getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
     getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
     getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
@@ -41,6 +42,7 @@ describe('answerOwnerReadQuery', () => {
   it('routes the snapshot kinds to their handlers', () => {
     const h = makeHandlers();
     expect(answerOwnerReadQuery({ kind: 'queue' }, h)).toEqual({ runningCount: 2 });
+    expect(answerOwnerReadQuery({ kind: 'worker-status' }, h)).toEqual({ workerStatus: { generatedAt: 'now', workers: [] } });
     expect(answerOwnerReadQuery({ kind: 'workflow-status' }, h)).toEqual({ 'wf-1': 'running' });
     expect(answerOwnerReadQuery({ kind: 'action-graph' }, h)).toEqual({ nodes: [] });
   });
@@ -137,6 +139,7 @@ describe('buildOwnerReadQueryHandlers', () => {
       getUiPerfStats: () => ({}),
       resetUiPerfStats: () => {},
       getStreamSequence: () => 5,
+      getWorkerStatus: () => ({ generatedAt: 'now', workers: [] }),
       resolveInvokerHomeRoot: () => '/home',
       orchestrator: { ...f.orchestrator, ...orch } as never,
       persistence: { ...f.persistence, ...persist } as never,
@@ -153,6 +156,7 @@ describe('buildOwnerReadQueryHandlers', () => {
     expect(h.getOutputChunks('t1')).toEqual([{ c: 1 }]);
     expect(h.replayOutput('t1', 9)).toEqual([{ id: 't1', off: 9 }]);
     expect(h.getAllCompletedTasks()).toEqual([{ id: 'done' }]);
+    expect(h.getWorkerStatus()).toEqual({ generatedAt: 'now', workers: [] });
   });
 
   it('loadWorkflowBundle syncs that workflow first, then returns workflow + tasks', () => {

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  AUTO_FIX_WORKER_KIND,
+  CI_FAILURE_WORKER_KIND,
+  createWorkerRegistry,
+  PR_STATUS_WORKER_KIND,
+  type WorkerRuntime,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
+
+import {
+  AUTO_STARTED_OWNER_WORKER_KINDS,
+  createWorkerRuntimeController,
+} from '../worker-control.js';
+
+interface TestWorkerRuntime extends WorkerRuntime {
+  forceExit: () => void;
+  readonly starts: number;
+  readonly stops: number;
+}
+
+function runtime(kind: string): TestWorkerRuntime {
+  let running = false;
+  let starts = 0;
+  let stops = 0;
+  return {
+    identity: { kind, instanceId: `${kind}-instance` },
+    start: vi.fn(() => {
+      starts += 1;
+      running = true;
+    }),
+    wake: vi.fn(),
+    tick: vi.fn(async () => {}),
+    stop: vi.fn(async () => {
+      stops += 1;
+      running = false;
+    }),
+    isRunning: vi.fn(() => running),
+    forceExit: () => { running = false; },
+    get starts() { return starts; },
+    get stops() { return stops; },
+  };
+}
+
+function persistence() {
+  return {
+    listWorkerActions: vi.fn(() => []),
+    listWorkflows: vi.fn(() => []),
+    loadTasks: vi.fn(() => []),
+    getEvents: vi.fn(() => []),
+  };
+}
+
+function deps(): WorkerRuntimeDependencies {
+  return {
+    store: {} as WorkerRuntimeDependencies['store'],
+    submitter: { submit: vi.fn(() => 1) },
+    logger: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  } as WorkerRuntimeDependencies;
+}
+
+function controller(options: { autoFixRetries?: number } = {}) {
+  const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+  const runtimes = new Map<string, TestWorkerRuntime[]>();
+  const register = (kind: string, note: string, runtimeKind = kind) => {
+    registry.register({
+      kind,
+      note,
+      factory: () => {
+        const created = runtime(runtimeKind);
+        const list = runtimes.get(kind) ?? [];
+        list.push(created);
+        runtimes.set(kind, list);
+        return created;
+      },
+    });
+  };
+  register(AUTO_FIX_WORKER_KIND, 'Auto-fixes failed tasks.', 'recovery');
+  register(PR_STATUS_WORKER_KIND, 'Checks pull request status.');
+  register(CI_FAILURE_WORKER_KIND, 'Repairs failed CI.');
+  register('external-preview', 'External preview worker.');
+
+  return {
+    runtimes,
+    controller: createWorkerRuntimeController({
+      registry,
+      deps: deps(),
+      autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      persistence: persistence() as never,
+      canControl: () => true,
+      autoFixRetries: options.autoFixRetries,
+    }),
+  };
+}
+
+describe('createWorkerRuntimeController', () => {
+  it('auto-start starts only pr-status and ci-failure', () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    setup.controller.startAutoStartedWorkers();
+    const snapshot = setup.controller.snapshot();
+
+    expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
+    expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)?.lifecycle).toBe('running');
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
+    expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.lifecycle).toBe('stopped');
+  });
+
+  it('autofix remains stopped until explicitly started', () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    setup.controller.startAutoStartedWorkers();
+    expect(setup.runtimes.get(AUTO_FIX_WORKER_KIND)).toBeUndefined();
+
+    const row = setup.controller.start(AUTO_FIX_WORKER_KIND);
+
+    expect(row.lifecycle).toBe('running');
+    expect(row.runtimeKind).toBe('recovery');
+  });
+
+  it('duplicate start is idempotent', () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    setup.controller.start(PR_STATUS_WORKER_KIND);
+    setup.controller.start(PR_STATUS_WORKER_KIND);
+
+    expect(setup.runtimes.get(PR_STATUS_WORKER_KIND)).toHaveLength(1);
+  });
+
+  it('stop is idempotent', async () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    const stoppedBeforeStart = await setup.controller.stop(PR_STATUS_WORKER_KIND);
+    expect(stoppedBeforeStart.lifecycle).toBe('stopped');
+
+    setup.controller.start(PR_STATUS_WORKER_KIND);
+    const stopped = await setup.controller.stop(PR_STATUS_WORKER_KIND);
+    const stoppedAgain = await setup.controller.stop(PR_STATUS_WORKER_KIND);
+
+    expect(stopped.lifecycle).toBe('stopped');
+    expect(stoppedAgain.lifecycle).toBe('stopped');
+    expect(setup.runtimes.get(PR_STATUS_WORKER_KIND)?.[0]?.stops).toBe(1);
+  });
+
+  it('autoFixRetries=0 disables autofix and ci-failure starts', () => {
+    const setup = controller({ autoFixRetries: 0 });
+
+    expect(() => setup.controller.start(AUTO_FIX_WORKER_KIND)).toThrow('Worker "autofix" is disabled by autoFixRetries=0');
+    expect(() => setup.controller.start(CI_FAILURE_WORKER_KIND)).toThrow('Worker "ci-failure" is disabled by autoFixRetries=0');
+    setup.controller.startAutoStartedWorkers();
+    expect(setup.controller.snapshot().workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
+    expect(setup.runtimes.get(CI_FAILURE_WORKER_KIND)).toBeUndefined();
+
+
+    const snapshot = setup.controller.snapshot();
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
+      policy: 'disabled',
+      policyReason: 'autoFixRetries=0',
+      startable: false,
+    });
+    expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)).toMatchObject({
+      policy: 'disabled',
+      policyReason: 'autoFixRetries=0',
+      startable: false,
+    });
+  });
+
+  it('an exited external worker row reports exited', () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    setup.controller.start('external-preview');
+    setup.runtimes.get('external-preview')?.[0]?.forceExit();
+
+    expect(setup.controller.snapshot().workers.find((worker) => worker.kind === 'external-preview')).toMatchObject({
+      lifecycle: 'exited',
+      policy: 'unknown',
+    });
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -116,7 +116,7 @@ import {
   registerBuiltinAgents,
   registerBuiltinWorkers,
   type AgentRegistry,
-  type WorkerRuntime,
+  type WorkerRegistry,
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
@@ -234,6 +234,13 @@ import { buildCurrentActionGraphSnapshot } from './action-graph-snapshot.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
+import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
+import {
+  AUTO_STARTED_OWNER_WORKER_KINDS,
+  createLocalWorkerStatusSnapshot,
+  createWorkerRuntimeController,
+  type WorkerRuntimeController,
+} from './worker-control.js';
 import { startSurfaceEventRelay } from './surface-event-relay.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
 import { buildWebInvokerDispatch } from './web/web-invoker-dispatch.js';
@@ -288,16 +295,14 @@ import {
 import { tryAcquireGuiInstanceLock, type GuiInstanceLock } from './gui-instance-lock.js';
 import { logProcessError } from './process-error-handling.js';
 
-const REGISTERED_OWNER_WORKER_KINDS = [
-  PR_STATUS_WORKER_KIND,
-  CI_FAILURE_WORKER_KIND,
-] as const;
-type RegisteredOwnerWorkerSubmit = WorkerRuntimeDependencies['submitter']['submit'];
 
 function submitRegisteredOwnerWorkerMutation(
-  ...args: Parameters<RegisteredOwnerWorkerSubmit>
-): ReturnType<RegisteredOwnerWorkerSubmit> {
-  const [workflowId, priority, channel, mutationArgs, options] = args;
+  workflowId: string,
+  priority: WorkflowMutationPriority,
+  channel: string,
+  mutationArgs: unknown[],
+  options?: { deferDrain?: boolean },
+): number {
   if (!workflowMutationCoordinator) {
     throw new Error('Workflow mutation coordinator is unavailable');
   }
@@ -328,27 +333,14 @@ function buildRegisteredOwnerWorkerDeps(
     },
   };
 }
-
-function startRegisteredOwnerWorkers(deps: WorkerRuntimeDependencies): WorkerRuntime[] {
-  const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
-  const workers: WorkerRuntime[] = [];
-  for (const kind of REGISTERED_OWNER_WORKER_KINDS) {
-    const definition = registry.get(kind);
-    if (!definition) {
-      deps.logger.warn(`registered owner worker "${kind}" is unavailable`, { module: 'worker-registry' });
-      continue;
-    }
-    const worker = definition.factory(deps);
-    worker.start();
-    workers.push(worker);
-  }
-  return workers;
+function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependencies> {
+  return registerExternalWorkersFromConfig(
+    invokerConfig.externalWorkers,
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
+  );
 }
 
-async function stopRegisteredOwnerWorkers(workers: WorkerRuntime[]): Promise<void> {
-  const stopping = workers.splice(0).map((worker) => worker.stop().catch(() => undefined));
-  await Promise.all(stopping);
-}
+
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -977,7 +969,7 @@ function startHeadlessMode(): void {
     }
 
     let exitCode = 0;
-    const registeredOwnerWorkers: WorkerRuntime[] = [];
+    let workerRuntimeController: WorkerRuntimeController | null = null;
     let lifecycleEventBridge: LifecycleEventBridge | null = null;
     let standaloneLaunchDispatcherController: StandaloneLaunchDispatcherController | null = null;
     try {
@@ -1186,6 +1178,18 @@ function startHeadlessMode(): void {
             await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
             failInFlightTasks();
             return undefined;
+          }
+          case 'invoker:start-worker': {
+            if (!workerRuntimeController) {
+              throw new Error('Worker runtime controller is unavailable');
+            }
+            return workerRuntimeController.start(String(payload.args[0]));
+          }
+          case 'invoker:stop-worker': {
+            if (!workerRuntimeController) {
+              throw new Error('Worker runtime controller is unavailable');
+            }
+            return workerRuntimeController.stop(String(payload.args[0]));
           }
           case 'invoker:inject-task-states': {
             if (process.env.NODE_ENV !== 'test') {
@@ -1661,6 +1665,7 @@ function startHeadlessMode(): void {
             getUiPerfStats: () => headlessDeps.getUiPerfStats?.() ?? {},
             resetUiPerfStats: () => headlessDeps.resetUiPerfStats?.(),
             getStreamSequence: () => 0,
+            getWorkerStatus: () => workerRuntimeController?.snapshot() ?? { generatedAt: new Date().toISOString(), workers: [] },
             resolveInvokerHomeRoot,
             orchestrator,
             persistence,
@@ -1735,14 +1740,20 @@ function startHeadlessMode(): void {
           logWarn: (message) => logger.warn(message, { module: 'surface-relay' }),
         });
 
-        registeredOwnerWorkers.push(...startRegisteredOwnerWorkers(
-          buildRegisteredOwnerWorkerDeps(
+        workerRuntimeController = createWorkerRuntimeController({
+          registry: createRegisteredWorkerRegistry(),
+          deps: buildRegisteredOwnerWorkerDeps(
             persistence,
             async () => {
               await createStandaloneTaskExecutor().checkMergeGateStatuses();
             },
           ),
-        ));
+          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          persistence,
+          autoFixRetries: invokerConfig.autoFixRetries,
+          canControl: () => !readOnlyMode,
+        });
+        workerRuntimeController.startAutoStartedWorkers();
 
         // Owner discovery and exec handlers must exist before dispatch polling starts.
         if (!readOnlyMode) {
@@ -1762,7 +1773,7 @@ function startHeadlessMode(): void {
     } finally {
       standaloneLaunchDispatcherController?.stop();
       lifecycleEventBridge?.stop();
-      await stopRegisteredOwnerWorkers(registeredOwnerWorkers);
+      await workerRuntimeController?.stopAll();
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
       }
@@ -1851,7 +1862,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const planningCommandBuilder = createPlanningCommandBuilderFromRegistry(agentRegistry);
   let mainWindow: BrowserWindow | null = null;
   let taskExecutor: TaskRunner | null = null;
-  const registeredOwnerWorkers: WorkerRuntime[] = [];
+  let workerRuntimeController: WorkerRuntimeController | null = null;
   let apiServer: ApiServer | null = null;
   let webBridge: WebBridge | null = null;
   let ownerMode = true;
@@ -2670,6 +2681,10 @@ function createEmbeddedTerminalBackendFromConfig(
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:clear':
         return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:start-worker':
+        return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:stop-worker':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
         const workflows = detachedViewerWorkflows ?? persistence.listWorkflows();
         const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
@@ -3407,6 +3422,7 @@ function createEmbeddedTerminalBackendFromConfig(
           ownerModeLabel: 'gui',
           getUiPerfStats: () => getUiPerfStats(),
           resetUiPerfStats: () => resetUiPerfStats(),
+          getWorkerStatus: () => workerRuntimeController?.snapshot() ?? { generatedAt: new Date().toISOString(), workers: [] },
           getStreamSequence: () => getTaskDeltaStreamSequence(),
           resolveInvokerHomeRoot,
           orchestrator,
@@ -3509,14 +3525,20 @@ function createEmbeddedTerminalBackendFromConfig(
     }
 
     if (ownerMode) {
-      registeredOwnerWorkers.push(...startRegisteredOwnerWorkers(
-        buildRegisteredOwnerWorkerDeps(
+      workerRuntimeController = createWorkerRuntimeController({
+        registry: createRegisteredWorkerRegistry(),
+        deps: buildRegisteredOwnerWorkerDeps(
           persistence,
           async () => {
             await requireTaskExecutor().checkMergeGateStatuses();
           },
         ),
-      ));
+        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        persistence,
+        autoFixRetries: invokerConfig.autoFixRetries,
+        canControl: () => ownerMode,
+      });
+      workerRuntimeController.startAutoStartedWorkers();
     }
 
     // Relaunch orphaned running tasks and start any pending-but-ready tasks.
@@ -4146,9 +4168,54 @@ function createEmbeddedTerminalBackendFromConfig(
       },
     );
 
+    registerGuiMutationHandler('invoker:start-worker', async (kindArg: unknown) => {
+      if (!workerRuntimeController) {
+        throw new Error('Worker runtime controller is unavailable');
+      }
+      return workerRuntimeController.start(String(kindArg));
+    });
+
+    registerGuiMutationHandler('invoker:stop-worker', async (kindArg: unknown) => {
+      if (!workerRuntimeController) {
+        throw new Error('Worker runtime controller is unavailable');
+      }
+      return workerRuntimeController.stop(String(kindArg));
+    });
+
     ipcMain.handle('invoker:get-queue-status', () => {
       return orchestrator.getQueueStatus();
     });
+    ipcMain.handle('invoker:get-worker-status', async () => {
+      if (!ownerMode) {
+        try {
+          const delegated = await messageBus.request<{ kind: string }, { workerStatus?: unknown }>(
+            'headless.query',
+            { kind: 'worker-status' },
+          );
+          if (delegated && typeof delegated === 'object' && 'workerStatus' in delegated) {
+            return delegated.workerStatus;
+          }
+        } catch (err) {
+          logger.warn(
+            `get-worker-status owner delegation failed; falling back to local read-only snapshot: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            { module: 'ipc' },
+          );
+        }
+        return createLocalWorkerStatusSnapshot({
+          registry: createRegisteredWorkerRegistry(),
+          persistence,
+          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        });
+      }
+      return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+        registry: createRegisteredWorkerRegistry(),
+        persistence,
+        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      });
+    });
+
 
     ipcMain.handle('invoker:get-action-graph', async () => {
       if (!ownerMode) {
@@ -5064,7 +5131,7 @@ function createEmbeddedTerminalBackendFromConfig(
       try {
         if (apiServer) await apiServer.close().catch(() => {});
         if (webBridge) await webBridge.close().catch(() => {});
-        await stopRegisteredOwnerWorkers(registeredOwnerWorkers);
+        await workerRuntimeController?.stopAll();
         if (dbPollInterval) clearInterval(dbPollInterval);
         if (activityPollInterval) clearInterval(activityPollInterval);
         if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -1,5 +1,6 @@
 import type { Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
+import type { WorkerStatusSnapshot } from '@invoker/contracts';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { isHeadlessReadOnlyCommand } from './headless-command-classification.js';
 import { runReadOnlyHeadlessQueryToString, type HeadlessQueryDeps } from './headless-query-list.js';
@@ -27,6 +28,7 @@ export interface OwnerReadQueryHandlers {
   getUiPerfStats: () => Record<string, unknown>;
   resetUiPerfStats: () => void;
   getQueueStatus: () => Record<string, unknown>;
+  getWorkerStatus: () => WorkerStatusSnapshot;
   getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
   getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
   getActionGraphSnapshot: () => Record<string, unknown>;
@@ -75,6 +77,8 @@ export function answerOwnerReadQuery(
       return { ownerMode: handlers.ownerModeLabel, ...handlers.getUiPerfStats() };
     case 'queue':
       return handlers.getQueueStatus();
+    case 'worker-status':
+      return { workerStatus: handlers.getWorkerStatus() };
     case 'workflow-status':
       return handlers.getWorkflowStatus(body.workflowId);
     case 'tasks':
@@ -156,6 +160,7 @@ export interface OwnerReadQueryDeps {
   getUiPerfStats: () => Record<string, unknown>;
   resetUiPerfStats: () => void;
   getStreamSequence: () => number;
+  getWorkerStatus: () => WorkerStatusSnapshot;
   resolveInvokerHomeRoot: () => string;
   orchestrator: ReadOrchestrator;
   persistence: ReadPersistence;
@@ -172,6 +177,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     getUiPerfStats: deps.getUiPerfStats,
     resetUiPerfStats: deps.resetUiPerfStats,
     getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
+    getWorkerStatus: deps.getWorkerStatus,
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
     getTasksSnapshot: ({ refresh }) => {
       if (refresh) orchestrator.syncAllFromDb();

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -1,0 +1,261 @@
+import type {
+  WorkerActionSummary,
+  WorkerPolicyStatus,
+  WorkerRecoverySummary,
+  WorkerStatusEntry,
+  WorkerStatusSnapshot,
+} from '@invoker/contracts';
+import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
+import {
+  AUTO_FIX_WORKER_KIND,
+  CI_FAILURE_WORKER_KIND,
+  PR_STATUS_WORKER_KIND,
+  type WorkerRegistry,
+  type WorkerRuntime,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
+
+import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
+
+export const AUTO_STARTED_OWNER_WORKER_KINDS = [PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND] as const;
+
+export interface WorkerRuntimeController {
+  startAutoStartedWorkers(): void;
+  start(kind: string): WorkerStatusEntry;
+  stop(kind: string): Promise<WorkerStatusEntry>;
+  stopAll(): Promise<void>;
+  snapshot(): WorkerStatusSnapshot;
+}
+
+type WorkerStatusPersistence = Pick<SQLiteAdapter, 'listWorkerActions' | 'listWorkflows' | 'loadTasks' | 'getEvents'>;
+
+interface RuntimeHandle {
+  runtime: WorkerRuntime;
+  startedAt: string;
+  stoppedAt?: string;
+}
+
+const BUILT_IN_WORKER_KINDS = new Set<string>([
+  AUTO_FIX_WORKER_KIND,
+  PR_STATUS_WORKER_KIND,
+  CI_FAILURE_WORKER_KIND,
+]);
+
+export function createWorkerRuntimeController(options: {
+  registry: WorkerRegistry<WorkerRuntimeDependencies>;
+  deps: WorkerRuntimeDependencies;
+  autoStartKinds: readonly string[];
+  persistence: WorkerStatusPersistence;
+  autoFixRetries?: number;
+  canControl: () => boolean;
+}): WorkerRuntimeController {
+  const handles = new Map<string, RuntimeHandle>();
+  const stoppedAtByKind = new Map<string, string>();
+
+  const requireDefinition = (kind: string) => {
+    const definition = options.registry.get(kind);
+    if (!definition) {
+      throw new Error(`Unknown worker kind: "${kind}"`);
+    }
+    return definition;
+  };
+
+  const assertStartAllowed = (kind: string): void => {
+    if (isDisabledByAutoFixRetries(kind, options.autoFixRetries)) {
+      throw new Error(`Worker "${kind}" is disabled by autoFixRetries=0`);
+    }
+  };
+
+  const rowForKind = (kind: string): WorkerStatusEntry => {
+    const definition = options.registry.get(kind);
+    if (!definition) {
+      throw new Error(`Unknown worker kind: "${kind}"`);
+    }
+    return buildWorkerStatusEntry({
+      definitionKind: definition.kind,
+      note: definition.note,
+      handle: handles.get(kind),
+      stoppedAt: stoppedAtByKind.get(kind),
+      autoStarts: options.autoStartKinds.includes(kind),
+      policy: policyForKind(kind, options.autoFixRetries),
+      persistence: options.persistence,
+      canControl: options.canControl(),
+    });
+  };
+
+  const stopHandle = async (kind: string, handle: RuntimeHandle): Promise<void> => {
+    await handle.runtime.stop();
+    const stoppedAt = new Date().toISOString();
+    stoppedAtByKind.set(kind, stoppedAt);
+    handles.delete(kind);
+  };
+
+  return {
+    startAutoStartedWorkers(): void {
+      for (const kind of options.autoStartKinds) {
+        if (!options.registry.get(kind)) continue;
+        if (isDisabledByAutoFixRetries(kind, options.autoFixRetries)) continue;
+        this.start(kind);
+      }
+    },
+
+    start(kind: string): WorkerStatusEntry {
+      const definition = requireDefinition(kind);
+      assertStartAllowed(kind);
+
+      const existing = handles.get(kind);
+      if (existing) {
+        if (existing.runtime.isRunning()) {
+          return rowForKind(kind);
+        }
+        void existing.runtime.stop().catch(() => undefined);
+        handles.delete(kind);
+      }
+
+      const runtime = definition.factory(options.deps);
+      runtime.start();
+      handles.set(kind, {
+        runtime,
+        startedAt: new Date().toISOString(),
+      });
+      stoppedAtByKind.delete(kind);
+      return rowForKind(kind);
+    },
+
+    async stop(kind: string): Promise<WorkerStatusEntry> {
+      requireDefinition(kind);
+      const handle = handles.get(kind);
+      if (!handle) {
+        return rowForKind(kind);
+      }
+      await stopHandle(kind, handle);
+      return rowForKind(kind);
+    },
+
+    async stopAll(): Promise<void> {
+      const stopping = [...handles.entries()].map(([kind, handle]) => stopHandle(kind, handle).catch(() => undefined));
+      await Promise.all(stopping);
+    },
+
+    snapshot(): WorkerStatusSnapshot {
+      return {
+        generatedAt: new Date().toISOString(),
+        workers: options.registry.list().map((definition) => rowForKind(definition.kind)),
+      };
+    },
+  };
+}
+export function createLocalWorkerStatusSnapshot(options: {
+  registry: WorkerRegistry<WorkerRuntimeDependencies>;
+  persistence: WorkerStatusPersistence;
+  autoStartKinds: readonly string[];
+}): WorkerStatusSnapshot {
+  return {
+    generatedAt: new Date().toISOString(),
+    workers: options.registry.list().map((definition) => buildWorkerStatusEntry({
+      definitionKind: definition.kind,
+      note: definition.note,
+      autoStarts: options.autoStartKinds.includes(definition.kind),
+      policy: 'unknown',
+      persistence: options.persistence,
+      canControl: false,
+    })),
+  };
+}
+
+
+function buildWorkerStatusEntry(args: {
+  definitionKind: string;
+  note: string;
+  handle?: RuntimeHandle;
+  stoppedAt?: string;
+  autoStarts: boolean;
+  policy: WorkerPolicyStatus;
+  persistence: WorkerStatusPersistence;
+  canControl: boolean;
+}): WorkerStatusEntry {
+  const lifecycle = args.handle
+    ? args.handle.runtime.isRunning() ? 'running' : 'exited'
+    : 'stopped';
+  const policyReason = args.policy === 'disabled' ? 'autoFixRetries=0' : undefined;
+  const controlDisabledReason = getControlDisabledReason({
+    canControl: args.canControl,
+    policyReason,
+  });
+  const runtime = args.handle?.runtime;
+  return {
+    kind: args.definitionKind,
+    note: args.note,
+    ...(runtime ? { runtimeKind: runtime.identity.kind, instanceId: runtime.identity.instanceId } : {}),
+    lifecycle,
+    policy: args.policy,
+    ...(policyReason ? { policyReason } : {}),
+    autoStarts: args.autoStarts,
+    startable: lifecycle !== 'running' && args.policy !== 'disabled' && args.canControl,
+    stoppable: lifecycle === 'running' && args.canControl,
+    ...(controlDisabledReason ? { controlDisabledReason } : {}),
+    ...(args.handle?.startedAt ? { startedAt: args.handle.startedAt } : {}),
+    ...(args.stoppedAt ? { stoppedAt: args.stoppedAt } : {}),
+    recentActions: args.persistence.listWorkerActions({ workerKind: args.definitionKind, limit: 5 }).map(toWorkerActionSummary),
+    ...(args.definitionKind === AUTO_FIX_WORKER_KIND ? { recovery: toWorkerRecoverySummary(args.persistence) } : {}),
+  };
+}
+
+function policyForKind(kind: string, autoFixRetries: number | undefined): WorkerPolicyStatus {
+  if (isDisabledByAutoFixRetries(kind, autoFixRetries)) return 'disabled';
+  if (BUILT_IN_WORKER_KINDS.has(kind)) return 'enabled';
+  return 'unknown';
+}
+
+function isDisabledByAutoFixRetries(kind: string, autoFixRetries: number | undefined): boolean {
+  return (kind === AUTO_FIX_WORKER_KIND || kind === CI_FAILURE_WORKER_KIND)
+    && autoFixRetries !== undefined
+    && autoFixRetries <= 0;
+}
+
+function getControlDisabledReason(args: { canControl: boolean; policyReason?: string }): string | undefined {
+  if (args.policyReason) return args.policyReason;
+  if (!args.canControl) return 'Controls unavailable';
+  return undefined;
+}
+
+function toWorkerActionSummary(action: WorkerActionRecord): WorkerActionSummary {
+  return {
+    id: action.id,
+    workerKind: action.workerKind,
+    actionType: action.actionType,
+    ...(action.workflowId ? { workflowId: action.workflowId } : {}),
+    ...(action.taskId ? { taskId: action.taskId } : {}),
+    subjectType: action.subjectType,
+    subjectId: action.subjectId,
+    externalKey: action.externalKey,
+    status: action.status,
+    attemptCount: action.attemptCount,
+    ...(action.intentId ? { intentId: action.intentId } : {}),
+    ...(action.agentName ? { agentName: action.agentName } : {}),
+    ...(action.executionModel ? { executionModel: action.executionModel } : {}),
+    ...(action.sessionId ? { sessionId: action.sessionId } : {}),
+    ...(action.summary ? { summary: action.summary } : {}),
+    createdAt: action.createdAt,
+    updatedAt: action.updatedAt,
+    ...(action.completedAt ? { completedAt: action.completedAt } : {}),
+  };
+}
+
+function toWorkerRecoverySummary(persistence: WorkerStatusPersistence): WorkerRecoverySummary {
+  const status = collectRecoveryWorkerStatus(persistence);
+  return {
+    workerId: status.workerId,
+    owner: status.owner,
+    ...(status.lastWakeupAt ? { lastWakeupAt: status.lastWakeupAt } : {}),
+    ...(status.lastScanAt ? { lastScanAt: status.lastScanAt } : {}),
+    ...(status.lastSubmitAt ? { lastSubmitAt: status.lastSubmitAt } : {}),
+    ...(status.lastSkipAt ? { lastSkipAt: status.lastSkipAt } : {}),
+    ...(status.lastSkipReason ? { lastSkipReason: status.lastSkipReason } : {}),
+    ...(status.lastSkipTaskId ? { lastSkipTaskId: status.lastSkipTaskId } : {}),
+    wakeups: status.wakeups,
+    scans: status.scans,
+    submissions: status.submissions,
+    skips: status.skips,
+  };
+}

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -144,6 +144,81 @@ export interface QueueStatus {
   running: Array<{ taskId: string; description: string }>;
   queued: Array<{ taskId: string; priority: number; description: string }>;
 }
+export type WorkerLifecycleStatus = 'running' | 'stopped' | 'exited';
+export type WorkerPolicyStatus = 'enabled' | 'disabled' | 'unknown';
+export type WorkerControlAction = 'start' | 'stop';
+export type WorkerActionStatus =
+  | 'queued'
+  | 'pending'
+  | 'running'
+  | 'needs_input'
+  | 'review_ready'
+  | 'completed'
+  | 'failed'
+  | 'skipped'
+  | 'abandoned'
+  | 'cancelled';
+
+export interface WorkerActionSummary {
+  id: string;
+  workerKind: string;
+  actionType: string;
+  workflowId?: string;
+  taskId?: string;
+  subjectType: string;
+  subjectId: string;
+  externalKey: string;
+  status: WorkerActionStatus;
+  attemptCount: number;
+  intentId?: string;
+  agentName?: string;
+  executionModel?: string;
+  sessionId?: string;
+  summary?: string;
+  createdAt: string;
+  updatedAt: string;
+  completedAt?: string;
+}
+
+export interface WorkerRecoverySummary {
+  workerId: string;
+  owner: string;
+  lastWakeupAt?: string;
+  lastScanAt?: string;
+  lastSubmitAt?: string;
+  lastSkipAt?: string;
+  lastSkipReason?: string;
+  lastSkipTaskId?: string;
+  wakeups: number;
+  scans: number;
+  submissions: number;
+  skips: number;
+}
+
+export interface WorkerStatusEntry {
+  kind: string;
+  note: string;
+  runtimeKind?: string;
+  instanceId?: string;
+  lifecycle: WorkerLifecycleStatus;
+  policy: WorkerPolicyStatus;
+  policyReason?: string;
+  autoStarts: boolean;
+  startable: boolean;
+  stoppable: boolean;
+  controlDisabledReason?: string;
+  startedAt?: string;
+  stoppedAt?: string;
+  lastError?: string;
+  recentActions: WorkerActionSummary[];
+  recovery?: WorkerRecoverySummary;
+}
+
+export interface WorkerStatusSnapshot {
+  generatedAt: string;
+  workers: WorkerStatusEntry[];
+}
+
 
 export type UIActionGraphNodeType =
   | 'user-action'
@@ -835,6 +910,18 @@ export const IpcChannels = {
   'invoker:get-queue-status': {} as {
     request: [];
     response: QueueStatus;
+  },
+  'invoker:get-worker-status': {} as {
+    request: [];
+    response: WorkerStatusSnapshot;
+  },
+  'invoker:start-worker': {} as {
+    request: [kind: string];
+    response: WorkerStatusEntry;
+  },
+  'invoker:stop-worker': {} as {
+    request: [kind: string];
+    response: WorkerStatusEntry;
   },
   'invoker:get-action-graph': {} as {
     request: [];

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2835,7 +2835,7 @@ export function App() {
 
   const renderPlanningTerminalSurface = (): JSX.Element => (
     <div className="flex-1 flex overflow-hidden">
-      <div data-testid="planning-session-rail" className="flex h-full w-80 shrink-0 flex-col border-r border-gray-800 bg-gray-950/45">
+      <div data-testid="planning-session-rail" className="flex h-full w-64 shrink-0 flex-col border-r border-gray-800 bg-gray-950/45">
         <div className="flex items-start justify-between gap-3 border-b border-gray-800 px-4 py-4">
           <div>
             <h2 className="text-sm font-semibold text-gray-100">Planning Terminal</h2>
@@ -2896,7 +2896,7 @@ export function App() {
     </div>
   );
   const renderBrowserRail = (): JSX.Element => (
-    <div data-testid="browser-rail" className="flex h-full w-80 shrink-0 flex-col border-r border-gray-800 bg-gray-950/45">
+    <div data-testid="browser-rail" className="flex h-full w-64 shrink-0 flex-col border-r border-gray-800 bg-gray-950/45">
       <div className="flex items-start justify-between gap-3 border-b border-gray-800 px-4 py-4">
         <div>
           <h2 className="text-sm font-semibold text-gray-100">{browserSurfaceTitle}</h2>
@@ -3099,8 +3099,8 @@ export function App() {
                   remoteTargets={remoteTargets}
                   executionPools={executionPools}
                   executionAgents={executionAgents}
-                  onApprove={(task) => void handleApprove(task.id)}
-                  onReject={(task) => void handleReject(task.id)}
+                  onApprove={openApprovalModal}
+                  onReject={openRejectModal}
                   onSetMergeBranch={handleSetMergeBranch}
                   onSetMergeMode={handleSetMergeMode}
                   onToggleCollapsed={handleToggleInspectorCollapsed}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -16,6 +16,7 @@ import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowM
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
+import { useWorkerStatus } from './hooks/useWorkerStatus.js';
 import { useActionGraphSnapshot } from './hooks/useActionGraphSnapshot.js';
 import { useInvoker } from './hooks/useInvoker.js';
 import { TaskDAG } from './components/TaskDAG.js';
@@ -31,6 +32,7 @@ import { SystemSetupModal } from './components/SystemSetupModal.js';
 import { WorkflowGraph } from './components/WorkflowGraph.js';
 import { FloatingGraphPanel } from './components/FloatingGraphPanel.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
+import { WorkerDetailsPanel } from './components/WorkerDetailsPanel.js';
 import { groupWorkflowCoreActivity } from './lib/workflow-core-activity.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
 import { WorkflowStatusChips } from './components/WorkflowStatusChips.js';
@@ -502,6 +504,15 @@ export function App() {
   );
   const invoker = useInvoker();
   const queueStatus = useQueueStatus();
+  const [workerStatus, refreshWorkerStatus] = useWorkerStatus();
+  const handleStartWorker = useCallback(async (kind: string) => {
+    await invoker.startWorker(kind);
+    await refreshWorkerStatus();
+  }, [invoker, refreshWorkerStatus]);
+  const handleStopWorker = useCallback(async (kind: string) => {
+    await invoker.stopWorker(kind);
+    await refreshWorkerStatus();
+  }, [invoker, refreshWorkerStatus]);
   const runningTaskIds = useMemo(
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
     [queueStatus],
@@ -512,6 +523,7 @@ export function App() {
   const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+  const [selectedWorkerKind, setSelectedWorkerKind] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
   const [reviewGateByWorkflowId, setReviewGateByWorkflowId] = useState<Record<string, ReviewGateQueryResponse | null>>({});
   const [stickySelectedWorkflow, setStickySelectedWorkflow] = useState<WorkflowMeta | null>(null);
@@ -759,6 +771,7 @@ export function App() {
   }, []);
 
   const selectedTask = selectedTaskId ? tasks.get(selectedTaskId) ?? null : null;
+  const selectedWorker = workerStatus?.workers.find((worker) => worker.kind === selectedWorkerKind) ?? null;
   const contextMenuTask = contextMenu ? tasks.get(contextMenu.taskId) ?? null : null;
   const selectedWorkflowTaskCount = useMemo(() => {
     if (!selectedWorkflowId) return 0;
@@ -1485,6 +1498,18 @@ export function App() {
     sidebarSurface,
     workflowEntries,
   ]);
+
+  useEffect(() => {
+    if (!workerStatus?.workers.some((worker) => worker.kind === selectedWorkerKind)) {
+      setSelectedWorkerKind(null);
+    }
+  }, [selectedWorkerKind, workerStatus]);
+
+  useEffect(() => {
+    if (sidebarSurface !== 'workers') return;
+    if (selectedWorkerKind && workerStatus?.workers.some((worker) => worker.kind === selectedWorkerKind)) return;
+    setSelectedWorkerKind(workerStatus?.workers[0]?.kind ?? null);
+  }, [selectedWorkerKind, sidebarSurface, workerStatus]);
   useEffect(() => {
     if (viewMode !== 'dag' || sidebarSurface === 'home' || displayedSelectedWorkflowGraph === null) {
       return;
@@ -2071,8 +2096,6 @@ export function App() {
       console.error('Failed to delete workflows:', err);
     }
   }, [clearTasks, invoker]);
-
-  // True when all tasks have reached a terminal state.
   const allSettled = useMemo(() => {
     if (tasks.size === 0) return false;
     for (const task of tasks.values()) {
@@ -2088,7 +2111,8 @@ export function App() {
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
   const autoCollapseInspector = sidebarSurface !== 'home' && viewportWidth < 1440;
   const effectiveInspectorCollapsed = inspectorCollapsed || (autoCollapseInspector && !inspectorManualOpen);
-  const showInspectorPlaceholder = !showEmptyGraphTutorial && !selectedTask && !selectedWorkflow && !(viewMode === 'actionGraph' && selectedActionNode);
+  const showWorkerDetailsPanel = viewMode === 'queue' && sidebarSurface === 'workers';
+  const showInspectorPlaceholder = !showEmptyGraphTutorial && !showWorkerDetailsPanel && !selectedTask && !selectedWorkflow && !(viewMode === 'actionGraph' && selectedActionNode);
 
   useEffect(() => {
     if (sidebarSurface === 'home' || !autoCollapseInspector) {
@@ -2130,7 +2154,13 @@ export function App() {
       setViewMode('dag');
       return;
     }
-    setSidebarSurface('home');
+    if (nextView === 'queue') {
+      setSidebarSurface('workers');
+      setInspectorCollapsed(true);
+      setInspectorManualOpen(false);
+    } else {
+      setSidebarSurface('home');
+    }
     setViewMode(nextView);
   }, [selectedActionNodeId]);
 
@@ -2146,6 +2176,15 @@ export function App() {
 
   const handleSelectSidebarSurface = useCallback((nextSurface: SidebarSurface) => {
     setGraphActionsMenuOpen(false);
+    if (nextSurface === 'workers') {
+      setSidebarSurface('workers');
+      setSidebarCollapsed(true);
+      setInspectorCollapsed(true);
+      setInspectorManualOpen(false);
+      setStatusFilters(new Set<WorkflowStatus>());
+      setViewMode('queue');
+      return;
+    }
     setViewMode('dag');
     if (nextSurface === 'home') {
       setSidebarSurface('home');
@@ -2593,10 +2632,14 @@ export function App() {
       {viewMode === 'queue' ? (
         <QueueView
           tasks={tasks}
-          queueStatus={queueStatus}
+          workerStatus={workerStatus}
+          readOnly={runtimeStatus?.readOnly === true}
+          onStartWorker={handleStartWorker}
+          onStopWorker={handleStopWorker}
           onTaskClick={handleTaskClick}
-          onCancel={handleCancelTask}
           selectedTaskId={selectedTaskId}
+          selectedWorkerKind={selectedWorkerKind}
+          onSelectWorker={setSelectedWorkerKind}
         />
       ) : viewMode === 'history' ? (
         <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
@@ -2986,6 +3029,7 @@ export function App() {
           workflows={workflows}
           tasks={tasks}
           queueStatus={queueStatus}
+          workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}
           selectedSurface={sidebarSurface}
           collapsed={sidebarCollapsed}
@@ -3025,6 +3069,14 @@ export function App() {
                 <EmptyGraphTutorial />
               ) : showInspectorPlaceholder ? (
                 <EmptyInspectorPlaceholder />
+              ) : showWorkerDetailsPanel ? (
+                <WorkerDetailsPanel
+                  worker={selectedWorker}
+                  tasks={tasks}
+                  collapsed={effectiveInspectorCollapsed}
+                  onToggleCollapsed={handleToggleInspectorCollapsed}
+                  onTaskClick={handleTaskClick}
+                />
               ) : (
                 <WorkflowInspector
                   workflow={displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -506,12 +506,22 @@ export function App() {
   const queueStatus = useQueueStatus();
   const [workerStatus, refreshWorkerStatus] = useWorkerStatus();
   const handleStartWorker = useCallback(async (kind: string) => {
-    await invoker.startWorker(kind);
-    await refreshWorkerStatus();
+    if (!invoker) return;
+    try {
+      await invoker.startWorker(kind);
+      await refreshWorkerStatus();
+    } catch (err) {
+      console.error('Failed to start worker:', err);
+    }
   }, [invoker, refreshWorkerStatus]);
   const handleStopWorker = useCallback(async (kind: string) => {
-    await invoker.stopWorker(kind);
-    await refreshWorkerStatus();
+    if (!invoker) return;
+    try {
+      await invoker.stopWorker(kind);
+      await refreshWorkerStatus();
+    } catch (err) {
+      console.error('Failed to stop worker:', err);
+    }
   }, [invoker, refreshWorkerStatus]);
   const runningTaskIds = useMemo(
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -47,6 +47,34 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
     expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
+  });
+  it('opens worker status from the left panel', async () => {
+    mock.setWorkerStatus({
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      workers: [
+        {
+          kind: 'pr-status',
+          note: 'PR status',
+          lifecycle: 'running',
+          policy: 'enabled',
+          autoStarts: true,
+          startable: false,
+          stoppable: true,
+          runtimeKind: 'pr-status',
+          recentActions: [],
+        },
+      ],
+    });
+
+    render(<App />);
+
+    const workersButton = await screen.findByTestId('sidebar-workers');
+    expect(workersButton).toHaveTextContent('Workers');
+    fireEvent.click(workersButton);
+
+    expect(await screen.findByTestId('worker-activity-card')).toBeInTheDocument();
+    expect(screen.getByText('PR status')).toBeInTheDocument();
   });
   it('renders the Apple-like source list without manual plan loading', async () => {
     render(<App />);
@@ -57,6 +85,7 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
     expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
+    expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
   });
 

--- a/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-draft-clear-repro.test.tsx
@@ -29,6 +29,13 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
     mock.cleanup();
   });
 
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
   it('dismisses the ready bar after a successful submit', async () => {
     const draftReply: InAppPlanningChatResponse = {
       ok: true,
@@ -40,17 +47,18 @@ describe('CodeRabbit PR #3050 — draft state cleared after submit', () => {
     mock.api.planningChatSend = vi.fn(async () => draftReply);
 
     render(<App />);
-    await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
-    });
+    await openPlanningTerminal();
 
     fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'draft the full plan' } });
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
 
     await screen.findByTestId('invoker-terminal-ready-bar');
     fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+    await waitFor(() => {
+      expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
+    });
+    await openPlanningTerminal();
     await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
-
     // The submit succeeded; the ready bar must be gone so it cannot resubmit the same session.
     await waitFor(() => {
       expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-ime-composition-repro.test.tsx
@@ -28,11 +28,16 @@ describe('CodeRabbit PR #3050 — Enter-to-submit ignores IME composition', () =
     mock.cleanup();
   });
 
-  it('does not submit while an IME composition is in progress', async () => {
-    render(<App />);
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });
+  }
+
+  it('does not submit while an IME composition is in progress', async () => {
+    render(<App />);
+    await openPlanningTerminal();
 
     const input = screen.getByTestId('invoker-terminal-input');
     fireEvent.change(input, { target: { value: 'こんにちは' } });

--- a/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
+++ b/packages/ui/src/__tests__/coderabbit-pr3050-run-guard-repro.test.tsx
@@ -12,12 +12,9 @@ vi.mock('@xyflow/react', async () => {
 // Dynamic import is required so App sees the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
 
-// CodeRabbit PR #3050 (discussion r3523490880): the "run" text command called
-// handleStart() directly, guarded only by `!hasLoadedPlan`. Unlike the Start
-// button (`showStart = hasLoadedPlan && !hasStarted`) it omitted the `hasStarted`
-// check, so typing "run" again after a run already started re-invoked
-// invoker.start(). This repro starts a run, then types "run" again and asserts
-// start() is not called a second time. Buggy code fires start() twice -> FAIL.
+// Submitted planning sessions are read-only. Starting work goes through the
+// graph Run button, and once a run starts the button disappears so it cannot
+// call invoker.start() a second time.
 describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () => {
   let mock: MockInvoker;
 
@@ -35,6 +32,13 @@ describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () 
     fireEvent.submit(screen.getByTestId('invoker-terminal-input').closest('form')!);
   }
 
+  async function openPlanningTerminal() {
+    fireEvent.click(await screen.findByTestId('sidebar-planning'));
+    await waitFor(() => {
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
+    });
+  }
+
   it('does not re-invoke start after a run has already started', async () => {
     const draftReply: InAppPlanningChatResponse = {
       ok: true,
@@ -46,24 +50,26 @@ describe('CodeRabbit PR #3050 — "run" respects the already-started guard', () 
     mock.api.planningChatSend = vi.fn(async () => draftReply);
 
     render(<App />);
-    await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
-    });
+    await openPlanningTerminal();
 
     submitPlanningText('draft the full plan');
     await screen.findByTestId('invoker-terminal-ready-bar');
     fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
+    await waitFor(() => {
+      expect(mock.api.planningChatSubmit).toHaveBeenCalledTimes(1);
+    });
+    await openPlanningTerminal();
     await screen.findByText('Plan "Mock Plan" submitted to Invoker. Review it, then Run.');
-
-    submitPlanningText('run');
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    fireEvent.click(await screen.findByTestId('rail-start'));
     await waitFor(() => {
       expect(mock.api.start).toHaveBeenCalledTimes(1);
-      expect(screen.getByText('Run started.')).toBeInTheDocument();
     });
+    expect(screen.queryByTestId('rail-start')).not.toBeInTheDocument();
 
-    // Run is already in progress; a second "run" must be rejected, not fire start again.
-    submitPlanningText('run');
-    await screen.findByText('Run already started.');
+    await openPlanningTerminal();
+    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    expect(screen.getByTestId('invoker-terminal-harness')).toBeDisabled();
     expect(mock.api.start).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -176,7 +176,7 @@ export function createMockInvoker(
       arch: 'x64',
       appVersion: '0.0.1',
       isPackaged: false,
-      tools: [],
+      tools: [{ id: 'codex', name: 'Codex', required: false, installed: true, installHint: 'Installed' }],
       bundledSkills: {
         available: false,
         promptRecommended: false,

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -16,7 +16,7 @@ import type {
   TaskConfig,
   TaskExecution,
 } from '../../types.js';
-import type { ActionGraphResponse, RuntimeStatus, TerminalOutputEvent, WorkflowMutationAcceptedResult } from '@invoker/contracts';
+import type { ActionGraphResponse, RuntimeStatus, TerminalOutputEvent, WorkerStatusEntry, WorkerStatusSnapshot, WorkflowMutationAcceptedResult } from '@invoker/contracts';
 
 export interface MockInvoker {
   /** The mock InvokerAPI object installed on window.invoker. */
@@ -35,6 +35,8 @@ export interface MockInvoker {
   setActionGraph: (response: ActionGraphResponse) => void;
   /** Replace the runtime status returned by getRuntimeStatus. */
   setRuntimeStatus: (status: RuntimeStatus) => void;
+  /** Replace the worker status snapshot returned by getWorkerStatus. */
+  setWorkerStatus: (status: WorkerStatusSnapshot) => void;
   /** Install the mock on window.invoker. */
   install: () => void;
   /** Remove window.invoker. */
@@ -60,6 +62,10 @@ export function createMockInvoker(
     ownerMode: true,
     readOnly: false,
     mode: 'local-owner',
+  };
+  let workerStatus: WorkerStatusSnapshot = {
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    workers: [],
   };
 
   const accepted = (channel: string, workflowId = 'wf-1'): WorkflowMutationAcceptedResult => ({
@@ -265,6 +271,15 @@ export function createMockInvoker(
       running: [],
       queued: [],
     })),
+    getWorkerStatus: vi.fn(async () => workerStatus),
+    startWorker: vi.fn(async (kind: string) => {
+      const row = workerStatus.workers.find((worker) => worker.kind === kind) ?? makeMockWorkerStatusEntry(kind);
+      return row;
+    }),
+    stopWorker: vi.fn(async (kind: string) => {
+      const row = workerStatus.workers.find((worker) => worker.kind === kind) ?? makeMockWorkerStatusEntry(kind);
+      return row;
+    }),
     getActionGraph: vi.fn(async () => actionGraphSnapshot),
     getClaudeSession: vi.fn(async () => null),
     getAgentSession: vi.fn(async () => null),
@@ -293,6 +308,9 @@ export function createMockInvoker(
   }
   function setRuntimeStatus(status: RuntimeStatus) {
     runtimeStatus = status;
+  }
+  function setWorkerStatus(status: WorkerStatusSnapshot) {
+    workerStatus = status;
   }
 
 
@@ -335,12 +353,26 @@ export function createMockInvoker(
     setTasks,
     setActionGraph,
     setRuntimeStatus,
+    setWorkerStatus,
     fireDelta,
     fireGraphEvent,
     fireWorkflowsChanged,
     fireTerminalOutput,
     install,
     cleanup,
+  };
+}
+
+function makeMockWorkerStatusEntry(kind: string): WorkerStatusEntry {
+  return {
+    kind,
+    note: '',
+    lifecycle: 'stopped',
+    policy: 'unknown',
+    autoStarts: false,
+    startable: false,
+    stoppable: false,
+    recentActions: [],
   };
 }
 

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -1,34 +1,87 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { QueueView } from '../components/QueueView.js';
 import { makeUITask } from './helpers/mock-invoker.js';
-import type { QueueStatus, TaskState } from '../types.js';
+import type { TaskState, WorkerActionSummary, WorkerStatusEntry, WorkerStatusSnapshot } from '../types.js';
 
 describe('QueueView', () => {
   const onTaskClick = vi.fn();
-  const onCancel = vi.fn();
-  const EMPTY_QUEUE_STATUS: QueueStatus = {
-    maxConcurrency: 0,
-    runningCount: 0,
-    running: [],
-    queued: [],
+  const onStartWorker = vi.fn();
+  const onStopWorker = vi.fn();
+  const onSelectWorker = vi.fn();
+
+  const EMPTY_WORKER_STATUS: WorkerStatusSnapshot = {
+    generatedAt: '2026-01-01T00:00:00.000Z',
+    workers: [],
   };
 
-  function renderQueueView(tasks: Map<string, TaskState>, queueStatus: QueueStatus, selectedTaskId: string | null = null) {
+  function makeWorkerAction(overrides: Partial<WorkerActionSummary> = {}): WorkerActionSummary {
+    return {
+      id: 'action-1',
+      workerKind: 'autofix',
+      actionType: 'fix-with-agent',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/fix-target',
+      subjectType: 'task',
+      subjectId: 'wf-1/fix-target',
+      externalKey: 'wf-1/fix-target',
+      status: 'running',
+      attemptCount: 1,
+      summary: 'Fix running',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  function makeWorker(overrides: Partial<WorkerStatusEntry> = {}): WorkerStatusEntry {
+    return {
+      kind: 'autofix',
+      note: 'Auto-fixes failed tasks.',
+      lifecycle: 'running',
+      policy: 'enabled',
+      autoStarts: true,
+      startable: false,
+      stoppable: true,
+      recentActions: [],
+      ...overrides,
+    };
+  }
+
+  function makeWorkerStatus(workers: WorkerStatusSnapshot['workers']): WorkerStatusSnapshot {
+    return {
+      generatedAt: '2026-01-01T00:00:00.000Z',
+      workers,
+    };
+  }
+
+  function renderQueueView(
+    tasks: Map<string, TaskState>,
+    workerStatus: WorkerStatusSnapshot = EMPTY_WORKER_STATUS,
+    selectedTaskId: string | null = null,
+    readOnly = false,
+    selectedWorkerKind: string | null = null,
+  ) {
     render(
       <QueueView
         tasks={tasks}
-        queueStatus={queueStatus}
+        workerStatus={workerStatus}
+        readOnly={readOnly}
+        onStartWorker={onStartWorker}
+        onStopWorker={onStopWorker}
         onTaskClick={onTaskClick}
-        onCancel={onCancel}
         selectedTaskId={selectedTaskId}
+        selectedWorkerKind={selectedWorkerKind}
+        onSelectWorker={onSelectWorker}
       />,
     );
   }
 
   beforeEach(() => {
     onTaskClick.mockReset();
-    onCancel.mockReset();
+    onStartWorker.mockReset();
+    onStopWorker.mockReset();
+    onSelectWorker.mockReset();
     vi.stubGlobal('confirm', vi.fn(() => true));
   });
 
@@ -36,424 +89,351 @@ describe('QueueView', () => {
     vi.unstubAllGlobals();
   });
 
-  it('renders action queue in running-then-queued order and separates backlog', () => {
-    const runningTask = makeUITask({
-      id: 'wf-1/running-task',
+  it('shows only active work recorded by worker processes', () => {
+    const targetTask = makeUITask({
+      id: 'wf-1/fix-target',
+      status: 'fixing_with_ai',
+      description: 'needs fix',
+    });
+    const randomRunningTask = makeUITask({
+      id: 'wf-1/random-runner',
       status: 'running',
-      description: 'running task',
-      execution: { phase: 'executing' },
+      description: 'normal scheduler work',
     });
-    const queuedTask = makeUITask({
-      id: 'wf-1/queued-task',
-      status: 'pending',
-      description: 'queued task',
-    });
-    const blockedTask = makeUITask({
-      id: 'wf-1/pending-task',
-      status: 'blocked',
-      description: 'pending task',
-      dependencies: ['wf-1/running-task'],
-    });
-    const tasks = new Map<string, TaskState>([
-      [runningTask.id, runningTask],
-      [queuedTask.id, queuedTask],
-      [blockedTask.id, blockedTask],
-    ]);
-    const queueStatus: QueueStatus = {
-      maxConcurrency: 6,
-      runningCount: 1,
-      running: [{ taskId: runningTask.id, description: runningTask.description }],
-      queued: [{ taskId: queuedTask.id, priority: 0, description: queuedTask.description }],
-    };
-
-    renderQueueView(tasks, queueStatus);
-
-    expect(screen.getByText('Action Queue (2)')).toBeInTheDocument();
-    expect(screen.getByText('Backlog (1)')).toBeInTheDocument();
-    expect(screen.getByText('#1')).toBeInTheDocument();
-    expect(screen.getByText('#2')).toBeInTheDocument();
-    expect(screen.getByText('Running')).toBeInTheDocument();
-    expect(screen.getByText('Pending')).toBeInTheDocument();
-    expect(screen.getByText('Running').closest('span')?.className).toContain('border-');
-    expect(screen.getByText('Pending').closest('span')?.className).toContain('border-');
-    expect(screen.getByText('phase: Executing')).toBeInTheDocument();
-    expect(screen.queryByText(/priority:/)).not.toBeInTheDocument();
-    expect(screen.getByText('deps: running-task')).toBeInTheDocument();
-    expect(screen.getByText('Blocked')).toBeInTheDocument();
-  });
-
-  it('renders queue-running launch tasks as Assigning rows', () => {
-    const assigningTask = makeUITask({
-      id: 'wf-1/assigning-task',
-      status: 'pending',
-      description: 'assigning task',
-      execution: { phase: 'launching', selectedAttemptId: 'wf-1/assigning-task-a1' },
-    });
-    const tasks = new Map<string, TaskState>([[assigningTask.id, assigningTask]]);
-    const queueStatus: QueueStatus = {
-      maxConcurrency: 6,
-      runningCount: 1,
-      running: [{ taskId: assigningTask.id, description: assigningTask.description }],
-      queued: [],
-    };
-
-    renderQueueView(tasks, queueStatus);
-
-    expect(screen.getByText('Active 1 / 6')).toBeInTheDocument();
-    expect(screen.getByText('Assigning 1 · Running 0')).toBeInTheDocument();
-    expect(screen.getByText('Assigning')).toBeInTheDocument();
-    expect(screen.queryByText('phase: Assigning')).not.toBeInTheDocument();
-    const row = screen.getByText('assigning-task').closest('[data-row-id]');
-    expect(row).not.toBeNull();
-    expect(row).not.toHaveTextContent('Pending');
-  });
-
-  it('supports click-through and cancel actions in queue rows', () => {
-    const runningTask = makeUITask({
-      id: 'wf-1/run-all-fixture-tests',
-      status: 'running',
-      description: 'failing task',
-      execution: { phase: 'executing' },
-    });
-    const queuedTask = makeUITask({
-      id: 'wf-2/another-task',
-      status: 'pending',
-      description: 'another task',
-    });
-    const tasks = new Map<string, TaskState>([
-      [runningTask.id, runningTask],
-      [queuedTask.id, queuedTask],
-    ]);
-    const queueStatus: QueueStatus = {
-      maxConcurrency: 6,
-      runningCount: 1,
-      running: [{ taskId: runningTask.id, description: runningTask.description }],
-      queued: [{ taskId: queuedTask.id, priority: 1, description: queuedTask.description }],
-    };
-
-    renderQueueView(tasks, queueStatus);
-
-    fireEvent.click(screen.getByText('run-all-fixture-tests'));
-    expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: runningTask.id }));
-
-    fireEvent.click(screen.getByLabelText('Cancel run-all-fixture-tests'));
-    expect(onCancel).toHaveBeenCalledWith(runningTask.id);
-    expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('run-all-fixture-tests'));
-    expect(window.confirm).not.toHaveBeenCalledWith(expect.stringContaining('wf-1/'));
-  });
-
-  it('renders merge gate ids with a stable label', () => {
     const mergeGateTask = makeUITask({
-      id: '__merge__wf-123',
+      id: '__merge__wf-1',
       status: 'blocked',
       description: 'Workflow gate for queued merge',
-      dependencies: ['wf-1/build'],
-    });
-    const tasks = new Map<string, TaskState>([[mergeGateTask.id, mergeGateTask]]);
-
-    renderQueueView(tasks, EMPTY_QUEUE_STATUS);
-
-    expect(screen.getByText('merge gate')).toBeInTheDocument();
-    expect(screen.queryByText('__merge__wf-123')).not.toBeInTheDocument();
-  });
-
-  it('places manual-action tasks in Action Queue with canonical labels', () => {
-    const fixingTask = makeUITask({
-      id: 'wf-1/fixing-task',
-      status: 'fixing_with_ai',
-      description: 'AI fix in progress',
-    });
-    const needsInputTask = makeUITask({
-      id: 'wf-1/input-task',
-      status: 'needs_input',
-      description: 'waiting for input',
-    });
-    const reviewTask = makeUITask({
-      id: 'wf-1/review-task',
-      status: 'review_ready',
-      description: 'ready for review',
-    });
-    const approvalTask = makeUITask({
-      id: 'wf-1/approval-task',
-      status: 'awaiting_approval',
-      description: 'needs approval',
-    });
-    const blockedTask = makeUITask({
-      id: 'wf-1/blocked-task',
-      status: 'blocked',
-      description: 'blocked by something',
-      dependencies: ['wf-1/fixing-task'],
     });
     const tasks = new Map<string, TaskState>([
-      [fixingTask.id, fixingTask],
-      [needsInputTask.id, needsInputTask],
-      [reviewTask.id, reviewTask],
-      [approvalTask.id, approvalTask],
-      [blockedTask.id, blockedTask],
+      [targetTask.id, targetTask],
+      [randomRunningTask.id, randomRunningTask],
+      [mergeGateTask.id, mergeGateTask],
     ]);
 
-    renderQueueView(tasks, EMPTY_QUEUE_STATUS);
+    renderQueueView(
+      tasks,
+      makeWorkerStatus([
+        makeWorker({
+          recentActions: [
+            makeWorkerAction({ taskId: targetTask.id, subjectId: targetTask.id, externalKey: targetTask.id }),
+            makeWorkerAction({ id: 'completed-action', status: 'completed', taskId: randomRunningTask.id }),
+          ],
+        }),
+      ]),
+    );
 
-    expect(screen.getByText('Action Queue (4)')).toBeInTheDocument();
-    expect(screen.getByText('Backlog (1)')).toBeInTheDocument();
-    expect(screen.getByText('Fixing With AI')).toBeInTheDocument();
-    expect(screen.getByText('Needs Input')).toBeInTheDocument();
-    expect(screen.getByText('Review Ready')).toBeInTheDocument();
-    expect(screen.getByText('Awaiting Approval')).toBeInTheDocument();
-    expect(screen.getByText('blocked by something')).toBeInTheDocument();
+    expect(screen.getByText('Worker Actions (1)')).toBeInTheDocument();
+    expect(screen.getByText('Only work started by a worker process appears here.')).toBeInTheDocument();
+    expect(screen.getByText('Fix With Agent · needs fix')).toBeInTheDocument();
+    expect(screen.queryByText('normal scheduler work')).not.toBeInTheDocument();
+    expect(screen.queryByText('Workflow gate for queued merge')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Backlog/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Action Queue/)).not.toBeInTheDocument();
   });
 
-  it('shows pending tasks in Action Queue when scheduler-queued with canonical Pending label', () => {
-    const pendingTask = makeUITask({
-      id: 'wf-1/pending-task',
-      status: 'pending',
-      description: 'waiting to run',
-    });
-    const tasks = new Map<string, TaskState>([[pendingTask.id, pendingTask]]);
-    const queueStatus: QueueStatus = {
-      maxConcurrency: 6,
-      runningCount: 0,
-      running: [],
-      queued: [{ taskId: pendingTask.id, priority: 5, description: pendingTask.description }],
-    };
+  it('opens the affected task from a worker action row', () => {
+    const task = makeUITask({ id: 'wf-1/fix-target', status: 'failed', description: 'needs fix' });
+    renderQueueView(
+      new Map([[task.id, task]]),
+      makeWorkerStatus([
+        makeWorker({ recentActions: [makeWorkerAction({ taskId: task.id, subjectId: task.id })] }),
+      ]),
+    );
 
-    renderQueueView(tasks, queueStatus);
+    fireEvent.click(screen.getByText('Fix With Agent · needs fix'));
 
-    expect(screen.getByText('Action Queue (1)')).toBeInTheDocument();
-    expect(screen.getByText('Backlog (0)')).toBeInTheDocument();
-    expect(screen.getByText('Pending')).toBeInTheDocument();
-    expect(screen.queryByText(/priority:/)).not.toBeInTheDocument();
+    expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: task.id }));
   });
 
-  describe('relationship expander', () => {
-    function setupRelationshipScenario() {
-      const taskA = makeUITask({
-        id: 'wf-1/task-a',
-        status: 'running',
-        description: 'first task',
-        dependencies: [],
-      });
-      const taskB = makeUITask({
-        id: 'wf-1/task-b',
-        status: 'blocked',
-        description: 'second task',
-        dependencies: ['wf-1/task-a'],
-      });
-      const taskC = makeUITask({
-        id: 'wf-1/task-c',
-        status: 'blocked',
-        description: 'third task',
-        dependencies: ['wf-1/task-b'],
-      });
-      const tasks = new Map<string, TaskState>([
-        [taskA.id, taskA],
-        [taskB.id, taskB],
-        [taskC.id, taskC],
-      ]);
-      const queueStatus: QueueStatus = {
-        maxConcurrency: 6,
-        runningCount: 1,
-        running: [{ taskId: taskA.id, description: taskA.description }],
-        queued: [],
-      };
+  it('keeps worker actions and worker processes in independent scroll panes', () => {
+    const task = makeUITask({ id: 'wf-1/action-task', status: 'running', description: 'running task' });
+    renderQueueView(
+      new Map([[task.id, task]]),
+      makeWorkerStatus([
+        makeWorker({
+          kind: 'autofix',
+          recentActions: [makeWorkerAction({ taskId: task.id, subjectId: task.id })],
+        }),
+      ]),
+    );
 
-      return { tasks, taskA, taskB, taskC, queueStatus };
-    }
+    const actionSection = screen.getByTestId('action-queue-section');
+    const actionList = screen.getByTestId('worker-action-list');
+    const workersSection = screen.getByTestId('worker-processes-section');
 
-    it('relationships are collapsed by default', () => {
-      const { tasks, queueStatus } = setupRelationshipScenario();
-
-      renderQueueView(tasks, queueStatus);
-
-      expect(screen.getByTestId('queue-rels-toggle-action-wf-1/task-a')).toBeInTheDocument();
-      expect(screen.getByTestId('queue-rels-toggle-backlog-wf-1/task-b')).toBeInTheDocument();
-      expect(screen.getByTestId('queue-rels-toggle-backlog-wf-1/task-c')).toBeInTheDocument();
-
-      // But no upstream/downstream labels should be visible (collapsed)
-      expect(screen.queryByText('upstream:')).not.toBeInTheDocument();
-      expect(screen.queryByText('downstream:')).not.toBeInTheDocument();
-    });
-
-    it('clicking expander toggles relationship section per row', () => {
-      const { tasks, queueStatus } = setupRelationshipScenario();
-
-      renderQueueView(tasks, queueStatus);
-
-      const expandButtons = screen.getAllByLabelText('Expand relationships');
-      fireEvent.click(expandButtons[0]);
-
-      const relsSection = screen.getByTestId('rels-wf-1/task-a');
-      expect(relsSection).toBeInTheDocument();
-      expect(relsSection.textContent).toContain('downstream:');
-      expect(relsSection.textContent).toContain('task-b');
-
-      const collapseButton = screen.getByLabelText('Collapse relationships');
-      fireEvent.click(collapseButton);
-      expect(screen.queryByTestId('rels-wf-1/task-a')).not.toBeInTheDocument();
-    });
-
-    it('shows both upstream and downstream in expanded row', () => {
-      const { tasks, queueStatus } = setupRelationshipScenario();
-
-      renderQueueView(tasks, queueStatus);
-
-      const expandButtons = screen.getAllByLabelText('Expand relationships');
-      fireEvent.click(expandButtons[1]);
-
-      expect(screen.getByText('upstream:')).toBeInTheDocument();
-      expect(screen.getByText('downstream:')).toBeInTheDocument();
-      expect(screen.getByTestId('rels-wf-1/task-b')).toBeInTheDocument();
-    });
-
-    it('clicking a related task chip selects and navigates to that task', () => {
-      const { tasks, queueStatus } = setupRelationshipScenario();
-
-      renderQueueView(tasks, queueStatus);
-
-      const expandButtons = screen.getAllByLabelText('Expand relationships');
-      fireEvent.click(expandButtons[0]);
-
-      const relsSection = screen.getByTestId('rels-wf-1/task-a');
-      const taskBChip = relsSection.querySelector('button');
-      expect(taskBChip).not.toBeNull();
-      fireEvent.click(taskBChip!);
-
-      expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: 'wf-1/task-b' }));
-    });
-
-    it('does not show rels button for tasks with no relationships', () => {
-      const loneTask = makeUITask({
-        id: 'wf-1/lone-task',
-        status: 'pending',
-        description: 'no deps',
-        dependencies: [],
-      });
-      const tasks = new Map<string, TaskState>([[loneTask.id, loneTask]]);
-      const queueStatus: QueueStatus = {
-        maxConcurrency: 6,
-        runningCount: 0,
-        running: [],
-        queued: [{ taskId: loneTask.id, priority: 0, description: loneTask.description }],
-      };
-
-      renderQueueView(tasks, queueStatus);
-
-      expect(screen.queryByTestId('queue-rels-toggle-action-wf-1/lone-task')).not.toBeInTheDocument();
-      expect(screen.queryByTestId('queue-rels-toggle-backlog-wf-1/lone-task')).not.toBeInTheDocument();
-      expect(screen.queryByLabelText('Expand relationships')).not.toBeInTheDocument();
-    });
+    expect(actionSection.compareDocumentPosition(workersSection) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(actionSection.className).toContain('overflow-hidden');
+    expect(actionList.className).toContain('overflow-y-auto');
+    expect(workersSection.className).toContain('overflow-hidden');
+    expect(within(actionSection).getByText('Worker Actions (1)')).toBeInTheDocument();
+    expect(within(workersSection).getByText('Worker processes (1)')).toBeInTheDocument();
+    expect(within(workersSection).getByTestId('worker-row-autofix')).toBeInTheDocument();
+    expect(within(actionSection).queryByTestId('worker-row-autofix')).not.toBeInTheDocument();
   });
 
-  describe('integrated queue hardening', () => {
-    it('canonical labels, expanded rels, and compact cancel coexist in a composed queue', () => {
-      // Scenario: running task with a downstream blocked dep, plus a manual-action task.
-      // Exercises all three prior-workflow features together:
-      // 1. Canonical status labels (Running, Fixing With AI, Blocked)
-      // 2. Relationship expanders (upstream/downstream chips)
-      // 3. Compact × cancel control on actionable rows
-      const runningTask = makeUITask({
-        id: 'wf-1/build',
-        status: 'running',
-        description: 'Build the project',
-        execution: { phase: 'executing' },
-        dependencies: [],
-      });
-      const fixingTask = makeUITask({
-        id: 'wf-1/lint',
-        status: 'fixing_with_ai',
-        description: 'Lint with AI fix',
-        dependencies: [],
-      });
-      const blockedTask = makeUITask({
-        id: 'wf-1/deploy',
-        status: 'blocked',
-        description: 'Deploy after build',
-        dependencies: ['wf-1/build'],
-      });
+  it('shows an empty worker-action state without showing unrelated tasks', () => {
+    const unrelatedTask = makeUITask({ id: 'wf-1/random-task', status: 'running', description: 'not worker owned' });
+    renderQueueView(
+      new Map([[unrelatedTask.id, unrelatedTask]]),
+      makeWorkerStatus([
+        makeWorker({ kind: 'pr-status', note: 'Checks pull request status.', recentActions: [] }),
+      ]),
+    );
 
-      const tasks = new Map<string, TaskState>([
-        [runningTask.id, runningTask],
-        [fixingTask.id, fixingTask],
-        [blockedTask.id, blockedTask],
-      ]);
-      const queueStatus: QueueStatus = {
-        maxConcurrency: 4,
-        runningCount: 1,
-        running: [{ taskId: runningTask.id, description: runningTask.description }],
-        queued: [],
-      };
+    expect(screen.getByText('Worker Actions (0)')).toBeInTheDocument();
+    expect(screen.getByText('No worker action is running.')).toBeInTheDocument();
+    expect(screen.queryByText('not worker owned')).not.toBeInTheDocument();
+    expect(screen.getByText('PR status')).toBeInTheDocument();
+  });
 
-      renderQueueView(tasks, queueStatus);
+  it('renders missing worker action targets without linking a random task', () => {
+    renderQueueView(
+      new Map(),
+      makeWorkerStatus([
+        makeWorker({
+          recentActions: [makeWorkerAction({ taskId: 'wf-1/missing-target', subjectId: 'wf-1/missing-target' })],
+        }),
+      ]),
+    );
 
-      expect(screen.getByText('Action Queue (2)')).toBeInTheDocument();
-      expect(screen.getByText('Backlog (1)')).toBeInTheDocument();
-      expect(screen.getByText('Running')).toBeInTheDocument();
-      expect(screen.getByText('Fixing With AI')).toBeInTheDocument();
-      expect(screen.getByText('Blocked')).toBeInTheDocument();
-      expect(screen.getByText('phase: Executing')).toBeInTheDocument();
+    expect(screen.getByText('Fix With Agent · missing-target')).toBeInTheDocument();
+    expect(screen.getByText('Target task is not loaded.')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('Fix With Agent · missing-target'));
+    expect(onTaskClick).not.toHaveBeenCalled();
+  });
 
-      const expandButtons = screen.getAllByLabelText('Expand relationships');
-      expect(expandButtons.length).toBe(2);
+  it('shows all registered workers in snapshot order', () => {
+    renderQueueView(
+      new Map(),
+      makeWorkerStatus([
+        makeWorker({
+          kind: 'autofix',
+          note: 'Auto-fixes failed tasks.',
+          lifecycle: 'stopped',
+          autoStarts: false,
+          startable: true,
+          stoppable: false,
+        }),
+        makeWorker({
+          kind: 'pr-status',
+          note: 'Checks pull request status.',
+          lifecycle: 'running',
+          autoStarts: true,
+          startable: false,
+          stoppable: true,
+        }),
+        makeWorker({
+          kind: 'ci-failure',
+          note: 'Repairs failed CI.',
+          lifecycle: 'running',
+          autoStarts: true,
+          startable: false,
+          stoppable: true,
+        }),
+      ]),
+    );
 
-      fireEvent.click(expandButtons[0]);
-      const buildRels = screen.getByTestId('rels-wf-1/build');
-      expect(buildRels.textContent).toContain('downstream:');
-      expect(buildRels.textContent).toContain('deploy');
+    const rows = screen.getAllByTestId(/^worker-row-/);
+    expect(rows.map((row) => row.getAttribute('data-testid'))).toEqual([
+      'worker-row-autofix',
+      'worker-row-pr-status',
+      'worker-row-ci-failure',
+    ]);
+    expect(screen.getByText('Worker processes (3)')).toBeInTheDocument();
+    expect(screen.getByText('Autofix')).toBeInTheDocument();
+    expect(screen.getByText('PR status')).toBeInTheDocument();
+    expect(screen.getByText('CI failure repair')).toBeInTheDocument();
+  });
 
-      fireEvent.click(expandButtons[1]);
-      const deployRels = screen.getByTestId('rels-wf-1/deploy');
-      expect(deployRels.textContent).toContain('upstream:');
-      expect(deployRels.textContent).toContain('build');
+  it('shows disabled Autofix and CI rows when policy is disabled', () => {
+    renderQueueView(
+      new Map(),
+      makeWorkerStatus([
+        makeWorker({
+          kind: 'autofix',
+          lifecycle: 'stopped',
+          policy: 'disabled',
+          policyReason: 'autoFixRetries=0',
+          controlDisabledReason: 'autoFixRetries=0',
+          autoStarts: false,
+          startable: false,
+          stoppable: false,
+        }),
+        makeWorker({
+          kind: 'ci-failure',
+          lifecycle: 'stopped',
+          policy: 'disabled',
+          policyReason: 'autoFixRetries=0',
+          controlDisabledReason: 'autoFixRetries=0',
+          autoStarts: true,
+          startable: false,
+          stoppable: false,
+        }),
+      ]),
+    );
 
-      // 3. Compact cancel controls present on all rows (× with accessible labels)
-      const cancelButtons = screen.getAllByLabelText(/^Cancel /);
-      expect(cancelButtons.length).toBe(3); // 2 action + 1 backlog
+    expect(within(screen.getByTestId('worker-row-autofix')).getByText('Disabled · autoFixRetries=0')).toBeInTheDocument();
+    expect(within(screen.getByTestId('worker-row-ci-failure')).getByText('Disabled · autoFixRetries=0')).toBeInTheDocument();
+    expect(within(screen.getByTestId('worker-row-ci-failure')).getByText('Auto-starts')).toBeInTheDocument();
+  });
 
-      // Click cancel on the running task — confirm uses display-friendly ID
-      fireEvent.click(cancelButtons[0]);
-      expect(window.confirm).toHaveBeenCalledWith(expect.stringContaining('build'));
-      expect(onCancel).toHaveBeenCalledWith(runningTask.id);
+  it('calls start worker for a stopped row', () => {
+    renderQueueView(
+      new Map(),
+      makeWorkerStatus([
+        makeWorker({
+          lifecycle: 'stopped',
+          autoStarts: false,
+          startable: true,
+          stoppable: false,
+        }),
+      ]),
+    );
 
-      const deployChip = buildRels.querySelector('button');
-      expect(deployChip).not.toBeNull();
-      fireEvent.click(deployChip!);
-      expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: 'wf-1/deploy' }));
+    fireEvent.click(within(screen.getByTestId('worker-row-autofix')).getByRole('button', { name: 'Start process' }));
+    expect(onStartWorker).toHaveBeenCalledWith('autofix');
+  });
+
+  it('calls stop worker for a running row', () => {
+    renderQueueView(
+      new Map(),
+      makeWorkerStatus([
+        makeWorker({
+          kind: 'ci-failure',
+          autoStarts: true,
+          startable: false,
+          stoppable: true,
+        }),
+      ]),
+    );
+
+    fireEvent.click(within(screen.getByTestId('worker-row-ci-failure')).getByRole('button', { name: 'Stop process' }));
+    expect(onStopWorker).toHaveBeenCalledWith('ci-failure');
+  });
+
+  it('disables worker controls in read-only mode', () => {
+    renderQueueView(
+      new Map(),
+      makeWorkerStatus([
+        makeWorker({
+          lifecycle: 'stopped',
+          autoStarts: false,
+          startable: true,
+          stoppable: false,
+        }),
+      ]),
+      null,
+      true,
+    );
+
+    const start = within(screen.getByTestId('worker-row-autofix')).getByRole('button', { name: 'Start process' });
+    expect(start).toBeDisabled();
+    expect(start).toHaveAttribute('title', 'Read-only window');
+  });
+
+  it('selects worker rows and keeps action details out of the process list', () => {
+    const task = makeUITask({ id: 'wf-1/fix-target', status: 'failed', description: 'needs fix' });
+    renderQueueView(
+      new Map([[task.id, task]]),
+      makeWorkerStatus([
+        makeWorker({
+          kind: 'ci-failure',
+          recentActions: [makeWorkerAction({
+            workerKind: 'ci-failure',
+            taskId: task.id,
+            subjectId: task.id,
+          })],
+        }),
+      ]),
+      null,
+      false,
+      'ci-failure',
+    );
+
+    const row = screen.getByTestId('worker-row-ci-failure');
+    expect(row.className).toContain('ring-cyan');
+    expect(within(row).getByText('Active work')).toBeInTheDocument();
+    expect(within(row).getByText('Active work: Fix With Agent · Running')).toBeInTheDocument();
+    expect(within(row).queryByText('Last recorded action')).not.toBeInTheDocument();
+    expect(within(row).queryByRole('button', { name: 'Open task: fix-target' })).not.toBeInTheDocument();
+
+    fireEvent.click(row);
+    expect(onSelectWorker).toHaveBeenCalledWith('ci-failure');
+  });
+
+  it('expands relationships only for the affected worker action task', () => {
+    const buildTask = makeUITask({
+      id: 'wf-1/build',
+      status: 'running',
+      description: 'Build the project',
+      dependencies: [],
     });
-
-    it('selection highlight persists on expanded rows', () => {
-      const taskA = makeUITask({
-        id: 'wf-1/task-a',
-        status: 'running',
-        description: 'task a',
-        dependencies: [],
-      });
-      const taskB = makeUITask({
-        id: 'wf-1/task-b',
-        status: 'blocked',
-        description: 'task b',
-        dependencies: ['wf-1/task-a'],
-      });
-      const tasks = new Map<string, TaskState>([
-        [taskA.id, taskA],
-        [taskB.id, taskB],
-      ]);
-      const queueStatus: QueueStatus = {
-        maxConcurrency: 4,
-        runningCount: 1,
-        running: [{ taskId: taskA.id, description: taskA.description }],
-        queued: [],
-      };
-
-      renderQueueView(tasks, queueStatus, 'wf-1/task-a');
-
-      const selectedRow = screen.getByText('task-a').closest('[data-row-id]');
-      expect(selectedRow?.className).toContain('bg-gray-600');
-
-      const expandButtons = screen.getAllByLabelText('Expand relationships');
-      fireEvent.click(expandButtons[0]);
-
-      expect(selectedRow?.className).toContain('bg-gray-600');
-      expect(screen.getByTestId('rels-wf-1/task-a')).toBeInTheDocument();
+    const deployTask = makeUITask({
+      id: 'wf-1/deploy',
+      status: 'blocked',
+      description: 'Deploy after build',
+      dependencies: ['wf-1/build'],
     });
+    const tasks = new Map<string, TaskState>([
+      [buildTask.id, buildTask],
+      [deployTask.id, deployTask],
+    ]);
+
+    renderQueueView(
+      tasks,
+      makeWorkerStatus([
+        makeWorker({ recentActions: [makeWorkerAction({ taskId: buildTask.id, subjectId: buildTask.id })] }),
+      ]),
+    );
+
+    expect(screen.getByTestId('queue-rels-toggle-action-wf-1/build')).toBeInTheDocument();
+    expect(screen.queryByTestId('queue-rels-toggle-backlog-wf-1/deploy')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByLabelText('Expand relationships'));
+
+    const relsSection = screen.getByTestId('rels-wf-1/build');
+    expect(relsSection.textContent).toContain('downstream:');
+    expect(relsSection.textContent).toContain('deploy');
+
+    const deployChip = relsSection.querySelector('button');
+    expect(deployChip).not.toBeNull();
+    fireEvent.click(deployChip!);
+    expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: deployTask.id }));
+  });
+
+  it('selection highlight persists on expanded worker action rows', () => {
+    const buildTask = makeUITask({
+      id: 'wf-1/build',
+      status: 'running',
+      description: 'Build the project',
+      dependencies: [],
+    });
+    const deployTask = makeUITask({
+      id: 'wf-1/deploy',
+      status: 'blocked',
+      description: 'Deploy after build',
+      dependencies: ['wf-1/build'],
+    });
+    const tasks = new Map<string, TaskState>([
+      [buildTask.id, buildTask],
+      [deployTask.id, deployTask],
+    ]);
+
+    renderQueueView(
+      tasks,
+      makeWorkerStatus([
+        makeWorker({ recentActions: [makeWorkerAction({ taskId: buildTask.id, subjectId: buildTask.id })] }),
+      ]),
+      buildTask.id,
+    );
+
+    const selectedRow = screen.getByText('Fix With Agent · Build the project').closest('[data-row-id]');
+    expect(selectedRow?.className).toContain('bg-cyan-950/30');
+
+    fireEvent.click(screen.getByLabelText('Expand relationships'));
+
+    expect(selectedRow?.className).toContain('bg-cyan-950/30');
+    expect(screen.getByTestId('rels-wf-1/build')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -39,7 +39,7 @@ describe('Visual proof snapshots', () => {
     expect(screen.getByTestId('sidebar-workflows')).toHaveTextContent('Workflows');
     expect(screen.getByTestId('sidebar-attention')).toHaveTextContent('Needs Attention');
     expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
-    expect(screen.getByText('Terminal planning and graph details live here.')).toBeInTheDocument();
+    expect(screen.getByText('Describe the change in the terminal to generate a plan.')).toBeInTheDocument();
     expect(screen.getByTestId('rail-settings')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Home' })).not.toBeInTheDocument();
     expect(screen.queryByText('System Setup')).not.toBeInTheDocument();

--- a/packages/ui/src/__tests__/worker-details-panel.test.tsx
+++ b/packages/ui/src/__tests__/worker-details-panel.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { WorkerDetailsPanel } from '../components/WorkerDetailsPanel.js';
+import { makeUITask } from './helpers/mock-invoker.js';
+import type { WorkerActionSummary, WorkerStatusEntry } from '../types.js';
+
+const onToggleCollapsed = vi.fn();
+const onTaskClick = vi.fn();
+
+function makeAction(overrides: Partial<WorkerActionSummary> = {}): WorkerActionSummary {
+  return {
+    id: 'act-1',
+    workerKind: 'ci-failure',
+    actionType: 'fix-with-agent',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/fix-target',
+    subjectType: 'task',
+    subjectId: 'wf-1/fix-target',
+    externalKey: 'wf-1/fix-target',
+    status: 'running',
+    attemptCount: 1,
+    summary: 'Inspecting failed typecheck output.',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeWorker(overrides: Partial<WorkerStatusEntry> = {}): WorkerStatusEntry {
+  return {
+    kind: 'ci-failure',
+    note: 'Repairs failed CI.',
+    lifecycle: 'running',
+    policy: 'enabled',
+    autoStarts: true,
+    startable: false,
+    stoppable: true,
+    recentActions: [makeAction()],
+    ...overrides,
+  };
+}
+
+function renderPanel(worker: WorkerStatusEntry | null, tasks = new Map(), collapsed = false) {
+  onToggleCollapsed.mockReset();
+  onTaskClick.mockReset();
+  render(
+    <WorkerDetailsPanel
+      worker={worker}
+      tasks={tasks}
+      collapsed={collapsed}
+      onToggleCollapsed={onToggleCollapsed}
+      onTaskClick={onTaskClick}
+    />,
+  );
+}
+
+describe('WorkerDetailsPanel', () => {
+  it('shows active worker action details and opens the target task', () => {
+    const task = makeUITask({ id: 'wf-1/fix-target', status: 'failed', description: 'needs fix' });
+    renderPanel(makeWorker(), new Map([[task.id, task]]));
+
+    expect(screen.getByTestId('worker-details-title')).toHaveTextContent('CI failure repair');
+    expect(screen.getByText('Current work')).toBeInTheDocument();
+    expect(screen.getAllByText('Action')).toHaveLength(2);
+    expect(screen.getAllByText('Fix With Agent')).toHaveLength(2);
+    expect(screen.getAllByText('Running')).toHaveLength(2);
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Open task: fix-target' })[0]!);
+    expect(onTaskClick).toHaveBeenCalledWith(expect.objectContaining({ id: task.id }));
+  });
+
+  it('shows completed merge gate target and Autofix history in details', () => {
+    renderPanel(makeWorker({
+      kind: 'autofix',
+      autoStarts: false,
+      startable: true,
+      stoppable: false,
+      recentActions: [makeAction({
+        workerKind: 'autofix',
+        taskId: '__merge__wf-1',
+        subjectId: '__merge__wf-1',
+        externalKey: '__merge__wf-1',
+        status: 'completed',
+        summary: 'Finished merge recovery.',
+      })],
+      recovery: {
+        workerId: 'autofix',
+        owner: 'autofix',
+        scans: 14,
+        submissions: 2,
+        skips: 1,
+        wakeups: 3,
+        lastSkipReason: 'retry budget exhausted',
+        lastSkipTaskId: '__merge__wf-1',
+      },
+    }), new Map());
+
+    expect(screen.getByText('Last recorded action')).toBeInTheDocument();
+    expect(screen.getByText('Target task: merge gate')).toBeInTheDocument();
+    expect(screen.getByText('Autofix history')).toBeInTheDocument();
+    expect(screen.getByText('Scanned 14 · submitted 2 · skipped 1 · last skip: retry budget exhausted on task merge gate')).toBeInTheDocument();
+  });
+
+  it('explains pr-status when no actions are persisted', () => {
+    renderPanel(makeWorker({
+      kind: 'pr-status',
+      note: 'Checks pull request status.',
+      recentActions: [],
+    }));
+
+    expect(screen.getByText('PR status')).toBeInTheDocument();
+    expect(screen.getByText('No persisted PR status actions. This worker updates review gates directly.')).toBeInTheDocument();
+  });
+
+  it('uses the same collapsed show control as the inspector', () => {
+    renderPanel(makeWorker(), new Map(), true);
+
+    const button = screen.getByRole('button', { name: 'Show details' });
+    fireEvent.click(button);
+    expect(onToggleCollapsed).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Last recorded action')).not.toBeInTheDocument();
+  });
+
+  it('shows empty guidance when no worker is selected', () => {
+    renderPanel(null);
+
+    expect(screen.getByText('Worker details')).toBeInTheDocument();
+    expect(screen.getByText('Select a worker process to inspect its current work and last recorded action.')).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -184,7 +184,7 @@ export function LeftStatusColumn({
       data-testid="app-sidebar"
       className={[
         'flex h-full shrink-0 flex-col border-r border-gray-800 bg-gray-950/85 py-4 text-sm text-gray-200 transition-all duration-150',
-        collapsed ? 'w-16 px-2' : 'w-72 px-3',
+        collapsed ? 'w-16 px-2' : 'w-60 px-3',
       ].join(' ')}
     >
       <button

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -1,13 +1,15 @@
 import type { QueueStatus } from '@invoker/contracts';
 import type { JSX } from 'react';
-import type { TaskState, WorkflowMeta } from '../types.js';
+import type { TaskState, WorkflowMeta, WorkerStatusSnapshot } from '../types.js';
 import type { SidebarSurface } from '../lib/workflow-progress-surfaces.js';
 import { getAttentionTaskEntries, getRunningTaskEntries, getSortedWorkflows } from '../lib/workflow-progress-surfaces.js';
+import { countActiveWorkerActions } from '../lib/worker-display.js';
 
 interface LeftStatusColumnProps {
   workflows: Map<string, WorkflowMeta>;
   tasks: Map<string, TaskState>;
   queueStatus: QueueStatus | null;
+  workerStatus: WorkerStatusSnapshot | null;
   selectedSurface: SidebarSurface;
   collapsed: boolean;
   onSelectSurface: (surface: SidebarSurface) => void;
@@ -57,6 +59,16 @@ function RunningIcon(): JSX.Element {
       <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
         <circle cx="12" cy="12" r="8.25" />
         <path strokeLinecap="round" strokeLinejoin="round" d="M12 7.5v4.75l3 1.75" />
+      </svg>
+    </SidebarIcon>
+  );
+}
+function WorkerIcon(): JSX.Element {
+  return (
+    <SidebarIcon>
+      <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.8}>
+        <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 7.5h9v7.5h-9z" />
+        <path strokeLinecap="round" strokeLinejoin="round" d="M9 3.75v2.25M15 3.75v2.25M9 16.5v2.25M15 16.5v2.25M3.75 9h2.25M3.75 13.5h2.25M18 9h2.25M18 13.5h2.25" />
       </svg>
     </SidebarIcon>
   );
@@ -145,6 +157,7 @@ export function LeftStatusColumn({
   workflows,
   tasks,
   queueStatus,
+  workerStatus,
   selectedSurface,
   collapsed,
   onSelectSurface,
@@ -155,10 +168,14 @@ export function LeftStatusColumn({
   const workflowEntries = getSortedWorkflows(workflows, tasks);
   const attentionEntries = getAttentionTaskEntries(tasks, workflows);
   const runningEntries = getRunningTaskEntries(tasks, workflows, queueStatus);
+  const runningWorkers = workerStatus?.workers.filter((worker) => worker.lifecycle === 'running').length ?? 0;
+  const registeredWorkers = workerStatus?.workers.length ?? 0;
+  const activeWorkerActions = workerStatus ? countActiveWorkerActions(workerStatus.workers) : 0;
 
   const sources: SourceItem[] = [
     { key: 'attention', label: 'Needs Attention', count: attentionEntries.length, tone: 'attention', icon: <AttentionIcon /> },
     { key: 'running', label: 'Running', count: runningEntries.length, tone: 'running', icon: <RunningIcon /> },
+    { key: 'workers', label: 'Workers', count: registeredWorkers, tone: activeWorkerActions > 0 ? 'running' : 'neutral', icon: <WorkerIcon /> },
     { key: 'workflows', label: 'Workflows', count: workflowEntries.length, tone: 'neutral', icon: <WorkflowsIcon /> },
   ];
 
@@ -295,6 +312,11 @@ export function LeftStatusColumn({
             runningEntries.length === 0
               ? 'No tasks are running right now.'
               : `${runningEntries.length} task${runningEntries.length === 1 ? '' : 's'} active now.`
+          )}
+          {selectedSurface === 'workers' && (
+            workerStatus === null
+              ? 'Worker status is not available yet.'
+              : `${runningWorkers} process${runningWorkers === 1 ? '' : 'es'} running · ${activeWorkerActions} active action${activeWorkerActions === 1 ? '' : 's'}`
           )}
           {selectedSurface === 'home' && 'Plan graph details live here.'}
           {selectedSurface === 'planning' && `${planningSessionCount} planning chat${planningSessionCount === 1 ? '' : 's'}.`}

--- a/packages/ui/src/components/QueueView.tsx
+++ b/packages/ui/src/components/QueueView.tsx
@@ -1,60 +1,55 @@
 /**
- * QueueView — Displays the Action Queue and Backlog.
+ * QueueView — Displays worker-owned actions next to worker processes.
  *
- * Action Queue shows all actionable tasks:
- * - scheduler-running and scheduler-queued tasks
- * - tasks in manual-action states (fixing_with_ai, needs_input,
- *   review_ready, awaiting_approval)
- *
- * Backlog shows blocked or otherwise non-actionable tasks.
+ * Worker Actions only shows active work recorded by workers. It does not mirror
+ * the scheduler queue or backlog, because those belong in the normal task views.
  */
 
 import { useCallback, useMemo, useRef, useState } from 'react';
-import type { QueueStatus, TaskState } from '../types.js';
+import type { TaskState, WorkerActionSummary, WorkerStatusEntry, WorkerStatusSnapshot } from '../types.js';
+import { getStatusColor } from '../lib/colors.js';
 import {
-  getRunningPhaseLabel,
-  getStatusColor,
-  getEffectiveVisualStatus,
-  formatStatusLabel,
-} from '../lib/colors.js';
+  displayWorkerTaskId,
+  formatWorkerValue,
+  getActiveWorkerActions,
+  getWorkerDisplayCopy,
+} from '../lib/worker-display.js';
+import { WorkerActivityCard } from './WorkerActivityCard.js';
 
 interface QueueViewProps {
   tasks: Map<string, TaskState>;
-  queueStatus: QueueStatus | null;
+  workerStatus: WorkerStatusSnapshot | null;
+  readOnly: boolean;
+  onStartWorker: (kind: string) => Promise<void> | void;
+  onStopWorker: (kind: string) => Promise<void> | void;
   onTaskClick: (task: TaskState) => void;
-  onCancel: (taskId: string) => void;
   selectedTaskId: string | null;
+  selectedWorkerKind: string | null;
+  onSelectWorker: (kind: string) => void;
 }
 
-function displayTaskId(taskId: string): string {
-  if (taskId.startsWith('__merge__')) return 'merge gate';
-  const slash = taskId.lastIndexOf('/');
-  return slash >= 0 ? taskId.slice(slash + 1) : taskId;
-}
-
-function displayDependencies(taskIds: readonly string[]): string {
-  return taskIds.map(displayTaskId).join(', ');
-}
-
-/** Statuses that represent manual-action states — always actionable. */
-const MANUAL_ACTION_STATUSES = new Set([
-  'fixing_with_ai',
-  'needs_input',
-  'review_ready',
-  'awaiting_approval',
-]);
-type QueueRowSource = 'running' | 'queued' | 'manual';
-
-type QueueRow = {
-  taskId: string;
-  description: string;
-  order: number;
-  source: QueueRowSource;
-  attemptId?: string;
-  priority?: number;
+type WorkerActionRow = {
+  action: WorkerActionSummary;
+  worker: WorkerStatusEntry;
 };
 
-export function QueueView({ tasks, queueStatus, onTaskClick, onCancel, selectedTaskId }: QueueViewProps) {
+
+function actionTargetLabel(action: WorkerActionSummary, tasks: Map<string, TaskState>): string {
+  if (action.taskId) {
+    return tasks.get(action.taskId)?.description || displayWorkerTaskId(action.taskId);
+  }
+  return `${formatWorkerValue(action.subjectType)} ${action.subjectId}`;
+}
+
+function actionRowKey(row: WorkerActionRow): string {
+  return `${row.worker.kind}:${row.action.id}`;
+}
+
+function actionTargetTask(action: WorkerActionSummary, tasks: Map<string, TaskState>): TaskState | null {
+  return action.taskId ? tasks.get(action.taskId) ?? null : null;
+}
+
+export function QueueView({ tasks, workerStatus, readOnly, onStartWorker, onStopWorker, onTaskClick, selectedTaskId, selectedWorkerKind, onSelectWorker }: QueueViewProps) {
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   const rowRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
@@ -74,12 +69,19 @@ export function QueueView({ tasks, queueStatus, onTaskClick, onCancel, selectedT
     return map;
   }, [tasks]);
 
-  const toggleExpanded = useCallback((taskId: string, e: React.MouseEvent) => {
+  const actionRows = useMemo<WorkerActionRow[]>(
+    () => (workerStatus?.workers ?? []).flatMap((worker) =>
+      getActiveWorkerActions(worker).map((action) => ({ action, worker })),
+    ),
+    [workerStatus],
+  );
+
+  const toggleExpanded = useCallback((rowKey: string, e: React.MouseEvent) => {
     e.stopPropagation();
     setExpandedRows((prev) => {
       const next = new Set(prev);
-      if (next.has(taskId)) next.delete(taskId);
-      else next.add(taskId);
+      if (next.has(rowKey)) next.delete(rowKey);
+      else next.add(rowKey);
       return next;
     });
   }, []);
@@ -89,327 +91,147 @@ export function QueueView({ tasks, queueStatus, onTaskClick, onCancel, selectedT
       e.stopPropagation();
       const task = tasks.get(taskId);
       if (task) onTaskClick(task);
-      // Scroll to the row if it exists in the current view
       const el = rowRefs.current.get(taskId);
       if (el?.scrollIntoView) el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
     },
     [tasks, onTaskClick],
   );
 
-
-  const handleCancel = useCallback(
-    (taskId: string) => {
-      const confirmed = window.confirm(`Terminate task "${displayTaskId(taskId)}" and all downstream dependents?`);
-      if (confirmed) onCancel(taskId);
-    },
-    [onCancel],
-  );
-
-  const actionRows = useMemo<QueueRow[]>(() => {
-    const schedulerTaskIds = new Set<string>();
-
-    const running: QueueRow[] = (queueStatus?.running ?? []).map((job, idx) => {
-      schedulerTaskIds.add(job.taskId);
-      return {
-        taskId: job.taskId,
-        description: job.description,
-        attemptId: job.attemptId,
-        order: idx + 1,
-        source: 'running',
-      };
-    });
-
-    const queued: QueueRow[] = (queueStatus?.queued ?? []).map((job, idx) => {
-      schedulerTaskIds.add(job.taskId);
-      return {
-        taskId: job.taskId,
-        description: job.description,
-        priority: job.priority,
-        order: running.length + idx + 1,
-        source: 'queued',
-      };
-    });
-
-    const manualAction: QueueRow[] = Array.from(tasks.values())
-      .filter((t) => MANUAL_ACTION_STATUSES.has(t.status) && !schedulerTaskIds.has(t.id))
-      .map((t, idx) => ({
-        taskId: t.id,
-        description: t.description,
-        order: running.length + queued.length + idx + 1,
-        source: 'manual',
-      }));
-
-    return [...running, ...queued, ...manualAction];
-  }, [queueStatus, tasks]);
-
-  const actionTaskIds = useMemo(
-    () => new Set(actionRows.map((a) => a.taskId)),
-    [actionRows],
-  );
-
-  const backlogTasks = useMemo(
-    () =>
-      Array.from(tasks.values()).filter(
-        (t) =>
-          (t.status === 'pending' || t.status === 'blocked')
-          && !actionTaskIds.has(t.id),
-      ),
-    [tasks, actionTaskIds],
-  );
-  const assigningCount = useMemo(
-    () => (queueStatus?.running ?? []).reduce(
-      (count, job) => count + (tasks.get(job.taskId)?.execution.phase === 'launching' ? 1 : 0),
-      0,
-    ),
-    [queueStatus, tasks],
-  );
-  const activeRunningCount = queueStatus ? Math.max(0, queueStatus.runningCount - assigningCount) : 0;
-
   return (
-    <div className="h-full overflow-y-auto bg-gray-900 p-4 flex flex-col gap-4">
-      <div>
-        <h3 className="text-sm font-semibold text-cyan-300 mb-1">
-          Action Queue ({actionRows.length})
-        </h3>
-        <div className="text-xs text-gray-400 mb-2">
-          Running, assigning, scheduled, and manual-action work.
+    <div className="grid h-full min-h-0 grid-cols-[minmax(20rem,24rem)_minmax(28rem,1fr)] overflow-hidden bg-gray-900">
+      <section data-testid="action-queue-section" className="flex h-full min-h-0 flex-col overflow-hidden border-r border-gray-800">
+        <div className="shrink-0 border-b border-gray-800 p-4">
+          <h3 className="text-lg font-semibold text-gray-100">
+            Worker Actions ({actionRows.length})
+          </h3>
+          <div className="mt-1 text-sm text-gray-400">
+            Only work started by a worker process appears here.
+          </div>
         </div>
-        {queueStatus && (
-          <>
-            <div className="text-xs text-gray-400 mb-2">
-              Active {queueStatus.runningCount} / {queueStatus.maxConcurrency}
-            </div>
-            <div className="text-xs text-gray-400 mb-2">
-              Assigning {assigningCount} · Running {activeRunningCount}
-            </div>
-          </>
-        )}
 
-        {actionRows.map((job) => {
-          const task = tasks.get(job.taskId);
-          const runningLike = job.source === 'running';
-          const visualStatus = task
-            ? getEffectiveVisualStatus(task.status, task.execution, { runningLike })
-            : 'pending';
-          const statusLabel = visualStatus === 'assigning'
-            ? 'Assigning'
-            : runningLike ? 'Running' : task ? formatStatusLabel(task.status) : 'Pending';
-          const colors = getStatusColor(visualStatus);
-          const phaseLabel = visualStatus === 'assigning'
-            ? null
-            : runningLike
-              ? getRunningPhaseLabel(task?.execution.phase)
-              : task?.status === 'running'
-                ? getRunningPhaseLabel(task.execution.phase)
-                : null;
-          const isExpanded = expandedRows.has(job.taskId);
-          const upstream = task?.dependencies ?? [];
-          const downstream = dependentsMap.get(job.taskId) ?? [];
-          const hasRelationships = upstream.length > 0 || downstream.length > 0;
-          return (
-            <div
-              key={`action-${job.taskId}`}
-              ref={(el) => { if (el) rowRefs.current.set(job.taskId, el); }}
-              data-row-id={job.taskId}
-              className={`rounded mb-1 ${
-                selectedTaskId === job.taskId ? 'bg-gray-600' : 'bg-gray-800 hover:bg-gray-700'
-              }`}
-            >
-              <div className="flex items-stretch">
-                {hasRelationships ? (
-                  <button
-                    onClick={(e) => toggleExpanded(job.taskId, e)}
-                    className="flex w-8 shrink-0 items-center justify-center rounded-l text-sm text-gray-400 hover:bg-gray-700 hover:text-gray-100"
-                    aria-label={isExpanded ? 'Collapse relationships' : 'Expand relationships'}
-                    aria-expanded={isExpanded}
-                    data-testid={`queue-rels-toggle-action-${job.taskId}`}
-                  >
-                    {isExpanded ? '▾' : '▸'}
-                  </button>
-                ) : (
-                  <div className="w-8 shrink-0" aria-hidden="true" />
-                )}
-                <div className="flex-1 min-w-0">
-                  <div
-                    onClick={() => task && onTaskClick(task)}
-                    className="flex cursor-pointer items-center justify-between p-2"
-                  >
-                    <div className="flex-1 min-w-0">
+        <div data-testid="worker-action-list" className="min-h-0 flex-1 overflow-y-auto px-4 py-3">
+          <div className="space-y-1">
+            {actionRows.map((row) => {
+              const { action, worker } = row;
+              const task = actionTargetTask(action, tasks);
+              const rowKey = actionRowKey(row);
+              const taskId = action.taskId;
+              const upstream = task?.dependencies ?? [];
+              const downstream = taskId ? dependentsMap.get(taskId) ?? [] : [];
+              const hasRelationships = upstream.length > 0 || downstream.length > 0;
+              const isExpanded = expandedRows.has(rowKey);
+              const colors = getStatusColor(action.status);
+              const copy = getWorkerDisplayCopy(worker.kind);
+              return (
+                <div
+                  key={rowKey}
+                  ref={(el) => {
+                    if (el && taskId) rowRefs.current.set(taskId, el);
+                  }}
+                  data-row-id={taskId ?? action.id}
+                  className={`rounded-xl border ${
+                    taskId && selectedTaskId === taskId
+                      ? 'border-cyan-500/80 bg-cyan-950/30 ring-1 ring-cyan-500/60'
+                      : 'border-gray-800 bg-gray-850/60 hover:border-gray-700 hover:bg-gray-800/80'
+                  }`}
+                >
+                  <div className="flex items-stretch">
+                    {hasRelationships ? (
+                      <button
+                        type="button"
+                        onClick={(e) => toggleExpanded(rowKey, e)}
+                        className="flex w-8 shrink-0 items-center justify-center rounded-l-xl text-sm text-gray-400 hover:bg-gray-700 hover:text-gray-100"
+                        aria-label={isExpanded ? 'Collapse relationships' : 'Expand relationships'}
+                        aria-expanded={isExpanded}
+                        data-testid={`queue-rels-toggle-action-${taskId}`}
+                      >
+                        {isExpanded ? '▾' : '▸'}
+                      </button>
+                    ) : (
+                      <div className="w-8 shrink-0" aria-hidden="true" />
+                    )}
+                    <button
+                      type="button"
+                      disabled={!task}
+                      onClick={() => task && onTaskClick(task)}
+                      className={`min-w-0 flex-1 p-3 text-left ${task ? 'cursor-pointer' : 'cursor-default'}`}
+                    >
                       <div className="flex items-center gap-2">
-                        <span className="text-xs text-gray-500">#{job.order}</span>
-                        <span className="text-sm text-gray-100 truncate">{displayTaskId(job.taskId)}</span>
-                        <span className={`inline-flex shrink-0 items-center gap-1 rounded border px-2 py-0.5 text-xs ${colors.bg} ${colors.border} ${colors.text}`}>
+                        <span className="truncate text-sm font-medium text-gray-100">{copy.name}</span>
+                        <span className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 text-xs ${colors.bg} ${colors.border} ${colors.text}`}>
                           <span className={`h-1.5 w-1.5 rounded-full ${colors.dot}`} aria-hidden="true" />
-                          {statusLabel}
+                          {formatWorkerValue(action.status)}
                         </span>
                       </div>
-                      <span className="text-xs text-gray-400 truncate block">{job.description}</span>
-                      {phaseLabel && (
-                        <span className="text-xs text-amber-300 truncate block">phase: {phaseLabel}</span>
-                      )}
-                    </div>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleCancel(job.taskId);
-                      }}
-                      title={`Cancel ${displayTaskId(job.taskId)}`}
-                      aria-label={`Cancel ${displayTaskId(job.taskId)}`}
-                      className="ml-2 px-1 py-0.5 text-xs text-gray-400 hover:text-gray-200 rounded shrink-0"
-                    >
-                      ×
+                      <div className="mt-1 truncate text-xs text-gray-400">
+                        {formatWorkerValue(action.actionType)} · {actionTargetLabel(action, tasks)}
+                      </div>
+                      {action.summary ? (
+                        <div className="mt-1 truncate text-xs text-gray-500">{action.summary}</div>
+                      ) : null}
+                      {taskId && !task ? (
+                        <div className="mt-1 truncate text-xs text-amber-300">Target task is not loaded.</div>
+                      ) : null}
                     </button>
                   </div>
+                  {isExpanded && taskId && (
+                    <div className="mx-3 mb-3 border-t border-gray-700 pb-1 pt-2 text-xs" data-testid={`rels-${taskId}`}>
+                      {upstream.length > 0 && (
+                        <div className="mb-1">
+                          <span className="text-gray-500">upstream: </span>
+                          {upstream.map((depId) => (
+                            <button
+                              key={depId}
+                              type="button"
+                              onClick={(e) => handleRelatedClick(depId, e)}
+                              className="mr-1 inline-block cursor-pointer rounded bg-blue-900 px-1.5 py-0.5 text-blue-300 hover:bg-blue-800"
+                            >
+                              {displayWorkerTaskId(depId)}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                      {downstream.length > 0 && (
+                        <div>
+                          <span className="text-gray-500">downstream: </span>
+                          {downstream.map((depId) => (
+                            <button
+                              key={depId}
+                              type="button"
+                              onClick={(e) => handleRelatedClick(depId, e)}
+                              className="mr-1 inline-block cursor-pointer rounded bg-green-900 px-1.5 py-0.5 text-green-300 hover:bg-green-800"
+                            >
+                              {displayWorkerTaskId(depId)}
+                            </button>
+                          ))}
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </div>
+              );
+            })}
+            {actionRows.length === 0 && (
+              <div className="rounded-xl border border-gray-800 bg-gray-850/60 p-4 text-sm text-gray-400">
+                No worker action is running.
               </div>
-              {isExpanded && (
-                <div className="mx-2 mb-2 pt-1 pb-1 border-t border-gray-700 text-xs" data-testid={`rels-${job.taskId}`}>
-                  {upstream.length > 0 && (
-                    <div className="mb-1">
-                      <span className="text-gray-500">upstream: </span>
-                      {upstream.map((depId) => (
-                        <button
-                          key={depId}
-                          onClick={(e) => handleRelatedClick(depId, e)}
-                          className="inline-block mr-1 px-1.5 py-0.5 rounded bg-blue-900 text-blue-300 hover:bg-blue-800 cursor-pointer"
-                        >
-                          {displayTaskId(depId)}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                  {downstream.length > 0 && (
-                    <div>
-                      <span className="text-gray-500">downstream: </span>
-                      {downstream.map((depId) => (
-                        <button
-                          key={depId}
-                          onClick={(e) => handleRelatedClick(depId, e)}
-                          className="inline-block mr-1 px-1.5 py-0.5 rounded bg-green-900 text-green-300 hover:bg-green-800 cursor-pointer"
-                        >
-                          {displayTaskId(depId)}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        })}
-        {actionRows.length === 0 && (
-          <div className="text-xs text-gray-500 italic">No running or queued actions</div>
-        )}
-      </div>
+            )}
+          </div>
+        </div>
+      </section>
 
-      <div>
-        <h3 className="text-sm font-semibold text-gray-300 mb-2">
-          Backlog ({backlogTasks.length})
-        </h3>
-        {backlogTasks.map((task) => {
-          const isExpanded = expandedRows.has(task.id);
-          const upstream = task.dependencies;
-          const downstream = dependentsMap.get(task.id) ?? [];
-          const hasRelationships = upstream.length > 0 || downstream.length > 0;
-          const backlogVisualStatus = getEffectiveVisualStatus(task.status, task.execution);
-          const backlogStatusLabel = formatStatusLabel(task.status);
-          const backlogColors = getStatusColor(backlogVisualStatus);
-          return (
-            <div
-              key={task.id}
-              ref={(el) => { if (el) rowRefs.current.set(task.id, el); }}
-              data-row-id={task.id}
-              className={`rounded mb-1 ${
-                selectedTaskId === task.id ? 'bg-gray-600' : 'bg-gray-800 hover:bg-gray-700'
-              }`}
-            >
-              <div className="flex items-stretch">
-                {hasRelationships ? (
-                  <button
-                    onClick={(e) => toggleExpanded(task.id, e)}
-                    className="flex w-8 shrink-0 items-center justify-center rounded-l text-sm text-gray-400 hover:bg-gray-700 hover:text-gray-100"
-                    aria-label={isExpanded ? 'Collapse relationships' : 'Expand relationships'}
-                    aria-expanded={isExpanded}
-                    data-testid={`queue-rels-toggle-backlog-${task.id}`}
-                  >
-                    {isExpanded ? '▾' : '▸'}
-                  </button>
-                ) : (
-                  <div className="w-8 shrink-0" aria-hidden="true" />
-                )}
-                <div className="flex-1 min-w-0">
-                  <div
-                    onClick={() => onTaskClick(task)}
-                    className="flex cursor-pointer items-center justify-between p-2"
-                  >
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm text-gray-100 truncate">{displayTaskId(task.id)}</span>
-                        <span className={`inline-flex shrink-0 items-center gap-1 rounded border px-2 py-0.5 text-xs ${backlogColors.bg} ${backlogColors.border} ${backlogColors.text}`}>
-                          <span className={`h-1.5 w-1.5 rounded-full ${backlogColors.dot}`} aria-hidden="true" />
-                          {backlogStatusLabel}
-                        </span>
-                      </div>
-                      <span className="text-xs text-gray-400 truncate block">{task.description}</span>
-                      {task.dependencies.length > 0 && (
-                        <span className="text-xs text-gray-500 truncate block">
-                          deps: {displayDependencies(task.dependencies)}
-                        </span>
-                      )}
-                    </div>
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        handleCancel(task.id);
-                      }}
-                      title={`Cancel ${displayTaskId(task.id)}`}
-                      aria-label={`Cancel ${displayTaskId(task.id)}`}
-                      className="ml-2 px-1 py-0.5 text-xs text-gray-400 hover:text-gray-200 rounded shrink-0"
-                    >
-                      ×
-                    </button>
-                  </div>
-                </div>
-              </div>
-              {isExpanded && (
-                <div className="mx-2 mb-2 pt-1 pb-1 border-t border-gray-700 text-xs" data-testid={`rels-${task.id}`}>
-                  {upstream.length > 0 && (
-                    <div className="mb-1">
-                      <span className="text-gray-500">upstream: </span>
-                      {upstream.map((depId) => (
-                        <button
-                          key={depId}
-                          onClick={(e) => handleRelatedClick(depId, e)}
-                          className="inline-block mr-1 px-1.5 py-0.5 rounded bg-blue-900 text-blue-300 hover:bg-blue-800 cursor-pointer"
-                        >
-                          {displayTaskId(depId)}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                  {downstream.length > 0 && (
-                    <div>
-                      <span className="text-gray-500">downstream: </span>
-                      {downstream.map((depId) => (
-                        <button
-                          key={depId}
-                          onClick={(e) => handleRelatedClick(depId, e)}
-                          className="inline-block mr-1 px-1.5 py-0.5 rounded bg-green-900 text-green-300 hover:bg-green-800 cursor-pointer"
-                        >
-                          {displayTaskId(depId)}
-                        </button>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-          );
-        })}
-        {backlogTasks.length === 0 && (
-          <div className="text-xs text-gray-500 italic">No pending or blocked tasks outside the queue</div>
-        )}
-      </div>
+      <section data-testid="worker-processes-section" className="flex h-full min-h-0 flex-col overflow-hidden">
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <WorkerActivityCard
+            snapshot={workerStatus}
+            selectedWorkerKind={selectedWorkerKind}
+            readOnly={readOnly}
+            onStartWorker={onStartWorker}
+            onStopWorker={onStopWorker}
+            onSelectWorker={onSelectWorker}
+          />
+        </div>
+      </section>
     </div>
   );
 }

--- a/packages/ui/src/components/QueueView.tsx
+++ b/packages/ui/src/components/QueueView.tsx
@@ -1,10 +1,3 @@
-/**
- * QueueView — Displays worker-owned actions next to worker processes.
- *
- * Worker Actions only shows active work recorded by workers. It does not mirror
- * the scheduler queue or backlog, because those belong in the normal task views.
- */
-
 import { useCallback, useMemo, useRef, useState } from 'react';
 import type { TaskState, WorkerActionSummary, WorkerStatusEntry, WorkerStatusSnapshot } from '../types.js';
 import { getStatusColor } from '../lib/colors.js';

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -122,6 +122,9 @@ export function WorkerActivityCard({
                     className="shrink-0 rounded border border-gray-600 px-2 py-1 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-700"
                     title={disabledTitle}
                     disabled={isControlDisabled}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Enter' || event.key === ' ') event.stopPropagation();
+                    }}
                     onClick={(event) => {
                       event.stopPropagation();
                       if (showStart) void onStartWorker(worker.kind);

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -1,0 +1,141 @@
+import type { WorkerStatusEntry, WorkerStatusSnapshot } from '../types.js';
+import { formatWorkerValue, getActiveWorkerAction, getWorkerDisplayCopy } from '../lib/worker-display.js';
+
+interface WorkerActivityCardProps {
+  snapshot: WorkerStatusSnapshot | null;
+  selectedWorkerKind: string | null;
+  readOnly: boolean;
+  onStartWorker: (kind: string) => Promise<void> | void;
+  onStopWorker: (kind: string) => Promise<void> | void;
+  onSelectWorker: (kind: string) => void;
+}
+
+function processClass(worker: WorkerStatusEntry): string {
+  if (worker.lifecycle === 'running') return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
+  if (worker.lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+  return 'border-gray-600 bg-gray-700/60 text-gray-300';
+}
+
+function activityClass(worker: WorkerStatusEntry): string {
+  if (getActiveWorkerAction(worker)) return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+  if (worker.lifecycle === 'running') return 'border-gray-600 bg-gray-700/60 text-gray-300';
+  if (worker.lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+  return 'border-gray-600 bg-gray-700/60 text-gray-300';
+}
+
+function policyClass(worker: WorkerStatusEntry): string {
+  if (worker.policy === 'disabled') return 'border-rose-500/40 bg-rose-500/10 text-rose-200';
+  return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+}
+
+function activityLabel(worker: WorkerStatusEntry): string {
+  if (getActiveWorkerAction(worker)) return 'Active work';
+  if (worker.lifecycle === 'running') return 'Idle';
+  if (worker.lifecycle === 'exited') return 'Exited';
+  return 'Stopped';
+}
+
+function activityExplanation(worker: WorkerStatusEntry): string {
+  const action = getActiveWorkerAction(worker);
+  if (action) return `Active work: ${formatWorkerValue(action.actionType)} · ${formatWorkerValue(action.status)}`;
+  if (worker.lifecycle === 'running') return getWorkerDisplayCopy(worker.kind).idleText;
+  if (worker.lifecycle === 'exited') return 'Process exited. Start it to create a fresh runtime.';
+  return 'Process stopped. Start it to listen for work.';
+}
+
+export function WorkerActivityCard({
+  snapshot,
+  selectedWorkerKind,
+  readOnly,
+  onStartWorker,
+  onStopWorker,
+  onSelectWorker,
+}: WorkerActivityCardProps) {
+  return (
+    <div data-testid="worker-activity-card">
+      <div className="mb-4">
+        <h3 className="text-lg font-semibold text-gray-100">Worker processes ({snapshot?.workers.length ?? 0})</h3>
+        <div className="mt-1 text-sm text-gray-400">Process status is separate from queue work. A running process can be idle.</div>
+      </div>
+
+      {!snapshot ? (
+        <div className="rounded border border-gray-800 bg-gray-950/60 px-3 py-2 text-sm text-gray-400">Worker status unavailable</div>
+      ) : (
+        <div className="space-y-3">
+          {snapshot.workers.map((worker) => {
+            const copy = getWorkerDisplayCopy(worker.kind);
+            const disabledTitle = readOnly ? 'Read-only window' : worker.controlDisabledReason;
+            const showStart = worker.lifecycle !== 'running';
+            const isControlDisabled = Boolean(disabledTitle);
+            const selected = selectedWorkerKind === worker.kind;
+            const footer = worker.kind === 'pr-status'
+              ? 'No queue task is expected for this worker.'
+              : selected
+                ? 'Details are in the right panel.'
+                : null;
+            return (
+              <div
+                key={worker.kind}
+                role="button"
+                tabIndex={0}
+                className={`block w-full cursor-pointer rounded-xl border p-3 text-left transition-colors ${
+                  selected
+                    ? 'border-cyan-500/80 bg-cyan-950/30 ring-1 ring-cyan-500/60'
+                    : 'border-gray-800 bg-gray-850/60 hover:border-gray-700 hover:bg-gray-800/80'
+                }`}
+                data-testid={`worker-row-${worker.kind}`}
+                onClick={() => onSelectWorker(worker.kind)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    onSelectWorker(worker.kind);
+                  }
+                }}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-semibold text-gray-100">{copy.name}</div>
+                    <div className="mt-0.5 text-xs text-gray-500">Kind: {worker.kind}</div>
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                      <span className={`rounded-full border px-2 py-0.5 text-[11px] ${processClass(worker)}`}>
+                        Process: {formatWorkerValue(worker.lifecycle)}
+                      </span>
+                      <span className={`rounded-full border px-2 py-0.5 text-[11px] ${activityClass(worker)}`}>
+                        {activityLabel(worker)}
+                      </span>
+                      {worker.policy !== 'enabled' && (
+                        <span className={`rounded-full border px-2 py-0.5 text-[11px] ${policyClass(worker)}`}>
+                          {formatWorkerValue(worker.policy)}{worker.policyReason ? ` · ${worker.policyReason}` : ''}
+                        </span>
+                      )}
+                      {worker.autoStarts && (
+                        <span className="rounded-full border border-blue-500/40 bg-blue-500/10 px-2 py-0.5 text-[11px] text-blue-200">
+                          Auto-starts
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-2 text-sm text-gray-300">{activityExplanation(worker)}</div>
+                    {footer ? <div className="mt-1 text-xs text-gray-500">{footer}</div> : null}
+                  </div>
+                  <button
+                    type="button"
+                    className="shrink-0 rounded border border-gray-600 px-2 py-1 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-700"
+                    title={disabledTitle}
+                    disabled={isControlDisabled}
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      if (showStart) void onStartWorker(worker.kind);
+                      else void onStopWorker(worker.kind);
+                    }}
+                  >
+                    {showStart ? 'Start process' : 'Stop process'}
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/WorkerDetailsPanel.tsx
+++ b/packages/ui/src/components/WorkerDetailsPanel.tsx
@@ -1,0 +1,188 @@
+import type { TaskState, WorkerActionSummary, WorkerStatusEntry } from '../types.js';
+import {
+  displayWorkerTaskId,
+  formatWorkerValue,
+  getActiveWorkerAction,
+  getWorkerDisplayCopy,
+} from '../lib/worker-display.js';
+
+interface WorkerDetailsPanelProps {
+  worker: WorkerStatusEntry | null;
+  tasks: Map<string, TaskState>;
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+  onTaskClick: (task: TaskState) => void;
+}
+
+function processClass(worker: WorkerStatusEntry): string {
+  if (worker.lifecycle === 'running') return 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200';
+  if (worker.lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+  return 'border-gray-600 bg-gray-700/60 text-gray-300';
+}
+
+function activityClass(worker: WorkerStatusEntry): string {
+  if (getActiveWorkerAction(worker)) return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+  if (worker.lifecycle === 'running') return 'border-gray-600 bg-gray-700/60 text-gray-300';
+  if (worker.lifecycle === 'exited') return 'border-amber-500/40 bg-amber-500/10 text-amber-200';
+  return 'border-gray-600 bg-gray-700/60 text-gray-300';
+}
+
+function activityLabel(worker: WorkerStatusEntry): string {
+  if (getActiveWorkerAction(worker)) return 'Active work';
+  if (worker.lifecycle === 'running') return 'Idle';
+  if (worker.lifecycle === 'exited') return 'Exited';
+  return 'Stopped';
+}
+
+function idleExplanation(worker: WorkerStatusEntry): string {
+  if (worker.lifecycle === 'running') return getWorkerDisplayCopy(worker.kind).idleText;
+  if (worker.lifecycle === 'exited') return 'Process exited. Start it to create a fresh runtime.';
+  return 'Process stopped. Start it to listen for work.';
+}
+
+function TargetLine({ action, tasks, onTaskClick }: {
+  action: WorkerActionSummary;
+  tasks: Map<string, TaskState>;
+  onTaskClick: (task: TaskState) => void;
+}) {
+  if (action.taskId) {
+    const task = tasks.get(action.taskId);
+    if (task) {
+      return (
+        <button
+          type="button"
+          className="mt-2 rounded border border-emerald-600/60 bg-emerald-900/40 px-2 py-1 text-xs font-medium text-emerald-100 hover:bg-emerald-800/60"
+          onClick={() => onTaskClick(task)}
+        >
+          Open task: {displayWorkerTaskId(action.taskId)}
+        </button>
+      );
+    }
+    return <div className="mt-2 text-xs text-gray-400">Target task: {displayWorkerTaskId(action.taskId)}</div>;
+  }
+  return <div className="mt-2 text-xs text-gray-400">Target: {action.subjectType} {action.subjectId}</div>;
+}
+
+function ActionDetails({ title, action, tasks, onTaskClick }: {
+  title: string;
+  action: WorkerActionSummary;
+  tasks: Map<string, TaskState>;
+  onTaskClick: (task: TaskState) => void;
+}) {
+  return (
+    <section className="rounded border border-gray-800 bg-gray-850/60 p-3">
+      <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">{title}</h3>
+      <dl className="mt-2 grid grid-cols-[4.5rem_1fr] gap-x-3 gap-y-1 text-xs">
+        <dt className="text-gray-500">Action</dt>
+        <dd className="text-gray-200">{formatWorkerValue(action.actionType)}</dd>
+        <dt className="text-gray-500">Status</dt>
+        <dd className="text-gray-200">{formatWorkerValue(action.status)}</dd>
+        {action.summary ? (
+          <>
+            <dt className="text-gray-500">Summary</dt>
+            <dd className="text-gray-200">{action.summary}</dd>
+          </>
+        ) : null}
+      </dl>
+      <TargetLine action={action} tasks={tasks} onTaskClick={onTaskClick} />
+    </section>
+  );
+}
+
+export function WorkerDetailsPanel({ worker, tasks, collapsed, onToggleCollapsed, onTaskClick }: WorkerDetailsPanelProps) {
+  if (collapsed) {
+    return (
+      <aside className="flex h-full w-full items-start justify-center border-l border-gray-800 bg-gray-900 pt-3">
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          aria-label="Show details"
+          data-sidebar-nav-item
+          data-sidebar-nav-order="10"
+          className="rounded border border-gray-700 px-2 py-1 text-xs text-gray-300 hover:bg-gray-800"
+        >
+          Show details
+        </button>
+      </aside>
+    );
+  }
+
+  const copy = worker ? getWorkerDisplayCopy(worker.kind) : null;
+  const activeAction = worker ? getActiveWorkerAction(worker) : undefined;
+  const latestAction = worker?.recentActions[0];
+
+  return (
+    <aside className="flex h-full w-full flex-col border-l border-gray-800 bg-gray-900">
+      <div className="flex items-center justify-between border-b border-gray-800 px-3 py-2">
+        <div className="min-w-0">
+          <h2 data-testid="worker-details-title" className="max-w-[270px] truncate text-sm font-medium text-gray-100">
+            {copy?.name ?? 'Worker details'}
+          </h2>
+          <div className="max-w-[270px] truncate text-[11px] text-gray-400">
+            {worker ? `Kind: ${worker.kind}` : 'Select a worker to see details.'}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          aria-label="Minimize inspector"
+          data-sidebar-nav-item
+          data-sidebar-nav-order="10"
+          className="rounded border border-gray-700 px-2 py-1 text-[11px] text-gray-300 hover:bg-gray-800"
+        >
+          Minimize
+        </button>
+      </div>
+
+      <div className="flex-1 space-y-3 overflow-auto p-3 text-sm">
+        {!worker ? (
+          <div className="rounded border border-gray-800 bg-gray-850/60 p-3 text-sm text-gray-400">
+            Select a worker process to inspect its current work and last recorded action.
+          </div>
+        ) : (
+          <>
+            <section className="rounded border border-gray-800 bg-gray-850/60 p-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className={`rounded-full border px-2 py-0.5 text-[11px] ${processClass(worker)}`}>
+                  Process: {formatWorkerValue(worker.lifecycle)}
+                </span>
+                <span className={`rounded-full border px-2 py-0.5 text-[11px] ${activityClass(worker)}`}>
+                  {activityLabel(worker)}
+                </span>
+              </div>
+            </section>
+
+            {activeAction ? (
+              <ActionDetails title="Current work" action={activeAction} tasks={tasks} onTaskClick={onTaskClick} />
+            ) : (
+              <section className="rounded border border-gray-800 bg-gray-850/60 p-3">
+                <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Current work</h3>
+                <div className="mt-2 text-sm text-gray-300">{idleExplanation(worker)}</div>
+              </section>
+            )}
+
+            {latestAction ? (
+              <ActionDetails title="Last recorded action" action={latestAction} tasks={tasks} onTaskClick={onTaskClick} />
+            ) : (
+              <section className="rounded border border-gray-800 bg-gray-850/60 p-3">
+                <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Last recorded action</h3>
+                <div className="mt-2 text-sm text-gray-400">{copy?.noActionText}</div>
+              </section>
+            )}
+
+            {worker.kind === 'autofix' && worker.recovery ? (
+              <section className="rounded border border-gray-800 bg-gray-850/60 p-3">
+                <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Autofix history</h3>
+                <div className="mt-2 text-sm text-gray-300">
+                  Scanned {worker.recovery.scans} · submitted {worker.recovery.submissions} · skipped {worker.recovery.skips}
+                  {worker.recovery.lastSkipReason ? ` · last skip: ${worker.recovery.lastSkipReason}` : ''}
+                  {worker.recovery.lastSkipTaskId ? ` on task ${displayWorkerTaskId(worker.recovery.lastSkipTaskId)}` : ''}
+                </div>
+              </section>
+            ) : null}
+          </>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/packages/ui/src/hooks/useWorkerStatus.ts
+++ b/packages/ui/src/hooks/useWorkerStatus.ts
@@ -1,0 +1,43 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { WorkerStatusSnapshot } from '../types.js';
+
+export function useWorkerStatus(pollMs = 2000): readonly [snapshot: WorkerStatusSnapshot | null, refresh: () => Promise<void>] {
+  const [snapshot, setSnapshot] = useState<WorkerStatusSnapshot | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      const status = await window.invoker?.getWorkerStatus();
+      if (status) {
+        setSnapshot(status);
+      }
+    } catch {
+      // ignore polling errors
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const poll = async () => {
+      try {
+        const status = await window.invoker?.getWorkerStatus();
+        if (!cancelled && status) {
+          setSnapshot(status);
+        }
+      } catch {
+        // ignore polling errors
+      }
+    };
+
+    void poll();
+    const interval = window.setInterval(() => {
+      void poll();
+    }, pollMs);
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [pollMs]);
+
+  return [snapshot, refresh] as const;
+}

--- a/packages/ui/src/hooks/useWorkerStatus.ts
+++ b/packages/ui/src/hooks/useWorkerStatus.ts
@@ -1,13 +1,18 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { WorkerStatusSnapshot } from '../types.js';
 
 export function useWorkerStatus(pollMs = 2000): readonly [snapshot: WorkerStatusSnapshot | null, refresh: () => Promise<void>] {
   const [snapshot, setSnapshot] = useState<WorkerStatusSnapshot | null>(null);
+  const mountedRef = useRef(true);
 
-  const refresh = useCallback(async () => {
+  useEffect(() => () => {
+    mountedRef.current = false;
+  }, []);
+
+  const fetchStatus = useCallback(async () => {
     try {
       const status = await window.invoker?.getWorkerStatus();
-      if (status) {
+      if (mountedRef.current && status) {
         setSnapshot(status);
       }
     } catch {
@@ -16,28 +21,12 @@ export function useWorkerStatus(pollMs = 2000): readonly [snapshot: WorkerStatus
   }, []);
 
   useEffect(() => {
-    let cancelled = false;
-
-    const poll = async () => {
-      try {
-        const status = await window.invoker?.getWorkerStatus();
-        if (!cancelled && status) {
-          setSnapshot(status);
-        }
-      } catch {
-        // ignore polling errors
-      }
-    };
-
-    void poll();
+    void fetchStatus();
     const interval = window.setInterval(() => {
-      void poll();
+      void fetchStatus();
     }, pollMs);
-    return () => {
-      cancelled = true;
-      window.clearInterval(interval);
-    };
-  }, [pollMs]);
+    return () => window.clearInterval(interval);
+  }, [fetchStatus, pollMs]);
 
-  return [snapshot, refresh] as const;
+  return [snapshot, fetchStatus] as const;
 }

--- a/packages/ui/src/lib/worker-display.ts
+++ b/packages/ui/src/lib/worker-display.ts
@@ -1,0 +1,70 @@
+import type { WorkerActionStatus, WorkerActionSummary, WorkerStatusEntry } from '../types.js';
+
+export interface WorkerDisplayCopy {
+  readonly name: string;
+  readonly idleText: string;
+  readonly noActionText: string;
+}
+
+export const ACTIVE_WORKER_ACTION_STATUSES: ReadonlySet<WorkerActionStatus> = new Set<WorkerActionStatus>([
+  'queued',
+  'pending',
+  'running',
+  'needs_input',
+  'review_ready',
+]);
+
+export function formatWorkerValue(value: string): string {
+  return value
+    .split(/[-_]/g)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+export function displayWorkerTaskId(taskId: string): string {
+  if (taskId.startsWith('__merge__')) return 'merge gate';
+  const slash = taskId.lastIndexOf('/');
+  return slash >= 0 ? taskId.slice(slash + 1) : taskId;
+}
+
+export function getWorkerDisplayCopy(kind: string): WorkerDisplayCopy {
+  if (kind === 'autofix') {
+    return {
+      name: 'Autofix',
+      idleText: 'Idle. Waiting for failed tasks that still have retry budget.',
+      noActionText: 'No autofix actions recorded yet.',
+    };
+  }
+  if (kind === 'pr-status') {
+    return {
+      name: 'PR status',
+      idleText: 'Idle. Polls review-gate PR status every minute; it does not create queue tasks.',
+      noActionText: 'No persisted PR status actions. This worker updates review gates directly.',
+    };
+  }
+  if (kind === 'ci-failure') {
+    return {
+      name: 'CI failure repair',
+      idleText: 'Idle. Waiting for review-gate CI failure events.',
+      noActionText: 'No CI repair actions recorded yet.',
+    };
+  }
+  return {
+    name: formatWorkerValue(kind),
+    idleText: 'Idle. Waiting for worker-owned work.',
+    noActionText: 'No worker actions recorded yet.',
+  };
+}
+
+export function getActiveWorkerActions(worker: WorkerStatusEntry): WorkerActionSummary[] {
+  return worker.recentActions.filter((action) => ACTIVE_WORKER_ACTION_STATUSES.has(action.status));
+}
+
+export function getActiveWorkerAction(worker: WorkerStatusEntry): WorkerActionSummary | undefined {
+  return getActiveWorkerActions(worker)[0];
+}
+
+export function countActiveWorkerActions(workers: readonly WorkerStatusEntry[]): number {
+  return workers.reduce((count, worker) => count + getActiveWorkerActions(worker).length, 0);
+}

--- a/packages/ui/src/lib/workflow-progress-surfaces.ts
+++ b/packages/ui/src/lib/workflow-progress-surfaces.ts
@@ -1,7 +1,7 @@
 import type { QueueStatus } from '@invoker/contracts';
 import type { TaskState, TaskStatus, WorkflowMeta, WorkflowStatus } from '../types.js';
 
-export type SidebarSurface = 'home' | 'planning' | 'workflows' | 'attention' | 'running';
+export type SidebarSurface = 'home' | 'planning' | 'workflows' | 'attention' | 'running' | 'workers';
 
 export interface WorkflowListEntry {
   workflow: WorkflowMeta;

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -315,7 +315,21 @@ export interface TaskReplacementDef {
 // InvokerAPI is derived from the IPC channel registry in @invoker/contracts.
 
 export type { ReviewGateArtifact, ReviewGateState } from '@invoker/workflow-graph';
-export type { InvokerAPI, ClaudeMessage, AgentSessionData, ReviewGateQueryResponse } from '@invoker/contracts';
+export type {
+  InvokerAPI,
+  ClaudeMessage,
+  AgentSessionData,
+  QueueStatus,
+  ReviewGateQueryResponse,
+  WorkerActionSummary,
+  WorkerActionStatus,
+  WorkerControlAction,
+  WorkerLifecycleStatus,
+  WorkerPolicyStatus,
+  WorkerRecoverySummary,
+  WorkerStatusEntry,
+  WorkerStatusSnapshot,
+} from '@invoker/contracts';
 
 import type { InvokerAPI, RuntimeStatus, TerminalOutputEvent } from '@invoker/contracts';
 // ── Augment global Window ───────────────────────────────────


### PR DESCRIPTION
## Summary

The visual proof tests now check real task data.

They assert the narrowed rails and capture workflow graph and Needs Attention data, not only empty states.

This is test-only. The UI behavior is in the earlier slices.

<details>
<summary>Review metadata</summary>

Review Claim: The visual proof scenarios cover real workflow and task data for the worker UI stack.

Review Lane: proof

Review Unit: proof

Safety Invariant: The change only updates visual proof test scenarios and expected layout checks.

Slice Rationale: Proof-only changes stay separate from the UI behavior slices.

</details>

## Non-goals

- Changing worker state data.
- Changing panel widths.
- Changing the worker activity UI.
- Changing queue execution behavior.

## Visual Proof

After: real task graph data is visible with the narrower sidebar.

![Task graph data proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260706-4f486e/dag-loaded.png)

After: the Needs Attention browser shows real task data, including `task-alpha` and `task-beta` state.

![Needs attention task data proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260706-4f486e/needs-attention-browser.png)

## Test Plan

- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app test:e2e visual-proof.spec.ts -g "terminal planning loads graph|workflows browser and home return|needs attention browser focuses the selected task|collapsible workflow browsers"`
- [x] `CAPTURE_MODE=after pnpm --filter @invoker/app test:e2e visual-proof.spec.ts -g "needs attention browser focuses the selected task|dag loaded"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f05833c93`
- Post-revert steps: None
- Data migration? No

Depends-On: #3130
