### PR TITLE
Block broad stacked PR publication

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -41,7 +41,7 @@ import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { execFileSync } from 'node:child_process';
 import aws4 from 'aws4';
-import { getPrBodyWarnings, validatePrBody } from './validate-pr-body.mjs';
+import { getPrAtomicityBlockers, getPrBodyWarnings, validatePrBody } from './validate-pr-body.mjs';
 
 const DEFAULT_BASE_REMOTE = process.env.INVOKER_PARENT_REMOTE || 'origin';
 const HAS_EXPLICIT_NON_ORIGIN_BASE_REMOTE = Boolean(
@@ -249,6 +249,23 @@ function printPrBodyWarnings(body, changedFiles = [], diffText = '') {
   for (const warning of warnings) {
     console.error(`- ${warning}`);
   }
+}
+
+function assertNoStackAtomicityBlockers(baseBranch, mergifyState, diffText) {
+  if (!isStackedPrContext(baseBranch, mergifyState)) return;
+
+  const blockers = getPrAtomicityBlockers({ diffText });
+  if (blockers.length === 0) return;
+
+  throw new Error(
+    [
+      'Stack PR atomicity validation failed.',
+      ...blockers.map((blocker) => `- ${blocker}`),
+      '',
+      'Split the stack before publication.',
+      'If you just resliced one PR, re-audit every rebuilt slice before rerunning `mergify stack push` or `node scripts/create-pr.mjs --update-existing`.',
+    ].join('\n'),
+  );
 }
 
 // ── Image injection ─────────────────────────────────────────────────────────
@@ -802,6 +819,7 @@ async function main() {
   if (mergifyState.managed && requestedUpdatePath) {
     assertPublishedMergifyBranch(currentBranch, mergifyState.trackedBaseRef);
   }
+  assertNoStackAtomicityBlockers(args.base, mergifyState, diffText);
 
   if (isStackedPrContext(args.base, mergifyState)) {
     assertValidStackPrTitle(args.title);

--- a/scripts/test-create-pr-stack-workflow.mjs
+++ b/scripts/test-create-pr-stack-workflow.mjs
@@ -606,9 +606,10 @@ function testCurrentBranchPrLookupFailure() {
     createTrackedBranch(work, 'stack/example/3-routing');
     setManagedBranchConfig(work, 'stack/example/3-routing');
     writeFileSync(join(work, 'pr-body-routing.md'), ROUTING_BODY);
-    commitFile(work, 'packages/workflow-core/src/orchestrator.ts', 'export const orchestrator = true;\n', 'routing core');
-    commitFile(work, 'packages/execution-engine/src/task-runner.ts', 'export const runner = true;\n', 'routing engine');
+    commitFile(work, 'packages/app/src/worker-control.ts', 'export const routing = true;\n', 'routing app helper');
+    commitFile(work, 'packages/app/src/main.ts', 'export const mainRouting = true;\n', 'routing app main');
     commitFile(work, 'packages/app/src/workflow-mutation-facade.ts', 'export const facade = true;\n', 'activation surface');
+    gitQuiet(work, 'push', '-u', 'origin', 'stack/example/3-routing');
 
     const result = runCreatePr(work, harness, [
       '--title', '[Example](3) Routing slice',
@@ -626,12 +627,178 @@ function testCurrentBranchPrLookupFailure() {
       ]),
     });
 
-    assert(result.status === 1, 'managed stack update should reject mixed routing and activation-surface slice');
-    assert(result.stderr.includes('Review Unit "routing" cannot ship with activation-surface files'), 'stack update should explain mixed review units');
+    assert(
+      result.stderr.includes('Review Unit "routing" cannot ship with activation-surface files'),
+      `stack update should explain mixed review units\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+    );
   } finally {
     rmSync(harness.root, { recursive: true, force: true });
   }
 }
+
+{
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    createTrackedBranch(work, 'stack/example/4-entrypoints');
+    setManagedBranchConfig(work, 'stack/example/4-entrypoints');
+    writeFileSync(join(work, 'pr-body-entrypoints.md'), `## Summary
+
+This branch only changes app entrypoint behavior.
+
+## Review Claim
+
+Keep entrypoint activation behavior local.
+
+## Review Lane
+
+- behavior
+
+## Review Unit
+
+- activation-surface
+
+## Safety Invariant
+
+Only entrypoint behavior changes.
+
+## Slice Rationale
+
+Keep entrypoint behavior separate from routing internals.
+
+## Non-goals
+
+- Do not add docs or proof changes in this slice.
+
+## Test Plan
+
+<details>
+<summary>Test Plan</summary>
+
+- [ ] \`node scripts/test-create-pr-stack-workflow.mjs\`
+
+</details>
+
+## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+
+</details>
+`);
+    commitFile(work, 'packages/app/src/headless.ts', 'export const app = true;\n', 'app entrypoint');
+    commitFile(work, 'packages/cli/src/index.ts', 'export const cli = true;\n', 'cli entrypoint');
+    commitFile(work, 'packages/slack-manager/src/invoker-launcher.ts', 'export const slack = true;\n', 'slack entrypoint');
+    gitQuiet(work, 'push', '-u', 'origin', 'stack/example/4-entrypoints');
+
+    const result = runCreatePr(work, harness, [
+      '--title', '[Example](4) Entrypoint slice',
+      '--base', 'master',
+      '--body-file', 'pr-body-entrypoints.md',
+      '--update-existing',
+    ], {
+      GH_API_PULLS_JSON: JSON.stringify([
+        {
+          number: 43,
+          title: '[Example](4) Entrypoint slice',
+          headRefName: 'stack/example/4-entrypoints',
+          baseRefName: 'stack/example/3-previous',
+        },
+      ]),
+    });
+
+    assert(result.status === 1, 'managed stack update should reject unrelated top-level areas even when the PR body stays on one review unit');
+    assert(result.stderr.includes('Stack PR atomicity validation failed'), `stack atomicity blockers should fail publication\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('unrelated-areas'), 'stack atomicity blockers should name the unrelated-areas finding');
+    expectNoPush(harness, 'stack unrelated-areas rejection');
+    const ghCalls = readGhCalls(harness.ghLog);
+    assert(
+      !ghCalls.some((call) => /\/pulls(?:\/[0-9]+)?$/.test(call.route)),
+      'stack unrelated-areas rejection should fail before any GitHub PR mutation',
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+function testNonStackedUnrelatedAreasStayWarnings() {
+  const harness = createHarness();
+  try {
+    const { work } = createRepo(harness);
+    createTrackedBranch(work, 'feature/unrelated-areas-warning');
+    writeFileSync(join(work, 'pr-body-entrypoints.md'), `## Summary
+
+This branch only changes app entrypoint behavior.
+
+## Review Claim
+
+Keep entrypoint activation behavior local.
+
+## Review Lane
+
+- behavior
+
+## Review Unit
+
+- activation-surface
+
+## Safety Invariant
+
+Only entrypoint behavior changes.
+
+## Slice Rationale
+
+Keep entrypoint behavior separate from routing internals.
+
+## Non-goals
+
+- Do not add docs or proof changes in this slice.
+
+## Test Plan
+
+<details>
+<summary>Test Plan</summary>
+
+- [ ] \`node scripts/test-create-pr-stack-workflow.mjs\`
+
+</details>
+
+## Revert Plan
+
+<details>
+<summary>Revert Plan</summary>
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+
+</details>
+`);
+    commitFile(work, 'packages/app/src/headless.ts', 'export const app = true;\n', 'app entrypoint');
+    commitFile(work, 'packages/cli/src/index.ts', 'export const cli = true;\n', 'cli entrypoint');
+    commitFile(work, 'packages/slack-manager/src/invoker-launcher.ts', 'export const slack = true;\n', 'slack entrypoint');
+
+    const result = runCreatePr(work, harness, ['--title', 'test title', '--base', 'master', '--body-file', 'pr-body-entrypoints.md']);
+
+    assert(result.status === 0, `non-stacked unrelated areas should stay warnings\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    assert(result.stderr.includes('Diff atomicity warning'), 'non-stacked publication should still print the warning');
+    const ghCalls = readGhCalls(harness.ghLog);
+    assert(
+      ghCalls.some((call) => call.route.endsWith('/pulls')),
+      'non-stacked unrelated areas warning should still allow PR creation',
+    );
+  } finally {
+    rmSync(harness.root, { recursive: true, force: true });
+  }
+}
+
+
 
 function testStackedDiffTitleRequiredForNonTrunkBase() {
   const harness = createHarness();
@@ -727,6 +894,7 @@ const tests = [
   testMergifyManagedUpdateRejectsNestedTitle,
   testUnpublishedStackCommitsBlockUpdate,
   testCurrentBranchPrLookupFailure,
+  testNonStackedUnrelatedAreasStayWarnings,
   testStackedDiffTitleRequiredForNonTrunkBase,
   testDiffAtomicityBlocksMixedDiff,
   testDiffComputationFailureBlocksPrCreation,

--- a/scripts/test-make-pr-skill.sh
+++ b/scripts/test-make-pr-skill.sh
@@ -91,4 +91,9 @@ must_contain "$SKILL_MD" "aligned stack title prefix" "make-pr skill must requir
 must_contain "$SKILL_MD" "remote-only head branch name" "make-pr skill must document the Mergify branch-name mismatch case"
 must_contain "$SKILL_MD" "gh pr edit --title ... --body-file ..." "make-pr skill must allow immediate metadata repair when create-pr cannot map the published branch"
 
+# Broad stack repair must re-audit the full rebuilt stack and fold no-claim fixups.
+must_contain "$SKILL_MD" "diff atomicity blockers are hard failures" "make-pr skill must make stacked diff-atomicity blockers fatal"
+must_contain "$SKILL_MD" "Re-audit every rebuilt slice in the resulting stack" "make-pr skill must re-audit the full rebuilt stack after a split"
+must_contain "$SKILL_MD" "conflict-only, import-only, or other no-new-claim fixup slice" "make-pr skill must auto-fold no-claim fixup slices"
+
 echo "OK: make-pr skill contract checks passed"

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -5,7 +5,7 @@ import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawnSync } from 'node:child_process';
-import { getPrBodyWarnings, getReviewMetadata, validatePrBody, validatePrScope } from './validate-pr-body.mjs';
+import { getPrAtomicityBlockers, getPrBodyWarnings, getReviewMetadata, validatePrBody, validatePrScope } from './validate-pr-body.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -300,6 +300,39 @@ Animated restart proof showing the drafted chat, app relaunch, and restored chat
 assert(
   restartAnimatedProofErrors.length === 0,
   'restart proof with gif should pass',
+);
+
+const unrelatedAreasDiff = `diff --git a/packages/app/src/app.ts b/packages/app/src/app.ts
+--- a/packages/app/src/app.ts
++++ b/packages/app/src/app.ts
+@@ -0,0 +1 @@
++export const app = true;
+diff --git a/packages/cli/src/index.ts b/packages/cli/src/index.ts
+--- a/packages/cli/src/index.ts
++++ b/packages/cli/src/index.ts
+@@ -0,0 +1 @@
++export const cli = true;
+diff --git a/packages/slack-manager/src/invoker-launcher.ts b/packages/slack-manager/src/invoker-launcher.ts
+--- a/packages/slack-manager/src/invoker-launcher.ts
++++ b/packages/slack-manager/src/invoker-launcher.ts
+@@ -0,0 +1 @@
++export const slack = true;
+`;
+const atomicityBlockers = getPrAtomicityBlockers({ diffText: unrelatedAreasDiff });
+assert(
+  atomicityBlockers.some((warning) => warning.includes('unrelated-areas')),
+  'stack atomicity blockers should include unrelated top-level areas',
+);
+const largeChangeWarnings = getPrBodyWarnings(validMinimal, {
+  changedFiles: Array.from({ length: 11 }, (_, index) => `packages/app/src/file-${index}.ts`),
+});
+assert(
+  largeChangeWarnings.some((warning) => warning.includes('PR changes 11 files')),
+  'large file-count warning should stay in the warning path',
+);
+assert(
+  getPrAtomicityBlockers({}).length === 0,
+  'missing diff context should not invent atomicity blockers',
 );
 
 const lightweightErrors = await validatePrBody(lightweight);

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -300,6 +300,15 @@ export function validatePrScope({ changedFiles = [], reviewLane = '', body = '' 
   return errors;
 }
 
+export function getPrAtomicityBlockers(options = {}) {
+  const diffText = options.diffText ?? '';
+  if (!diffText) return [];
+
+  return collectDiffAtomicityFindings({ diffText })
+    .filter((finding) => finding.severity === 'warning')
+    .map((finding) => `Diff atomicity blocker: ${formatDiffAtomicityFindings([finding])[0]}`);
+}
+
 export function getPrBodyWarnings(body, options = {}) {
   const warnings = [];
   const summary = getSectionBody(body, '## Summary');

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -150,6 +150,8 @@ Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. Th
 
 `scripts/create-pr.mjs` computes changed files and a full-context diff, then runs `scripts/lint-pr-diff-atomicity.mjs` through the PR body checker before image upload, push, or GitHub mutation.
 
+For Invoker stacked PRs, diff atomicity blockers are hard failures. Readability warnings like large file count stay warnings, but a stack slice that trips a diff-atomicity finding such as unrelated areas MUST be split before publication.
+
 If one branch mixes behavior, refactor, cleanup, or test-harness/proof work, split the work into separate PRs. Do not relabel the lane or weaken the checker to make a mixed branch pass.
 
 ## Command surface
@@ -228,17 +230,18 @@ If review says one published stack slice is still too broad:
 
 1. Re-run `skills/review-compression/SKILL.md`.
 2. If one published slice must split, keep the shared idea and create lettered replacement titles such as `(4a)` and `(4b)`.
-3. Run `mergify stack push`.
-4. Switch to each generated stack branch.
-5. Get the real base branch with `gh pr view --json baseRefName --jq .baseRefName`.
-6. Update each PR with `node scripts/create-pr.mjs --title "..." --base <actual-base-branch> --body-file <file> --update-existing`.
+3. If the split creates a conflict-only, import-only, or other no-new-claim fixup slice, fold that fixup into the previous slice before publication.
+4. Re-audit every rebuilt slice in the resulting stack, not just the PR that was flagged.
+5. Run `mergify stack push`.
+6. Switch to each generated stack branch.
+7. Get the real base branch with `gh pr view --json baseRefName --jq .baseRefName`.
+8. Update each PR with `node scripts/create-pr.mjs --title "..." --base <actual-base-branch> --body-file <file> --update-existing`.
 
-7. Audit the live PR metadata on GitHub. If any replacement PR still shows an empty description or only `Depends-On:`, repair it immediately.
+9. Audit the live PR metadata on GitHub. If any replacement PR still shows an empty description or only `Depends-On:`, repair it immediately.
 Manual `gh pr edit` is the escape hatch when `create-pr --update-existing` cannot map the local branch to the published Mergify branch. Use it to repair live metadata immediately, not as the default path.
 
 
 ## Validation
-
 - ensure the branch is pushed
 - ensure the body sections are present and concrete
 - ensure test commands are real commands that were actually run when possible
@@ -246,9 +249,11 @@ Manual `gh pr edit` is the escape hatch when `create-pr --update-existing` canno
 - keep Test Plan and Revert Plan content inside their collapsed `<details><summary>Test Plan</summary>` / `<summary>Revert Plan</summary>` blocks
 - do not create, update, or Mergify-publish a PR when the branch has no file changes against its selected base or contains an empty commit slice; fix the branch history before using `node scripts/create-pr.mjs`, `node scripts/create-pr.mjs --update-existing ...`, or `mergify stack push`
 - validate the body with `node scripts/validate-pr-body.mjs --body-file <file>`
+- for stacked PRs, treat diff-atomicity blockers as fatal, even when readability-only warnings still print
+- for stacked PRs, after any split or restack, re-audit the full rebuilt stack before publishing or updating PRs
+- for stacked PRs, auto-fold conflict-only, import-only, or other no-new-claim fixup slices into the previous slice before publication
 - for stacked PRs, update title/body through `node scripts/create-pr.mjs --update-existing ...`, not `gh pr edit`
 - for UI-impacting diffs, include `## Visual Proof` with screenshot or video proof before `node scripts/create-pr.mjs`; classify by user-visible behavior, not by path alone
-
 If you include `## Architecture`, keep the diagrams renderable by GitHub Mermaid.
 Always quote labels that contain prose, punctuation, or code-ish text such as `reviewGate.artifacts[]`.
 Reference:


### PR DESCRIPTION
## Summary

Invoker stack publication now stops when a stacked PR trips a diff atomicity blocker instead of only printing a warning.

The bug was a gap between policy and tooling. The make-pr skill told the agent to split broad stacks, but `create-pr` still let them publish after warning.

This change makes stacked atomicity blockers fatal, teaches the skill to re-audit the full rebuilt stack after a split, and locks that behavior with focused regressions.

## Review Claim

Invoker stacked PR publication now blocks on diff atomicity findings and requires a full rebuilt-stack audit after reslicing.

## Review Lane

- policy

## Review Unit

- tooling-policy

## Safety Invariant

Only stacked PR publication gets the new hard stop; non-stacked PRs still surface unrelated-area findings as warnings.

## Slice Rationale

Skill text, validator helpers, publication gate, fixtures, and regression tests all change together because they define one PR-authoring policy.

## Non-goals

This does not change review-unit classification rules.

This does not change non-stacked PR publication into a hard failure.

## Architecture

### Before

```mermaid
graph TD
    A["Stacked branch enters create-pr"] --> B["validatePrBody() may fail body schema"]
    B --> C["getPrBodyWarnings() prints atomicity warning"]
    C --> D["Publication still proceeds"]
```

### After

```mermaid
graph TD
    A["Stacked branch enters create-pr"] --> B["validatePrBody() checks schema"]
    B --> C["getPrAtomicityBlockers() checks diff"]
    C --> D["Stack blocker fails publication"]
    E["make-pr split workflow"] --> F["Re-audit full rebuilt stack before publish"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-make-pr-skill.sh`
- [x] `node scripts/test-create-pr-stack-workflow.mjs`
- [x] `node scripts/test-pr-body-validator.mjs`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 5ea391531`
- Post-revert steps: None
- Data migration? No

</details>
