### PR TITLE
[Workers Surface](3) Route worker snapshot reads

### DIFF
--- a/packages/app/src/__tests__/owner-read-query.test.ts
+++ b/packages/app/src/__tests__/owner-read-query.test.ts
@@ -14,6 +14,7 @@ function makeHandlers(over: Partial<OwnerReadQueryHandlers> = {}): OwnerReadQuer
     getQueueStatus: vi.fn(() => ({ runningCount: 2 })),
     listWorkerActionHistory: vi.fn((request) => ({ workerKind: request.workerKind, actions: [], limit: request.limit ?? 20, offset: request.offset ?? 0, hasMore: false })),
     getWorkerStatus: vi.fn(() => ({ generatedAt: 'now', workers: [] })),
+    getWorkers: vi.fn(() => ({ generatedAt: 'workers-now', workers: [] })),
     getWorkflowStatus: vi.fn(() => ({ 'wf-1': 'running' })),
     getTasksSnapshot: vi.fn(({ refresh }) => ({ tasks: [], workflows: [], refreshed: refresh })),
     getActionGraphSnapshot: vi.fn(() => ({ nodes: [] })),
@@ -47,6 +48,7 @@ describe('answerOwnerReadQuery', () => {
     expect(answerOwnerReadQuery({ kind: 'worker-action-history', workerKind: 'autofix', limit: 2, offset: 4 }, h)).toEqual({
       workerActionHistory: { workerKind: 'autofix', actions: [], limit: 2, offset: 4, hasMore: false },
     });
+    expect(answerOwnerReadQuery({ kind: 'workers' }, h)).toEqual({ generatedAt: 'workers-now', workers: [] });
     expect(answerOwnerReadQuery({ kind: 'workflow-status' }, h)).toEqual({ 'wf-1': 'running' });
     expect(answerOwnerReadQuery({ kind: 'action-graph' }, h)).toEqual({ nodes: [] });
   });
