### PR TITLE
[Make PR Proof](1) Document unique visual proof media paths

### DIFF
--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -51,6 +51,10 @@ must_contain "$SKILL_MD" "open every screenshot or video and verify the user-vis
 must_contain "$SKILL_MD" "For conditional or event-driven UI, drive the exact condition that triggers the new state" "make-pr visual proof must cover conditional UI states"
 must_contain "$SKILL_MD" "A generic task panel, unchanged sidebar, unrelated graph, or stale screenshot is not proof" "make-pr visual proof must reject generic task-panel screenshots"
 must_contain "$SKILL_MD" "caption each visual proof item with the concrete thing the reviewer should see" "make-pr visual proof captions must name the visible target"
+must_contain "$SKILL_MD" "Before/after visual proof images must use distinct local filenames" "make-pr visual proof must prevent before/after basename upload collisions"
+must_contain "$SKILL_MD" 'The uploader keys media by basename inside one upload prefix' "make-pr visual proof must explain why duplicate basenames are unsafe"
+must_contain "$SKILL_MD" "cursor, pointer, hover-only affordance" "make-pr visual proof must call out states static screenshots cannot show"
+must_contain "$SKILL_MD" "do not present an unchanged screenshot as proof of the behavior" "make-pr visual proof must reject unchanged screenshots for cursor-like behavior"
 
 # The publication checklist must stop empty PR slices before create/update/stack publish.
 must_contain "$SKILL_MD" "has no file changes against its selected base" "make-pr skill must reject branches with no reviewable file diff"

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -112,6 +112,10 @@ Visual proof must show the changed behavior itself, not just the changed screen 
 
 In the PR body, caption each visual proof item with the concrete thing the reviewer should see, for example "amber Workspace recreated notice in the task inspector." If the reviewer cannot tell what changed from the image and caption, recapture proof before publishing.
 
+Before/after visual proof images must use distinct local filenames before `node scripts/create-pr.mjs` uploads them. The uploader keys media by basename inside one upload prefix, so `before/foo.png` and `after/foo.png` can collapse to one final URL. Copy or rename the files first, for example `/tmp/proof/foo-before.png` and `/tmp/proof/foo-after.png`, then put those unique paths in the PR body.
+
+If the changed behavior is a cursor, pointer, hover-only affordance, or other state that a static screenshot cannot show, do not present an unchanged screenshot as proof of the behavior. Add a short video, an inspectable state proof, or a focused test reference, and say plainly why the screenshot alone cannot show it.
+
 When a PR changes skill instructions under `skills/**/SKILL.md`, add or update a focused skill contract test for the exact issue being fixed. The test must fail if the instruction that prevents the regression is removed.
 
 Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Review Claim / ## Review Lane / ## Safety Invariant / ## Slice Rationale / ## Non-goals / ## Test Plan / ## Revert Plan` as the floor, add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.


### PR DESCRIPTION
## Summary

The make-pr skill now blocks the proof mistake from PR #3211.

The failure happened because before and after screenshots had the same basename. The upload step stored both under one key, so one link overwrote the other.

The skill now says to rename proof files first. It also says cursor-only changes need proof beyond a static screenshot.

<details>
<summary>Review metadata</summary>

Review Claim: The make-pr skill now prevents duplicate visual-proof media paths and static cursor screenshots from being accepted as proof.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This only changes agent instructions and the contract test that locks those instructions.

Slice Rationale: The skill policy fix is separate from the planning cursor UI fix.

</details>

## Non-goals

This does not change PR creation code, media upload code, or visual proof capture scripts.

This does not change the planning cursor behavior PR.

## Test Plan

- [x] `bash scripts/test-make-pr-skill.sh`
- [x] `git diff --check`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert b55408366`
- Post-revert steps: None
- Data migration? No
