### PR TITLE
[Worker Registration Step 4: CodeRabbit and Merge-Conflict Workers](3) Expose PR maintenance workers through CLI and headless

### DIFF
--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -101,6 +101,8 @@ describe('headless worker autofix', () => {
 
     expect(stdout).toContain('Worker kinds');
     expect(stdout).toContain('autofix');
+    expect(stdout).toContain('coderabbit-update');
+    expect(stdout).toContain('merge-conflict-rebase');
   });
 
   it('rejects unknown worker kinds with a clear error', async () => {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -19,9 +19,12 @@ import {
   createAutoFixAttemptLedger,
   createWorkerRegistry,
   registerAutoFixWorker,
+  registerCoderabbitUpdateWorker,
+  registerMergeConflictRebaseWorker,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
   type WorkerRuntimeDependencies,
+  type WorkerRegistry,
 } from '@invoker/execution-engine';
 import {
   parseMetadataValue,
@@ -424,7 +427,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
     deps.invokerConfig?.externalWorkers,
-    registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+    registerHeadlessBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
   );
 
   if (subCommand === 'list') {
@@ -487,6 +490,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         attemptLedger: autoFixAttemptLedger,
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
+      prMaintenance: deps.invokerConfig.prMaintenance,
     });
     await worker.tick('manual');
     await worker.stop();
@@ -497,6 +501,15 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   }
   const label = definition.kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : definition.kind;
   process.stdout.write(`${label} worker scan completed.\n`);
+}
+
+function registerHeadlessBuiltinWorkers(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registerAutoFixWorker(registry);
+  registerCoderabbitUpdateWorker(registry);
+  registerMergeConflictRebaseWorker(registry);
+  return registry;
 }
 
 function formatRecoveryWorkerStatus(status: RecoveryWorkerStatus): string {
@@ -964,4 +977,3 @@ async function headlessSetTaskMetadata(
   );
   process.stdout.write(`Updated task "${result.id}" ${result.fieldPath} → ${JSON.stringify(result.value)}\n`);
 }
-

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -115,6 +115,8 @@ describe('invoker-cli', () => {
     expect(code).toBe(0);
     expect(output.stdout).toContain('Worker kinds');
     expect(output.stdout).toContain('autofix');
+    expect(output.stdout).toContain('coderabbit-update');
+    expect(output.stdout).toContain('merge-conflict-rebase');
     output.restore();
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,8 @@ import {
   createAutoFixAttemptLedger,
   createWorkerRegistry,
   registerAutoFixWorker,
+  registerCoderabbitUpdateWorker,
+  registerMergeConflictRebaseWorker,
   registerExternalWorkers,
   WorkerLockHeldError,
   registerBuiltinAgents,
@@ -111,6 +113,29 @@ type CliRuntimeConfig = {
   autoFixAgent?: string;
   autoFixExecutionModel?: string;
   autoApproveAIFixes?: boolean;
+  prMaintenance?: {
+    targetRepo?: string;
+    author?: string;
+    coderabbit?: {
+      targetRepo?: string;
+      author?: string;
+      login?: string;
+      maxAttempts?: number;
+      workDir?: string;
+      executionAgent?: string;
+      executionModel?: string;
+      timeoutMs?: number;
+      pollIntervalMs?: number;
+    };
+    mergeConflictRebase?: {
+      targetRepo?: string;
+      author?: string;
+      maxAttempts?: number;
+      pollIntervalMs?: number;
+      confirmTimeoutMs?: number;
+      confirmPollIntervalMs?: number;
+    };
+  };
   externalWorkers?: ExternalWorkerConfig[];
 };
 
@@ -472,6 +497,7 @@ async function createDefaultMessageBus(): Promise<MessageBus> {
 function readWorkerConfig(homeRoot: string): {
   autoFixRetries?: number;
   autoFixAgent?: string;
+  prMaintenance?: CliRuntimeConfig['prMaintenance'];
   externalWorkers?: ExternalWorkerConfig[];
 } {
   const configPath = join(homeRoot, 'config.json');
@@ -481,6 +507,7 @@ function readWorkerConfig(homeRoot: string): {
     return {
       autoFixRetries: typeof parsed.autoFixRetries === 'number' ? parsed.autoFixRetries : undefined,
       autoFixAgent: typeof parsed.autoFixAgent === 'string' ? parsed.autoFixAgent : undefined,
+      prMaintenance: parsed.prMaintenance,
       externalWorkers: Array.isArray(parsed.externalWorkers) ? parsed.externalWorkers : undefined,
     };
   } catch (err) {
@@ -515,7 +542,7 @@ function isExternalWorkerRuntime(worker: WorkerRuntime): worker is ExternalWorke
 async function runWorker(definition: WorkerDefinition<WorkerRuntimeDependencies>, bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
-  const { autoFixRetries, autoFixAgent } = readWorkerConfig(homeRoot);
+  const { autoFixRetries, autoFixAgent, prMaintenance } = readWorkerConfig(homeRoot);
 
   // Single-instance guard: refuse if another worker of this kind (this door or
   // the dev `--headless worker <kind>` door) already holds the cross-process
@@ -553,6 +580,7 @@ async function runWorker(definition: WorkerDefinition<WorkerRuntimeDependencies>
         attemptLedger: autoFixAttemptLedger,
         getAutoFixAgent: () => autoFixAgent,
       },
+      prMaintenance,
     });
 
     worker.start();
@@ -596,7 +624,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';
       const registry = registerExternalWorkers(
-        registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+        registerCliBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
         readWorkerConfig(resolveInvokerHomeRoot()).externalWorkers,
       );
       if (subcommand === 'list') {
@@ -665,6 +693,15 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
       disconnect.call(bus);
     }
   }
+}
+
+function registerCliBuiltinWorkers(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registerAutoFixWorker(registry);
+  registerCoderabbitUpdateWorker(registry);
+  registerMergeConflictRebaseWorker(registry);
+  return registry;
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {


### PR DESCRIPTION
## Summary

This exposes the PR maintenance workers through the CLI and the headless runner.

Both surfaces now name every built-in worker kind and pass the PR maintenance settings into the worker runtime.

Operators can now start these workers from the command line.

## Review Claim

Approve exposing the PR maintenance workers through the CLI and headless surfaces.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

These surfaces only start already-registered workers, so no new PR mutation path is introduced.

## Slice Rationale

Exposure lands after registration so the CLI and headless surfaces reference workers that already exist.

## Non-goals

Does not change worker behavior. Does not add new PR mutations. Does not touch the worker registry internals.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/cli && pnpm test`
- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

