### PR TITLE
[Worker-triggered history in Workers tab Step 1](4) Guard read-only opens against live WAL

### DIFF
--- a/packages/app/src/__tests__/ipc-read-handlers.test.ts
+++ b/packages/app/src/__tests__/ipc-read-handlers.test.ts
@@ -120,6 +120,63 @@ describe('registerReadOnlyIpcHandlers', () => {
       ready: false,
     });
   });
+
+  it('get-worker-action-history returns paged action summaries', async () => {
+    const handlers = new Map<string, (...args: unknown[]) => unknown>();
+    const ipcMain = {
+      handle: vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {
+        handlers.set(channel, handler);
+      }),
+    };
+    const listWorkerActions = vi.fn(() => [
+      {
+        id: 'wa-1',
+        workerKind: 'autofix',
+        actionType: 'repair',
+        subjectType: 'task',
+        subjectId: 'wf-1/task-1',
+        externalKey: 'key-1',
+        status: 'completed',
+        attemptCount: 1,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:02.000Z',
+      },
+      {
+        id: 'wa-2',
+        workerKind: 'autofix',
+        actionType: 'repair',
+        subjectType: 'task',
+        subjectId: 'wf-1/task-2',
+        externalKey: 'key-2',
+        status: 'failed',
+        attemptCount: 1,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:01.000Z',
+      },
+    ]);
+
+    registerReadOnlyIpcHandlers({
+      ipcMain: ipcMain as never,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as never,
+      persistence: { listWorkerActions } as never,
+      getOrchestrator: () => ({}) as never,
+      agentRegistry: {} as never,
+      loadTaskByIdFromPersistence: () => undefined,
+      resolveAgentSession: vi.fn(async () => null),
+      recordStartupDuration: vi.fn(),
+      getTaskDeltaStreamSequence: () => 1,
+    });
+
+    await expect(handlers.get('invoker:get-worker-action-history')?.({}, { workerKind: 'autofix', limit: 1, offset: 3 })).resolves.toMatchObject({
+      workerKind: 'autofix',
+      actions: [{ id: 'wa-1' }],
+      limit: 1,
+      offset: 3,
+      hasMore: true,
+      nextOffset: 4,
+    });
+    expect(listWorkerActions).toHaveBeenCalledWith({ workerKind: 'autofix', limit: 2, offset: 3 });
+  });
   it('does not expose renderer write tools to read handlers', () => {
     expectReadContextWriteToolsAreAbsent();
   });

--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -12,6 +12,7 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     getUiPerfStats: vi.fn(() => ({ mainDeltaToUi: 7 })),
     resetUiPerfStats: vi.fn(),
     getQueueStatus: vi.fn(() => ({ runningCount: 2 })),
+    listWorkerActionHistory: vi.fn((request) => ({ workerKind: request.workerKind, actions: [], limit: request.limit ?? 20, offset: request.offset ?? 0, hasMore: false })),
     getWorkerStatus: vi.fn(() => ({ generatedAt: 'now', workers: [] })),
     getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
     getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
@@ -43,6 +44,9 @@ describe('answerOwnerReadQuery', () => {
     const h = makeHandlers();
     expect(answerOwnerReadQuery({ kind: 'queue' }, h)).toEqual({ runningCount: 2 });
     expect(answerOwnerReadQuery({ kind: 'worker-status' }, h)).toEqual({ workerStatus: { generatedAt: 'now', workers: [] } });
+    expect(answerOwnerReadQuery({ kind: 'worker-action-history', workerKind: 'autofix', limit: 2, offset: 4 }, h)).toEqual({
+      workerActionHistory: { workerKind: 'autofix', actions: [], limit: 2, offset: 4, hasMore: false },
+    });
     expect(answerOwnerReadQuery({ kind: 'workflow-status' }, h)).toEqual({ 'wf-1': 'running' });
     expect(answerOwnerReadQuery({ kind: 'action-graph' }, h)).toEqual({ nodes: [] });
   });
