### PR TITLE
[Collapsed plan sections](2) Emit collapsed plan sections from the PR body fallback

### DIFF
--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -358,6 +358,8 @@ export function buildMakePrStackPublishPrompt(args: {
       + '`node scripts/validate-pr-body.mjs`. Required visible sections: ## Summary, '
       + '## Review Claim, ## Review Lane, ## Review Unit, ## Safety Invariant, '
       + '## Slice Rationale, ## Non-goals, ## Test Plan, and ## Revert Plan. '
+      + '## Test Plan and ## Revert Plan content must sit inside collapsed '
+      + '<details><summary>Test Plan</summary> / <summary>Revert Plan</summary> blocks. '
       + 'Never hide review metadata inside a <details> block.',
     '- Do NOT let Mergify default the PR body to the commit message; author the body explicitly.',
     '',
@@ -482,8 +484,11 @@ export function buildCanonicalPrBody(args: {
   }
   lines.push('');
 
-  // ## Test Plan
+  // ## Test Plan — content collapsed per the canonical schema.
   lines.push('## Test Plan');
+  lines.push('');
+  lines.push('<details>');
+  lines.push('<summary>Test Plan</summary>');
   lines.push('');
   const ctx = args.structuredContext;
   const commandTasks = ctx?.tasks.filter((t) => t.command && t.status === 'completed') ?? [];
@@ -495,14 +500,21 @@ export function buildCanonicalPrBody(args: {
     lines.push('- [ ] Manual verification required');
   }
   lines.push('');
+  lines.push('</details>');
+  lines.push('');
 
-  // ## Revert Plan
+  // ## Revert Plan — content collapsed per the canonical schema.
   lines.push('## Revert Plan');
+  lines.push('');
+  lines.push('<details>');
+  lines.push('<summary>Revert Plan</summary>');
   lines.push('');
   lines.push('- Safe to revert? Yes');
   lines.push('- Revert command: `git revert <sha>`');
   lines.push('- Post-revert steps: None');
   lines.push('- Data migration? No');
+  lines.push('');
+  lines.push('</details>');
   lines.push('');
 
   // Visual proof (preserve verbatim if present)
@@ -535,6 +547,7 @@ export function buildMakePrPrompt(args: {
     '- Use the repo-local PR conventions and tooling referenced by the skill.',
     '- Only include `## Architecture` when the change modifies component interactions, control flow, state flow, or data flow.',
     '- If the change is small and has no architectural impact, omit `## Architecture`.',
+    '- Wrap the ## Test Plan and ## Revert Plan content in a collapsed <details> block with <summary>Test Plan</summary> / <summary>Revert Plan</summary>; keep the ## headings visible.',
     '- Ensure the final body satisfies the canonical schema required by this repo.',
   ];
 


### PR DESCRIPTION
## Summary

Merge gates that write a pull request description without an agent now fold Test Plan and Revert Plan content behind collapsed details blocks.

The make-pr prompts ask agents for the same collapsed shape, so authored and fallback descriptions match the tooling gate from the previous slice.

## Review Claim

The deterministic fallback and the make-pr prompts wrap Test Plan and Revert Plan content in collapsed details blocks.

## Review Lane

- behavior

## Review Unit

- routing

## Safety Invariant

Only the fallback description builder and prompt text change. Agent selection, fallback order, and the publish flow stay untouched, and the existing engine suite covers the emitted sections.

## Slice Rationale

The engine change may not ride with the tooling gate per the review boundary between scripts and packages, so it lands in its own slice.

## Non-goals

- No change to authorPrBodyWithSkill agent selection or fallback order.
- No change to validateReviewStackPrBody or validateCanonicalPrBody.
- No changelog entry in this slice; it lands separately.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm vitest run src/__tests__/pr-authoring.test.ts src/__tests__/task-runner.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts` (packages/execution-engine; the 8 SSH-executor failures also fail on pristine master and are unrelated)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>