### PR TITLE
Wrap PR maintenance cron jobs as built-in workers

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -1,0 +1,217 @@
+import { spawn } from 'node:child_process';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from '@invoker/contracts';
+
+import {
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+  createCoderabbitAddressWorker,
+  createPrConflictRebaseWorker,
+  type PrMaintenanceLockProbeOptions,
+} from '../workers/pr-maintenance-workers.js';
+
+type SpawnCall = {
+  command: string;
+  args: string[];
+  options: SpawnOptions;
+};
+
+function makeLogger(): Logger & {
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+} {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+function makeSpawnHarness(options: {
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+} = {}): { calls: SpawnCall[]; spawnProcess: typeof spawn } {
+  const calls: SpawnCall[] = [];
+  const spawnProcess = vi.fn((command: string, args: string[], spawnOptions: SpawnOptions) => {
+    calls.push({ command, args, options: spawnOptions });
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+      stdin: null,
+      killed: false,
+      pid: 12345,
+      kill: vi.fn(),
+    }) as unknown as ChildProcess;
+
+    queueMicrotask(() => {
+      stdout.end(options.stdout ?? '');
+      stderr.end(options.stderr ?? '');
+      child.emit('close', options.exitCode ?? 0, null);
+    });
+
+    return child;
+  });
+
+  return { calls, spawnProcess: spawnProcess as unknown as typeof spawn };
+}
+
+describe('PR maintenance workers', () => {
+  let tmpRoot: string | undefined;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    if (tmpRoot) {
+      rmSync(tmpRoot, { recursive: true, force: true });
+      tmpRoot = undefined;
+    }
+  });
+
+  function makeRepoRoot(): string {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'invoker-pr-maintenance-test-'));
+    return tmpRoot;
+  }
+
+  it('spawns the CodeRabbit shell entrypoint with the configured cwd and env', async () => {
+    const repoRoot = makeRepoRoot();
+    const lockPath = join(repoRoot, 'locks', 'pr-crons.lock');
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness({ stdout: 'addressed one PR\n', stderr: 'diagnostic line\n' });
+    const lockProbe = vi.fn((_options: PrMaintenanceLockProbeOptions) => ({ held: false }));
+    const worker = createCoderabbitAddressWorker({
+      logger,
+      repoRoot,
+      env: {
+        INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
+        INVOKER_PR_CRON_AUTHOR: 'octocat',
+      },
+      lockPath,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe,
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(lockProbe).toHaveBeenCalledWith(expect.objectContaining({
+      lockPath,
+      env: expect.objectContaining({
+        INVOKER_REPO_ROOT: repoRoot,
+        INVOKER_PR_CRON_LOCK: lockPath,
+        INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
+        INVOKER_PR_CRON_AUTHOR: 'octocat',
+      }),
+    }));
+    expect(spawnHarness.calls).toEqual([
+      expect.objectContaining({
+        command: 'bash',
+        args: [resolve(repoRoot, 'scripts/cron-coderabbit-address.sh')],
+        options: expect.objectContaining({
+          cwd: repoRoot,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          env: expect.objectContaining({
+            INVOKER_REPO_ROOT: repoRoot,
+            INVOKER_PR_CRON_LOCK: lockPath,
+            INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
+            INVOKER_PR_CRON_AUTHOR: 'octocat',
+          }),
+        }),
+      }),
+    ]);
+    expect(logger.info).toHaveBeenCalledWith(
+      `[worker:${CODERABBIT_ADDRESS_WORKER_KIND}] addressed one PR`,
+      expect.objectContaining({ stream: 'stdout' }),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      `[worker:${CODERABBIT_ADDRESS_WORKER_KIND}] diagnostic line`,
+      expect.objectContaining({ stream: 'stderr' }),
+    );
+  });
+
+  it('spawns the PR conflict rebase shell entrypoint', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createPrConflictRebaseWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
+      command: 'bash',
+      args: [resolve(repoRoot, 'scripts/cron-pr-conflict-rebase.sh')],
+      options: expect.objectContaining({ cwd: repoRoot }),
+    }));
+  });
+
+  it('skips cleanly when the shared PR-maintenance lock is already held', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createPrConflictRebaseWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: true, reason: 'test-lock-held' }),
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(spawnHarness.calls).toEqual([]);
+    expect(logger.info).toHaveBeenCalledWith(
+      `[worker:${PR_CONFLICT_REBASE_WORKER_KIND}] shared PR maintenance lock held; skipping tick`,
+      expect.objectContaining({
+        worker: PR_CONFLICT_REBASE_WORKER_KIND,
+        reason: 'test-lock-held',
+      }),
+    );
+  });
+
+  it('polls on the five-minute default interval without ticking on start', async () => {
+    vi.useFakeTimers();
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createCoderabbitAddressWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+    });
+
+    worker.start();
+    expect(spawnHarness.calls).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS - 1);
+    expect(spawnHarness.calls).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(spawnHarness.calls).toHaveLength(1);
+    await worker.stop();
+  });
+});

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -11,6 +11,10 @@ import { registerBuiltinWorkers } from '../builtin-workers.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import { createWorkerRegistry } from '../worker-registry.js';
 import { CI_FAILURE_WORKER_KIND } from '../workers/ci-failure-worker.js';
