### PR TITLE
[Autoapprove single config](2) Use shared config path in app loader

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -1,4 +1,7 @@
+import type * as NodeOs from 'node:os';
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveInvokerConfigPath } from '@invoker/contracts';
 import {
   loadConfig,
   resolveConfigFilePath,
@@ -23,7 +26,7 @@ afterEach(() => {
 });
 
 vi.mock('node:os', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:os')>();
+  const actual = await importOriginal<typeof NodeOs>();
   return {
     ...actual,
     homedir: () => `${actual.tmpdir()}/invoker-config-test-${process.pid}/home`,
@@ -602,7 +605,9 @@ describe('loadConfig', () => {
       JSON.stringify({ defaultBranch: 'main' }),
     );
     process.env.INVOKER_REPO_CONFIG_PATH = '   ';
-    expect(resolveConfigFilePath()).toBe(join(fakeHome, '.invoker', 'config.json'));
+    const expected = join(fakeHome, '.invoker', 'config.json');
+    expect(resolveInvokerConfigPath(process.env, fakeHome)).toBe(expected);
+    expect(resolveConfigFilePath()).toBe(expected);
     expect(loadConfig().defaultBranch).toBe('main');
   });
 });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -2,12 +2,13 @@
  * Configuration loader for Invoker.
  *
  * Reads from ~/.invoker/config.json (user-level config).
- * Override with INVOKER_REPO_CONFIG_PATH env var (for tests).
+ * INVOKER_REPO_CONFIG_PATH is a test/CLI override only.
  */
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { resolveInvokerConfigPath } from '@invoker/contracts';
 import { validateInvokerConfig } from './config-validation.js';
 
 export type HarnessModelPolicy =
@@ -329,8 +330,7 @@ function readJsonSafe(path: string): InvokerConfig {
 }
 
 export function resolveConfigFilePath(): string {
-  const override = process.env.INVOKER_REPO_CONFIG_PATH?.trim();
-  return override || join(homedir(), '.invoker', 'config.json');
+  return resolveInvokerConfigPath(process.env, homedir());
 }
 
 export function resolveConfigFileState(): { path: string; exists: boolean } {

--- a/packages/contracts/src/invoker-home.ts
+++ b/packages/contracts/src/invoker-home.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 export interface InvokerHomeEnv {
   INVOKER_DB_DIR?: string;
   INVOKER_IPC_SOCKET?: string;
+  INVOKER_REPO_CONFIG_PATH?: string;
   NODE_ENV?: string;
 }
 
@@ -17,6 +18,14 @@ export function resolveInvokerHomeRoot(
       ? join(homeDir, '.invoker', 'test')
       : join(homeDir, '.invoker'))
   );
+}
+
+export function resolveInvokerConfigPath(
+  env: InvokerHomeEnv = process.env,
+  homeDir: string = homedir(),
+): string {
+  const override = env.INVOKER_REPO_CONFIG_PATH?.trim();
+  return override || join(homeDir, '.invoker', 'config.json');
 }
 
 export function resolveInvokerIpcSocketPath(


### PR DESCRIPTION
## Summary

The app config loader now uses the shared config-path helper.

The bug was blank override drift. A blank `INVOKER_REPO_CONFIG_PATH` could fall back inconsistently.

This slice makes the app loader fall back to `~/.invoker/config.json` through the shared resolver and locks that rule in tests.

<details>
<summary>Review metadata</summary>

Review Claim: The app config loader now resolves config paths only through the shared helper, including blank override fallback.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: This slice only changes config-file selection in the app loader and its direct tests.

Slice Rationale: This is the first runtime reader, so it proves the shared rule before other surfaces adopt it.

</details>

## Non-goals

This does not change CLI, Slack, or worker entrypoints yet.

This does not change auto-approval behavior.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert fbd2b2d`
- Post-revert steps: None
- Data migration? No

Depends-On: #3250