### PR TITLE
[Workspace Recreate Notice](1) Show missing workspace explanation

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -1356,6 +1356,7 @@ describe('fixWithAgentAction', () => {
       appendTaskOutput: vi.fn(),
       loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 2 })),
       updateWorkflow: vi.fn(),
+      logEvent: vi.fn(),
     };
     const taskExecutor = {
       preparePoolForRebaseRetry: vi.fn().mockResolvedValue(undefined),
@@ -1373,6 +1374,16 @@ describe('fixWithAgentAction', () => {
     expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
       'task-a',
       expect.stringContaining('Startup merge conflict detected; recreating workflow wf-1 from a fresh base.'),
+    );
+    expect(persistence.logEvent).toHaveBeenCalledWith(
+      'task-a',
+      'task.workflow_recreated',
+      expect.objectContaining({
+        level: 'warn',
+        workflowId: 'wf-1',
+        reason: 'missing-workspace-startup-merge-conflict',
+        message: 'Workspace was missing, so Invoker recreated workflow wf-1 from a fresh base instead of fixing this task in-place.',
+      }),
     );
     expect(persistence.updateWorkflow).not.toHaveBeenCalled();
     expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1', expect.any(Object));

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -879,6 +879,12 @@ export async function fixWithAgentAction(
     throw new Error(msg);
   }
   if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
+    persistence.logEvent?.(taskId, 'task.workflow_recreated', {
+      level: 'warn',
+      workflowId: recoveryRoute.workflowId,
+      reason: 'missing-workspace-startup-merge-conflict',
+      message: `Workspace was missing, so Invoker recreated workflow ${recoveryRoute.workflowId} from a fresh base instead of fixing this task in-place.`,
+    });
     if (options.recreateOutputLabel) {
       persistence.appendTaskOutput(
         taskId,

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -687,6 +687,46 @@ describe('WorkflowInspector', () => {
     }
   });
 
+  it('shows a visible notice when fix recreated the workflow because workspace was missing', async () => {
+    (window as unknown as {
+      invoker: { getEvents: (taskId: string) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };
+    }).invoker = {
+      getEvents: vi.fn(async () => [
+        {
+          id: 1,
+          eventType: 'task.workflow_recreated',
+          payload: JSON.stringify({
+            level: 'warn',
+            workflowId: 'wf-1',
+            reason: 'missing-workspace-startup-merge-conflict',
+            message: 'Workspace was missing, so Invoker recreated workflow wf-1 from a fresh base instead of fixing this task in-place.',
+          }),
+          createdAt: '2025-01-01T00:00:04.000Z',
+        },
+      ]),
+    };
+
+    try {
+      render(
+        <WorkflowInspector
+          workflow={workflow}
+          task={makeTask({ status: 'failed' })}
+          collapsed={false}
+          advancedExpanded={false}
+          onToggleCollapsed={() => {}}
+          onToggleAdvanced={() => {}}
+        />,
+      );
+
+      const notice = await screen.findByTestId('workspace-recreate-notice');
+      expect(notice).toHaveTextContent('Workspace recreated');
+      expect(notice).toHaveTextContent('Workspace was missing, so Invoker recreated workflow wf-1 from a fresh base instead of fixing this task in-place.');
+      expect(notice).toHaveTextContent('Workflow: wf-1');
+    } finally {
+      delete (window as unknown as { invoker?: unknown }).invoker;
+    }
+  });
+
   it('shows a retrying log error when task events fail to load', async () => {
     (window as unknown as {
       invoker: { getEvents: (taskId: string) => Promise<Array<{ id: number; eventType: string; payload?: string; createdAt?: string }>> };

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -33,6 +33,9 @@ const SAFE_LOG_DETAIL_KEYS = new Set([
   'reviewId',
   'reviewUrl',
   'status',
+  'reason',
+  'route',
+  'workflowId',
 ]);
 
 const LOG_LEVELS: readonly TaskLogLevel[] = ['debug', 'info', 'warn', 'error'];
@@ -89,6 +92,24 @@ function taskEventToLogEntry(event: TaskAuditEvent, index: number): TaskLogEntry
       : event.eventType,
     detail: formatLogDetail(payload),
     createdAt: event.createdAt,
+  };
+}
+
+interface WorkspaceRecreateNotice {
+  message: string;
+  workflowId?: string;
+}
+
+function workspaceRecreateNoticeFromEvent(event: TaskAuditEvent): WorkspaceRecreateNotice | undefined {
+  if (event.eventType !== 'task.workflow_recreated') return undefined;
+  const payload = parseEventPayload(event.payload);
+  const payloadMessage = payload?.message;
+  const workflowId = typeof payload?.workflowId === 'string' ? payload.workflowId : undefined;
+  return {
+    message: typeof payloadMessage === 'string' && payloadMessage.trim()
+      ? payloadMessage
+      : 'Invoker recreated this workflow from a fresh workspace because the old workspace was missing.',
+    workflowId,
   };
 }
 
@@ -344,6 +365,10 @@ export function WorkflowInspector({
     && onReject,
   );
   const statusHeading = task ? 'Task Status' : 'Status';
+  const workspaceRecreateNotice = [...taskLogEvents]
+    .reverse()
+    .map(workspaceRecreateNoticeFromEvent)
+    .find((notice): notice is WorkspaceRecreateNotice => Boolean(notice));
   const logEntries = taskLogEvents.map(taskEventToLogEntry);
   const visibleLogEntries = logEntries
     .filter((entry) => LOG_LEVEL_RANK[entry.level] >= LOG_LEVEL_RANK[logLevelFilter])
@@ -463,6 +488,16 @@ export function WorkflowInspector({
             </div>
           )}
         </section>
+
+        {workspaceRecreateNotice && (
+          <section data-testid="workspace-recreate-notice" className="rounded border border-amber-700 bg-amber-950/40 p-3">
+            <h3 className="text-[11px] uppercase tracking-wide text-amber-200">Workspace recreated</h3>
+            <p className="mt-1 text-xs text-amber-100 break-words">{workspaceRecreateNotice.message}</p>
+            {workspaceRecreateNotice.workflowId && (
+              <p className="mt-2 text-[11px] text-amber-300">Workflow: {workspaceRecreateNotice.workflowId}</p>
+            )}
+          </section>
+        )}
 
         {actionNode && (
           <section data-testid="workflow-inspector-action-node" className="rounded border border-blue-500/40 bg-blue-950/20 p-3">


### PR DESCRIPTION
## Summary

Fix with Codex can recreate a workflow when the original workspace is missing. The selected task sidebar now explains that outcome.

The recreate path also writes a `task.workflow_recreated` event. That gives the UI and logs the same user-facing reason.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the user-visible notice and audit event for missing-workspace workflow recreation.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The existing recreate behavior still runs; this only adds a logged event and renders that event in the inspector.

Slice Rationale: This keeps the user-facing explanation separate from any future retry or workspace behavior changes.

</details>

## Non-goals

- Does not change when Fix with Codex recreates a workflow.
- Does not change task execution, workspace allocation, or retry behavior.
- Does not add a new manual confirmation step.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts -t 'dispatches startup merge conflicts without a workspace to workflow recreate'`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-inspector.test.tsx -t 'shows a visible notice when fix recreated the workflow because workspace was missing|shows task logs and filters by minimum level'`
- [x] `pnpm run check:types`
- [x] `bash scripts/ui-visual-proof.sh capture-before` captured 49 screenshots before the UI change; the existing visual-proof suite reported unrelated failures in terminal planning, queue, and SSH-resume states.
- [x] `bash scripts/ui-visual-proof.sh capture-after` captured 50 screenshots after the UI change; the existing visual-proof suite reported the same terminal planning and queue failures.
- [x] Focused UI proof: selected the failed task, ran the actual `fixWithAgent` recreate route, and captured the new sidebar notice.

## Visual Proof

Before missing-workspace recreate:

![Before missing-workspace recreate](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-6dba6e/workspace-recreate-notice-before.png)

After missing-workspace recreate:

![After missing-workspace recreate](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-6dba6e/workspace-recreate-notice-after.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge_commit_sha>`
- Post-revert steps: None
- Data migration? No