@@ -104,6 +108,7 @@ describe('answerOwnerReadQuery', () => {
     // Non-finite / negative replay offsets must be rejected too.
     expect(() => answerOwnerReadQuery({ kind: 'replay-output', taskId: 't', fromOffset: -1 }, h)).toThrow(/fromOffset/);
     expect(() => answerOwnerReadQuery({ kind: 'replay-output', taskId: 't', fromOffset: Number.NaN }, h)).toThrow(/fromOffset/);
+    expect(() => answerOwnerReadQuery({ kind: 'worker-action-history' }, h)).toThrow(/workerKind/);
     expect(h.replayOutput).not.toHaveBeenCalled();
   });
 });
@@ -129,6 +134,7 @@ describe('buildOwnerReadQueryHandlers', () => {
         getOutputTail: () => ({ t: 1 }),
         replayOutputFrom: (id: string, off: number) => [{ id, off }],
         loadAllCompletedTasks: () => [{ id: 'done' }],
+        listWorkerActions: vi.fn(() => []),
       },
     };
   }
@@ -157,6 +163,13 @@ describe('buildOwnerReadQueryHandlers', () => {
     expect(h.replayOutput('t1', 9)).toEqual([{ id: 't1', off: 9 }]);
     expect(h.getAllCompletedTasks()).toEqual([{ id: 'done' }]);
     expect(h.getWorkerStatus()).toEqual({ generatedAt: 'now', workers: [] });
+    expect(h.listWorkerActionHistory({ workerKind: 'autofix', limit: 1, offset: 2 })).toEqual({
+      workerKind: 'autofix',
+      actions: [],
+      limit: 1,
+      offset: 2,
+      hasMore: false,
+    });
   });
 
   it('loadWorkflowBundle syncs that workflow first, then returns workflow + tasks', () => {

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   AUTO_STARTED_OWNER_WORKER_KINDS,
   createWorkerRuntimeController,
+  listWorkerActionHistory,
 } from '../worker-control.js';
 
 interface TestWorkerRuntime extends WorkerRuntime {
@@ -174,5 +175,63 @@ describe('createWorkerRuntimeController', () => {
       lifecycle: 'exited',
       policy: 'unknown',
     });
+  });
+
+  it('keeps status recentActions capped to five items', () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registry.register({
+      kind: 'history',
+      note: 'History worker.',
+      factory: () => runtime('history'),
+    });
+    const listWorkerActions = vi.fn(() => Array.from({ length: 6 }, (_value, index) => ({
+      id: `wa-${index}`,
+      workerKind: 'history',
+      actionType: 'check',
+      subjectType: 'task',
+      subjectId: `task-${index}`,
+      externalKey: `key-${index}`,
+      status: 'completed',
+      attemptCount: 1,
+      createdAt: `2026-01-01T00:00:0${index}.000Z`,
+      updatedAt: `2026-01-01T00:00:0${index}.000Z`,
+    })));
+
+    const controller = createWorkerRuntimeController({
+      registry,
+      deps: deps(),
+      autoStartKinds: [],
+      persistence: { ...persistence(), listWorkerActions } as never,
+      canControl: () => true,
+    });
+
+    const worker = controller.snapshot().workers[0];
+    expect(listWorkerActions).toHaveBeenCalledWith({ workerKind: 'history', limit: 5 });
+    expect(worker?.recentActions).toHaveLength(5);
+  });
+
+  it('returns worker action history with paging metadata', () => {
+    const listWorkerActions = vi.fn(() => Array.from({ length: 3 }, (_value, index) => ({
+      id: `wa-${index}`,
+      workerKind: 'history',
+      actionType: 'check',
+      subjectType: 'task',
+      subjectId: `task-${index}`,
+      externalKey: `key-${index}`,
+      status: 'completed',
+      attemptCount: 1,
+      createdAt: `2026-01-01T00:00:0${index}.000Z`,
+      updatedAt: `2026-01-01T00:00:0${index}.000Z`,
+    })));
+
+    expect(listWorkerActionHistory({ listWorkerActions } as never, { workerKind: ' history ', limit: 2, offset: 4 })).toMatchObject({
+      workerKind: 'history',
+      actions: [{ id: 'wa-0' }, { id: 'wa-1' }],
+      limit: 2,
+      offset: 4,
+      hasMore: true,
+      nextOffset: 6,
+    });
+    expect(listWorkerActions).toHaveBeenCalledWith({ workerKind: 'history', limit: 3, offset: 4 });
   });
 });

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -1,5 +1,5 @@
 import type { IpcMain } from 'electron';
