### PR TITLE
[Planning Chat Raw Stream Step 1](1) Add planner raw stdout stream hook

### DIFF
--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -29,6 +29,7 @@ export type PlanningCommandBuilder = (opts: {
   model?: string;
   prompt: string;
 }) => { command: string; args: string[] };
+export type RawPlannerOutputHandler = (chunk: string) => void;
 
 export function defaultPlanningCommand(
   cursorCommand: string,
@@ -68,6 +69,8 @@ export interface PlanConversationConfig {
   experimentalPlanner?: boolean;
   /** Prefer top-level `workflows:` stack plans for multi-slice reviewable work. */
   preferStackedWorkflows?: boolean;
+  /** Optional callback for raw stdout chunks emitted by the planner subprocess. */
+  onRawPlannerOutput?: RawPlannerOutputHandler;
   /** Logging callback. Defaults to console.log/console.error. */
   log?: LogFn;
 }
@@ -268,6 +271,7 @@ export class PlanConversation {
   private experimentalPlanner?: boolean;
   private preferStackedWorkflows?: boolean;
   private log: LogFn;
+  private onRawPlannerOutput?: RawPlannerOutputHandler;
   private _initialized = false;
 
   constructor(config: PlanConversationConfig) {
@@ -284,6 +288,7 @@ export class PlanConversation {
     this.repoUrl = config.repoUrl;
     this.experimentalPlanner = config.experimentalPlanner;
     this.preferStackedWorkflows = config.preferStackedWorkflows;
+    this.onRawPlannerOutput = config.onRawPlannerOutput;
     this.log = config.log ?? ((src, lvl, msg) => {
       (lvl === 'error' ? console.error : console.log)(`[${src}] ${msg}`);
     });
@@ -458,6 +463,13 @@ export class PlanConversation {
         const chunkStr = chunk.toString();
         stdout += chunkStr;
         stdoutChunks++;
+        if (this.onRawPlannerOutput) {
+          try {
+            this.onRawPlannerOutput(chunkStr);
+          } catch (err) {
+            this.log('plan-conversation', 'error', `Raw planner output handler failed: ${err}`);
+          }
+        }
         this.log('plan-conversation', 'info', `[PERF] cursor_stdout chunk #${stdoutChunks}: +${chunkStr.length} bytes (total=${stdout.length}, elapsed=${Date.now() - spawnStart}ms)`);
       });
 


### PR DESCRIPTION
## Summary

The in-app planner can now show live progress. It gains an opt-in hook that hands each raw stdout chunk to a caller the moment the planner subprocess emits it.

The final reply behavior is unchanged. A caller that never sets the hook still receives one final reply string at the end of the turn.

Nothing partial is written into conversation history before the final reply lands, so streamed text stays purely a live view.

<details>
<summary>Review metadata</summary>

Review Claim: PlanConversation can expose raw planner stdout incrementally while keeping its final reply behavior unchanged.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice stays inside the surfaces package and only adds an opt-in stdout hook around existing output handling; the default path is untouched.

Slice Rationale: The raw stream source must exist before app or UI code can consume it, so it lands first as its own behavior slice.

</details>

## Non-goals

- No app, UI, or Slack wiring that consumes the new hook.
- No change to how the final reply is built or returned.
- No new persistence of partial planner text.

## Test Plan

- [ ] `cd packages/surfaces && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
