### PR TITLE
[Workflow Delete](1) Capture workflow delete propagation proof

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -574,6 +574,17 @@ test.describe('Visual proof capture', () => {
     await assertPageScreenshot(page, 'empty-state');
   });
 
+  test('workflow delete propagation', async ({ page }) => {
+    const workflowId = await loadPlanAndSelectWorkflow(page, TEST_PLAN);
+    await expect(workflowNode(page, workflowId)).toBeVisible();
+    await captureScreenshot(page, 'workflow-delete-before');
+
+    await page.evaluate((id) => window.invoker.deleteWorkflow(id), workflowId);
+
+    await page.waitForTimeout(3000);
+    await captureScreenshot(page, 'workflow-delete-after-3s');
+  });
+
   test('terminal planning loads graph', async ({ page }) => {
     const plannedYaml = yamlStringify(TERMINAL_PLANNED_PLAN);
     // Mirror the real planner reply shape: prose followed by the full fenced


### PR DESCRIPTION
## Summary

Deleting a workflow leaves a ghost "pending" node on the plan graph until someone clicks Refresh. This slice adds the capture case that demonstrates it.

The new visual-proof test loads a plan, deletes the workflow through the same bridge call the UI uses, waits 3 seconds without refreshing, and screenshots the graph.

On current master the final screenshot still shows the deleted workflow as a "pending" node. The fix slices that follow make the same capture come back empty.

## Review Claim

Approve a capture-only Playwright case that records what the plan graph shows 3 seconds after a workflow is deleted.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Capture-only test. It asserts nothing about post-delete state, so it stays green before and after the fix, and it changes no shipped code.

## Slice Rationale

The evidence lands before the fix so reviewers can see the bug demonstrated first. Repo policy also keeps proof files out of behavior slices.

## Non-goals

- No behavior change to deletion or the graph.
- No assertion on the fixed behavior; the regression test ships with the renderer slice.

## Test Plan

- [ ] `bash scripts/ui-visual-proof.sh capture-before --spec "visual-proof.spec.ts:577"`
- [ ] `bash scripts/ui-visual-proof.sh capture-after --spec "visual-proof.spec.ts:577"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No