### PR TITLE
[Autoapprove single config](3) Route AI fix approval through autoapprove worker

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -1,4 +1,7 @@
+import type * as NodeOs from 'node:os';
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveInvokerConfigPath } from '@invoker/contracts';
 import {
   loadConfig,
   resolveConfigFilePath,
@@ -23,7 +26,7 @@ afterEach(() => {
 });
 
 vi.mock('node:os', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:os')>();
+  const actual = await importOriginal<typeof NodeOs>();
   return {
     ...actual,
     homedir: () => `${actual.tmpdir()}/invoker-config-test-${process.pid}/home`,
@@ -602,7 +605,9 @@ describe('loadConfig', () => {
       JSON.stringify({ defaultBranch: 'main' }),
     );
     process.env.INVOKER_REPO_CONFIG_PATH = '   ';
-    expect(resolveConfigFilePath()).toBe(join(fakeHome, '.invoker', 'config.json'));
+    const expected = join(fakeHome, '.invoker', 'config.json');
+    expect(resolveInvokerConfigPath(process.env, fakeHome)).toBe(expected);
+    expect(resolveConfigFilePath()).toBe(expected);
     expect(loadConfig().defaultBranch).toBe('main');
   });
 });

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  AUTO_APPROVE_WORKER_KIND,
   AUTO_FIX_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
   createWorkerRegistry,
@@ -9,8 +10,8 @@ import {
 } from '@invoker/execution-engine';
 
 import {
-  AUTO_STARTED_OWNER_WORKER_KINDS,
   createWorkerRuntimeController,
+  getAutoStartedOwnerWorkerKinds,
 } from '../worker-control.js';
 
 interface TestWorkerRuntime extends WorkerRuntime {
@@ -64,7 +65,7 @@ function deps(): WorkerRuntimeDependencies {
   } as WorkerRuntimeDependencies;
 }
 
-function controller() {
+function controller(options: { autoFixRetries?: number; autoApproveAIFixes?: boolean; autoStartKinds?: readonly string[] } = {}) {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
   const runtimes = new Map<string, TestWorkerRuntime[]>();
   const register = (kind: string, note: string, runtimeKind = kind) => {
@@ -81,6 +82,7 @@ function controller() {
     });
   };
   register(AUTO_FIX_WORKER_KIND, 'Auto-fixes failed tasks.', 'recovery');
+  register(AUTO_APPROVE_WORKER_KIND, 'Approves AI fixes.');
   register(PR_STATUS_WORKER_KIND, 'Checks pull request status.');
   register(CI_FAILURE_WORKER_KIND, 'Repairs failed CI.');
   register('external-preview', 'External preview worker.');
@@ -90,36 +92,70 @@ function controller() {
     controller: createWorkerRuntimeController({
       registry,
       deps: deps(),
-      autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      autoStartKinds: options.autoStartKinds ?? getAutoStartedOwnerWorkerKinds({ autoApproveAIFixes: options.autoApproveAIFixes }),
       persistence: persistence() as never,
+      autoFixRetries: options.autoFixRetries,
+      autoApproveAIFixes: options.autoApproveAIFixes,
       canControl: () => true,
     }),
   };
 }
 
 describe('createWorkerRuntimeController', () => {
-  it('auto-start starts only pr-status and ci-failure', () => {
-    const setup = controller();
+  it('auto-starts autoapprove only when AI fix auto-approval is enabled', () => {
+    expect(getAutoStartedOwnerWorkerKinds({ autoApproveAIFixes: true })).toEqual([
+      AUTO_FIX_WORKER_KIND,
+      AUTO_APPROVE_WORKER_KIND,
+      PR_STATUS_WORKER_KIND,
+      CI_FAILURE_WORKER_KIND,
+    ]);
+    expect(getAutoStartedOwnerWorkerKinds({})).toEqual([
+      AUTO_FIX_WORKER_KIND,
+      PR_STATUS_WORKER_KIND,
+      CI_FAILURE_WORKER_KIND,
+    ]);
+  });
+
+  it('auto-start starts autofix, pr-status, and ci-failure by default', () => {
+    const setup = controller({ autoFixRetries: 3 });
 
     setup.controller.startAutoStartedWorkers();
     const snapshot = setup.controller.snapshot();
 
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)?.lifecycle).toBe('running');
-    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
     expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.lifecycle).toBe('stopped');
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_APPROVE_WORKER_KIND)).toMatchObject({
+      lifecycle: 'stopped',
+      policy: 'disabled',
+      policyReason: 'autoApproveAIFixes=false',
+      startable: false,
+    });
   });
 
