### PR TITLE
[Terminal Sessions](1) Persist terminal session rows

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync, existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
-import type { Workflow, Conversation, WorkerActionWrite } from '../adapter.js';
+import type { Workflow, Conversation, WorkerActionWrite, TerminalSessionRecord } from '../adapter.js';
 import { createAttempt } from '@invoker/workflow-core';
 import type { Attempt, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 
@@ -36,6 +36,29 @@ describe('SQLiteAdapter', () => {
       config: {},
       execution: {},
       taskStateVersion: 1,
+      ...overrides,
+    };
+  }
+
+  function makeTerminalSession(
+    sessionId: string,
+    taskId: string,
+    overrides: Partial<TerminalSessionRecord> = {},
+  ): TerminalSessionRecord {
+    return {
+      sessionId,
+      taskId,
+      targetKey: `target-${sessionId}`,
+      status: 'running',
+      cwd: '/tmp/invoker-terminal-test',
+      command: 'bash',
+      args: ['-lc', 'echo terminal'],
+      linuxTerminalTail: 'exec_bash',
+      mode: 'spawn',
+      attached: false,
+      outputSnapshot: 'terminal output\n',
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:01.000Z',
       ...overrides,
     };
   }
@@ -131,6 +154,163 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  describe('terminal_sessions', () => {
+    it('creates the terminal_sessions schema with strict checks', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      expect(tableColumns(adapter, 'terminal_sessions')).toEqual([
+        'session_id',
+        'task_id',
+        'target_key',
+        'status',
+        'exit_code',
+        'cwd',
+        'command',
+        'args_json',
+        'linux_terminal_tail',
+        'mode',
+        'attached',
+        'output_snapshot',
+        'created_at',
+        'updated_at',
+      ]);
+      expect(tableIndexes(adapter, 'terminal_sessions')).toEqual(
+        expect.arrayContaining([
+          'idx_terminal_sessions_task_updated',
+          'idx_terminal_sessions_status_updated',
+          'idx_terminal_sessions_running_target',
+        ]),
+      );
+      expect(() => (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at
+        ) VALUES ('term-bad-status', 't1', 'target-bad-status', 'paused', 'spawn', 0, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z')`,
+      )).toThrow();
+      expect(() => (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at
+        ) VALUES ('term-bad-mode', 't1', 'target-bad-mode', 'running', 'pty', 0, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z')`,
+      )).toThrow();
+      expect(() => (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at
+        ) VALUES ('term-bad-attached', 't1', 'target-bad-attached', 'running', 'spawn', 2, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z')`,
+      )).toThrow();
+      expect(() => (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at, args_json
+        ) VALUES ('term-bad-args', 't1', 'target-bad-args', 'running', 'spawn', 0, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z', 'not-json')`,
+      )).toThrow();
+    });
+
+    it('round-trips terminal sessions across adapter reopen', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-terminal-sessions-'));
+      const dbPath = join(dir, 'invoker.db');
+      try {
+        const first = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        first.saveWorkflow(testWorkflow);
+        first.saveTask('wf-1', makeTask('t1'));
+        first.upsertTerminalSession(makeTerminalSession('term-1', 't1', {
+          targetKey: 'target-1',
+          status: 'running',
+          exitCode: undefined,
+          cwd: '/tmp/terminal-cwd',
+          command: 'zsh',
+          args: ['-l'],
+          linuxTerminalTail: 'pause',
+          mode: 'spawn',
+          attached: false,
+          outputSnapshot: 'restored output\n',
+          createdAt: '2026-07-07T01:00:00.000Z',
+          updatedAt: '2026-07-07T01:00:02.000Z',
+        }));
+        first.close();
+
+        const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        expect(reopened.loadTerminalSession('term-1')).toEqual({
+          sessionId: 'term-1',
+          taskId: 't1',
+          targetKey: 'target-1',
+          status: 'running',
+          exitCode: undefined,
+          cwd: '/tmp/terminal-cwd',
+          command: 'zsh',
+          args: ['-l'],
+          linuxTerminalTail: 'pause',
+          mode: 'spawn',
+          attached: false,
+          outputSnapshot: 'restored output\n',
+          createdAt: '2026-07-07T01:00:00.000Z',
+          updatedAt: '2026-07-07T01:00:02.000Z',
+        });
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('updates and deletes terminal session rows', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      adapter.upsertTerminalSession(makeTerminalSession('term-1', 't1'));
+
+      adapter.updateTerminalSession('term-1', {
+        status: 'exited',
+        exitCode: 7,
+        updatedAt: '2026-07-07T02:00:00.000Z',
+      });
+
+      expect(adapter.loadTerminalSession('term-1')).toMatchObject({
+        status: 'exited',
+        exitCode: 7,
+        updatedAt: '2026-07-07T02:00:00.000Z',
+      });
+
+      adapter.deleteTerminalSession('term-1');
+      expect(adapter.loadTerminalSession('term-1')).toBeUndefined();
+    });
+
+    it('uses safe defaults for malformed persisted terminal rows', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at, args_json
+        ) VALUES ('term-object-args', 't1', 'target-object-args', 'running', 'spawn', 0, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z', '{"bad":true}')`,
+      );
+      (adapter as any).db.run('PRAGMA ignore_check_constraints = ON');
+      (adapter as any).db.run(
+        `INSERT INTO terminal_sessions (
+          session_id, task_id, target_key, status, mode, attached, output_snapshot, created_at, updated_at
+        ) VALUES ('term-unknown-status', 't1', 'target-unknown-status', 'paused', 'spawn', 0, '', '2026-07-07T00:00:00.000Z', '2026-07-07T00:00:00.000Z')`,
+      );
+      (adapter as any).db.run('PRAGMA ignore_check_constraints = OFF');
+
+      expect(adapter.loadTerminalSession('term-object-args')?.args).toEqual([]);
+      expect(adapter.listTerminalSessions().map((row) => row.sessionId)).not.toContain('term-unknown-status');
+      expect(adapter.loadTerminalSession('term-unknown-status')).toBeUndefined();
+    });
+
+    it('removes terminal rows when deleting workflows and tasks', () => {
+      adapter.saveWorkflow({ ...testWorkflow, id: 'wf-delete-one' });
+      adapter.saveTask('wf-delete-one', makeTask('wf-delete-one/t1'));
+      adapter.saveWorkflow({ ...testWorkflow, id: 'wf-delete-all' });
+      adapter.saveTask('wf-delete-all', makeTask('wf-delete-all/t1'));
+      adapter.upsertTerminalSession(makeTerminalSession('term-delete-one', 'wf-delete-one/t1'));
+      adapter.upsertTerminalSession(makeTerminalSession('term-delete-all', 'wf-delete-all/t1'));
+
+      adapter.deleteWorkflow('wf-delete-one');
+
+      expect(adapter.loadTerminalSession('term-delete-one')).toBeUndefined();
+      expect(adapter.loadTerminalSession('term-delete-all')).toBeDefined();
+
+      adapter.deleteAllWorkflows();
+
+      expect(adapter.listTerminalSessions()).toEqual([]);
+    });
+  });
+
   describe('saveTask + loadTasks', () => {
     it('round-trips a task through save and load', () => {
       adapter.saveWorkflow(testWorkflow);
@@ -180,6 +360,19 @@ describe('SQLiteAdapter', () => {
       expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM events WHERE task_id = 't1'")).toBe(0);
       expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM task_output WHERE task_id = 't1'")).toBe(0);
       expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM output_spool WHERE task_id = 't1'")).toBe(0);
+    });
+
+    it('deleteTask removes terminal sessions for the deleted task', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      adapter.saveTask('wf-1', makeTask('t2'));
+      adapter.upsertTerminalSession(makeTerminalSession('term-t1', 't1'));
+      adapter.upsertTerminalSession(makeTerminalSession('term-t2', 't2'));
+
+      adapter.deleteTask('t1');
+
+      expect(adapter.loadTerminalSession('term-t1')).toBeUndefined();
+      expect(adapter.loadTerminalSession('term-t2')).toBeDefined();
     });
 
     it('persists executionModel through saveTask, updateTask, and loadTask', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -195,6 +195,27 @@ export interface WorkerActionListFilters {
   limit?: number;
 }
 
+export interface TerminalSessionRecord {
+  sessionId: string;
+  taskId: string;
+  targetKey: string;
+  status: 'running' | 'exited';
+  exitCode?: number;
+  cwd?: string;
+  command?: string;
+  args?: string[];
+  linuxTerminalTail?: 'exec_bash' | 'pause';
+  mode: 'spawn' | 'attached';
+  attached: boolean;
+  outputSnapshot: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type TerminalSessionPatch = Partial<
+  Pick<TerminalSessionRecord, 'status' | 'exitCode' | 'outputSnapshot' | 'updatedAt'>
+>;
+
 export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: WorkflowSaveInput): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -58,6 +58,8 @@ import type {
   WorkerActionListFilters,
   WorkerActionRecord,
   WorkerActionWrite,
+  TerminalSessionPatch,
+  TerminalSessionRecord,
 } from './adapter.js';
 import {
   SCHEMA_DDL,
@@ -370,6 +372,33 @@ export interface TaskLaunchDispatch {
   attemptsCount: number;
   lastError?: string;
   generation: number;
+}
+
+type TerminalSessionRow = {
+  session_id?: unknown;
+  task_id?: unknown;
+  target_key?: unknown;
+  status?: unknown;
+  exit_code?: unknown;
+  cwd?: unknown;
+  command?: unknown;
+  args_json?: unknown;
+  linux_terminal_tail?: unknown;
+  mode?: unknown;
+  attached?: unknown;
+  output_snapshot?: unknown;
+  created_at?: unknown;
+  updated_at?: unknown;
+};
+
+function parseTerminalArgsJson(value: unknown): string[] {
+  if (typeof value !== 'string' || value.length === 0) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) && parsed.every((item) => typeof item === 'string') ? parsed : [];
+  } catch {
+    return [];
+  }
 }
 
 export class SQLiteAdapter implements PersistenceAdapter {
@@ -1659,6 +1688,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     values.push(taskId);
     const heartbeatOnly =
       setClauses.length === 1 && setClauses[0].trimStart().startsWith('last_heartbeat_at =');
+
     if (!heartbeatOnly && process.env.NODE_ENV !== 'test' && process.env.INVOKER_TRACE_PERSIST_SQL === '1') {
       const cols = setClauses.map((c) => c.split(/\s*=\s*/)[0]!.trim()).join(', ');
       console.log(`[persist-sql] taskId=${taskId} columns=[${cols}]`);
@@ -1687,6 +1717,108 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'SELECT DISTINCT branch FROM tasks WHERE branch IS NOT NULL',
     ) as Array<{ branch: string }>;
     return rows.map((r) => r.branch);
+  }
+
+  upsertTerminalSession(record: TerminalSessionRecord): void {
+    this.ensureWritable();
+    this.db.run(
+      `INSERT INTO terminal_sessions (
+        session_id,
+        task_id,
+        target_key,
+        status,
+        exit_code,
+        cwd,
+        command,
+        args_json,
+        linux_terminal_tail,
+        mode,
+        attached,
+        output_snapshot,
+        created_at,
+        updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(session_id) DO UPDATE SET
+        task_id = excluded.task_id,
+        target_key = excluded.target_key,
+        status = excluded.status,
+        exit_code = excluded.exit_code,
+        cwd = excluded.cwd,
+        command = excluded.command,
+        args_json = excluded.args_json,
+        linux_terminal_tail = excluded.linux_terminal_tail,
+        mode = excluded.mode,
+        attached = excluded.attached,
+        output_snapshot = excluded.output_snapshot,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at`,
+      [
+        record.sessionId,
+        record.taskId,
+        record.targetKey,
+        record.status,
+        record.exitCode ?? null,
+        record.cwd ?? null,
+        record.command ?? null,
+        JSON.stringify(record.args ?? []),
+        record.linuxTerminalTail ?? null,
+        record.mode,
+        record.attached ? 1 : 0,
+        record.outputSnapshot,
+        record.createdAt,
+        record.updatedAt,
+      ],
+    );
+    this.dirty = true;
+  }
+
+  listTerminalSessions(): TerminalSessionRecord[] {
+    const rows = this.queryAll(
+      'SELECT * FROM terminal_sessions ORDER BY updated_at ASC, created_at ASC',
+    ) as TerminalSessionRow[];
+    const records: TerminalSessionRecord[] = [];
+    for (const row of rows) {
+      const record = this.mapTerminalSessionRow(row);
+      if (record) records.push(record);
+    }
+    return records;
+  }
+
+  loadTerminalSession(sessionId: string): TerminalSessionRecord | undefined {
+    const row = this.queryOne('SELECT * FROM terminal_sessions WHERE session_id = ?', [sessionId]);
+    return row ? this.mapTerminalSessionRow(row as TerminalSessionRow) : undefined;
+  }
+
+  updateTerminalSession(sessionId: string, patch: TerminalSessionPatch): void {
+    this.ensureWritable();
+    const setClauses: string[] = [];
+    const values: unknown[] = [];
+    if (Object.hasOwn(patch, 'status')) {
+      setClauses.push('status = ?');
+      values.push(patch.status ?? null);
+    }
+    if (Object.hasOwn(patch, 'exitCode')) {
+      setClauses.push('exit_code = ?');
+      values.push(patch.exitCode ?? null);
+    }
+    if (Object.hasOwn(patch, 'outputSnapshot')) {
+      setClauses.push('output_snapshot = ?');
+      values.push(patch.outputSnapshot ?? '');
+    }
+    if (Object.hasOwn(patch, 'updatedAt')) {
+      setClauses.push('updated_at = ?');
+      values.push(patch.updatedAt ?? null);
+    }
+    if (setClauses.length === 0) return;
+    values.push(sessionId);
+    this.db.run(`UPDATE terminal_sessions SET ${setClauses.join(', ')} WHERE session_id = ?`, values);
+    this.dirty = true;
+  }
+
+  deleteTerminalSession(sessionId: string): void {
+    this.ensureWritable();
+    this.db.run('DELETE FROM terminal_sessions WHERE session_id = ?', [sessionId]);
+    this.dirty = true;
   }
 
   private getTaskIdsForWorkflow(workflowId: string): string[] {
@@ -1794,6 +1926,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM task_output WHERE task_id = ?', [taskId]);
       this.db.run('DELETE FROM attempts WHERE node_id = ?', [taskId]);
       this.db.run('DELETE FROM output_spool WHERE task_id = ?', [taskId]);
+      this.db.run('DELETE FROM terminal_sessions WHERE task_id = ?', [taskId]);
       this.db.run('DELETE FROM tasks WHERE id = ?', [taskId]);
     });
     this.removeOutputFiles([taskId]);
@@ -1835,6 +1968,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
+      this.db.run(`
+        DELETE FROM terminal_sessions WHERE task_id IN (
+          SELECT id FROM tasks WHERE workflow_id = ?
+        )
+      `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
     });
     this.removeOutputFiles(taskIds);
@@ -1852,6 +1990,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM task_output');
       this.db.run('DELETE FROM attempts');
       this.db.run('DELETE FROM output_spool');
+      this.db.run('DELETE FROM terminal_sessions');
       this.db.run('DELETE FROM tasks');
       this.db.run('DELETE FROM workflows');
     });
