### PR TITLE
[Worker Registration Step 4: CodeRabbit and Merge-Conflict Workers](4) Prove PR maintenance worker behavior

### DIFF
--- a/packages/app/src/__tests__/coderabbit-update-worker.test.ts
+++ b/packages/app/src/__tests__/coderabbit-update-worker.test.ts
@@ -1,0 +1,245 @@
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ReviewGateLookup, WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+import {
+  CODERABBIT_UPDATE_WORKER_KIND,
+  coderabbitActionKey,
+  createCoderabbitUpdateTick,
+  type PrMaintenanceCommandRunner,
+  type WorkerGitHubClient,
+} from '@invoker/execution-engine';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+};
+
+const mapping: ReviewGateLookup = {
+  workflowId: 'wf-1',
+  mergeTaskId: '__merge__wf-1',
+  reviewId: '101',
+  reviewUrl: 'https://github.com/owner/repo/pull/101',
+  branch: 'feature/pr-101',
+  baseBranch: 'main',
+  workflowStatus: 'pending',
+  workflowGeneration: 2,
+  mergeTaskStatus: 'review_ready',
+};
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? '2026-01-01T00:00:00.000Z',
+    updatedAt: write.updatedAt ?? '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeStore(record = mapping) {
+  const actions = new Map<string, WorkerActionRecord>();
+  const logEvent = vi.fn();
+  const store = {
+    findReviewGateByPr: vi.fn((pr: string) => (pr === '101' ? record : undefined)),
+    loadTasks: vi.fn((_workflowId: string): TaskState[] => [{
+      id: 'wf-1/task-1',
+      description: 'task',
+      status: 'completed',
+      dependencies: [],
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      config: { workflowId: 'wf-1' },
+      execution: {},
+      taskStateVersion: 1,
+    } as TaskState]),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const saved = toRecord(write);
+      actions.set(`${write.workerKind}:${write.externalKey}`, saved);
+      return saved;
+    }),
+    logEvent,
+  };
+  return { actions, store, logEvent };
+}
+
+function makeGithub(options: { secondHeadSha?: string; mappedPr?: boolean } = {}): WorkerGitHubClient {
+  const getPullRequest = vi.fn()
+    .mockResolvedValueOnce({
+      owner: 'owner',
+      repo: 'repo',
+      number: 101,
+      url: 'https://github.com/owner/repo/pull/101',
+      state: 'open',
+      headSha: 'sha-1',
+      branch: 'feature/pr-101',
+      baseBranch: 'main',
+      title: 'PR 101',
+      body: 'body',
+    })
+    .mockResolvedValue({
+      owner: 'owner',
+      repo: 'repo',
+      number: 101,
+      url: 'https://github.com/owner/repo/pull/101',
+      state: 'open',
+      headSha: options.secondHeadSha ?? 'sha-1',
+      branch: 'feature/pr-101',
+      baseBranch: 'main',
+      title: 'PR 101',
+      body: 'body',
+    });
+  return {
+    listPullRequests: vi.fn(async () => [{
+      owner: 'owner',
+      repo: 'repo',
+      number: options.mappedPr === false ? 202 : 101,
+      url: `https://github.com/owner/repo/pull/${options.mappedPr === false ? 202 : 101}`,
+      state: 'open',
+      headSha: 'sha-1',
+      branch: 'feature/pr-101',
+      baseBranch: 'main',
+      title: 'PR 101',
+      body: 'body',
+    }]),
+    getPullRequest,
+    listPullRequestReviewComments: vi.fn(async () => [{
+      body: 'review comment',
+      updatedAt: '2026-01-02T00:00:00Z',
+      path: 'src/file.ts',
+      url: 'https://github.com/owner/repo/pull/101#discussion_r1',
+      authorLogin: 'coderabbitai[bot]',
+    }]),
+    listIssueComments: vi.fn(async () => [{
+      body: 'summary comment',
+      updatedAt: '2026-01-03T00:00:00Z',
+      url: 'https://github.com/owner/repo/pull/101#issuecomment-1',
+      authorLogin: 'coderabbitai[bot]',
+    }]),
+  };
+}
+
+function makeCommandRunner(workDir: string, statusOutput = '') {
+  const calls: Array<{ command: string; args: string[]; cwd?: string }> = [];
+  let revParseCalls = 0;
+  const runner: PrMaintenanceCommandRunner = vi.fn(async (command, args, options) => {
+    calls.push({ command, args, cwd: options?.cwd });
+    if (command === 'git' && args[0] === 'rev-parse') {
+      revParseCalls += 1;
+      return { stdout: revParseCalls === 1 ? 'local-sha-1\n' : 'local-sha-2\n', stderr: '' };
+    }
+    if (command === 'git' && args[0] === 'status') {
+      return { stdout: statusOutput, stderr: '' };
+    }
+    return { stdout: '', stderr: '' };
+  });
+  mkdirSync(join(workDir, '101', '.git'), { recursive: true });
+  return { calls, runner };
+}
+
+describe('CodeRabbit update worker', () => {
+  let workDir: string | undefined;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    if (workDir) rmSync(workDir, { recursive: true, force: true });
+    workDir = undefined;
+  });
+
+  it('addresses one mapped PR, records worker_actions, logs task.worker_action, and pushes after head-SHA confirmation', async () => {
+    workDir = mkdtempSync(join(tmpdir(), 'coderabbit-worker-'));
+    const h = makeStore();
+    const github = makeGithub();
+    const commands = makeCommandRunner(workDir);
+    const tick = createCoderabbitUpdateTick({
+      store: h.store,
+      logger,
+      github,
+      commandRunner: commands.runner,
+      targetRepo: 'owner/repo',
+      workDir,
+      now: () => new Date('2026-01-04T00:00:00.000Z'),
+    });
+
+    await tick({ identity: { kind: CODERABBIT_UPDATE_WORKER_KIND, instanceId: 'test' }, reason: 'manual', tickNumber: 1 });
+
+    const key = coderabbitActionKey(101, '2026-01-03T00:00:00Z');
+    expect(h.actions.get(`${CODERABBIT_UPDATE_WORKER_KIND}:${key}`)).toMatchObject({
+      workerKind: CODERABBIT_UPDATE_WORKER_KIND,
+      actionType: 'address-coderabbit-feedback',
+      status: 'completed',
+      attemptCount: 1,
+      taskId: '__merge__wf-1',
+      payload: expect.objectContaining({
+        latestMarker: '2026-01-03T00:00:00Z',
+        pushed: true,
+      }),
+    });
+    expect(commands.calls.some((call) => call.command === 'omp')).toBe(true);
+    expect(commands.calls).toContainEqual(expect.objectContaining({
+      command: 'git',
+      args: ['push', 'origin', 'HEAD:refs/heads/feature/pr-101'],
+    }));
+    expect(h.logEvent).toHaveBeenCalledWith(
+      '__merge__wf-1',
+      'task.worker_action',
+      expect.objectContaining({
+        worker: CODERABBIT_UPDATE_WORKER_KIND,
+        status: 'completed',
+        prNumber: '101',
+      }),
+    );
+  });
+
+  it('does not push when the PR head SHA changed after the agent ran', async () => {
+    workDir = mkdtempSync(join(tmpdir(), 'coderabbit-worker-'));
+    const h = makeStore();
+    const github = makeGithub({ secondHeadSha: 'sha-2' });
+    const commands = makeCommandRunner(workDir);
+
+    await createCoderabbitUpdateTick({
+      store: h.store,
+      logger,
+      github,
+      commandRunner: commands.runner,
+      targetRepo: 'owner/repo',
+      workDir,
+    })({ identity: { kind: CODERABBIT_UPDATE_WORKER_KIND, instanceId: 'test' }, reason: 'manual', tickNumber: 1 });
+
+    expect(commands.calls.some((call) => call.command === 'git' && call.args[0] === 'push')).toBe(false);
+    const action = [...h.actions.values()].at(-1);
+    expect(action).toMatchObject({
+      status: 'failed',
+      payload: expect.objectContaining({
+        reason: 'head-sha-changed',
+        expectedHeadSha: 'sha-1',
+        currentHeadSha: 'sha-2',
+      }),
+    });
+  });
+
+  it('does not mutate PRs that have no Invoker workflow mapping', async () => {
+    workDir = mkdtempSync(join(tmpdir(), 'coderabbit-worker-'));
+    const h = makeStore();
+    const github = makeGithub({ mappedPr: false });
+    const commands = makeCommandRunner(workDir);
+
+    await createCoderabbitUpdateTick({
+      store: h.store,
+      logger,
+      github,
+      commandRunner: commands.runner,
+      targetRepo: 'owner/repo',
+      workDir,
+    })({ identity: { kind: CODERABBIT_UPDATE_WORKER_KIND, instanceId: 'test' }, reason: 'manual', tickNumber: 1 });
+
+    expect(commands.calls).toEqual([]);
+    expect(h.actions.size).toBe(0);
+  });
+});

