### PR TITLE
Prove the planning conversation renders in the terminal e2e

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -576,9 +576,13 @@ test.describe('Visual proof capture', () => {
 
   test('terminal planning loads graph', async ({ page }) => {
     const plannedYaml = yamlStringify(TERMINAL_PLANNED_PLAN);
-    await page.evaluate(async ({ planYaml, planName }) => {
-      await window.invoker.setTestPlanningChatResponse({ planYaml, planName, reply: 'I drafted the plan.' });
-    }, { planYaml: plannedYaml, planName: 'Terminal Planned Flow' });
+    // Mirror the real planner reply shape: prose followed by the full fenced
+    // plan YAML. The transcript must render every line of it untruncated
+    // (regression: planning terminal plan truncation).
+    const fullPlanReply = `I drafted the plan.\n\n\`\`\`yaml\n${plannedYaml}\`\`\``;
+    await page.evaluate(async ({ planYaml, planName, reply }) => {
+      await window.invoker.setTestPlanningChatResponse({ planYaml, planName, reply });
+    }, { planYaml: plannedYaml, planName: 'Terminal Planned Flow', reply: fullPlanReply });
 
     await page.getByTestId('sidebar-planning').click();
     await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-16/);
@@ -586,6 +590,37 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByRole('heading', { name: 'Planning Terminal' })).toBeVisible();
     await page.getByTestId('invoker-terminal-input').fill('Add README');
     await page.getByRole('button', { name: 'Send' }).click();
+
+    // The conversation renders in the terminal transcript: the user message,
+    // the assistant prose, and the drafted plan YAML from first to last line.
+    const transcript = page.getByTestId('invoker-terminal-transcript');
+    await expect(transcript).toContainText('Add README');
+    await expect(transcript).toContainText('I drafted the plan.');
+    await expect(transcript).toContainText('name: Terminal Planned Flow');
+    await expect(transcript).toContainText('sleep 5 && echo hello-alpha');
+    await expect(transcript).toContainText('sleep 2 && echo hello-gamma');
+
+    await captureScreenshot(page, 'terminal-planned-conversation');
+
+    // Expand the chat and scroll the transcript to the very end: the last
+    // YAML line must be reachable, proving nothing was cut off.
+    await page.getByRole('button', { name: 'Expand planning chat' }).click();
+    await expect(page.getByTestId('invoker-terminal-expanded')).toBeVisible();
+    const expandedTranscript = page
+      .getByTestId('invoker-terminal-expanded')
+      .getByTestId('invoker-terminal-transcript');
+    const scrollGap = await expandedTranscript.evaluate((el) => {
+      el.scrollTop = el.scrollHeight;
+      return el.scrollHeight - el.scrollTop - el.clientHeight;
+    });
+    expect(scrollGap).toBeLessThanOrEqual(1);
+    const tailText = await expandedTranscript.evaluate((el) => el.textContent ?? '');
+    expect(tailText.trimEnd().endsWith('```')).toBe(true);
+    expect(tailText).toContain('command: echo B');
+    await captureScreenshot(page, 'terminal-planned-conversation-end');
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('invoker-terminal-expanded')).toHaveCount(0);
+
     await expect(page.getByTestId('invoker-terminal-ready-bar')).toBeVisible();
     await page.getByRole('button', { name: 'Submit to Invoker' }).click();
 
@@ -594,6 +629,14 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByTestId('workflow-inspector-title')).toContainText('Terminal Planned Flow');
     await expect(page.getByText('What to expect')).toHaveCount(0);
     await captureScreenshot(page, 'terminal-planned-graph');
+
+    // Returning to the Planning Terminal keeps the full conversation:
+    // submitting must not clear or truncate the transcript.
+    await page.getByTestId('sidebar-planning').click();
+    await expect(transcript).toContainText('Add README');
+    await expect(transcript).toContainText('sleep 2 && echo hello-gamma');
+    await expect(transcript).toContainText('Plan "Terminal Planned Flow" submitted to Invoker. Review it, then Run.');
+    await captureScreenshot(page, 'terminal-planned-conversation-after-submit');
 
     await page.evaluate(async () => {
       await window.invoker.setTestPlanningChatResponse(null);


### PR DESCRIPTION
## Summary

The terminal-planning e2e now proves the planning conversation renders in the terminal window UI.

The mocked planner reply mirrors a real one: prose followed by the full fenced plan YAML.

After Send, the test asserts the transcript shows the user message, the assistant prose, and the plan YAML from its first line to its final task line.

The test then expands the chat, scrolls the transcript to the very end, and asserts the scroll actually reached the bottom and the text ends with the closing YAML fence.

After Submit, the test returns to the Planning Terminal and asserts the full conversation is still there, along with the submitted confirmation.

The test also captures the conversation state as visual-proof screenshots. Capture stays a no-op outside `CAPTURE_MODE` runs.

<details>
<summary>Review metadata</summary>

Review Claim: Approve e2e coverage proving the planning terminal renders the full mocked conversation, untruncated, before and after submit.

Review Lane: proof

Review Unit: proof

Safety Invariant: This slice changes one e2e spec file only. It changes no product code, so it reads safely on its own.

Slice Rationale: The unit tests from #3180 cover transcript rendering in jsdom only. This closes the remaining gap at the Electron e2e layer without touching product code.

</details>

## Non-goals

- No product code changes; the truncation fix shipped in #3179.
- No coverage of the in-app planner reply path; the e2e mock bypasses `in-app-planner.ts`, which stays covered by its unit test.
- No new screenshot baselines for `toHaveScreenshot` comparisons.

## Test Plan

- [ ] `cd packages/app && pnpm run test:e2e e2e/visual-proof.spec.ts --grep "terminal planning loads graph"`

## Visual Proof

Conversation rendered in the Planning Terminal before submit (user message, assistant prose, plan YAML head in the scrollable transcript):

![terminal-planned-conversation](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-db6cdd/terminal-planned-conversation.png)

Expanded chat scrolled to the very end of the transcript: the last YAML lines (task-gamma, both experiment variants) and the closing fence are rendered, so nothing was cut off:

![terminal-planned-conversation-end](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-db6cdd/terminal-planned-conversation-end.png)

Conversation kept after submit (session marked Submitted, transcript intact):

![terminal-planned-conversation-after-submit](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-db6cdd/terminal-planned-conversation-after-submit.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