@@ -1876,33 +2015,32 @@ export class SQLiteAdapter implements PersistenceAdapter {
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
-
       this.db.run(`
         DELETE FROM events WHERE task_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
-
       this.db.run(`
         DELETE FROM task_output WHERE task_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
-
       this.db.run(`
         DELETE FROM attempts WHERE node_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
-
       this.db.run(`
         DELETE FROM output_spool WHERE task_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
-
+      this.db.run(`
+        DELETE FROM terminal_sessions WHERE task_id IN (
+          SELECT id FROM tasks WHERE workflow_id = ?
+        )
+      `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
-
       this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
     });
     this.removeOutputFiles(taskIds);
@@ -2861,6 +2999,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       };
     }
 
+
     if (attempt.status === 'completed') {
       return {
         ...task,
@@ -2891,6 +3030,36 @@ export class SQLiteAdapter implements PersistenceAdapter {
     }
 
     return task;
+  }
+
+  private mapTerminalSessionRow(row: TerminalSessionRow): TerminalSessionRecord | undefined {
+    if (row.status !== 'running' && row.status !== 'exited') return undefined;
+    if (row.mode !== 'spawn' && row.mode !== 'attached') return undefined;
+    const sessionId = typeof row.session_id === 'string' ? row.session_id : '';
+    const taskId = typeof row.task_id === 'string' ? row.task_id : '';
+    const targetKey = typeof row.target_key === 'string' ? row.target_key : '';
+    const createdAt = typeof row.created_at === 'string' ? row.created_at : '';
+    const updatedAt = typeof row.updated_at === 'string' ? row.updated_at : '';
+    if (!sessionId || !taskId || !targetKey || !createdAt || !updatedAt) return undefined;
+    return {
+      sessionId,
+      taskId,
+      targetKey,
+      status: row.status,
+      exitCode: typeof row.exit_code === 'number' ? row.exit_code : undefined,
+      cwd: typeof row.cwd === 'string' ? row.cwd : undefined,
+      command: typeof row.command === 'string' ? row.command : undefined,
+      args: parseTerminalArgsJson(row.args_json),
+      linuxTerminalTail:
+        row.linux_terminal_tail === 'exec_bash' || row.linux_terminal_tail === 'pause'
+          ? row.linux_terminal_tail
+          : undefined,
+      mode: row.mode,
+      attached: row.attached === 1,
+      outputSnapshot: typeof row.output_snapshot === 'string' ? row.output_snapshot : '',
+      createdAt,
+      updatedAt,
+    };
   }
 
   private rowToAttempt(row: any): Attempt {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -343,6 +343,34 @@ export const SCHEMA_DDL = `
 
       CREATE INDEX IF NOT EXISTS idx_output_spool_task_offset
         ON output_spool(task_id, offset);
+
+      CREATE TABLE IF NOT EXISTS terminal_sessions (
+        session_id TEXT PRIMARY KEY,
+        task_id TEXT NOT NULL,
+        target_key TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('running', 'exited')),
+        exit_code INTEGER,
+        cwd TEXT,
+        command TEXT,
+        args_json TEXT CHECK (args_json IS NULL OR json_valid(args_json)),
+        linux_terminal_tail TEXT CHECK (linux_terminal_tail IS NULL OR linux_terminal_tail IN ('exec_bash', 'pause')),
+        mode TEXT NOT NULL CHECK (mode IN ('spawn', 'attached')),
+        attached INTEGER NOT NULL DEFAULT 0 CHECK (attached IN (0, 1)),
+        output_snapshot TEXT NOT NULL DEFAULT '',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        FOREIGN KEY (task_id) REFERENCES tasks(id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_terminal_sessions_task_updated
+        ON terminal_sessions(task_id, updated_at);
+
+      CREATE INDEX IF NOT EXISTS idx_terminal_sessions_status_updated
+        ON terminal_sessions(status, updated_at);
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_terminal_sessions_running_target
+        ON terminal_sessions(target_key)
+        WHERE status = 'running';
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */


### PR DESCRIPTION
## Summary

Terminal sessions now have their own SQLite table instead of living only in memory.

The adapter can save, return, load, patch, and close those rows safely.

<details>
<summary>Review metadata</summary>

Review Claim: The database can store bounded terminal session state without mixing it into task output stores.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This slice only adds a new table and optional adapter methods; existing task output tables keep their current purpose.

Slice Rationale: Persistence storage lands first so app restore logic has a small typed surface to call.

</details>

## Non-goals

This does not restore Electron sessions or change renderer behavior.

This does not persist full terminal scrollback.

## Architecture

### Before

Terminal tab state lived only in process memory.

```mermaid
graph TD
    A["Embedded terminal manager"] --> B["in-memory session maps"]
```

### After

SQLite owns one bounded row per terminal session.

```mermaid
graph TD
    A["Embedded terminal manager"] --> B["SQLiteAdapter terminal session methods"]
    B --> C["terminal_sessions"]
```

## Test Plan

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No destructive migration; the unused table can remain.