+import {
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+} from '../workers/pr-maintenance-workers.js';
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
 
 const silentLogger = {
@@ -61,10 +65,14 @@ describe('worker registry', () => {
       AUTO_FIX_WORKER_KIND,
       PR_STATUS_WORKER_KIND,
       CI_FAILURE_WORKER_KIND,
+      CODERABBIT_ADDRESS_WORKER_KIND,
+      PR_CONFLICT_REBASE_WORKER_KIND,
     ]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_STATUS_WORKER_KIND)).toBeDefined();
     expect(registry.get(CI_FAILURE_WORKER_KIND)).toBeDefined();
+    expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_CONFLICT_REBASE_WORKER_KIND)).toBeDefined();
   });
   it('returns nothing for an unknown kind', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());
@@ -89,5 +97,9 @@ describe('worker registry', () => {
 
     expect(registry.get(PR_STATUS_WORKER_KIND)?.factory(deps()).identity.kind).toBe(PR_STATUS_WORKER_KIND);
     expect(registry.get(CI_FAILURE_WORKER_KIND)?.factory(deps()).identity.kind).toBe(CI_FAILURE_WORKER_KIND);
+    expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(CODERABBIT_ADDRESS_WORKER_KIND);
+    expect(registry.get(PR_CONFLICT_REBASE_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(PR_CONFLICT_REBASE_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -2,6 +2,7 @@ import { registerAutoFixWorker } from './auto-fix-recovery.js';
 import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
 import type { WorkerRegistry } from './worker-registry.js';
 import { registerCiFailureWorker } from './workers/ci-failure-worker.js';
+import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
 
 /** Register every built-in worker in the stable built-in order. */
@@ -11,5 +12,6 @@ export function registerBuiltinWorkers(
   registerAutoFixWorker(registry);
   registerPrStatusWorker(registry);
   registerCiFailureWorker(registry);
+  registerPrMaintenanceWorkers(registry);
   return registry;
 }

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -42,6 +42,7 @@ export * from './builtin-workers.js';
 export * from './auto-fix-recovery.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/ci-failure-worker.js';
+export * from './workers/pr-maintenance-workers.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-attempt-ledger.js';
 export * from './auto-fix-intents.js';

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -7,6 +7,7 @@ import type {
   AutoFixWorkerConfig,
 } from './auto-fix-recovery.js';
 import type { CiFailureWorkerStore, CiFailureWorkerSubmitter } from './workers/ci-failure-worker.js';
+import type { PrMaintenanceWorkerConfig } from './workers/pr-maintenance-workers.js';
 import type { PrStatusReviewGate } from './workers/pr-status-worker.js';
 
 /** Dependencies injected into a built-in worker factory when its runtime is built. */
@@ -23,4 +24,6 @@ export interface WorkerRuntimeDependencies {
   reviewGate?: PrStatusReviewGate;
   /** Auto-fix tuning shared by workers that submit fix intents. */
   autoFix?: AutoFixWorkerConfig;
+  /** PR-maintenance shell worker launch configuration. */
+  prMaintenance?: PrMaintenanceWorkerConfig;
 }

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -1,0 +1,371 @@
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { Readable } from 'node:stream';
+
+import { resolveRepoRoot, type Logger } from '@invoker/contracts';
+
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const CODERABBIT_ADDRESS_WORKER_KIND = 'coderabbit-address';
+export const PR_CONFLICT_REBASE_WORKER_KIND = 'pr-conflict-rebase';
+export const DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS = 5 * 60_000;
+
+export type PrMaintenanceWorkerKind =
+  | typeof CODERABBIT_ADDRESS_WORKER_KIND
+  | typeof PR_CONFLICT_REBASE_WORKER_KIND;
+
+type EnvOverrides = Record<string, string | undefined>;
+
+export interface PrMaintenanceEntrypoint {
+  kind: PrMaintenanceWorkerKind;
+  scriptRelativePath: string;
+  note: string;
+}
+
+const CODERABBIT_ADDRESS_ENTRYPOINT: PrMaintenanceEntrypoint = {
+  kind: CODERABBIT_ADDRESS_WORKER_KIND,
+  scriptRelativePath: 'scripts/cron-coderabbit-address.sh',
+  note: 'Runs the CodeRabbit review-address cron entrypoint under worker scheduling.',
+};
+
+const PR_CONFLICT_REBASE_ENTRYPOINT: PrMaintenanceEntrypoint = {
+  kind: PR_CONFLICT_REBASE_WORKER_KIND,
+  scriptRelativePath: 'scripts/cron-pr-conflict-rebase.sh',
+  note: 'Runs the PR conflict rebase-recreate cron entrypoint under worker scheduling.',
+};
+
+export interface PrMaintenanceWorkerConfig {
+  /** Repository root that owns the shell scripts. Defaults to the current Invoker repo root. */
+  repoRoot?: string;
+  /** Environment overrides passed to the shell entrypoint. `undefined` removes a variable. */
+  env?: EnvOverrides;
+  /** Poll cadence for both PR-maintenance workers. Defaults to five minutes. */
+  intervalMs?: number;
+  /** Shared cron lock path. Defaults to the shell script's `INVOKER_PR_CRON_LOCK` behavior. */
+  lockPath?: string;
+  /** Shell executable used to run the existing entrypoint. Defaults to `bash`. */
+  shell?: string;
+}
+
+export interface PrMaintenanceLockProbeOptions {
+  lockPath: string;
+  env: NodeJS.ProcessEnv;
+  staleLockSeconds?: number;
+}
+
+export interface PrMaintenanceLockProbeResult {
+  held: boolean;
+  reason?: string;
+}
+
+export type PrMaintenanceLockProbe = (
+  options: PrMaintenanceLockProbeOptions,
+) => PrMaintenanceLockProbeResult | Promise<PrMaintenanceLockProbeResult>;
+
+export interface PrMaintenanceWorkerOptions extends PrMaintenanceWorkerConfig {
+  logger: Logger;
+  instanceId?: string;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  onTick?: WorkerTick;
+  spawnProcess?: typeof spawn;
+  lockProbe?: PrMaintenanceLockProbe;
+}
+
+export interface PrMaintenanceTickOptions extends PrMaintenanceWorkerConfig {
+  entrypoint: PrMaintenanceEntrypoint;
+  logger: Logger;
+  spawnProcess?: typeof spawn;
+  lockProbe?: PrMaintenanceLockProbe;
+}
+
+/** Register both built-in PR-maintenance workers in cron job order. */
+export function registerPrMaintenanceWorkers(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registerCoderabbitAddressWorker(registry);
+  registerPrConflictRebaseWorker(registry);
+  return registry;
+}
+
+export function registerCoderabbitAddressWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: CODERABBIT_ADDRESS_WORKER_KIND,
+    note: CODERABBIT_ADDRESS_ENTRYPOINT.note,
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createCoderabbitAddressWorker({
+        logger: deps.logger,
+        ...deps.prMaintenance,
+      }),
+  });
+  return registry;
+}
+
+export function registerPrConflictRebaseWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: PR_CONFLICT_REBASE_WORKER_KIND,
+    note: PR_CONFLICT_REBASE_ENTRYPOINT.note,
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createPrConflictRebaseWorker({
+        logger: deps.logger,
+        ...deps.prMaintenance,
+      }),
+  });
+  return registry;
+}
+
+export function createCoderabbitAddressWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
+  return createPrMaintenanceWorker(CODERABBIT_ADDRESS_ENTRYPOINT, options);
+}
+
+export function createPrConflictRebaseWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
+  return createPrMaintenanceWorker(PR_CONFLICT_REBASE_ENTRYPOINT, options);
+}
+
+export function createPrMaintenanceTick(options: PrMaintenanceTickOptions): WorkerTick {
+  return async () => {
+    await runPrMaintenanceEntrypoint(options);
+  };
+}
+
+export function probePrMaintenanceLock(options: PrMaintenanceLockProbeOptions): PrMaintenanceLockProbeResult {
+  const flockProbe = spawnSync('flock', ['-n', options.lockPath, '-c', 'true'], {
+    env: options.env,
+    stdio: 'ignore',
+  });
+  if (!flockProbe.error || (flockProbe.error as NodeJS.ErrnoException).code !== 'ENOENT') {
+    return flockProbe.status === 0
+      ? { held: false }
+      : { held: true, reason: 'flock-held' };
+  }
+
+  const lockDir = `${options.lockPath}.d`;
+  if (!existsSync(lockDir)) return { held: false };
+
+  const holderPid = readMkdirLockHolder(lockDir);
+  if (holderPid !== undefined) {
+    return isProcessAlive(holderPid)
+      ? { held: true, reason: 'mkdir-lock-held' }
+      : { held: false, reason: 'mkdir-lock-stale-dead-holder' };
+  }
+
+  const staleLockSeconds = options.staleLockSeconds ?? 3600;
+  const ageSeconds = Math.max(0, Math.floor((Date.now() - statSync(lockDir).mtimeMs) / 1000));
+  return ageSeconds < staleLockSeconds
+    ? { held: true, reason: 'mkdir-lock-held-without-pid' }
+    : { held: false, reason: 'mkdir-lock-stale-without-pid' };
+}
+
+function createPrMaintenanceWorker(
+  entrypoint: PrMaintenanceEntrypoint,
+  options: PrMaintenanceWorkerOptions,
+): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: entrypoint.kind,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: options.onTick ?? createPrMaintenanceTick({
+      entrypoint,
+      logger: options.logger,
+      repoRoot: options.repoRoot,
+      env: options.env,
+      intervalMs: options.intervalMs,
+      lockPath: options.lockPath,
+      shell: options.shell,
+      spawnProcess: options.spawnProcess,
+      lockProbe: options.lockProbe,
+    }),
+  });
+}
+
+async function runPrMaintenanceEntrypoint(options: PrMaintenanceTickOptions): Promise<void> {
+  const repoRoot = resolvePrMaintenanceRepoRoot(options.repoRoot);
+  const env = buildPrMaintenanceEnv(repoRoot, options.env);
+  const lockPath = options.lockPath ?? env.INVOKER_PR_CRON_LOCK ?? defaultPrCronLockPath(env);
+  env.INVOKER_PR_CRON_LOCK = lockPath;
+  const lockProbe = options.lockProbe ?? probePrMaintenanceLock;
+  const lock = await lockProbe({
+    lockPath,
+    env,
+    staleLockSeconds: parsePositiveInteger(env.INVOKER_PR_CRON_LOCK_STALE_SECS),
+  });
+
+  if (lock.held) {
+    options.logger.info(`[worker:${options.entrypoint.kind}] shared PR maintenance lock held; skipping tick`, {
+      module: 'pr-maintenance-worker',
+      worker: options.entrypoint.kind,
+      lockPath,
+      reason: lock.reason ?? 'lock-held',
+    });
+    return;
+  }
+
+  const scriptPath = resolve(repoRoot, options.entrypoint.scriptRelativePath);
+  const shell = options.shell ?? 'bash';
+  const spawnProcess = options.spawnProcess ?? spawn;
+  options.logger.info(`[worker:${options.entrypoint.kind}] spawning ${options.entrypoint.scriptRelativePath}`, {
+    module: 'pr-maintenance-worker',
+    worker: options.entrypoint.kind,
+    cwd: repoRoot,
+    command: shell,
+    args: [scriptPath],
+    lockPath,
+  });
+
+  let child: ChildProcess;
+  try {
+    child = spawnProcess(shell, [scriptPath], {
+      cwd: repoRoot,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    options.logger.error(`[worker:${options.entrypoint.kind}] spawn failed`, {
+      module: 'pr-maintenance-worker',
+      worker: options.entrypoint.kind,
+      err,
+    });
+    throw err;
+  }
+
+  attachChildStreamLogger(options, child.stdout, 'stdout');
+  attachChildStreamLogger(options, child.stderr, 'stderr');
+
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    let settled = false;
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+
+    child.once('error', (err) => {
+      settle(() => {
+        options.logger.error(`[worker:${options.entrypoint.kind}] process error`, {
+          module: 'pr-maintenance-worker',
+          worker: options.entrypoint.kind,
+          err,
+        });
+        rejectPromise(err);
+      });
+    });
+
+    child.once('close', (code, signal) => {
+      settle(() => {
+        const fields = {
+          module: 'pr-maintenance-worker',
+          worker: options.entrypoint.kind,
+          code,
+          signal,
+        };
+        if (code === 0) {
+          options.logger.info(`[worker:${options.entrypoint.kind}] shell entrypoint completed`, fields);
+          resolvePromise();
+          return;
+        }
+        const message = `PR maintenance worker ${options.entrypoint.kind} exited with code ${code ?? 'null'}`
+          + (signal ? ` signal ${signal}` : '');
+        options.logger.error(`[worker:${options.entrypoint.kind}] shell entrypoint failed`, fields);
+        rejectPromise(new Error(message));
+      });
+    });
+  });
+}
+
+function attachChildStreamLogger(
+  options: PrMaintenanceTickOptions,
+  stream: Readable | null,
+  streamName: 'stdout' | 'stderr',
+): void {
+  if (!stream) return;
+  let buffer = '';
+  stream.setEncoding('utf8');
+  stream.on('data', (chunk: string | Buffer) => {
+    buffer += String(chunk);
+    const lines = buffer.split(/\r?\n/);
+    buffer = lines.pop() ?? '';
+    for (const line of lines) {
+      logChildLine(options, streamName, line);
+    }
+  });
+  stream.on('end', () => {
+    if (buffer.length > 0) {
+      logChildLine(options, streamName, buffer);
+      buffer = '';
+    }
+  });
+}
+
+function logChildLine(
+  options: PrMaintenanceTickOptions,
+  streamName: 'stdout' | 'stderr',
+  line: string,
+): void {
+  const fields = {
+    module: 'pr-maintenance-worker',
+    worker: options.entrypoint.kind,
+    stream: streamName,
+  };
+  if (streamName === 'stderr') {
+    options.logger.warn(`[worker:${options.entrypoint.kind}] ${line}`, fields);
+    return;
+  }
+  options.logger.info(`[worker:${options.entrypoint.kind}] ${line}`, fields);
+}
+
+function resolvePrMaintenanceRepoRoot(repoRoot: string | undefined): string {
+  return repoRoot ? resolve(repoRoot) : resolveRepoRoot(process.cwd());
+}
+
+function buildPrMaintenanceEnv(repoRoot: string, overrides: EnvOverrides | undefined): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const [key, value] of Object.entries(overrides ?? {})) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+  env.INVOKER_REPO_ROOT = repoRoot;
+  return env;
+}
+
+function defaultPrCronLockPath(env: NodeJS.ProcessEnv): string {
+  const tmpRoot = env.TMPDIR && env.TMPDIR.length > 0 ? env.TMPDIR : '/tmp';
+  return resolve(tmpRoot, 'invoker-pr-crons.lock');
+}
+
+function parsePositiveInteger(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function readMkdirLockHolder(lockDir: string): number | undefined {
+  try {
+    const raw = readFileSync(resolve(lockDir, 'pid'), 'utf8').trim();
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}


### PR DESCRIPTION
## Summary

This slice wraps the two existing PR-maintenance cron jobs as built-in execution-engine workers.

The shell scripts stay authoritative. Scheduling and registration move into the worker runtime; the repair logic itself does not change.

The new worker module exports stable worker kinds plus registration helpers, and the built-in registry wires them in.

The proof surface adds focused tests for the new workers and for registry exposure.

## Review Claim

The existing PR-maintenance cron jobs are available as built-in workers through the execution-engine registry without changing their underlying shell behavior.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This is adapter work around the existing shell scripts: it adds worker kinds, dependency plumbing, and focused tests, but leaves the authoritative cron scripts untouched.

## Slice Rationale

This is the missing parent slice that the auto-follow workflow accidentally stacked on top of a dead base branch. Landing it first gives the child PR a real parent.

## Non-goals

- Does not rewrite the cron shell scripts.
- Does not add UI surfaces or owner wiring for these workers.
- Does not change non-PR-maintenance worker behavior.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pr-maintenance-workers.test.ts src/__tests__/worker-registry.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 65727d7`
- Post-revert steps: None
- Data migration? No

</details>
