### PR TITLE
[Fix sessions](1) Add an explicit fix-session mechanism to the orchestrator

### DIFF
--- a/packages/data-store/src/__tests__/orchestrator-sqlite-worker-response.test.ts
+++ b/packages/data-store/src/__tests__/orchestrator-sqlite-worker-response.test.ts
@@ -167,7 +167,7 @@ describe('Orchestrator + SQLite worker response persistence', () => {
     expect(row.execution.error).toContain('attempt failed first');
   });
 
-  it('beginConflictResolution persists fixing_with_ai and clears error/exit/completed', () => {
+  it('beginFixSession persists fixing_with_ai and clears error/exit/completed', () => {
     adapter.saveTask(wf.id, baseTask('task-fix'));
     orchestrator.syncFromDb(wf.id);
 
@@ -181,7 +181,7 @@ describe('Orchestrator + SQLite worker response persistence', () => {
     });
     orchestrator.syncFromDb(wf.id);
 
-    orchestrator.beginConflictResolution('task-fix');
+    orchestrator.beginFixSession('task-fix');
 
     const row = adapter.loadTasks(wf.id).find((t) => t.id === 'task-fix')!;
     expect(row.status).toBe('fixing_with_ai');

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -471,7 +471,6 @@ function parseInAppPlanningPlanSummary(value: unknown): InAppPlanningPlanSummary
     steps: candidate.steps,
   };
 }
-
 export class SQLiteAdapter implements PersistenceAdapter {
   private db: NativeDatabaseCompat;
   private nativeDb: DatabaseSync;
@@ -1522,7 +1521,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         last_agent_session_id, last_agent_name,
         action_request_id, experiments,
         created_at, launch_phase, launch_started_at, launch_completed_at, started_at, completed_at, last_heartbeat_at,
-        utilization, pending_fix_error,
+        utilization, pending_fix_error, fix_session_entry_status,
         review_url, review_id, review_status, review_provider_id, review_gate,
         is_fixing_with_ai,
         execution_generation,
@@ -1542,7 +1541,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ?, ?,
         ?, ?, ?,
         ?, ?, ?, ?, ?, ?, ?, ?,
-        ?, ?,
+        ?, ?, ?,
         ?, ?,
         ?, ?, ?, ?,
         ?, ?,
@@ -1599,6 +1598,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       exec.lastHeartbeatAt?.toISOString() ?? null,
       null,
       exec.pendingFixError ?? null,
+      exec.fixSessionEntryStatus ?? null,
       exec.reviewUrl ?? null,
       exec.reviewId ?? null,
       exec.reviewStatus ?? null,
@@ -1702,6 +1702,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         containerId: 'container_id',
         selectedExperiment: 'selected_experiment',
         pendingFixError: 'pending_fix_error',
+        fixSessionEntryStatus: 'fix_session_entry_status',
         reviewUrl: 'review_url',
         reviewId: 'review_id',
         reviewStatus: 'review_status',
@@ -2045,7 +2046,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM in_app_planning_sessions WHERE session_id = ?', [sessionId]);
     });
   }
-
   private getTaskIdsForWorkflow(workflowId: string): string[] {
     const rows = this.queryAll(
       'SELECT id FROM tasks WHERE workflow_id = ?',
@@ -3378,7 +3378,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
       return undefined;
     }
   }