-import type { Logger, SearchOptions } from '@invoker/contracts';
+import type { Logger, SearchOptions, WorkerActionHistoryRequest, WorkerActionHistoryResponse } from '@invoker/contracts';
 import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { DEFAULT_EXECUTION_AGENT, type AgentRegistry } from '@invoker/execution-engine';
@@ -8,6 +8,7 @@ import type { MessageBus } from '@invoker/transport';
 import { loadConfig } from './config.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { buildTaskGraphSnapshot } from './web/task-graph-snapshot.js';
+import { listWorkerActionHistory } from './worker-control.js';
 
 export interface RegisterReadOnlyIpcHandlersContext {
   ipcMain: IpcMain;
@@ -181,6 +182,13 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     delegatedRead('output-tail', { taskId }, 'tail', () => persistence.getOutputTail(taskId)));
   ipcMain.handle('invoker:get-all-completed-tasks', () =>
     delegatedRead('all-completed-tasks', {}, 'tasks', () => persistence.loadAllCompletedTasks()));
+  ipcMain.handle('invoker:get-worker-action-history', (_event, request: WorkerActionHistoryRequest) =>
+    delegatedRead<WorkerActionHistoryResponse>(
+      'worker-action-history',
+      request as unknown as Record<string, unknown>,
+      'workerActionHistory',
+      () => listWorkerActionHistory(persistence, request),
+    ));
 
   ipcMain.handle('invoker:get-claude-session', async (_event, sessionId: string) => {
     logger.info(`get-claude-session: "${sessionId}"`, { module: 'ipc' });

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -1,9 +1,10 @@
 import type { Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { WorkerStatusSnapshot } from '@invoker/contracts';
+import type { WorkerActionHistoryRequest, WorkerActionHistoryResponse, WorkerStatusSnapshot } from '@invoker/contracts';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { isHeadlessReadOnlyCommand } from './headless-command-classification.js';
 import { runReadOnlyHeadlessQueryToString, type HeadlessQueryDeps } from './headless-query-list.js';
+import { listWorkerActionHistory } from './worker-control.js';
 
 /**
  * Shared dispatcher for the owner's `headless.query` IPC channel.
@@ -28,6 +29,7 @@ export interface OwnerReadQueryHandlers {
   getUiPerfStats: () => Record<string, unknown>;
   resetUiPerfStats: () => void;
   getQueueStatus: () => Record<string, unknown>;
+  listWorkerActionHistory: (request: WorkerActionHistoryRequest) => WorkerActionHistoryResponse;
   getWorkerStatus: () => WorkerStatusSnapshot;
   getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
   getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
@@ -54,6 +56,9 @@ export function answerOwnerReadQuery(
     workflowId?: string;
     taskId?: string;
     fromOffset?: number;
+    workerKind?: string;
+    limit?: number;
+    offset?: number;
   };
   const { kind, reset } = body;
   handlers.onActivity?.();
@@ -70,6 +75,12 @@ export function answerOwnerReadQuery(
     }
     return offset;
   };
+  const workerActionHistoryRequest = (): WorkerActionHistoryRequest => ({
+    workerKind: requiredString(body.workerKind, 'workerKind'),
+    ...(body.limit !== undefined ? { limit: body.limit } : {}),
+    ...(body.offset !== undefined ? { offset: body.offset } : {}),
+  });
+
 
   switch (kind) {
     case 'ui-perf':
@@ -79,6 +90,8 @@ export function answerOwnerReadQuery(
       return handlers.getQueueStatus();
     case 'worker-status':
       return { workerStatus: handlers.getWorkerStatus() };
+    case 'worker-action-history':
+      return { workerActionHistory: handlers.listWorkerActionHistory(workerActionHistoryRequest()) };
     case 'workflow-status':
       return handlers.getWorkflowStatus(body.workflowId);
     case 'tasks':
@@ -152,6 +165,7 @@ type ReadPersistence = Pick<
   | 'getOutputTail'
   | 'replayOutputFrom'
   | 'loadAllCompletedTasks'
+  | 'listWorkerActions'
 >;
 
 export interface OwnerReadQueryDeps {
@@ -178,6 +192,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     resetUiPerfStats: deps.resetUiPerfStats,
     getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
     getWorkerStatus: deps.getWorkerStatus,
+    listWorkerActionHistory: (request: WorkerActionHistoryRequest) => listWorkerActionHistory(persistence, request),
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
     getTasksSnapshot: ({ refresh }) => {
       if (refresh) orchestrator.syncAllFromDb();

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -1,4 +1,6 @@
 import type {
+  WorkerActionHistoryRequest,
+  WorkerActionHistoryResponse,
   WorkerActionSummary,
   WorkerPolicyStatus,
   WorkerRecoverySummary,
@@ -30,6 +32,53 @@ export interface WorkerRuntimeController {
 }
 
 type WorkerStatusPersistence = Pick<SQLiteAdapter, 'listWorkerActions' | 'listWorkflows' | 'loadTasks' | 'getEvents'>;
+
+const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
+const MAX_WORKER_ACTION_HISTORY_LIMIT = 100;
+
+function positiveIntegerOrDefault(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const normalized = Math.floor(value);
+  if (!Number.isFinite(normalized) || normalized <= 0) {
+    return fallback;
+  }
+  return normalized;
+}
+
+function nonNegativeIntegerOrZero(value: number | undefined): number {
+  if (value === undefined) return 0;
+  const normalized = Math.floor(value);
+  if (!Number.isFinite(normalized) || normalized < 0) {
+    return 0;
+  }
+  return normalized;
+}
+
+export function listWorkerActionHistory(
+  persistence: Pick<SQLiteAdapter, 'listWorkerActions'>,
+  request: WorkerActionHistoryRequest,
+): WorkerActionHistoryResponse {
+  const workerKind = typeof request?.workerKind === 'string' ? request.workerKind.trim() : '';
+  if (workerKind.length === 0) {
+    throw new Error('workerKind is required');
+  }
+  const limit = Math.min(
+    positiveIntegerOrDefault(request?.limit, DEFAULT_WORKER_ACTION_HISTORY_LIMIT),
+    MAX_WORKER_ACTION_HISTORY_LIMIT,
+  );
+  const offset = nonNegativeIntegerOrZero(request?.offset);
+  const rows = persistence.listWorkerActions({ workerKind, limit: limit + 1, offset });
+  const actions = rows.slice(0, limit).map(toWorkerActionSummary);
+  const hasMore = rows.length > limit;
+  return {
+    workerKind,
+    actions,
+    limit,
+    offset,
+    hasMore,
+    ...(hasMore ? { nextOffset: offset + actions.length } : {}),
+  };
+}
 
 interface RuntimeHandle {
   runtime: WorkerRuntime;
@@ -187,7 +236,7 @@ function buildWorkerStatusEntry(args: {
     ...(controlDisabledReason ? { controlDisabledReason } : {}),
     ...(args.handle?.startedAt ? { startedAt: args.handle.startedAt } : {}),
     ...(args.stoppedAt ? { stoppedAt: args.stoppedAt } : {}),
-    recentActions: args.persistence.listWorkerActions({ workerKind: args.definitionKind, limit: 5 }).map(toWorkerActionSummary),
+    recentActions: args.persistence.listWorkerActions({ workerKind: args.definitionKind, limit: 5 }).slice(0, 5).map(toWorkerActionSummary),
     ...(args.definitionKind === AUTO_FIX_WORKER_KIND ? { recovery: toWorkerRecoverySummary(args.persistence) } : {}),
   };
 }
@@ -202,7 +251,7 @@ function getControlDisabledReason(canControl: boolean): string | undefined {
   return undefined;
 }
 
-function toWorkerActionSummary(action: WorkerActionRecord): WorkerActionSummary {
+export function toWorkerActionSummary(action: WorkerActionRecord): WorkerActionSummary {
   return {
     id: action.id,
     workerKind: action.workerKind,

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -221,6 +221,21 @@ export interface WorkerStatusSnapshot {
   workers: WorkerStatusEntry[];
 }
 
+export interface WorkerActionHistoryRequest {
+  workerKind: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface WorkerActionHistoryResponse {
+  workerKind: string;
+  actions: WorkerActionSummary[];
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+  nextOffset?: number;
+}
+
 
 export type UIActionGraphNodeType =
   | 'user-action'
@@ -916,6 +931,10 @@ export const IpcChannels = {
   'invoker:get-worker-status': {} as {
     request: [];
     response: WorkerStatusSnapshot;
+  },
+  'invoker:get-worker-action-history': {} as {
+    request: [request: WorkerActionHistoryRequest];
+    response: WorkerActionHistoryResponse;
   },
   'invoker:start-worker': {} as {
     request: [kind: string];

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -778,6 +778,8 @@ describe('SQLiteAdapter', () => {
       expect(adapter.listWorkerActions({ taskId: 'wf-1/task-1' }).map((action) => action.id)).toEqual(['wa-1']);
       expect(adapter.listWorkerActions({ workerKind: 'github' }).map((action) => action.id)).toEqual(['wa-3']);
       expect(adapter.listWorkerActions({ status: 'running', limit: 1 }).map((action) => action.id)).toEqual(['wa-3']);
+      expect(adapter.listWorkerActions({ status: 'running', limit: 1, offset: 1 }).map((action) => action.id)).toEqual(['wa-2']);
+      expect(adapter.listWorkerActions({ workerKind: 'autofix', limit: 1, offset: 1 }).map((action) => action.id)).toEqual(['wa-1']);
       expect(adapter.listWorkerActions({ limit: 0 })).toEqual([]);
     });
   });

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -193,6 +193,7 @@ export interface WorkerActionListFilters {
   workerKind?: string;
   status?: WorkerActionStatus | string;
   limit?: number;
+  offset?: number;
 }
 
 export interface TerminalSessionRecord {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2389,9 +2389,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   listWorkerActions(filters: WorkerActionListFilters = {}): WorkerActionRecord[] {
-    if (filters.limit !== undefined && Math.floor(filters.limit) <= 0) {
+    const limit = filters.limit === undefined ? undefined : Math.floor(filters.limit);
+    if (limit !== undefined && (!Number.isFinite(limit) || limit <= 0)) {
       return [];
     }
+    const offset = filters.offset === undefined ? undefined : Math.floor(filters.offset);
     const where: string[] = [];
     const params: unknown[] = [];
     if (filters.workflowId) {
@@ -2410,14 +2412,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
       where.push('status = ?');
       params.push(normalizeWorkerActionStatus(String(filters.status)));
     }
-    let limitSql = '';
-    if (filters.limit !== undefined) {
-      limitSql = ' LIMIT ?';
-      params.push(Math.floor(filters.limit));
+    let pageSql = '';
+    if (limit !== undefined) {
+      pageSql = ' LIMIT ?';
+      params.push(limit);
+    }
+    if (offset !== undefined && Number.isFinite(offset) && offset > 0) {
+      if (limit === undefined) {
+        pageSql = ' LIMIT -1';
+      }
+      pageSql += ' OFFSET ?';
+      params.push(offset);
     }
     const rows = this.queryAll(
       `SELECT * FROM worker_actions ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''} ` +
-        `ORDER BY updated_at DESC, id ASC${limitSql}`,
+        `ORDER BY updated_at DESC, id ASC${pageSql}`,
       params,
     );
     return rows.map((row) => this.rowToWorkerAction(row));

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -543,6 +543,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
       );
     }
 
+    if (isFile && options?.readOnly === true && (existsSync(`${dbPath}-wal`) || existsSync(`${dbPath}-shm`))) {
+      throw new Error(
+        `Cannot open SQLite database read-only while WAL sidecars exist for ${dbPath}. ` +
+        'Close the writable owner cleanly before opening a file-backed read-only adapter.',
+      );
+    }
+
     // Enforce owner-only writable initialization for file-backed databases
     if (isFile && requestWritable && !options?.ownerCapability) {
       throw new Error(


### PR DESCRIPTION
## Summary

Blocks opening a file-backed SQLite database read-only while its write-ahead-log sidecars still exist on disk.

Without this guard, a read-only reader could return a snapshot that predates the owner's un-checkpointed writes, so paginated history reads would surface wrong rows.

## Review Claim

Reject a file-backed read-only adapter open when WAL or SHM sidecars are present.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The check runs only for file-backed read-only opens and only inspects for the `-wal` / `-shm` sidecar files; writable and owner opens are untouched, so it can only turn a previously silent unsafe open into an explicit error.

## Slice Rationale

The read path slice lands first; this slice adds the open-time invariant on its own so reviewers approve one safety rule at a time.

## Non-goals

Does not change the paginated history query or its paging math.

Does not alter writable or owner database opens.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/data-store && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
