### PR TITLE
[Fix sessions](7) Reclaim orphaned fixing_with_ai sessions

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3314,6 +3314,48 @@ function createEmbeddedTerminalBackendFromConfig(
                   }
                 }
 
+                // Stalled-fix-session watchdog: a fix session whose owner died
+                // mid-fix (heartbeat stopped, attempt lease expired) is invisible
+                // to the running-task path above because its status is
+                // `fixing_with_ai`, not `running`. Evaluate it as an executing
+                // task; a live fix refreshes its lease every 30s via
+                // withAttemptHeartbeat, so only an orphaned one is ever stalled.
+                if (task.status === 'fixing_with_ai') {
+                  const fixStartedAt = parseExecutionDate(task.execution.startedAt);
+                  const { executingStalled, staleReason } = evaluateExecutingStall({
+                    now,
+                    phase: 'executing',
+                    runnerKind: task.config.runnerKind,
+                    executingStartedAt: fixStartedAt,
+                    leaseExpiresAt,
+                    executorHeartbeatAt: previousHeartbeat,
+                    remoteHeartbeatAt: remoteHeartbeat,
+                    executingStallTimeoutMs,
+                  });
+                  if (executingStalled) {
+                    const fixAgeMs = fixStartedAt ? now.getTime() - fixStartedAt.getTime() : 0;
+                    const reason =
+                      `Fix session stalled: task remained in fixing_with_ai for ${Math.floor(fixAgeMs / 1000)}s ` +
+                      `without a live fix handle (${staleReason}).`;
+                    logger.error(`[fix-session-stall] reclaiming "${task.id}": ${reason}`, { module: 'db-poll' });
+                    const outcome = orchestrator.reclaimStalledFixSession(task.id, {
+                      reason,
+                      expectedLineage: {
+                        taskId: task.id,
+                        selectedAttemptId: task.execution.selectedAttemptId,
+                        generation: task.execution.generation ?? 0,
+                      },
+                    });
+                    logger.info(
+                      `[fix-session-stall] reclaim outcome=${outcome} task="${task.id}" ` +
+                        `selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
+                        `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'}`,
+                      { module: 'db-poll' },
+                    );
+                    continue;
+                  }
+                }
+
                 const snapshot = JSON.stringify(task);
                 const prev = lastKnownTaskStates.get(task.id);
                 if (!prev) {

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -721,6 +721,63 @@ describe('Orchestrator', () => {
     });
   });
 
