### PR TITLE
[Planner MCP](1) Bundle MCP in Invoker CLI

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -95,12 +95,19 @@ describe('invoker-cli', () => {
     expect(result.stdout).toContain('Emit only a machine-readable result summary on stdout.');
   });
 
+  it('--help lists the bundled planner MCP command', async () => {
+    const result = await runCli(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('invoker-cli planner-mcp');
+    expect(result.stdout).toContain('Start the bundled Drafter planner MCP stdio server.');
+  });
+
   it('--help lists the planner setup command', async () => {
     const result = await runCli(['--help']);
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('invoker-cli setup [planner|slack]');
     expect(result.stdout).toContain('--planner-url <url>');
-    expect(result.stdout).toContain('Required unless INVOKER_MCP_CONFIG_PATH is set');
+    expect(result.stdout).toContain('Defaults to ~/.invoker/mcp.json');
   });
 
   it('lists worker kinds from the registry', async () => {
@@ -135,6 +142,15 @@ describe('invoker-cli', () => {
 
     expect(code).toBe(0);
     expect(runMcpServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('planner-mcp command starts the bundled planner MCP server runner', async () => {
+    const runPlannerMcpServer = vi.fn(async () => {});
+
+    const code = await main(['planner-mcp'], { runPlannerMcpServer });
+
+    expect(code).toBe(0);
+    expect(runPlannerMcpServer).toHaveBeenCalledTimes(1);
   });
 
   it('runs the hello-world fixture with an isolated db dir', async () => {

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES } from '@invoker/contracts';
 
 import {
+  defaultExperimentalPlannerMcpPath,
   buildDoctorChecks,
   generateSlackManifest,
+  ensureExperimentalPlannerMcp,
   installExperimentalPlannerMcp,
   loadInvokerEnv,
   readExperimentalPlannerSetup,
@@ -112,15 +113,39 @@ describe('buildDoctorChecks', () => {
 });
 describe('runSetup', () => {
   it('keeps Slack enabled by default and lets the user opt out', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-home-'));
+    const saved = {
+      HOME: process.env.HOME,
+      target: process.env.INVOKER_MCP_CONFIG_PATH,
+    };
     const lines: string[] = [];
-    const code = await runSetup([], {
-      print: (line) => lines.push(line),
-      prompt: async () => 'n',
-    });
+    try {
+      process.env.HOME = home;
+      delete process.env.INVOKER_MCP_CONFIG_PATH;
 
-    expect(lines.join('\n')).toContain('Invoker setup');
-    expect(lines.join('\n')).toContain('Run `invoker-cli setup slack` later');
-    expect(typeof code).toBe('number');
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => 'n',
+      });
+
+      const mcpPath = join(home, '.invoker', 'mcp.json');
+      const invokerConfigPath = join(home, '.invoker', 'config.json');
+      expect(lines.join('\n')).toContain('Invoker setup');
+      expect(lines.join('\n')).toContain(`Experimental planner MCP available at ${mcpPath}`);
+      expect(lines.join('\n')).toContain('experimentalPlanner flag: off');
+      expect(lines.join('\n')).toContain('Run `invoker-cli setup slack` later');
+      expect(JSON.parse(readFileSync(mcpPath, 'utf8')).mcpServers['experimental-planner']).toEqual({
+        type: 'stdio',
+        command: 'invoker-cli',
+        args: ['planner-mcp'],
+      });
+      expect(existsSync(invokerConfigPath)).toBe(false);
+      expect(typeof code).toBe('number');
+    } finally {
+      restoreEnv('HOME', saved.HOME);
+      restoreEnv('INVOKER_MCP_CONFIG_PATH', saved.target);
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('writes Slack env from environment values without prompts', async () => {
@@ -229,8 +254,8 @@ describe('experimental planner MCP setup', () => {
       expect(mcpConfig.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
       expect(mcpConfig.mcpServers['experimental-planner']).toEqual({
         type: 'stdio',
-        command: 'uvx',
-        args: ['--from', DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES.drafterMcp.commandName],
+        command: 'invoker-cli',
+        args: ['planner-mcp'],
         env: { PLANNER_URL: 'http://planner.test', PLANNER_ACCESS_TOKEN: 'sek' },
       });
       expect(JSON.parse(readFileSync(configPath, 'utf8')).experimentalPlanner).toBe(true);
@@ -238,23 +263,19 @@ describe('experimental planner MCP setup', () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
-  it('can pin a different planner package without changing Invoker', () => {
+  it('uses the bundled Invoker planner MCP command', () => {
     const dir = mkdtempSync(join(tmpdir(), 'invoker-planner-setup-'));
     const targetPath = join(dir, 'mcp.json');
     const configPath = join(dir, 'config.json');
     try {
-      installExperimentalPlannerMcp({
-        targetPath,
-        configPath,
-        plannerPackage: `${EXTERNAL_DEPENDENCIES.drafterMcp.packageName}==0.1.1`,
-      });
+      installExperimentalPlannerMcp({ targetPath, configPath });
 
       const mcpConfig = JSON.parse(readFileSync(targetPath, 'utf8'));
-      expect(mcpConfig.mcpServers['experimental-planner'].args).toEqual([
-        '--from',
-        `${EXTERNAL_DEPENDENCIES.drafterMcp.packageName}==0.1.1`,
-        EXTERNAL_DEPENDENCIES.drafterMcp.commandName,
-      ]);
+      expect(mcpConfig.mcpServers['experimental-planner']).toEqual({
+        type: 'stdio',
+        command: 'invoker-cli',
+        args: ['planner-mcp'],
+      });
       expect(readExperimentalPlannerSetup({ targetPath, configPath }).installed).toBe(true);
     } finally {
       rmSync(dir, { recursive: true, force: true });
@@ -279,16 +300,28 @@ describe('experimental planner MCP setup', () => {
     }
   });
 
-  it('requires an MCP target instead of assuming OMP is installed', () => {
+  it('can install the default Invoker MCP entry without enabling planner', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-planner-setup-'));
+    const configPath = join(dir, 'config.json');
+    const targetPath = join(dir, 'mcp.json');
     const savedTarget = process.env.INVOKER_MCP_CONFIG_PATH;
     try {
       delete process.env.INVOKER_MCP_CONFIG_PATH;
 
-      expect(() => installExperimentalPlannerMcp({ configPath: join(tmpdir(), 'invoker-config.json') })).toThrow(
-        'Missing MCP config path. Pass --target <path> or set INVOKER_MCP_CONFIG_PATH.',
-      );
+      const state = ensureExperimentalPlannerMcp({ configPath });
+
+      expect(defaultExperimentalPlannerMcpPath(configPath)).toBe(targetPath);
+      expect(state).toEqual({ targetPath, configPath, installed: true, experimentalPlanner: false });
+      const mcpConfig = JSON.parse(readFileSync(targetPath, 'utf8'));
+      expect(mcpConfig.mcpServers['experimental-planner']).toEqual({
+        type: 'stdio',
+        command: 'invoker-cli',
+        args: ['planner-mcp'],
+      });
+      expect(existsSync(configPath)).toBe(false);
     } finally {
       restoreEnv('INVOKER_MCP_CONFIG_PATH', savedTarget);
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 
@@ -308,7 +341,7 @@ describe('experimental planner MCP setup', () => {
     }
   });
 
-  it('uninstalls the redirect server and disables the Invoker flag', () => {
+  it('removes the MCP entry and disables the Invoker flag', () => {
     const dir = mkdtempSync(join(tmpdir(), 'invoker-planner-setup-'));
     const targetPath = join(dir, 'mcp.json');
     const configPath = join(dir, 'config.json');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
 import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
-import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
+import { resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
 import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
 import {
   AUTO_FIX_WORKER_KIND,
@@ -38,6 +38,7 @@ import {
 } from '@invoker/workflow-core';
 import { logCaughtException } from './logging.js';
 import { runMcpServer } from './mcp-server.js';
+import { runPlannerMcpServer } from './planner-mcp-server.js';
 import { runDoctor, runSetup } from './onboarding.js';
 
 const VERSION = '0.0.6';
@@ -71,6 +72,7 @@ type LiveSubmissionResult = {
 type CliDeps = {
   createMessageBus?: () => Promise<MessageBus> | MessageBus;
   runMcpServer?: () => Promise<void>;
+  runPlannerMcpServer?: () => Promise<void>;
 };
 
 type CliRuntimeConfig = {
@@ -133,6 +135,7 @@ function usage(): string {
     '  invoker-cli doctor [--fix] [--json]',
     '  invoker-cli setup [planner|slack] [--check|--from-env] [--json]',
     '  invoker-cli mcp',
+    '  invoker-cli planner-mcp',
     '  invoker-cli worker [autofix|list]',
     '  invoker-cli --help',
     '  invoker-cli --version',
@@ -142,13 +145,12 @@ function usage(): string {
     '  doctor          Validate tools, config, and your default planning preset.',
     '  setup [planner|slack]  Run the setup wizard, or directly configure planner MCP or Slack.',
     '  mcp             Start the Invoker MCP stdio server.',
-    '  worker [kind|list]  Run a registry-selected worker or list available worker kinds.',
+    '  planner-mcp     Start the bundled Drafter planner MCP stdio server.',
     '',
     'Options:',
     '  --planner-url <url>   Planner service URL for `setup planner`.',
     '  --access-token <tok>  Planner service access token for `setup planner`.',
-    `  --planner-package <spec>  Planner MCP package spec for \`setup planner\`. Defaults to ${DEFAULT_DRAFTER_MCP_PACKAGE_SPEC}.`,
-    '  --target <path>       MCP config path for `setup planner`. Required unless INVOKER_MCP_CONFIG_PATH is set.',
+    '  --target <path>       MCP config path for planner setup. Defaults to ~/.invoker/mcp.json.',
     '  --uninstall           Remove the experimental planner MCP entry and disable its Invoker flag.',
     '  --live           Require a running Invoker UI owner and submit over IPC.',
     '  --standalone     Skip IPC and run with an isolated CLI database.',
@@ -591,6 +593,10 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     }
     if (argv[0] === 'mcp') {
       await (deps.runMcpServer ?? runMcpServer)();
+      return 0;
+    }
+    if (argv[0] === 'planner-mcp') {
+      await (deps.runPlannerMcpServer ?? runPlannerMcpServer)();
       return 0;
     }
     if (argv[0] === 'worker') {

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -6,9 +6,7 @@ import { createInterface } from 'node:readline/promises';
 import {
   assembleReadinessChecks,
   buildReport,
-  DEFAULT_DRAFTER_MCP_PACKAGE_SPEC,
   DEFAULT_TOOL_REQUIREMENTS,
-  EXTERNAL_DEPENDENCIES,
   formatReport,
   type IsInstalled,
   type PlanningPresetSpec,
@@ -21,13 +19,14 @@ import { formatCaughtException, logCaughtException } from './logging.js';
 type JsonRecord = Record<string, unknown>;
 
 const EXPERIMENTAL_PLANNER_SERVER_KEY = 'experimental-planner';
-const EXPERIMENTAL_PLANNER_PACKAGE_NAME = DEFAULT_DRAFTER_MCP_PACKAGE_SPEC;
-const EXPERIMENTAL_PLANNER_COMMAND_NAME = EXTERNAL_DEPENDENCIES.drafterMcp.commandName;
-function experimentalPlannerServerSpec(packageSpec: string = EXPERIMENTAL_PLANNER_PACKAGE_NAME): JsonRecord {
+const EXPERIMENTAL_PLANNER_COMMAND = 'invoker-cli';
+const EXPERIMENTAL_PLANNER_ARGS = ['planner-mcp'];
+
+function experimentalPlannerServerSpec(): JsonRecord {
   return {
     type: 'stdio',
-    command: 'uvx',
-    args: ['--from', packageSpec, EXPERIMENTAL_PLANNER_COMMAND_NAME],
+    command: EXPERIMENTAL_PLANNER_COMMAND,
+    args: EXPERIMENTAL_PLANNER_ARGS,
   };
 }
 
@@ -40,17 +39,19 @@ export function defaultConfigPath(): string {
 export function envFilePath(): string {
   return join(invokerHomeDir(), '.env');
 }
+export function defaultExperimentalPlannerMcpPath(configPath: string = defaultConfigPath()): string {
+  return join(dirname(configPath), 'mcp.json');
+}
+
 export function manifestFilePath(): string {
   return join(invokerHomeDir(), 'slack-app-manifest.json');
 }
-export function experimentalPlannerMcpPath(): string | undefined {
-  return process.env.INVOKER_MCP_CONFIG_PATH;
+export function experimentalPlannerMcpPath(configPath: string = defaultConfigPath()): string {
+  return process.env.INVOKER_MCP_CONFIG_PATH ?? defaultExperimentalPlannerMcpPath(configPath);
 }
 
-function requireExperimentalPlannerMcpPath(targetPath?: string): string {
-  const resolvedPath = targetPath ?? experimentalPlannerMcpPath();
-  if (resolvedPath) return resolvedPath;
-  throw new Error('Missing MCP config path. Pass --target <path> or set INVOKER_MCP_CONFIG_PATH.');
+function resolveExperimentalPlannerMcpPath(targetPath: string | undefined, configPath: string): string {
+  return targetPath ?? experimentalPlannerMcpPath(configPath);
 }
 
 // ── Tool probing & install ───────────────────────────────────
@@ -139,12 +140,10 @@ function isExperimentalPlannerServer(value: unknown): boolean {
   if (!isJsonRecord(value)) return false;
   const args = value.args;
   return value.type === 'stdio'
-    && value.command === 'uvx'
+    && value.command === EXPERIMENTAL_PLANNER_COMMAND
     && Array.isArray(args)
-    && args.length === 3
-    && args[0] === '--from'
-    && typeof args[1] === 'string'
-    && args[2] === EXPERIMENTAL_PLANNER_COMMAND_NAME;
+    && args.length === EXPERIMENTAL_PLANNER_ARGS.length
+    && args.every((arg, index) => arg === EXPERIMENTAL_PLANNER_ARGS[index]);
 }
 
 export interface ExperimentalPlannerSetupOptions {
@@ -153,7 +152,6 @@ export interface ExperimentalPlannerSetupOptions {
   plannerUrl?: string;
   accessToken?: string;
   uninstall?: boolean;
-  plannerPackage?: string;
 }
 
 export interface ExperimentalPlannerSetupState {
@@ -172,8 +170,8 @@ export function setExperimentalPlannerFlag(enabled: boolean, configPath: string 
 }
 
 export function readExperimentalPlannerSetup(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
-  const targetPath = requireExperimentalPlannerMcpPath(options.targetPath);
   const configPath = options.configPath ?? defaultConfigPath();
+  const targetPath = resolveExperimentalPlannerMcpPath(options.targetPath, configPath);
   const invokerConfig = existsSync(configPath) ? readMutableJson(configPath, {}) : {};
   const mcpConfig = existsSync(targetPath) ? readMutableJson(targetPath, {}) : {};
   const servers = isJsonRecord(mcpConfig.mcpServers) ? mcpConfig.mcpServers : {};
@@ -185,9 +183,9 @@ export function readExperimentalPlannerSetup(options: ExperimentalPlannerSetupOp
   };
 }
 
-export function installExperimentalPlannerMcp(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
-  const targetPath = requireExperimentalPlannerMcpPath(options.targetPath);
+function writeExperimentalPlannerMcpEntry(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
   const configPath = options.configPath ?? defaultConfigPath();
+  const targetPath = resolveExperimentalPlannerMcpPath(options.targetPath, configPath);
   const mcpConfig = readMutableJson(targetPath, { $schema: 'https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json' });
   const existingServers = mutableMcpServers(mcpConfig, targetPath);
   const servers: JsonRecord = { ...existingServers };
@@ -198,7 +196,7 @@ export function installExperimentalPlannerMcp(options: ExperimentalPlannerSetupO
     const env: JsonRecord = {};
     if (options.plannerUrl) env.PLANNER_URL = options.plannerUrl;
     if (options.accessToken) env.PLANNER_ACCESS_TOKEN = options.accessToken;
-    const spec = experimentalPlannerServerSpec(options.plannerPackage);
+    const spec = experimentalPlannerServerSpec();
     servers[EXPERIMENTAL_PLANNER_SERVER_KEY] = Object.keys(env).length > 0 ? { ...spec, env } : spec;
   }
 
@@ -208,8 +206,17 @@ export function installExperimentalPlannerMcp(options: ExperimentalPlannerSetupO
   if (writesPlannerAccessToken && existsSync(targetPath)) chmodSync(targetPath, 0o600);
   writeFileSync(targetPath, `${JSON.stringify(mcpConfig, null, 2)}\n`, writesPlannerAccessToken ? { mode: 0o600 } : undefined);
   if (writesPlannerAccessToken) chmodSync(targetPath, 0o600);
-  setExperimentalPlannerFlag(!options.uninstall, configPath);
   return readExperimentalPlannerSetup({ targetPath, configPath });
+}
+
+export function ensureExperimentalPlannerMcp(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
+  return writeExperimentalPlannerMcpEntry(options);
+}
+
+export function installExperimentalPlannerMcp(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
+  const state = writeExperimentalPlannerMcpEntry(options);
+  setExperimentalPlannerFlag(!options.uninstall, state.configPath);
+  return readExperimentalPlannerSetup({ targetPath: state.targetPath, configPath: state.configPath });
 }
 
 export function buildDoctorChecks(cfg: CliConfigState, isInstalled: IsInstalled = commandExists): PrerequisiteCheck[] {
@@ -476,7 +483,6 @@ interface ParsedSetupArgs {
   targetPath?: string;
   plannerUrl?: string;
   accessToken?: string;
-  plannerPackage?: string;
   fromEnv: boolean;
 }
 
@@ -507,10 +513,6 @@ function parseSetupArgs(argv: string[]): ParsedSetupArgs {
       const value = argv[++i];
       if (!value) throw new Error('Missing value for --access-token');
       parsed.accessToken = value;
-    } else if (arg === '--planner-package') {
-      const value = argv[++i];
-      if (!value) throw new Error('Missing value for --planner-package');
-      parsed.plannerPackage = value;
     } else {
       throw new Error(`Unknown setup option: ${arg}`);
     }
@@ -539,13 +541,12 @@ async function maybeInstallPlanner(parsed: ParsedSetupArgs, io: SetupIO): Promis
     targetPath: parsed.targetPath,
     plannerUrl: parsed.plannerUrl,
     accessToken: parsed.accessToken ?? process.env.PLANNER_ACCESS_TOKEN,
-    plannerPackage: parsed.plannerPackage ?? process.env.INVOKER_PLANNER_PACKAGE,
     uninstall: parsed.uninstall,
   });
   if (parsed.json) {
     io.print(JSON.stringify(state));
   } else if (parsed.uninstall) {
-    io.print(`Removed experimental planner MCP from ${state.targetPath}.`);
+    io.print(`Kept experimental planner MCP available at ${state.targetPath}.`);
     io.print(`Disabled experimentalPlanner in ${state.configPath}.`);
   } else {
     io.print(`Installed experimental planner MCP into ${state.targetPath}.`);
@@ -582,8 +583,13 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
     const core = buildReport(buildDoctorChecks(loadCliConfig()));
     io.print(formatReport(core));
     io.print('');
-
-    if (!wantSlack && !fromEnv && await promptYes(io, 'Set up the experimental planner MCP now? [y/N] ')) {
+    const plannerState = ensureExperimentalPlannerMcp({
+      targetPath: parsed.targetPath,
+    });
+    io.print(`Experimental planner MCP available at ${plannerState.targetPath}.`);
+    io.print(`experimentalPlanner flag: ${plannerState.experimentalPlanner ? 'on' : 'off'}`);
+    io.print('');
+    if (!wantSlack && !fromEnv && await promptYes(io, 'Enable the experimental planner now? [y/N] ')) {
       await maybeInstallPlanner(parsed, io);
       io.print('');
     }
@@ -593,7 +599,7 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
       doSlack = await promptYes(io, 'Set up the Slack integration now? [y/N] ');
     }
     if (!doSlack) {
-      io.print('\nYou are good to go for CLI and UI workflows. Run `invoker-cli setup planner` later to add the experimental planner. Run `invoker-cli setup slack` later to add Slack.');
+      io.print('\nYou are good to go for CLI and UI workflows. Run `invoker-cli setup planner` later to enable the experimental planner. Run `invoker-cli setup slack` later to add Slack.');
       return core.ok ? 0 : 1;
     }
 

--- a/packages/cli/src/planner-mcp-server.ts
+++ b/packages/cli/src/planner-mcp-server.ts
@@ -1,0 +1,232 @@
+import { readFileSync } from 'node:fs';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+import { defaultConfigPath } from './onboarding.js';
+import { logCaughtException } from './logging.js';
+
+const DEFAULT_PLANNER_URL = 'https://api.invoker-control.dev';
+const PLANNER_SERVER_NAME = 'experimental-planner';
+const PLANNER_SERVER_VERSION = '0.0.6';
+
+type JsonRecord = Record<string, unknown>;
+
+type HostedPlan = JsonRecord & {
+  order?: unknown[];
+  stack?: unknown[];
+  featureEdges?: unknown[];
+  flags?: unknown[];
+  analytics?: { planId?: unknown };
+};
+
+function configPath(): string {
+  return process.env.INVOKER_CONFIG_PATH ?? defaultConfigPath();
+}
+
+function experimentalPlannerEnabled(): boolean {
+  try {
+    const raw = readFileSync(configPath(), 'utf8');
+    const config = JSON.parse(raw) as JsonRecord;
+    return Boolean(config.experimentalPlanner || config.EXPERIMENTAL_PLANNER);
+  } catch (err) {
+    logCaughtException(`Planner MCP could not read Invoker config at ${configPath()}`, err);
+    return false;
+  }
+}
+
+async function postJson(path: string, body: JsonRecord, timeoutMs = 300_000): Promise<JsonRecord> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  timeout.unref?.();
+  try {
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (process.env.ANTHROPIC_API_KEY) headers['X-Anthropic-Key'] = process.env.ANTHROPIC_API_KEY;
+    if (process.env.PLANNER_ACCESS_TOKEN) headers['X-Planner-Token'] = process.env.PLANNER_ACCESS_TOKEN;
+    const baseUrl = process.env.PLANNER_URL ?? DEFAULT_PLANNER_URL;
+    const response = await fetch(`${baseUrl.replace(/\/$/, '')}${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+      signal: controller.signal,
+    });
+    const text = await response.text();
+    if (!response.ok) {
+      throw new Error(`planner HTTP ${response.status}: ${text.slice(0, 200)}`);
+    }
+    return JSON.parse(text) as JsonRecord;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function stackRowToTask(row: unknown, index: number): JsonRecord {
+  if (typeof row !== 'object' || row === null || Array.isArray(row)) {
+    return { id: `t${index + 1}`, description: String(row) };
+  }
+  const record = row as JsonRecord;
+  return {
+    id: `t${typeof record.order === 'number' ? record.order : index + 1}`,
+    feature: record.feature,
+    description: record.intent,
+    layer: record.layer,
+    depBasis: record.depBasis,
+  };
+}
+
+function adaptHostedPlan(plan: HostedPlan): JsonRecord {
+  const stack = Array.isArray(plan.stack) ? plan.stack : [];
+  return {
+    order: Array.isArray(plan.order) ? plan.order : [],
+    tasks: stack.map(stackRowToTask),
+    featureEdges: Array.isArray(plan.featureEdges) ? plan.featureEdges : [],
+    flags: Array.isArray(plan.flags) ? plan.flags : [],
+    planId: typeof plan.analytics?.planId === 'string' ? plan.analytics.planId : undefined,
+  };
+}
+
+async function recordEvent(person: string, kind: string, payload: JsonRecord): Promise<void> {
+  try {
+    await postJson('/analytics/event', { person, kind, payload }, 5_000);
+  } catch (err) {
+    logCaughtException(`Planner MCP failed to record ${kind}`, err);
+  }
+}
+
+async function recordRedirectDisabled(person: string, surface: string): Promise<void> {
+  await recordEvent(person, 'invoker.redirect.disabled', {
+    source: 'invoker_redirect',
+    surface,
+    configPath: configPath(),
+  });
+}
+
+async function plan(conversation: string, person: string): Promise<JsonRecord> {
+  if (!experimentalPlannerEnabled()) {
+    await recordRedirectDisabled(person, 'plan');
+    throw new Error(`EXPERIMENTAL_PLANNER is off; enable it in ${configPath()}`);
+  }
+  const hosted = await postJson('/plan', { conversation, person }) as HostedPlan;
+  const adapted = adaptHostedPlan(hosted);
+  const planId = adapted.planId;
+  if (typeof planId === 'string') {
+    await recordEvent(person, 'plan.delivered', {
+      planId,
+      source: 'invoker_redirect',
+      tool: 'plan',
+      delivered: true,
+    });
+  }
+  return adapted;
+}
+
+async function feedback(planId: string, liked: boolean, comment: string, person: string): Promise<JsonRecord> {
+  if (!experimentalPlannerEnabled()) {
+    await recordRedirectDisabled(person, 'feedback');
+    throw new Error(`EXPERIMENTAL_PLANNER is off; enable it in ${configPath()}`);
+  }
+  return postJson('/feedback', { person, plan_id: planId, liked, comment });
+}
+
+async function correct(input: {
+  correctedPlan?: JsonRecord;
+  correctedOrder?: unknown[];
+  proposedOrder?: unknown[];
+  planId?: string;
+  person: string;
+}): Promise<JsonRecord> {
+  if (!experimentalPlannerEnabled()) {
+    await recordRedirectDisabled(input.person, 'correct');
+    throw new Error(`EXPERIMENTAL_PLANNER is off; enable it in ${configPath()}`);
+  }
+  return postJson('/correct', {
+    person: input.person,
+    corrected_plan: input.correctedPlan,
+    corrected_order: input.correctedOrder,
+    proposed_order: input.proposedOrder,
+    plan_id: input.planId,
+  });
+}
+
+function toolResult(value: JsonRecord): { content: [{ type: 'text'; text: string }] } {
+  return { content: [{ type: 'text', text: JSON.stringify(value, null, 2) }] };
+}
+
+function toolError(err: unknown): { content: [{ type: 'text'; text: string }]; isError: true } {
+  logCaughtException('Planner MCP tool failed', err);
+  return {
+    content: [{ type: 'text', text: err instanceof Error ? err.message : String(err) }],
+    isError: true,
+  };
+}
+
+export async function runPlannerMcpServer(): Promise<void> {
+  const server = new McpServer({ name: PLANNER_SERVER_NAME, version: PLANNER_SERVER_VERSION });
+
+  if (experimentalPlannerEnabled()) {
+    server.registerTool(
+      'plan',
+      {
+        description: 'Order a planning conversation into an Invoker-friendly build plan.',
+        inputSchema: { conversation: z.string(), person: z.string().optional() },
+      },
+      async ({ conversation, person }) => {
+        try {
+          return toolResult(await plan(conversation, person ?? 'edbert'));
+        } catch (err) {
+          return toolError(err);
+        }
+      },
+    );
+
+    server.registerTool(
+      'feedback',
+      {
+        description: 'Record acceptance or dislike for a delivered planner plan.',
+        inputSchema: {
+          planId: z.string(),
+          liked: z.boolean().optional(),
+          comment: z.string().optional(),
+          person: z.string().optional(),
+        },
+      },
+      async ({ planId, liked, comment, person }) => {
+        try {
+          return toolResult(await feedback(planId, liked ?? true, comment ?? '', person ?? 'edbert'));
+        } catch (err) {
+          return toolError(err);
+        }
+      },
+    );
+
+    server.registerTool(
+      'correct',
+      {
+        description: 'Record a corrected planner order or plan.',
+        inputSchema: {
+          correctedPlan: z.record(z.string(), z.unknown()).optional(),
+          correctedOrder: z.array(z.unknown()).optional(),
+          proposedOrder: z.array(z.unknown()).optional(),
+          planId: z.string().optional(),
+          person: z.string().optional(),
+        },
+      },
+      async ({ correctedPlan, correctedOrder, proposedOrder, planId, person }) => {
+        try {
+          return toolResult(await correct({
+            correctedPlan,
+            correctedOrder,
+            proposedOrder,
+            planId,
+            person: person ?? 'edbert',
+          }));
+        } catch (err) {
+          return toolError(err);
+        }
+      },
+    );
+  } else {
+    await recordRedirectDisabled('edbert', 'startup');
+  }
+
+  await server.connect(new StdioServerTransport());
+}


### PR DESCRIPTION
## Summary

Invoker setup now writes a Drafter MCP entry that points back at Invoker itself.

The bundled `invoker-cli planner-mcp` server runs the planner proxy. The planner feature still stays off until `experimentalPlanner` is enabled.

<details>
<summary>Review metadata</summary>

Review Claim: Approve running the Drafter MCP through the Invoker CLI while keeping planner behavior behind the flag.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Setup creates the MCP entry, but the planner server exposes no tools unless the existing `experimentalPlanner` config flag is true.

Slice Rationale: This keeps the install/setup behavior in one reviewable CLI slice before removing the old external dependency catalog entry.

</details>

## Non-goals

This does not enable planner behavior by default.

This does not change the hosted planner API contract.

## Architecture

### Before

Setup wrote an MCP entry that used `uvx` to fetch and run `drafter-mcp` as a separate package.

### After

Setup writes an MCP entry for `invoker-cli planner-mcp` in Invoker’s generated MCP config.

The bundled MCP server reads the same Invoker config flag. When the flag is off, it does not expose planner tools.

## Test Plan

- [x] `pnpm --filter @invoker/cli test`
- [x] `pnpm --filter @invoker/contracts test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 36492463`
- Post-revert steps: None
- Data migration? No
