### PR TITLE
[Terminal Sessions](6) Enforce terminal and planner invariants

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -405,6 +405,39 @@ describe('EmbeddedTerminalManager', () => {
     expect(spawned.written).toEqual(['echo after\n']);
   });
 
+  it('rejects restoring a second running session for the same terminal target', () => {
+    const spawned = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+    const backend: EmbeddedTerminalBackend = {
+      name: 'pty',
+      spawn: vi.fn(() => spawned),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+
+    mgr.restoreSpawnSession({
+      sessionId: 'restored-session-a',
+      taskId: 'task-restored',
+      targetKey: 'target-restored',
+      spec: { command: 'bash', args: ['-l'] },
+      cwd: '/tmp/restored',
+      createdAt: '2026-07-07T00:00:00.000Z',
+      outputSnapshot: 'before restart\n',
+    });
+
+    expect(() => mgr.restoreSpawnSession({
+      sessionId: 'restored-session-b',
+      taskId: 'task-restored',
+      targetKey: 'target-restored',
+      spec: { command: 'bash', args: ['-l'] },
+      cwd: '/tmp/restored',
+      createdAt: '2026-07-07T00:00:01.000Z',
+      outputSnapshot: 'duplicate restart\n',
+    })).toThrow(/already has running session/);
+  });
+
   it('resize() is accepted by the bash backend as a no-op', () => {
     const child = createFakeChild();
     const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -610,6 +610,85 @@ tasks:
     }
   });
 
+  it('rebuilds missing draft summaries from hidden planner state on restore', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const conversationRepo = new ConversationRepository(adapter);
+      const record: InAppPlanningSessionRecord = {
+        id: 'planning-summary-restore',
+        title: 'Recovered summary',
+        presetKey: 'codex',
+        status: 'draft_ready',
+        messages: [
+          { id: 1, role: 'system', text: 'Ask Invoker what you want to build.', tone: 'muted', createdAt: '2026-07-07T00:00:00.000Z' },
+          { id: 2, role: 'assistant', text: VALID_PLAN, createdAt: '2026-07-07T00:00:01.000Z' },
+        ],
+        pendingResponse: false,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:01.000Z',
+      };
+      conversationRepo.saveConversation('planning-summary-restore', [
+        { role: 'assistant', content: VALID_PLAN },
+      ], null, false, undefined, undefined, 'plan');
+
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo,
+        planningSessionStore: adapter,
+      });
+
+      expect(sessions.get('planning-summary-restore')?.draftPlanSummary).toMatchObject({
+        name: 'Mock Plan',
+        taskCount: 2,
+      });
+      expect(adapter.loadInAppPlanningSession('planning-summary-restore')?.draftPlanSummary).toMatchObject({
+        name: 'Mock Plan',
+        taskCount: 2,
+      });
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('clears submitted pending-response state during restore', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const record: InAppPlanningSessionRecord = {
+        id: 'planning-submitted',
+        title: 'Submitted plan',
+        presetKey: 'codex',
+        status: 'submitted',
+        messages: [
+          { id: 1, role: 'system', text: 'Ask Invoker what you want to build.', tone: 'muted', createdAt: '2026-07-07T00:00:00.000Z' },
+        ],
+        submittedWorkflowId: 'wf-123',
+        submittedPlanName: 'Submitted plan',
+        pendingResponse: true,
+        createdAt: '2026-07-07T00:00:00.000Z',
+        updatedAt: '2026-07-07T00:00:01.000Z',
+      };
+
+      const sessions = createInAppPlanningChatSessions();
+      await restorePlanningChatSessions([record], {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        conversationRepo: new ConversationRepository(adapter),
+        planningSessionStore: adapter,
+      });
+
+      expect(sessions.get('planning-submitted')?.messages).toHaveLength(1);
+      expect(adapter.loadInAppPlanningSession('planning-submitted')?.pendingResponse).toBe(false);
+    } finally {
+      adapter.close();
+    }
+  });
+
   it('restores interrupted sessions idle with an interruption system line', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     try {

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -315,8 +315,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
         attach: opts.attach,
         unsubscribeOutput: () => {},
       };
-      this.sessions.set(sessionId, state);
-      this.targetIndex.set(targetKey, sessionId);
+      this.registerLiveSession(state);
 
       let unsubscribe: () => void;
       try {
@@ -324,10 +323,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
           this.emitOutput(state, data);
         });
       } catch (err) {
-        this.sessions.delete(sessionId);
-        if (this.targetIndex.get(targetKey) === sessionId) {
-          this.targetIndex.delete(targetKey);
-        }
+        this.removeLiveSession(state);
         throw err;
       }
       state.unsubscribeOutput = unsubscribe;
