### PR TITLE
[Terminal Sessions](5) Persist Planning Terminal session state

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -6,10 +6,12 @@ import {
   listInAppPlanningPresets,
   planFromGoal,
   resetPlanningChat,
+  restorePlanningChatSessions,
   sendPlanningChatMessage,
   submitPlanningChatDraft,
   type LoadedGeneratedPlan,
 } from '../in-app-planner.js';
+import { ConversationRepository, SQLiteAdapter, type InAppPlanningSessionRecord } from '@invoker/data-store';
 
 const VALID_PLAN = `Here is the plan.
 
@@ -525,6 +527,144 @@ tasks:
     })).resolves.toEqual({ ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' });
   });
 
+
+  it('persists visible planning sessions and hidden planner context while sending', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue('What should the README include?');
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const sessions = createInAppPlanningChatSessions();
+
+      const result = await sendPlanningChatMessage({
+        message: 'Add README',
+        presetKey: 'codex',
+      }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+
+      if (!result.ok) throw new Error(result.error);
+      expect(adapter.loadInAppPlanningSession(result.sessionId)).toMatchObject({
+        id: result.sessionId,
+        title: 'Add README',
+        presetKey: 'codex',
+        pendingResponse: false,
+        messages: expect.arrayContaining([
+          expect.objectContaining({ role: 'user', text: 'Add README' }),
+          expect.objectContaining({ role: 'assistant', text: 'What should the README include?' }),
+        ]),
+      });
+      expect(conversationRepo.loadConversation(result.sessionId)?.threadTs).toBe(result.sessionId);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('restores draft-ready sessions and submits from hidden planner context', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const record: InAppPlanningSessionRecord = {
+        id: 'planning-restored',
+        title: 'Restored plan',
+        presetKey: 'codex',
+        status: 'draft_ready',
+        messages: [
+          { id: 1, role: 'system', text: 'Ask Invoker what you want to build.', tone: 'muted', createdAt: '2026-07-07T00:00:00.000Z' },
+          { id: 2, role: 'user', text: 'Draft it', createdAt: '2026-07-07T00:00:01.000Z' },
+          { id: 3, role: 'assistant', text: VALID_PLAN, createdAt: '2026-07-07T00:00:02.000Z' },
+        ],
+        draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First task', 'Second task'] },
+        pendingResponse: false,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:02.000Z',
+      };
+      conversationRepo.saveConversation('planning-restored', [
+        { role: 'user', content: 'Draft it' },
+        { role: 'assistant', content: VALID_PLAN },
+      ], null, false, undefined, undefined, 'plan');
+
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+      const loadGeneratedPlan = vi.fn().mockResolvedValue({ planName: 'Mock Plan', workflowId: 'wf-1' });
+
+      await expect(submitPlanningChatDraft({ sessionId: 'planning-restored' }, {
+        sessions,
+        loadGeneratedPlan,
+        planningSessionStore: adapter,
+      })).resolves.toMatchObject({ ok: true, planName: 'Mock Plan', workflowId: 'wf-1' });
+      expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('restores interrupted sessions idle with an interruption system line', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const record: InAppPlanningSessionRecord = {
+        id: 'planning-interrupted',
+        title: 'Interrupted plan',
+        presetKey: 'codex',
+        status: 'still_discussing',
+        messages: [
+          { id: 1, role: 'system', text: 'Ask Invoker what you want to build.', tone: 'muted', createdAt: '2026-07-07T00:00:00.000Z' },
+          { id: 2, role: 'user', text: 'Continue', createdAt: '2026-07-07T00:00:01.000Z' },
+        ],
+        pendingResponse: true,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:01.000Z',
+      };
+      adapter.upsertInAppPlanningSession(record);
+      const sessions = createInAppPlanningChatSessions();
+
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo: new ConversationRepository(adapter),
+        planningSessionStore: adapter,
+      });
+
+      const restored = sessions.get('planning-interrupted');
+      expect(restored?.pendingSend).toBeUndefined();
+      expect(restored?.messages.at(-1)).toMatchObject({
+        role: 'system',
+        text: 'Planner was interrupted before it could answer. Send another message to continue.',
+        tone: 'error',
+      });
+      expect(adapter.loadInAppPlanningSession('planning-interrupted')?.pendingResponse).toBe(false);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('is a no-op without loading planner surfaces when there are no sessions', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const builder = vi.fn(() => ({ command: 'planner', args: [] }));
+
+    await expect(restorePlanningChatSessions([], {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder: builder,
+    })).resolves.toBeUndefined();
+
+    expect(sessions.size).toBe(0);
+    expect(builder).not.toHaveBeenCalled();
+  });
   it('resets a planning chat session', () => {
     const sessions = createInAppPlanningChatSessions();
     sessions.set('session-1', {

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -17,8 +17,14 @@ import type {
   InAppPlanningSubmitResponse,
   PlanningPresetOption,
 } from '@invoker/contracts';
+import type {
+  ConversationMessageEntry,
+  ConversationRepository,
+  InAppPlanningSessionPatch,
+  InAppPlanningSessionRecord,
+} from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
-import type { HarnessPreset, PlanConversation, PlanningCommandBuilder } from '@invoker/surfaces';
+import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
 
 export interface LoadedGeneratedPlan {
@@ -28,11 +34,19 @@ export interface LoadedGeneratedPlan {
   workflowCount?: number;
 }
 
+export interface InAppPlanningSessionStore {
+  upsertInAppPlanningSession(record: InAppPlanningSessionRecord): void;
+  updateInAppPlanningSession(sessionId: string, patch: InAppPlanningSessionPatch): void;
+  deleteInAppPlanningSession(sessionId: string): void;
+}
+
 export interface InAppPlannerDeps {
   config: InvokerConfig;
   loadGeneratedPlan: (planText: string) => LoadedGeneratedPlan | Promise<LoadedGeneratedPlan>;
   workingDir?: string;
   planningCommandBuilder?: PlanningCommandBuilder;
+  conversationRepo?: ConversationRepository;
+  plannerReplyOverride?: (formattedMessage: string) => Promise<string>;
 }
 
 export interface InAppPlanningChatSession {
@@ -43,6 +57,7 @@ export interface InAppPlanningChatSession {
   messages: InAppPlanningChatLine[];
   conversation: PlanConversation;
   draftPlanSummary?: InAppPlanningPlanSummary;
+  draftPlanText?: string;
   submittedWorkflowId?: string;
   submittedPlanName?: string;
   createdAt: string;
@@ -68,13 +83,17 @@ function isModuleResolutionError(error: unknown): boolean {
   );
 }
 
-async function loadPlannerSurfaces(): Promise<{
+type PlanConversationConstructor = new (config: PlanConversationConfig) => PlanConversation;
+
+interface PlannerSurfacesModule {
   BUILTIN_HARNESS_PRESETS: Record<string, HarnessPreset>;
   DEFAULT_HARNESS_PRESET: string;
-  PlanConversation: new (...args: any[]) => PlanConversation;
+  PlanConversation: PlanConversationConstructor;
   extractYamlPlan: (output: string) => string | null;
   summarizePlanText: (planText: string) => InAppPlanningPlanSummary | null;
-}> {
+}
+
+async function loadPlannerSurfaces(): Promise<PlannerSurfacesModule> {
   try {
     // Static import cannot work in required-fast CI because that job boots the built app
     // before the workspace @invoker/surfaces package has produced dist/index.js.
@@ -85,6 +104,7 @@ async function loadPlannerSurfaces(): Promise<{
     }
     const builtSurfacesModulePath = '../../surfaces/dist/index.js';
     try {
+      // Runtime fallback: built Electron tests may run before workspace package exports resolve.
       return await import(builtSurfacesModulePath);
     } catch (distError) {
       if (!isModuleResolutionError(distError)) {
@@ -94,6 +114,7 @@ async function loadPlannerSurfaces(): Promise<{
         throw new Error('Unable to load @invoker/surfaces. Build packages/surfaces first so dist/index.js exists.');
       }
       const sourceSurfacesModulePath = '../../surfaces/src/index.ts';
+      // Runtime fallback: Vitest can execute TypeScript sources before package dist exists.
       return await import(sourceSurfacesModulePath);
     }
   }
@@ -155,11 +176,113 @@ function appendSessionMessage(
   session.updatedAt = createdAt;
 }
 
+function sessionToRecord(session: InAppPlanningChatSession, pendingResponse: boolean): InAppPlanningSessionRecord {
+  return {
+    id: session.id,
+    title: session.title,
+    presetKey: session.presetKey,
+    status: session.status,
+    messages: session.messages,
+    draftPlanSummary: session.draftPlanSummary,
+    submittedWorkflowId: session.submittedWorkflowId,
+    submittedPlanName: session.submittedPlanName,
+    pendingResponse,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+  };
+}
+
+function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessionSummary {
+  return {
+    id: session.id,
+    title: session.title,
+    status: session.status,
+    presetKey: session.presetKey,
+    messages: session.messages,
+    draftPlanAvailable: Boolean(session.draftPlanSummary),
+    draftPlanSummary: session.draftPlanSummary,
+    submittedWorkflowId: session.submittedWorkflowId,
+    submittedPlanName: session.submittedPlanName,
+    createdAt: session.createdAt,
+    updatedAt: session.updatedAt,
+  };
+}
+
+function persistPlanningSession(
+  session: InAppPlanningChatSession,
+  store: InAppPlanningSessionStore | undefined,
+  pendingResponse: boolean,
+): void {
+  if (!store) return;
+  store.upsertInAppPlanningSession(sessionToRecord(session, pendingResponse));
+}
+
+function saveOverrideConversation(
+  repo: ConversationRepository | undefined,
+  sessionId: string,
+  formattedMessage: string,
+  reply: string,
+): void {
+  if (!repo) return;
+  const existing = repo.loadConversation(sessionId);
+  const priorMessages: ConversationMessageEntry[] = existing?.messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+  })) ?? [];
+  repo.saveConversation(
+    sessionId,
+    [
+      ...priorMessages,
+      { role: 'user', content: formattedMessage },
+      { role: 'assistant', content: reply },
+    ],
+    null,
+    false,
+    undefined,
+    undefined,
+    'plan',
+  );
+}
+
+function formatConversationalPlanningMessage(message: string): string {
+  return [
+    message,
+    '',
+    'In-app planning chat rule:',
+    '- Treat this as a conversation before a plan.',
+    '- Talk through edge cases, corner cases, architecture, and ambiguity with the human.',
+    '- Resolve those points before producing a YAML plan.',
+    '- If anything important is unclear, ask concise questions instead of drafting.',
+    '- Draft YAML only after the human asks you to draft/proceed, or after the conversation has already resolved the important choices.',
+  ].join('\n');
+}
+
+function planConversationConfig(
+  preset: HarnessPreset,
+  deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'conversationRepo'>,
+  threadTs: string,
+): PlanConversationConfig {
+  return {
+    threadTs,
+    conversationRepo: deps.conversationRepo,
+    tool: preset.tool,
+    model: preset.model,
+    workingDir: deps.workingDir,
+    timeoutMs: (deps.config.planningTimeoutSeconds ?? 7200) * 1000,
+    defaultBranch: deps.config.defaultBranch,
+    repoUrl: deps.config.defaultRepoUrl,
+    experimentalPlanner: deps.config.experimentalPlanner,
+    preferStackedWorkflows: true,
+    planningCommandBuilder: deps.planningCommandBuilder,
+  };
+}
+
 async function createSession(
   request: Partial<InAppPlanningCreateSessionRequest> | null | undefined,
   deps: InAppPlannerDeps & {
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
+    planningSessionStore?: InAppPlanningSessionStore;
   },
 ): Promise<InAppPlanningChatSession | { error: string }> {
   const presets = await resolveHarnessPresets(deps.config);
@@ -174,8 +297,9 @@ async function createSession(
 
   const { PlanConversation } = await loadPlannerSurfaces();
   const createdAt = new Date().toISOString();
+  const id = randomUUID();
   const session: InAppPlanningChatSession = {
-    id: randomUUID(),
+    id,
     title: typeof request?.title === 'string' && request.title.trim() ? request.title.trim() : 'Untitled plan',
     presetKey,
     status: 'still_discussing',
@@ -186,22 +310,13 @@ async function createSession(
       tone: 'muted',
       createdAt,
     }],
-    conversation: new PlanConversation({
-      tool: preset.tool,
-      model: preset.model,
-      workingDir: deps.workingDir,
-      timeoutMs: (deps.config.planningTimeoutSeconds ?? 7200) * 1000,
-      defaultBranch: deps.config.defaultBranch,
-      repoUrl: deps.config.defaultRepoUrl,
-      experimentalPlanner: deps.config.experimentalPlanner,
-      preferStackedWorkflows: true,
-      planningCommandBuilder: deps.planningCommandBuilder,
-    }),
+    conversation: new PlanConversation(planConversationConfig(preset, deps, id)),
     createdAt,
     updatedAt: createdAt,
     nextMessageId: 2,
   };
   deps.sessions.set(session.id, session);
+  persistPlanningSession(session, deps.planningSessionStore, false);
   return session;
 }
 
@@ -242,17 +357,7 @@ export async function planFromGoal(
 
   try {
     const { PlanConversation, extractYamlPlan } = await loadPlannerSurfaces();
-    const conversation = new PlanConversation({
-      tool: preset.tool,
-      model: preset.model,
-      workingDir: deps.workingDir,
-      timeoutMs: (deps.config.planningTimeoutSeconds ?? 7200) * 1000,
-      defaultBranch: deps.config.defaultBranch,
-      repoUrl: deps.config.defaultRepoUrl,
-      experimentalPlanner: deps.config.experimentalPlanner,
-      preferStackedWorkflows: true,
-      planningCommandBuilder: deps.planningCommandBuilder,
-    });
+    const conversation = new PlanConversation(planConversationConfig(preset, deps, randomUUID()));
     const plannerOutput = await conversation.sendMessage(goal);
     const planText = extractYamlPlan(plannerOutput);
     if (!planText) {
@@ -275,25 +380,12 @@ export async function planFromGoal(
   }
 }
 
-
-function formatConversationalPlanningMessage(message: string): string {
-  return [
-    message,
-    '',
-    'In-app planning chat rule:',
-    '- Treat this as a conversation before a plan.',
-    '- Talk through edge cases, corner cases, architecture, and ambiguity with the human.',
-    '- Resolve those points before producing a YAML plan.',
-    '- If anything important is unclear, ask concise questions instead of drafting.',
-    '- Draft YAML only after the human asks you to draft/proceed, or after the conversation has already resolved the important choices.',
-  ].join('\n');
-}
-
 export async function createPlanningChatSession(
   request: InAppPlanningCreateSessionRequest | undefined,
   deps: InAppPlannerDeps & {
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
+    planningSessionStore?: InAppPlanningSessionStore;
   },
 ): Promise<InAppPlanningCreateSessionResponse> {
   try {
@@ -301,20 +393,7 @@ export async function createPlanningChatSession(
     if ('error' in session) {
       return { ok: false, error: session.error };
     }
-    const summary: InAppPlanningSessionSummary = {
-      id: session.id,
-      title: session.title,
-      status: session.status,
-      presetKey: session.presetKey,
-      messages: session.messages,
-      draftPlanAvailable: Boolean(session.draftPlanSummary),
-      draftPlanSummary: session.draftPlanSummary,
-      submittedWorkflowId: session.submittedWorkflowId,
-      submittedPlanName: session.submittedPlanName,
-      createdAt: session.createdAt,
-      updatedAt: session.updatedAt,
-    };
-    return { ok: true, session: summary };
+    return { ok: true, session: sessionToSummary(session) };
   } catch (error) {
     return { ok: false, error: error instanceof Error ? error.message : String(error) };
   }
@@ -325,19 +404,7 @@ export function listPlanningChatSessions(
 ): InAppPlanningListSessionsResponse {
   const sessions = [...deps.sessions.values()]
     .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
-    .map((session): InAppPlanningSessionSummary => ({
-      id: session.id,
-      title: session.title,
-      status: session.status,
-      presetKey: session.presetKey,
-      messages: session.messages,
-      draftPlanAvailable: Boolean(session.draftPlanSummary),
-      draftPlanSummary: session.draftPlanSummary,
-      submittedWorkflowId: session.submittedWorkflowId,
-      submittedPlanName: session.submittedPlanName,
-      createdAt: session.createdAt,
-      updatedAt: session.updatedAt,
-    }));
+    .map(sessionToSummary);
   return { ok: true, sessions };
 }
 
@@ -346,6 +413,7 @@ export async function sendPlanningChatMessage(
   deps: InAppPlannerDeps & {
     sessions: InAppPlanningChatSessions;
     planningCommandBuilder: PlanningCommandBuilder;
+    planningSessionStore?: InAppPlanningSessionStore;
   },
 ): Promise<InAppPlanningChatResponse> {
   const rawRequest = request as Partial<InAppPlanningChatRequest> | null | undefined;
@@ -379,40 +447,62 @@ export async function sendPlanningChatMessage(
       if (activeSession.title === 'Untitled plan') {
         activeSession.title = titleFromMessage(message);
       }
+      persistPlanningSession(activeSession, deps.planningSessionStore, true);
 
-      const reply = await activeSession.conversation.sendMessage(formatConversationalPlanningMessage(message));
-      const planText = activeSession.conversation.getDraftedPlan();
-      if (!planText) {
-        activeSession.draftPlanSummary = undefined;
-        activeSession.status = reply.includes('?') ? 'waiting_for_answer' : 'still_discussing';
+      try {
+        const { extractYamlPlan, summarizePlanText } = await loadPlannerSurfaces();
+        const formattedMessage = formatConversationalPlanningMessage(message);
+        const reply = deps.plannerReplyOverride
+          ? await deps.plannerReplyOverride(formattedMessage)
+          : await activeSession.conversation.sendMessage(formattedMessage);
+        if (deps.plannerReplyOverride) {
+          saveOverrideConversation(deps.conversationRepo, activeSession.id, formattedMessage, reply);
+        }
+        const planText = activeSession.conversation.getDraftedPlan() ?? extractYamlPlan(reply);
+        if (!planText) {
+          activeSession.draftPlanSummary = undefined;
+          activeSession.draftPlanText = undefined;
+          activeSession.status = reply.includes('?') ? 'waiting_for_answer' : 'still_discussing';
+          appendSessionMessage(activeSession, 'assistant', reply);
+          persistPlanningSession(activeSession, deps.planningSessionStore, false);
+          return { ok: true, sessionId: activeSession.id, reply, draftPlanAvailable: false };
+        }
+
+        const summary = summarizePlanText(planText);
+        if (!summary) {
+          const fallbackReply = 'I drafted a plan, but I could not turn it into simple steps. Ask me to regenerate it before submitting.';
+          activeSession.draftPlanSummary = undefined;
+          activeSession.draftPlanText = undefined;
+          activeSession.status = 'still_discussing';
+          appendSessionMessage(activeSession, 'assistant', fallbackReply);
+          persistPlanningSession(activeSession, deps.planningSessionStore, false);
+          return {
+            ok: true,
+            sessionId: activeSession.id,
+            reply: fallbackReply,
+            draftPlanAvailable: false,
+          };
+        }
+        activeSession.draftPlanSummary = summary;
+        activeSession.draftPlanText = planText;
+        activeSession.status = 'draft_ready';
         appendSessionMessage(activeSession, 'assistant', reply);
-        return { ok: true, sessionId: activeSession.id, reply, draftPlanAvailable: false };
-      }
-
-      const { summarizePlanText } = await loadPlannerSurfaces();
-      const summary = summarizePlanText(planText);
-      if (!summary) {
-        const fallbackReply = 'I drafted a plan, but I could not turn it into simple steps. Ask me to regenerate it before submitting.';
-        activeSession.draftPlanSummary = undefined;
-        activeSession.status = 'still_discussing';
-        appendSessionMessage(activeSession, 'assistant', fallbackReply);
+        persistPlanningSession(activeSession, deps.planningSessionStore, false);
         return {
           ok: true,
           sessionId: activeSession.id,
-          reply: fallbackReply,
-          draftPlanAvailable: false,
+          reply,
+          draftPlanAvailable: true,
+          draftPlanSummary: summary,
+        };
+      } catch (error) {
+        persistPlanningSession(activeSession, deps.planningSessionStore, false);
+        return {
+          ok: false,
+          sessionId: activeSession.id,
+          error: error instanceof Error ? error.message : String(error),
         };
       }
-      activeSession.draftPlanSummary = summary;
-      activeSession.status = 'draft_ready';
-      appendSessionMessage(activeSession, 'assistant', reply);
-      return {
-        ok: true,
-        sessionId: activeSession.id,
-        reply,
-        draftPlanAvailable: true,
-        draftPlanSummary: summary,
-      };
     });
     activeSession.pendingSend = turn.then(() => undefined, () => undefined);
     return await turn;
@@ -430,6 +520,7 @@ export async function submitPlanningChatDraft(
   deps: {
     sessions: InAppPlanningChatSessions;
     loadGeneratedPlan: (planText: string) => LoadedGeneratedPlan | Promise<LoadedGeneratedPlan>;
+    planningSessionStore?: InAppPlanningSessionStore;
   },
 ): Promise<InAppPlanningSubmitResponse> {
   const rawRequest = request as Partial<InAppPlanningSubmitRequest> | null | undefined;
@@ -445,7 +536,7 @@ export async function submitPlanningChatDraft(
     return session.pendingSubmit;
   }
 
-  const planText = session.conversation.getDraftedPlan();
+  const planText = session.conversation.getDraftedPlan() ?? session.draftPlanText;
   if (!planText) {
     return { ok: false, error: 'No complete plan drafted yet. Ask the AI to create a full plan, then submit again.' };
   }
@@ -470,6 +561,7 @@ export async function submitPlanningChatDraft(
           : `Plan "${loaded.planName}" submitted to Invoker. Review it, then Run.`,
         'success',
       );
+      persistPlanningSession(session, deps.planningSessionStore, false);
       return {
         ok: true,
         planName: loaded.planName,
@@ -489,8 +581,79 @@ export async function submitPlanningChatDraft(
 
 export function resetPlanningChat(
   request: InAppPlanningResetRequest,
-  deps: { sessions: InAppPlanningChatSessions },
+  deps: { sessions: InAppPlanningChatSessions; planningSessionStore?: InAppPlanningSessionStore },
 ): InAppPlanningResetResponse {
   deps.sessions.delete(request.sessionId);
+  deps.planningSessionStore?.deleteInAppPlanningSession(request.sessionId);
   return { ok: true };
+}
+
+export async function restorePlanningChatSessions(
+  records: InAppPlanningSessionRecord[],
+  deps: InAppPlannerDeps & {
+    sessions: InAppPlanningChatSessions;
+    planningCommandBuilder: PlanningCommandBuilder;
+    planningSessionStore?: InAppPlanningSessionStore;
+  },
+): Promise<void> {
+  // Nothing persisted → skip loading @invoker/surfaces. The built required-fast CI app
+  // boots without surfaces/dist, so an eager load here would crash startup with no sessions.
+  if (records.length === 0) return;
+  const presets = await resolveHarnessPresets(deps.config);
+  const { PlanConversation } = await loadPlannerSurfaces();
+
+  for (const record of records) {
+    const preset = presets[record.presetKey];
+    if (!preset) continue;
+
+    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id));
+    await conversation.init();
+
+    const nextMessageId = Math.max(0, ...record.messages.map((message) => message.id)) + 1;
+    const session: InAppPlanningChatSession = {
+      id: record.id,
+      title: record.title,
+      presetKey: record.presetKey,
+      status: record.status,
+      messages: [...record.messages],
+      conversation,
+      draftPlanSummary: record.draftPlanSummary,
+      submittedWorkflowId: record.submittedWorkflowId,
+      submittedPlanName: record.submittedPlanName,
+      createdAt: record.createdAt,
+      updatedAt: record.updatedAt,
+      nextMessageId,
+    };
+
+    let shouldPersist = false;
+    if (record.pendingResponse && record.status !== 'submitted') {
+      appendSessionMessage(
+        session,
+        'system',
+        'Planner was interrupted before it could answer. Send another message to continue.',
+        'error',
+      );
+      shouldPersist = true;
+    }
+
+    const draftedPlan = conversation.getDraftedPlan();
+    if (session.status === 'draft_ready' && !draftedPlan) {
+      session.status = 'still_discussing';
+      session.draftPlanSummary = undefined;
+      appendSessionMessage(
+        session,
+        'system',
+        'The saved draft could not be restored. Ask the planner to draft it again.',
+        'error',
+      );
+      shouldPersist = true;
+    } else if (draftedPlan) {
+      session.draftPlanText = draftedPlan;
+    }
+
+    deps.sessions.set(session.id, session);
+    if (shouldPersist) {
+      persistPlanningSession(session, deps.planningSessionStore, false);
+    }
+  }
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -92,7 +92,7 @@ import type {
   WorkResponse,
   TerminalSessionDescriptor,
 } from '@invoker/contracts';
-import { SqliteTaskRepository } from '@invoker/data-store';
+import { ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import {
@@ -279,6 +279,7 @@ import {
   listPlanningChatSessions,
   planFromGoal as planFromGoalInApp,
   resetPlanningChat,
+  restorePlanningChatSessions,
   sendPlanningChatMessage,
   submitPlanningChatDraft,
 } from './in-app-planner.js';
@@ -1094,6 +1095,21 @@ function startHeadlessMode(): void {
         };
       };
 
+      const planningConversationRepo = new ConversationRepository(persistence, {
+        info: (message) => logger.info(message, { module: 'planning-chat' }),
+        warn: (message) => logger.warn(message, { module: 'planning-chat' }),
+        error: (message) => logger.error(message, { module: 'planning-chat' }),
+      });
+      await restorePlanningChatSessions(persistence.listInAppPlanningSessions(), {
+        config: invokerConfig,
+        workingDir: repoRoot,
+        sessions: planningChatSessions,
+        planningCommandBuilder,
+        loadGeneratedPlan,
+        conversationRepo: planningConversationRepo,
+        planningSessionStore: readOnlyMode ? undefined : persistence,
+      });
+
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
         switch (payload.channel) {
           case 'invoker:clear': {
@@ -1123,6 +1139,7 @@ function startHeadlessMode(): void {
               workingDir: repoRoot,
               loadGeneratedPlan,
               planningCommandBuilder,
+              conversationRepo: planningConversationRepo,
             });
           }
           case 'invoker:planning-chat-create': {
@@ -1132,6 +1149,8 @@ function startHeadlessMode(): void {
               sessions: planningChatSessions,
               planningCommandBuilder,
               loadGeneratedPlan,
+              conversationRepo: planningConversationRepo,
+              planningSessionStore: readOnlyMode ? undefined : persistence,
             });
           }
           case 'invoker:planning-chat-list': {
@@ -1144,16 +1163,22 @@ function startHeadlessMode(): void {
               sessions: planningChatSessions,
               planningCommandBuilder,
               loadGeneratedPlan,
+              conversationRepo: planningConversationRepo,
+              planningSessionStore: readOnlyMode ? undefined : persistence,
             });
           }
           case 'invoker:planning-chat-submit': {
             return submitPlanningChatDraft(payload.args[0] as InAppPlanningSubmitRequest, {
               sessions: planningChatSessions,
               loadGeneratedPlan,
+              planningSessionStore: readOnlyMode ? undefined : persistence,
             });
           }
           case 'invoker:planning-chat-reset': {
-            return resetPlanningChat(payload.args[0] as InAppPlanningResetRequest, { sessions: planningChatSessions });
+            return resetPlanningChat(payload.args[0] as InAppPlanningResetRequest, {
+              sessions: planningChatSessions,
+              planningSessionStore: readOnlyMode ? undefined : persistence,
+            });
           }
           case 'invoker:load-plan': {
             const planText = String(payload.args[0] ?? '');
@@ -3735,6 +3760,21 @@ function createEmbeddedTerminalBackendFromConfig(
         workflowCount: loadedWorkflowIds.length,
       };
     }
+
+    const planningConversationRepo = new ConversationRepository(persistence, {
+      info: (message) => logger.info(message, { module: 'planning-chat' }),
+      warn: (message) => logger.warn(message, { module: 'planning-chat' }),
+      error: (message) => logger.error(message, { module: 'planning-chat' }),
+    });
+    await restorePlanningChatSessions(persistence.listInAppPlanningSessions(), {
+      config: invokerConfig,
+      workingDir: repoRoot,
+      sessions: planningChatSessions,
+      planningCommandBuilder,
+      loadGeneratedPlan: loadGeneratedPlanPreview,
+      conversationRepo: planningConversationRepo,
+      planningSessionStore: ownerMode ? persistence : undefined,
+    });
     let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
     let testPlanningChatResponse: { planYaml: string; planName: string; reply?: string } | null = null;
 
@@ -3749,6 +3789,7 @@ function createEmbeddedTerminalBackendFromConfig(
         workingDir: repoRoot,
         loadGeneratedPlan: loadGeneratedPlanPreview,
         planningCommandBuilder,
+        conversationRepo: planningConversationRepo,
       });
     });
     registerGuiMutationHandler('invoker:planning-chat-create', async (request: unknown) => {
@@ -3758,49 +3799,44 @@ function createEmbeddedTerminalBackendFromConfig(
         sessions: planningChatSessions,
         planningCommandBuilder,
         loadGeneratedPlan: loadGeneratedPlanPreview,
+        conversationRepo: planningConversationRepo,
+        planningSessionStore: ownerMode ? persistence : undefined,
       });
     });
     registerGuiMutationHandler('invoker:planning-chat-list', async () => {
       return listPlanningChatSessions({ sessions: planningChatSessions });
     });
     registerGuiMutationHandler('invoker:planning-chat-send', async (request: unknown) => {
-      if (process.env.NODE_ENV === 'test' && testPlanningChatResponse) {
-        const { summarizePlanText } = await import('@invoker/surfaces');
-        const draftPlanSummary = summarizePlanText(testPlanningChatResponse.planYaml) ?? undefined;
-        return {
-          ok: true,
-          sessionId: 'test-session',
-          reply: testPlanningChatResponse.reply ?? 'Draft plan ready.',
-          draftPlanAvailable: true,
-          draftPlanSummary,
-        };
-      }
+      const planningChatResponseOverride = process.env.NODE_ENV === 'test' ? testPlanningChatResponse : null;
+      const plannerReplyOverride = planningChatResponseOverride
+        ? async (): Promise<string> => `${planningChatResponseOverride.reply ?? 'Draft plan ready.'}\n\n\`\`\`yaml\n${planningChatResponseOverride.planYaml}\n\`\`\``
+        : undefined;
       return sendPlanningChatMessage(request as InAppPlanningChatRequest, {
         config: invokerConfig,
         workingDir: repoRoot,
         sessions: planningChatSessions,
         planningCommandBuilder,
         loadGeneratedPlan: loadGeneratedPlanPreview,
+        conversationRepo: planningConversationRepo,
+        planningSessionStore: ownerMode ? persistence : undefined,
+        plannerReplyOverride,
       });
     });
     registerGuiMutationHandler('invoker:planning-chat-submit', async (request: unknown) => {
-      if (process.env.NODE_ENV === 'test' && testPlanningChatResponse) {
-        const loaded = await loadGeneratedPlanPreview(testPlanningChatResponse.planYaml, {
-          preserveTaskHandles: true,
-          logLabel: 'planning-chat-submit',
-        });
-        return { ok: true, planName: testPlanningChatResponse.planName, workflowId: loaded.workflowId, workflowIds: loaded.workflowIds, workflowCount: loaded.workflowCount };
-      }
       return submitPlanningChatDraft(request as InAppPlanningSubmitRequest, {
         sessions: planningChatSessions,
         loadGeneratedPlan: (planText) => loadGeneratedPlanPreview(planText, {
           preserveTaskHandles: true,
           logLabel: 'planning-chat-submit',
         }),
+        planningSessionStore: ownerMode ? persistence : undefined,
       });
     });
     registerGuiMutationHandler('invoker:planning-chat-reset', async (request: unknown) => {
-      return resetPlanningChat(request as InAppPlanningResetRequest, { sessions: planningChatSessions });
+      return resetPlanningChat(request as InAppPlanningResetRequest, {
+        sessions: planningChatSessions,
+        planningSessionStore: ownerMode ? persistence : undefined,
+      });
     });
     registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
       const planText = String(planTextArg);

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, statSync, existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SQLiteAdapter } from '../sqlite-adapter.js';
-import type { Workflow, Conversation, WorkerActionWrite, TerminalSessionRecord } from '../adapter.js';
+import type { Workflow, Conversation, WorkerActionWrite, TerminalSessionRecord, InAppPlanningSessionRecord } from '../adapter.js';
 import { createAttempt } from '@invoker/workflow-core';
 import type { Attempt, TaskState, TaskStateChanges } from '@invoker/workflow-core';
 
