### PR TITLE
[Autoapprove single config](6) Document shared Invoker config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The tutorial creates a tiny local git repo, generates both Codex and Claude plan
 
 Invoker reads user config from `~/.invoker/config.json`.
 
-If you want a repo-specific config file, point the app at it explicitly:
+Use that file for production settings. `INVOKER_REPO_CONFIG_PATH` is only for tests or isolated CLI runs:
 
 ```bash
 INVOKER_REPO_CONFIG_PATH=$PWD/.invoker.local.json ./run.sh

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -1,6 +1,6 @@
 {
   "comment": "Example Invoker configuration file",
-  "description": "Default location: ~/.invoker/config.json. For repo-specific configs, set INVOKER_REPO_CONFIG_PATH when launching Invoker.",
+  "description": "Default location: ~/.invoker/config.json. INVOKER_REPO_CONFIG_PATH is a test/CLI override only.",
   "maxConcurrency": 6,
   "defaultExecutionAgent": "codex",
 
@@ -105,8 +105,8 @@
     "web_surface": "webToken enables the browser UI + Slack live status card surfaces. Env vars INVOKER_WEB_TOKEN / INVOKER_WEB_HOST / INVOKER_WEB_PORT override these. Set webHost to 0.0.0.0 to reach it from another machine (e.g. the DigitalOcean host); open http://<host>:<webPort>/?token=<webToken>.",
     "fetch_behavior": "Git fetch failures always abort the task. Fix the underlying network/auth issue and rerun.",
     "config_locations": [
-      "~/.invoker/config.json - Default user-level settings",
-      "INVOKER_REPO_CONFIG_PATH=/path/to/config.json - Explicit override for repo/test-specific config"
+      "~/.invoker/config.json - Normal production settings",
+      "INVOKER_REPO_CONFIG_PATH=/path/to/config.json - Test/CLI override only"
     ],
     "runner_kinds": [
       "worktree - Git worktree isolation (default)",

--- a/docs/remote-ssh-targets.md
+++ b/docs/remote-ssh-targets.md
@@ -10,9 +10,7 @@ Each remote target is defined in the Invoker config with a host, user, and path 
 
 ## Configuration
 
-Add remote targets to `~/.invoker/config.json`.
-
-If you want to use a repo-specific config file, launch Invoker with `INVOKER_REPO_CONFIG_PATH=/path/to/config.json`.
+Add remote targets to `~/.invoker/config.json`. `INVOKER_REPO_CONFIG_PATH` is only for tests or isolated CLI runs.
 
 ```json
 {


### PR DESCRIPTION
## Summary

The operator docs now describe one normal Invoker config file.

The bug was doc drift. README and setup docs still implied a second production-style config path.

This slice updates the docs to say `~/.invoker/config.json` is the normal path and `INVOKER_REPO_CONFIG_PATH` is only an explicit override.

<details>
<summary>Review metadata</summary>

Review Claim: The operator docs now match the shipped shared config-path behavior.

Review Lane: docs

Review Unit: docs

Safety Invariant: This slice only changes docs.

Slice Rationale: Docs come last so they describe the final shipped behavior instead of an in-flight intermediate state.

</details>

## Non-goals

This does not change runtime behavior.

This does not change shell tooling text.

## Test Plan

- [x] `pnpm --filter @invoker/contracts build && pnpm --filter @invoker/execution-engine build && pnpm --filter @invoker/app build && pnpm --filter @invoker/slack-manager build && pnpm --filter @invoker/cli build && pnpm --filter @invoker/data-store build`
- [x] `TMP_ROOT="$(mktemp -d)" && CONFIG_PATH="$TMP_ROOT/config.json" && HOME_ROOT="$TMP_ROOT/home" && mkdir -p "$HOME_ROOT" && DB_PATH="$HOME_ROOT/invoker.db" OUTPUT_DIR="$HOME_ROOT/outputs" CONFIG_PATH="$CONFIG_PATH" node -e "const fs = require('node:fs'); (async () => { const { SQLiteAdapter } = await import('./packages/data-store/dist/index.js'); const db = await SQLiteAdapter.create(process.env.DB_PATH, { ownerCapability: true, outputDir: process.env.OUTPUT_DIR }); const now = new Date().toISOString(); db.saveWorkflow({ id: 'wf-1', name: 'Autoapprove smoke', onFinish: 'none', createdAt: now, updatedAt: now }); db.saveTask('wf-1', { id: 'wf-1/task-1', description: 'Awaiting AI fix approval', status: 'awaiting_approval', dependencies: [], createdAt: new Date(now), config: { workflowId: 'wf-1' }, execution: { pendingFixError: 'boom', generation: 1, selectedAttemptId: 'attempt-1' }, taskStateVersion: 4 }); db.close(); fs.writeFileSync(process.env.CONFIG_PATH, JSON.stringify({ autoApproveAIFixes: true })); })().catch((err) => { console.error(err); process.exit(1); });" && INVOKER_HEADLESS_STANDALONE=1 INVOKER_DB_DIR="$HOME_ROOT" INVOKER_REPO_CONFIG_PATH="$CONFIG_PATH" ./run.sh --headless worker autoapprove && DB_PATH="$HOME_ROOT/invoker.db" OUTPUT_DIR="$HOME_ROOT/outputs" node -e "(async () => { const { SQLiteAdapter } = await import('./packages/data-store/dist/index.js'); const db = await SQLiteAdapter.create(process.env.DB_PATH, { ownerCapability: true, outputDir: process.env.OUTPUT_DIR }); const intents = db.listWorkflowMutationIntents('wf-1'); const match = intents.find((intent) => intent.channel === 'invoker:approve' && intent.args[0] === 'wf-1/task-1' && intent.status === 'queued'); console.log(JSON.stringify({ intents })); db.close(); if (!match) process.exit(1); })().catch((err) => { console.error(err); process.exit(1); });"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 33423a3`
- Post-revert steps: None
- Data migration? No

Depends-On: #3254