### PR TITLE
[UI Responsiveness Guardrails Step 1](2) Cover chat and terminal ui-perf metrics with focused tests

### DIFF
--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -49,6 +49,32 @@ describe('Invoker terminal (component)', () => {
     expect(screen.queryByText(/Unknown command/)).not.toBeInTheDocument();
   });
 
+  it('reports planning chat input and render perf through the bridge', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+    (mock.api.reportUiPerf as ReturnType<typeof vi.fn>).mockClear();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello' } });
+
+    await waitFor(() => {
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'planning_chat_input_change',
+        expect.objectContaining({
+          inputLength: 5,
+          deltaChars: 5,
+          transcriptLineCount: expect.any(Number),
+        }),
+      );
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'planning_chat_render_commit',
+        expect.objectContaining({
+          inputLength: 5,
+          transcriptLineCount: expect.any(Number),
+        }),
+      );
+    });
+  });
+
   it('sends plain language when Enter is pressed', async () => {
     render(<App />);
     await openPlanningTerminal();

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -357,6 +357,71 @@ describe('Terminal drawer (component)', () => {
     });
   });
 
+  it('reports terminal attach, seed, and live output burst perf through the bridge', async () => {
+    const session = makeTerminalSession('task-alpha', {
+      outputSnapshot: 'early line\n',
+    });
+    (mock.api.openTerminal as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      opened: true,
+      session,
+    });
+
+    render(<App />);
+    act(() => mock.setTasks([taskAlpha], workflows));
+    await selectWorkflow();
+    (mock.api.reportUiPerf as ReturnType<typeof vi.fn>).mockClear();
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+
+    await waitFor(() => {
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'embedded_terminal_attach',
+        expect.objectContaining({
+          sessionId: session.sessionId,
+          taskId: session.taskId,
+          hasOutputSnapshot: true,
+        }),
+      );
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'embedded_terminal_seed_output_snapshot',
+        expect.objectContaining({
+          sessionId: session.sessionId,
+          taskId: session.taskId,
+          charCount: 'early line\n'.length,
+        }),
+      );
+    });
+
+    vi.useFakeTimers();
+    try {
+      act(() => {
+        mock.fireTerminalOutput({
+          sessionId: session.sessionId,
+          taskId: session.taskId,
+          data: 'live line\n',
+        });
+      });
+      act(() => {
+        vi.advanceTimersByTime(250);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    await waitFor(() => {
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'embedded_terminal_output_burst',
+        expect.objectContaining({
+          sessionId: session.sessionId,
+          taskId: session.taskId,
+          eventCount: 1,
+          charCount: 'live line\n'.length,
+          maxChunkChars: 'live line\n'.length,
+        }),
+      );
+    });
+  });
+
   it('does not duplicate the replay snapshot when the same session re-renders', async () => {
     const session = makeTerminalSession('task-alpha', {
       outputSnapshot: 'replayed once\n',


### PR DESCRIPTION
## Summary

Focused renderer tests now exercise the planning chat and embedded terminal `ui-perf` markers.

The tests cover the metric names and rolled-up payload shape that later threshold work will depend on.

If the metric path regresses, this slice points at the broken bridge before thresholds add noise.

<details>
<summary>Review metadata</summary>

Review Claim: The new `ui-perf` metric path is exercised by focused renderer and owner tests.

Review Lane: proof

Review Unit: proof

Safety Invariant: Verification stays on the repo's existing `@invoker/ui` and `@invoker/app` test runners.

Slice Rationale: This proof is split from the instrumentation so metric-path regressions fail next to the numbers later slices depend on.

</details>

## Non-goals

- No product behavior changes.
- No thresholds, alerts, or merge gates are added.
- No owner runtime wiring changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx src/__tests__/terminal-drawer.test.tsx`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/owner-read-query.test.ts src/__tests__/headless-query-capture.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert d5cfea0a`
- Post-revert steps: None
- Data migration? No

</details>

<!--
## Review Claim

The new `ui-perf` metric path is exercised by focused renderer and owner tests.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Verification stays on the repo's existing `@invoker/ui` and `@invoker/app` test runners.

## Slice Rationale

This proof is split from the instrumentation so metric-path regressions fail next to the numbers later slices depend on.

-->
