### PR TITLE
[PR Maintenance Workers](3) Add PR maintenance repro proofs

### DIFF
--- a/scripts/repro/repro-mergify-admin-requeue.sh
+++ b/scripts/repro/repro-mergify-admin-requeue.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-mergify-admin-requeue.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+cat > "$TMP/bin/gh" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+
+HEAD = "c2532d229dbed2fd57419698c48d973001c78e9e"
+REQUIRED = [
+    "build-artifacts",
+    "quality / Dependency Cruise",
+    "PR Body",
+    "quality / TypeScript Types",
+    "required-fast / Guardrails",
+    "required-fast / Vitest Workspace",
+    "required-fast / Submit Workflow Chain",
+    "e2e-proof / aggregate",
+    "playwright / 1-of-3",
+    "playwright / 2-of-3",
+    "playwright / 3-of-3",
+    "ssh / shard-30",
+    "ssh / shard-31",
+    "optional / Worktree Provisioning",
+    "optional / Visual Proof Validate",
+]
+
+
+def contexts(number):
+    nodes = []
+    for name in REQUIRED:
+        conclusion = "FAILURE" if number == 2606 and name == "PR Body" else "SUCCESS"
+        nodes.append({
+            "__typename": "CheckRun",
+            "name": name,
+            "conclusion": conclusion,
+            "status": "COMPLETED",
+            "completedAt": "2026-07-03T00:00:00Z",
+            "startedAt": "2026-07-03T00:00:00Z",
+            "detailsUrl": "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2",
+            "checkSuite": {"commit": {"oid": HEAD}},
+        })
+    nodes.append({
+        "__typename": "CheckRun",
+        "name": "Rule: autoqueue admin-bypass PRs to master",
+        "conclusion": "FAILURE",
+        "status": "COMPLETED",
+        "completedAt": "2026-07-03T00:00:00Z",
+        "detailsUrl": "https://example.invalid/mergify",
+        "checkSuite": {"commit": {"oid": HEAD}},
+    })
+    return {"contexts": {"nodes": nodes}}
+
+
+def pr(number):
+    labels = ["admin-bypass"]
+    if number == 2605:
+        labels.append("dequeued")
+    threads = []
+    if number == 2607:
+        threads = [{
+            "id": "thread-human",
+            "isResolved": False,
+            "comments": {"nodes": [{"author": {"login": "alice"}, "body": "please fix", "url": "https://example.invalid/thread"}]},
+        }]
+    return {
+        "number": number,
+        "title": f"PR {number}",
+        "url": f"https://github.com/Neko-Catpital-Labs/Invoker/pull/{number}",
+        "isDraft": False,
+        "state": "OPEN",
+        "baseRefName": "master",
+        "headRefName": f"stack/{number}",
+        "headRefOid": HEAD,
+        "mergeStateStatus": "CLEAN",
+        "mergeable": "MERGEABLE",
+        "labels": {"nodes": [{"name": label} for label in labels]},
+        "reviewThreads": {"pageInfo": {"hasNextPage": False}, "nodes": threads},
+        "statusCheckRollup": contexts(number),
+    }
+
+args = sys.argv[1:]
+if args[:2] == ["pr", "list"]:
+    print(json.dumps([pr(2605), pr(2606), pr(2607)]))
+    raise SystemExit(0)
+if args[:2] == ["api", "graphql"]:
+    number = 0
+    for arg in args:
+        if arg.startswith("number="):
+            number = int(arg.split("=", 1)[1])
+    print(json.dumps({"data": {"repository": {"pullRequest": pr(number)}}}))
+    raise SystemExit(0)
+if args[:2] == ["api", "repos/Neko-Catpital-Labs/Invoker/issues/2605/comments"]:
+    body = """Left the queue `admin-bypass` at `c2532d229dbed2fd57419698c48d973001c78e9e`.
+-*- Mergify Payload -*-
+{"state":"dequeued","queue_rule_name":"admin-bypass"}
+"""
+    print(json.dumps([{"id": "m2605", "user": {"login": "mergify[bot]"}, "updated_at": "2026-07-03T00:00:00Z", "html_url": "https://example.invalid/m2605", "body": body}]))
+    raise SystemExit(0)
+if args[:2] == ["api", "repos/Neko-Catpital-Labs/Invoker/issues/2606/comments"] or args[:2] == ["api", "repos/Neko-Catpital-Labs/Invoker/issues/2607/comments"]:
+    print("[]")
+    raise SystemExit(0)
+print(f"unexpected gh args: {args}", file=sys.stderr)
+raise SystemExit(2)
+PY
+chmod +x "$TMP/bin/gh"
+
+export PATH="$TMP/bin:$PATH"
+out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo Neko-Catpital-Labs/Invoker --author EdbertChan --state-file "$TMP/ledger.jsonl")"
+printf '%s\n' "$out"
+
+case "$out" in
+  *"DRY-RUN requeue PR #2605 head=c2532d229dbed2fd57419698c48d973001c78e9e reason=eligible-after-dequeue"*) ;;
+  *) echo "[repro] missing requeue line" >&2; exit 1 ;;
+esac
+case "$out" in
+  *"DRY-RUN repair-check PR #2606 check=\"PR Body\""*) ;;
+  *) echo "[repro] missing repair line" >&2; exit 1 ;;
+esac
+case "$out" in
+  *"BLOCK PR #2607 human-review-thread"*) ;;
+  *) echo "[repro] missing human block line" >&2; exit 1 ;;
+esac
+
+echo "[repro] passed"

