### PR TITLE
[Autoapprove single config](4) Move approval and config behavior to entrypoints

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -1,4 +1,7 @@
+import type * as NodeOs from 'node:os';
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolveInvokerConfigPath } from '@invoker/contracts';
 import {
   loadConfig,
   resolveConfigFilePath,
@@ -23,7 +26,7 @@ afterEach(() => {
 });
 
 vi.mock('node:os', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:os')>();
+  const actual = await importOriginal<typeof NodeOs>();
   return {
     ...actual,
     homedir: () => `${actual.tmpdir()}/invoker-config-test-${process.pid}/home`,
@@ -602,7 +605,9 @@ describe('loadConfig', () => {
       JSON.stringify({ defaultBranch: 'main' }),
     );
     process.env.INVOKER_REPO_CONFIG_PATH = '   ';
-    expect(resolveConfigFilePath()).toBe(join(fakeHome, '.invoker', 'config.json'));
+    const expected = join(fakeHome, '.invoker', 'config.json');
+    expect(resolveInvokerConfigPath(process.env, fakeHome)).toBe(expected);
+    expect(resolveConfigFilePath()).toBe(expected);
     expect(loadConfig().defaultBranch).toBe('main');
   });
 });

--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -86,6 +86,52 @@ describe('headless worker autofix', () => {
     );
   });
 