-  it('autofix remains stopped until explicitly started', () => {
-    const setup = controller();
+  it('auto-start starts autoapprove when configured', () => {
+    const setup = controller({ autoFixRetries: 3, autoApproveAIFixes: true });
 
     setup.controller.startAutoStartedWorkers();
-    expect(setup.runtimes.get(AUTO_FIX_WORKER_KIND)).toBeUndefined();
+    const row = setup.controller.snapshot().workers.find((worker) => worker.kind === AUTO_APPROVE_WORKER_KIND);
 
+    expect(row).toMatchObject({
+      lifecycle: 'running',
+      policy: 'enabled',
+      startable: false,
+    });
+  });
+
+  it('autofix duplicate start is idempotent after autostart', () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    setup.controller.startAutoStartedWorkers();
     const row = setup.controller.start(AUTO_FIX_WORKER_KIND);
 
     expect(row.lifecycle).toBe('running');
     expect(row.runtimeKind).toBe('recovery');
+    expect(setup.runtimes.get(AUTO_FIX_WORKER_KIND)).toHaveLength(1);
   });
 
   it('duplicate start is idempotent', () => {
@@ -146,22 +182,25 @@ describe('createWorkerRuntimeController', () => {
     expect(setup.runtimes.get(PR_STATUS_WORKER_KIND)?.[0]?.stops).toBe(1);
   });
 
-  it('retry budget policy does not disable worker starts', () => {
-    const setup = controller();
+  it('autoFixRetries=0 disables autofix and ci-failure but not autoapprove', () => {
+    const setup = controller({ autoFixRetries: 0, autoApproveAIFixes: true });
 
-    const autoFix = setup.controller.start(AUTO_FIX_WORKER_KIND);
-    const ciFailure = setup.controller.start(CI_FAILURE_WORKER_KIND);
+    expect(() => setup.controller.start(AUTO_FIX_WORKER_KIND)).toThrow('Worker "autofix" is disabled by autoFixRetries=0');
+    expect(() => setup.controller.start(CI_FAILURE_WORKER_KIND)).toThrow('Worker "ci-failure" is disabled by autoFixRetries=0');
+    expect(() => setup.controller.start(AUTO_APPROVE_WORKER_KIND)).not.toThrow();
 
-    expect(autoFix).toMatchObject({
-      lifecycle: 'running',
-      policy: 'enabled',
+    const snapshot = setup.controller.snapshot();
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
+      policy: 'disabled',
+      policyReason: 'autoFixRetries=0',
       startable: false,
     });
-    expect(ciFailure).toMatchObject({
-      lifecycle: 'running',
-      policy: 'enabled',
+    expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)).toMatchObject({
+      policy: 'disabled',
+      policyReason: 'autoFixRetries=0',
       startable: false,
     });
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_APPROVE_WORKER_KIND)?.lifecycle).toBe('running');
   });
 
   it('an exited external worker row reports exited', () => {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -2,12 +2,13 @@
  * Configuration loader for Invoker.
  *
  * Reads from ~/.invoker/config.json (user-level config).
- * Override with INVOKER_REPO_CONFIG_PATH env var (for tests).
+ * INVOKER_REPO_CONFIG_PATH is a test/CLI override only.
  */
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { resolveInvokerConfigPath } from '@invoker/contracts';
 import { validateInvokerConfig } from './config-validation.js';
 
 export type HarnessModelPolicy =
@@ -329,8 +330,7 @@ function readJsonSafe(path: string): InvokerConfig {
 }
 
 export function resolveConfigFilePath(): string {
-  const override = process.env.INVOKER_REPO_CONFIG_PATH?.trim();
-  return override || join(homedir(), '.invoker', 'config.json');
+  return resolveInvokerConfigPath(process.env, homedir());
 }
 
 export function resolveConfigFileState(): { path: string; exists: boolean } {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -237,9 +237,9 @@ import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import {
-  AUTO_STARTED_OWNER_WORKER_KINDS,
   createLocalWorkerStatusSnapshot,
   createWorkerRuntimeController,
+  getAutoStartedOwnerWorkerKinds,
   type WorkerRuntimeController,
 } from './worker-control.js';
 import { startSurfaceEventRelay } from './surface-event-relay.js';
@@ -334,6 +334,9 @@ function buildRegisteredOwnerWorkerDeps(
       attemptLedger: autoFixAttemptLedger,
       getAutoFixAgent: () => invokerConfig.autoFixAgent,
       getAutoFixExecutionModel: () => invokerConfig.defaultExecutionModel,
+    },
+    autoApprove: {
+      enabled: invokerConfig.autoApproveAIFixes === true,
     },
   };
 }
@@ -1751,9 +1754,10 @@ function startHeadlessMode(): void {
               await createStandaloneTaskExecutor().checkMergeGateStatuses();
             },
           ),
-          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
           persistence,
           autoFixRetries: invokerConfig.autoFixRetries,
+          autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
           canControl: () => !readOnlyMode,
         });
         workerRuntimeController.startAutoStartedWorkers();
@@ -2199,7 +2203,6 @@ function createEmbeddedTerminalBackendFromConfig(
         commandService,
         taskExecutor: requireTaskExecutor(),
         mutationTiming: activeMutationContext?.mutationTiming,
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
       },
       {
         agentName,
@@ -3052,7 +3055,6 @@ function createEmbeddedTerminalBackendFromConfig(
         persistence,
         commandService,
         taskExecutor: requireTaskExecutor(),
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
         killRunningTask,
       });
       apiServer = startApiServer({
@@ -3525,9 +3527,10 @@ function createEmbeddedTerminalBackendFromConfig(
             await requireTaskExecutor().checkMergeGateStatuses();
           },
         ),
-        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
         persistence,
         autoFixRetries: invokerConfig.autoFixRetries,
+        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
         canControl: () => ownerMode,
       });
       workerRuntimeController.startAutoStartedWorkers();
@@ -4198,13 +4201,13 @@ function createEmbeddedTerminalBackendFromConfig(
         return createLocalWorkerStatusSnapshot({
           registry: createRegisteredWorkerRegistry(),
           persistence,
-          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
         });
       }
       return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
         registry: createRegisteredWorkerRegistry(),
         persistence,
-        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
       });
     });
 
