### PR TITLE
[Workflow Delete](3) Emit removed rollup patch when last task is removed

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -574,6 +574,17 @@ test.describe('Visual proof capture', () => {
     await assertPageScreenshot(page, 'empty-state');
   });
 
+  test('workflow delete propagation', async ({ page }) => {
+    const workflowId = await loadPlanAndSelectWorkflow(page, TEST_PLAN);
+    await expect(workflowNode(page, workflowId)).toBeVisible();
+    await captureScreenshot(page, 'workflow-delete-before');
+
+    await page.evaluate((id) => window.invoker.deleteWorkflow(id), workflowId);
+
+    await page.waitForTimeout(3000);
+    await captureScreenshot(page, 'workflow-delete-after-3s');
+  });
+
   test('terminal planning loads graph', async ({ page }) => {
     const plannedYaml = yamlStringify(TERMINAL_PLANNED_PLAN);
     // Mirror the real planner reply shape: prose followed by the full fenced

--- a/packages/app/src/__tests__/workflow-rollup-projection.test.ts
+++ b/packages/app/src/__tests__/workflow-rollup-projection.test.ts
@@ -114,7 +114,7 @@ describe('WorkflowRollupProjection', () => {
     ]);
   });
 
-  it('returns a pending patch when the last workflow task is removed', () => {
+  it('marks the patch removed when the last workflow task is removed', () => {
     const projection = new WorkflowRollupProjection();
     projection.replaceAll([makeTask('wf-1/task-a', 'wf-1', 'running')]);
 
@@ -125,8 +125,27 @@ describe('WorkflowRollupProjection', () => {
     });
 
     expect(patches).toHaveLength(1);
-    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'pending' });
+    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'pending', removed: true });
     expect(patches[0]?.rollup.countsByStatus.running).toBe(0);
+  });
+
+  it('does not mark the patch removed while other workflow tasks remain', () => {
+    const projection = new WorkflowRollupProjection();
+    projection.replaceAll([
+      makeTask('wf-1/task-a', 'wf-1', 'running'),
+      makeTask('wf-1/task-b', 'wf-1', 'pending'),
+    ]);
+
+    const patches = projection.applyDelta({
+      type: 'removed',
+      taskId: 'wf-1/task-a',
+      previousTaskStateVersion: 1,
+    });
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0]?.removed).toBeUndefined();
+    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'pending' });
+    expect(patches[0]?.rollup.countsByStatus.pending).toBe(1);
   });
 
   it('does not patch unknown removed tasks', () => {

--- a/packages/app/src/workflow-rollup-projection.ts
+++ b/packages/app/src/workflow-rollup-projection.ts
@@ -59,6 +59,10 @@ export class WorkflowRollupProjection {
     }
 
     this.removeTaskFromWorkflow(taskId, workflowId);
+    const remainingTaskIds = this.taskIdsByWorkflowId.get(workflowId);
+    if (!remainingTaskIds || remainingTaskIds.size === 0) {
+      return [{ ...this.patchFor(workflowId), removed: true }];
+    }
     return this.patchWorkflowById(workflowId);
   }
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -68,6 +68,8 @@ export interface WorkflowRollupPatch {
   workflowId: string;
   status: WorkflowDerivedStatus;
   rollup: WorkflowRollup;
+  /** True when the workflow no longer has any tasks (e.g. it was deleted); consumers must drop the workflow instead of patching it. */
+  removed?: boolean;
 }
 
 export type TaskGraphEvent =


### PR DESCRIPTION
## Summary

After a workflow deletion, its task removal deltas end with a rollup computed over zero tasks. That rollup reads as "pending", which is how the ghost node gets its label.

This slice makes the projection say what actually happened. When a removal delta leaves a workflow with zero tasks, the emitted patch now carries the removal marker.

The signal rides the same ordered delta stream as the removals themselves. It cannot race the separately coalesced workflows-changed publish, which is the race behind the ghost.

If a workflow still exists after losing its last task, the next metadata publish re-adds it, so the marker is safe for that edge.

## Review Claim

Approve WorkflowRollupProjection.applyRemovedTask setting the removal marker on its patch when zero tasks remain for the workflow.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the last-task branch of applyRemovedTask changes. Patches for workflows that still have tasks are byte-identical to before, and unit tests pin both branches.

## Slice Rationale

The producer side is one process-local projection change; the renderer consumer is a different review unit and lands in the next slice.

## Non-goals

- No renderer change; the UI still ignores the marker until the next slice.
- No change to how deltas are published or batched.

## Test Plan

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-rollup-projection.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #3287