@@ -59,6 +59,51 @@ describe('SQLiteAdapter', () => {
       outputSnapshot: 'terminal output\n',
       createdAt: '2026-07-07T00:00:00.000Z',
       updatedAt: '2026-07-07T00:00:01.000Z',
+      ...overrides,
+    };
+  }
+
+  function makePlanningSession(
+    id: string,
+    overrides: Partial<InAppPlanningSessionRecord> = {},
+  ): InAppPlanningSessionRecord {
+    return {
+      id,
+      title: `Planning ${id}`,
+      presetKey: 'codex',
+      status: 'draft_ready',
+      messages: [
+        {
+          id: 1,
+          role: 'system',
+          text: 'Ask Invoker what you want to build.',
+          tone: 'muted',
+          createdAt: '2026-07-07T00:00:00.000Z',
+        },
+        {
+          id: 2,
+          role: 'user',
+          text: 'Add README',
+          createdAt: '2026-07-07T00:00:01.000Z',
+        },
+        {
+          id: 3,
+          role: 'assistant',
+          text: 'Draft plan ready.',
+          createdAt: '2026-07-07T00:00:02.000Z',
+        },
+      ],
+      draftPlanSummary: {
+        name: 'README plan',
+        taskCount: 1,
+        workflowCount: 1,
+        steps: ['Update README'],
+      },
+      submittedWorkflowId: 'wf-planning',
+      submittedPlanName: 'README plan',
+      pendingResponse: true,
+      createdAt: '2026-07-07T00:00:00.000Z',
+      updatedAt: '2026-07-07T00:00:03.000Z',
       ...overrides,
     };
   }
