### PR TITLE
[Worker Registration Step 4: CodeRabbit and Merge-Conflict Workers](5) Keep merge gate check polling current

### DIFF
--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -591,5 +591,150 @@ describe('GitHubMergeGateProvider', () => {
         ],
       });
     });
+
+    it('ignores stale failed check runs when a newer run for the same check passed', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/5',
+            statusCheckRollup: [
+              {
+                __typename: 'CheckRun',
+                name: 'PR Body',
+                workflowName: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'FAILURE',
+                startedAt: '2026-07-07T01:34:31Z',
+                completedAt: '2026-07-07T01:34:50Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/1',
+              },
+              {
+                __typename: 'CheckRun',
+                name: 'PR Body',
+                workflowName: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+                startedAt: '2026-07-07T01:35:05Z',
+                completedAt: '2026-07-07T01:35:36Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/2',
+              },
+              {
+                __typename: 'StatusContext',
+                context: 'CodeRabbit',
+                state: 'SUCCESS',
+              },
+            ],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '5', cwd: '/tmp/repo' });
+
+      expect(result.checks).toEqual({ state: 'success', failed: [] });
+    });
+
+    it('ignores stale cancelled check runs when a newer run for the same check passed', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/7',
+            statusCheckRollup: [
+              {
+                __typename: 'CheckRun',
+                name: 'PR Body',
+                workflowName: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'CANCELLED',
+                startedAt: '2026-07-07T01:34:52Z',
+                completedAt: '2026-07-07T01:35:18Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/28835212616/job/85517432174',
+              },
+              {
+                __typename: 'CheckRun',
+                name: 'PR Body',
+                workflowName: 'PR Body',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+                startedAt: '2026-07-07T01:35:21Z',
+                completedAt: '2026-07-07T01:35:54Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/28835273831/job/85517627979',
+              },
+            ],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '7', cwd: '/tmp/repo' });
+
+      expect(result.checks).toEqual({ state: 'success', failed: [] });
+    });
+
+    it('keeps duplicate check jobs from the current workflow run', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/6',
+            statusCheckRollup: [
+              {
+                __typename: 'CheckRun',
+                name: 'required-fast / ${{ matrix.name }}',
+                workflowName: 'CI',
+                status: 'COMPLETED',
+                conclusion: 'FAILURE',
+                startedAt: '2026-07-07T01:33:35Z',
+                completedAt: '2026-07-07T01:34:05Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/3/job/1',
+                summary: 'Unit shard failed',
+              },
+              {
+                __typename: 'CheckRun',
+                name: 'required-fast / ${{ matrix.name }}',
+                workflowName: 'CI',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+                startedAt: '2026-07-07T01:33:36Z',
+                completedAt: '2026-07-07T01:34:06Z',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/3/job/2',
+              },
+            ],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '6', cwd: '/tmp/repo' });
+
+      expect(result.checks).toEqual({
+        state: 'failure',
+        failed: [
+          {
+            name: 'required-fast / ${{ matrix.name }}',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/owner/repo/actions/runs/3/job/1',
+            summary: 'Unit shard failed',
+          },
+        ],
+      });
+    });
   });
 });

--- a/packages/execution-engine/src/__tests__/pool-member-mismatch-publish-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-member-mismatch-publish-repro.test.ts
@@ -83,7 +83,7 @@ describe('publishApprovedFix pool member mismatch', () => {
         // poolMemberId NOT yet set — first run populates it
       },
     });
-    const execExecutor = runner.selectExecutor(execTask);
+    const execExecutor = runner.selectExecutor(execTask).executor;
     expect((execExecutor as any).host).toBe('alpha.example.com'); // RR cursor=0 → alpha
 
     // Step 2: Now simulate another task execution — round-rotates to beta
@@ -94,7 +94,7 @@ describe('publishApprovedFix pool member mismatch', () => {
         poolId: 'ssh-pool',
       },
     });
-    const otherExecutor = runner.selectExecutor(otherTask);
+    const otherExecutor = runner.selectExecutor(otherTask).executor;
     expect((otherExecutor as any).host).toBe('beta.example.com'); // RR cursor=1 → beta
 
     // Advance the round-robin cursor so a fresh pool selection would choose beta.
@@ -124,7 +124,7 @@ describe('publishApprovedFix pool member mismatch', () => {
     selectPoolMemberSpy.mockClear();
 
     // Call selectExecutor exactly as publishApprovedFix does.
-    const publishExecutor = runner.selectExecutor(publishTask);
+    const publishExecutor = runner.selectExecutor(publishTask).executor;
 
     expect(selectPoolMemberSpy).not.toHaveBeenCalled();
     expect((publishExecutor as any).host).toBe('alpha.example.com');

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2423,7 +2423,12 @@ describe('TaskRunner', () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => undefined } as any,
         persistence: {} as any,
-        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executorRegistry: {
+          getDefault: () => ({ type: 'worktree' }),
+          get: () => null,
+          getAll: () => [],
+          register: vi.fn(),
+        } as any,
         cwd: '/tmp',
         remoteTargetsProvider: provider,
       });