+  describe('reclaimStalledFixSession (stalled-fix watchdog recovery)', () => {
+    beforeEach(() => {
+      orchestrator.loadPlan({
+        name: 'reclaim-plan',
+        tasks: [{ id: 'r1', description: 'Root task' }],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'r1', status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
+      );
+      expect(orchestrator.getTask('r1')!.status).toBe('failed');
+    });
+
+    const beginFix = () => {
+      orchestrator.beginFixSession('r1');
+      const task = orchestrator.getTask('r1')!;
+      expect(task.status).toBe('fixing_with_ai');
+      return {
+        taskId: task.id,
+        selectedAttemptId: task.execution.selectedAttemptId,
+        generation: task.execution.generation ?? 0,
+      };
+    };
+
+    it('leases the fix attempt so an orphaned session becomes reclaimable', () => {
+      orchestrator.beginFixSession('r1');
+      const attemptId = orchestrator.getTask('r1')!.execution.selectedAttemptId!;
+      expect(persistence.loadAttempt(attemptId)?.leaseExpiresAt).toBeInstanceOf(Date);
+    });
+
+    it('reverts a stalled fix session to its entry status', () => {
+      const expectedLineage = beginFix();
+      const outcome = orchestrator.reclaimStalledFixSession('r1', { reason: 'owner died', expectedLineage });
+      expect(outcome).toBe('reverted');
+      const task = orchestrator.getTask('r1')!;
+      expect(task.status).toBe('failed');
+      expect(task.execution.isFixingWithAI).toBeFalsy();
+    });
+
+    it('no-ops when the task is not in a fix session', () => {
+      const outcome = orchestrator.reclaimStalledFixSession('r1', { reason: 'x' });
+      expect(outcome).toBe('noop');
+      expect(orchestrator.getTask('r1')!.status).toBe('failed');
+      expect(orchestrator.getTask('r1')!.execution.fixSessionEntryStatus).toBeUndefined();
+    });
+
+    it('no-ops on lineage mismatch and leaves the live fix session untouched', () => {
+      const { taskId, generation } = beginFix();
+      const outcome = orchestrator.reclaimStalledFixSession('r1', {
+        reason: 'x',
+        expectedLineage: { taskId, selectedAttemptId: 'stale-attempt', generation },
+      });
+      expect(outcome).toBe('noop');
+      expect(orchestrator.getTask('r1')!.execution.fixSessionEntryStatus).toBe('failed');
+    });
+  });
+
   describe('beginFixSession / revertFixSession', () => {
     beforeEach(() => {
       orchestrator.loadPlan({

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -112,6 +112,7 @@ import {
   getKnownFreshBaseCommitImpl,
   beginFixSessionImpl,
   revertFixSessionImpl,
+  reclaimStalledFixSessionImpl,
   getMergeNodeImpl,
 } from './orchestrator/merge.js';
 import type { MergeHost } from './orchestrator/merge.js';
@@ -2636,6 +2637,17 @@ export class Orchestrator {
     },
   ): void {
     revertFixSessionImpl(this as unknown as MergeHost, taskId, opts);
+  }
+
+  /**
+   * Reclaim a fix session orphaned by owner death: revert it to its entry
+   * status. Driven by the stalled-fix-session watchdog.
+   */
+  reclaimStalledFixSession(
+    taskId: string,
+    opts: { reason: string; expectedLineage?: TaskLineageExpectation },
+  ): 'reverted' | 'noop' {
+    return reclaimStalledFixSessionImpl(this as unknown as MergeHost, taskId, opts);
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/merge.ts
+++ b/packages/workflow-core/src/orchestrator/merge.ts
@@ -15,6 +15,7 @@
  */
 
 import type { TaskState, TaskDelta, TaskStateChanges, TaskStatus, Attempt } from '@invoker/workflow-graph';
+import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import type { Logger } from '@invoker/contracts';
 import { parseMergeConflictError } from '../merge-conflict-error.js';
 import type { TaskStateMachine } from '../state-machine.js';
@@ -212,6 +213,7 @@ function startFixSession(
     status: 'running',
     startedAt,
     lastHeartbeatAt: startedAt,
+    leaseExpiresAt: new Date(startedAt.getTime() + ATTEMPT_LEASE_MS),
     branch: task.execution.branch,
     commit: task.execution.commit,
     workspacePath: task.execution.workspacePath,
@@ -308,6 +310,45 @@ export function revertFixSessionImpl(
     fixError: opts.fixError ?? null,
   });
   publishTaskDelta(host.messageBus, delta);
+}
+
+/**
+ * Reclaim a fix session (`status: 'fixing_with_ai'`) whose owner process died
+ * mid-fix: its attempt lease has expired and no live executor is driving it.
+ *
+ * Reverts the session to its recorded entry status (via `revertFixSessionImpl`,
+ * so a `failed` task returns to `failed` and a `review_ready` merge gate returns
+ * to review polling). `expectedLineage` guards against reclaiming a newer,
+ * live session a concurrent restart re-dispatched between observation and
+ * revert.
+ *
+ * Returns `'reverted'` when it reclaimed the session, or `'noop'` when the task
+ * is no longer a stalled fix session or the lineage no longer matches.
+ */
+export function reclaimStalledFixSessionImpl(
+  host: MergeHost,
+  taskId: string,
+  opts: { reason: string; expectedLineage?: TaskLineageExpectation },
+): 'reverted' | 'noop' {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task || task.status !== 'fixing_with_ai') return 'noop';
+  if (!host.taskMatchesLineageExpectation(task, opts.expectedLineage)) return 'noop';
+
+  revertFixSessionImpl(host, taskId, {
+    savedError: task.execution.error ?? task.execution.pendingFixError ?? '',
+    fixError: opts.reason,
+    expectedLineage: opts.expectedLineage,
+  });
+
+  const reverted = host.stateGetTask(taskId);
+  if (!reverted || reverted.status === 'fixing_with_ai') return 'noop';
+
+  host.persistence.logEvent?.(taskId, 'task.fix_session_reclaimed', {
+    reason: opts.reason,
+    restoreStatus: reverted.status,
+  });
+  return 'reverted';
 }
 
 function restoreFailedEntry(


### PR DESCRIPTION
## Summary

This reclaims dead AI fix sessions instead of leaving them stuck forever.

Before this change, an owner crash could leave a task in `fixing_with_ai` with no live worker and no path back to `failed` or `review_ready`.

This change seeds a lease when a fix starts, then lets the existing stall watchdog route expired fix sessions back through the normal revert path.

## Review Claim

Orphaned `fixing_with_ai` sessions are reclaimed back to their recorded entry state instead of leaking queue slots forever after an owner crash.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Live fix sessions refresh their attempt lease every 30 seconds, so only orphaned sessions with expired execution state are reclaimed.

## Slice Rationale

The base branch already introduces fix sessions. This slice stays focused on the missing watchdog recovery path.

## Non-goals

This does not redesign auto-fix budgeting.

This does not add a durable per-task counter.

This does not change UI layout or rendering.

## Architecture

### Before

```mermaid
graph TD
    A["Task enters fixing_with_ai"] --> B["Owner dies"]
    B --> C["Watchdog only handles running work"]
    C --> D["Task leaks queue slot forever"]
```

### After

```mermaid
graph TD
    A["Task enters fixing_with_ai with attempt lease"] --> B["Owner dies"]
    B --> C["Watchdog also handles fixing_with_ai"]
    C --> D["reclaimStalledFixSession applies lineage guard"]
    D --> E["revertFixSession restores failed or review_ready"]
```

## Test Plan

- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts -t "reclaimStalledFixSession"`
- [x] `pnpm run check:types` (verified on the equivalent local patch before porting onto this clean stacked branch)
- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/task-reset-policy.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts` (verified on the equivalent local patch before porting onto this clean stacked branch)
- [x] `cd packages/app && CAPTURE_MODE=after pnpm exec playwright test e2e/visual-proof.spec.ts -g "task-status-all-states"`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/auto-fix-recovery.test.ts` (verified on the equivalent local patch before porting onto this clean stacked branch)
- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/pr-ci-workers.test.ts` (verified on the equivalent local patch before porting onto this clean stacked branch)

## Visual Proof

![Task status surface](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-da980a/task-status-all-states.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
