### PR TITLE
[Make PR](1) Require post-push metadata audit

### DIFF
--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -62,5 +62,12 @@ must_contain "$SKILL_MD" "contains an empty commit slice" "make-pr skill must re
 must_contain "$SKILL_MD" 'node scripts/create-pr.mjs`' "make-pr skill must apply the empty-slice rule to normal PR creation"
 must_contain "$SKILL_MD" "node scripts/create-pr.mjs --update-existing" "make-pr skill must apply the empty-slice rule to PR updates"
 must_contain "$SKILL_MD" "mergify stack push" "make-pr skill must apply the empty-slice rule to Mergify stack publication"
+# Mergify-published stacks must be audited and repaired before yielding.
+must_contain "$SKILL_MD" "After \`mergify stack push\`, you MUST audit the live PRs immediately" "make-pr skill must require a post-push audit of live PR metadata"
+must_contain "$SKILL_MD" "empty description or a bare \`Depends-On:\` line are a publication failure" "make-pr skill must reject placeholder Mergify PR metadata"
+must_contain "$SKILL_MD" "Read each live PR (\`gh pr view\` or \`pr://\`) for title, body, base, and head" "make-pr skill must inspect live PR metadata after publication"
+must_contain "$SKILL_MD" "aligned stack title prefix" "make-pr skill must require aligned stack titles after publication"
+must_contain "$SKILL_MD" "remote-only head branch name" "make-pr skill must document the Mergify branch-name mismatch case"
+must_contain "$SKILL_MD" "gh pr edit --title ... --body-file ..." "make-pr skill must allow immediate metadata repair when create-pr cannot map the published branch"
 
 echo "OK: make-pr skill contract checks passed"

--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -6,11 +6,15 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SKILL_MD="$REPO_ROOT/skills/make-pr/SKILL.md"
 REVIEW_COMPRESSION_MD="$REPO_ROOT/skills/review-compression/SKILL.md"
 
+# Tiny shell helpers only. This test does not parse GitHub payloads.
+# It locks specific policy lines in the skill docs so the regression fails
+# if someone removes the instruction text later.
 fail() {
   echo "FAIL: $*" >&2
   exit 1
 }
 
+# Require one exact literal string in the target markdown file.
 must_contain() {
   local file="$1"
   local needle="$2"
@@ -59,6 +63,7 @@ must_contain "$SKILL_MD" "do not present an unchanged screenshot as proof of the
 # The publication checklist must stop empty PR slices before create/update/stack publish.
 must_contain "$SKILL_MD" "has no file changes against its selected base" "make-pr skill must reject branches with no reviewable file diff"
 must_contain "$SKILL_MD" "contains an empty commit slice" "make-pr skill must reject empty commit slices"
+must_contain "$SKILL_MD" "No custom payload parsing is required here" "make-pr skill must explain that the post-push audit checks rendered PR metadata, not ad hoc payload parsing"
 must_contain "$SKILL_MD" 'node scripts/create-pr.mjs`' "make-pr skill must apply the empty-slice rule to normal PR creation"
 must_contain "$SKILL_MD" "node scripts/create-pr.mjs --update-existing" "make-pr skill must apply the empty-slice rule to PR updates"
 must_contain "$SKILL_MD" "mergify stack push" "make-pr skill must apply the empty-slice rule to Mergify stack publication"

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -157,6 +157,7 @@ For Mergify-managed stack PRs, this update path is REQUIRED after `mergify stack
 After `mergify stack push`, you MUST audit the live PRs immediately. Default Mergify-created titles/bodies like an empty description or a bare `Depends-On:` line are a publication failure, not a follow-up chore.
 
 Required post-push audit:
+No custom payload parsing is required here. The check is simple: verify the rendered title/body and the base/head branch names on each live PR.
 
 1. Read each live PR (`gh pr view` or `pr://`) for title, body, base, and head.
 2. If any PR is missing the preferred body sections or the aligned stack title prefix, repair it before yielding.

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -153,7 +153,18 @@ Update an existing PR with:
 node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-pr.md --update <pr-number>
 ```
 
-For Mergify-managed stack PRs, this update path is REQUIRED after `mergify stack push`. Do not use `gh pr edit` for stack PR body/title updates, because it bypasses the changed-file scope checks in `create-pr.mjs`.
+For Mergify-managed stack PRs, this update path is REQUIRED after `mergify stack push`. Do not leave the Mergify-generated placeholder title/body live.
+After `mergify stack push`, you MUST audit the live PRs immediately. Default Mergify-created titles/bodies like an empty description or a bare `Depends-On:` line are a publication failure, not a follow-up chore.
+
+Required post-push audit:
+
+1. Read each live PR (`gh pr view` or `pr://`) for title, body, base, and head.
+2. If any PR is missing the preferred body sections or the aligned stack title prefix, repair it before yielding.
+3. Prefer `node scripts/create-pr.mjs --update-existing ...` when the current local branch matches the published PR branch.
+4. If Mergify generated a remote-only head branch name that `create-pr` cannot map from the local branch, use `gh pr edit --title ... --body-file ...` immediately rather than leaving placeholder metadata live.
+
+Do not stop after `mergify stack push` until the GitHub-side metadata matches the intended titles and bodies.
+
 
 This script handles local image path upload/injection when configured. It also rejects UI-impacting diffs unless the body includes visual proof media.
 
@@ -195,7 +206,8 @@ If review says one published stack slice is still too broad:
 5. Get the real base branch with `gh pr view --json baseRefName --jq .baseRefName`.
 6. Update each PR with `node scripts/create-pr.mjs --title "..." --base <actual-base-branch> --body-file <file> --update-existing`.
 
-Manual `gh pr edit` is a last-resort escape hatch only when `create-pr` itself is broken. The normal path is `create-pr --update-existing`.
+7. Audit the live PR metadata on GitHub. If any replacement PR still shows an empty description or only `Depends-On:`, repair it immediately.
+Manual `gh pr edit` is the escape hatch when `create-pr --update-existing` cannot map the local branch to the published Mergify branch. Use it to repair live metadata immediately, not as the default path.
 
 
 ## Validation


### PR DESCRIPTION
## Summary

Tells the PR skill to audit live GitHub metadata right after `mergify stack push`.

This closes the gap where Mergify could create placeholder titles or empty bodies and the agent could stop before repairing them.

The skill now says when `create-pr --update-existing` is required, when `gh pr edit` is the fallback, and what to inspect on every published PR.

<details>
<summary>Review metadata</summary>

Review Claim: The make-pr skill now forbids yielding after `mergify stack push` until the live PR titles and bodies are repaired.

Review Lane: policy

Review Unit: tooling-policy

Safety Invariant: This changes only authoring guidance and its contract test.

Slice Rationale: The guidance and the focused test land together so the regression comes back if the new rule is removed.

</details>

## Non-goals

No change to `create-pr.mjs` behavior.

No change to Mergify itself.

No application code change.

## Test Plan

- [x] `bash scripts/test-make-pr-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0290b5947`
- Post-revert steps: None
- Data migration? No