@@ -146,6 +148,7 @@ describe('buildOwnerReadQueryHandlers', () => {
       resetUiPerfStats: () => {},
       getStreamSequence: () => 5,
       getWorkerStatus: () => ({ generatedAt: 'now', workers: [] }),
+      getWorkers: () => ({ generatedAt: 'workers-now', workers: [] }),
       resolveInvokerHomeRoot: () => '/home',
       orchestrator: { ...f.orchestrator, ...orch } as never,
       persistence: { ...f.persistence, ...persist } as never,
@@ -170,6 +173,7 @@ describe('buildOwnerReadQueryHandlers', () => {
       offset: 2,
       hasMore: false,
     });
+    expect(h.getWorkers()).toEqual({ generatedAt: 'workers-now', workers: [] });
   });
 
   it('loadWorkflowBundle syncs that workflow first, then returns workflow + tasks', () => {

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -12,6 +12,7 @@ import {
   AUTO_STARTED_OWNER_WORKER_KINDS,
   createWorkerRuntimeController,
   listWorkerActionHistory,
+  createLocalWorkerStatusSnapshot,
 } from '../worker-control.js';
 
 interface TestWorkerRuntime extends WorkerRuntime {
@@ -99,28 +100,24 @@ function controller() {
 }
 
 describe('createWorkerRuntimeController', () => {
-  it('auto-start starts only pr-status and ci-failure', () => {
+  it('auto-start starts every built-in owner worker', () => {
     const setup = controller();
 
     setup.controller.startAutoStartedWorkers();
     const snapshot = setup.controller.snapshot();
 
+    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)).toMatchObject({
+      lifecycle: 'running',
+      source: 'built-in',
+      availability: 'available',
+      running: true,
+    });
     expect(snapshot.workers.find((worker) => worker.kind === PR_STATUS_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)?.lifecycle).toBe('running');
-    expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
-    expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.lifecycle).toBe('stopped');
-  });
-
-  it('autofix remains stopped until explicitly started', () => {
-    const setup = controller();
-
-    setup.controller.startAutoStartedWorkers();
-    expect(setup.runtimes.get(AUTO_FIX_WORKER_KIND)).toBeUndefined();
-
-    const row = setup.controller.start(AUTO_FIX_WORKER_KIND);
-
-    expect(row.lifecycle).toBe('running');
-    expect(row.runtimeKind).toBe('recovery');
+    expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')).toMatchObject({
+      lifecycle: 'stopped',
+      source: 'external',
+    });
   });
 
   it('duplicate start is idempotent', () => {
@@ -233,5 +230,59 @@ describe('createWorkerRuntimeController', () => {
       nextOffset: 6,
     });
     expect(listWorkerActions).toHaveBeenCalledWith({ workerKind: 'history', limit: 3, offset: 4 });
+  });
+  it('combines worker action rows and auto-fix task events in recent logs', () => {
+    const registry = createWorkerRegistry<WorkerRuntimeDependencies>();
+    registry.register({
+      kind: AUTO_FIX_WORKER_KIND,
+      note: 'Auto-fixes failed tasks.',
+      source: 'built-in',
+      factory: () => runtime('recovery'),
+    });
+
+    const snapshot = createLocalWorkerStatusSnapshot({
+      registry,
+      autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      persistence: {
+        listWorkerActions: vi.fn(() => [{
+          id: 'action-1',
+          workerKind: AUTO_FIX_WORKER_KIND,
+          actionType: 'fix-with-agent',
+          workflowId: 'wf-1',
+          taskId: 'wf-1/task-1',
+          subjectType: 'task',
+          subjectId: 'wf-1/task-1',
+          externalKey: 'wf-1/task-1',
+          status: 'queued',
+          attemptCount: 1,
+          payload: { reason: 'failed' },
+          createdAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:01.000Z',
+        }]),
+        listTaskEvents: vi.fn(() => [{
+          id: 7,
+          taskId: 'wf-1/task-1',
+          eventType: 'debug.auto-fix',
+          payload: '{"phase":"worker-autofix-skip","reason":"not-eligible"}',
+          createdAt: '2026-01-01T00:00:02.000Z',
+        }]),
+        listWorkflows: vi.fn(() => []),
+        loadTasks: vi.fn(() => []),
+        getEvents: vi.fn(() => []),
+      } as never,
+    });
+
+    expect(snapshot.workers[0]?.recentLogs).toEqual([
+      expect.objectContaining({
+        source: 'task_events',
+        eventType: 'debug.auto-fix',
+        payload: expect.objectContaining({ phase: 'worker-autofix-skip' }),
+      }),
+      expect.objectContaining({
+        source: 'worker_actions',
+        actionType: 'fix-with-agent',
+        status: 'queued',
+      }),
+    ]);
   });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -209,7 +209,6 @@ import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from './delta-m
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
 import { WorkflowRollupProjection } from './workflow-rollup-projection.js';
 import { seedTaskCachesFromSnapshot } from './viewer-cache-hydration.js';
-import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
 import { submitWorkflowMutationOrAcknowledgeDeleted } from './workflow-mutation-submit.js';
@@ -227,9 +226,7 @@ import { evaluateExecutingStall } from './executing-stall.js';
 
 
 import {
-  buildFixWithAgentMutationArgs,
   buildHeadlessFixArgs,
-  listOpenFixIntentsForTask,
   parseFixWithAgentMutationArgs,
   type ReviewGateCiContext,
 } from './auto-fix-intents.js';
@@ -259,11 +256,6 @@ import {
 } from './ipc/ipc-registration.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import { startLifecycleEventBridge, type LifecycleEventBridge } from './lifecycle-event-bridge.js';
-import {
-  buildRecoveryWorkerAuditPayload,
-  classifyAutoFixRecoveryPhase,
-  recoveryWorkerEventType,
-} from './recovery-worker-observability.js';
 import {
   executeNoTrackHeadlessBatch,
   type HeadlessBatchExecRequest,
@@ -1472,187 +1464,7 @@ function startHeadlessMode(): void {
           );
         }
 
-        const buildStandaloneAutoFixQueueSnapshot = (taskId: string): Record<string, unknown> => {
-          const workflowId = standaloneWorkflowIdForTaskArg(taskId);
-          if (!workflowId) {
-            return {
-              workflowId: null,
-              openIntentCountForWorkflow: 0,
-              openFixIntentCountForWorkflow: 0,
-              openFixIntentCountForTask: 0,
-              openFixIntentForTask: false,
-              openFixIntentHead: null,
-              openFixIntentPreview: [],
-            };
-          }
-          const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-          const openFixIntents = openIntents.filter((intent) => (
-            intent.channel === 'invoker:fix-with-agent' || intent.channel === 'headless.exec'
-          ));
-          const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-          return {
-            workflowId,
-            openIntentCountForWorkflow: openIntents.length,
-            openFixIntentCountForWorkflow: openFixIntents.length,
-            openFixIntentCountForTask: openTaskFixIntents.length,
-            openFixIntentForTask: openTaskFixIntents.length > 0,
-            openFixIntentHead: openTaskFixIntents[0]
-              ? {
-                id: openTaskFixIntents[0].id,
-                status: openTaskFixIntents[0].status,
-                channel: openTaskFixIntents[0].channel,
-              }
-              : null,
-            openFixIntentPreview: openTaskFixIntents.slice(0, 5).map((intent) => ({
-              id: intent.id,
-              status: intent.status,
-              channel: intent.channel,
-            })),
-          };
-        };
 
-        const logStandaloneAutoFixDebug = (
-          taskId: string,
-          phase: string,
-          details: Record<string, unknown> = {},
-        ): void => {
-          const task = orchestrator.getTask(taskId);
-          const payload = {
-            phase,
-            status: task?.status ?? 'missing',
-            ...buildStandaloneAutoFixQueueSnapshot(taskId),
-            ...details,
-          };
-          persistence.logEvent?.(taskId, 'debug.auto-fix', payload);
-          const recoveryAction = classifyAutoFixRecoveryPhase(phase, payload);
-          if (recoveryAction) {
-            persistence.logEvent?.(
-              taskId,
-              recoveryWorkerEventType(recoveryAction),
-              buildRecoveryWorkerAuditPayload(recoveryAction, phase, payload),
-            );
-          }
-          logger.info(
-            `[auto-fix-debug][standalone] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}`,
-            { module: 'auto-fix' },
-          );
-        };
-
-        const scheduleStandaloneAutoFix = (taskId: string): void => {
-          logStandaloneAutoFixDebug(taskId, 'schedule-enter');
-          if (!workflowMutationCoordinator) {
-            logStandaloneAutoFixDebug(taskId, 'schedule-skip', { reason: 'no-workflow-mutation-coordinator' });
-            return;
-          }
-          if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
-            logStandaloneAutoFixDebug(taskId, 'schedule-skip', { reason: 'fix-handler-not-ready' });
-            return;
-          }
-          const workflowId = standaloneWorkflowIdForTaskArg(taskId);
-          if (!workflowId) {
-            logStandaloneAutoFixDebug(taskId, 'schedule-skip', { reason: 'workflow-not-found' });
-            return;
-          }
-          const shouldAutoFixNow = orchestrator.shouldAutoFix(taskId);
-          if (!shouldAutoFixNow) {
-            logStandaloneAutoFixDebug(taskId, 'schedule-skip', {
-              reason: 'shouldAutoFix-false',
-              shouldAutoFix: shouldAutoFixNow,
-            });
-            return;
-          }
-          const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-          const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-          if (openTaskFixIntents.length > 0) {
-            logStandaloneAutoFixDebug(taskId, 'schedule-skip', {
-              reason: 'already-queued-intent',
-              existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
-            });
-            return;
-          }
-          const configuredAgent = loadConfig().autoFixAgent?.trim();
-          const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
-          logStandaloneAutoFixDebug(taskId, 'schedule-enqueue');
-          logStandaloneAutoFixDebug(taskId, 'schedule-enqueued');
-          void workflowMutationCoordinator.enqueue(
-            workflowId,
-            'normal',
-            'invoker:fix-with-agent',
-            buildFixWithAgentMutationArgs(taskId, selectedAgent, { autoFix: true }),
-          )
-            .then(() => {
-              logStandaloneAutoFixDebug(taskId, 'schedule-dispatch-finished');
-            })
-            .catch((err) => {
-              if (err instanceof StaleLineageError) {
-                logger.info(`auto-fix discarded stale result for "${taskId}": ${err.message}`, { module: 'auto-fix' });
-                return;
-              }
-              logStandaloneAutoFixDebug(taskId, 'schedule-dispatch-error', {
-                error: err instanceof Error ? err.stack ?? err.message : String(err),
-              });
-            });
-        };
-
-        const maybeScheduleStandaloneAutoFix = (
-          task: TaskState,
-          trigger: 'delta' | 'poll',
-        ): boolean => {
-          if (task.status !== 'failed') return false;
-          const cancellationError = shouldSkipAutoFixForError(task.execution.error);
-          const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(task.id);
-          logStandaloneAutoFixDebug(task.id, `${trigger}-failed`, {
-            shouldSkipForCancellation: cancellationError,
-            shouldAutoFixFromOrchestrator,
-          });
-          if (!cancellationError && shouldAutoFixFromOrchestrator) {
-            logStandaloneAutoFixDebug(task.id, `${trigger}-trigger-schedule`);
-            scheduleStandaloneAutoFix(task.id);
-            return true;
-          }
-          logStandaloneAutoFixDebug(task.id, `${trigger}-skip`, {
-            reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
-            shouldSkipForCancellation: cancellationError,
-            shouldAutoFixFromOrchestrator,
-          });
-          return false;
-        };
-
-        const startStandaloneAutoFixRecoveryPoll = (workflowId: string): void => {
-          const startedAtMs = Date.now();
-          const maxPollMs = 90_000;
-          const poll = setInterval(() => {
-            if (Date.now() - startedAtMs > maxPollMs) {
-              clearInterval(poll);
-              return;
-            }
-            try {
-              orchestrator.syncFromDb(workflowId);
-              const scheduled = orchestrator
-                .getAllTasks()
-                .filter((task) => task.config.workflowId === workflowId)
-                .some((task) => maybeScheduleStandaloneAutoFix(task, 'poll'));
-              if (scheduled) {
-                clearInterval(poll);
-              }
-            } catch (err) {
-              logger.warn(
-                `standalone auto-fix recovery poll failed for "${workflowId}": ${
-                  err instanceof Error ? err.message : String(err)
-                }`,
-                { module: 'auto-fix' },
-              );
-            }
-          }, 1_000);
-          poll.unref?.();
-        };
-
-        messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
-          const d = delta as TaskDelta;
-          if (d.type !== 'updated' || d.changes.status !== 'failed') return;
-          const task = orchestrator.getTask(d.taskId);
-          if (task) maybeScheduleStandaloneAutoFix(task, 'delta');
-        });
 
         const executeStandaloneHeadlessRun = async (
           payload: HeadlessRunMutationPayload,
@@ -1664,7 +1476,6 @@ function startHeadlessMode(): void {
           orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
           const workflowId = orchestrator.getWorkflowIds().find(id => !wfIdsBefore.has(id))!;
           const started = orchestrator.startExecution();
-          startStandaloneAutoFixRecoveryPoll(workflowId);
           logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
           const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
           return { workflowId, tasks };
@@ -1710,7 +1521,16 @@ function startHeadlessMode(): void {
             getUiPerfStats: () => headlessDeps.getUiPerfStats?.() ?? {},
             resetUiPerfStats: () => headlessDeps.resetUiPerfStats?.(),
             getStreamSequence: () => 0,
-            getWorkerStatus: () => workerRuntimeController?.snapshot() ?? { generatedAt: new Date().toISOString(), workers: [] },
+            getWorkerStatus: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+              registry: createRegisteredWorkerRegistry(),
+              persistence,
+              autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+            }),
+            getWorkers: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+              registry: createRegisteredWorkerRegistry(),
+              persistence,
+              autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+            }),
             resolveInvokerHomeRoot,
             orchestrator,
             persistence,
