### PR TITLE
[Worker Subscriptions](4) Add Mergify requeue CLI runner

### DIFF
--- a/scripts/mergify_admin_requeue.py
+++ b/scripts/mergify_admin_requeue.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Mapping, Sequence
+
+try:
+    from . import mergify_admin_requeue_exec as exec_impl
+    from .mergify_admin_requeue_model import Action, Blocker, CheckContext, Ledger, MergifyQueueEvent, PrSnapshot, ReviewThread, StackGroup, latest_contexts_by_required_check, load_mergify_rules
+    from .mergify_admin_requeue_plan import classify_pr, plan_stack_actions
+    from .mergify_admin_requeue_snapshot import group_stack_prs, parse_mergify_queue_event, parse_stack_metadata
+except ImportError:
+    import mergify_admin_requeue_exec as exec_impl
+    from mergify_admin_requeue_model import Action, Blocker, CheckContext, Ledger, MergifyQueueEvent, PrSnapshot, ReviewThread, StackGroup, latest_contexts_by_required_check, load_mergify_rules
+    from mergify_admin_requeue_plan import classify_pr, plan_stack_actions
+    from mergify_admin_requeue_snapshot import group_stack_prs, parse_mergify_queue_event, parse_stack_metadata
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+parse_args = exec_impl.parse_args
+run_once = exec_impl.run_once
+subprocess = exec_impl.subprocess
+_repair_conflict = exec_impl.repair_conflict
+_repair_check = exec_impl.repair_check
+_resolve_workflow = exec_impl.resolve_workflow
+
+
+def _execute_action(action: Action, repo: str, gh, ledger: Ledger, pr_by_number: Mapping[int, PrSnapshot], now: int) -> None:
+    pr = pr_by_number[action.pr_number]
+    if action.kind == "requeue":
+        gh.comment(repo, action.pr_number, "@mergifyio queue")
+        ledger.record("requeue", action.pr_number, pr.head_ref_oid, action.key, now)
+    elif action.kind == "add_admin_bypass_label":
+        gh.edit_label(repo, action.pr_number, add="admin-bypass")
+        ledger.record("add_admin_bypass_label", action.pr_number, pr.head_ref_oid, "admin-bypass", now)
+    elif action.kind == "remove_merge_hold":
+        gh.edit_label(repo, action.pr_number, remove="merge-hold")
+        ledger.record("remove-merge-hold", action.pr_number, pr.head_ref_oid, "merge-hold", now)
+    elif action.kind == "resolve_bot_threads":
+        gh.resolve_review_thread(action.key)
+    elif action.kind == "repair_check":
+        check_name = action.key.split(":", 1)[-1]
+        kind = "repair-bot-thread" if action.key.startswith("bot_review_thread:") else "repair-check"
+        ledger.record(kind, action.pr_number, pr.head_ref_oid, check_name, now)
+        _repair_check(repo, pr, check_name)
+    elif action.kind == "rebase_recreate":
+        ledger.record("conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now)
+        try:
+            workflow, _generation = _resolve_workflow(action.pr_number)
+        except RuntimeError as exc:
+            _repair_conflict(repo, pr, str(exc))
+            return
+        subprocess.run(["node", "scripts/headless-ipc.js", "exec", "--", "rebase-recreate", workflow], cwd=str(REPO_ROOT), check=True, text=True, capture_output=True)
+    elif action.kind == "comment_blocked" and action.key == "capped":
+        key = f"capped:{action.detail}"
+        if ledger.count("comment-blocked", action.pr_number, pr.head_ref_oid, key) == 0:
+            gh.comment(repo, action.pr_number, f"Invoker Mergify repair stopped: {action.detail}")
+            ledger.record("comment-blocked", action.pr_number, pr.head_ref_oid, key, now)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    return run_once(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mergify_admin_requeue_exec.py
+++ b/scripts/mergify_admin_requeue_exec.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import replace
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+import time
+try:
+    from .mergify_admin_requeue_model import Action, GH_ACTIONS_JOB_RE, Ledger, MergifyQueueEvent, PrSnapshot, load_mergify_rules
+    from .mergify_admin_requeue_plan import plan_stack_actions
+    from .mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, group_stack_prs, parse_stack_metadata, snapshot_from_detail
+except ImportError:
+    from mergify_admin_requeue_model import Action, GH_ACTIONS_JOB_RE, Ledger, MergifyQueueEvent, PrSnapshot, load_mergify_rules
+    from mergify_admin_requeue_plan import plan_stack_actions
+    from mergify_admin_requeue_snapshot import GhClient, checkout_pr_head, group_stack_prs, parse_stack_metadata, snapshot_from_detail
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def resolve_workflow(pr_number: int) -> tuple[str, str]:
+    try:
+        out = subprocess.run(["./run.sh", "--headless", "query", "review-gate", str(pr_number), "--output", "json"], cwd=str(REPO_ROOT), check=True, text=True, capture_output=True).stdout
+    except subprocess.CalledProcessError as exc:
+        detail = exc.stderr.strip() or exc.stdout.strip() or str(exc)
+        raise RuntimeError(f"cannot resolve local workflow for PR #{pr_number}: {detail}") from exc
+    value = json.loads(out) if out.strip() else {}
+    workflow = str(value.get("workflowId") or "")
+    generation = str(value.get("workflowGeneration") or "0")
+    if not workflow:
+        raise RuntimeError(f"no local workflow for PR #{pr_number}")
+    return workflow, generation
+
+
+def github_job_log(repo: str, details_url: str, pr_number: int, check_name: str) -> str:
+    match = GH_ACTIONS_JOB_RE.search(details_url)
+    if not match:
+        return ""
+    tmp = Path(tempfile.mkdtemp(prefix=f"mergify-admin-requeue-{pr_number}-"))
+    path = tmp / (re.sub(r"[^A-Za-z0-9_.-]+", "-", check_name).strip("-") + ".log")
+    out = subprocess.run(["gh", "run", "view", "--repo", repo, "--job", match.group(1), "--log"], check=True, text=True, capture_output=True).stdout
+    path.write_text(out, encoding="utf-8")
+    return str(path)
+
+
+def mergify_check_urls(event: MergifyQueueEvent | None, check_name: str) -> tuple[str, ...]:
+    if not event:
+        return ()
+    for name, urls in event.failing_check_urls:
+        if name == check_name:
+            return urls
+    return ()
+
+
+def repair_check(repo: str, pr: PrSnapshot, check_name: str) -> None:
+    ctx = pr.checks.get(check_name)
+    mergify_urls = mergify_check_urls(pr.latest_mergify, check_name)
+    details_url = (ctx.details_url if ctx and ctx.details_url else "") or (mergify_urls[0] if mergify_urls else "")
+    log_path = github_job_log(repo, details_url, pr.number, check_name) if details_url else ""
+    work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
+    work_root.parent.mkdir(parents=True, exist_ok=True)
+    checkout_pr_head(repo, pr, work_root)
+    latest = pr.latest_mergify
+    prompt = (
+        f"Fix only the failing check. Add or update a repro if the failure is reproducible. "
+        f"Commit and push to the PR head branch. If local proof shows the check is already green on the current head, make no commit and exit 0.\n\n"
+        f"PR: #{pr.number}\nFailed check: {check_name}\nDetails URL: {details_url}\nJob log path: {log_path}\n"
+        f"Latest Mergify event: {json.dumps(latest.__dict__ if latest else None, sort_keys=True)}\n"
+    )
+    subprocess.run(["omp", "--no-title", "--auto-approve", "-p", prompt], cwd=str(work_root), check=True, text=True)
+
+
+def repair_conflict(repo: str, pr: PrSnapshot, reason: str) -> None:
+    work_root = Path(os.environ.get("HOME", ".")) / ".invoker" / "mergify-admin-requeue-work" / str(pr.number)
+    work_root.parent.mkdir(parents=True, exist_ok=True)
+    checkout_pr_head(repo, pr, work_root)
+    prompt = (
+        f"Resolve only the merge conflict that keeps this PR from merging. "
+        f"Rebase or recreate the PR head branch onto its base branch, keep the PR's intended changes, "
+        f"run the narrow proof for the conflict resolution, then commit and push to the PR head branch. "
+        f"If the PR is already closed or merged, or the head branch no longer exists, make no commit and exit 0.\n\n"
+        f"PR: #{pr.number}\nBase branch: {pr.base_ref_name}\nHead branch: {pr.head_ref_name}\n"
+        f"Head SHA: {pr.head_ref_oid}\nReason: {reason}\n"
+    )
+    subprocess.run(["omp", "--no-title", "--auto-approve", "-p", prompt], cwd=str(work_root), check=True, text=True)
+
+
+def print_action(action: Action, pr: PrSnapshot | None, dry_run: bool, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(action.__dict__, sort_keys=True))
+        return
+    prefix = "DRY-RUN " if dry_run else ""
+    if action.kind == "requeue":
+        head = pr.head_ref_oid if pr else ""
+        print(f"{prefix}requeue PR #{action.pr_number} head={head} reason={action.detail}")
+    elif action.kind == "repair_check":
+        key = action.key.split(":", 1)[-1]
+        print(f"{prefix}repair-check PR #{action.pr_number} check={json.dumps(key)}")
+    elif action.kind == "comment_blocked":
+        print(f"BLOCK PR #{action.pr_number} {action.detail}")
+    elif action.kind == "add_admin_bypass_label":
+        print(f"{prefix}add-admin-bypass-label PR #{action.pr_number}")
+    elif action.kind == "remove_merge_hold":
+        print(f"{prefix}remove-merge-hold PR #{action.pr_number}")
+    elif action.kind == "resolve_bot_threads":
+        print(f"{prefix}resolve-bot-threads PR #{action.pr_number} thread={action.key}")
+    elif action.kind == "rebase_recreate":
+        print(f"{prefix}rebase-recreate PR #{action.pr_number} {action.detail}")
+
+
+def execute_action(action: Action, repo: str, gh: GhClient, ledger: Ledger, pr_by_number: Mapping[int, PrSnapshot], now: int) -> None:
+    pr = pr_by_number[action.pr_number]
+    if action.kind == "requeue":
+        gh.comment(repo, action.pr_number, "@mergifyio queue")
+        ledger.record("requeue", action.pr_number, pr.head_ref_oid, action.key, now)
+    elif action.kind == "add_admin_bypass_label":
+        gh.edit_label(repo, action.pr_number, add="admin-bypass")
+        ledger.record("add_admin_bypass_label", action.pr_number, pr.head_ref_oid, "admin-bypass", now)
+    elif action.kind == "remove_merge_hold":
+        gh.edit_label(repo, action.pr_number, remove="merge-hold")
+        ledger.record("remove-merge-hold", action.pr_number, pr.head_ref_oid, "merge-hold", now)
+    elif action.kind == "resolve_bot_threads":
+        gh.resolve_review_thread(action.key)
+    elif action.kind == "repair_check":
+        check_name = action.key.split(":", 1)[-1]
+        kind = "repair-bot-thread" if action.key.startswith("bot_review_thread:") else "repair-check"
+        ledger.record(kind, action.pr_number, pr.head_ref_oid, check_name, now)
+        repair_check(repo, pr, check_name)
+    elif action.kind == "rebase_recreate":
+        ledger.record("conflict-repair", action.pr_number, pr.head_ref_oid, action.key, now)
+        try:
+            workflow, _generation = resolve_workflow(action.pr_number)
+        except RuntimeError as exc:
+            repair_conflict(repo, pr, str(exc))
+            return
+        subprocess.run(["node", "scripts/headless-ipc.js", "exec", "--", "rebase-recreate", workflow], cwd=str(REPO_ROOT), check=True, text=True, capture_output=True)
+    elif action.kind == "comment_blocked" and action.key == "capped":
+        key = f"capped:{action.detail}"
+        if ledger.count("comment-blocked", action.pr_number, pr.head_ref_oid, key) == 0:
+            gh.comment(repo, action.pr_number, f"Invoker Mergify repair stopped: {action.detail}")
+            ledger.record("comment-blocked", action.pr_number, pr.head_ref_oid, key, now)
+
+
+def run_once(args: argparse.Namespace) -> int:
+    rule_path = REPO_ROOT / ".mergify.yml"
+    try:
+        trunk, _labels, required_checks = load_mergify_rules(rule_path)
+    except ValueError:
+        print("ERROR: failed to load admin-bypass Mergify rule", file=sys.stderr)
+        return 2
+
+    gh = GhClient()
+    raw_prs = gh.list_candidate_prs(args.repo, args.author, args.pr)
+    details: list[tuple[Mapping[str, object], list[dict]]] = []
+    for raw in raw_prs:
+        number = int(raw.get("number") or 0)
+        detail = raw if "reviewThreads" in raw else gh.pr_detail(args.repo, number)
+        comments = gh.issue_comments(args.repo, number)
+        details.append((detail, comments))
+
+    snapshots = [snapshot_from_detail(detail, comments, required_checks) for detail, comments in details]
+    if args.pr:
+        manual = set(args.pr)
+        snapshots = [
+            replace(
+                item,
+                latest_mergify=MergifyQueueEvent(
+                    "manual",
+                    "dequeued",
+                    "manual",
+                    "",
+                    item.head_ref_oid,
+                    (),
+                    (),
+                    "",
+                ),
+            ) if (
+                item.number in manual
+                and not ((item.latest_mergify and item.latest_mergify.state == "dequeued") or "dequeued" in item.labels)
+            ) else item
+            for item in snapshots
+        ]
+    metadata: dict[int, tuple[str, tuple[int, ...]]] = {}
+    for detail, comments in details:
+        number = int(detail.get("number") or 0)
+        meta = parse_stack_metadata(comments)
+        if meta:
+            for pr_num in meta[1]:
+                metadata[pr_num] = meta
+            if number not in metadata:
+                metadata[number] = meta
+    stacks = group_stack_prs(snapshots, metadata, trunk)
+    ledger = Ledger(Path(args.state_file).expanduser())
+    now = int(time.time())
+    pr_by_number = {pr.number: pr for pr in snapshots}
+    for stack in stacks:
+        for action in plan_stack_actions(stack, required_checks, ledger, now):
+            pr = pr_by_number.get(action.pr_number)
+            print_action(action, pr, args.dry_run, args.json)
+            if not args.dry_run:
+                execute_action(action, args.repo, gh, ledger, pr_by_number, now)
+                if action.kind not in {"comment_blocked"}:
+                    return 0
+    return 0
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Repair and requeue eligible admin-bypass PRs after Mergify dequeue events.")
+    parser.add_argument("--once", action="store_true", help="Run one scan/action cycle and exit. Cron uses this.")
+    parser.add_argument("--dry-run", action="store_true", help="Print planned actions; perform no GitHub/Invoker mutations.")
+    parser.add_argument("--repo", default="Neko-Catpital-Labs/Invoker", help="Default: Neko-Catpital-Labs/Invoker.")
+    parser.add_argument("--author", default="EdbertChan", help="Default: EdbertChan.")
+    parser.add_argument("--state-file", default=str(Path.home() / ".invoker" / "mergify-admin-requeue-state.jsonl"), help="Ledger JSONL path.")
+    parser.add_argument("--pr", type=int, action="append", default=[], help="Limit to a PR; repeatable.")
+    parser.add_argument("--max-requeue-attempts", type=int, default=2, help="Default: 2 per PR/head/dequeue event.")
+    parser.add_argument("--max-repair-attempts", type=int, default=3, help="Default: 3 per PR/head/blocker.")
+    parser.add_argument("--json", action="store_true", help="Emit one JSON object per decision/action.")
+    return parser.parse_args(argv)

--- a/scripts/mergify_admin_requeue_model.py
+++ b/scripts/mergify_admin_requeue_model.py
@@ -1,0 +1,378 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from pathlib import Path
+import re
+import time
+from typing import Collection, Mapping
+
+
+SELF_CHECK_NAMES = {"Mergify Merge Queue", "Summary"}
+BOT_OR_SELF_AUTHORS = {"coderabbitai", "coderabbitai[bot]", "EdbertChan"}
+STACK_MARKER_RE = re.compile(r"<!--\s*mergify-stack-data:\s*(\{.*?\})\s*-->", re.DOTALL)
+SHA_RE = re.compile(r"`([0-9a-fA-F]{40})`")
+GH_ACTIONS_JOB_RE = re.compile(r"/actions/runs/\d+/job/(\d+)")
+
+
+@dataclass(frozen=True)
+class CheckContext:
+    name: str
+    state: str
+    details_url: str
+    head_sha: str
+    completed_at: str
+
+
+@dataclass(frozen=True)
+class ReviewThread:
+    id: str
+    is_resolved: bool
+    author_logins: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class MergifyQueueEvent:
+    comment_id: str
+    state: str
+    queue_rule_name: str
+    queued_at: str
+    head_sha: str
+    waiting_for: tuple[str, ...]
+    failing_checks: tuple[str, ...]
+    comment_url: str
+    queue_pr_number: int = 0
+    failing_check_urls: tuple[tuple[str, tuple[str, ...]], ...] = ()
+    condition_states: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class PrSnapshot:
+    number: int
+    title: str
+    url: str
+    state: str
+    is_draft: bool
+    base_ref_name: str
+    head_ref_name: str
+    head_ref_oid: str
+    merge_state_status: str
+    mergeable: str
+    labels: frozenset[str]
+    checks: Mapping[str, CheckContext]
+    review_threads: tuple[ReviewThread, ...]
+    latest_mergify: MergifyQueueEvent | None
+
+
+@dataclass(frozen=True)
+class StackGroup:
+    stack_id: str
+    prs: tuple[PrSnapshot, ...]
+
+
+@dataclass(frozen=True)
+class Blocker:
+    key: str
+    kind: str
+    pr_number: int
+    detail: str
+
+
+@dataclass(frozen=True)
+class Action:
+    kind: str
+    pr_number: int
+    key: str
+    detail: str
+
+
+class Ledger:
+    def __init__(self, path: Path):
+        self.path = path
+        self.rows: list[dict[str, object]] = []
+        if path.exists():
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if not line.strip():
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict):
+                    self.rows.append(row)
+
+    def count(self, kind: str, pr: int, head_sha: str, key: str) -> int:
+        return sum(
+            1 for row in self.rows
+            if row.get("kind") == kind
+            and int(row.get("pr", -1)) == pr
+            and row.get("headSha") == head_sha
+            and row.get("key") == key
+        )
+
+    def has_different_head(self, kind: str, pr: int, current_head: str, key: str) -> bool:
+        for row in self.rows:
+            if row.get("kind") != kind:
+                continue
+            if int(row.get("pr", -1)) != pr:
+                continue
+            if row.get("key") != key:
+                continue
+            if row.get("headSha") and row.get("headSha") != current_head:
+                return True
+        return False
+
+    def record(self, kind: str, pr: int, head_sha: str, key: str, epoch: int | None = None) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        row = {"kind": kind, "pr": pr, "headSha": head_sha, "key": key, "epoch": epoch if epoch is not None else int(time.time())}
+        with self.path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(row, sort_keys=True) + "\n")
+        self.rows.append(row)
+
+
+def load_mergify_rules(path: Path) -> tuple[str, frozenset[str], frozenset[str]]:
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        raise ValueError("failed to load admin-bypass Mergify rule")
+
+    start = -1
+    start_indent = 0
+    for i, line in enumerate(lines):
+        match = re.match(r"^(\s*)-\s+name:\s*admin-bypass\s*$", line)
+        if match:
+            start = i
+            start_indent = len(match.group(1))
+            break
+    if start < 0:
+        raise ValueError("failed to load admin-bypass Mergify rule")
+
+    block: list[str] = []
+    for line in lines[start + 1:]:
+        match = re.match(r"^(\s*)-\s+name:\s+", line)
+        if match and len(match.group(1)) <= start_indent:
+            break
+        block.append(line)
+
+    trunk = ""
+    labels: set[str] = set()
+    required: set[str] = set()
+    in_merge = False
+    for raw in block:
+        stripped = raw.strip()
+        if re.match(r"^[A-Za-z_].*:$", stripped):
+            in_merge = stripped == "merge_conditions:"
+        if stripped.startswith("- base="):
+            trunk = stripped.split("=", 1)[1].strip()
+        elif stripped.startswith("- label="):
+            labels.add(stripped.split("=", 1)[1].strip())
+        elif in_merge and stripped.startswith("- check-success = "):
+            required.add(stripped.split("=", 1)[1].strip())
+
+    if not trunk or not labels or not required:
+        raise ValueError("failed to load admin-bypass Mergify rule")
+    return trunk, frozenset(labels), frozenset(required)
+
+
+def latest_contexts_by_required_check(raw_contexts: list[Mapping[str, object]], head_sha: str, required_checks: Collection[str]) -> dict[str, CheckContext]:
+    required = set(required_checks)
+    latest: dict[str, CheckContext] = {}
+    for node in raw_contexts:
+        name, state, url, sha, completed = norm_check_state(node)
+        if not name or name in SELF_CHECK_NAMES or name.startswith("Rule: "):
+            continue
+        if sha and sha != head_sha:
+            continue
+        if name not in required:
+            continue
+        ctx = CheckContext(name=name, state=state, details_url=url, head_sha=sha or head_sha, completed_at=completed)
+        old = latest.get(name)
+        if old is None or (old.completed_at, old.state) <= (ctx.completed_at, ctx.state):
+            latest[name] = ctx
+    return latest
+
+
+def extract_first_json_object(text: str) -> Mapping[str, object] | None:
+    start = text.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    in_str = False
+    esc = False
+    for i in range(start, len(text)):
+        ch = text[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == "\\":
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    value = json.loads(text[start:i + 1])
+                except json.JSONDecodeError:
+                    return None
+                return value if isinstance(value, Mapping) else None
+    return None
+
+
+def payload_state(payload: Mapping[str, object], body: str) -> str:
+    for key in ("state", "queue_state", "event", "action"):
+        value = str(payload.get(key) or "").lower()
+        if "dequeue" in value or value == "left":
+            return "dequeued"
+        if "queue" in value:
+            return "queued"
+    low = body.lower()
+    if "left the queue" in low or "dequeued" in low:
+        return "dequeued"
+    if "queued" in low or "entered the queue" in low:
+        return "queued"
+    return "unknown"
+
+
+def payload_rule(payload: Mapping[str, object], body: str) -> str:
+    candidates = ["queue_rule_name", "queue_rule", "rule", "queue"]
+    for key in candidates:
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+        if isinstance(value, Mapping):
+            nested = value.get("name")
+            if nested:
+                return str(nested)
+    match = re.search(r"queue rule [`']?([^`'\n]+)[`']?", body, re.I)
+    return match.group(1).strip() if match else ""
+
+
+def clean_markdown(text: str) -> str:
+    clean = re.sub(r"<[^>]+>", "", text)
+    clean = re.sub(r"[*_]", "", clean)
+    return clean.strip()
+
+
+def section_lines(body: str, heading: str) -> tuple[str, ...]:
+    lines = body.splitlines()
+    out: list[str] = []
+    in_section = False
+    known_headings = {"waiting for", "failing checks", "all conditions", "reason", "hint", "merge queue status"}
+    for line in lines:
+        clean = clean_markdown(line)
+        heading_text = re.sub(r"^#+\s*", "", clean).strip("` :")
+        heading_lower = heading_text.lower()
+        if heading_lower == heading.lower():
+            in_section = True
+            continue
+        if in_section and (clean.startswith("#") or (heading_lower in known_headings and heading_lower != heading.lower())):
+            break
+        if in_section and clean:
+            out.append(clean)
+    return tuple(out)
+
+
+def normalize_check_item(item: str) -> str:
+    link = re.search(r"\[([^\]]+)\]\([^)]+\)", item)
+    if link:
+        item = link.group(1)
+    item = re.sub(r"^[-*]\s*", "", item)
+    item = re.sub(r"^\[[ xX]\]\s*", "", item)
+    item = re.sub(r"^[^\w`]+", "", item)
+    item = item.strip("` ")
+    if item.startswith("check-success = "):
+        item = item.split(" = ", 1)[1].strip()
+    return item
+
+
+def section_items(body: str, heading: str) -> tuple[str, ...]:
+    out: list[str] = []
+    for line in section_lines(body, heading):
+        item = normalize_check_item(line)
+        if item:
+            out.append(item)
+    return tuple(out)
+
+
+def all_condition_states(body: str) -> tuple[tuple[str, str], ...]:
+    out: list[tuple[str, str]] = []
+    for line in section_lines(body, "All conditions"):
+        if "check-success = " not in line:
+            continue
+        state = "success" if re.search(r"\[[xX]\]", line) else "failure"
+        item = normalize_check_item(line)
+        if item:
+            out.append((item, state))
+    return tuple(out)
+
+
+def failing_check_urls(body: str) -> tuple[tuple[str, tuple[str, ...]], ...]:
+    pairs: list[tuple[str, tuple[str, ...]]] = []
+    for line in section_lines(body, "Failing checks"):
+        name = normalize_check_item(line)
+        urls = tuple(re.findall(r"https://github\.com/[^)\s]+/actions/runs/\d+/job/\d+", line))
+        if name:
+            pairs.append((name, urls))
+    return tuple(pairs)
+
+
+def reason_failed_checks(body: str) -> tuple[str, ...]:
+    reason = section_lines(body, "Reason")
+    if not reason or not any("failing checks" in line.lower() for line in reason):
+        return ()
+    out: list[str] = []
+    for line in reason:
+        if not line.startswith("-"):
+            continue
+        item = normalize_check_item(line)
+        if item:
+            out.append(item)
+    return tuple(out)
+
+
+def norm_check_state(node: Mapping[str, object]) -> tuple[str, str, str, str, str]:
+    typename = str(node.get("__typename") or "")
+    if typename == "StatusContext" or "context" in node:
+        name = str(node.get("context") or "")
+        raw = str(node.get("state") or "").lower()
+        state = {
+            "success": "success",
+            "failure": "failure",
+            "error": "failure",
+            "pending": "pending",
+            "expected": "pending",
+        }.get(raw, "unknown")
+        url = str(node.get("targetUrl") or "")
+        commit = node.get("commit") if isinstance(node.get("commit"), Mapping) else {}
+        sha = str(commit.get("oid") or "")
+        return name, state, url, sha, ""
+
+    name = str(node.get("name") or "")
+    conclusion = str(node.get("conclusion") or "").upper()
+    status = str(node.get("status") or "").upper()
+    if conclusion in {"SUCCESS"}:
+        state = "success"
+    elif conclusion in {"FAILURE", "ACTION_REQUIRED", "TIMED_OUT", "CANCELLED", "STARTUP_FAILURE"}:
+        state = "failure"
+    elif conclusion == "SKIPPED":
+        state = "skipped"
+    elif conclusion == "NEUTRAL":
+        state = "neutral"
+    elif status and status != "COMPLETED":
+        state = "pending"
+    elif conclusion:
+        state = "unknown"
+    else:
+        state = "pending" if status else "unknown"
+    url = str(node.get("detailsUrl") or "")
+    suite = node.get("checkSuite") if isinstance(node.get("checkSuite"), Mapping) else {}
+    commit = suite.get("commit") if isinstance(suite.get("commit"), Mapping) else {}
+    sha = str(commit.get("oid") or "")
+    completed = str(node.get("completedAt") or node.get("startedAt") or "")
+    return name, state, url, sha, completed

--- a/scripts/mergify_admin_requeue_plan.py
+++ b/scripts/mergify_admin_requeue_plan.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from typing import Collection
+
+try:
+    from .mergify_admin_requeue_model import Action, BOT_OR_SELF_AUTHORS, Blocker, Ledger, MergifyQueueEvent, PrSnapshot, StackGroup
+except ImportError:
+    from mergify_admin_requeue_model import Action, BOT_OR_SELF_AUTHORS, Blocker, Ledger, MergifyQueueEvent, PrSnapshot, StackGroup
+
+
+TRUNK = "master"
+
+
+def classify_pr(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
+    blockers: list[Blocker] = []
+    if pr.state != "OPEN":
+        blockers.append(Blocker("closed", "closed", pr.number, f"state={pr.state}"))
+        return tuple(blockers)
+    if pr.is_draft:
+        blockers.append(Blocker("draft", "draft", pr.number, "PR is draft"))
+        return tuple(blockers)
+    if pr.base_ref_name != trunk:
+        blockers.append(Blocker("not_current_bottom", "not_current_bottom", pr.number, f"base={pr.base_ref_name}"))
+    if "merge-hold" in pr.labels:
+        blockers.append(Blocker("merge-hold", "merge_hold", pr.number, "merge-hold label present"))
+
+    for thread in pr.review_threads:
+        if thread.is_resolved:
+            continue
+        authors = set(thread.author_logins)
+        if not authors or authors - BOT_OR_SELF_AUTHORS:
+            blockers.append(Blocker(thread.id, "human_review_thread", pr.number, f"unresolved human review thread {thread.id}"))
+        else:
+            blockers.append(Blocker(thread.id, "bot_review_thread", pr.number, f"unresolved bot review thread {thread.id}"))
+
+    if pr.merge_state_status == "DIRTY" or pr.mergeable == "CONFLICTING":
+        blockers.append(Blocker("conflict", "conflict", pr.number, "GitHub reports merge conflict"))
+
+    for name in sorted(required_checks):
+        ctx = pr.checks.get(name)
+        if ctx is None:
+            if pr.base_ref_name == trunk:
+                blockers.append(Blocker(name, "missing_check", pr.number, f"missing required check {name}"))
+            continue
+        if ctx.state == "success":
+            continue
+        if ctx.state == "failure":
+            blockers.append(Blocker(name, "failed_check", pr.number, f"required check failed: {name}"))
+        elif ctx.state in {"pending", "unknown"}:
+            blockers.append(Blocker(name, "pending_check", pr.number, f"required check not green: {name}={ctx.state}"))
+    return tuple(blockers)
+
+
+def public_blocker_kind(kind: str) -> str:
+    return kind.replace("_", "-")
+
+
+def cap_action(pr: PrSnapshot, blocker: Blocker, detail: str) -> Action:
+    return Action("comment_blocked", pr.number, "capped", f"{detail}. The retry cap was reached for current head {pr.head_ref_oid}.")
+
+
+def mergify_condition_map(event: MergifyQueueEvent | None) -> dict[str, str]:
+    return dict(event.condition_states) if event else {}
+
+
+def effective_blockers(pr: PrSnapshot, required_checks: Collection[str], trunk: str) -> tuple[Blocker, ...]:
+    blockers = [b for b in classify_pr(pr, required_checks, trunk) if b.kind != "not_current_bottom"]
+    latest = pr.latest_mergify
+    if not latest or latest.head_sha != pr.head_ref_oid:
+        return tuple(blockers)
+    conditions = mergify_condition_map(latest)
+    return tuple(
+        blocker for blocker in blockers
+        if not (blocker.kind == "missing_check" and conditions.get(blocker.key) == "success")
+    )
+
+
+def mergify_failed_check_actions(pr: PrSnapshot, ledger: Ledger) -> tuple[Action, ...]:
+    latest = pr.latest_mergify
+    if not latest or latest.state != "dequeued" or latest.head_sha != pr.head_ref_oid:
+        return ()
+    for name in latest.failing_checks:
+        if ledger.count("repair-check", pr.number, pr.head_ref_oid, name) >= 3:
+            return (cap_action(pr, Blocker(name, "failed_check", pr.number, f"Mergify queue check failed: {name}"), f"Mergify queue check failed: {name}"),)
+        return (Action("repair_check", pr.number, name, f"Mergify queue check failed: {name}"),)
+    return ()
+
+
+def plan_stack_actions(stack: StackGroup, required_checks: Collection[str], ledger: Ledger, now_epoch: int) -> tuple[Action, ...]:
+    del now_epoch
+    blockers_by_pr = {pr.number: effective_blockers(pr, required_checks, TRUNK) for pr in stack.prs}
+    all_blockers = [b for blockers in blockers_by_pr.values() for b in blockers]
+
+    for pr in stack.prs:
+        actions = mergify_failed_check_actions(pr, ledger)
+        if actions:
+            return actions
+
+    for pr in stack.prs:
+        for blocker in blockers_by_pr[pr.number]:
+            if blocker.kind == "conflict":
+                key = f"conflict:{pr.number}"
+                if ledger.count("conflict-repair", pr.number, pr.head_ref_oid, key) >= 3:
+                    return (cap_action(pr, blocker, blocker.detail),)
+                return (Action("rebase_recreate", pr.number, key, blocker.detail),)
+            if blocker.kind == "failed_check":
+                if ledger.count("repair-check", pr.number, pr.head_ref_oid, blocker.key) >= 3:
+                    return (cap_action(pr, blocker, blocker.detail),)
+                return (Action("repair_check", pr.number, blocker.key, blocker.detail),)
+
+    for pr in stack.prs:
+        for blocker in blockers_by_pr[pr.number]:
+            if blocker.kind == "bot_review_thread":
+                if ledger.has_different_head("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key):
+                    return (Action("resolve_bot_threads", pr.number, blocker.key, blocker.detail),)
+                if ledger.count("repair-bot-thread", pr.number, pr.head_ref_oid, blocker.key) >= 3:
+                    return (cap_action(pr, blocker, blocker.detail),)
+                return (Action("repair_check", pr.number, "bot_review_thread:" + blocker.key, blocker.detail),)
+
+    for pr in stack.prs:
+        for blocker in blockers_by_pr[pr.number]:
+            if blocker.kind == "pending_check":
+                return ()
+            if blocker.kind in {"draft", "human_review_thread", "missing_check", "closed"}:
+                return (Action("comment_blocked", pr.number, blocker.key, public_blocker_kind(blocker.kind)),)
+
+    current_bottoms = [pr for pr in stack.prs if pr.state == "OPEN" and pr.base_ref_name == TRUNK]
+    if not current_bottoms:
+        first = stack.prs[0]
+        return (Action("comment_blocked", first.number, "no-current-bottom", "no current bottom on master"),)
+    bottom = current_bottoms[0]
+
+    non_hold_blockers = [b for b in all_blockers if b.kind != "merge_hold"]
+    hold_blockers = [b for b in all_blockers if b.kind == "merge_hold"]
+    if hold_blockers and not non_hold_blockers:
+        blocker = hold_blockers[0]
+        pr = next(p for p in stack.prs if p.number == blocker.pr_number)
+        if ledger.count("remove-merge-hold", pr.number, pr.head_ref_oid, "merge-hold") >= 1:
+            return (cap_action(pr, blocker, blocker.detail),)
+        return (Action("remove_merge_hold", pr.number, "merge-hold", blocker.detail),)
+    if hold_blockers:
+        return ()
+
+    if "admin-bypass" not in bottom.labels:
+        if ledger.count("add_admin_bypass_label", bottom.number, bottom.head_ref_oid, "admin-bypass") >= 1:
+            return (cap_action(bottom, Blocker("admin-bypass", "capped", bottom.number, "admin-bypass label add"), "admin-bypass label add"),)
+        return (Action("add_admin_bypass_label", bottom.number, "admin-bypass", "missing admin-bypass label"),)
+
+    latest = bottom.latest_mergify
+    requeue_reason = ""
+    requeue_key = "manual"
+    if latest and latest.state == "dequeued":
+        requeue_reason = "eligible-after-dequeue"
+        requeue_key = latest.comment_id or "manual"
+    elif "dequeued" in bottom.labels:
+        requeue_reason = "eligible-after-dequeued-label"
+    if not requeue_reason:
+        return ()
+    if ledger.count("requeue", bottom.number, bottom.head_ref_oid, requeue_key) >= 2:
+        return (cap_action(bottom, Blocker(requeue_key, "capped", bottom.number, "requeue"), "requeue"),)
+    return (Action("requeue", bottom.number, requeue_key, requeue_reason),)

--- a/scripts/mergify_admin_requeue_snapshot.py
+++ b/scripts/mergify_admin_requeue_snapshot.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Mapping, Sequence
+
+try:
+    from .mergify_admin_requeue_model import (
+        MergifyQueueEvent,
+        PrSnapshot,
+        ReviewThread,
+        STACK_MARKER_RE,
+        StackGroup,
+        all_condition_states,
+        extract_first_json_object,
+        failing_check_urls,
+        latest_contexts_by_required_check,
+        payload_rule,
+        payload_state,
+        reason_failed_checks,
+        section_items,
+    )
+except ImportError:
+    from mergify_admin_requeue_model import (
+        MergifyQueueEvent,
+        PrSnapshot,
+        ReviewThread,
+        STACK_MARKER_RE,
+        StackGroup,
+        all_condition_states,
+        extract_first_json_object,
+        failing_check_urls,
+        latest_contexts_by_required_check,
+        payload_rule,
+        payload_state,
+        reason_failed_checks,
+        section_items,
+    )
+
+
+class GhClient:
+    def _run_json(self, args: Sequence[str]) -> object:
+        out = self._run(args)
+        return json.loads(out) if out.strip() else None
+
+    def _run(self, args: Sequence[str]) -> str:
+        return run_logged(args)
+
+    def list_candidate_prs(self, repo: str, author: str, pr_numbers: Sequence[int]) -> list[dict]:
+        if pr_numbers:
+            return [self.pr_detail(repo, number) for number in pr_numbers]
+        args = [
+            "gh", "pr", "list", "--repo", repo, "--author", author, "--state", "open",
+            "--label", "admin-bypass", "--limit", "200", "--json",
+            "number,title,url,headRefName,headRefOid,baseRefName,state,isDraft,labels,mergeStateStatus,mergeable,reviewDecision,statusCheckRollup",
+        ]
+        value = self._run_json(args)
+        return value if isinstance(value, list) else []
+
+    def pr_detail(self, repo: str, number: int) -> dict:
+        owner, name = repo.split("/", 1)
+        query = (
+            "query($owner:String!, $name:String!, $number:Int!) { repository(owner:$owner, name:$name) { "
+            "pullRequest(number:$number) { number title url isDraft state baseRefName headRefName headRefOid "
+            "mergeStateStatus mergeable labels(first:50) { nodes { name } } "
+            "reviewThreads(first:100) { pageInfo { hasNextPage } nodes { id isResolved comments(first:50) { nodes { author { login } body url } } } } "
+            "statusCheckRollup { contexts(first:100) { nodes { __typename ... on CheckRun { name conclusion status completedAt startedAt detailsUrl checkSuite { commit { oid } } } "
+            "... on StatusContext { context state targetUrl commit { oid } } } } } } } }"
+        )
+        value = self._run_json([
+            "gh", "api", "graphql", "-f", f"owner={owner}", "-f", f"name={name}", "-F", f"number={number}", "-f", f"query={query}",
+        ])
+        if not isinstance(value, dict):
+            raise RuntimeError("empty GraphQL response")
+        pr = value.get("data", {}).get("repository", {}).get("pullRequest")
+        if not isinstance(pr, dict):
+            raise RuntimeError(f"missing PR #{number}")
+        return pr
+
+    def issue_comments(self, repo: str, number: int) -> list[dict]:
+        value = self._run_json(["gh", "api", f"repos/{repo}/issues/{number}/comments", "--paginate"])
+        return value if isinstance(value, list) else []
+
+    def comment(self, repo: str, number: int, body: str) -> None:
+        subprocess.run(["gh", "pr", "comment", str(number), "--repo", repo, "--body", body], check=True, text=True, capture_output=True)
+
+    def edit_label(self, repo: str, number: int, add: str | None = None, remove: str | None = None) -> None:
+        args = ["gh", "pr", "edit", str(number), "--repo", repo]
+        if add:
+            args.extend(["--add-label", add])
+        if remove:
+            args.extend(["--remove-label", remove])
+        subprocess.run(args, check=True, text=True, capture_output=True)
+
+    def resolve_review_thread(self, thread_id: str) -> None:
+        query = "mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { id isResolved } } }"
+        subprocess.run(["gh", "api", "graphql", "-f", f"threadId={thread_id}", "-f", f"query={query}"], check=True, text=True, capture_output=True)
+
+
+def run_logged(args: Sequence[str], *, cwd: Path | str | None = None, capture: bool = True) -> str:
+    try:
+        completed = subprocess.run(
+            list(args),
+            cwd=str(cwd) if cwd is not None else None,
+            check=True,
+            text=True,
+            capture_output=capture,
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"ERROR: command failed: {' '.join(str(part) for part in args)}", file=sys.stderr)
+        if exc.stdout:
+            print(exc.stdout, file=sys.stderr, end="" if exc.stdout.endswith("\n") else "\n")
+        if exc.stderr:
+            print(exc.stderr, file=sys.stderr, end="" if exc.stderr.endswith("\n") else "\n")
+        raise
+    return completed.stdout or ""
+
+
+def checkout_pr_head(repo: str, pr: PrSnapshot, work_root: Path) -> None:
+    if not work_root.exists():
+        run_logged(["gh", "repo", "clone", repo, str(work_root)])
+    refspec = f"+refs/heads/{pr.head_ref_name}:refs/remotes/origin/{pr.head_ref_name}"
+    remote_ref = f"refs/remotes/origin/{pr.head_ref_name}"
+    run_logged(["git", "fetch", "origin", refspec], cwd=work_root)
+    run_logged(["git", "checkout", "-B", pr.head_ref_name, remote_ref], cwd=work_root)
+    run_logged(["git", "reset", "--hard", remote_ref], cwd=work_root)
+    run_logged(["git", "clean", "-fd"], cwd=work_root)
+
+
+def parse_mergify_queue_event(comment: Mapping[str, object]) -> MergifyQueueEvent | None:
+    author = comment.get("user") if isinstance(comment.get("user"), Mapping) else comment.get("author")
+    login = ""
+    if isinstance(author, Mapping):
+        login = str(author.get("login") or "")
+    elif isinstance(author, str):
+        login = author
+    if login not in {"mergify[bot]", "mergify"}:
+        return None
+    body = str(comment.get("body") or "")
+    if "-*- Mergify Payload -*-" not in body:
+        return None
+    payload = extract_first_json_object(body[body.find("-*- Mergify Payload -*-"):]) or {}
+    sha_match = re.search(r"Left the queue.*?`([0-9a-fA-F]{40})`", body, re.I | re.S)
+    head_sha = sha_match.group(1) if sha_match else ""
+    queue_pr_match = re.search(r"on draft #(\d+)", body, re.I)
+    queue_pr_number = int(queue_pr_match.group(1)) if queue_pr_match else 0
+    failing_checks = section_items(body, "Failing checks")
+    return MergifyQueueEvent(
+        comment_id=str(comment.get("id") or comment.get("databaseId") or ""),
+        state=payload_state(payload, body),
+        queue_rule_name=payload_rule(payload, body),
+        queued_at=str(comment.get("updated_at") or comment.get("created_at") or ""),
+        head_sha=head_sha,
+        waiting_for=section_items(body, "Waiting for"),
+        failing_checks=failing_checks or reason_failed_checks(body),
+        comment_url=str(comment.get("html_url") or comment.get("url") or ""),
+        queue_pr_number=queue_pr_number,
+        failing_check_urls=failing_check_urls(body),
+        condition_states=all_condition_states(body),
+    )
+
+
+def parse_stack_metadata(comments: Sequence[Mapping[str, object]]) -> tuple[str, tuple[int, ...]] | None:
+    ordered = sorted(comments, key=lambda c: str(c.get("updated_at") or c.get("created_at") or ""), reverse=True)
+    for comment in ordered:
+        body = str(comment.get("body") or "")
+        match = STACK_MARKER_RE.search(body)
+        if not match:
+            continue
+        try:
+            payload = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        stack_id = str(payload.get("stack_id") or payload.get("stackId") or payload.get("id") or "")
+        numbers = payload.get("pull_numbers_bottom_to_top") or payload.get("pullNumbersBottomToTop") or payload.get("prs") or payload.get("pulls")
+        if stack_id and isinstance(numbers, Sequence) and not isinstance(numbers, (str, bytes)):
+            try:
+                return stack_id, tuple(int(n) for n in numbers)
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def group_stack_prs(prs: Sequence[PrSnapshot], stack_metadata: Mapping[int, tuple[str, tuple[int, ...]]], trunk: str) -> tuple[StackGroup, ...]:
+    by_number = {pr.number: pr for pr in prs}
+    used: set[int] = set()
+    groups: list[StackGroup] = []
+    seen_meta: set[tuple[str, tuple[int, ...]]] = set()
+    for pr in prs:
+        meta = stack_metadata.get(pr.number)
+        if not meta or meta in seen_meta:
+            continue
+        seen_meta.add(meta)
+        stack_id, numbers = meta
+        present = tuple(by_number[n] for n in numbers if n in by_number)
+        for item in present:
+            used.add(item.number)
+        if present:
+            groups.append(StackGroup(stack_id=stack_id, prs=present))
+
+    remaining = [pr for pr in prs if pr.number not in used]
+    by_head = {pr.head_ref_name: pr for pr in remaining if pr.state == "OPEN" and pr.head_ref_name}
+    children_by_base: dict[str, list[PrSnapshot]] = {}
+    for pr in remaining:
+        children_by_base.setdefault(pr.base_ref_name, []).append(pr)
+
+    roots = [pr for pr in remaining if pr.base_ref_name == trunk or pr.base_ref_name not in by_head]
+    for root in sorted(roots, key=lambda p: p.number):
+        if root.number in used:
+            continue
+        stack = [root]
+        used.add(root.number)
+        top = root
+        while True:
+            children = [child for child in children_by_base.get(top.head_ref_name, []) if child.number not in used]
+            if len(children) != 1:
+                break
+            child = children[0]
+            stack.append(child)
+            used.add(child.number)
+            top = child
+        groups.append(StackGroup(stack_id="branch:" + str(stack[0].number), prs=tuple(stack)))
+
+    for pr in remaining:
+        if pr.number not in used:
+            groups.append(StackGroup(stack_id="single:" + str(pr.number), prs=(pr,)))
+    return tuple(groups)
+
+
+def labels_from_nodes(value: object) -> frozenset[str]:
+    if isinstance(value, Mapping):
+        nodes = value.get("nodes")
+    else:
+        nodes = value
+    labels: set[str] = set()
+    if isinstance(nodes, Sequence) and not isinstance(nodes, (str, bytes)):
+        for item in nodes:
+            if isinstance(item, Mapping):
+                name = item.get("name")
+            else:
+                name = item
+            if name:
+                labels.add(str(name))
+    return frozenset(labels)
+
+
+def review_threads(value: object) -> tuple[ReviewThread, ...]:
+    if not isinstance(value, Mapping):
+        return ()
+    page = value.get("pageInfo") if isinstance(value.get("pageInfo"), Mapping) else {}
+    if page.get("hasNextPage"):
+        return (ReviewThread("review-thread-pagination-not-implemented", False, ("human",)),)
+    threads: list[ReviewThread] = []
+    nodes = value.get("nodes") if isinstance(value.get("nodes"), Sequence) else []
+    for node in nodes:
+        if not isinstance(node, Mapping):
+            continue
+        authors: list[str] = []
+        comments = node.get("comments") if isinstance(node.get("comments"), Mapping) else {}
+        comment_nodes = comments.get("nodes") if isinstance(comments.get("nodes"), Sequence) else []
+        for comment in comment_nodes:
+            if not isinstance(comment, Mapping):
+                continue
+            author = comment.get("author") if isinstance(comment.get("author"), Mapping) else {}
+            login = author.get("login") if isinstance(author, Mapping) else None
+            if login:
+                authors.append(str(login))
+        threads.append(ReviewThread(str(node.get("id") or ""), bool(node.get("isResolved")), tuple(authors)))
+    return tuple(threads)
+
+
+def raw_contexts(pr: Mapping[str, object]) -> list[Mapping[str, object]]:
+    rollup = pr.get("statusCheckRollup")
+    if not isinstance(rollup, Mapping):
+        return []
+    contexts = rollup.get("contexts")
+    if isinstance(contexts, Mapping):
+        nodes = contexts.get("nodes")
+    else:
+        nodes = contexts
+    return [node for node in nodes] if isinstance(nodes, list) else []
+
+
+def snapshot_from_detail(detail: Mapping[str, object], comments: Sequence[Mapping[str, object]], required_checks: Sequence[str]) -> PrSnapshot:
+    head = str(detail.get("headRefOid") or detail.get("head_ref_oid") or "")
+    events = [event for comment in comments for event in [parse_mergify_queue_event(comment)] if event]
+    events.sort(key=lambda event: event.queued_at, reverse=True)
+    return PrSnapshot(
+        number=int(detail.get("number") or 0),
+        title=str(detail.get("title") or ""),
+        url=str(detail.get("url") or ""),
+        state=str(detail.get("state") or ""),
+        is_draft=bool(detail.get("isDraft") or detail.get("is_draft")),
+        base_ref_name=str(detail.get("baseRefName") or detail.get("base_ref_name") or ""),
+        head_ref_name=str(detail.get("headRefName") or detail.get("head_ref_name") or ""),
+        head_ref_oid=head,
+        merge_state_status=str(detail.get("mergeStateStatus") or detail.get("merge_state_status") or ""),
+        mergeable=str(detail.get("mergeable") or ""),
+        labels=labels_from_nodes(detail.get("labels")),
+        checks=latest_contexts_by_required_check(raw_contexts(detail), head, required_checks),
+        review_threads=review_threads(detail.get("reviewThreads")),
+        latest_mergify=events[0] if events else None,
+    )

--- a/scripts/test_mergify_admin_requeue_model.py
+++ b/scripts/test_mergify_admin_requeue_model.py
@@ -1,0 +1,342 @@
+"""Behavioural tests for ``mergify_admin_requeue_model``.
+
+These tests double as documentation. The requeue worker has to reconstruct the
+*real* state of a PR from two messy sources:
+
+  1. Mergify's merge-queue **status comment** — free-text Markdown, no API.
+  2. GitHub's **checks** — returned in two different GraphQL shapes.
+
+Every test below feeds a realistic slice of that raw input to one function and
+pins the structured value it produces, so a reader can see exactly what each
+parser is for and why it exists.
+
+Run:  python3 scripts/test_mergify_admin_requeue_model.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import mergify_admin_requeue_model as m
+
+
+# --------------------------------------------------------------------------- #
+# A realistic Mergify merge-queue status comment.
+#
+# This is the kind of comment Mergify posts on a PR that is queued but blocked.
+# There is no API for "why won't this merge" — the answer only lives here, as
+# prose under Markdown headings. The section parsers below all read this body.
+# --------------------------------------------------------------------------- #
+MERGIFY_COMMENT = """\
+## Merge Queue status
+
+The pull request is embarked in the merge queue.
+
+### Waiting for
+
+- all queue conditions to match
+
+### Failing checks
+
+- [ ] [build (ubuntu-latest)](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/123/job/456)
+- [ ] [test:all](https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/123/job/789)
+
+### All conditions
+
+- [X] check-success = lint
+- [ ] check-success = build (ubuntu-latest)
+- [ ] check-success = test:all
+- [X] base = master
+
+### Reason
+
+The merge is blocked by failing checks:
+- build (ubuntu-latest)
+- test:all
+
+<!-- mergify-stack-data: {"stack_id":"stack/demo","pulls":[{"number":3221,"head_sha":"0c55361"}]} -->
+"""
+
+
+class SectionExtraction(unittest.TestCase):
+    """Turning headed Markdown prose into per-section lines/items."""
+
+    def test_section_lines_is_scoped_to_one_heading(self):
+        # "Waiting for" must yield ONLY its own line, not bleed into the next
+        # "### Failing checks" section. Section boundaries = Markdown headings.
+        self.assertEqual(
+            m.section_lines(MERGIFY_COMMENT, "Waiting for"),
+            ("- all queue conditions to match",),
+        )
+
+    def test_failing_checks_become_clean_check_names(self):
+        # The raw lines are checkbox bullets wrapping Markdown links. We want the
+        # bare check names the worker can match against required checks.
+        self.assertEqual(
+            m.section_items(MERGIFY_COMMENT, "Failing checks"),
+            ("build (ubuntu-latest)", "test:all"),
+        )
+
+    def test_all_conditions_are_parsed_with_pass_fail_state(self):
+        # The "All conditions" checklist is the ground truth for which required
+        # checks passed ([X]) vs failed ([ ]). Non check-success rows (base=...)
+        # are ignored because they are not checks.
+        self.assertEqual(
+            m.all_condition_states(MERGIFY_COMMENT),
+            (
+                ("lint", "success"),
+                ("build (ubuntu-latest)", "failure"),
+                ("test:all", "failure"),
+            ),
+        )
+
+    def test_failing_check_urls_pairs_name_with_job_links(self):
+        # So a human (or a later step) can jump straight to the failing GitHub
+        # Actions job. Each failing check keeps its own run/job URL(s).
+        self.assertEqual(
+            m.failing_check_urls(MERGIFY_COMMENT),
+            (
+                (
+                    "build (ubuntu-latest)",
+                    ("https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/123/job/456",),
+                ),
+                (
+                    "test:all",
+                    ("https://github.com/Neko-Catpital-Labs/Invoker/actions/runs/123/job/789",),
+                ),
+            ),
+        )
+
+    def test_reason_failed_checks_only_fires_when_reason_blames_checks(self):
+        # The "Reason" section is only mined for check names when it actually
+        # says the block is due to failing checks; otherwise we don't guess.
+        self.assertEqual(
+            m.reason_failed_checks(MERGIFY_COMMENT),
+            ("build (ubuntu-latest)", "test:all"),
+        )
+        no_check_reason = "### Reason\n\nThe base branch was updated.\n- rebase me\n"
+        self.assertEqual(m.reason_failed_checks(no_check_reason), ())
+
+
+class ItemNormalisation(unittest.TestCase):
+    """`normalize_check_item` strips the many bullet/link/checkbox wrappers."""
+
+    def test_strips_markdown_link_to_inner_text(self):
+        self.assertEqual(m.normalize_check_item("[build](https://x/y)"), "build")
+
+    def test_strips_checkbox_and_bullet(self):
+        self.assertEqual(m.normalize_check_item("- [x] lint"), "lint")
+
+    def test_unwraps_check_success_condition(self):
+        self.assertEqual(
+            m.normalize_check_item("- [ ] check-success = test:all"), "test:all"
+        )
+
+    def test_clean_markdown_drops_html_and_emphasis(self):
+        self.assertEqual(
+            m.clean_markdown("<sub>**bold** _x_</sub>"), "bold x"
+        )
+
+
+class QueueStateAndRule(unittest.TestCase):
+    """Reading queued/dequeued and the queue rule from payload or body."""
+
+    def test_state_from_structured_payload(self):
+        self.assertEqual(m.payload_state({"state": "dequeued"}, ""), "dequeued")
+        self.assertEqual(m.payload_state({"event": "queued"}, ""), "queued")
+
+    def test_state_falls_back_to_comment_text(self):
+        # Older Mergify comments carry no machine payload — only prose.
+        self.assertEqual(m.payload_state({}, "The PR left the queue."), "dequeued")
+        self.assertEqual(m.payload_state({}, "It entered the queue."), "queued")
+        self.assertEqual(m.payload_state({}, "nothing relevant"), "unknown")
+
+    def test_rule_from_payload_then_body(self):
+        self.assertEqual(m.payload_rule({"queue_rule_name": "default"}, ""), "default")
+        self.assertEqual(m.payload_rule({"queue": {"name": "hotfix"}}, ""), "hotfix")
+        self.assertEqual(
+            m.payload_rule({}, "removed from the queue rule `admin-bypass` now"),
+            "admin-bypass",
+        )
+
+
+class StackMarker(unittest.TestCase):
+    """Pulling the hidden stack metadata out of the comment."""
+
+    def test_stack_marker_regex_captures_embedded_json(self):
+        match = m.STACK_MARKER_RE.search(MERGIFY_COMMENT)
+        self.assertIsNotNone(match)
+        import json
+
+        data = json.loads(match.group(1))
+        self.assertEqual(data["stack_id"], "stack/demo")
+        self.assertEqual(data["pulls"][0]["number"], 3221)
+
+    def test_extract_first_json_object_handles_braces_inside_strings(self):
+        # The brace/quote state machine must not be fooled by "}" inside a
+        # string value, and must stop at the first *balanced* object.
+        text = 'noise {"a": "x}y", "b": {"c": 1}} trailing {"d": 2}'
+        self.assertEqual(
+            m.extract_first_json_object(text), {"a": "x}y", "b": {"c": 1}}
+        )
+        self.assertIsNone(m.extract_first_json_object("no json here"))
+
+
+class CheckNormalisation(unittest.TestCase):
+    """GitHub returns checks in two shapes; both must flatten to one."""
+
+    def test_check_run_shape(self):
+        node = {
+            "name": "build",
+            "status": "COMPLETED",
+            "conclusion": "SUCCESS",
+            "detailsUrl": "https://x/run",
+            "checkSuite": {"commit": {"oid": "a" * 40}},
+            "completedAt": "2026-01-02T00:00:00Z",
+        }
+        name, state, url, sha, completed = m.norm_check_state(node)
+        self.assertEqual(
+            (name, state, url, sha, completed),
+            ("build", "success", "https://x/run", "a" * 40, "2026-01-02T00:00:00Z"),
+        )
+
+    def test_status_context_legacy_shape(self):
+        node = {
+            "__typename": "StatusContext",
+            "context": "ci/legacy",
+            "state": "FAILURE",
+            "targetUrl": "https://x/legacy",
+            "commit": {"oid": "b" * 40},
+        }
+        name, state, url, sha, _ = m.norm_check_state(node)
+        self.assertEqual(
+            (name, state, url, sha), ("ci/legacy", "failure", "https://x/legacy", "b" * 40)
+        )
+
+    def test_conclusion_word_mapping(self):
+        def state(conclusion, status="COMPLETED"):
+            return m.norm_check_state(
+                {"name": "c", "status": status, "conclusion": conclusion}
+            )[1]
+
+        self.assertEqual(state("TIMED_OUT"), "failure")
+        self.assertEqual(state("SKIPPED"), "skipped")
+        self.assertEqual(state("NEUTRAL"), "neutral")
+        self.assertEqual(state("", status="IN_PROGRESS"), "pending")
+
+    def test_latest_contexts_keeps_newest_required_only(self):
+        head = "a" * 40
+        contexts = [
+            # required "build": an old pass, then a newer fail -> newest wins.
+            {"name": "build", "status": "COMPLETED", "conclusion": "SUCCESS",
+             "checkSuite": {"commit": {"oid": head}}, "completedAt": "2026-01-01T00:00:00Z"},
+            {"name": "build", "status": "COMPLETED", "conclusion": "FAILURE",
+             "checkSuite": {"commit": {"oid": head}}, "completedAt": "2026-01-02T00:00:00Z"},
+            # required "test:all" via the legacy status shape.
+            {"__typename": "StatusContext", "context": "test:all", "state": "SUCCESS",
+             "commit": {"oid": head}},
+            # noise that must be dropped:
+            {"name": "Summary", "status": "COMPLETED", "conclusion": "SUCCESS",
+             "checkSuite": {"commit": {"oid": head}}},          # self check
+            {"name": "Rule: admin-bypass", "status": "COMPLETED", "conclusion": "SUCCESS",
+             "checkSuite": {"commit": {"oid": head}}},           # mergify rule row
+            {"name": "codecov", "status": "COMPLETED", "conclusion": "FAILURE",
+             "checkSuite": {"commit": {"oid": head}}},           # not required
+            {"name": "build", "status": "COMPLETED", "conclusion": "SUCCESS",
+             "checkSuite": {"commit": {"oid": "z" * 40}}},        # wrong commit
+        ]
+        latest = m.latest_contexts_by_required_check(
+            contexts, head, required_checks={"build", "test:all", "lint"}
+        )
+        self.assertEqual(set(latest), {"build", "test:all"})  # "lint" simply absent
+        self.assertEqual(latest["build"].state, "failure")    # newest run wins
+        self.assertEqual(latest["test:all"].state, "success")
+
+
+MERGIFY_YML = """\
+pull_request_rules:
+  - name: admin-bypass
+    conditions:
+      - base=master
+      - label=admin-bypass
+    merge_conditions:
+      - check-success = lint
+      - check-success = build (ubuntu-latest)
+    actions:
+      queue:
+        name: default
+  - name: some-other-rule
+    conditions:
+      - base=master
+"""
+
+
+class MergifyRuleLoading(unittest.TestCase):
+    """`load_mergify_rules` reads what 'green + landable' means from config."""
+
+    def _write(self, text):
+        fd, path = tempfile.mkstemp(suffix=".yml")
+        os.close(fd)
+        Path(path).write_text(text, encoding="utf-8")
+        self.addCleanup(os.unlink, path)
+        return Path(path)
+
+    def test_reads_trunk_label_and_required_checks(self):
+        trunk, labels, required = m.load_mergify_rules(self._write(MERGIFY_YML))
+        self.assertEqual(trunk, "master")
+        self.assertEqual(labels, frozenset({"admin-bypass"}))
+        self.assertEqual(required, frozenset({"lint", "build (ubuntu-latest)"}))
+
+    def test_missing_admin_bypass_rule_is_an_error(self):
+        with self.assertRaises(ValueError):
+            m.load_mergify_rules(self._write("pull_request_rules:\n  - name: other\n"))
+
+
+class LedgerIdempotency(unittest.TestCase):
+    """The ledger stops the worker repeating an action on the same commit."""
+
+    def _ledger_path(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        return Path(d) / "ledger.jsonl"
+
+    def test_record_then_count_and_reload(self):
+        path = self._ledger_path()
+        led = m.Ledger(path)
+        self.assertEqual(led.count("requeue", 3221, "sha1", "flaky"), 0)
+        led.record("requeue", 3221, "sha1", "flaky")
+        self.assertEqual(led.count("requeue", 3221, "sha1", "flaky"), 1)
+        # A different key is a different action -> not counted.
+        self.assertEqual(led.count("requeue", 3221, "sha1", "other"), 0)
+        # Persisted: a fresh Ledger reads the same row back from disk.
+        self.assertEqual(m.Ledger(path).count("requeue", 3221, "sha1", "flaky"), 1)
+
+    def test_has_different_head_detects_new_commit(self):
+        path = self._ledger_path()
+        led = m.Ledger(path)
+        led.record("requeue", 3221, "sha1", "flaky")
+        # Same commit -> already handled, do not act again.
+        self.assertFalse(led.has_different_head("requeue", 3221, "sha1", "flaky"))
+        # New commit pushed -> prior action is stale, acting again is allowed.
+        self.assertTrue(led.has_different_head("requeue", 3221, "sha2", "flaky"))
+
+    def test_malformed_ledger_lines_are_skipped(self):
+        path = self._ledger_path()
+        path.write_text(
+            'not json\n'
+            '[1, 2, 3]\n'  # valid json, wrong type
+            '{"kind": "requeue", "pr": 3221, "headSha": "sha1", "key": "flaky"}\n',
+            encoding="utf-8",
+        )
+        led = m.Ledger(path)
+        self.assertEqual(led.count("requeue", 3221, "sha1", "flaky"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_mergify_admin_requeue_plan.py
+++ b/scripts/test_mergify_admin_requeue_plan.py
@@ -1,0 +1,152 @@
+"""Behavioural tests for ``mergify_admin_requeue_plan``.
+
+Documentation-by-test for the planner. This layer does not parse text — it reads
+a typed ``PrSnapshot``/``StackGroup`` and decides the single next ``Action`` to
+take, via a fixed priority ladder. The ``Ledger`` caps how often the same repair
+repeats on the same commit.
+
+`classify_pr` reads a PR's state into blockers; `plan_stack_actions` turns those
+blockers into exactly one action, honouring priority and the retry caps. Each
+test pins one rung of that ladder and why it fires.
+
+Run:  python3 scripts/test_mergify_admin_requeue_plan.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import mergify_admin_requeue_model as m
+import mergify_admin_requeue_plan as p
+
+
+HEAD = "a" * 40
+REQUIRED = {"build"}
+
+
+def check(state, name="build"):
+    return m.CheckContext(name=name, state=state, details_url="", head_sha=HEAD, completed_at="")
+
+
+def event(state="dequeued", head=HEAD, comment_id="cm1", failing=(), conditions=()):
+    return m.MergifyQueueEvent(
+        comment_id=comment_id, state=state, queue_rule_name="default",
+        queued_at="2026-07-07T05:00:00Z", head_sha=head, waiting_for=(),
+        failing_checks=failing, comment_url="u", condition_states=conditions,
+    )
+
+
+def pr(**kw):
+    base = dict(
+        number=1, title="t", url="u", state="OPEN", is_draft=False,
+        base_ref_name="master", head_ref_name="branch", head_ref_oid=HEAD,
+        merge_state_status="BLOCKED", mergeable="MERGEABLE",
+        labels=frozenset(), checks={"build": check("success")},
+        review_threads=(), latest_mergify=None,
+    )
+    base.update(kw)
+    return m.PrSnapshot(**base)
+
+
+class ClassifyPr(unittest.TestCase):
+    """Reading a PR's state into blocker reasons."""
+
+    def _kinds(self, snapshot):
+        return {b.kind for b in p.classify_pr(snapshot, REQUIRED, trunk="master")}
+
+    def test_green_pr_has_no_blockers(self):
+        self.assertEqual(self._kinds(pr()), set())
+
+    def test_draft_short_circuits(self):
+        self.assertEqual(self._kinds(pr(is_draft=True)), {"draft"})
+
+    def test_closed_short_circuits(self):
+        self.assertEqual(self._kinds(pr(state="CLOSED")), {"closed"})
+
+    def test_failed_required_check(self):
+        self.assertEqual(self._kinds(pr(checks={"build": check("failure")})), {"failed_check"})
+
+    def test_missing_required_check_only_on_bottom(self):
+        # Missing check counts as a blocker only when the PR sits on trunk.
+        self.assertEqual(self._kinds(pr(checks={})), {"missing_check"})
+        self.assertEqual(self._kinds(pr(checks={}, base_ref_name="other")),
+                         {"not_current_bottom"})
+
+    def test_conflict_from_git_state(self):
+        self.assertIn("conflict", self._kinds(pr(merge_state_status="DIRTY")))
+        self.assertIn("conflict", self._kinds(pr(mergeable="CONFLICTING")))
+
+    def test_human_vs_bot_review_threads(self):
+        human = pr(review_threads=(m.ReviewThread("t", False, ("alice",)),))
+        bot = pr(review_threads=(m.ReviewThread("t", False, ("coderabbitai[bot]",)),))
+        self.assertIn("human_review_thread", self._kinds(human))
+        self.assertIn("bot_review_thread", self._kinds(bot))
+
+    def test_merge_hold_label(self):
+        self.assertIn("merge_hold", self._kinds(pr(labels=frozenset({"merge-hold"}))))
+
+
+class EffectiveBlockers(unittest.TestCase):
+    def test_mergify_success_condition_clears_missing_check(self):
+        # classify_pr flags "build" as missing, but the current Mergify event
+        # says that condition passed -> the loader-derived blocker is dropped.
+        snapshot = pr(checks={}, latest_mergify=event(conditions=(("build", "success"),)))
+        kinds = {b.kind for b in p.effective_blockers(snapshot, REQUIRED, trunk="master")}
+        self.assertNotIn("missing_check", kinds)
+
+
+class PlanStackActions(unittest.TestCase):
+    """The priority ladder: one PR state in, one Action out."""
+
+    def _ledger(self):
+        d = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        return m.Ledger(Path(d) / "ledger.jsonl")
+
+    def _plan(self, snapshot, ledger=None):
+        ledger = ledger or self._ledger()
+        return p.plan_stack_actions(m.StackGroup("s", (snapshot,)), REQUIRED, ledger, now_epoch=0)
+
+    def test_pending_check_means_wait_do_nothing(self):
+        self.assertEqual(self._plan(pr(checks={"build": check("pending")})), ())
+
+    def test_conflict_triggers_rebase_recreate(self):
+        actions = self._plan(pr(merge_state_status="DIRTY"))
+        self.assertEqual((actions[0].kind, actions[0].pr_number), ("rebase_recreate", 1))
+
+    def test_failed_check_triggers_repair(self):
+        actions = self._plan(pr(checks={"build": check("failure")}))
+        self.assertEqual((actions[0].kind, actions[0].key), ("repair_check", "build"))
+
+    def test_mergify_dequeue_with_failing_check_repairs_first(self):
+        # A Mergify dequeue naming a failing check outranks everything else.
+        actions = self._plan(pr(latest_mergify=event(failing=("build",))))
+        self.assertEqual(actions[0].kind, "repair_check")
+
+    def test_clean_bottom_missing_label_adds_admin_bypass(self):
+        actions = self._plan(pr())  # green, no admin-bypass label
+        self.assertEqual((actions[0].kind, actions[0].key), ("add_admin_bypass_label", "admin-bypass"))
+
+    def test_clean_bottom_dequeued_gets_requeued(self):
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued"))
+        actions = self._plan(snapshot)
+        self.assertEqual((actions[0].kind, actions[0].detail), ("requeue", "eligible-after-dequeue"))
+
+    def test_requeue_is_capped_after_repeated_attempts(self):
+        ledger = self._ledger()
+        # Two prior requeue attempts on this head+key -> the third is capped.
+        ledger.record("requeue", 1, HEAD, "cm1")
+        ledger.record("requeue", 1, HEAD, "cm1")
+        snapshot = pr(labels=frozenset({"admin-bypass"}), latest_mergify=event(state="dequeued", comment_id="cm1"))
+        actions = self._plan(snapshot, ledger)
+        self.assertEqual((actions[0].kind, actions[0].key), ("comment_blocked", "capped"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/test_mergify_admin_requeue_snapshot.py
+++ b/scripts/test_mergify_admin_requeue_snapshot.py
@@ -1,0 +1,206 @@
+"""Behavioural tests for ``mergify_admin_requeue_snapshot``.
+
+Documentation-by-test for the loader. This layer takes the *raw* shapes GitHub's
+`gh` CLI returns — issue comments, GraphQL PR detail, status-check rollups,
+review threads — and folds them into the typed ``PrSnapshot`` the planner reads.
+
+Each test feeds one realistic raw shape and pins what gets parsed out of it and
+why. The subprocess/`gh`-calling helpers are intentionally not exercised here;
+only the pure parse/transform functions are.
+
+Run:  python3 scripts/test_mergify_admin_requeue_snapshot.py
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import mergify_admin_requeue_model as m
+import mergify_admin_requeue_snapshot as s
+
+
+HEAD = "a" * 40
+
+# A real Mergify "dequeued" comment: prose plus the hidden `-*- Mergify Payload
+# -*-` blob. The loader only trusts comments authored by mergify[bot].
+MERGIFY_DEQUEUE_COMMENT = {
+    "user": {"login": "mergify[bot]"},
+    "id": "c-9001",
+    "updated_at": "2026-07-07T05:00:00Z",
+    "html_url": "https://github.com/o/r/pull/4242#issuecomment-9001",
+    "body": """\
+## Merge Queue status
+
+The pull request has been dequeued. Left the queue for head `%s`.
+
+on draft #4242
+
+### Failing checks
+
+- [ ] [build (ubuntu-latest)](https://github.com/o/r/actions/runs/1/job/2)
+
+### Waiting for
+
+- all queue conditions to match
+
+<!-- -*- Mergify Payload -*-
+{"state": "dequeued", "queue_rule_name": "default"}
+-*- Mergify Payload -*- -->
+""" % HEAD,
+}
+
+
+class ParseMergifyQueueEvent(unittest.TestCase):
+    def test_ignores_comments_not_from_mergify(self):
+        # Only Mergify's own comments describe the queue; a human/bot comment
+        # that happens to look similar must be ignored.
+        self.assertIsNone(
+            s.parse_mergify_queue_event({"user": {"login": "coderabbitai[bot]"},
+                                         "body": "Left the queue `%s`" % HEAD})
+        )
+
+    def test_ignores_mergify_comment_without_payload_marker(self):
+        self.assertIsNone(
+            s.parse_mergify_queue_event({"user": {"login": "mergify[bot]"},
+                                         "body": "some chatter, no payload"})
+        )
+
+    def test_parses_dequeue_comment_into_event(self):
+        event = s.parse_mergify_queue_event(MERGIFY_DEQUEUE_COMMENT)
+        assert event is not None
+        self.assertEqual(event.state, "dequeued")
+        self.assertEqual(event.queue_rule_name, "default")
+        self.assertEqual(event.head_sha, HEAD)          # from "Left the queue ... `sha`"
+        self.assertEqual(event.queue_pr_number, 4242)   # from "on draft #4242"
+        self.assertEqual(event.failing_checks, ("build (ubuntu-latest)",))
+        self.assertEqual(event.comment_id, "c-9001")
+        self.assertEqual(event.queued_at, "2026-07-07T05:00:00Z")
+
+
+class ParseStackMetadata(unittest.TestCase):
+    def test_newest_comment_with_marker_wins(self):
+        old = {"updated_at": "2026-07-01T00:00:00Z",
+               "body": '<!-- mergify-stack-data: {"stack_id":"old","pull_numbers_bottom_to_top":[1,2]} -->'}
+        new = {"updated_at": "2026-07-07T00:00:00Z",
+               "body": '<!-- mergify-stack-data: {"stack_id":"new","pull_numbers_bottom_to_top":[10,11,12]} -->'}
+        self.assertEqual(s.parse_stack_metadata([old, new]), ("new", (10, 11, 12)))
+
+    def test_no_marker_returns_none(self):
+        self.assertIsNone(s.parse_stack_metadata([{"body": "nothing here"}]))
+
+
+class LabelsFromNodes(unittest.TestCase):
+    def test_graphql_nodes_shape(self):
+        self.assertEqual(
+            s.labels_from_nodes({"nodes": [{"name": "admin-bypass"}, {"name": "x"}]}),
+            frozenset({"admin-bypass", "x"}),
+        )
+
+    def test_plain_list_and_strings(self):
+        self.assertEqual(s.labels_from_nodes([{"name": "y"}]), frozenset({"y"}))
+        self.assertEqual(s.labels_from_nodes(["z"]), frozenset({"z"}))
+
+    def test_missing_is_empty(self):
+        self.assertEqual(s.labels_from_nodes(None), frozenset())
+
+
+class ReviewThreadsParsing(unittest.TestCase):
+    def test_collects_thread_id_resolution_and_authors(self):
+        value = {
+            "pageInfo": {"hasNextPage": False},
+            "nodes": [
+                {"id": "t1", "isResolved": False,
+                 "comments": {"nodes": [{"author": {"login": "coderabbitai[bot]"}}]}},
+                {"id": "t2", "isResolved": True, "comments": {"nodes": []}},
+            ],
+        }
+        self.assertEqual(
+            s.review_threads(value),
+            (m.ReviewThread("t1", False, ("coderabbitai[bot]",)),
+             m.ReviewThread("t2", True, ())),
+        )
+
+    def test_pagination_is_flagged_conservatively(self):
+        # If threads paginate, we can't be sure they're all resolved, so the
+        # loader emits a sentinel unresolved-by-a-human thread to stay safe.
+        threads = s.review_threads({"pageInfo": {"hasNextPage": True}})
+        self.assertEqual(len(threads), 1)
+        self.assertFalse(threads[0].is_resolved)
+
+
+class RawContexts(unittest.TestCase):
+    def test_digs_through_status_check_rollup(self):
+        pr = {"statusCheckRollup": {"contexts": {"nodes": [{"name": "build"}]}}}
+        self.assertEqual(s.raw_contexts(pr), [{"name": "build"}])
+
+    def test_missing_rollup_is_empty(self):
+        self.assertEqual(s.raw_contexts({}), [])
+
+
+class GroupStackPrs(unittest.TestCase):
+    def _pr(self, number, base, head, state="OPEN"):
+        return m.PrSnapshot(
+            number=number, title="t", url="u", state=state, is_draft=False,
+            base_ref_name=base, head_ref_name=head, head_ref_oid=HEAD,
+            merge_state_status="BLOCKED", mergeable="MERGEABLE",
+            labels=frozenset(), checks={}, review_threads=(), latest_mergify=None,
+        )
+
+    def test_groups_by_declared_stack_metadata(self):
+        prs = [self._pr(10, "master", "b10"), self._pr(11, "b10", "b11"), self._pr(12, "b11", "b12")]
+        meta = {n: ("declared", (10, 11, 12)) for n in (10, 11, 12)}
+        groups = s.group_stack_prs(prs, meta, trunk="master")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].stack_id, "declared")
+        self.assertEqual(tuple(pr.number for pr in groups[0].prs), (10, 11, 12))
+
+    def test_falls_back_to_branch_chain_when_no_metadata(self):
+        # No stack comment: reconstruct the chain from base->head links.
+        prs = [self._pr(1, "master", "brA"), self._pr(2, "brA", "brB")]
+        groups = s.group_stack_prs(prs, {}, trunk="master")
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].stack_id, "branch:1")
+        self.assertEqual(tuple(pr.number for pr in groups[0].prs), (1, 2))
+
+
+class SnapshotFromDetail(unittest.TestCase):
+    """End-to-end: raw `gh` PR detail + comments -> one typed PrSnapshot."""
+
+    def test_builds_full_snapshot(self):
+        detail = {
+            "number": 3221, "title": "Add model", "url": "https://x/3221",
+            "state": "OPEN", "isDraft": False,
+            "baseRefName": "master", "headRefName": "stack/x", "headRefOid": HEAD,
+            "mergeStateStatus": "BLOCKED", "mergeable": "MERGEABLE",
+            "labels": {"nodes": [{"name": "admin-bypass"}]},
+            "statusCheckRollup": {"contexts": {"nodes": [
+                {"name": "build", "status": "COMPLETED", "conclusion": "FAILURE",
+                 "checkSuite": {"commit": {"oid": HEAD}}, "completedAt": "2026-01-02T00:00:00Z"},
+                {"__typename": "StatusContext", "context": "lint", "state": "SUCCESS",
+                 "commit": {"oid": HEAD}},
+            ]}},
+            "reviewThreads": {"pageInfo": {"hasNextPage": False},
+                              "nodes": [{"id": "t1", "isResolved": True, "comments": {"nodes": []}}]},
+        }
+        snap = s.snapshot_from_detail(detail, [MERGIFY_DEQUEUE_COMMENT], required_checks=["build", "lint"])
+        self.assertEqual(snap.number, 3221)
+        self.assertEqual(snap.state, "OPEN")
+        self.assertEqual(snap.base_ref_name, "master")
+        self.assertEqual(snap.labels, frozenset({"admin-bypass"}))
+        # only required checks, on the current head, flattened from both shapes:
+        self.assertEqual(set(snap.checks), {"build", "lint"})
+        self.assertEqual(snap.checks["build"].state, "failure")
+        self.assertEqual(snap.checks["lint"].state, "success")
+        self.assertEqual(snap.review_threads, (m.ReviewThread("t1", True, ()),))
+        # the Mergify comment is attached as the latest queue event:
+        assert snap.latest_mergify is not None
+        self.assertEqual(snap.latest_mergify.state, "dequeued")
+        self.assertEqual(snap.latest_mergify.head_sha, HEAD)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Adds the Mergify admin-requeue entry point and the executor that applies each planned repair, making the script runnable end to end.

## Review Claim

The Mergify admin-requeue script becomes runnable end to end.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This slice adds the runnable entry point and the executor; other scripts keep their current behaviour.

## Slice Rationale

The runnable entry point lands after the planner so the phases stay in order.

## Non-goals

No new maintenance checks beyond the existing ones. Behavior of other scripts stays unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -m py_compile scripts/mergify_admin_requeue.py scripts/mergify_admin_requeue_exec.py`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