@@ -355,9 +351,19 @@ export class EmbeddedTerminalManager extends EventEmitter {
     outputSnapshot: string;
   }): TerminalSessionDescriptor {
     const existingSession = this.sessions.get(seed.sessionId);
-    if (existingSession) return describeSession(existingSession);
+    if (existingSession) {
+      if (
+        existingSession.taskId !== seed.taskId
+        || existingSession.targetKey !== seed.targetKey
+      ) {
+        throw new Error(`Terminal session "${seed.sessionId}" restored with mismatched identity.`);
+      }
+      return describeSession(existingSession);
+    }
     const existingTarget = this.getRunningDescriptorForTarget(seed.targetKey);
-    if (existingTarget) return existingTarget;
+    if (existingTarget && existingTarget.sessionId !== seed.sessionId) {
+      throw new Error(`Terminal target "${seed.targetKey}" already has running session "${existingTarget.sessionId}".`);
+    }
 
     return this.registerSpawnSession({
       sessionId: seed.sessionId,
@@ -446,11 +452,65 @@ export class EmbeddedTerminalManager extends EventEmitter {
       }
       this.sessions.clear();
       this.targetIndex.clear();
+      this.assertLiveSessionInvariants();
       return;
     }
 
     for (const state of Array.from(this.sessions.values())) {
       this.finalizeSession(state, undefined);
+    }
+  }
+
+  private registerLiveSession(state: SessionState): void {
+    const existingSession = this.sessions.get(state.sessionId);
+    if (existingSession) {
+      throw new Error(`Terminal session "${state.sessionId}" is already registered.`);
+    }
+
+    const existingTargetSessionId = this.targetIndex.get(state.targetKey);
+    if (existingTargetSessionId && existingTargetSessionId !== state.sessionId) {
+      const existingTargetSession = this.sessions.get(existingTargetSessionId);
+      if (existingTargetSession?.status === 'running') {
+        throw new Error(
+          `Terminal target "${state.targetKey}" is already registered to session "${existingTargetSessionId}".`,
+        );
+      }
+      this.targetIndex.delete(state.targetKey);
+      if (existingTargetSession) {
+        this.sessions.delete(existingTargetSessionId);
+      }
+    }
+
+    this.sessions.set(state.sessionId, state);
+    this.targetIndex.set(state.targetKey, state.sessionId);
+    this.assertLiveSessionInvariants();
+  }
+
+  private removeLiveSession(state: SessionState): void {
+    if (this.targetIndex.get(state.targetKey) === state.sessionId) {
+      this.targetIndex.delete(state.targetKey);
+    }
+    this.sessions.delete(state.sessionId);
+  }
+
+  private assertLiveSessionInvariants(): void {
+    for (const [targetKey, sessionId] of this.targetIndex.entries()) {
+      const state = this.sessions.get(sessionId);
+      if (!state) {
+        throw new Error(`Terminal target index for "${targetKey}" points to missing session "${sessionId}".`);
+      }
+      if (state.targetKey !== targetKey) {
+        throw new Error(`Terminal target index for "${targetKey}" points to mismatched session "${sessionId}".`);
+      }
+      if (state.status !== 'running') {
+        throw new Error(`Terminal target index for "${targetKey}" points to non-running session "${sessionId}".`);
+      }
+    }
+
+    for (const [sessionId, state] of this.sessions.entries()) {
+      if (this.targetIndex.get(state.targetKey) !== sessionId) {
+        throw new Error(`Terminal session "${sessionId}" is missing target index entry for "${state.targetKey}".`);
+      }
     }
   }
 
@@ -484,8 +544,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
       backend: this.backend.name,
       process: pendingProcess,
     };
-    this.sessions.set(state.sessionId, state);
-    this.targetIndex.set(state.targetKey, state.sessionId);
+    this.registerLiveSession(state);
 
     const noPendingExit = Symbol('no-pending-exit');
     let pendingExitCode: number | undefined | typeof noPendingExit = noPendingExit;
@@ -512,10 +571,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
         }
       }
     } catch (err) {
-      this.sessions.delete(state.sessionId);
-      if (this.targetIndex.get(state.targetKey) === state.sessionId) {
-        this.targetIndex.delete(state.targetKey);
-      }
+      this.removeLiveSession(state);
       throw err;
     }
 
@@ -545,10 +601,9 @@ export class EmbeddedTerminalManager extends EventEmitter {
       }
     }
 
-    if (this.targetIndex.get(state.targetKey) === state.sessionId) {
-      this.targetIndex.delete(state.targetKey);
-    }
-    this.sessions.delete(state.sessionId);
+    this.removeLiveSession(state);
+
+    this.assertLiveSessionInvariants();
 
     const payload: TerminalExitEvent = {
       sessionId: state.sessionId,

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -208,12 +208,30 @@ function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessi
   };
 }
 