--- a/scripts/repro/repro-mergify-closed-pr-guard.sh
+++ b/scripts/repro/repro-mergify-closed-pr-guard.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-mergify-closed-pr-guard.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+cat > "$TMP/bin/gh" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+
+HEAD = "1111111111111111111111111111111111111111"
+REQUIRED = [
+    "build-artifacts",
+    "quality / Dependency Cruise",
+    "PR Body",
+    "quality / TypeScript Types",
+    "required-fast / Guardrails",
+    "required-fast / Vitest Workspace",
+    "required-fast / Submit Workflow Chain",
+    "e2e-proof / aggregate",
+    "playwright / 1-of-3",
+    "playwright / 2-of-3",
+    "playwright / 3-of-3",
+    "ssh / shard-30",
+    "ssh / shard-31",
+    "optional / Worktree Provisioning",
+    "optional / Visual Proof Validate",
+]
+
+
+def pr():
+    nodes = [{
+        "__typename": "CheckRun",
+        "name": name,
+        "conclusion": "SUCCESS",
+        "status": "COMPLETED",
+        "completedAt": "2026-07-03T00:00:00Z",
+        "detailsUrl": "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2",
+        "checkSuite": {"commit": {"oid": HEAD}},
+    } for name in REQUIRED]
+    return {
+        "number": 2999,
+        "title": "Closed admin bypass PR",
+        "url": "https://github.com/Neko-Catpital-Labs/Invoker/pull/2999",
+        "isDraft": False,
+        "state": "CLOSED",
+        "baseRefName": "master",
+        "headRefName": "closed/admin-bypass",
+        "headRefOid": HEAD,
+        "mergeStateStatus": "CLEAN",
+        "mergeable": "MERGEABLE",
+        "labels": {"nodes": [{"name": "admin-bypass"}, {"name": "dequeued"}]},
+        "reviewThreads": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+        "statusCheckRollup": {"contexts": {"nodes": nodes}},
+    }
+
+args = sys.argv[1:]
+if args[:2] == ["api", "graphql"]:
+    print(json.dumps({"data": {"repository": {"pullRequest": pr()}}}))
+    raise SystemExit(0)
+if args[:2] == ["api", "repos/Neko-Catpital-Labs/Invoker/issues/2999/comments"]:
+    print(json.dumps([{"id": "m2999", "user": {"login": "mergify"}, "updated_at": "2026-07-03T00:00:00Z", "body": "-*- Mergify Payload -*-\n{\"state\":\"dequeued\",\"queue_rule_name\":\"admin-bypass\"}\nLeft the queue at `1111111111111111111111111111111111111111`"}]))
+    raise SystemExit(0)
+print(f"unexpected gh args: {args}", file=sys.stderr)
+raise SystemExit(2)
+PY
+chmod +x "$TMP/bin/gh"
+
+export PATH="$TMP/bin:$PATH"
+out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo Neko-Catpital-Labs/Invoker --author EdbertChan --state-file "$TMP/ledger.jsonl" --pr 2999)"
+printf '%s\n' "$out"
+
+case "$out" in
+  *"BLOCK PR #2999 closed"*) ;;
+  *) echo "[repro] missing closed block line" >&2; exit 1 ;;
+esac
+case "$out" in
+  *"DRY-RUN requeue PR #2999"*) echo "[repro] wrongly requeued closed PR" >&2; exit 1 ;;
+esac
+
+echo "[repro] passed"

