### PR TITLE
[Collapsed plan sections](2) Require collapsed Test Plan and Revert Plan in PR bodies

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -30,7 +30,8 @@
  *   Enforces the canonical PR schema:
  *   ## Summary, ## Review Claim, ## Review Lane, ## Review Unit,
  *   ## Safety Invariant, ## Slice Rationale, ## Non-goals,
- *   ## Test Plan, ## Revert Plan, plus optional ## Architecture
+ *   ## Test Plan, ## Revert Plan (each plan section with content in a
+ *   collapsed <details> block), plus optional ## Architecture
  *   and required ## Visual Proof for UI changes.
  */
 
@@ -154,6 +155,7 @@ Stack flow:
 
 PR body schema:
   Required: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
+  Test Plan and Revert Plan content must sit inside collapsed <details><summary>Test Plan</summary> / <summary>Revert Plan</summary> blocks.
   Optional: ## Architecture (must include ### Before and ### After when present)
   UI-impacting diffs require ## Visual Proof with screenshot or video proof.
   Animated proof is required for restarts and multi-state transitions.

--- a/scripts/fixtures/pr-body-mermaid-reviewgate-quoted.md
+++ b/scripts/fixtures/pr-body-mermaid-reviewgate-quoted.md
@@ -44,11 +44,21 @@ graph TD
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] `node scripts/validate-pr-body.mjs --body-file scripts/fixtures/pr-body-mermaid-reviewgate-quoted.md`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: `git revert <sha>`
 - Post-revert steps: None
 - Data migration? No
+
+</details>

--- a/scripts/fixtures/pr-body-mermaid-reviewgate-unquoted.md
+++ b/scripts/fixtures/pr-body-mermaid-reviewgate-unquoted.md
@@ -44,11 +44,21 @@ graph TD
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] `node scripts/validate-pr-body.mjs --body-file scripts/fixtures/pr-body-mermaid-reviewgate-unquoted.md`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: `git revert <sha>`
 - Post-revert steps: None
 - Data migration? No
+
+</details>

--- a/scripts/pr-body-template.md
+++ b/scripts/pr-body-template.md
@@ -50,8 +50,13 @@ graph TD
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] `exact command`
 - [ ] `exact command`
+
+</details>
 
 ## Visual Proof
 
@@ -59,7 +64,12 @@ Required when the diff changes UI-impacting files. Include before/after screensh
 
 ## Revert Plan
 
+<details>
+<summary>Revert Plan</summary>
+
 - Safe to revert? Yes/No
 - Revert command: `git revert <sha>`
 - Post-revert steps: None
 - Data migration? No
+
+</details>

