### PR TITLE
[Workers Surface](3) Add read-only workers surface

### DIFF
--- a/packages/app/e2e/workers-surface.spec.ts
+++ b/packages/app/e2e/workers-surface.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect, captureScreenshot } from './fixtures/electron-app.js';
+
+test('workers surface shows read-only worker activity', async ({ page }) => {
+  await page.getByTestId('sidebar-workers').click();
+
+  await expect(page.getByTestId('workers-rail')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Workers' })).toBeVisible();
+  await expect(page.getByText('3 workers registered.')).toBeVisible();
+  await expect(page.getByTestId('worker-process-list')).toBeVisible();
+  await expect(page.getByTestId('worker-row-autofix')).toBeVisible();
+  await expect(page.getByTestId('worker-row-pr-status')).toBeVisible();
+  await expect(page.getByTestId('worker-row-ci-failure')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Start process' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Stop process' })).toHaveCount(0);
+
+  await captureScreenshot(page, 'workers-read-only-surface');
+});

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -18,9 +18,7 @@ import {
   acquireWorkerLock,
   createAutoFixAttemptLedger,
   createWorkerRegistry,
-  registerAutoFixWorker,
-  registerPrMaintenanceWorkers,
-  registerPrSummaryRefreshWorker,
+  registerBuiltinWorkers,
   resolveInvokerHomeRoot,
   GitHubMergeGateProvider,
   WorkerLockHeldError,
@@ -432,11 +430,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
     deps.invokerConfig?.externalWorkers,
-    registerPrSummaryRefreshWorker(
-      registerPrMaintenanceWorkers(
-        registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
-      ),
-    ),
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
   );
 
   if (subCommand === 'list') {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,7 +12,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
 import type { ActionGraphNode, ExecutionDefaults, ExecutionHarnessOption, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, StartReadyRequest, StartReadyResult, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
-import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
+import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { reportUiNavigation } from './lib/report-ui-navigation.js';
 
@@ -35,6 +35,7 @@ import { WorkflowGraph } from './components/WorkflowGraph.js';
 import { FloatingGraphPanel } from './components/FloatingGraphPanel.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
 import { WorkerDetailsPanel } from './components/WorkerDetailsPanel.js';
+import { WorkerActivityCard } from './components/WorkerActivityCard.js';
 import { groupWorkflowCoreActivity } from './lib/workflow-core-activity.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
 import { WorkflowStatusChips } from './components/WorkflowStatusChips.js';
@@ -55,6 +56,7 @@ import {
   formatWorkflowStatus,
 } from './lib/workflow-progress-surfaces.js';
 import { computeSearchResults, type SearchResult } from './lib/search.js';
+import { displayWorkerTaskId, formatWorkerValue, getActiveWorkerAction, getWorkerDisplayCopy } from './lib/worker-display.js';
 import {
   isExperimentSpawnPivotTask,
   EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE,
@@ -401,6 +403,32 @@ function getOrderedSidebarNavItems(root: ParentNode): HTMLElement[] {
 function isEditableKeyboardTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   return Boolean(target.closest(EDITABLE_SELECTOR));
+}
+
+function normalizedSearchText(value: string | undefined): string {
+  return (value ?? '').toLowerCase();
+}
+
+function workerActionTarget(action: WorkerActionSummary): string {
+  if (action.taskId) return `Task: ${displayWorkerTaskId(action.taskId)}`;
+  return `${formatWorkerValue(action.subjectType)}: ${action.subjectId}`;
+}
+
+function workerLogTarget(log: WorkerLogEntry): string {
+  if (log.taskId) return `Task: ${displayWorkerTaskId(log.taskId)}`;
+  if (log.subjectType && log.subjectId) return `${formatWorkerValue(log.subjectType)}: ${log.subjectId}`;
+  if (log.workflowId) return `Workflow: ${log.workflowId}`;
+  return 'No target';
+}
+
+function workerStateLabel(worker: WorkerStatusEntry): string {
+  const activeAction = getActiveWorkerAction(worker);
+  if (activeAction) return `${formatWorkerValue(worker.lifecycle)} · ${formatWorkerValue(activeAction.status)}`;
+  return formatWorkerValue(worker.lifecycle);
+}
+
+function workerLogTitle(log: WorkerLogEntry): string {
+  return formatWorkerValue(log.eventType ?? log.actionType ?? log.source);
 }
 
 interface WorkflowContextMenuProps {
@@ -2910,7 +2938,7 @@ export function App() {
       return;
     }
     if (nextView === 'queue') {
-      setSidebarSurface('workers');
+      setSidebarSurface('home');
       setInspectorCollapsed(true);
       setInspectorManualOpen(false);
     } else {
@@ -2950,7 +2978,7 @@ export function App() {
       setInspectorCollapsed(true);
       setInspectorManualOpen(false);
       setStatusFilters(new Set<WorkflowStatus>());
-      setViewMode('queue');
+      setViewMode('dag');
       return;
     }
     if (nextSurface === 'home') {
@@ -3571,6 +3599,171 @@ export function App() {
     )
   );
 
+  const renderWorkerActionEntry = (action: WorkerActionSummary): JSX.Element => (
+    <div key={action.id} className="rounded-lg border border-gray-800 bg-gray-850/60 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="text-sm font-medium text-gray-100">{formatWorkerValue(action.actionType)}</div>
+        <span className="rounded-full border border-gray-700 bg-gray-800 px-2 py-0.5 text-[11px] text-gray-200">
+          {formatWorkerValue(action.status)}
+        </span>
+      </div>
+      <div className="mt-1 text-xs text-gray-500">{workerActionTarget(action)}</div>
+      {action.summary ? <div className="mt-2 text-sm text-gray-300">{action.summary}</div> : null}
+      <div className="mt-2 text-[11px] text-gray-500">Updated {action.updatedAt}</div>
+    </div>
+  );
+
+  const renderWorkerLogEntry = (log: WorkerLogEntry): JSX.Element => (
+    <div key={log.id} className="rounded-lg border border-gray-800 bg-gray-850/60 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="text-sm font-medium text-gray-100">{workerLogTitle(log)}</div>
+        {log.status ? (
+          <span className="rounded-full border border-gray-700 bg-gray-800 px-2 py-0.5 text-[11px] text-gray-200">
+            {formatWorkerValue(log.status)}
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-1 text-xs text-gray-500">{workerLogTarget(log)}</div>
+      {log.summary ? <div className="mt-2 text-sm text-gray-300">{log.summary}</div> : null}
+      <div className="mt-2 text-[11px] text-gray-500">Logged {log.createdAt}</div>
+    </div>
+  );
+
+  const renderWorkersDetail = (): JSX.Element => {
+    if (!selectedWorker) {
+      return renderBrowserEmptyState('No workers found', 'Invoker has not returned any worker registry rows yet.');
+    }
+
+    const copy = getWorkerDisplayCopy(selectedWorker.kind);
+    const activeAction = getActiveWorkerAction(selectedWorker);
+    const recentLogs = selectedWorker.recentLogs ?? [];
+    const hasResponseHistory = selectedWorker.recentActions.length > 0 || recentLogs.length > 0;
+
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="border-b border-gray-800 bg-gray-950/50 px-4 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-100">{copy.name}</h2>
+              <p className="mt-1 text-sm text-gray-400">{selectedWorker.note || 'Worker registry entry'}</p>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-gray-700 bg-gray-800 px-2.5 py-1 text-[11px] font-medium text-gray-200">
+                  Kind: {selectedWorker.kind}
+                </span>
+                <span className="rounded-full border border-gray-700 bg-gray-800 px-2.5 py-1 text-[11px] font-medium text-gray-200">
+                  Source: {formatWorkerValue(selectedWorker.source)}
+                </span>
+                <span className="rounded-full border border-cyan-500/40 bg-cyan-500/10 px-2.5 py-1 text-[11px] font-medium text-cyan-100">
+                  State: {workerStateLabel(selectedWorker)}
+                </span>
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-label="Return home"
+              data-testid="workers-return-home"
+              onClick={handleDismissBrowserSurface}
+              className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+            >
+              Home
+            </button>
+          </div>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+            <section className="rounded-xl border border-gray-800 bg-gray-900/80 p-4">
+              <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Registry</h3>
+              <dl className="mt-3 grid grid-cols-[7rem_1fr] gap-x-3 gap-y-2 text-sm">
+                <dt className="text-gray-500">Kind</dt>
+                <dd className="text-gray-200">{selectedWorker.kind}</dd>
+                <dt className="text-gray-500">Note</dt>
+                <dd className="text-gray-200">{selectedWorker.note || 'No note'}</dd>
+                <dt className="text-gray-500">Source</dt>
+                <dd className="text-gray-200">{formatWorkerValue(selectedWorker.source)}</dd>
+                <dt className="text-gray-500">Availability</dt>
+                <dd className="text-gray-200">{formatWorkerValue(selectedWorker.availability)}</dd>
+                <dt className="text-gray-500">Policy</dt>
+                <dd className="text-gray-200">{formatWorkerValue(selectedWorker.policy)}{selectedWorker.policyReason ? ` · ${selectedWorker.policyReason}` : ''}</dd>
+                <dt className="text-gray-500">Runtime</dt>
+                <dd className="text-gray-200">{selectedWorker.runtimeKind ?? 'Not running'}</dd>
+              </dl>
+            </section>
+            <section className="rounded-xl border border-gray-800 bg-gray-900/80 p-4">
+              <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Current state</h3>
+              <div className="mt-3 text-sm text-gray-300">
+                Process is {formatWorkerValue(selectedWorker.lifecycle)}.
+                {activeAction ? ` Current response is ${formatWorkerValue(activeAction.actionType)} (${formatWorkerValue(activeAction.status)}).` : ' No response is running.'}
+              </div>
+              {selectedWorker.lastError ? <div className="mt-3 rounded border border-rose-800 bg-rose-950/40 p-3 text-sm text-rose-100">{selectedWorker.lastError}</div> : null}
+            </section>
+          </div>
+
+          <div className="mt-4 grid gap-4 xl:grid-cols-2">
+            <section className="rounded-xl border border-gray-800 bg-gray-900/80 p-4">
+              <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Latest responses</h3>
+              <div className="mt-3 space-y-2">
+                {selectedWorker.recentActions.length > 0
+                  ? selectedWorker.recentActions.slice(0, 5).map(renderWorkerActionEntry)
+                  : <div className="rounded-lg border border-gray-800 bg-gray-950/60 p-3 text-sm text-gray-400">No worker responses have been logged yet.</div>}
+              </div>
+            </section>
+            <section className="rounded-xl border border-gray-800 bg-gray-900/80 p-4">
+              <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Latest logs</h3>
+              <div className="mt-3 space-y-2">
+                {recentLogs.length > 0
+                  ? recentLogs.slice(0, 5).map(renderWorkerLogEntry)
+                  : <div className="rounded-lg border border-gray-800 bg-gray-950/60 p-3 text-sm text-gray-400">No worker responses have been logged yet.</div>}
+              </div>
+            </section>
+          </div>
+
+          {!hasResponseHistory ? (
+            <div className="mt-4 rounded-xl border border-gray-800 bg-gray-950/60 p-4 text-sm text-gray-400">
+              No worker responses have been logged yet.
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  };
+
+  const workersSubtitle = workerStatus === null
+    ? 'Worker status is not available yet.'
+    : `${workerStatus.workers.length} worker${workerStatus.workers.length === 1 ? '' : 's'} registered.`;
+
+  const renderWorkersSurface = (): JSX.Element => (
+    <div className="flex-1 flex overflow-hidden">
+      <div data-testid="workers-rail" className="flex h-full w-80 shrink-0 flex-col border-r border-gray-800 bg-gray-950/45">
+        <div className="flex items-start justify-between gap-3 border-b border-gray-800 px-4 py-4">
+          <div>
+            <h2 className="text-sm font-semibold text-gray-100">Workers</h2>
+            <p className="mt-1 text-xs text-gray-500">{workersSubtitle}</p>
+          </div>
+          <button
+            type="button"
+            aria-label="Close workers panel"
+            data-testid="workers-rail-dismiss"
+            onClick={handleDismissBrowserSurface}
+            className="rounded-lg border border-gray-700 px-2 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+          >
+            Close
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <WorkerActivityCard
+            snapshot={workerStatus}
+            selectedWorkerKind={selectedWorkerKind}
+            onSelectWorker={setSelectedWorkerKind}
+            showControls={false}
+          />
+        </div>
+      </div>
+      <div className="min-w-0 flex-1 overflow-hidden">
+        {renderWorkersDetail()}
+      </div>
+    </div>
+  );
+
 
   const renderPlanningSessionList = (): JSX.Element => (
     <div data-testid="planning-session-list" className={`${RAIL_SCROLL_BODY_CLASS} py-1`}>
@@ -3889,9 +4082,7 @@ export function App() {
             ) : sidebarSurface === 'planning' ? (
               renderPlanningTerminalSurface()
             ) : sidebarSurface === 'workers' ? (
-              <div className="flex min-h-0 flex-1 overflow-hidden">
-                {renderBrowserDetailWorkspace()}
-              </div>
+              renderWorkersSurface()
             ) : (
               <div className="flex min-h-0 flex-1 overflow-hidden">
                 {renderBrowserRail()}
@@ -3902,7 +4093,7 @@ export function App() {
             {sidebarSurface === 'home' && viewMode === 'dag' && renderGraphTerminalChrome()}
           </main>
 
-          {sidebarSurface !== 'planning' && (
+          {sidebarSurface !== 'planning' && sidebarSurface !== 'workers' && (
             <div
               data-testid="workflow-inspector-shell"
               data-keyboard-region="inspector"

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -65,7 +65,7 @@ describe('App launch (component)', () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
   });
 
-  it('opens worker status from the left panel', async () => {
+  it('opens read-only worker status from the left panel', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
     act(() => window.dispatchEvent(new Event('resize')));
     mock.setWorkerStatus({
@@ -74,13 +74,56 @@ describe('App launch (component)', () => {
         {
           kind: 'pr-status',
           note: 'PR status',
+          source: 'built-in',
+          availability: 'available',
+          running: true,
           lifecycle: 'running',
           policy: 'enabled',
           autoStarts: true,
           startable: false,
           stoppable: true,
           runtimeKind: 'pr-status',
+          recentActions: [
+            {
+              id: 'action-1',
+              workerKind: 'pr-status',
+              actionType: 'check-pr',
+              subjectType: 'workflow',
+              subjectId: 'wf-1',
+              externalKey: 'wf-1',
+              status: 'completed',
+              attemptCount: 1,
+              summary: 'Checked PR status',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:01:00.000Z',
+            },
+          ],
+          recentLogs: [
+            {
+              id: 'log-1',
+              workerKind: 'pr-status',
+              source: 'worker_actions',
+              actionType: 'check-pr',
+              subjectType: 'workflow',
+              subjectId: 'wf-1',
+              status: 'completed',
+              summary: 'PR check finished',
+              createdAt: '2026-01-01T00:01:00.000Z',
+            },
+          ],
+        },
+        {
+          kind: 'autofix',
+          note: 'Autofix worker',
+          source: 'built-in',
+          availability: 'available',
+          lifecycle: 'stopped',
+          policy: 'enabled',
+          autoStarts: false,
+          startable: true,
+          stoppable: false,
           recentActions: [],
+          recentLogs: [],
         },
       ],
     });
@@ -92,7 +135,13 @@ describe('App launch (component)', () => {
     fireEvent.click(workersButton);
 
     expect(await screen.findByTestId('worker-activity-card')).toBeInTheDocument();
-    expect(screen.getByText('PR status')).toBeInTheDocument();
+    expect(screen.getAllByText('PR status').length).toBeGreaterThan(0);
+    expect(screen.getByText('Autofix worker')).toBeInTheDocument();
+    expect(screen.getAllByText('Source: Built In').length).toBeGreaterThan(0);
+    expect(screen.getByText('Checked PR status')).toBeInTheDocument();
+    expect(screen.getByText('PR check finished')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Start process' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Stop process' })).not.toBeInTheDocument();
   });
   it('renders the Apple-like source list without manual plan loading', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
@@ -189,7 +238,7 @@ describe('App launch (component)', () => {
     fireEvent.click(await screen.findByTestId('sidebar-workers'));
     expect(screen.queryByTestId('browser-rail')).not.toBeInTheDocument();
     expect(screen.queryByTestId('running-rail-list')).not.toBeInTheDocument();
-    expect(screen.getByTestId('workflow-graph-surface')).toBeInTheDocument();
+    expect(screen.getByTestId('workers-rail')).toBeInTheDocument();
   });
 
 

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -42,12 +42,16 @@ describe('QueueView', () => {
     return {
       kind: 'autofix',
       note: 'Auto-fixes failed tasks.',
+      source: 'built-in',
+      availability: 'available',
+      running: true,
       lifecycle: 'running',
       policy: 'enabled',
       autoStarts: true,
       startable: false,
       stoppable: true,
       recentActions: [],
+      recentLogs: [],
       ...overrides,
     };
   }

--- a/packages/ui/src/__tests__/worker-details-panel.test.tsx
+++ b/packages/ui/src/__tests__/worker-details-panel.test.tsx
@@ -34,12 +34,16 @@ function makeWorker(overrides: Partial<WorkerStatusEntry> = {}): WorkerStatusEnt
   return {
     kind: 'ci-failure',
     note: 'Repairs failed CI.',
+    source: 'built-in',
+    availability: 'available',
+    running: true,
     lifecycle: 'running',
     policy: 'enabled',
     autoStarts: true,
     startable: false,
     stoppable: true,
     recentActions: [makeAction()],
+    recentLogs: [],
     ...overrides,
   };
 }

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -5,10 +5,11 @@ import { formatWorkerValue, getActiveWorkerAction, getWorkerDisplayCopy } from '
 interface WorkerActivityCardProps {
   snapshot: WorkerStatusSnapshot | null;
   selectedWorkerKind: string | null;
-  readOnly: boolean;
-  onStartWorker: (kind: string) => Promise<void> | void;
-  onStopWorker: (kind: string) => Promise<void> | void;
+  readOnly?: boolean;
+  onStartWorker?: (kind: string) => Promise<void> | void;
+  onStopWorker?: (kind: string) => Promise<void> | void;
   onSelectWorker: (kind: string) => void;
+  showControls?: boolean;
 }
 
 type OptimisticLifecycle = 'running' | 'stopped';
@@ -49,10 +50,11 @@ function activityExplanation(worker: WorkerStatusEntry, lifecycle: string): stri
 export function WorkerActivityCard({
   snapshot,
   selectedWorkerKind,
-  readOnly,
+  readOnly = false,
   onStartWorker,
   onStopWorker,
   onSelectWorker,
+  showControls = true,
 }: WorkerActivityCardProps) {
   const [optimisticByKind, setOptimisticByKind] = useState<Record<string, OptimisticLifecycle>>({});
   const [pendingByKind, setPendingByKind] = useState<Record<string, boolean>>({});
@@ -107,14 +109,23 @@ export function WorkerActivityCard({
             const lifecycle = optimisticByKind[worker.kind] ?? worker.lifecycle;
             const showStart = lifecycle !== 'running';
             const pending = Boolean(pendingByKind[worker.kind]);
-            const isControlDisabled = Boolean(disabledTitle) || pending;
+            const controlUnavailable = showStart ? !onStartWorker : !onStopWorker;
+            const isControlDisabled = Boolean(disabledTitle) || pending || controlUnavailable;
+            const controlTitle = disabledTitle ?? (controlUnavailable ? 'Worker control unavailable' : undefined);
             const selected = selectedWorkerKind === worker.kind;
             const launchesOnStart = worker.desiredEnabled ?? worker.autoStarts;
-            const footer = worker.kind === 'pr-status'
-              ? 'No queue task is expected for this worker.'
-              : selected
-                ? 'Details are in the right panel.'
-                : null;
+            const recentLogs = worker.recentLogs ?? [];
+            const latestLog = recentLogs[0];
+            const latestAction = worker.recentActions[0];
+            const footer = latestLog
+              ? `Latest log: ${latestLog.summary ?? formatWorkerValue(latestLog.eventType ?? latestLog.actionType ?? latestLog.source)}`
+              : latestAction
+                ? `Latest response: ${latestAction.summary ?? `${formatWorkerValue(latestAction.actionType)} · ${formatWorkerValue(latestAction.status)}`}`
+                : worker.kind === 'pr-status'
+                  ? 'No queue task is expected for this worker.'
+                  : selected
+                    ? 'Details are in the right panel.'
+                    : 'No worker responses have been logged yet.';
             return (
               <div
                 key={worker.kind}
@@ -138,6 +149,8 @@ export function WorkerActivityCard({
                   <div className="min-w-0 flex-1">
                     <div className="text-sm font-semibold text-foreground">{copy.name}</div>
                     <div className="mt-0.5 text-xs text-muted-foreground">Kind: {worker.kind}</div>
+                    {worker.note ? <div className="mt-1 text-xs text-muted-foreground">{worker.note}</div> : null}
+                    <div className="mt-1 text-xs text-muted-foreground">Source: {formatWorkerValue(worker.source)}</div>
                     <div className="mt-2 flex flex-wrap items-center gap-2">
                       <span
                         className={`rounded-full border px-2 py-0.5 text-[11px] ${processClass(lifecycle)}`}
@@ -163,34 +176,36 @@ export function WorkerActivityCard({
                     <div className="mt-2 text-sm text-muted-foreground">{activityExplanation(worker, lifecycle)}</div>
                     {footer ? <div className="mt-1 text-xs text-muted-foreground">{footer}</div> : null}
                   </div>
-                  <button
-                    type="button"
-                    className="shrink-0 rounded border border-border-strong px-2 py-1 text-xs text-foreground disabled:cursor-not-allowed disabled:opacity-50 hover:bg-muted"
-                    title={disabledTitle}
-                    disabled={isControlDisabled}
-                    data-testid={`worker-start-stop-${worker.kind}`}
-                    data-action={showStart ? 'start' : 'stop'}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter' || event.key === ' ') event.stopPropagation();
-                    }}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      if (pending || isControlDisabled) return;
-                      const nextLifecycle: OptimisticLifecycle = showStart ? 'running' : 'stopped';
-                      setOptimisticByKind((prev) => ({ ...prev, [worker.kind]: nextLifecycle }));
-                      setPendingByKind((prev) => ({ ...prev, [worker.kind]: true }));
-                      const action = showStart ? onStartWorker(worker.kind) : onStopWorker(worker.kind);
-                      void Promise.resolve(action).finally(() => {
-                        setPendingByKind((prev) => {
-                          const next = { ...prev };
-                          delete next[worker.kind];
-                          return next;
+                  {showControls ? (
+                    <button
+                      type="button"
+                      className="shrink-0 rounded border border-border-strong px-2 py-1 text-xs text-foreground disabled:cursor-not-allowed disabled:opacity-50 hover:bg-muted"
+                      title={controlTitle}
+                      disabled={isControlDisabled}
+                      data-testid={`worker-start-stop-${worker.kind}`}
+                      data-action={showStart ? 'start' : 'stop'}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') event.stopPropagation();
+                      }}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        if (pending || isControlDisabled) return;
+                        const nextLifecycle: OptimisticLifecycle = showStart ? 'running' : 'stopped';
+                        setOptimisticByKind((prev) => ({ ...prev, [worker.kind]: nextLifecycle }));
+                        setPendingByKind((prev) => ({ ...prev, [worker.kind]: true }));
+                        const action = showStart ? onStartWorker?.(worker.kind) : onStopWorker?.(worker.kind);
+                        void Promise.resolve(action).finally(() => {
+                          setPendingByKind((prev) => {
+                            const next = { ...prev };
+                            delete next[worker.kind];
+                            return next;
+                          });
                         });
-                      });
-                    }}
-                  >
-                    {pending ? (showStart ? 'Enabling…' : 'Disabling…') : showStart ? 'Enable worker' : 'Disable worker'}
-                  </button>
+                      }}
+                    >
+                      {pending ? (showStart ? 'Enabling…' : 'Disabling…') : showStart ? 'Enable worker' : 'Disable worker'}
+                    </button>
+                  ) : null}
                 </div>
               </div>
             );

--- a/packages/ui/src/hooks/useWorkerStatus.ts
+++ b/packages/ui/src/hooks/useWorkerStatus.ts
@@ -19,7 +19,7 @@ export function useWorkerStatus(
     if (inFlightRef.current) return;
     inFlightRef.current = true;
     try {
-      const status = await window.invoker?.getWorkerStatus();
+      const status = await window.invoker?.getWorkers();
       if (mountedRef.current && status) {
         setSnapshot((previous) =>
           areStructurallyEqual(previous, status) ? previous : status,

--- a/packages/ui/src/lib/worker-display.ts
+++ b/packages/ui/src/lib/worker-display.ts
@@ -27,7 +27,8 @@ export const ACTIVE_WORKER_ACTION_STATUSES: ReadonlySet<WorkerActionStatus> = ne
   'review_ready',
 ]);
 
-export function formatWorkerValue(value: string): string {
+export function formatWorkerValue(value: string | undefined): string {
+  if (!value) return 'Unknown';
   return value
     .split(/[-_]/g)
     .filter(Boolean)

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -330,10 +330,13 @@ export type {
   WorkerDecisionsRequest,
   WorkerDecisionsResponse,
   WorkerActionStatus,
+  WorkerAvailability,
   WorkerControlAction,
   WorkerLifecycleStatus,
+  WorkerLogEntry,
   WorkerPolicyStatus,
   WorkerRecoverySummary,
+  WorkerSource,
   WorkerStatusEntry,
   WorkerStatusSnapshot,
 } from '@invoker/contracts';


### PR DESCRIPTION
## Summary

Adds a read-only Workers browser to the sidebar.

The page shows workers, their current state, and recent responses without exposing start or stop controls.

The headless worker view uses the same built-in worker registration path.

## Review Claim

Approve the Workers sidebar browser and headless activation path.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The UI only reads the worker snapshot and hides controls in this surface, so it cannot mutate workers.

## Slice Rationale

The visible browser lands separately from the data assembly work.

## Non-goals

Does not add worker write controls. Does not change snapshot persistence. Does not alter review-gate merge behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `git diff --check upstream/pr/3148..HEAD && git diff --check`
- [x] `pnpm --filter @invoker/ui test -- src/__tests__/app-launch.test.tsx src/__tests__/queue-view.test.tsx src/__tests__/worker-details-panel.test.tsx`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-3149-body.md --changed-files-file <(git diff --name-only upstream/pr/3148..HEAD) --diff-file <(git diff upstream/pr/3148..HEAD)`
- [ ] `pnpm --filter @invoker/app test:e2e -- workers-surface.spec.ts` blocked locally before the test body because Electron closed before `firstWindow()` returned.

</details>

## Visual Proof

![Workers read-only surface](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-7b7216/workers-read-only-surface.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
