### PR TITLE
[Worker Subscriptions](4) Add owner-managed worker wake subscriptions

### DIFF
--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { LocalBus, type MessageBus } from '@invoker/transport';
 import {
   AUTO_FIX_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
@@ -6,6 +7,7 @@ import {
   PR_STATUS_WORKER_KIND,
   type WorkerRuntime,
   type WorkerRuntimeDependencies,
+  type WorkerSubscriptionFactory,
 } from '@invoker/execution-engine';
 
 import {
@@ -51,7 +53,7 @@ function persistence() {
   };
 }
 
-function deps(): WorkerRuntimeDependencies {
+function deps(messageBus?: MessageBus): WorkerRuntimeDependencies {
   return {
     store: {} as WorkerRuntimeDependencies['store'],
     submitter: { submit: vi.fn(() => 1) },
@@ -61,13 +63,19 @@ function deps(): WorkerRuntimeDependencies {
       error: vi.fn(),
       debug: vi.fn(),
     },
+    messageBus,
   } as WorkerRuntimeDependencies;
 }
 
-function controller() {
+function controller(messageBus?: MessageBus) {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
   const runtimes = new Map<string, TestWorkerRuntime[]>();
-  const register = (kind: string, note: string, runtimeKind = kind) => {
+  const register = (
+    kind: string,
+    note: string,
+    runtimeKind = kind,
+    subscriptions?: WorkerSubscriptionFactory<WorkerRuntimeDependencies>,
+  ) => {
     registry.register({
       kind,
       note,
@@ -78,6 +86,7 @@ function controller() {
         runtimes.set(kind, list);
         return created;
       },
+      ...(subscriptions ? { subscriptions } : {}),
     });
   };
   register(AUTO_FIX_WORKER_KIND, 'Auto-fixes failed tasks.', 'recovery');
@@ -86,10 +95,11 @@ function controller() {
   register('external-preview', 'External preview worker.');
 
   return {
+    registry,
     runtimes,
     controller: createWorkerRuntimeController({
       registry,
-      deps: deps(),
+      deps: deps(messageBus),
       autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
       persistence: persistence() as never,
       canControl: () => true,
@@ -174,5 +184,62 @@ describe('createWorkerRuntimeController', () => {
       lifecycle: 'exited',
       policy: 'unknown',
     });
+  });
+  it('wakes subscribed workers on matching bus messages', () => {
+    const bus = new LocalBus();
+    const setup = controller(bus);
+    setup.registry.register({
+      kind: 'subscribed-worker',
+      note: 'Wakes on matching test messages.',
+      factory: () => {
+        const created = runtime('subscribed-worker');
+        const list = setup.runtimes.get('subscribed-worker') ?? [];
+        list.push(created);
+        setup.runtimes.set('subscribed-worker', list);
+        return created;
+      },
+      subscriptions: () => [{
+        channel: 'test.channel',
+        shouldWake: (message: { kind?: string }) => message.kind === 'wake-me',
+      }],
+    });
+
+    setup.controller.start('subscribed-worker');
+    const created = setup.runtimes.get('subscribed-worker')?.[0];
+    expect(created).toBeDefined();
+
+    bus.publish('test.channel', { kind: 'ignore-me' });
+    bus.publish('test.channel', { kind: 'wake-me' });
+
+    expect(created?.wake).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribes worker wake handlers on stop', async () => {
+    const bus = new LocalBus();
+    const setup = controller(bus);
+    setup.registry.register({
+      kind: 'stoppable-worker',
+      note: 'Stops listening after stop.',
+      factory: () => {
+        const created = runtime('stoppable-worker');
+        const list = setup.runtimes.get('stoppable-worker') ?? [];
+        list.push(created);
+        setup.runtimes.set('stoppable-worker', list);
+        return created;
+      },
+      subscriptions: () => [{
+        channel: 'test.channel',
+        shouldWake: (message: { wake?: boolean }) => message.wake === true,
+      }],
+    });
+
+    setup.controller.start('stoppable-worker');
+    const created = setup.runtimes.get('stoppable-worker')?.[0];
+    expect(created).toBeDefined();
+
+    await setup.controller.stop('stoppable-worker');
+    bus.publish('test.channel', { wake: true });
+
+    expect(created?.wake).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -32,6 +32,7 @@ type WorkerStatusPersistence = Pick<SQLiteAdapter, 'listWorkerActions' | 'listWo
 interface RuntimeHandle {
   runtime: WorkerRuntime;
   startedAt: string;
+  unsubscribes: Array<() => void>;
   stoppedAt?: string;
 }
 
@@ -78,8 +79,15 @@ export function createWorkerRuntimeController(options: {
       canControl: options.canControl(),
     });
   };
+  const disposeSubscriptions = (handle: RuntimeHandle): void => {
+    for (const unsubscribe of handle.unsubscribes.splice(0)) {
+      unsubscribe();
+    }
+  };
+
 
   const stopHandle = async (kind: string, handle: RuntimeHandle): Promise<void> => {
+    disposeSubscriptions(handle);
     await handle.runtime.stop();
     const stoppedAt = new Date().toISOString();
     stoppedAtByKind.set(kind, stoppedAt);
@@ -102,15 +110,27 @@ export function createWorkerRuntimeController(options: {
         if (existing.runtime.isRunning()) {
           return rowForKind(kind);
         }
+        disposeSubscriptions(existing);
         void existing.runtime.stop().catch(() => undefined);
         handles.delete(kind);
       }
 
       const runtime = definition.factory(options.deps);
       runtime.start();
+      const unsubscribes = options.deps.messageBus
+        ? (definition.subscriptions?.(options.deps) ?? []).map((subscription) => options.deps.messageBus!.subscribe(
+          subscription.channel,
+          (message: unknown) => {
+            if (subscription.shouldWake(message)) {
+              runtime.wake('wake');
+            }
+          },
+        ))
+        : [];
       handles.set(kind, {
         runtime,
         startedAt: new Date().toISOString(),
+        unsubscribes,
       });
       stoppedAtByKind.delete(kind);
       return rowForKind(kind);

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -53,6 +53,32 @@ describe('worker registry', () => {
 
     expect(registry.list().map((d) => d.kind)).toEqual([AUTO_FIX_WORKER_KIND]);
   });
+  it('keeps owner-owned wake subscriptions on a registered definition', () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registry.register({
+      kind: 'subscribed-worker',
+      note: 'Wakes on test events.',
+      factory: () => ({
+        identity: { kind: 'subscribed-worker', instanceId: 'subscribed-worker-1' },
+        start: () => {},
+        wake: () => {},
+        tick: async () => {},
+        stop: async () => {},
+        isRunning: () => false,
+      }),
+      subscriptions: () => [{
+        channel: 'test.channel',
+        shouldWake: (message: { wake?: boolean }) => message.wake === true,
+      }],
+    });
+
+    const definition = registry.get('subscribed-worker');
+    expect(definition?.subscriptions?.(deps())).toEqual([
+      expect.objectContaining({ channel: 'test.channel' }),
+    ]);
+    expect(definition?.subscriptions?.(deps())[0]?.shouldWake({ wake: false })).toBe(false);
+    expect(definition?.subscriptions?.(deps())[0]?.shouldWake({ wake: true })).toBe(true);
+  });
 
   it('registers every built-in worker in one call', () => {
     const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -10,6 +10,18 @@ import type { WorkerRuntime } from './worker-runtime.js';
 
 /** Builds a worker runtime from injected dependencies. */
 export type WorkerFactory<TDeps = unknown> = (deps: TDeps) => WorkerRuntime;
+/** Predicate-based wake subscription owned by the Invoker process. */
+export interface WorkerWakeSubscription<TMessage = unknown> {
+  /** Message bus channel to subscribe to. */
+  readonly channel: string;
+  /** Return true when the worker should wake for this message. */
+  readonly shouldWake: (message: TMessage) => boolean;
+}
+
+/** Builds owner-owned wake subscriptions from injected dependencies. */
+export type WorkerSubscriptionFactory<TDeps = unknown> = (
+  deps: TDeps,
+) => readonly WorkerWakeSubscription[];
 
 /** A single worker declared in the registry. */
 export interface WorkerDefinition<TDeps = unknown> {
@@ -19,6 +31,8 @@ export interface WorkerDefinition<TDeps = unknown> {
   readonly note: string;
   /** Builds the worker runtime from injected dependencies. */
   readonly factory: WorkerFactory<TDeps>;
+  /** Optional owner-owned wake subscriptions installed while the runtime runs. */
+  readonly subscriptions?: WorkerSubscriptionFactory<TDeps>;
 }
 
 /** Mutable collection of worker definitions keyed by kind. */


### PR DESCRIPTION
## Summary

Adds owner-managed worker wake subscriptions.

Workers can now declare the bus channels that should wake them. The owner installs those subscriptions on start, removes them on stop, and routes matching messages to the existing worker runtime wake path.

Existing workers keep their current behavior until they opt in.

<details>
<summary>Review metadata</summary>

Review Claim: The owner can now wake long-running workers from bus events instead of only startup or polling.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Workers only change behavior when a definition explicitly declares subscriptions.

Slice Rationale: This lifecycle layer must land before any GitHub event source or PR maintenance worker can use subscriptions.

</details>

## Non-goals

No GitHub event publisher yet.

No PR maintenance worker wiring yet.

No external worker bus protocol.

## Architecture

### Before

```mermaid
graph TD
    A["owner starts worker"] --> B["startup or poll only"]
```

### After

```mermaid
graph TD
    A["owner starts worker"] --> B["install bus subscriptions"]
    B --> C["matching event"]
    C --> D["runtime.wake('wake')"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/worker-registry.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/worker-control.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert d0f17a485`
- Post-revert steps: None
- Data migration? No
