### PR TITLE
[Planner Dependencies](2) Use shared catalog in CLI

### DIFF
--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -3,6 +3,8 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'nod
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
+import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES } from '@invoker/contracts';
+
 import {
   buildDoctorChecks,
   generateSlackManifest,
@@ -16,7 +18,6 @@ import {
   validateSlackCredentials,
   type CliConfigState,
 } from '../onboarding.js';
-import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES } from '../external-dependencies.js';
 
 describe('generateSlackManifest', () => {
   it('requests the required bot scopes, socket mode, and app_mention events', () => {

--- a/packages/cli/src/external-dependencies.ts
+++ b/packages/cli/src/external-dependencies.ts
@@ -1,9 +1,0 @@
-export const EXTERNAL_DEPENDENCIES = {
-  drafterMcp: {
-    packageName: 'drafter-mcp',
-    version: '0.1.0',
-    commandName: 'drafter-mcp',
-  },
-} as const;
-
-export const DEFAULT_DRAFTER_MCP_PACKAGE_SPEC = `${EXTERNAL_DEPENDENCIES.drafterMcp.packageName}==${EXTERNAL_DEPENDENCIES.drafterMcp.version}`;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
 import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
-import { resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
+import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
 import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
 import {
   AUTO_FIX_WORKER_KIND,
@@ -36,7 +36,6 @@ import {
   type PlanDefinition,
   type TaskState,
 } from '@invoker/workflow-core';
-import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.js';
 import { logCaughtException } from './logging.js';
 import { runMcpServer } from './mcp-server.js';
 import { runDoctor, runSetup } from './onboarding.js';

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -6,14 +6,15 @@ import { createInterface } from 'node:readline/promises';
 import {
   assembleReadinessChecks,
   buildReport,
-  formatReport,
+  DEFAULT_DRAFTER_MCP_PACKAGE_SPEC,
   DEFAULT_TOOL_REQUIREMENTS,
+  EXTERNAL_DEPENDENCIES,
+  formatReport,
   type IsInstalled,
   type PlanningPresetSpec,
   type PrerequisiteCheck,
 } from '@invoker/contracts';
 import { formatCaughtException, logCaughtException } from './logging.js';
-import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES } from './external-dependencies.js';
 
 // ── Paths ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

The CLI now uses the shared dependency catalog for the Drafter MCP pin.

Planner setup still writes `uvx --from drafter-mcp==0.1.0 drafter-mcp`.

The help text still shows the same default package spec.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the CLI using the shared dependency catalog for planner package metadata.

Review Lane: refactor

Review Unit: activation-surface

Safety Invariant: The generated MCP server entry keeps the same command, args, and package version.

Slice Rationale: This is stacked after the catalog so this slice only changes CLI wiring.

</details>

## Non-goals

Behavior unchanged.

This does not change onboarding prompts, install behavior, or the Drafter MCP version.

## Architecture

### Before

The CLI had its own Drafter MCP package constants.

### After

The CLI imports the Drafter MCP package constants from the shared dependency catalog.

## Test Plan

- [x] `pnpm --filter @invoker/cli test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 55df27cd`
- Post-revert steps: None
- Data migration? No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared CLI configuration values to come from a single source.
  * Simplified internal imports across onboarding and startup logic for consistency.
* **Tests**
  * Updated onboarding setup tests to use the shared configuration values from the new source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->