### PR TITLE
[Autoapprove single config](3a) Simplify autoapprove autostart helper

### DIFF
--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -19,9 +19,11 @@ import {
 import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
 
 export function getAutoStartedOwnerWorkerKinds(config: { autoApproveAIFixes?: boolean }): string[] {
-  return config.autoApproveAIFixes === true
-    ? [AUTO_FIX_WORKER_KIND, AUTO_APPROVE_WORKER_KIND, PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND]
-    : [AUTO_FIX_WORKER_KIND, PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND];
+  const kinds = [AUTO_FIX_WORKER_KIND, PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND];
+  if (config.autoApproveAIFixes === true) {
+    kinds.splice(1, 0, AUTO_APPROVE_WORKER_KIND);
+  }
+  return kinds;
 }
 
 export interface WorkerRuntimeController {


### PR DESCRIPTION
## Summary

The auto-start helper now builds the owner worker order once and inserts `autoapprove` only when that flag is enabled.

The old version worked, but the conditional return made that ordering rule harder to read.

This slice keeps the same behavior and makes the worker order explicit in one small helper.

<details>
<summary>Review metadata</summary>

Review Claim: The auto-start helper keeps the same worker order while expressing the `autoapprove` insert step more clearly.

Review Lane: behavior

Review Unit: routing

Safety Invariant: This slice only reshapes one helper in `worker-control.ts`; the returned worker order stays the same.

Slice Rationale: This is a tiny follow-up to the worker-order slice, so it stands alone instead of hiding inside a larger behavior PR.

</details>

## Non-goals

This does not change which workers auto-start.

This does not change any entrypoint behavior.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/worker-control.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 03463810c`
- Post-revert steps: None
- Data migration? No