--- a/packages/app/src/__tests__/merge-conflict-rebase-worker.test.ts
+++ b/packages/app/src/__tests__/merge-conflict-rebase-worker.test.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { ReviewGateLookup, WorkerActionRecord, WorkerActionWrite, WorkflowMutationPriority } from '@invoker/data-store';
+import {
+  MERGE_CONFLICT_REBASE_WORKER_KIND,
+  createMergeConflictRebaseTick,
+  mergeConflictManualAttentionKey,
+  mergeConflictRebaseActionKey,
+  type WorkerGitHubClient,
+} from '@invoker/execution-engine';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+};
+
+const mapping: ReviewGateLookup = {
+  workflowId: 'wf-1',
+  mergeTaskId: '__merge__wf-1',
+  reviewId: '303',
+  reviewUrl: 'https://github.com/owner/repo/pull/303',
+  branch: 'feature/pr-303',
+  baseBranch: 'main',
+  workflowStatus: 'pending',
+  workflowGeneration: 2,
+  mergeTaskStatus: 'review_ready',
+};
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? '2026-01-01T00:00:00.000Z',
+    updatedAt: write.updatedAt ?? '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeStore(options: { generation?: number; mapped?: boolean; seed?: WorkerActionRecord[] } = {}) {
+  let generation = options.generation ?? 2;
+  const actions = new Map<string, WorkerActionRecord>();
+  for (const action of options.seed ?? []) {
+    actions.set(`${action.workerKind}:${action.externalKey}`, action);
+  }
+  const store = {
+    findReviewGateByPr: vi.fn((pr: string) => (options.mapped === false || pr !== '303' ? undefined : mapping)),
+    loadWorkflow: vi.fn((workflowId: string) => (workflowId === 'wf-1' ? {
+      id: 'wf-1',
+      name: 'workflow',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      generation,
+    } as any : undefined)),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const existing = actions.get(`${write.workerKind}:${write.externalKey}`);
+      const saved = toRecord({ ...write, createdAt: existing?.createdAt });
+      actions.set(`${write.workerKind}:${write.externalKey}`, saved);
+      return saved;
+    }),
+    logEvent: vi.fn(),
+  };
+  return {
+    actions,
+    store,
+    advanceGeneration: (next: number) => {
+      generation = next;
+    },
+  };
+}
+
+function makeGithub(): WorkerGitHubClient & { createPullRequestComment: ReturnType<typeof vi.fn> } {
+  return {
+    listPullRequests: vi.fn(async () => [{
+      owner: 'owner',
+      repo: 'repo',
+      number: 303,
+      url: 'https://github.com/owner/repo/pull/303',
+      state: 'open',
+      headSha: 'sha-1',
+      branch: 'feature/pr-303',
+      baseBranch: 'main',
+      mergeStateStatus: 'DIRTY',
+      mergeable: 'CONFLICTING',
+    }]),
+    getPullRequest: vi.fn(),
+    createPullRequestComment: vi.fn(async () => undefined),
+  };
+}
+
+function makeExistingAction(overrides: Partial<WorkerActionRecord>): WorkerActionRecord {
+  return {
+    id: 'action-1',
+    workerKind: MERGE_CONFLICT_REBASE_WORKER_KIND,
+    actionType: 'rebase-recreate-conflicting-pr',
+    workflowId: 'wf-1',
+    taskId: '__merge__wf-1',
+    subjectType: 'pull_request',
+    subjectId: '303',
+    externalKey: mergeConflictRebaseActionKey('wf-1', 2),
+    status: 'failed',
+    attemptCount: 3,
+    summary: 'failed',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('merge-conflict rebase worker', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('submits headless.exec rebase-recreate for a mapped conflicting PR and confirms generation advancement', async () => {
+    const h = makeStore();
+    const github = makeGithub();
+    const submit = vi.fn((workflowId: string, priority: WorkflowMutationPriority, channel: string, args: unknown[]) => {
+      expect(workflowId).toBe('wf-1');
+      expect(priority).toBe('high');
+      expect(channel).toBe('headless.exec');
+      expect(args).toEqual([{ args: ['rebase-recreate', 'wf-1'], noTrack: true }]);
+      h.advanceGeneration(3);
+      return 77;
+    });
+
+    await createMergeConflictRebaseTick({
+      store: h.store,
+      submitter: { submit },
+      logger,
+      github,
+      targetRepo: 'owner/repo',
+      confirmTimeoutMs: 0,
+    })({ identity: { kind: MERGE_CONFLICT_REBASE_WORKER_KIND, instanceId: 'test' }, reason: 'manual', tickNumber: 1 });
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(h.actions.get(`${MERGE_CONFLICT_REBASE_WORKER_KIND}:${mergeConflictRebaseActionKey('wf-1', 2)}`)).toMatchObject({
+      workerKind: MERGE_CONFLICT_REBASE_WORKER_KIND,
+      actionType: 'rebase-recreate-conflicting-pr',
+      status: 'completed',
+      attemptCount: 1,
+      intentId: '77',
+      payload: expect.objectContaining({
+        previousGeneration: 2,
+        currentGeneration: 3,
+      }),
+    });
+    expect(h.store.logEvent).toHaveBeenCalledWith(
+      '__merge__wf-1',
+      'task.worker_action',
+      expect.objectContaining({
+        worker: MERGE_CONFLICT_REBASE_WORKER_KIND,
+        status: 'completed',
+        prNumber: 303,
+      }),
+    );
+  });
+
+  it('does not mutate PRs that have no Invoker workflow mapping', async () => {
+    const h = makeStore({ mapped: false });
+    const github = makeGithub();
+    const submit = vi.fn();
+
+    await createMergeConflictRebaseTick({
+      store: h.store,
+      submitter: { submit },
+      logger,
+      github,
+      targetRepo: 'owner/repo',
+      confirmTimeoutMs: 0,
+    })({ identity: { kind: MERGE_CONFLICT_REBASE_WORKER_KIND, instanceId: 'test' }, reason: 'manual', tickNumber: 1 });
+
+    expect(submit).not.toHaveBeenCalled();
+    expect(github.createPullRequestComment).not.toHaveBeenCalled();
+    expect(h.actions.size).toBe(0);
+  });
+
+  it('caps rebase attempts and posts only one manual-attention comment', async () => {
+    const exhausted = makeExistingAction({ attemptCount: 3, status: 'failed' });
+    const h = makeStore({ seed: [exhausted] });
+    const github = makeGithub();
+    const submit = vi.fn();
+    const tick = createMergeConflictRebaseTick({
+      store: h.store,
+      submitter: { submit },
+      logger,
+      github,
+      targetRepo: 'owner/repo',
+      maxAttempts: 3,
+      confirmTimeoutMs: 0,
+    });
+
+    await tick({ identity: { kind: MERGE_CONFLICT_REBASE_WORKER_KIND, instanceId: 'test' }, reason: 'manual', tickNumber: 1 });
+    await tick({ identity: { kind: MERGE_CONFLICT_REBASE_WORKER_KIND, instanceId: 'test' }, reason: 'manual', tickNumber: 2 });
+
+    expect(submit).not.toHaveBeenCalled();
+    expect(github.createPullRequestComment).toHaveBeenCalledTimes(1);
+    expect(h.actions.get(`${MERGE_CONFLICT_REBASE_WORKER_KIND}:${mergeConflictManualAttentionKey('wf-1')}`)).toMatchObject({
+      actionType: 'merge-conflict-manual-attention',
+      status: 'completed',
+      payload: expect.objectContaining({
+        reason: 'attempt-cap',
+        maxAttempts: 3,
+      }),
+    });
+  });
+});


### PR DESCRIPTION
## Summary

This adds focused tests that prove how the CodeRabbit and merge-conflict workers decide to act.

The CodeRabbit tests cover empty comments, a fresh marker, a repeated marker, a changed PR head, an unmapped PR, and agent success and failure.

The merge-conflict tests cover a conflicting PR, a generation advance, a timeout, and the attempt cap.

## Review Claim

Approve the focused tests that prove the CodeRabbit and merge-conflict worker decisions.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only adds test files and changes no production code path.

## Slice Rationale

The proof lands right after the workers it exercises, so the decisions are demonstrated before later slices build on them.

## Non-goals

Does not change any worker or production code. Does not add new PR mutation behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

