### PR TITLE
[Prove Review Gate Fix No-op Root Cause](2) Verify the repro runs green

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -1394,7 +1394,7 @@ describe('fixWithAgentAction', () => {
     });
   });
 
-  it('surfaces corrupt merge gates when the saved fix workspace is not a git repo', async () => {
+  it('fixWithAgentAction rejects invalid merge-gate workspaces before fix execution', async () => {
     const orchestrator = {
       getTask: vi.fn(() => makeTask({
         id: 'merge-a',
@@ -1433,6 +1433,8 @@ describe('fixWithAgentAction', () => {
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
       commandService: makeCommandService(),
+    }, {
+      agentName: 'Codex',
     })).rejects.toThrow('Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository');
 
     expect(taskExecutor.execGitIn).toHaveBeenCalledWith(
@@ -1440,10 +1442,12 @@ describe('fixWithAgentAction', () => {
       '/tmp/invoker-empty-launch-placeholder',
     );
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
+    expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
     expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
     expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
       'merge-a',
-      expect.stringContaining('\n[Fix with claude] Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository: /tmp/invoker-empty-launch-placeholder. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.'),
+      expect.stringContaining('\n[Fix with Codex] Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository: /tmp/invoker-empty-launch-placeholder. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.'),
     );
     expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith(
       'merge-a',


### PR DESCRIPTION
## Summary

This slice proves the merge-gate workspace regression stays fixed in two ways.

It tightens the focused `workflow-actions` regression around the invalid merge-gate workspace path.

It also adds an operator repro script that reruns that regression from the repo root and prints a clear pass/fail line.

This is proof only. No product behavior changes.

## Review Claim

Approve the proof surface for the invalid merge-gate workspace fix: one focused regression plus one repo-root repro script.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only touches one test file and one `scripts/repro` runner. No production code or assertions outside the proof surface change.

## Slice Rationale

The regression and its repo-root runner belong together: the script is only useful once the regression itself exists and stays focused on the same bug.

## Non-goals

- Does not modify product behavior.
- Does not broaden CI coverage beyond this proof surface.
- Does not change any non-proof files.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts`
- [x] `bash scripts/repro/repro-review-gate-fix-noop-invalid-merge-workspace.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 986cc85`
- Post-revert steps: None
- Data migration? No

</details>
