### PR TITLE
[Autoapprove single config](1) Add shared invoker config path helper

### DIFF
--- a/packages/contracts/src/invoker-home.ts
+++ b/packages/contracts/src/invoker-home.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 export interface InvokerHomeEnv {
   INVOKER_DB_DIR?: string;
   INVOKER_IPC_SOCKET?: string;
+  INVOKER_REPO_CONFIG_PATH?: string;
   NODE_ENV?: string;
 }
 
@@ -17,6 +18,14 @@ export function resolveInvokerHomeRoot(
       ? join(homeDir, '.invoker', 'test')
       : join(homeDir, '.invoker'))
   );
+}
+
+export function resolveInvokerConfigPath(
+  env: InvokerHomeEnv = process.env,
+  homeDir: string = homedir(),
+): string {
+  const override = env.INVOKER_REPO_CONFIG_PATH?.trim();
+  return override || join(homeDir, '.invoker', 'config.json');
 }
 
 export function resolveInvokerIpcSocketPath(


### PR DESCRIPTION
## Summary

Invoker now has a shared helper for config-path resolution.

The bug was duplicated path rules. The config location logic had no single contract.

This slice adds `resolveInvokerConfigPath()` and extends the shared env type with the explicit override field.

<details>
<summary>Review metadata</summary>

Review Claim: Invoker now has one shared contract helper for config-path resolution.

Review Lane: behavior

Review Unit: contract

Safety Invariant: This slice only adds a helper and shared type field. No config-reader behavior changes yet.

Slice Rationale: The shared resolver is the foundation for later runtime changes.

</details>

## Non-goals

This does not change any config reader yet.

This does not change approval behavior.

## Test Plan

- [x] `pnpm --filter @invoker/contracts build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert fecd165`
- Post-revert steps: None
- Data migration? No