### PR TITLE
[Workflow Delete](5) Document workflow delete propagation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to Invoker will be documented in this file.
 ## Unreleased
 
 - Hold merge PRs that Invoker opens against its own repo to the full review-stack PR body before publication. When no agent can author a compliant body, PR creation fails loudly instead of shipping a fallback body that the PR Body CI check rejects.
+- Remove a deleted workflow from the UI within one second instead of leaving a ghost "pending" node until manual refresh. Task removal deltas now carry an in-stream `removed` rollup patch when a workflow's last task is removed, the renderer drops the workflow entry instead of resurrecting it, and a `workflow_removed_applied` UI perf metric records the propagation for regression tracking.
 - Restore Planning Terminal chats after desktop restart, including visible transcripts and draft-ready state.
 - Persist embedded terminal tabs across desktop app restarts, restoring their recent output and reopening spawn-backed sessions.
 - Move auto-fix attempt counts out of SQLite task state and into in-memory worker runtime policy.

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -574,6 +574,17 @@ test.describe('Visual proof capture', () => {
     await assertPageScreenshot(page, 'empty-state');
   });
 
+  test('workflow delete propagation', async ({ page }) => {
+    const workflowId = await loadPlanAndSelectWorkflow(page, TEST_PLAN);
+    await expect(workflowNode(page, workflowId)).toBeVisible();
+    await captureScreenshot(page, 'workflow-delete-before');
+
+    await page.evaluate((id) => window.invoker.deleteWorkflow(id), workflowId);
+
+    await page.waitForTimeout(3000);
+    await captureScreenshot(page, 'workflow-delete-after-3s');
+  });
+
   test('terminal planning loads graph', async ({ page }) => {
     const plannedYaml = yamlStringify(TERMINAL_PLANNED_PLAN);
     // Mirror the real planner reply shape: prose followed by the full fenced

--- a/packages/app/src/__tests__/workflow-rollup-projection.test.ts
+++ b/packages/app/src/__tests__/workflow-rollup-projection.test.ts
@@ -114,7 +114,7 @@ describe('WorkflowRollupProjection', () => {
     ]);
   });
 
-  it('returns a pending patch when the last workflow task is removed', () => {
+  it('marks the patch removed when the last workflow task is removed', () => {
     const projection = new WorkflowRollupProjection();
     projection.replaceAll([makeTask('wf-1/task-a', 'wf-1', 'running')]);
 
@@ -125,8 +125,27 @@ describe('WorkflowRollupProjection', () => {
     });
 
     expect(patches).toHaveLength(1);
-    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'pending' });
+    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'pending', removed: true });
     expect(patches[0]?.rollup.countsByStatus.running).toBe(0);
