### PR TITLE
[Local Restart](1) Fix Electron restart tooling

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,6 +16,10 @@ has_bootstrap_artifacts() {
     && [ -x "$REPO_ROOT/packages/app/node_modules/.bin/electron" ]
 }
 
+bootstrap_tools_are_healthy() {
+  "$REPO_ROOT/node_modules/.bin/tsup" --version >/dev/null 2>&1
+}
+
 # An existing install goes stale when the lockfile changes (e.g. a git pull
 # adds a dependency) but node_modules is left untouched. The artifacts check
 # above only proves *some* install exists, so without this check run.sh would
@@ -27,7 +31,7 @@ workspace_install_is_stale() {
 }
 
 ensure_workspace_bootstrapped() {
-  if has_bootstrap_artifacts && ! workspace_install_is_stale && [ "${INVOKER_FORCE_BOOTSTRAP:-0}" != "1" ]; then
+  if has_bootstrap_artifacts && bootstrap_tools_are_healthy && ! workspace_install_is_stale && [ "${INVOKER_FORCE_BOOTSTRAP:-0}" != "1" ]; then
     return 0
   fi
 

--- a/scripts/kill-all-electron.sh
+++ b/scripts/kill-all-electron.sh
@@ -1,20 +1,48 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-pattern='Electron|electron'
+list_electron_processes() {
+  ps -axo pid=,command= | while read -r pid command; do
+    if [ -z "${pid:-}" ] || [ "$pid" = "$$" ] || [ "$pid" = "${PPID:-}" ]; then
+      continue
+    fi
 
-if ! pgrep -af "$pattern" >/dev/null 2>&1; then
+    case "$command" in
+      *kill-all-electron.sh*)
+        continue
+        ;;
+      *Electron.app/Contents/MacOS/Electron*|*"node "*scripts/electron.cjs*)
+        printf '%s %s\n' "$pid" "$command"
+        ;;
+    esac
+  done
+}
+
+kill_electron_processes() {
+  local signal="$1"
+  local processes
+  processes="$(list_electron_processes)"
+  if [ -z "$processes" ]; then
+    return 0
+  fi
+  printf '%s\n' "$processes" | while read -r pid _; do
+    kill "-$signal" "$pid" 2>/dev/null || true
+  done
+}
+
+processes="$(list_electron_processes)"
+if [ -z "$processes" ]; then
   echo "No Electron processes found"
   exit 0
 fi
 
 echo "Electron processes before kill:"
-pgrep -af "$pattern"
+printf '%s\n' "$processes"
 
-pkill -f "$pattern" 2>/dev/null || true
+kill_electron_processes TERM
 
 for _ in $(seq 1 10); do
-  if ! pgrep -af "$pattern" >/dev/null 2>&1; then
+  if [ -z "$(list_electron_processes)" ]; then
     echo "All Electron processes stopped"
     exit 0
   fi
@@ -22,12 +50,13 @@ for _ in $(seq 1 10); do
 done
 
 echo "Forcing SIGKILL on remaining Electron processes..."
-pkill -9 -f "$pattern" 2>/dev/null || true
+kill_electron_processes KILL
 sleep 0.5
 
-if pgrep -af "$pattern" >/dev/null 2>&1; then
+processes="$(list_electron_processes)"
+if [ -n "$processes" ]; then
   echo "Some Electron processes are still running:"
-  pgrep -af "$pattern"
+  printf '%s\n' "$processes"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

The launcher checks package shims before using the existing install.

The Electron kill helper now uses narrow process matching. It no longer treats its own shell process as Electron.

Together, these changes make local restart work again.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the local shell guards that make restart reliable when package shims are bad.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: The change only touches local shell tooling. It does not change runtime behavior after Electron starts.

Slice Rationale: The two edits serve one local developer workflow and were verified together.

</details>

## Non-goals

This does not change autofix behavior, worker settings, task scheduling, or Electron internals.

## Test Plan

- [x] `bash -n scripts/kill-all-electron.sh run.sh`
- [x] `./scripts/kill-all-electron.sh; ./run.sh`
- [x] `./run.sh --headless query queue --output json`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Run `pnpm install --frozen-lockfile` manually if local package shims are bad.
- Data migration? No
