### PR TITLE
[docs] Note Planning Terminal restart restore in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+- Restore Planning Terminal chats after desktop restart, including visible transcripts and draft-ready state.
 - Persist embedded terminal tabs across desktop app restarts, restoring their recent output and reopening spawn-backed sessions.
 - Move auto-fix attempt counts out of SQLite task state and into in-memory worker runtime policy.
 - Add a local master-head full-test repair cron that runs the destructive suite, asks OMP/Codex to fix confirmed failures, reruns the suite, and opens one validated PR per broken upstream SHA.


### PR DESCRIPTION
## Summary

Records the Planning Terminal restart-restore feature in the changelog.

This entry was split out of the UI PR so that behavior and changelog land in separate review slices.

## Review Claim

The changelog notes that Planning Terminal chats are restored after a desktop restart.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

This changes only CHANGELOG.md; no code or runtime behavior is affected.

## Slice Rationale

The changelog entry is a note about shipped work, so it lands as its own docs slice separate from the behavior PRs.

## Non-goals

This does not change any runtime behavior.

This does not change the Planning Terminal code.

## Test Plan

- [x] `node scripts/validate-pr-body.mjs --body-file <body> --changed-files-file <files>`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge sha>`
- Post-revert steps: None
- Data migration? No