-
   private rowToAttempt(row: any): Attempt {
     return mapRowToAttempt(row);
   }

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -114,6 +114,7 @@ export function mapRowToTask(row: any): TaskState {
       selectedExperiments: row.selected_experiments ? JSON.parse(row.selected_experiments) : undefined,
       experimentResults: row.experiment_results ? JSON.parse(row.experiment_results) : undefined,
       pendingFixError: row.pending_fix_error ?? undefined,
+      fixSessionEntryStatus: row.fix_session_entry_status ?? undefined,
       reviewUrl: row.review_url ?? undefined,
       reviewId: row.review_id ?? undefined,
       reviewStatus: row.review_status ?? undefined,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -397,7 +397,6 @@ export const SCHEMA_DDL = `
 
       CREATE INDEX IF NOT EXISTS idx_terminal_sessions_status_updated
         ON terminal_sessions(status, updated_at);
-
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */
@@ -466,6 +465,8 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
   'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
   'ALTER TABLE tasks ADD COLUMN task_state_version INTEGER NOT NULL DEFAULT 1',
+  // fix_session_entry_status: resting status recorded while a fix session is open
+  'ALTER TABLE tasks ADD COLUMN fix_session_entry_status TEXT',
 ];
 
 /**

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -26,7 +26,7 @@ function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
     resumeTaskAfterFixApproval: vi.fn().mockResolvedValue([] as TaskState[]),
     reject: vi.fn(),
     getTask: vi.fn().mockReturnValue(undefined),
-    revertConflictResolution: vi.fn(),
+    revertFixSession: vi.fn(),
     provideInput: vi.fn(),
     retryTask: vi.fn().mockReturnValue([]),
     recreateTask: vi.fn().mockReturnValue([]),
@@ -114,10 +114,10 @@ describe('CommandService', () => {
 
       expect(result).toEqual({ ok: true, data: undefined });
       expect(orchestrator.reject).toHaveBeenCalledWith('t-1', 'bad');
-      expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+      expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
     });
 
-    it('calls revertConflictResolution when pendingFixError exists', async () => {
+    it('calls revertFixSession when pendingFixError exists', async () => {
       (orchestrator.getTask as ReturnType<typeof vi.fn>).mockReturnValue({
         execution: { pendingFixError: 'merge conflict' },
       });
@@ -125,9 +125,9 @@ describe('CommandService', () => {
       const result = await service.reject(envelope);
 
       expect(result).toEqual({ ok: true, data: undefined });
-      expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith(
+      expect(orchestrator.revertFixSession).toHaveBeenCalledWith(
         't-1',
-        'merge conflict',
+        { savedError: 'merge conflict' },
       );
       expect(orchestrator.reject).not.toHaveBeenCalled();
     });

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -563,7 +563,7 @@ describe('Orchestrator', () => {
     });
   });
 
-  describe('beginConflictResolution / revertConflictResolution', () => {
+  describe('beginFixSession / revertFixSession (failed entry)', () => {
     const mergeConflictError = JSON.stringify({
       type: 'merge_conflict',
       failedBranch: 'experiment/upstream-branch-abc123',
@@ -598,7 +598,7 @@ describe('Orchestrator', () => {
 
     it('sets task to fixing_with_ai, clears terminal execution fields, and emits delta', () => {
       const failedAttemptId = orchestrator.getTask('t2')!.execution.selectedAttemptId;
-      orchestrator.beginConflictResolution('t2');
+      orchestrator.beginFixSession('t2');
 
       const task = orchestrator.getTask('t2')!;
       const fixAttemptId = task.execution.selectedAttemptId;
@@ -623,7 +623,7 @@ describe('Orchestrator', () => {
 
     it('resets startedAt and lastHeartbeatAt timestamps', () => {
       const before = Date.now();
-      orchestrator.beginConflictResolution('t2');
+      orchestrator.beginFixSession('t2');
       const after = Date.now();
 
       const task = orchestrator.getTask('t2')!;
@@ -636,17 +636,17 @@ describe('Orchestrator', () => {
     });
 
     it('returns savedError for later revert', () => {
-      const { savedError } = orchestrator.beginConflictResolution('t2');
+      const { savedError } = orchestrator.beginFixSession('t2');
       expect(savedError).toBe(mergeConflictError);
     });
 
-    it('revertConflictResolution restores failed state with mergeConflict', () => {
-      const { savedError } = orchestrator.beginConflictResolution('t2');
+    it('revertFixSession restores failed state with mergeConflict', () => {
+      const { savedError } = orchestrator.beginFixSession('t2');
       const fixAttemptId = orchestrator.getTask('t2')!.execution.selectedAttemptId;
       expect(orchestrator.getTask('t2')!.status).toBe('fixing_with_ai');
 
       publishedDeltas = [];
-      orchestrator.revertConflictResolution('t2', savedError);
+      orchestrator.revertFixSession('t2', { savedError: savedError });
 
       const task = orchestrator.getTask('t2')!;
       expect(task.status).toBe('failed');
@@ -667,17 +667,17 @@ describe('Orchestrator', () => {
       expect(failedDeltas).toHaveLength(1);
     });
 
-    it('revertConflictResolution uses agent-agnostic fix failure prefix', () => {
-      const { savedError } = orchestrator.beginConflictResolution('t2');
-      orchestrator.revertConflictResolution('t2', savedError, 'startup failed');
+    it('revertFixSession uses agent-agnostic fix failure prefix', () => {
+      const { savedError } = orchestrator.beginFixSession('t2');
+      orchestrator.revertFixSession('t2', { savedError: savedError, fixError: 'startup failed' });
       const task = orchestrator.getTask('t2')!;
       expect(task.execution.error).toContain('[Fix with Agent failed] startup failed');
     });
 
-    it('revertConflictResolution does not duplicate an existing fix failure wrapper', () => {
+    it('revertFixSession does not duplicate an existing fix failure wrapper', () => {
       const wrappedSavedError =
         '[Fix with Claude failed] first attempt failed\n\n' + mergeConflictError;
-      orchestrator.revertConflictResolution('t2', wrappedSavedError, 'second attempt failed');
+      orchestrator.revertFixSession('t2', { savedError: wrappedSavedError, fixError: 'second attempt failed' });
       const task = orchestrator.getTask('t2')!;
       expect(task.execution.error).toContain('[Fix with Agent failed] second attempt failed');
       expect(task.execution.error).not.toContain('first attempt failed');
@@ -687,14 +687,14 @@ describe('Orchestrator', () => {
       });
     });
 
-    it('throws if task is not failed', () => {
-      expect(() => orchestrator.beginConflictResolution('t1')).toThrow(
-        'is not failed',
+    it('throws if task is not in a fix-session entry state', () => {
+      expect(() => orchestrator.beginFixSession('t1')).toThrow(
+        'not in a fix-session entry state',
       );
     });
 
     it('throws if task does not exist', () => {
-      expect(() => orchestrator.beginConflictResolution('nonexistent')).toThrow(
+      expect(() => orchestrator.beginFixSession('nonexistent')).toThrow(
         'not found',
       );
     });
@@ -710,14 +710,135 @@ describe('Orchestrator', () => {
         }),
       );
 
-      const { savedError } = orchestrator.beginConflictResolution('t2');
-      orchestrator.revertConflictResolution('t2', savedError);
+      const { savedError } = orchestrator.beginFixSession('t2');
+      orchestrator.revertFixSession('t2', { savedError: savedError });
 
       const task = orchestrator.getTask('t2')!;
       expect(task.status).toBe('failed');
       expect(task.execution.error).toBe('plain error string');
       expect(task.execution.mergeConflict).toBeUndefined();
       expect(task.execution.isFixingWithAI).toBeFalsy();
+    });
+  });
+
+  describe('beginFixSession / revertFixSession', () => {
+    beforeEach(() => {
+      orchestrator.loadPlan({
+        name: 'fix-session-plan',
+        tasks: [
+          { id: 's1', description: 'Root task' },
+          { id: 's2', description: 'Downstream task', dependencies: ['s1'] },
+        ],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 's1', status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 's2', status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
+      );
+      publishedDeltas = [];
+    });
+
+    function mergeGateInReviewReady(): string {
+      const mergeId = orchestrator.getAllTasks().find((t) => t.config.isMergeNode)!.id;
+      persistence.updateTask(mergeId, { status: 'review_ready', execution: { error: undefined } });
+      orchestrator.getWorkflowStatus(); // force refreshFromDb
+      expect(orchestrator.getTask(mergeId)!.status).toBe('review_ready');
+      return mergeId;
+    }
+
+    it('records the entry status and restores review_ready on revert', () => {
+      const mergeId = mergeGateInReviewReady();
+      const { savedError } = orchestrator.beginFixSession(mergeId);
+
+      const during = orchestrator.getTask(mergeId)!;
+      expect(during.status).toBe('fixing_with_ai');
+      expect(during.execution.fixSessionEntryStatus).toBe('review_ready');
+      const bumpedGeneration = during.execution.generation ?? 0;
+      expect(bumpedGeneration).toBeGreaterThan(0);
+
+      orchestrator.revertFixSession(mergeId, { savedError, fixError: 'agent exploded' });
+
+      const after = orchestrator.getTask(mergeId)!;
+      expect(after.status).toBe('review_ready');
+      expect(after.execution.error).toBeUndefined();
+      expect(after.execution.pendingFixError).toBeUndefined();
+      expect(after.execution.fixSessionEntryStatus).toBeUndefined();
+      // Monotonic fields stay monotonic: revert is not a time machine.
+      expect(after.execution.generation).toBe(bumpedGeneration);
+      expect(persistence.loadAttempt(during.execution.selectedAttemptId!)?.status).toBe('failed');
+    });
+
+    it('restores failed entries with the wrapped error and clears the session', () => {
+      const { savedError } = orchestrator.beginFixSession('s2');
+      expect(orchestrator.getTask('s2')!.execution.fixSessionEntryStatus).toBe('failed');
+
+      orchestrator.revertFixSession('s2', { savedError, fixError: 'startup failed' });
+
+      const task = orchestrator.getTask('s2')!;
+      expect(task.status).toBe('failed');
+      expect(task.execution.error).toContain('[Fix with Agent failed] startup failed');
+      expect(task.execution.fixSessionEntryStatus).toBeUndefined();
+    });
+
+    it('reverts a parked fix (reject path) back to the recorded review_ready entry', () => {
+      const mergeId = mergeGateInReviewReady();
+      const { savedError } = orchestrator.beginFixSession(mergeId);
+      orchestrator.setFixAwaitingApproval(mergeId, savedError || 'ci failed');
+
+      const parked = orchestrator.getTask(mergeId)!;
+      expect(parked.status).toBe('awaiting_approval');
+      expect(parked.execution.fixSessionEntryStatus).toBe('review_ready');
+
+      orchestrator.revertFixSession(mergeId, { savedError: parked.execution.pendingFixError ?? '' });
+
+      const after = orchestrator.getTask(mergeId)!;
+      expect(after.status).toBe('review_ready');
+      expect(after.execution.pendingFixError).toBeUndefined();
+      expect(after.execution.fixSessionEntryStatus).toBeUndefined();
+    });
+
+    it('refuses to begin while a pending fix is parked', () => {
+      const { savedError } = orchestrator.beginFixSession('s2');
+      orchestrator.setFixAwaitingApproval('s2', savedError || 'boom');
+      expect(() => orchestrator.beginFixSession('s2')).toThrow('pending fix awaiting approval');
+    });
+
+    it('refuses to begin from non-entry states', () => {
+      expect(() => orchestrator.beginFixSession('s1')).toThrow(
+        'not in a fix-session entry state',
+      );
+    });
+
+    it('revert without a session on a review gate is an idempotent no-op', () => {
+      const mergeId = mergeGateInReviewReady();
+      orchestrator.revertFixSession(mergeId, { savedError: '', fixError: 'nothing began' });
+      expect(orchestrator.getTask(mergeId)!.status).toBe('review_ready');
+    });
+
+    it('legacy sessions without a recorded entry restore failed', () => {
+      orchestrator.beginFixSession('s2');
+      // Simulate a row written before the entry status existed.
+      persistence.updateTask('s2', { execution: { fixSessionEntryStatus: undefined } });
+      orchestrator.getWorkflowStatus();
+
+      orchestrator.revertFixSession('s2', { savedError: 'boom', fixError: 'legacy' });
+      const task = orchestrator.getTask('s2')!;
+      expect(task.status).toBe('failed');
+      expect(task.execution.error).toContain('[Fix with Agent failed] legacy');
+    });
+
+    it('approve of a parked fix clears the recorded entry', async () => {
+      const mergeId = mergeGateInReviewReady();
+      const { savedError } = orchestrator.beginFixSession(mergeId);
+      orchestrator.setFixAwaitingApproval(mergeId, savedError || 'ci failed');
+
+      await orchestrator.resumeTaskAfterFixApproval(mergeId);
+
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.execution.pendingFixError).toBeUndefined();
+      expect(task.execution.fixSessionEntryStatus).toBeUndefined();
     });
   });
 
@@ -746,7 +867,7 @@ describe('Orchestrator', () => {
     });
 
     it('setFixAwaitingApproval transitions to awaiting_approval with pendingFixError', () => {
-      orchestrator.beginConflictResolution('f2');
+      orchestrator.beginFixSession('f2');
       expect(orchestrator.getTask('f2')!.status).toBe('fixing_with_ai');
       expect(orchestrator.getTask('f2')!.execution.isFixingWithAI).toBeFalsy();
       const fixAttemptId = orchestrator.getTask('f2')!.execution.selectedAttemptId;
@@ -759,7 +880,7 @@ describe('Orchestrator', () => {
     });
 
     it('setFixAwaitingApproval delta includes agentSessionId from DB', () => {
-      orchestrator.beginConflictResolution('f2');
+      orchestrator.beginFixSession('f2');
       // Simulate conflict-resolver persisting sessionId directly to DB
       persistence.updateTask('f2', {
         execution: {
@@ -786,7 +907,7 @@ describe('Orchestrator', () => {
     });
 
     it('pendingFixError is readable via getTask', () => {
-      orchestrator.beginConflictResolution('f2');
+      orchestrator.beginFixSession('f2');
       orchestrator.setFixAwaitingApproval('f2', 'original error');
       expect(orchestrator.getTask('f2')!.execution.pendingFixError).toBe('original error');
     });
@@ -796,7 +917,7 @@ describe('Orchestrator', () => {
     });
 
     it('restartTask clears the fix state', () => {
-      orchestrator.beginConflictResolution('f2');
+      orchestrator.beginFixSession('f2');
       orchestrator.setFixAwaitingApproval('f2', 'error');
       orchestrator.retryTask('f2');
       const task = orchestrator.getTask('f2')!;
@@ -805,10 +926,10 @@ describe('Orchestrator', () => {
       expect(task.execution.pendingFixError).toBeUndefined();
     });
 
-    it('revertConflictResolution restores failed state', () => {
-      orchestrator.beginConflictResolution('f2');
+    it('revertFixSession restores failed state', () => {
+      orchestrator.beginFixSession('f2');
       orchestrator.setFixAwaitingApproval('f2', 'test failed: expected 1 to be 2');
-      orchestrator.revertConflictResolution('f2', 'test failed: expected 1 to be 2');
+      orchestrator.revertFixSession('f2', { savedError: 'test failed: expected 1 to be 2' });
       const task = orchestrator.getTask('f2')!;
       expect(task.status).toBe('failed');
       expect(task.execution.error).toBe('test failed: expected 1 to be 2');
@@ -825,7 +946,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('f2')!.config.isMergeNode).toBeFalsy();
       expect(orchestrator.getTask('f2')!.status).toBe('failed');
 
-      const { savedError } = orchestrator.beginConflictResolution('f2');
+      const { savedError } = orchestrator.beginFixSession('f2');
       expect(savedError).toBe(mergeConflictError);
       expect(orchestrator.getTask('f2')!.status).toBe('fixing_with_ai');
       const fixAttemptId = orchestrator.getTask('f2')!.execution.selectedAttemptId;
@@ -848,7 +969,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('f2')!.config.isMergeNode).toBeFalsy();
       expect(orchestrator.getTask('f2')!.status).toBe('failed');
 
-      const { savedError } = orchestrator.beginConflictResolution('f2');
+      const { savedError } = orchestrator.beginFixSession('f2');
       expect(savedError).toBe(plainTextError);
       expect(orchestrator.getTask('f2')!.status).toBe('fixing_with_ai');
       const fixAttemptId = orchestrator.getTask('f2')!.execution.selectedAttemptId;
@@ -915,7 +1036,7 @@ describe('Orchestrator', () => {
       // Move fd2 through the fix attempt into awaiting_approval
       // with a pendingFixError. This is exactly the state an
       // `approveTask` invocation lands on in the fix flow.
-      const { savedError } = orchestrator.beginConflictResolution('fd2');
+      const { savedError } = orchestrator.beginFixSession('fd2');
       // Hydrate workspace lineage on the task so the preservation
       // half of the assertion is meaningful (the in-memory mock
       // does not synthesize branch/workspacePath itself).
@@ -974,8 +1095,8 @@ describe('Orchestrator', () => {
       expect(cancelWorkflowSpy).not.toHaveBeenCalled();
     });
 
-    it('reject (revertConflictResolution): status -> failed (original error), generation unchanged on edited task and dependents, no retry/recreate/cancel spy fires', () => {
-      const { savedError } = orchestrator.beginConflictResolution('fd2');
+    it('reject (revertFixSession): status -> failed (original error), generation unchanged on edited task and dependents, no retry/recreate/cancel spy fires', () => {
+      const { savedError } = orchestrator.beginFixSession('fd2');
       orchestrator.setFixAwaitingApproval('fd2', savedError);
       expect(orchestrator.getTask('fd2')!.status).toBe('awaiting_approval');
       expect(orchestrator.getTask('fd2')!.execution.pendingFixError).toBe(savedError);
@@ -992,7 +1113,7 @@ describe('Orchestrator', () => {
       const cancelTaskSpy = vi.spyOn(orchestrator, 'cancelTask');
       const cancelWorkflowSpy = vi.spyOn(orchestrator, 'cancelWorkflow');
 
-      orchestrator.revertConflictResolution('fd2', savedError);
+      orchestrator.revertFixSession('fd2', { savedError: savedError });
 
       const fd2After = orchestrator.getTask('fd2')!;
       expect(fd2After.status).toBe('failed');
@@ -1016,7 +1137,7 @@ describe('Orchestrator', () => {
       // Non-fix path: a task parked in `awaiting_approval` without
       // a `pendingFixError`. This is the branch `rejectTask` takes
       // when the task is NOT in a fix flow (it routes to
-      // `Orchestrator.reject` instead of `revertConflictResolution`).
+      // `Orchestrator.reject` instead of `revertFixSession`).
       orchestrator.retryTask('fd2');
       expect(orchestrator.getTask('fd2')!.status).toBe('running');
       orchestrator.setTaskAwaitingApproval('fd2');
@@ -1073,7 +1194,7 @@ describe('Orchestrator', () => {
           outputs: { exitCode: 1, error: 'merge conflict' },
         }),
       );
-      orchestrator.beginConflictResolution(mergeNode.id);
+      orchestrator.beginFixSession(mergeNode.id);
       orchestrator.setFixAwaitingApproval(mergeNode.id, 'merge conflict');
       return mergeNode.id;
     }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2716,7 +2716,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('a2')!.status).toBe('pending');
 
       // Fix with Claude → awaiting_approval
-      orchestrator.beginConflictResolution('a1');
+      orchestrator.beginFixSession('a1');
       orchestrator.setFixAwaitingApproval('a1', 'some error');
       expect(orchestrator.getTask('a1')!.status).toBe('awaiting_approval');
 
@@ -8120,8 +8120,8 @@ describe('Orchestrator', () => {
   // while `fixing_with_ai`" maps the `fixContext` mutation to
   // InvalidationAction = 'retryTask' with InvalidationScope = 'task'
   // applied to the failed/fixing task. Step 10 lifts the previously
-  // bespoke fix-session handling (`beginConflictResolution` /
-  // `revertConflictResolution`) into a proper orchestrator policy
+  // bespoke fix-session handling (`beginFixSession` /
+  // `revertFixSession`) into a proper orchestrator policy
   // seam: `Orchestrator.editTaskFixContext` owns the same-content
   // no-op detection, cancel-first interruption when the task is
   // actively running an AI fix (`fixing_with_ai`), the
@@ -8171,7 +8171,7 @@ describe('Orchestrator', () => {
     }
 
     function driveTaskToFixingWithAi(taskId: string): void {
-      orchestrator.beginConflictResolution(taskId);
+      orchestrator.beginFixSession(taskId);
       expect(orchestrator.getTask(taskId)?.status).toBe('fixing_with_ai');
       publishedDeltas = [];
     }

--- a/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
@@ -39,6 +39,7 @@ const expectedExecutionFields = [
   'selectedExperiments',
   'experimentResults',
   'pendingFixError',
+  'fixSessionEntryStatus',
   'isFixingWithAI',
   'reviewUrl',
   'reviewId',

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -105,10 +105,11 @@ export class CommandService {
       () => {
         const task = this.orchestrator.getTask(envelope.payload.taskId);
         if (task?.execution.pendingFixError !== undefined) {
-          this.orchestrator.revertConflictResolution(
-            envelope.payload.taskId,
-            task.execution.pendingFixError,
-          );
+          // Revert the fix session to its recorded entry status: rejecting a
+          // review-gate fix returns the gate to review_ready, not failed.
+          this.orchestrator.revertFixSession(envelope.payload.taskId, {
+            savedError: task.execution.pendingFixError,
+          });
         } else {
           this.orchestrator.reject(
             envelope.payload.taskId,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -111,8 +111,9 @@ import {
   recreateWorkflowFromFreshBaseImpl,
   getKnownFreshBaseCommitImpl,
   beginConflictResolutionImpl,
-  beginAutoFixSessionImpl,
+  beginFixSessionImpl,
   revertConflictResolutionImpl,
+  revertFixSessionImpl,
   getMergeNodeImpl,
 } from './orchestrator/merge.js';
 import type { MergeHost } from './orchestrator/merge.js';
@@ -1864,7 +1865,7 @@ export class Orchestrator {
 
     const changes: TaskStateChanges = {
       status: 'completed',
-      execution: { completedAt: new Date() },
+      execution: { completedAt: new Date(), fixSessionEntryStatus: undefined },
     };
     const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
@@ -1913,7 +1914,7 @@ export class Orchestrator {
     const now = new Date();
     const changes: TaskStateChanges = {
       status: 'running',
-      execution: { pendingFixError: undefined, startedAt: now, lastHeartbeatAt: now },
+      execution: { pendingFixError: undefined, fixSessionEntryStatus: undefined, startedAt: now, lastHeartbeatAt: now },
     };
     const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
@@ -1937,7 +1938,7 @@ export class Orchestrator {
 
     const changes: TaskStateChanges = {
       status: 'failed',
-      execution: { error: reason ?? 'Rejected', completedAt: new Date() },
+      execution: { error: reason ?? 'Rejected', completedAt: new Date(), fixSessionEntryStatus: undefined },
     };
     const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
@@ -2610,29 +2611,46 @@ export class Orchestrator {
   }
 
   /**
-   * Transition a failed task to fixing_with_ai before an async conflict resolution.
-   * Clears terminal failure fields on the row so SQLite does not show stale error/exit/completed.
-   * Returns the saved error string so the caller can revert on failure.
+   * Begin a fix session from an explicit resting state (`failed`,
+   * `review_ready`, or `awaiting_approval`). Records the entry status on the
+   * task so `revertFixSession` — possibly running after a restart, from an
+   * approve/reject surface — restores exactly where the session started.
+   * Refuses to begin while a pending fix is parked awaiting approval.
+   */
+  beginFixSession(
+    taskId: string,
+    opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
+  ): { savedError: string } {
+    return beginFixSessionImpl(this as unknown as MergeHost, taskId, opts);
+  }
+
+  /**
+   * Revert a fix session to its recorded entry status. Sessions with no
+   * recorded entry (legacy rows) restore `failed`; a revert with no session
+   * evidence is an idempotent no-op.
+   */
+  revertFixSession(
+    taskId: string,
+    opts: {
+      savedError: string;
+      fixError?: string;
+      expectedLineage?: TaskLineageExpectation;
+    },
+  ): void {
+    revertFixSessionImpl(this as unknown as MergeHost, taskId, opts);
+  }
+
+  /**
+   * @deprecated Use `beginFixSession`. Failed-only entry guard kept for
+   * callers not yet migrated; removed once call sites move over.
    */
   beginConflictResolution(taskId: string, expectedLineage?: TaskLineageExpectation): { savedError: string } {
     return beginConflictResolutionImpl(this as unknown as MergeHost, taskId, expectedLineage);
   }
 
   /**
-   * Begin an AI fix session from either a failed task or an external review
-   * gate state. Review-gate CI failures use this path because the merge task
-   * may still be review_ready/awaiting_approval while the PR checks are red.
-   */
-  beginAutoFixSession(
-    taskId: string,
-    opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
-  ): { savedError: string } {
-    return beginAutoFixSessionImpl(this as unknown as MergeHost, taskId, opts);
-  }
-
-  /**
-   * Revert a conflict resolution attempt: restore the task to failed
-   * with its original error and re-parsed mergeConflict field.
+   * @deprecated Use `revertFixSession`. Always restores `failed`; removed
+   * once call sites move over.
    */
   revertConflictResolution(
     taskId: string,
@@ -2985,7 +3003,7 @@ export class Orchestrator {
    * "only command edit has explicit handling today; no general
    * fix-context mutation policy" and the chart's "Fix-session
    * inconsistency" subsection calls out the bespoke
-   * `beginConflictResolution` / `revertConflictResolution` rollback
+   * `beginFixSession` / `revertFixSession` rollback
    * as "one special active invalidation mechanism, not a general
    * one". Step 10 lifts that bespoke fix-session handling into a
    * proper orchestrator policy seam (`Orchestrator.editTaskFixContext`)

--- a/packages/workflow-core/src/orchestrator/merge.ts
+++ b/packages/workflow-core/src/orchestrator/merge.ts
@@ -14,7 +14,7 @@
  * exactly so merge/experiment behavior and the TASK_DELTA contract stay stable.
  */
 
-import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskStatus, Attempt } from '@invoker/workflow-graph';
 import type { Logger } from '@invoker/contracts';
 import { parseMergeConflictError } from '../merge-conflict-error.js';
 import type { TaskStateMachine } from '../state-machine.js';
@@ -127,6 +127,65 @@ export function getKnownFreshBaseCommitImpl(host: MergeHost, workflowId: string)
   return host.knownFreshBaseCommits.get(workflowId);
 }
 
+/**
+ * Resting states a fix session may begin from — and therefore the only
+ * states `revertFixSessionImpl` will ever restore. Explicit allow-list:
+ *
+ * - `failed`             — the classic fix-a-broken-task flow.
+ * - `review_ready`       — a merge gate with an open review whose PR checks
+ *                          went red; the gate task itself never failed.
+ * - `awaiting_approval`  — a manual gate waiting on a human.
+ *
+ * Everything else is deliberately out: `pending`/`running`/`needs_input`/
+ * `blocked` belong to the launch and input lifecycles (restoring `running`
+ * would claim a live process that does not exist), and `completed`/`closed`/
+ * `stale` are terminal — a revert that resurrects finished work is a
+ * different, dangerous operation.
+ */
+export const FIX_SESSION_ENTRY_STATUSES = ['failed', 'review_ready', 'awaiting_approval'] as const;
+export type FixSessionEntryStatus = (typeof FIX_SESSION_ENTRY_STATUSES)[number];
+
+function isFixSessionEntryStatus(status: TaskStatus): status is FixSessionEntryStatus {
+  return (FIX_SESSION_ENTRY_STATUSES as readonly TaskStatus[]).includes(status);
+}
+
+/**
+ * Begin a fix session: record the entry status on the task (persisted, so a
+ * later revert — possibly after a restart, from an approve/reject surface —
+ * knows exactly where to return), then move the task to `fixing_with_ai`.
+ *
+ * At most one session may be open per task: beginning while a pending fix is
+ * parked (`pendingFixError` set) is refused; the human must approve or reject
+ * the parked fix first.
+ */
+export function beginFixSessionImpl(
+  host: MergeHost,
+  taskId: string,
+  opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
+): { savedError: string } {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+  if (!host.taskMatchesLineageExpectation(task, opts.expectedLineage)) {
+    throw new Error(`Task ${taskId} lineage is stale for fix session start`);
+  }
+  if (task.execution.pendingFixError !== undefined) {
+    throw new Error(
+      `Task ${taskId} already has a pending fix awaiting approval or rejection; approve or reject it before starting another fix`,
+    );
+  }
+  if (!isFixSessionEntryStatus(task.status)) {
+    throw new Error(
+      `Task ${taskId} is not in a fix-session entry state (status: ${task.status}; allowed: ${FIX_SESSION_ENTRY_STATUSES.join(', ')})`,
+    );
+  }
+  return startFixSession(host, task, task.status, opts.savedError);
+}
+
+/**
+ * @deprecated Use `beginFixSessionImpl`. Failed-only entry guard kept for
+ * callers not yet migrated; removed once call sites move over.
+ */
 export function beginConflictResolutionImpl(
   host: MergeHost,
   taskId: string,
@@ -139,68 +198,19 @@ export function beginConflictResolutionImpl(
     throw new Error(`Task ${taskId} lineage is stale for conflict resolution start`);
   }
   if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
-
-  const savedError = task.execution.error ?? '';
-  const startedAt = new Date();
-
-  const id = task.id;
-  const changes: TaskStateChanges = {
-    status: 'fixing_with_ai',
-    execution: {
-      error: undefined,
-      exitCode: undefined,
-      completedAt: undefined,
-      mergeConflict: undefined,
-      isFixingWithAI: false,
-      startedAt,
-      lastHeartbeatAt: startedAt,
-    },
-  };
-  const changesWithGeneration = host.withBumpedExecutionGeneration(task, changes);
-  const conflictUpdated = host.writeAndSync(taskId, changesWithGeneration);
-  const attemptId = host.replaceSelectedAttempt(task);
-  host.taskRepository.updateAttempt(attemptId, {
-    status: 'running',
-    startedAt,
-    lastHeartbeatAt: startedAt,
-    branch: task.execution.branch,
-    commit: task.execution.commit,
-    workspacePath: task.execution.workspacePath,
-    agentSessionId: task.execution.agentSessionId,
-    containerId: task.execution.containerId,
-    mergeConflict: undefined,
-    error: undefined,
-    exitCode: undefined,
-  });
-  const delta: TaskDelta = host.buildUpdateDelta(task, conflictUpdated, changesWithGeneration);
-  host.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
-  publishTaskDelta(host.messageBus, delta);
-
-  return { savedError };
+  return startFixSession(host, task, task.status, undefined);
 }
 
-export function beginAutoFixSessionImpl(
+function startFixSession(
   host: MergeHost,
-  taskId: string,
-  opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
+  task: TaskState,
+  entryStatus: FixSessionEntryStatus,
+  savedErrorOverride: string | undefined,
 ): { savedError: string } {
-  host.refreshFromDb();
-  const task = host.stateGetTask(taskId);
-  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-  if (!host.taskMatchesLineageExpectation(task, opts.expectedLineage)) {
-    throw new Error(`Task ${taskId} lineage is stale for auto-fix start`);
-  }
-  if (
-    task.status !== 'failed' &&
-    task.status !== 'review_ready' &&
-    task.status !== 'awaiting_approval'
-  ) {
-    throw new Error(`Task ${taskId} is not in an auto-fixable state (status: ${task.status})`);
-  }
-
-  const savedError = opts.savedError ?? task.execution.error ?? '';
+  const savedError = savedErrorOverride ?? task.execution.error ?? '';
   const startedAt = new Date();
   const id = task.id;
+
   const changes: TaskStateChanges = {
     status: 'fixing_with_ai',
     execution: {
@@ -209,6 +219,7 @@ export function beginAutoFixSessionImpl(
       completedAt: undefined,
       mergeConflict: undefined,
       isFixingWithAI: false,
+      fixSessionEntryStatus: entryStatus,
       startedAt,
       lastHeartbeatAt: startedAt,
     },
@@ -232,9 +243,96 @@ export function beginAutoFixSessionImpl(
   const delta: TaskDelta = host.buildUpdateDelta(task, updated, changesWithGeneration);
   host.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
   publishTaskDelta(host.messageBus, delta);
+
   return { savedError };
 }
 
+/**
+ * Revert a fix session to the entry status recorded by `beginFixSessionImpl`.
+ *
+ * Valid at two points of the session: while the fix runs (`fixing_with_ai`)
+ * and after it parked awaiting a human (`awaiting_approval` +
+ * `pendingFixError`, the reject path). Restore means "status equals entry
+ * status" — monotonic fields stay monotonic: the execution generation stays
+ * bumped (it guards against orphaned async work) and the replaced attempt
+ * stays replaced, marked failed.
+ *
+ * Legacy rows (a session begun before the entry status was recorded) restore
+ * `failed`, which is exact: every pre-existing session came through the
+ * failed-only guard. A revert with no session and no legacy evidence is an
+ * idempotent no-op — reverts run inside catch blocks and retried mutation
+ * intents, where throwing would mask the original error.
+ */
+export function revertFixSessionImpl(
+  host: MergeHost,
+  taskId: string,
+  opts: {
+    savedError: string;
+    fixError?: string;
+    expectedLineage?: TaskLineageExpectation;
+  },
+): void {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) {
+    throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+  }
+  if (!host.taskMatchesLineageExpectation(task, opts.expectedLineage)) return;
+
+  const recorded = task.execution.fixSessionEntryStatus;
+  const entryStatus: FixSessionEntryStatus | undefined =
+    recorded !== undefined && isFixSessionEntryStatus(recorded)
+      ? recorded
+      : task.status === 'fixing_with_ai' ||
+          task.status === 'failed' ||
+          task.execution.pendingFixError !== undefined
+        ? 'failed' // legacy session or failed-task error rewrite: pre-column behavior
+        : undefined;
+  if (entryStatus === undefined) {
+    host.persistence.logEvent?.(task.id, 'task.fix_session_revert_noop', {
+      status: task.status,
+      fixError: opts.fixError ?? null,
+    });
+    return;
+  }
+
+  if (entryStatus === 'failed') {
+    restoreFailedEntry(host, task, opts.savedError, opts.fixError);
+    return;
+  }
+
+  const completedAt = new Date();
+  const attemptError = opts.fixError
+    ? `[Fix with Agent failed] ${opts.fixError}`
+    : opts.savedError;
+  const changes: TaskStateChanges = {
+    status: entryStatus,
+    execution: {
+      error: undefined,
+      isFixingWithAI: false,
+      pendingFixError: undefined,
+      fixSessionEntryStatus: undefined,
+      completedAt,
+    },
+  };
+  const updated = host.writeAndSync(taskId, changes);
+  host.updateSelectedAttempt(taskId, {
+    status: 'failed',
+    error: attemptError,
+    completedAt,
+  });
+  const delta: TaskDelta = host.buildUpdateDelta(task, updated, changes);
+  host.persistence.logEvent?.(task.id, 'task.fix_session_reverted', {
+    restoreStatus: entryStatus,
+    fixError: opts.fixError ?? null,
+  });
+  publishTaskDelta(host.messageBus, delta);
+}
+
+/**
+ * @deprecated Use `revertFixSessionImpl`. Always restores `failed`; removed
+ * once call sites move over.
+ */
 export function revertConflictResolutionImpl(
   host: MergeHost,
   taskId: string,
@@ -248,8 +346,16 @@ export function revertConflictResolutionImpl(
     throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
   }
   if (!host.taskMatchesLineageExpectation(task, expectedLineage)) return;
-  const id = task.id;
+  restoreFailedEntry(host, task, savedError, fixError);
+}
 
+function restoreFailedEntry(
+  host: MergeHost,
+  task: TaskState,
+  savedError: string,
+  fixError?: string,
+): void {
+  const id = task.id;
   const normalizedSavedError = stripFixFailureWrapper(savedError);
   const mergeConflict = parseMergeConflictError(normalizedSavedError);
 
@@ -263,11 +369,13 @@ export function revertConflictResolutionImpl(
       error: displayError,
       mergeConflict,
       isFixingWithAI: false,
+      pendingFixError: undefined,
+      fixSessionEntryStatus: undefined,
       completedAt,
     },
   };
-  const revertUpdated = host.writeAndSync(taskId, changes);
-  host.updateSelectedAttempt(taskId, {
+  const revertUpdated = host.writeAndSync(id, changes);
+  host.updateSelectedAttempt(id, {
     status: 'failed',
     error: displayError,
     mergeConflict,

--- a/packages/workflow-core/src/task-reset-policy.ts
+++ b/packages/workflow-core/src/task-reset-policy.ts
@@ -80,6 +80,7 @@ export const TASK_EXECUTION_RESET_RULES = {
   selectedExperiments: preserve,
   experimentResults: preserve,
   pendingFixError: clearFor(['detach', 'retryTask', 'retryWorkflow', 'newAttempt']),
+  fixSessionEntryStatus: clearFor(['detach', 'retryTask', 'retryWorkflow', 'newAttempt']),
   isFixingWithAI: falseFor(['detach', 'retryTask', 'retryWorkflow', 'newAttempt']),
   reviewUrl: clearFor(['recreate', 'detach']),
   reviewId: clearFor(['recreate', 'detach']),

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -201,6 +201,13 @@ export interface TaskExecution {
   readonly selectedExperiments?: readonly string[];
   readonly experimentResults?: readonly ExperimentResultEntry[];
   readonly pendingFixError?: string;
+  /**
+   * Resting status recorded when a fix session began (`failed`,
+   * `review_ready`, or `awaiting_approval`). Present only while the session
+   * is open (fixing or parked awaiting approval); `revertFixSession` restores
+   * this status and every session exit clears it.
+   */
+  readonly fixSessionEntryStatus?: TaskStatus;
   readonly isFixingWithAI?: boolean;
   readonly reviewUrl?: string;
   readonly reviewId?: string;


### PR DESCRIPTION
## Summary

The fix flow could only start from a `failed` task. A review gate whose PR check goes red stays `review_ready`, so its repair died at dispatch in 50ms.

This adds an explicit fix-session mechanism. `beginFixSession` names the allowed resting entry states: `failed`, `review_ready`, `awaiting_approval` — nothing else.

The entry status is recorded on the task in a new `fix_session_entry_status` column. It survives restarts and late approve/decline decisions.

`revertFixSession` restores exactly the recorded entry on every exit. An open review gate returns to review polling instead of being flipped to `failed`.

Beginning a second session while a fix is parked awaiting approval is refused. Legacy rows with no recorded entry restore `failed`, which is exact for them.

Reverts with no session evidence are idempotent no-ops, because reverts run inside error handlers where throwing masks the original failure.

The old begin/revertConflictResolution surface stays as deprecated delegates until call sites migrate in the slices above.

## Review Claim

Fix sessions begin only from an explicit allowed set of resting states, record their entry status durably, and every exit restores that recorded status.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The deprecated delegates keep their exact old behavior: a failed-only entry guard with the same message, and a revert that always writes `failed`. No caller changes in this slice; monotonic fields (execution generation, attempt history) never rewind on revert.

## Slice Rationale

This is the orchestrator mechanism the app-side call sites adopt in slice 3 and the deprecated surface drop in slice 4 both depend on; landing it first keeps those slices small.

## Non-goals

- No caller is wired up here; `fixWithAgentAction`, decline, and approve adopt the mechanism in slice 3.
- No backfill of tasks already parked with a pending fix; they restore `failed` exactly as before.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts src/__tests__/command-service.test.ts src/__tests__/task-reset-policy.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/orchestrator-sqlite-worker-response.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5800d84`
- Post-revert steps: None
- Data migration? No — the added column is nullable and ignored by older code.

</details>
