### PR TITLE
[Merge branch retrievability](1) Verify pushed workflow branches are on origin

### DIFF
--- a/packages/execution-engine/src/__tests__/assert-branch-retrievable.test.ts
+++ b/packages/execution-engine/src/__tests__/assert-branch-retrievable.test.ts
@@ -1,0 +1,112 @@
+/**
+ * assertBranchRetrievableOnOrigin invariant tests (real git).
+ *
+ * Proves the "do not progress on a lost push" invariant: after a feature branch
+ * is pushed, it must be retrievable from origin at the exact commit we pushed.
+ * A downstream gate resolves the base ref against origin only, so a branch that
+ * never landed there must fail loudly here instead of surfacing later as a
+ * confusing "merge gate workspace missing" error.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { assertBranchRetrievableOnOrigin, type MergeRunnerHost } from '../merge-runner.js';
+
+function git(cwd: string, args: string[]): string {
+  const r = spawnSync('git', args, { cwd, encoding: 'utf8' });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(' ')} failed: ${r.stderr || r.stdout}`);
+  }
+  return (r.stdout ?? '').trim();
+}
+
+/** Minimal host: assertBranchRetrievableOnOrigin only needs cwd + execGitIn. */
+function makeHost(cwd: string): MergeRunnerHost {
+  return {
+    cwd,
+    execGitIn: async (args: string[], dir: string) => git(dir, args),
+  } as unknown as MergeRunnerHost;
+}
+
+function createSandbox() {
+  const root = mkdtempSync(join(tmpdir(), 'assert-retr-'));
+  const bare = join(root, 'bare.git');
+  git(root, ['init', '--bare', '-b', 'master', bare]);
+
+  const work = join(root, 'work');
+  git(root, ['clone', bare, work]);
+  git(work, ['config', 'user.email', 'test@test.com']);
+  git(work, ['config', 'user.name', 'Test']);
+  writeFileSync(join(work, 'init.txt'), 'init');
+  git(work, ['add', '-A']);
+  git(work, ['commit', '-m', 'initial']);
+  git(work, ['branch', '-M', 'master']);
+  git(work, ['push', 'origin', 'master']);
+  return { root, bare, work };
+}
+
+function commitOnBranch(work: string, branch: string, file: string): void {
+  git(work, ['checkout', '-b', branch]);
+  writeFileSync(join(work, file), file);
+  git(work, ['add', '-A']);
+  git(work, ['commit', '-m', `add ${file}`]);
+}
+
+describe('assertBranchRetrievableOnOrigin (real git)', { timeout: 30_000 }, () => {
+  let root: string;
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  it('passes when the pushed branch is present on origin at the pushed commit', async () => {
+    const sandbox = createSandbox();
+    root = sandbox.root;
+    commitOnBranch(sandbox.work, 'plan/feature', 'feature.txt');
+    git(sandbox.work, ['push', 'origin', 'plan/feature:refs/heads/plan/feature']);
+
+    await expect(
+      assertBranchRetrievableOnOrigin(makeHost(sandbox.root), sandbox.work, 'plan/feature'),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws an explicit error when the branch never landed on origin', async () => {
+    const sandbox = createSandbox();
+    root = sandbox.root;
+    // Branch exists locally but is deliberately NOT pushed — simulates a lost push.
+    commitOnBranch(sandbox.work, 'plan/feature', 'feature.txt');
+
+    await expect(
+      assertBranchRetrievableOnOrigin(makeHost(sandbox.root), sandbox.work, 'plan/feature'),
+    ).rejects.toThrow(/branch "plan\/feature" is not on origin after push/);
+  });
+
+  it('throws when origin has the branch at a different commit than the local tip', async () => {
+    const sandbox = createSandbox();
+    root = sandbox.root;
+    commitOnBranch(sandbox.work, 'plan/feature', 'feature.txt');
+    git(sandbox.work, ['push', 'origin', 'plan/feature:refs/heads/plan/feature']);
+    // Advance the local tip past what origin has (origin is now stale).
+    writeFileSync(join(sandbox.work, 'extra.txt'), 'extra');
+    git(sandbox.work, ['add', '-A']);
+    git(sandbox.work, ['commit', '-m', 'local-only extra commit']);
+
+    await expect(
+      assertBranchRetrievableOnOrigin(makeHost(sandbox.root), sandbox.work, 'plan/feature'),
+    ).rejects.toThrow(/push should have advanced it to/);
+  });
+
+  it('is a no-op when git is stubbed (no local tip to verify)', async () => {
+    // Mocked execGitIn returns '' for every command — mirrors unit tests that
+    // stub git. With no resolvable local tip there is nothing to assert.
+    const host = {
+      cwd: '/tmp/does-not-matter-host',
+      execGitIn: async () => '',
+    } as unknown as MergeRunnerHost;
+
+    await expect(
+      assertBranchRetrievableOnOrigin(host, '/tmp/does-not-matter-clone', 'plan/feature'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -3787,6 +3787,9 @@ console.log(JSON.stringify(out));
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
         if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'abc123';
         if (args[0] === 'rev-parse') return 'feature-sha';
+        // A successful push means the branch is retrievable on origin at the
+        // pushed tip. Model that so the post-push retrievability check passes.
+        if (args[0] === 'ls-remote') return `feature-sha\trefs/heads/${args[args.length - 1]}`;
         if (args[0] === 'merge-base' && args[1] === '--is-ancestor') throw new Error('not ancestor');
         return '';
       };

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -189,6 +189,41 @@ async function pushFeatureBranchWithRefLockRetry(
     ], dir);
     await execGitInMergeSafe(host, pushArgs, dir);
   }
+  await assertBranchRetrievableOnOrigin(host, dir, featureBranch);
+}
+
+export async function assertBranchRetrievableOnOrigin(
+  host: MergeRunnerHost,
+  dir: string,
+  branch: string,
+): Promise<void> {
+  const localSha = (await execGitInMergeSafe(host, ['rev-parse', '--verify', `${branch}^{commit}`], dir)
+    .catch(() => '')).trim();
+  if (!localSha) return;
+
+  const wantRef = `refs/heads/${branch}`;
+  const lsRemote = (await execGitInMergeSafe(host, ['ls-remote', '--heads', 'origin', '--', branch], dir)).trim();
+  const remoteSha = lsRemote
+    .split('\n')
+    .map((line) => line.trim().split(/\s+/))
+    .find((parts) => parts[1] === wantRef)?.[0] ?? '';
+
+  if (!remoteSha) {
+    throw new Error(
+      `Push verification failed: branch "${branch}" is not on origin after push. ` +
+      `A later merge/gate step retrieves this branch from origin, so the workflow ` +
+      `must not progress while it is unretrievable. Local tip ${localSha.slice(0, 12)} ` +
+      `was reported pushed, but origin has no ${wantRef}. ` +
+      `Re-run the merge, or check the push remote URL and credentials.`,
+    );
+  }
+  if (remoteSha !== localSha) {
+    throw new Error(
+      `Push verification failed: origin has "${branch}" at ${remoteSha.slice(0, 12)}, but the ` +
+      `push should have advanced it to ${localSha.slice(0, 12)}. Downstream retrieval would get ` +
+      `the wrong commit, so the workflow must not progress.`,
+    );
+  }
 }
 
 async function syncGateWorkspaceToFeatureBranch(


### PR DESCRIPTION
## Summary

A chained workflow's later step reads a branch from GitHub that an earlier step pushed. If that push never lands, the later step fails somewhere confusing.

Git treating a push as done does not prove the branch is on GitHub. A wrong remote, a lost ref, or a no-op refspec can hide the miss.

This change confirms the branch is on GitHub at the pushed commit before the workflow continues. If not, the push step fails right away with a plain reason.

## Review Claim

Confirm a just-pushed workflow branch is present on GitHub at the pushed commit before the push helper reports success.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only appends a post-push check inside the existing push helper. The happy path (branch present at the pushed commit) is unchanged, and real-git tests exercise both the present and the missing outcomes.

## Slice Rationale

The poll-side error-message change lives in its own PR because the review-boundary rule forbids editing both merge-runner and task-runner in one PR.

## Non-goals

- Does not change how the branch is pushed, only checks afterward that it landed.
- Does not touch the gate resolve error text (that is the paired PR).
- Does not add retries or network backoff to the check.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/assert-branch-retrievable.test.ts`
- [ ] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts src/__tests__/publish-after-fix.test.ts src/__tests__/auto-commit.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>