### PR TITLE
[Worker Subscriptions](3) Fix PR maintenance lock repro wording

### DIFF
--- a/scripts/repro/repro-pr-crons-mutex.sh
+++ b/scripts/repro/repro-pr-crons-mutex.sh
@@ -53,7 +53,7 @@ for worker in cron-coderabbit-address cron-pr-conflict-rebase; do
   out="$(bash "scripts/$worker.sh" 2>&1)"
   code=$?
   set -e
-  echo "$out" | grep -q "another PR maintenance operation in progress" \
+  echo "$out" | grep -q "another PR cron operation in progress" \
     || fail "$worker did not report the lock as held" "$out"
   [ "$code" -eq 0 ] || fail "$worker exited $code (expected 0 clean no-op)" "$out"
 done


### PR DESCRIPTION
## Summary

Fixes the shared PR maintenance lock repro to match the current lock message.

The lock already reported `another PR cron operation in progress`. The repro was still checking the old phrase, so it failed even when the lock behavior was correct.

<details>
<summary>Review metadata</summary>

Review Claim: The PR maintenance lock repro now matches the current script output.

Review Lane: proof

Review Unit: proof

Safety Invariant: This changes only the repro assertion text; it does not change worker behavior.

Slice Rationale: The wording fix stays separate so the later worker-routing slices remain behavior-only.

</details>

## Non-goals

No application code change.

No worker routing change.

No GitHub mutation.

## Test Plan

- [x] `bash scripts/repro/repro-pr-crons-mutex.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert d8f37aea0`
- Post-revert steps: None
- Data migration? No
