### PR TITLE
[make-pr] Tighten visual proof publishing

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -28,7 +28,8 @@
  *
  * PR body validation:
  *   Enforces the canonical PR schema:
- *   ## Summary with collapsed Review metadata, ## Non-goals,
+ *   ## Summary, ## Review Claim, ## Review Lane, ## Review Unit,
+ *   ## Safety Invariant, ## Slice Rationale, ## Non-goals,
  *   ## Test Plan, ## Revert Plan, plus optional ## Architecture
  *   and required ## Visual Proof for UI changes.
  */
@@ -152,9 +153,10 @@ Stack flow:
   3. Run \`node scripts/create-pr.mjs --title "[Graph Blanking](3a) <slice title>" --base <branch> --body-file <file> --update-existing\`
 
 PR body schema:
-  Required: ## Summary with collapsed Review metadata, ## Non-goals, ## Test Plan, ## Revert Plan
+  Required: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
   Optional: ## Architecture (must include ### Before and ### After when present)
   UI-impacting diffs require ## Visual Proof with screenshot or video proof.
+  Animated proof is required for restarts and multi-state transitions.
   Template: scripts/pr-body-template.md`);
   process.exit(1);
 }
@@ -268,15 +270,23 @@ async function injectImages(body, dryRun) {
   if (localFiles.length === 0) return body;
 
   const r2Config = loadR2Config();
+  const urlMap = new Map();
   if (!r2Config && !dryRun) {
-    console.error('Warning: R2 config not found. Local image paths will not be replaced.');
-    console.error('Set imageStorage in ~/.invoker/config.json or export R2_* env vars.');
-    return body;
+    const nwo = getRepoNwo();
+    const branch = getCurrentBranch();
+    for (const filePath of localFiles) {
+      if (!isTrackedFile(filePath)) continue;
+      urlMap.set(filePath, buildGitHubRawMediaUrl(nwo, branch, filePath));
+    }
+    if (urlMap.size === 0) {
+      console.error('Warning: R2 config not found and local media files are not tracked. Visual proof URLs will not be replaced.');
+      console.error('Set imageStorage in ~/.invoker/config.json, export R2_* env vars, or commit the proof assets first.');
+      return body;
+    }
+    console.error('Warning: R2 config not found. Falling back to GitHub raw URLs for tracked proof assets.');
   }
 
   const prefix = generatePrefix();
-  const urlMap = new Map();
-
   for (const filePath of localFiles) {
     if (urlMap.has(filePath)) continue;
     const name = basename(filePath);
@@ -285,7 +295,7 @@ async function injectImages(body, dryRun) {
     if (dryRun) {
       urlMap.set(filePath, `https://DRY-RUN/${key}`);
       console.error(`[dry-run] Would upload: ${filePath} → ${key}`);
-    } else {
+    } else if (r2Config) {
       try {
         const publicUrl = await uploadToR2(filePath, key, r2Config);
         urlMap.set(filePath, publicUrl);
@@ -300,6 +310,20 @@ async function injectImages(body, dryRun) {
     const replacement = urlMap.get(url);
     return replacement ? `${bracket}(${replacement})` : full;
   });
+}
+
+function isTrackedFile(filePath) {
+  try {
+    runGit(['ls-files', '--error-unmatch', filePath], { stdio: ['ignore', 'ignore', 'ignore'] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function buildGitHubRawMediaUrl(nwo, branch, filePath) {
+  const normalizedPath = filePath.replace(/\\/g, '/').replace(/^\.\/+/, '');
+  return `https://github.com/${nwo}/blob/${branch}/${normalizedPath}?raw=1`;
 }
 
 // ── Git + GitHub helpers ────────────────────────────────────────────────────

--- a/scripts/fixtures/pr-body-mermaid-reviewgate-quoted.md
+++ b/scripts/fixtures/pr-body-mermaid-reviewgate-quoted.md
@@ -2,30 +2,25 @@
 
 Tighten Mermaid validation.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 Quoted Mermaid labels with code-ish text still pass local PR-body validation.
 
-Review Lane:
+## Review Lane
 
 - policy
 
-Review Unit:
+## Review Unit
 
 - tooling-policy
 
-Safety Invariant:
+## Safety Invariant
 
 Only the local PR-body guardrail changes.
 
-Slice Rationale:
+## Slice Rationale
 
 The validator hardening lands separately from other PR workflow edits.
-
-</details>
 
 ## Non-goals
 

--- a/scripts/fixtures/pr-body-mermaid-reviewgate-unquoted.md
+++ b/scripts/fixtures/pr-body-mermaid-reviewgate-unquoted.md
@@ -2,30 +2,25 @@
 
 Tighten Mermaid validation.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 Bad Mermaid labels now fail local PR-body validation.
 
-Review Lane:
+## Review Lane
 
 - policy
 
-Review Unit:
+## Review Unit
 
 - tooling-policy
 
-Safety Invariant:
+## Safety Invariant
 
 Only the local PR-body guardrail changes.
 
-Slice Rationale:
+## Slice Rationale
 
 The validator hardening lands separately from other PR workflow edits.
-
-</details>
 
 ## Non-goals
 

--- a/scripts/pr-body-template.md
+++ b/scripts/pr-body-template.md
@@ -5,21 +5,25 @@ Describe what changed and why in plain English.
 Write paragraphs, not bullets. Keep each paragraph under 30 words.
 
 Put one idea in each paragraph. If one idea leads to another, split them into separate short paragraphs.
+## Review Claim
 
-<details>
-<summary>Review metadata</summary>
+State the one thing the reviewer is being asked to approve.
 
-Review Claim: State the one thing the reviewer is being asked to approve.
+## Review Lane
 
-Review Lane: Choose exactly one: `behavior`, `refactor`, `proof`, `cleanup`, `policy`, or `docs`.
+Choose exactly one: `behavior`, `refactor`, `proof`, `cleanup`, `policy`, or `docs`.
 
-Review Unit: Choose the matching review unit, such as `tooling-policy`, `routing`, or `docs`.
+## Review Unit
 
-Safety Invariant: Explain why this slice is safe to review locally.
+Choose the matching review unit, such as `tooling-policy`, `routing`, or `docs`.
 
-Slice Rationale: Explain why this work is split here instead of bundled elsewhere.
+## Safety Invariant
 
-</details>
+Explain why this slice is safe to review locally.
+
+## Slice Rationale
+
+Explain why this work is split here instead of bundled elsewhere.
 
 ## Non-goals
 

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -273,6 +273,7 @@ export function classifyReviewUnitsForPath(filePath) {
     path === 'scripts/pr-body-template.md'
     || path === 'scripts/test-create-pr-visual-proof.mjs'
   ) return ['tooling-policy'];
+  if (path.startsWith('packages/app/e2e/visual-proof/')) return ['activation-surface'];
   if (/(benchmark|performance|visual-proof)/.test(lowerPath)) return ['proof'];
   if (path === 'skills/make-pr/SKILL.md') return ['tooling-policy'];
   if (path.startsWith('docs/') || path.startsWith('skills/') || path.endsWith('.md')) return ['docs'];

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -14,30 +14,25 @@ const VALID_BODY = `## Summary
 
 This branch updates the PR workflow.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 Keep stack publication on the supported path.
 
-Review Lane:
+## Review Lane
 
 - policy
 
-Review Unit:
+## Review Unit
 
 - tooling-policy
 
-Safety Invariant:
+## Safety Invariant
 
 Only PR workflow tooling changes.
 
-Slice Rationale:
+## Slice Rationale
 
 Stack publishing stays separate from unrelated cleanup.
-
-</details>
 
 ## Non-goals
 
@@ -59,30 +54,25 @@ const ROUTING_BODY = `## Summary
 
 This branch only changes invalidation routing.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 Keep invalidation routing local.
 
-Review Lane:
+## Review Lane
 
 - behavior
 
-Review Unit:
+## Review Unit
 
 - routing
 
-Safety Invariant:
+## Safety Invariant
 
 Only invalidation routing changes.
 
-Slice Rationale:
+## Slice Rationale
 
 Keep app exposure separate from core runtime behavior.
-
-</details>
 
 ## Non-goals
 

--- a/scripts/test-create-pr-visual-proof.mjs
+++ b/scripts/test-create-pr-visual-proof.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { getUiImpactingFiles, isUiImpactingPath } from './create-pr.mjs';
+import { buildGitHubRawMediaUrl, getUiImpactingFiles, isUiImpactingPath } from './create-pr.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -25,4 +25,10 @@ assert(uiFiles.length === 2, 'only UI-impacting files should be returned');
 assert(uiFiles.includes('packages/ui/src/components/TaskPanel.tsx'), 'UI component file should be returned');
 assert(uiFiles.includes('packages/app/src/window/window-lifecycle.ts'), 'window file should be returned');
 
+
+assert(
+  buildGitHubRawMediaUrl('owner/repo', 'stack/example/proof', 'packages/app/e2e/visual-proof/after/demo.gif')
+    === 'https://github.com/owner/repo/blob/stack/example/proof/packages/app/e2e/visual-proof/after/demo.gif?raw=1',
+  'tracked proof assets should fall back to GitHub raw URLs when R2 upload is unavailable',
+);
 console.log('OK: create-pr visual proof checks passed');

--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -55,10 +55,17 @@ must_contain "$SKILL_MD" "open every screenshot or video and verify the user-vis
 must_contain "$SKILL_MD" "For conditional or event-driven UI, drive the exact condition that triggers the new state" "make-pr visual proof must cover conditional UI states"
 must_contain "$SKILL_MD" "A generic task panel, unchanged sidebar, unrelated graph, or stale screenshot is not proof" "make-pr visual proof must reject generic task-panel screenshots"
 must_contain "$SKILL_MD" "caption each visual proof item with the concrete thing the reviewer should see" "make-pr visual proof captions must name the visible target"
+
+must_contain "$SKILL_MD" "Use visible markdown sections for review metadata" "make-pr skill must require visible review metadata sections"
+must_contain "$SKILL_MD" "Do not hide" "make-pr skill must forbid details-wrapped review metadata"
 must_contain "$SKILL_MD" "Before/after visual proof images must use distinct local filenames" "make-pr visual proof must prevent before/after basename upload collisions"
 must_contain "$SKILL_MD" 'The uploader keys media by basename inside one upload prefix' "make-pr visual proof must explain why duplicate basenames are unsafe"
 must_contain "$SKILL_MD" "cursor, pointer, hover-only affordance" "make-pr visual proof must call out states static screenshots cannot show"
 must_contain "$SKILL_MD" "do not present an unchanged screenshot as proof of the behavior" "make-pr visual proof must reject unchanged screenshots for cursor-like behavior"
+
+must_contain "$SKILL_MD" "If the changed behavior spans multiple states or a state transition" "make-pr skill must call out restart and transition proof"
+must_contain "$SKILL_MD" "A gif, mp4, webm, or walkthrough video is required" "make-pr skill must require animated proof for restart or multi-state behavior"
+must_contain "$SKILL_MD" "must not leave repo-relative proof paths in markdown" "make-pr skill must forbid broken repo-relative proof links in published PRs"
 
 # The publication checklist must stop empty PR slices before create/update/stack publish.
 must_contain "$SKILL_MD" "has no file changes against its selected base" "make-pr skill must reject branches with no reviewable file diff"

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -27,30 +27,25 @@ const validMinimal = `## Summary
 
 Small fix.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 Keep the owner fallback local.
 
-Review Lane:
+## Review Lane
 
 - behavior
 
-Review Unit:
+## Review Unit
 
 - routing
 
-Safety Invariant:
+## Safety Invariant
 
 Only the refresh path changes.
 
-Slice Rationale:
+## Slice Rationale
 
 Proof and cleanup stay separate.
-
-</details>
 
 ## Non-goals
 
@@ -72,30 +67,25 @@ const validArchitecture = `## Summary
 
 Flow change.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 Route refresh through one helper.
 
-Review Lane:
+## Review Lane
 
 - behavior
 
-Review Unit:
+## Review Unit
 
 - routing
 
-Safety Invariant:
+## Safety Invariant
 
 The same callers keep the same contract.
 
-Slice Rationale:
+## Slice Rationale
 
 Move behavior without mixing cleanup.
-
-</details>
 
 ## Non-goals
 
@@ -169,96 +159,16 @@ assert((await validatePrBody(validMinimal)).length === 0, 'valid minimal body sh
 assert((await validatePrBody(validArchitecture)).length === 0, 'valid architecture body should pass');
 assert(getPrBodyWarnings(validMinimal).length === 0, 'short summary should produce no warnings');
 
-const visibleMetadataErrors = await validatePrBody(`## Summary
+const hiddenMetadataErrors = await validatePrBody(`## Summary
 
 Small fix.
 
-## Review Claim
-
-Keep visible metadata out of the main PR body.
-
-## Non-goals
-
-- No docs.
-
-## Test Plan
-
-- [ ] \`pnpm test\`
-
-## Revert Plan
-
-- Safe to revert? Yes
-- Revert command: \`git revert <sha>\`
-- Post-revert steps: None
-- Data migration? No
-`);
-assert(
-  visibleMetadataErrors.some((error) => error.includes('belongs in the collapsed Review metadata block')),
-  'visible review metadata headings should fail',
-);
-
-const openMetadataErrors = await validatePrBody(validMinimal.replace('<details>', '<details open>'));
-assert(
-  openMetadataErrors.some((error) => error.includes('collapsed by default')),
-  'review metadata should stay collapsed by default',
-);
-
-const lightweightErrors = await validatePrBody(lightweight);
-assert(lightweightErrors.some((error) => error.includes('Unsupported section: ## Testing')), 'lightweight format should reject ## Testing');
-assert(lightweightErrors.some((error) => error.includes('Unsupported section: ## Notes')), 'lightweight format should reject ## Notes');
-
-const missingTestPlanErrors = await validatePrBody(`## Summary
-
-Only summary.
-
 <details>
 <summary>Review metadata</summary>
 
 Review Claim:
 
-One claim.
-
-Review Lane:
-
-- behavior
-
-Review Unit:
-
-- validation-policy
-
-Safety Invariant:
-
-Local only.
-
-Slice Rationale:
-
-Small slice.
-
-</details>
-
-## Non-goals
-
-- No docs.
-
-## Revert Plan
-
-- Safe to revert? Yes
-- Revert command: \`git revert <sha>\`
-- Post-revert steps: None
-- Data migration? No
-`);
-assert(missingTestPlanErrors.some((error) => error.includes('Missing required section: ## Test Plan')), 'missing test plan should fail');
-
-const malformedArchitectureErrors = await validatePrBody(`## Summary
-
-Flow change.
-
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
-
-One claim.
+Keep hidden metadata out of the main PR body.
 
 Review Lane:
 
@@ -277,6 +187,121 @@ Slice Rationale:
 Small slice.
 
 </details>
+
+## Non-goals
+
+- No docs.
+
+## Test Plan
+
+- [ ] \`pnpm test\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`);
+assert(
+  hiddenMetadataErrors.some((error) => error.includes('Do not hide review metadata in <details>')),
+  'details-wrapped review metadata should fail',
+);
+
+const restartStillProofErrors = await validatePrBody(`${validMinimal}
+
+## Visual Proof
+
+Before — base branch after restart loses the saved chat.
+
+![Before](proof-before.png)
+
+After — this branch restores the saved chat after restart.
+
+![After](proof-after.png)
+`, { requiresVisualProof: true });
+assert(
+  restartStillProofErrors.some((error) => error.includes('must include animated media')),
+  'restart proof with only static screenshots should fail',
+);
+
+const restartAnimatedProofErrors = await validatePrBody(`${validMinimal}
+
+## Visual Proof
+
+Animated restart proof showing the drafted chat, app relaunch, and restored chat.
+
+![Restart walkthrough](proof-restart.gif)
+`, { requiresVisualProof: true });
+assert(
+  restartAnimatedProofErrors.length === 0,
+  'restart proof with gif should pass',
+);
+
+const lightweightErrors = await validatePrBody(lightweight);
+assert(lightweightErrors.some((error) => error.includes('Unsupported section: ## Testing')), 'lightweight format should reject ## Testing');
+assert(lightweightErrors.some((error) => error.includes('Unsupported section: ## Notes')), 'lightweight format should reject ## Notes');
+
+const missingTestPlanErrors = await validatePrBody(`## Summary
+
+Only summary.
+
+## Review Claim
+
+One claim.
+
+## Review Lane
+
+- behavior
+
+## Review Unit
+
+- validation-policy
+
+## Safety Invariant
+
+Local only.
+
+## Slice Rationale
+
+Small slice.
+
+## Non-goals
+
+- No docs.
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`);
+assert(missingTestPlanErrors.some((error) => error.includes('Missing required section: ## Test Plan')), 'missing test plan should fail');
+
+const malformedArchitectureErrors = await validatePrBody(`## Summary
+
+Flow change.
+
+## Review Claim
+
+One claim.
+
+## Review Lane
+
+- behavior
+
+## Review Unit
+
+- routing
+
+## Safety Invariant
+
+Local only.
+
+## Slice Rationale
+
+Small slice.
 
 ## Non-goals
 
@@ -308,26 +333,21 @@ const missingReviewLaneErrors = await validatePrBody(`## Summary
 
 Small fix.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 One claim.
 
-Review Unit:
+## Review Unit
 
 - routing
 
-Safety Invariant:
+## Safety Invariant
 
 Local only.
 
-Slice Rationale:
+## Slice Rationale
 
 Small slice.
-
-</details>
 
 ## Non-goals
 
@@ -344,7 +364,7 @@ Small slice.
 - Post-revert steps: None
 - Data migration? No
 `);
-assert(missingReviewLaneErrors.some((error) => error.includes('Review metadata is missing required field: Review Lane:')), 'missing review lane should fail');
+assert(missingReviewLaneErrors.some((error) => error.includes('Missing required section: ## Review Lane')), 'missing review lane should fail');
 
 const invalidReviewLaneErrors = await validatePrBody(validMinimal.replace('- behavior', '- impossible'));
 assert(invalidReviewLaneErrors.some((error) => error.includes('Invalid review lane: impossible')), 'invalid review lane should fail');
@@ -355,30 +375,25 @@ This adds the dormant auto-fix recovery policy.
 
 It scans persisted failed tasks, validates retry and stale-state eligibility, suppresses duplicate open fix intents, and submits fix-with-agent mutation intents.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 Auto-fix recovery can scan persisted failed tasks and enqueue the normal fix intent without a CLI surface.
 
-Review Lane:
+## Review Lane
 
 - behavior
 
-Review Unit:
+## Review Unit
 
 - validation-policy
 
-Safety Invariant:
+## Safety Invariant
 
 The policy only submits through the existing mutation route and skips stale or already queued candidates.
 
-Slice Rationale:
+## Slice Rationale
 
 Durable-state scan behavior is reviewable separately from lifecycle wakeup routing and CLI activation.
-
-</details>
 
 ## Non-goals
 
@@ -407,30 +422,25 @@ This moves the recovery worker out of the generic runtime.
 
 It scans persisted failed tasks, validates candidates, submits fix intents, routes lifecycle wakeups, and exposes the headless worker command.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 The recovery worker owns auto-fix recovery end to end.
 
-Review Lane:
+## Review Lane
 
 - behavior
 
-Review Unit:
+## Review Unit
 
 - validation-policy
 
-Safety Invariant:
+## Safety Invariant
 
 Every submitted fix still goes through the existing mutation route.
 
-Slice Rationale:
+## Slice Rationale
 
 The complete auto-fix recovery path lands together for one rollout.
-
-</details>
 
 ## Non-goals
 
@@ -457,30 +467,25 @@ const longSummary = `## Summary
 
 This summary paragraph uses too many words because it tries to explain several related implementation details at the same time instead of giving a tired reviewer one clear idea they can understand immediately.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 One claim.
 
-Review Lane:
+## Review Lane
 
 - behavior
 
-Review Unit:
+## Review Unit
 
 - routing
 
-Safety Invariant:
+## Safety Invariant
 
 Local only.
 
-Slice Rationale:
+## Slice Rationale
 
 Small slice.
-
-</details>
 
 ## Non-goals
 
@@ -512,13 +517,13 @@ const validVisualProof = `${validMinimal}
 
 ## Visual Proof
 
-| Before | After |
-|--------|-------|
-| ![before](before.png) | ![after](after.png) |
+Restored chat with the draft-ready bar visible.
+
+![restored chat](restored-chat.png)
 `;
 assert(
   (await validatePrBody(validVisualProof, { requiresVisualProof: true })).length === 0,
-  'visual proof with screenshots should satisfy UI proof requirement',
+  'single-state screenshot proof should satisfy UI proof requirement',
 );
 
 const warningOnlyVisualProofErrors = await validatePrBody(`${validMinimal}
@@ -591,30 +596,25 @@ const refactorBody = `## Summary
 
 Route code first.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 Move refresh routing without changing behavior.
 
-Review Lane:
+## Review Lane
 
 - refactor
 
-Review Unit:
+## Review Unit
 
 - routing
 
-Safety Invariant:
+## Safety Invariant
 
 Behavior stays unchanged.
 
-Slice Rationale:
+## Slice Rationale
 
 Field additions land in a later behavior PR.
-
-</details>
 
 ## Non-goals
 
@@ -661,30 +661,25 @@ const old1756MixedRuntimeBody = `## Summary
 
 Publish review gate artifacts and approve merge tasks from review polling.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 External review publication and approval polling both use the same review gate state.
 
-Review Lane:
+## Review Lane
 
 - behavior
 
-Review Unit:
+## Review Unit
 
 - routing
 
-Safety Invariant:
+## Safety Invariant
 
 The merge task still waits for required review gates.
 
-Slice Rationale:
+## Slice Rationale
 
 Publication and polling landed together around the same review gate contract.
-
-</details>
 
 ## Non-goals
 
@@ -715,30 +710,25 @@ const validationPolicyBody = `## Summary
 
 Validate stale recovery candidates.
 
-<details>
-<summary>Review metadata</summary>
-
-Review Claim:
+## Review Claim
 
 Reject stale auto-fix recovery candidates before submission.
 
-Review Lane:
+## Review Lane
 
 - behavior
 
-Review Unit:
+## Review Unit
 
 - validation-policy
 
-Safety Invariant:
+## Safety Invariant
 
 The slice returns validated candidates only.
 
-Slice Rationale:
+## Slice Rationale
 
 Validation policy stays separate from command submission.
-
-</details>
 
 ## Non-goals
 

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -22,7 +22,7 @@ const REQUIRED_SECTIONS = [
   '## Test Plan',
   '## Revert Plan',
 ];
-const VISIBLE_METADATA_SECTIONS = [
+const REQUIRED_METADATA_SECTIONS = [
   '## Review Claim',
   '## Review Lane',
   '## Review Unit',
@@ -136,38 +136,72 @@ function countWords(text) {
     .filter(Boolean).length;
 }
 
+function getVisualProofBody(body) {
+  return getSectionBody(body, '## Visual Proof');
+}
+
 function hasVisualProofMedia(body) {
-  const visualProof = getSectionBody(body, '## Visual Proof');
+  const visualProof = getVisualProofBody(body);
   if (!visualProof) return false;
 
   return /!\[[^\]]*\]\([^)]+\)/.test(visualProof)
-    || /\[[^\]]*(?:video|walkthrough|recording)[^\]]*\]\([^)]+\)/i.test(visualProof)
+    || /\[[^\]]*(?:video|walkthrough|recording|animation|gif)[^\]]*\]\([^)]+\)/i.test(visualProof)
     || /\bhttps?:\/\/\S+\.(?:png|jpe?g|gif|webp|webm|mp4)\b/i.test(visualProof);
 }
 
-function normalizeSectionValue(sectionBody) {
-  return normalizeReviewUnit(sectionBody);
+function hasAnimatedVisualProofMedia(body) {
+  const visualProof = getVisualProofBody(body);
+  if (!visualProof) return false;
+
+  return /!\[[^\]]*\]\([^)]+\.(?:gif|webm|mp4)(?:\?[^)]*)?\)/i.test(visualProof)
+    || /\[[^\]]*(?:video|walkthrough|recording|animation|gif)[^\]]*\]\([^)]+\)/i.test(visualProof)
+    || /\bhttps?:\/\/\S+\.(?:gif|webm|mp4)\b/i.test(visualProof);
 }
 
