### PR TITLE
[Workers Surface](4) Add read-only workers surface

### DIFF
--- a/packages/app/e2e/workers-surface.spec.ts
+++ b/packages/app/e2e/workers-surface.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect, captureScreenshot } from './fixtures/electron-app.js';
+
+test('workers surface shows read-only worker activity', async ({ page }) => {
+  await page.getByTestId('sidebar-workers').click();
+
+  await expect(page.getByTestId('workers-rail')).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Workers' })).toBeVisible();
+  await expect(page.getByText('Worker processes (3)')).toBeVisible();
+  await expect(page.getByTestId('worker-row-autofix')).toBeVisible();
+  await expect(page.getByTestId('worker-row-pr-status')).toBeVisible();
+  await expect(page.getByTestId('worker-row-ci-failure')).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Start process' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Stop process' })).toHaveCount(0);
+
+  await captureScreenshot(page, 'workers-read-only-surface');
+});

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -18,7 +18,7 @@ import {
   acquireWorkerLock,
   createAutoFixAttemptLedger,
   createWorkerRegistry,
-  registerAutoFixWorker,
+  registerBuiltinWorkers,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
   type WorkerRuntimeDependencies,
@@ -424,7 +424,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
     deps.invokerConfig?.externalWorkers,
-    registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
   );
 
   if (subCommand === 'list') {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,7 +12,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
 import type { ActionGraphNode, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor } from '@invoker/contracts';
-import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
+import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus, WorkerActionSummary, WorkerLogEntry, WorkerStatusEntry } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { useTasks } from './hooks/useTasks.js';
 import { useQueueStatus } from './hooks/useQueueStatus.js';
@@ -33,6 +33,7 @@ import { WorkflowGraph } from './components/WorkflowGraph.js';
 import { FloatingGraphPanel } from './components/FloatingGraphPanel.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
 import { WorkerDetailsPanel } from './components/WorkerDetailsPanel.js';
+import { WorkerActivityCard } from './components/WorkerActivityCard.js';
 import { groupWorkflowCoreActivity } from './lib/workflow-core-activity.js';
 import { ActionGraphView } from './components/ActionGraphView.js';
 import { WorkflowStatusChips } from './components/WorkflowStatusChips.js';
@@ -46,6 +47,7 @@ import {
   formatTaskStatus,
   formatWorkflowStatus,
 } from './lib/workflow-progress-surfaces.js';