+function assertPersistablePlanningSession(
+  session: InAppPlanningChatSession,
+  pendingResponse: boolean,
+): void {
+  if (session.status === 'draft_ready' && !session.draftPlanSummary) {
+    throw new Error(`Planning session "${session.id}" is draft_ready without a draft summary.`);
+  }
+  if (session.status === 'submitted') {
+    if (pendingResponse) {
+      throw new Error(`Planning session "${session.id}" cannot stay pending after submission.`);
+    }
+    if (!session.submittedWorkflowId || !session.submittedPlanName) {
+      throw new Error(`Planning session "${session.id}" is submitted without submission metadata.`);
+    }
+  }
+}
+
 function persistPlanningSession(
   session: InAppPlanningChatSession,
   store: InAppPlanningSessionStore | undefined,
   pendingResponse: boolean,
 ): void {
   if (!store) return;
+  assertPersistablePlanningSession(session, pendingResponse);
   store.upsertInAppPlanningSession(sessionToRecord(session, pendingResponse));
 }
 
@@ -600,7 +618,7 @@ export async function restorePlanningChatSessions(
   // boots without surfaces/dist, so an eager load here would crash startup with no sessions.
   if (records.length === 0) return;
   const presets = await resolveHarnessPresets(deps.config);
-  const { PlanConversation } = await loadPlannerSurfaces();
+  const { PlanConversation, summarizePlanText } = await loadPlannerSurfaces();
 
   for (const record of records) {
     const preset = presets[record.presetKey];
@@ -626,27 +644,52 @@ export async function restorePlanningChatSessions(
     };
 
     let shouldPersist = false;
-    if (record.pendingResponse && record.status !== 'submitted') {
-      appendSessionMessage(
-        session,
-        'system',
-        'Planner was interrupted before it could answer. Send another message to continue.',
-        'error',
-      );
+    if (record.pendingResponse) {
+      if (record.status !== 'submitted') {
+        appendSessionMessage(
+          session,
+          'system',
+          'Planner was interrupted before it could answer. Send another message to continue.',
+          'error',
+        );
+      }
       shouldPersist = true;
     }
 
     const draftedPlan = conversation.getDraftedPlan();
-    if (session.status === 'draft_ready' && !draftedPlan) {
-      session.status = 'still_discussing';
-      session.draftPlanSummary = undefined;
-      appendSessionMessage(
-        session,
-        'system',
-        'The saved draft could not be restored. Ask the planner to draft it again.',
-        'error',
-      );
-      shouldPersist = true;
+    if (session.status === 'draft_ready') {
+      if (!draftedPlan) {
+        session.status = 'still_discussing';
+        session.draftPlanSummary = undefined;
+        session.draftPlanText = undefined;
+        appendSessionMessage(
+          session,
+          'system',
+          'The saved draft could not be restored. Ask the planner to draft it again.',
+          'error',
+        );
+        shouldPersist = true;
+      } else {
+        session.draftPlanText = draftedPlan;
+        if (!session.draftPlanSummary) {
+          const restoredSummary = summarizePlanText(draftedPlan);
+          if (!restoredSummary) {
+            session.status = 'still_discussing';
+            session.draftPlanSummary = undefined;
+            session.draftPlanText = undefined;
+            appendSessionMessage(
+              session,
+              'system',
+              'The saved draft could not be restored. Ask the planner to draft it again.',
+              'error',
+            );
+            shouldPersist = true;
+          } else {
+            session.draftPlanSummary = restoredSummary;
+            shouldPersist = true;
+          }
+        }
+      }
     } else if (draftedPlan) {
       session.draftPlanText = draftedPlan;
     }

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -295,6 +295,38 @@ describe('SQLiteAdapter', () => {
       }
     });
 
+    it('reconciles duplicate running terminal targets before enforcing the unique running-target index', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-terminal-target-invariants-'));
+      const dbPath = join(dir, 'invoker.db');
+      try {
+        const first = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        first.saveWorkflow(testWorkflow);
+        first.saveTask('wf-1', makeTask('t1'));
+        first.saveTask('wf-1', makeTask('t2'));
+        first.upsertTerminalSession(makeTerminalSession('term-a', 't1', {
+          targetKey: 'target-dup',
+          status: 'running',
+          updatedAt: '2026-07-07T01:00:01.000Z',
+        }));
+        (first as any).db.run('DROP INDEX IF EXISTS idx_terminal_sessions_running_target');
+        first.upsertTerminalSession(makeTerminalSession('term-b', 't2', {
+          targetKey: 'target-dup',
+          status: 'running',
+          updatedAt: '2026-07-07T01:00:02.000Z',
+        }));
+        first.close();
+
+        const reopened = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        expect(reopened.loadTerminalSession('term-a')?.status).toBe('exited');
+        expect(reopened.loadTerminalSession('term-b')?.status).toBe('running');
+        expect(tableIndexes(reopened, 'terminal_sessions')).toContain('idx_terminal_sessions_running_target');
+        expect(sqliteScalar(reopened, "SELECT COUNT(*) FROM terminal_sessions WHERE target_key = 'target-dup' AND status = 'running'")).toBe(1);
+        reopened.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
     it('updates and deletes terminal session rows', () => {
       adapter.saveWorkflow(testWorkflow);
       adapter.saveTask('wf-1', makeTask('t1'));

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -947,6 +947,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.migrateWorkflowStatusColumn();
     this.dropTaskAutoFixAttemptsColumn();
 
+    if (!this.readOnly) {
+      this.reconcileTerminalSessionInvariants();
+    }
+
     // Replace old attempt_number index with created_at index, etc.
     for (const sql of POST_MIGRATION_STATEMENTS) {
       this.db.run(sql);
@@ -1177,6 +1181,38 @@ export class SQLiteAdapter implements PersistenceAdapter {
     } catch {
       // Tables/columns may not exist yet on first run.
     }
+  }
+
+  private reconcileTerminalSessionInvariants(): void {
+    const rows = this.queryAll(
+      `SELECT session_id, target_key
+       FROM terminal_sessions
+       WHERE status = 'running'
+       ORDER BY target_key ASC, updated_at DESC, created_at DESC, session_id DESC`,
+    ) as Array<{ session_id: string; target_key: string }>;
+
+    const seenTargets = new Set<string>();
+    const now = new Date().toISOString();
+    for (const row of rows) {
+      if (!row.target_key || !row.session_id) continue;
+      if (!seenTargets.has(row.target_key)) {
+        seenTargets.add(row.target_key);
+        continue;
+      }
+      this.db.run(
+        `UPDATE terminal_sessions
+            SET status = 'exited',
+                updated_at = ?
+          WHERE session_id = ?`,
+        [now, row.session_id],
+      );
+    }
+
+    this.db.run(
+      `CREATE UNIQUE INDEX IF NOT EXISTS idx_terminal_sessions_running_target
+         ON terminal_sessions(target_key)
+         WHERE status = 'running'`,
+    );
   }
 
   // ── Workflows ─────────────────────────────────────────
@@ -3279,6 +3315,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     }
   }
 
+
   private mapInAppPlanningSessionRow(row: InAppPlanningSessionRow): InAppPlanningSessionRecord | undefined {
     try {
       const id = typeof row.session_id === 'string' ? row.session_id : '';
@@ -3287,6 +3324,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
       const createdAt = typeof row.created_at === 'string' ? row.created_at : '';
       const updatedAt = typeof row.updated_at === 'string' ? row.updated_at : '';
       if (!id || !title || !presetKey || !createdAt || !updatedAt || !isInAppPlanningSessionStatus(row.status)) {
+        return undefined;
+      }
+      if (
+        row.status === 'submitted'
+        && (
+          typeof row.submitted_workflow_id !== 'string'
+          || typeof row.submitted_plan_name !== 'string'
+        )
+      ) {
         return undefined;
       }
 

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -398,9 +398,6 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_terminal_sessions_status_updated
         ON terminal_sessions(status, updated_at);
 
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_terminal_sessions_running_target
-        ON terminal_sessions(target_key)
-        WHERE status = 'running';
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */


### PR DESCRIPTION
## Summary

Terminal and planner state now enforce their core invariants after a restart.

At most one live terminal and one running row are kept per target on startup, and a planning session that cannot be safely persisted is repaired when loaded.

## Review Claim

Startup keeps at most one running terminal row per target and one live terminal per target, and only sound planning sessions are brought back.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Existing rows are repaired in place; only redundant running rows are marked exited, never erased.

## Slice Rationale

Invariants sit between the raw persistence below and the on-screen restore above, so the renderer can assume the state it loads already holds.

## Non-goals

This does not change how task terminals render.

This does not add new persisted fields.

This does not change owner or read-only gating.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/embedded-terminal-manager.test.ts src/__tests__/in-app-planner.test.ts`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0f7412542`
- Post-revert steps: None
- Data migration? Reconciliation runs on startup and is idempotent; safe to leave in place.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session recovery so duplicate running sessions are detected and prevented.
  * Better restores in planning chat sessions after reloads or interruptions, including recovering missing plan summaries and clearing stale pending states.
  * Strengthened session data validation to avoid saving incomplete planning records and to keep stored terminal session data consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->