### PR TITLE
[Workflow Delete Latency](1) Flush removal deltas immediately in the renderer

### DIFF
--- a/packages/app/e2e/workflow-delete-latency.spec.ts
+++ b/packages/app/e2e/workflow-delete-latency.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * E2E perf gate: workflow delete propagation latency.
+ *
+ * Measures the wall-clock time from the window.invoker.deleteWorkflow()
+ * bridge call to the workflow node leaving the DOM, sampled per animation
+ * frame, and enforces the 500ms propagation budget. Locally this measures
+ * ~43ms; the budget leaves headroom for slower CI machines.
+ */
+
+import { expect, test, TEST_PLAN, loadPlan } from './fixtures/electron-app.js';
+
+const DELETE_PROPAGATION_BUDGET_MS = 500;
+
+test('workflow delete reaches the graph within the propagation budget', async ({ page }) => {
+  await loadPlan(page, TEST_PLAN);
+  const workflowId = await page.evaluate(async () => {
+    const workflows = await window.invoker.listWorkflows();
+    return workflows[workflows.length - 1]?.id as string;
+  });
+
+  const latency = await page.evaluate(async (id) => {
+    const selector = `[data-testid="rf__node-${id}"]`;
+    const gone = new Promise<number>((resolve) => {
+      const check = () => {
+        if (!document.querySelector(selector)) {
+          resolve(performance.now());
+        } else {
+          requestAnimationFrame(check);
+        }
+      };
+      requestAnimationFrame(check);
+    });
+    const startedAt = performance.now();
+    await window.invoker.deleteWorkflow(id);
+    const acceptedAt = performance.now();
+    const goneAt = await gone;
+    return { totalMs: goneAt - startedAt, acceptRoundtripMs: acceptedAt - startedAt };
+  }, workflowId);
+
+  console.log(
+    `workflow-delete-latency: total=${latency.totalMs.toFixed(1)}ms ` +
+      `acceptRoundtrip=${latency.acceptRoundtripMs.toFixed(1)}ms`,
+  );
+  expect(latency.totalMs).toBeLessThan(DELETE_PROPAGATION_BUDGET_MS);
+});

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -600,7 +600,7 @@ describe('useTasks', () => {
     expect(result.current.workflows.get('wf-1')?.status).toBe('failed');
   });
 
-  it('drops a deleted workflow within 1s of its removal deltas without a manual refresh', async () => {
+  it('drops a deleted workflow within 500ms of its removal deltas without a manual refresh', async () => {
     // Regression: deleting a workflow published workflows-changed (workflow
     // absent) before the task removal deltas flushed, so the task-backed
     // preservation kept the entry alive; the final zero-task rollup patch then
@@ -646,7 +646,8 @@ describe('useTasks', () => {
     expect(result.current.workflows.get('wf-doomed')?.name).toBe('Doomed workflow');
 
     const deletionStartedAt = performance.now();
-    await act(async () => {
+    // Removal deltas flush the batch window immediately — no 100ms timer wait.
+    act(() => {
       taskGraphEventHandler!({
         type: 'delta',
         delta: { type: 'removed', taskId: 'wf-doomed/task-a', previousTaskStateVersion: 1 },
@@ -657,18 +658,17 @@ describe('useTasks', () => {
         delta: { type: 'removed', taskId: 'wf-doomed/task-b', previousTaskStateVersion: 1 },
         workflowRollups: [{ workflowId: 'wf-doomed', status: 'pending', rollup: makeWorkflowRollup('pending'), removed: true }],
       });
-      await new Promise((resolve) => setTimeout(resolve, 110));
     });
 
     // Propagation budget: deltas already delivered, so the UI must converge
-    // within the 1s deletion budget without any snapshot refresh.
+    // within the 500ms deletion budget without any snapshot refresh.
     await waitFor(
       () => {
         expect(result.current.workflows.has('wf-doomed')).toBe(false);
       },
-      { timeout: 1000 },
+      { timeout: 500 },
     );
-    expect(performance.now() - deletionStartedAt).toBeLessThan(1000);
+    expect(performance.now() - deletionStartedAt).toBeLessThan(500);
     expect(result.current.tasks.has('wf-doomed/task-a')).toBe(false);
     expect(result.current.tasks.has('wf-doomed/task-b')).toBe(false);
     expect(result.current.workflows.get('wf-keeper')?.name).toBe('Keeper workflow');

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -398,6 +398,11 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
       }
 
       graphEventPipelineRef.current?.push(event);
+      if (delta.type === 'removed') {
+        // Removals are rare, user-initiated, and destructive: flush the batch
+        // window so the graph reflects them immediately instead of ~100ms later.
+        graphEventPipelineRef.current?.flushNow();
+      }
     };
 
     const unsub = window.invoker.onTaskGraphEvent(handleTaskGraphEvent);


### PR DESCRIPTION
## Summary

Workflow deletion reached the graph about 140ms after the bridge call. Most of that was the renderer's 100ms batch window for graph events.

Removal deltas now flush the batch window the moment they arrive. Removals are rare, user-initiated, and destructive, so instant application is safe.

Batching stays in place for high-churn update deltas. Measured end-to-end propagation drops from about 140ms to about 43ms.

The regression budget tightens from one second to 500ms, and a new end-to-end perf gate measures the real bridge-call-to-DOM latency.

## Review Claim

Approve the renderer flushing its graph event batch window immediately when a removal delta arrives, within the 500ms propagation budget.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only removal deltas trigger the early flush; flushing drains the same FIFO queue the timer would, so ordering is unchanged. Update and snapshot batching behave exactly as before.

## Slice Rationale

One renderer change with its regression budget and perf gate. The release note lands in the follow-up slice.

## Non-goals

- No change to main-process publishing, batching, or the mutation queue.
- No change to snapshot handling or the 100ms window for update deltas.

## Test Plan

- [ ] `pnpm --filter @invoker/ui exec vitest run src/__tests__/use-tasks.test.tsx`
- [ ] `cd packages/app && npx playwright test workflow-delete-latency.spec.ts`

## Visual Proof

Timing-only change: the post-deletion end state is pixel-identical to the landed fix, so the honest evidence is the measured latency, not stills.

E2E perf gate output on this branch (three runs of the probe methodology, bridge call to node leaving the DOM, sampled per animation frame):

```
workflow-delete-latency: total=38.7ms acceptRoundtrip=7.4ms
DELETE_LATENCY total=46.2ms acceptRoundtrip=8.2ms   (pre-gate probe run)
DELETE_LATENCY total=44.1ms acceptRoundtrip=8.7ms   (pre-gate probe run)
```

Baseline on master before this change: 140.5ms / 143.0ms / 310.5ms (cold).

Walkthrough of the capture case on this branch — the node is gone on the first frame after the click:

[after walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-a9c67c/flush-fast-walkthrough.webm)

![graph 3s after deletion](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-a9c67c/flush-fast-after-3s.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None; propagation returns to ~140ms and the 500ms budget still passes.
- Data migration? No
