### PR TITLE
[PR Body Gate](3) Document the Invoker PR body gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+- Hold merge PRs that Invoker opens against its own repo to the full review-stack PR body before publication. When no agent can author a compliant body, PR creation fails loudly instead of shipping a fallback body that the PR Body CI check rejects.
 - Restore Planning Terminal chats after desktop restart, including visible transcripts and draft-ready state.
 - Persist embedded terminal tabs across desktop app restarts, restoring their recent output and reopening spawn-backed sessions.
 - Move auto-fix attempt counts out of SQLite task state and into in-memory worker runtime policy.

--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -160,10 +160,49 @@ const PR_2170_COMMIT_MESSAGE_BODY = [
   '- Safe to revert? Yes',
 ].join('\n');
 
-// Canonical shape: review-compression fields live in a collapsed Review
-// metadata block inside ## Summary; Non-goals/Test Plan/Revert Plan are
-// top-level. Mirrors scripts/validate-pr-body.mjs.
+// Canonical shape: review-compression fields are visible top-level sections.
+// Mirrors scripts/validate-pr-body.mjs.
 const COMPLIANT_REVIEW_STACK_BODY = [
+  '## Summary',
+  '',
+  'Plain explanation of the slice.',
+  '',
+  '## Review Claim',
+  '',
+  'Approve the one thing this slice does.',
+  '',
+  '## Review Lane',
+  '',
+  'cleanup',
+  '',
+  '## Review Unit',
+  '',
+  'scalar',
+  '',
+  '## Safety Invariant',
+  '',
+  'Why this slice is safe to review locally.',
+  '',
+  '## Slice Rationale',
+  '',
+  'Why the work is split here.',
+  '',
+  '## Non-goals',
+  '',
+  '- Does not change behavior.',
+  '',
+  '## Test Plan',
+  '',
+  '- [x] `pnpm test`',
+  '',
+  '## Revert Plan',
+  '',
+  '- Safe to revert? Yes',
+].join('\n');
+
+// Legacy shape rejected since the schema flip: metadata hidden in a collapsed
+// <details> block inside ## Summary.
+const LEGACY_DETAILS_REVIEW_STACK_BODY = [
   '## Summary',
   '',
   'Plain explanation of the slice.',
@@ -193,12 +232,10 @@ const COMPLIANT_REVIEW_STACK_BODY = [
 ].join('\n');
 
 describe('validateReviewStackPrBody', () => {
-  it('rejects a commit-message body that lacks the review metadata block + Non-goals (PR #2170)', () => {
+  it('rejects a commit-message body that lacks the metadata sections + Non-goals (PR #2170)', () => {
     const errors = validateReviewStackPrBody(PR_2170_COMMIT_MESSAGE_BODY);
     expect(errors).toContain('Missing required section: ## Non-goals');
-    expect(errors).toContain(
-      '## Summary must include a collapsed <details> block with <summary>Review metadata</summary>.',
-    );
+    expect(errors).toContain('Missing required section: ## Review Claim');
     // The same body passes the looser canonical validator — proving why #2170
     // shipped: the Invoker stack path never applied the stricter schema.
     expect(validateCanonicalPrBody(PR_2170_COMMIT_MESSAGE_BODY)).toEqual([]);
@@ -208,22 +245,31 @@ describe('validateReviewStackPrBody', () => {
     expect(validateReviewStackPrBody(COMPLIANT_REVIEW_STACK_BODY)).toEqual([]);
   });
 
-  it('rejects visible top-level metadata sections', () => {
-    const visible = COMPLIANT_REVIEW_STACK_BODY + '\n\n## Review Claim\n\nshould be in metadata';
-    const errors = validateReviewStackPrBody(visible);
-    expect(errors.some((e) => e.includes('## Review Claim belongs in the collapsed Review metadata block'))).toBe(true);
+  it('rejects metadata hidden in a legacy <details> block', () => {
+    const errors = validateReviewStackPrBody(LEGACY_DETAILS_REVIEW_STACK_BODY);
+    expect(errors.some((e) => e.includes('Do not hide review metadata in <details>'))).toBe(true);
+    expect(errors).toContain('Missing required section: ## Review Claim');
   });
 
-  it('rejects a metadata block missing a required field', () => {
-    const missingUnit = COMPLIANT_REVIEW_STACK_BODY.replace('Review Unit: scalar\n', '');
+  it('rejects a body missing one metadata section', () => {
+    const missingUnit = COMPLIANT_REVIEW_STACK_BODY.replace('## Review Unit\n\nscalar\n\n', '');
     const errors = validateReviewStackPrBody(missingUnit);
-    expect(errors).toContain('Review metadata is missing required field: Review Unit:');
+    expect(errors).toContain('Missing required section: ## Review Unit');
+  });
+
+  it('rejects a metadata section with an empty body', () => {
+    const emptyClaim = COMPLIANT_REVIEW_STACK_BODY.replace(
+      'Approve the one thing this slice does.',
+      '',
+    );
+    const errors = validateReviewStackPrBody(emptyClaim);
+    expect(errors).toContain('Missing required section: ## Review Claim');
   });
 
   it('rejects an empty body with a schema hint', () => {
     const errors = validateReviewStackPrBody('');
     expect(errors).toHaveLength(1);
-    expect(errors[0]).toContain('Review metadata block');
+    expect(errors[0]).toContain('## Review Claim');
   });
 
   it('does not count schema headings that appear inside fenced code blocks', () => {
@@ -241,34 +287,13 @@ describe('validateReviewStackPrBody', () => {
     expect(errors).toContain('Missing required section: ## Non-goals');
   });
 
-  it('does not accept a Review metadata block that only appears inside a code fence', () => {
-    const fencedMeta = [
-      '## Summary',
-      '',
-      'Prose.',
-      '',
-      '```md',
-      '<details>',
-      '<summary>Review metadata</summary>',
-      'Review Claim: c',
-      'Review Lane: cleanup',
-      'Review Unit: scalar',
-      'Safety Invariant: s',
-      'Slice Rationale: r',
-      '</details>',
-      '```',
-      '',
-      '## Non-goals',
-      '- none',
-      '',
-      '## Test Plan',
-      '- [x] x',
-      '',
-      '## Revert Plan',
-      '- yes',
-    ].join('\n');
+  it('does not count metadata sections that only appear inside a code fence', () => {
+    const fencedMeta = COMPLIANT_REVIEW_STACK_BODY.replace(
+      '## Review Claim\n',
+      '```md\n## Review Claim\n```\n',
+    );
     const errors = validateReviewStackPrBody(fencedMeta);
-    expect(errors).toContain('## Summary must include a collapsed <details> block with <summary>Review metadata</summary>.');
+    expect(errors).toContain('Missing required section: ## Review Claim');
   });
 
   it('requires real Markdown headings, not section names mentioned inline', () => {
@@ -296,7 +321,7 @@ describe('make-pr stack publish body contract', () => {
     });
     expect(prompt).toContain('"body":"string"');
     expect(prompt).toContain('artifact.body MUST be the exact PR body');
-    expect(prompt).toContain('Review metadata');
+    expect(prompt).toContain('Never hide review metadata');
     expect(prompt).toContain('Review Unit');
     expect(prompt).toContain('Do NOT let Mergify default the PR body');
   });

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1237,7 +1237,7 @@ describe('TaskRunner', () => {
             attempts.push('codex');
             return {
               cmd: 'node',
-              args: ['-e', 'var b=["## Summary","","Slice prose.","","<details>","<summary>Review metadata</summary>","","Review Claim: c","Review Lane: cleanup","Review Unit: scalar","Safety Invariant: s","Slice Rationale: r","","</details>","","## Non-goals","- none","","## Test Plan","- [x] pnpm test","","## Revert Plan","- Safe to revert? Yes"].join("\\n");process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master",body:b},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"],body:b}]}))'],
+              args: ['-e', 'var b=["## Summary","","Slice prose.","","## Review Claim","","c","","## Review Lane","","cleanup","","## Review Unit","","scalar","","## Safety Invariant","","s","","## Slice Rationale","","r","","## Non-goals","- none","","## Test Plan","- [x] pnpm test","","## Revert Plan","- Safe to revert? Yes"].join("\\n");process.stdout.write(JSON.stringify({artifacts:[{id:"contracts",title:"Contracts",url:"https://example.test/pr/1",providerId:"1",branch:"stack/contracts",baseBranch:"master",body:b},{id:"runtime",title:"Runtime",url:"https://example.test/pr/2",providerId:"2",branch:"stack/runtime",baseBranch:"stack/contracts",dependsOn:["contracts"],body:b}]}))'],
               sessionId: 'sess-codex',
             };
           },
@@ -1389,7 +1389,7 @@ describe('TaskRunner', () => {
         }),
         buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
       };
-      // A bare commit-message body: no ## Non-goals, no collapsed Review metadata block.
+      // A bare commit-message body: no ## Non-goals, no review metadata sections.
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
         persistence: {} as any,
@@ -1416,9 +1416,12 @@ describe('TaskRunner', () => {
     it('publishReviewStackWithMakePrSkill validates the published body, not just the agent-reported one', async () => {
       // Agent reports a fully compliant body in JSON...
       const goodBody = [
-        '## Summary', '', 'x', '', '<details>', '<summary>Review metadata</summary>', '',
-        'Review Claim: c', 'Review Lane: cleanup', 'Review Unit: scalar',
-        'Safety Invariant: s', 'Slice Rationale: r', '', '</details>', '',
+        '## Summary', '', 'x', '',
+        '## Review Claim', '', 'c', '',
+        '## Review Lane', '', 'cleanup', '',
+        '## Review Unit', '', 'scalar', '',
+        '## Safety Invariant', '', 's', '',
+        '## Slice Rationale', '', 'r', '',
         '## Non-goals', '- none', '', '## Test Plan', '- [x] t', '', '## Revert Plan', '- yes',
       ].join('\n');
       const tempHome = createTempWorkspace();
@@ -1519,6 +1522,186 @@ describe('TaskRunner', () => {
         expect(result.body).toContain('## Summary');
         expect(result.body).toContain('## Test Plan');
         expect(result.body).toContain('## Revert Plan');
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
+    const STRICT_COMPLIANT_REVIEW_STACK_BODY = [
+      '## Summary',
+      '',
+      'Authored change.',
+      '',
+      '## Review Claim',
+      '',
+      'One reviewable gate change.',
+      '',
+      '## Review Lane',
+      '',
+      'behavior',
+      '',
+      '## Review Unit',
+      '',
+      'write-path',
+      '',
+      '## Safety Invariant',
+      '',
+      'Existing tests cover the gate.',
+      '',
+      '## Slice Rationale',
+      '',
+      'Single slice.',
+      '',
+      '## Non-goals',
+      '',
+      '- Nothing else.',
+      '',
+      '## Test Plan',
+      '',
+      '- [x] `pnpm test`',
+      '',
+      '## Revert Plan',
+      '',
+      '- Safe to revert? Yes',
+    ].join('\n');
+
+    const CANONICAL_ONLY_BODY = '## Summary\n\nAuthored\n\n## Test Plan\n\n- [x] `pnpm test`\n\n## Revert Plan\n\n- Safe to revert? Yes';
+
+    function makeBodyEmittingAgent(tempHome: string, body: string) {
+      return {
+        name: 'codex',
+        stdinMode: 'ignore',
+        linuxTerminalTail: 'exec_bash',
+        bundledSkillRoot: join(tempHome, '.codex', 'skills'),
+        bundledSkills: ['make-pr'],
+        buildCommand: () => ({
+          cmd: 'node',
+          args: ['-e', `process.stdout.write(${JSON.stringify(body)})`],
+          sessionId: 'sess-strict-gate',
+        }),
+        buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+      };
+    }
+
+    function makeStrictGateExecutor(agent: any) {
+      return new TaskRunner({
+        orchestrator: {
+          getTask: () => null,
+          getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-1', executionAgent: 'codex' } })],
+        } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executionAgentRegistry: {
+          get: (name: string) => name === 'codex' ? agent : undefined,
+          getOrThrow: vi.fn().mockReturnValue(agent),
+          getSessionDriver: vi.fn().mockReturnValue(undefined),
+          listWithCapability: vi.fn().mockReturnValue([agent]),
+        } as any,
+        cwd: '/tmp',
+        logger: createMockLogger(),
+      });
+    }
+
+    it('authorPrBodyWithSkill rejects a canonical-only body and refuses fallback for Invoker repoUrl', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const executor = makeStrictGateExecutor(makeBodyEmittingAgent(tempHome, CANONICAL_ONLY_BODY));
+
+        await expect((executor as any).authorPrBodyWithSkill({
+          workflowId: 'wf-1',
+          title: 'Test Workflow',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: '## Summary\nSource summary',
+          cwd: '/tmp',
+          repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker',
+        })).rejects.toThrow(/refusing canonical fallback/);
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
+    it('authorPrBodyWithSkill accepts a review-stack-compliant body for Invoker repoUrl', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const executor = makeStrictGateExecutor(makeBodyEmittingAgent(tempHome, STRICT_COMPLIANT_REVIEW_STACK_BODY));
+
+        const result = await (executor as any).authorPrBodyWithSkill({
+          workflowId: 'wf-1',
+          title: 'Test Workflow',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: '## Summary\nSource summary',
+          cwd: '/tmp',
+          repoUrl: 'git@github.com:EdbertChan/Invoker.git',
+        });
+
+        expect(result.agentName).toBe('codex');
+        expect(result.body).toContain('## Non-goals');
+        expect(result.body).toContain('## Review Claim');
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
+    it('authorPrBodyWithSkill throws for Invoker repoUrl when no execution agent registry is configured', async () => {
+      const executor = new TaskRunner({
+        orchestrator: {
+          getTask: () => null,
+          getAllTasks: () => [],
+        } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+        logger: createMockLogger(),
+      });
+
+      await expect((executor as any).authorPrBodyWithSkill({
+        workflowId: 'wf-1',
+        title: 'Canonical Test',
+        baseBranch: 'master',
+        featureBranch: 'plan/canonical',
+        workflowSummary: 'Summary.',
+        cwd: '/tmp',
+        repoUrl: 'https://github.com/EdbertChan/Invoker',
+      })).rejects.toThrow(/cannot pass scripts\/validate-pr-body\.mjs/);
+    });
+
+    it('authorPrBodyWithSkill keeps the lenient gate and canonical fallback for non-Invoker repoUrl', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const executor = makeStrictGateExecutor(makeBodyEmittingAgent(tempHome, CANONICAL_ONLY_BODY));
+
+        const result = await (executor as any).authorPrBodyWithSkill({
+          workflowId: 'wf-1',
+          title: 'Test Workflow',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: '## Summary\nSource summary',
+          cwd: '/tmp',
+          repoUrl: 'https://github.com/other/repo',
+        });
+
+        expect(result.agentName).toBe('codex');
+        expect(result.body).toContain('## Test Plan');
       } finally {
         if (originalHome === undefined) delete process.env.HOME;
         else process.env.HOME = originalHome;

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -245,6 +245,7 @@ export interface MergeRunnerHost {
     workflowSummary: string;
     structuredContext?: PrAuthoringContext;
     cwd: string;
+    repoUrl?: string;
   }): Promise<{ body: string; sessionId: string; agentName: string }>;
   detectDefaultBranch(): Promise<string>;
   gitLogMessage(commitHash: string, cwd?: string): Promise<string>;
@@ -279,6 +280,7 @@ async function authorPrBodyForMerge(
     workflowSummary: string;
     structuredContext?: PrAuthoringContext;
     cwd: string;
+    repoUrl?: string;
   },
 ): Promise<string> {
   if (!host.authorPrBodyWithSkill) {
@@ -749,6 +751,7 @@ export async function runMergeGateActionImpl(
             workflowSummary: fullSummary ?? '',
             structuredContext: structuredCtx,
             cwd: gateWorkspacePath!,
+            repoUrl: workflow?.repoUrl,
           });
 
           // Create PR via provider (consolidation already done above).
@@ -1032,6 +1035,7 @@ export async function approveMergeImpl(
         workflowSummary: fullSummary ?? '',
         structuredContext,
         cwd: worktreeDir,
+        repoUrl: workflow.repoUrl,
       });
       const reviewUrl = await host.execPr(baseBranch, featureBranch, mergeMessage, prBody, worktreeDir);
       mergeTrace('PR_CREATED', { featureBranch, baseBranch, reviewUrl });
@@ -1354,6 +1358,7 @@ export async function publishAfterFixImpl(
           workflowSummary: fullSummary ?? '',
           structuredContext: structuredCtxReview,
           cwd: consolidateDir,
+          repoUrl: workflow?.repoUrl,
         });
 
         logTaskProgress(host, task.id, 'info', 'Creating review PR', {
@@ -1421,6 +1426,7 @@ export async function publishAfterFixImpl(
         workflowSummary: fullSummary ?? '',
         structuredContext: structuredCtx,
         cwd: consolidateDir,
+        repoUrl: workflow?.repoUrl,
       });
       const reviewUrl = await host.execPr(baseBranch, featureBranch, workflow?.name ?? 'Workflow', prBody, consolidateDir);
       console.log(`[merge] Post-fix: created pull request ${reviewUrl}`);
@@ -1753,6 +1759,7 @@ export async function consolidateAndMergeImpl(
         workflowSummary: body ?? '',
         structuredContext: structuredCtx3,
         cwd: worktreeDir,
+        repoUrl: repoUrlForMerge,
       });
       const reviewUrl = await host.execPr(baseBranch, featureBranch, workflowName ?? 'Workflow', prBody, worktreeDir);
       console.log(`[merge] Created pull request: ${reviewUrl}`);

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -51,30 +51,18 @@ export interface PrAuthoringContext {
 }
 
 const REQUIRED_SECTIONS = ['## Summary', '## Test Plan', '## Revert Plan'] as const;
-// Canonical review-stack schema, mirrored structurally from
-// scripts/validate-pr-body.mjs — the authoritative validator the make-pr skill
-// runs. The review-compression fields live INSIDE a collapsed
-// <details>Review metadata</details> block in ## Summary, not as visible
-// top-level sections, so a bare commit-message body (e.g. PR #2170) is rejected.
 const REVIEW_STACK_REQUIRED_SECTIONS = [
   '## Summary',
   '## Non-goals',
   '## Test Plan',
   '## Revert Plan',
 ] as const;
-const REVIEW_STACK_VISIBLE_METADATA_SECTIONS = [
+const REVIEW_STACK_METADATA_SECTIONS = [
   '## Review Claim',
   '## Review Lane',
   '## Review Unit',
   '## Safety Invariant',
   '## Slice Rationale',
-] as const;
-const REVIEW_STACK_METADATA_LABELS = [
-  'Review Claim',
-  'Review Lane',
-  'Review Unit',
-  'Safety Invariant',
-  'Slice Rationale',
 ] as const;
 const DISCOURAGED_HEADINGS = ['## Testing', '## Notes'] as const;
 const DEFAULT_MAX_INLINE_PROMPT_BYTES = 64 * 1024;
@@ -207,26 +195,13 @@ function getReviewMetadataBlock(body: string): { body: string; openAttributes: s
   return { body: match[2].trim(), openAttributes: match[1] };
 }
 
-/** True when the metadata block carries a non-empty `Label:` field. */
-function hasMetadataLabel(metadata: string, label: string): boolean {
-  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp(`(^|\\n)\\s*${escaped}:\\s*\\S`, 'i').test(metadata);
-}
-
-/**
- * Validate a published Invoker review-stack PR body. This mirrors the structural
- * checks in scripts/validate-pr-body.mjs (the authoritative validator the make-pr
- * skill is told to run): required top-level sections, no visible metadata
- * sections, and a collapsed Review metadata block carrying every required field.
- * A mergify-default commit-message body cannot pass. The deeper review-unit and
- * mermaid rules stay in validate-pr-body.mjs; this is the in-process backstop.
- */
 export function validateReviewStackPrBody(body: string): string[] {
   const trimmed = body.trim();
   if (!trimmed) {
     return [
-      'PR body is empty. Use the canonical review-stack schema: ## Summary with a collapsed '
-        + 'Review metadata block, ## Non-goals, ## Test Plan, and ## Revert Plan.',
+      'PR body is empty. Use the canonical review-stack schema: ## Summary, ## Review Claim, '
+        + '## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, '
+        + '## Test Plan, and ## Revert Plan.',
     ];
   }
 
@@ -236,13 +211,17 @@ export function validateReviewStackPrBody(body: string): string[] {
       errors.push(`Missing required section: ${heading}`);
     }
   }
-  for (const heading of REVIEW_STACK_VISIBLE_METADATA_SECTIONS) {
-    if (hasMarkdownHeading(trimmed, heading)) {
-      errors.push(
-        `${heading} belongs in the collapsed Review metadata block inside ## Summary, `
-          + 'not as a visible top-level section.',
-      );
-    }
+  const missingMetadataSections = REVIEW_STACK_METADATA_SECTIONS.filter(
+    (heading) => !getMarkdownSection(trimmed, heading),
+  );
+  for (const heading of missingMetadataSections) {
+    errors.push(`Missing required section: ${heading}`);
+  }
+  if (getReviewMetadataBlock(trimmed) && missingMetadataSections.length > 0) {
+    errors.push(
+      'Do not hide review metadata in <details>. Use visible ## Review Claim / ## Review Lane / '
+        + '## Review Unit / ## Safety Invariant / ## Slice Rationale sections.',
+    );
   }
   for (const heading of DISCOURAGED_HEADINGS) {
     if (hasMarkdownHeading(trimmed, heading)) {
@@ -256,20 +235,6 @@ export function validateReviewStackPrBody(body: string): string[] {
     for (const subsection of ['### Before', '### After']) {
       if (!hasMarkdownHeading(trimmed, subsection)) {
         errors.push(`Architecture section is missing required subsection: ${subsection}`);
-      }
-    }
-  }
-
-  const metadata = getReviewMetadataBlock(trimmed);
-  if (!metadata) {
-    errors.push('## Summary must include a collapsed <details> block with <summary>Review metadata</summary>.');
-  } else {
-    if (/\bopen\b/i.test(metadata.openAttributes)) {
-      errors.push('Review metadata details must be collapsed by default; remove the open attribute.');
-    }
-    for (const label of REVIEW_STACK_METADATA_LABELS) {
-      if (!hasMetadataLabel(metadata.body, label)) {
-        errors.push(`Review metadata is missing required field: ${label}:`);
       }
     }
   }
@@ -390,10 +355,10 @@ export function buildMakePrStackPublishPrompt(args: {
     '- Do not add Mergify-specific fields to the JSON.',
     '- Each artifact.body MUST be the exact PR body you published for that PR.',
     '- Each body MUST follow the canonical review-stack schema and pass '
-      + '`node scripts/validate-pr-body.mjs`. Required: ## Summary containing a collapsed '
-      + '<details><summary>Review metadata</summary> block with Review Claim, Review Lane, '
-      + 'Review Unit, Safety Invariant, and Slice Rationale fields; plus top-level ## Non-goals, '
-      + '## Test Plan, and ## Revert Plan. Do not use visible ## Review Claim / ## Review Lane sections.',
+      + '`node scripts/validate-pr-body.mjs`. Required visible sections: ## Summary, '
+      + '## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, '
+      + '## Slice Rationale, ## Non-goals, ## Test Plan, and ## Revert Plan. '
+      + 'Never hide review metadata inside a <details> block.',
     '- Do NOT let Mergify default the PR body to the commit message; author the body explicitly.',
     '',
     'Workflow summary:',
@@ -556,6 +521,7 @@ export function buildMakePrPrompt(args: {
   featureBranch: string;
   workflowSummary: string;
   structuredContext?: PrAuthoringContext;
+  strictReviewStack?: boolean;
 }): string {
   const lines = [
     `You are authoring the GitHub PR body for the branch "${args.featureBranch}" targeting "${args.baseBranch}".`,
@@ -570,6 +536,17 @@ export function buildMakePrPrompt(args: {
     '- Only include `## Architecture` when the change modifies component interactions, control flow, state flow, or data flow.',
     '- If the change is small and has no architectural impact, omit `## Architecture`.',
     '- Ensure the final body satisfies the canonical schema required by this repo.',
+  ];
+
+  if (args.strictReviewStack) {
+    lines.push(
+      '- This PR targets the Invoker repo: CI validates the published body with `scripts/validate-pr-body.mjs`.',
+      '- Required sections: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan.',
+      '- Review Claim, Review Lane, Review Unit, Safety Invariant, and Slice Rationale must be visible top-level ## sections; never hide them inside a <details> block.',
+    );
+  }
+
+  lines.push(
     '',
     'You may inspect the working tree, git diff, `scripts/pr-body-template.md`, and `scripts/validate-pr-body.mjs` before writing.',
     '',
@@ -577,7 +554,7 @@ export function buildMakePrPrompt(args: {
     '```md',
     args.workflowSummary.trim(),
     '```',
-  ];
+  );
 
   const ctx = args.structuredContext;
   if (ctx) {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -53,6 +53,7 @@ import {
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import {
   buildCanonicalPrBody,
+  isInvokerRepoUrl,
   buildMakePrStackPublishPrompt,
   buildMakePrPrompt,
   parseMakePrStackPublishResult,
@@ -2316,8 +2317,16 @@ export class TaskRunner {
     workflowSummary: string;
     structuredContext?: PrAuthoringContext;
     cwd: string;
+    repoUrl?: string;
   }): Promise<{ body: string; sessionId: string; agentName: string }> {
+    const strictReviewStack = isInvokerRepoUrl(args.repoUrl);
     if (!this.executionAgentRegistry) {
+      if (strictReviewStack) {
+        throw new Error(
+          '[pr-authoring] executionAgentRegistry missing and target is the Invoker repo; '
+            + 'refusing canonical fallback PR body (it cannot pass scripts/validate-pr-body.mjs).',
+        );
+      }
       this.logger.warn(
         '[pr-authoring] executionAgentRegistry missing, using canonical fallback PR body.',
       );
@@ -2352,15 +2361,19 @@ export class TaskRunner {
         featureBranch: args.featureBranch,
         workflowSummary: args.workflowSummary,
         structuredContext: args.structuredContext,
+        strictReviewStack,
       });
 
       try {
         this.logger.info(
           `[pr-authoring] body authoring starting agent=${agent.name} `
-            + `workflow=${args.workflowId ?? 'unknown'} skill=invoker-make-pr`,
+            + `workflow=${args.workflowId ?? 'unknown'} skill=invoker-make-pr`
+            + (strictReviewStack ? ' schema=review-stack' : ''),
         );
         const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
-        const validationErrors = validateCanonicalPrBody(result.body);
+        const validationErrors = strictReviewStack
+          ? validateReviewStackPrBody(result.body)
+          : validateCanonicalPrBody(result.body);
         if (validationErrors.length > 0) {
           this.logger.warn(
             `[pr-authoring] body validation failed agent=${agent.name} `
@@ -2378,6 +2391,13 @@ export class TaskRunner {
           `${agent.name}: ${err instanceof Error ? err.message : String(err)}`,
         );
       }
+    }
+
+    if (strictReviewStack) {
+      throw new Error(
+        '[pr-authoring] All AI agents failed to author a review-stack PR body for the Invoker repo; '
+          + `refusing canonical fallback (it cannot pass scripts/validate-pr-body.mjs). Errors: ${errors.join(' | ')}`,
+      );
     }
 
     // No AI agent succeeded — emit deterministic canonical PR body


### PR DESCRIPTION
## Summary

Add the changelog note for the strict Invoker PR body gate.

Merge PRs that Invoker opens against its own repo must now carry the full review-compression body, and PR creation fails loudly when no agent can author one.

## Review Claim

The changelog records the strict Invoker-repo PR body gate.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Changelog-only edit; no runtime files change.

## Slice Rationale

The gate slices could not carry a Markdown file per the lane scope rule, so the note lands in its own docs slice.

## Non-goals

- No behavior change; the gate landed in the previous two slices (#3259, #3260).

## Test Plan

- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr3-body.md --changed-files-file /tmp/pr3-files.txt --diff-file /tmp/pr3.diff`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