--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -272,6 +272,7 @@ export function classifyReviewUnitsForPath(filePath) {
   if (
     path === 'scripts/pr-body-template.md'
     || path === 'scripts/test-create-pr-visual-proof.mjs'
+    || path.startsWith('scripts/fixtures/')
   ) return ['tooling-policy'];
   if (path.startsWith('packages/app/e2e/visual-proof/')) return ['activation-surface'];
   if (/(benchmark|performance|visual-proof)/.test(lowerPath)) return ['proof'];

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -40,14 +40,24 @@ Stack publishing stays separate from unrelated cleanup.
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`node scripts/test-create-pr-stack-workflow.mjs\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `;
 
 const ROUTING_BODY = `## Summary
@@ -80,14 +90,24 @@ Keep app exposure separate from core runtime behavior.
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`node scripts/test-create-pr-stack-workflow.mjs\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `;
 
 function assert(condition, message) {

--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -35,6 +35,11 @@ must_contain "$SKILL_MD" "cleanup and docs come last" "make-pr skill must order 
 must_contain "$SKILL_MD" "lint-pr-diff-atomicity.mjs" "make-pr skill must mention the diff atomicity gate"
 must_contain "$SKILL_MD" "mixes behavior, refactor, cleanup, or test-harness/proof work" "make-pr skill must tell authors to split mixed work"
 
+# Test Plan and Revert Plan content must be collapsed in a details block.
+must_contain "$SKILL_MD" "<summary>Test Plan</summary>" "make-pr skill must collapse Test Plan content in a details block"
+must_contain "$SKILL_MD" "<summary>Revert Plan</summary>" "make-pr skill must collapse Revert Plan content in a details block"
+must_contain "$SKILL_MD" "rejects a plan section whose content is not collapsed" "make-pr skill must state the validator enforces collapsed plan sections"
+
 # The ordering section delegates the rest of the rules to review-compression,
 # so that referenced section must actually exist.
 must_contain "$SKILL_MD" "Ordering Rules" "make-pr skill must point at review-compression Ordering Rules"

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -53,14 +53,24 @@ Proof and cleanup stay separate.
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`pnpm test\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `;
 
 const validArchitecture = `## Summary
@@ -109,14 +119,24 @@ graph TD
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`pnpm test\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `;
 
 const unquotedMermaidFixture = readFileSync(resolve(scriptDir, 'fixtures/pr-body-mermaid-reviewgate-unquoted.md'), 'utf8');
@@ -194,18 +214,62 @@ Small slice.
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`pnpm test\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `);
 assert(
   hiddenMetadataErrors.some((error) => error.includes('Do not hide review metadata in <details>')),
   'details-wrapped review metadata should fail',
+);
+
+const flatTestPlanErrors = await validatePrBody(
+  validMinimal.replace('<details>\n<summary>Test Plan</summary>\n\n- [ ] `pnpm test`\n\n</details>', '- [ ] `pnpm test`'),
+);
+assert(
+  flatTestPlanErrors.some((error) => error.includes('## Test Plan must wrap its content in a collapsed <details> block')),
+  'un-collapsed test plan content should fail',
+);
+
+const flatRevertPlanErrors = await validatePrBody(
+  validMinimal
+    .replace('<details>\n<summary>Revert Plan</summary>\n\n- Safe to revert? Yes', '- Safe to revert? Yes')
+    .replace('- Data migration? No\n\n</details>', '- Data migration? No'),
+);
+assert(
+  flatRevertPlanErrors.some((error) => error.includes('## Revert Plan must wrap its content in a collapsed <details> block')),
+  'un-collapsed revert plan content should fail',
+);
+
+const openTestPlanErrors = await validatePrBody(
+  validMinimal.replace('<details>\n<summary>Test Plan</summary>', '<details open>\n<summary>Test Plan</summary>'),
+);
+assert(
+  openTestPlanErrors.some((error) => error.includes('Test Plan details must be collapsed by default')),
+  'test plan details should stay collapsed by default',
+);
+
+const openRevertPlanErrors = await validatePrBody(
+  validMinimal.replace('<details>\n<summary>Revert Plan</summary>', '<details open>\n<summary>Revert Plan</summary>'),
+);
+assert(
+  openRevertPlanErrors.some((error) => error.includes('Revert Plan details must be collapsed by default')),
+  'revert plan details should stay collapsed by default',
 );
 
 const restartStillProofErrors = await validatePrBody(`${validMinimal}
@@ -272,10 +336,15 @@ Small slice.
 
 ## Revert Plan
 
+<details>
+<summary>Revert Plan</summary>
+
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `);
 assert(missingTestPlanErrors.some((error) => error.includes('Missing required section: ## Test Plan')), 'missing test plan should fail');
 
@@ -318,14 +387,24 @@ graph TD
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`pnpm test\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `);
 assert(malformedArchitectureErrors.some((error) => error.includes('Architecture section is missing required subsection: ### After')), 'missing architecture after section should fail');
 
@@ -355,14 +434,24 @@ Small slice.
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`pnpm test\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `);
 assert(missingReviewLaneErrors.some((error) => error.includes('Missing required section: ## Review Lane')), 'missing review lane should fail');
 
