### PR TITLE
[Workflow Delete](4) Drop deleted workflows from the renderer graph

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -574,6 +574,17 @@ test.describe('Visual proof capture', () => {
     await assertPageScreenshot(page, 'empty-state');
   });
 
+  test('workflow delete propagation', async ({ page }) => {
+    const workflowId = await loadPlanAndSelectWorkflow(page, TEST_PLAN);
+    await expect(workflowNode(page, workflowId)).toBeVisible();
+    await captureScreenshot(page, 'workflow-delete-before');
+
+    await page.evaluate((id) => window.invoker.deleteWorkflow(id), workflowId);
+
+    await page.waitForTimeout(3000);
+    await captureScreenshot(page, 'workflow-delete-after-3s');
+  });
+
   test('terminal planning loads graph', async ({ page }) => {
     const plannedYaml = yamlStringify(TERMINAL_PLANNED_PLAN);
     // Mirror the real planner reply shape: prose followed by the full fenced

--- a/packages/app/src/__tests__/workflow-rollup-projection.test.ts
+++ b/packages/app/src/__tests__/workflow-rollup-projection.test.ts
@@ -114,7 +114,7 @@ describe('WorkflowRollupProjection', () => {
     ]);
   });
 
-  it('returns a pending patch when the last workflow task is removed', () => {
+  it('marks the patch removed when the last workflow task is removed', () => {
     const projection = new WorkflowRollupProjection();
     projection.replaceAll([makeTask('wf-1/task-a', 'wf-1', 'running')]);
 
@@ -125,8 +125,27 @@ describe('WorkflowRollupProjection', () => {
     });
 
     expect(patches).toHaveLength(1);
-    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'pending' });
+    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'pending', removed: true });
     expect(patches[0]?.rollup.countsByStatus.running).toBe(0);
+  });
+
+  it('does not mark the patch removed while other workflow tasks remain', () => {
+    const projection = new WorkflowRollupProjection();
+    projection.replaceAll([
+      makeTask('wf-1/task-a', 'wf-1', 'running'),
+      makeTask('wf-1/task-b', 'wf-1', 'pending'),
+    ]);
+
+    const patches = projection.applyDelta({
+      type: 'removed',
+      taskId: 'wf-1/task-a',
+      previousTaskStateVersion: 1,
+    });
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0]?.removed).toBeUndefined();
+    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'pending' });
+    expect(patches[0]?.rollup.countsByStatus.pending).toBe(1);
   });
 
   it('does not patch unknown removed tasks', () => {

--- a/packages/app/src/workflow-rollup-projection.ts
+++ b/packages/app/src/workflow-rollup-projection.ts
@@ -59,6 +59,10 @@ export class WorkflowRollupProjection {
     }
 
     this.removeTaskFromWorkflow(taskId, workflowId);
+    const remainingTaskIds = this.taskIdsByWorkflowId.get(workflowId);
+    if (!remainingTaskIds || remainingTaskIds.size === 0) {
+      return [{ ...this.patchFor(workflowId), removed: true }];
+    }
     return this.patchWorkflowById(workflowId);
   }
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -68,6 +68,8 @@ export interface WorkflowRollupPatch {
   workflowId: string;
   status: WorkflowDerivedStatus;
   rollup: WorkflowRollup;
+  /** True when the workflow no longer has any tasks (e.g. it was deleted); consumers must drop the workflow instead of patching it. */
+  removed?: boolean;
 }
 
 export type TaskGraphEvent =

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -599,4 +599,80 @@ describe('useTasks', () => {
 
     expect(result.current.workflows.get('wf-1')?.status).toBe('failed');
   });
+
+  it('drops a deleted workflow within 1s of its removal deltas without a manual refresh', async () => {
+    // Regression: deleting a workflow published workflows-changed (workflow
+    // absent) before the task removal deltas flushed, so the task-backed
+    // preservation kept the entry alive; the final zero-task rollup patch then
+    // resurrected it as a ghost "pending" node that only a manual refresh
+    // cleared. The removal patch (removed: true) must drop it in-stream.
+    const taskA = makeUITask({ id: 'wf-doomed/task-a', workflowId: 'wf-doomed', status: 'completed' });
+    const taskB = makeUITask({ id: 'wf-doomed/task-b', workflowId: 'wf-doomed', status: 'completed' });
+    const keeperTask = makeUITask({ id: 'wf-keeper/task-a', workflowId: 'wf-keeper', status: 'running' });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [taskA, taskB, keeperTask],
+      workflows: [
+        { id: 'wf-doomed', name: 'Doomed workflow', status: 'completed' },
+        { id: 'wf-keeper', name: 'Keeper workflow', status: 'running' },
+      ],
+    };
+    const getTasks = vi.fn().mockResolvedValue({ tasks: [keeperTask], workflows: [] });
+    const reportUiPerf = vi.fn().mockResolvedValue(undefined);
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks,
+      reportUiPerf,
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn((cb: (wfList: unknown[]) => void) => {
+        workflowsChangedHandler = cb;
+        return () => {};
+      }),
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(workflowsChangedHandler).toBeDefined();
+      expect(taskGraphEventHandler).toBeDefined();
+    });
+
+    // Coalesced metadata publish lands first — deleted workflow already absent,
+    // but its tasks are still in the map, so the entry is preserved (the race).
+    act(() => {
+      workflowsChangedHandler!([{ id: 'wf-keeper', name: 'Keeper workflow', status: 'running' }]);
+    });
+    expect(result.current.workflows.get('wf-doomed')?.name).toBe('Doomed workflow');
+
+    const deletionStartedAt = performance.now();
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: { type: 'removed', taskId: 'wf-doomed/task-a', previousTaskStateVersion: 1 },
+        workflowRollups: [{ workflowId: 'wf-doomed', status: 'completed', rollup: makeWorkflowRollup('completed', { completed: 1 }) }],
+      });
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: { type: 'removed', taskId: 'wf-doomed/task-b', previousTaskStateVersion: 1 },
+        workflowRollups: [{ workflowId: 'wf-doomed', status: 'pending', rollup: makeWorkflowRollup('pending'), removed: true }],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 110));
+    });
+
+    // Propagation budget: deltas already delivered, so the UI must converge
+    // within the 1s deletion budget without any snapshot refresh.
+    await waitFor(
+      () => {
+        expect(result.current.workflows.has('wf-doomed')).toBe(false);
+      },
+      { timeout: 1000 },
+    );
+    expect(performance.now() - deletionStartedAt).toBeLessThan(1000);
+    expect(result.current.tasks.has('wf-doomed/task-a')).toBe(false);
+    expect(result.current.tasks.has('wf-doomed/task-b')).toBe(false);
+    expect(result.current.workflows.get('wf-keeper')?.name).toBe('Keeper workflow');
+    expect(getTasks).not.toHaveBeenCalled();
+    expect(reportUiPerf).toHaveBeenCalledWith('workflow_removed_applied', { workflowIds: ['wf-doomed'] });
+  });
 });

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -64,6 +64,11 @@ function applyWorkflowRollupPatches(
   }
   const next = new Map(previous);
   for (const patch of patches) {
+    if (patch.removed) {
+      // Safety invariant: drop, never patch — patching resurrects a ghost node.
+      next.delete(patch.workflowId);
+      continue;
+    }
     const existing = next.get(patch.workflowId);
     next.set(patch.workflowId, {
       ...(existing ?? { id: patch.workflowId, name: patch.workflowId }),
@@ -290,6 +295,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
           });
         }
 
