### PR TITLE
[Planner MCP](1) Install Drafter MCP during setup

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -100,7 +100,7 @@ describe('invoker-cli', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('invoker-cli setup [planner|slack]');
     expect(result.stdout).toContain('--planner-url <url>');
-    expect(result.stdout).toContain('Required unless INVOKER_MCP_CONFIG_PATH is set');
+    expect(result.stdout).toContain('Defaults to ~/.invoker/mcp.json');
   });
 
   it('lists worker kinds from the registry', async () => {

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES } from '@invoker/contracts';
 
 import {
+  defaultExperimentalPlannerMcpPath,
+  ensureExperimentalPlannerMcp,
   buildDoctorChecks,
   generateSlackManifest,
   installExperimentalPlannerMcp,
@@ -111,16 +113,40 @@ describe('buildDoctorChecks', () => {
   });
 });
 describe('runSetup', () => {
-  it('keeps Slack enabled by default and lets the user opt out', async () => {
+  it('installs the public planner MCP by default without enabling planner behavior', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'invoker-setup-home-'));
+    const saved = {
+      HOME: process.env.HOME,
+      target: process.env.INVOKER_MCP_CONFIG_PATH,
+    };
     const lines: string[] = [];
-    const code = await runSetup([], {
-      print: (line) => lines.push(line),
-      prompt: async () => 'n',
-    });
+    try {
+      process.env.HOME = home;
+      delete process.env.INVOKER_MCP_CONFIG_PATH;
 
-    expect(lines.join('\n')).toContain('Invoker setup');
-    expect(lines.join('\n')).toContain('Run `invoker-cli setup slack` later');
-    expect(typeof code).toBe('number');
+      const code = await runSetup([], {
+        print: (line) => lines.push(line),
+        prompt: async () => 'n',
+      });
+
+      const mcpPath = join(home, '.invoker', 'mcp.json');
+      const invokerConfigPath = join(home, '.invoker', 'config.json');
+      expect(lines.join('\n')).toContain('Invoker setup');
+      expect(lines.join('\n')).toContain(`Experimental planner MCP installed into ${mcpPath}`);
+      expect(lines.join('\n')).toContain('experimentalPlanner flag: off');
+      expect(lines.join('\n')).toContain('Run `invoker-cli setup slack` later');
+      expect(JSON.parse(readFileSync(mcpPath, 'utf8')).mcpServers['experimental-planner']).toEqual({
+        type: 'stdio',
+        command: 'uvx',
+        args: ['--from', DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES.drafterMcp.commandName],
+      });
+      expect(existsSync(invokerConfigPath)).toBe(false);
+      expect(typeof code).toBe('number');
+    } finally {
+      restoreEnv('HOME', saved.HOME);
+      restoreEnv('INVOKER_MCP_CONFIG_PATH', saved.target);
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   it('writes Slack env from environment values without prompts', async () => {
@@ -261,34 +287,28 @@ describe('experimental planner MCP setup', () => {
     }
   });
 
-  it('uses INVOKER_MCP_CONFIG_PATH when no target is passed', () => {
+  it('uses a packaged Invoker MCP config path when no target is passed', () => {
     const dir = mkdtempSync(join(tmpdir(), 'invoker-planner-setup-'));
-    const targetPath = join(dir, 'mcp.json');
     const configPath = join(dir, 'config.json');
-    const savedTarget = process.env.INVOKER_MCP_CONFIG_PATH;
-    try {
-      process.env.INVOKER_MCP_CONFIG_PATH = targetPath;
-
-      const state = installExperimentalPlannerMcp({ configPath });
-
-      expect(state.targetPath).toBe(targetPath);
-      expect(readExperimentalPlannerSetup({ configPath }).installed).toBe(true);
-    } finally {
-      restoreEnv('INVOKER_MCP_CONFIG_PATH', savedTarget);
-      rmSync(dir, { recursive: true, force: true });
-    }
-  });
-
-  it('requires an MCP target instead of assuming OMP is installed', () => {
+    const targetPath = join(dir, 'mcp.json');
     const savedTarget = process.env.INVOKER_MCP_CONFIG_PATH;
     try {
       delete process.env.INVOKER_MCP_CONFIG_PATH;
 
-      expect(() => installExperimentalPlannerMcp({ configPath: join(tmpdir(), 'invoker-config.json') })).toThrow(
-        'Missing MCP config path. Pass --target <path> or set INVOKER_MCP_CONFIG_PATH.',
-      );
+      const state = ensureExperimentalPlannerMcp({ configPath });
+
+      expect(defaultExperimentalPlannerMcpPath(configPath)).toBe(targetPath);
+      expect(state).toEqual({ targetPath, configPath, installed: true, experimentalPlanner: false });
+      const mcpConfig = JSON.parse(readFileSync(targetPath, 'utf8'));
+      expect(mcpConfig.mcpServers['experimental-planner'].args).toEqual([
+        '--from',
+        DEFAULT_DRAFTER_MCP_PACKAGE_SPEC,
+        EXTERNAL_DEPENDENCIES.drafterMcp.commandName,
+      ]);
+      expect(existsSync(configPath)).toBe(false);
     } finally {
       restoreEnv('INVOKER_MCP_CONFIG_PATH', savedTarget);
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -148,7 +148,7 @@ function usage(): string {
     '  --planner-url <url>   Planner service URL for `setup planner`.',
     '  --access-token <tok>  Planner service access token for `setup planner`.',
     `  --planner-package <spec>  Planner MCP package spec for \`setup planner\`. Defaults to ${DEFAULT_DRAFTER_MCP_PACKAGE_SPEC}.`,
-    '  --target <path>       MCP config path for `setup planner`. Required unless INVOKER_MCP_CONFIG_PATH is set.',
+    '  --target <path>       MCP config path for planner setup. Defaults to ~/.invoker/mcp.json.',
     '  --uninstall           Remove the experimental planner MCP entry and disable its Invoker flag.',
     '  --live           Require a running Invoker UI owner and submit over IPC.',
     '  --standalone     Skip IPC and run with an isolated CLI database.',

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -43,14 +43,16 @@ export function envFilePath(): string {
 export function manifestFilePath(): string {
   return join(invokerHomeDir(), 'slack-app-manifest.json');
 }
-export function experimentalPlannerMcpPath(): string | undefined {
-  return process.env.INVOKER_MCP_CONFIG_PATH;
+export function defaultExperimentalPlannerMcpPath(configPath: string = defaultConfigPath()): string {
+  return join(dirname(configPath), 'mcp.json');
 }
 
-function requireExperimentalPlannerMcpPath(targetPath?: string): string {
-  const resolvedPath = targetPath ?? experimentalPlannerMcpPath();
-  if (resolvedPath) return resolvedPath;
-  throw new Error('Missing MCP config path. Pass --target <path> or set INVOKER_MCP_CONFIG_PATH.');
+export function experimentalPlannerMcpPath(configPath: string = defaultConfigPath()): string {
+  return process.env.INVOKER_MCP_CONFIG_PATH ?? defaultExperimentalPlannerMcpPath(configPath);
+}
+
+function resolveExperimentalPlannerMcpPath(targetPath: string | undefined, configPath: string): string {
+  return targetPath ?? experimentalPlannerMcpPath(configPath);
 }
 
 // ── Tool probing & install ───────────────────────────────────
@@ -172,8 +174,8 @@ export function setExperimentalPlannerFlag(enabled: boolean, configPath: string 
 }
 
 export function readExperimentalPlannerSetup(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
-  const targetPath = requireExperimentalPlannerMcpPath(options.targetPath);
   const configPath = options.configPath ?? defaultConfigPath();
+  const targetPath = resolveExperimentalPlannerMcpPath(options.targetPath, configPath);
   const invokerConfig = existsSync(configPath) ? readMutableJson(configPath, {}) : {};
   const mcpConfig = existsSync(targetPath) ? readMutableJson(targetPath, {}) : {};
   const servers = isJsonRecord(mcpConfig.mcpServers) ? mcpConfig.mcpServers : {};
@@ -185,9 +187,9 @@ export function readExperimentalPlannerSetup(options: ExperimentalPlannerSetupOp
   };
 }
 
-export function installExperimentalPlannerMcp(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
-  const targetPath = requireExperimentalPlannerMcpPath(options.targetPath);
+function writeExperimentalPlannerMcpEntry(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
   const configPath = options.configPath ?? defaultConfigPath();
+  const targetPath = resolveExperimentalPlannerMcpPath(options.targetPath, configPath);
   const mcpConfig = readMutableJson(targetPath, { $schema: 'https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json' });
   const existingServers = mutableMcpServers(mcpConfig, targetPath);
   const servers: JsonRecord = { ...existingServers };
@@ -208,8 +210,17 @@ export function installExperimentalPlannerMcp(options: ExperimentalPlannerSetupO
   if (writesPlannerAccessToken && existsSync(targetPath)) chmodSync(targetPath, 0o600);
   writeFileSync(targetPath, `${JSON.stringify(mcpConfig, null, 2)}\n`, writesPlannerAccessToken ? { mode: 0o600 } : undefined);
   if (writesPlannerAccessToken) chmodSync(targetPath, 0o600);
-  setExperimentalPlannerFlag(!options.uninstall, configPath);
   return readExperimentalPlannerSetup({ targetPath, configPath });
+}
+
+export function ensureExperimentalPlannerMcp(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
+  return writeExperimentalPlannerMcpEntry(options);
+}
+
+export function installExperimentalPlannerMcp(options: ExperimentalPlannerSetupOptions = {}): ExperimentalPlannerSetupState {
+  const state = writeExperimentalPlannerMcpEntry(options);
+  setExperimentalPlannerFlag(!options.uninstall, state.configPath);
+  return readExperimentalPlannerSetup({ targetPath: state.targetPath, configPath: state.configPath });
 }
 
 export function buildDoctorChecks(cfg: CliConfigState, isInstalled: IsInstalled = commandExists): PrerequisiteCheck[] {
@@ -583,7 +594,15 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
     io.print(formatReport(core));
     io.print('');
 
-    if (!wantSlack && !fromEnv && await promptYes(io, 'Set up the experimental planner MCP now? [y/N] ')) {
+    const plannerState = ensureExperimentalPlannerMcp({
+      targetPath: parsed.targetPath,
+      plannerPackage: parsed.plannerPackage ?? process.env.INVOKER_PLANNER_PACKAGE,
+    });
+    io.print(`Experimental planner MCP installed into ${plannerState.targetPath}.`);
+    io.print(`experimentalPlanner flag: ${plannerState.experimentalPlanner ? 'on' : 'off'}`);
+    io.print('');
+
+    if (!wantSlack && !fromEnv && await promptYes(io, 'Enable the experimental planner now? [y/N] ')) {
       await maybeInstallPlanner(parsed, io);
       io.print('');
     }
@@ -593,7 +612,7 @@ export async function runSetup(argv: string[], io: SetupIO = defaultIO()): Promi
       doSlack = await promptYes(io, 'Set up the Slack integration now? [y/N] ');
     }
     if (!doSlack) {
-      io.print('\nYou are good to go for CLI and UI workflows. Run `invoker-cli setup planner` later to add the experimental planner. Run `invoker-cli setup slack` later to add Slack.');
+      io.print('\nYou are good to go for CLI and UI workflows. Run `invoker-cli setup planner` later to enable the experimental planner. Run `invoker-cli setup slack` later to add Slack.');
       return core.ok ? 0 : 1;
     }
 


### PR DESCRIPTION
## Summary

`invoker-cli setup` now creates Invoker's default MCP config and installs the Drafter MCP entry there.

That entry runs the pinned public PyPI build through `uvx`. It does not bundle Drafter into Invoker.

Planner behavior still stays off by default. The planner only runs after `experimentalPlanner` is enabled through `setup planner` or the setup prompt.

<details>
<summary>Review metadata</summary>

Review Claim: Approve setup installing the public Drafter MCP entry while keeping planner behavior behind the flag.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: Setup writes the MCP entry, but only `setup planner` or the setup prompt turns on `experimentalPlanner`.

Slice Rationale: This keeps the MCP entry and planner flag behavior in one CLI slice.

</details>

## Non-goals

This does not bundle Drafter into the Invoker binary.

This does not enable planner behavior by default.

This does not remove the Drafter package pin from external dependencies.

## Architecture

### Before

Planner setup required a user-supplied MCP config path.

### After

Invoker setup writes `~/.invoker/mcp.json` by default with `uvx --from drafter-mcp==0.1.0 drafter-mcp`.

The generated entry exists before the planner flag is enabled. The flag controls planner behavior, not whether the MCP entry is present.

## Test Plan

- [x] `pnpm --filter @invoker/cli test`
- [x] `pnpm --filter @invoker/contracts test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f0d7e29e`
- Post-revert steps: None
- Data migration? No