@@ -2217,71 +2037,6 @@ function createEmbeddedTerminalBackendFromConfig(
     workflowMetadataPublisher?.requestPublish(reason);
   };
 
-  const buildAutoFixQueueSnapshot = (taskId: string): Record<string, unknown> => {
-    const workflowId = workflowIdForTaskArg(taskId);
-    if (!workflowId) {
-      return {
-        workflowId: null,
-        openIntentCountForWorkflow: 0,
-        openFixIntentCountForWorkflow: 0,
-        openFixIntentCountForTask: 0,
-        openFixIntentForTask: false,
-        openFixIntentHead: null,
-        openFixIntentPreview: [],
-      };
-    }
-    const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-    const openFixIntents = openIntents.filter((intent) => (
-      intent.channel === 'invoker:fix-with-agent' || intent.channel === 'headless.exec'
-    ));
-    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-    return {
-      workflowId,
-      openIntentCountForWorkflow: openIntents.length,
-      openFixIntentCountForWorkflow: openFixIntents.length,
-      openFixIntentCountForTask: openTaskFixIntents.length,
-      openFixIntentForTask: openTaskFixIntents.length > 0,
-      openFixIntentHead: openTaskFixIntents[0]
-        ? {
-          id: openTaskFixIntents[0].id,
-          status: openTaskFixIntents[0].status,
-          channel: openTaskFixIntents[0].channel,
-        }
-        : null,
-      openFixIntentPreview: openTaskFixIntents.slice(0, 5).map((intent) => ({
-        id: intent.id,
-        status: intent.status,
-        channel: intent.channel,
-      })),
-    };
-  };
-
-  const logAutoFixDebug = (
-    taskId: string,
-    phase: string,
-    details: Record<string, unknown> = {},
-  ): void => {
-    const task = orchestrator.getTask(taskId);
-    const payload = {
-      phase,
-      status: task?.status ?? 'missing',
-      ...buildAutoFixQueueSnapshot(taskId),
-      ...details,
-    };
-    persistence.logEvent?.(taskId, 'debug.auto-fix', payload);
-    const recoveryAction = classifyAutoFixRecoveryPhase(phase, payload);
-    if (recoveryAction) {
-      persistence.logEvent?.(
-        taskId,
-        recoveryWorkerEventType(recoveryAction),
-        buildRecoveryWorkerAuditPayload(recoveryAction, phase, payload),
-      );
-    }
-    logger.info(
-      `[auto-fix-debug] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}`,
-      { module: 'auto-fix' },
-    );
-  };
 
   const executeFixWithAgentMutation = async (
     taskId: string,
@@ -2323,62 +2078,6 @@ function createEmbeddedTerminalBackendFromConfig(
     return result.started;
   };
 
-  const scheduleAutoFix = (taskId: string): void => {
-    logAutoFixDebug(taskId, 'schedule-enter');
-    if (!workflowMutationCoordinator) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'no-workflow-mutation-coordinator' });
-      return;
-    }
-    if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'fix-handler-not-ready' });
-      return;
-    }
-    const workflowId = workflowIdForTaskArg(taskId);
-    if (!workflowId) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'workflow-not-found' });
-      return;
-    }
-    const shouldAutoFixNow = orchestrator.shouldAutoFix(taskId);
-    if (!shouldAutoFixNow) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'shouldAutoFix-false',
-        shouldAutoFix: shouldAutoFixNow,
-      });
-      return;
-    }
-    const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-    if (openTaskFixIntents.length > 0) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'already-queued-intent',
-        existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
-      });
-      return;
-    }
-    const configuredAgent = loadConfig().autoFixAgent?.trim();
-    const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
-    logAutoFixDebug(taskId, 'schedule-enqueue');
-    logAutoFixDebug(taskId, 'schedule-enqueued');
-    void runWorkflowMutation(
-      workflowId,
-      'normal',
-      'invoker:fix-with-agent',
-      [taskId, selectedAgent],
-      async () => executeFixWithAgentMutation(taskId, selectedAgent, 'auto-fix'),
-    )
-      .then(() => {
-        logAutoFixDebug(taskId, 'schedule-dispatch-finished');
-      })
-      .catch((err) => {
-        if (err instanceof StaleLineageError) {
-          logger.info(`auto-fix discarded stale result for "${taskId}": ${err.message}`, { module: 'auto-fix' });
-          return;
-        }
-        logAutoFixDebug(taskId, 'schedule-dispatch-error', {
-          error: err instanceof Error ? err.stack ?? err.message : String(err),
-        });
-      });
-  };
 
   const parseExecutionDate = (value: unknown): Date | undefined => {
     if (!value) return undefined;
@@ -2999,31 +2698,12 @@ function createEmbeddedTerminalBackendFromConfig(
   }
 
   // Apply one owner task delta to the local cache and forward results to the
-  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
-  // can replay deltas that were buffered during hydration.
+  // renderer. Owner-started workers consume workflow lifecycle events from the
+  // lifecycle bridge, so failure-triggered auto-fix stays in the worker path.
   function processIncomingTaskDelta(d: TaskDelta): void {
     uiPerfStats.mainDeltaToUi += 1;
     if (traceUiDeltaFlow) {
       logger.debug(`delta→ui: ${JSON.stringify(d)}`, { module: 'ui' });
-    }
-    const deltaTaskId = d.type === 'updated' || d.type === 'removed' ? d.taskId : undefined;
-    if (d.type === 'updated' && d.changes.status === 'failed') {
-      const cancellationError = shouldSkipAutoFixForError(d.changes.execution?.error);
-      const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(d.taskId);
-      logAutoFixDebug(d.taskId, 'delta-failed', {
-        shouldSkipForCancellation: cancellationError,
-        shouldAutoFixFromOrchestrator,
-      });
-      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
-        logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
-        scheduleAutoFix(deltaTaskId);
-      } else if (deltaTaskId) {
-        logAutoFixDebug(deltaTaskId, 'delta-skip', {
-          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
-          shouldSkipForCancellation: cancellationError,
-          shouldAutoFixFromOrchestrator,
-        });
-      }
     }
     for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(d)) {
       publishTaskDeltaToRenderer(rendererDelta);
@@ -3205,6 +2885,11 @@ function createEmbeddedTerminalBackendFromConfig(
           deleteWorkflow: performDeleteWorkflow,
           detachWorkflow: performDetachWorkflow,
           getBundledSkillsStatus,
+          getWorkers: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+            registry: createRegisteredWorkerRegistry(),
+            persistence,
+            autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          }),
           getSystemDiagnostics: () => collectSystemDiagnostics({
             appVersion: app.getVersion(),
             isPackaged: app.isPackaged,
@@ -3529,7 +3214,16 @@ function createEmbeddedTerminalBackendFromConfig(
           ownerModeLabel: 'gui',
           getUiPerfStats: () => getUiPerfStats(),
           resetUiPerfStats: () => resetUiPerfStats(),
-          getWorkerStatus: () => workerRuntimeController?.snapshot() ?? { generatedAt: new Date().toISOString(), workers: [] },
+          getWorkerStatus: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+            registry: createRegisteredWorkerRegistry(),
+            persistence,
+            autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          }),
+          getWorkers: () => workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+            registry: createRegisteredWorkerRegistry(),
+            persistence,
+            autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+          }),
           getStreamSequence: () => getTaskDeltaStreamSequence(),
           resolveInvokerHomeRoot,
           orchestrator,
