### PR TITLE
Execute review-gate CI auto-fix from review_ready gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+- Make review-gate CI auto-fix actually execute: fix intents for a `review_ready`/`awaiting_approval` merge gate now enter the fix lifecycle through `beginAutoFixSession` instead of dying on the `beginConflictResolution` failed-only guard, and a failing agent fix restores the gate to its review state instead of marking an open gate failed. The ci-failure worker also folds terminal fix-intent outcomes back into its dedupe action, so a failed intent no longer leaves a repair showing "queued" forever and the worker retries within its attempt budget.
 - Move auto-fix attempt counts out of SQLite task state and into in-memory worker runtime policy.
 - Add a local master-head full-test repair cron that runs the destructive suite, asks OMP/Codex to fix confirmed failures, reruns the suite, and opens one validated PR per broken upstream SHA.
 - Make the browser UI load heavy Action Graph data only when that tab opens, trim huge diagnostic strings, gzip large `/invoke` JSON responses, and stop checking PR statuses on initial page load.

--- a/packages/app/src/__tests__/repro-review-gate-ci-fix-review-ready.test.ts
+++ b/packages/app/src/__tests__/repro-review-gate-ci-fix-review-ready.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Repro: review-gate CI auto-fix intents die at dispatch because the fix
+ * entry path only accepts `failed` tasks.
+ *
+ * Production failure (workflow "Prove Review Gate Fix No-op Root Cause",
+ * mutation intent 27908):
+ *
+ *   Error: Task __merge__wf-... is not failed (status: review_ready)
+ *       at beginConflictResolutionImpl
+ *       at fixWithAgentAction
+ *       at executeFixWithAgentMutation
+ *
+ * A merge gate whose review PR has a red CI check stays `review_ready` — the
+ * gate task itself never failed. The ci-failure worker intentionally targets
+ * gates in `review_ready` / `awaiting_approval` (see `staleReasonForEvent` in
+ * ci-failure-worker.ts), but `fixWithAgentAction` entered the fix lifecycle
+ * through `beginConflictResolution`, whose guard requires `status === 'failed'`.
+ * Every review-gate CI repair intent therefore failed within milliseconds of
+ * being queued.
+ *
+ * Fixed behavior, proven here against a REAL orchestrator:
+ *   1. `beginConflictResolution` still throws for a review_ready gate — the
+ *      root cause stays reproducible.
+ *   2. `fixWithAgentAction` with a reviewGateContext routes through
+ *      `beginAutoFixSession`, runs the agent fix, and parks the gate in
+ *      `awaiting_approval`.
+ *   3. When the agent fix throws, the gate is restored to `review_ready` —
+ *      not flipped to `failed`, which would eject an open review gate from
+ *      the review-polling loop.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTestHarness, type TestHarness } from '@invoker/test-kit';
+import type { PlanDefinition } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { TaskRunner } from '@invoker/execution-engine';
+import { fixWithAgentAction } from '../workflow-actions.js';
+
+const MANUAL_MERGE_PLAN: PlanDefinition = {
+  name: 'Review Gate CI Fix Plan',
+  onFinish: 'none',
+  mergeMode: 'manual',
+  featureBranch: 'plan/review-gate-ci-fix',
+  tasks: [
+    { id: 'A', description: 'Task A', command: 'echo a' },
+  ],
+};
+
+async function driveGateToReviewReady(h: TestHarness): Promise<string> {
+  h.loadAndStart(MANUAL_MERGE_PLAN);
+  h.completeTask('A');
+  const mergeId = h.getAllTasks().find((t) => t.config.isMergeNode)!.id;
+  await h.executor.executeTasks([h.getTask(mergeId)!]);
+  expect(h.getTask(mergeId)!.status).toBe('review_ready');
+
+  // Give the gate the review + workspace lineage a live external-review gate
+  // carries. The workspace path only needs to exist as a value: workspace
+  // validation goes through taskExecutor.execGitIn, stubbed below.
+  h.persistence.updateTask(mergeId, {
+    execution: {
+      reviewId: 'pr-7',
+      workspacePath: '/tmp/fake-merge-gate-workspace',
+    },
+  });
+  // Direct persistence writes bypass the orchestrator cache; getWorkflowStatus()
+  // forces a refreshFromDb so fixWithAgentAction sees the review lineage.
+  h.orchestrator.getWorkflowStatus();
+  return mergeId;
+}
+
+function reviewGateContextFor(h: TestHarness, mergeId: string, fixContext: string) {
+  const gate = h.orchestrator.getTask(mergeId)!;
+  return {
+    reviewId: 'pr-7',
+    generation: gate.execution.generation ?? 0,
+    selectedAttemptId: gate.execution.selectedAttemptId,
+    branch: gate.execution.branch,
+    fixContext,
+  };
+}
+
+function makeDeps(h: TestHarness, taskExecutor: Record<string, unknown>) {
+  const persistence = Object.create(h.persistence) as Record<string, unknown>;
+  persistence.getTaskOutput = vi.fn(() => 'gate output');
+  persistence.appendTaskOutput = vi.fn();
+  return {
+    orchestrator: h.orchestrator,
+    persistence: persistence as unknown as SQLiteAdapter,
+    taskExecutor: taskExecutor as unknown as TaskRunner,
+  };
+}
+
+describe('review-gate CI auto-fix from review_ready (repro)', () => {
+  let h: TestHarness;
+
+  beforeEach(() => {
+    h = createTestHarness();
+  });
+
+  it('root cause: beginConflictResolution rejects a review_ready merge gate', async () => {
+    const mergeId = await driveGateToReviewReady(h);
+
+    // This is the exact production error from mutation intent 27908.
+    expect(() => h.orchestrator.beginConflictResolution(mergeId))
+      .toThrow(`Task ${mergeId} is not failed (status: review_ready)`);
+  });
+
+  it('fixed: a review-gate CI fix starts from review_ready and parks in awaiting_approval', async () => {
+    const mergeId = await driveGateToReviewReady(h);
+    const fixWithAgent = vi.fn(async () => {
+      // The agent must run while the gate is in the fix lifecycle.
+      expect(h.getTask(mergeId)!.status).toBe('fixing_with_ai');
+    });
+    const taskExecutor = {
+      fixWithAgent,
+      resolveConflict: vi.fn(),
+      execGitIn: vi.fn(async () => 'true'),
+    };
+
+    const result = await fixWithAgentAction(mergeId, makeDeps(h, taskExecutor), {
+      agentName: 'codex',
+      reviewGateContext: reviewGateContextFor(h, mergeId, 'make the failed checks pass'),
+    });
+
+    expect(fixWithAgent).toHaveBeenCalledWith(
+      mergeId, 'gate output', 'codex', '', 'make the failed checks pass',
+    );
+    expect(result).toMatchObject({ kind: 'fixWithAgent' });
+    expect(h.getTask(mergeId)!.status).toBe('awaiting_approval');
+  });
+
+  it('fixed: a failing agent fix restores the gate to review_ready, not failed', async () => {
+    const mergeId = await driveGateToReviewReady(h);
+    const taskExecutor = {
+      fixWithAgent: vi.fn(async () => {
+        throw new Error('agent exploded');
+      }),
+      resolveConflict: vi.fn(),
+      execGitIn: vi.fn(async () => 'true'),
+    };
+
+    await expect(fixWithAgentAction(mergeId, makeDeps(h, taskExecutor), {
+      agentName: 'codex',
+      reviewGateContext: reviewGateContextFor(h, mergeId, 'make the failed checks pass'),
+    })).rejects.toThrow('agent exploded');
+
+    // The open review gate must return to the review-polling loop.
+    expect(h.getTask(mergeId)!.status).toBe('review_ready');
+  });
+});

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -2446,8 +2446,10 @@ describe('fixWithAgentAction review-gate CI context', () => {
         execution: { error: 'ci failed', ...execution },
       })),
       beginConflictResolution: vi.fn(() => ({ savedError: 'ci failed' })),