@@ -2433,11 +2438,11 @@ describe('TaskRunner', () => {
         config: { runnerKind: 'ssh', poolMemberId: 'do-droplet' },
       });
 
-      const executor1 = executor.selectExecutor(task);
+      const executor1 = executor.selectExecutor(task).executor;
       expect(executor1.type).toBe('ssh');
       expect((executor1 as any).sshKeyPath).toBe('/old/key');
 
-      const executor2 = executor.selectExecutor(task);
+      const executor2 = executor.selectExecutor(task).executor;
       expect((executor2 as any).sshKeyPath).toBe('/new/key');
 
       expect(provider).toHaveBeenCalledTimes(2);
@@ -2866,7 +2871,12 @@ describe('TaskRunner', () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
         persistence: {} as any,
-        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executorRegistry: {
+          getDefault: () => ({ type: 'worktree' }),
+          get: () => null,
+          getAll: () => [],
+          register: vi.fn(),
+        } as any,
         cwd: '/tmp',
         remoteTargetsProvider: () => remoteTargets,
       });
@@ -2884,9 +2894,9 @@ describe('TaskRunner', () => {
         config: { runnerKind: 'ssh', poolMemberId: 'remote-b' },
       });
 
-      const executor1 = executor.selectExecutor(task1);
-      const executor2 = executor.selectExecutor(task2);
-      const executor3 = executor.selectExecutor(task3);
+      const executor1 = executor.selectExecutor(task1).executor;
+      const executor2 = executor.selectExecutor(task2).executor;
+      const executor3 = executor.selectExecutor(task3).executor;
 
       // task1 and task2 share the same poolMemberId → same executor instance
       expect(executor1).toBe(executor2);
@@ -2917,8 +2927,8 @@ describe('TaskRunner', () => {
         config: { runnerKind: 'worktree' },
       });
 
-      const executor1 = executor.selectExecutor(task1);
-      const executor2 = executor.selectExecutor(task2);
+      const executor1 = executor.selectExecutor(task1).executor;
+      const executor2 = executor.selectExecutor(task2).executor;
 
       // Worktree executors are created fresh each time (lazy registration creates new instances)
       // Both should be worktree type but may be different instances
@@ -2939,7 +2949,12 @@ describe('TaskRunner', () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
         persistence: {} as any,
-        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executorRegistry: {
+          getDefault: () => ({ type: 'worktree' }),
+          get: () => null,
+          getAll: () => [],
+          register: vi.fn(),
+        } as any,
         cwd: '/tmp',
         remoteTargetsProvider: () => remoteTargets,
       });
@@ -2953,9 +2968,9 @@ describe('TaskRunner', () => {
         config: { runnerKind: 'ssh', poolMemberId: 'remote-a' },
       });
 
-      const executor1 = executor.selectExecutor(task1);
+      const executor1 = executor.selectExecutor(task1).executor;
       await executor.clearSshExecutorCache();
-      const executor2 = executor.selectExecutor(task2);
+      const executor2 = executor.selectExecutor(task2).executor;
 
       // After clearing cache, a new executor instance should be created
       expect(executor1).not.toBe(executor2);