+import { displayWorkerTaskId, formatWorkerValue, getActiveWorkerAction, getWorkerDisplayCopy } from './lib/worker-display.js';
 import {
   isExperimentSpawnPivotTask,
   EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE,
@@ -192,6 +194,28 @@ function isEditableKeyboardTarget(target: EventTarget | null): boolean {
 
 function normalizedSearchText(value: string | undefined): string {
   return (value ?? '').toLowerCase();
+}
+
+function workerActionTarget(action: WorkerActionSummary): string {
+  if (action.taskId) return `Task: ${displayWorkerTaskId(action.taskId)}`;
+  return `${formatWorkerValue(action.subjectType)}: ${action.subjectId}`;
+}
+
+function workerLogTarget(log: WorkerLogEntry): string {
+  if (log.taskId) return `Task: ${displayWorkerTaskId(log.taskId)}`;
+  if (log.subjectType && log.subjectId) return `${formatWorkerValue(log.subjectType)}: ${log.subjectId}`;
+  if (log.workflowId) return `Workflow: ${log.workflowId}`;
+  return 'No target';
+}
+
+function workerStateLabel(worker: WorkerStatusEntry): string {
+  const activeAction = getActiveWorkerAction(worker);
+  if (activeAction) return `${formatWorkerValue(worker.lifecycle)} · ${formatWorkerValue(activeAction.status)}`;
+  return formatWorkerValue(worker.lifecycle);
+}
+
+function workerLogTitle(log: WorkerLogEntry): string {
+  return formatWorkerValue(log.eventType ?? log.actionType ?? log.source);
 }
 
 interface WorkflowContextMenuProps {
@@ -2160,7 +2184,7 @@ export function App() {
       return;
     }
     if (nextView === 'queue') {
-      setSidebarSurface('workers');
+      setSidebarSurface('home');
       setInspectorCollapsed(true);
       setInspectorManualOpen(false);
     } else {
@@ -2187,7 +2211,7 @@ export function App() {
       setInspectorCollapsed(true);
       setInspectorManualOpen(false);
       setStatusFilters(new Set<WorkflowStatus>());
-      setViewMode('queue');
+      setViewMode('dag');
       return;
     }
     setViewMode('dag');
@@ -2798,6 +2822,171 @@ export function App() {
     )
   );
 
+  const renderWorkerActionEntry = (action: WorkerActionSummary): JSX.Element => (
+    <div key={action.id} className="rounded-lg border border-gray-800 bg-gray-850/60 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="text-sm font-medium text-gray-100">{formatWorkerValue(action.actionType)}</div>
+        <span className="rounded-full border border-gray-700 bg-gray-800 px-2 py-0.5 text-[11px] text-gray-200">
+          {formatWorkerValue(action.status)}
+        </span>
+      </div>
+      <div className="mt-1 text-xs text-gray-500">{workerActionTarget(action)}</div>
+      {action.summary ? <div className="mt-2 text-sm text-gray-300">{action.summary}</div> : null}
+      <div className="mt-2 text-[11px] text-gray-500">Updated {action.updatedAt}</div>
+    </div>
+  );
+
+  const renderWorkerLogEntry = (log: WorkerLogEntry): JSX.Element => (
+    <div key={log.id} className="rounded-lg border border-gray-800 bg-gray-850/60 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="text-sm font-medium text-gray-100">{workerLogTitle(log)}</div>
+        {log.status ? (
+          <span className="rounded-full border border-gray-700 bg-gray-800 px-2 py-0.5 text-[11px] text-gray-200">
+            {formatWorkerValue(log.status)}
+          </span>
+        ) : null}
+      </div>
+      <div className="mt-1 text-xs text-gray-500">{workerLogTarget(log)}</div>
+      {log.summary ? <div className="mt-2 text-sm text-gray-300">{log.summary}</div> : null}
+      <div className="mt-2 text-[11px] text-gray-500">Logged {log.createdAt}</div>
+    </div>
+  );
+
+  const renderWorkersDetail = (): JSX.Element => {
+    if (!selectedWorker) {
+      return renderBrowserEmptyState('No workers found', 'Invoker has not returned any worker registry rows yet.');
+    }
+
+    const copy = getWorkerDisplayCopy(selectedWorker.kind);
+    const activeAction = getActiveWorkerAction(selectedWorker);
+    const recentLogs = selectedWorker.recentLogs ?? [];
+    const hasResponseHistory = selectedWorker.recentActions.length > 0 || recentLogs.length > 0;
+
+    return (
+      <div className="flex h-full min-h-0 flex-col">
+        <div className="border-b border-gray-800 bg-gray-950/50 px-4 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-semibold text-gray-100">{copy.name}</h2>
+              <p className="mt-1 text-sm text-gray-400">{selectedWorker.note || 'Worker registry entry'}</p>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                <span className="rounded-full border border-gray-700 bg-gray-800 px-2.5 py-1 text-[11px] font-medium text-gray-200">
+                  Kind: {selectedWorker.kind}
+                </span>
+                <span className="rounded-full border border-gray-700 bg-gray-800 px-2.5 py-1 text-[11px] font-medium text-gray-200">
+                  Source: {formatWorkerValue(selectedWorker.source)}
+                </span>
+                <span className="rounded-full border border-cyan-500/40 bg-cyan-500/10 px-2.5 py-1 text-[11px] font-medium text-cyan-100">
+                  State: {workerStateLabel(selectedWorker)}
+                </span>
+              </div>
+            </div>
+            <button
+              type="button"
+              aria-label="Return home"
+              data-testid="workers-return-home"
+              onClick={handleDismissBrowserSurface}
+              className="rounded border border-gray-700 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+            >
+              Home
+            </button>
+          </div>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <div className="grid gap-4 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+            <section className="rounded-xl border border-gray-800 bg-gray-900/80 p-4">
+              <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Registry</h3>
+              <dl className="mt-3 grid grid-cols-[7rem_1fr] gap-x-3 gap-y-2 text-sm">
+                <dt className="text-gray-500">Kind</dt>
+                <dd className="text-gray-200">{selectedWorker.kind}</dd>
+                <dt className="text-gray-500">Note</dt>
+                <dd className="text-gray-200">{selectedWorker.note || 'No note'}</dd>
+                <dt className="text-gray-500">Source</dt>
+                <dd className="text-gray-200">{formatWorkerValue(selectedWorker.source)}</dd>
+                <dt className="text-gray-500">Availability</dt>
+                <dd className="text-gray-200">{formatWorkerValue(selectedWorker.availability)}</dd>
+                <dt className="text-gray-500">Policy</dt>
+                <dd className="text-gray-200">{formatWorkerValue(selectedWorker.policy)}{selectedWorker.policyReason ? ` · ${selectedWorker.policyReason}` : ''}</dd>
+                <dt className="text-gray-500">Runtime</dt>
+                <dd className="text-gray-200">{selectedWorker.runtimeKind ?? 'Not running'}</dd>
+              </dl>
+            </section>
+            <section className="rounded-xl border border-gray-800 bg-gray-900/80 p-4">
+              <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Current state</h3>
+              <div className="mt-3 text-sm text-gray-300">
+                Process is {formatWorkerValue(selectedWorker.lifecycle)}.
+                {activeAction ? ` Current response is ${formatWorkerValue(activeAction.actionType)} (${formatWorkerValue(activeAction.status)}).` : ' No response is running.'}
+              </div>
+              {selectedWorker.lastError ? <div className="mt-3 rounded border border-rose-800 bg-rose-950/40 p-3 text-sm text-rose-100">{selectedWorker.lastError}</div> : null}
+            </section>
+          </div>
+
+          <div className="mt-4 grid gap-4 xl:grid-cols-2">
+            <section className="rounded-xl border border-gray-800 bg-gray-900/80 p-4">
+              <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Latest responses</h3>
+              <div className="mt-3 space-y-2">
+                {selectedWorker.recentActions.length > 0
+                  ? selectedWorker.recentActions.slice(0, 5).map(renderWorkerActionEntry)
+                  : <div className="rounded-lg border border-gray-800 bg-gray-950/60 p-3 text-sm text-gray-400">No worker responses have been logged yet.</div>}
+              </div>
+            </section>
+            <section className="rounded-xl border border-gray-800 bg-gray-900/80 p-4">
+              <h3 className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">Latest logs</h3>
+              <div className="mt-3 space-y-2">
+                {recentLogs.length > 0
+                  ? recentLogs.slice(0, 5).map(renderWorkerLogEntry)
+                  : <div className="rounded-lg border border-gray-800 bg-gray-950/60 p-3 text-sm text-gray-400">No worker responses have been logged yet.</div>}
+              </div>
+            </section>
+          </div>
+
+          {!hasResponseHistory ? (
+            <div className="mt-4 rounded-xl border border-gray-800 bg-gray-950/60 p-4 text-sm text-gray-400">
+              No worker responses have been logged yet.
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  };
+
+  const workersSubtitle = workerStatus === null
+    ? 'Worker status is not available yet.'
+    : `${workerStatus.workers.length} worker${workerStatus.workers.length === 1 ? '' : 's'} registered.`;
+
+  const renderWorkersSurface = (): JSX.Element => (
+    <div className="flex-1 flex overflow-hidden">
+      <div data-testid="workers-rail" className="flex h-full w-80 shrink-0 flex-col border-r border-gray-800 bg-gray-950/45">
+        <div className="flex items-start justify-between gap-3 border-b border-gray-800 px-4 py-4">
+          <div>
+            <h2 className="text-sm font-semibold text-gray-100">Workers</h2>
+            <p className="mt-1 text-xs text-gray-500">{workersSubtitle}</p>
+          </div>
+          <button
+            type="button"
+            aria-label="Close workers panel"
+            data-testid="workers-rail-dismiss"
+            onClick={handleDismissBrowserSurface}
+            className="rounded-lg border border-gray-700 px-2 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+          >
+            Close
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto p-4">
+          <WorkerActivityCard
+            snapshot={workerStatus}
+            selectedWorkerKind={selectedWorkerKind}
+            onSelectWorker={setSelectedWorkerKind}
+            showControls={false}
+          />
+        </div>
+      </div>
+      <div className="min-w-0 flex-1 overflow-hidden">
+        {renderWorkersDetail()}
+      </div>
+    </div>
+  );
+
 
   const renderPlanningSessionList = (): JSX.Element => (
     <div className="overflow-y-auto p-3">
@@ -3053,6 +3242,8 @@ export function App() {
               renderGraphWorkspace('Plan graph', homeSubtitle, true)
             ) : sidebarSurface === 'planning' ? (
               renderPlanningTerminalSurface()
+            ) : sidebarSurface === 'workers' ? (
+              renderWorkersSurface()
             ) : (
               <div className="flex-1 flex overflow-hidden">
                 {renderBrowserRail()}
@@ -3063,7 +3254,7 @@ export function App() {
             {sidebarSurface === 'home' && viewMode === 'dag' && renderGraphTerminalChrome()}
           </main>
 
-          {sidebarSurface !== 'planning' && (
+          {sidebarSurface !== 'planning' && sidebarSurface !== 'workers' && (
             <div
               data-testid="workflow-inspector-shell"
               data-keyboard-region="inspector"
@@ -3347,4 +3538,3 @@ export function App() {
     </div>
   );
 }
-

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -49,20 +49,63 @@ describe('App launch (component)', () => {
     expect(screen.getByTestId('sidebar-running')).toHaveTextContent('Running');
     expect(screen.getByTestId('sidebar-workers')).toHaveTextContent('Workers');
   });
-  it('opens worker status from the left panel', async () => {
+  it('opens read-only worker status from the left panel', async () => {
     mock.setWorkerStatus({
       generatedAt: '2026-01-01T00:00:00.000Z',
       workers: [
         {
           kind: 'pr-status',
           note: 'PR status',
+          source: 'built-in',
+          availability: 'available',
+          running: true,
           lifecycle: 'running',
           policy: 'enabled',
           autoStarts: true,
           startable: false,
           stoppable: true,
           runtimeKind: 'pr-status',
+          recentActions: [
+            {
+              id: 'action-1',
+              workerKind: 'pr-status',
+              actionType: 'check-pr',
+              subjectType: 'workflow',
+              subjectId: 'wf-1',
+              externalKey: 'wf-1',
+              status: 'completed',
+              attemptCount: 1,
+              summary: 'Checked PR status',
+              createdAt: '2026-01-01T00:00:00.000Z',
+              updatedAt: '2026-01-01T00:01:00.000Z',
+            },
+          ],
+          recentLogs: [
+            {
+              id: 'log-1',
+              workerKind: 'pr-status',
+              source: 'worker_actions',
+              actionType: 'check-pr',
+              subjectType: 'workflow',
+              subjectId: 'wf-1',
+              status: 'completed',
+              summary: 'PR check finished',
+              createdAt: '2026-01-01T00:01:00.000Z',
+            },
+          ],
+        },
+        {
+          kind: 'autofix',
+          note: 'Autofix worker',
+          source: 'built-in',
+          availability: 'available',
+          lifecycle: 'stopped',
+          policy: 'enabled',
+          autoStarts: false,
+          startable: true,
+          stoppable: false,
           recentActions: [],
+          recentLogs: [],
         },
       ],
     });
@@ -74,7 +117,13 @@ describe('App launch (component)', () => {
     fireEvent.click(workersButton);
 
     expect(await screen.findByTestId('worker-activity-card')).toBeInTheDocument();
-    expect(screen.getByText('PR status')).toBeInTheDocument();
+    expect(screen.getAllByText('PR status').length).toBeGreaterThan(0);
+    expect(screen.getByText('Autofix worker')).toBeInTheDocument();
+    expect(screen.getAllByText('Source: Built In').length).toBeGreaterThan(0);
+    expect(screen.getByText('Checked PR status')).toBeInTheDocument();
+    expect(screen.getByText('PR check finished')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Start process' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Stop process' })).not.toBeInTheDocument();
   });
   it('renders the Apple-like source list without manual plan loading', async () => {
     render(<App />);

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -38,12 +38,16 @@ describe('QueueView', () => {
     return {
       kind: 'autofix',
       note: 'Auto-fixes failed tasks.',
+      source: 'built-in',
+      availability: 'available',
+      running: true,
       lifecycle: 'running',
       policy: 'enabled',
       autoStarts: true,
       startable: false,
       stoppable: true,
       recentActions: [],
+      recentLogs: [],
       ...overrides,
     };
   }

--- a/packages/ui/src/__tests__/worker-details-panel.test.tsx
+++ b/packages/ui/src/__tests__/worker-details-panel.test.tsx
@@ -30,12 +30,16 @@ function makeWorker(overrides: Partial<WorkerStatusEntry> = {}): WorkerStatusEnt
   return {
     kind: 'ci-failure',
     note: 'Repairs failed CI.',
+    source: 'built-in',
+    availability: 'available',
+    running: true,
     lifecycle: 'running',
     policy: 'enabled',
     autoStarts: true,
     startable: false,
     stoppable: true,
     recentActions: [makeAction()],
+    recentLogs: [],
     ...overrides,
   };
 }

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -4,10 +4,11 @@ import { formatWorkerValue, getActiveWorkerAction, getWorkerDisplayCopy } from '
 interface WorkerActivityCardProps {
   snapshot: WorkerStatusSnapshot | null;
   selectedWorkerKind: string | null;
-  readOnly: boolean;
-  onStartWorker: (kind: string) => Promise<void> | void;
-  onStopWorker: (kind: string) => Promise<void> | void;
+  readOnly?: boolean;
+  onStartWorker?: (kind: string) => Promise<void> | void;
+  onStopWorker?: (kind: string) => Promise<void> | void;
   onSelectWorker: (kind: string) => void;
+  showControls?: boolean;
 }
 
 function processClass(worker: WorkerStatusEntry): string {
@@ -46,10 +47,11 @@ function activityExplanation(worker: WorkerStatusEntry): string {
 export function WorkerActivityCard({
   snapshot,
   selectedWorkerKind,
-  readOnly,
+  readOnly = false,
   onStartWorker,
   onStopWorker,
   onSelectWorker,
+  showControls = true,
 }: WorkerActivityCardProps) {
   return (
     <div data-testid="worker-activity-card">
@@ -68,11 +70,14 @@ export function WorkerActivityCard({
             const showStart = worker.lifecycle !== 'running';
             const isControlDisabled = Boolean(disabledTitle);
             const selected = selectedWorkerKind === worker.kind;
-            const footer = worker.kind === 'pr-status'
-              ? 'No queue task is expected for this worker.'
-              : selected
-                ? 'Details are in the right panel.'
-                : null;
+            const recentLogs = worker.recentLogs ?? [];
+            const latestLog = recentLogs[0];
+            const latestAction = worker.recentActions[0];
+            const footer = latestLog
+              ? `Latest log: ${latestLog.summary ?? formatWorkerValue(latestLog.eventType ?? latestLog.actionType ?? latestLog.source)}`
+              : latestAction
+                ? `Latest response: ${latestAction.summary ?? `${formatWorkerValue(latestAction.actionType)} · ${formatWorkerValue(latestAction.status)}`}`
+                : 'No worker responses have been logged yet.';
             return (
               <div
                 key={worker.kind}
@@ -96,6 +101,8 @@ export function WorkerActivityCard({
                   <div className="min-w-0 flex-1">
                     <div className="text-sm font-semibold text-gray-100">{copy.name}</div>
                     <div className="mt-0.5 text-xs text-gray-500">Kind: {worker.kind}</div>
+                    {worker.note ? <div className="mt-1 text-xs text-gray-400">{worker.note}</div> : null}
+                    <div className="mt-1 text-xs text-gray-500">Source: {formatWorkerValue(worker.source)}</div>
                     <div className="mt-2 flex flex-wrap items-center gap-2">
                       <span className={`rounded-full border px-2 py-0.5 text-[11px] ${processClass(worker)}`}>
                         Process: {formatWorkerValue(worker.lifecycle)}
@@ -115,24 +122,26 @@ export function WorkerActivityCard({
                       )}
                     </div>
                     <div className="mt-2 text-sm text-gray-300">{activityExplanation(worker)}</div>
-                    {footer ? <div className="mt-1 text-xs text-gray-500">{footer}</div> : null}
+                    <div className="mt-1 text-xs text-gray-500">{footer}</div>
                   </div>
-                  <button
-                    type="button"
-                    className="shrink-0 rounded border border-gray-600 px-2 py-1 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-700"
-                    title={disabledTitle}
-                    disabled={isControlDisabled}
-                    onKeyDown={(event) => {
-                      if (event.key === 'Enter' || event.key === ' ') event.stopPropagation();
-                    }}
-                    onClick={(event) => {
-                      event.stopPropagation();
-                      if (showStart) void onStartWorker(worker.kind);
-                      else void onStopWorker(worker.kind);
-                    }}
-                  >
-                    {showStart ? 'Start process' : 'Stop process'}
-                  </button>
+                  {showControls ? (
+                    <button
+                      type="button"
+                      className="shrink-0 rounded border border-gray-600 px-2 py-1 text-xs text-gray-200 disabled:cursor-not-allowed disabled:opacity-50 hover:bg-gray-700"
+                      title={disabledTitle}
+                      disabled={isControlDisabled}
+                      onKeyDown={(event) => {
+                        if (event.key === 'Enter' || event.key === ' ') event.stopPropagation();
+                      }}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        if (showStart) void onStartWorker?.(worker.kind);
+                        else void onStopWorker?.(worker.kind);
+                      }}
+                    >
+                      {showStart ? 'Start process' : 'Stop process'}
+                    </button>
+                  ) : null}
                 </div>
               </div>
             );

--- a/packages/ui/src/hooks/useWorkerStatus.ts
+++ b/packages/ui/src/hooks/useWorkerStatus.ts
@@ -11,7 +11,7 @@ export function useWorkerStatus(pollMs = 2000): readonly [snapshot: WorkerStatus
 
   const fetchStatus = useCallback(async () => {
     try {
-      const status = await window.invoker?.getWorkerStatus();
+      const status = await window.invoker?.getWorkers();
       if (mountedRef.current && status) {
         setSnapshot(status);
       }

--- a/packages/ui/src/lib/worker-display.ts
+++ b/packages/ui/src/lib/worker-display.ts
@@ -14,7 +14,8 @@ export const ACTIVE_WORKER_ACTION_STATUSES: ReadonlySet<WorkerActionStatus> = ne
   'review_ready',
 ]);
 
-export function formatWorkerValue(value: string): string {
+export function formatWorkerValue(value: string | undefined): string {
+  if (!value) return 'Unknown';
   return value
     .split(/[-_]/g)
     .filter(Boolean)

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -324,10 +324,13 @@ export type {
   ReviewGateQueryResponse,
   WorkerActionSummary,
   WorkerActionStatus,
+  WorkerAvailability,
   WorkerControlAction,
   WorkerLifecycleStatus,
+  WorkerLogEntry,
   WorkerPolicyStatus,
   WorkerRecoverySummary,
+  WorkerSource,
   WorkerStatusEntry,
   WorkerStatusSnapshot,
 } from '@invoker/contracts';


### PR DESCRIPTION
## Summary

Activates the worker snapshot in the headless output and the UI, adding a read-only Workers panel with a response-log detail view.

Users can open the Workers panel to see each worker and its recent responses; nothing here changes running work.

## Review Claim

Approve the read-only Workers panel and the headless worker snapshot output.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The Workers panel only reads snapshot data; it has no controls that change workers, so it cannot affect running work.

## Slice Rationale

This surface lands after its data foundations so reviewers approve the UI against stable inputs, kept separate from the field-tightening slice that follows.

## Non-goals

Does not add worker controls, change the snapshot fields, or alter how work runs. Read-only only.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test`
- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 86c7955b1110c9c335d3de74d50dd7e92d0189eb`
- Post-revert steps: None
- Data migration? No

</details>
