### PR TITLE
[Disk headroom] Monitor local and remote disk usage

### DIFF
--- a/packages/app/src/__tests__/disk-headroom-monitor.test.ts
+++ b/packages/app/src/__tests__/disk-headroom-monitor.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildRemoteDfScript,
+  runDiskHeadroomCheck,
+  type DiskHeadroomMonitorDeps,
+  type RemoteDiskTarget,
+} from '../disk-headroom-monitor.js';
+
+function makeLogger() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: () => logger,
+  };
+  return logger;
+}
+
+/** `df -P -k` output for a filesystem at `pct`% used. */
+function dfAt(pct: number): string {
+  return `Filesystem 1024-blocks Used Available Capacity Mounted on
+/dev/vda1 100 ${pct} ${100 - pct} ${pct}% /`;
+}
+
+const THRESHOLDS = { warnPercent: 85, criticalPercent: 95 };
+
+function baseDeps(overrides: Partial<DiskHeadroomMonitorDeps>): DiskHeadroomMonitorDeps {
+  return {
+    logger: makeLogger() as unknown as DiskHeadroomMonitorDeps['logger'],
+    thresholds: THRESHOLDS,
+    localPath: '/tmp',
+    remoteTargets: [],
+    ...overrides,
+  };
+}
+
+const CONN = { host: 'h', user: 'u', sshKeyPath: '/k' };
+
+describe('runDiskHeadroomCheck — local disk', () => {
+  it('warns (not errors) between the warn and critical thresholds', async () => {
+    const deps = baseDeps({
+      runLocalDf: async () => dfAt(90),
+    });
+
+    const results = await runDiskHeadroomCheck(deps);
+    expect(results).toHaveLength(1);
+    expect(results[0]?.level).toBe('warn');
+
+    expect((deps.logger as any).warn).toHaveBeenCalled();
+    expect((deps.logger as any).error).not.toHaveBeenCalled();
+  });
+
+  it('errors at/above the critical threshold', async () => {
+    const deps = baseDeps({
+      runLocalDf: async () => dfAt(95),
+    });
+
+    const results = await runDiskHeadroomCheck(deps);
+    expect(results[0]?.level).toBe('critical');
+    expect((deps.logger as any).error).toHaveBeenCalled();
+  });
+
+  it('stays quiet (debug only) below the warn threshold', async () => {
+    const deps = baseDeps({
+      runLocalDf: async () => dfAt(10),
+    });
+
+    const results = await runDiskHeadroomCheck(deps);
+    expect(results[0]?.level).toBe('ok');
+    expect((deps.logger as any).warn).not.toHaveBeenCalled();
+    expect((deps.logger as any).error).not.toHaveBeenCalled();
+    expect((deps.logger as any).debug).toHaveBeenCalled();
+  });
+
+  it('logs and swallows a df failure without throwing', async () => {
+    const deps = baseDeps({
+      runLocalDf: async () => {
+        throw new Error('no df');
+      },
+    });
+
+    await expect(runDiskHeadroomCheck(deps)).resolves.toEqual([]);
+    expect((deps.logger as any).error).toHaveBeenCalled();
+  });
+
+  it('logs unparseable df output', async () => {
+    const deps = baseDeps({
+      runLocalDf: async () => 'not df',
+    });
+
+    await expect(runDiskHeadroomCheck(deps)).resolves.toEqual([]);
+    expect((deps.logger as any).error).toHaveBeenCalled();
+  });
+
+  it('never lets a wedged audit sink mask the alert', async () => {
+    const deps = baseDeps({
+      runLocalDf: async () => dfAt(95),
+      writeActivityLog: () => {
+        throw new Error('wedged');
+      },
+    });
+
+    const results = await runDiskHeadroomCheck(deps);
+    expect(results[0]?.level).toBe('critical');
+    expect((deps.logger as any).error).toHaveBeenCalled();
+  });
+});
+
+describe('runDiskHeadroomCheck — remote targets', () => {
+  it('checks remotes in parallel and includes successful evaluations', async () => {
+    const remoteTargets: RemoteDiskTarget[] = [
+      { name: 'a', connection: CONN, remotePath: '~/.invoker' },
+      { name: 'b', connection: CONN, remotePath: '~/.invoker' },
+    ];
+
+    const deps = baseDeps({
+      remoteTargets,
+      runLocalDf: async () => dfAt(10),
+      runRemoteDf: async (t) => (t.name === 'a' ? dfAt(90) : dfAt(10)),
+    });
+
+    const results = await runDiskHeadroomCheck(deps);
+    expect(results.map((r) => r.level).sort()).toEqual(['ok', 'ok', 'warn'].sort());
+    expect((deps.logger as any).warn).toHaveBeenCalled();
+  });
+
+  it('logs and swallows a remote df failure', async () => {
+    const deps = baseDeps({
+      remoteTargets: [{ name: 'a', connection: CONN, remotePath: '~/.invoker' }],
+      runLocalDf: async () => dfAt(10),
+      runRemoteDf: async () => {
+        throw new Error('remote down');
+      },
+    });
+
+    const results = await runDiskHeadroomCheck(deps);
+    expect(results).toHaveLength(1);
+    expect((deps.logger as any).error).toHaveBeenCalled();
+  });
+});
+
+describe('buildRemoteDfScript', () => {
+  it('normalizes a leading tilde before running df', () => {
+    const script = buildRemoteDfScript('~/.invoker');
+    expect(script).toContain('WT=');
+    expect(script).toContain('HOME');
+    expect(script).toContain('df -P -k');
+  });
+});