+        const removedWorkflowIds: string[] = [];
         for (const event of deltaEvents) {
           if (event.type !== 'delta') continue;
           const delta = event.delta;
@@ -308,6 +314,11 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
             shouldRefreshWorkflows = true;
           }
           nextTasks = applyDelta(nextTasks, delta);
+          for (const patch of event.workflowRollups) {
+            if (patch.removed && nextWorkflows.has(patch.workflowId)) {
+              removedWorkflowIds.push(patch.workflowId);
+            }
+          }
           nextWorkflows = applyWorkflowRollupPatches(nextWorkflows, event.workflowRollups);
         }
 
@@ -319,6 +330,12 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
         workflowsRef.current = nextWorkflows;
         setTasks(nextTasks);
         setWorkflows(nextWorkflows);
+        if (removedWorkflowIds.length > 0) {
+          // Pairs with the main-process delete log to measure delete → UI removal.
+          void window.invoker.reportUiPerf?.('workflow_removed_applied', {
+            workflowIds: removedWorkflowIds,
+          });
+        }
         if (shouldRefreshWorkflows) {
           void refreshWorkflowMetadata();
         }

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -191,6 +191,8 @@ export interface WorkflowRollupPatch {
   readonly workflowId: string;
   readonly status: WorkflowStatus;
   readonly rollup: WorkflowRollup;
+  /** True when the workflow no longer has any tasks (e.g. it was deleted); the entry must be dropped, not patched. */
+  readonly removed?: boolean;
 }
 
 


### PR DESCRIPTION
## Summary

Workflow deletion left a ghost "pending" node on the plan graph until the user clicked Refresh.

The backend finished in about a second; the UI never let go of the node.

Two things kept the ghost alive. The workflows-changed publish raced ahead of the removal deltas, so the entry stayed task-backed. Then the final zero-task rollup patch re-created it.

Now a patch carrying the removal marker drops the workflow entry instead of patching it. The drop rides the same ordered stream as the removals; nothing needs a refresh.

The hook also reports a workflow_removed_applied perf event when the drop lands. Paired with the main-process deletion log line, that measures deletion-to-UI propagation.

A regression test replays the exact incident ordering and asserts the workflow leaves the graph within one second, with zero snapshot refreshes.

## Review Claim

Approve the renderer dropping workflow entries when a rollup patch carries the removal marker, within the one-second propagation budget.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Patches without the removal marker apply exactly as before. The drop path only runs for the marker the previous slice emits solely when a workflow has zero tasks left.

## Slice Rationale

This is the consumer half of the fix and the only UI-facing change, so it reviews as its own surface slice after the field and producer slices.

## Non-goals

- No change to delete mutation handling or to how the graph event pipeline batches events.
- No change to snapshot or refresh behavior.

## Test Plan

- [ ] `pnpm --filter @invoker/ui exec vitest run src/__tests__/use-tasks.test.tsx`

## Visual Proof

Captured with the stack's capture case: load a plan, delete the workflow via the same bridge call the UI uses, wait 3 seconds, no Refresh click.

Before the fix — 3 seconds after delete, a ghost "pending" node is still on the canvas:

![before fix: ghost pending node 3s after delete](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-67b6ef/before-fix-ghost-after-3s.png)

After the fix — same moment, the graph is empty and the workflow count is 0:

![after fix: graph empty 3s after delete](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-67b6ef/after-fix-empty-after-3s.png)

State just before deletion, for reference (identical in both builds):

![pre-delete state](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-67b6ef/pre-delete-state.png)

Full runs: [before walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-67b6ef/before-fix-walkthrough.webm) · [after walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-67b6ef/after-fix-walkthrough.webm)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None; the ghost-node behavior returns until re-fixed.
- Data migration? No

Depends-On: #3288