### PR TITLE
[Make PR Proof](1) Require action-visible frames for persistence proof

### DIFF
--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -65,6 +65,10 @@ must_contain "$SKILL_MD" "do not present an unchanged screenshot as proof of the
 
 must_contain "$SKILL_MD" "If the changed behavior spans multiple states or a state transition" "make-pr skill must call out restart and transition proof"
 must_contain "$SKILL_MD" "A gif, mp4, webm, or walkthrough video is required" "make-pr skill must require animated proof for restart or multi-state behavior"
+must_contain "$SKILL_MD" "each screenshot must also show the action happened" "make-pr persistence proof frames must show the triggering action"
+must_contain "$SKILL_MD" "Two frames that differ only in the preserved state do not prove the action occurred" "make-pr must reject persistence proof without visible action evidence"
+must_contain "$SKILL_MD" "from the PR's target base branch" "make-pr must be read from the target base, not a stale working-branch copy"
+must_contain "$SKILL_MD" "Working branches and merge clones can carry stale policy copies" "make-pr must warn that branch copies of the skill drift behind master"
 must_contain "$SKILL_MD" "must not leave repo-relative proof paths in markdown" "make-pr skill must forbid broken repo-relative proof links in published PRs"
 
 # The publication checklist must stop empty PR slices before create/update/stack publish.

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -11,6 +11,8 @@ description: >
 
 Use this skill when the work is already done and the user wants a PR created, updated, rewritten, split, or republished.
 
+Read this skill and `skills/visual-proof/SKILL.md` from the PR's target base branch (for example `git show origin/master:skills/make-pr/SKILL.md`) before authoring proof or PR bodies. Working branches and merge clones can carry stale policy copies, and the validators enforce the base branch's rules.
+
 For stacked PRs, apply `skills/review-compression/SKILL.md` before you write titles or PR bodies. If one branch mixes more than one local review claim, split the stack first.
 For decomposition or extraction refactors (splitting a large file into modules), one PR moves one cohesive unit: create the target file, move ONE function/class/phase, re-point references, keep the public surface stable. The next unit is the next PR. Bundling several extractions into one branch ("extract prepare + dispatch + finalize") is the default mistake this rule prevents — see the **Decomposition & Extraction Refactors** section of `skills/review-compression/SKILL.md`.
 
@@ -117,6 +119,8 @@ When an existing PR changes after its body or proof was written, rerun this skil
 Visual proof must show the changed behavior itself, not just the changed screen area. Before creating or updating the PR, open every screenshot or video and verify the user-visible target is present and identifiable. For conditional or event-driven UI, drive the exact condition that triggers the new state and capture that state. A generic task panel, unchanged sidebar, unrelated graph, or stale screenshot is not proof, even when the right file changed.
 
 If the changed behavior spans multiple states or a state transition — for example restart persistence, before/after workflow transitions, progress animations, opening then dismissing overlays, or any proof labeled “before” and “after” — use animated proof. A gif, mp4, webm, or walkthrough video is required; static screenshots alone are not enough.
+
+When the claim is that a state persists across an action — navigation, restart, refresh, resize — each screenshot must also show the action happened. Number the frames as a sequence and make every frame identify its step through an on-screen cue: the moved selection highlight, the changed route, or the swapped panel, with the preserved state unchanged beside it. Two frames that differ only in the preserved state do not prove the action occurred; if no on-screen cue distinguishes the steps, rely on the walkthrough video as the primary proof.
 
 In the PR body, caption each visual proof item with the concrete thing the reviewer should see, for example "amber Workspace recreated notice in the task inspector." If the reviewer cannot tell what changed from the image and caption, recapture proof before publishing.
 


### PR DESCRIPTION
## Summary

The make-pr skill now demands persistence proof frames that show the action being survived.

This closes the miss behind PR #3202's first proof pass: a lone after screenshot of an expanded sidebar could not show that a navigation had happened at all.

Each frame in a persistence sequence now needs an on-screen cue for its step, like the selection highlight on a different item, while the preserved state holds.

The skill also now says to read make-pr and visual-proof text from the PR's target base branch.

The first proof pass came from a merge clone whose older skill copy lacked the animated-proof rule master already had.

A focused skill test locks both instructions so future edits cannot drop them silently.

## Review Claim

The make-pr skill requires action-visible frames for persistence proof and base-branch skill text for authoring.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

This changes skill text and its focused test only; app behavior and PR tooling code are unchanged.

## Slice Rationale

The policy fix is separate from the sidebar behavior stack it was learned from, so review can focus on PR authoring rules.

## Non-goals

- No changes to PR creation code, media upload code, or visual proof capture scripts.
- No new enforcement in tooling; the rule lives in the skill text and its test.

## Test Plan

- [x] `bash scripts/test-make-pr-skill.sh`
- [x] Editing out the new instruction from `skills/make-pr/SKILL.md` makes the test exit 1

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