@@ -308,6 +353,91 @@ describe('SQLiteAdapter', () => {
       adapter.deleteAllWorkflows();
 
       expect(adapter.listTerminalSessions()).toEqual([]);
+    });
+  });
+
+  describe('in_app_planning_sessions', () => {
+    it('creates the planning session schema with visible message storage', () => {
+      expect(tableColumns(adapter, 'in_app_planning_sessions')).toEqual([
+        'session_id',
+        'title',
+        'preset_key',
+        'status',
+        'draft_plan_summary_json',
+        'submitted_workflow_id',
+        'submitted_plan_name',
+        'pending_response',
+        'created_at',
+        'updated_at',
+      ]);
+      expect(tableColumns(adapter, 'in_app_planning_messages')).toEqual([
+        'session_id',
+        'message_id',
+        'role',
+        'text',
+        'tone',
+        'created_at',
+      ]);
+      expect(tableIndexes(adapter, 'in_app_planning_sessions')).toContain('idx_in_app_planning_sessions_updated');
+      expect(tableIndexes(adapter, 'in_app_planning_messages')).toContain('idx_in_app_planning_messages_session');
+      expect(tableForeignKeys(adapter, 'in_app_planning_messages')).toContain('in_app_planning_sessions.session_id:NO ACTION');
+    });
+
+    it('round-trips planning sessions across adapter reopen', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-planning-sessions-'));
+      const dbPath = join(dir, 'invoker.db');
+      try {
+        const first = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        first.upsertInAppPlanningSession(makePlanningSession('planning-1'));
+        first.close();
+
+        const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        expect(reopened.loadInAppPlanningSession('planning-1')).toEqual(makePlanningSession('planning-1'));
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('updates planning sessions and replaces visible messages', () => {
+      adapter.upsertInAppPlanningSession(makePlanningSession('planning-1'));
+      adapter.updateInAppPlanningSession('planning-1', {
+        status: 'still_discussing',
+        messages: [{
+          id: 7,
+          role: 'system',
+          text: 'Planner was interrupted before it could answer. Send another message to continue.',
+          tone: 'error',
+          createdAt: '2026-07-07T00:00:04.000Z',
+        }],
+        draftPlanSummary: undefined,
+        pendingResponse: false,
+        updatedAt: '2026-07-07T00:00:05.000Z',
+      });
+
+      const loaded = adapter.loadInAppPlanningSession('planning-1');
+      expect(loaded).toMatchObject({
+        status: 'still_discussing',
+        messages: [{
+          id: 7,
+          role: 'system',
+          text: 'Planner was interrupted before it could answer. Send another message to continue.',
+          tone: 'error',
+          createdAt: '2026-07-07T00:00:04.000Z',
+        }],
+        pendingResponse: false,
+        updatedAt: '2026-07-07T00:00:05.000Z',
+      });
+      expect(loaded?.draftPlanSummary).toBeUndefined();
+    });
+
+    it('deletes planning sessions and their visible messages', () => {
+      adapter.upsertInAppPlanningSession(makePlanningSession('planning-1'));
+
+      adapter.deleteInAppPlanningSession('planning-1');
+
+      expect(adapter.loadInAppPlanningSession('planning-1')).toBeUndefined();
+      expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM in_app_planning_messages WHERE session_id = 'planning-1'")).toBe(0);
     });
   });
 

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -6,7 +6,7 @@
  */
 
 import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency } from '@invoker/workflow-core';
-import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, SearchResultItem, SearchOptions } from '@invoker/contracts';
 
 
 export type ConversationMode = 'agent' | 'plan';
