### PR TITLE
[Workers Surface](2) Add worker snapshot read foundations

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -2219,6 +2219,26 @@ describe('SQLiteAdapter', () => {
       );
       expect(adapter.getEvents('t1', 'desc', 0)).toEqual([]);
     });
+
+    it('lists recent task events across tasks by event type', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      adapter.saveTask('wf-1', makeTask('t2'));
+
+      adapter.logEvent('t1', 'debug.auto-fix', { phase: 'worker-autofix-skip' });
+      adapter.logEvent('t2', 'other.event');
+      adapter.logEvent('t2', 'recovery.worker.submit', { phase: 'worker-autofix-submitted' });
+
+      const events = adapter.listTaskEvents({
+        eventTypes: ['debug.auto-fix', 'recovery.worker.submit'],
+        sortBy: 'desc',
+        limit: 2,
+      });
+
+      expect(events.map((event) => event.eventType)).toEqual(['recovery.worker.submit', 'debug.auto-fix']);
+      expect(events.map((event) => event.taskId)).toEqual(['t2', 't1']);
+      expect(adapter.listTaskEvents({ eventTypes: [], limit: 2 })).toEqual([]);
+    });
   });
 
   describe('JSON fields', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -142,6 +142,14 @@ export type WorkerActionStatus =
   | 'abandoned'
   | 'cancelled';
 
+export interface TaskEventListFilters {
+  taskId?: string;
+  eventTypes?: readonly string[];
+  sortBy?: 'asc' | 'desc';
+  limit?: number;
+}
+
+
 export interface WorkerActionRecord {
   id: string;
   workerKind: string;
@@ -272,6 +280,7 @@ export interface PersistenceAdapter {
   logEvent(taskId: string, eventType: string, payload?: unknown): void;
   getEvents(taskId: string): TaskEvent[];
   getEvents(taskId: string, sortBy: 'asc' | 'desc', limit: number): TaskEvent[];
+  listTaskEvents?(filters?: TaskEventListFilters): TaskEvent[];
 
   // Worker actions (durable worker-owned action state/history)
   getWorkerAction(workerKind: string, externalKey: string): WorkerActionRecord | undefined;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -51,6 +51,7 @@ import type {
   WorkflowSaveInput,
   WorkflowTaskSnapshot,
   TaskEvent,
+  TaskEventListFilters,
   ActivityLogEntry,
   Conversation,
   ConversationMessage,
@@ -2304,6 +2305,45 @@ export class SQLiteAdapter implements PersistenceAdapter {
           `SELECT * FROM events WHERE task_id = ? ORDER BY id ${orderBy} LIMIT ?`,
           [taskId, Math.floor(limit)],
         );
+    return rows.map((row: any) => ({
+      id: row.id,
+      taskId: row.task_id,
+      eventType: row.event_type,
+      payload: row.payload ?? undefined,
+      createdAt: row.created_at,
+    }));
+  }
+
+  listTaskEvents(filters: TaskEventListFilters = {}): TaskEvent[] {
+    if (filters.limit !== undefined && Math.floor(filters.limit) <= 0) {
+      return [];
+    }
+    if (filters.eventTypes && filters.eventTypes.length === 0) {
+      return [];
+    }
+
+    const where: string[] = [];
+    const params: unknown[] = [];
+    if (filters.taskId) {
+      where.push('task_id = ?');
+      params.push(filters.taskId);
+    }
+    if (filters.eventTypes) {
+      where.push(`event_type IN (${filters.eventTypes.map(() => '?').join(', ')})`);
+      params.push(...filters.eventTypes);
+    }
+
+    const orderBy = filters.sortBy === 'asc' ? 'ASC' : 'DESC';
+    let limitSql = '';
+    if (filters.limit !== undefined) {
+      limitSql = ' LIMIT ?';
+      params.push(Math.floor(filters.limit));
+    }
+
+    const rows = this.queryAll(
+      `SELECT * FROM events ${where.length > 0 ? `WHERE ${where.join(' AND ')}` : ''} ORDER BY id ${orderBy}${limitSql}`,
+      params,
+    );
     return rows.map((row: any) => ({
       id: row.id,
       taskId: row.task_id,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -108,6 +108,9 @@ export const SCHEMA_DDL = `
 
       CREATE INDEX IF NOT EXISTS idx_events_task_id_id
         ON events(task_id, id);
+      CREATE INDEX IF NOT EXISTS idx_events_event_type_id
+        ON events(event_type, id);
+
 
       CREATE TABLE IF NOT EXISTS activity_log (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -479,6 +482,7 @@ export const POST_MIGRATION_STATEMENTS = [
   'DROP INDEX IF EXISTS idx_attempts_node',
   'CREATE INDEX IF NOT EXISTS idx_attempts_node_created ON attempts(node_id, created_at)',
   'CREATE INDEX IF NOT EXISTS idx_events_task_id_id ON events(task_id, id)',
+  'CREATE INDEX IF NOT EXISTS idx_events_event_type_id ON events(event_type, id)',
   'CREATE INDEX IF NOT EXISTS idx_tasks_workflow_id ON tasks(workflow_id)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_task_updated ON worker_actions(task_id, updated_at)',
   'CREATE INDEX IF NOT EXISTS idx_worker_actions_workflow_status ON worker_actions(workflow_id, worker_kind, status)',

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -87,6 +87,7 @@ export function registerAutoFixWorker(
   registry.register({
     kind: AUTO_FIX_WORKER_KIND,
     note: 'Auto-fixes failed tasks by submitting fix-with-agent recovery intents.',
+    source: 'built-in',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createRecoveryWorker({
         logger: deps.logger,

--- a/packages/execution-engine/src/external-worker.ts
+++ b/packages/execution-engine/src/external-worker.ts
@@ -152,6 +152,7 @@ export function registerExternalWorkers<TDeps>(
     registry.register({
       kind: config.kind,
       note: `Supervises external worker process ${config.launch.executable}.`,
+      source: 'external',
       factory: (_deps: TDeps) => createExternalWorkerRuntime(config),
     });
   }

--- a/packages/execution-engine/src/worker-registry.ts
+++ b/packages/execution-engine/src/worker-registry.ts
@@ -17,6 +17,8 @@ export interface WorkerDefinition<TDeps = unknown> {
   readonly kind: string;
   /** Human-readable note surfaced in operator output. */
   readonly note: string;
+  /** Registration source surfaced in read-only snapshots. */
+  readonly source?: 'built-in' | 'external';
   /** Builds the worker runtime from injected dependencies. */
   readonly factory: WorkerFactory<TDeps>;
 }

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -95,6 +95,7 @@ export function registerCiFailureWorker(
   registry.register({
     kind: CI_FAILURE_WORKER_KIND,
     note: 'Submits head-SHA guarded CI repair intents for failed review-gate checks.',
+    source: 'built-in',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createCiFailureWorker({
         logger: deps.logger,

--- a/packages/execution-engine/src/workers/pr-status-worker.ts
+++ b/packages/execution-engine/src/workers/pr-status-worker.ts
@@ -31,6 +31,7 @@ export function registerPrStatusWorker(
   registry.register({
     kind: PR_STATUS_WORKER_KIND,
     note: 'Polls review-gate PR status through the registered TaskRunner review-gate check.',
+    source: 'built-in',
     factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
       createPrStatusWorker({
         logger: deps.logger,


### PR DESCRIPTION
## Summary

Adds a source label to each worker registry entry and an indexed task-event lookup on the data-store adapter.

These are the foundations the worker snapshot route reads from; nothing calls them yet.

## Review Claim

Approve the worker registry source field and the indexed task-event accessor that the worker snapshot route will use.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new field and accessor are additive and unused, so existing worker behavior and stored data stay the same.

## Slice Rationale

Landing the storage foundations before the route keeps the later read wiring reviewable on its own.

## Non-goals

Does not add IPC handlers, app wiring, or UI. Behavior stays unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/data-store && pnpm test`
- [ ] `cd packages/execution-engine && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9275c72388c0817362399f23b8e9b67fd27ded65`
- Post-revert steps: None
- Data migration? No

</details>
