### PR TITLE
[Worker Subscriptions](6) Wire event-driven PR maintenance workers

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -209,6 +209,49 @@ describe('loadConfig', () => {
     const config = loadConfig();
     expect(config.externalWorkers).toEqual(externalWorkers);
   });
+  it('reads PR maintenance config from user config', () => {
+    const prMaintenance = {
+      githubPrEvents: {
+        enabled: true,
+        repo: 'owner/repo',
+        author: 'octocat',
+        coderabbitLogin: 'coderabbitai[bot]',
+        mergifyLogin: 'mergify[bot]',
+        pollIntervalMs: 60000,
+      },
+      coderabbitAddress: {
+        enabled: true,
+        repoRoot: '/repo',
+        repo: 'owner/repo',
+        author: 'octocat',
+        coderabbitLogin: 'coderabbitai[bot]',
+        trigger: 'subscription',
+      },
+      prConflictRebase: {
+        enabled: true,
+        repoRoot: '/repo',
+        repo: 'owner/repo',
+        author: 'octocat',
+        trigger: 'subscription',
+      },
+      mergifyRequeue: {
+        enabled: true,
+        repoRoot: '/repo',
+        repo: 'owner/repo',
+        author: 'octocat',
+        trigger: 'subscription',
+        pythonExecutable: '/usr/bin/python3',
+        stateFile: '/tmp/mergify-state.jsonl',
+        extraArgs: ['--dry-run'],
+      },
+    };
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ prMaintenance }),
+    );
+    const config = loadConfig();
+    expect(config.prMaintenance).toEqual(prMaintenance);
+  });
 
   it('reads imageStorage from user config', () => {
     const imageStorage = {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -40,6 +40,38 @@ export interface ExternalWorkerConfig {
   /** Process invocation used by the loader to start the external worker. */
   launch: ExternalWorkerLaunchConfig;
 }
+export interface PrProcessWorkerConfig {
+  enabled?: boolean;
+  repoRoot?: string;
+  repo?: string;
+  author?: string;
+  coderabbitLogin?: string;
+  pollIntervalMs?: number;
+  trigger?: 'subscription' | 'poll';
+  env?: Record<string, string>;
+}
+
+export interface MergifyRequeueConfig extends PrProcessWorkerConfig {
+  pythonExecutable?: string;
+  stateFile?: string;
+  extraArgs?: string[];
+}
+
+export interface PrMaintenanceEventSourceConfig {
+  enabled?: boolean;
+  repo: string;
+  author: string;
+  coderabbitLogin?: string;
+  mergifyLogin?: string;
+  pollIntervalMs?: number;
+}
+
+export interface PrMaintenanceConfig {
+  githubPrEvents?: PrMaintenanceEventSourceConfig;
+  coderabbitAddress?: PrProcessWorkerConfig;
+  prConflictRebase?: PrProcessWorkerConfig;
+  mergifyRequeue?: MergifyRequeueConfig;
+}
 export interface DefaultExecutionConfig {
   /**
    * Default task execution harness when a task omits executionAgent.
@@ -292,6 +324,8 @@ export interface InvokerConfig {
     /** Routing strategy. Defaults to "enforce". */
     strategy?: 'enforce' | 'route';
   }>;
+  /** Optional PR maintenance worker and GitHub event-source config. */
+  prMaintenance?: PrMaintenanceConfig;
   /**
    * Operator-declared external worker list, with each worker identified by registry kind.
    * The loader consumes this later; absent means no external workers.

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -18,7 +18,7 @@ import {
   acquireWorkerLock,
   createAutoFixAttemptLedger,
   createWorkerRegistry,
-  registerAutoFixWorker,
+  registerBuiltinWorkers,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
   type WorkerRuntimeDependencies,
@@ -424,7 +424,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
     deps.invokerConfig?.externalWorkers,
-    registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
   );
 
   if (subCommand === 'list') {
@@ -487,6 +487,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         attemptLedger: autoFixAttemptLedger,
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
+      prMaintenance: deps.invokerConfig?.prMaintenance,
     });
     await worker.tick('manual');
     await worker.stop();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -237,9 +237,9 @@ import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import {
-  AUTO_STARTED_OWNER_WORKER_KINDS,
   createLocalWorkerStatusSnapshot,
   createWorkerRuntimeController,
+  getAutoStartedOwnerWorkerKinds,
   type WorkerRuntimeController,
 } from './worker-control.js';
 import { startSurfaceEventRelay } from './surface-event-relay.js';
@@ -335,8 +335,52 @@ function buildRegisteredOwnerWorkerDeps(
       getAutoFixAgent: () => invokerConfig.autoFixAgent,
       getAutoFixExecutionModel: () => invokerConfig.defaultExecutionModel,
     },
+    prMaintenance: buildPrMaintenanceWorkerDepsConfig(invokerConfig),
   };
 }
+function buildPrMaintenanceWorkerDepsConfig(
+  config: InvokerConfig,
+  fallbackRepoRoot?: string,
+): WorkerRuntimeDependencies['prMaintenance'] {
+  const prMaintenance = config.prMaintenance;
+  if (!prMaintenance) return undefined;
+  return {
+    githubPrEvents: prMaintenance.githubPrEvents
+      ? {
+        ...prMaintenance.githubPrEvents,
+        intervalMs: prMaintenance.githubPrEvents.pollIntervalMs,
+      }
+      : undefined,
+    coderabbitAddress: prMaintenance.coderabbitAddress
+      ? {
+        ...prMaintenance.coderabbitAddress,
+        ...(fallbackRepoRoot ? { repoRoot: prMaintenance.coderabbitAddress.repoRoot ?? fallbackRepoRoot } : {}),
+        ...(typeof prMaintenance.coderabbitAddress.pollIntervalMs === 'number'
+          ? { intervalMs: prMaintenance.coderabbitAddress.pollIntervalMs }
+          : {}),
+      }
+      : undefined,
+    prConflictRebase: prMaintenance.prConflictRebase
+      ? {
+        ...prMaintenance.prConflictRebase,
+        ...(fallbackRepoRoot ? { repoRoot: prMaintenance.prConflictRebase.repoRoot ?? fallbackRepoRoot } : {}),
+        ...(typeof prMaintenance.prConflictRebase.pollIntervalMs === 'number'
+          ? { intervalMs: prMaintenance.prConflictRebase.pollIntervalMs }
+          : {}),
+      }
+      : undefined,
+    mergifyRequeue: prMaintenance.mergifyRequeue
+      ? {
+        ...prMaintenance.mergifyRequeue,
+        ...(fallbackRepoRoot ? { repoRoot: prMaintenance.mergifyRequeue.repoRoot ?? fallbackRepoRoot } : {}),
+        ...(typeof prMaintenance.mergifyRequeue.pollIntervalMs === 'number'
+          ? { intervalMs: prMaintenance.mergifyRequeue.pollIntervalMs }
+          : {}),
+      }
+      : undefined,
+  };
+}
+
 function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependencies> {
   return registerExternalWorkersFromConfig(
     invokerConfig.externalWorkers,
@@ -1751,7 +1795,7 @@ function startHeadlessMode(): void {
               await createStandaloneTaskExecutor().checkMergeGateStatuses();
             },
           ),
-          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
           persistence,
           autoFixRetries: invokerConfig.autoFixRetries,
           canControl: () => !readOnlyMode,
@@ -3525,7 +3569,7 @@ function createEmbeddedTerminalBackendFromConfig(
             await requireTaskExecutor().checkMergeGateStatuses();
           },
         ),
-        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
         persistence,
         autoFixRetries: invokerConfig.autoFixRetries,
         canControl: () => ownerMode,
@@ -4198,13 +4242,13 @@ function createEmbeddedTerminalBackendFromConfig(
         return createLocalWorkerStatusSnapshot({
           registry: createRegisteredWorkerRegistry(),
           persistence,
-          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
         });
       }
       return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
         registry: createRegisteredWorkerRegistry(),
         persistence,
-        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
       });
     });
 

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -9,13 +9,31 @@ import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
 import {
   AUTO_FIX_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  GITHUB_PR_EVENTS_WORKER_KIND,
+  MERGIFY_REQUEUE_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   type WorkerRegistry,
   type WorkerRuntime,
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 
+import type { InvokerConfig } from './config.js';
 import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
+
+export function getAutoStartedOwnerWorkerKinds(config: Pick<InvokerConfig, 'prMaintenance'>): string[] {
+  const kinds: string[] = [...AUTO_STARTED_OWNER_WORKER_KINDS];
+  const wantsSubscriptionPublisher = config.prMaintenance?.coderabbitAddress?.enabled === true
+    || config.prMaintenance?.prConflictRebase?.enabled === true
+    || config.prMaintenance?.mergifyRequeue?.enabled === true
+    || config.prMaintenance?.githubPrEvents?.enabled === true;
+  if (wantsSubscriptionPublisher) kinds.push(GITHUB_PR_EVENTS_WORKER_KIND);
+  if (config.prMaintenance?.coderabbitAddress?.enabled === true) kinds.push(CODERABBIT_ADDRESS_WORKER_KIND);
+  if (config.prMaintenance?.prConflictRebase?.enabled === true) kinds.push(PR_CONFLICT_REBASE_WORKER_KIND);
+  if (config.prMaintenance?.mergifyRequeue?.enabled === true) kinds.push(MERGIFY_REQUEUE_WORKER_KIND);
+  return kinds;
+}
 
 export const AUTO_STARTED_OWNER_WORKER_KINDS = [PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND] as const;
 
@@ -40,6 +58,10 @@ const BUILT_IN_WORKER_KINDS = new Set<string>([
   AUTO_FIX_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
+  GITHUB_PR_EVENTS_WORKER_KIND,
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+  MERGIFY_REQUEUE_WORKER_KIND,
 ]);
 
 export function createWorkerRuntimeController(options: {

--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -1,0 +1,215 @@
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { PassThrough } from 'node:stream';
+import { spawn } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Logger } from '@invoker/contracts';
+import { Channels } from '@invoker/transport';
+
+import {
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  createCoderabbitAddressWorker,
+  createMergifyRequeueWorker,
+  createPrConflictRebaseWorker,
+  registerPrMaintenanceWorkers,
+} from '../workers/pr-maintenance-workers.js';
+import { createWorkerRegistry } from '../worker-registry.js';
+import { acquireWorkerLock } from '../worker-lock.js';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+const spawnMock = vi.mocked(spawn);
+
+function logger(): Logger {
+  const log = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => log,
+  };
+  return log;
+}
+
+function mockChild(exitCode: number, stdout = '', stderr = ''): ReturnType<typeof spawn> {
+  const child = new EventEmitter() as ReturnType<typeof spawn>;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  setImmediate(() => {
+    if (stdout) child.stdout?.write(stdout);
+    if (stderr) child.stderr?.write(stderr);
+    child.stdout?.end();
+    child.stderr?.end();
+    child.emit('close', exitCode, null);
+  });
+  return child;
+}
+
+describe('PR maintenance workers', () => {
+  let invokerHome: string;
+  let originalInvokerDbDir: string | undefined;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    invokerHome = mkdtempSync(join(tmpdir(), 'pr-maintenance-workers-'));
+    originalInvokerDbDir = process.env.INVOKER_DB_DIR;
+    process.env.INVOKER_DB_DIR = invokerHome;
+    spawnMock.mockReset();
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+    if (originalInvokerDbDir === undefined) delete process.env.INVOKER_DB_DIR;
+    else process.env.INVOKER_DB_DIR = originalInvokerDbDir;
+    rmSync(invokerHome, { recursive: true, force: true });
+  });
+
+  it('spawns the CodeRabbit address shell tick', async () => {
+    spawnMock.mockReturnValueOnce(mockChild(0));
+    const worker = createCoderabbitAddressWorker({ logger: logger(), tickOnStart: false, config: { repoRoot: '/repo' } });
+
+    await worker.tick();
+
+    expect(spawnMock).toHaveBeenCalledWith('bash', ['/repo/scripts/cron-coderabbit-address.sh'], expect.objectContaining({ cwd: '/repo' }));
+  });
+
+  it('spawns the PR conflict rebase shell tick', async () => {
+    spawnMock.mockReturnValueOnce(mockChild(0));
+    const worker = createPrConflictRebaseWorker({ logger: logger(), tickOnStart: false, config: { repoRoot: '/repo' } });
+
+    await worker.tick();
+
+    expect(spawnMock).toHaveBeenCalledWith('bash', ['/repo/scripts/cron-pr-conflict-rebase.sh'], expect.objectContaining({ cwd: '/repo' }));
+  });
+
+  it('spawns the default Mergify requeue Python argv', async () => {
+    spawnMock.mockReturnValueOnce(mockChild(0));
+    const worker = createMergifyRequeueWorker({ logger: logger(), tickOnStart: false, config: { repoRoot: '/repo', stateFile: '/tmp/state.jsonl' } });
+
+    await worker.tick();
+
+    expect(spawnMock).toHaveBeenCalledWith('python3', [
+      '/repo/scripts/mergify_admin_requeue.py',
+      '--once',
+      '--repo', 'Neko-Catpital-Labs/Invoker',
+      '--author', 'EdbertChan',
+      '--state-file', '/tmp/state.jsonl',
+    ], expect.objectContaining({ cwd: '/repo' }));
+  });
+
+  it('spawns the overridden Mergify requeue argv', async () => {
+    spawnMock.mockReturnValueOnce(mockChild(0));
+    const worker = createMergifyRequeueWorker({
+      logger: logger(),
+      tickOnStart: false,
+      config: {
+        repoRoot: '/repo',
+        pythonExecutable: '/usr/bin/python3',
+        repo: 'owner/repo',
+        author: 'octocat',
+        stateFile: '/tmp/state.jsonl',
+        extraArgs: ['--dry-run', '--pr', '2969'],
+      },
+    });
+
+    await worker.tick();
+
+    expect(spawnMock).toHaveBeenCalledWith('/usr/bin/python3', [
+      '/repo/scripts/mergify_admin_requeue.py',
+      '--once',
+      '--repo', 'owner/repo',
+      '--author', 'octocat',
+      '--state-file', '/tmp/state.jsonl',
+      '--dry-run', '--pr', '2969',
+    ], expect.objectContaining({ cwd: '/repo' }));
+  });
+  it('does not spawn on start when subscription mode is enabled', async () => {
+    spawnMock.mockReturnValueOnce(mockChild(0));
+    const worker = createCoderabbitAddressWorker({
+      logger: logger(),
+      tickOnStart: false,
+      installSignalHandlers: false,
+      config: { enabled: true, trigger: 'subscription', repoRoot: '/repo' },
+    });
+
+    worker.start();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    await worker.stop();
+  });
+
+  it('registers GitHub event subscriptions for enabled PR maintenance workers', () => {
+    const registry = registerPrMaintenanceWorkers(createWorkerRegistry());
+    const definition = registry.get(CODERABBIT_ADDRESS_WORKER_KIND);
+    const subscriptions = definition?.subscriptions?.({
+      store: {} as any,
+      submitter: { submit: () => 0 },
+      logger: logger(),
+      prMaintenance: {
+        githubPrEvents: { enabled: true, repo: 'owner/repo', author: 'octocat' },
+        coderabbitAddress: { enabled: true, trigger: 'subscription' },
+      },
+    });
+
+    expect(subscriptions).toHaveLength(1);
+    expect(subscriptions?.[0]?.channel).toBe(Channels.GITHUB_PR_EVENT);
+    expect(subscriptions?.[0]?.shouldWake({
+      eventKey: 'event-1',
+      repo: 'owner/repo',
+      prNumber: 42,
+      author: 'octocat',
+      headRefName: 'feature/test',
+      mergeState: 'clean',
+      labels: [],
+      changes: ['coderabbit_comment'],
+      createdAt: '2026-07-07T01:00:00Z',
+    })).toBe(true);
+  });
+
+  it('forwards stdout and stderr from the child process', async () => {
+    spawnMock.mockReturnValueOnce(mockChild(0, 'out\n', 'err\n'));
+    const worker = createCoderabbitAddressWorker({ logger: logger(), tickOnStart: false, config: { repoRoot: '/repo' } });
+
+    await worker.tick();
+
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.objectContaining({}));
+    expect(stderrSpy).toHaveBeenCalledWith(expect.objectContaining({}));
+  });
+
+  it('logs a non-zero child exit and lets the runtime catch it', async () => {
+    spawnMock.mockReturnValueOnce(mockChild(2, '', 'boom'));
+    const log = logger();
+    const worker = createCoderabbitAddressWorker({ logger: log, tickOnStart: false, config: { repoRoot: '/repo' } });
+
+    await worker.tick();
+
+    expect(log.error).toHaveBeenCalledWith('[worker:coderabbit-address] tick failed', expect.objectContaining({ stderr: 'boom' }));
+  });
+
+  it('skips spawning when another PR maintenance worker holds the shared lock', async () => {
+    const log = logger();
+    const held = acquireWorkerLock({ kind: 'pr-maintenance', homeRoot: invokerHome, logger: log });
+    try {
+      const worker = createCoderabbitAddressWorker({ logger: log, tickOnStart: false, config: { repoRoot: '/repo' } });
+
+      await worker.tick();
+
+      expect(spawnMock).not.toHaveBeenCalled();
+      expect(log.info).toHaveBeenCalledWith(
+        '[worker:coderabbit-address] another PR maintenance worker is running; skipping tick',
+        expect.objectContaining({ kind: CODERABBIT_ADDRESS_WORKER_KIND }),
+      );
+    } finally {
+      held.release();
+    }
+  });
+});

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -11,6 +11,12 @@ import { registerBuiltinWorkers } from '../builtin-workers.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import { createWorkerRegistry } from '../worker-registry.js';
 import { CI_FAILURE_WORKER_KIND } from '../workers/ci-failure-worker.js';
+import { GITHUB_PR_EVENTS_WORKER_KIND } from '../workers/github-pr-events-worker.js';
+import {
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  MERGIFY_REQUEUE_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+} from '../workers/pr-maintenance-workers.js';
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
 
 const silentLogger = {
@@ -25,6 +31,20 @@ const emptyStore: AutoFixRecoveryStore = {
   listWorkflows: () => [],
   loadTasks: () => [],
   listWorkflowMutationIntents: () => [],
+  getWorkerAction: () => undefined,
+  upsertWorkerAction: (action) => ({
+    id: action.id,
+    workerKind: action.workerKind,
+    actionType: action.actionType,
+    subjectType: action.subjectType,
+    subjectId: action.subjectId,
+    externalKey: action.externalKey,
+    status: action.status,
+    attemptCount: action.attemptCount ?? 0,
+    createdAt: action.createdAt ?? '',
+    updatedAt: action.updatedAt ?? '',
+  }),
+  listWorkerActions: () => [],
 };
 
 const noopSubmitter: AutoFixRecoverySubmitter = {
@@ -87,10 +107,18 @@ describe('worker registry', () => {
       AUTO_FIX_WORKER_KIND,
       PR_STATUS_WORKER_KIND,
       CI_FAILURE_WORKER_KIND,
+      GITHUB_PR_EVENTS_WORKER_KIND,
+      CODERABBIT_ADDRESS_WORKER_KIND,
+      PR_CONFLICT_REBASE_WORKER_KIND,
+      MERGIFY_REQUEUE_WORKER_KIND,
     ]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_STATUS_WORKER_KIND)).toBeDefined();
     expect(registry.get(CI_FAILURE_WORKER_KIND)).toBeDefined();
+    expect(registry.get(GITHUB_PR_EVENTS_WORKER_KIND)).toBeDefined();
+    expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_CONFLICT_REBASE_WORKER_KIND)).toBeDefined();
+    expect(registry.get(MERGIFY_REQUEUE_WORKER_KIND)).toBeDefined();
   });
   it('returns nothing for an unknown kind', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -2,6 +2,8 @@ import { registerAutoFixWorker } from './auto-fix-recovery.js';
 import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
 import type { WorkerRegistry } from './worker-registry.js';
 import { registerCiFailureWorker } from './workers/ci-failure-worker.js';
+import { registerGitHubPrEventsWorker } from './workers/github-pr-events-worker.js';
+import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
 
 /** Register every built-in worker in the stable built-in order. */
@@ -11,5 +13,7 @@ export function registerBuiltinWorkers(
   registerAutoFixWorker(registry);
   registerPrStatusWorker(registry);
   registerCiFailureWorker(registry);
+  registerGitHubPrEventsWorker(registry);
+  registerPrMaintenanceWorkers(registry);
   return registry;
 }

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -48,4 +48,5 @@ export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';
 export * from './pr-maintenance-events.js';
 export * from './workers/github-pr-events-worker.js';
+export * from './workers/pr-maintenance-workers.js';
 export * from './external-worker.js';

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -7,12 +7,14 @@ import type {
   AutoFixWorkerConfig,
 } from './auto-fix-recovery.js';
 import type { CiFailureWorkerStore, CiFailureWorkerSubmitter } from './workers/ci-failure-worker.js';
+import type { GitHubPrEventsStore } from './workers/github-pr-events-worker.js';
+import type { PrMaintenanceWorkersConfig } from './workers/pr-maintenance-workers.js';
 import type { PrStatusReviewGate } from './workers/pr-status-worker.js';
 
 /** Dependencies injected into a built-in worker factory when its runtime is built. */
 export interface WorkerRuntimeDependencies {
   /** Persisted workflow/task state accessor. */
-  store: AutoFixRecoveryStore & CiFailureWorkerStore;
+  store: AutoFixRecoveryStore & CiFailureWorkerStore & GitHubPrEventsStore;
   /** Action-output channel used to submit follow-up mutation intents. */
   submitter: AutoFixRecoverySubmitter & CiFailureWorkerSubmitter;
   /** Operator logger. */
@@ -23,4 +25,6 @@ export interface WorkerRuntimeDependencies {
   reviewGate?: PrStatusReviewGate;
   /** Auto-fix tuning shared by workers that submit fix intents. */
   autoFix?: AutoFixWorkerConfig;
+  /** Optional PR maintenance worker and event-source config. */
+  prMaintenance?: PrMaintenanceWorkersConfig;
 }

--- a/packages/execution-engine/src/workers/github-pr-events-worker.ts
+++ b/packages/execution-engine/src/workers/github-pr-events-worker.ts
@@ -6,7 +6,9 @@ import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store'
 import { Channels, type MessageBus } from '@invoker/transport';
 
 import type { GitHubPrEvent, GitHubPrEventChange } from '../pr-maintenance-events.js';
+import type { WorkerRegistry } from '../worker-registry.js';
 import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 
 export const GITHUB_PR_EVENTS_WORKER_KIND = 'github-pr-events';
 export const DEFAULT_GITHUB_PR_EVENTS_INTERVAL_MS = 300_000;
@@ -314,4 +316,31 @@ export function createGitHubPrEventsWorker(options: GitHubPrEventsWorkerOptions)
     installSignalHandlers: options.installSignalHandlers,
     onTick: options.onTick ?? createGitHubPrEventsTick(options),
   });
+}
+export function registerGitHubPrEventsWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: GITHUB_PR_EVENTS_WORKER_KIND,
+    note: 'Polls GitHub once and publishes shared PR maintenance wake events.',
+    factory: (deps) => {
+      const config = deps.prMaintenance?.githubPrEvents;
+      if (!config?.enabled || !deps.messageBus) {
+        return createWorkerRuntime({
+          kind: GITHUB_PR_EVENTS_WORKER_KIND,
+          logger: deps.logger,
+          intervalMs: 0,
+          tickOnStart: false,
+          onTick: async () => {},
+        });
+      }
+      return createGitHubPrEventsWorker({
+        logger: deps.logger,
+        store: deps.store,
+        messageBus: deps.messageBus,
+        config,
+      });
+    },
+  });
+  return registry;
 }

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -1,0 +1,317 @@
+import { spawn } from 'node:child_process';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { Logger } from '@invoker/contracts';
+import { Channels } from '@invoker/transport';
+
+import type { GitHubPrEvent } from '../pr-maintenance-events.js';
+import { isGitHubPrEvent } from '../pr-maintenance-events.js';
+import { cleanElectronEnv, getEffectivePath } from '../process-utils.js';
+import type { WorkerRegistry, WorkerSubscriptionFactory } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import { acquireWorkerLock, WorkerLockHeldError } from '../worker-lock.js';
+import type { GitHubPrEventsConfig } from './github-pr-events-worker.js';
+
+export const CODERABBIT_ADDRESS_WORKER_KIND = 'coderabbit-address';
+export const PR_CONFLICT_REBASE_WORKER_KIND = 'pr-conflict-rebase';
+export const MERGIFY_REQUEUE_WORKER_KIND = 'mergify-requeue';
+export const DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS = 300_000;
+
+const PR_MAINTENANCE_LOCK_KIND = 'pr-maintenance';
+
+export interface PrScriptWorkerConfig {
+  enabled?: boolean;
+  repoRoot?: string;
+  repo?: string;
+  author?: string;
+  coderabbitLogin?: string;
+  env?: NodeJS.ProcessEnv;
+  intervalMs?: number;
+  trigger?: 'subscription' | 'poll';
+}
+
+export interface MergifyRequeueWorkerConfig extends PrScriptWorkerConfig {
+  pythonExecutable?: string;
+  stateFile?: string;
+  extraArgs?: string[];
+}
+
+export interface PrMaintenanceEventSourceConfig extends GitHubPrEventsConfig {
+  enabled?: boolean;
+}
+
+export interface PrMaintenanceWorkersConfig {
+  githubPrEvents?: PrMaintenanceEventSourceConfig;
+  coderabbitAddress?: PrScriptWorkerConfig;
+  prConflictRebase?: PrScriptWorkerConfig;
+  mergifyRequeue?: MergifyRequeueWorkerConfig;
+}
+
+export interface PrMaintenanceWorkerOptions<TConfig extends PrScriptWorkerConfig> {
+  logger: Logger;
+  instanceId?: string;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  config?: TConfig;
+}
+
+interface PrMaintenanceCommand {
+  command: string;
+  args: string[];
+}
+
+function subscriptionFactory(
+  kind: string,
+  readConfig: (deps: WorkerRuntimeDependencies) => PrScriptWorkerConfig | undefined,
+): WorkerSubscriptionFactory<WorkerRuntimeDependencies> {
+  return (deps) => {
+    const eventSource = deps.prMaintenance?.githubPrEvents;
+    const config = readConfig(deps);
+    if (!eventSource?.enabled || !config?.enabled || config.trigger === 'poll') return [];
+
+    return [{
+      channel: Channels.GITHUB_PR_EVENT,
+      shouldWake: (message: unknown) => {
+        if (!isGitHubPrEvent(message)) return false;
+        return shouldWakePrMaintenanceWorker(kind, message);
+      },
+    }];
+  };
+}
+
+function shouldWakePrMaintenanceWorker(kind: string, event: GitHubPrEvent): boolean {
+  if (event.changes.includes('closed')) return false;
+  if (kind === CODERABBIT_ADDRESS_WORKER_KIND) {
+    return event.changes.includes('coderabbit_comment');
+  }
+  if (kind === PR_CONFLICT_REBASE_WORKER_KIND) {
+    return event.mergeState === 'dirty' && (
+      event.changes.includes('opened')
+      || event.changes.includes('head_ref_changed')
+      || event.changes.includes('merge_state_changed')
+    );
+  }
+  if (kind === MERGIFY_REQUEUE_WORKER_KIND) {
+    return event.changes.some((change) => change !== 'coderabbit_comment');
+  }
+  return false;
+}
+
+export function registerPrMaintenanceWorkers(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: CODERABBIT_ADDRESS_WORKER_KIND,
+    note: 'Runs the CodeRabbit review-addressing PR maintenance worker tick script.',
+    factory: (deps) => createCoderabbitAddressWorker({
+      logger: deps.logger,
+      config: deps.prMaintenance?.coderabbitAddress,
+    }),
+    subscriptions: subscriptionFactory(CODERABBIT_ADDRESS_WORKER_KIND, (deps) => deps.prMaintenance?.coderabbitAddress),
+  });
+  registry.register({
+    kind: PR_CONFLICT_REBASE_WORKER_KIND,
+    note: 'Runs the PR conflict rebase/recreate maintenance worker tick script.',
+    factory: (deps) => createPrConflictRebaseWorker({
+      logger: deps.logger,
+      config: deps.prMaintenance?.prConflictRebase,
+    }),
+    subscriptions: subscriptionFactory(PR_CONFLICT_REBASE_WORKER_KIND, (deps) => deps.prMaintenance?.prConflictRebase),
+  });
+  registry.register({
+    kind: MERGIFY_REQUEUE_WORKER_KIND,
+    note: 'Repairs and requeues admin-bypass PRs after Mergify dequeue events.',
+    factory: (deps) => createMergifyRequeueWorker({
+      logger: deps.logger,
+      config: deps.prMaintenance?.mergifyRequeue,
+    }),
+    subscriptions: subscriptionFactory(MERGIFY_REQUEUE_WORKER_KIND, (deps) => deps.prMaintenance?.mergifyRequeue),
+  });
+  return registry;
+}
+
+export function createCoderabbitAddressWorker(
+  options: PrMaintenanceWorkerOptions<PrScriptWorkerConfig>,
+): WorkerRuntime {
+  return createPrMaintenanceWorker(CODERABBIT_ADDRESS_WORKER_KIND, options, (repoRoot) => ({
+    command: 'bash',
+    args: [join(repoRoot, 'scripts', 'cron-coderabbit-address.sh')],
+  }));
+}
+
+export function createPrConflictRebaseWorker(
+  options: PrMaintenanceWorkerOptions<PrScriptWorkerConfig>,
+): WorkerRuntime {
+  return createPrMaintenanceWorker(PR_CONFLICT_REBASE_WORKER_KIND, options, (repoRoot) => ({
+    command: 'bash',
+    args: [join(repoRoot, 'scripts', 'cron-pr-conflict-rebase.sh')],
+  }));
+}
+
+export function createMergifyRequeueWorker(
+  options: PrMaintenanceWorkerOptions<MergifyRequeueWorkerConfig>,
+): WorkerRuntime {
+  return createPrMaintenanceWorker(MERGIFY_REQUEUE_WORKER_KIND, options, (repoRoot, config) => {
+    const pythonExecutable = config.pythonExecutable ?? process.env.INVOKER_MERGIFY_REQUEUE_PYTHON ?? 'python3';
+    const repo = config.repo ?? process.env.INVOKER_MERGIFY_REQUEUE_REPO ?? 'Neko-Catpital-Labs/Invoker';
+    const author = config.author ?? process.env.INVOKER_MERGIFY_REQUEUE_AUTHOR ?? 'EdbertChan';
+    const stateFile = config.stateFile
+      ?? process.env.INVOKER_MERGIFY_REQUEUE_STATE_FILE
+      ?? join(homedir(), '.invoker', 'mergify-admin-requeue-state.jsonl');
+    return {
+      command: pythonExecutable,
+      args: [
+        join(repoRoot, 'scripts', 'mergify_admin_requeue.py'),
+        '--once',
+        '--repo', repo,
+        '--author', author,
+        '--state-file', stateFile,
+        ...(config.extraArgs ?? []),
+      ],
+    };
+  });
+}
+
+function createPrMaintenanceWorker<TConfig extends PrScriptWorkerConfig>(
+  kind: string,
+  options: PrMaintenanceWorkerOptions<TConfig>,
+  buildCommand: (repoRoot: string, config: TConfig) => PrMaintenanceCommand,
+): WorkerRuntime {
+  const config = options.config ?? ({} as TConfig);
+  const trigger = config.trigger ?? 'subscription';
+  return createWorkerRuntime({
+    kind,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: trigger === 'poll' ? (config.intervalMs ?? DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS) : 0,
+    tickOnStart: options.tickOnStart ?? true,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: createPrMaintenanceTick(kind, options.logger, config, buildCommand),
+  });
+}
+
+function createPrMaintenanceTick<TConfig extends PrScriptWorkerConfig>(
+  kind: string,
+  logger: Logger,
+  config: TConfig,
+  buildCommand: (repoRoot: string, config: TConfig) => PrMaintenanceCommand,
+): WorkerTick {
+  return async () => {
+    let lock;
+    try {
+      lock = acquireWorkerLock({ kind: PR_MAINTENANCE_LOCK_KIND, logger });
+    } catch (err) {
+      if (err instanceof WorkerLockHeldError) {
+        logger.info(`[worker:${kind}] another PR maintenance worker is running; skipping tick`, {
+          module: 'pr-maintenance-workers',
+          kind,
+        });
+        return;
+      }
+      throw err;
+    }
+
+    try {
+      const repoRoot = config.repoRoot ?? process.env.INVOKER_PR_MAINTENANCE_REPO_ROOT ?? process.cwd();
+      const command = buildCommand(repoRoot, config);
+      await runPrMaintenanceCommand(kind, logger, repoRoot, config, command);
+    } finally {
+      lock.release();
+    }
+  };
+}
+
+async function runPrMaintenanceCommand(
+  kind: string,
+  logger: Logger,
+  repoRoot: string,
+  config: PrScriptWorkerConfig,
+  prCommand: PrMaintenanceCommand,
+): Promise<void> {
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  let resolve!: () => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  let settled = false;
+
+  const settle = (fn: () => void): void => {
+    if (settled) return;
+    settled = true;
+    fn();
+  };
+
+  const workerEnv: NodeJS.ProcessEnv = {
+    ...cleanElectronEnv(),
+    ...(config.env ?? {}),
+    PATH: getEffectivePath(),
+  };
+  if (config.repo) workerEnv.INVOKER_GITHUB_TARGET_REPO = config.repo;
+  if (config.author) workerEnv.INVOKER_PR_CRON_AUTHOR = config.author;
+  if (config.coderabbitLogin) workerEnv.INVOKER_CODERABBIT_LOGIN = config.coderabbitLogin;
+  workerEnv.INVOKER_PR_MAINTENANCE_REPO_ROOT = repoRoot;
+
+  let child;
+  try {
+    child = spawn(prCommand.command, prCommand.args, {
+      cwd: repoRoot,
+      env: workerEnv,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    const stderr = Buffer.concat(stderrChunks).toString('utf8');
+    logger.error(`[worker:${kind}] tick failed`, {
+      module: 'pr-maintenance-workers',
+      kind,
+      stderr,
+      err,
+    });
+    throw new Error(`${kind} worker tick failed to spawn`);
+  }
+
+  child.stdout?.on('data', (chunk: Buffer | string) => {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    stdoutChunks.push(buffer);
+    process.stdout.write(chunk);
+  });
+  child.stderr?.on('data', (chunk: Buffer | string) => {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    stderrChunks.push(buffer);
+    process.stderr.write(chunk);
+  });
+  child.once('error', (err: Error) => settle(() => {
+    const stderr = Buffer.concat(stderrChunks).toString('utf8');
+    logger.error(`[worker:${kind}] tick failed`, {
+      module: 'pr-maintenance-workers',
+      kind,
+      stderr,
+      err,
+    });
+    reject(new Error(`${kind} worker tick failed to spawn`));
+  }));
+  child.once('close', (code: number | null, signal: NodeJS.Signals | null) => settle(() => {
+    if (code === 0) {
+      logger.info(`[worker:${kind}] tick completed`, {
+        module: 'pr-maintenance-workers',
+        kind,
+      });
+      resolve();
+      return;
+    }
+    const stderr = Buffer.concat(stderrChunks).toString('utf8');
+    logger.error(`[worker:${kind}] tick failed`, {
+      module: 'pr-maintenance-workers',
+      kind,
+      exitCode: code,
+      signal,
+      stderr,
+    });
+    reject(new Error(`${kind} worker tick failed with exit code ${code}`));
+  }));
+
+  await promise;
+}


### PR DESCRIPTION
## Summary

Wires the optional PR maintenance workers into the owner worker system.

When `~/.invoker/config.json` enables them, the owner starts one shared GitHub event source plus the selected workers. The workers wake from `github.pr_event` messages instead of each running their own steady poll loop.

The scripts and shared PR maintenance lock stay the same. Only the wake path changes.

<details>
<summary>Review metadata</summary>

Review Claim: Optional PR maintenance workers now run through owner-managed event wakes instead of per-worker polling.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: The same scripts, locks, and ledgers still decide whether any GitHub mutation is safe.

Slice Rationale: Activation lands last so it can reuse the shared script entrypoints, proofs, owner wake router, and shared GitHub event stream.

</details>

## Non-goals

No external worker bus protocol.

No GitHub webhook server.

No user-visible UI change.

## Architecture

### Before

```mermaid
graph TD
    A["enabled PR maintenance script"] --> B["own poll loop"]
```

### After

```mermaid
graph TD
    A["github-pr-events worker"] --> B["github.pr_event"]
    B --> C["owner-managed subscriptions"]
    C --> D["optional PR maintenance workers"]
    D --> E["existing scripts + lock + ledgers"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/worker-registry.test.ts src/__tests__/github-pr-events-worker.test.ts src/__tests__/pr-maintenance-workers.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts src/__tests__/worker-control.test.ts src/__tests__/headless-autofix.test.ts`
- [x] `PYTHONPATH=. python3 scripts/test_mergify_admin_requeue.py`
- [x] `bash scripts/repro/repro-mergify-admin-requeue.sh`
- [x] `bash scripts/repro/repro-mergify-closed-pr-guard.sh`
- [x] `bash scripts/repro/repro-mergify-rejected-pr.sh`
- [x] `bash scripts/repro/repro-pr-crons-mutex.sh`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 97b5de93c`
- Post-revert steps: Restart the Invoker owner process.
- Data migration? No