+  });
+
+  it('does not mark the patch removed while other workflow tasks remain', () => {
+    const projection = new WorkflowRollupProjection();
+    projection.replaceAll([
+      makeTask('wf-1/task-a', 'wf-1', 'running'),
+      makeTask('wf-1/task-b', 'wf-1', 'pending'),
+    ]);
+
+    const patches = projection.applyDelta({
+      type: 'removed',
+      taskId: 'wf-1/task-a',
+      previousTaskStateVersion: 1,
+    });
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0]?.removed).toBeUndefined();
+    expect(patches[0]).toMatchObject({ workflowId: 'wf-1', status: 'pending' });
+    expect(patches[0]?.rollup.countsByStatus.pending).toBe(1);
   });
 
   it('does not patch unknown removed tasks', () => {

--- a/packages/app/src/workflow-rollup-projection.ts
+++ b/packages/app/src/workflow-rollup-projection.ts
@@ -59,6 +59,10 @@ export class WorkflowRollupProjection {
     }
 
     this.removeTaskFromWorkflow(taskId, workflowId);
+    const remainingTaskIds = this.taskIdsByWorkflowId.get(workflowId);
+    if (!remainingTaskIds || remainingTaskIds.size === 0) {
+      return [{ ...this.patchFor(workflowId), removed: true }];
+    }
     return this.patchWorkflowById(workflowId);
   }
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -68,6 +68,8 @@ export interface WorkflowRollupPatch {
   workflowId: string;
   status: WorkflowDerivedStatus;
   rollup: WorkflowRollup;
+  /** True when the workflow no longer has any tasks (e.g. it was deleted); consumers must drop the workflow instead of patching it. */
+  removed?: boolean;
 }
 
 export type TaskGraphEvent =

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -599,4 +599,80 @@ describe('useTasks', () => {
 
     expect(result.current.workflows.get('wf-1')?.status).toBe('failed');
   });
+
+  it('drops a deleted workflow within 1s of its removal deltas without a manual refresh', async () => {
+    // Regression: deleting a workflow published workflows-changed (workflow
+    // absent) before the task removal deltas flushed, so the task-backed
+    // preservation kept the entry alive; the final zero-task rollup patch then
+    // resurrected it as a ghost "pending" node that only a manual refresh
+    // cleared. The removal patch (removed: true) must drop it in-stream.
+    const taskA = makeUITask({ id: 'wf-doomed/task-a', workflowId: 'wf-doomed', status: 'completed' });
+    const taskB = makeUITask({ id: 'wf-doomed/task-b', workflowId: 'wf-doomed', status: 'completed' });
+    const keeperTask = makeUITask({ id: 'wf-keeper/task-a', workflowId: 'wf-keeper', status: 'running' });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [taskA, taskB, keeperTask],
+      workflows: [
+        { id: 'wf-doomed', name: 'Doomed workflow', status: 'completed' },
+        { id: 'wf-keeper', name: 'Keeper workflow', status: 'running' },
+      ],
+    };
+    const getTasks = vi.fn().mockResolvedValue({ tasks: [keeperTask], workflows: [] });
+    const reportUiPerf = vi.fn().mockResolvedValue(undefined);
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks,
+      reportUiPerf,
+      onTaskGraphEvent: vi.fn((cb: (event: unknown) => void) => {
+        taskGraphEventHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn((cb: (wfList: unknown[]) => void) => {
+        workflowsChangedHandler = cb;
+        return () => {};
+      }),
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(workflowsChangedHandler).toBeDefined();
+      expect(taskGraphEventHandler).toBeDefined();
+    });
+
+    // Coalesced metadata publish lands first — deleted workflow already absent,
+    // but its tasks are still in the map, so the entry is preserved (the race).
+    act(() => {
+      workflowsChangedHandler!([{ id: 'wf-keeper', name: 'Keeper workflow', status: 'running' }]);
+    });
+    expect(result.current.workflows.get('wf-doomed')?.name).toBe('Doomed workflow');
+
+    const deletionStartedAt = performance.now();
+    await act(async () => {
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: { type: 'removed', taskId: 'wf-doomed/task-a', previousTaskStateVersion: 1 },
+        workflowRollups: [{ workflowId: 'wf-doomed', status: 'completed', rollup: makeWorkflowRollup('completed', { completed: 1 }) }],
+      });
+      taskGraphEventHandler!({
+        type: 'delta',
+        delta: { type: 'removed', taskId: 'wf-doomed/task-b', previousTaskStateVersion: 1 },
+        workflowRollups: [{ workflowId: 'wf-doomed', status: 'pending', rollup: makeWorkflowRollup('pending'), removed: true }],
+      });
+      await new Promise((resolve) => setTimeout(resolve, 110));
+    });
+
+    // Propagation budget: deltas already delivered, so the UI must converge
+    // within the 1s deletion budget without any snapshot refresh.
+    await waitFor(
+      () => {
+        expect(result.current.workflows.has('wf-doomed')).toBe(false);
+      },
+      { timeout: 1000 },
+    );
+    expect(performance.now() - deletionStartedAt).toBeLessThan(1000);
+    expect(result.current.tasks.has('wf-doomed/task-a')).toBe(false);
+    expect(result.current.tasks.has('wf-doomed/task-b')).toBe(false);
+    expect(result.current.workflows.get('wf-keeper')?.name).toBe('Keeper workflow');
+    expect(getTasks).not.toHaveBeenCalled();
+    expect(reportUiPerf).toHaveBeenCalledWith('workflow_removed_applied', { workflowIds: ['wf-doomed'] });
+  });
 });

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -64,6 +64,11 @@ function applyWorkflowRollupPatches(
   }
   const next = new Map(previous);
   for (const patch of patches) {
+    if (patch.removed) {
+      // Safety invariant: drop, never patch — patching resurrects a ghost node.
+      next.delete(patch.workflowId);
+      continue;
+    }
     const existing = next.get(patch.workflowId);
     next.set(patch.workflowId, {
       ...(existing ?? { id: patch.workflowId, name: patch.workflowId }),
@@ -290,6 +295,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
           });
         }
 
+        const removedWorkflowIds: string[] = [];
         for (const event of deltaEvents) {
           if (event.type !== 'delta') continue;
           const delta = event.delta;
@@ -308,6 +314,11 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
             shouldRefreshWorkflows = true;
           }
           nextTasks = applyDelta(nextTasks, delta);
+          for (const patch of event.workflowRollups) {
+            if (patch.removed && nextWorkflows.has(patch.workflowId)) {
+              removedWorkflowIds.push(patch.workflowId);
+            }
+          }
           nextWorkflows = applyWorkflowRollupPatches(nextWorkflows, event.workflowRollups);
         }
 
@@ -319,6 +330,12 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
         workflowsRef.current = nextWorkflows;
         setTasks(nextTasks);
         setWorkflows(nextWorkflows);
+        if (removedWorkflowIds.length > 0) {
+          // Pairs with the main-process delete log to measure delete → UI removal.
+          void window.invoker.reportUiPerf?.('workflow_removed_applied', {
+            workflowIds: removedWorkflowIds,
+          });
+        }
         if (shouldRefreshWorkflows) {
           void refreshWorkflowMetadata();
         }

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -191,6 +191,8 @@ export interface WorkflowRollupPatch {
   readonly workflowId: string;
   readonly status: WorkflowStatus;
   readonly rollup: WorkflowRollup;
+  /** True when the workflow no longer has any tasks (e.g. it was deleted); the entry must be dropped, not patched. */
+  readonly removed?: boolean;
 }
 
 


### PR DESCRIPTION
## Summary

Add the changelog entry for the workflow deletion propagation fix.

After a deletion, the workflow now leaves the UI within one second instead of lingering as a ghost node until a manual refresh.

## Review Claim

Approve one changelog line describing the workflow deletion propagation fix.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Text-only change to CHANGELOG.md. No code is touched.

## Slice Rationale

Repo policy keeps changelog notes in their own docs slice, so the entry lands at the top of the stack.

## Non-goals

- No code, test, or tooling changes.

## Test Plan

- [ ] `node scripts/validate-pr-body.mjs --body-file /tmp/wf-delete-pr-5.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #3289