### PR TITLE
[Autoapprove single config](4c) Move Slack entrypoints to shared config path

### DIFF
--- a/packages/slack-manager/deploy/install.sh
+++ b/packages/slack-manager/deploy/install.sh
@@ -22,6 +22,11 @@ if [ ! -f "$ENV_FILE" ]; then
   echo "Missing $ENV_FILE — create it with SLACK_BOT_TOKEN/APP_TOKEN/SIGNING_SECRET/CHANNEL_ID first." >&2
   exit 1
 fi
+if grep -Eq '^[[:space:]]*(INVOKER_REPO_CONFIG_PATH|INVOKER_CONFIG)=' "$ENV_FILE"; then
+  echo "Remove INVOKER_REPO_CONFIG_PATH/INVOKER_CONFIG from ~/.invoker/.slack-owner.env; Slack-managed Invoker reads ~/.invoker/config.json." >&2
+  exit 1
+fi
+
 
 echo "Building @invoker/slack-manager…"
 ( cd "$REPO_ROOT" && pnpm --filter @invoker/slack-manager build )

--- a/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
+++ b/packages/slack-manager/src/__tests__/invoker-launcher.test.ts
@@ -1,0 +1,49 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createInvokerLauncher } from '../invoker-launcher.js';
+
+vi.mock('node:fs', () => ({
+  openSync: vi.fn(() => 99),
+}));
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(() => ({ pid: 123, exitCode: null, unref: vi.fn() } as unknown as ChildProcess)),
+}));
+
+const STRIPPED_ENV_KEYS = [
+  'SLACK_BOT_TOKEN',
+  'SLACK_APP_TOKEN',
+  'SLACK_SIGNING_SECRET',
+  'SLACK_CHANNEL_ID',
+  'SLACK_LOBBY_CHANNEL_ID',
+  'INVOKER_REPO_CONFIG_PATH',
+  'INVOKER_CONFIG',
+] as const;
+
+describe('createInvokerLauncher', () => {
+  const savedEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...savedEnv };
+    vi.clearAllMocks();
+  });
+
+  it('strips Slack secrets and config overrides from spawned GUI env', () => {
+    for (const key of STRIPPED_ENV_KEYS) process.env[key] = `${key}-value`;
+
+    createInvokerLauncher({
+      repoRoot: '/repo',
+      logPath: '/tmp/invoker.log',
+      log: vi.fn(),
+    }).spawnInvoker();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const options = vi.mocked(spawn).mock.calls[0]?.[2];
+    expect(options?.env).toBeDefined();
+    for (const key of STRIPPED_ENV_KEYS) {
+      expect(options?.env).not.toHaveProperty(key);
+    }
+    expect(options?.env).toMatchObject({ LIBGL_ALWAYS_SOFTWARE: '1' });
+  });
+});

--- a/packages/slack-manager/src/invoker-launcher.ts
+++ b/packages/slack-manager/src/invoker-launcher.ts
@@ -3,19 +3,20 @@
  * group, matching `run.sh`'s headless-Linux path. Tracks the spawned child so a
  * forced restart can tear down a manager-managed instance before respawning.
  *
- * Slack credentials are stripped from the child env: post-cutover Invoker has no
- * Slack surface, and the manager owns the only Slack connection.
+ * Slack credentials and config path overrides are stripped from the child env:
+ * post-cutover Invoker has no Slack surface and reads ~/.invoker/config.json.
  */
-
 import { spawn, type ChildProcess } from 'node:child_process';
 import { openSync } from 'node:fs';
 
-const SLACK_ENV_VARS = [
+const STRIPPED_CHILD_ENV_VARS = [
   'SLACK_BOT_TOKEN',
   'SLACK_APP_TOKEN',
   'SLACK_SIGNING_SECRET',
   'SLACK_CHANNEL_ID',
   'SLACK_LOBBY_CHANNEL_ID',
+  'INVOKER_REPO_CONFIG_PATH',
+  'INVOKER_CONFIG',
 ];
 
 export interface InvokerLauncherOptions {
@@ -45,7 +46,7 @@ export function createInvokerLauncher(options: InvokerLauncherOptions): InvokerL
       }
 
       const env: NodeJS.ProcessEnv = { ...process.env, LIBGL_ALWAYS_SOFTWARE: '1' };
-      for (const key of SLACK_ENV_VARS) delete env[key];
+      for (const key of STRIPPED_CHILD_ENV_VARS) delete env[key];
 
       const out = openSync(options.logPath, 'a');
       child = spawn(


### PR DESCRIPTION
## Summary

Slack-managed launches now follow the shared config-path rule and flag old config override env in `.slack-owner.env` during install.

The bug was Slack drift. Slack-managed GUI launches could still pick up a second live config path after the app adopted one normal config file.

This slice clears config override env from the spawned GUI process and adds an install-time check for old Slack owner env files.

<details>
<summary>Review metadata</summary>

Review Claim: Slack-managed entrypoints now enforce the shared config-path rule instead of inheriting live override env.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: This slice only changes Slack-managed launch surfaces and their direct guardrails.

Slice Rationale: The Slack launcher and install check belong together because both control the same Slack-managed config rule.

</details>

## Non-goals

This does not change app or CLI entrypoints.

This does not change worker routing.

## Test Plan

- [x] `pnpm --filter @invoker/slack-manager exec vitest run src/__tests__/invoker-launcher.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 4441f71fe`
- Post-revert steps: None
- Data migration? No
