### PR TITLE
[Collapsed plan sections](1) Classify PR body fixtures as tooling-policy

### DIFF
--- a/scripts/review-unit-rules.mjs
+++ b/scripts/review-unit-rules.mjs
@@ -272,6 +272,7 @@ export function classifyReviewUnitsForPath(filePath) {
   if (
     path === 'scripts/pr-body-template.md'
     || path === 'scripts/test-create-pr-visual-proof.mjs'
+    || path.startsWith('scripts/fixtures/')
   ) return ['tooling-policy'];
   if (path.startsWith('packages/app/e2e/visual-proof/')) return ['activation-surface'];
   if (/(benchmark|performance|visual-proof)/.test(lowerPath)) return ['proof'];


### PR DESCRIPTION
## Summary

PR body fixtures under scripts/fixtures/ are inputs for the validator suite, yet the generic .md mapping kept them out of tooling-policy PRs.

They now classify as tooling-policy, like the PR body template already does.

## Review Claim

Files under scripts/fixtures/ classify as tooling-policy so validator fixture updates can ride with the validator.

## Review Lane

- policy

## Review Unit

- tooling-policy

## Safety Invariant

One classifier line changes; it only affects how the PR body gate buckets changed files under scripts/fixtures/.

## Slice Rationale

The next slice updates these fixtures together with the PR body validator, and that slice cannot pass the gate until the fixtures stop bucketing elsewhere.

## Non-goals

- No change to validate-pr-body.mjs itself; the collapsed plan-section gate lands in the next slice.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `node scripts/test-pr-body-validator.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
