### PR TITLE
[Planning chat auto-follow behavior](1) Keep transcript pinned while active

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -106,6 +106,7 @@ type PlanningSessionView = Omit<InAppPlanningSessionSummary, 'messages'> & {
   messages: InvokerTerminalLine[];
   input: string;
   busy: boolean;
+  conversationKey: string;
 };
 
 function makeInitialPlanningSession(now: string = new Date().toISOString()): PlanningSessionView {
@@ -120,6 +121,7 @@ function makeInitialPlanningSession(now: string = new Date().toISOString()): Pla
     busy: false,
     createdAt: now,
     updatedAt: now,
+    conversationKey: 'local-planning-session-1',
   };
 }
 
@@ -544,6 +546,7 @@ export function App() {
     () => planningSessions.find((session) => session.id === activePlanningSessionId) ?? planningSessions[0] ?? makeInitialPlanningSession(),
     [activePlanningSessionId, planningSessions],
   );
+  const activePlanningConversationKey = activePlanningSession.conversationKey;
   const terminalLines = activePlanningSession.messages;
   const planningInput = activePlanningSession.input;
   const planningSessionId = activePlanningSession.id.startsWith('local-') ? null : activePlanningSession.id;
@@ -2030,9 +2033,11 @@ export function App() {
     const index = nextPlanningSessionLocalIdRef.current;
     nextPlanningSessionLocalIdRef.current += 1;
     const now = new Date().toISOString();
+    const localId = `local-planning-session-${index}`;
     const session: PlanningSessionView = {
       ...makeInitialPlanningSession(now),
-      id: `local-planning-session-${index}`,
+      id: localId,
+      conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
     };
     nextTerminalLineIdRef.current += 1;
@@ -2866,6 +2871,7 @@ export function App() {
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto bg-gray-900 p-4">
           <InvokerTerminal
+            activeConversationKey={activePlanningConversationKey}
             lines={terminalLines}
             busy={activePlanningSessionBusy}
             value={planningInput}
@@ -3112,6 +3118,7 @@ export function App() {
           className="fixed inset-0 z-50 flex flex-col bg-gray-950"
         >
           <InvokerTerminal
+            activeConversationKey={activePlanningConversationKey}
             lines={terminalLines}
             busy={activePlanningSessionBusy}
             value={planningInput}

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -9,8 +9,9 @@ vi.mock('@xyflow/react', async () => {
   return createReactFlowMock();
 });
 
-// Dynamic import is required so App sees the hoisted @xyflow/react mock.
+// Dynamic imports are required so modules see the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
+const { InvokerTerminal } = await import('../components/InvokerTerminal.js');
 
 describe('Invoker terminal (component)', () => {
   let mock: MockInvoker;
@@ -310,5 +311,86 @@ describe('Invoker terminal (component)', () => {
       draftPlanAvailable: false,
     });
     await waitFor(() => expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('second session request'));
+  });
+
+  it('follows new transcript lines until the user scrolls away from the bottom', async () => {
+    const props = {
+      activeConversationKey: 'chat-1',
+      lines: [{ id: 1, text: 'First line', role: 'system' as const }],
+      busy: false,
+      value: '',
+      selectedPresetKey: 'codex',
+      presetOptions: [{ key: 'codex', label: 'Codex' }],
+      draftPlanAvailable: false,
+      onValueChange: vi.fn(),
+      onSubmit: vi.fn(),
+      onSubmitDraft: vi.fn(),
+      onPresetChange: vi.fn(),
+      onExpand: vi.fn(),
+    };
+    const { rerender } = render(<InvokerTerminal {...props} />);
+    const transcript = screen.getByTestId('invoker-terminal-transcript');
+    Object.defineProperty(transcript, 'clientHeight', { configurable: true, value: 100 });
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 400 });
+
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 500 });
+    rerender(<InvokerTerminal {...props} lines={[...props.lines, { id: 2, text: 'Second line', role: 'assistant' as const }]} />);
+
+    await waitFor(() => expect(transcript.scrollTop).toBe(500));
+
+    transcript.scrollTop = 50;
+    fireEvent.scroll(transcript);
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 600 });
+    rerender(<InvokerTerminal {...props} lines={[
+      ...props.lines,
+      { id: 2, text: 'Second line', role: 'assistant' as const },
+      { id: 3, text: 'Third line', role: 'assistant' as const },
+    ]} />);
+
+    expect(transcript.scrollTop).toBe(50);
+
+    transcript.scrollTop = 500;
+    fireEvent.scroll(transcript);
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 700 });
+    rerender(<InvokerTerminal {...props} lines={[
+      ...props.lines,
+      { id: 2, text: 'Second line', role: 'assistant' as const },
+      { id: 3, text: 'Third line', role: 'assistant' as const },
+      { id: 4, text: 'Fourth line', role: 'assistant' as const },
+    ]} />);
+
+    await waitFor(() => expect(transcript.scrollTop).toBe(700));
+  });
+
+  it('resets transcript follow mode when the active planning conversation changes', async () => {
+    const props = {
+      activeConversationKey: 'chat-1',
+      lines: [{ id: 1, text: 'First chat', role: 'system' as const }],
+      busy: false,
+      value: '',
+      selectedPresetKey: 'codex',
+      presetOptions: [{ key: 'codex', label: 'Codex' }],
+      draftPlanAvailable: false,
+      onValueChange: vi.fn(),
+      onSubmit: vi.fn(),
+      onSubmitDraft: vi.fn(),
+      onPresetChange: vi.fn(),
+      onExpand: vi.fn(),
+    };
+    const { rerender } = render(<InvokerTerminal {...props} />);
+    const transcript = screen.getByTestId('invoker-terminal-transcript');
+    Object.defineProperty(transcript, 'clientHeight', { configurable: true, value: 100 });
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 400 });
+
+    transcript.scrollTop = 50;
+    fireEvent.scroll(transcript);
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 500 });
+    rerender(<InvokerTerminal
+      {...props}
+      activeConversationKey="chat-2"
+      lines={[{ id: 2, text: 'Second chat', role: 'system' as const }]}
+    />);
+
+    await waitFor(() => expect(transcript.scrollTop).toBe(500));
   });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 export interface InvokerTerminalLine {
   id: number;
@@ -10,6 +10,12 @@ export interface InvokerTerminalLine {
 interface PlanningPresetOptionView {
   key: string;
   label: string;
+}
+
+const TRANSCRIPT_BOTTOM_TOLERANCE_PX = 32;
+
+function isTranscriptNearBottom(element: HTMLDivElement): boolean {
+  return element.scrollHeight - element.scrollTop - element.clientHeight <= TRANSCRIPT_BOTTOM_TOLERANCE_PX;
 }
 
 interface InvokerTerminalProps {
@@ -30,6 +36,7 @@ interface InvokerTerminalProps {
   onExpand: () => void;
   onCloseExpanded?: () => void;
   onCollapse?: () => void;
+  activeConversationKey: string;
 }
 
 interface SubmitErrorView {
@@ -55,8 +62,34 @@ export function InvokerTerminal({
   onExpand,
   onCloseExpanded,
   onCollapse,
+  activeConversationKey,
 }: InvokerTerminalProps): JSX.Element {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const transcriptRef = useRef<HTMLDivElement | null>(null);
+  const [shouldFollowTranscript, setShouldFollowTranscript] = useState(true);
+
+  const scrollTranscriptToBottom = useCallback((): void => {
+    const transcript = transcriptRef.current;
+    if (!transcript) return;
+    transcript.scrollTop = transcript.scrollHeight;
+  }, []);
+
+  useLayoutEffect(() => {
+    setShouldFollowTranscript(true);
+    scrollTranscriptToBottom();
+  }, [activeConversationKey, scrollTranscriptToBottom]);
+
+  useLayoutEffect(() => {
+    if (shouldFollowTranscript) {
+      scrollTranscriptToBottom();
+    }
+  }, [lines.length, scrollTranscriptToBottom, shouldFollowTranscript]);
+
+  const handleTranscriptScroll = useCallback((): void => {
+    const transcript = transcriptRef.current;
+    if (!transcript) return;
+    setShouldFollowTranscript(isTranscriptNearBottom(transcript));
+  }, []);
 
   useEffect(() => {
     if (!busy && !readOnly) {
@@ -113,7 +146,9 @@ export function InvokerTerminal({
       </div>
 
       <div
+        ref={transcriptRef}
         data-testid="invoker-terminal-transcript"
+        onScroll={handleTranscriptScroll}
         className={`min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-5 text-sm ${expanded ? '' : 'max-h-64'}`}
       >
         {lines.map((line) => {


### PR DESCRIPTION
## Summary

The planning chat transcript now follows new replies while the active conversation is already near the bottom.

When a user scrolls upward, the transcript holds position so older context stays readable.

Changing to another planning chat re-arms follow mode for that conversation.

<details>
<summary>Review metadata</summary>

Review Claim: The planning terminal owns local transcript follow state and resets it when the active conversation changes.

Review Lane: behavior

Review Unit: activation-surface

Safety Invariant: This only touches renderer-side planning terminal state and its focused UI tests.

Slice Rationale: The behavior is isolated from backend planning and later proof-only work.

</details>

## Non-goals

- Do not change planner backend behavior.
- Do not change planning persistence or workflow submission.
- Do not change non-planning terminal surfaces.

## Architecture

### Before

`InvokerTerminal` rendered transcript lines without knowing when the selected planning conversation changed or whether the user had scrolled away.

### After

`App` passes a stable conversation key into `InvokerTerminal`. The terminal uses local follow state to scroll new lines only while the transcript remains near the bottom.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`

</details>

## Visual Proof

![Planning terminal transcript with draft-ready composer](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-22a4b3/stacked-workflows.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge_commit_sha>`
- Post-revert steps: None
- Data migration? No

</details>
