### PR TITLE
[Autoapprove single config](4a) Move app approval entrypoints to queued autoapprove

### DIFF
--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -86,6 +86,52 @@ describe('headless worker autofix', () => {
     );
   });
 
+  it('runs a one-shot autoapprove scan and enqueues the normal approval command intent', async () => {
+    const task = makeTask({
+      status: 'awaiting_approval',
+      execution: { pendingFixError: 'boom', generation: 1, selectedAttemptId: 'attempt-1' },
+    });
+    const enqueueWorkflowMutationIntent = vi.fn((
+      _workflowId: string,
+      _channel: string,
+      _args: unknown[],
+      _priority: WorkflowMutationPriority,
+    ) => 2);
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const homeRoot = mkdtempSync(join(tmpdir(), 'invoker-headless-autoapprove-'));
+    const previousDbDir = process.env.INVOKER_DB_DIR;
+    process.env.INVOKER_DB_DIR = homeRoot;
+
+    try {
+      await runHeadless(['worker', 'autoapprove'], {
+        logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn() },
+        persistence: {
+          listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+          loadTasks: vi.fn(() => [task]),
+          loadTask: vi.fn(() => task),
+          listWorkflowMutationIntents: vi.fn(() => []),
+          getWorkerAction: vi.fn(() => undefined),
+          upsertWorkerAction: vi.fn(),
+          logEvent: vi.fn(),
+          enqueueWorkflowMutationIntent,
+        },
+        invokerConfig: { autoApproveAIFixes: true },
+      } as any);
+    } finally {
+      write.mockRestore();
+      if (previousDbDir === undefined) delete process.env.INVOKER_DB_DIR;
+      else process.env.INVOKER_DB_DIR = previousDbDir;
+      rmSync(homeRoot, { recursive: true, force: true });
+    }
+
+    expect(enqueueWorkflowMutationIntent).toHaveBeenCalledWith(
+      'wf-1',
+      'invoker:approve',
+      ['wf-1/task-1'],
+      'normal',
+    );
+  });
+
   it('lists worker kinds from the registry', async () => {
     let stdout = '';
     const write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
@@ -101,6 +147,7 @@ describe('headless worker autofix', () => {
 
     expect(stdout).toContain('Worker kinds');
     expect(stdout).toContain('autofix');
+    expect(stdout).toContain('autoapprove');
   });
 
   it('rejects unknown worker kinds with a clear error', async () => {

--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -37,6 +37,10 @@ describe('headless-command-classification', () => {
     expect(isHeadlessReadOnlyCommand(['list'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['session'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['open-terminal'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['worker'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['worker', 'list'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['worker', 'status'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['worker', 'autoapprove'])).toBe(false);
     expect(isHeadlessReadOnlyCommand(['run'])).toBe(false);
   });
 
@@ -45,7 +49,9 @@ describe('headless-command-classification', () => {
     expect(isHeadlessMutatingCommand(['query'])).toBe(false);
     expect(isHeadlessMutatingCommand(['open-terminal'])).toBe(false);
     expect(isHeadlessMutatingCommand(['slack'])).toBe(false);
-
+    expect(isHeadlessMutatingCommand(['worker', 'autoapprove'])).toBe(true);
+    expect(isHeadlessMutatingCommand(['worker'])).toBe(false);
+    expect(isHeadlessMutatingCommand(['worker', 'status'])).toBe(false);
     expect(isHeadlessMutatingCommand(['run'])).toBe(true);
     expect(isHeadlessMutatingCommand(['migrate-compat'])).toBe(true);
     expect(isHeadlessMutatingCommand(['cancel-workflow'])).toBe(true);

--- a/packages/app/src/__tests__/resolve-conflict-action.test.ts
+++ b/packages/app/src/__tests__/resolve-conflict-action.test.ts
@@ -56,31 +56,22 @@ describe('resolveConflictAction', () => {
     expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
 
-  it('auto-approves after conflict resolution when configured', async () => {
-    const approve = vi.fn(async () => [{ id: 'task-a', status: 'completed', config: {}, execution: {} }]);
-    const getTask = orchestrator.getTask;
+  it('does not approve inline after conflict resolution', async () => {
+    const approve = vi.fn();
     orchestrator = {
       ...orchestrator,
-      getTask,
       approve,
     };
-    const taskExecutorWithApprove = {
-      ...taskExecutor,
-      executeTasks: vi.fn(),
-      publishAfterFix: vi.fn(),
-    };
 
-    await resolveConflictAction('task-a', {
+    const result = await resolveConflictAction('task-a', {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
-      taskExecutor: taskExecutorWithApprove as unknown as TaskRunner,
-      autoApproveAIFixes: true,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
+    expect(result).toEqual({ autoApproved: false, started: [] });
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');
-    expect(approve).toHaveBeenCalledWith('task-a');
-    expect(taskExecutorWithApprove.executeTasks).not.toHaveBeenCalled();
-    expect(taskExecutorWithApprove.publishAfterFix).not.toHaveBeenCalled();
+    expect(approve).not.toHaveBeenCalled();
   });
 
   it('on failure appends output and reverts conflict resolution (does not set awaiting approval)', async () => {

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -470,95 +470,19 @@ describe('provideInput', () => {
 });
 
 describe('finalizeAppliedFix', () => {
-  it('leaves task awaiting approval when autoApproveAIFixes is disabled', async () => {
+  it('sets the task awaiting approval and does not approve inline', async () => {
     const orchestrator = {
       setFixAwaitingApproval: vi.fn(),
       approve: vi.fn(),
     };
-    const taskExecutor = {
-      commitApprovedFix: vi.fn(),
-      publishAfterFix: vi.fn(),
-      executeTasks: vi.fn(),
-    };
 
     const result = await finalizeAppliedFix('task-a', 'saved-error', {
       orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
-      autoApproveAIFixes: false,
     });
 
     expect(result).toEqual({ autoApproved: false, started: [] });
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-error');
     expect(orchestrator.approve).not.toHaveBeenCalled();
-  });
-
-  it('auto-approves and returns runnable tasks when enabled', async () => {
-    const started = [
-      makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } }),
-    ];
-    const orchestrator = {
-      setFixAwaitingApproval: vi.fn(),
-      approve: vi.fn().mockResolvedValue(started),
-      getTask: vi.fn().mockReturnValue(makeTask({
-        id: 'task-a',
-        status: 'awaiting_approval',
-        config: { workflowId: 'wf-1' },
-        execution: { pendingFixError: 'saved-error', workspacePath: '/tmp/task-a', branch: 'task-a' },
-      })),
-    };
-    const taskExecutor = {
-      commitApprovedFix: vi.fn(),
-      publishAfterFix: vi.fn(),
-      executeTasks: vi.fn(),
-    };
-
-    const result = await finalizeAppliedFix('task-a', 'saved-error', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
-      autoApproveAIFixes: true,
-    });
-
-    expect(result).toEqual({ autoApproved: true, started });
-    expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
-    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'task-a' }),
-    );
-    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
-    expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
-  });
-
-  it('auto-approves and publishes post-fix merge gates when enabled', async () => {
-    const started = [
-      makeRunningTask({ id: 'merge-a', config: { workflowId: 'wf-1', isMergeNode: true } }),
-    ];
-    const orchestrator = {
-      setFixAwaitingApproval: vi.fn(),
-      approve: vi.fn().mockResolvedValue(started),
-      getTask: vi.fn().mockReturnValue(makeTask({
-        id: 'merge-a',
-        status: 'awaiting_approval',
-        config: { workflowId: 'wf-1', isMergeNode: true },
-        execution: { pendingFixError: 'saved-error', workspacePath: '/tmp/merge-a' },
-      })),
-      resumeTaskAfterFixApproval: vi.fn().mockResolvedValue(started),
-    };
-    const taskExecutor = {
-      commitApprovedFix: vi.fn(),
-      publishAfterFix: vi.fn(),
-      executeTasks: vi.fn(),
-    };
-
-    await finalizeAppliedFix('merge-a', 'saved-error', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
-      autoApproveAIFixes: true,
-    });
-
-    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'merge-a' }),
-    );
-    expect(taskExecutor.publishAfterFix).toHaveBeenCalledWith(started[0]);
-    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 
@@ -807,10 +731,7 @@ describe('autoFixOnFailure', () => {
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
   });
 
-  it('records fixed integration anchor and routes merge gates to finalize/publish flow', async () => {
-    const started = [
-      makeRunningTask({ id: 'merge-a', config: { workflowId: 'wf-1', isMergeNode: true } }),
-    ];
+  it('records fixed integration anchor and leaves merge-gate approval to the worker', async () => {
     const orchestrator = {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => makeTask({
@@ -823,7 +744,7 @@ describe('autoFixOnFailure', () => {
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
       retryTask: vi.fn(() => []),
       setFixAwaitingApproval: vi.fn(),
-      approve: vi.fn().mockResolvedValue(started),
+      approve: vi.fn(),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -858,62 +779,30 @@ describe('autoFixOnFailure', () => {
         }),
       }),
     );
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('merge-a', 'boom');
     expect(orchestrator.retryTask).not.toHaveBeenCalled();
-    expect(taskExecutor.publishAfterFix).toHaveBeenCalledWith(started[0]);
+    expect(orchestrator.approve).not.toHaveBeenCalled();
+    expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
   });
 
-  it('retries inline when merge post-fix publish fails during auto-fix dispatch', async () => {
-    const started = [
-      makeRunningTask({ id: 'merge-a', config: { workflowId: 'wf-1', isMergeNode: true } }),
-    ];
-    // The getTask mock is driven by a state machine that tracks which
-    // phase the auto-fix flow is in.  Each phase may call getTask
-    // multiple times (entry check, lineage capture, lineage assert,
-    // approveTask, post-finalize).  We use a phase counter that
-    // advances at known transition points (beginConflictResolution
-    // and setFixAwaitingApproval) to keep return values consistent.
+  it('does not retry inline after a merge fix is queued for approval', async () => {
     let phase = 0;
-    const phases: Record<string, unknown>[] = [
-      // Phase 0: entry check + lineage capture (cycle 1)
-      { status: 'failed', execution: { workspacePath: '/tmp/merge-a', selectedAttemptId: 'att-1', generation: 1 } },
-      // Phase 1: after fix returns, lineage check + finalize + approveTask (cycle 1)
-      { status: 'awaiting_approval', execution: { workspacePath: '/tmp/merge-a', pendingFixError: 'boom', selectedAttemptId: 'att-1', generation: 1 } },
-      // Phase 2: post-finalize check — task re-failed after publish
-      { status: 'failed', execution: { workspacePath: '/tmp/merge-a', error: 'Post-fix PR prep failed: conflict', selectedAttemptId: 'att-1', generation: 1 } },
-      // Phase 3: inline retry entry + lineage capture (cycle 2)
-      { status: 'failed', execution: { workspacePath: '/tmp/merge-a', selectedAttemptId: 'att-3', generation: 3 } },
-      // Phase 4: after fix returns, lineage check + finalize + approveTask (cycle 2)
-      { status: 'awaiting_approval', execution: { workspacePath: '/tmp/merge-a', pendingFixError: 'boom', selectedAttemptId: 'att-3', generation: 3 } },
-    ];
-    const getTask = vi.fn(() => {
-      const idx = Math.min(phase, phases.length - 1);
-      return makeTask({
-        id: 'merge-a',
-        config: { workflowId: 'wf-1', isMergeNode: true },
-        ...phases[idx],
-      });
-    });
-    // Advance phase at key transition points
-    const origBeginConflictResolution = vi.fn(() => {
-      phase++;
-      return { savedError: 'boom' };
-    });
-    const origSetFixAwaitingApproval = vi.fn(() => { phase++; });
-    const shouldAutoFix = vi
-      .fn()
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
-      .mockReturnValue(false);
     const orchestrator = {
-      shouldAutoFix,
-      getTask,
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => makeTask({
+        id: 'merge-a',
+        status: phase === 0 ? 'failed' : 'awaiting_approval',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: phase === 0
+          ? { workspacePath: '/tmp/merge-a', selectedAttemptId: 'att-1', generation: 1 }
+          : { workspacePath: '/tmp/merge-a', pendingFixError: 'boom', selectedAttemptId: 'att-1', generation: 1 },
+      })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: origBeginConflictResolution,
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
       retryTask: vi.fn(() => []),
-      setFixAwaitingApproval: origSetFixAwaitingApproval,
-      approve: vi.fn().mockResolvedValue(started),
-      resumeTaskAfterFixApproval: vi.fn().mockResolvedValue(started),
+      setFixAwaitingApproval: vi.fn(() => { phase = 1; }),
+      approve: vi.fn(),
+      resumeTaskAfterFixApproval: vi.fn(),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -925,13 +814,10 @@ describe('autoFixOnFailure', () => {
     const taskExecutor = {
       fixWithAgent: vi.fn().mockResolvedValue(undefined),
       resolveConflict: vi.fn(),
-      commitApprovedFix: vi.fn().mockResolvedValue(undefined),
+      commitApprovedFix: vi.fn(),
       execGitIn: vi.fn().mockResolvedValue('abc123'),
-      publishAfterFix: vi
-        .fn()
-        .mockImplementationOnce(async () => undefined)
-        .mockImplementationOnce(async () => undefined),
-      executeTasks: vi.fn().mockResolvedValue(undefined),
+      publishAfterFix: vi.fn(),
+      executeTasks: vi.fn(),
     };
 
     await autoFixOnFailure('merge-a', {
@@ -942,16 +828,9 @@ describe('autoFixOnFailure', () => {
       getAutoApproveAIFixes: () => true,
     });
 
-    expect(taskExecutor.fixWithAgent).toHaveBeenCalledTimes(2);
-    expect(taskExecutor.execGitIn).toHaveBeenCalledTimes(2);
-    expect(taskExecutor.publishAfterFix).toHaveBeenCalledTimes(2);
-    expect(persistence.logEvent).toHaveBeenCalledWith(
-      'merge-a',
-      'debug.auto-fix',
-      expect.objectContaining({
-        phase: 'auto-fix-post-route-inline-retry',
-      }),
-    );
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledTimes(1);
+    expect(taskExecutor.execGitIn).toHaveBeenCalledTimes(1);
+    expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).not.toHaveBeenCalled();
   });
 
@@ -2415,7 +2294,6 @@ describe('finalizeAppliedFix lineage guard', () => {
 
     await expect(finalizeAppliedFix('task-a', 'saved-error', {
       orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: {} as TaskRunner,
     }, ac.signal)).rejects.toThrow(StaleLineageError);
 
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
@@ -2429,7 +2307,6 @@ describe('finalizeAppliedFix lineage guard', () => {
 
     const result = await finalizeAppliedFix('task-a', 'saved-error', {
       orchestrator: orchestrator as unknown as Orchestrator,
-      taskExecutor: {} as TaskRunner,
     }, ac.signal);
 
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-error');

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -349,12 +349,12 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               agent = parsed.agent;
             } catch { /* not JSON, ignore */ }
           }
-          const result = await mutations.resolveConflict(taskId, agent);
+          await mutations.resolveConflict(taskId, agent);
           json(res, 200, {
             ok: true,
             taskId,
             action: 'resolve_conflict',
-            status: result.autoApproved ? 'auto_approved' : 'awaiting_approval',
+            status: 'awaiting_approval',
           });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -99,16 +99,22 @@ export function resolveHeadlessTargetWorkflowId(
 export function isHeadlessReadOnlyCommand(args: string[]): boolean {
   const command = args[0];
   if (!command || command === '--help' || command === '-h') return true;
+  if (command === 'worker') {
+    const subcommand = args[1] ?? 'list';
+    return subcommand === 'list' || subcommand === 'status';
+  }
   return findHeadlessCommandDefinition(command)?.kind === 'read';
 }
 
 export function isHeadlessMutatingCommand(args: string[]): boolean {
   const command = args[0];
   if (!command || command === '--help' || command === '-h') return false;
-
+  if (command === 'worker') {
+    const subcommand = args[1] ?? 'list';
+    return subcommand !== 'list' && subcommand !== 'status';
+  }
   if (command === 'set') {
     return isMutatingSetSubcommand(args[1]);
   }
-
   return findHeadlessCommandDefinition(command)?.kind === 'write';
 }

--- a/packages/app/src/headless-run-resume.ts
+++ b/packages/app/src/headless-run-resume.ts
@@ -309,7 +309,6 @@ export async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promis
       commandService: deps.commandService,
       taskExecutor: te,
       mutationTiming: deps.mutationTiming,
-      autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
     }, {
       agentName: agent,
       recreateOutputLabel: 'Fix with AI',
@@ -335,8 +334,8 @@ export async function headlessFix(rawArgs: string[], deps: HeadlessDeps): Promis
       return;
     }
     process.stdout.write(
-      result.autoApproved
-        ? `Fix applied and auto-approved for task: ${taskId} (${agent}).\n`
+      deps.invokerConfig.autoApproveAIFixes
+        ? `Fix applied and queued for auto-approval for task: ${taskId} (${agent}).\n`
         : `Fix applied for task: ${taskId} (${agent}). Use 'approve ${taskId}' or 'reject ${taskId}' to finalize.\n`,
     );
   } catch (err) {
@@ -362,9 +361,9 @@ export async function headlessResolveConflict(taskId: string, deps: HeadlessDeps
   const agent = (agentArg ?? resolveDefaultExecutionAgent(deps.invokerConfig)).toLowerCase();
   try {
     const result = await resolveConflictAction(taskId, {
-      ...deps,
+      orchestrator: deps.orchestrator,
+      persistence: deps.persistence,
       taskExecutor: te,
-      autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
     }, agent, deps.signal);
     await finalizeMutationWithGlobalTopup({
       orchestrator: deps.orchestrator,
@@ -377,7 +376,7 @@ export async function headlessResolveConflict(taskId: string, deps: HeadlessDeps
     });
     process.stdout.write(
       deps.invokerConfig.autoApproveAIFixes
-        ? `Conflict resolved and auto-approved for task: ${taskId} (${agent}).\n`
+        ? `Conflict resolved and queued for auto-approval for task: ${taskId} (${agent}).\n`
         : `Conflict resolved for task: ${taskId} (${agent}). Use 'approve ${taskId}' or 'reject ${taskId}' to finalize.\n`,
     );
   } catch (err) {

--- a/packages/app/src/headless-shared.ts
+++ b/packages/app/src/headless-shared.ts
@@ -100,7 +100,6 @@ export function buildHeadlessApiServerDeps(
       persistence: deps.persistence,
       taskExecutor,
       dispatchMode: deps.mutationTiming ? 'fire-and-forget' : 'await',
-      autoApproveAIFixes: deps.invokerConfig?.autoApproveAIFixes,
       killRunningTask: async (taskId: string) => {
         await taskExecutor.killActiveExecution(taskId);
       },

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -13,12 +13,13 @@ import type { BundledSkillsInstallMode } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import {
+  AUTO_APPROVE_WORKER_KIND,
   AUTO_FIX_WORKER_KIND,
   TaskRunner,
   acquireWorkerLock,
   createAutoFixAttemptLedger,
   createWorkerRegistry,
-  registerAutoFixWorker,
+  registerBuiltinWorkers,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
   type WorkerRuntimeDependencies,
@@ -424,7 +425,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
     deps.invokerConfig?.externalWorkers,
-    registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
   );
 
   if (subCommand === 'list') {
@@ -487,6 +488,9 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         attemptLedger: autoFixAttemptLedger,
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
+      autoApprove: {
+        enabled: deps.invokerConfig.autoApproveAIFixes === true,
+      },
     });
     await worker.tick('manual');
     await worker.stop();
@@ -495,7 +499,9 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
     // blocks the next legitimate start.
     lock.release();
   }
-  const label = definition.kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : definition.kind;
+  const label = definition.kind === AUTO_FIX_WORKER_KIND
+    ? 'Auto-fix'
+    : definition.kind === AUTO_APPROVE_WORKER_KIND ? 'Autoapprove' : definition.kind;
   process.stdout.write(`${label} worker scan completed.\n`);
 }
 

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -141,8 +141,6 @@ export interface ActionDeps {
   /** When set, fresh-base actions refresh the pool mirror and remove managed branches before retry/recreate. */
   taskExecutor?: TaskRunner;
   mutationTiming?: WorkflowMutationTiming;
-  /** When true, successful AI-applied fixes are approved immediately. */
-  autoApproveAIFixes?: boolean;
 }
 
 export interface CommandActionDeps extends ActionDeps {
@@ -812,7 +810,7 @@ export async function setTaskFixContext(
 
 export async function resolveConflictAction(
   taskId: string,
-  deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
+  deps: Pick<ActionDeps, 'orchestrator' | 'persistence'> & { taskExecutor: TaskRunner },
   agentName?: string,
   signal?: AbortSignal,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
@@ -850,7 +848,7 @@ function resolveTaskRunnerDefaultExecutionAgent(taskExecutor: TaskRunner): strin
 
 export async function fixWithAgentAction(
   taskId: string,
-  deps: Pick<CommandActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'autoApproveAIFixes' | 'commandService' | 'mutationTiming'> & { taskExecutor: TaskRunner },
+  deps: Pick<CommandActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'commandService' | 'mutationTiming'> & { taskExecutor: TaskRunner },
   options: {
     agentName?: string;
     recoveryRoute?: FailureRecoveryRoute;
@@ -939,7 +937,7 @@ export async function fixWithAgentAction(
 export async function finalizeAppliedFix(
   taskId: string,
   savedError: string,
-  deps: Pick<ActionDeps, 'orchestrator' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
+  deps: Pick<ActionDeps, 'orchestrator'>,
   signal?: AbortSignal,
   lineage?: TaskLineageSnapshot,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
@@ -950,13 +948,7 @@ export async function finalizeAppliedFix(
   }
   if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
   deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
-  if (!deps.autoApproveAIFixes) {
-    return { autoApproved: false, started: [] };
-  }
-
-  if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
-  const { started } = await approveTask(taskId, deps);
-  return { autoApproved: true, started };
+  return { autoApproved: false, started: [] };
 }
 
 // ── Auto-fix helpers ─────────────────────────────────────────
@@ -1273,8 +1265,6 @@ export async function autoFixOnFailure(
       assertLineageCurrent(lineage, orchestrator, deps.signal);
       const finalizeResult = await finalizeAppliedFix(taskId, persistedSavedError, {
         orchestrator,
-        taskExecutor,
-        autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
       }, deps.signal, lineage);
       persistence.logEvent?.(taskId, 'debug.auto-fix', {
         phase: 'auto-fix-post-route-finalize',

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -109,7 +109,6 @@ export interface WorkflowMutationFacadeDeps {
   commandService: CommandService;
   taskExecutor: TaskRunner;
   dispatchMode?: 'await' | 'fire-and-forget';
-  autoApproveAIFixes?: boolean;
   /** Optional pre-kill hook for active task executions. */
   killRunningTask?: (taskId: string) => Promise<void>;
 }
@@ -422,7 +421,6 @@ export class WorkflowMutationFacade {
         orchestrator: this.deps.orchestrator,
         persistence: this.deps.persistence,
         taskExecutor: this.deps.taskExecutor,
-        autoApproveAIFixes: this.deps.autoApproveAIFixes,
       },
       agentName,
     );
@@ -456,7 +454,6 @@ export class WorkflowMutationFacade {
         persistence: this.deps.persistence,
         commandService: this.deps.commandService,
         taskExecutor: this.deps.taskExecutor,
-        autoApproveAIFixes: this.deps.autoApproveAIFixes,
       },
       options,
     );
@@ -483,7 +480,6 @@ export class WorkflowMutationFacade {
       persistence: this.deps.persistence,
       commandService: this.deps.commandService,
       taskExecutor: this.deps.taskExecutor,
-      autoApproveAIFixes: this.deps.autoApproveAIFixes,
     };
   }
 


### PR DESCRIPTION
## Summary

App approval entrypoints now stop after moving tasks into `awaiting_approval` and leave AI-fix approval to the queued worker flow.

The bug was inline approval. App-side fix and resolve flows could still approve immediately instead of waiting for the worker-owned approval step.

This slice updates app entrypoints, status mapping, and user-facing messages so app behavior matches the queued approval model.

<details>
<summary>Review metadata</summary>

Review Claim: App approval entrypoints now stop at `awaiting_approval` and leave approval to the queued worker flow.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice only changes app-side entrypoints and status presentation; the actual approval implementation still stays in `approveTask()`.

Slice Rationale: The app surfaces form one reviewable behavior boundary because they all expose the same queued-approval change to users.

</details>

## Non-goals

This does not change worker internals.

This does not change CLI or Slack entrypoints.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-command-classification.test.ts src/__tests__/headless-autofix.test.ts src/__tests__/resolve-conflict-action.test.ts src/__tests__/workflow-actions.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0936731a1`
- Post-revert steps: None
- Data migration? No
