### PR TITLE
[Autoapprove single config](4b) Move CLI config entrypoints to shared path

### DIFF
--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { LocalBus } from '@invoker/transport';
@@ -115,9 +115,65 @@ describe('invoker-cli', () => {
     expect(code).toBe(0);
     expect(output.stdout).toContain('Worker kinds');
     expect(output.stdout).toContain('autofix');
+    expect(output.stdout).toContain('autoapprove');
     output.restore();
   });
 
+
+  it('reads worker config from INVOKER_REPO_CONFIG_PATH for worker list', async () => {
+    const output = captureProcessOutput();
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-worker-config-'));
+    const previous = process.env.INVOKER_REPO_CONFIG_PATH;
+    try {
+      const configPath = join(dir, 'config.json');
+      writeFileSync(
+        configPath,
+        JSON.stringify({
+          externalWorkers: [{ kind: 'external-from-env', launch: { executable: 'node', args: ['-v'] } }],
+        }),
+        'utf8',
+      );
+      process.env.INVOKER_REPO_CONFIG_PATH = configPath;
+
+      const code = await main(['worker', 'list'], {
+        createMessageBus: () => {
+          throw new Error('worker list should not open IPC');
+        },
+      });
+
+      expect(code).toBe(0);
+      expect(output.stdout).toContain('external-from-env');
+    } finally {
+      if (previous === undefined) delete process.env.INVOKER_REPO_CONFIG_PATH;
+      else process.env.INVOKER_REPO_CONFIG_PATH = previous;
+      output.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('restores INVOKER_REPO_CONFIG_PATH after standalone run with --config', async () => {
+    const output = captureProcessOutput();
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-config-restore-'));
+    const previous = process.env.INVOKER_REPO_CONFIG_PATH;
+    const previousValue = '/tmp/previous-invoker-config.json';
+    try {
+      process.env.INVOKER_REPO_CONFIG_PATH = previousValue;
+      const configPath = join(dir, 'config.json');
+      const planPath = join(dir, 'invalid.yaml');
+      writeFileSync(configPath, JSON.stringify({ maxConcurrency: 1 }), 'utf8');
+      writeFileSync(planPath, 'name: [broken\\n', 'utf8');
+
+      const code = await main(['run', planPath, '--standalone', '--db-dir', join(dir, 'db'), '--config', configPath]);
+
+      expect(code).toBe(1);
+      expect(process.env.INVOKER_REPO_CONFIG_PATH).toBe(previousValue);
+    } finally {
+      if (previous === undefined) delete process.env.INVOKER_REPO_CONFIG_PATH;
+      else process.env.INVOKER_REPO_CONFIG_PATH = previous;
+      output.restore();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
   it('rejects unknown worker kinds with a clear non-zero error', async () => {
     const output = captureProcessOutput();
 

--- a/packages/cli/src/__tests__/onboarding.test.ts
+++ b/packages/cli/src/__tests__/onboarding.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { resolveInvokerConfigPath } from '@invoker/contracts';
 
 import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, EXTERNAL_DEPENDENCIES } from '@invoker/contracts';
 
@@ -9,6 +10,7 @@ import {
   defaultExperimentalPlannerMcpPath,
   ensureExperimentalPlannerMcp,
   buildDoctorChecks,
+  defaultConfigPath,
   generateSlackManifest,
   installExperimentalPlannerMcp,
   loadInvokerEnv,
@@ -110,6 +112,26 @@ describe('buildDoctorChecks', () => {
   it('passes the default-preset check when its tool is installed', () => {
     const checks = buildDoctorChecks({ ...cfg, defaultPreset: 'omp' }, (cmd) => cmd === 'omp');
     expect(checks.find((c) => c.id === 'default-preset')?.status).toBe('ok');
+  });
+});
+
+describe('defaultConfigPath', () => {
+  const previous = process.env.INVOKER_REPO_CONFIG_PATH;
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.INVOKER_REPO_CONFIG_PATH;
+    else process.env.INVOKER_REPO_CONFIG_PATH = previous;
+  });
+
+  it('matches the shared config resolver for default, override, and blank override', () => {
+    delete process.env.INVOKER_REPO_CONFIG_PATH;
+    expect(defaultConfigPath()).toBe(resolveInvokerConfigPath(process.env, homedir()));
+
+    process.env.INVOKER_REPO_CONFIG_PATH = '/tmp/invoker-cli-config.json';
+    expect(defaultConfigPath()).toBe(resolveInvokerConfigPath(process.env, homedir()));
+
+    process.env.INVOKER_REPO_CONFIG_PATH = '   ';
+    expect(defaultConfigPath()).toBe(resolveInvokerConfigPath(process.env, homedir()));
   });
 });
 describe('runSetup', () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,9 +2,10 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
 import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
-import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
+import { DEFAULT_DRAFTER_MCP_PACKAGE_SPEC, resolveInvokerConfigPath, resolveInvokerHomeRoot, type Logger } from '@invoker/contracts';
 import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
 import {
+  AUTO_APPROVE_WORKER_KIND,
   AUTO_FIX_WORKER_KIND,
   ExecutorRegistry,
   TaskRunner,
@@ -12,7 +13,7 @@ import {
   acquireWorkerLock,
   createAutoFixAttemptLedger,
   createWorkerRegistry,
-  registerAutoFixWorker,
+  registerBuiltinWorkers,
   registerExternalWorkers,
   WorkerLockHeldError,
   registerBuiltinAgents,
@@ -360,8 +361,8 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
   mkdirSync(dbDir, { recursive: true });
 
   const previousInvokerDbDir = process.env.INVOKER_DB_DIR;
+  const previousInvokerRepoConfigPath = process.env.INVOKER_REPO_CONFIG_PATH;
   if (options.config) {
-    process.env.INVOKER_CONFIG = resolve(options.config);
     process.env.INVOKER_REPO_CONFIG_PATH = resolve(options.config);
   }
   process.env.INVOKER_DB_DIR = dbDir;
@@ -447,6 +448,11 @@ async function runPlan(planPath: string, options: CliOptions): Promise<RunResult
     } else {
       process.env.INVOKER_DB_DIR = previousInvokerDbDir;
     }
+    if (previousInvokerRepoConfigPath === undefined) {
+      delete process.env.INVOKER_REPO_CONFIG_PATH;
+    } else {
+      process.env.INVOKER_REPO_CONFIG_PATH = previousInvokerRepoConfigPath;
+    }
     persistence.close();
   }
 }
@@ -472,15 +478,18 @@ async function createDefaultMessageBus(): Promise<MessageBus> {
 function readWorkerConfig(homeRoot: string): {
   autoFixRetries?: number;
   autoFixAgent?: string;
+  autoApproveAIFixes?: boolean;
   externalWorkers?: ExternalWorkerConfig[];
 } {
-  const configPath = join(homeRoot, 'config.json');
+  void homeRoot;
+  const configPath = resolveInvokerConfigPath(process.env, homedir());
   if (!existsSync(configPath)) return {};
   try {
     const parsed = JSON.parse(readFileSync(configPath, 'utf8')) as CliRuntimeConfig;
     return {
       autoFixRetries: typeof parsed.autoFixRetries === 'number' ? parsed.autoFixRetries : undefined,
       autoFixAgent: typeof parsed.autoFixAgent === 'string' ? parsed.autoFixAgent : undefined,
+      autoApproveAIFixes: typeof parsed.autoApproveAIFixes === 'boolean' ? parsed.autoApproveAIFixes : undefined,
       externalWorkers: Array.isArray(parsed.externalWorkers) ? parsed.externalWorkers : undefined,
     };
   } catch (err) {
@@ -490,7 +499,7 @@ function readWorkerConfig(homeRoot: string): {
 }
 
 function workerDisplayName(kind: string): string {
-  return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind;
+  return kind === AUTO_FIX_WORKER_KIND ? 'Auto-fix' : kind === AUTO_APPROVE_WORKER_KIND ? 'Autoapprove' : kind;
 }
 
 function printWorkerKinds<TDeps>(registry: WorkerRegistry<TDeps>): void {
@@ -515,7 +524,7 @@ function isExternalWorkerRuntime(worker: WorkerRuntime): worker is ExternalWorke
 async function runWorker(definition: WorkerDefinition<WorkerRuntimeDependencies>, bus: MessageBus): Promise<number> {
   const owner = await discoverLiveOwner(bus);
   const homeRoot = resolveInvokerHomeRoot();
-  const { autoFixRetries, autoFixAgent } = readWorkerConfig(homeRoot);
+  const { autoFixRetries, autoFixAgent, autoApproveAIFixes } = readWorkerConfig(homeRoot);
 
   // Single-instance guard: refuse if another worker of this kind (this door or
   // the dev `--headless worker <kind>` door) already holds the cross-process
@@ -552,6 +561,9 @@ async function runWorker(definition: WorkerDefinition<WorkerRuntimeDependencies>
         defaultAutoFixRetries: autoFixRetries,
         attemptLedger: autoFixAttemptLedger,
         getAutoFixAgent: () => autoFixAgent,
+      },
+      autoApprove: {
+        enabled: autoApproveAIFixes === true,
       },
     });
 
@@ -596,7 +608,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
     if (argv[0] === 'worker') {
       const subcommand = argv[1] ?? 'list';
       const registry = registerExternalWorkers(
-        registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+        registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
         readWorkerConfig(resolveInvokerHomeRoot()).externalWorkers,
       );
       if (subcommand === 'list') {

--- a/packages/cli/src/onboarding.ts
+++ b/packages/cli/src/onboarding.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_TOOL_REQUIREMENTS,
   EXTERNAL_DEPENDENCIES,
   formatReport,
+  resolveInvokerConfigPath,
   type IsInstalled,
   type PlanningPresetSpec,
   type PrerequisiteCheck,
@@ -35,7 +36,7 @@ export function invokerHomeDir(): string {
   return join(homedir(), '.invoker');
 }
 export function defaultConfigPath(): string {
-  return process.env.INVOKER_REPO_CONFIG_PATH ?? join(invokerHomeDir(), 'config.json');
+  return resolveInvokerConfigPath(process.env, homedir());
 }
 export function envFilePath(): string {
   return join(invokerHomeDir(), '.env');


### PR DESCRIPTION
## Summary

CLI entrypoints now follow the shared config-path rule instead of carrying their own config-file behavior.

The bug was CLI drift. Worker display, onboarding defaults, and `--config` handling could disagree with the shared config rule.

This slice switches CLI entrypoints to the shared resolver and restores the prior override env after isolated runs.

<details>
<summary>Review metadata</summary>

Review Claim: CLI entrypoints now resolve and restore config paths through the shared config rule.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This slice only changes CLI entrypoints and their direct tests; it does not change app or Slack runtime behavior.

Slice Rationale: The CLI files form one reviewable surface because they all expose the same shared-config behavior in the command-line path.

</details>

## Non-goals

This does not change app approval entrypoints.

This does not change Slack-managed launches.

## Test Plan

- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/onboarding.test.ts -t "matches the shared config resolver for default, override, and blank override"`
- [x] `pnpm --filter @invoker/cli exec vitest run src/__tests__/cli.test.ts -t "lists worker kinds from the registry|reads worker config from INVOKER_REPO_CONFIG_PATH for worker list|restores INVOKER_REPO_CONFIG_PATH after standalone run with --config"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert be39096dd`
- Post-revert steps: None
- Data migration? No
