### PR TITLE
[Worker-triggered history in Workers tab Step 1](1) Add worker action history IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -221,6 +221,21 @@ export interface WorkerStatusSnapshot {
   workers: WorkerStatusEntry[];
 }
 
+export interface WorkerActionHistoryRequest {
+  workerKind: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface WorkerActionHistoryResponse {
+  workerKind: string;
+  actions: WorkerActionSummary[];
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+  nextOffset?: number;
+}
+
 
 export type UIActionGraphNodeType =
   | 'user-action'
@@ -916,6 +931,10 @@ export const IpcChannels = {
   'invoker:get-worker-status': {} as {
     request: [];
     response: WorkerStatusSnapshot;
+  },
+  'invoker:get-worker-action-history': {} as {
+    request: [request: WorkerActionHistoryRequest];
+    response: WorkerActionHistoryResponse;
   },
   'invoker:start-worker': {} as {
     request: [kind: string];


### PR DESCRIPTION
## Summary

Adds the IPC contract types and channel Invoker uses to request a worker's action history one page at a time.

The request carries the worker kind plus an optional page size and offset; the response echoes them and reports whether more actions remain.

## Review Claim

Add the `WorkerActionHistoryRequest` / `WorkerActionHistoryResponse` types and the `invoker:get-worker-action-history` channel.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

This slice adds interface types and one channel entry only. No runtime code implements or calls the channel yet, so it cannot change any behavior.

## Slice Rationale

Land the shared contract first so the paging reader and the app wiring can build against a stable interface without redefining it.

## Non-goals

Does not implement the query or wire any handler.

Does not add or modify any Workers tab UI.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
