### PR TITLE
[Keep left sidebar state during navigation](1) Decouple navigation from sidebar collapse

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -545,7 +545,7 @@ export function App() {
   const graphActionsMenuRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
   const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkerKind, setSelectedWorkerKind] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
@@ -2118,7 +2118,7 @@ export function App() {
       setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
-      setSidebarCollapsed(false);
+      setSidebarCollapsed(null);
       setViewMode('dag');
       setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
@@ -2143,7 +2143,7 @@ export function App() {
       setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
-      setSidebarCollapsed(false);
+      setSidebarCollapsed(null);
       setViewMode('dag');
       setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
@@ -2167,6 +2167,8 @@ export function App() {
   const showStart = hasLoadedPlan && !hasStarted;
   const showStop = hasStarted && !allSettled;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
+  const autoCollapseSidebar = sidebarSurface !== 'home' && sidebarSurface !== 'planning' && viewportWidth < 1440;
+  const effectiveSidebarCollapsed = sidebarCollapsed ?? autoCollapseSidebar;
   const autoCollapseInspector = sidebarSurface !== 'home' && viewportWidth < 1440;
   const effectiveInspectorCollapsed = inspectorCollapsed || (autoCollapseInspector && !inspectorManualOpen);
   const showWorkerDetailsPanel = viewMode === 'queue' && sidebarSurface === 'workers';
@@ -2236,7 +2238,6 @@ export function App() {
     setGraphActionsMenuOpen(false);
     if (nextSurface === 'workers') {
       setSidebarSurface('workers');
-      setSidebarCollapsed(true);
       setInspectorCollapsed(true);
       setInspectorManualOpen(false);
       setStatusFilters(new Set<WorkflowStatus>());
@@ -2246,12 +2247,10 @@ export function App() {
     setViewMode('dag');
     if (nextSurface === 'home') {
       setSidebarSurface('home');
-      setSidebarCollapsed(false);
       setInspectorManualOpen(false);
       return;
     }
     setSidebarSurface(nextSurface);
-    setSidebarCollapsed(true);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
   }, []);
@@ -2259,9 +2258,7 @@ export function App() {
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
     setSidebarSurface('home');
-    setSidebarCollapsed(false);
     setInspectorManualOpen(false);
-    setViewMode('dag');
   }, []);
 
   // ── Task actions ──────────────────────────────────────────
@@ -3090,9 +3087,9 @@ export function App() {
           workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}
           selectedSurface={sidebarSurface}
-          collapsed={sidebarCollapsed}
+          collapsed={effectiveSidebarCollapsed}
           onSelectSurface={handleSelectSidebarSurface}
-          onToggleCollapsed={() => setSidebarCollapsed((value) => !value)}
+          onToggleCollapsed={() => setSidebarCollapsed(!effectiveSidebarCollapsed)}
           onOpenSettings={() => {
             cancelPendingSystemSetupAutoOpen();
             setShowSystemSetup(true);


### PR DESCRIPTION
## Summary

Your chosen left rail width now sticks. Switching between home, planning, workflows, attention, running, and workers no longer snaps the rail back.

Before, each left-rail destination forced its own collapsed or expanded width, so a manual choice was thrown away on the next click.

Now the App shell keeps one manual value as the source of truth. When you have not chosen, a narrow window still auto-collapses the rail on non-home surfaces.

## Review Claim

The left navigation rail no longer overwrites a manual sidebar collapse choice.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change stays inside the App shell and keeps the existing narrow-window auto-collapse behavior for the browser surfaces.

## Slice Rationale

This slice carries only the shell behavior change; its regression guards ship in the next slice so each PR holds one claim.

## Non-goals

- No change to the manual collapse toggle control in the left status column.
- No change to the narrow-window auto-collapse for browser surfaces.
- The regression guards (component test and visual e2e) live in the follow-up slice, not here.

## Test Plan

- [x] `cd packages/ui && pnpm test`
- [x] `cd packages/app && npx playwright test visual-proof.spec.ts -g "sidebar-collapse-state"` (from the follow-up slice; fails on this branch's base, passes with this fix)

## Visual Proof

The `sidebar-collapse-state` e2e case walks the rail through navigation. Full recordings of that walk:

- [walkthrough video — before (base): the rail snaps back when navigating](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-21789b/sidebar-collapse-state-walkthrough-before.webm)
- [walkthrough video — after (this PR): the rail width sticks across navigation](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-21789b/sidebar-collapse-state-walkthrough-after.webm)

Step 1 — on **Workflows**, the rail is manually expanded ("Workflows" is the highlighted item). Same on both builds; this is the state navigation must preserve.

![step 1 — Workflows surface, rail manually expanded](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-21789b/sidebar-collapse-state-1-workflows-manually-expanded.png)

Step 2 — click **Needs Attention**. The highlight moves to the new item, so the navigation is visible in the frame.

Before (base): the manual choice is thrown away — the rail snaps back to the icon strip.

![step 2 before — Needs Attention surface, rail snapped back to icon strip](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-21789b/sidebar-collapse-state-2-attention-after-navigation-before.png)

After (this PR): the rail is still expanded on the new surface.

![step 2 after — Needs Attention surface, rail still expanded](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-21789b/sidebar-collapse-state-2-attention-after-navigation-after.png)

Step 3 — back on **Workflows**, the rail is manually collapsed to the icon strip (this PR).

![step 3 — Workflows surface, rail manually collapsed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-21789b/sidebar-collapse-state-3-workflows-manually-collapsed-after.png)

Step 4 — click **Home** (workspace switches to the Plan graph). The rail stays collapsed; the base build forced it open on this click.

![step 4 — Home surface, rail still collapsed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-21789b/sidebar-collapse-state-4-home-still-collapsed-after.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
