### PR TITLE
[Worker Controls](12f) Document autofix worker ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+- Move auto-fix attempt counts out of SQLite task state and into in-memory worker runtime policy.
 - Add a local master-head full-test repair cron that runs the destructive suite, asks OMP/Codex to fix confirmed failures, reruns the suite, and opens one validated PR per broken upstream SHA.
 - Make the browser UI load heavy Action Graph data only when that tab opens, trim huge diagnostic strings, gzip large `/invoke` JSON responses, and stop checking PR statuses on initial page load.
 - Move the Slack bot out of the Invoker app into its own always-on `@invoker/slack-manager` daemon. Previously the bot ran inside Invoker, so when Invoker died the bot died with it and no one could ask it to bring Invoker back. The manager now owns the Slack connection, keeps its planning sessions and per-workflow channel map in its own database, and drives Invoker over IPC (`headless.query`/`exec`/`run`). It watches Invoker's health and relaunches the GUI when it goes down, and a new `@Invoker restart` verb (Approve to confirm) brings it back on demand; a backoff guard prevents restart storms. Invoker itself now launches with Slack disabled — the manager is the sole Slack surface, supervised independently via a systemd user unit (cron keepalive fallback).
@@ -16,9 +17,11 @@ All notable changes to Invoker will be documented in this file.
 - Stop treating every lobby/DM `@Invoker` mention as a build request. Mentions and a new `/invoker` slash command now recognize explicit verbs — `status`, `recreate`, `rebase`, `retry`, `cancel` (one workflow or `all`), and `submit` — and run the real workflow operation. A fuzzy operational ask falls back to an LLM classifier that proposes the action and waits for confirmation. Destructive all-workflow operations always confirm (Approve/Cancel buttons or a `yes`/`no` reply), and `submit` shows a plain-English, one-line-per-step summary of the plan to approve instead of raw YAML. The Slack app manifest now enables the `/invoker` slash command and Block Kit interactivity.
 - Make Slack lobby mentions normal agent threads by default: plain `@Invoker fix X` now runs a recoverable OMP/Codex-style repo session, `local:` and `run local:` are aliases for that path, workflow count/status questions route to Invoker status directly, `exec local:`/`local command:` run raw shell, and `plan:` is the explicit opt-in for Invoker YAML plus `submit` approval.
 - Stream live progress for bulk lobby workflow operations into the Slack thread: a long `recreate`/`rebase`/`cancel all` now edits one in-thread message with a running `done/total` count (and the workflow being processed) as it works, instead of going silent between the "On it…" acknowledgement and the final summary.
+- Treat `autoFixRetries` as a real finite cap for auto-fix and CI-repair workers. A value like `3` now stops after three submitted attempts for a failed task instead of enabling unlimited retries.
+- Auto-start the auto-fix worker in owner processes and remove direct failed-delta auto-fix scheduling from the app layer. Failures now wake the worker through lifecycle events, then the worker submits the normal fix intent.
 - Emit first-class recovery.worker submit/skip audit events from the auto-fix worker and add a mocked browser E2E proving worker-triggered fixes reach the Approve Fix UI.
-- Treat `autoFixRetries` as worker policy, not task policy. Worker starts are no longer disabled by retry budget, while the worker still caps submissions against each task's consumed `autoFixAttempts`.
 - Add task deletion across the desktop app, HTTP API, and headless commands. Deleting a task now kills it first when needed, rewires direct dependents to the deleted task's upstream dependencies, and blocks deleting the last task in a workflow so users delete the whole workflow instead.