--- a/scripts/repro/repro-mergify-rejected-pr.sh
+++ b/scripts/repro/repro-mergify-rejected-pr.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/repro-mergify-rejected-pr.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/bin"
+
+cat > "$TMP/bin/gh" <<'PY'
+#!/usr/bin/env python3
+import json
+import sys
+
+HEAD = "79035e5e42f8eda9f22a68697c241eb459555081"
+REQUIRED = [
+    "build-artifacts",
+    "quality / Dependency Cruise",
+    "PR Body",
+    "quality / TypeScript Types",
+    "required-fast / Guardrails",
+    "required-fast / Vitest Workspace",
+    "required-fast / Submit Workflow Chain",
+    "e2e-proof / aggregate",
+    "playwright / 1-of-3",
+    "playwright / 2-of-3",
+    "playwright / 3-of-3",
+    "ssh / shard-30",
+    "ssh / shard-31",
+    "optional / Worktree Provisioning",
+]
+
+
+def pr():
+    nodes = []
+    for name in REQUIRED:
+        nodes.append({
+            "__typename": "CheckRun",
+            "name": name,
+            "conclusion": "SUCCESS",
+            "status": "COMPLETED",
+            "completedAt": "2026-07-03T06:10:00Z",
+            "detailsUrl": "https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/1/job/2",
+            "checkSuite": {"commit": {"oid": HEAD}},
+        })
+    return {
+        "number": 2969,
+        "title": "[Mergify Runner Isolation](1) Route queue jobs to dedicated runners",
+        "url": "https://github.com/Neko-Catpital-Labs/Invoker/pull/2969",
+        "isDraft": False,
+        "state": "OPEN",
+        "baseRefName": "master",
+        "headRefName": "stack/EdbertChan/mergify-runner-isolation/isolate-mergify-queue-runners--cfb9a3aa",
+        "headRefOid": HEAD,
+        "mergeStateStatus": "BLOCKED",
+        "mergeable": "MERGEABLE",
+        "labels": {"nodes": [{"name": "admin-bypass"}, {"name": "dequeued"}]},
+        "reviewThreads": {"pageInfo": {"hasNextPage": False}, "nodes": []},
+        "statusCheckRollup": {"contexts": {"nodes": nodes}},
+    }
+
+args = sys.argv[1:]
+if args[:2] == ["api", "graphql"]:
+    print(json.dumps({"data": {"repository": {"pullRequest": pr()}}}))
+    raise SystemExit(0)
+if args[:2] == ["api", "repos/Neko-Catpital-Labs/Invoker/issues/2969/comments"]:
+    body = """<!---
+DO NOT EDIT
+-*- Mergify Payload -*-
+{"version":1,"state":"dequeued","queue_rule_name":"admin-bypass","queued_at":"2026-07-03T05:47:54.103584+00:00","required_conditions":[]}
+-*- Mergify Payload End -*-
+-->
+
+# Merge Queue Status
+
+- ❌ **Checks failed** · on draft #2985
+- 🚫 **Left the queue** — `2026-07-03 06:13 UTC` · at `79035e5e42f8eda9f22a68697c241eb459555081`
+
+<details>
+<summary><strong>Waiting for</strong></summary>
+
+- [ ] `check-success = e2e-proof / aggregate`
+
+</details>
+<details>
+<summary>All conditions</summary>
+
+- [ ] `check-success = e2e-proof / aggregate`
+- [X] `check-success = PR Body`
+- [X] `check-success = optional / Visual Proof Validate`
+
+</details>
+
+## Reason
+
+The merge conditions cannot be satisfied due to failing checks
+
+- `e2e-proof / aggregate`
+
+Failing checks:
+- 🛑 [PR Body](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/28641642476/job/84938961337) ([job log](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/28641642476/job/84938961337))
+"""
+    print(json.dumps([{"id": "m2969", "user": {"login": "mergify"}, "updated_at": "2026-07-03T06:14:00Z", "html_url": "https://github.com/Neko-Catpital-Labs/Invoker/pull/2969#issuecomment-4872966494", "body": body}]))
+    raise SystemExit(0)
+print(f"unexpected gh args: {args}", file=sys.stderr)
+raise SystemExit(2)
+PY
+chmod +x "$TMP/bin/gh"
+
+export PATH="$TMP/bin:$PATH"
+out="$(python3 scripts/mergify_admin_requeue.py --dry-run --once --repo Neko-Catpital-Labs/Invoker --author EdbertChan --state-file "$TMP/ledger.jsonl" --pr 2969)"
+printf '%s\n' "$out"
+
+case "$out" in
+  *"DRY-RUN repair-check PR #2969 check=\"PR Body\""*) ;;
+  *) echo "[repro] missing Mergify rejection repair line" >&2; exit 1 ;;
+esac
+case "$out" in
+  *"BLOCK PR #2969 missing-check"*) echo "[repro] wrongly blocked on missing current check" >&2; exit 1 ;;
+esac
+case "$out" in
+  *"DRY-RUN requeue PR #2969"*) echo "[repro] wrongly requeued before repair" >&2; exit 1 ;;
+esac
+
+echo "[repro] passed"

