### PR TITLE
[Make PR Proof](1) Require visible proof target

### DIFF
--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -46,6 +46,11 @@ must_contain "$SKILL_MD" "Do not reuse earlier proof media after UI behavior cha
 must_contain "$SKILL_MD" "This script handles local image path upload/injection" "make-pr must route media upload through create-pr"
 must_contain "$SKILL_MD" "add or update a focused skill contract test for the exact issue being fixed" "make-pr must require focused tests for skill policy changes"
 must_contain "$SKILL_MD" "fail if the instruction that prevents the regression is removed" "make-pr skill tests must lock the regression rule"
+must_contain "$SKILL_MD" "Visual proof must show the changed behavior itself" "make-pr visual proof must show the actual changed behavior"
+must_contain "$SKILL_MD" "open every screenshot or video and verify the user-visible target is present" "make-pr visual proof must require inspecting proof media"
+must_contain "$SKILL_MD" "For conditional or event-driven UI, drive the exact condition that triggers the new state" "make-pr visual proof must cover conditional UI states"
+must_contain "$SKILL_MD" "A generic task panel, unchanged sidebar, unrelated graph, or stale screenshot is not proof" "make-pr visual proof must reject generic task-panel screenshots"
+must_contain "$SKILL_MD" "caption each visual proof item with the concrete thing the reviewer should see" "make-pr visual proof captions must name the visible target"
 
 # The publication checklist must stop empty PR slices before create/update/stack publish.
 must_contain "$SKILL_MD" "has no file changes against its selected base" "make-pr skill must reject branches with no reviewable file diff"

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -108,6 +108,9 @@ If the change is small and has no architectural impact, omit `## Architecture` r
 If the change is UI-impacting, use `skills/visual-proof/SKILL.md` first and include its screenshot/video markdown in `## Visual Proof`. UI-impacting means the user-visible experience changes, even when no file under `packages/ui/**` changes. This includes `packages/ui/**`, Electron window lifecycle files, preload, main process window wiring, app menu changes, task status changes, task error or output text shown in panels, approval/reject behavior, workflow state shown in the DAG or inspector, and web-surface output.
 
 When an existing PR changes after its body or proof was written, rerun this skill from the current diff before updating the PR. If the new diff touches UI-impacting files, rerun `skills/visual-proof/SKILL.md` and replace old screenshot or video links with fresh proof for the current code. Do not reuse earlier proof media after UI behavior changes.
+Visual proof must show the changed behavior itself, not just the changed screen area. Before creating or updating the PR, open every screenshot or video and verify the user-visible target is present and identifiable. For conditional or event-driven UI, drive the exact condition that triggers the new state and capture that state. A generic task panel, unchanged sidebar, unrelated graph, or stale screenshot is not proof, even when the right file changed.
+
+In the PR body, caption each visual proof item with the concrete thing the reviewer should see, for example "amber Workspace recreated notice in the task inspector." If the reviewer cannot tell what changed from the image and caption, recapture proof before publishing.
 
 When a PR changes skill instructions under `skills/**/SKILL.md`, add or update a focused skill contract test for the exact issue being fixed. The test must fail if the instruction that prevents the regression is removed.
 


### PR DESCRIPTION
## Summary

The make-pr skill now says visual proof must show the actual changed behavior.

This prevents generic screenshots from looking valid when the important notice, state, or panel is missing.

The contract test locks that rule so future skill edits cannot drop it silently.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the visual-proof policy guard in the make-pr skill.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This changes skill text and its contract test only; app behavior is unchanged.

Slice Rationale: This policy fix is separate from the UI notice PR so review can focus on PR authoring rules.

</details>

## Non-goals

- Does not change PR creation code.
- Does not change visual-proof capture scripts.
- Does not change app or UI behavior.

## Test Plan

- [x] `bash scripts/test-make-pr-skill.sh`
- [x] `node scripts/validate-pr-body.mjs --body-file .pr-body-make-pr-proof-guidance.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge_commit_sha>`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified visual proof requirements for pull requests, including showing the actual changed behavior, using current screenshots or videos, and capturing event-driven UI in the right state.
  * Added guidance to label each visual proof item with a clear, reviewer-friendly description of what changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->