@@ -3089,7 +3104,7 @@ describe('TaskRunner', () => {
       expect(JSON.stringify(selectedPayload)).not.toContain('sshKeyPath');
       expect(JSON.stringify(selectedPayload)).not.toContain('/secret/key');
       expect(updateTask).toHaveBeenCalledWith('task-1', {
-        config: { runnerKind: 'ssh', poolMemberId: 'remote-a' },
+        config: expect.objectContaining({ runnerKind: 'ssh', poolMemberId: 'remote-a' }),
         execution: expect.objectContaining({
           workspacePath: '/remote/worktrees/task-1',
           branch: 'experiment/task-1',
@@ -3165,7 +3180,7 @@ describe('TaskRunner', () => {
         remoteHost: 'b.example.com',
       }));
       expect(updateTask).toHaveBeenCalledWith('task-retry', {
-        config: { runnerKind: 'ssh', poolMemberId: 'remote-b' },
+        config: expect.objectContaining({ runnerKind: 'ssh', poolMemberId: 'remote-b' }),
         execution: expect.objectContaining({
           workspacePath: '/remote/worktrees/task-retry',
           branch: 'experiment/task-retry',
@@ -3392,15 +3407,15 @@ describe('TaskRunner', () => {
 
       // Check that metadata was persisted immediately after start
       expect(updateSpy).toHaveBeenCalledWith('ssh-task-1', {
-        config: { runnerKind: 'ssh', poolMemberId: 'remote-1' },
-        execution: {
+        config: expect.objectContaining({ runnerKind: 'ssh', poolMemberId: 'remote-1' }),
+        execution: expect.objectContaining({
           workspacePath: '~/.invoker/worktrees/abc123/experiment-ssh-task-1-def456',
           branch: 'experiment/ssh-task-1-def456',
           agentSessionId: 'session-123',
           lastAgentSessionId: 'session-123',
           lastAgentName: undefined,
           containerId: undefined,
-        },
+        }),
       });
     });
 
@@ -3644,15 +3659,15 @@ describe('TaskRunner', () => {
 
       // Check that metadata was persisted with workspacePath and branch=undefined
       expect(updateSpy).toHaveBeenCalledWith('byo-task-1', {
-        config: { runnerKind: 'ssh' },
-        execution: {
+        config: expect.objectContaining({ runnerKind: 'ssh' }),
+        execution: expect.objectContaining({
           workspacePath: '/remote/user-provided/workspace',
           branch: undefined,
           agentSessionId: undefined,
           lastAgentSessionId: undefined,
           lastAgentName: undefined,
           containerId: undefined,
-        },
+        }),
       });
     });
   });

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -11,6 +11,8 @@ import { registerBuiltinWorkers } from '../builtin-workers.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import { createWorkerRegistry } from '../worker-registry.js';
 import { CI_FAILURE_WORKER_KIND } from '../workers/ci-failure-worker.js';
+import { CODERABBIT_UPDATE_WORKER_KIND } from '../workers/coderabbit-update-worker.js';
+import { MERGE_CONFLICT_REBASE_WORKER_KIND } from '../workers/merge-conflict-rebase-worker.js';
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
 
 const silentLogger = {
@@ -61,10 +63,14 @@ describe('worker registry', () => {
       AUTO_FIX_WORKER_KIND,
       PR_STATUS_WORKER_KIND,
       CI_FAILURE_WORKER_KIND,
+      CODERABBIT_UPDATE_WORKER_KIND,
+      MERGE_CONFLICT_REBASE_WORKER_KIND,
     ]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_STATUS_WORKER_KIND)).toBeDefined();
     expect(registry.get(CI_FAILURE_WORKER_KIND)).toBeDefined();
+    expect(registry.get(CODERABBIT_UPDATE_WORKER_KIND)).toBeDefined();
+    expect(registry.get(MERGE_CONFLICT_REBASE_WORKER_KIND)).toBeDefined();
   });
   it('returns nothing for an unknown kind', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());
@@ -89,5 +95,9 @@ describe('worker registry', () => {
 
     expect(registry.get(PR_STATUS_WORKER_KIND)?.factory(deps()).identity.kind).toBe(PR_STATUS_WORKER_KIND);
     expect(registry.get(CI_FAILURE_WORKER_KIND)?.factory(deps()).identity.kind).toBe(CI_FAILURE_WORKER_KIND);
+    expect(registry.get(CODERABBIT_UPDATE_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(CODERABBIT_UPDATE_WORKER_KIND);
+    expect(registry.get(MERGE_CONFLICT_REBASE_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(MERGE_CONFLICT_REBASE_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -321,12 +321,113 @@ function stringProp(value: Record<string, unknown>, ...keys: string[]): string |
   return undefined;
 }
 
+function timestampProp(value: Record<string, unknown>, ...keys: string[]): number | undefined {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate !== 'string' || !candidate.trim()) continue;
+    const timestamp = Date.parse(candidate);
+    if (Number.isFinite(timestamp)) return timestamp;
+  }
+  return undefined;
+}
+
+function checkIdentity(value: Record<string, unknown>): string | undefined {
+  const context = stringProp(value, 'context');
+  if (context) return `status:${context}`;
+
+  const name = stringProp(value, 'name');
+  const workflowName = stringProp(value, 'workflowName');
+  if (name || workflowName) return `check:${workflowName ?? ''}:${name ?? ''}`;
+  return undefined;
+}
+
+function githubActionsRunKey(value: Record<string, unknown>): string | undefined {
+  const url = stringProp(value, 'detailsUrl', 'targetUrl');
+  if (!url) return undefined;
+  const match = /\/actions\/runs\/([^/?#]+)/.exec(url);
+  return match ? `github-actions:${match[1]}` : undefined;
+}
+
+type RollupItemGroup = { index: number; items: unknown[] };
+type LatestRollupItem = { index: number; item: unknown; timestamp: number };
+type ActionRunRollupGroup = { index: number; items: unknown[]; timestamp: number };
+
+function latestStatusCheckRollupItems(items: unknown[]): unknown[] {
+  const groups: RollupItemGroup[] = [];
+  const latestStatusByIdentity = new Map<string, LatestRollupItem>();
+  const actionRunsByIdentity = new Map<string, Map<string, ActionRunRollupGroup>>();
+
+  for (const [index, item] of items.entries()) {
+    if (!item || typeof item !== 'object') {
+      groups.push({ index, items: [item] });
+      continue;
+    }
+
+    const check = item as Record<string, unknown>;
+    const identity = checkIdentity(check);
+    const timestamp = timestampProp(check, 'startedAt', 'completedAt');
+    if (!identity || timestamp === undefined) {
+      groups.push({ index, items: [item] });
+      continue;
+    }
+
+    if (identity.startsWith('status:')) {
+      const existing = latestStatusByIdentity.get(identity);
+      if (!existing || timestamp >= existing.timestamp) {
+        latestStatusByIdentity.set(identity, { index, item, timestamp });
+      }
+      continue;
+    }
+
+    const runKey = githubActionsRunKey(check);
+    if (!runKey) {
+      groups.push({ index, items: [item] });
+      continue;
+    }
+
+    let runs = actionRunsByIdentity.get(identity);
+    if (!runs) {
+      runs = new Map();
+      actionRunsByIdentity.set(identity, runs);
+    }
+
+    const run = runs.get(runKey);
+    if (run) {
+      run.items.push(item);
+      run.timestamp = Math.max(run.timestamp, timestamp);
+      continue;
+    }
+    runs.set(runKey, { index, items: [item], timestamp });
+  }
+
+  for (const entry of latestStatusByIdentity.values()) {
+    groups.push({ index: entry.index, items: [entry.item] });
+  }
+  for (const runs of actionRunsByIdentity.values()) {
+    let latest: ActionRunRollupGroup | undefined;
+    for (const run of runs.values()) {
+      if (
+        !latest ||
+        run.timestamp > latest.timestamp ||
+        (run.timestamp === latest.timestamp && run.index > latest.index)
+      ) {
+        latest = run;
+      }
+    }
+    if (latest) groups.push({ index: latest.index, items: latest.items });
+  }
+
+  return groups
+    .sort((a, b) => a.index - b.index)
+    .flatMap((group) => group.items);
+}
+
 function summarizeStatusChecks(items: unknown[] | undefined): MergeGateApprovalStatus['checks'] {
   if (!Array.isArray(items) || items.length === 0) return undefined;
 
   let hasPending = false;
   const failed: MergeGateFailedCheck[] = [];
-  for (const item of items) {
+  for (const item of latestStatusCheckRollupItems(items)) {
     if (!item || typeof item !== 'object') continue;
     const check = item as Record<string, unknown>;
     const name = stringProp(check, 'name', 'workflowName', 'context') ?? 'unknown check';


### PR DESCRIPTION
## Summary

Merge gate approval polling now groups repeated GitHub Actions rollup entries by run.

The gate reads the current run for each check name while preserving parallel jobs from that run.

<details>
<summary>Review metadata</summary>

Review Claim: Merge gate approval polling reads the current check state for repeated GitHub Actions rollups.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Only the local rollup summarizer changes; unknown entries still pass through unchanged.

Slice Rationale: This follows the worker proof because the published stack must be judged against the current CI run.

</details>

<details>
<summary>Validator metadata</summary>

## Review Claim

Merge gate approval polling reads the current check state for repeated GitHub Actions rollups.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the local rollup summarizer changes; unknown entries still pass through unchanged.

## Slice Rationale

This follows the worker proof because the published stack must be judged against the current CI run.

</details>

## Non-goals

- Do not change required check names or review decision handling.
- Do not change PR publication or stack update behavior.
- Do not mutate any workflow, task, or PR state.

## Architecture

### Before

```mermaid
graph TD
    A["GitHub statusCheckRollup"] --> B["Every returned entry"]
    B --> C["Merge gate approval result"]
```

### After

```mermaid
graph TD
    A["GitHub statusCheckRollup"] --> B["Group entries by check identity and Actions run"]
    B --> C["Latest run entries"]
    C --> D["Merge gate approval result"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/github-merge-gate-provider.test.ts src/__tests__/worker-registry.test.ts src/__tests__/pool-member-mismatch-publish-repro.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a22d1a5c8`
- Post-revert steps: None.
- Data migration? No

</details>
