### PR TITLE
[make-pr] Sync Mergify stack comments

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -20,7 +20,7 @@
  *   1. Publish stack branches with `mergify stack push`
  *   2. Switch to the created stack branch if needed
  *   3. Run `node scripts/create-pr.mjs --title "..." --base <branch> --body-file <file> --update-existing`
- *
+ *   4. `create-pr` refreshes the machine-managed full-stack comment across every PR in the connected stack
  * Image injection:
  *   Scans the body for markdown image/link patterns where the URL is a local
  *   file path. Uploads those files to Cloudflare R2 and replaces the paths
@@ -41,6 +41,7 @@ import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import aws4 from 'aws4';
+import { syncStackCommentsForPr } from './sync-stack-comments.mjs';
 import { getPrAtomicityBlockers, getPrBodyWarnings, validatePrBody } from './validate-pr-body.mjs';
 
 const DEFAULT_BASE_REMOTE = process.env.INVOKER_PARENT_REMOTE || 'origin';
@@ -152,7 +153,7 @@ Stack flow:
   1. Publish stack branches with \`mergify stack push\`
   2. Switch to the created stack branch if needed
   3. Run \`node scripts/create-pr.mjs --title "[Graph Blanking](3a) <slice title>" --base <branch> --body-file <file> --update-existing\`
-
+  4. \`create-pr\` refreshes the machine-managed full-stack comment across every PR in the connected stack
 PR body schema:
   Required: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
   Test Plan and Revert Plan content must sit inside collapsed <details><summary>Test Plan</summary> / <summary>Revert Plan</summary> blocks.
@@ -357,6 +358,7 @@ function runGit(args, options = {}) {
 function runGh(args, options = {}) {
   return execFileSync('gh', args, {
     encoding: 'utf-8',
+    maxBuffer: 20 * 1024 * 1024,
     ...options,
   });
 }
@@ -750,7 +752,7 @@ async function createPr(nwo, title, base, body, dryRun) {
   if (dryRun) {
     console.error(`[dry-run] Would create PR: "${title}" (${head} → ${base})`);
     console.error(`[dry-run] Body length: ${body.length} chars`);
-    return 'https://DRY-RUN/pull/0';
+    return { url: 'https://DRY-RUN/pull/0', number: 0 };
   }
 
   const payload = JSON.stringify({ title, body, head, base });
@@ -758,14 +760,14 @@ async function createPr(nwo, title, base, body, dryRun) {
     input: payload,
   });
   const pr = JSON.parse(result);
-  return pr.html_url;
+  return { url: String(pr.html_url), number: Number(pr.number) };
 }
 
 async function updatePr(nwo, prNum, title, body, dryRun) {
   if (dryRun) {
     console.error(`[dry-run] Would update PR #${prNum}: "${title}"`);
     console.error(`[dry-run] Body length: ${body.length} chars`);
-    return `https://DRY-RUN/pull/${prNum}`;
+    return { url: `https://DRY-RUN/pull/${prNum}`, number: Number(prNum) };
   }
 
   const payload = JSON.stringify({ title, body });
@@ -773,7 +775,7 @@ async function updatePr(nwo, prNum, title, body, dryRun) {
     input: payload,
   });
   const pr = JSON.parse(result);
-  return pr.html_url;
+  return { url: String(pr.html_url), number: Number(pr.number ?? prNum) };
 }
 
 // ── Main ────────────────────────────────────────────────────────────────────
@@ -835,11 +837,14 @@ async function main() {
     gitPush(args.dryRun);
   }
 
-  const prUrl = updatePrNumber
+  const pr = updatePrNumber
     ? await updatePr(nwo, updatePrNumber, args.title, body, args.dryRun)
     : await createPr(nwo, args.title, args.base, body, args.dryRun);
+  if (isStackedPrContext(args.base, mergifyState)) {
+    syncStackCommentsForPr(nwo, pr.number, { dryRun: args.dryRun });
+  }
 
