### PR TITLE
[Fix sessions](3) Route app fix and reject surfaces through fix sessions

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -92,9 +92,9 @@ function createMocks() {
       getTask: vi.fn((id: string) => (id === 'task-1' ? makeTask() : undefined)),
       approve: vi.fn().mockResolvedValue([]),
       reject: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
       provideInput: vi.fn(),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'saved-error' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'saved-error' })),
       setFixAwaitingApproval: vi.fn(),
       retryTask: vi.fn(() => [makeTask()]),
       recreateTask: vi.fn(() => [makeTask()]),
@@ -287,7 +287,7 @@ beforeEach(() => {
   mocks.orchestrator.retryTask.mockReturnValue([makeTask()]);
   mocks.orchestrator.recreateTask.mockReturnValue([makeTask()]);
   mocks.orchestrator.recreateDownstream.mockReturnValue([makeTask()]);
-  mocks.orchestrator.beginConflictResolution.mockReturnValue({ savedError: 'saved-error' });
+  mocks.orchestrator.beginFixSession.mockReturnValue({ savedError: 'saved-error' });
   mocks.orchestrator.editTaskCommand.mockReturnValue([makeTask()]);
   mocks.orchestrator.editTaskPrompt.mockReturnValue([makeTask()]);
   mocks.orchestrator.setTaskExternalGatePolicies.mockReturnValue([makeTask()]);
@@ -796,7 +796,7 @@ describe('POST /api/tasks/:id/reject', () => {
     );
     const res = await request(port, 'POST', '/api/tasks/task-1/reject');
     expect(res.status).toBe(200);
-    expect(mocks.orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-1', 'merge conflict');
+    expect(mocks.orchestrator.revertFixSession).toHaveBeenCalledWith('task-1', { savedError: 'merge conflict' });
     expect(mocks.orchestrator.reject).not.toHaveBeenCalled();
   });
 
@@ -830,10 +830,7 @@ describe('POST /api/tasks/:id/reject', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.action).toBe('rejected');
-    expect(mocks.orchestrator.revertConflictResolution).toHaveBeenCalledWith(
-      'task-1',
-      'merge conflict',
-    );
+    expect(mocks.orchestrator.revertFixSession).toHaveBeenCalledWith('task-1', { savedError: 'merge conflict' });
     expect(mocks.orchestrator.reject).not.toHaveBeenCalled();
     expect(mocks.orchestrator.retryTask).not.toHaveBeenCalled();
     expect(mocks.orchestrator.recreateTask).not.toHaveBeenCalled();

--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -131,11 +131,11 @@ describe('global top-up dispatch', () => {
     });
     (h.orchestrator as any).refreshFromDb();
 
-    const { savedError } = h.orchestrator.beginConflictResolution(taskA.id);
+    const { savedError } = h.orchestrator.beginFixSession(taskA.id);
     expect(h.getTask('A')!.status).toBe('fixing_with_ai');
     expect(h.getTask('B')!.status).toBe('pending');
 
-    h.orchestrator.revertConflictResolution(taskA.id, savedError, 'Remote agent fix timed out after 600000ms');
+    h.orchestrator.revertFixSession(taskA.id, { savedError: savedError, fixError: 'Remote agent fix timed out after 600000ms' });
 
     expect(h.getTask('A')!.status).toBe('failed');
     expect(h.getTask('B')!.status).toBe('pending');

--- a/packages/app/src/__tests__/parity-regression.test.ts
+++ b/packages/app/src/__tests__/parity-regression.test.ts
@@ -311,9 +311,9 @@ describe('Parity: API endpoints wire to facade methods', () => {
         getTask: vi.fn(() => makeTask()),
         approve: vi.fn().mockResolvedValue([]),
         reject: vi.fn(),
-        revertConflictResolution: vi.fn(),
+        revertFixSession: vi.fn(),
         provideInput: vi.fn(),
-        beginConflictResolution: vi.fn(() => ({ savedError: 'saved-error' })),
+        beginFixSession: vi.fn(() => ({ savedError: 'saved-error' })),
         setFixAwaitingApproval: vi.fn(),
         retryTask: vi.fn(() => [makeTask()]),
         recreateTask: vi.fn(() => [makeTask()]),
@@ -520,7 +520,7 @@ describe('Parity: CommandService routes to correct orchestrator primitives', () 
       approve: vi.fn(async () => [makeTask()]),
       resumeTaskAfterFixApproval: vi.fn(async () => []),
       reject: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
       provideInput: vi.fn(),
       retryTask: vi.fn(() => [makeTask()]),
       recreateTask: vi.fn(() => [makeTask()]),
@@ -595,17 +595,17 @@ describe('Parity: CommandService routes to correct orchestrator primitives', () 
 
     expect(result.ok).toBe(true);
     expect(orchestrator.reject).toHaveBeenCalledWith('task-1', 'bad');
-    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
   });
 
-  it('reject routes to revertConflictResolution when pendingFixError exists', async () => {
+  it('reject routes to revertFixSession when pendingFixError exists', async () => {
     orchestrator.getTask.mockReturnValue(
       makeTask({ execution: { pendingFixError: 'merge conflict' } }),
     );
     const result = await commandService.reject(envelope({ taskId: 'task-1' }));
 
     expect(result.ok).toBe(true);
-    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-1', 'merge conflict');
+    expect(orchestrator.revertFixSession).toHaveBeenCalledWith('task-1', { savedError: 'merge conflict' });
     expect(orchestrator.reject).not.toHaveBeenCalled();
   });
 

--- a/packages/app/src/__tests__/repro-review-gate-ci-fix-review-ready.test.ts
+++ b/packages/app/src/__tests__/repro-review-gate-ci-fix-review-ready.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Repro: review-gate CI auto-fix intents die at dispatch because the fix
+ * entry path only accepted `failed` tasks.
+ *
+ * Production failure (workflow "Prove Review Gate Fix No-op Root Cause",
+ * mutation intent 27908):
+ *
+ *   Error: Task __merge__wf-... is not failed (status: review_ready)
+ *       at beginConflictResolutionImpl
+ *       at fixWithAgentAction
+ *       at executeFixWithAgentMutation
+ *
+ * A merge gate whose review PR has a red CI check stays `review_ready` — the
+ * gate task itself never failed. The ci-failure worker intentionally targets
+ * gates in `review_ready` / `awaiting_approval` (see `staleReasonForEvent` in
+ * ci-failure-worker.ts), but the fix action entered the lifecycle through a
+ * failed-only guard. Every review-gate CI repair intent therefore failed
+ * within milliseconds of being queued.
+ *
+ * Fixed behavior, proven here against a REAL orchestrator: fix sessions have
+ * an explicit entry-state allow-list (`failed`, `review_ready`,
+ * `awaiting_approval`) recorded at begin time, and every exit restores the
+ * recorded entry:
+ *   1. A review-gate CI fix starts from `review_ready` and parks in
+ *      `awaiting_approval`.
+ *   2. A failing agent fix restores the gate to `review_ready` — not `failed`,
+ *      which would eject an open review gate from the review-polling loop.
+ *   3. Rejecting the parked fix also restores `review_ready` (the same bug one
+ *      screen later — reject used to hard-code `failed`).
+ *   4. Non-resting states stay out: the allow-list refuses them loudly.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createTestHarness, type TestHarness } from '@invoker/test-kit';
+import type { PlanDefinition } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { TaskRunner } from '@invoker/execution-engine';
+import { fixWithAgentAction, rejectTask } from '../workflow-actions.js';
+
+const MANUAL_MERGE_PLAN: PlanDefinition = {
+  name: 'Review Gate CI Fix Plan',
+  onFinish: 'none',
+  mergeMode: 'manual',
+  featureBranch: 'plan/review-gate-ci-fix',
+  tasks: [
+    { id: 'A', description: 'Task A', command: 'echo a' },
+  ],
+};
+
+async function driveGateToReviewReady(h: TestHarness): Promise<string> {
+  h.loadAndStart(MANUAL_MERGE_PLAN);
+  h.completeTask('A');
+  const mergeId = h.getAllTasks().find((t) => t.config.isMergeNode)!.id;
+  await h.executor.executeTasks([h.getTask(mergeId)!]);
+  expect(h.getTask(mergeId)!.status).toBe('review_ready');
+
+  // Give the gate the review + workspace lineage a live external-review gate
+  // carries. The workspace path only needs to exist as a value: workspace
+  // validation goes through taskExecutor.execGitIn, stubbed below.
+  h.persistence.updateTask(mergeId, {
+    execution: {
+      reviewId: 'pr-7',
+      workspacePath: '/tmp/fake-merge-gate-workspace',
+    },
+  });
+  // Direct persistence writes bypass the orchestrator cache; getWorkflowStatus()
+  // forces a refreshFromDb so fixWithAgentAction sees the review lineage.
+  h.orchestrator.getWorkflowStatus();
+  return mergeId;
+}
+
+function reviewGateContextFor(h: TestHarness, mergeId: string, fixContext: string) {
+  const gate = h.orchestrator.getTask(mergeId)!;
+  return {
+    reviewId: 'pr-7',
+    generation: gate.execution.generation ?? 0,
+    selectedAttemptId: gate.execution.selectedAttemptId,
+    branch: gate.execution.branch,
+    fixContext,
+  };
+}
+
+function makeDeps(h: TestHarness, taskExecutor: Record<string, unknown>) {
+  const persistence = Object.create(h.persistence) as Record<string, unknown>;
+  persistence.getTaskOutput = vi.fn(() => 'gate output');
+  persistence.appendTaskOutput = vi.fn();
+  return {
+    orchestrator: h.orchestrator,
+    persistence: persistence as unknown as SQLiteAdapter,
+    taskExecutor: taskExecutor as unknown as TaskRunner,
+  };
+}
+
+describe('review-gate CI auto-fix from review_ready (repro)', () => {
+  let h: TestHarness;
+
+  beforeEach(() => {
+    h = createTestHarness();
+  });
+
+  it('root cause guard: fix sessions refuse non-resting entry states explicitly', async () => {
+    const mergeId = await driveGateToReviewReady(h);
+
+    // review_ready is on the allow-list now — this used to throw
+    // "Task ... is not failed (status: review_ready)" (intent 27908).
+    expect(() => h.orchestrator.beginFixSession(mergeId)).not.toThrow();
+    h.orchestrator.revertFixSession(mergeId, { savedError: '' });
+
+    // The allow-list still refuses states that are not resting states.
+    expect(() => h.orchestrator.beginFixSession('A')).toThrow(
+      'not in a fix-session entry state',
+    );
+  });
+
+  it('fixed: a review-gate CI fix starts from review_ready and parks in awaiting_approval', async () => {
+    const mergeId = await driveGateToReviewReady(h);
+    const fixWithAgent = vi.fn(async () => {
+      // The agent must run while the gate is in the fix lifecycle.
+      expect(h.getTask(mergeId)!.status).toBe('fixing_with_ai');
+      expect(h.getTask(mergeId)!.execution.fixSessionEntryStatus).toBe('review_ready');
+    });
+    const taskExecutor = {
+      fixWithAgent,
+      resolveConflict: vi.fn(),
+      execGitIn: vi.fn(async () => 'true'),
+    };
+
+    const result = await fixWithAgentAction(mergeId, makeDeps(h, taskExecutor), {
+      agentName: 'codex',
+      reviewGateContext: reviewGateContextFor(h, mergeId, 'make the failed checks pass'),
+    });
+
+    expect(fixWithAgent).toHaveBeenCalledWith(
+      mergeId, 'gate output', 'codex', '', 'make the failed checks pass',
+    );
+    expect(result).toMatchObject({ kind: 'fixWithAgent' });
+    expect(h.getTask(mergeId)!.status).toBe('awaiting_approval');
+  });
+
+  it('fixed: a failing agent fix restores the gate to review_ready, not failed', async () => {
+    const mergeId = await driveGateToReviewReady(h);
+    const taskExecutor = {
+      fixWithAgent: vi.fn(async () => {
+        throw new Error('agent exploded');
+      }),
+      resolveConflict: vi.fn(),
+      execGitIn: vi.fn(async () => 'true'),
+    };
+
+    await expect(fixWithAgentAction(mergeId, makeDeps(h, taskExecutor), {
+      agentName: 'codex',
+      reviewGateContext: reviewGateContextFor(h, mergeId, 'make the failed checks pass'),
+    })).rejects.toThrow('agent exploded');
+
+    // The open review gate must return to the review-polling loop.
+    const gate = h.getTask(mergeId)!;
+    expect(gate.status).toBe('review_ready');
+    expect(gate.execution.fixSessionEntryStatus).toBeUndefined();
+  });
+
+  it('fixed: rejecting a parked review-gate fix restores review_ready, not failed', async () => {
+    const mergeId = await driveGateToReviewReady(h);
+    const taskExecutor = {
+      fixWithAgent: vi.fn(async () => undefined),
+      resolveConflict: vi.fn(),
+      execGitIn: vi.fn(async () => 'true'),
+    };
+
+    await fixWithAgentAction(mergeId, makeDeps(h, taskExecutor), {
+      agentName: 'codex',
+      reviewGateContext: reviewGateContextFor(h, mergeId, 'make the failed checks pass'),
+    });
+    expect(h.getTask(mergeId)!.status).toBe('awaiting_approval');
+    expect(h.getTask(mergeId)!.execution.pendingFixError).toBeDefined();
+
+    rejectTask(mergeId, { orchestrator: h.orchestrator });
+
+    const gate = h.getTask(mergeId)!;
+    expect(gate.status).toBe('review_ready');
+    expect(gate.execution.pendingFixError).toBeUndefined();
+    expect(gate.execution.fixSessionEntryStatus).toBeUndefined();
+  });
+});

--- a/packages/app/src/__tests__/resolve-conflict-action.test.ts
+++ b/packages/app/src/__tests__/resolve-conflict-action.test.ts
@@ -13,9 +13,9 @@ import { resolveConflictAction } from '../workflow-actions.js';
 describe('resolveConflictAction', () => {
   let orchestrator: {
     getTask: ReturnType<typeof vi.fn>;
-    beginConflictResolution: ReturnType<typeof vi.fn>;
+    beginFixSession: ReturnType<typeof vi.fn>;
     setFixAwaitingApproval: ReturnType<typeof vi.fn>;
-    revertConflictResolution: ReturnType<typeof vi.fn>;
+    revertFixSession: ReturnType<typeof vi.fn>;
     approve?: ReturnType<typeof vi.fn>;
   };
   let persistence: { appendTaskOutput: ReturnType<typeof vi.fn> };
@@ -32,9 +32,9 @@ describe('resolveConflictAction', () => {
         status: 'fixing_with_ai',
         execution: { selectedAttemptId: 'att-1', generation: 1 },
       })),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'saved-err' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'saved-err' })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     persistence = { appendTaskOutput: vi.fn() };
     taskExecutor = {
@@ -42,17 +42,17 @@ describe('resolveConflictAction', () => {
     };
   });
 
-  it('runs beginConflictResolution → resolveConflict → setFixAwaitingApproval', async () => {
+  it('runs beginFixSession → resolveConflict → setFixAwaitingApproval', async () => {
     await resolveConflictAction('task-a', {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginFixSession).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', 'saved-err', undefined);
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');
-    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
     expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
 
@@ -98,11 +98,7 @@ describe('resolveConflictAction', () => {
       'task-a',
       expect.stringContaining('[Resolve Conflict] Failed:'),
     );
-    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith(
-      'task-a',
-      'saved-err',
-      'claude failed',
-    );
+    expect(orchestrator.revertFixSession).toHaveBeenCalledWith('task-a', { savedError: 'saved-err', fixError: 'claude failed' });
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -322,7 +322,7 @@ describe('approveTask', () => {
       approve: vi.fn(),
       getTask: vi.fn().mockReturnValue(approvedTask),
       resumeTaskAfterFixApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const taskExecutor = {
       commitApprovedFix: vi.fn().mockRejectedValue(new Error('git status --porcelain failed (code 128): fatal: not a git repository')),
@@ -336,11 +336,7 @@ describe('approveTask', () => {
     });
 
     expect(result).toEqual({ approvedTask, fixedTask: true, started: [] });
-    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith(
-      'merge-a',
-      'original gate failure',
-      expect.stringContaining('Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository: /tmp/invoker-empty-launch-placeholder. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.'),
-    );
+    expect(orchestrator.revertFixSession).toHaveBeenCalledWith('merge-a', { savedError: 'original gate failure', fixError: expect.stringContaining('Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository: /tmp/invoker-empty-launch-placeholder. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.') });
     expect(orchestrator.resumeTaskAfterFixApproval).not.toHaveBeenCalled();
     expect(orchestrator.approve).not.toHaveBeenCalled();
     expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
@@ -421,14 +417,14 @@ describe('rejectTask', () => {
   let orchestrator: {
     getTask: ReturnType<typeof vi.fn>;
     reject: ReturnType<typeof vi.fn>;
-    revertConflictResolution: ReturnType<typeof vi.fn>;
+    revertFixSession: ReturnType<typeof vi.fn>;
   };
 
   beforeEach(() => {
     orchestrator = {
       getTask: vi.fn(() => makeTask({ execution: {} })),
       reject: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
   });
 
@@ -436,17 +432,17 @@ describe('rejectTask', () => {
     rejectTask('task-a', { orchestrator: orchestrator as unknown as Orchestrator }, 'bad output');
 
     expect(orchestrator.reject).toHaveBeenCalledWith('task-a', 'bad output');
-    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
   });
 
-  it('calls orchestrator.revertConflictResolution when pendingFixError exists', () => {
+  it('calls orchestrator.revertFixSession when pendingFixError exists', () => {
     orchestrator.getTask.mockReturnValue(
       makeTask({ execution: { pendingFixError: 'merge conflict' } }),
     );
 
     rejectTask('task-a', { orchestrator: orchestrator as unknown as Orchestrator });
 
-    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-a', 'merge conflict');
+    expect(orchestrator.revertFixSession).toHaveBeenCalledWith('task-a', { savedError: 'merge conflict' });
     expect(orchestrator.reject).not.toHaveBeenCalled();
   });
 
@@ -580,7 +576,7 @@ describe('autoFixOnFailure', () => {
         execution: { error: mergeError },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      beginFixSession: vi.fn(() => ({ savedError: mergeError })),
       recreateWorkflowFromFreshBase: vi.fn(async (_workflowId: string, options?: { refreshBase?: () => Promise<unknown> }) => {
         await options?.refreshBase?.();
         return started;
@@ -588,7 +584,7 @@ describe('autoFixOnFailure', () => {
       cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
       cascadeInvalidationToDownstream: vi.fn(() => []),
       retryTask: vi.fn(() => []),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -617,7 +613,7 @@ describe('autoFixOnFailure', () => {
       commandService: makeCommandService(),
     });
 
-    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.beginFixSession).not.toHaveBeenCalled();
     expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
       'wf-1',
       expect.objectContaining({ refreshBase: expect.any(Function) }),
@@ -641,11 +637,11 @@ describe('autoFixOnFailure', () => {
         execution: { error: 'boom', workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       retryTask: vi.fn(() => started),
       cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
       cascadeInvalidationToDownstream: vi.fn(() => []),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -665,7 +661,7 @@ describe('autoFixOnFailure', () => {
       commandService: makeCommandService(),
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginFixSession).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'codex', 'boom');
     expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
@@ -680,9 +676,9 @@ describe('autoFixOnFailure', () => {
         execution: { error: 'boom' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       retryTask: vi.fn(() => []),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -703,7 +699,7 @@ describe('autoFixOnFailure', () => {
       commandService: makeCommandService(),
     });
 
-    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.beginFixSession).not.toHaveBeenCalled();
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
     expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
     expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
@@ -736,11 +732,11 @@ describe('autoFixOnFailure', () => {
         execution: { error: mergeError, workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      beginFixSession: vi.fn(() => ({ savedError: mergeError })),
       retryTask: vi.fn(() => started),
       cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
       cascadeInvalidationToDownstream: vi.fn(() => []),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -760,7 +756,7 @@ describe('autoFixOnFailure', () => {
       commandService: makeCommandService(),
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginFixSession).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
@@ -781,9 +777,9 @@ describe('autoFixOnFailure', () => {
         execution: { error: mergeError, workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      beginFixSession: vi.fn(() => ({ savedError: mergeError })),
       retryTask: vi.fn(() => started),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -820,11 +816,11 @@ describe('autoFixOnFailure', () => {
         execution: { workspacePath: '/tmp/merge-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       retryTask: vi.fn(() => []),
       setFixAwaitingApproval: vi.fn(),
       approve: vi.fn().mockResolvedValue(started),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -870,7 +866,7 @@ describe('autoFixOnFailure', () => {
     // phase the auto-fix flow is in.  Each phase may call getTask
     // multiple times (entry check, lineage capture, lineage assert,
     // approveTask, post-finalize).  We use a phase counter that
-    // advances at known transition points (beginConflictResolution
+    // advances at known transition points (beginFixSession
     // and setFixAwaitingApproval) to keep return values consistent.
     let phase = 0;
     const phases: Record<string, unknown>[] = [
@@ -894,7 +890,7 @@ describe('autoFixOnFailure', () => {
       });
     });
     // Advance phase at key transition points
-    const origBeginConflictResolution = vi.fn(() => {
+    const origBeginFixSession = vi.fn(() => {
       phase++;
       return { savedError: 'boom' };
     });
@@ -909,12 +905,12 @@ describe('autoFixOnFailure', () => {
       shouldAutoFix,
       getTask,
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: origBeginConflictResolution,
+      beginFixSession: origBeginFixSession,
       retryTask: vi.fn(() => []),
       setFixAwaitingApproval: origSetFixAwaitingApproval,
       approve: vi.fn().mockResolvedValue(started),
       resumeTaskAfterFixApproval: vi.fn().mockResolvedValue(started),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -967,9 +963,9 @@ describe('autoFixOnFailure', () => {
         execution: { workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       retryTask: vi.fn(() => started),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -1018,9 +1014,9 @@ describe('autoFixOnFailure', () => {
         execution: { workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       retryTask: vi.fn(() => started),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -1070,9 +1066,9 @@ describe('autoFixOnFailure', () => {
         execution: { error: mergeError, workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      beginFixSession: vi.fn(() => ({ savedError: mergeError })),
       retryTask: vi.fn(() => started),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -1197,9 +1193,9 @@ describe('fixWithAgentAction', () => {
         config: { workflowId: 'wf-1' },
         execution: { error: 'boom' },
       })),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       getTaskOutput: vi.fn(() => 'test output'),
@@ -1232,9 +1228,9 @@ describe('fixWithAgentAction', () => {
         config: { workflowId: 'wf-1' },
         execution: { error: 'boom', workspacePath: '/tmp/task-a' },
       })),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       getTaskOutput: vi.fn(() => 'test output'),
@@ -1258,7 +1254,7 @@ describe('fixWithAgentAction', () => {
       'task-a',
       '\n[Fix with custom-agent] Failed: agent failed',
     );
-    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-a', 'boom', 'agent failed');
+    expect(orchestrator.revertFixSession).toHaveBeenCalledWith('task-a', { savedError: 'boom', fixError: 'agent failed' });
   });
 
   it('dispatches merge conflicts with a workspace to taskExecutor.resolveConflict', async () => {
@@ -1273,9 +1269,9 @@ describe('fixWithAgentAction', () => {
         config: { workflowId: 'wf-1' },
         execution: { error: mergeError, workspacePath: '/tmp/task-a' },
       })),
-      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      beginFixSession: vi.fn(() => ({ savedError: mergeError })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       getTaskOutput: vi.fn(),
@@ -1309,9 +1305,9 @@ describe('fixWithAgentAction', () => {
         config: { workflowId: 'wf-1' },
         execution: { error: mergeError, workspacePath: '/tmp/stale-task-a' },
       })),
-      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      beginFixSession: vi.fn(() => ({ savedError: mergeError })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       getTaskOutput: vi.fn(),
@@ -1410,9 +1406,9 @@ describe('fixWithAgentAction', () => {
       cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
       recreateWorkflowFromFreshBase: vi.fn(async () => [makeRunningTask({ id: 'merge-a', status: 'running' })]),
       cascadeInvalidationToDownstream: vi.fn(() => []),
-      beginConflictResolution: vi.fn(),
+      beginFixSession: vi.fn(),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       appendTaskOutput: vi.fn(),
@@ -1440,16 +1436,12 @@ describe('fixWithAgentAction', () => {
       '/tmp/invoker-empty-launch-placeholder',
     );
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
-    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.beginFixSession).not.toHaveBeenCalled();
     expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
       'merge-a',
       expect.stringContaining('\n[Fix with claude] Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository: /tmp/invoker-empty-launch-placeholder. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.'),
     );
-    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith(
-      'merge-a',
-      'Unable to resolve merge worktree ref "plan/old-base"',
-      expect.stringContaining('Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository: /tmp/invoker-empty-launch-placeholder. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.'),
-    );
+    expect(orchestrator.revertFixSession).toHaveBeenCalledWith('merge-a', { savedError: 'Unable to resolve merge worktree ref "plan/old-base"', fixError: expect.stringContaining('Cannot apply a fix because this merge gate\'s saved workspace is missing or is not a git repository: /tmp/invoker-empty-launch-placeholder. This task state is stale or corrupted. Recreate this merge-gate task from a fresh base, then rerun the gate.') });
     expect(orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
   });
 });
@@ -1691,7 +1683,7 @@ describe('buildWorkflowInvalidationDeps', () => {
         return [makeRunningTask({ id: 'task-a' })];
       }),
       resumeTaskAfterFixApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
   }
 
@@ -1824,7 +1816,7 @@ describe('buildWorkflowInvalidationDeps', () => {
     expect(await deps.fixApprove!('task-a')).toEqual(started);
     expect(await deps.fixReject!('task-a')).toEqual([]);
     expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
-    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-a', 'merge conflict');
+    expect(orchestrator.revertFixSession).toHaveBeenCalledWith('task-a', { savedError: 'merge conflict' });
     expect(orchestrator.cancelTask).not.toHaveBeenCalled();
     expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
   });
@@ -2018,9 +2010,9 @@ describe('fixWithAgentAction lineage guard', () => {
           execution: { selectedAttemptId: 'att-2', generation: 6 },
         });
       }),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       getTaskOutput: vi.fn(() => 'test output'),
@@ -2040,8 +2032,8 @@ describe('fixWithAgentAction lineage guard', () => {
 
     // Should NOT have called setFixAwaitingApproval (the late write)
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
-    // Should NOT have called revertConflictResolution either
-    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    // Should NOT have called revertFixSession either
+    expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
   });
 
   it('throws StaleLineageError when signal is aborted during async fix', async () => {
@@ -2052,9 +2044,9 @@ describe('fixWithAgentAction lineage guard', () => {
         config: { workflowId: 'wf-1' },
         execution: { error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
       })),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       getTaskOutput: vi.fn(() => 'test output'),
@@ -2078,10 +2070,10 @@ describe('fixWithAgentAction lineage guard', () => {
     })).rejects.toThrow(StaleLineageError);
 
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
-    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
   });
 
-  it('skips revertConflictResolution when lineage changed and fix threw', async () => {
+  it('skips revertFixSession when lineage changed and fix threw', async () => {
     let getTaskCallCount = 0;
     const orchestrator = {
       getTask: vi.fn(() => {
@@ -2100,9 +2092,9 @@ describe('fixWithAgentAction lineage guard', () => {
           execution: { selectedAttemptId: 'att-2', generation: 6 },
         });
       }),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       getTaskOutput: vi.fn(() => 'test output'),
@@ -2120,8 +2112,8 @@ describe('fixWithAgentAction lineage guard', () => {
       commandService: makeCommandService(),
     })).rejects.toThrow(StaleLineageError);
 
-    // revertConflictResolution must NOT be called when lineage is stale
-    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    // revertFixSession must NOT be called when lineage is stale
+    expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
     expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
 
@@ -2132,9 +2124,9 @@ describe('fixWithAgentAction lineage guard', () => {
         config: { workflowId: 'wf-1' },
         execution: { error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
       })),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       getTaskOutput: vi.fn(() => 'test output'),
@@ -2183,9 +2175,9 @@ describe('resolveConflictAction lineage guard', () => {
           execution: { selectedAttemptId: 'att-2', generation: 6 },
         });
       }),
-      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      beginFixSession: vi.fn(() => ({ savedError: mergeError })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       appendTaskOutput: vi.fn(),
@@ -2201,10 +2193,10 @@ describe('resolveConflictAction lineage guard', () => {
     })).rejects.toThrow(StaleLineageError);
 
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
-    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
   });
 
-  it('skips revertConflictResolution when lineage changed and resolution threw', async () => {
+  it('skips revertFixSession when lineage changed and resolution threw', async () => {
     let getTaskCallCount = 0;
     const orchestrator = {
       getTask: vi.fn(() => {
@@ -2222,9 +2214,9 @@ describe('resolveConflictAction lineage guard', () => {
           execution: { selectedAttemptId: 'att-2', generation: 6 },
         });
       }),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'merge err' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'merge err' })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       appendTaskOutput: vi.fn(),
@@ -2239,7 +2231,7 @@ describe('resolveConflictAction lineage guard', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     })).rejects.toThrow(StaleLineageError);
 
-    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
     expect(persistence.appendTaskOutput).not.toHaveBeenCalledWith(
       'task-a',
       expect.stringContaining('[Auto-fix] Agent failed'),
@@ -2274,10 +2266,10 @@ describe('autoFixOnFailure lineage guard', () => {
         });
       }),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       setFixAwaitingApproval: vi.fn(),
       retryTask: vi.fn(() => []),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -2302,7 +2294,7 @@ describe('autoFixOnFailure lineage guard', () => {
     expect(orchestrator.retryTask).not.toHaveBeenCalled();
   });
 
-  it('skips revertConflictResolution on failure when lineage changed', async () => {
+  it('skips revertFixSession on failure when lineage changed', async () => {
     let getTaskCallCount = 0;
     const orchestrator = {
       shouldAutoFix: vi.fn(() => true),
@@ -2327,10 +2319,10 @@ describe('autoFixOnFailure lineage guard', () => {
         });
       }),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       setFixAwaitingApproval: vi.fn(),
       retryTask: vi.fn(() => []),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -2351,7 +2343,7 @@ describe('autoFixOnFailure lineage guard', () => {
       commandService: makeCommandService(),
     })).rejects.toThrow(StaleLineageError);
 
-    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
     expect(persistence.appendTaskOutput).not.toHaveBeenCalledWith(
       'task-a',
       expect.stringContaining('[Auto-fix] Agent failed'),
@@ -2373,10 +2365,10 @@ describe('autoFixOnFailure lineage guard', () => {
         },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'boom' })),
       setFixAwaitingApproval: vi.fn(),
       retryTask: vi.fn(() => []),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
     const persistence = {
       updateTask: vi.fn(),
@@ -2445,9 +2437,9 @@ describe('fixWithAgentAction review-gate CI context', () => {
         config: { workflowId: 'wf-1' },
         execution: { error: 'ci failed', ...execution },
       })),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'ci failed' })),
+      beginFixSession: vi.fn(() => ({ savedError: 'ci failed' })),
       setFixAwaitingApproval: vi.fn(),
-      revertConflictResolution: vi.fn(),
+      revertFixSession: vi.fn(),
     };
   }
 
@@ -2470,7 +2462,7 @@ describe('fixWithAgentAction review-gate CI context', () => {
     })).rejects.toThrow(StaleLineageError);
 
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
-    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.beginFixSession).not.toHaveBeenCalled();
   });
 
   it('fixes with the carried fix context when the review-gate context is current', async () => {
@@ -2504,6 +2496,43 @@ describe('fixWithAgentAction review-gate CI context', () => {
     expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith(
       'task-a', 'output', 'claude', 'ci failed', 'make the failed checks pass',
     );
+    // Review-gate CI fixes enter through beginFixSession, which accepts
+    // review_ready/awaiting_approval entry states and records them.
+    expect(orchestrator.beginFixSession).toHaveBeenCalledWith('task-a');
     expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
+  });
+
+  it('reverts the fix session when a review-gate CI fix fails', async () => {
+    const orchestrator = makeReviewGateOrchestrator({
+      selectedAttemptId: 'attempt-1',
+      generation: 3,
+      reviewId: 'review-1',
+      branch: 'experiment/foo',
+    });
+    const persistence = { getTaskOutput: vi.fn(() => 'output'), appendTaskOutput: vi.fn() };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockRejectedValue(new Error('agent exploded')),
+      resolveConflict: vi.fn(),
+    };
+
+    await expect(fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      agentName: 'claude',
+      reviewGateContext: {
+        reviewId: 'review-1',
+        generation: 3,
+        selectedAttemptId: 'attempt-1',
+        branch: 'experiment/foo',
+        fixContext: 'make the failed checks pass',
+      },
+    })).rejects.toThrow('agent exploded');
+
+    expect(orchestrator.revertFixSession).toHaveBeenCalledWith('task-a', {
+      savedError: 'ci failed',
+      fixError: 'agent exploded',
+    });
   });
 });

--- a/packages/app/src/__tests__/workflow-mutation-facade.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-facade.test.ts
@@ -323,14 +323,11 @@ describe('WorkflowMutationFacade', () => {
         execution: { pendingFixError: 'merge conflict' },
       });
       (deps.orchestrator.getTask as ReturnType<typeof vi.fn>).mockReturnValue(task);
-      (deps.orchestrator as any).revertConflictResolution = vi.fn();
+      (deps.orchestrator as any).revertFixSession = vi.fn();
 
       facade.rejectTask('task-a');
 
-      expect((deps.orchestrator as any).revertConflictResolution).toHaveBeenCalledWith(
-        'task-a',
-        'merge conflict',
-      );
+      expect((deps.orchestrator as any).revertFixSession).toHaveBeenCalledWith('task-a', { savedError: 'merge conflict' });
     });
   });
 

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -192,7 +192,12 @@ export async function approveTask(
         kind: 'invalidMergeWorkspace',
         workspacePath: task.execution.workspacePath?.trim() || undefined,
       });
-      deps.orchestrator.revertConflictResolution(taskId, task.execution.pendingFixError ?? '', msg);
+      // Restore the session's recorded entry status: a review-gate fix whose
+      // workspace vanished must return to review polling, not flip to failed.
+      deps.orchestrator.revertFixSession(taskId, {
+        savedError: task.execution.pendingFixError ?? '',
+        fixError: msg,
+      });
       return { approvedTask: task, started: [], fixedTask };
     }
   }
@@ -218,9 +223,11 @@ export async function approveTask(
 }
 
 /**
- * Reject a task. Handles pendingFixError (from fix-with-claude) consistently
- * across all surfaces: if the task has a pending fix error, revert the
- * conflict resolution instead of rejecting outright.
+ * Reject a task. Handles pendingFixError (from fix-with-agent) consistently
+ * across all surfaces: if the task has a pending fix error, revert the fix
+ * session to its recorded entry status — a rejected review-gate fix returns
+ * the gate to `review_ready`, a rejected plain fix returns the task to
+ * `failed` — instead of rejecting outright.
  */
 export function rejectTask(
   taskId: string,
@@ -229,7 +236,7 @@ export function rejectTask(
 ): void {
   const task = deps.orchestrator.getTask(taskId);
   if (task?.execution.pendingFixError !== undefined) {
-    deps.orchestrator.revertConflictResolution(taskId, task.execution.pendingFixError);
+    deps.orchestrator.revertFixSession(taskId, { savedError: task.execution.pendingFixError });
   } else {
     deps.orchestrator.reject(taskId, reason);
   }
@@ -819,7 +826,7 @@ export async function resolveConflictAction(
   const { orchestrator, persistence, taskExecutor } = deps;
   const entryLineage = captureTaskLineage(taskId, orchestrator);
   assertLineageCurrent(entryLineage, orchestrator, signal);
-  const { savedError } = orchestrator.beginConflictResolution(taskId);
+  const { savedError } = orchestrator.beginFixSession(taskId);
   const lineage = captureTaskLineage(taskId, orchestrator);
   try {
     assertLineageCurrent(lineage, orchestrator, signal);
@@ -832,7 +839,7 @@ export async function resolveConflictAction(
     assertLineageCurrent(lineage, orchestrator, signal);
     persistence.appendTaskOutput(taskId, `\n[Resolve Conflict] Failed: ${msg}`);
     assertLineageCurrent(lineage, orchestrator, signal);
-    orchestrator.revertConflictResolution(taskId, savedError, msg);
+    orchestrator.revertFixSession(taskId, { savedError, fixError: msg });
     throw err;
   }
 }
@@ -864,6 +871,12 @@ export async function fixWithAgentAction(
   const task = orchestrator.getTask(taskId);
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
+  // Review-gate CI fixes target a merge gate that is still in an open review
+  // state (`review_ready` / `awaiting_approval`) — the gate task itself never
+  // failed, only a CI check on its review PR did. `beginFixSession` accepts
+  // those entry states and records them, so `revertFixSession` returns the
+  // gate to the review-polling loop instead of flipping an open gate to
+  // `failed`.
   if (options.reviewGateContext) {
     assertReviewGateCiContextCurrent(taskId, options.reviewGateContext, task);
   }
@@ -875,7 +888,9 @@ export async function fixWithAgentAction(
     const msg = invalidMergeWorkspaceMessage(recoveryRoute);
     const errorLabel = options.failureOutputLabel ?? `Fix with ${effectiveAgentName}`;
     persistence.appendTaskOutput(taskId, `\n[${errorLabel}] ${msg}`);
-    orchestrator.revertConflictResolution(taskId, savedError, msg);
+    // No session has begun; on a task with no fix-session evidence this is a
+    // no-op, on a failed task it rewrites the error to the workspace message.
+    orchestrator.revertFixSession(taskId, { savedError, fixError: msg });
     throw new Error(msg);
   }
   if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
@@ -901,7 +916,7 @@ export async function fixWithAgentAction(
 
   const entryLineage = captureTaskLineage(taskId, orchestrator);
   assertLineageCurrent(entryLineage, orchestrator, options.signal);
-  const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
+  const { savedError: persistedSavedError } = orchestrator.beginFixSession(taskId);
   const lineage = captureTaskLineage(taskId, orchestrator);
   try {
     assertLineageCurrent(lineage, orchestrator, options.signal);
@@ -931,7 +946,7 @@ export async function fixWithAgentAction(
     assertLineageCurrent(lineage, orchestrator, options.signal);
     persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
     assertLineageCurrent(lineage, orchestrator, options.signal);
-    orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
+    orchestrator.revertFixSession(taskId, { savedError: persistedSavedError, fixError: msg });
     throw err;
   }
 }
@@ -1243,7 +1258,7 @@ export async function autoFixOnFailure(
       return;
     }
 
-    ({ savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId));
+    ({ savedError: persistedSavedError } = orchestrator.beginFixSession(taskId));
     lineage = captureTaskLineage(taskId, orchestrator);
     assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
@@ -1338,7 +1353,7 @@ export async function autoFixOnFailure(
     const detailedMsg = diagnostics ? `${msg}\n\n${diagnostics}` : msg;
     if (persistedSavedError !== undefined) {
       if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
-      orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg);
+      orchestrator.revertFixSession(taskId, { savedError: persistedSavedError, fixError: detailedMsg });
     }
   }
 }


### PR DESCRIPTION
## Summary

"Fix with Codex" on a review gate looked queued but never ran. The repair intent died in 50ms.

The error was `Task ... is not failed (status: review_ready)`. A gate whose PR check fails stays `review_ready`; only the check is red.

`fixWithAgentAction`, `resolveConflictAction`, and `autoFixOnFailure` now begin through `beginFixSession`, which accepts the review-gate entry states and records them.

On agent failure the gate is restored to its recorded entry via `revertFixSession`, keeping the open gate in review polling.

Declining a parked review-gate fix returns the gate to `review_ready` too. Before, that path hard-coded `failed` — the same bug one screen later.

Approving a parked fix whose merge workspace vanished also restores the recorded entry instead of failing the gate.

## Review Claim

App fix and decline surfaces begin and revert through fix sessions, so review-gate repairs run from `review_ready` and never strand an open gate in `failed`.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

For a plain failed task every path is byte-equivalent: entry still requires a resting state, failure still restores `failed` with the same wrapped error. The repro drives a real orchestrator from `review_ready` through fix success, fix failure, and decline.

## Slice Rationale

Pure call-site adoption of the mechanism from slice 1; keeping it separate makes the entry swap and the decline change reviewable in one file.

## Non-goals

- No change to how the fix agent pushes its result to the review PR.
- No change to worker-side intent bookkeeping (slice 2).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/repro-review-gate-ci-fix-review-ready.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts src/__tests__/resolve-conflict-action.test.ts src/__tests__/api-server.test.ts src/__tests__/parity-regression.test.ts src/__tests__/workflow-mutation-facade.test.ts src/__tests__/bridge-orchestrator-executor.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 72cad57`
- Post-revert steps: None
- Data migration? No

</details>