-function getReviewMetadataBlock(body) {
+function visualProofNeedsAnimation(body) {
+  const visualProof = getVisualProofBody(body);
+  if (!visualProof) return false;
+
+  return (
+    /\brestart|relaunch|reload\b/i.test(visualProof)
+    || /\btransition|state change\b/i.test(visualProof)
+    || (/\bbefore\b/i.test(visualProof) && /\bafter\b/i.test(visualProof))
+  );
+}
+
+function getLegacyReviewMetadataBlock(body) {
   const summary = getSectionBody(body, '## Summary');
   const match = summary.match(/<details\b([^>]*)>\s*<summary>\s*Review metadata\s*<\/summary>([\s\S]*?)<\/details>/i);
   if (!match) return { body: '', openAttributes: '' };
   return { body: match[2].trim(), openAttributes: match[1] };
 }
 
-function getReviewMetadataValue(metadata, label) {
-  return getLabelSection(metadata, label);
+function hasVisibleReviewMetadata(body) {
+  return REQUIRED_METADATA_SECTIONS.some((heading) => getSectionBody(body, heading));
+}
+
+function normalizeSectionValue(sectionBody) {
+  return normalizeReviewUnit(sectionBody);
 }
 
 export function getReviewMetadata(body) {
-  const block = getReviewMetadataBlock(body);
+  if (hasVisibleReviewMetadata(body)) {
+    return {
+      reviewClaim: getSectionBody(body, '## Review Claim'),
+      reviewLane: normalizeSectionValue(getSectionBody(body, '## Review Lane')),
+      reviewUnit: normalizeReviewUnit(getSectionBody(body, '## Review Unit')),
+      safetyInvariant: getSectionBody(body, '## Safety Invariant'),
+      sliceRationale: getSectionBody(body, '## Slice Rationale'),
+    };
+  }
+
+  const legacy = getLegacyReviewMetadataBlock(body);
   return {
-    reviewClaim: getReviewMetadataValue(block.body, 'Review Claim'),
-    reviewLane: normalizeSectionValue(getReviewMetadataValue(block.body, 'Review Lane')),
-    reviewUnit: normalizeReviewUnit(getReviewMetadataValue(block.body, 'Review Unit')),
-    safetyInvariant: getReviewMetadataValue(block.body, 'Safety Invariant'),
-    sliceRationale: getReviewMetadataValue(block.body, 'Slice Rationale'),
+    reviewClaim: getLabelSection(legacy.body, 'Review Claim'),
+    reviewLane: normalizeSectionValue(getLabelSection(legacy.body, 'Review Lane')),
+    reviewUnit: normalizeReviewUnit(getLabelSection(legacy.body, 'Review Unit')),
+    safetyInvariant: getLabelSection(legacy.body, 'Safety Invariant'),
+    sliceRationale: getLabelSection(legacy.body, 'Slice Rationale'),
   };
 }
 
@@ -179,6 +213,7 @@ function classifyScopeKind(filePath) {
   const path = filePath.replace(/\\/g, '/');
 
   if (path.startsWith('scripts/repro/')) return 'proof';
+  if (path.startsWith('packages/app/e2e/visual-proof/')) return 'product-test';
   if (path.startsWith('skills/') || path.startsWith('docs/') || path.endsWith('.md')) return 'docs';
   if (path.startsWith('scripts/')) return 'policy';
   if (
@@ -186,10 +221,10 @@ function classifyScopeKind(filePath) {
     || path.includes('/__tests__/')
     || /\.(spec|test)\.[jt]sx?$/.test(path)
   ) {
-    if (/(benchmark|performance|visual-proof)/.test(path)) return 'proof';
+    if (/(benchmark|performance)/.test(path)) return 'proof';
     return 'product-test';
   }
-  if (/(benchmark|performance|visual-proof)/.test(path)) return 'proof';
+  if (/(benchmark|performance)/.test(path)) return 'proof';
   if (path.startsWith('packages/')) return 'product';
   return 'other';
 }
@@ -290,21 +325,15 @@ export function getPrBodyWarnings(body, options = {}) {
 export async function validatePrBody(body, options = {}) {
   const errors = [];
   const trimmed = body.trim();
-
   if (!trimmed) {
     return [
-      'PR body is empty. Use the canonical schema: ## Summary with a collapsed Review metadata block, ## Non-goals, ## Test Plan, and ## Revert Plan.',
+      'PR body is empty. Use the canonical schema: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, and ## Revert Plan.',
     ];
   }
 
   for (const heading of REQUIRED_SECTIONS) {
     if (!trimmed.includes(heading)) {
       errors.push(`Missing required section: ${heading}`);
-    }
-  }
-  for (const heading of VISIBLE_METADATA_SECTIONS) {
-    if (trimmed.includes(heading)) {
-      errors.push(`${heading} belongs in the collapsed Review metadata block inside ## Summary, not as a visible top-level section.`);
     }
   }
 
@@ -324,25 +353,39 @@ export async function validatePrBody(body, options = {}) {
     }
   }
 
-  const reviewMetadata = getReviewMetadataBlock(trimmed);
-  if (!reviewMetadata.body) {
-    errors.push('## Summary must include a collapsed <details> block with <summary>Review metadata</summary>.');
-  } else if (/\bopen\b/i.test(reviewMetadata.openAttributes)) {
-    errors.push('Review metadata details must be collapsed by default; remove the open attribute.');
+  const legacyReviewMetadata = getLegacyReviewMetadataBlock(trimmed);
+  const reviewMetadataFromVisibleSections = hasVisibleReviewMetadata(trimmed);
+  if (legacyReviewMetadata.body && !reviewMetadataFromVisibleSections) {
+    errors.push('Do not hide review metadata in <details>. Use visible ## Review Claim / ## Review Lane / ## Review Unit / ## Safety Invariant / ## Slice Rationale sections.');
   }
 
-  for (const label of REQUIRED_METADATA_LABELS) {
-    if (!getReviewMetadataValue(reviewMetadata.body, label)) {
-      errors.push(`Review metadata is missing required field: ${label}:`);
+  const reviewMetadata = getReviewMetadata(trimmed);
+  const reviewClaim = reviewMetadata.reviewClaim;
+  const reviewLane = reviewMetadata.reviewLane;
+  const reviewUnit = reviewMetadata.reviewUnit;
+  const safetyInvariant = reviewMetadata.safetyInvariant;
+  const sliceRationale = reviewMetadata.sliceRationale;
+
+  if (reviewMetadataFromVisibleSections) {
+    for (const heading of REQUIRED_METADATA_SECTIONS) {
+      if (!getSectionBody(trimmed, heading)) {
+        errors.push(`Missing required section: ${heading}`);
+      }
+    }
+  } else if (!legacyReviewMetadata.body) {
+    errors.push('Missing review metadata. Add visible ## Review Claim / ## Review Lane / ## Review Unit / ## Safety Invariant / ## Slice Rationale sections.');
+  } else {
+    for (const label of REQUIRED_METADATA_LABELS) {
+      if (!getLabelSection(legacyReviewMetadata.body, label)) {
+        errors.push(`Review metadata is missing required field: ${label}:`);
+      }
     }
   }
 
-  const reviewLane = normalizeSectionValue(getReviewMetadataValue(reviewMetadata.body, 'Review Lane'));
   if (reviewLane && !VALID_REVIEW_LANES.has(reviewLane)) {
     errors.push(`Invalid review lane: ${reviewLane}. Expected one of ${Array.from(VALID_REVIEW_LANES).join(', ')}.`);
   }
 
-  const reviewUnit = normalizeReviewUnit(getReviewMetadataValue(reviewMetadata.body, 'Review Unit'));
   errors.push(...validateReviewUnitValue(reviewUnit, 'PR body'));
   errors.push(...validateReviewLaneUnitCompatibility({
     reviewLane,
@@ -350,17 +393,22 @@ export async function validatePrBody(body, options = {}) {
     context: 'PR body',
   }));
 
-  const reviewClaim = getReviewMetadataValue(reviewMetadata.body, 'Review Claim');
   if (reviewClaim && !reviewClaim.trim()) {
-    errors.push('Review metadata field Review Claim must not be empty.');
+    errors.push('## Review Claim must not be empty.');
+  }
+  if (safetyInvariant && !safetyInvariant.trim()) {
+    errors.push('## Safety Invariant must not be empty.');
+  }
+  if (sliceRationale && !sliceRationale.trim()) {
+    errors.push('## Slice Rationale must not be empty.');
   }
   errors.push(...validateReviewUnitFocus({
     declaredReviewUnit: reviewUnit,
     context: 'PR body',
     texts: [
-      stripDetailsBlocks(getSectionBody(trimmed, '## Summary')),
+      getSectionBody(trimmed, '## Summary'),
       reviewClaim,
-      getReviewMetadataValue(reviewMetadata.body, 'Slice Rationale'),
+      sliceRationale,
     ],
   }));
 
@@ -369,6 +417,10 @@ export async function validatePrBody(body, options = {}) {
   if (options.requiresVisualProof && !hasVisualProofMedia(trimmed)) {
     errors.push(
       'UI-impacting changes require a ## Visual Proof section with at least one screenshot image or video/walkthrough link.',
+    );
+  } else if (options.requiresVisualProof && visualProofNeedsAnimation(trimmed) && !hasAnimatedVisualProofMedia(trimmed)) {
+    errors.push(
+      'Restart or multi-state visual proof must include animated media such as a gif, webm, mp4, or walkthrough/video link.',
     );
   }
 
@@ -401,9 +453,9 @@ function usage() {
   console.error(`Usage: node scripts/validate-pr-body.mjs (--body-file <file> | --body <markdown>) [--require-visual-proof] [--changed-files-file <file>] [--diff-file <file>]
 
 Validates the canonical PR schema:
-  Required: ## Summary with a collapsed Review metadata block, ## Non-goals, ## Test Plan, ## Revert Plan
+  Required: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
   Optional: ## Architecture (must include ### Before and ### After when present)
-  UI changes: pass --require-visual-proof to require screenshot or video proof.
+  UI changes: pass --require-visual-proof to require screenshot or video proof; restart or multi-state proof must be animated.
   --changed-files-file <file>  Newline-separated changed file paths for scope checks.
   --diff-file <file>           Unified diff text to run the diff atomicity engine.`);
   process.exit(1);

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -56,6 +56,10 @@ State the one thing the reviewer is being asked to approve.
 
 Choose exactly one: `behavior`, `refactor`, `proof`, `cleanup`, `policy`, or `docs`.
 
+## Review Unit
+
+Choose the matching review unit, such as `tooling-policy`, `routing`, or `docs`.
+
 ## Safety Invariant
 
 Explain why this slice is safe to review locally.
@@ -107,18 +111,24 @@ If the change is small and has no architectural impact, omit `## Architecture` r
 
 If the change is UI-impacting, use `skills/visual-proof/SKILL.md` first and include its screenshot/video markdown in `## Visual Proof`. UI-impacting means the user-visible experience changes, even when no file under `packages/ui/**` changes. This includes `packages/ui/**`, Electron window lifecycle files, preload, main process window wiring, app menu changes, task status changes, task error or output text shown in panels, approval/reject behavior, workflow state shown in the DAG or inspector, and web-surface output.
 
+Use visible markdown sections for review metadata. Do not hide `Review Claim`, `Review Lane`, `Review Unit`, `Safety Invariant`, or `Slice Rationale` inside `<details>` or other HTML disclosure blocks. Review metadata must render directly in the PR body.
+
 When an existing PR changes after its body or proof was written, rerun this skill from the current diff before updating the PR. If the new diff touches UI-impacting files, rerun `skills/visual-proof/SKILL.md` and replace old screenshot or video links with fresh proof for the current code. Do not reuse earlier proof media after UI behavior changes.
 Visual proof must show the changed behavior itself, not just the changed screen area. Before creating or updating the PR, open every screenshot or video and verify the user-visible target is present and identifiable. For conditional or event-driven UI, drive the exact condition that triggers the new state and capture that state. A generic task panel, unchanged sidebar, unrelated graph, or stale screenshot is not proof, even when the right file changed.
+
+If the changed behavior spans multiple states or a state transition — for example restart persistence, before/after workflow transitions, progress animations, opening then dismissing overlays, or any proof labeled “before” and “after” — use animated proof. A gif, mp4, webm, or walkthrough video is required; static screenshots alone are not enough.
 
 In the PR body, caption each visual proof item with the concrete thing the reviewer should see, for example "amber Workspace recreated notice in the task inspector." If the reviewer cannot tell what changed from the image and caption, recapture proof before publishing.
 
 Before/after visual proof images must use distinct local filenames before `node scripts/create-pr.mjs` uploads them. The uploader keys media by basename inside one upload prefix, so `before/foo.png` and `after/foo.png` can collapse to one final URL. Copy or rename the files first, for example `/tmp/proof/foo-before.png` and `/tmp/proof/foo-after.png`, then put those unique paths in the PR body.
 
+The final published PR body must not leave repo-relative proof paths in markdown. Use `node scripts/create-pr.mjs` so local proof files are uploaded or rewritten to published URLs before the PR is created or updated.
+
 If the changed behavior is a cursor, pointer, hover-only affordance, or other state that a static screenshot cannot show, do not present an unchanged screenshot as proof of the behavior. Add a short video, an inspectable state proof, or a focused test reference, and say plainly why the screenshot alone cannot show it.
 
 When a PR changes skill instructions under `skills/**/SKILL.md`, add or update a focused skill contract test for the exact issue being fixed. The test must fail if the instruction that prevents the regression is removed.
 
-Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Review Claim / ## Review Lane / ## Safety Invariant / ## Slice Rationale / ## Non-goals / ## Test Plan / ## Revert Plan` as the floor, add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.
+Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Review Claim / ## Review Lane / ## Review Unit / ## Safety Invariant / ## Slice Rationale / ## Non-goals / ## Test Plan / ## Revert Plan` as the floor, add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.
 
 ## Diff atomicity gate
 


### PR DESCRIPTION
## Summary

This tightens the make-pr path for visual proof and PR body publishing.

It switches the PR template and validator to visible review-metadata sections, requires animated proof for restart or other multi-state UI transitions, and makes `create-pr` rewrite tracked local proof paths to published GitHub raw URLs when R2 upload is unavailable.

It also adds focused tests so these rules fail loudly if they regress.

## Review Claim

The PR authoring toolchain now prevents hidden review metadata, broken proof URLs, and still-image proof for restart-style UI transitions.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This changes only PR authoring tooling, validation, and skill guidance. Product runtime behavior is untouched.

## Slice Rationale

The regression came from the PR publication path itself, so the guardrails belong in a standalone tooling PR instead of the Planning Terminal product stack.

## Non-goals

This does not change Planning Terminal runtime behavior.

This does not change Mergify stack-comment behavior.

This does not add new UI product tests beyond the PR-tooling contract tests.

## Test Plan

- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/test-create-pr-visual-proof.mjs`
- [x] `node scripts/test-create-pr-stack-workflow.mjs`
- [x] `bash scripts/test-make-pr-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 83fff5363`
- Post-revert steps: None
- Data migration? No

