### PR TITLE
[Fix sessions](5) Add repro scripts for both root causes

### DIFF
--- a/scripts/repro/repro-ci-failure-action-stuck-queued.sh
+++ b/scripts/repro/repro-ci-failure-action-stuck-queued.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Repro: a review-gate CI repair shows "queued" forever after its fix intent
+# fails.
+#
+# Root cause guarded here:
+#   The ci-failure worker records its dedupe worker action as `queued` when it
+#   submits an invoker:fix-with-agent mutation intent, but nothing wrote the
+#   intent's terminal outcome back to the action row. When the intent failed,
+#   the action stayed `queued`; every subsequent tick skipped the same failed
+#   check with
+#
+#     worker-ci-failure-skip reason=already-recorded existingStatus=queued
+#
+#   so the UI showed a repair "queued up" that never executed and the worker
+#   never retried.
+#
+# Fixed behavior:
+#   Before the dedupe check, the worker folds the terminal intent outcome back
+#   into the action row: a failed intent marks the action failed and the same
+#   tick requeues a fresh repair (bounded by the attempt ledger); a completed
+#   intent marks the action completed; open intents keep the action deduped.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] execution-engine: failed fix intents must not leave the CI repair action queued"
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/repro-ci-failure-action-stuck-queued.test.ts
+
+echo "[repro] passed"

--- a/scripts/repro/repro-review-gate-ci-fix-not-failed-guard.sh
+++ b/scripts/repro/repro-review-gate-ci-fix-not-failed-guard.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Repro: review-gate CI auto-fix intents die at dispatch with
+#
+#   Error: Task __merge__wf-... is not failed (status: review_ready)
+#       at beginConflictResolutionImpl
+#       at fixWithAgentAction
+#       at executeFixWithAgentMutation
+#
+# Root cause guarded here:
+#   A merge gate whose review PR has a red CI check stays `review_ready` — the
+#   gate task itself never failed. The ci-failure worker intentionally targets
+#   gates in review_ready/awaiting_approval (staleReasonForEvent), but the fix
+#   action entered the lifecycle through a failed-only guard. Every
+#   review-gate CI repair intent therefore failed within milliseconds of being
+#   queued, so "Fix with <agent>" appeared queued but never executed.
+#
+# Fixed behavior:
+#   Fix sessions have an explicit entry-state allow-list (failed,
+#   review_ready, awaiting_approval). `beginFixSession` records the entry
+#   status on the task, and every exit — agent failure, reject, invalid
+#   workspace — restores the recorded entry via `revertFixSession`, so an open
+#   review gate returns to the review-polling loop instead of being flipped to
+#   failed.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] app: review-gate CI fix must start from a review_ready merge gate and revert there"
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/repro-review-gate-ci-fix-review-ready.test.ts
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

One repro script per root cause behind the stuck "Fix with Codex" review-gate repair, following the `scripts/repro/` convention.

`repro-review-gate-ci-fix-not-failed-guard.sh` covers the dispatch guard: a `review_ready` gate used to die with `Task ... is not failed`.

`repro-ci-failure-action-stuck-queued.sh` covers the bookkeeping gap: a failed repair intent used to leave the worker action `queued` forever.

Each script runs its checked-in regression test and exits non-zero on regression.

## Review Claim

Both root causes behind the stuck review-gate repair have a single-script repro that fails if either regresses.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only adds executable documentation under `scripts/repro/`; no runtime code changes.

## Slice Rationale

Repro entrypoints are proof artifacts and ship separately from the behavior slices they guard.

## Non-goals

- No new test logic; the scripts wrap regressions landed in slices 2 and 3.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/repro/repro-review-gate-ci-fix-not-failed-guard.sh`
- [x] `bash scripts/repro/repro-ci-failure-action-stuck-queued.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 71ea9a4`
- Post-revert steps: None
- Data migration? No

</details>
