### PR TITLE
[Workers Surface](2) Expose worker snapshot read routing

### DIFF
--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -25,6 +25,7 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     listWorkerActionHistory: vi.fn((request) => ({ workerKind: request.workerKind, actions: [], limit: request.limit ?? 20, offset: request.offset ?? 0, hasMore: false })),
     listWorkerDecisions: vi.fn((request) => ({ decision: request.decision, actions: [], limit: request.limit ?? 20, offset: request.offset ?? 0, hasMore: false })),
     getWorkerStatus: vi.fn(() => ({ generatedAt: 'now', workers: [] })),
+    getWorkers: vi.fn(() => ({ generatedAt: 'workers-now', workers: [] })),
     getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
     getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
     getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
@@ -67,6 +68,7 @@ describe('answerOwnerReadQuery', () => {
     const h = makeHandlers();
     expect(answerOwnerReadQuery({ kind: 'queue' }, h)).toEqual({ runningCount: 2 });
     expect(answerOwnerReadQuery({ kind: 'worker-status' }, h)).toEqual({ workerStatus: { generatedAt: 'now', workers: [] } });
+    expect(answerOwnerReadQuery({ kind: 'workers' }, h)).toEqual({ generatedAt: 'workers-now', workers: [] });
     expect(answerOwnerReadQuery({ kind: 'worker-action-history', workerKind: 'autofix', limit: 2, offset: 4 }, h)).toEqual({
       workerActionHistory: { workerKind: 'autofix', actions: [], limit: 2, offset: 4, hasMore: false },
     });
@@ -176,6 +178,7 @@ describe('buildOwnerReadQueryHandlers', () => {
       resetUiPerfStats: () => {},
       getStreamSequence: () => 5,
       getWorkerStatus: () => ({ generatedAt: 'now', workers: [] }),
+      getWorkers: () => ({ generatedAt: 'workers-now', workers: [] }),
       resolveInvokerHomeRoot: () => '/home',
       orchestrator: { ...f.orchestrator, ...orch } as never,
       persistence: { ...f.persistence, ...persist } as never,
@@ -194,6 +197,7 @@ describe('buildOwnerReadQueryHandlers', () => {
     expect(h.getAllCompletedTasks()).toEqual([{ id: 'done' }]);
     expect(h.getHistoryTasks()).toEqual([{ id: 'hist-1', workflowName: 'Plan', lastEventAt: null, eventCount: 0 }]);
     expect(h.getWorkerStatus()).toEqual({ generatedAt: 'now', workers: [] });
+    expect(h.getWorkers()).toEqual({ generatedAt: 'workers-now', workers: [] });
     expect(h.listWorkerActionHistory({ workerKind: 'autofix', limit: 1, offset: 2 })).toEqual({
       workerKind: 'autofix',
       actions: [],

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -17,6 +17,7 @@ import {
 import type { WorkerActionRecord } from '@invoker/data-store';
 import {
   AUTO_STARTED_OWNER_WORKER_KINDS,
+  createLocalWorkerStatusSnapshot,
   createWorkerRuntimeController,
   listWorkerActionHistory,
   listWorkerDecisions,
@@ -304,7 +305,68 @@ describe('createWorkerRuntimeController', () => {
     expect(worker?.recentActions).toHaveLength(5);
   });
 
-it('returns worker action history with paging metadata', () => {
+  it('combines worker action rows and auto-fix task events in recent logs', () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registry.register({
+      kind: AUTO_FIX_WORKER_KIND,
+      note: 'Auto-fixes failed tasks.',
+      source: 'built-in',
+      factory: () => runtime('recovery'),
+    });
+
+    const snapshot = createLocalWorkerStatusSnapshot({
+      registry,
+      autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      persistence: {
+        listWorkerActions: vi.fn(() => [{
+          id: 'action-1',
+          workerKind: AUTO_FIX_WORKER_KIND,
+          actionType: 'fix-with-agent',
+          workflowId: 'wf-1',
+          taskId: 'wf-1/task-1',
+          subjectType: 'task',
+          subjectId: 'wf-1/task-1',
+          externalKey: 'wf-1/task-1',
+          status: 'queued',
+          attemptCount: 1,
+          payload: { reason: 'failed' },
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:01.000Z',
+        }]),
+        listTaskEvents: vi.fn(() => [{
+          id: 7,
+          taskId: 'wf-1/task-1',
+          eventType: 'debug.auto-fix',
+          payload: '{"phase":"worker-autofix-skip","reason":"not-eligible"}',
+          createdAt: '2026-01-01T00:00:02.000Z',
+        }]),
+        listWorkflows: vi.fn(() => []),
+        loadTasks: vi.fn(() => []),
+        getEvents: vi.fn(() => []),
+        getEventsByTypes: vi.fn(() => []),
+        countEventsByTypes: vi.fn(() => []),
+      } as never,
+    });
+
+    expect(snapshot.workers[0]).toMatchObject({
+      source: 'built-in',
+      availability: 'available',
+    });
+    expect(snapshot.workers[0]?.recentLogs).toEqual([
+      expect.objectContaining({
+        source: 'task_events',
+        eventType: 'debug.auto-fix',
+        payload: expect.objectContaining({ phase: 'worker-autofix-skip' }),
+      }),
+      expect.objectContaining({
+        source: 'worker_actions',
+        actionType: 'fix-with-agent',
+        status: 'queued',
+      }),
+    ]);
+  });
+
+  it('returns worker action history with paging metadata', () => {
     const listWorkerActions = vi.fn(() => Array.from({ length: 3 }, (_value, index) => ({
       id: `wa-${index}`,
       workerKind: 'history',

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -201,6 +201,7 @@ import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-r
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import {
   AUTO_STARTED_OWNER_WORKER_KINDS,
+  createLocalWorkerStatusSnapshot,
   createWorkerRuntimeController,
   type WorkerRuntimeController,
 } from './worker-control.js';
@@ -1602,7 +1603,16 @@ function startHeadlessMode(): void {
             getUiPerfStats: () => headlessDeps.getUiPerfStats?.() ?? {},
             resetUiPerfStats: () => headlessDeps.resetUiPerfStats?.(),
             getStreamSequence: () => 0,
-            getWorkerStatus: () => workerRuntimeController?.snapshot() ?? { generatedAt: new Date().toISOString(), workers: [] },
+            getWorkerStatus: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+              registry: createRegisteredWorkerRegistry(),
+              persistence,
+              autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+            }),
+            getWorkers: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+              registry: createRegisteredWorkerRegistry(),
+              persistence,
+              autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+            }),
             resolveInvokerHomeRoot,
             orchestrator,
             persistence,
@@ -2276,6 +2286,11 @@ function createEmbeddedTerminalBackendFromConfig(
           detachWorkflow: (workflowId, upstreamWorkflowId) =>
             requireGuiMutationTaskActions().performDetachWorkflow(workflowId, upstreamWorkflowId),
           getBundledSkillsStatus,
+          getWorkers: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+            registry: createRegisteredWorkerRegistry(),
+            persistence,
+            autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          }),
           getSystemDiagnostics: () => collectSystemDiagnostics({
             appVersion: app.getVersion(),
             isPackaged: app.isPackaged,
@@ -2550,7 +2565,16 @@ function createEmbeddedTerminalBackendFromConfig(
           ownerModeLabel: 'gui',
           getUiPerfStats: () => getUiPerfStats(),
           resetUiPerfStats: () => resetUiPerfStats(),
-          getWorkerStatus: () => workerRuntimeController?.snapshot() ?? { generatedAt: new Date().toISOString(), workers: [] },
+          getWorkerStatus: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+            registry: createRegisteredWorkerRegistry(),
+            persistence,
+            autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          }),
+          getWorkers: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+            registry: createRegisteredWorkerRegistry(),
+            persistence,
+            autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          }),
           getStreamSequence: () => getTaskDeltaStreamSequence(),
           resolveInvokerHomeRoot,
           orchestrator,
@@ -2822,6 +2846,32 @@ function createEmbeddedTerminalBackendFromConfig(
       resolveSetupCliPath,
       getBundledSkillsStatus,
       installPackagedSkills,
+    });
+
+    ipcMain.handle('invoker:get-workers', async () => {
+      if (!ownerMode) {
+        try {
+          return await messageBus.request('headless.query', { kind: 'workers' });
+        } catch (err) {
+          if (isMutationOwnerUnavailableError(err)) markDaemonOwnerUnavailable(err instanceof Error ? err.message : String(err));
+          logger.warn(
+            `get-workers owner delegation failed; falling back to local read-only snapshot: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            { module: 'ipc' },
+          );
+        }
+        return createLocalWorkerStatusSnapshot({
+          registry: createRegisteredWorkerRegistry(),
+          persistence,
+          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        });
+      }
+      return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+        registry: createRegisteredWorkerRegistry(),
+        persistence,
+        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      });
     });
 
     ipcMain.handle('invoker:get-activity-logs', (_event, sinceId?: number, limit?: number) => {

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -40,6 +40,7 @@ export interface OwnerReadQueryHandlers {
   listWorkerActionHistory: (request: WorkerActionHistoryRequest) => WorkerActionHistoryResponse;
   listWorkerDecisions: (request: WorkerDecisionsRequest) => WorkerDecisionsResponse;
   getWorkerStatus: () => WorkerStatusSnapshot;
+  getWorkers: () => WorkerStatusSnapshot;
   getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
   getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
   getActionGraphSnapshot: () => Record<string, unknown>;
@@ -113,6 +114,8 @@ export function answerOwnerReadQuery(
       return handlers.getQueueStatus();
     case 'worker-status':
       return { workerStatus: handlers.getWorkerStatus() };
+    case 'workers':
+      return handlers.getWorkers() as unknown as Record<string, unknown>;
     case 'worker-action-history':
       return { workerActionHistory: handlers.listWorkerActionHistory(workerActionHistoryRequest()) };
     case 'worker-decisions':
@@ -211,6 +214,7 @@ export interface OwnerReadQueryDeps {
   resetUiPerfStats: () => void;
   getStreamSequence: () => number;
   getWorkerStatus: () => WorkerStatusSnapshot;
+  getWorkers: () => WorkerStatusSnapshot;
   resolveInvokerHomeRoot: () => string;
   orchestrator: ReadOrchestrator;
   persistence: ReadPersistence;
@@ -228,6 +232,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     resetUiPerfStats: deps.resetUiPerfStats,
     getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
     getWorkerStatus: deps.getWorkerStatus,
+    getWorkers: deps.getWorkers,
     listWorkerActionHistory: (request: WorkerActionHistoryRequest) => listWorkerActionHistory(persistence, request),
     listWorkerDecisions: (request: WorkerDecisionsRequest) => listWorkerDecisions(persistence, request),
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,

--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -19,7 +19,7 @@ import type {
 } from '@invoker/contracts';
 import { Channels, type MessageBus } from '@invoker/transport';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import { registerBuiltinAgents, type AgentRegistry } from '@invoker/execution-engine';
+import { createWorkerRegistry, registerBuiltinAgents, registerBuiltinWorkers, type AgentRegistry, type WorkerRuntimeDependencies } from '@invoker/execution-engine';
 import type { Orchestrator, TaskDelta } from '@invoker/workflow-core';
 import { loadConfig, type InvokerConfig } from '../config.js';
 import type { ApiMutationFacade } from '../api-server.js';
@@ -27,6 +27,8 @@ import { createTaskGraphEventPublisher } from '../task-graph-event-publisher.js'
 import { createTaskDeltaStreamSequence } from '../task-delta-stream-sequence.js';
 import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
 import { buildWebInvokerDispatch } from './web-invoker-dispatch.js';
+import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
+import { AUTO_STARTED_OWNER_WORKER_KINDS, createLocalWorkerStatusSnapshot } from '../worker-control.js';
 import { startWebBridge, resolveWebUiDistDir, type WebBridge } from './web-bridge-server.js';
 
 const DEFAULT_WEB_HOST = '127.0.0.1';
@@ -119,6 +121,14 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
     deleteWorkflow: deps.deleteWorkflow,
     detachWorkflow: deps.detachWorkflow,
     getBundledSkillsStatus: deps.getBundledSkillsStatus,
+    getWorkers: () => createLocalWorkerStatusSnapshot({
+      registry: registerExternalWorkersFromConfig(
+        deps.config.externalWorkers,
+        registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
+      ),
+      persistence: deps.persistence,
+      autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+    }),
     logger: deps.logger,
   });
 

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -17,6 +17,7 @@ import type {
   BundledSkillsStatus,
   Logger,
   SystemDiagnostics,
+  WorkerStatusSnapshot,
 } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
@@ -47,6 +48,7 @@ export interface WebInvokerDispatchDeps {
   getSystemDiagnostics?: () => SystemDiagnostics;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
   checkPrStatuses?: () => void | Promise<void>;
+  getWorkers?: () => WorkerStatusSnapshot;
   logger?: Logger;
 }
 
@@ -107,6 +109,9 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return orchestrator.getWorkflowStatus();
       case 'invoker:get-queue-status':
         return orchestrator.getQueueStatus();
+      case 'invoker:get-worker-status':
+      case 'invoker:get-workers':
+        return deps.getWorkers?.() ?? { generatedAt: new Date().toISOString(), workers: [] };
       case 'invoker:get-action-graph':
         return buildCurrentActionGraphSnapshot({
           orchestrator,

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -4,12 +4,14 @@ import type {
   WorkerActionSummary,
   WorkerDecisionsRequest,
   WorkerDecisionsResponse,
+  WorkerLogEntry,
   WorkerPolicyStatus,
   WorkerRecoverySummary,
+  WorkerSource,
   WorkerStatusEntry,
   WorkerStatusSnapshot,
 } from '@invoker/contracts';
-import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
+import type { SQLiteAdapter, TaskEvent, WorkerActionRecord } from '@invoker/data-store';
 import {
   AUTO_FIX_WORKER_KIND,
   AUTO_APPROVE_WORKER_KIND,
@@ -51,7 +53,13 @@ export interface WorkerRuntimeController {
 
 type WorkerStatusPersistence = Pick<
   SQLiteAdapter,
-  'listWorkerActions' | 'listWorkflows' | 'loadTasks' | 'getEvents' | 'getEventsByTypes' | 'countEventsByTypes'
+  | 'listWorkerActions'
+  | 'listTaskEvents'
+  | 'listWorkflows'
+  | 'loadTasks'
+  | 'getEvents'
+  | 'getEventsByTypes'
+  | 'countEventsByTypes'
 > & Partial<Pick<SQLiteAdapter, 'getWorkerDesiredState' | 'setWorkerDesiredState' | 'listWorkerDesiredStates'>>;
 
 const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
@@ -207,6 +215,7 @@ export function createWorkerRuntimeController(options: {
     return buildWorkerStatusEntry({
       definitionKind: definition.kind,
       note: definition.note,
+      source: sourceForDefinition(definition),
       handle: handles.get(kind),
       stoppedAt: stoppedAtByKind.get(kind),
       autoStarts: desiredEnabled,
@@ -217,6 +226,7 @@ export function createWorkerRuntimeController(options: {
       recovery: definition.kind === AUTO_FIX_WORKER_KIND
         ? toWorkerRecoverySummary(options.persistence)
         : undefined,
+      runningKnown: true,
     });
   };
 
@@ -305,12 +315,14 @@ export function createLocalWorkerStatusSnapshot(options: {
       return buildWorkerStatusEntry({
         definitionKind: definition.kind,
         note: definition.note,
+        source: sourceForDefinition(definition),
         autoStarts: desiredEnabled,
         desiredEnabled,
         policy: 'unknown',
         persistence: options.persistence,
         canControl: false,
         recovery: definition.kind === AUTO_FIX_WORKER_KIND ? recovery : undefined,
+        runningKnown: false,
       });
     }),
   };
@@ -320,6 +332,7 @@ export function createLocalWorkerStatusSnapshot(options: {
 function buildWorkerStatusEntry(args: {
   definitionKind: string;
   note: string;
+  source: WorkerSource;
   handle?: RuntimeHandle;
   stoppedAt?: string;
   autoStarts: boolean;
@@ -328,15 +341,21 @@ function buildWorkerStatusEntry(args: {
   persistence: WorkerStatusPersistence;
   canControl: boolean;
   recovery?: WorkerRecoverySummary;
+  runningKnown: boolean;
 }): WorkerStatusEntry {
   const lifecycle = args.handle
     ? args.handle.runtime.isRunning() ? 'running' : 'exited'
     : 'stopped';
   const controlDisabledReason = getControlDisabledReason(args.canControl);
   const runtime = args.handle?.runtime;
+  const rawActions = args.persistence.listWorkerActions({ workerKind: args.definitionKind, limit: 5 }).slice(0, 5);
+  const recentActions = rawActions.map(toWorkerActionSummary);
   return {
     kind: args.definitionKind,
     note: args.note,
+    source: args.source,
+    availability: 'available',
+    ...(args.runningKnown ? { running: lifecycle === 'running' } : {}),
     ...(runtime ? { runtimeKind: runtime.identity.kind, instanceId: runtime.identity.instanceId } : {}),
     lifecycle,
     policy: args.policy,
@@ -347,9 +366,14 @@ function buildWorkerStatusEntry(args: {
     ...(controlDisabledReason ? { controlDisabledReason } : {}),
     ...(args.handle?.startedAt ? { startedAt: args.handle.startedAt } : {}),
     ...(args.stoppedAt ? { stoppedAt: args.stoppedAt } : {}),
-    recentActions: args.persistence.listWorkerActions({ workerKind: args.definitionKind, limit: 5 }).slice(0, 5).map(toWorkerActionSummary),
+    recentActions,
+    recentLogs: buildRecentWorkerLogs(args.definitionKind, args.persistence, rawActions),
     ...(args.recovery ? { recovery: args.recovery } : {}),
   };
+}
+
+function sourceForDefinition(definition: { kind: string; source?: 'built-in' | 'external' }): WorkerSource {
+  return definition.source ?? (BUILT_IN_WORKER_KINDS.has(definition.kind) ? 'built-in' : 'external');
 }
 
 function policyForKind(kind: string): WorkerPolicyStatus {
@@ -390,6 +414,97 @@ export function toWorkerActionSummary(action: WorkerActionRecord): WorkerActionS
     updatedAt: action.updatedAt,
     ...(action.completedAt ? { completedAt: action.completedAt } : {}),
   };
+}
+
+const AUTO_FIX_WORKER_EVENT_TYPES = [
+  'debug.auto-fix',
+  'recovery.worker.wakeup',
+  'recovery.worker.scan',
+  'recovery.worker.submit',
+  'recovery.worker.skip',
+] as const;
+
+function buildRecentWorkerLogs(
+  workerKind: string,
+  persistence: WorkerStatusPersistence,
+  actions: readonly WorkerActionRecord[],
+): WorkerLogEntry[] {
+  const actionLogs = actions.map(toWorkerActionLog);
+  const eventLogs = workerKind === AUTO_FIX_WORKER_KIND
+    ? listRecentAutoFixWorkerEvents(persistence).map((event) => toTaskEventLog(workerKind, event))
+    : [];
+
+  return [...actionLogs, ...eventLogs]
+    .sort((a, b) => workerLogTimestamp(b).localeCompare(workerLogTimestamp(a)) || a.id.localeCompare(b.id))
+    .slice(0, 10);
+}
+
+function listRecentAutoFixWorkerEvents(persistence: WorkerStatusPersistence): TaskEvent[] {
+  if (persistence.listTaskEvents) {
+    return persistence.listTaskEvents({
+      eventTypes: AUTO_FIX_WORKER_EVENT_TYPES,
+      sortBy: 'desc',
+      limit: 10,
+    });
+  }
+
+  const events: TaskEvent[] = [];
+  for (const workflow of persistence.listWorkflows()) {
+    for (const task of persistence.loadTasks(workflow.id)) {
+      for (const event of persistence.getEvents(task.id, 'desc', 20)) {
+        if (AUTO_FIX_WORKER_EVENT_TYPES.includes(event.eventType as typeof AUTO_FIX_WORKER_EVENT_TYPES[number])) {
+          events.push(event);
+        }
+      }
+    }
+  }
+  return events
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || String(b.id).localeCompare(String(a.id)))
+    .slice(0, 10);
+}
+
+function toWorkerActionLog(action: WorkerActionRecord): WorkerLogEntry {
+  return {
+    id: action.id,
+    workerKind: action.workerKind,
+    source: 'worker_actions',
+    actionType: action.actionType,
+    ...(action.workflowId ? { workflowId: action.workflowId } : {}),
+    ...(action.taskId ? { taskId: action.taskId } : {}),
+    subjectType: action.subjectType,
+    subjectId: action.subjectId,
+    externalKey: action.externalKey,
+    status: action.status,
+    ...(action.summary ? { summary: action.summary } : {}),
+    ...(action.payload !== undefined ? { payload: action.payload } : {}),
+    createdAt: action.createdAt,
+    updatedAt: action.updatedAt,
+  };
+}
+
+function toTaskEventLog(workerKind: string, event: TaskEvent): WorkerLogEntry {
+  return {
+    id: String(event.id),
+    workerKind,
+    source: 'task_events',
+    eventType: event.eventType,
+    taskId: event.taskId,
+    ...(event.payload !== undefined ? { payload: parseTaskEventPayload(event.payload) } : {}),
+    createdAt: event.createdAt,
+  };
+}
+
+function parseTaskEventPayload(payload: unknown): unknown {
+  if (typeof payload !== 'string') return payload;
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return payload;
+  }
+}
+
+function workerLogTimestamp(log: WorkerLogEntry): string {
+  return log.updatedAt ?? log.createdAt;
 }
 
 function toWorkerRecoverySummary(persistence: WorkerStatusPersistence): WorkerRecoverySummary {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2509,6 +2509,26 @@ describe('SQLiteAdapter', () => {
       expect(second.every((event) => event.id < oldest.id)).toBe(true);
       expect(second[0]!.eventType).toBe(`event-${29 - 10}`);
     });
+
+    it('lists recent task events across tasks by event type', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      adapter.saveTask('wf-1', makeTask('t2'));
+
+      adapter.logEvent('t1', 'debug.auto-fix', { phase: 'worker-autofix-skip' });
+      adapter.logEvent('t2', 'other.event');
+      adapter.logEvent('t2', 'recovery.worker.submit', { phase: 'worker-autofix-submitted' });
+
+      const events = adapter.listTaskEvents({
+        eventTypes: ['debug.auto-fix', 'recovery.worker.submit'],
+        sortBy: 'desc',
+        limit: 2,
+      });
+
+      expect(events.map((event) => event.eventType)).toEqual(['recovery.worker.submit', 'debug.auto-fix']);
+      expect(events.map((event) => event.taskId)).toEqual(['t2', 't1']);
+      expect(adapter.listTaskEvents({ eventTypes: [], limit: 2 })).toEqual([]);
+    });
   });
 
   describe('JSON fields', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -142,6 +142,13 @@ export type WorkerActionStatus =
   | 'abandoned'
   | 'cancelled';
 
+export interface TaskEventListFilters {
+  taskId?: string;
+  eventTypes?: readonly string[];
+  sortBy?: 'asc' | 'desc';
+  limit?: number;
+}
+
 export interface WorkerActionRecord {
   id: string;
   workerKind: string;
@@ -302,6 +309,7 @@ export interface PersistenceAdapter {
     count: number;
     lastCreatedAt: string | null;
   }>;
+  listTaskEvents?(filters?: TaskEventListFilters): TaskEvent[];
 
   // Worker actions (durable worker-owned action state/history)
   getWorkerAction(workerKind: string, externalKey: string): WorkerActionRecord | undefined;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -40,6 +40,7 @@ import type {
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
+  TaskEventListFilters,
   ActivityLogEntry,
   Conversation,
   ConversationMessage,
@@ -1588,6 +1589,45 @@ export class SQLiteAdapter implements PersistenceAdapter {
       payload: row.payload ?? undefined,
       createdAt: row.created_at,
     };
+  }
+
+  listTaskEvents(filters: TaskEventListFilters = {}): TaskEvent[] {
+    if (filters.limit !== undefined && Math.floor(filters.limit) <= 0) {
+      return [];
+    }
+    if (filters.eventTypes && filters.eventTypes.length === 0) {
+      return [];
+    }
+
+    const where: string[] = [];
+    const params: unknown[] = [];
+    if (filters.taskId) {
+      where.push('task_id = ?');
+      params.push(filters.taskId);
+    }
+    if (filters.eventTypes) {
+      where.push(`event_type IN (${filters.eventTypes.map(() => '?').join(', ')})`);
+      params.push(...filters.eventTypes);
+    }
+
+    const orderBy = filters.sortBy === 'asc' ? 'ASC' : 'DESC';
+    let limitSql = '';
+    if (filters.limit !== undefined) {
+      limitSql = ' LIMIT ?';
+      params.push(Math.floor(filters.limit));
+    }
+
+    const rows = this.queryAll(
+      `SELECT * FROM events ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''} ORDER BY id ${orderBy}${limitSql}`,
+      params,
+    );
+    return rows.map((row: any) => ({
+      id: row.id,
+      taskId: row.task_id,
+      eventType: row.event_type,
+      payload: row.payload ?? undefined,
+      createdAt: row.created_at,
+    }));
   }
 
   getWorkerAction(workerKind: string, externalKey: string): WorkerActionRecord | undefined {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -120,6 +120,9 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_events_task_id_id
         ON events(task_id, id);
 
+      CREATE INDEX IF NOT EXISTS idx_events_event_type_id
+        ON events(event_type, id);
+
       CREATE INDEX IF NOT EXISTS idx_events_type_created
         ON events(event_type, created_at);
 
@@ -541,6 +544,7 @@ export const POST_MIGRATION_STATEMENTS = [
   'DROP INDEX IF EXISTS idx_attempts_node',
   'CREATE INDEX IF NOT EXISTS idx_attempts_node_created ON attempts(node_id, created_at)',
   'CREATE INDEX IF NOT EXISTS idx_events_task_id_id ON events(task_id, id)',
+  'CREATE INDEX IF NOT EXISTS idx_events_event_type_id ON events(event_type, id)',
   'CREATE INDEX IF NOT EXISTS idx_events_type_created ON events(event_type, created_at)',
   'CREATE INDEX IF NOT EXISTS idx_tasks_workflow_id ON tasks(workflow_id)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_task_updated ON worker_actions(task_id, updated_at)',

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -102,6 +102,7 @@ export function registerAutoFixWorker(
   registry.register({
     kind: AUTO_FIX_WORKER_KIND,
     note: 'Auto-fixes failed tasks by submitting fix-with-agent recovery intents.',
+    source: 'built-in',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createRecoveryWorker({
         logger: deps.logger,

--- a/packages/execution-engine/src/external-worker.ts
+++ b/packages/execution-engine/src/external-worker.ts
@@ -152,6 +152,7 @@ export function registerExternalWorkers<TDeps>(
     registry.register({
       kind: config.kind,
       note: `Supervises external worker process ${config.launch.executable}.`,
+      source: 'external',
       factory: (_deps: TDeps) => createExternalWorkerRuntime(config),
     });
   }

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -17,6 +17,8 @@ export interface WorkerDefinition<TDeps = unknown> {
   readonly kind: string;
   /** Human-readable note surfaced in operator output. */
   readonly note: string;
+  /** Registration source surfaced in read-only snapshots. */
+  readonly source?: 'built-in' | 'external';
   /** Builds the worker runtime from injected dependencies. */
   readonly factory: WorkerFactory<TDeps>;
 }

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -50,6 +50,7 @@ export function registerCiFailureWorker(
   registry.register({
     kind: CI_FAILURE_WORKER_KIND,
     note: 'Submits head-SHA guarded CI repair intents for failed review-gate checks.',
+    source: 'built-in',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createCiFailureWorker({
         logger: deps.logger,

--- a/packages/execution-engine/src/workers/pr-status-worker.ts
+++ b/packages/execution-engine/src/workers/pr-status-worker.ts
@@ -31,6 +31,7 @@ export function registerPrStatusWorker(
   registry.register({
     kind: PR_STATUS_WORKER_KIND,
     note: 'Polls review-gate PR status through the registered TaskRunner review-gate check.',
+    source: 'built-in',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createPrStatusWorker({
         logger: deps.logger,


### PR DESCRIPTION
## Summary

Routes the worker snapshot through the existing app query path.

The snapshot includes worker metadata, current process state, recent actions, and recent log entries.

This uses existing store reads and does not mutate worker state.

## Review Claim

Approve the worker snapshot query routing.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The slice only adds read handlers and snapshot assembly; it does not add worker write controls or mutate worker state.

## Slice Rationale

This slice wires the query route separately from the visible worker browser.

## Non-goals

Does not add a Workers page. Does not expose new worker controls. Does not change the shared contract shape beyond the prior slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff --check upstream/stack/EdbertChan/workers-surface-stack/workers-surface-1-add-worker-snapshot-read-api--a4c2d9cd..HEAD`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/worker-control.test.ts src/__tests__/owner-read-query.test.ts`
- [x] `cd packages/data-store && pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/worker-registry.test.ts src/__tests__/external-worker.test.ts src/__tests__/pr-ci-workers.test.ts src/__tests__/pr-maintenance-workers.test.ts`
- [x] `pnpm run check:types`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-3148-body.md --require-visual-proof --changed-files-file <(git diff --name-only upstream/stack/EdbertChan/workers-surface-stack/workers-surface-1-add-worker-snapshot-read-api--a4c2d9cd..HEAD) --diff-file <(git diff --find-renames --unified=200000 --diff-filter=ACMRTD upstream/stack/EdbertChan/workers-surface-stack/workers-surface-1-add-worker-snapshot-read-api--a4c2d9cd..HEAD --)`

</details>

## Visual Proof

This routing slice has no independent visible UI behavior change; proof is included because Electron app wiring under `packages/app/**` changes.

![Workers read-only surface](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-346c4b/workers-read-only-surface.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert b4638d60853f012ff6d3f023403378abf7af77c1`
- Post-revert steps: None
- Data migration? No

</details>