-  console.log(prUrl);
+  console.log(pr.url);
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/sync-stack-comments.mjs
+++ b/scripts/sync-stack-comments.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const STACK_COMMENT_MARKER = '<!-- invoker-stack-comment -->';
+
+function runGh(args, options = {}) {
+  return execFileSync('gh', args, {
+    encoding: 'utf-8',
+    maxBuffer: 20 * 1024 * 1024,
+    ...options,
+  });
+}
+
+function ghApiJson(path, { method = 'GET', payload, dryRun = false } = {}) {
+  if (dryRun) return null;
+  const args = ['api', path];
+  if (method !== 'GET') {
+    args.push('--method', method);
+  }
+  if (payload !== undefined) {
+    args.push('--input', '-');
+  }
+  const raw = runGh(args, payload === undefined ? {} : { input: JSON.stringify(payload) });
+  return JSON.parse(raw);
+}
+
+function getRepoNwo() {
+  return runGh(['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner']).trim();
+}
+
+function getSourceBranchRef(headRef) {
+  if (!headRef.startsWith('stack/')) return headRef;
+  const parts = headRef.split('/');
+  if (parts.length < 4) return headRef;
+  const originalBranch = parts.slice(2).join('/');
+  const localBranch = dirname(originalBranch);
+  return localBranch === '.' ? headRef : localBranch;
+}
+
+function findCurrentStack(openPrs, currentPrNumber) {
+  const decorated = openPrs.map((pr) => ({
+    number: Number(pr.number),
+    title: String(pr.title ?? ''),
+    url: String(pr.html_url ?? ''),
+    baseRef: String(pr.base?.ref ?? ''),
+    headRef: String(pr.head?.ref ?? ''),
+    localBranchRef: getSourceBranchRef(String(pr.head?.ref ?? '')),
+  }));
+  const byNumber = new Map(decorated.map((pr) => [pr.number, pr]));
+
+  function findByLocalBranch(localBranchRef) {
+    return decorated.filter((pr) => pr.localBranchRef === localBranchRef);
+  }
+
+  const current = byNumber.get(Number(currentPrNumber));
+  if (!current) {
+    throw new Error(`Current PR #${currentPrNumber} is not open, so its stack cannot be resolved.`);
+  }
+
+  const chain = [current];
+  const seen = new Set([current.number]);
+
+  let parentCandidates = findByLocalBranch(current.baseRef);
+  while (parentCandidates.length > 0) {
+    if (parentCandidates.length > 1) {
+      throw new Error(`Multiple parent PRs publish local branch ${current.baseRef}.`);
+    }
+    const parent = parentCandidates[0];
+    if (seen.has(parent.number)) {
+      throw new Error(`Cycle detected while walking stack ancestors from PR #${currentPrNumber}.`);
+    }
+    chain.unshift(parent);
+    seen.add(parent.number);
+    parentCandidates = findByLocalBranch(parent.baseRef);
+  }
+
+  let cursor = current;
+  while (true) {
+    const children = decorated.filter((pr) => pr.baseRef === cursor.localBranchRef);
+    if (children.length === 0) break;
+    if (children.length > 1) {
+      throw new Error(`Multiple child PRs depend on local branch ${cursor.localBranchRef}.`);
+    }
+    const child = children[0];
+    if (seen.has(child.number)) {
+      throw new Error(`Cycle detected while walking stack descendants from PR #${currentPrNumber}.`);
+    }
+    chain.push(child);
+    seen.add(child.number);
+    cursor = child;
+  }
+
+  return chain;
+}
+
+function formatStackComment(stack, targetPrNumber) {
+  const lines = [
+    STACK_COMMENT_MARKER,
+    'Full stack for this PR series (bottom → top):',
+    '',
+  ];
+
+  for (const pr of stack) {
+    const suffix = pr.number === targetPrNumber ? ' ← this PR' : '';
+    lines.push(`${pr.number}. #${pr.number} — ${pr.title}${suffix}`);
+    lines.push(`   Base: ${pr.baseRef}`);
+    lines.push(`   Link: ${pr.url}`);
+  }
+
+  return `${lines.join('\n')}\n`;
+}
+
+function listOpenPullRequests(nwo, dryRun = false) {
+  if (dryRun) return [];
+  const data = ghApiJson(`repos/${nwo}/pulls?state=open&per_page=100`, { dryRun });
+  return Array.isArray(data) ? data : [];
+}
+
+function listIssueComments(nwo, prNumber, dryRun = false) {
+  if (dryRun) return [];
+  const data = ghApiJson(`repos/${nwo}/issues/${prNumber}/comments?per_page=100`, { dryRun });
+  return Array.isArray(data) ? data : [];
+}
+
+function upsertStackComment(nwo, prNumber, body, dryRun = false) {
+  const existing = listIssueComments(nwo, prNumber, dryRun).find((comment) => {
+    return typeof comment?.body === 'string' && comment.body.includes(STACK_COMMENT_MARKER);
+  });
+  if (dryRun) return;
+  if (existing?.id) {
+    ghApiJson(`repos/${nwo}/issues/comments/${existing.id}`, {
+      method: 'PATCH',
+      payload: { body },
+    });
+    return;
+  }
+  ghApiJson(`repos/${nwo}/issues/${prNumber}/comments`, {
+    method: 'POST',
+    payload: { body },
+  });
+}
+
+export function syncStackCommentsForPr(nwo, currentPrNumber, { dryRun = false } = {}) {
+  const stack = findCurrentStack(listOpenPullRequests(nwo, dryRun), currentPrNumber);
+  for (const pr of stack) {
+    upsertStackComment(nwo, pr.number, formatStackComment(stack, pr.number), dryRun);
+  }
+  return stack;
+}
+
+function parseArgs(argv) {
+  let repo = '';
+  let pr = 0;
+  let dryRun = false;
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--repo') {
+      repo = argv[index + 1] ?? '';
+      index += 1;
+      continue;
+    }
+    if (arg === '--pr') {
+      pr = Number(argv[index + 1] ?? '0');
+      index += 1;
+      continue;
+    }
+    if (arg === '--dry-run') {
+      dryRun = true;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  if (!pr) {
+    throw new Error('Missing required --pr <number>.');
+  }
+
+  return {
+    repo: repo || getRepoNwo(),
+    pr,
+    dryRun,
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const stack = syncStackCommentsForPr(args.repo, args.pr, { dryRun: args.dryRun });
+  if (args.dryRun) {
+    console.error(`Would sync stack comments across ${stack.length} PRs.`);
+  }
+}
+
+if (fileURLToPath(import.meta.url) === resolve(process.argv[1] || '')) {
+  try {
+    main();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Error: ${message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -189,10 +189,34 @@ if [ "$1" = "api" ]; then
 
   case "$route" in
     *"/pulls?"*)
-      if [ -n "$GH_API_PULLS_JSON" ]; then
+      if printf '%s' "$route" | grep -q 'head='; then
+        if [ -n "$GH_API_PULLS_JSON" ]; then
+          printf '%s' "$GH_API_PULLS_JSON"
+        else
+          printf '%s' '[]'
+        fi
+      elif [ -n "$GH_API_OPEN_PULLS_JSON" ]; then
+        printf '%s' "$GH_API_OPEN_PULLS_JSON"
+      elif [ -n "$GH_API_PULLS_JSON" ]; then
         printf '%s' "$GH_API_PULLS_JSON"
       else
         printf '%s' '[]'
+      fi
+      exit 0
+      ;;
+    */issues/[0-9]*/comments?*)
+      if [ -n "$GH_API_ISSUE_COMMENTS_JSON" ]; then
+        printf '%s' "$GH_API_ISSUE_COMMENTS_JSON"
+      else
+        printf '%s' '[]'
+      fi
+      exit 0
+      ;;
+    */issues/comments/[0-9]*|*/issues/[0-9]*/comments)
+      if [ -n "$GH_COMMENT_RESPONSE" ]; then
+        printf '%s' "$GH_COMMENT_RESPONSE"
+      else
+        printf '%s' '{"id":123}'
       fi
       exit 0
       ;;
@@ -437,7 +461,30 @@ function testMergifyManagedUpdateSkipsPush() {
           head: { ref: branch, repo: { full_name: 'owner/repo' } },
         },
       ]),