--- a/scripts/repro/repro-pr-crons-mutex.sh
+++ b/scripts/repro/repro-pr-crons-mutex.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
-# Cross-job mutual exclusion proof: while the shared lock is held, EACH PR cron
-# worker must print "another PR cron operation in progress" and exit 0 (clean
-# no-op), so only one operation (Job 1 or Job 2) ever runs at a time.
+# Cross-job mutual exclusion proof: while the shared lock is held, EACH PR
+# maintenance worker tick script must print "another PR maintenance operation in
+# progress" and exit 0 (clean no-op), so only one operation ever runs at a time.
 #
 # Holds the lock the same way the lib acquires it (flock if available, else the
 # atomic mkdir fallback), then runs each worker. Fully offline; cron_lock is the
@@ -53,7 +53,7 @@ for worker in cron-coderabbit-address cron-pr-conflict-rebase; do
   out="$(bash "scripts/$worker.sh" 2>&1)"
   code=$?
   set -e
-  echo "$out" | grep -q "another PR cron operation in progress" \
+  echo "$out" | grep -q "another PR maintenance operation in progress" \
     || fail "$worker did not report the lock as held" "$out"
   [ "$code" -eq 0 ] || fail "$worker exited $code (expected 0 clean no-op)" "$out"
 done


### PR DESCRIPTION
## Summary

Adds repro scripts for PR maintenance worker cases.

These repros show what the optional PR maintenance scripts are meant to do and how they fail safely. They cover Mergify planning, closed PR handling, review-request handling, and the shared lock that prevents two PR maintenance workers from running at once.

<details>
<summary>Review metadata</summary>

Review Claim: PR maintenance examples are reproducible without live GitHub state.

Review Lane: proof

Review Unit: proof

Safety Invariant: The repros stub external tools and only assert local dry-run output.

Slice Rationale: Repros land before owner-worker wiring so failures are easier to diagnose.

</details>

## Non-goals

No production worker startup.

No live GitHub mutation.

No application code change.

## Test Plan

- [x] `bash scripts/repro/repro-mergify-*.sh`
- [x] `bash scripts/repro/repro-pr-crons-mutex.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 83784ed5b`
- Post-revert steps: None
- Data migration? No