+- Keep the launch dispatcher topping up ready work before each poll, so queued tasks do not sit idle after launch rows expire or are abandoned.
 
 ## 0.0.6
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ Minimal example:
 }
 ```
 
+`autoFixRetries` is a finite per-task cap. `3` means the worker keeps consumed attempts in process memory and can submit at most three auto-fix attempts for the same failed task lineage; `0` disables auto-fix workers.
+
 More examples: [docs/invoker-config-example.json](docs/invoker-config-example.json), [docs/remote-ssh-targets.md](docs/remote-ssh-targets.md), [docs/docker-executor.md](docs/docker-executor.md).
 
 ### Multiple SSH Executors
@@ -274,11 +276,11 @@ If you need to turn a product or implementation plan into an Invoker workflow, i
 
 If you need to operate existing workflows or tasks, use the `invoker-ops` skill.
 
-Use `--output text|label|json|jsonl` on headless `query` commands. Use `./run.sh --headless retry-tasks --status pending|failed --parallel 8` for bulk safe retries. Inspect recovery ownership and decisions with `./run.sh --headless worker status --output text|json|jsonl`. Normal `run`, `resume`, and retry commands do not start recovery loops; recovery is owned by the explicit recovery worker path. Only **one** process should **write** the workflow database at a time; see [docs/persistence-architecture-single-writer.md](docs/persistence-architecture-single-writer.md).
+Use `--output text|label|json|jsonl` on headless `query` commands. Use `./run.sh --headless retry-tasks --status pending|failed --parallel 8` for bulk safe retries. Inspect recovery ownership and decisions with `./run.sh --headless worker status --output text|json|jsonl`. Only **one** process should **write** the workflow database at a time; see [docs/persistence-architecture-single-writer.md](docs/persistence-architecture-single-writer.md).
 
 ### Auto-fix worker (single shared engine)
 
-Auto-fix recovery runs through **one** shared worker engine in `@invoker/execution-engine`. Two doors reach that same single engine: `invoker-cli worker autofix` (production) and `./run.sh --headless worker autofix` (dev). Whichever door you use, the worker is **foreground** — it lives and dies with the process, with no detached background service. `autoFixRetries` is worker policy: it caps worker-submitted fixes per failed task, while tasks only store the attempts already used. A single-instance lock means only one auto-fix worker runs at a time: a second start, from either door, refuses rather than spawning a second loop. A sweep-and-assert guard test fails the build if auto-fix is ever triggered outside this shared worker engine. See [docs/architecture/recovery-lifecycle-workers.md](docs/architecture/recovery-lifecycle-workers.md).
+Auto-fix recovery runs through **one** shared worker engine in `@invoker/execution-engine`. Owner processes auto-start that worker when `autoFixRetries > 0`; failure lifecycle events wake it, and its periodic scan covers missed wakeups. The manual dev door `./run.sh --headless worker autofix` runs the same engine for an explicit one-shot scan. `autoFixRetries` is enforced from a worker-local in-memory ledger before the worker submits another fix intent. A sweep-and-assert guard test fails the build if auto-fix is ever triggered outside this shared worker engine. See [docs/architecture/recovery-lifecycle-workers.md](docs/architecture/recovery-lifecycle-workers.md).
 
 ## Architecture (at a glance)
 

--- a/docs/architecture/recovery-lifecycle-workers.md
+++ b/docs/architecture/recovery-lifecycle-workers.md
@@ -6,21 +6,18 @@ State transitions publish lifecycle events. Recovery behavior is owned by subscr
 
 The producer of a persisted workflow or task state change is responsible for publishing a lifecycle wakeup after the durable state change is recorded. The producer must not directly auto-fix, recreate, or launch external recovery scripts as part of handling a failed delta. Auto-fix and external recovery are worker responsibilities, and workers must act through the same normal command routes used by operators.
 
-This is a docs-only architecture note. It describes the achieved contract and does not change runtime behavior.
+This note describes the runtime contract.
 
 ## Resolved Overlap (Single Engine)
 
 Earlier, auto-fix ran from more than one place: a producer could schedule auto-fix directly from failure handling, and a separate worker loop could also act on the same failed state. Two engines could observe the same failure and compete over what recovery meant.
 
-That overlap is now resolved. There is exactly **one** shared auto-fix worker engine, and it lives in `@invoker/execution-engine`. Both entry points drive that same single engine instead of running their own loops:
-
-1. The production door: `invoker-cli worker autofix`.
-2. The dev door: `./run.sh --headless worker autofix`.
+That overlap is now resolved. There is exactly **one** shared auto-fix worker engine, and it lives in `@invoker/execution-engine`.
 
 Two properties keep the single engine truly single:
 
-- **Foreground lifetime.** The worker lives and dies with its process. There is no detached or background recovery service; stopping the process stops the engine.
-- **Single-instance lock.** A cross-door lock refuses a second concurrent start. If one door already runs the engine, the other door refuses to start a second loop rather than spawning one.
+- **Owner auto-start.** Owner processes start the auto-fix worker automatically when `autoFixRetries > 0`, so normal task failures do not need an external bash loop.
+- **Manual one-shot scan.** `./run.sh --headless worker autofix` drives the same engine for an explicit operator scan.
 
 A **sweep-and-assert guard** test fails the build if auto-fix is triggered from any code path outside the shared worker engine (with an allowlist for the engine itself and the sanctioned operator fix command). This locks the single-engine invariant in against future drift, so a new direct auto-fix call cannot reintroduce a second recovery path.
 
@@ -79,18 +76,18 @@ Workers may subscribe to the same lifecycle event stream. Contention is controll
 
 ## Auto-Fix Worker
 
-Automatic fix attempts are owned by a **single** shared auto-fix worker engine in `@invoker/execution-engine`. Both doors — `invoker-cli worker autofix` (production) and `./run.sh --headless worker autofix` (dev) — drive that one engine. The engine subscribes to lifecycle wakeups, scans persisted state, and decides whether an auto-fix command should be submitted. `autoFixRetries` belongs to that worker policy; a task records only `autoFixAttempts`, not its own retry budget.
+Automatic fix attempts are owned by a **single** shared auto-fix worker engine in `@invoker/execution-engine`. Owner processes auto-start that worker when `autoFixRetries > 0`. The engine subscribes to lifecycle wakeups, scans persisted state, keys consumed attempts in worker runtime memory by task lineage, and decides whether an auto-fix command should be submitted. `./run.sh --headless worker autofix` is only a manual one-shot scan through the same engine.
 
 Lifetime and concurrency are constrained so the single engine stays single:
 
-- The worker is **foreground**: it lives and dies with its process, with no detached background service.
-- A **single-instance lock** refuses a second concurrent start across both doors, so at most one recovery loop runs process-wide.
+- The worker is **process-owned**: it lives and dies with the owner process that started it.
+- A **single-instance lock** refuses a second concurrent explicit worker start, so manual scans cannot race another explicit worker door.
 
 The engine should only act when persisted state shows that:
 
 1. The workflow or task is in a state eligible for auto-fix.
 2. No newer generation has superseded the failed state.
-3. The worker retry budget allows another attempt for that failed task.
+3. `autoFixRetries` leaves in-memory retry budget for the task lineage; `0` disables auto-fix and a finite value such as `3` permits at most three submitted attempts until the worker restarts or the task lineage changes.
 4. No incompatible recovery action is already in progress.
 
 When those checks pass, the auto-fix worker submits the normal fix command. It must not be invoked directly by the producer that recorded the failed transition. A sweep-and-assert guard test fails the build if any auto-fix is triggered outside this shared worker engine.


### PR DESCRIPTION
## Summary

The docs now describe the worker ledger for auto-fix attempts.

The README, architecture notes, and changelog match the new storage and worker wording.

<details>
<summary>Review metadata</summary>

Review Claim: Documentation matches the worker ledger for auto-fix attempts.

Review Lane: docs

Review Unit: docs

Safety Invariant: This slice only changes documentation files.

Slice Rationale: Documentation lands after the runtime and support-script slices it describes.

</details>

## Non-goals

- Changing code.
- Changing tests.
- Changing scripts.

## Test Plan

- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-docs-cleanup.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 5b6a4fcd9`
- Post-revert steps: None
- Data migration? No

Depends-On: #3152