@@ -401,14 +490,24 @@ Durable-state scan behavior is reviewable separately from lifecycle wakeup routi
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`pnpm test\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `;
 const broad1574Errors = await validatePrBody(broad1574Body);
 assert(
@@ -448,14 +547,24 @@ The complete auto-fix recovery path lands together for one rollout.
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`pnpm test\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `;
 const originalAllInOneErrors = await validatePrBody(originalAllInOneBody);
 assert(
@@ -493,14 +602,24 @@ Small slice.
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`pnpm test\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `;
 
 const longSummaryWarnings = getPrBodyWarnings(longSummary);
@@ -623,14 +742,24 @@ Field additions land in a later behavior PR.
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`pnpm test\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `;
 assert(
   (await validatePrBody(refactorBody, { changedFiles: ['packages/app/src/main.ts', 'packages/app/src/refresh-task-graph.ts'] })).length === 0,
@@ -687,14 +816,24 @@ Publication and polling landed together around the same review gate contract.
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`pnpm test\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `;
 const old1756BoundaryErrors = await validatePrBody(old1756MixedRuntimeBody, {
   changedFiles: [
@@ -736,14 +875,24 @@ Validation policy stays separate from command submission.
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] \`pnpm test\`
 
+</details>
+
 ## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
 
 - Safe to revert? Yes
 - Revert command: \`git revert <sha>\`
 - Post-revert steps: None
 - Data migration? No
+
+</details>
 `;
 assert((await validatePrBody(validationPolicyBody)).length === 0, 'validation policy non-goal mentioning submit should pass');
 

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -36,6 +36,10 @@ const REQUIRED_METADATA_LABELS = [
   'Safety Invariant',
   'Slice Rationale',
 ];
+const COLLAPSED_PLAN_SECTIONS = [
+  { heading: '## Test Plan', label: 'Test Plan' },
+  { heading: '## Revert Plan', label: 'Revert Plan' },
+];
 const DISCOURAGED_HEADINGS = ['## Testing', '## Notes'];
 const SUMMARY_WORD_LIMIT = 30;
 const VALID_REVIEW_LANES = new Set(['behavior', 'refactor', 'proof', 'cleanup', 'policy', 'docs']);
@@ -127,6 +131,17 @@ export async function validateMermaidBlocks(body, options = {}) {
 
 function getSectionBody(body, heading) {
   return getMarkdownSection(body, heading);
+}
+
+function getCollapsedPlanBlock(body, heading, label) {
+  const section = getSectionBody(body, heading);
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = section.match(new RegExp(
+    `<details\\b([^>]*)>\\s*<summary>\\s*${escaped}\\s*</summary>([\\s\\S]*?)</details>`,
+    'i',
+  ));
+  if (!match) return null;
+  return { body: match[2].trim(), openAttributes: match[1] };
 }
 
 function countWords(text) {
@@ -327,7 +342,7 @@ export async function validatePrBody(body, options = {}) {
   const trimmed = body.trim();
   if (!trimmed) {
     return [
-      'PR body is empty. Use the canonical schema: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, and ## Revert Plan.',
+      'PR body is empty. Use the canonical schema: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, and ## Test Plan and ## Revert Plan with collapsed details blocks.',
     ];
   }
 
@@ -379,6 +394,21 @@ export async function validatePrBody(body, options = {}) {
       if (!getLabelSection(legacyReviewMetadata.body, label)) {
         errors.push(`Review metadata is missing required field: ${label}:`);
       }
+    }
+  }
+
+  for (const { heading, label } of COLLAPSED_PLAN_SECTIONS) {
+    if (!trimmed.includes(heading)) continue;
+    const block = getCollapsedPlanBlock(trimmed, heading, label);
+    if (!block) {
+      errors.push(`${heading} must wrap its content in a collapsed <details> block with <summary>${label}</summary>.`);
+      continue;
+    }
+    if (/\bopen\b/i.test(block.openAttributes)) {
+      errors.push(`${label} details must be collapsed by default; remove the open attribute.`);
+    }
+    if (!block.body) {
+      errors.push(`${label} details block must not be empty.`);
     }
   }
 
@@ -454,6 +484,7 @@ function usage() {
 
 Validates the canonical PR schema:
   Required: ## Summary, ## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert Plan
+  Test Plan and Revert Plan content must sit inside a collapsed <details><summary>Test Plan</summary> / <summary>Revert Plan</summary> block.
   Optional: ## Architecture (must include ### Before and ### After when present)
   UI changes: pass --require-visual-proof to require screenshot or video proof; restart or multi-state proof must be animated.
   --changed-files-file <file>  Newline-separated changed file paths for scope checks.

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -92,8 +92,13 @@ graph TD
 
 ## Test Plan
 
+<details>
+<summary>Test Plan</summary>
+
 - [ ] exact command
 - [ ] exact command
+
+</details>
 
 ## Visual Proof
 
@@ -101,10 +106,15 @@ Required when the diff changes UI-impacting files. Include before/after screensh
 
 ## Revert Plan
 
+<details>
+<summary>Revert Plan</summary>
+
 - Safe to revert? Yes/No
 - Revert command: `git revert <sha>` or equivalent
 - Post-revert steps: None / concrete steps
 - Data migration? No / concrete steps
+
+</details>
 ```
 
 If the change is small and has no architectural impact, omit `## Architecture` rather than forcing filler.
@@ -112,6 +122,8 @@ If the change is small and has no architectural impact, omit `## Architecture` r
 If the change is UI-impacting, use `skills/visual-proof/SKILL.md` first and include its screenshot/video markdown in `## Visual Proof`. UI-impacting means the user-visible experience changes, even when no file under `packages/ui/**` changes. This includes `packages/ui/**`, Electron window lifecycle files, preload, main process window wiring, app menu changes, task status changes, task error or output text shown in panels, approval/reject behavior, workflow state shown in the DAG or inspector, and web-surface output.
 
 Use visible markdown sections for review metadata. Do not hide `Review Claim`, `Review Lane`, `Review Unit`, `Safety Invariant`, or `Slice Rationale` inside `<details>` or other HTML disclosure blocks. Review metadata must render directly in the PR body.
+
+Test Plan and Revert Plan are the opposite: keep their `## Test Plan` / `## Revert Plan` headings visible, but their content must sit inside a collapsed `<details>` block with `<summary>Test Plan</summary>` / `<summary>Revert Plan</summary>`. `scripts/validate-pr-body.mjs` rejects a plan section whose content is not collapsed, and rejects the `open` attribute.
 
 When an existing PR changes after its body or proof was written, rerun this skill from the current diff before updating the PR. If the new diff touches UI-impacting files, rerun `skills/visual-proof/SKILL.md` and replace old screenshot or video links with fresh proof for the current code. Do not reuse earlier proof media after UI behavior changes.
 Visual proof must show the changed behavior itself, not just the changed screen area. Before creating or updating the PR, open every screenshot or video and verify the user-visible target is present and identifiable. For conditional or event-driven UI, drive the exact condition that triggers the new state and capture that state. A generic task panel, unchanged sidebar, unrelated graph, or stale screenshot is not proof, even when the right file changed.
@@ -128,7 +140,7 @@ If the changed behavior is a cursor, pointer, hover-only affordance, or other st
 
 When a PR changes skill instructions under `skills/**/SKILL.md`, add or update a focused skill contract test for the exact issue being fixed. The test must fail if the instruction that prevents the regression is removed.
 
-Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Review Claim / ## Review Lane / ## Review Unit / ## Safety Invariant / ## Slice Rationale / ## Non-goals / ## Test Plan / ## Revert Plan` as the floor, add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.
+Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. That shape is ad hoc drift, not the repo standard. Use `## Summary / ## Review Claim / ## Review Lane / ## Review Unit / ## Safety Invariant / ## Slice Rationale / ## Non-goals / ## Test Plan / ## Revert Plan` as the floor, keep Test Plan and Revert Plan content in their collapsed `<details>` blocks, add `## Visual Proof` for UI-impacting diffs, and add `## Architecture` when the change affects component interactions or data/control flow.
 
 ## Diff atomicity gate
 
@@ -227,6 +239,7 @@ Manual `gh pr edit` is the escape hatch when `create-pr --update-existing` canno
 - ensure the body sections are present and concrete
 - ensure test commands are real commands that were actually run when possible
 - ensure revert guidance is honest
+- keep Test Plan and Revert Plan content inside their collapsed `<details><summary>Test Plan</summary>` / `<summary>Revert Plan</summary>` blocks
 - do not create, update, or Mergify-publish a PR when the branch has no file changes against its selected base or contains an empty commit slice; fix the branch history before using `node scripts/create-pr.mjs`, `node scripts/create-pr.mjs --update-existing ...`, or `mergify stack push`
 - validate the body with `node scripts/validate-pr-body.mjs --body-file <file>`
 - for stacked PRs, update title/body through `node scripts/create-pr.mjs --update-existing ...`, not `gh pr edit`


### PR DESCRIPTION
## Summary

PR bodies now show Test Plan and Revert Plan as collapsed sections. Headings stay visible; the checklist and revert steps fold behind a details block on GitHub.

The PR body template, the make-pr skill, and the PR body validator all require the same collapsed shape.

## Review Claim

The PR body toolchain requires Test Plan and Revert Plan content inside collapsed details blocks and fails plan sections that are not collapsed or carry the open attribute.

## Review Lane

- policy

## Review Unit

- tooling-policy

## Safety Invariant

Only PR authoring tooling, its fixtures, and its checks change. Nothing under packages/ changes in this slice, so product runtime behavior is untouched.

## Slice Rationale

The engine fallback and the changelog note cannot ride along per the lane scope rule, so they land in the following slices; the previous slice only reclassified the fixtures.

## Non-goals

- No change to review metadata placement; the visible metadata sections required since #3257 stay as they are.
- No change to the deterministic fallback in packages/execution-engine; that lands in the next slice.
- No changelog entry in this slice; it lands separately.
- No re-wrapping of existing open PR bodies.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `bash scripts/test-make-pr-skill.sh`
- [x] `node scripts/test-create-pr-stack-workflow.mjs`
- [x] `node scripts/test-create-pr-visual-proof.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
