### PR TITLE
[Terminal Sessions](4) Document terminal session restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+- Persist embedded terminal tabs across desktop app restarts, restoring their recent output and reopening spawn-backed sessions.
 - Move auto-fix attempt counts out of SQLite task state and into in-memory worker runtime policy.
 - Add a local master-head full-test repair cron that runs the destructive suite, asks OMP/Codex to fix confirmed failures, reruns the suite, and opens one validated PR per broken upstream SHA.
 - Make the browser UI load heavy Action Graph data only when that tab opens, trim huge diagnostic strings, gzip large `/invoke` JSON responses, and stop checking PR statuses on initial page load.

--- a/packages/app/e2e/embedded-terminal-restart-persistence.spec.ts
+++ b/packages/app/e2e/embedded-terminal-restart-persistence.spec.ts
@@ -1,0 +1,203 @@
+import { test as base, _electron as electron, expect, type ElectronApplication, type Page } from '@playwright/test';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
+import { stringify as yamlStringify } from 'yaml';
+import { E2E_REPO_URL, injectTaskStates } from './fixtures/electron-app.js';
+import { registerTrackedBrowserUserDataDir } from './fixtures/browser-process-registry.js';
+
+const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
+
+const TERMINAL_RESTART_PLAN = {
+  name: 'Embedded terminal restart persistence',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'terminal-task',
+      description: 'Completed task with terminal',
+      command: 'echo unused',
+      dependencies: [],
+    },
+  ],
+};
+
+function launchArgs(): string[] {
+  return [
+    ...(process.platform === 'linux'
+      ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
+      : []),
+    MAIN_JS,
+  ];
+}
+
+async function waitForInvoker(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
+}
+
+async function launchApp(paths: { dbDir: string; userDataDir: string; ipcSocketPath: string; configPath: string }): Promise<{ app: ElectronApplication; page: Page }> {
+  registerTrackedBrowserUserDataDir(paths.userDataDir);
+  const app = await electron.launch({
+    args: [
+      ...launchArgs().slice(0, -1),
+      `--user-data-dir=${paths.userDataDir}`,
+      MAIN_JS,
+    ],
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      INVOKER_USER_DATA_DIR: paths.userDataDir,
+      INVOKER_DISABLE_SLACK: '1',
+      TZ: 'UTC',
+      INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
+      INVOKER_DB_DIR: paths.dbDir,
+      INVOKER_IPC_SOCKET: paths.ipcSocketPath,
+      INVOKER_ALLOW_DELETE_ALL: '1',
+      INVOKER_E2E_ENABLE_COMPOSITOR: '1',
+      INVOKER_REPO_CONFIG_PATH: paths.configPath,
+      INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:
+        process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '10000',
+      INVOKER_EMBEDDED_TERMINAL_BACKEND: 'pty',
+    },
+  });
+  const page = await app.firstWindow();
+  await waitForInvoker(page);
+  return { app, page };
+}
+
+async function closeApp(app: ElectronApplication): Promise<void> {
+  const child = app.process();
+  const closePromise = app.close().catch(() => undefined);
+  const timedOut = await Promise.race([
+    closePromise.then(() => false),
+    delay(5_000).then(() => true),
+  ]);
+  if (timedOut) {
+    child.kill('SIGTERM');
+    await Promise.race([closePromise, delay(2_000)]);
+    if (!child.killed) child.kill('SIGKILL');
+  }
+}
+
+async function loadPlan(page: Page): Promise<void> {
+  await page.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(TERMINAL_RESTART_PLAN));
+  await page.waitForFunction(() => window.invoker.getTasks().then((result) => {
+    const tasks = Array.isArray(result) ? result : result.tasks;
+    return tasks.some((task: { id: string }) => task.id.endsWith('/terminal-task'));
+  }), null, { timeout: 10000 });
+  await page.getByRole('button', { name: 'Refresh' }).click();
+  await page.locator('.react-flow__node[data-testid$="terminal-task"]').first().waitFor({ state: 'visible', timeout: 10000 });
+}
+
+async function resolveFullTaskId(page: Page): Promise<string> {
+  const fullTaskId = await page.evaluate(async () => {
+    const result = await window.invoker.getTasks();
+    const tasks = Array.isArray(result) ? result : result.tasks;
+    return tasks.find((task: { id: string }) => task.id.endsWith('/terminal-task'))?.id;
+  });
+  if (!fullTaskId) throw new Error('terminal-task was not loaded');
+  return fullTaskId;
+}
+
+async function openTerminalForTask(page: Page, taskId: string): Promise<void> {
+  const taskNode = page.locator('.react-flow__node[data-testid$="terminal-task"]').first();
+  const box = await taskNode.boundingBox();
+  if (!box) throw new Error('terminal-task node has no bounding box');
+  const target = taskNode.locator('> div');
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await target.dispatchEvent('dblclick', {
+      bubbles: true,
+      cancelable: true,
+      clientX: box.x + box.width / 2,
+      clientY: box.y + box.height / 2,
+    });
+    await page.waitForTimeout(500);
+    const sessions = await page.evaluate(() => window.invoker.terminalList());
+    if (Array.isArray(sessions) && sessions.length > 0) break;
+  }
+  const sessions = await page.evaluate(() => window.invoker.terminalList());
+  if (!Array.isArray(sessions) || sessions.length === 0) {
+    const result = await page.evaluate((id) => window.invoker.openTerminal(id), taskId);
+    if (!result?.opened) throw new Error(`openTerminal failed: ${result?.reason ?? 'unknown reason'}`);
+  }
+  await expect.poll(() => page.evaluate(() => window.invoker.terminalList().then((rows) => rows.length))).toBeGreaterThan(0);
+  await expect(page.getByTestId('terminal-drawer-body')).toBeVisible({ timeout: 10000 });
+}
+
+base.describe('Embedded terminal restart persistence', () => {
+  base('restores a terminal tab and accepts input after relaunch', async () => {
+    const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-terminal-restart-'));
+    const configPath = path.join(testDir, 'e2e-config.json');
+    const userDataDir = path.join(testDir, 'electron-user-data');
+    const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
+
+    let app: ElectronApplication | undefined;
+    let page: Page | undefined;
+    try {
+      ({ app, page } = await launchApp({ dbDir: testDir, userDataDir, ipcSocketPath, configPath }));
+      await page.evaluate(async () => {
+        await window.invoker.clear();
+        await window.invoker.deleteAllWorkflows();
+      });
+      await loadPlan(page);
+
+      const workspacePath = path.join(testDir, 'terminal-workspace');
+      mkdirSync(workspacePath, { recursive: true });
+      await injectTaskStates(page, [
+        {
+          taskId: 'terminal-task',
+          changes: {
+            status: 'completed',
+            config: { runnerKind: 'worktree' },
+            execution: {
+              workspacePath,
+              completedAt: new Date('2025-01-01T00:00:00.000Z'),
+            },
+          },
+        },
+      ]);
+      const fullTaskId = await resolveFullTaskId(page);
+      await openTerminalForTask(page, fullTaskId);
+      const terminalPane = page.getByTestId(`terminal-pane-${fullTaskId}`);
+      await expect(terminalPane).toBeVisible();
+      await terminalPane.click();
+      await page.keyboard.type('printf "before-restart-terminal-sentinel\\n"');
+      await page.keyboard.press('Enter');
+      await expect(terminalPane.getByText('before-restart-terminal-sentinel')).toBeVisible({ timeout: 10000 });
+
+      const before = await page.evaluate(() => window.invoker.terminalList());
+      expect(before).toHaveLength(1);
+      expect(before[0]).toMatchObject({ status: 'running', mode: 'spawn' });
+      const sessionId = before[0].sessionId;
+
+      await closeApp(app);
+      app = undefined;
+      page = undefined;
+      await delay(1500);
+
+      ({ app, page } = await launchApp({ dbDir: testDir, userDataDir, ipcSocketPath, configPath }));
+      const after = await page.evaluate(() => window.invoker.terminalList());
+      expect(after).toHaveLength(1);
+      expect(after[0].sessionId).toBe(sessionId);
+      await expect(page.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial', { timeout: 10000 });
+      await expect(page.getByTestId(`terminal-tab-${fullTaskId}`)).toBeVisible();
+      const restoredPane = page.getByTestId(`terminal-pane-${fullTaskId}`);
+      await expect(restoredPane.getByText('before-restart-terminal-sentinel')).toBeVisible({ timeout: 10000 });
+      await page.screenshot({
+        path: path.join(process.cwd(), 'visual-proof-terminal-restart.png'),
+        fullPage: true,
+      });
+
+      await restoredPane.click();
+      await page.keyboard.type('printf "after-restart-terminal-sentinel\\n"');
+      await page.keyboard.press('Enter');
+      await expect(restoredPane.getByText('after-restart-terminal-sentinel')).toBeVisible({ timeout: 10000 });
+    } finally {
+      if (app) await closeApp(app).catch(() => undefined);
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -302,6 +302,56 @@ describe('EmbeddedTerminalManager', () => {
     expect(snapshot).toBe(`${'a'.repeat(maxSnapshotChars - 'tail'.length)}tail`);
   });
 
+  it('emits session-updated on open, output, and natural exit', () => {
+    const child = createFakeChild();
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createBashTerminalBackend({ spawnFn: bashSpawnFn }),
+    });
+    const updates: Array<{
+      sessionId: string;
+      status: 'running' | 'exited';
+      outputSnapshot: string;
+      targetKey: string;
+      exitCode?: number;
+    }> = [];
+    mgr.on('session-updated', (record) => {
+      updates.push({
+        sessionId: record.sessionId,
+        status: record.status,
+        outputSnapshot: record.outputSnapshot,
+        targetKey: record.targetKey,
+        exitCode: record.exitCode,
+      });
+    });
+
+    const session = mgr.openOrReuse({ taskId: 'task-updates', spec: {}, cwd: '/tmp/wt' });
+    child.stdout.emit('data', Buffer.from('hello'));
+    child.emit('exit', 4);
+
+    expect(updates).toEqual([
+      expect.objectContaining({
+        sessionId: session.sessionId,
+        status: 'running',
+        outputSnapshot: '',
+        targetKey: expect.any(String),
+      }),
+      expect.objectContaining({
+        sessionId: session.sessionId,
+        status: 'running',
+        outputSnapshot: 'hello',
+        targetKey: expect.any(String),
+      }),
+      expect.objectContaining({
+        sessionId: session.sessionId,
+        status: 'exited',
+        outputSnapshot: 'hello',
+        targetKey: expect.any(String),
+        exitCode: 4,
+      }),
+    ]);
+  });
+
   it('write() forwards data to bash stdin in spawn mode', () => {
     const child = createFakeChild();
     const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
@@ -314,6 +364,45 @@ describe('EmbeddedTerminalManager', () => {
 
     expect(res.ok).toBe(true);
     expect(child.__written).toEqual(['ls\n']);
+  });
+
+  it('restoreSpawnSession preserves identity, snapshot, and live input', () => {
+    const spawned = {
+      written: [] as string[],
+      write(data: string) {
+        this.written.push(data);
+      },
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+    const backend: EmbeddedTerminalBackend = {
+      name: 'pty',
+      spawn: vi.fn(() => spawned),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+
+    const session = mgr.restoreSpawnSession({
+      sessionId: 'restored-session',
+      taskId: 'task-restored',
+      targetKey: 'target-restored',
+      spec: { command: 'bash', args: ['-l'] },
+      cwd: '/tmp/restored',
+      createdAt: '2026-07-07T00:00:00.000Z',
+      outputSnapshot: 'before restart\n',
+    });
+    const writeResult = mgr.write('restored-session', 'echo after\n');
+
+    expect(session).toMatchObject({
+      sessionId: 'restored-session',
+      taskId: 'task-restored',
+      createdAt: '2026-07-07T00:00:00.000Z',
+      outputSnapshot: 'before restart\n',
+      status: 'running',
+      mode: 'spawn',
+    });
+    expect(backend.spawn).toHaveBeenCalledTimes(1);
+    expect(writeResult.ok).toBe(true);
+    expect(spawned.written).toEqual(['echo after\n']);
   });
 
   it('resize() is accepted by the bash backend as a no-op', () => {
@@ -429,6 +518,35 @@ describe('EmbeddedTerminalManager', () => {
     expect(res.ok).toBe(true);
     expect(child.killed).toBe(true);
     expect(exits).toEqual([{ sessionId: session.sessionId }]);
+  });
+
+  it('closeAll preserveForRestart closes without exit or exited persistence updates', () => {
+    let emitExit: ((exitCode?: number) => void) | undefined;
+    const spawned = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(() => emitExit?.(0)),
+    };
+    const backend: EmbeddedTerminalBackend = {
+      name: 'bash',
+      spawn: vi.fn((opts) => {
+        emitExit = opts.emitExit;
+        return spawned;
+      }),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+    const exits: unknown[] = [];
+    const updates: Array<{ status: 'running' | 'exited' }> = [];
+    mgr.on('exit', (event) => exits.push(event));
+    mgr.on('session-updated', (record) => updates.push({ status: record.status }));
+
+    mgr.openOrReuse({ taskId: 'task-preserve', spec: {}, cwd: '/tmp' });
+    mgr.closeAll({ preserveForRestart: true });
+
+    expect(spawned.close).toHaveBeenCalledTimes(1);
+    expect(exits).toEqual([]);
+    expect(updates).toEqual([{ status: 'running' }]);
+    expect(mgr.list()).toEqual([]);
   });
 
   it('attached mode forwards executor output and routes sendInput', () => {

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -19,6 +19,7 @@ import type {
   TerminalOutputEvent,
   TerminalExitEvent,
 } from '@invoker/contracts';
+import type { TerminalSessionRecord } from '@invoker/data-store';
 import type { Executor, ExecutorHandle, TerminalSpec } from '@invoker/execution-engine';
 
 export type EmbeddedTerminalBackendName = 'bash' | 'pty';
@@ -88,6 +89,10 @@ export interface AttachContext {
   executor: Executor;
 }
 
+
+export interface TerminalSessionPersistenceRecord extends TerminalSessionRecord {
+  spec: TerminalSpec;
+}
 export interface OpenSessionOptions {
   taskId: string;
   spec: TerminalSpec;
@@ -95,7 +100,6 @@ export interface OpenSessionOptions {
   /** When provided, the session attaches to the running executor rather than spawning a child. */
   attach?: AttachContext;
 }
-
 interface BaseSessionState {
   sessionId: string;
   taskId: string;
@@ -103,6 +107,7 @@ interface BaseSessionState {
   spec: TerminalSpec;
   cwd: string;
   createdAt: string;
+  updatedAt: string;
   status: 'running' | 'exited';
   exitCode?: number;
   outputSnapshot: string;
@@ -129,6 +134,26 @@ export interface EmbeddedTerminalManagerOptions {
   defaultShell?: string;
 }
 
+
+function describePersistenceRecord(state: SessionState): TerminalSessionPersistenceRecord {
+  return {
+    sessionId: state.sessionId,
+    taskId: state.taskId,
+    targetKey: state.targetKey,
+    status: state.status,
+    exitCode: state.exitCode,
+    cwd: state.cwd,
+    command: state.spec.command,
+    args: state.spec.args,
+    linuxTerminalTail: state.spec.linuxTerminalTail,
+    mode: state.mode,
+    attached: state.mode === 'attached',
+    outputSnapshot: state.outputSnapshot,
+    createdAt: state.createdAt,
+    updatedAt: state.updatedAt,
+    spec: state.spec,
+  };
+}
 function describeSession(state: SessionState): TerminalSessionDescriptor {
   return {
     sessionId: state.sessionId,
@@ -248,6 +273,7 @@ export function createPtyTerminalBackend(
 export class EmbeddedTerminalManager extends EventEmitter {
   private readonly sessions = new Map<string, SessionState>();
   private readonly targetIndex = new Map<string, string>();
+  private readonly preserveForRestartSessionIds = new Set<string>();
   private readonly backend: EmbeddedTerminalBackend;
   private readonly defaultShell: string;
 
@@ -265,15 +291,8 @@ export class EmbeddedTerminalManager extends EventEmitter {
    */
   openOrReuse(opts: OpenSessionOptions): TerminalSessionDescriptor {
     const targetKey = buildTargetKey(opts);
-    const existingId = this.targetIndex.get(targetKey);
-    if (existingId) {
-      const existing = this.sessions.get(existingId);
-      if (existing && existing.status === 'running') {
-        return describeSession(existing);
-      }
-      this.targetIndex.delete(targetKey);
-      if (existing) this.sessions.delete(existingId);
-    }
+    const existing = this.getRunningDescriptorForTarget(targetKey);
+    if (existing) return existing;
 
     const sessionId = randomUUID();
     const createdAt = new Date().toISOString();
@@ -284,6 +303,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
       spec: opts.spec,
       cwd: opts.cwd,
       createdAt,
+      updatedAt: createdAt,
       status: 'running' as const,
       outputSnapshot: '',
     };
@@ -318,66 +338,38 @@ export class EmbeddedTerminalManager extends EventEmitter {
           /* unsubscribe is best-effort */
         }
       }
+      this.emitSessionUpdated(state);
       return describeSession(state);
     }
 
-    const pendingProcess: SpawnedTerminalProcess = {
-      write() {
-        throw new Error(`Session "${sessionId}" process is not ready.`);
-      },
-      resize() {
-        // Resize before the backend returns a process handle is ignored.
-      },
-      close() {
-        // There is no process handle to close yet.
-      },
-    };
-    const state: SpawnSessionState = {
-      ...base,
-      mode: 'spawn',
-      backend: this.backend.name,
-      process: pendingProcess,
-    };
-    this.sessions.set(sessionId, state);
-    this.targetIndex.set(targetKey, sessionId);
+    return this.registerSpawnSession(base);
+  }
 
-    const noPendingExit = Symbol('no-pending-exit');
-    let pendingExitCode: number | undefined | typeof noPendingExit = noPendingExit;
-    try {
-      const process = this.backend.spawn({
-        spec: opts.spec,
-        cwd: opts.cwd,
-        defaultShell: this.defaultShell,
-        emitOutput: (data) => this.emitOutput(state, data),
-        emitExit: (exitCode) => {
-          if (state.process === pendingProcess) {
-            pendingExitCode = exitCode;
-            return;
-          }
-          this.finalizeSession(state, exitCode);
-        },
-      });
-      state.process = process;
-      if (state.status === 'exited') {
-        try {
-          process.close();
-        } catch {
-          /* process cleanup is best-effort */
-        }
-      }
-    } catch (err) {
-      this.sessions.delete(sessionId);
-      if (this.targetIndex.get(targetKey) === sessionId) {
-        this.targetIndex.delete(targetKey);
-      }
-      throw err;
-    }
+  restoreSpawnSession(seed: {
+    sessionId: string;
+    taskId: string;
+    targetKey: string;
+    spec: TerminalSpec;
+    cwd: string;
+    createdAt: string;
+    outputSnapshot: string;
+  }): TerminalSessionDescriptor {
+    const existingSession = this.sessions.get(seed.sessionId);
+    if (existingSession) return describeSession(existingSession);
+    const existingTarget = this.getRunningDescriptorForTarget(seed.targetKey);
+    if (existingTarget) return existingTarget;
 
-    if (pendingExitCode !== noPendingExit) {
-      this.finalizeSession(state, pendingExitCode);
-    }
-
-    return describeSession(state);
+    return this.registerSpawnSession({
+      sessionId: seed.sessionId,
+      taskId: seed.taskId,
+      targetKey: seed.targetKey,
+      spec: seed.spec,
+      cwd: seed.cwd,
+      createdAt: seed.createdAt,
+      updatedAt: new Date().toISOString(),
+      status: 'running' as const,
+      outputSnapshot: seed.outputSnapshot,
+    });
   }
 
   list(): TerminalSessionDescriptor[] {
@@ -387,6 +379,11 @@ export class EmbeddedTerminalManager extends EventEmitter {
   get(sessionId: string): TerminalSessionDescriptor | undefined {
     const state = this.sessions.get(sessionId);
     return state ? describeSession(state) : undefined;
+  }
+
+  getPersistenceRecord(sessionId: string): TerminalSessionPersistenceRecord | undefined {
+    const state = this.sessions.get(sessionId);
+    return state ? describePersistenceRecord(state) : undefined;
   }
 
   write(sessionId: string, data: string): { ok: boolean; reason?: string } {
@@ -433,16 +430,110 @@ export class EmbeddedTerminalManager extends EventEmitter {
     return { ok: true };
   }
 
-  closeAll(): void {
+  closeAll(options?: { preserveForRestart?: boolean }): void {
+    if (options?.preserveForRestart) {
+      for (const state of Array.from(this.sessions.values())) {
+        this.preserveForRestartSessionIds.add(state.sessionId);
+        if (state.mode === 'spawn') {
+          state.process.close();
+        } else {
+          try {
+            state.unsubscribeOutput();
+          } catch {
+            /* unsubscribe is best-effort */
+          }
+        }
+      }
+      this.sessions.clear();
+      this.targetIndex.clear();
+      return;
+    }
+
     for (const state of Array.from(this.sessions.values())) {
       this.finalizeSession(state, undefined);
     }
   }
 
+  private getRunningDescriptorForTarget(targetKey: string): TerminalSessionDescriptor | undefined {
+    const existingId = this.targetIndex.get(targetKey);
+    if (!existingId) return undefined;
+    const existing = this.sessions.get(existingId);
+    if (existing && existing.status === 'running') return describeSession(existing);
+    this.targetIndex.delete(targetKey);
+    if (existing) this.sessions.delete(existingId);
+    return undefined;
+  }
+
+  private registerSpawnSession(
+    base: Omit<SpawnSessionState, 'backend' | 'process' | 'mode'>,
+  ): TerminalSessionDescriptor {
+    const pendingProcess: SpawnedTerminalProcess = {
+      write() {
+        throw new Error(`Session "${base.sessionId}" process is not ready.`);
+      },
+      resize() {
+        // Resize before the backend returns a process handle is ignored.
+      },
+      close() {
+        // There is no process handle to close yet.
+      },
+    };
+    const state: SpawnSessionState = {
+      ...base,
+      mode: 'spawn',
+      backend: this.backend.name,
+      process: pendingProcess,
+    };
+    this.sessions.set(state.sessionId, state);
+    this.targetIndex.set(state.targetKey, state.sessionId);
+
+    const noPendingExit = Symbol('no-pending-exit');
+    let pendingExitCode: number | undefined | typeof noPendingExit = noPendingExit;
+    try {
+      const process = this.backend.spawn({
+        spec: state.spec,
+        cwd: state.cwd,
+        defaultShell: this.defaultShell,
+        emitOutput: (data) => this.emitOutput(state, data),
+        emitExit: (exitCode) => {
+          if (state.process === pendingProcess) {
+            pendingExitCode = exitCode;
+            return;
+          }
+          this.finalizeSession(state, exitCode);
+        },
+      });
+      state.process = process;
+      if (state.status === 'exited') {
+        try {
+          process.close();
+        } catch {
+          /* process cleanup is best-effort */
+        }
+      }
+    } catch (err) {
+      this.sessions.delete(state.sessionId);
+      if (this.targetIndex.get(state.targetKey) === state.sessionId) {
+        this.targetIndex.delete(state.targetKey);
+      }
+      throw err;
+    }
+
+    if (pendingExitCode !== noPendingExit) {
+      this.finalizeSession(state, pendingExitCode);
+    } else if (state.status === 'running') {
+      this.emitSessionUpdated(state);
+    }
+
+    return describeSession(state);
+  }
+
   private finalizeSession(state: SessionState, exitCode: number | undefined): void {
-    if (state.status === 'exited') return;
+    if (state.status === 'exited' || this.preserveForRestartSessionIds.has(state.sessionId)) return;
     state.status = 'exited';
     state.exitCode = exitCode;
+    state.updatedAt = new Date().toISOString();
+    this.emitSessionUpdated(state);
 
     if (state.mode === 'spawn') {
       state.process.close();
@@ -469,12 +560,18 @@ export class EmbeddedTerminalManager extends EventEmitter {
 
   private emitOutput(state: SessionState, data: string): void {
     state.outputSnapshot = trimOutputSnapshot(state.outputSnapshot + data);
+    state.updatedAt = new Date().toISOString();
     const payload: TerminalOutputEvent = {
       sessionId: state.sessionId,
       taskId: state.taskId,
       data,
     };
     this.emit('output', payload);
+    this.emitSessionUpdated(state);
+  }
+
+  private emitSessionUpdated(state: SessionState): void {
+    this.emit('session-updated', describePersistenceRecord(state));
   }
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -90,6 +90,7 @@ import type {
   WorkflowMeta,
   WorkflowMutationAcceptedResult,
   WorkResponse,
+  TerminalSessionDescriptor,
 } from '@invoker/contracts';
 import { SqliteTaskRepository } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
@@ -1873,6 +1874,74 @@ function createEmbeddedTerminalBackendFromConfig(
   const embeddedTerminalManager = new EmbeddedTerminalManager({
     backend: createEmbeddedTerminalBackendFromConfig(resolveEmbeddedTerminalBackendConfig(invokerConfig)),
   });
+  const terminalRowToDescriptor = (row: ReturnType<SQLiteAdapter['listTerminalSessions']>[number]): TerminalSessionDescriptor => ({
+    sessionId: row.sessionId,
+    taskId: row.taskId,
+    status: row.status,
+    exitCode: row.exitCode,
+    cwd: row.cwd,
+    command: row.command,
+    args: row.args,
+    mode: row.mode,
+    attached: row.attached,
+    createdAt: row.createdAt,
+    outputSnapshot: row.outputSnapshot,
+  });
+
+  const restorePersistedTerminalSessions = (): void => {
+    const nowIso = () => new Date().toISOString();
+    for (const row of persistence.listTerminalSessions()) {
+      if (!persistence.loadTask(row.taskId)) {
+        persistence.deleteTerminalSession(row.sessionId);
+        continue;
+      }
+      if (row.status !== 'running') continue;
+      if (row.mode === 'attached') {
+        persistence.updateTerminalSession(row.sessionId, { status: 'exited', updatedAt: nowIso() });
+        continue;
+      }
+      try {
+        embeddedTerminalManager.restoreSpawnSession({
+          sessionId: row.sessionId,
+          taskId: row.taskId,
+          targetKey: row.targetKey,
+          spec: {
+            cwd: row.cwd,
+            command: row.command,
+            args: row.args,
+            linuxTerminalTail: row.linuxTerminalTail,
+          },
+          cwd: row.cwd ?? process.cwd(),
+          createdAt: row.createdAt,
+          outputSnapshot: row.outputSnapshot,
+        });
+      } catch {
+        persistence.updateTerminalSession(row.sessionId, { status: 'exited', updatedAt: nowIso() });
+      }
+    }
+  };
+
+  const registerTerminalSessionPersistence = (): void => {
+    embeddedTerminalManager.on('session-updated', (record) => {
+      persistence.upsertTerminalSession({
+        sessionId: record.sessionId,
+        taskId: record.taskId,
+        targetKey: record.targetKey,
+        status: record.status,
+        exitCode: record.exitCode,
+        cwd: record.cwd,
+        command: record.spec.command,
+        args: record.spec.args,
+        linuxTerminalTail: record.spec.linuxTerminalTail,
+        mode: record.mode,
+        attached: record.attached,
+        outputSnapshot: record.outputSnapshot,
+        createdAt: record.createdAt,
+        updatedAt: record.updatedAt,
+      });
+    });
+    restorePersistedTerminalSessions();
+  };
   embeddedTerminalManager.on('output', (payload) => {
     if (mainWindow && !mainWindow.isDestroyed()) {
       mainWindow.webContents.send('invoker:terminal-output', payload);
@@ -3281,6 +3350,7 @@ function createEmbeddedTerminalBackendFromConfig(
     // - daemon: GUI is a client; a background daemon owns workflow writes, and startup failure is serious.
     // - gui/local: GUI owns workflow writes directly with no daemon.
     // - auto: GUI uses an existing daemon when one is available, otherwise it runs locally as owner.
+
     const guiOwnerPreference = resolveGuiOwnerPreference();
     let daemonGuiOwner = false;
     if (guiOwnerPreference === 'daemon') {
@@ -3348,6 +3418,10 @@ function createEmbeddedTerminalBackendFromConfig(
         guiUsingDaemonOwner = false;
         recordStartupMark('initServices.readOnly.end', { ownerMode: false, ownerId: owner.ownerId });
       }
+    }
+
+    if (ownerMode) {
+      registerTerminalSessionPersistence();
     }
 
     if (ownerMode) {
@@ -5041,7 +5115,15 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     ipcMain.handle('invoker:terminal-list', async () => {
-      return embeddedTerminalManager.list();
+      const live = new Map(embeddedTerminalManager.list().map((session) => [session.sessionId, session]));
+      const merged = persistence.listTerminalSessions().map((row) => live.get(row.sessionId) ?? terminalRowToDescriptor(row));
+      const persistedIds = new Set(merged.map((session) => session.sessionId));
+      for (const session of live.values()) {
+        if (!persistedIds.has(session.sessionId)) {
+          merged.push(session);
+        }
+      }
+      return merged;
     });
 
     ipcMain.handle('invoker:terminal-write', async (_event, sessionId: string, data: string) => {
@@ -5053,7 +5135,9 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     ipcMain.handle('invoker:terminal-close', async (_event, sessionId: string) => {
-      return embeddedTerminalManager.close(sessionId);
+      const result = embeddedTerminalManager.close(sessionId);
+      persistence.deleteTerminalSession(sessionId);
+      return result.ok ? result : { ok: true };
     });
 
     Menu.setApplicationMenu(
@@ -5122,7 +5206,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
       try {
         if (apiServer) await apiServer.close().catch(() => {});
-        if (webBridge) await webBridge.close().catch(() => {});
+        embeddedTerminalManager.closeAll({ preserveForRestart: true });
         await workerRuntimeController?.stopAll();
         if (dbPollInterval) clearInterval(dbPollInterval);
         if (activityPollInterval) clearInterval(activityPollInterval);

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync, existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
-import type { Workflow, Conversation, WorkerActionWrite } from '../adapter.js';
+import type { Workflow, Conversation, WorkerActionWrite, TerminalSessionRecord } from '../adapter.js';
 import { createAttempt } from '@invoker/workflow-core';
 import type { Attempt, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 
@@ -36,6 +36,29 @@ describe('SQLiteAdapter', () => {
       config: {},
       execution: {},
       taskStateVersion: 1,
+      ...overrides,
+    };
+  }
+
+  function makeTerminalSession(
+    sessionId: string,
+    taskId: string,
+    overrides: Partial<TerminalSessionRecord> = {},
+  ): TerminalSessionRecord {
+    return {
+      sessionId,
+      taskId,
+      targetKey: `target-${sessionId}`,
+      status: 'running',
+      cwd: '/tmp/invoker-terminal-test',
+      command: 'bash',
+      args: ['-lc', 'echo terminal'],
+      linuxTerminalTail: 'exec_bash',
+      mode: 'spawn',
+      attached: false,
+      outputSnapshot: 'terminal output\n',
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:01.000Z',
       ...overrides,
     };
   }
@@ -131,6 +154,163 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  describe('terminal_sessions', () => {
+    it('creates the terminal_sessions schema with strict checks', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      expect(tableColumns(adapter, 'terminal_sessions')).toEqual([
+        'session_id',
+        'task_id',
+        'target_key',
+        'status',
+        'exit_code',
+        'cwd',
+        'command',
+        'args_json',
+        'linux_terminal_tail',
+        'mode',
+        'attached',
+        'output_snapshot',
+        'created_at',
+        'updated_at',
+      ]);
+      expect(tableIndexes(adapter, 'terminal_sessions')).toEqual(
+        expect.arrayContaining([
+          'idx_terminal_sessions_task_updated',
+          'idx_terminal_sessions_status_updated',
+          'idx_terminal_sessions_running_target',
+        ]),
+      );
+      expect(() => (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at
+        ) VALUES ('term-bad-status', 't1', 'target-bad-status', 'paused', 'spawn', 0, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z')`,
+      )).toThrow();
+      expect(() => (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at
+        ) VALUES ('term-bad-mode', 't1', 'target-bad-mode', 'running', 'pty', 0, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z')`,
+      )).toThrow();
+      expect(() => (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at
+        ) VALUES ('term-bad-attached', 't1', 'target-bad-attached', 'running', 'spawn', 2, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z')`,
+      )).toThrow();
+      expect(() => (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at, args_json
+        ) VALUES ('term-bad-args', 't1', 'target-bad-args', 'running', 'spawn', 0, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z', 'not-json')`,
+      )).toThrow();
+    });
+
+    it('round-trips terminal sessions across adapter reopen', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-terminal-sessions-'));
+      const dbPath = join(dir, 'invoker.db');
+      try {
+        const first = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        first.saveWorkflow(testWorkflow);
+        first.saveTask('wf-1', makeTask('t1'));
+        first.upsertTerminalSession(makeTerminalSession('term-1', 't1', {
+          targetKey: 'target-1',
+          status: 'running',
+          exitCode: undefined,
+          cwd: '/tmp/terminal-cwd',
+          command: 'zsh',
+          args: ['-l'],
+          linuxTerminalTail: 'pause',
+          mode: 'spawn',
+          attached: false,
+          outputSnapshot: 'restored output\n',
+          createdAt: '2026-07-07T01:00:00.000Z',
+          updatedAt: '2026-07-07T01:00:02.000Z',
+        }));
+        first.close();
+
+        const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        expect(reopened.loadTerminalSession('term-1')).toEqual({
+          sessionId: 'term-1',
+          taskId: 't1',
+          targetKey: 'target-1',
+          status: 'running',
+          exitCode: undefined,
+          cwd: '/tmp/terminal-cwd',
+          command: 'zsh',
+          args: ['-l'],
+          linuxTerminalTail: 'pause',
+          mode: 'spawn',
+          attached: false,
+          outputSnapshot: 'restored output\n',
+          createdAt: '2026-07-07T01:00:00.000Z',
+          updatedAt: '2026-07-07T01:00:02.000Z',
+        });
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('updates and deletes terminal session rows', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      adapter.upsertTerminalSession(makeTerminalSession('term-1', 't1'));
+
+      adapter.updateTerminalSession('term-1', {
+        status: 'exited',
+        exitCode: 7,
+        updatedAt: '2026-07-07T02:00:00.000Z',
+      });
+
+      expect(adapter.loadTerminalSession('term-1')).toMatchObject({
+        status: 'exited',
+        exitCode: 7,
+        updatedAt: '2026-07-07T02:00:00.000Z',
+      });
+
+      adapter.deleteTerminalSession('term-1');
+      expect(adapter.loadTerminalSession('term-1')).toBeUndefined();
+    });
+
+    it('uses safe defaults for malformed persisted terminal rows', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at, args_json
+        ) VALUES ('term-object-args', 't1', 'target-object-args', 'running', 'spawn', 0, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z', '{"bad":true}')`,
+      );
+      (adapter as any).db.run('PRAGMA ignore_check_constraints = ON');
+      (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at
+        ) VALUES ('term-unknown-status', 't1', 'target-unknown-status', 'paused', 'spawn', 0, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z')`,
+      );
+      (adapter as any).db.run('PRAGMA ignore_check_constraints = OFF');
+
+      expect(adapter.loadTerminalSession('term-object-args')?.args).toEqual([]);
+      expect(adapter.listTerminalSessions().map((row) => row.sessionId)).not.toContain('term-unknown-status');
+      expect(adapter.loadTerminalSession('term-unknown-status')).toBeUndefined();
+    });
+
+    it('removes terminal rows when deleting workflows and tasks', () => {
+      adapter.saveWorkflow({ ...testWorkflow, id: 'wf-delete-one' });
+      adapter.saveTask('wf-delete-one', makeTask('wf-delete-one/t1'));
+      adapter.saveWorkflow({ ...testWorkflow, id: 'wf-delete-all' });
+      adapter.saveTask('wf-delete-all', makeTask('wf-delete-all/t1'));
+      adapter.upsertTerminalSession(makeTerminalSession('term-delete-one', 'wf-delete-one/t1'));
+      adapter.upsertTerminalSession(makeTerminalSession('term-delete-all', 'wf-delete-all/t1'));
+
+      adapter.deleteWorkflow('wf-delete-one');
+
+      expect(adapter.loadTerminalSession('term-delete-one')).toBeUndefined();
+      expect(adapter.loadTerminalSession('term-delete-all')).toBeDefined();
+
+      adapter.deleteAllWorkflows();
+
+      expect(adapter.listTerminalSessions()).toEqual([]);
+    });
+  });
+
   describe('saveTask + loadTasks', () => {
     it('round-trips a task through save and load', () => {
       adapter.saveWorkflow(testWorkflow);
@@ -180,6 +360,19 @@ describe('SQLiteAdapter', () => {
       expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM events WHERE task_id = 't1'")).toBe(0);
       expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM task_output WHERE task_id = 't1'")).toBe(0);
       expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM output_spool WHERE task_id = 't1'")).toBe(0);
+    });
+
+    it('deleteTask removes terminal sessions for the deleted task', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      adapter.saveTask('wf-1', makeTask('t2'));
+      adapter.upsertTerminalSession(makeTerminalSession('term-t1', 't1'));
+      adapter.upsertTerminalSession(makeTerminalSession('term-t2', 't2'));
+
+      adapter.deleteTask('t1');
+
+      expect(adapter.loadTerminalSession('term-t1')).toBeUndefined();
+      expect(adapter.loadTerminalSession('term-t2')).toBeDefined();
     });
 
     it('persists executionModel through saveTask, updateTask, and loadTask', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -195,6 +195,27 @@ export interface WorkerActionListFilters {
   limit?: number;
 }
 
+export interface TerminalSessionRecord {
+  sessionId: string;
+  taskId: string;
+  targetKey: string;
+  status: 'running' | 'exited';
+  exitCode?: number;
+  cwd?: string;
+  command?: string;
+  args?: string[];
+  linuxTerminalTail?: 'exec_bash' | 'pause';
+  mode: 'spawn' | 'attached';
+  attached: boolean;
+  outputSnapshot: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type TerminalSessionPatch = Partial<
+  Pick<TerminalSessionRecord, 'status' | 'exitCode' | 'outputSnapshot' | 'updatedAt'>
+>;
+
 export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -58,6 +58,8 @@ import type {
   WorkerActionListFilters,
   WorkerActionRecord,
   WorkerActionWrite,
+  TerminalSessionPatch,
+  TerminalSessionRecord,
 } from './adapter.js';
 import {
   SCHEMA_DDL,
@@ -370,6 +372,33 @@ export interface TaskLaunchDispatch {
   attemptsCount: number;
   lastError?: string;
   generation: number;
+}
+
+type TerminalSessionRow = {
+  session_id?: unknown;
+  task_id?: unknown;
+  target_key?: unknown;
+  status?: unknown;
+  exit_code?: unknown;
+  cwd?: unknown;
+  command?: unknown;
+  args_json?: unknown;
+  linux_terminal_tail?: unknown;
+  mode?: unknown;
+  attached?: unknown;
+  output_snapshot?: unknown;
+  created_at?: unknown;
+  updated_at?: unknown;
+};
+
+function parseTerminalArgsJson(value: unknown): string[] {
+  if (typeof value !== 'string' || value.length === 0) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) && parsed.every((item) => typeof item === 'string') ? parsed : [];
+  } catch {
+    return [];
+  }
 }
 
 export class SQLiteAdapter implements PersistenceAdapter {
@@ -1659,6 +1688,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     values.push(taskId);
     const heartbeatOnly =
       setClauses.length === 1 && setClauses[0].trimStart().startsWith('last_heartbeat_at =');
+
     if (!heartbeatOnly && process.env.NODE_ENV !== 'test' && process.env.INVOKER_TRACE_PERSIST_SQL === '1') {
       const cols = setClauses.map((c) => c.split(/\s*=\s*/)[0]!.trim()).join(', ');
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
@@ -1687,6 +1717,108 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'SELECT DISTINCT branch FROM tasks WHERE branch IS NOT NULL',
     ) as Array<{ branch: string }>;
     return rows.map((r) => r.branch);
+  }
+
+  upsertTerminalSession(record: TerminalSessionRecord): void {
+    this.ensureWritable();
+    this.db.run(
+      `INSERT INTO terminal_sessions (
+        session_id,
+        task_id,
+        target_key,
+        status,
+        exit_code,
+        cwd,
+        command,
+        args_json,
+        linux_terminal_tail,
+        mode,
+        attached,
+        output_snapshot,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(session_id) DO UPDATE SET
+        task_id = excluded.task_id,
+        target_key = excluded.target_key,
+        status = excluded.status,
+        exit_code = excluded.exit_code,
+        cwd = excluded.cwd,
+        command = excluded.command,
+        args_json = excluded.args_json,
+        linux_terminal_tail = excluded.linux_terminal_tail,
+        mode = excluded.mode,
+        attached = excluded.attached,
+        output_snapshot = excluded.output_snapshot,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at`,
+      [
+        record.sessionId,
+        record.taskId,
+        record.targetKey,
+        record.status,
+        record.exitCode ?? null,
+        record.cwd ?? null,
+        record.command ?? null,
+        JSON.stringify(record.args ?? []),
+        record.linuxTerminalTail ?? null,
+        record.mode,
+        record.attached ? 1 : 0,
+        record.outputSnapshot,
+        record.createdAt,
+        record.updatedAt,
+      ],
+    );
+    this.dirty = true;
+  }
+
+  listTerminalSessions(): TerminalSessionRecord[] {
+    const rows = this.queryAll(
+      'SELECT * FROM terminal_sessions ORDER BY updated_at ASC, created_at ASC',
+    ) as TerminalSessionRow[];
+    const records: TerminalSessionRecord[] = [];
+    for (const row of rows) {
+      const record = this.mapTerminalSessionRow(row);
+      if (record) records.push(record);
+    }
+    return records;
+  }
+
+  loadTerminalSession(sessionId: string): TerminalSessionRecord | undefined {
+    const row = this.queryOne('SELECT * FROM terminal_sessions WHERE session_id = ?', [sessionId]);
+    return row ? this.mapTerminalSessionRow(row as TerminalSessionRow) : undefined;
+  }
+
+  updateTerminalSession(sessionId: string, patch: TerminalSessionPatch): void {
+    this.ensureWritable();
+    const setClauses: string[] = [];
+    const values: unknown[] = [];
+    if (Object.hasOwn(patch, 'status')) {
+      setClauses.push('status = ?');
+      values.push(patch.status ?? null);
+    }
+    if (Object.hasOwn(patch, 'exitCode')) {
+      setClauses.push('exit_code = ?');
+      values.push(patch.exitCode ?? null);
+    }
+    if (Object.hasOwn(patch, 'outputSnapshot')) {
+      setClauses.push('output_snapshot = ?');
+      values.push(patch.outputSnapshot ?? '');
+    }
+    if (Object.hasOwn(patch, 'updatedAt')) {
+      setClauses.push('updated_at = ?');
+      values.push(patch.updatedAt ?? null);
+    }
+    if (setClauses.length === 0) return;
+    values.push(sessionId);
+    this.db.run(`UPDATE terminal_sessions SET ${setClauses.join(', ')} WHERE session_id = ?`, values);
+    this.dirty = true;
+  }
+
+  deleteTerminalSession(sessionId: string): void {
+    this.ensureWritable();
+    this.db.run('DELETE FROM terminal_sessions WHERE session_id = ?', [sessionId]);
+    this.dirty = true;
   }
 
   private getTaskIdsForWorkflow(workflowId: string): string[] {
@@ -1794,6 +1926,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM task_output WHERE task_id = ?', [taskId]);
       this.db.run('DELETE FROM attempts WHERE node_id = ?', [taskId]);
       this.db.run('DELETE FROM output_spool WHERE task_id = ?', [taskId]);
+      this.db.run('DELETE FROM terminal_sessions WHERE task_id = ?', [taskId]);
       this.db.run('DELETE FROM tasks WHERE id = ?', [taskId]);
     });
     this.removeOutputFiles([taskId]);
@@ -1835,6 +1968,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
+      this.db.run(`
+        DELETE FROM terminal_sessions WHERE task_id IN (
+          SELECT id FROM tasks WHERE workflow_id = ?
+        )
+      `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
     });
     this.removeOutputFiles(taskIds);
@@ -1852,6 +1990,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM task_output');
       this.db.run('DELETE FROM attempts');
       this.db.run('DELETE FROM output_spool');
+      this.db.run('DELETE FROM terminal_sessions');
       this.db.run('DELETE FROM tasks');
       this.db.run('DELETE FROM workflows');
     });
@@ -1876,33 +2015,32 @@ export class SQLiteAdapter implements PersistenceAdapter {
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
-
       this.db.run(`
         DELETE FROM events WHERE task_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
-
       this.db.run(`
         DELETE FROM task_output WHERE task_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
-
       this.db.run(`
         DELETE FROM attempts WHERE node_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
-
       this.db.run(`
         DELETE FROM output_spool WHERE task_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
-
+      this.db.run(`
+        DELETE FROM terminal_sessions WHERE task_id IN (
+          SELECT id FROM tasks WHERE workflow_id = ?
+        )
+      `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-
       this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
     });
     this.removeOutputFiles(taskIds);
@@ -2861,6 +2999,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       };
     }
 
+
     if (attempt.status === 'completed') {
       return {
         ...task,
@@ -2891,6 +3030,36 @@ export class SQLiteAdapter implements PersistenceAdapter {
     }
 
     return task;
+  }
+
+  private mapTerminalSessionRow(row: TerminalSessionRow): TerminalSessionRecord | undefined {
+    if (row.status !== 'running' && row.status !== 'exited') return undefined;
+    if (row.mode !== 'spawn' && row.mode !== 'attached') return undefined;
+    const sessionId = typeof row.session_id === 'string' ? row.session_id : '';
+    const taskId = typeof row.task_id === 'string' ? row.task_id : '';
+    const targetKey = typeof row.target_key === 'string' ? row.target_key : '';
+    const createdAt = typeof row.created_at === 'string' ? row.created_at : '';
+    const updatedAt = typeof row.updated_at === 'string' ? row.updated_at : '';
+    if (!sessionId || !taskId || !targetKey || !createdAt || !updatedAt) return undefined;
+    return {
+      sessionId,
+      taskId,
+      targetKey,
+      status: row.status,
+      exitCode: typeof row.exit_code === 'number' ? row.exit_code : undefined,
+      cwd: typeof row.cwd === 'string' ? row.cwd : undefined,
+      command: typeof row.command === 'string' ? row.command : undefined,
+      args: parseTerminalArgsJson(row.args_json),
+      linuxTerminalTail:
+        row.linux_terminal_tail === 'exec_bash' || row.linux_terminal_tail === 'pause'
+          ? row.linux_terminal_tail
+          : undefined,
+      mode: row.mode,
+      attached: row.attached === 1,
+      outputSnapshot: typeof row.output_snapshot === 'string' ? row.output_snapshot : '',
+      createdAt,
+      updatedAt,
+    };
   }
 
   private rowToAttempt(row: any): Attempt {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -343,6 +343,34 @@ export const SCHEMA_DDL = `
 
       CREATE INDEX IF NOT EXISTS idx_output_spool_task_offset
         ON output_spool(task_id, offset);
+
+      CREATE TABLE IF NOT EXISTS terminal_sessions (
+        session_id TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        target_key TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('running', 'exited')),
+        exit_code INTEGER,
+        cwd TEXT,
+        command TEXT,
+        args_json TEXT CHECK (args_json IS NULL OR json_valid(args_json)),
+        linux_terminal_tail TEXT CHECK (linux_terminal_tail IS NULL OR linux_terminal_tail IN ('exec_bash', 'pause')),
+        mode TEXT NOT NULL CHECK (mode IN ('spawn', 'attached')),
+        attached INTEGER NOT NULL DEFAULT 0 CHECK (attached IN (0, 1)),
+        output_snapshot TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        FOREIGN KEY (task_id) REFERENCES tasks(id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_terminal_sessions_task_updated
+        ON terminal_sessions(task_id, updated_at);
+
+      CREATE INDEX IF NOT EXISTS idx_terminal_sessions_status_updated
+        ON terminal_sessions(status, updated_at);
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_terminal_sessions_running_target
+        ON terminal_sessions(target_key)
+        WHERE status = 'running';
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -685,6 +685,8 @@ export function App() {
     window.invoker?.terminalList?.().then((list) => {
       if (Array.isArray(list) && list.length > 0) {
         setTerminalSessions(list);
+        setActiveTerminalSessionId(list[list.length - 1]?.sessionId ?? null);
+        setTerminalDrawerState('partial');
       }
     }).catch(() => {});
   }, []);

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -145,6 +145,21 @@ describe('Terminal drawer (component)', () => {
     expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
   });
 
+  it('restores persisted terminal sessions from startup terminalList', async () => {
+    const restored = makeTerminalSession('task-alpha', {
+      outputSnapshot: 'restored before restart\n',
+    });
+    vi.mocked(mock.api.terminalList).mockResolvedValue([restored]);
+
+    render(<App />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'partial');
+      expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+      expect(xtermMock.writeLog).toContain('restored before restart\n');
+    });
+  });
+
   it('opens the drawer in the partial state (not maximized) when opening a terminal via double-click', async () => {
     render(<App />);
     act(() => mock.setTasks([taskAlpha, taskBeta], workflows));


### PR DESCRIPTION
## Summary

The changelog now calls out terminal tab persistence for the next release.

This gives users one place to see the restart behavior change.

<details>
<summary>Review metadata</summary>

Review Claim: The unreleased changelog mentions restored embedded terminal tabs.

Review Lane: docs

Review Unit: docs

Safety Invariant: This slice changes only release notes.

Slice Rationale: The changelog is separate so behavior slices stay locally reviewable.

</details>

## Non-goals

This does not change runtime behavior.

This does not add setup docs for web terminals.

## Test Plan

- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