-      GH_PATCH_RESPONSE: JSON.stringify({ html_url: 'https://example.com/pull/42' }),
+      GH_API_OPEN_PULLS_JSON: JSON.stringify([
+        {
+          number: 41,
+          title: '[Graph Blanking](1) Base slice',
+          html_url: 'https://example.com/pull/41',
+          base: { ref: 'master' },
+          head: { ref: 'stack/TestOwner/stack/example/base/root--aaaa', repo: { full_name: 'owner/repo' } },
+        },
+        {
+          number: 42,
+          title: '[Graph Blanking](2) Middle slice',
+          html_url: 'https://example.com/pull/42',
+          base: { ref: 'stack/example/base' },
+          head: { ref: branch, repo: { full_name: 'owner/repo' } },
+        },
+        {
+          number: 43,
+          title: '[Graph Blanking](3) Top slice',
+          html_url: 'https://example.com/pull/43',
+          base: { ref: branch },
+          head: { ref: 'stack/TestOwner/stack/example/top/top--bbbb', repo: { full_name: 'owner/repo' } },
+        },
+      ]),
+      GH_PATCH_RESPONSE: JSON.stringify({ html_url: 'https://example.com/pull/42', number: 42 }),
     });
 
     const ghLog = existsSync(harness.ghLog) ? readFileSync(harness.ghLog, 'utf-8') : '';