--- a/packages/app/src/__tests__/disk-headroom.test.ts
+++ b/packages/app/src/__tests__/disk-headroom.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_DISK_CHECK_INTERVAL_MS,
+  DEFAULT_DISK_CRITICAL_PERCENT,
+  DEFAULT_DISK_WARN_PERCENT,
+  evaluateDiskHeadroom,
+  parseDfOutput,
+  resolveDiskCheckIntervalMs,
+  resolveDiskHeadroomThresholds,
+} from '../disk-headroom.js';
+
+const LINUX_DF = `Filesystem     1024-blocks     Used Available Capacity Mounted on
+/dev/vda1         81071768 34567890  46503878      43% /`;
+
+describe('parseDfOutput', () => {
+  it('parses a standard linux `df -P -k` row', () => {
+    const parsed = parseDfOutput(LINUX_DF);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.filesystem).toBe('/dev/vda1');
+    expect(parsed?.usedPercent).toBe(43);
+    expect(parsed?.mountedOn).toBe('/');
+  });
+
+  it('rejoins a mount point that contains spaces', () => {
+    const out = `Filesystem 1024-blocks Used Available Capacity Mounted on
+/dev/disk2s1 100 50 50 50% /Volumes/My Drive`;
+    const parsed = parseDfOutput(out);
+    expect(parsed?.mountedOn).toBe('/Volumes/My Drive');
+  });
+
+  it('reads the capacity column as the used percent', () => {
+    const out = `Filesystem 1024-blocks Used Available Capacity Mounted on
+/dev/vda1 100 90 10 90% /`;
+    expect(parseDfOutput(out)?.usedPercent).toBe(90);
+  });
+
+  it('returns null for header-only output', () => {
+    expect(parseDfOutput('Filesystem 1024-blocks Used Available Capacity Mounted on')).toBeNull();
+  });
+
+  it('returns null for malformed / short rows', () => {
+    expect(parseDfOutput('Filesystem 1024-blocks Used')).toBeNull();
+  });
+});
+
+describe('evaluateDiskHeadroom', () => {
+  const thresholds = { warnPercent: 85, criticalPercent: 95 };
+  const usage = (usedPercent: number) => ({
+    filesystem: '/dev/vda1',
+    blocks1024: 100,
+    usedBlocks1024: usedPercent,
+    availableBlocks1024: 100 - usedPercent,
+    usedPercent,
+    mountedOn: '/',
+  });
+
+  it('is ok below the warn threshold', () => {
+    expect(evaluateDiskHeadroom(usage(84), thresholds, 'local /').level).toBe('ok');
+  });
+
+  it('warns at exactly the warn threshold', () => {
+    expect(evaluateDiskHeadroom(usage(85), thresholds, 'local /').level).toBe('warn');
+  });
+
+  it('stays warn between warn and critical', () => {
+    expect(evaluateDiskHeadroom(usage(94), thresholds, 'local /').level).toBe('warn');
+  });
+
+  it('is critical at exactly the critical threshold and above', () => {
+    expect(evaluateDiskHeadroom(usage(95), thresholds, 'local /').level).toBe('critical');
+    expect(evaluateDiskHeadroom(usage(99), thresholds, 'local /').level).toBe('critical');
+  });
+});
+
+describe('resolveDiskHeadroomThresholds', () => {
+  it('defaults to 85/95', () => {
+    expect(resolveDiskHeadroomThresholds({} as NodeJS.ProcessEnv)).toEqual({
+      warnPercent: DEFAULT_DISK_WARN_PERCENT,
+      criticalPercent: DEFAULT_DISK_CRITICAL_PERCENT,
+    });
+  });
+
+  it('reads from env and clamps critical >= warn', () => {
+    expect(
+      resolveDiskHeadroomThresholds({
+        INVOKER_DISK_WARN_PERCENT: '90',
+        INVOKER_DISK_CRITICAL_PERCENT: '80',
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ warnPercent: 90, criticalPercent: 90 });
+  });
+
+  it('ignores invalid values', () => {
+    expect(
+      resolveDiskHeadroomThresholds({
+        INVOKER_DISK_WARN_PERCENT: 'nope',
+        INVOKER_DISK_CRITICAL_PERCENT: '-1',
+      } as NodeJS.ProcessEnv),
+    ).toEqual({ warnPercent: DEFAULT_DISK_WARN_PERCENT, criticalPercent: DEFAULT_DISK_CRITICAL_PERCENT });
+  });
+});
+
+describe('resolveDiskCheckIntervalMs', () => {
+  it('defaults to 5 minutes', () => {
+    expect(resolveDiskCheckIntervalMs({} as NodeJS.ProcessEnv)).toBe(DEFAULT_DISK_CHECK_INTERVAL_MS);
+  });
+
+  it('reads a positive integer from env', () => {
+    expect(resolveDiskCheckIntervalMs({ INVOKER_DISK_CHECK_INTERVAL_MS: '1234' } as NodeJS.ProcessEnv)).toBe(1234);
+  });
+
+  it('falls back for invalid or non-positive values', () => {
+    expect(resolveDiskCheckIntervalMs({ INVOKER_DISK_CHECK_INTERVAL_MS: '0' } as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_DISK_CHECK_INTERVAL_MS,
+    );
+    expect(resolveDiskCheckIntervalMs({ INVOKER_DISK_CHECK_INTERVAL_MS: '-5' } as NodeJS.ProcessEnv)).toBe(
+      DEFAULT_DISK_CHECK_INTERVAL_MS,
+    );
+  });
+});

--- a/packages/app/src/disk-headroom-monitor.ts
+++ b/packages/app/src/disk-headroom-monitor.ts
@@ -1,0 +1,213 @@
+/**
+ * Disk-headroom monitor: the I/O + logging shell around the pure evaluation in
+ * `disk-headroom.ts`.
+ *
+ * This module never blocks scheduling or fails tasks. It exists to surface
+ * early warnings (e.g. 85% used) before a box reaches 100% and everything
+ * wedges.
+ */
+
+import { execFile } from 'node:child_process';
+
+import type { Logger } from '@invoker/contracts';
+import {
+  bashNormalizeTildePath,
+  buildSshConnectionArgs,
+  execRemoteCapture,
+  shellPosixSingleQuote,
+  type SshTargetConnection,
+} from '@invoker/execution-engine';
+
+import {
+  evaluateDiskHeadroom,
+  parseDfOutput,
+  type DiskHeadroomEvaluation,
+  type DiskHeadroomThresholds,
+} from './disk-headroom.js';
+
+const MODULE = 'disk-headroom';
+const DF_ARGS = ['-P', '-k'];
+const LOCAL_DF_TIMEOUT_MS = 10_000;
+
+export interface RemoteDiskTarget {
+  name: string;
+  connection: SshTargetConnection;
+  remotePath: string;
+}
+
+export type ActivityLogLevel = 'info' | 'warn' | 'error';
+
+export interface DiskHeadroomMonitorDeps {
+  logger: Logger;
+  thresholds: DiskHeadroomThresholds;
+  localPath: string;
+  remoteTargets: RemoteDiskTarget[];
+
+  runLocalDf?: (path: string) => Promise<string>;
+  runRemoteDf?: (target: RemoteDiskTarget) => Promise<string>;
+
+  writeActivityLog?: (source: string, level: ActivityLogLevel, message: string) => void;
+}
+
+function defaultRunLocalDf(path: string): Promise<string> {
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
+
+  execFile('df', [...DF_ARGS, path], { timeout: LOCAL_DF_TIMEOUT_MS }, (err, stdout, stderr) => {
+    if (err) {
+      const suffix = stderr?.trim() ? `; stderr=${stderr.trim()}` : '';
+      reject(new Error(`df failed for ${path}: ${err.message}${suffix}`));
+      return;
+    }
+
+    resolve(stdout);
+  });
+
+  return promise;
+}
+
+/**
+ * Build the remote `df` script. Expands a leading `~` to `$HOME` on the remote
+ * (config paths like `~/.invoker`) before df'ing the single-quoted path.
+ */
+export function buildRemoteDfScript(path: string): string {
+  const quoted = shellPosixSingleQuote(path);
+
+  return [
+    'set -euo pipefail',
+    `WT=${quoted}`,
+    bashNormalizeTildePath('WT'),
+    'df -P -k "$WT"',
+  ].join('\n');
+}
+
+function defaultRunRemoteDf(target: RemoteDiskTarget): Promise<string> {
+  const sshArgs = buildSshConnectionArgs(target.connection, { batchMode: true });
+  const script = buildRemoteDfScript(target.remotePath);
+  return execRemoteCapture({ sshArgs, script, phase: `disk-headroom:${target.name}` });
+}
+
+function auditLog(
+  deps: DiskHeadroomMonitorDeps,
+  level: ActivityLogLevel,
+  message: string,
+): void {
+  if (!deps.writeActivityLog) return;
+
+  try {
+    deps.writeActivityLog(MODULE, level, message);
+  } catch (err) {
+    deps.logger.debug('Disk headroom: audit sink failed', {
+      module: MODULE,
+      error: String(err),
+    });
+  }
+}
+
+function emit(deps: DiskHeadroomMonitorDeps, result: DiskHeadroomEvaluation): void {
+  const fields = {
+    module: MODULE,
+    label: result.label,
+    usedPercent: result.usage.usedPercent,
+    filesystem: result.usage.filesystem,
+    mountedOn: result.usage.mountedOn,
+    warnPercent: result.thresholds.warnPercent,
+    criticalPercent: result.thresholds.criticalPercent,
+  };
+
+  if (result.level === 'critical') {
+    deps.logger.error(result.message, fields);
+    auditLog(deps, 'error', result.message);
+    return;
+  }
+
+  if (result.level === 'warn') {
+    deps.logger.warn(result.message, fields);
+    auditLog(deps, 'warn', result.message);
+    return;
+  }
+
+  deps.logger.debug(result.message, fields);
+}
+
+async function checkOne(
+  deps: DiskHeadroomMonitorDeps,
+  label: string,
+  runDf: () => Promise<string>,
+): Promise<DiskHeadroomEvaluation | null> {
+  let output: string;
+
+  try {
+    output = await runDf();
+  } catch (err) {
+    deps.logger.error('Disk headroom: df failed', {
+      module: MODULE,
+      label,
+      error: String(err),
+    });
+    return null;
+  }
+
+  const usage = parseDfOutput(output);
+  if (!usage) {
+    deps.logger.error('Disk headroom: failed to parse df output', {
+      module: MODULE,
+      label,
+      output,
+    });
+    return null;
+  }
+
+  const result = evaluateDiskHeadroom(usage, deps.thresholds, label);
+  emit(deps, result);
+  return result;
+}
+
+/**
+ * Run one disk-headroom pass: the local disk, then every remote target in
+ * parallel. Returns the evaluations that succeeded (parse/df failures are
+ * logged and omitted). Never throws.
+ */
+export async function runDiskHeadroomCheck(
+  deps: DiskHeadroomMonitorDeps,
+): Promise<DiskHeadroomEvaluation[]> {
+  const runLocal = deps.runLocalDf ?? defaultRunLocalDf;
+  const runRemote = deps.runRemoteDf ?? defaultRunRemoteDf;
+
+  const localLabel = `local ${deps.localPath}`;
+  const local = await checkOne(deps, localLabel, () => runLocal(deps.localPath));
+
+  const remote = await Promise.all(
+    deps.remoteTargets.map((t) => {
+      const label = `remote ${t.name} ${t.remotePath}`;
+      return checkOne(deps, label, () => runRemote(t));
+    }),
+  );
+
+  return [local, ...remote].filter((x): x is DiskHeadroomEvaluation => Boolean(x));
+}
+
+export interface DiskHeadroomMonitorHandle {
+  stop: () => void;
+}
+
+/**
+ * Start the periodic monitor. Runs an immediate check (so a box that starts
+ * already-full alerts at once), then repeats on `intervalMs`. The interval is
+ * `unref`'d so it never keeps the process alive on its own.
+ */
+export function startDiskHeadroomMonitor(
+  deps: DiskHeadroomMonitorDeps,
+  intervalMs: number,
+): DiskHeadroomMonitorHandle {
+  void runDiskHeadroomCheck(deps);
+
+  const timer = setInterval(() => {
+    void runDiskHeadroomCheck(deps);
+  }, intervalMs);
+
+  timer.unref?.();
+
+  return {
+    stop: () => clearInterval(timer),
+  };
+}

--- a/packages/app/src/disk-headroom.ts
+++ b/packages/app/src/disk-headroom.ts
@@ -1,0 +1,144 @@
+/**
+ * Pure disk-headroom evaluation.
+ *
+ * Parses `df -P -k <path>` output and classifies filesystem usage against
+ * warn/critical thresholds. No I/O here — the caller runs `df` (locally via
+ * child_process or remotely over SSH) and feeds the text in, which keeps the
+ * classification logic trivially unit-testable.
+ *
+ * This is observability only: it never blocks scheduling or fails tasks. Its
+ * value is warning at ~85% used, while the disk (and the DB the alert is
+ * written to) still works, instead of discovering a 100%-full box after tasks
+ * have already wedged.
+ */
+
+export interface DiskUsage {
+  filesystem: string;
+  blocks1024: number;
+  usedBlocks1024: number;
+  availableBlocks1024: number;
+  usedPercent: number;
+  mountedOn: string;
+}
+
+export type DiskHeadroomLevel = 'ok' | 'warn' | 'critical';
+
+export interface DiskHeadroomThresholds {
+  warnPercent: number;
+  criticalPercent: number;
+}
+
+export interface DiskHeadroomEvaluation {
+  label: string;
+  level: DiskHeadroomLevel;
+  usage: DiskUsage;
+  thresholds: DiskHeadroomThresholds;
+  message: string;
+}
+
+/**
+ * Parse the data row of `df -P -k <path>`. The `-P` flag guarantees one line
+ * per filesystem. A mount point may contain spaces; everything after the 5th
+ * column is rejoined into the mount path.
+ */
+export function parseDfOutput(output: string): DiskUsage | null {
+  const lines = output
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+
+  if (lines.length < 2) return null;
+
+  // `df -P -k <path>` should emit one header line + one data line.
+  // Use the last non-empty line as the data row and ignore the header.
+  const dataLine = lines[lines.length - 1];
+  if (!dataLine) return null;
+  if (/^Filesystem/i.test(dataLine)) return null;
+
+  const parts = dataLine.split(/\s+/);
+  if (parts.length < 6) return null;
+
+  const filesystem = parts[0] ?? '';
+  const blocks1024 = Number.parseInt(parts[1] ?? '', 10);
+  const usedBlocks1024 = Number.parseInt(parts[2] ?? '', 10);
+  const availableBlocks1024 = Number.parseInt(parts[3] ?? '', 10);
+  const rawPercent = (parts[4] ?? '').replace(/%$/, '');
+  const usedPercent = Number.parseInt(rawPercent, 10);
+  const mountedOn = parts.slice(5).join(' ');
+
+  if (!filesystem) return null;
+  if (![blocks1024, usedBlocks1024, availableBlocks1024, usedPercent].every((n) => Number.isFinite(n))) return null;
+  if (usedPercent < 0 || usedPercent > 100) return null;
+
+  return {
+    filesystem,
+    blocks1024,
+    usedBlocks1024,
+    availableBlocks1024,
+    usedPercent,
+    mountedOn,
+  };
+}
+
+export function evaluateDiskHeadroom(
+  usage: DiskUsage,
+  thresholds: DiskHeadroomThresholds,
+  label: string,
+): DiskHeadroomEvaluation {
+  const warnPercent = thresholds.warnPercent;
+  const criticalPercent = thresholds.criticalPercent;
+
+  const level: DiskHeadroomLevel =
+    usage.usedPercent >= criticalPercent
+      ? 'critical'
+      : usage.usedPercent >= warnPercent
+        ? 'warn'
+        : 'ok';
+
+  const totalGb = Math.max(0, usage.blocks1024) / (1024 * 1024);
+  const usedGb = Math.max(0, usage.usedBlocks1024) / (1024 * 1024);
+  const availGb = Math.max(0, usage.availableBlocks1024) / (1024 * 1024);
+
+  const message =
+    level === 'ok'
+      ? `${label}: ${usage.usedPercent}% used`
+      : `${label}: ${usage.usedPercent}% used (used=${usedGb.toFixed(1)}GB avail=${availGb.toFixed(1)}GB total=${totalGb.toFixed(1)}GB, warn>=${warnPercent}% critical>=${criticalPercent}%)`;
+
+  return { label, level, usage, thresholds: { warnPercent, criticalPercent }, message };
+}
+
+export const DEFAULT_DISK_WARN_PERCENT = 85;
+export const DEFAULT_DISK_CRITICAL_PERCENT = 95;
+export const DEFAULT_DISK_CHECK_INTERVAL_MS = 5 * 60 * 1000;
+
+function readPercent(raw: string | undefined, fallback: number): number {
+  const text = raw?.trim();
+  if (!text) return fallback;
+  const parsed = Number.parseInt(text, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  if (parsed < 0 || parsed > 100) return fallback;
+  return parsed;
+}
+
+/**
+ * Resolve warn/critical thresholds from env (`INVOKER_DISK_WARN_PERCENT`,
+ * `INVOKER_DISK_CRITICAL_PERCENT`), defaulting to 85/95. `criticalPercent` is
+ * clamped to be >= `warnPercent` so the two tiers can never invert.
+ */
+export function resolveDiskHeadroomThresholds(
+  env: NodeJS.ProcessEnv = process.env,
+): DiskHeadroomThresholds {
+  const warnPercent = readPercent(env.INVOKER_DISK_WARN_PERCENT, DEFAULT_DISK_WARN_PERCENT);
+  const configuredCritical = readPercent(env.INVOKER_DISK_CRITICAL_PERCENT, DEFAULT_DISK_CRITICAL_PERCENT);
+  const criticalPercent = Math.max(configuredCritical, warnPercent);
+  return { warnPercent, criticalPercent };
+}
+
+/** Resolve the check interval (ms) from `INVOKER_DISK_CHECK_INTERVAL_MS`, default 5 min. */
+export function resolveDiskCheckIntervalMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.INVOKER_DISK_CHECK_INTERVAL_MS?.trim();
+  if (!raw) return DEFAULT_DISK_CHECK_INTERVAL_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_DISK_CHECK_INTERVAL_MS;
+  return parsed;
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -225,6 +225,16 @@ import {
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { evaluateExecutingStall } from './executing-stall.js';
 import {
+  resolveDiskCheckIntervalMs,
+  resolveDiskHeadroomThresholds,
+} from './disk-headroom.js';
+import {
+  startDiskHeadroomMonitor,
+  type DiskHeadroomMonitorHandle,
+  type RemoteDiskTarget,
+} from './disk-headroom-monitor.js';
+
+import {
   buildFixWithAgentMutationArgs,
   buildHeadlessFixArgs,
   listOpenFixIntentsForTask,
@@ -471,6 +481,8 @@ const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promi
  */
 let activeMutationContext: WorkflowMutationContext | undefined;
 let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
+let diskHeadroomMonitor: DiskHeadroomMonitorHandle | null = null;
+
 let writerLock: DbWriterLockResult | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
 const appProcessStartedAt = Date.now();
@@ -806,6 +818,34 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
       logger.info(`hourly snapshots enabled (interval=${hourlyMs}ms)`, { module: 'backup' });
     }
   }
+  if (!readOnly && !diskHeadroomMonitor) {
+    const thresholds = resolveDiskHeadroomThresholds();
+    const intervalMs = resolveDiskCheckIntervalMs();
+    const remoteTargets: RemoteDiskTarget[] = Object.entries(invokerConfig.remoteTargets ?? {}).map(
+      ([name, target]) => ({
+        name,
+        connection: {
+          host: target.host,
+          user: target.user,
+          port: target.port,
+          sshKeyPath: target.sshKeyPath,
+        },
+        remotePath: '~/.invoker',
+      }),
+    );
+
+    diskHeadroomMonitor = startDiskHeadroomMonitor(
+      {
+        logger,
+        thresholds,
+        localPath: invokerHomeRoot,
+        remoteTargets,
+        writeActivityLog: (source, level, message) => persistence.writeActivityLog(source, level, message),
+      },
+      intervalMs,
+    );
+  }
+
   // Compose runtime services from persistence-backed adapters.
   // Headless startup routes through composeHeadlessStartup so the
   // headless path has an explicit composition entry point.
@@ -5251,6 +5291,11 @@ function createEmbeddedTerminalBackendFromConfig(
           clearInterval(hourlyBackupInterval);
           hourlyBackupInterval = null;
         }
+        if (diskHeadroomMonitor) {
+          diskHeadroomMonitor.stop();
+          diskHeadroomMonitor = null;
+        }
+
         embeddedTerminalManager.closeAll();
         if (executorRegistry) {
           await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -15,6 +15,13 @@ export * from './docker-executor.js';
 export * from './worktree-executor.js';
 export * from './merge-gate-executor.js';
 export * from './ssh-executor.js';
+export {
+  buildSshConnectionArgs,
+  buildSshTransportOptions,
+  type SshTargetConnection,
+} from './ssh-transport-options.js';
+export { bashNormalizeTildePath, execRemoteCapture, shellPosixSingleQuote } from './ssh-git-exec.js';
+
 export * from './repo-pool.js';
 export * from './registry.js';
 export * from './task-runner.js';


### PR DESCRIPTION
## Summary
- Add best-effort disk utilization checks for the owner host and configured SSH targets.
- Log warn/critical at configurable thresholds (defaults 85%/95% used); never blocks scheduling.

## Review Claim
Surface disk pressure early (local or remote `~/.invoker`) so the owner doesn’t wedge on 100% full disks.

## Review Lane
behavior

## Review Unit
routing

## Safety Invariant
Monitoring is alert-only. Failures to run `df` or SSH are logged and ignored; workflow mutations and scheduling are never blocked.

## Slice Rationale
Slice 1 adds the disk evaluation + df parsing + check runner. Slice 2 runs it inside the worker framework.

## Non-goals
- Enforcing headroom (no blocking), automatic cleanup, or UI changes.
- Persisting disk metrics beyond existing logs/activity entries.

## Test Plan
<details>
<summary>Test Plan</summary>

- `pnpm exec vitest run src/__tests__/disk-headroom.test.ts src/__tests__/disk-headroom-monitor.test.ts`
- `pnpm run check:types`

</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

- Revert this PR.
- No schema/data migrations; removing the monitor returns the system to the prior behavior.

</details>
