### PR TITLE
[Planning Cursor](1) Fix submitted planning cursor state

### DIFF
--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -253,6 +253,29 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
+  it('shows the wait cursor only while a planning request is busy', async () => {
+    let resolveSend: ((value: any) => void) | null = null;
+    mock.api.planningChatSend = vi.fn(() => {
+      return new Promise((resolve) => {
+        resolveSend = resolve;
+      }) as any;
+    }) as any;
+
+    render(<App />);
+    await openPlanningTerminal();
+
+    submitPlanningText('draft a plan');
+
+    const input = screen.getByTestId('invoker-terminal-input');
+    await waitFor(() => expect(input).toBeDisabled());
+    expect(input).toHaveClass('disabled:cursor-wait');
+    expect(input).not.toHaveClass('disabled:cursor-not-allowed');
+
+    await act(async () => {
+      resolveSend?.({ ok: true, sessionId: 'session-1', reply: 'Done.', draftPlanAvailable: false });
+    });
+  });
+
   it('reports planning chat input, submit, and transcript render perf markers', async () => {
     const props = {
       activeConversationKey: 'chat-1',
@@ -704,7 +727,10 @@ describe('Invoker terminal (component)', () => {
 
     fireEvent.click(screen.getByTestId('sidebar-planning'));
 
-    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
+    const input = screen.getByTestId('invoker-terminal-input');
+    expect(input).toBeDisabled();
+    expect(input).toHaveClass('disabled:cursor-not-allowed');
+    expect(input).not.toHaveClass('disabled:cursor-wait');
     expect(screen.getAllByText(/submitted/i).length).toBeGreaterThan(0);
   });
 

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -396,6 +396,8 @@ export function InvokerTerminal({
     inputRef.current?.focus();
   };
 
+  const composerDisabledCursorClass = busy ? 'disabled:cursor-wait' : readOnly ? 'disabled:cursor-not-allowed' : '';
+
   const handleValueChange = (event: ChangeEvent<HTMLTextAreaElement>): void => {
     const startedAt = nowMs();
     const nextValue = event.target.value;
@@ -673,7 +675,7 @@ export function InvokerTerminal({
                 onChange={handleValueChange}
                 onKeyDown={handleInputKeyDown}
                 placeholder={readOnly ? 'This planning session was already submitted.' : 'Describe the change, ask questions, or say “draft the full plan”.'}
-                className="min-h-20 w-full resize-none border-0 bg-transparent py-2 font-mono text-[13px] leading-6 text-foreground outline-none placeholder:text-muted-foreground focus:ring-0 disabled:cursor-wait"
+                className={`min-h-20 w-full resize-none border-0 bg-transparent py-2 font-mono text-[13px] leading-6 text-foreground outline-none placeholder:text-muted-foreground focus:ring-0 ${composerDisabledCursorClass}`}
               />
             </div>
             <div className="mt-2 flex flex-wrap items-center justify-between gap-3">


### PR DESCRIPTION
## Summary

Read-only planning chats no longer look busy when you hover the text box.

The bug was one shared disabled cursor style. Busy requests and read-only chats both used the wait cursor.

This keeps the wait cursor for real in-flight work. Read-only chats now use the blocked cursor instead.

## Review Claim

Read-only planning sessions no longer advertise a busy state through the composer cursor.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Runtime state and event handlers are unchanged; only the disabled cursor class changes.

## Slice Rationale

This is one UI state bug with one regression test path.

## Non-goals

This does not change planning data flow, session status, task execution, or workflow recovery.

This does not change the read-only badge text or the read-only placeholder.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/invoker-terminal.test.tsx`

</details>

## Visual Proof

The first proof upload was wrong: the before and after images used the same upload name, and a normal screenshot cannot show the cursor glyph.

This replacement uses unique screenshot files for the visible terminal state, plus a source-backed state proof for the cursor class itself.

![Cursor state proof](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-9ad0cf/planning-cursor-state-proof.svg)

Before visible terminal state:

![Before planning terminal](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-9ad0cf/planning-cursor-before.png)

After visible terminal state:

![After planning terminal](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-9ad0cf/planning-cursor-after.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 88e63c561`
- Post-revert steps: None
- Data migration? No

</details>