+  it('runs a one-shot autoapprove scan and enqueues the normal approval command intent', async () => {
+    const task = makeTask({
+      status: 'awaiting_approval',
+      execution: { pendingFixError: 'boom', generation: 1, selectedAttemptId: 'attempt-1' },
+    });
+    const enqueueWorkflowMutationIntent = vi.fn((
+      _workflowId: string,
+      _channel: string,
+      _args: unknown[],
+      _priority: WorkflowMutationPriority,
+    ) => 2);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const homeRoot = mkdtempSync(join(tmpdir(), 'invoker-headless-autoapprove-'));
+    const previousDbDir = process.env.INVOKER_DB_DIR;
+    process.env.INVOKER_DB_DIR = homeRoot;
+
+    try {
+      await runHeadless(['worker', 'autoapprove'], {
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn() },
+        persistence: {
+          listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+          loadTasks: vi.fn(() => [task]),
+          loadTask: vi.fn(() => task),
+          listWorkflowMutationIntents: vi.fn(() => []),
+          getWorkerAction: vi.fn(() => undefined),
+          upsertWorkerAction: vi.fn(),
+          logEvent: vi.fn(),
+          enqueueWorkflowMutationIntent,
+        },
+        invokerConfig: { autoApproveAIFixes: true },
+      } as any);
+    } finally {
+      write.mockRestore();
+      if (previousDbDir === undefined) delete process.env.INVOKER_DB_DIR;
+      else process.env.INVOKER_DB_DIR = previousDbDir;
+      rmSync(homeRoot, { recursive: true, force: true });
+    }
+
+    expect(enqueueWorkflowMutationIntent).toHaveBeenCalledWith(
+      'wf-1',
+      'invoker:approve',
+      ['wf-1/task-1'],
+      'normal',
+    );
+  });
+
   it('lists worker kinds from the registry', async () => {
     let stdout = '';
     const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
@@ -101,6 +147,7 @@ describe('headless worker autofix', () => {
 
     expect(stdout).toContain('Worker kinds');
     expect(stdout).toContain('autofix');
+    expect(stdout).toContain('autoapprove');
   });
 
   it('rejects unknown worker kinds with a clear error', async () => {

--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -37,6 +37,10 @@ describe('headless-command-classification', () => {
     expect(isHeadlessReadOnlyCommand(['list'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['session'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['open-terminal'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['worker'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['worker', 'list'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['worker', 'status'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['worker', 'autoapprove'])).toBe(false);
     expect(isHeadlessReadOnlyCommand(['run'])).toBe(false);
   });
 
@@ -45,7 +49,9 @@ describe('headless-command-classification', () => {
     expect(isHeadlessMutatingCommand(['query'])).toBe(false);
     expect(isHeadlessMutatingCommand(['open-terminal'])).toBe(false);
     expect(isHeadlessMutatingCommand(['slack'])).toBe(false);
-
+    expect(isHeadlessMutatingCommand(['worker', 'autoapprove'])).toBe(true);
+    expect(isHeadlessMutatingCommand(['worker'])).toBe(false);
+    expect(isHeadlessMutatingCommand(['worker', 'status'])).toBe(false);
     expect(isHeadlessMutatingCommand(['run'])).toBe(true);
     expect(isHeadlessMutatingCommand(['migrate-compat'])).toBe(true);
     expect(isHeadlessMutatingCommand(['cancel-workflow'])).toBe(true);

--- a/packages/app/src/__tests__/resolve-conflict-action.test.ts
+++ b/packages/app/src/__tests__/resolve-conflict-action.test.ts
@@ -56,31 +56,22 @@ describe('resolveConflictAction', () => {
     expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
 
-  it('auto-approves after conflict resolution when configured', async () => {
-    const approve = vi.fn(async () => [{ id: 'task-a', status: 'completed', config: {}, execution: {} }]);
-    const getTask = orchestrator.getTask;
+  it('does not approve inline after conflict resolution', async () => {
+    const approve = vi.fn();
     orchestrator = {
       ...orchestrator,
-      getTask,
       approve,
     };
-    const taskExecutorWithApprove = {
-      ...taskExecutor,
-      executeTasks: vi.fn(),
-      publishAfterFix: vi.fn(),
-    };
 
-    await resolveConflictAction('task-a', {
+    const result = await resolveConflictAction('task-a', {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
-      taskExecutor: taskExecutorWithApprove as unknown as TaskRunner,
-      autoApproveAIFixes: true,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
+    expect(result).toEqual({ autoApproved: false, started: [] });
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');
-    expect(approve).toHaveBeenCalledWith('task-a');
-    expect(taskExecutorWithApprove.executeTasks).not.toHaveBeenCalled();
-    expect(taskExecutorWithApprove.publishAfterFix).not.toHaveBeenCalled();
+    expect(approve).not.toHaveBeenCalled();
   });
 
   it('on failure appends output and reverts conflict resolution (does not set awaiting approval)', async () => {

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  AUTO_APPROVE_WORKER_KIND,
   AUTO_FIX_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
   createWorkerRegistry,
@@ -9,8 +10,8 @@ import {
 } from '@invoker/execution-engine';
 
 import {
-  AUTO_STARTED_OWNER_WORKER_KINDS,
   createWorkerRuntimeController,
+  getAutoStartedOwnerWorkerKinds,
 } from '../worker-control.js';
 
 interface TestWorkerRuntime extends WorkerRuntime {
@@ -64,7 +65,7 @@ function deps(): WorkerRuntimeDependencies {
   } as WorkerRuntimeDependencies;
 }
 
-function controller() {
+function controller(options: { autoFixRetries?: number; autoApproveAIFixes?: boolean; autoStartKinds?: readonly string[] } = {}) {
   const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
   const runtimes = new Map<string, TestWorkerRuntime[]>();
   const register = (kind: string, note: string, runtimeKind = kind) => {
@@ -81,6 +82,7 @@ function controller() {
     });
   };
   register(AUTO_FIX_WORKER_KIND, 'Auto-fixes failed tasks.', 'recovery');
+  register(AUTO_APPROVE_WORKER_KIND, 'Approves AI fixes.');
   register(PR_STATUS_WORKER_KIND, 'Checks pull request status.');
   register(CI_FAILURE_WORKER_KIND, 'Repairs failed CI.');
   register('external-preview', 'External preview worker.');
@@ -90,36 +92,70 @@ function controller() {
     controller: createWorkerRuntimeController({
       registry,
       deps: deps(),
-      autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      autoStartKinds: options.autoStartKinds ?? getAutoStartedOwnerWorkerKinds({ autoApproveAIFixes: options.autoApproveAIFixes }),
       persistence: persistence() as never,
+      autoFixRetries: options.autoFixRetries,
+      autoApproveAIFixes: options.autoApproveAIFixes,
       canControl: () => true,
     }),
   };
 }
 
 describe('createWorkerRuntimeController', () => {
-  it('auto-start starts only pr-status and ci-failure', () => {
-    const setup = controller();
+  it('auto-starts autoapprove only when AI fix auto-approval is enabled', () => {
+    expect(getAutoStartedOwnerWorkerKinds({ autoApproveAIFixes: true })).toEqual([
+      AUTO_FIX_WORKER_KIND,
+      AUTO_APPROVE_WORKER_KIND,
+      PR_STATUS_WORKER_KIND,
+      CI_FAILURE_WORKER_KIND,
+    ]);
+    expect(getAutoStartedOwnerWorkerKinds({})).toEqual([
+      AUTO_FIX_WORKER_KIND,
+      PR_STATUS_WORKER_KIND,
+      CI_FAILURE_WORKER_KIND,
+    ]);
+  });
+
+  it('auto-start starts autofix, pr-status, and ci-failure by default', () => {
+    const setup = controller({ autoFixRetries: 3 });
 
     setup.controller.startAutoStartedWorkers();
     const snapshot = setup.controller.snapshot();
 
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)?.lifecycle).toBe('running');
-    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
     expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.lifecycle).toBe('stopped');
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_APPROVE_WORKER_KIND)).toMatchObject({
+      lifecycle: 'stopped',
+      policy: 'disabled',
+      policyReason: 'autoApproveAIFixes=false',
+      startable: false,
+    });
   });
 
-  it('autofix remains stopped until explicitly started', () => {
-    const setup = controller();
+  it('auto-start starts autoapprove when configured', () => {
+    const setup = controller({ autoFixRetries: 3, autoApproveAIFixes: true });
 
     setup.controller.startAutoStartedWorkers();
-    expect(setup.runtimes.get(AUTO_FIX_WORKER_KIND)).toBeUndefined();
+    const row = setup.controller.snapshot().workers.find((worker) => worker.kind === AUTO_APPROVE_WORKER_KIND);
 
+    expect(row).toMatchObject({
+      lifecycle: 'running',
+      policy: 'enabled',
+      startable: false,
+    });
+  });
+
+  it('autofix duplicate start is idempotent after autostart', () => {
+    const setup = controller({ autoFixRetries: 3 });
+
+    setup.controller.startAutoStartedWorkers();
     const row = setup.controller.start(AUTO_FIX_WORKER_KIND);
 
     expect(row.lifecycle).toBe('running');
     expect(row.runtimeKind).toBe('recovery');
+    expect(setup.runtimes.get(AUTO_FIX_WORKER_KIND)).toHaveLength(1);
   });
 
   it('duplicate start is idempotent', () => {
@@ -146,22 +182,25 @@ describe('createWorkerRuntimeController', () => {
     expect(setup.runtimes.get(PR_STATUS_WORKER_KIND)?.[0]?.stops).toBe(1);
   });
 
-  it('retry budget policy does not disable worker starts', () => {
-    const setup = controller();
+  it('autoFixRetries=0 disables autofix and ci-failure but not autoapprove', () => {
+    const setup = controller({ autoFixRetries: 0, autoApproveAIFixes: true });
 
-    const autoFix = setup.controller.start(AUTO_FIX_WORKER_KIND);
-    const ciFailure = setup.controller.start(CI_FAILURE_WORKER_KIND);
+    expect(() => setup.controller.start(AUTO_FIX_WORKER_KIND)).toThrow('Worker "autofix" is disabled by autoFixRetries=0');
+    expect(() => setup.controller.start(CI_FAILURE_WORKER_KIND)).toThrow('Worker "ci-failure" is disabled by autoFixRetries=0');
+    expect(() => setup.controller.start(AUTO_APPROVE_WORKER_KIND)).not.toThrow();
 
-    expect(autoFix).toMatchObject({
-      lifecycle: 'running',
-      policy: 'enabled',
+    const snapshot = setup.controller.snapshot();
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
+      policy: 'disabled',
+      policyReason: 'autoFixRetries=0',
       startable: false,
     });
-    expect(ciFailure).toMatchObject({
-      lifecycle: 'running',
-      policy: 'enabled',
+    expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)).toMatchObject({
+      policy: 'disabled',
+      policyReason: 'autoFixRetries=0',
       startable: false,
     });
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_APPROVE_WORKER_KIND)?.lifecycle).toBe('running');
   });
 
   it('an exited external worker row reports exited', () => {

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -470,95 +470,19 @@ describe('provideInput', () => {
 });
 
 describe('finalizeAppliedFix', () => {
-  it('leaves task awaiting approval when autoApproveAIFixes is disabled', async () => {
+  it('sets the task awaiting approval and does not approve inline', async () => {
     const orchestrator = {
       setFixAwaitingApproval: vi.fn(),
       approve: vi.fn(),
     };
-    const taskExecutor = {
-      commitApprovedFix: vi.fn(),
-      publishAfterFix: vi.fn(),
-      executeTasks: vi.fn(),
-    };
 
     const result = await finalizeAppliedFix('task-a', 'saved-error', {
       orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
-      autoApproveAIFixes: false,
     });
 
     expect(result).toEqual({ autoApproved: false, started: [] });
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-error');
     expect(orchestrator.approve).not.toHaveBeenCalled();
-  });
-
-  it('auto-approves and returns runnable tasks when enabled', async () => {
-    const started = [
-      makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } }),
-    ];
-    const orchestrator = {
-      setFixAwaitingApproval: vi.fn(),
-      approve: vi.fn().mockResolvedValue(started),
-      getTask: vi.fn().mockReturnValue(makeTask({
-        id: 'task-a',
-        status: 'awaiting_approval',
-        config: { workflowId: 'wf-1' },
-        execution: { pendingFixError: 'saved-error', workspacePath: '/tmp/task-a', branch: 'task-a' },
-      })),
-    };
-    const taskExecutor = {
-      commitApprovedFix: vi.fn(),
-      publishAfterFix: vi.fn(),
-      executeTasks: vi.fn(),
-    };
-
-    const result = await finalizeAppliedFix('task-a', 'saved-error', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
-      autoApproveAIFixes: true,
-    });
-
-    expect(result).toEqual({ autoApproved: true, started });
-    expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
-    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'task-a' }),
-    );
-    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
-    expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
-  });
-
-  it('auto-approves and publishes post-fix merge gates when enabled', async () => {
-    const started = [
-      makeRunningTask({ id: 'merge-a', config: { workflowId: 'wf-1', isMergeNode: true } }),
-    ];
-    const orchestrator = {
-      setFixAwaitingApproval: vi.fn(),
-      approve: vi.fn().mockResolvedValue(started),
-      getTask: vi.fn().mockReturnValue(makeTask({
-        id: 'merge-a',
-        status: 'awaiting_approval',
-        config: { workflowId: 'wf-1', isMergeNode: true },
-        execution: { pendingFixError: 'saved-error', workspacePath: '/tmp/merge-a' },
-      })),
-      resumeTaskAfterFixApproval: vi.fn().mockResolvedValue(started),
-    };
-    const taskExecutor = {
-      commitApprovedFix: vi.fn(),
-      publishAfterFix: vi.fn(),
-      executeTasks: vi.fn(),
-    };
-
-    await finalizeAppliedFix('merge-a', 'saved-error', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
-      autoApproveAIFixes: true,
-    });
-
-    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'merge-a' }),
-    );
-    expect(taskExecutor.publishAfterFix).toHaveBeenCalledWith(started[0]);
-    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 
@@ -807,10 +731,7 @@ describe('autoFixOnFailure', () => {
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
   });
 
-  it('records fixed integration anchor and routes merge gates to finalize/publish flow', async () => {
-    const started = [
-      makeRunningTask({ id: 'merge-a', config: { workflowId: 'wf-1', isMergeNode: true } }),
-    ];
+  it('records fixed integration anchor and leaves merge-gate approval to the worker', async () => {
     const orchestrator = {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => makeTask({
@@ -823,7 +744,7 @@ describe('autoFixOnFailure', () => {
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
       retryTask: vi.fn(() => []),
       setFixAwaitingApproval: vi.fn(),
-      approve: vi.fn().mockResolvedValue(started),
+      approve: vi.fn(),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -858,62 +779,30 @@ describe('autoFixOnFailure', () => {
         }),
       }),
     );
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('merge-a', 'boom');
     expect(orchestrator.retryTask).not.toHaveBeenCalled();
-    expect(taskExecutor.publishAfterFix).toHaveBeenCalledWith(started[0]);
+    expect(orchestrator.approve).not.toHaveBeenCalled();
+    expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
   });
 
-  it('retries inline when merge post-fix publish fails during auto-fix dispatch', async () => {
-    const started = [
-      makeRunningTask({ id: 'merge-a', config: { workflowId: 'wf-1', isMergeNode: true } }),
-    ];
-    // The getTask mock is driven by a state machine that tracks which
-    // phase the auto-fix flow is in.  Each phase may call getTask
-    // multiple times (entry check, lineage capture, lineage assert,
-    // approveTask, post-finalize).  We use a phase counter that
-    // advances at known transition points (beginConflictResolution
-    // and setFixAwaitingApproval) to keep return values consistent.
+  it('does not retry inline after a merge fix is queued for approval', async () => {
     let phase = 0;
-    const phases: Record<string, unknown>[] = [
-      // Phase 0: entry check + lineage capture (cycle 1)
-      { status: 'failed', execution: { workspacePath: '/tmp/merge-a', selectedAttemptId: 'att-1', generation: 1 } },
-      // Phase 1: after fix returns, lineage check + finalize + approveTask (cycle 1)
-      { status: 'awaiting_approval', execution: { workspacePath: '/tmp/merge-a', pendingFixError: 'boom', selectedAttemptId: 'att-1', generation: 1 } },
-      // Phase 2: post-finalize check — task re-failed after publish
-      { status: 'failed', execution: { workspacePath: '/tmp/merge-a', error: 'Post-fix PR prep failed: conflict', selectedAttemptId: 'att-1', generation: 1 } },
-      // Phase 3: inline retry entry + lineage capture (cycle 2)
-      { status: 'failed', execution: { workspacePath: '/tmp/merge-a', selectedAttemptId: 'att-3', generation: 3 } },
-      // Phase 4: after fix returns, lineage check + finalize + approveTask (cycle 2)
-      { status: 'awaiting_approval', execution: { workspacePath: '/tmp/merge-a', pendingFixError: 'boom', selectedAttemptId: 'att-3', generation: 3 } },
-    ];
-    const getTask = vi.fn(() => {
-      const idx = Math.min(phase, phases.length - 1);
-      return makeTask({
-        id: 'merge-a',
-        config: { workflowId: 'wf-1', isMergeNode: true },
-        ...phases[idx],
-      });
-    });
-    // Advance phase at key transition points
-    const origBeginConflictResolution = vi.fn(() => {
-      phase++;
-      return { savedError: 'boom' };
-    });
-    const origSetFixAwaitingApproval = vi.fn(() => { phase++; });
-    const shouldAutoFix = vi
-      .fn()
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValue(false);
     const orchestrator = {
-      shouldAutoFix,
-      getTask,
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => makeTask({
+        id: 'merge-a',
+        status: phase === 0 ? 'failed' : 'awaiting_approval',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: phase === 0
+          ? { workspacePath: '/tmp/merge-a', selectedAttemptId: 'att-1', generation: 1 }
+          : { workspacePath: '/tmp/merge-a', pendingFixError: 'boom', selectedAttemptId: 'att-1', generation: 1 },
+      })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: origBeginConflictResolution,
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
       retryTask: vi.fn(() => []),
-      setFixAwaitingApproval: origSetFixAwaitingApproval,
-      approve: vi.fn().mockResolvedValue(started),
-      resumeTaskAfterFixApproval: vi.fn().mockResolvedValue(started),
+      setFixAwaitingApproval: vi.fn(() => { phase = 1; }),
+      approve: vi.fn(),
+      resumeTaskAfterFixApproval: vi.fn(),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -925,13 +814,10 @@ describe('autoFixOnFailure', () => {
     const taskExecutor = {
       fixWithAgent: vi.fn().mockResolvedValue(undefined),
       resolveConflict: vi.fn(),
-      commitApprovedFix: vi.fn().mockResolvedValue(undefined),
+      commitApprovedFix: vi.fn(),
       execGitIn: vi.fn().mockResolvedValue('abc123'),
-      publishAfterFix: vi
-        .fn()
-        .mockImplementationOnce(async () => undefined)
-        .mockImplementationOnce(async () => undefined),
-      executeTasks: vi.fn().mockResolvedValue(undefined),
+      publishAfterFix: vi.fn(),
+      executeTasks: vi.fn(),
     };
 
     await autoFixOnFailure('merge-a', {
@@ -942,16 +828,9 @@ describe('autoFixOnFailure', () => {
       getAutoApproveAIFixes: () => true,
     });
 
-    expect(taskExecutor.fixWithAgent).toHaveBeenCalledTimes(2);
-    expect(taskExecutor.execGitIn).toHaveBeenCalledTimes(2);
-    expect(taskExecutor.publishAfterFix).toHaveBeenCalledTimes(2);
-    expect(persistence.logEvent).toHaveBeenCalledWith(
-      'merge-a',
-      'debug.auto-fix',
-      expect.objectContaining({
-        phase: 'auto-fix-post-route-inline-retry',
-      }),
-    );
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledTimes(1);
+    expect(taskExecutor.execGitIn).toHaveBeenCalledTimes(1);
+    expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).not.toHaveBeenCalled();
   });
 
@@ -2415,7 +2294,6 @@ describe('finalizeAppliedFix lineage guard', () => {
 
     await expect(finalizeAppliedFix('task-a', 'saved-error', {
       orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: {} as TaskRunner,
     }, ac.signal)).rejects.toThrow(StaleLineageError);
 
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
@@ -2429,7 +2307,6 @@ describe('finalizeAppliedFix lineage guard', () => {
 
     const result = await finalizeAppliedFix('task-a', 'saved-error', {
       orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: {} as TaskRunner,
     }, ac.signal);
 
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-error');

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -349,12 +349,12 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               agent = parsed.agent;
             } catch { /* not JSON, ignore */ }
           }
-          const result = await mutations.resolveConflict(taskId, agent);
+          await mutations.resolveConflict(taskId, agent);
           json(res, 200, {
             ok: true,
             taskId,
             action: 'resolve_conflict',
-            status: result.autoApproved ? 'auto_approved' : 'awaiting_approval',
+            status: 'awaiting_approval',
           });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -2,12 +2,13 @@
  * Configuration loader for Invoker.
  *
  * Reads from ~/.invoker/config.json (user-level config).
- * Override with INVOKER_REPO_CONFIG_PATH env var (for tests).
+ * INVOKER_REPO_CONFIG_PATH is a test/CLI override only.
  */
 
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import { resolveInvokerConfigPath } from '@invoker/contracts';
 import { validateInvokerConfig } from './config-validation.js';
 
 export type HarnessModelPolicy =
@@ -329,8 +330,7 @@ function readJsonSafe(path: string): InvokerConfig {
 }
 
 export function resolveConfigFilePath(): string {
-  const override = process.env.INVOKER_REPO_CONFIG_PATH?.trim();
-  return override || join(homedir(), '.invoker', 'config.json');
+  return resolveInvokerConfigPath(process.env, homedir());
 }
 
 export function resolveConfigFileState(): { path: string; exists: boolean } {

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -99,16 +99,22 @@ export function resolveHeadlessTargetWorkflowId(
 export function isHeadlessReadOnlyCommand(args: string[]): boolean {
   const command = args[0];
   if (!command || command === '--help' || command === '-h') return true;
+  if (command === 'worker') {
+    const subcommand = args[1] ?? 'list';
+    return subcommand === 'list' || subcommand === 'status';
+  }
   return findHeadlessCommandDefinition(command)?.kind === 'read';
 }
 
 export function isHeadlessMutatingCommand(args: string[]): boolean {
   const command = args[0];
   if (!command || command === '--help' || command === '-h') return false;
-
+  if (command === 'worker') {
+    const subcommand = args[1] ?? 'list';
+    return subcommand !== 'list' && subcommand !== 'status';
+  }
   if (command === 'set') {
     return isMutatingSetSubcommand(args[1]);
   }
-
   return findHeadlessCommandDefinition(command)?.kind === 'write';
 }

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -309,7 +309,6 @@ export async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promis
       commandService: deps.commandService,
       taskExecutor: te,
       mutationTiming: deps.mutationTiming,
-      autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
     }, {
       agentName: agent,
       recreateOutputLabel: 'Fix with AI',
@@ -335,8 +334,8 @@ export async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promis
       return;
     }
     process.stdout.write(
-      result.autoApproved
-        ? `Fix applied and auto-approved for task: ${taskId} (${agent}).\n`
+      deps.invokerConfig.autoApproveAIFixes
+        ? `Fix applied and queued for auto-approval for task: ${taskId} (${agent}).\n`
         : `Fix applied for task: ${taskId} (${agent}). Use 'approve ${taskId}' or 'reject ${taskId}' to finalize.\n`,
     );
   } catch (err) {
@@ -362,9 +361,9 @@ export async function headlessResolveConflict(taskId: string, deps: HeadlessDeps
   const agent = (agentArg ?? resolveDefaultExecutionAgent(deps.invokerConfig)).toLowerCase();
   try {
     const result = await resolveConflictAction(taskId, {
-      ...deps,
+      orchestrator: deps.orchestrator,
+      persistence: deps.persistence,
       taskExecutor: te,
-      autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
     }, agent, deps.signal);
     await finalizeMutationWithGlobalTopup({
       orchestrator: deps.orchestrator,
@@ -377,7 +376,7 @@ export async function headlessResolveConflict(taskId: string, deps: HeadlessDeps
     });
     process.stdout.write(
       deps.invokerConfig.autoApproveAIFixes
-        ? `Conflict resolved and auto-approved for task: ${taskId} (${agent}).\n`
+        ? `Conflict resolved and queued for auto-approval for task: ${taskId} (${agent}).\n`
         : `Conflict resolved for task: ${taskId} (${agent}). Use 'approve ${taskId}' or 'reject ${taskId}' to finalize.\n`,
     );
   } catch (err) {

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -100,7 +100,6 @@ export function buildHeadlessApiServerDeps(
       persistence: deps.persistence,
       taskExecutor,
       dispatchMode: deps.mutationTiming ? 'fire-and-forget' : 'await',
-      autoApproveAIFixes: deps.invokerConfig?.autoApproveAIFixes,
       killRunningTask: async (taskId: string) => {
         await taskExecutor.killActiveExecution(taskId);
       },

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -13,12 +13,13 @@ import type { BundledSkillsInstallMode } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import {
+  AUTO_APPROVE_WORKER_KIND,
   AUTO_FIX_WORKER_KIND,
   TaskRunner,
   acquireWorkerLock,
   createAutoFixAttemptLedger,
   createWorkerRegistry,
-  registerAutoFixWorker,
+  registerBuiltinWorkers,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
   type WorkerRuntimeDependencies,
@@ -424,7 +425,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
     deps.invokerConfig?.externalWorkers,
-    registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
   );
 
   if (subCommand === 'list') {
@@ -487,6 +488,9 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         attemptLedger: autoFixAttemptLedger,
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
+      autoApprove: {
+        enabled: deps.invokerConfig.autoApproveAIFixes === true,
+      },
     });
     await worker.tick('manual');
     await worker.stop();
@@ -495,7 +499,9 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
     // blocks the next legitimate start.
     lock.release();
   }
-  const label = definition.kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : definition.kind;
+  const label = definition.kind === AUTO_FIX_WORKER_KIND
+    ? 'Auto-fix'
+    : definition.kind === AUTO_APPROVE_WORKER_KIND ? 'Autoapprove' : definition.kind;
   process.stdout.write(`${label} worker scan completed.\n`);
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -237,9 +237,9 @@ import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { answerOwnerHeadlessQuery, buildOwnerReadQueryHandlers } from './owner-read-query.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
 import {
-  AUTO_STARTED_OWNER_WORKER_KINDS,
   createLocalWorkerStatusSnapshot,
   createWorkerRuntimeController,
+  getAutoStartedOwnerWorkerKinds,
   type WorkerRuntimeController,
 } from './worker-control.js';
 import { startSurfaceEventRelay } from './surface-event-relay.js';
@@ -334,6 +334,9 @@ function buildRegisteredOwnerWorkerDeps(
       attemptLedger: autoFixAttemptLedger,
       getAutoFixAgent: () => invokerConfig.autoFixAgent,
       getAutoFixExecutionModel: () => invokerConfig.defaultExecutionModel,
+    },
+    autoApprove: {
+      enabled: invokerConfig.autoApproveAIFixes === true,
     },
   };
 }
@@ -1751,9 +1754,10 @@ function startHeadlessMode(): void {
               await createStandaloneTaskExecutor().checkMergeGateStatuses();
             },
           ),
-          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
           persistence,
           autoFixRetries: invokerConfig.autoFixRetries,
+          autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
           canControl: () => !readOnlyMode,
         });
         workerRuntimeController.startAutoStartedWorkers();
@@ -2199,7 +2203,6 @@ function createEmbeddedTerminalBackendFromConfig(
         commandService,
         taskExecutor: requireTaskExecutor(),
         mutationTiming: activeMutationContext?.mutationTiming,
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
       },
       {
         agentName,
@@ -3052,7 +3055,6 @@ function createEmbeddedTerminalBackendFromConfig(
         persistence,
         commandService,
         taskExecutor: requireTaskExecutor(),
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
         killRunningTask,
       });
       apiServer = startApiServer({
@@ -3525,9 +3527,10 @@ function createEmbeddedTerminalBackendFromConfig(
             await requireTaskExecutor().checkMergeGateStatuses();
           },
         ),
-        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
         persistence,
         autoFixRetries: invokerConfig.autoFixRetries,
+        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
         canControl: () => ownerMode,
       });
       workerRuntimeController.startAutoStartedWorkers();
@@ -4198,13 +4201,13 @@ function createEmbeddedTerminalBackendFromConfig(
         return createLocalWorkerStatusSnapshot({
           registry: createRegisteredWorkerRegistry(),
           persistence,
-          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
         });
       }
       return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
         registry: createRegisteredWorkerRegistry(),
         persistence,
-        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        autoStartKinds: getAutoStartedOwnerWorkerKinds(invokerConfig),
       });
     });
 
@@ -4659,7 +4662,6 @@ function createEmbeddedTerminalBackendFromConfig(
           orchestrator,
           persistence,
           taskExecutor: requireTaskExecutor(),
-          autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
         }, agentName, activeMutationContext?.signal);
         await finalizeMutationWithGlobalTopup({
           orchestrator,

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -7,6 +7,7 @@ import type {
 } from '@invoker/contracts';
 import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
 import {
+  AUTO_APPROVE_WORKER_KIND,
   AUTO_FIX_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
@@ -17,7 +18,11 @@ import {
 
 import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
 
-export const AUTO_STARTED_OWNER_WORKER_KINDS = [PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND] as const;
+export function getAutoStartedOwnerWorkerKinds(config: { autoApproveAIFixes?: boolean }): string[] {
+  return config.autoApproveAIFixes === true
+    ? [AUTO_FIX_WORKER_KIND, AUTO_APPROVE_WORKER_KIND, PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND]
+    : [AUTO_FIX_WORKER_KIND, PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND];
+}
 
 export interface WorkerRuntimeController {
   startAutoStartedWorkers(): void;
@@ -37,6 +42,7 @@ interface RuntimeHandle {
 
 const BUILT_IN_WORKER_KINDS = new Set<string>([
   AUTO_FIX_WORKER_KIND,
+  AUTO_APPROVE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
 ]);
@@ -46,8 +52,8 @@ export function createWorkerRuntimeController(options: {
   deps: WorkerRuntimeDependencies;
   autoStartKinds: readonly string[];
   persistence: WorkerStatusPersistence;
-  /** Compatibility input; retry budget is enforced inside worker policy, not by controller start gating. */
   autoFixRetries?: number;
+  autoApproveAIFixes?: boolean;
   canControl: () => boolean;
 }): WorkerRuntimeController {
   const handles = new Map<string, RuntimeHandle>();
@@ -61,6 +67,12 @@ export function createWorkerRuntimeController(options: {
     return definition;
   };
 
+  const assertStartAllowed = (kind: string): void => {
+    const reason = disabledPolicyReasonForKind(kind, options.autoFixRetries, options.autoApproveAIFixes);
+    if (reason) {
+      throw new Error(`Worker "${kind}" is disabled by ${reason}`);
+    }
+  };
 
   const rowForKind = (kind: string): WorkerStatusEntry => {
     const definition = options.registry.get(kind);
@@ -73,7 +85,8 @@ export function createWorkerRuntimeController(options: {
       handle: handles.get(kind),
       stoppedAt: stoppedAtByKind.get(kind),
       autoStarts: options.autoStartKinds.includes(kind),
-      policy: policyForKind(kind),
+      policy: policyForKind(kind, options.autoFixRetries, options.autoApproveAIFixes),
+      policyReason: disabledPolicyReasonForKind(kind, options.autoFixRetries, options.autoApproveAIFixes),
       persistence: options.persistence,
       canControl: options.canControl(),
     });
@@ -90,12 +103,14 @@ export function createWorkerRuntimeController(options: {
     startAutoStartedWorkers(): void {
       for (const kind of options.autoStartKinds) {
         if (!options.registry.get(kind)) continue;
+        if (disabledPolicyReasonForKind(kind, options.autoFixRetries, options.autoApproveAIFixes)) continue;
         this.start(kind);
       }
     },
 
     start(kind: string): WorkerStatusEntry {
       const definition = requireDefinition(kind);
+      assertStartAllowed(kind);
 
       const existing = handles.get(kind);
       if (existing) {
@@ -115,6 +130,7 @@ export function createWorkerRuntimeController(options: {
       stoppedAtByKind.delete(kind);
       return rowForKind(kind);
     },
+
     async stop(kind: string): Promise<WorkerStatusEntry> {
       requireDefinition(kind);
       const handle = handles.get(kind);
@@ -138,6 +154,7 @@ export function createWorkerRuntimeController(options: {
     },
   };
 }
+
 export function createLocalWorkerStatusSnapshot(options: {
   registry: WorkerRegistry<WorkerRuntimeDependencies>;
   persistence: WorkerStatusPersistence;
@@ -156,7 +173,6 @@ export function createLocalWorkerStatusSnapshot(options: {
   };
 }
 
-
 function buildWorkerStatusEntry(args: {
   definitionKind: string;
   note: string;
@@ -164,12 +180,14 @@ function buildWorkerStatusEntry(args: {
   stoppedAt?: string;
   autoStarts: boolean;
   policy: WorkerPolicyStatus;
+  policyReason?: string;
   persistence: WorkerStatusPersistence;
   canControl: boolean;
 }): WorkerStatusEntry {
   const lifecycle = args.handle
     ? args.handle.runtime.isRunning() ? 'running' : 'exited'
     : 'stopped';
+  const policyReason = args.policy === 'disabled' ? args.policyReason : undefined;
   const controlDisabledReason = getControlDisabledReason(args.canControl);
   const runtime = args.handle?.runtime;
   return {
@@ -178,6 +196,7 @@ function buildWorkerStatusEntry(args: {
     ...(runtime ? { runtimeKind: runtime.identity.kind, instanceId: runtime.identity.instanceId } : {}),
     lifecycle,
     policy: args.policy,
+    ...(policyReason ? { policyReason } : {}),
     autoStarts: args.autoStarts,
     startable: lifecycle !== 'running' && args.policy !== 'disabled' && args.canControl,
     stoppable: lifecycle === 'running' && args.canControl,
@@ -189,9 +208,26 @@ function buildWorkerStatusEntry(args: {
   };
 }
 
-function policyForKind(kind: string): WorkerPolicyStatus {
+function policyForKind(
+  kind: string,
+  autoFixRetries: number | undefined,
+  autoApproveAIFixes: boolean | undefined,
+): WorkerPolicyStatus {
+  if (disabledPolicyReasonForKind(kind, autoFixRetries, autoApproveAIFixes)) return 'disabled';
   if (BUILT_IN_WORKER_KINDS.has(kind)) return 'enabled';
   return 'unknown';
+}
+
+function disabledPolicyReasonForKind(
+  kind: string,
+  autoFixRetries: number | undefined,
+  autoApproveAIFixes: boolean | undefined,
+): string | undefined {
+  if ((kind === AUTO_FIX_WORKER_KIND || kind === CI_FAILURE_WORKER_KIND) && autoFixRetries !== undefined && autoFixRetries <= 0) {
+    return 'autoFixRetries=0';
+  }
+  if (kind === AUTO_APPROVE_WORKER_KIND && autoApproveAIFixes !== true) return 'autoApproveAIFixes=false';
+  return undefined;
 }
 
 function getControlDisabledReason(canControl: boolean): string | undefined {

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -141,8 +141,6 @@ export interface ActionDeps {
   /** When set, fresh-base actions refresh the pool mirror and remove managed branches before retry/recreate. */
   taskExecutor?: TaskRunner;
   mutationTiming?: WorkflowMutationTiming;
-  /** When true, successful AI-applied fixes are approved immediately. */
-  autoApproveAIFixes?: boolean;
 }
 
 export interface CommandActionDeps extends ActionDeps {
@@ -812,7 +810,7 @@ export async function setTaskFixContext(
 
 export async function resolveConflictAction(
   taskId: string,
-  deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
+  deps: Pick<ActionDeps, 'orchestrator' | 'persistence'> & { taskExecutor: TaskRunner },
   agentName?: string,
   signal?: AbortSignal,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
@@ -850,7 +848,7 @@ function resolveTaskRunnerDefaultExecutionAgent(taskExecutor: TaskRunner): strin
 
 export async function fixWithAgentAction(
   taskId: string,
-  deps: Pick<CommandActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'autoApproveAIFixes' | 'commandService' | 'mutationTiming'> & { taskExecutor: TaskRunner },
+  deps: Pick<CommandActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'commandService' | 'mutationTiming'> & { taskExecutor: TaskRunner },
   options: {
     agentName?: string;
     recoveryRoute?: FailureRecoveryRoute;
@@ -939,7 +937,7 @@ export async function fixWithAgentAction(
 export async function finalizeAppliedFix(
   taskId: string,
   savedError: string,
-  deps: Pick<ActionDeps, 'orchestrator' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
+  deps: Pick<ActionDeps, 'orchestrator'>,
   signal?: AbortSignal,
   lineage?: TaskLineageSnapshot,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
@@ -950,13 +948,7 @@ export async function finalizeAppliedFix(
   }
   if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
   deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
-  if (!deps.autoApproveAIFixes) {
-    return { autoApproved: false, started: [] };
-  }
-
-  if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
-  const { started } = await approveTask(taskId, deps);
-  return { autoApproved: true, started };
+  return { autoApproved: false, started: [] };
 }
 
 // ── Auto-fix helpers ─────────────────────────────────────────
@@ -1273,8 +1265,6 @@ export async function autoFixOnFailure(
       assertLineageCurrent(lineage, orchestrator, deps.signal);
       const finalizeResult = await finalizeAppliedFix(taskId, persistedSavedError, {
         orchestrator,
-        taskExecutor,
-        autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
       }, deps.signal, lineage);
       persistence.logEvent?.(taskId, 'debug.auto-fix', {
         phase: 'auto-fix-post-route-finalize',

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -109,7 +109,6 @@ export interface WorkflowMutationFacadeDeps {
   commandService: CommandService;
   taskExecutor: TaskRunner;
   dispatchMode?: 'await' | 'fire-and-forget';
-  autoApproveAIFixes?: boolean;
   /** Optional pre-kill hook for active task executions. */
   killRunningTask?: (taskId: string) => Promise<void>;
 }
@@ -422,7 +421,6 @@ export class WorkflowMutationFacade {
         orchestrator: this.deps.orchestrator,
         persistence: this.deps.persistence,
         taskExecutor: this.deps.taskExecutor,
-        autoApproveAIFixes: this.deps.autoApproveAIFixes,
       },
       agentName,
     );
@@ -456,7 +454,6 @@ export class WorkflowMutationFacade {
         persistence: this.deps.persistence,
         commandService: this.deps.commandService,
         taskExecutor: this.deps.taskExecutor,
-        autoApproveAIFixes: this.deps.autoApproveAIFixes,
       },
       options,
     );
@@ -483,7 +480,6 @@ export class WorkflowMutationFacade {
       persistence: this.deps.persistence,
       commandService: this.deps.commandService,
       taskExecutor: this.deps.taskExecutor,
-      autoApproveAIFixes: this.deps.autoApproveAIFixes,
     };
   }
 

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { LocalBus } from '@invoker/transport';
@@ -115,9 +115,65 @@ describe('invoker-cli', () => {
     expect(code).toBe(0);
     expect(output.stdout).toContain('Worker kinds');
     expect(output.stdout).toContain('autofix');
+    expect(output.stdout).toContain('autoapprove');
     output.restore();
   });
 
+
+  it('reads worker config from INVOKER_REPO_CONFIG_PATH for worker list', async () => {
+    const output = captureProcessOutput();
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-worker-config-'));
+    const previous = process.env.INVOKER_REPO_CONFIG_PATH;
+    try {
+      const configPath = join(dir, 'config.json');
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          externalWorkers: [{ kind: 'external-from-env', launch: { executable: 'node', args: ['-v'] } }],
+        }),
+        'utf8',
+      );
+      process.env.INVOKER_REPO_CONFIG_PATH = configPath;
+
+      const code = await main(['worker', 'list'], {
+        createMessageBus: () => {
+          throw new Error('worker list should not open IPC');
+        },
+      });
+
+      expect(code).toBe(0);
+      expect(output.stdout).toContain('external-from-env');
+    } finally {
+      if (previous === undefined) delete process.env.INVOKER_REPO_CONFIG_PATH;
+      else process.env.INVOKER_REPO_CONFIG_PATH = previous;
+      output.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('restores INVOKER_REPO_CONFIG_PATH after standalone run with --config', async () => {
+    const output = captureProcessOutput();
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-config-restore-'));
+    const previous = process.env.INVOKER_REPO_CONFIG_PATH;
+    const previousValue = '/tmp/previous-invoker-config.json';
+    try {
+      process.env.INVOKER_REPO_CONFIG_PATH = previousValue;
+      const configPath = join(dir, 'config.json');
+      const planPath = join(dir, 'invalid.yaml');
+      writeFileSync(configPath, JSON.stringify({ maxConcurrency: 1 }), 'utf8');
+      writeFileSync(planPath, 'name: [broken\\n', 'utf8');
+
+      const code = await main(['run', planPath, '--standalone', '--db-dir', join(dir, 'db'), '--config', configPath]);
+
+      expect(code).toBe(1);
+      expect(process.env.INVOKER_REPO_CONFIG_PATH).toBe(previousValue);
+    } finally {
+      if (previous === undefined) delete process.env.INVOKER_REPO_CONFIG_PATH;
+      else process.env.INVOKER_REPO_CONFIG_PATH = previous;
+      output.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
   it('rejects unknown worker kinds with a clear non-zero error', async () => {
     const output = captureProcessOutput();
 

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -1,7 +1,18 @@
+<<<<<<< HEAD
 import { describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+||||||| parent of 104536738 (Move approval and config behavior to entrypoints)
+import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+=======
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+>>>>>>> 104536738 (Move approval and config behavior to entrypoints)
 import { join } from 'node:path';
+import { resolveInvokerConfigPath } from '@invoker/contracts';
 
 import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES } from '@invoker/contracts';
 
@@ -9,6 +20,7 @@ import {
   defaultExperimentalPlannerMcpPath,
   ensureExperimentalPlannerMcp,
   buildDoctorChecks,
+  defaultConfigPath,
   generateSlackManifest,
   installExperimentalPlannerMcp,
   loadInvokerEnv,
@@ -110,6 +122,26 @@ describe('buildDoctorChecks', () => {
   it('passes the default-preset check when its tool is installed', () => {
     const checks = buildDoctorChecks({ ...cfg, defaultPreset: 'omp' }, (cmd) => cmd === 'omp');
     expect(checks.find((c) => c.id === 'default-preset')?.status).toBe('ok');
+  });
+});
+
+describe('defaultConfigPath', () => {
+  const previous = process.env.INVOKER_REPO_CONFIG_PATH;
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.INVOKER_REPO_CONFIG_PATH;
+    else process.env.INVOKER_REPO_CONFIG_PATH = previous;
+  });
+
+  it('matches the shared config resolver for default, override, and blank override', () => {
+    delete process.env.INVOKER_REPO_CONFIG_PATH;
+    expect(defaultConfigPath()).toBe(resolveInvokerConfigPath(process.env, homedir()));
+
+    process.env.INVOKER_REPO_CONFIG_PATH = '/tmp/invoker-cli-config.json';
+    expect(defaultConfigPath()).toBe(resolveInvokerConfigPath(process.env, homedir()));
+
+    process.env.INVOKER_REPO_CONFIG_PATH = '   ';
+    expect(defaultConfigPath()).toBe(resolveInvokerConfigPath(process.env, homedir()));
   });
 });
 describe('runSetup', () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,9 +2,10 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
 import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
-import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
+import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, resolveInvokerConfigPath, resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
 import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
 import {
+  AUTO_APPROVE_WORKER_KIND,
   AUTO_FIX_WORKER_KIND,
   ExecutorRegistry,
   TaskRunner,
@@ -12,7 +13,7 @@ import {
   acquireWorkerLock,
   createAutoFixAttemptLedger,
   createWorkerRegistry,
-  registerAutoFixWorker,
+  registerBuiltinWorkers,
   registerExternalWorkers,
   WorkerLockHeldError,
   registerBuiltinAgents,
@@ -360,8 +361,8 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
   mkdirSync(dbDir, { recursive: true });
 
   const previousInvokerDbDir = process.env.INVOKER_DB_DIR;
+  const previousInvokerRepoConfigPath = process.env.INVOKER_REPO_CONFIG_PATH;
   if (options.config) {
-    process.env.INVOKER_CONFIG = resolve(options.config);
     process.env.INVOKER_REPO_CONFIG_PATH = resolve(options.config);
   }
   process.env.INVOKER_DB_DIR = dbDir;
@@ -447,6 +448,11 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
     } else {
       process.env.INVOKER_DB_DIR = previousInvokerDbDir;
     }
+    if (previousInvokerRepoConfigPath === undefined) {
+      delete process.env.INVOKER_REPO_CONFIG_PATH;
+    } else {
+      process.env.INVOKER_REPO_CONFIG_PATH = previousInvokerRepoConfigPath;
+    }
     persistence.close();
   }
 }
@@ -472,15 +478,18 @@ async function createDefaultMessageBus(): Promise<MessageBus> {
 function readWorkerConfig(homeRoot: string): {
   autoFixRetries?: number;
   autoFixAgent?: string;
+  autoApproveAIFixes?: boolean;
   externalWorkers?: ExternalWorkerConfig[];
 } {
-  const configPath = join(homeRoot, 'config.json');
+  void homeRoot;
+  const configPath = resolveInvokerConfigPath(process.env, homedir());
   if (!existsSync(configPath)) return {};
   try {
     const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as CliRuntimeConfig;
     return {
       autoFixRetries: typeof parsed.autoFixRetries === 'number' ? parsed.autoFixRetries : undefined,
       autoFixAgent: typeof parsed.autoFixAgent === 'string' ? parsed.autoFixAgent : undefined,
+      autoApproveAIFixes: typeof parsed.autoApproveAIFixes === 'boolean' ? parsed.autoApproveAIFixes : undefined,
       externalWorkers: Array.isArray(parsed.externalWorkers) ? parsed.externalWorkers : undefined,
     };
   } catch (err) {
@@ -490,7 +499,7 @@ function readWorkerConfig(homeRoot: string): {
 }
 
 function workerDisplayName(kind: string): string {
-  return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind;
+  return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind === AUTO_APPROVE_WORKER_KIND ? 'Autoapprove' : kind;
 }
 
 function printWorkerKinds<TDeps>(registry: WorkerRegistry<TDeps>): void {
@@ -515,7 +524,7 @@ function isExternalWorkerRuntime(worker: WorkerRuntime): worker is ExternalWorke
 async function runWorker(definition: WorkerDefinition<WorkerRuntimeDependencies>, bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
-  const { autoFixRetries, autoFixAgent } = readWorkerConfig(homeRoot);
+  const { autoFixRetries, autoFixAgent, autoApproveAIFixes } = readWorkerConfig(homeRoot);
 
   // Single-instance guard: refuse if another worker of this kind (this door or
   // the dev `--headless worker <kind>` door) already holds the cross-process
@@ -552,6 +561,9 @@ async function runWorker(definition: WorkerDefinition<WorkerRuntimeDependencies>
         defaultAutoFixRetries: autoFixRetries,
         attemptLedger: autoFixAttemptLedger,
         getAutoFixAgent: () => autoFixAgent,
+      },
+      autoApprove: {
+        enabled: autoApproveAIFixes === true,
       },
     });
 
@@ -596,7 +608,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';
       const registry = registerExternalWorkers(
-        registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+        registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
         readWorkerConfig(resolveInvokerHomeRoot()).externalWorkers,
       );
       if (subcommand === 'list') {

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_TOOL_REQUIREMENTS,
   EXTERNAL_DEPENDENCIES,
   formatReport,
+  resolveInvokerConfigPath,
   type IsInstalled,
   type PlanningPresetSpec,
   type PrerequisiteCheck,
@@ -35,7 +36,7 @@ export function invokerHomeDir(): string {
   return join(homedir(), '.invoker');
 }
 export function defaultConfigPath(): string {
-  return process.env.INVOKER_REPO_CONFIG_PATH ?? join(invokerHomeDir(), 'config.json');
+  return resolveInvokerConfigPath(process.env, homedir());
 }
 export function envFilePath(): string {
   return join(invokerHomeDir(), '.env');

--- a/packages/contracts/src/invoker-home.ts
+++ b/packages/contracts/src/invoker-home.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 export interface InvokerHomeEnv {
   INVOKER_DB_DIR?: string;
   INVOKER_IPC_SOCKET?: string;
+  INVOKER_REPO_CONFIG_PATH?: string;
   NODE_ENV?: string;
 }
 
@@ -17,6 +18,14 @@ export function resolveInvokerHomeRoot(
       ? join(homeDir, '.invoker', 'test')
       : join(homeDir, '.invoker'))
   );
+}
+
+export function resolveInvokerConfigPath(
+  env: InvokerHomeEnv = process.env,
+  homeDir: string = homedir(),
+): string {
+  const override = env.INVOKER_REPO_CONFIG_PATH?.trim();
+  return override || join(homeDir, '.invoker', 'config.json');
 }
 
 export function resolveInvokerIpcSocketPath(

--- a/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
@@ -1,0 +1,225 @@
+import type { Logger } from '@invoker/contracts';
+import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationIntent } from '@invoker/data-store';
+import type { RecoveryWorkerWakeupHint } from '../lifecycle-events.js';
+import type { TaskState } from '@invoker/workflow-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  collectValidatedAutoApproveCandidates,
+  createAutoApproveTick,
+  isApproveIntentForTask,
+  listAutoApproveScanCandidates,
+  type AutoApproveCandidate,
+  type AutoApproveWorkerStore,
+} from '../workers/auto-approve-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+} as unknown as Logger;
+
+function task(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/task-1',
+    description: 'Task 1',
+    status: 'awaiting_approval',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    config: { id: 'task-1', workflowId: 'wf-1', ...config },
+    execution: {
+      pendingFixError: 'boom',
+      generation: 1,
+      selectedAttemptId: 'attempt-1',
+      ...execution,
+    },
+    taskStateVersion: 4,
+    ...rest,
+  } as TaskState;
+}
+
+function intent(overrides: Partial<WorkflowMutationIntent>): WorkflowMutationIntent {
+  return {
+    id: 1,
+    workflowId: 'wf-1',
+    channel: 'invoker:approve',
+    args: ['wf-1/task-1'],
+    priority: 'normal',
+    status: 'queued',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function wakeup(overrides: Partial<RecoveryWorkerWakeupHint> = {}): RecoveryWorkerWakeupHint {
+  return {
+    eventKey: 'event-1',
+    eventKind: 'task.awaiting_approval',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/task-1',
+    taskStateVersion: 4,
+    generation: 1,
+    attemptId: 'attempt-1',
+    createdAt: '2026-01-01T00:00:00Z',
+    reason: 'task_lifecycle',
+    authoritative: false,
+    ...overrides,
+  };
+}
+
+function makeStore(tasks: TaskState[], openIntents: WorkflowMutationIntent[] = []) {
+  const actions = new Map<string, WorkerActionRecord>();
+  const writes: WorkerActionWrite[] = [];
+  const store: AutoApproveWorkerStore = {
+    listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+    loadTasks: vi.fn(() => tasks),
+    loadTask: vi.fn((taskId: string) => tasks.find((candidate) => candidate.id === taskId)),
+    listWorkflowMutationIntents: vi.fn(() => openIntents),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      writes.push(write);
+      const now = new Date('2026-01-01T00:00:00Z').toISOString();
+      const record: WorkerActionRecord = {
+        attemptCount: 0,
+        createdAt: now,
+        updatedAt: now,
+        ...write,
+      };
+      actions.set(`${write.workerKind}:${write.externalKey}`, record);
+      return record;
+    }),
+    logEvent: vi.fn(),
+  };
+  return { store, writes };
+}
+
+function candidate(overrides: Partial<AutoApproveCandidate> = {}): AutoApproveCandidate {
+  return {
+    taskId: 'wf-1/task-1',
+    workflowId: 'wf-1',
+    generation: 1,
+    taskStateVersion: 4,
+    attemptId: 'attempt-1',
+    source: 'scan',
+    ...overrides,
+  };
+}
+
+describe('autoapprove worker', () => {
+  it('scan candidates include only awaiting approval tasks with pending fix errors', () => {
+    const eligible = task();
+    const noPendingFix = task({ id: 'wf-1/task-2', execution: { pendingFixError: undefined } });
+    const failed = task({ id: 'wf-1/task-3', status: 'failed' });
+    const { store } = makeStore([eligible, noPendingFix, failed]);
+
+    expect(listAutoApproveScanCandidates({ store })).toEqual([
+      expect.objectContaining({ taskId: 'wf-1/task-1', workflowId: 'wf-1', generation: 1, taskStateVersion: 4 }),
+    ]);
+  });
+
+  it('does not submit awaiting approval tasks without pending fix errors', async () => {
+    const { store } = makeStore([task({ execution: { pendingFixError: undefined } })]);
+    const submitter = { submit: vi.fn() };
+
+    await createAutoApproveTick({ store, submitter, logger, enabled: true })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+    });
+
+    expect(submitter.submit).not.toHaveBeenCalled();
+  });
+
+  it('skips review-ready tasks with pending fix errors as ambiguous', () => {
+    const { store, writes } = makeStore([task({ status: 'review_ready' })]);
+
+    expect(collectValidatedAutoApproveCandidates({ store, submitter: { submit: vi.fn() }, logger, enabled: true }, [candidate()])).toEqual([]);
+    expect(writes[0]).toMatchObject({ status: 'skipped', summary: 'Skipped AI fix approval: review-ready-ambiguous' });
+  });
+
+  it('skips stale workflow, generation, task-state version, and attempt snapshots', () => {
+    const cases: Array<[string, TaskState, AutoApproveCandidate]> = [
+      ['stale-workflow', task({ config: { workflowId: 'wf-2' } }), candidate()],
+      ['stale-generation', task({ execution: { generation: 2 } }), candidate()],
+      ['stale-task-state-version', task({ taskStateVersion: 5 }), candidate()],
+      ['stale-attempt', task({ execution: { selectedAttemptId: 'attempt-2' } }), candidate()],
+    ];
+
+    for (const [reason, latest, snapshot] of cases) {
+      const { store, writes } = makeStore([latest]);
+      const result = collectValidatedAutoApproveCandidates({ store, submitter: { submit: vi.fn() }, logger, enabled: true }, [snapshot]);
+      expect(result).toEqual([]);
+      expect(writes[0]).toMatchObject({ status: 'skipped', summary: `Skipped AI fix approval: ${reason}` });
+    }
+  });
+
+  it('dedupes duplicate wakeups for the same snapshot', async () => {
+    const { store } = makeStore([task()]);
+    const submitter = { submit: vi.fn(() => 42) };
+
+    await createAutoApproveTick({
+      store,
+      submitter,
+      logger,
+      enabled: true,
+      drainWakeupHints: () => [wakeup(), wakeup()],
+    })({ identity: { kind: 'autoapprove', instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+
+    expect(submitter.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips open invoker and headless approval intents', () => {
+    const openInvoker = intent({ id: 10, channel: 'invoker:approve', args: ['wf-1/task-1'] });
+    const openHeadless = intent({ id: 11, channel: 'headless.exec', args: [{ args: ['approve', 'wf-1/task-1'] }] });
+    expect(isApproveIntentForTask(openInvoker, 'wf-1/task-1')).toBe(true);
+    expect(isApproveIntentForTask(openHeadless, 'wf-1/task-1')).toBe(true);
+
+    for (const openIntent of [openInvoker, openHeadless]) {
+      const { store, writes } = makeStore([task()], [openIntent]);
+      const result = collectValidatedAutoApproveCandidates({ store, submitter: { submit: vi.fn() }, logger, enabled: true }, [candidate()]);
+      expect(result).toEqual([]);
+      expect(writes[0]).toMatchObject({ status: 'skipped', summary: 'Skipped AI fix approval: already-queued-intent' });
+    }
+  });
+
+  it('submits a valid approval intent and records a queued worker action', async () => {
+    const { store, writes } = makeStore([task()]);
+    const submitter = { submit: vi.fn(() => 42) };
+
+    await createAutoApproveTick({ store, submitter, logger, enabled: true })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+    });
+
+    expect(submitter.submit).toHaveBeenCalledWith('wf-1', 'normal', 'invoker:approve', ['wf-1/task-1']);
+    expect(writes[0]).toMatchObject({
+      id: 'autoapprove:autoapprove:wf-1/task-1:1:4:attempt-1',
+      workerKind: 'autoapprove',
+      actionType: 'approve-ai-fix',
+      subjectType: 'task',
+      subjectId: 'wf-1/task-1',
+      status: 'queued',
+      summary: 'Queued AI fix approval',
+      intentId: '42',
+    });
+  });
+
+  it('does not scan or submit when disabled', async () => {
+    const { store } = makeStore([task()]);
+    const submitter = { submit: vi.fn() };
+
+    await createAutoApproveTick({ store, submitter, logger, enabled: false })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+    });
+
+    expect(store.listWorkflows).not.toHaveBeenCalled();
+    expect(submitter.submit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -1,4 +1,5 @@
 import { registerAutoFixWorker } from './auto-fix-recovery.js';
+import { registerAutoApproveWorker } from './workers/auto-approve-worker.js';
 import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
 import type { WorkerRegistry } from './worker-registry.js';
 import { registerCiFailureWorker } from './workers/ci-failure-worker.js';
@@ -9,6 +10,7 @@ export function registerBuiltinWorkers(
   registry: WorkerRegistry<WorkerRuntimeDependencies>,
 ): WorkerRegistry<WorkerRuntimeDependencies> {
   registerAutoFixWorker(registry);
+  registerAutoApproveWorker(registry);
   registerPrStatusWorker(registry);
   registerCiFailureWorker(registry);
   return registry;

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -41,6 +41,7 @@ export * from './worker-lock.js';
 export * from './builtin-workers.js';
 export * from './auto-fix-recovery.js';
 export * from './workers/pr-status-worker.js';
+export * from './workers/auto-approve-worker.js';
 export * from './workers/ci-failure-worker.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-attempt-ledger.js';

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -6,15 +6,20 @@ import type {
   AutoFixRecoverySubmitter,
   AutoFixWorkerConfig,
 } from './auto-fix-recovery.js';
+import type {
+  AutoApproveWorkerConfig,
+  AutoApproveWorkerStore,
+  AutoApproveWorkerSubmitter,
+} from './workers/auto-approve-worker.js';
 import type { CiFailureWorkerStore, CiFailureWorkerSubmitter } from './workers/ci-failure-worker.js';
 import type { PrStatusReviewGate } from './workers/pr-status-worker.js';
 
 /** Dependencies injected into a built-in worker factory when its runtime is built. */
 export interface WorkerRuntimeDependencies {
   /** Persisted workflow/task state accessor. */
-  store: AutoFixRecoveryStore & CiFailureWorkerStore;
+  store: AutoFixRecoveryStore & AutoApproveWorkerStore & CiFailureWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
-  submitter: AutoFixRecoverySubmitter & CiFailureWorkerSubmitter;
+  submitter: AutoFixRecoverySubmitter & AutoApproveWorkerSubmitter & CiFailureWorkerSubmitter;
   /** Operator logger. */
   logger: Logger;
   /** Optional bus that turns lifecycle events into immediate wakeups. */
@@ -23,4 +28,6 @@ export interface WorkerRuntimeDependencies {
   reviewGate?: PrStatusReviewGate;
   /** Auto-fix tuning shared by workers that submit fix intents. */
   autoFix?: AutoFixWorkerConfig;
+  /** Auto-approval tuning for worker-owned AI fix approvals. */
+  autoApprove?: AutoApproveWorkerConfig;
 }

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -1,0 +1,492 @@
+import type { Logger } from '@invoker/contracts';
+import type {
+  WorkerActionRecord,
+  WorkerActionStatus,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+
+import type { RecoveryWorkerWakeupHint, WorkflowLifecycleEvent } from '../lifecycle-events.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const AUTO_APPROVE_WORKER_KIND = 'autoapprove';
+export const DEFAULT_AUTO_APPROVE_WORKER_INTERVAL_MS = 60_000;
+const AUTO_APPROVE_COMMAND_CHANNEL = 'invoker:approve';
+const AUTO_APPROVE_ACTION_TYPE = 'approve-ai-fix';
+
+type AutoApproveActionStatus = WorkerActionStatus;
+
+export interface AutoApproveWorkerStore {
+  listWorkflows(): ReadonlyArray<{ id: string }>;
+  loadTasks(workflowId: string): TaskState[];
+  loadTask?(taskId: string): TaskState | undefined;
+  listWorkflowMutationIntents?(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[];
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
+  logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+}
+
+export interface AutoApproveWorkerSubmitter {
+  submit(
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: typeof AUTO_APPROVE_COMMAND_CHANNEL,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number;
+}
+
+export interface AutoApproveWorkerConfig {
+  enabled?: boolean;
+}
+
+export interface AutoApproveWorkerPolicyOptions {
+  store: AutoApproveWorkerStore;
+  submitter: AutoApproveWorkerSubmitter;
+  logger: Logger;
+  enabled?: boolean;
+  drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
+}
+
+export interface AutoApproveWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  messageBus?: MessageBus;
+  autoApprove?: Omit<AutoApproveWorkerPolicyOptions, 'logger' | 'drainWakeupHints'>;
+  onTick?: WorkerTick;
+}
+
+export type AutoApproveCandidate = {
+  taskId: string;
+  workflowId: string;
+  generation: number;
+  taskStateVersion: number;
+  attemptId?: string;
+  source: 'scan' | 'wakeup';
+};
+
+type AutoApproveTaskRef = Omit<AutoApproveCandidate, 'source'>;
+
+type ValidatedAutoApproveCandidate = AutoApproveTaskRef & {
+  source: AutoApproveCandidate['source'];
+  task: TaskState;
+};
+
+type AutoApproveSnapshotMismatchReason =
+  | 'stale-workflow'
+  | 'stale-generation'
+  | 'stale-task-state-version'
+  | 'stale-attempt';
+
+type AutoApproveSnapshotComparison =
+  | { ok: true; ref: AutoApproveTaskRef }
+  | { ok: false; reason: AutoApproveSnapshotMismatchReason; details: Record<string, unknown> };
+
+export function registerAutoApproveWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: AUTO_APPROVE_WORKER_KIND,
+    note: 'Approves AI fixes that are awaiting approval after a pending fix error.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createAutoApproveWorker({
+        logger: deps.logger,
+        messageBus: deps.messageBus,
+        autoApprove: {
+          store: deps.store,
+          submitter: deps.submitter,
+          enabled: deps.autoApprove?.enabled,
+        },
+      }),
+  });
+  return registry;
+}
+
+function workflowIdForTask(task: TaskState): string | undefined {
+  return task.config.workflowId ?? task.id.split('/')[0];
+}
+
+function taskRefFromTask(task: TaskState): AutoApproveTaskRef | undefined {
+  const workflowId = workflowIdForTask(task);
+  if (!workflowId) return undefined;
+  return {
+    taskId: task.id,
+    workflowId,
+    generation: task.execution.generation ?? 0,
+    taskStateVersion: task.taskStateVersion,
+    attemptId: task.execution.selectedAttemptId,
+  };
+}
+
+function candidateFromTask(task: TaskState): AutoApproveCandidate | undefined {
+  const ref = taskRefFromTask(task);
+  if (!ref) return undefined;
+  return { ...ref, source: 'scan' };
+}
+
+export function listAutoApproveScanCandidates(
+  options: Pick<AutoApproveWorkerPolicyOptions, 'store'>,
+): AutoApproveCandidate[] {
+  const candidates: AutoApproveCandidate[] = [];
+  for (const workflow of options.store.listWorkflows()) {
+    for (const task of options.store.loadTasks(workflow.id)) {
+      if (task.status !== 'awaiting_approval') continue;
+      if (task.execution.pendingFixError === undefined) continue;
+      const candidate = candidateFromTask(task);
+      if (candidate) candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+
+function candidateFromWakeup(wakeup: RecoveryWorkerWakeupHint): AutoApproveCandidate | undefined {
+  if (!wakeup.taskId || wakeup.taskStateVersion == null) return undefined;
+  return {
+    taskId: wakeup.taskId,
+    workflowId: wakeup.workflowId,
+    generation: wakeup.generation,
+    taskStateVersion: wakeup.taskStateVersion,
+    attemptId: wakeup.attemptId,
+    source: 'wakeup',
+  };
+}
+
+function dedupeCandidates(candidates: AutoApproveCandidate[]): AutoApproveCandidate[] {
+  const seen = new Set<string>();
+  const deduped: AutoApproveCandidate[] = [];
+  for (const candidate of candidates) {
+    const key = `${candidate.taskId}:${candidate.generation}:${candidate.taskStateVersion}:${candidate.attemptId ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(candidate);
+  }
+  return deduped;
+}
+
+function loadLatestTask(
+  candidate: AutoApproveCandidate,
+  options: AutoApproveWorkerPolicyOptions,
+): TaskState | undefined {
+  const direct = options.store.loadTask?.(candidate.taskId);
+  if (direct) return direct;
+  return options.store.loadTasks(candidate.workflowId).find((task) => task.id === candidate.taskId);
+}
+
+function compareCandidateSnapshot(
+  candidate: AutoApproveCandidate,
+  latest: TaskState,
+): AutoApproveSnapshotComparison {
+  const latestRef = taskRefFromTask(latest);
+  if (!latestRef || latestRef.workflowId !== candidate.workflowId) {
+    return { ok: false, reason: 'stale-workflow', details: { latestWorkflowId: latestRef?.workflowId ?? null } };
+  }
+  if (latestRef.generation !== candidate.generation) {
+    return { ok: false, reason: 'stale-generation', details: { latestGeneration: latestRef.generation } };
+  }
+  if (latestRef.taskStateVersion !== candidate.taskStateVersion) {
+    return {
+      ok: false,
+      reason: 'stale-task-state-version',
+      details: { latestTaskStateVersion: latestRef.taskStateVersion },
+    };
+  }
+  if ((latestRef.attemptId ?? null) !== (candidate.attemptId ?? null)) {
+    return { ok: false, reason: 'stale-attempt', details: { latestAttemptId: latestRef.attemptId ?? null } };
+  }
+  return { ok: true, ref: latestRef };
+}
+
+function actionExternalKey(candidate: Pick<AutoApproveCandidate, 'taskId' | 'generation' | 'taskStateVersion' | 'attemptId'>): string {
+  return `autoapprove:${candidate.taskId}:${candidate.generation}:${candidate.taskStateVersion}:${candidate.attemptId ?? 'no-attempt'}`;
+}
+
+function actionIdForExternalKey(externalKey: string): string {
+  return `${AUTO_APPROVE_WORKER_KIND}:${externalKey}`;
+}
+
+function isOpenOrCompletedActionStatus(status: string): boolean {
+  return status === 'queued'
+    || status === 'pending'
+    || status === 'running'
+    || status === 'needs_input'
+    || status === 'review_ready'
+    || status === 'completed';
+}
+
+function coerceActionStatus(status: AutoApproveActionStatus): WorkerActionStatus {
+  return status;
+}
+
+function recordAutoApproveAction(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+  status: AutoApproveActionStatus,
+  summary: string,
+  payload: Record<string, unknown> = {},
+  intentId?: number | string,
+): WorkerActionRecord | undefined {
+  const externalKey = actionExternalKey(candidate);
+  const existing = options.store.getWorkerAction?.(AUTO_APPROVE_WORKER_KIND, externalKey);
+  const now = new Date().toISOString();
+  return options.store.upsertWorkerAction?.({
+    id: existing?.id ?? actionIdForExternalKey(externalKey),
+    workerKind: AUTO_APPROVE_WORKER_KIND,
+    actionType: AUTO_APPROVE_ACTION_TYPE,
+    workflowId: candidate.workflowId,
+    taskId: candidate.taskId,
+    subjectType: 'task',
+    subjectId: candidate.taskId,
+    externalKey,
+    status: coerceActionStatus(status),
+    attemptCount: status === 'queued' || status === 'failed'
+      ? (existing?.attemptCount ?? 0) + 1
+      : existing?.attemptCount ?? 0,
+    ...(intentId !== undefined ? { intentId: String(intentId) } : {}),
+    summary,
+    payload: {
+      taskId: candidate.taskId,
+      workflowId: candidate.workflowId,
+      generation: candidate.generation,
+      taskStateVersion: candidate.taskStateVersion,
+      selectedAttemptId: candidate.attemptId ?? null,
+      source: candidate.source,
+      ...payload,
+    },
+    updatedAt: now,
+    ...(status === 'skipped' || status === 'failed' || status === 'completed' ? { completedAt: now } : {}),
+  });
+}
+
+function logAutoApproveWorkerEvent(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+  phase: string,
+  details: Record<string, unknown>,
+): void {
+  const payload = {
+    phase,
+    worker: AUTO_APPROVE_WORKER_KIND,
+    workflowId: candidate.workflowId,
+    generation: candidate.generation,
+    taskStateVersion: candidate.taskStateVersion,
+    selectedAttemptId: candidate.attemptId ?? null,
+    source: candidate.source,
+    ...details,
+  };
+  options.store.logEvent?.(candidate.taskId, 'debug.autoapprove-worker', payload);
+  options.logger.debug?.(`[worker:${AUTO_APPROVE_WORKER_KIND}] ${phase}`, {
+    module: 'auto-approve-worker',
+    taskId: candidate.taskId,
+    ...payload,
+  });
+}
+
+function skipAutoApproveCandidate(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+  reason: string,
+  details: Record<string, unknown> = {},
+): void {
+  recordAutoApproveAction(
+    options,
+    candidate,
+    'skipped',
+    `Skipped AI fix approval: ${reason}`,
+    { reason, ...details },
+  );
+  logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-skip', { reason, ...details });
+}
+
+function hasAlreadyRecordedAction(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+): boolean {
+  const externalKey = actionExternalKey(candidate);
+  const existing = options.store.getWorkerAction?.(AUTO_APPROVE_WORKER_KIND, externalKey);
+  if (!existing) return false;
+  if (!isOpenOrCompletedActionStatus(existing.status)) return false;
+  logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-skip', {
+    reason: 'already-recorded',
+    existingStatus: existing.status,
+    intentId: existing.intentId ?? null,
+  });
+  return true;
+}
+
+export function isApproveIntentForTask(intent: WorkflowMutationIntent, taskId: string): boolean {
+  if (intent.channel === AUTO_APPROVE_COMMAND_CHANNEL) return intent.args[0] === taskId;
+  if (intent.channel !== 'headless.exec') return false;
+  const firstArg = intent.args[0];
+  if (typeof firstArg !== 'object' || firstArg === null || Array.isArray(firstArg)) return false;
+  const args = (firstArg as { args?: unknown }).args;
+  return Array.isArray(args) && args[0] === 'approve' && args[1] === taskId;
+}
+
+function openApprovalIntents(
+  options: AutoApproveWorkerPolicyOptions,
+  workflowId: string,
+  taskId: string,
+): WorkflowMutationIntent[] {
+  const open = options.store.listWorkflowMutationIntents?.(workflowId, ['queued', 'running']) ?? [];
+  return open.filter((intent) => isApproveIntentForTask(intent, taskId));
+}
+
+function validateAutoApproveCandidate(
+  candidate: AutoApproveCandidate,
+  options: AutoApproveWorkerPolicyOptions,
+): ValidatedAutoApproveCandidate | undefined {
+  const latest = loadLatestTask(candidate, options);
+  if (!latest) {
+    skipAutoApproveCandidate(options, candidate, 'task-not-found');
+    return undefined;
+  }
+
+  const snapshotComparison = compareCandidateSnapshot(candidate, latest);
+  if (!snapshotComparison.ok) {
+    skipAutoApproveCandidate(options, candidate, snapshotComparison.reason, snapshotComparison.details);
+    return undefined;
+  }
+
+  if (latest.status === 'review_ready') {
+    skipAutoApproveCandidate(options, candidate, 'review-ready-ambiguous');
+    return undefined;
+  }
+  if (latest.status !== 'awaiting_approval') {
+    skipAutoApproveCandidate(options, candidate, 'status-changed', { status: latest.status });
+    return undefined;
+  }
+  if (latest.execution.pendingFixError === undefined) {
+    skipAutoApproveCandidate(options, candidate, 'no-pending-fix');
+    return undefined;
+  }
+
+  if (hasAlreadyRecordedAction(options, candidate)) return undefined;
+
+  const openIntents = openApprovalIntents(options, snapshotComparison.ref.workflowId, candidate.taskId);
+  if (openIntents.length > 0) {
+    skipAutoApproveCandidate(options, candidate, 'already-queued-intent', {
+      existingIntentIds: openIntents.map((intent) => intent.id),
+    });
+    return undefined;
+  }
+
+  return { ...snapshotComparison.ref, source: candidate.source, task: latest };
+}
+
+export function collectValidatedAutoApproveCandidates(
+  options: AutoApproveWorkerPolicyOptions,
+  candidates: AutoApproveCandidate[] = listAutoApproveScanCandidates(options),
+): ValidatedAutoApproveCandidate[] {
+  return candidates
+    .map((candidate) => validateAutoApproveCandidate(candidate, options))
+    .filter((candidate): candidate is ValidatedAutoApproveCandidate => Boolean(candidate));
+}
+
+export function createAutoApproveTick(options: AutoApproveWorkerPolicyOptions): WorkerTick {
+  return async (ctx) => {
+    if (options.enabled !== true) return;
+    const wakeups = options.drainWakeupHints?.() ?? [];
+    const wakeupCandidates = wakeups.map(candidateFromWakeup).filter((c): c is AutoApproveCandidate => Boolean(c));
+    const candidates = dedupeCandidates(
+      wakeupCandidates.length > 0 && ctx.reason === 'wake'
+        ? wakeupCandidates
+        : listAutoApproveScanCandidates(options),
+    );
+    const submittedThisTick = new Set<string>();
+
+    for (const candidate of collectValidatedAutoApproveCandidates(options, candidates)) {
+      if (submittedThisTick.has(candidate.taskId)) {
+        skipAutoApproveCandidate(options, candidate, 'duplicate-candidate');
+        continue;
+      }
+      const intentId = options.submitter.submit(
+        candidate.workflowId,
+        'normal',
+        AUTO_APPROVE_COMMAND_CHANNEL,
+        [candidate.taskId],
+      );
+      submittedThisTick.add(candidate.taskId);
+      recordAutoApproveAction(
+        options,
+        candidate,
+        'queued',
+        'Queued AI fix approval',
+        { channel: AUTO_APPROVE_COMMAND_CHANNEL },
+        intentId,
+      );
+      logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-submitted', {
+        intentId,
+        channel: AUTO_APPROVE_COMMAND_CHANNEL,
+      });
+    }
+  };
+}
+
+function isAwaitingApprovalEvent(event: WorkflowLifecycleEvent): boolean {
+  return event.kind === 'task.awaiting_approval' && Boolean(event.taskId);
+}
+
+export function createAutoApproveWorker(options: AutoApproveWorkerOptions): WorkerRuntime {
+  const pendingWakeups: RecoveryWorkerWakeupHint[] = [];
+  let lifecycleUnsubscribe: Unsubscribe | undefined;
+  const onTick = options.onTick ?? (
+    options.autoApprove
+      ? createAutoApproveTick({
+        ...options.autoApprove,
+        logger: options.logger,
+        drainWakeupHints: () => pendingWakeups.splice(0),
+      })
+      : (() => {})
+  );
+  const runtime = createWorkerRuntime({
+    kind: AUTO_APPROVE_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_AUTO_APPROVE_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick,
+  });
+
+  if (!options.messageBus || !options.autoApprove || options.onTick) return runtime;
+
+  const start = (): void => {
+    if (!lifecycleUnsubscribe) {
+      lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
+        Channels.WORKFLOW_LIFECYCLE,
+        (event) => {
+          if (!isAwaitingApprovalEvent(event)) return;
+          pendingWakeups.push(event.recoveryWakeup);
+          runtime.wake('wake');
+        },
+      );
+    }
+    runtime.start();
+  };
+  const stop = async (): Promise<void> => {
+    lifecycleUnsubscribe?.();
+    lifecycleUnsubscribe = undefined;
+    await runtime.stop();
+  };
+
+  return {
+    identity: runtime.identity,
+    start,
+    wake: runtime.wake,
+    tick: runtime.tick,
+    stop,
+    isRunning: runtime.isRunning,
+  };
+}

--- a/packages/slack-manager/deploy/install.sh
+++ b/packages/slack-manager/deploy/install.sh
@@ -22,6 +22,11 @@ if [ ! -f "$ENV_FILE" ]; then
   echo "Missing $ENV_FILE — create it with SLACK_BOT_TOKEN/APP_TOKEN/SIGNING_SECRET/CHANNEL_ID first." >&2
   exit 1
 fi
+if grep -Eq '^[[:space:]]*(INVOKER_REPO_CONFIG_PATH|INVOKER_CONFIG)=' "$ENV_FILE"; then
+  echo "Remove INVOKER_REPO_CONFIG_PATH/INVOKER_CONFIG from ~/.invoker/.slack-owner.env; Slack-managed Invoker reads ~/.invoker/config.json." >&2
+  exit 1
+fi
+
 
 echo "Building @invoker/slack-manager…"
 ( cd "$REPO_ROOT" && pnpm --filter @invoker/slack-manager build )

--- a/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
@@ -1,0 +1,49 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createInvokerLauncher } from '../invoker-launcher.js';
+
+vi.mock('node:fs', () => ({
+  openSync: vi.fn(() => 99),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => ({ pid: 123, exitCode: null, unref: vi.fn() } as unknown as ChildProcess)),
+}));
+
+const STRIPPED_ENV_KEYS = [
+  'SLACK_BOT_TOKEN',
+  'SLACK_APP_TOKEN',
+  'SLACK_SIGNING_SECRET',
+  'SLACK_CHANNEL_ID',
+  'SLACK_LOBBY_CHANNEL_ID',
+  'INVOKER_REPO_CONFIG_PATH',
+  'INVOKER_CONFIG',
+] as const;
+
+describe('createInvokerLauncher', () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    vi.clearAllMocks();
+  });
+
+  it('strips Slack secrets and config overrides from spawned GUI env', () => {
+    for (const key of STRIPPED_ENV_KEYS) process.env[key] = `${key}-value`;
+
+    createInvokerLauncher({
+      repoRoot: '/repo',
+      logPath: '/tmp/invoker.log',
+      log: vi.fn(),
+    }).spawnInvoker();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const options = vi.mocked(spawn).mock.calls[0]?.[2];
+    expect(options?.env).toBeDefined();
+    for (const key of STRIPPED_ENV_KEYS) {
+      expect(options?.env).not.toHaveProperty(key);
+    }
+    expect(options?.env).toMatchObject({ LIBGL_ALWAYS_SOFTWARE: '1' });
+  });
+});

--- a/packages/slack-manager/src/invoker-launcher.ts
+++ b/packages/slack-manager/src/invoker-launcher.ts
@@ -3,19 +3,20 @@
  * group, matching `run.sh`'s headless-Linux path. Tracks the spawned child so a
  * forced restart can tear down a manager-managed instance before respawning.
  *
- * Slack credentials are stripped from the child env: post-cutover Invoker has no
- * Slack surface, and the manager owns the only Slack connection.
+ * Slack credentials and config path overrides are stripped from the child env:
+ * post-cutover Invoker has no Slack surface and reads ~/.invoker/config.json.
  */
-
 import { spawn, type ChildProcess } from 'node:child_process';
 import { openSync } from 'node:fs';
 
-const SLACK_ENV_VARS = [
+const STRIPPED_CHILD_ENV_VARS = [
   'SLACK_BOT_TOKEN',
   'SLACK_APP_TOKEN',
   'SLACK_SIGNING_SECRET',
   'SLACK_CHANNEL_ID',
   'SLACK_LOBBY_CHANNEL_ID',
+  'INVOKER_REPO_CONFIG_PATH',
+  'INVOKER_CONFIG',
 ];
 
 export interface InvokerLauncherOptions {
@@ -45,7 +46,7 @@ export function createInvokerLauncher(options: InvokerLauncherOptions): InvokerL
       }
 
       const env: NodeJS.ProcessEnv = { ...process.env, LIBGL_ALWAYS_SOFTWARE: '1' };
-      for (const key of SLACK_ENV_VARS) delete env[key];
+      for (const key of STRIPPED_CHILD_ENV_VARS) delete env[key];
 
       const out = openSync(options.logPath, 'a');
       child = spawn(


### PR DESCRIPTION
## Summary

App, headless, CLI, and Slack-managed entrypoints now use the shared config rule and stop doing inline AI-fix approval.

The bug was surface drift. Different doors read config differently, and fix actions could approve immediately instead of waiting for the queued worker path.

This slice switches those entrypoints to the shared resolver, changes user-facing fix messages to queued auto-approval, and keeps approval inside the normal `invoker:approve` path.

<details>
<summary>Review metadata</summary>

Review Claim: Every approval and config entrypoint now uses the same surface behavior: shared config resolution and queued AI approval.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice only changes the outer entrypoints; the actual approval implementation still stays in `approveTask()`.

Slice Rationale: These files are the exposed doors for fix, resolve, worker, CLI, and Slack behavior, so they need to change together.

</details>

## Non-goals

This does not change worker core routing.

This does not change shell tooling or docs.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-command-classification.test.ts src/__tests__/headless-autofix.test.ts src/__tests__/resolve-conflict-action.test.ts src/__tests__/workflow-actions.test.ts`
- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/onboarding.test.ts -t "matches the shared config resolver for default, override, and blank override"`
- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/cli.test.ts -t "lists worker kinds from the registry|reads worker config from INVOKER_REPO_CONFIG_PATH for worker list|restores INVOKER_REPO_CONFIG_PATH after standalone run with --config"`
- [x] `pnpm --filter @invoker/slack-manager exec vitest run src/__tests__/invoker-launcher.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e9abbbd`
- Post-revert steps: None
- Data migration? No
