### PR TITLE
[Planner MCP](2) Drop external package pin

### DIFF
--- a/packages/contracts/src/__tests__/prerequisites.test.ts
+++ b/packages/contracts/src/__tests__/prerequisites.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import {
-  DEFAULT_DRAFTER_MCP_PACKAGE_SPEC,
   DEFAULT_TOOL_REQUIREMENTS,
   EXTERNAL_DEPENDENCIES,
 } from '../index.js';
@@ -49,15 +48,8 @@ describe('external dependency manifest', () => {
     expect(EXTERNAL_DEPENDENCIES.pnpm.version).toBe('10.31.0');
   });
 
-  it('pins the Drafter MCP as an independently versioned package', () => {
-    expect(EXTERNAL_DEPENDENCIES.drafterMcp).toMatchObject({
-      packageName: 'drafter-mcp',
-      version: '0.1.0',
-      commandName: 'drafter-mcp',
-      runner: 'uvx',
-      configEnvVar: 'INVOKER_MCP_CONFIG_PATH',
-    });
-    expect(DEFAULT_DRAFTER_MCP_PACKAGE_SPEC).toBe('drafter-mcp==0.1.0');
+  it('does not list the bundled Drafter MCP as an external package', () => {
+    expect('drafterMcp' in EXTERNAL_DEPENDENCIES).toBe(false);
   });
 });
 

--- a/packages/contracts/src/external-dependencies.ts
+++ b/packages/contracts/src/external-dependencies.ts
@@ -29,14 +29,6 @@ interface ToolDependency extends ExternalDependencyBase {
   command: string;
 }
 
-interface PythonMcpDependency extends ExternalDependencyBase {
-  kind: 'python-mcp';
-  packageName: string;
-  version: string;
-  commandName: string;
-  runner: 'uvx';
-  configEnvVar: string;
-}
 
 const RUNTIME_DEPENDENCIES = {
   node: {
@@ -129,25 +121,10 @@ const TOOL_DEPENDENCIES = {
   },
 } as const satisfies Record<string, ToolDependency>;
 
-const MCP_DEPENDENCIES = {
-  drafterMcp: {
-    id: 'drafter-mcp',
-    name: 'Drafter MCP',
-    kind: 'python-mcp',
-    packageName: 'drafter-mcp',
-    version: '0.1.0',
-    commandName: 'drafter-mcp',
-    runner: 'uvx',
-    configEnvVar: 'INVOKER_MCP_CONFIG_PATH',
-    requiredFor: 'conversation-to-plan splitting through the planner MCP',
-    installHint: 'uvx --from drafter-mcp==0.1.0 drafter-mcp',
-  },
-} as const satisfies Record<string, PythonMcpDependency>;
 
 export const EXTERNAL_DEPENDENCIES = {
   ...RUNTIME_DEPENDENCIES,
   ...TOOL_DEPENDENCIES,
-  ...MCP_DEPENDENCIES,
 } as const;
 
 export const DEFAULT_TOOL_REQUIREMENTS: ToolRequirement[] = Object.values(TOOL_DEPENDENCIES).map((dependency) => ({
@@ -158,5 +135,3 @@ export const DEFAULT_TOOL_REQUIREMENTS: ToolRequirement[] = Object.values(TOOL_D
   required: 'required' in dependency ? dependency.required : undefined,
   installHint: dependency.installHint,
 }));
-
-export const DEFAULT_DRAFTER_MCP_PACKAGE_SPEC = `${EXTERNAL_DEPENDENCIES.drafterMcp.packageName}==${EXTERNAL_DEPENDENCIES.drafterMcp.version}`;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -10,4 +10,4 @@ export * from './cost-types.ts';
 export * from './launch-timeouts.ts';
 export * from './invoker-home.ts';
 export * from './prerequisites.ts';
-export { EXTERNAL_DEPENDENCIES, DEFAULT_DRAFTER_MCP_PACKAGE_SPEC } from './external-dependencies.ts';
+export { EXTERNAL_DEPENDENCIES } from './external-dependencies.ts';


### PR DESCRIPTION
## Summary

The shared dependency contract no longer names Drafter as a PyPI package.

Drafter no longer has a package pin in this contract.

<details>
<summary>Review metadata</summary>

Review Claim: Approve the dependency contract no longer exporting a Drafter PyPI package pin.

Review Lane: refactor

Review Unit: contract

Safety Invariant: No runtime import references this export in this PR stack.

Slice Rationale: This PR only changes the dependency contract.

</details>

## Non-goals

Behavior unchanged.

This does not change the remaining dependency entries.

## Test Plan

- [x] `pnpm --filter @invoker/contracts test`
- [x] `pnpm --filter @invoker/cli test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a481938a`
- Post-revert steps: None
- Data migration? No