@@ -457,6 +504,10 @@ function testMergifyManagedUpdateSkipsPush() {
     assert(Boolean(patchCall), 'managed update should patch the existing PR');
     assert(patchCall.stdin.includes('"title":"[Graph Blanking](1) Preserve graph blanking"'), 'managed update patch should include title');
     assert(patchCall.stdin.includes('## Summary'), 'managed update patch should include PR body');
+    const commentPosts = ghCalls.filter((call) => /\/issues\/(41|42|43)\/comments$/.test(call.route));
+    assert(commentPosts.length === 3, `managed update should upsert stack comments across the full stack\n${JSON.stringify(ghCalls, null, 2)}`);
+    assert(commentPosts.some((call) => call.stdin.includes('Full stack for this PR series (bottom → top):')), 'stack comments should include the full stack header');
+    assert(commentPosts.some((call) => call.stdin.includes('#42 — [Graph Blanking](2) Middle slice ← this PR')), 'stack comments should mark each target PR');
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }

--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -96,4 +96,9 @@ must_contain "$SKILL_MD" "diff atomicity blockers are hard failures" "make-pr sk
 must_contain "$SKILL_MD" "Re-audit every rebuilt slice in the resulting stack" "make-pr skill must re-audit the full rebuilt stack after a split"
 must_contain "$SKILL_MD" "conflict-only, import-only, or other no-new-claim fixup slice" "make-pr skill must auto-fold no-claim fixup slices"
 
