### PR TITLE
[Worker Subscriptions](8) Add shared GitHub PR maintenance events

### DIFF
--- a/packages/execution-engine/src/__tests__/github-pr-events-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/github-pr-events-worker.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it } from 'vitest';
+import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+import { Channels, LocalBus } from '@invoker/transport';
+
+import type { GitHubPrEvent } from '../pr-maintenance-events.js';
+import { isGitHubPrEvent } from '../pr-maintenance-events.js';
+import {
+  GITHUB_PR_EVENTS_WORKER_KIND,
+  buildClosedGitHubPrEvent,
+  buildGitHubPrEvent,
+  createGitHubPrEventsTick,
+} from '../workers/github-pr-events-worker.js';
+
+const logger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+  child: () => logger,
+};
+
+function createStore() {
+  const byKey = new Map<string, WorkerActionRecord>();
+  return {
+    store: {
+      getWorkerAction(workerKind: string, externalKey: string) {
+        const action = byKey.get(`${workerKind}:${externalKey}`);
+        return action ? { ...action } : undefined;
+      },
+      upsertWorkerAction(action: WorkerActionWrite) {
+        const key = `${action.workerKind}:${action.externalKey}`;
+        const existing = byKey.get(key);
+        const record: WorkerActionRecord = {
+          id: existing?.id ?? action.id,
+          workerKind: action.workerKind,
+          actionType: action.actionType,
+          workflowId: action.workflowId,
+          taskId: action.taskId,
+          subjectType: action.subjectType,
+          subjectId: action.subjectId,
+          externalKey: action.externalKey,
+          status: action.status,
+          attemptCount: action.attemptCount ?? existing?.attemptCount ?? 0,
+          intentId: action.intentId,
+          agentName: action.agentName,
+          executionModel: action.executionModel,
+          sessionId: action.sessionId,
+          summary: action.summary,
+          payload: action.payload,
+          createdAt: existing?.createdAt ?? action.createdAt ?? '2026-01-01T00:00:00.000Z',
+          updatedAt: action.updatedAt ?? '2026-01-01T00:00:00.000Z',
+          completedAt: action.completedAt,
+        };
+        byKey.set(key, record);
+        return { ...record };
+      },
+      listWorkerActions(filters?: { workerKind?: string }) {
+        return [...byKey.values()]
+          .filter((action) => !filters?.workerKind || action.workerKind === filters.workerKind)
+          .map((action) => ({ ...action }));
+      },
+    },
+    byKey,
+  };
+}
+
+describe('github PR maintenance events', () => {
+  it('builds an opened event for a first-seen PR snapshot', () => {
+    const event = buildGitHubPrEvent(undefined, {
+      prNumber: 17,
+      repo: 'owner/repo',
+      author: 'octocat',
+      headRefName: 'feature/red-ci',
+      mergeState: 'clean',
+      labels: ['queue'],
+      coderabbitCommentUpdatedAt: '2026-07-07T00:00:00Z',
+      mergifyCommentUpdatedAt: undefined,
+      open: true,
+    }, '2026-07-07T01:00:00Z');
+
+    expect(event).toMatchObject({
+      repo: 'owner/repo',
+      prNumber: 17,
+      changes: ['opened'],
+    });
+    expect(isGitHubPrEvent(event)).toBe(true);
+  });
+
+  it('builds delta events for merge-state, label, and bot-comment changes', () => {
+    const event = buildGitHubPrEvent({
+      prNumber: 17,
+      repo: 'owner/repo',
+      author: 'octocat',
+      headRefName: 'feature/red-ci',
+      mergeState: 'clean',
+      labels: ['queue'],
+      coderabbitCommentUpdatedAt: '2026-07-07T00:00:00Z',
+      mergifyCommentUpdatedAt: '2026-07-07T00:10:00Z',
+      open: true,
+    }, {
+      prNumber: 17,
+      repo: 'owner/repo',
+      author: 'octocat',
+      headRefName: 'feature/red-ci',
+      mergeState: 'dirty',
+      labels: ['queue', 'needs-attention'],
+      coderabbitCommentUpdatedAt: '2026-07-07T00:20:00Z',
+      mergifyCommentUpdatedAt: '2026-07-07T00:10:00Z',
+      open: true,
+    }, '2026-07-07T01:00:00Z');
+
+    expect(event?.changes).toEqual([
+      'merge_state_changed',
+      'coderabbit_comment',
+      'labels_changed',
+    ]);
+  });
+
+  it('publishes change and close events while persisting snapshots', async () => {
+    const bus = new LocalBus();
+    const events: GitHubPrEvent[] = [];
+    bus.subscribe<GitHubPrEvent>(Channels.GITHUB_PR_EVENT, (event) => events.push(event));
+    const store = createStore();
+
+    const state = {
+      prs: [{ number: 42, headRefName: 'feature/start', mergeStateStatus: 'CLEAN', labels: [{ name: 'queue' }] }],
+      issueComments: [{ user: { login: 'coderabbitai[bot]' }, updated_at: '2026-07-07T00:00:00Z' }],
+      reviewComments: [{ user: { login: 'mergify[bot]' }, updated_at: '2026-07-07T00:10:00Z' }],
+    };
+
+    const tick = createGitHubPrEventsTick({
+      logger,
+      store: store.store,
+      messageBus: bus,
+      config: { repo: 'owner/repo', author: 'octocat' },
+      now: () => new Date('2026-07-07T01:00:00Z'),
+      client: {
+        listOpenPullRequests: () => state.prs,
+        listIssueComments: () => state.issueComments,
+        listReviewComments: () => state.reviewComments,
+      },
+    });
+
+    await tick({ identity: { kind: GITHUB_PR_EVENTS_WORKER_KIND, instanceId: 'w1' }, reason: 'manual', tickNumber: 1 });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.changes).toEqual(['opened']);
+    expect(store.byKey.get(`${GITHUB_PR_EVENTS_WORKER_KIND}:snapshot:42`)?.payload).toMatchObject({
+      mergeState: 'clean',
+      open: true,
+    });
+
+    state.prs = [{ number: 42, headRefName: 'feature/start', mergeStateStatus: 'DIRTY', labels: [{ name: 'queue' }, { name: 'needs-attention' }] }];
+    state.issueComments = [{ user: { login: 'coderabbitai[bot]' }, updated_at: '2026-07-07T00:20:00Z' }];
+    await tick({ identity: { kind: GITHUB_PR_EVENTS_WORKER_KIND, instanceId: 'w1' }, reason: 'manual', tickNumber: 2 });
+    expect(events[1]?.changes).toEqual([
+      'merge_state_changed',
+      'coderabbit_comment',
+      'labels_changed',
+    ]);
+
+    state.prs = [];
+    state.issueComments = [];
+    state.reviewComments = [];
+    await tick({ identity: { kind: GITHUB_PR_EVENTS_WORKER_KIND, instanceId: 'w1' }, reason: 'manual', tickNumber: 3 });
+    expect(events[2]).toEqual(buildClosedGitHubPrEvent({
+      prNumber: 42,
+      repo: 'owner/repo',
+      author: 'octocat',
+      headRefName: 'feature/start',
+      mergeState: 'dirty',
+      labels: ['needs-attention', 'queue'],
+      coderabbitCommentUpdatedAt: '2026-07-07T00:20:00Z',
+      mergifyCommentUpdatedAt: '2026-07-07T00:10:00Z',
+      open: true,
+    }, '2026-07-07T01:00:00.000Z'));
+    expect(store.byKey.get(`${GITHUB_PR_EVENTS_WORKER_KIND}:snapshot:42`)?.payload).toMatchObject({
+      open: false,
+    });
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -46,4 +46,6 @@ export * from './auto-fix-gating.js';
 export * from './auto-fix-attempt-ledger.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';
+export * from './pr-maintenance-events.js';
+export * from './workers/github-pr-events-worker.js';
 export * from './external-worker.js';

--- a/packages/execution-engine/src/pr-maintenance-events.ts
+++ b/packages/execution-engine/src/pr-maintenance-events.ts
@@ -1,0 +1,38 @@
+export type GitHubPrEventChange =
+  | 'opened'
+  | 'closed'
+  | 'head_ref_changed'
+  | 'merge_state_changed'
+  | 'labels_changed'
+  | 'coderabbit_comment'
+  | 'mergify_comment';
+
+export interface GitHubPrEvent {
+  readonly eventKey: string;
+  readonly repo: string;
+  readonly prNumber: number;
+  readonly author: string;
+  readonly headRefName: string;
+  readonly mergeState: 'clean' | 'dirty' | 'unknown';
+  readonly labels: readonly string[];
+  readonly coderabbitCommentUpdatedAt?: string;
+  readonly mergifyCommentUpdatedAt?: string;
+  readonly changes: readonly GitHubPrEventChange[];
+  readonly createdAt: string;
+}
+
+export function isGitHubPrEvent(value: unknown): value is GitHubPrEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const event = value as Record<string, unknown>;
+  return typeof event.eventKey === 'string'
+    && typeof event.repo === 'string'
+    && typeof event.prNumber === 'number'
+    && typeof event.author === 'string'
+    && typeof event.headRefName === 'string'
+    && (event.mergeState === 'clean' || event.mergeState === 'dirty' || event.mergeState === 'unknown')
+    && Array.isArray(event.labels)
+    && event.labels.every((entry) => typeof entry === 'string')
+    && Array.isArray(event.changes)
+    && event.changes.every((entry) => typeof entry === 'string')
+    && typeof event.createdAt === 'string';
+}

--- a/packages/execution-engine/src/workers/github-pr-events-worker.ts
+++ b/packages/execution-engine/src/workers/github-pr-events-worker.ts
@@ -1,0 +1,317 @@
+import { execFileSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+
+import type { Logger } from '@invoker/contracts';
+import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
+import { Channels, type MessageBus } from '@invoker/transport';
+
+import type { GitHubPrEvent, GitHubPrEventChange } from '../pr-maintenance-events.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const GITHUB_PR_EVENTS_WORKER_KIND = 'github-pr-events';
+export const DEFAULT_GITHUB_PR_EVENTS_INTERVAL_MS = 300_000;
+const CODERABBIT_LOGIN = 'coderabbitai[bot]';
+const MERGIFY_LOGIN = 'mergify[bot]';
+const SNAPSHOT_EXTERNAL_KEY_PREFIX = 'snapshot:';
+
+interface GitHubPrListItem {
+  number: number;
+  headRefName?: string;
+  mergeStateStatus?: string;
+  labels?: Array<{ name?: string | null }>;
+}
+
+interface GitHubComment {
+  updated_at?: string;
+  user?: { login?: string | null };
+}
+
+export interface GitHubPrSnapshot {
+  readonly prNumber: number;
+  readonly repo: string;
+  readonly author: string;
+  readonly headRefName: string;
+  readonly mergeState: 'clean' | 'dirty' | 'unknown';
+  readonly labels: readonly string[];
+  readonly coderabbitCommentUpdatedAt?: string;
+  readonly mergifyCommentUpdatedAt?: string;
+  readonly open: boolean;
+}
+
+export interface GitHubPrEventsStore {
+  getWorkerAction(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction(action: WorkerActionWrite): WorkerActionRecord;
+  listWorkerActions(filters?: { workerKind?: string; status?: string; limit?: number }): WorkerActionRecord[];
+}
+
+export interface GitHubPrEventsConfig {
+  readonly repo: string;
+  readonly author: string;
+  readonly coderabbitLogin?: string;
+  readonly mergifyLogin?: string;
+  readonly intervalMs?: number;
+}
+
+export interface GitHubPrClient {
+  listOpenPullRequests(repo: string, author: string): readonly GitHubPrListItem[];
+  listIssueComments(repo: string, prNumber: number): readonly GitHubComment[];
+  listReviewComments(repo: string, prNumber: number): readonly GitHubComment[];
+}
+
+export interface GitHubPrEventsTickOptions {
+  readonly logger: Logger;
+  readonly store: GitHubPrEventsStore;
+  readonly messageBus: MessageBus;
+  readonly config: GitHubPrEventsConfig;
+  readonly client?: GitHubPrClient;
+  readonly now?: () => Date;
+}
+
+export interface GitHubPrEventsWorkerOptions extends GitHubPrEventsTickOptions {
+  readonly instanceId?: string;
+  readonly installSignalHandlers?: boolean;
+  readonly tickOnStart?: boolean;
+  readonly onTick?: WorkerTick;
+}
+
+function parseJsonArray<T>(command: string[], logger: Logger): readonly T[] {
+  try {
+    const stdout = execFileSync('gh', command, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+    const parsed = JSON.parse(stdout) as unknown;
+    return Array.isArray(parsed) ? parsed as readonly T[] : [];
+  } catch (error) {
+    logger.warn?.('[worker:github-pr-events] gh command failed', {
+      module: 'github-pr-events-worker',
+      command,
+      error,
+    });
+    return [];
+  }
+}
+
+export function createGitHubPrClient(logger: Logger): GitHubPrClient {
+  return {
+    listOpenPullRequests(repo: string, author: string): readonly GitHubPrListItem[] {
+      return parseJsonArray<GitHubPrListItem>([
+        'pr', 'list',
+        '--repo', repo,
+        '--author', author,
+        '--state', 'open',
+        '--limit', '100',
+        '--json', 'number,headRefName,mergeStateStatus,labels',
+      ], logger);
+    },
+    listIssueComments(repo: string, prNumber: number): readonly GitHubComment[] {
+      return parseJsonArray<GitHubComment>([
+        'api',
+        `repos/${repo}/issues/${prNumber}/comments`,
+        '--paginate',
+      ], logger);
+    },
+    listReviewComments(repo: string, prNumber: number): readonly GitHubComment[] {
+      return parseJsonArray<GitHubComment>([
+        'api',
+        `repos/${repo}/pulls/${prNumber}/comments`,
+        '--paginate',
+      ], logger);
+    },
+  };
+}
+
+function normalizeMergeState(raw: string | undefined): 'clean' | 'dirty' | 'unknown' {
+  if (raw === 'CLEAN') return 'clean';
+  if (raw === 'DIRTY' || raw === 'CONFLICTING') return 'dirty';
+  return 'unknown';
+}
+
+function latestCommentUpdatedAt(comments: readonly GitHubComment[], login: string): string | undefined {
+  let latest: string | undefined;
+  for (const comment of comments) {
+    if (comment.user?.login !== login || typeof comment.updated_at !== 'string') continue;
+    if (!latest || comment.updated_at > latest) latest = comment.updated_at;
+  }
+  return latest;
+}
+
+function snapshotExternalKey(prNumber: number): string {
+  return `${SNAPSHOT_EXTERNAL_KEY_PREFIX}${prNumber}`;
+}
+
+function loadSnapshot(record: WorkerActionRecord | undefined): GitHubPrSnapshot | undefined {
+  if (!record?.payload || typeof record.payload !== 'object') return undefined;
+  const payload = record.payload as Record<string, unknown>;
+  const labels = payload.labels;
+  if (!Array.isArray(labels) || !labels.every((entry) => typeof entry === 'string')) return undefined;
+  if (typeof payload.prNumber !== 'number' || typeof payload.repo !== 'string' || typeof payload.author !== 'string') {
+    return undefined;
+  }
+  if (typeof payload.headRefName !== 'string' || (payload.mergeState !== 'clean' && payload.mergeState !== 'dirty' && payload.mergeState !== 'unknown')) {
+    return undefined;
+  }
+  return {
+    prNumber: payload.prNumber,
+    repo: payload.repo,
+    author: payload.author,
+    headRefName: payload.headRefName,
+    mergeState: payload.mergeState,
+    labels,
+    coderabbitCommentUpdatedAt: typeof payload.coderabbitCommentUpdatedAt === 'string' ? payload.coderabbitCommentUpdatedAt : undefined,
+    mergifyCommentUpdatedAt: typeof payload.mergifyCommentUpdatedAt === 'string' ? payload.mergifyCommentUpdatedAt : undefined,
+    open: payload.open !== false,
+  };
+}
+
+function createEventKey(snapshot: GitHubPrSnapshot, changes: readonly GitHubPrEventChange[]): string {
+  const marker = [
+    snapshot.headRefName,
+    snapshot.mergeState,
+    snapshot.coderabbitCommentUpdatedAt ?? 'no-coderabbit',
+    snapshot.mergifyCommentUpdatedAt ?? 'no-mergify',
+    snapshot.labels.join(','),
+    snapshot.open ? 'open' : 'closed',
+  ].join('|');
+  return `${snapshot.repo}#${snapshot.prNumber}:${changes.join(',')}:${marker}`;
+}
+
+function saveSnapshot(
+  store: GitHubPrEventsStore,
+  snapshot: GitHubPrSnapshot,
+  existing: WorkerActionRecord | undefined,
+  nowIso: string,
+): void {
+  store.upsertWorkerAction({
+    id: existing?.id ?? randomUUID(),
+    workerKind: GITHUB_PR_EVENTS_WORKER_KIND,
+    actionType: 'snapshot',
+    subjectType: 'pull_request',
+    subjectId: String(snapshot.prNumber),
+    externalKey: snapshotExternalKey(snapshot.prNumber),
+    status: 'completed',
+    summary: `${snapshot.repo}#${snapshot.prNumber} ${snapshot.open ? 'open' : 'closed'} ${snapshot.mergeState}`,
+    payload: snapshot,
+    createdAt: existing?.createdAt ?? nowIso,
+    updatedAt: nowIso,
+    completedAt: nowIso,
+  });
+}
+
+function buildSnapshot(
+  pr: GitHubPrListItem,
+  comments: readonly GitHubComment[],
+  repo: string,
+  author: string,
+  coderabbitLogin: string,
+  mergifyLogin: string,
+): GitHubPrSnapshot {
+  const labels: string[] = [];
+  for (const label of pr.labels ?? []) {
+    if (typeof label.name === 'string' && label.name.length > 0) labels.push(label.name);
+  }
+  labels.sort();
+  return {
+    prNumber: pr.number,
+    repo,
+    author,
+    headRefName: pr.headRefName ?? '',
+    mergeState: normalizeMergeState(pr.mergeStateStatus),
+    labels,
+    coderabbitCommentUpdatedAt: latestCommentUpdatedAt(comments, coderabbitLogin),
+    mergifyCommentUpdatedAt: latestCommentUpdatedAt(comments, mergifyLogin),
+    open: true,
+  };
+}
+
+export function buildGitHubPrEvent(
+  previous: GitHubPrSnapshot | undefined,
+  current: GitHubPrSnapshot,
+  nowIso: string,
+): GitHubPrEvent | undefined {
+  const changes: GitHubPrEventChange[] = [];
+  if (!previous) {
+    changes.push('opened');
+  } else {
+    if (previous.headRefName !== current.headRefName) changes.push('head_ref_changed');
+    if (previous.mergeState !== current.mergeState) changes.push('merge_state_changed');
+    if (previous.coderabbitCommentUpdatedAt !== current.coderabbitCommentUpdatedAt) changes.push('coderabbit_comment');
+    if (previous.mergifyCommentUpdatedAt !== current.mergifyCommentUpdatedAt) changes.push('mergify_comment');
+    if (previous.labels.join('\u0000') !== current.labels.join('\u0000')) changes.push('labels_changed');
+  }
+  if (changes.length === 0) return undefined;
+  return {
+    eventKey: createEventKey(current, changes),
+    repo: current.repo,
+    prNumber: current.prNumber,
+    author: current.author,
+    headRefName: current.headRefName,
+    mergeState: current.mergeState,
+    labels: [...current.labels],
+    coderabbitCommentUpdatedAt: current.coderabbitCommentUpdatedAt,
+    mergifyCommentUpdatedAt: current.mergifyCommentUpdatedAt,
+    changes,
+    createdAt: nowIso,
+  };
+}
+
+export function buildClosedGitHubPrEvent(previous: GitHubPrSnapshot, nowIso: string): GitHubPrEvent {
+  const current: GitHubPrSnapshot = { ...previous, open: false };
+  return {
+    eventKey: createEventKey(current, ['closed']),
+    repo: previous.repo,
+    prNumber: previous.prNumber,
+    author: previous.author,
+    headRefName: previous.headRefName,
+    mergeState: previous.mergeState,
+    labels: [...previous.labels],
+    coderabbitCommentUpdatedAt: previous.coderabbitCommentUpdatedAt,
+    mergifyCommentUpdatedAt: previous.mergifyCommentUpdatedAt,
+    changes: ['closed'],
+    createdAt: nowIso,
+  };
+}
+
+export function createGitHubPrEventsTick(options: GitHubPrEventsTickOptions): WorkerTick {
+  const client = options.client ?? createGitHubPrClient(options.logger);
+  const coderabbitLogin = options.config.coderabbitLogin ?? CODERABBIT_LOGIN;
+  const mergifyLogin = options.config.mergifyLogin ?? MERGIFY_LOGIN;
+  return async () => {
+    const nowIso = (options.now ?? (() => new Date()))().toISOString();
+    const currentByPr = new Map<number, GitHubPrSnapshot>();
+    const prs = client.listOpenPullRequests(options.config.repo, options.config.author);
+
+    for (const pr of prs) {
+      const comments = [
+        ...client.listIssueComments(options.config.repo, pr.number),
+        ...client.listReviewComments(options.config.repo, pr.number),
+      ];
+      const snapshot = buildSnapshot(pr, comments, options.config.repo, options.config.author, coderabbitLogin, mergifyLogin);
+      currentByPr.set(snapshot.prNumber, snapshot);
+      const existing = options.store.getWorkerAction(GITHUB_PR_EVENTS_WORKER_KIND, snapshotExternalKey(snapshot.prNumber));
+      const previous = loadSnapshot(existing);
+      const event = buildGitHubPrEvent(previous, snapshot, nowIso);
+      if (event) {
+        options.messageBus.publish(Channels.GITHUB_PR_EVENT, event);
+      }
+      saveSnapshot(options.store, snapshot, existing, nowIso);
+    }
+
+    for (const action of options.store.listWorkerActions({ workerKind: GITHUB_PR_EVENTS_WORKER_KIND })) {
+      if (!action.externalKey.startsWith(SNAPSHOT_EXTERNAL_KEY_PREFIX)) continue;
+      const previous = loadSnapshot(action);
+      if (!previous || !previous.open || currentByPr.has(previous.prNumber)) continue;
+      options.messageBus.publish(Channels.GITHUB_PR_EVENT, buildClosedGitHubPrEvent(previous, nowIso));
+      saveSnapshot(options.store, { ...previous, open: false }, action, nowIso);
+    }
+  };
+}
+
+export function createGitHubPrEventsWorker(options: GitHubPrEventsWorkerOptions): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: GITHUB_PR_EVENTS_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.config.intervalMs ?? DEFAULT_GITHUB_PR_EVENTS_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? true,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: options.onTick ?? createGitHubPrEventsTick(options),
+  });
+}

--- a/packages/transport/src/message-bus.ts
+++ b/packages/transport/src/message-bus.ts
@@ -45,6 +45,8 @@ export const Channels = {
   WORKFLOW_LOADED: 'workflow.loaded',
   EXPERIMENT_SPAWNED: 'experiment.spawned',
   EXPERIMENT_SELECTED: 'experiment.selected',
+  /** Shared GitHub PR maintenance events published by the owner. */
+  GITHUB_PR_EVENT: 'github.pr_event',
   /** Orchestrator → surface events (workflow progress cards, etc.) for out-of-process surfaces. */
   SURFACE_EVENT: 'surface.event',
 } as const;


### PR DESCRIPTION
## Summary

Adds the shared GitHub PR maintenance event shapes and the transport channel that carries them between the engine and its workers.

## Review Claim

The engine gains shared GitHub PR maintenance event shapes and their transport channel.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice adds the event shapes and the transport channel; existing workers are untouched.

## Slice Rationale

The shared events land before the workers that consume them.

## Non-goals

No worker behavior change beyond the new channel. No GitHub writes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine test github-pr-events-worker`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- ci-refresh -->
