### PR TITLE
[Workflow Delete](2) Add removed flag to workflow rollup patches

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -574,6 +574,17 @@ test.describe('Visual proof capture', () => {
     await assertPageScreenshot(page, 'empty-state');
   });
 
+  test('workflow delete propagation', async ({ page }) => {
+    const workflowId = await loadPlanAndSelectWorkflow(page, TEST_PLAN);
+    await expect(workflowNode(page, workflowId)).toBeVisible();
+    await captureScreenshot(page, 'workflow-delete-before');
+
+    await page.evaluate((id) => window.invoker.deleteWorkflow(id), workflowId);
+
+    await page.waitForTimeout(3000);
+    await captureScreenshot(page, 'workflow-delete-after-3s');
+  });
+
   test('terminal planning loads graph', async ({ page }) => {
     const plannedYaml = yamlStringify(TERMINAL_PLANNED_PLAN);
     // Mirror the real planner reply shape: prose followed by the full fenced

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -68,6 +68,8 @@ export interface WorkflowRollupPatch {
   workflowId: string;
   status: WorkflowDerivedStatus;
   rollup: WorkflowRollup;
+  /** True when the workflow no longer has any tasks (e.g. it was deleted); consumers must drop the workflow instead of patching it. */
+  removed?: boolean;
 }
 
 export type TaskGraphEvent =


### PR DESCRIPTION
## Summary

Workflow rollup patches can only describe a workflow that still has tasks. A zero-task rollup is ambiguous, so consumers had to guess what it meant.

This slice adds one optional boolean, a removal marker, to the shared patch type. When set, the workflow has nothing left and the entry must be dropped rather than patched.

The producer and the consumer of the marker land in the next two slices.

## Review Claim

Approve one optional boolean removal marker on the WorkflowRollupPatch interface in the shared IPC contract.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Additive optional field on a shared type. No producer sets it and no consumer reads it in this slice, so runtime behavior is unchanged.

## Slice Rationale

Contract changes review separately from the code that uses them. The next slices need this field to exist first.

## Non-goals

- No producer or consumer changes; those are the following slices.
- No change to any other field on the patch or event types.

## Test Plan

- [ ] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #3286