+# Published Mergify stacks must keep a synced full-stack comment on every PR.
+must_contain "$SKILL_MD" "machine-managed stack comment on every PR in the stack" "make-pr skill must require one stack comment per published PR"
+must_contain "$SKILL_MD" "full stack bottom-to-top" "make-pr skill stack comment must list the entire stack in order"
+must_contain "$SKILL_MD" "must be refreshed whenever the stack changes" "make-pr skill must refresh stack comments when the stack changes"
+must_contain "$SKILL_MD" "marks the target PR with" "make-pr skill must explain how the synced stack comment identifies the current PR"
 echo "OK: make-pr skill contract checks passed"

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -33,6 +33,8 @@ Order slices so a reviewer reads the evidence before the change it justifies (se
   - Invoker-on-Invoker stacks may use `mergify stack push`
   - unrelated target repos should keep their own normal PR workflow unless they independently use Mergify Stacks
 
+
+- For published Mergify stacks, maintain one machine-managed stack comment on every PR in the stack. The comment lists the full stack bottom-to-top and must be refreshed whenever the stack changes.
 ## Preferred PR schema
 
 Default to this structure:
@@ -181,6 +183,8 @@ Update an existing PR with:
 node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-pr.md --update <pr-number>
 ```
 
+For stacked PRs, `create-pr` also refreshes the machine-managed full-stack comment across every PR in the connected stack. The comment marks the target PR with `← this PR`.
+
 For Mergify-managed stack PRs, this update path is REQUIRED after `mergify stack push`. Do not leave the Mergify-generated placeholder title/body live.
 After `mergify stack push`, you MUST audit the live PRs immediately. Default Mergify-created titles/bodies like an empty description or a bare `Depends-On:` line are a publication failure, not a follow-up chore.
 
@@ -193,7 +197,6 @@ No custom payload parsing is required here. The check is simple: verify the rend
 4. If Mergify generated a remote-only head branch name that `create-pr` cannot map from the local branch, use `gh pr edit --title ... --body-file ...` immediately rather than leaving placeholder metadata live.
 
 Do not stop after `mergify stack push` until the GitHub-side metadata matches the intended titles and bodies.
-
 
 This script handles local image path upload/injection when configured. It also rejects UI-impacting diffs unless the body includes visual proof media.
 
@@ -236,8 +239,9 @@ If review says one published stack slice is still too broad:
 6. Switch to each generated stack branch.
 7. Get the real base branch with `gh pr view --json baseRefName --jq .baseRefName`.
 8. Update each PR with `node scripts/create-pr.mjs --title "..." --base <actual-base-branch> --body-file <file> --update-existing`.
+9. After any stack reorder, replacement slice, or new top slice, rerun `create-pr --update-existing` on one published branch so the machine-managed stack comment is refreshed across the whole stack.
 
-9. Audit the live PR metadata on GitHub. If any replacement PR still shows an empty description or only `Depends-On:`, repair it immediately.
+10. Audit the live PR metadata on GitHub. If any replacement PR still shows an empty description or only `Depends-On:`, repair it immediately.
 Manual `gh pr edit` is the escape hatch when `create-pr --update-existing` cannot map the local branch to the published Mergify branch. Use it to repair live metadata immediately, not as the default path.
 
 
@@ -253,6 +257,7 @@ Manual `gh pr edit` is the escape hatch when `create-pr --update-existing` canno
 - for stacked PRs, after any split or restack, re-audit the full rebuilt stack before publishing or updating PRs
 - for stacked PRs, auto-fold conflict-only, import-only, or other no-new-claim fixup slices into the previous slice before publication
 - for stacked PRs, update title/body through `node scripts/create-pr.mjs --update-existing ...`, not `gh pr edit`
+- for stacked PRs, verify that `create-pr` refreshed the machine-managed full-stack comment across every PR in the stack
 - for UI-impacting diffs, include `## Visual Proof` with screenshot or video proof before `node scripts/create-pr.mjs`; classify by user-visible behavior, not by path alone
 If you include `## Architecture`, keep the diagrams renderable by GitHub Mermaid.
 Always quote labels that contain prose, punctuation, or code-ish text such as `reviewGate.artifacts[]`.


### PR DESCRIPTION
## Summary

Published Mergify stacks now keep one machine-managed stack comment on every PR in the stack.

`create-pr` refreshes that comment after it creates or updates a stacked PR, and the make-pr skill now requires the full-stack comment to stay in sync whenever the stack changes.

The tests cover both the automation path and the skill contract.

## Review Claim

Mergify stack publication keeps a synced full-stack comment on every PR and documents that rule in the make-pr skill.

## Review Lane

- policy

## Review Unit

- tooling-policy

## Safety Invariant

This only changes PR publication tooling and its contract tests. It does not touch product runtime behavior.

## Slice Rationale

The stack-comment policy is separate repo tooling and stays out of any product behavior slice.

## Non-goals

- Do not change Planning Terminal persistence.
- Do not change terminal restore behavior.
- Do not change GitHub merge behavior outside PR metadata.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/test-create-pr-stack-workflow.mjs`
- [ ] `bash scripts/test-make-pr-skill.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
