### PR TITLE
[Workers Surface](1) Add worker snapshot IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -160,6 +160,28 @@ export type WorkerActionStatus =
   | 'skipped'
   | 'abandoned'
   | 'cancelled';
+export type WorkerSource = 'built-in' | 'external';
+export type WorkerAvailability = 'available' | 'unknown';
+export type WorkerLogSource = 'worker_actions' | 'task_events';
+
+export interface WorkerLogEntry {
+  id: string;
+  workerKind: string;
+  source: WorkerLogSource;
+  actionType?: string;
+  eventType?: string;
+  workflowId?: string;
+  taskId?: string;
+  subjectType?: string;
+  subjectId?: string;
+  externalKey?: string;
+  status?: WorkerActionStatus;
+  summary?: string;
+  payload?: unknown;
+  createdAt: string;
+  updatedAt?: string;
+}
+
 
 export interface WorkerActionSummary {
   id: string;
@@ -197,6 +219,7 @@ export interface WorkerRecoverySummary {
   skips: number;
 }
 
+
 export interface WorkerStatusEntry {
   kind: string;
   note: string;
@@ -213,7 +236,11 @@ export interface WorkerStatusEntry {
   stoppedAt?: string;
   lastError?: string;
   recentActions: WorkerActionSummary[];
+  recentLogs?: WorkerLogEntry[];
   recovery?: WorkerRecoverySummary;
+  source?: WorkerSource;
+  availability?: WorkerAvailability;
+  running?: boolean;
 }
 
 export interface WorkerStatusSnapshot {
@@ -935,6 +962,10 @@ export const IpcChannels = {
   'invoker:get-worker-action-history': {} as {
     request: [request: WorkerActionHistoryRequest];
     response: WorkerActionHistoryResponse;
+  },
+  'invoker:get-workers': {} as {
+    request: [];
+    response: WorkerStatusSnapshot;
   },
   'invoker:start-worker': {} as {
     request: [kind: string];

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -309,6 +309,7 @@ export function createMockInvoker(
       queued: [],
     })),
     getWorkerStatus: vi.fn(async () => workerStatus),
+    getWorkers: vi.fn(async () => workerStatus),
     startWorker: vi.fn(async (kind: string) => {
       const row = workerStatus.workers.find((worker) => worker.kind === kind) ?? makeMockWorkerStatusEntry(kind);
       return row;
@@ -404,12 +405,15 @@ function makeMockWorkerStatusEntry(kind: string): WorkerStatusEntry {
   return {
     kind,
     note: '',
+    source: 'built-in',
+    availability: 'available',
     lifecycle: 'stopped',
     policy: 'unknown',
     autoStarts: false,
     startable: false,
     stoppable: false,
     recentActions: [],
+    recentLogs: [],
   };
 }
 


### PR DESCRIPTION
## Summary

Adds the worker snapshot contract fields and a get-workers IPC channel so later slices can carry worker state to the surface.

The new snapshot fields stay optional for now, so existing producers and readers keep working unchanged.

## Review Claim

Approve the new worker snapshot contract fields and the get-workers IPC channel definition.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new fields are optional and no producer or reader depends on them yet, so nothing changes at runtime.

## Slice Rationale

The contract lands alone so every following slice builds against a fixed shape instead of a moving target.

## Non-goals

Does not populate the new fields, add any handler, or change UI behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`
- [ ] `cd packages/ui && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 2847c1ca460c515f3b05d1ed2499680bfeb63899`
- Post-revert steps: None
- Data migration? No

</details>
