### PR TITLE
[Fix sessions](4) Remove the deprecated conflict-resolution fix surface

### DIFF
--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -110,9 +110,7 @@ import {
 import {
   recreateWorkflowFromFreshBaseImpl,
   getKnownFreshBaseCommitImpl,
-  beginConflictResolutionImpl,
   beginFixSessionImpl,
-  revertConflictResolutionImpl,
   revertFixSessionImpl,
   getMergeNodeImpl,
 } from './orchestrator/merge.js';
@@ -2638,27 +2636,6 @@ export class Orchestrator {
     },
   ): void {
     revertFixSessionImpl(this as unknown as MergeHost, taskId, opts);
-  }
-
-  /**
-   * @deprecated Use `beginFixSession`. Failed-only entry guard kept for
-   * callers not yet migrated; removed once call sites move over.
-   */
-  beginConflictResolution(taskId: string, expectedLineage?: TaskLineageExpectation): { savedError: string } {
-    return beginConflictResolutionImpl(this as unknown as MergeHost, taskId, expectedLineage);
-  }
-
-  /**
-   * @deprecated Use `revertFixSession`. Always restores `failed`; removed
-   * once call sites move over.
-   */
-  revertConflictResolution(
-    taskId: string,
-    savedError: string,
-    fixError?: string,
-    expectedLineage?: TaskLineageExpectation,
-  ): void {
-    revertConflictResolutionImpl(this as unknown as MergeHost, taskId, savedError, fixError, expectedLineage);
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/merge.ts
+++ b/packages/workflow-core/src/orchestrator/merge.ts
@@ -182,25 +182,6 @@ export function beginFixSessionImpl(
   return startFixSession(host, task, task.status, opts.savedError);
 }
 
-/**
- * @deprecated Use `beginFixSessionImpl`. Failed-only entry guard kept for
- * callers not yet migrated; removed once call sites move over.
- */
-export function beginConflictResolutionImpl(
-  host: MergeHost,
-  taskId: string,
-  expectedLineage?: TaskLineageExpectation,
-): { savedError: string } {
-  host.refreshFromDb();
-  const task = host.stateGetTask(taskId);
-  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-  if (!host.taskMatchesLineageExpectation(task, expectedLineage)) {
-    throw new Error(`Task ${taskId} lineage is stale for conflict resolution start`);
-  }
-  if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
-  return startFixSession(host, task, task.status, undefined);
-}
-
 function startFixSession(
   host: MergeHost,
   task: TaskState,
@@ -327,26 +308,6 @@ export function revertFixSessionImpl(
     fixError: opts.fixError ?? null,
   });
   publishTaskDelta(host.messageBus, delta);
-}
-
-/**
- * @deprecated Use `revertFixSessionImpl`. Always restores `failed`; removed
- * once call sites move over.
- */
-export function revertConflictResolutionImpl(
-  host: MergeHost,
-  taskId: string,
-  savedError: string,
-  fixError?: string,
-  expectedLineage?: TaskLineageExpectation,
-): void {
-  host.refreshFromDb();
-  const task = host.stateGetTask(taskId);
-  if (!task) {
-    throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-  }
-  if (!host.taskMatchesLineageExpectation(task, expectedLineage)) return;
-  restoreFailedEntry(host, task, savedError, fixError);
 }
 
 function restoreFailedEntry(


### PR DESCRIPTION
## Summary

Every caller now goes through `beginFixSession` and `revertFixSession`. The deprecated `beginConflictResolution` and `revertConflictResolution` delegates have no users left.

This drops the delegates and their impls, so the fix-session mechanism is the only entry and exit for fix work.

## Review Claim

The deprecated conflict-resolution fix surface is gone and nothing referenced it.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Dead-code drop only: slices 1–3 migrated every production caller and test to the fix-session mechanism, so no behavior changes here.

## Slice Rationale

The drop rides above the call-site migrations so each earlier slice still builds and passes on its own.

## Non-goals

- No behavior changes: behavior stays unchanged; the fix-session mechanism keeps its exact signatures and semantics.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/workflow-core build && pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 8525d03`
- Post-revert steps: None
- Data migration? No

</details>