@@ -4316,6 +4010,31 @@ function createEmbeddedTerminalBackendFromConfig(
         } catch (err) {
           logger.warn(
             `get-worker-status owner delegation failed; falling back to local read-only snapshot: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            { module: 'ipc' },
+          );
+        }
+        return createLocalWorkerStatusSnapshot({
+          registry: createRegisteredWorkerRegistry(),
+          persistence,
+          autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+        });
+      }
+      return workerRuntimeController?.snapshot() ?? createLocalWorkerStatusSnapshot({
+        registry: createRegisteredWorkerRegistry(),
+        persistence,
+        autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+      });
+    });
+
+    ipcMain.handle('invoker:get-workers', async () => {
+      if (!ownerMode) {
+        try {
+          return await messageBus.request('headless.query', { kind: 'workers' });
+        } catch (err) {
+          logger.warn(
+            `get-workers owner delegation failed; falling back to local read-only snapshot: ${
               err instanceof Error ? err.message : String(err)
             }`,
             { module: 'ipc' },

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -31,6 +31,7 @@ export interface OwnerReadQueryHandlers {
   getQueueStatus: () => Record<string, unknown>;
   listWorkerActionHistory: (request: WorkerActionHistoryRequest) => WorkerActionHistoryResponse;
   getWorkerStatus: () => WorkerStatusSnapshot;
+  getWorkers: () => WorkerStatusSnapshot;
   getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
   getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
   getActionGraphSnapshot: () => Record<string, unknown>;
@@ -92,6 +93,8 @@ export function answerOwnerReadQuery(
       return { workerStatus: handlers.getWorkerStatus() };
     case 'worker-action-history':
       return { workerActionHistory: handlers.listWorkerActionHistory(workerActionHistoryRequest()) };
+    case 'workers':
+      return handlers.getWorkers() as unknown as Record<string, unknown>;
     case 'workflow-status':
       return handlers.getWorkflowStatus(body.workflowId);
     case 'tasks':
@@ -175,6 +178,7 @@ export interface OwnerReadQueryDeps {
   resetUiPerfStats: () => void;
   getStreamSequence: () => number;
   getWorkerStatus: () => WorkerStatusSnapshot;
+  getWorkers: () => WorkerStatusSnapshot;
   resolveInvokerHomeRoot: () => string;
   orchestrator: ReadOrchestrator;
   persistence: ReadPersistence;
@@ -193,6 +197,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
     getWorkerStatus: deps.getWorkerStatus,
     listWorkerActionHistory: (request: WorkerActionHistoryRequest) => listWorkerActionHistory(persistence, request),
+    getWorkers: deps.getWorkers,
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
     getTasksSnapshot: ({ refresh }) => {
       if (refresh) orchestrator.syncAllFromDb();

--- a/packages/app/src/web/start-web-surface.ts
+++ b/packages/app/src/web/start-web-surface.ts
@@ -19,7 +19,7 @@ import type {
 } from '@invoker/contracts';
 import { Channels, type MessageBus } from '@invoker/transport';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import { registerBuiltinAgents, type AgentRegistry } from '@invoker/execution-engine';
+import { createWorkerRegistry, registerBuiltinAgents, registerBuiltinWorkers, type AgentRegistry, type WorkerRuntimeDependencies } from '@invoker/execution-engine';
 import type { Orchestrator, TaskDelta } from '@invoker/workflow-core';
 import { loadConfig, type InvokerConfig } from '../config.js';
 import type { ApiMutationFacade } from '../api-server.js';
@@ -27,6 +27,8 @@ import { createTaskGraphEventPublisher } from '../task-graph-event-publisher.js'
 import { createTaskDeltaStreamSequence } from '../task-delta-stream-sequence.js';
 import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
 import { buildWebInvokerDispatch } from './web-invoker-dispatch.js';
+import { registerExternalWorkersFromConfig } from '../external-worker-loader.js';
+import { AUTO_STARTED_OWNER_WORKER_KINDS, createLocalWorkerStatusSnapshot } from '../worker-control.js';
 import { startWebBridge, resolveWebUiDistDir, type WebBridge } from './web-bridge-server.js';
 
 const DEFAULT_WEB_HOST = '127.0.0.1';
@@ -118,6 +120,14 @@ export function startHeadlessWebSurface(deps: StartHeadlessWebSurfaceDeps): WebB
     deleteWorkflow: deps.deleteWorkflow,
     detachWorkflow: deps.detachWorkflow,
     getBundledSkillsStatus: deps.getBundledSkillsStatus,
+    getWorkers: () => createLocalWorkerStatusSnapshot({
+      registry: registerExternalWorkersFromConfig(
+        deps.config.externalWorkers,
+        registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
+      ),
+      persistence: deps.persistence,
+      autoStartKinds: AUTO_STARTED_OWNER_WORKER_KINDS,
+    }),
     logger: deps.logger,
   });
 

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -17,6 +17,7 @@ import type {
   BundledSkillsStatus,
   Logger,
   SystemDiagnostics,
+  WorkerStatusSnapshot,
 } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
@@ -46,6 +47,7 @@ export interface WebInvokerDispatchDeps {
   getSystemDiagnostics?: () => SystemDiagnostics;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
   checkPrStatuses?: () => void | Promise<void>;
+  getWorkers?: () => WorkerStatusSnapshot;
   logger?: Logger;
 }
 
@@ -106,6 +108,9 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return orchestrator.getWorkflowStatus();
       case 'invoker:get-queue-status':
         return orchestrator.getQueueStatus();
+      case 'invoker:get-worker-status':
+      case 'invoker:get-workers':
+        return deps.getWorkers?.() ?? { generatedAt: new Date().toISOString(), workers: [] };
       case 'invoker:get-action-graph':
         return buildCurrentActionGraphSnapshot({
           orchestrator,

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -2,12 +2,14 @@ import type {
   WorkerActionHistoryRequest,
   WorkerActionHistoryResponse,
   WorkerActionSummary,
+  WorkerLogEntry,
   WorkerPolicyStatus,
   WorkerRecoverySummary,
+  WorkerSource,
   WorkerStatusEntry,
   WorkerStatusSnapshot,
 } from '@invoker/contracts';
-import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
+import type { SQLiteAdapter, TaskEvent, WorkerActionRecord } from '@invoker/data-store';
 import {
   AUTO_FIX_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
@@ -21,7 +23,7 @@ import {
 
 import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
 
-export const AUTO_STARTED_OWNER_WORKER_KINDS = [PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND, DISK_HEADROOM_WORKER_KIND] as const;
+export const AUTO_STARTED_OWNER_WORKER_KINDS = [AUTO_FIX_WORKER_KIND, PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND, DISK_HEADROOM_WORKER_KIND] as const;
 
 export interface WorkerRuntimeController {
   startAutoStartedWorkers(): void;
@@ -31,7 +33,7 @@ export interface WorkerRuntimeController {
   snapshot(): WorkerStatusSnapshot;
 }
 
-type WorkerStatusPersistence = Pick<SQLiteAdapter, 'listWorkerActions' | 'listWorkflows' | 'loadTasks' | 'getEvents'>;
+type WorkerStatusPersistence = Pick<SQLiteAdapter, 'listWorkerActions' | 'listTaskEvents' | 'listWorkflows' | 'loadTasks' | 'getEvents'>;
 
 const DEFAULT_WORKER_ACTION_HISTORY_LIMIT = 20;
 const MAX_WORKER_ACTION_HISTORY_LIMIT = 100;
@@ -122,12 +124,14 @@ export function createWorkerRuntimeController(options: {
     return buildWorkerStatusEntry({
       definitionKind: definition.kind,
       note: definition.note,
+      source: sourceForDefinition(definition),
       handle: handles.get(kind),
       stoppedAt: stoppedAtByKind.get(kind),
       autoStarts: options.autoStartKinds.includes(kind),
       policy: policyForKind(kind),
       persistence: options.persistence,
       canControl: options.canControl(),
+      runningKnown: true,
     });
   };
 
@@ -200,10 +204,12 @@ export function createLocalWorkerStatusSnapshot(options: {
     workers: options.registry.list().map((definition) => buildWorkerStatusEntry({
       definitionKind: definition.kind,
       note: definition.note,
+      source: sourceForDefinition(definition),
       autoStarts: options.autoStartKinds.includes(definition.kind),
       policy: 'unknown',
       persistence: options.persistence,
       canControl: false,
+      runningKnown: false,
     })),
   };
 }
@@ -212,21 +218,28 @@ export function createLocalWorkerStatusSnapshot(options: {
 function buildWorkerStatusEntry(args: {
   definitionKind: string;
   note: string;
+  source: WorkerSource;
   handle?: RuntimeHandle;
   stoppedAt?: string;
   autoStarts: boolean;
   policy: WorkerPolicyStatus;
   persistence: WorkerStatusPersistence;
   canControl: boolean;
+  runningKnown: boolean;
 }): WorkerStatusEntry {
   const lifecycle = args.handle
     ? args.handle.runtime.isRunning() ? 'running' : 'exited'
     : 'stopped';
   const controlDisabledReason = getControlDisabledReason(args.canControl);
   const runtime = args.handle?.runtime;
+  const rawActions = args.persistence.listWorkerActions({ workerKind: args.definitionKind, limit: 5 });
+  const recentActions = rawActions.map(toWorkerActionSummary).slice(0, 5);
   return {
     kind: args.definitionKind,
     note: args.note,
+    source: args.source,
+    availability: 'available',
+    ...(args.runningKnown ? { running: lifecycle === 'running' } : {}),
     ...(runtime ? { runtimeKind: runtime.identity.kind, instanceId: runtime.identity.instanceId } : {}),
     lifecycle,
     policy: args.policy,
@@ -236,9 +249,15 @@ function buildWorkerStatusEntry(args: {
     ...(controlDisabledReason ? { controlDisabledReason } : {}),
     ...(args.handle?.startedAt ? { startedAt: args.handle.startedAt } : {}),
     ...(args.stoppedAt ? { stoppedAt: args.stoppedAt } : {}),
-    recentActions: args.persistence.listWorkerActions({ workerKind: args.definitionKind, limit: 5 }).slice(0, 5).map(toWorkerActionSummary),
+    recentActions,
+    recentLogs: buildRecentWorkerLogs(args.definitionKind, args.persistence, rawActions),
     ...(args.definitionKind === AUTO_FIX_WORKER_KIND ? { recovery: toWorkerRecoverySummary(args.persistence) } : {}),
   };
+}
+
+
+function sourceForDefinition(definition: { kind: string; source?: 'built-in' | 'external' }): WorkerSource {
+  return definition.source ?? (BUILT_IN_WORKER_KINDS.has(definition.kind) ? 'built-in' : 'external');
 }
 
 function policyForKind(kind: string): WorkerPolicyStatus {
@@ -272,6 +291,97 @@ export function toWorkerActionSummary(action: WorkerActionRecord): WorkerActionS
     updatedAt: action.updatedAt,
     ...(action.completedAt ? { completedAt: action.completedAt } : {}),
   };
+}
+
+const AUTO_FIX_WORKER_EVENT_TYPES = [
+  'debug.auto-fix',
+  'recovery.worker.wakeup',
+  'recovery.worker.scan',
+  'recovery.worker.submit',
+  'recovery.worker.skip',
+] as const;
+
+function buildRecentWorkerLogs(
+  workerKind: string,
+  persistence: WorkerStatusPersistence,
+  actions: readonly WorkerActionRecord[],
+): WorkerLogEntry[] {
+  const actionLogs = actions.map(toWorkerActionLog);
+  const eventLogs = workerKind === AUTO_FIX_WORKER_KIND
+    ? listRecentAutoFixWorkerEvents(persistence).map((event) => toTaskEventLog(workerKind, event))
+    : [];
+
+  return [...actionLogs, ...eventLogs]
+    .sort((a, b) => workerLogTimestamp(b).localeCompare(workerLogTimestamp(a)) || a.id.localeCompare(b.id))
+    .slice(0, 10);
+}
+
+function listRecentAutoFixWorkerEvents(persistence: WorkerStatusPersistence): TaskEvent[] {
+  if (persistence.listTaskEvents) {
+    return persistence.listTaskEvents({
+      eventTypes: AUTO_FIX_WORKER_EVENT_TYPES,
+      sortBy: 'desc',
+      limit: 10,
+    });
+  }
+
+  const events: TaskEvent[] = [];
+  for (const workflow of persistence.listWorkflows()) {
+    for (const task of persistence.loadTasks(workflow.id)) {
+      for (const event of persistence.getEvents(task.id, 'desc', 20)) {
+        if (AUTO_FIX_WORKER_EVENT_TYPES.includes(event.eventType as typeof AUTO_FIX_WORKER_EVENT_TYPES[number])) {
+          events.push(event);
+        }
+      }
+    }
+  }
+  return events
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt) || String(b.id).localeCompare(String(a.id)))
+    .slice(0, 10);
+}
+
+function toWorkerActionLog(action: WorkerActionRecord): WorkerLogEntry {
+  return {
+    id: action.id,
+    workerKind: action.workerKind,
+    source: 'worker_actions',
+    actionType: action.actionType,
+    ...(action.workflowId ? { workflowId: action.workflowId } : {}),
+    ...(action.taskId ? { taskId: action.taskId } : {}),
+    subjectType: action.subjectType,
+    subjectId: action.subjectId,
+    externalKey: action.externalKey,
+    status: action.status,
+    ...(action.summary ? { summary: action.summary } : {}),
+    ...(action.payload !== undefined ? { payload: action.payload } : {}),
+    createdAt: action.createdAt,
+    updatedAt: action.updatedAt,
+  };
+}
+
+function toTaskEventLog(workerKind: string, event: TaskEvent): WorkerLogEntry {
+  return {
+    id: String(event.id),
+    workerKind,
+    source: 'task_events',
+    eventType: event.eventType,
+    taskId: event.taskId,
+    ...(event.payload !== undefined ? { payload: parseTaskEventPayload(event.payload) } : {}),
+    createdAt: event.createdAt,
+  };
+}
+
+function parseTaskEventPayload(payload: unknown): unknown {
+  if (typeof payload !== 'string') return payload;
+  try {
+    return JSON.parse(payload);
+  } catch {
+    return payload;
+  }
+}
+
+function workerLogTimestamp(log: WorkerLogEntry): string {
+  return log.updatedAt ?? log.createdAt;
 }
 
 function toWorkerRecoverySummary(persistence: WorkerStatusPersistence): WorkerRecoverySummary {


### PR DESCRIPTION
## Summary

Routes worker snapshot reads through the app owner, the web surface, and the IPC handlers, replacing the large inline block in main.ts.

Each caller returns the same worker snapshot, so the owner, web, and IPC paths share one route.

## Review Claim

Approve routing worker snapshot reads through the owner, web, and IPC handlers.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Every caller returns the same worker snapshot as before; this reorganizes the wiring without changing what callers receive.

## Slice Rationale

The route lands after its storage foundations and before the UI, kept separate from any surface change.

## Non-goals

Does not change the worker snapshot shape, add new fields, or change UI. Behavior for existing callers is unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1afe07895699adb35be51d2e51f1548d5cad92b7`
- Post-revert steps: None
- Data migration? No

</details>
