### PR TITLE
[Fix Planning Terminal Plan Truncation](1) Show full drafted plan reply

### DIFF
--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -275,16 +275,6 @@ export async function planFromGoal(
   }
 }
 
-function formatDraftPlanReply(summary: { name: string; steps: string[] }): string {
-  const stepLines = summary.steps.map((step, index) => `${index + 1}. ${step}`);
-  return [
-    `I drafted "${summary.name}". Here is the simple version:`,
-    '',
-    ...stepLines,
-    '',
-    'If this looks right, choose Submit to Invoker.',
-  ].join('\n');
-}
 
 function formatConversationalPlanningMessage(message: string): string {
   return [
@@ -413,14 +403,13 @@ export async function sendPlanningChatMessage(
           draftPlanAvailable: false,
         };
       }
-      const formattedReply = formatDraftPlanReply(summary);
       activeSession.draftPlanSummary = summary;
       activeSession.status = 'draft_ready';
-      appendSessionMessage(activeSession, 'assistant', formattedReply);
+      appendSessionMessage(activeSession, 'assistant', reply);
       return {
         ok: true,
         sessionId: activeSession.id,
-        reply: formattedReply,
+        reply,
         draftPlanAvailable: true,
         draftPlanSummary: summary,
       };

--- a/packages/surfaces/src/slack/plan-summary.ts
+++ b/packages/surfaces/src/slack/plan-summary.ts
@@ -23,8 +23,6 @@ interface PlanTask {
   dependencies: string[];
 }
 
-const MAX_STEP_WORDS = 8;
-
 // ── Public API ──────────────────────────────────────────────
 
 export function summarizePlanText(planText: string): PlanSummary | null {
@@ -140,8 +138,5 @@ function topoSort(tasks: PlanTask[]): PlanTask[] {
 }
 
 function summarizeDescription(description: string): string {
-  const normalized = description.replace(/\s+/g, ' ').trim();
-  const words = normalized.split(' ').filter(Boolean);
-  if (words.length <= MAX_STEP_WORDS) return normalized;
-  return `${words.slice(0, MAX_STEP_WORDS).join(' ')} …`;
+  return description.replace(/\s+/g, ' ').trim();
 }


### PR DESCRIPTION
## Summary

The planning terminal now shows the full drafted plan text instead of a shortened preview.

Two places dropped detail. The in-app planner replaced the model answer with a condensed version. The plan summary shortened each step to eight words.

Both now keep the full text, so the drafted plan a person sees matches what will run.

<details>
<summary>Review metadata</summary>

Review Claim: Approve returning the full drafted-plan text to the planning terminal instead of a shortened preview.

Review Lane: behavior

Review Unit: routing

Safety Invariant: This slice only changes the text handed back to the planning terminal in packages/app and packages/surfaces. It touches no tests, tooling, or docs, so it reads safely on its own.

Slice Rationale: The behavior change ships on its own. Its regression tests are kept in a separate follow-up slice so this diff stays focused on the user-facing output.

</details>

## Non-goals

- No change to the planning terminal UI components or their styling.
- No change to how plans are checked or handed to Invoker for execution.
- No new tests in this slice; regression coverage lands in the follow-up.

## Test Plan

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/surfaces && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