@@ -215,6 +215,32 @@ export interface TerminalSessionRecord {
 export type TerminalSessionPatch = Partial<
   Pick<TerminalSessionRecord, 'status' | 'exitCode' | 'outputSnapshot' | 'updatedAt'>
 >;
+
+export interface InAppPlanningSessionRecord {
+  id: string;
+  title: string;
+  presetKey: string;
+  status: InAppPlanningSessionStatus;
+  messages: InAppPlanningChatLine[];
+  draftPlanSummary?: InAppPlanningPlanSummary;
+  submittedWorkflowId?: string;
+  submittedPlanName?: string;
+  pendingResponse: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type InAppPlanningSessionPatch = Partial<Pick<
+  InAppPlanningSessionRecord,
+  | 'title'
+  | 'status'
+  | 'messages'
+  | 'draftPlanSummary'
+  | 'submittedWorkflowId'
+  | 'submittedPlanName'
+  | 'pendingResponse'
+  | 'updatedAt'
+>>;
 
 export interface PersistenceAdapter {
   // Workflows

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -33,7 +33,7 @@ import type {
   DetachedExternalDependency,
 } from '@invoker/workflow-core';
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
-import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, SearchResultItem, SearchOptions } from '@invoker/contracts';
 import {
   assertTaskConsistent,
   assertWorkflowConsistent,
@@ -60,6 +60,8 @@ import type {
   WorkerActionWrite,
   TerminalSessionPatch,
   TerminalSessionRecord,
+  InAppPlanningSessionPatch,
+  InAppPlanningSessionRecord,
 } from './adapter.js';
 import {
   SCHEMA_DDL,
@@ -391,6 +393,28 @@ type TerminalSessionRow = {
   updated_at?: unknown;
 };
 
+type InAppPlanningSessionRow = {
+  session_id?: unknown;
+  title?: unknown;
+  preset_key?: unknown;
+  status?: unknown;
+  draft_plan_summary_json?: unknown;
+  submitted_workflow_id?: unknown;
+  submitted_plan_name?: unknown;
+  pending_response?: unknown;
+  created_at?: unknown;
+  updated_at?: unknown;
+};
+
+type InAppPlanningMessageRow = {
+  session_id?: unknown;
+  message_id?: unknown;
+  role?: unknown;
+  text?: unknown;
+  tone?: unknown;
+  created_at?: unknown;
+};
+
 function parseTerminalArgsJson(value: unknown): string[] {
   if (typeof value !== 'string' || value.length === 0) return [];
   try {
@@ -399,6 +423,53 @@ function parseTerminalArgsJson(value: unknown): string[] {
   } catch {
     return [];
   }
+}
+
+function isInAppPlanningSessionStatus(value: unknown): value is InAppPlanningSessionStatus {
+  return value === 'still_discussing'
+    || value === 'waiting_for_answer'
+    || value === 'draft_ready'
+    || value === 'submitted';
+}
+
+function isInAppPlanningMessageRole(value: unknown): value is InAppPlanningChatLine['role'] {
+  return value === 'user' || value === 'assistant' || value === 'system';
+}
+
+function isInAppPlanningMessageTone(value: unknown): value is InAppPlanningChatLine['tone'] {
+  return value === undefined
+    || value === null
+    || value === 'muted'
+    || value === 'error'
+    || value === 'success';
+}
+
+function parseInAppPlanningPlanSummary(value: unknown): InAppPlanningPlanSummary | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value !== 'string' || value.length === 0) return undefined;
+  const parsed = JSON.parse(value) as unknown;
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error('planning summary must be an object');
+  }
+  const candidate = parsed as Partial<InAppPlanningPlanSummary>;
+  if (
+    typeof candidate.name !== 'string'
+    || typeof candidate.taskCount !== 'number'
+    || !Array.isArray(candidate.steps)
+    || !candidate.steps.every((step) => typeof step === 'string')
+    || (
+      candidate.workflowCount !== undefined
+      && typeof candidate.workflowCount !== 'number'
+    )
+  ) {
+    throw new Error('planning summary has invalid shape');
+  }
+  return {
+    name: candidate.name,
+    taskCount: candidate.taskCount,
+    ...(candidate.workflowCount === undefined ? {} : { workflowCount: candidate.workflowCount }),
+    steps: candidate.steps,
+  };
 }
 
 export class SQLiteAdapter implements PersistenceAdapter {
@@ -1821,6 +1892,124 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.dirty = true;
   }
 
+  upsertInAppPlanningSession(record: InAppPlanningSessionRecord): void {
+    this.runTransaction(() => {
+      this.db.run(
+        `INSERT INTO in_app_planning_sessions (
+          session_id,
+          title,
+          preset_key,
+          status,
+          draft_plan_summary_json,
+          submitted_workflow_id,
+          submitted_plan_name,
+          pending_response,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(session_id) DO UPDATE SET
+          title = excluded.title,
+          preset_key = excluded.preset_key,
+          status = excluded.status,
+          draft_plan_summary_json = excluded.draft_plan_summary_json,
+          submitted_workflow_id = excluded.submitted_workflow_id,
+          submitted_plan_name = excluded.submitted_plan_name,
+          pending_response = excluded.pending_response,
+          created_at = excluded.created_at,
+          updated_at = excluded.updated_at`,
+        [
+          record.id,
+          record.title,
+          record.presetKey,
+          record.status,
+          record.draftPlanSummary ? JSON.stringify(record.draftPlanSummary) : null,
+          record.submittedWorkflowId ?? null,
+          record.submittedPlanName ?? null,
+          record.pendingResponse ? 1 : 0,
+          record.createdAt,
+          record.updatedAt,
+        ],
+      );
+      this.replaceInAppPlanningMessages(record.id, record.messages, record.updatedAt);
+    });
+  }
+
+  listInAppPlanningSessions(): InAppPlanningSessionRecord[] {
+    const rows = this.queryAll(
+      'SELECT * FROM in_app_planning_sessions ORDER BY updated_at DESC, created_at DESC',
+    ) as InAppPlanningSessionRow[];
+    const records: InAppPlanningSessionRecord[] = [];
+    for (const row of rows) {
+      const record = this.mapInAppPlanningSessionRow(row);
+      if (record) records.push(record);
+    }
+    return records;
+  }
+
+  loadInAppPlanningSession(sessionId: string): InAppPlanningSessionRecord | undefined {
+    const row = this.queryOne('SELECT * FROM in_app_planning_sessions WHERE session_id = ?', [sessionId]);
+    return row ? this.mapInAppPlanningSessionRow(row as InAppPlanningSessionRow) : undefined;
+  }
+
+  updateInAppPlanningSession(sessionId: string, patch: InAppPlanningSessionPatch): void {
+    this.ensureWritable();
+    const updateSession = (): void => {
+      const setClauses: string[] = [];
+      const values: unknown[] = [];
+      if (Object.hasOwn(patch, 'title')) {
+        setClauses.push('title = ?');
+        values.push(patch.title ?? null);
+      }
+      if (Object.hasOwn(patch, 'status')) {
+        setClauses.push('status = ?');
+        values.push(patch.status ?? null);
+      }
+      if (Object.hasOwn(patch, 'draftPlanSummary')) {
+        setClauses.push('draft_plan_summary_json = ?');
+        values.push(patch.draftPlanSummary ? JSON.stringify(patch.draftPlanSummary) : null);
+      }
+      if (Object.hasOwn(patch, 'submittedWorkflowId')) {
+        setClauses.push('submitted_workflow_id = ?');
+        values.push(patch.submittedWorkflowId ?? null);
+      }
+      if (Object.hasOwn(patch, 'submittedPlanName')) {
+        setClauses.push('submitted_plan_name = ?');
+        values.push(patch.submittedPlanName ?? null);
+      }
+      if (Object.hasOwn(patch, 'pendingResponse')) {
+        setClauses.push('pending_response = ?');
+        values.push(patch.pendingResponse ? 1 : 0);
+      }
+      if (Object.hasOwn(patch, 'updatedAt')) {
+        setClauses.push('updated_at = ?');
+        values.push(patch.updatedAt ?? null);
+      }
+      if (setClauses.length > 0) {
+        values.push(sessionId);
+        this.db.run(`UPDATE in_app_planning_sessions SET ${setClauses.join(', ')} WHERE session_id = ?`, values);
+      }
+      if (patch.messages) {
+        const updatedAt = patch.updatedAt ?? new Date().toISOString();
+        this.replaceInAppPlanningMessages(sessionId, patch.messages, updatedAt);
+      }
+    };
+
+    if (patch.messages) {
+      this.runTransaction(updateSession);
+      return;
+    }
+
+    updateSession();
+    this.dirty = true;
+  }
+
+  deleteInAppPlanningSession(sessionId: string): void {
+    this.runTransaction(() => {
+      this.db.run('DELETE FROM in_app_planning_messages WHERE session_id = ?', [sessionId]);
+      this.db.run('DELETE FROM in_app_planning_sessions WHERE session_id = ?', [sessionId]);
+    });
+  }
+
   private getTaskIdsForWorkflow(workflowId: string): string[] {
     const rows = this.queryAll(
       'SELECT id FROM tasks WHERE workflow_id = ?',
@@ -3060,6 +3249,88 @@ export class SQLiteAdapter implements PersistenceAdapter {
       createdAt,
       updatedAt,
     };
+  }
+
+  private replaceInAppPlanningMessages(
+    sessionId: string,
+    messages: InAppPlanningChatLine[],
+    fallbackCreatedAt: string,
+  ): void {
+    this.db.run('DELETE FROM in_app_planning_messages WHERE session_id = ?', [sessionId]);
+    for (const message of messages) {
+      this.db.run(
+        `INSERT INTO in_app_planning_messages (
+          session_id,
+          message_id,
+          role,
+          text,
+          tone,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?)`,
+        [
+          sessionId,
+          message.id,
+          message.role,
+          message.text,
+          message.tone ?? null,
+          message.createdAt ?? fallbackCreatedAt,
+        ],
+      );
+    }
+  }
+
+  private mapInAppPlanningSessionRow(row: InAppPlanningSessionRow): InAppPlanningSessionRecord | undefined {
+    try {
+      const id = typeof row.session_id === 'string' ? row.session_id : '';
+      const title = typeof row.title === 'string' ? row.title : '';
+      const presetKey = typeof row.preset_key === 'string' ? row.preset_key : '';
+      const createdAt = typeof row.created_at === 'string' ? row.created_at : '';
+      const updatedAt = typeof row.updated_at === 'string' ? row.updated_at : '';
+      if (!id || !title || !presetKey || !createdAt || !updatedAt || !isInAppPlanningSessionStatus(row.status)) {
+        return undefined;
+      }
+
+      const messageRows = this.queryAll(
+        'SELECT * FROM in_app_planning_messages WHERE session_id = ? ORDER BY message_id ASC',
+        [id],
+      ) as InAppPlanningMessageRow[];
+      const draftPlanSummary = parseInAppPlanningPlanSummary(row.draft_plan_summary_json);
+      const messages: InAppPlanningChatLine[] = [];
+      for (const messageRow of messageRows) {
+        if (
+          typeof messageRow.message_id !== 'number'
+          || !isInAppPlanningMessageRole(messageRow.role)
+          || typeof messageRow.text !== 'string'
+          || typeof messageRow.created_at !== 'string'
+          || !isInAppPlanningMessageTone(messageRow.tone)
+        ) {
+          return undefined;
+        }
+        messages.push({
+          id: messageRow.message_id,
+          role: messageRow.role,
+          text: messageRow.text,
+          ...(messageRow.tone ? { tone: messageRow.tone } : {}),
+          createdAt: messageRow.created_at,
+        });
+      }
+
+      return {
+        id,
+        title,
+        presetKey,
+        status: row.status,
+        messages,
+        ...(draftPlanSummary ? { draftPlanSummary } : {}),
+        ...(typeof row.submitted_workflow_id === 'string' ? { submittedWorkflowId: row.submitted_workflow_id } : {}),
+        ...(typeof row.submitted_plan_name === 'string' ? { submittedPlanName: row.submitted_plan_name } : {}),
+        pendingResponse: row.pending_response === 1,
+        createdAt,
+        updatedAt,
+      };
+    } catch {
+      return undefined;
+    }
   }
 
   private rowToAttempt(row: any): Attempt {

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -141,6 +141,36 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_conv_messages_thread
         ON conversation_messages(thread_ts, seq);
 
+      CREATE TABLE IF NOT EXISTS in_app_planning_sessions (
+        session_id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        preset_key TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('still_discussing', 'waiting_for_answer', 'draft_ready', 'submitted')),
+        draft_plan_summary_json TEXT CHECK (draft_plan_summary_json IS NULL OR json_valid(draft_plan_summary_json)),
+        submitted_workflow_id TEXT,
+        submitted_plan_name TEXT,
+        pending_response INTEGER NOT NULL DEFAULT 0 CHECK (pending_response IN (0, 1)),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS in_app_planning_messages (
+        session_id TEXT NOT NULL,
+        message_id INTEGER NOT NULL,
+        role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
+        text TEXT NOT NULL,
+        tone TEXT CHECK (tone IS NULL OR tone IN ('muted', 'error', 'success')),
+        created_at TEXT NOT NULL,
+        PRIMARY KEY (session_id, message_id),
+        FOREIGN KEY (session_id) REFERENCES in_app_planning_sessions(session_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_in_app_planning_sessions_updated
+        ON in_app_planning_sessions(updated_at);
+
+      CREATE INDEX IF NOT EXISTS idx_in_app_planning_messages_session
+        ON in_app_planning_messages(session_id, message_id);
+
       CREATE TABLE IF NOT EXISTS workflow_channels (
         workflow_id TEXT PRIMARY KEY,
         channel_id TEXT NOT NULL,


### PR DESCRIPTION
## Summary

Planning Terminal chats now survive a desktop restart. Their saved state is written to SQLite and read back on launch, so an interrupted planning conversation is not lost.

This is the backend half; bringing the chats back on screen lands in a later slice.

## Review Claim

Planning Terminal session state is saved to and loaded from SQLite across app restarts.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only Planning Terminal session persistence is added; owner and read-only gating are unchanged and task terminal persistence is untouched.

## Slice Rationale

The persistence layer must exist before the renderer can bring anything back, so the SQLite tables and store land first, below the UI slice.

## Non-goals

This does not bring the Planning Terminal back on screen; that lands in the UI slice.

This does not change task terminal persistence.

This does not change owner or read-only gating.

## Test Plan

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 128b16a5c`
- Post-revert steps: None
- Data migration? Additive tables only; safe to leave in place.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Planning chats can now be saved and restored across app restarts.
  * Drafted plans and interrupted conversations resume with their previous state intact.

* **Bug Fixes**
  * Restored sessions now handle pending responses more reliably.
  * Empty session restores no longer trigger unnecessary planner work.
  * Session updates now keep visible chat history and draft status in sync.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