+      beginAutoFixSession: vi.fn(() => ({ savedError: 'ci failed' })),
       setFixAwaitingApproval: vi.fn(),
       revertConflictResolution: vi.fn(),
+      revertAutoFixSession: vi.fn(),
     };
   }
 
@@ -2471,6 +2473,7 @@ describe('fixWithAgentAction review-gate CI context', () => {
 
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
     expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.beginAutoFixSession).not.toHaveBeenCalled();
   });
 
   it('fixes with the carried fix context when the review-gate context is current', async () => {
@@ -2504,6 +2507,46 @@ describe('fixWithAgentAction review-gate CI context', () => {
     expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith(
       'task-a', 'output', 'claude', 'ci failed', 'make the failed checks pass',
     );
+    // Review-gate CI fixes must enter through beginAutoFixSession: the gate
+    // may be review_ready/awaiting_approval, which beginConflictResolution rejects.
+    expect(orchestrator.beginAutoFixSession).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
     expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
+  });
+
+  it('restores the entry status when a review-gate CI fix fails', async () => {
+    const orchestrator = makeReviewGateOrchestrator({
+      selectedAttemptId: 'attempt-1',
+      generation: 3,
+      reviewId: 'review-1',
+      branch: 'experiment/foo',
+    });
+    const persistence = { getTaskOutput: vi.fn(() => 'output'), appendTaskOutput: vi.fn() };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockRejectedValue(new Error('agent exploded')),
+      resolveConflict: vi.fn(),
+    };
+
+    await expect(fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      agentName: 'claude',
+      reviewGateContext: {
+        reviewId: 'review-1',
+        generation: 3,
+        selectedAttemptId: 'attempt-1',
+        branch: 'experiment/foo',
+        fixContext: 'make the failed checks pass',
+      },
+    })).rejects.toThrow('agent exploded');
+
+    expect(orchestrator.revertAutoFixSession).toHaveBeenCalledWith('task-a', {
+      savedError: 'ci failed',
+      fixError: 'agent exploded',
+      restoreStatus: 'failed',
+    });
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -864,6 +864,13 @@ export async function fixWithAgentAction(
   const task = orchestrator.getTask(taskId);
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
+  // Review-gate CI fixes target a merge gate that is still in an open review
+  // state (`review_ready` / `awaiting_approval`) — the gate task itself never
+  // failed, only a CI check on its review PR did. They must enter the fix
+  // lifecycle through `beginAutoFixSession` (which accepts those states) and
+  // must never flip an open gate to `failed` on the way out.
+  const isReviewGateCiFix = options.reviewGateContext !== undefined;
+  const entryStatus = task.status;
   if (options.reviewGateContext) {
     assertReviewGateCiContextCurrent(taskId, options.reviewGateContext, task);
   }
@@ -875,7 +882,9 @@ export async function fixWithAgentAction(
     const msg = invalidMergeWorkspaceMessage(recoveryRoute);
     const errorLabel = options.failureOutputLabel ?? `Fix with ${effectiveAgentName}`;
     persistence.appendTaskOutput(taskId, `\n[${errorLabel}] ${msg}`);
-    orchestrator.revertConflictResolution(taskId, savedError, msg);
+    if (!isReviewGateCiFix) {
+      orchestrator.revertConflictResolution(taskId, savedError, msg);
+    }
     throw new Error(msg);
   }
   if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
@@ -901,7 +910,9 @@ export async function fixWithAgentAction(
 
   const entryLineage = captureTaskLineage(taskId, orchestrator);
   assertLineageCurrent(entryLineage, orchestrator, options.signal);
-  const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
+  const { savedError: persistedSavedError } = isReviewGateCiFix
+    ? orchestrator.beginAutoFixSession(taskId)
+    : orchestrator.beginConflictResolution(taskId);
   const lineage = captureTaskLineage(taskId, orchestrator);
   try {
     assertLineageCurrent(lineage, orchestrator, options.signal);
@@ -931,7 +942,15 @@ export async function fixWithAgentAction(
     assertLineageCurrent(lineage, orchestrator, options.signal);
     persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
     assertLineageCurrent(lineage, orchestrator, options.signal);
-    orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
+    if (isReviewGateCiFix) {
+      orchestrator.revertAutoFixSession(taskId, {
+        savedError: persistedSavedError,
+        fixError: msg,
+        restoreStatus: entryStatus,
+      });
+    } else {
+      orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
+    }
     throw err;
   }
 }

--- a/packages/execution-engine/src/__tests__/repro-ci-failure-action-stuck-queued.test.ts
+++ b/packages/execution-engine/src/__tests__/repro-ci-failure-action-stuck-queued.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Repro: a review-gate CI repair stays "queued" forever after its fix intent
+ * fails.
+ *
+ * Production failure (workflow "Prove Review Gate Fix No-op Root Cause"):
+ * the ci-failure worker recorded its dedupe action as `queued` when it
+ * submitted fix intent 27908. The intent failed 50ms later, but nothing wrote
+ * that outcome back to the worker action. From then on every tick logged
+ *
+ *   worker-ci-failure-skip reason=already-recorded existingStatus=queued
+ *
+ * because `shouldSkipExistingAction` treats `queued` as open work. The UI
+ * showed a repair "queued up" that would never execute, and the worker never
+ * retried the same failed check.
+ *
+ * Fixed behavior, proven here: before the dedupe check, the worker folds a
+ * terminal intent outcome back into the action row. A failed intent marks the
+ * action `failed` and the same tick requeues a fresh repair (bounded by the
+ * attempt ledger); a completed intent marks the action `completed` and stays
+ * deduped; an intent that is still open keeps the action queued untouched.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type {
+  WorkerActionRecord,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { createAutoFixAttemptLedger } from '../auto-fix-attempt-ledger.js';
+import type { ReviewGateCiFailedLifecycleEvent } from '../lifecycle-events.js';
+import {
+  CI_FAILURE_WORKER_KIND,
+  ciFailureActionKey,
+  createCiFailureTick,
+} from '../workers/ci-failure-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function makeTask(): TaskState {
+  return {
+    id: 'wf-1/merge',
+    description: 'merge',
+    status: 'review_ready',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1', isMergeNode: true },
+    execution: {
+      generation: 2,
+      selectedAttemptId: 'attempt-1',
+      branch: 'feature/ci',
+      reviewGate: {
+        activeGeneration: 2,
+        completion: { required: 'all', status: 'approved' },
+        artifacts: [{
+          id: 'pr-123',
+          providerId: '123',
+          provider: 'github',
+          required: true,
+          status: 'open',
+          generation: 2,
+          headSha: 'sha-1',
+        }],
+      },
+    },
+    taskStateVersion: 10,
+  } as unknown as TaskState;
+}
+
+function makeEvent(): ReviewGateCiFailedLifecycleEvent {
+  return {
+    eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge',
+    kind: 'review_gate.ci_failed',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/merge',
+    status: 'review_ready',
+    taskStateVersion: 10,
+    generation: 2,
+    attemptId: 'attempt-1',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    recoveryWakeup: {
+      eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge',
+      eventKind: 'review_gate.ci_failed',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      taskStateVersion: 10,
+      generation: 2,
+      attemptId: 'attempt-1',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      reason: 'review_gate_failure',
+      authoritative: false,
+    },
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    headSha: 'sha-1',
+    headRef: 'feature/ci',
+    branch: 'feature/ci',
+    failedChecks: [
+      { name: 'PR Body', conclusion: 'CANCELLED', detailsUrl: 'https://github.com/owner/repo/actions/1' },
+    ],
+    statusText: 'Awaiting review',
+  };
+}
+
+function toRecord(write: WorkerActionWrite): WorkerActionRecord {
+  const now = '2026-01-01T00:00:00.000Z';
+  return {
+    ...write,
+    attemptCount: write.attemptCount ?? 0,
+    createdAt: write.createdAt ?? now,
+    updatedAt: write.updatedAt ?? now,
+  };
+}
+
+function makeIntent(id: number, status: WorkflowMutationIntentStatus, error?: string): WorkflowMutationIntent {
+  return {
+    id,
+    workflowId: 'wf-1',
+    channel: 'invoker:fix-with-agent',
+    args: ['wf-1/merge', 'codex', { autoFix: true }],
+    priority: 'normal',
+    status,
+    error,
+    createdAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeHarness(opts: { intents: WorkflowMutationIntent[]; existingActionStatus: string; existingIntentId: string }) {
+  const task = makeTask();
+  const event = makeEvent();
+  const externalKey = ciFailureActionKey(event);
+  const actions = new Map<string, WorkerActionRecord>();
+  actions.set(`${CI_FAILURE_WORKER_KIND}:${externalKey}`, toRecord({
+    id: `${CI_FAILURE_WORKER_KIND}:${externalKey}`,
+    workerKind: CI_FAILURE_WORKER_KIND,
+    actionType: 'fix-ci-failure',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/merge',
+    subjectType: 'review',
+    subjectId: '123',
+    externalKey,
+    status: opts.existingActionStatus as WorkerActionRecord['status'],
+    attemptCount: 1,
+    intentId: opts.existingIntentId,
+    summary: 'Queued CI repair with agent',
+  }));
+  const submit = vi.fn((_workflowId: string, _priority: WorkflowMutationPriority, _channel: string, _args: unknown[]) => 42);
+  const store = {
+    loadTasks: vi.fn(() => [task]),
+    loadTask: vi.fn(() => task),
+    listWorkflowMutationIntents: vi.fn((_workflowId?: string, statuses?: WorkflowMutationIntentStatus[]) =>
+      opts.intents.filter((intent) => !statuses || statuses.includes(intent.status)),
+    ),
+    getWorkerAction: vi.fn((workerKind: string, key: string) => actions.get(`${workerKind}:${key}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const existing = actions.get(`${write.workerKind}:${write.externalKey}`);
+      const saved = toRecord({ ...write, id: existing?.id ?? write.id, createdAt: existing?.createdAt });
+      actions.set(`${write.workerKind}:${write.externalKey}`, saved);
+      return saved;
+    }),
+    logEvent: vi.fn(),
+  };
+  const tick = createCiFailureTick({
+    store,
+    submitter: { submit },
+    logger,
+    attemptLedger: createAutoFixAttemptLedger(),
+    defaultAutoFixRetries: 10,
+    getAutoFixAgent: () => 'codex',
+    drainEvents: () => [event],
+  });
+  const runTick = () => tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+  return { actions, store, submit, event, externalKey, runTick };
+}
+
+describe('ci-failure worker stale queued action (repro)', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fixed: a failed intent flips the queued action to failed and requeues the repair', async () => {
+    const h = makeHarness({
+      intents: [makeIntent(27908, 'failed', 'Error: Task wf-1/merge is not failed (status: review_ready)\n    at beginConflictResolutionImpl')],
+      existingActionStatus: 'queued',
+      existingIntentId: '27908',
+    });
+
+    await h.runTick();
+
+    // The stale queued action was reconciled from the failed intent...
+    const failedWrite = h.store.upsertWorkerAction.mock.calls
+      .map(([write]) => write)
+      .find((write) => write.status === 'failed');
+    expect(failedWrite).toMatchObject({
+      status: 'failed',
+      summary: 'CI repair intent failed: Error: Task wf-1/merge is not failed (status: review_ready)',
+      attemptCount: 1,
+    });
+
+    // ...and the same tick requeued a fresh repair instead of skipping with
+    // reason=already-recorded forever.
+    expect(h.submit).toHaveBeenCalledTimes(1);
+    const final = h.actions.get(`${CI_FAILURE_WORKER_KIND}:${h.externalKey}`);
+    expect(final).toMatchObject({ status: 'queued', intentId: '42', attemptCount: 2 });
+  });
+
+  it('fixed: a completed intent flips the queued action to completed without requeueing', async () => {
+    const h = makeHarness({
+      intents: [makeIntent(27908, 'completed')],
+      existingActionStatus: 'queued',
+      existingIntentId: '27908',
+    });
+
+    await h.runTick();
+
+    expect(h.submit).not.toHaveBeenCalled();
+    const final = h.actions.get(`${CI_FAILURE_WORKER_KIND}:${h.externalKey}`);
+    expect(final).toMatchObject({ status: 'completed', summary: 'CI repair intent completed' });
+  });
+
+  it('an open intent leaves the queued action deduped and does not resubmit', async () => {
+    const h = makeHarness({
+      intents: [makeIntent(27908, 'running')],
+      existingActionStatus: 'queued',
+      existingIntentId: '27908',
+    });
+
+    await h.runTick();
+
+    expect(h.submit).not.toHaveBeenCalled();
+    const final = h.actions.get(`${CI_FAILURE_WORKER_KIND}:${h.externalKey}`);
+    expect(final).toMatchObject({ status: 'queued', intentId: '27908', attemptCount: 1 });
+  });
+});

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -385,6 +385,61 @@ function shouldSkipExistingAction(
   return false;
 }
 
+function firstLine(text: string | undefined): string | undefined {
+  const trimmed = text?.trim();
+  if (!trimmed) return undefined;
+  return trimmed.split('\n', 1)[0];
+}
+
+/**
+ * Fold a terminal mutation-intent outcome back into the dedupe action row.
+ *
+ * The worker records its action as `queued` when it submits a fix intent, but
+ * nothing updated the row when the intent later failed or completed. A failed
+ * intent left the action `queued` forever: the UI showed a repair "queued up"
+ * that would never execute, and `shouldSkipExistingAction` treated the stale
+ * `queued` row as open work, blocking every retry of the same failed check.
+ */
+function reconcileFinishedIntentAction(
+  options: CiFailureWorkerPolicyOptions,
+  event: ReviewGateCiFailedLifecycleEvent,
+): void {
+  const externalKey = ciFailureActionKey(event);
+  const existing = options.store.getWorkerAction?.(CI_FAILURE_WORKER_KIND, externalKey);
+  if (!existing || !existing.intentId) return;
+  if (existing.status !== 'queued' && existing.status !== 'pending' && existing.status !== 'running') return;
+
+  const terminalIntents = options.store.listWorkflowMutationIntents?.(event.workflowId, ['completed', 'failed']) ?? [];
+  const intent = terminalIntents.find((candidate) => String(candidate.id) === existing.intentId);
+  if (!intent) return;
+
+  const now = new Date().toISOString();
+  const status: WorkerActionStatus = intent.status === 'completed' ? 'completed' : 'failed';
+  const summary = status === 'completed'
+    ? 'CI repair intent completed'
+    : `CI repair intent failed: ${firstLine(intent.error) ?? 'unknown error'}`;
+  const payload = existing.payload && typeof existing.payload === 'object'
+    ? { ...(existing.payload as Record<string, unknown>) }
+    : {};
+  options.store.upsertWorkerAction?.({
+    ...existing,
+    status,
+    summary,
+    payload: {
+      ...payload,
+      reconciledIntentStatus: intent.status,
+      intentError: intent.error ?? null,
+    },
+    updatedAt: now,
+    completedAt: now,
+  });
+  logCiFailureWorkerEvent(options, event, 'worker-ci-failure-intent-reconciled', {
+    intentId: existing.intentId,
+    intentStatus: intent.status,
+    actionStatus: status,
+  });
+}
+
 async function handleCiFailureEvent(
   options: CiFailureWorkerPolicyOptions,
   event: ReviewGateCiFailedLifecycleEvent,
@@ -399,6 +454,8 @@ async function handleCiFailureEvent(
   }
 
   const workerRetryBudget = retryBudgetForTask(task, options);
+
+  reconcileFinishedIntentAction(options, event);
 
   if (shouldSkipExistingAction(options, event)) return;
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -113,6 +113,7 @@ import {
   beginConflictResolutionImpl,
   beginAutoFixSessionImpl,
   revertConflictResolutionImpl,
+  revertAutoFixSessionImpl,
   getMergeNodeImpl,
 } from './orchestrator/merge.js';
 import type { MergeHost } from './orchestrator/merge.js';
@@ -2628,6 +2629,25 @@ export class Orchestrator {
     opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
   ): { savedError: string } {
     return beginAutoFixSessionImpl(this as unknown as MergeHost, taskId, opts);
+  }
+
+  /**
+   * Revert an auto-fix session begun by `beginAutoFixSession`. When the
+   * session started from a review-gate state (`review_ready` /
+   * `awaiting_approval`), pass that status as `restoreStatus` so a failed fix
+   * returns the gate to the review-polling loop instead of marking an open
+   * review gate `failed`. Defaults to the `revertConflictResolution` shape.
+   */
+  revertAutoFixSession(
+    taskId: string,
+    opts: {
+      savedError: string;
+      fixError?: string;
+      restoreStatus?: TaskStatus;
+      expectedLineage?: TaskLineageExpectation;
+    },
+  ): void {
+    revertAutoFixSessionImpl(this as unknown as MergeHost, taskId, opts);
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/merge.ts
+++ b/packages/workflow-core/src/orchestrator/merge.ts
@@ -14,7 +14,7 @@
  * exactly so merge/experiment behavior and the TASK_DELTA contract stay stable.
  */
 
-import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskStatus, Attempt } from '@invoker/workflow-graph';
 import type { Logger } from '@invoker/contracts';
 import { parseMergeConflictError } from '../merge-conflict-error.js';
 import type { TaskStateMachine } from '../state-machine.js';
@@ -233,6 +233,67 @@ export function beginAutoFixSessionImpl(
   host.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
   publishTaskDelta(host.messageBus, delta);
   return { savedError };
+}
+
+/**
+ * Statuses an auto-fix session may restore on revert. Mirrors the entry
+ * states accepted by `beginAutoFixSessionImpl`: a review-gate CI fix starts
+ * from `review_ready`/`awaiting_approval` and must return there on failure —
+ * flipping an open review gate to `failed` would knock it out of the
+ * review-gate polling loop.
+ */
+const AUTO_FIX_RESTORABLE_STATUSES: readonly TaskStatus[] = ['review_ready', 'awaiting_approval'];
+
+export function revertAutoFixSessionImpl(
+  host: MergeHost,
+  taskId: string,
+  opts: {
+    savedError: string;
+    fixError?: string;
+    /** Task status captured before `beginAutoFixSession`; defaults to `failed`. */
+    restoreStatus?: TaskStatus;
+    expectedLineage?: TaskLineageExpectation;
+  },
+): void {
+  const restoreStatus = opts.restoreStatus !== undefined && AUTO_FIX_RESTORABLE_STATUSES.includes(opts.restoreStatus)
+    ? opts.restoreStatus
+    : 'failed';
+  if (restoreStatus === 'failed') {
+    revertConflictResolutionImpl(host, taskId, opts.savedError, opts.fixError, opts.expectedLineage);
+    return;
+  }
+
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) {
+    throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+  }
+  if (!host.taskMatchesLineageExpectation(task, opts.expectedLineage)) return;
+
+  const completedAt = new Date();
+  const attemptError = opts.fixError
+    ? `[Fix with Agent failed] ${opts.fixError}`
+    : opts.savedError;
+  const changes: TaskStateChanges = {
+    status: restoreStatus,
+    execution: {
+      error: undefined,
+      isFixingWithAI: false,
+      completedAt,
+    },
+  };
+  const updated = host.writeAndSync(taskId, changes);
+  host.updateSelectedAttempt(taskId, {
+    status: 'failed',
+    error: attemptError,
+    completedAt,
+  });
+  const delta: TaskDelta = host.buildUpdateDelta(task, updated, changes);
+  host.persistence.logEvent?.(task.id, 'task.auto_fix_reverted', {
+    restoreStatus,
+    fixError: opts.fixError ?? null,
+  });
+  publishTaskDelta(host.messageBus, delta);
 }
 
 export function revertConflictResolutionImpl(

--- a/scripts/repro/repro-ci-failure-action-stuck-queued.sh
+++ b/scripts/repro/repro-ci-failure-action-stuck-queued.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Repro: a review-gate CI repair shows "queued" forever after its fix intent
+# fails.
+#
+# Root cause guarded here:
+#   The ci-failure worker records its dedupe worker action as `queued` when it
+#   submits an invoker:fix-with-agent mutation intent, but nothing wrote the
+#   intent's terminal outcome back to the action row. When the intent failed,
+#   the action stayed `queued`; every subsequent tick skipped the same failed
+#   check with
+#
+#     worker-ci-failure-skip reason=already-recorded existingStatus=queued
+#
+#   so the UI showed a repair "queued up" that never executed and the worker
+#   never retried.
+#
+# Fixed behavior:
+#   Before the dedupe check, the worker folds the terminal intent outcome back
+#   into the action row: a failed intent marks the action failed and the same
+#   tick requeues a fresh repair (bounded by the attempt ledger); a completed
+#   intent marks the action completed; open intents keep the action deduped.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] execution-engine: failed fix intents must not leave the CI repair action queued"
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/repro-ci-failure-action-stuck-queued.test.ts
+
+echo "[repro] passed"

--- a/scripts/repro/repro-review-gate-ci-fix-not-failed-guard.sh
+++ b/scripts/repro/repro-review-gate-ci-fix-not-failed-guard.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Repro: review-gate CI auto-fix intents die at dispatch with
+#
+#   Error: Task __merge__wf-... is not failed (status: review_ready)
+#       at beginConflictResolutionImpl
+#       at fixWithAgentAction
+#       at executeFixWithAgentMutation
+#
+# Root cause guarded here:
+#   A merge gate whose review PR has a red CI check stays `review_ready` — the
+#   gate task itself never failed. The ci-failure worker intentionally targets
+#   gates in review_ready/awaiting_approval (staleReasonForEvent), but
+#   fixWithAgentAction entered the fix lifecycle through
+#   beginConflictResolution, whose guard only accepts `failed` tasks. Every
+#   review-gate CI repair intent therefore failed within milliseconds of being
+#   queued, so "Fix with <agent>" appeared queued but never executed.
+#
+# Fixed behavior:
+#   Review-gate CI fixes route through beginAutoFixSession (accepts
+#   review_ready/awaiting_approval), run the agent fix, and park the gate in
+#   awaiting_approval. A failing agent fix restores the gate to review_ready
+#   instead of flipping an open review gate to failed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] app: review-gate CI fix must start from a review_ready merge gate"
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/repro-review-gate-ci-fix-review-ready.test.ts
+
+echo "[repro] passed"


### PR DESCRIPTION
Review-gate CI fix intents route through beginAutoFixSession (accepts
review_ready/awaiting_approval) instead of beginConflictResolution's
failed-only guard, and a failing agent fix restores the gate to its
review state via the new revertAutoFixSession.

The ci-failure worker reconciles terminal fix-intent outcomes into its
dedupe worker action, so a failed intent no longer leaves the repair
'queued' forever and the worker requeues within its attempt budget.