### PR TITLE
[Collapsed plan sections](3) Note collapsed plan sections in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to Invoker will be documented in this file.
 
 ## Unreleased
 
+- Collapse the Test Plan and Revert Plan sections in GitHub PR bodies. Both sections keep their headings but their content now sits inside a collapsed `<details>` block. The PR body template, the make-pr skill, the deterministic fallback body, and `validate-pr-body.mjs` all enforce the new shape.
 - Hold merge PRs that Invoker opens against its own repo to the full review-stack PR body before publication. When no agent can author a compliant body, PR creation fails loudly instead of shipping a fallback body that the PR Body CI check rejects.
 - Remove a deleted workflow from the UI within one second instead of leaving a ghost "pending" node until manual refresh. Task removal deltas now carry an in-stream `removed` rollup patch when a workflow's last task is removed, the renderer drops the workflow entry instead of resurrecting it, and a `workflow_removed_applied` UI perf metric records the propagation for regression tracking.
 - Restore Planning Terminal chats after desktop restart, including visible transcripts and draft-ready state.


### PR DESCRIPTION
## Summary

Add the changelog note for the collapsed Test Plan and Revert Plan sections in pull request descriptions.

## Review Claim

The changelog records the collapsed plan-section shape.

## Review Lane

- docs

## Review Unit

- docs

## Safety Invariant

Changelog-only edit; no runtime files change.

## Slice Rationale

The tooling and engine slices could not carry the changelog per the lane scope rule, so the note lands in its own docs slice.

## Non-goals

- No behavior change; the collapsed shape landed in the previous slices.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-3292-body.md --changed-files-file /tmp/pr-3292-files.txt --diff-file /tmp/pr-3292.diff`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR templates now present the Test Plan and Revert Plan sections in a collapsed expandable block for cleaner review summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->