@@ -4659,7 +4662,6 @@ function createEmbeddedTerminalBackendFromConfig(
           orchestrator,
           persistence,
           taskExecutor: requireTaskExecutor(),
-          autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
         }, agentName, activeMutationContext?.signal);
         await finalizeMutationWithGlobalTopup({
           orchestrator,

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -7,6 +7,7 @@ import type {
 } from '@invoker/contracts';
 import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
 import {
+  AUTO_APPROVE_WORKER_KIND,
   AUTO_FIX_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
@@ -17,7 +18,11 @@ import {
 
 import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
 
-export const AUTO_STARTED_OWNER_WORKER_KINDS = [PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND] as const;
+export function getAutoStartedOwnerWorkerKinds(config: { autoApproveAIFixes?: boolean }): string[] {
+  return config.autoApproveAIFixes === true
+    ? [AUTO_FIX_WORKER_KIND, AUTO_APPROVE_WORKER_KIND, PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND]
+    : [AUTO_FIX_WORKER_KIND, PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND];
+}
 
 export interface WorkerRuntimeController {
   startAutoStartedWorkers(): void;
@@ -37,6 +42,7 @@ interface RuntimeHandle {
 
 const BUILT_IN_WORKER_KINDS = new Set<string>([
   AUTO_FIX_WORKER_KIND,
+  AUTO_APPROVE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
 ]);
@@ -46,8 +52,8 @@ export function createWorkerRuntimeController(options: {
   deps: WorkerRuntimeDependencies;
   autoStartKinds: readonly string[];
   persistence: WorkerStatusPersistence;
-  /** Compatibility input; retry budget is enforced inside worker policy, not by controller start gating. */
   autoFixRetries?: number;
+  autoApproveAIFixes?: boolean;
   canControl: () => boolean;
 }): WorkerRuntimeController {
   const handles = new Map<string, RuntimeHandle>();
@@ -61,6 +67,12 @@ export function createWorkerRuntimeController(options: {
     return definition;
   };
 
+  const assertStartAllowed = (kind: string): void => {
+    const reason = disabledPolicyReasonForKind(kind, options.autoFixRetries, options.autoApproveAIFixes);
+    if (reason) {
+      throw new Error(`Worker "${kind}" is disabled by ${reason}`);
+    }
+  };
 
   const rowForKind = (kind: string): WorkerStatusEntry => {
     const definition = options.registry.get(kind);
@@ -73,7 +85,8 @@ export function createWorkerRuntimeController(options: {
       handle: handles.get(kind),
       stoppedAt: stoppedAtByKind.get(kind),
       autoStarts: options.autoStartKinds.includes(kind),
-      policy: policyForKind(kind),
+      policy: policyForKind(kind, options.autoFixRetries, options.autoApproveAIFixes),
+      policyReason: disabledPolicyReasonForKind(kind, options.autoFixRetries, options.autoApproveAIFixes),
       persistence: options.persistence,
       canControl: options.canControl(),
     });
@@ -90,12 +103,14 @@ export function createWorkerRuntimeController(options: {
     startAutoStartedWorkers(): void {
       for (const kind of options.autoStartKinds) {
         if (!options.registry.get(kind)) continue;
+        if (disabledPolicyReasonForKind(kind, options.autoFixRetries, options.autoApproveAIFixes)) continue;
         this.start(kind);
       }
     },
 
     start(kind: string): WorkerStatusEntry {
       const definition = requireDefinition(kind);
+      assertStartAllowed(kind);
 
       const existing = handles.get(kind);
       if (existing) {
@@ -115,6 +130,7 @@ export function createWorkerRuntimeController(options: {
       stoppedAtByKind.delete(kind);
       return rowForKind(kind);
     },
+
     async stop(kind: string): Promise<WorkerStatusEntry> {
       requireDefinition(kind);
       const handle = handles.get(kind);
@@ -138,6 +154,7 @@ export function createWorkerRuntimeController(options: {
     },
   };
 }
+
 export function createLocalWorkerStatusSnapshot(options: {
   registry: WorkerRegistry<WorkerRuntimeDependencies>;
   persistence: WorkerStatusPersistence;
@@ -156,7 +173,6 @@ export function createLocalWorkerStatusSnapshot(options: {
   };
 }
 
-
 function buildWorkerStatusEntry(args: {
   definitionKind: string;
   note: string;
@@ -164,12 +180,14 @@ function buildWorkerStatusEntry(args: {
   stoppedAt?: string;
   autoStarts: boolean;
   policy: WorkerPolicyStatus;
+  policyReason?: string;
   persistence: WorkerStatusPersistence;
   canControl: boolean;
 }): WorkerStatusEntry {
   const lifecycle = args.handle
     ? args.handle.runtime.isRunning() ? 'running' : 'exited'
     : 'stopped';
+  const policyReason = args.policy === 'disabled' ? args.policyReason : undefined;
   const controlDisabledReason = getControlDisabledReason(args.canControl);
   const runtime = args.handle?.runtime;
   return {
@@ -178,6 +196,7 @@ function buildWorkerStatusEntry(args: {
     ...(runtime ? { runtimeKind: runtime.identity.kind, instanceId: runtime.identity.instanceId } : {}),
     lifecycle,
     policy: args.policy,
+    ...(policyReason ? { policyReason } : {}),
     autoStarts: args.autoStarts,
     startable: lifecycle !== 'running' && args.policy !== 'disabled' && args.canControl,
     stoppable: lifecycle === 'running' && args.canControl,
@@ -189,9 +208,26 @@ function buildWorkerStatusEntry(args: {
   };
 }
 
-function policyForKind(kind: string): WorkerPolicyStatus {
+function policyForKind(
+  kind: string,
+  autoFixRetries: number | undefined,
+  autoApproveAIFixes: boolean | undefined,
+): WorkerPolicyStatus {
+  if (disabledPolicyReasonForKind(kind, autoFixRetries, autoApproveAIFixes)) return 'disabled';
   if (BUILT_IN_WORKER_KINDS.has(kind)) return 'enabled';
   return 'unknown';
+}
+
+function disabledPolicyReasonForKind(
+  kind: string,
+  autoFixRetries: number | undefined,
+  autoApproveAIFixes: boolean | undefined,
+): string | undefined {
+  if ((kind === AUTO_FIX_WORKER_KIND || kind === CI_FAILURE_WORKER_KIND) && autoFixRetries !== undefined && autoFixRetries <= 0) {
+    return 'autoFixRetries=0';
+  }
+  if (kind === AUTO_APPROVE_WORKER_KIND && autoApproveAIFixes !== true) return 'autoApproveAIFixes=false';
+  return undefined;
 }
 
 function getControlDisabledReason(canControl: boolean): string | undefined {

--- a/packages/contracts/src/invoker-home.ts
+++ b/packages/contracts/src/invoker-home.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 export interface InvokerHomeEnv {
   INVOKER_DB_DIR?: string;
   INVOKER_IPC_SOCKET?: string;
+  INVOKER_REPO_CONFIG_PATH?: string;
   NODE_ENV?: string;
 }
 
@@ -17,6 +18,14 @@ export function resolveInvokerHomeRoot(
       ? join(homeDir, '.invoker', 'test')
       : join(homeDir, '.invoker'))
   );
+}
+
+export function resolveInvokerConfigPath(
+  env: InvokerHomeEnv = process.env,
+  homeDir: string = homedir(),
+): string {
+  const override = env.INVOKER_REPO_CONFIG_PATH?.trim();
+  return override || join(homeDir, '.invoker', 'config.json');
 }
 
 export function resolveInvokerIpcSocketPath(

--- a/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
@@ -1,0 +1,225 @@
+import type { Logger } from '@invoker/contracts';
+import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationIntent } from '@invoker/data-store';
+import type { RecoveryWorkerWakeupHint } from '../lifecycle-events.js';
+import type { TaskState } from '@invoker/workflow-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  collectValidatedAutoApproveCandidates,
+  createAutoApproveTick,
+  isApproveIntentForTask,
+  listAutoApproveScanCandidates,
+  type AutoApproveCandidate,
+  type AutoApproveWorkerStore,
+} from '../workers/auto-approve-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+} as unknown as Logger;
+
+function task(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/task-1',
+    description: 'Task 1',
+    status: 'awaiting_approval',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    config: { id: 'task-1', workflowId: 'wf-1', ...config },
+    execution: {
+      pendingFixError: 'boom',
+      generation: 1,
+      selectedAttemptId: 'attempt-1',
+      ...execution,
+    },
+    taskStateVersion: 4,
+    ...rest,
+  } as TaskState;
+}
+
+function intent(overrides: Partial<WorkflowMutationIntent>): WorkflowMutationIntent {
+  return {
+    id: 1,
+    workflowId: 'wf-1',
+    channel: 'invoker:approve',
+    args: ['wf-1/task-1'],
+    priority: 'normal',
+    status: 'queued',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function wakeup(overrides: Partial<RecoveryWorkerWakeupHint> = {}): RecoveryWorkerWakeupHint {
+  return {
+    eventKey: 'event-1',
+    eventKind: 'task.awaiting_approval',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/task-1',
+    taskStateVersion: 4,
+    generation: 1,
+    attemptId: 'attempt-1',
+    createdAt: '2026-01-01T00:00:00Z',
+    reason: 'task_lifecycle',
+    authoritative: false,
+    ...overrides,
+  };
+}
+
+function makeStore(tasks: TaskState[], openIntents: WorkflowMutationIntent[] = []) {
+  const actions = new Map<string, WorkerActionRecord>();
+  const writes: WorkerActionWrite[] = [];
+  const store: AutoApproveWorkerStore = {
+    listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+    loadTasks: vi.fn(() => tasks),
+    loadTask: vi.fn((taskId: string) => tasks.find((candidate) => candidate.id === taskId)),
+    listWorkflowMutationIntents: vi.fn(() => openIntents),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      writes.push(write);
+      const now = new Date('2026-01-01T00:00:00Z').toISOString();
+      const record: WorkerActionRecord = {
+        attemptCount: 0,
+        createdAt: now,
+        updatedAt: now,
+        ...write,
+      };
+      actions.set(`${write.workerKind}:${write.externalKey}`, record);
+      return record;
+    }),
+    logEvent: vi.fn(),
+  };
+  return { store, writes };
+}
+
+function candidate(overrides: Partial<AutoApproveCandidate> = {}): AutoApproveCandidate {
+  return {
+    taskId: 'wf-1/task-1',
+    workflowId: 'wf-1',
+    generation: 1,
+    taskStateVersion: 4,
+    attemptId: 'attempt-1',
+    source: 'scan',
+    ...overrides,
+  };
+}
+
+describe('autoapprove worker', () => {
+  it('scan candidates include only awaiting approval tasks with pending fix errors', () => {
+    const eligible = task();
+    const noPendingFix = task({ id: 'wf-1/task-2', execution: { pendingFixError: undefined } });
+    const failed = task({ id: 'wf-1/task-3', status: 'failed' });
+    const { store } = makeStore([eligible, noPendingFix, failed]);
+
+    expect(listAutoApproveScanCandidates({ store })).toEqual([
+      expect.objectContaining({ taskId: 'wf-1/task-1', workflowId: 'wf-1', generation: 1, taskStateVersion: 4 }),
+    ]);
+  });
+
+  it('does not submit awaiting approval tasks without pending fix errors', async () => {
+    const { store } = makeStore([task({ execution: { pendingFixError: undefined } })]);
+    const submitter = { submit: vi.fn() };
+
+    await createAutoApproveTick({ store, submitter, logger, enabled: true })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+    });
+
+    expect(submitter.submit).not.toHaveBeenCalled();
+  });
+
+  it('skips review-ready tasks with pending fix errors as ambiguous', () => {
+    const { store, writes } = makeStore([task({ status: 'review_ready' })]);
+
+    expect(collectValidatedAutoApproveCandidates({ store, submitter: { submit: vi.fn() }, logger, enabled: true }, [candidate()])).toEqual([]);
+    expect(writes[0]).toMatchObject({ status: 'skipped', summary: 'Skipped AI fix approval: review-ready-ambiguous' });
+  });
+
+  it('skips stale workflow, generation, task-state version, and attempt snapshots', () => {
+    const cases: Array<[string, TaskState, AutoApproveCandidate]> = [
+      ['stale-workflow', task({ config: { workflowId: 'wf-2' } }), candidate()],
+      ['stale-generation', task({ execution: { generation: 2 } }), candidate()],
+      ['stale-task-state-version', task({ taskStateVersion: 5 }), candidate()],
+      ['stale-attempt', task({ execution: { selectedAttemptId: 'attempt-2' } }), candidate()],
+    ];
+
+    for (const [reason, latest, snapshot] of cases) {
+      const { store, writes } = makeStore([latest]);
+      const result = collectValidatedAutoApproveCandidates({ store, submitter: { submit: vi.fn() }, logger, enabled: true }, [snapshot]);
+      expect(result).toEqual([]);
+      expect(writes[0]).toMatchObject({ status: 'skipped', summary: `Skipped AI fix approval: ${reason}` });
+    }
+  });
+
+  it('dedupes duplicate wakeups for the same snapshot', async () => {
+    const { store } = makeStore([task()]);
+    const submitter = { submit: vi.fn(() => 42) };
+
+    await createAutoApproveTick({
+      store,
+      submitter,
+      logger,
+      enabled: true,
+      drainWakeupHints: () => [wakeup(), wakeup()],
+    })({ identity: { kind: 'autoapprove', instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+
+    expect(submitter.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips open invoker and headless approval intents', () => {
+    const openInvoker = intent({ id: 10, channel: 'invoker:approve', args: ['wf-1/task-1'] });
+    const openHeadless = intent({ id: 11, channel: 'headless.exec', args: [{ args: ['approve', 'wf-1/task-1'] }] });
+    expect(isApproveIntentForTask(openInvoker, 'wf-1/task-1')).toBe(true);
+    expect(isApproveIntentForTask(openHeadless, 'wf-1/task-1')).toBe(true);
+
+    for (const openIntent of [openInvoker, openHeadless]) {
+      const { store, writes } = makeStore([task()], [openIntent]);
+      const result = collectValidatedAutoApproveCandidates({ store, submitter: { submit: vi.fn() }, logger, enabled: true }, [candidate()]);
+      expect(result).toEqual([]);
+      expect(writes[0]).toMatchObject({ status: 'skipped', summary: 'Skipped AI fix approval: already-queued-intent' });
+    }
+  });
+
+  it('submits a valid approval intent and records a queued worker action', async () => {
+    const { store, writes } = makeStore([task()]);
+    const submitter = { submit: vi.fn(() => 42) };
+
+    await createAutoApproveTick({ store, submitter, logger, enabled: true })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+    });
+
+    expect(submitter.submit).toHaveBeenCalledWith('wf-1', 'normal', 'invoker:approve', ['wf-1/task-1']);
+    expect(writes[0]).toMatchObject({
+      id: 'autoapprove:autoapprove:wf-1/task-1:1:4:attempt-1',
+      workerKind: 'autoapprove',
+      actionType: 'approve-ai-fix',
+      subjectType: 'task',
+      subjectId: 'wf-1/task-1',
+      status: 'queued',
+      summary: 'Queued AI fix approval',
+      intentId: '42',
+    });
+  });
+
+  it('does not scan or submit when disabled', async () => {
+    const { store } = makeStore([task()]);
+    const submitter = { submit: vi.fn() };
+
+    await createAutoApproveTick({ store, submitter, logger, enabled: false })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+    });
+
+    expect(store.listWorkflows).not.toHaveBeenCalled();
+    expect(submitter.submit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -1,4 +1,5 @@
 import { registerAutoFixWorker } from './auto-fix-recovery.js';
+import { registerAutoApproveWorker } from './workers/auto-approve-worker.js';
 import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
 import type { WorkerRegistry } from './worker-registry.js';
 import { registerCiFailureWorker } from './workers/ci-failure-worker.js';
@@ -9,6 +10,7 @@ export function registerBuiltinWorkers(
   registry: WorkerRegistry<WorkerRuntimeDependencies>,
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registerAutoFixWorker(registry);
+  registerAutoApproveWorker(registry);
   registerPrStatusWorker(registry);
   registerCiFailureWorker(registry);
   return registry;

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -41,6 +41,7 @@ export * from './worker-lock.js';
 export * from './builtin-workers.js';
 export * from './auto-fix-recovery.js';
 export * from './workers/pr-status-worker.js';
+export * from './workers/auto-approve-worker.js';
 export * from './workers/ci-failure-worker.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-attempt-ledger.js';

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -6,15 +6,20 @@ import type {
   AutoFixRecoverySubmitter,
   AutoFixWorkerConfig,
 } from './auto-fix-recovery.js';
+import type {
+  AutoApproveWorkerConfig,
+  AutoApproveWorkerStore,
+  AutoApproveWorkerSubmitter,
+} from './workers/auto-approve-worker.js';
 import type { CiFailureWorkerStore, CiFailureWorkerSubmitter } from './workers/ci-failure-worker.js';
 import type { PrStatusReviewGate } from './workers/pr-status-worker.js';
 
 /** Dependencies injected into a built-in worker factory when its runtime is built. */
 export interface WorkerRuntimeDependencies {
   /** Persisted workflow/task state accessor. */
-  store: AutoFixRecoveryStore & CiFailureWorkerStore;
+  store: AutoFixRecoveryStore & AutoApproveWorkerStore & CiFailureWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
-  submitter: AutoFixRecoverySubmitter & CiFailureWorkerSubmitter;
+  submitter: AutoFixRecoverySubmitter & AutoApproveWorkerSubmitter & CiFailureWorkerSubmitter;
   /** Operator logger. */
   logger: Logger;
   /** Optional bus that turns lifecycle events into immediate wakeups. */
@@ -23,4 +28,6 @@ export interface WorkerRuntimeDependencies {
   reviewGate?: PrStatusReviewGate;
   /** Auto-fix tuning shared by workers that submit fix intents. */
   autoFix?: AutoFixWorkerConfig;
+  /** Auto-approval tuning for worker-owned AI fix approvals. */
+  autoApprove?: AutoApproveWorkerConfig;
 }

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -1,0 +1,492 @@
+import type { Logger } from '@invoker/contracts';
+import type {
+  WorkerActionRecord,
+  WorkerActionStatus,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+
+import type { RecoveryWorkerWakeupHint, WorkflowLifecycleEvent } from '../lifecycle-events.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const AUTO_APPROVE_WORKER_KIND = 'autoapprove';
+export const DEFAULT_AUTO_APPROVE_WORKER_INTERVAL_MS = 60_000;
+const AUTO_APPROVE_COMMAND_CHANNEL = 'invoker:approve';
+const AUTO_APPROVE_ACTION_TYPE = 'approve-ai-fix';
+
+type AutoApproveActionStatus = WorkerActionStatus;
+
+export interface AutoApproveWorkerStore {
+  listWorkflows(): ReadonlyArray<{ id: string }>;
+  loadTasks(workflowId: string): TaskState[];
+  loadTask?(taskId: string): TaskState | undefined;
+  listWorkflowMutationIntents?(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[];
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
+  logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+}
+
+export interface AutoApproveWorkerSubmitter {
+  submit(
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: typeof AUTO_APPROVE_COMMAND_CHANNEL,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number;
+}
+
+export interface AutoApproveWorkerConfig {
+  enabled?: boolean;
+}
+
+export interface AutoApproveWorkerPolicyOptions {
+  store: AutoApproveWorkerStore;
+  submitter: AutoApproveWorkerSubmitter;
+  logger: Logger;
+  enabled?: boolean;
+  drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
+}
+
+export interface AutoApproveWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  messageBus?: MessageBus;
+  autoApprove?: Omit<AutoApproveWorkerPolicyOptions, 'logger' | 'drainWakeupHints'>;
+  onTick?: WorkerTick;
+}
+
+export type AutoApproveCandidate = {
+  taskId: string;
+  workflowId: string;
+  generation: number;
+  taskStateVersion: number;
+  attemptId?: string;
+  source: 'scan' | 'wakeup';
+};
+
+type AutoApproveTaskRef = Omit<AutoApproveCandidate, 'source'>;
+
+type ValidatedAutoApproveCandidate = AutoApproveTaskRef & {
+  source: AutoApproveCandidate['source'];
+  task: TaskState;
+};
+
+type AutoApproveSnapshotMismatchReason =
+  | 'stale-workflow'
+  | 'stale-generation'
+  | 'stale-task-state-version'
+  | 'stale-attempt';
+
+type AutoApproveSnapshotComparison =
+  | { ok: true; ref: AutoApproveTaskRef }
+  | { ok: false; reason: AutoApproveSnapshotMismatchReason; details: Record<string, unknown> };
+
+export function registerAutoApproveWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: AUTO_APPROVE_WORKER_KIND,
+    note: 'Approves AI fixes that are awaiting approval after a pending fix error.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createAutoApproveWorker({
+        logger: deps.logger,
+        messageBus: deps.messageBus,
+        autoApprove: {
+          store: deps.store,
+          submitter: deps.submitter,
+          enabled: deps.autoApprove?.enabled,
+        },
+      }),
+  });
+  return registry;
+}
+
+function workflowIdForTask(task: TaskState): string | undefined {
+  return task.config.workflowId ?? task.id.split('/')[0];
+}
+
+function taskRefFromTask(task: TaskState): AutoApproveTaskRef | undefined {
+  const workflowId = workflowIdForTask(task);
+  if (!workflowId) return undefined;
+  return {
+    taskId: task.id,
+    workflowId,
+    generation: task.execution.generation ?? 0,
+    taskStateVersion: task.taskStateVersion,
+    attemptId: task.execution.selectedAttemptId,
+  };
+}
+
+function candidateFromTask(task: TaskState): AutoApproveCandidate | undefined {
+  const ref = taskRefFromTask(task);
+  if (!ref) return undefined;
+  return { ...ref, source: 'scan' };
+}
+
+export function listAutoApproveScanCandidates(
+  options: Pick<AutoApproveWorkerPolicyOptions, 'store'>,
+): AutoApproveCandidate[] {
+  const candidates: AutoApproveCandidate[] = [];
+  for (const workflow of options.store.listWorkflows()) {
+    for (const task of options.store.loadTasks(workflow.id)) {
+      if (task.status !== 'awaiting_approval') continue;
+      if (task.execution.pendingFixError === undefined) continue;
+      const candidate = candidateFromTask(task);
+      if (candidate) candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+
+function candidateFromWakeup(wakeup: RecoveryWorkerWakeupHint): AutoApproveCandidate | undefined {
+  if (!wakeup.taskId || wakeup.taskStateVersion == null) return undefined;
+  return {
+    taskId: wakeup.taskId,
+    workflowId: wakeup.workflowId,
+    generation: wakeup.generation,
+    taskStateVersion: wakeup.taskStateVersion,
+    attemptId: wakeup.attemptId,
+    source: 'wakeup',
+  };
+}
+
+function dedupeCandidates(candidates: AutoApproveCandidate[]): AutoApproveCandidate[] {
+  const seen = new Set<string>();
+  const deduped: AutoApproveCandidate[] = [];
+  for (const candidate of candidates) {
+    const key = `${candidate.taskId}:${candidate.generation}:${candidate.taskStateVersion}:${candidate.attemptId ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(candidate);
+  }
+  return deduped;
+}
+
+function loadLatestTask(
+  candidate: AutoApproveCandidate,
+  options: AutoApproveWorkerPolicyOptions,
+): TaskState | undefined {
+  const direct = options.store.loadTask?.(candidate.taskId);
+  if (direct) return direct;
+  return options.store.loadTasks(candidate.workflowId).find((task) => task.id === candidate.taskId);
+}
+
+function compareCandidateSnapshot(
+  candidate: AutoApproveCandidate,
+  latest: TaskState,
+): AutoApproveSnapshotComparison {
+  const latestRef = taskRefFromTask(latest);
+  if (!latestRef || latestRef.workflowId !== candidate.workflowId) {
+    return { ok: false, reason: 'stale-workflow', details: { latestWorkflowId: latestRef?.workflowId ?? null } };
+  }
+  if (latestRef.generation !== candidate.generation) {
+    return { ok: false, reason: 'stale-generation', details: { latestGeneration: latestRef.generation } };
+  }
+  if (latestRef.taskStateVersion !== candidate.taskStateVersion) {
+    return {
+      ok: false,
+      reason: 'stale-task-state-version',
+      details: { latestTaskStateVersion: latestRef.taskStateVersion },
+    };
+  }
+  if ((latestRef.attemptId ?? null) !== (candidate.attemptId ?? null)) {
+    return { ok: false, reason: 'stale-attempt', details: { latestAttemptId: latestRef.attemptId ?? null } };
+  }
+  return { ok: true, ref: latestRef };
+}
+
+function actionExternalKey(candidate: Pick<AutoApproveCandidate, 'taskId' | 'generation' | 'taskStateVersion' | 'attemptId'>): string {
+  return `autoapprove:${candidate.taskId}:${candidate.generation}:${candidate.taskStateVersion}:${candidate.attemptId ?? 'no-attempt'}`;
+}
+
+function actionIdForExternalKey(externalKey: string): string {
+  return `${AUTO_APPROVE_WORKER_KIND}:${externalKey}`;
+}
+
+function isOpenOrCompletedActionStatus(status: string): boolean {
+  return status === 'queued'
+    || status === 'pending'
+    || status === 'running'
+    || status === 'needs_input'
+    || status === 'review_ready'
+    || status === 'completed';
+}
+
+function coerceActionStatus(status: AutoApproveActionStatus): WorkerActionStatus {
+  return status;
+}
+
+function recordAutoApproveAction(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+  status: AutoApproveActionStatus,
+  summary: string,
+  payload: Record<string, unknown> = {},
+  intentId?: number | string,
+): WorkerActionRecord | undefined {
+  const externalKey = actionExternalKey(candidate);
+  const existing = options.store.getWorkerAction?.(AUTO_APPROVE_WORKER_KIND, externalKey);
+  const now = new Date().toISOString();
+  return options.store.upsertWorkerAction?.({
+    id: existing?.id ?? actionIdForExternalKey(externalKey),
+    workerKind: AUTO_APPROVE_WORKER_KIND,
+    actionType: AUTO_APPROVE_ACTION_TYPE,
+    workflowId: candidate.workflowId,
+    taskId: candidate.taskId,
+    subjectType: 'task',
+    subjectId: candidate.taskId,
+    externalKey,
+    status: coerceActionStatus(status),
+    attemptCount: status === 'queued' || status === 'failed'
+      ? (existing?.attemptCount ?? 0) + 1
+      : existing?.attemptCount ?? 0,
+    ...(intentId !== undefined ? { intentId: String(intentId) } : {}),
+    summary,
+    payload: {
+      taskId: candidate.taskId,
+      workflowId: candidate.workflowId,
+      generation: candidate.generation,
+      taskStateVersion: candidate.taskStateVersion,
+      selectedAttemptId: candidate.attemptId ?? null,
+      source: candidate.source,
+      ...payload,
+    },
+    updatedAt: now,
+    ...(status === 'skipped' || status === 'failed' || status === 'completed' ? { completedAt: now } : {}),
+  });
+}
+
+function logAutoApproveWorkerEvent(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+  phase: string,
+  details: Record<string, unknown>,
+): void {
+  const payload = {
+    phase,
+    worker: AUTO_APPROVE_WORKER_KIND,
+    workflowId: candidate.workflowId,
+    generation: candidate.generation,
+    taskStateVersion: candidate.taskStateVersion,
+    selectedAttemptId: candidate.attemptId ?? null,
+    source: candidate.source,
+    ...details,
+  };
+  options.store.logEvent?.(candidate.taskId, 'debug.autoapprove-worker', payload);
+  options.logger.debug?.(`[worker:${AUTO_APPROVE_WORKER_KIND}] ${phase}`, {
+    module: 'auto-approve-worker',
+    taskId: candidate.taskId,
+    ...payload,
+  });
+}
+
+function skipAutoApproveCandidate(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+  reason: string,
+  details: Record<string, unknown> = {},
+): void {
+  recordAutoApproveAction(
+    options,
+    candidate,
+    'skipped',
+    `Skipped AI fix approval: ${reason}`,
+    { reason, ...details },
+  );
+  logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-skip', { reason, ...details });
+}
+
+function hasAlreadyRecordedAction(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+): boolean {
+  const externalKey = actionExternalKey(candidate);
+  const existing = options.store.getWorkerAction?.(AUTO_APPROVE_WORKER_KIND, externalKey);
+  if (!existing) return false;
+  if (!isOpenOrCompletedActionStatus(existing.status)) return false;
+  logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-skip', {
+    reason: 'already-recorded',
+    existingStatus: existing.status,
+    intentId: existing.intentId ?? null,
+  });
+  return true;
+}
+
+export function isApproveIntentForTask(intent: WorkflowMutationIntent, taskId: string): boolean {
+  if (intent.channel === AUTO_APPROVE_COMMAND_CHANNEL) return intent.args[0] === taskId;
+  if (intent.channel !== 'headless.exec') return false;
+  const firstArg = intent.args[0];
+  if (typeof firstArg !== 'object' || firstArg === null || Array.isArray(firstArg)) return false;
+  const args = (firstArg as { args?: unknown }).args;
+  return Array.isArray(args) && args[0] === 'approve' && args[1] === taskId;
+}
+
+function openApprovalIntents(
+  options: AutoApproveWorkerPolicyOptions,
+  workflowId: string,
+  taskId: string,
+): WorkflowMutationIntent[] {
+  const open = options.store.listWorkflowMutationIntents?.(workflowId, ['queued', 'running']) ?? [];
+  return open.filter((intent) => isApproveIntentForTask(intent, taskId));
+}
+
+function validateAutoApproveCandidate(
+  candidate: AutoApproveCandidate,
+  options: AutoApproveWorkerPolicyOptions,
+): ValidatedAutoApproveCandidate | undefined {
+  const latest = loadLatestTask(candidate, options);
+  if (!latest) {
+    skipAutoApproveCandidate(options, candidate, 'task-not-found');
+    return undefined;
+  }
+
+  const snapshotComparison = compareCandidateSnapshot(candidate, latest);
+  if (!snapshotComparison.ok) {
+    skipAutoApproveCandidate(options, candidate, snapshotComparison.reason, snapshotComparison.details);
+    return undefined;
+  }
+
+  if (latest.status === 'review_ready') {
+    skipAutoApproveCandidate(options, candidate, 'review-ready-ambiguous');
+    return undefined;
+  }
+  if (latest.status !== 'awaiting_approval') {
+    skipAutoApproveCandidate(options, candidate, 'status-changed', { status: latest.status });
+    return undefined;
+  }
+  if (latest.execution.pendingFixError === undefined) {
+    skipAutoApproveCandidate(options, candidate, 'no-pending-fix');
+    return undefined;
+  }
+
+  if (hasAlreadyRecordedAction(options, candidate)) return undefined;
+
+  const openIntents = openApprovalIntents(options, snapshotComparison.ref.workflowId, candidate.taskId);
+  if (openIntents.length > 0) {
+    skipAutoApproveCandidate(options, candidate, 'already-queued-intent', {
+      existingIntentIds: openIntents.map((intent) => intent.id),
+    });
+    return undefined;
+  }
+
+  return { ...snapshotComparison.ref, source: candidate.source, task: latest };
+}
+
+export function collectValidatedAutoApproveCandidates(
+  options: AutoApproveWorkerPolicyOptions,
+  candidates: AutoApproveCandidate[] = listAutoApproveScanCandidates(options),
+): ValidatedAutoApproveCandidate[] {
+  return candidates
+    .map((candidate) => validateAutoApproveCandidate(candidate, options))
+    .filter((candidate): candidate is ValidatedAutoApproveCandidate => Boolean(candidate));
+}
+
+export function createAutoApproveTick(options: AutoApproveWorkerPolicyOptions): WorkerTick {
+  return async (ctx) => {
+    if (options.enabled !== true) return;
+    const wakeups = options.drainWakeupHints?.() ?? [];
+    const wakeupCandidates = wakeups.map(candidateFromWakeup).filter((c): c is AutoApproveCandidate => Boolean(c));
+    const candidates = dedupeCandidates(
+      wakeupCandidates.length > 0 && ctx.reason === 'wake'
+        ? wakeupCandidates
+        : listAutoApproveScanCandidates(options),
+    );
+    const submittedThisTick = new Set<string>();
+
+    for (const candidate of collectValidatedAutoApproveCandidates(options, candidates)) {
+      if (submittedThisTick.has(candidate.taskId)) {
+        skipAutoApproveCandidate(options, candidate, 'duplicate-candidate');
+        continue;
+      }
+      const intentId = options.submitter.submit(
+        candidate.workflowId,
+        'normal',
+        AUTO_APPROVE_COMMAND_CHANNEL,
+        [candidate.taskId],
+      );
+      submittedThisTick.add(candidate.taskId);
+      recordAutoApproveAction(
+        options,
+        candidate,
+        'queued',
+        'Queued AI fix approval',
+        { channel: AUTO_APPROVE_COMMAND_CHANNEL },
+        intentId,
+      );
+      logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-submitted', {
+        intentId,
+        channel: AUTO_APPROVE_COMMAND_CHANNEL,
+      });
+    }
+  };
+}
+
+function isAwaitingApprovalEvent(event: WorkflowLifecycleEvent): boolean {
+  return event.kind === 'task.awaiting_approval' && Boolean(event.taskId);
+}
+
+export function createAutoApproveWorker(options: AutoApproveWorkerOptions): WorkerRuntime {
+  const pendingWakeups: RecoveryWorkerWakeupHint[] = [];
+  let lifecycleUnsubscribe: Unsubscribe | undefined;
+  const onTick = options.onTick ?? (
+    options.autoApprove
+      ? createAutoApproveTick({
+        ...options.autoApprove,
+        logger: options.logger,
+        drainWakeupHints: () => pendingWakeups.splice(0),
+      })
+      : (() => {})
+  );
+  const runtime = createWorkerRuntime({
+    kind: AUTO_APPROVE_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_AUTO_APPROVE_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick,
+  });
+
+  if (!options.messageBus || !options.autoApprove || options.onTick) return runtime;
+
+  const start = (): void => {
+    if (!lifecycleUnsubscribe) {
+      lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
+        Channels.WORKFLOW_LIFECYCLE,
+        (event) => {
+          if (!isAwaitingApprovalEvent(event)) return;
+          pendingWakeups.push(event.recoveryWakeup);
+          runtime.wake('wake');
+        },
+      );
+    }
+    runtime.start();
+  };
+  const stop = async (): Promise<void> => {
+    lifecycleUnsubscribe?.();
+    lifecycleUnsubscribe = undefined;
+    await runtime.stop();
+  };
+
+  return {
+    identity: runtime.identity,
+    start,
+    wake: runtime.wake,
+    tick: runtime.tick,
+    stop,
+    isRunning: runtime.isRunning,
+  };
+}


### PR DESCRIPTION
## Summary

AI fix approval now routes through a dedicated `autoapprove` worker instead of approving inline from the failed-fix path.

The bug was two separate steps. Candidate discovery and approval submission did not live in one queued path.

This slice adds the worker, wires it into startup, and records each queued decision in worker actions.

<details>
<summary>Review metadata</summary>

Review Claim: AI fix approval now uses one queued routing path through the new `autoapprove` worker.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The worker only queues approval when the task snapshot still matches and `pendingFixError` is still present.

Slice Rationale: Worker routing and startup wiring need one slice because the worker cannot run until startup can register and start it.

</details>

## Non-goals

This does not change fix and resolve entrypoints yet.

This does not change docs or shell tooling.

## Architecture

### Before

```mermaid
graph TD
    A["Failed fix reaches awaiting approval"] --> B["No dedicated approval worker exists"]
    C["Startup worker controller"] --> D["No autoapprove runtime"]
```

### After

```mermaid
graph TD
    A["Awaiting approval task appears"] --> B["autoapprove worker revalidates snapshot"]
    B --> C["Queue invoker:approve mutation"]
    D["Startup worker controller"] --> E["Start autoapprove when enabled"]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/auto-approve-worker.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/worker-control.test.ts`
- [x] `pnpm --filter @invoker/contracts build && pnpm --filter @invoker/execution-engine build && pnpm --filter @invoker/app build`

## Visual Proof

Before

![Before autoapprove worker routing](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-a2f146/before-merge-gate-no-inline-approve.png)

After

![After autoapprove worker routing](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-a2f146/after-merge-gate-no-inline-approve.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 728f69b`
- Post-revert steps: None
- Data migration? No

Depends-On: #3251