### PR TITLE
[Planning workflow recovery](2) Keep planning transcript pinned while active

### DIFF
--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -1,0 +1,217 @@
+import { spawn } from 'node:child_process';
+import type { ChildProcess, SpawnOptions } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from '@invoker/contracts';
+
+import {
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+  createCoderabbitAddressWorker,
+  createPrConflictRebaseWorker,
+  type PrMaintenanceLockProbeOptions,
+} from '../workers/pr-maintenance-workers.js';
+
+type SpawnCall = {
+  command: string;
+  args: string[];
+  options: SpawnOptions;
+};
+
+function makeLogger(): Logger & {
+  info: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+} {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    child: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+function makeSpawnHarness(options: {
+  exitCode?: number;
+  stdout?: string;
+  stderr?: string;
+} = {}): { calls: SpawnCall[]; spawnProcess: typeof spawn } {
+  const calls: SpawnCall[] = [];
+  const spawnProcess = vi.fn((command: string, args: string[], spawnOptions: SpawnOptions) => {
+    calls.push({ command, args, options: spawnOptions });
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+      stdin: null,
+      killed: false,
+      pid: 12345,
+      kill: vi.fn(),
+    }) as unknown as ChildProcess;
+
+    queueMicrotask(() => {
+      stdout.end(options.stdout ?? '');
+      stderr.end(options.stderr ?? '');
+      child.emit('close', options.exitCode ?? 0, null);
+    });
+
+    return child;
+  });
+
+  return { calls, spawnProcess: spawnProcess as unknown as typeof spawn };
+}
+
+describe('PR maintenance workers', () => {
+  let tmpRoot: string | undefined;
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    if (tmpRoot) {
+      rmSync(tmpRoot, { recursive: true, force: true });
+      tmpRoot = undefined;
+    }
+  });
+
+  function makeRepoRoot(): string {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'invoker-pr-maintenance-test-'));
+    return tmpRoot;
+  }
+
+  it('spawns the CodeRabbit shell entrypoint with the configured cwd and env', async () => {
+    const repoRoot = makeRepoRoot();
+    const lockPath = join(repoRoot, 'locks', 'pr-crons.lock');
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness({ stdout: 'addressed one PR\n', stderr: 'diagnostic line\n' });
+    const lockProbe = vi.fn((_options: PrMaintenanceLockProbeOptions) => ({ held: false }));
+    const worker = createCoderabbitAddressWorker({
+      logger,
+      repoRoot,
+      env: {
+        INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
+        INVOKER_PR_CRON_AUTHOR: 'octocat',
+      },
+      lockPath,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe,
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(lockProbe).toHaveBeenCalledWith(expect.objectContaining({
+      lockPath,
+      env: expect.objectContaining({
+        INVOKER_REPO_ROOT: repoRoot,
+        INVOKER_PR_CRON_LOCK: lockPath,
+        INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
+        INVOKER_PR_CRON_AUTHOR: 'octocat',
+      }),
+    }));
+    expect(spawnHarness.calls).toEqual([
+      expect.objectContaining({
+        command: 'bash',
+        args: [resolve(repoRoot, 'scripts/cron-coderabbit-address.sh')],
+        options: expect.objectContaining({
+          cwd: repoRoot,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          env: expect.objectContaining({
+            INVOKER_REPO_ROOT: repoRoot,
+            INVOKER_PR_CRON_LOCK: lockPath,
+            INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
+            INVOKER_PR_CRON_AUTHOR: 'octocat',
+          }),
+        }),
+      }),
+    ]);
+    expect(logger.info).toHaveBeenCalledWith(
+      `[worker:${CODERABBIT_ADDRESS_WORKER_KIND}] addressed one PR`,
+      expect.objectContaining({ stream: 'stdout' }),
+    );
+    expect(logger.warn).toHaveBeenCalledWith(
+      `[worker:${CODERABBIT_ADDRESS_WORKER_KIND}] diagnostic line`,
+      expect.objectContaining({ stream: 'stderr' }),
+    );
+  });
+
+  it('spawns the PR conflict rebase shell entrypoint', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createPrConflictRebaseWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(spawnHarness.calls[0]).toEqual(expect.objectContaining({
+      command: 'bash',
+      args: [resolve(repoRoot, 'scripts/cron-pr-conflict-rebase.sh')],
+      options: expect.objectContaining({ cwd: repoRoot }),
+    }));
+  });
+
+  it('skips cleanly when the shared PR-maintenance lock is already held', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createPrConflictRebaseWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: true, reason: 'test-lock-held' }),
+      installSignalHandlers: false,
+    });
+
+    await worker.tick();
+
+    expect(spawnHarness.calls).toEqual([]);
+    expect(logger.info).toHaveBeenCalledWith(
+      `[worker:${PR_CONFLICT_REBASE_WORKER_KIND}] shared PR maintenance lock held; skipping tick`,
+      expect.objectContaining({
+        worker: PR_CONFLICT_REBASE_WORKER_KIND,
+        reason: 'test-lock-held',
+      }),
+    );
+  });
+
+  it('polls on the five-minute default interval without ticking on start', async () => {
+    vi.useFakeTimers();
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness();
+    const worker = createCoderabbitAddressWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+    });
+
+    worker.start();
+    expect(spawnHarness.calls).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS - 1);
+    expect(spawnHarness.calls).toEqual([]);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(spawnHarness.calls).toHaveLength(1);
+    await worker.stop();
+  });
+});

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -11,6 +11,10 @@ import { registerBuiltinWorkers } from '../builtin-workers.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import { createWorkerRegistry } from '../worker-registry.js';
 import { CI_FAILURE_WORKER_KIND } from '../workers/ci-failure-worker.js';
+import {
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+} from '../workers/pr-maintenance-workers.js';
 import { PR_STATUS_WORKER_KIND } from '../workers/pr-status-worker.js';
 
 const silentLogger = {
@@ -61,10 +65,14 @@ describe('worker registry', () => {
       AUTO_FIX_WORKER_KIND,
       PR_STATUS_WORKER_KIND,
       CI_FAILURE_WORKER_KIND,
+      CODERABBIT_ADDRESS_WORKER_KIND,
+      PR_CONFLICT_REBASE_WORKER_KIND,
     ]);
     expect(registry.get(AUTO_FIX_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_STATUS_WORKER_KIND)).toBeDefined();
     expect(registry.get(CI_FAILURE_WORKER_KIND)).toBeDefined();
+    expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)).toBeDefined();
+    expect(registry.get(PR_CONFLICT_REBASE_WORKER_KIND)).toBeDefined();
   });
   it('returns nothing for an unknown kind', () => {
     const registry = registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>());
@@ -89,5 +97,9 @@ describe('worker registry', () => {
 
     expect(registry.get(PR_STATUS_WORKER_KIND)?.factory(deps()).identity.kind).toBe(PR_STATUS_WORKER_KIND);
     expect(registry.get(CI_FAILURE_WORKER_KIND)?.factory(deps()).identity.kind).toBe(CI_FAILURE_WORKER_KIND);
+    expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(CODERABBIT_ADDRESS_WORKER_KIND);
+    expect(registry.get(PR_CONFLICT_REBASE_WORKER_KIND)?.factory(deps()).identity.kind)
+      .toBe(PR_CONFLICT_REBASE_WORKER_KIND);
   });
 });

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -2,6 +2,7 @@ import { registerAutoFixWorker } from './auto-fix-recovery.js';
 import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
 import type { WorkerRegistry } from './worker-registry.js';
 import { registerCiFailureWorker } from './workers/ci-failure-worker.js';
+import { registerPrMaintenanceWorkers } from './workers/pr-maintenance-workers.js';
 import { registerPrStatusWorker } from './workers/pr-status-worker.js';
 
 /** Register every built-in worker in the stable built-in order. */
@@ -11,5 +12,6 @@ export function registerBuiltinWorkers(
   registerAutoFixWorker(registry);
   registerPrStatusWorker(registry);
   registerCiFailureWorker(registry);
+  registerPrMaintenanceWorkers(registry);
   return registry;
 }

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -42,6 +42,7 @@ export * from './builtin-workers.js';
 export * from './auto-fix-recovery.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/ci-failure-worker.js';
+export * from './workers/pr-maintenance-workers.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-attempt-ledger.js';
 export * from './auto-fix-intents.js';

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -7,6 +7,7 @@ import type {
   AutoFixWorkerConfig,
 } from './auto-fix-recovery.js';
 import type { CiFailureWorkerStore, CiFailureWorkerSubmitter } from './workers/ci-failure-worker.js';
+import type { PrMaintenanceWorkerConfig } from './workers/pr-maintenance-workers.js';
 import type { PrStatusReviewGate } from './workers/pr-status-worker.js';
 
 /** Dependencies injected into a built-in worker factory when its runtime is built. */
@@ -23,4 +24,6 @@ export interface WorkerRuntimeDependencies {
   reviewGate?: PrStatusReviewGate;
   /** Auto-fix tuning shared by workers that submit fix intents. */
   autoFix?: AutoFixWorkerConfig;
+  /** PR-maintenance shell worker launch configuration. */
+  prMaintenance?: PrMaintenanceWorkerConfig;
 }

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -1,0 +1,371 @@
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { Readable } from 'node:stream';
+
+import { resolveRepoRoot, type Logger } from '@invoker/contracts';
+
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const CODERABBIT_ADDRESS_WORKER_KIND = 'coderabbit-address';
+export const PR_CONFLICT_REBASE_WORKER_KIND = 'pr-conflict-rebase';
+export const DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS = 5 * 60_000;
+
+export type PrMaintenanceWorkerKind =
+  | typeof CODERABBIT_ADDRESS_WORKER_KIND
+  | typeof PR_CONFLICT_REBASE_WORKER_KIND;
+
+type EnvOverrides = Record<string, string | undefined>;
+
+export interface PrMaintenanceEntrypoint {
+  kind: PrMaintenanceWorkerKind;
+  scriptRelativePath: string;
+  note: string;
+}
+
+const CODERABBIT_ADDRESS_ENTRYPOINT: PrMaintenanceEntrypoint = {
+  kind: CODERABBIT_ADDRESS_WORKER_KIND,
+  scriptRelativePath: 'scripts/cron-coderabbit-address.sh',
+  note: 'Runs the CodeRabbit review-address cron entrypoint under worker scheduling.',
+};
+
+const PR_CONFLICT_REBASE_ENTRYPOINT: PrMaintenanceEntrypoint = {
+  kind: PR_CONFLICT_REBASE_WORKER_KIND,
+  scriptRelativePath: 'scripts/cron-pr-conflict-rebase.sh',
+  note: 'Runs the PR conflict rebase-recreate cron entrypoint under worker scheduling.',
+};
+
+export interface PrMaintenanceWorkerConfig {
+  /** Repository root that owns the shell scripts. Defaults to the current Invoker repo root. */
+  repoRoot?: string;
+  /** Environment overrides passed to the shell entrypoint. `undefined` removes a variable. */
+  env?: EnvOverrides;
+  /** Poll cadence for both PR-maintenance workers. Defaults to five minutes. */
+  intervalMs?: number;
+  /** Shared cron lock path. Defaults to the shell script's `INVOKER_PR_CRON_LOCK` behavior. */
+  lockPath?: string;
+  /** Shell executable used to run the existing entrypoint. Defaults to `bash`. */
+  shell?: string;
+}
+
+export interface PrMaintenanceLockProbeOptions {
+  lockPath: string;
+  env: NodeJS.ProcessEnv;
+  staleLockSeconds?: number;
+}
+
+export interface PrMaintenanceLockProbeResult {
+  held: boolean;
+  reason?: string;
+}
+
+export type PrMaintenanceLockProbe = (
+  options: PrMaintenanceLockProbeOptions,
+) => PrMaintenanceLockProbeResult | Promise<PrMaintenanceLockProbeResult>;
+
+export interface PrMaintenanceWorkerOptions extends PrMaintenanceWorkerConfig {
+  logger: Logger;
+  instanceId?: string;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  onTick?: WorkerTick;
+  spawnProcess?: typeof spawn;
+  lockProbe?: PrMaintenanceLockProbe;
+}
+
+export interface PrMaintenanceTickOptions extends PrMaintenanceWorkerConfig {
+  entrypoint: PrMaintenanceEntrypoint;
+  logger: Logger;
+  spawnProcess?: typeof spawn;
+  lockProbe?: PrMaintenanceLockProbe;
+}
+
+/** Register both built-in PR-maintenance workers in cron job order. */
+export function registerPrMaintenanceWorkers(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registerCoderabbitAddressWorker(registry);
+  registerPrConflictRebaseWorker(registry);
+  return registry;
+}
+
+export function registerCoderabbitAddressWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: CODERABBIT_ADDRESS_WORKER_KIND,
+    note: CODERABBIT_ADDRESS_ENTRYPOINT.note,
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createCoderabbitAddressWorker({
+        logger: deps.logger,
+        ...deps.prMaintenance,
+      }),
+  });
+  return registry;
+}
+
+export function registerPrConflictRebaseWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: PR_CONFLICT_REBASE_WORKER_KIND,
+    note: PR_CONFLICT_REBASE_ENTRYPOINT.note,
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createPrConflictRebaseWorker({
+        logger: deps.logger,
+        ...deps.prMaintenance,
+      }),
+  });
+  return registry;
+}
+
+export function createCoderabbitAddressWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
+  return createPrMaintenanceWorker(CODERABBIT_ADDRESS_ENTRYPOINT, options);
+}
+
+export function createPrConflictRebaseWorker(options: PrMaintenanceWorkerOptions): WorkerRuntime {
+  return createPrMaintenanceWorker(PR_CONFLICT_REBASE_ENTRYPOINT, options);
+}
+
+export function createPrMaintenanceTick(options: PrMaintenanceTickOptions): WorkerTick {
+  return async () => {
+    await runPrMaintenanceEntrypoint(options);
+  };
+}
+
+export function probePrMaintenanceLock(options: PrMaintenanceLockProbeOptions): PrMaintenanceLockProbeResult {
+  const flockProbe = spawnSync('flock', ['-n', options.lockPath, '-c', 'true'], {
+    env: options.env,
+    stdio: 'ignore',
+  });
+  if (!flockProbe.error || (flockProbe.error as NodeJS.ErrnoException).code !== 'ENOENT') {
+    return flockProbe.status === 0
+      ? { held: false }
+      : { held: true, reason: 'flock-held' };
+  }
+
+  const lockDir = `${options.lockPath}.d`;
+  if (!existsSync(lockDir)) return { held: false };
+
+  const holderPid = readMkdirLockHolder(lockDir);
+  if (holderPid !== undefined) {
+    return isProcessAlive(holderPid)
+      ? { held: true, reason: 'mkdir-lock-held' }
+      : { held: false, reason: 'mkdir-lock-stale-dead-holder' };
+  }
+
+  const staleLockSeconds = options.staleLockSeconds ?? 3600;
+  const ageSeconds = Math.max(0, Math.floor((Date.now() - statSync(lockDir).mtimeMs) / 1000));
+  return ageSeconds < staleLockSeconds
+    ? { held: true, reason: 'mkdir-lock-held-without-pid' }
+    : { held: false, reason: 'mkdir-lock-stale-without-pid' };
+}
+
+function createPrMaintenanceWorker(
+  entrypoint: PrMaintenanceEntrypoint,
+  options: PrMaintenanceWorkerOptions,
+): WorkerRuntime {
+  return createWorkerRuntime({
+    kind: entrypoint.kind,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_PR_MAINTENANCE_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick: options.onTick ?? createPrMaintenanceTick({
+      entrypoint,
+      logger: options.logger,
+      repoRoot: options.repoRoot,
+      env: options.env,
+      intervalMs: options.intervalMs,
+      lockPath: options.lockPath,
+      shell: options.shell,
+      spawnProcess: options.spawnProcess,
+      lockProbe: options.lockProbe,
+    }),
+  });
+}
+
+async function runPrMaintenanceEntrypoint(options: PrMaintenanceTickOptions): Promise<void> {
+  const repoRoot = resolvePrMaintenanceRepoRoot(options.repoRoot);
+  const env = buildPrMaintenanceEnv(repoRoot, options.env);
+  const lockPath = options.lockPath ?? env.INVOKER_PR_CRON_LOCK ?? defaultPrCronLockPath(env);
+  env.INVOKER_PR_CRON_LOCK = lockPath;
+  const lockProbe = options.lockProbe ?? probePrMaintenanceLock;
+  const lock = await lockProbe({
+    lockPath,
+    env,
+    staleLockSeconds: parsePositiveInteger(env.INVOKER_PR_CRON_LOCK_STALE_SECS),
+  });
+
+  if (lock.held) {
+    options.logger.info(`[worker:${options.entrypoint.kind}] shared PR maintenance lock held; skipping tick`, {
+      module: 'pr-maintenance-worker',
+      worker: options.entrypoint.kind,
+      lockPath,
+      reason: lock.reason ?? 'lock-held',
+    });
+    return;
+  }
+
+  const scriptPath = resolve(repoRoot, options.entrypoint.scriptRelativePath);
+  const shell = options.shell ?? 'bash';
+  const spawnProcess = options.spawnProcess ?? spawn;
+  options.logger.info(`[worker:${options.entrypoint.kind}] spawning ${options.entrypoint.scriptRelativePath}`, {
+    module: 'pr-maintenance-worker',
+    worker: options.entrypoint.kind,
+    cwd: repoRoot,
+    command: shell,
+    args: [scriptPath],
+    lockPath,
+  });
+
+  let child: ChildProcess;
+  try {
+    child = spawnProcess(shell, [scriptPath], {
+      cwd: repoRoot,
+      env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (err) {
+    options.logger.error(`[worker:${options.entrypoint.kind}] spawn failed`, {
+      module: 'pr-maintenance-worker',
+      worker: options.entrypoint.kind,
+      err,
+    });
+    throw err;
+  }
+
+  attachChildStreamLogger(options, child.stdout, 'stdout');
+  attachChildStreamLogger(options, child.stderr, 'stderr');
+
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    let settled = false;
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+
+    child.once('error', (err) => {
+      settle(() => {
+        options.logger.error(`[worker:${options.entrypoint.kind}] process error`, {
+          module: 'pr-maintenance-worker',
+          worker: options.entrypoint.kind,
+          err,
+        });
+        rejectPromise(err);
+      });
+    });
+
+    child.once('close', (code, signal) => {
+      settle(() => {
+        const fields = {
+          module: 'pr-maintenance-worker',
+          worker: options.entrypoint.kind,
+          code,
+          signal,
+        };
+        if (code === 0) {
+          options.logger.info(`[worker:${options.entrypoint.kind}] shell entrypoint completed`, fields);
+          resolvePromise();
+          return;
+        }
+        const message = `PR maintenance worker ${options.entrypoint.kind} exited with code ${code ?? 'null'}`
+          + (signal ? ` signal ${signal}` : '');
+        options.logger.error(`[worker:${options.entrypoint.kind}] shell entrypoint failed`, fields);
+        rejectPromise(new Error(message));
+      });
+    });
+  });
+}
+
+function attachChildStreamLogger(
+  options: PrMaintenanceTickOptions,
+  stream: Readable | null,
+  streamName: 'stdout' | 'stderr',
+): void {
+  if (!stream) return;
+  let buffer = '';
+  stream.setEncoding('utf8');
+  stream.on('data', (chunk: string | Buffer) => {
+    buffer += String(chunk);
+    const lines = buffer.split(/\r?\n/);
+    buffer = lines.pop() ?? '';
+    for (const line of lines) {
+      logChildLine(options, streamName, line);
+    }
+  });
+  stream.on('end', () => {
+    if (buffer.length > 0) {
+      logChildLine(options, streamName, buffer);
+      buffer = '';
+    }
+  });
+}
+
+function logChildLine(
+  options: PrMaintenanceTickOptions,
+  streamName: 'stdout' | 'stderr',
+  line: string,
+): void {
+  const fields = {
+    module: 'pr-maintenance-worker',
+    worker: options.entrypoint.kind,
+    stream: streamName,
+  };
+  if (streamName === 'stderr') {
+    options.logger.warn(`[worker:${options.entrypoint.kind}] ${line}`, fields);
+    return;
+  }
+  options.logger.info(`[worker:${options.entrypoint.kind}] ${line}`, fields);
+}
+
+function resolvePrMaintenanceRepoRoot(repoRoot: string | undefined): string {
+  return repoRoot ? resolve(repoRoot) : resolveRepoRoot(process.cwd());
+}
+
+function buildPrMaintenanceEnv(repoRoot: string, overrides: EnvOverrides | undefined): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  for (const [key, value] of Object.entries(overrides ?? {})) {
+    if (value === undefined) {
+      delete env[key];
+    } else {
+      env[key] = value;
+    }
+  }
+  env.INVOKER_REPO_ROOT = repoRoot;
+  return env;
+}
+
+function defaultPrCronLockPath(env: NodeJS.ProcessEnv): string {
+  const tmpRoot = env.TMPDIR && env.TMPDIR.length > 0 ? env.TMPDIR : '/tmp';
+  return resolve(tmpRoot, 'invoker-pr-crons.lock');
+}
+
+function parsePositiveInteger(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function readMkdirLockHolder(lockDir: string): number | undefined {
+  try {
+    const raw = readFileSync(resolve(lockDir, 'pid'), 'utf8').trim();
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -106,6 +106,7 @@ type PlanningSessionView = Omit<InAppPlanningSessionSummary, 'messages'> & {
   messages: InvokerTerminalLine[];
   input: string;
   busy: boolean;
+  conversationKey: string;
 };
 
 function makeInitialPlanningSession(now: string = new Date().toISOString()): PlanningSessionView {
@@ -120,20 +121,7 @@ function makeInitialPlanningSession(now: string = new Date().toISOString()): Pla
     busy: false,
     createdAt: now,
     updatedAt: now,
-  };
-}
-
-function summaryToPlanningSessionView(summary: InAppPlanningSessionSummary): PlanningSessionView {
-  return {
-    ...summary,
-    messages: summary.messages.map((message) => ({
-      id: message.id,
-      text: message.text,
-      role: message.role,
-      tone: message.tone,
-    })),
-    input: '',
-    busy: false,
+    conversationKey: 'local-planning-session-1',
   };
 }
 
@@ -520,22 +508,12 @@ export function App() {
   const queueStatus = useQueueStatus();
   const [workerStatus, refreshWorkerStatus] = useWorkerStatus();
   const handleStartWorker = useCallback(async (kind: string) => {
-    if (!invoker) return;
-    try {
-      await invoker.startWorker(kind);
-      await refreshWorkerStatus();
-    } catch (err) {
-      console.error('Failed to start worker:', err);
-    }
+    await invoker.startWorker(kind);
+    await refreshWorkerStatus();
   }, [invoker, refreshWorkerStatus]);
   const handleStopWorker = useCallback(async (kind: string) => {
-    if (!invoker) return;
-    try {
-      await invoker.stopWorker(kind);
-      await refreshWorkerStatus();
-    } catch (err) {
-      console.error('Failed to stop worker:', err);
-    }
+    await invoker.stopWorker(kind);
+    await refreshWorkerStatus();
   }, [invoker, refreshWorkerStatus]);
   const runningTaskIds = useMemo(
     () => new Set((queueStatus?.running ?? []).map((entry) => entry.taskId)),
@@ -545,7 +523,7 @@ export function App() {
   const graphActionsMenuRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
   const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
-  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean | null>(null);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkerKind, setSelectedWorkerKind] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
@@ -560,7 +538,6 @@ export function App() {
   const [activePlanningSessionId, setActivePlanningSessionId] = useState('local-planning-session-1');
   const nextPlanningSessionLocalIdRef = useRef(2);
   const nextTerminalLineIdRef = useRef(2);
-  const planningSessionRestoreBlockedRef = useRef(false);
   const [planningPresetOptions, setPlanningPresetOptions] = useState<Array<{ key: string; label: string; isDefault?: boolean }>>([]);
   const [selectedPlanningPresetKey, setSelectedPlanningPresetKey] = useState('');
   const [planningSubmitError, setPlanningSubmitError] = useState<{ title: string; message: string } | null>(null);
@@ -569,11 +546,7 @@ export function App() {
     () => planningSessions.find((session) => session.id === activePlanningSessionId) ?? planningSessions[0] ?? makeInitialPlanningSession(),
     [activePlanningSessionId, planningSessions],
   );
-
-  useEffect(() => {
-    if (!activePlanningSession.presetKey || activePlanningSession.presetKey === selectedPlanningPresetKey) return;
-    setSelectedPlanningPresetKey(activePlanningSession.presetKey);
-  }, [activePlanningSession.presetKey, selectedPlanningPresetKey]);
+  const activePlanningConversationKey = activePlanningSession.conversationKey;
   const terminalLines = activePlanningSession.messages;
   const planningInput = activePlanningSession.input;
   const planningSessionId = activePlanningSession.id.startsWith('local-') ? null : activePlanningSession.id;
@@ -705,34 +678,8 @@ export function App() {
     window.invoker?.terminalList?.().then((list) => {
       if (Array.isArray(list) && list.length > 0) {
         setTerminalSessions(list);
-        setActiveTerminalSessionId(list[list.length - 1]?.sessionId ?? null);
-        setTerminalDrawerState('partial');
       }
     }).catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    let cancelled = false;
-    window.invoker?.planningChatList?.()
-      .then((result) => {
-        if (cancelled) return;
-        if (planningSessionRestoreBlockedRef.current) return;
-        if (!result?.sessions?.length) return;
-        const restoredSessions = result.sessions.map(summaryToPlanningSessionView);
-        setPlanningSessions(restoredSessions);
-        setActivePlanningSessionId(restoredSessions[0]?.id ?? 'local-planning-session-1');
-        const starterSession = makeInitialPlanningSession();
-        const maxLineId = Math.max(
-          0,
-          ...starterSession.messages.map((line) => line.id),
-          ...restoredSessions.flatMap((session) => session.messages.map((line) => line.id)),
-        );
-        nextTerminalLineIdRef.current = maxLineId + 1;
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
   }, []);
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -1900,7 +1847,6 @@ export function App() {
   }, [activePlanningSessionId, updatePlanningSessionById]);
 
   const setPlanningInput = useCallback((value: string) => {
-    if (value.length > 0) planningSessionRestoreBlockedRef.current = true;
     updateActivePlanningSession((session) => ({ ...session, input: value }));
   }, [updateActivePlanningSession]);
 
@@ -2084,13 +2030,14 @@ export function App() {
   ]);
 
   const handleCreatePlanningSession = useCallback(() => {
-    planningSessionRestoreBlockedRef.current = true;
     const index = nextPlanningSessionLocalIdRef.current;
     nextPlanningSessionLocalIdRef.current += 1;
     const now = new Date().toISOString();
+    const localId = `local-planning-session-${index}`;
     const session: PlanningSessionView = {
       ...makeInitialPlanningSession(now),
-      id: `local-planning-session-${index}`,
+      id: localId,
+      conversationKey: localId,
       presetKey: selectedPlanningPresetKey,
     };
     nextTerminalLineIdRef.current += 1;
@@ -2118,7 +2065,7 @@ export function App() {
       setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
-      setSidebarCollapsed(null);
+      setSidebarCollapsed(false);
       setViewMode('dag');
       setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
@@ -2143,7 +2090,7 @@ export function App() {
       setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
-      setSidebarCollapsed(null);
+      setSidebarCollapsed(false);
       setViewMode('dag');
       setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
@@ -2167,8 +2114,6 @@ export function App() {
   const showStart = hasLoadedPlan && !hasStarted;
   const showStop = hasStarted && !allSettled;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
-  const autoCollapseSidebar = sidebarSurface !== 'home' && sidebarSurface !== 'planning' && viewportWidth < 1440;
-  const effectiveSidebarCollapsed = sidebarCollapsed ?? autoCollapseSidebar;
   const autoCollapseInspector = sidebarSurface !== 'home' && viewportWidth < 1440;
   const effectiveInspectorCollapsed = inspectorCollapsed || (autoCollapseInspector && !inspectorManualOpen);
   const showWorkerDetailsPanel = viewMode === 'queue' && sidebarSurface === 'workers';
@@ -2238,6 +2183,7 @@ export function App() {
     setGraphActionsMenuOpen(false);
     if (nextSurface === 'workers') {
       setSidebarSurface('workers');
+      setSidebarCollapsed(true);
       setInspectorCollapsed(true);
       setInspectorManualOpen(false);
       setStatusFilters(new Set<WorkflowStatus>());
@@ -2247,10 +2193,12 @@ export function App() {
     setViewMode('dag');
     if (nextSurface === 'home') {
       setSidebarSurface('home');
+      setSidebarCollapsed(false);
       setInspectorManualOpen(false);
       return;
     }
     setSidebarSurface(nextSurface);
+    setSidebarCollapsed(true);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
   }, []);
@@ -2258,7 +2206,9 @@ export function App() {
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
     setSidebarSurface('home');
+    setSidebarCollapsed(false);
     setInspectorManualOpen(false);
+    setViewMode('dag');
   }, []);
 
   // ── Task actions ──────────────────────────────────────────
@@ -2921,6 +2871,7 @@ export function App() {
         </div>
         <div className="min-h-0 flex-1 overflow-y-auto bg-gray-900 p-4">
           <InvokerTerminal
+            activeConversationKey={activePlanningConversationKey}
             lines={terminalLines}
             busy={activePlanningSessionBusy}
             value={planningInput}
@@ -3087,9 +3038,9 @@ export function App() {
           workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}
           selectedSurface={sidebarSurface}
-          collapsed={effectiveSidebarCollapsed}
+          collapsed={sidebarCollapsed}
           onSelectSurface={handleSelectSidebarSurface}
-          onToggleCollapsed={() => setSidebarCollapsed(!effectiveSidebarCollapsed)}
+          onToggleCollapsed={() => setSidebarCollapsed((value) => !value)}
           onOpenSettings={() => {
             cancelPendingSystemSetupAutoOpen();
             setShowSystemSetup(true);
@@ -3167,6 +3118,7 @@ export function App() {
           className="fixed inset-0 z-50 flex flex-col bg-gray-950"
         >
           <InvokerTerminal
+            activeConversationKey={activePlanningConversationKey}
             lines={terminalLines}
             busy={activePlanningSessionBusy}
             value={planningInput}

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, within, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { vi } from 'vitest';
-import { createMockInvoker, makePlanningSessionSummary, type MockInvoker } from './helpers/mock-invoker.js';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
 
 vi.mock('@xyflow/react', async () => {
   // Dynamic import is required because Vitest hoists mock factories before test imports.
@@ -9,8 +9,9 @@ vi.mock('@xyflow/react', async () => {
   return createReactFlowMock();
 });
 
-// Dynamic import is required so App sees the hoisted @xyflow/react mock.
+// Dynamic imports are required so modules see the hoisted @xyflow/react mock.
 const { App } = await import('../App.js');
+const { InvokerTerminal } = await import('../components/InvokerTerminal.js');
 
 describe('Invoker terminal (component)', () => {
   let mock: MockInvoker;
@@ -24,10 +25,10 @@ describe('Invoker terminal (component)', () => {
     mock.cleanup();
   });
 
-  async function openPlanningTerminal(expectedPresetKey = 'codex') {
+  async function openPlanningTerminal() {
     fireEvent.click(await screen.findByTestId('sidebar-planning'));
     await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue(expectedPresetKey);
+      expect(screen.getByTestId('invoker-terminal-harness')).toHaveValue('codex');
     });
   }
 
@@ -94,23 +95,11 @@ describe('Invoker terminal (component)', () => {
     });
   });
 
-  it('shows full draft YAML in the transcript, then submits without starting execution', async () => {
-    const fullYamlReply = [
-      'Here is the plan.',
-      '',
-      '```yaml',
-      'name: Mock Plan',
-      'tasks:',
-      '  - id: first',
-      '    description: First full task description that remains visible',
-      '  - id: second',
-      '    description: Second full task description that remains visible',
-      '```',
-    ].join('\n');
+  it('shows the sticky ready bar and submits without starting execution', async () => {
     mock.api.planningChatSend = vi.fn(async () => ({
       ok: true,
       sessionId: 'session-1',
-      reply: fullYamlReply,
+      reply: 'Here is the plan.',
       draftPlanAvailable: true,
       draftPlanSummary: { name: 'Mock Plan', taskCount: 2, steps: ['First', 'Second'] },
     })) as any;
@@ -122,7 +111,6 @@ describe('Invoker terminal (component)', () => {
     await waitFor(() => {
       expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('Draft plan ready: "Mock Plan" (2 steps).');
     });
-    expect(screen.getByTestId('invoker-terminal-transcript').textContent).toContain(fullYamlReply);
 
     fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
 
@@ -252,136 +240,6 @@ describe('Invoker terminal (component)', () => {
     expect(screen.getAllByText('Submitted').length).toBeGreaterThan(0);
   });
 
-
-  it('hydrates restored planning chats from the backend list', async () => {
-    vi.mocked(mock.api.planningChatList).mockResolvedValueOnce({
-      ok: true,
-      sessions: [
-        makePlanningSessionSummary({
-          id: 'saved-newest',
-          title: 'Newest saved chat',
-          updatedAt: '2026-07-07T00:05:00.000Z',
-          messages: [
-            { id: 10, role: 'system', text: 'Ask Invoker what you want to build.', tone: 'muted', createdAt: '2026-07-07T00:00:00.000Z' },
-            { id: 11, role: 'user', text: 'Saved user request', createdAt: '2026-07-07T00:01:00.000Z' },
-            { id: 12, role: 'assistant', text: 'Saved assistant draft', createdAt: '2026-07-07T00:02:00.000Z' },
-          ],
-        }),
-        makePlanningSessionSummary({
-          id: 'saved-older',
-          title: 'Older saved chat',
-          status: 'still_discussing',
-          draftPlanAvailable: false,
-          draftPlanSummary: undefined,
-          updatedAt: '2026-07-07T00:04:00.000Z',
-        }),
-      ],
-    });
-
-    render(<App />);
-    await openPlanningTerminal();
-
-    await waitFor(() => {
-      expect(screen.getByText('2 chats · 1 ready')).toBeInTheDocument();
-      expect(screen.getByRole('heading', { name: 'Newest saved chat' })).toBeInTheDocument();
-      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Saved user request');
-      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Saved assistant draft');
-    });
-    expect(screen.getByTestId('invoker-terminal-ready-bar')).toHaveTextContent('Draft plan ready: \"Saved plan\" (1 step).');
-
-    fireEvent.click(screen.getByRole('button', { name: 'Submit to Invoker' }));
-
-    await waitFor(() => {
-      expect(mock.api.planningChatSubmit).toHaveBeenCalledWith({ sessionId: 'saved-newest' });
-    });
-  });
-
-  it('keeps a local planning draft when backend restore resolves later', async () => {
-    let resolvePlanningList: (value: any) => void = () => {};
-    vi.mocked(mock.api.planningChatList).mockImplementationOnce(() => new Promise((resolve) => {
-      resolvePlanningList = resolve;
-    }));
-
-    render(<App />);
-    await openPlanningTerminal();
-
-    fireEvent.change(screen.getByTestId('invoker-terminal-input'), {
-      target: { value: 'local draft before restore' },
-    });
-
-    await act(async () => {
-      resolvePlanningList({
-        ok: true,
-        sessions: [makePlanningSessionSummary({
-          id: 'saved-late',
-          title: 'Late saved chat',
-          updatedAt: '2026-07-07T00:05:00.000Z',
-        })],
-      });
-    });
-
-    expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('local draft before restore');
-    expect(screen.queryByRole('heading', { name: 'Late saved chat' })).not.toBeInTheDocument();
-  });
-
-  it('restores interrupted planning chats idle and sends continuation with the saved preset', async () => {
-    vi.mocked(mock.api.planningChatList).mockResolvedValueOnce({
-      ok: true,
-      sessions: [makePlanningSessionSummary({
-        id: 'saved-interrupted',
-        title: 'Interrupted saved chat',
-        status: 'still_discussing',
-        presetKey: 'omp+claude',
-        draftPlanAvailable: false,
-        draftPlanSummary: undefined,
-        messages: [
-          { id: 1, role: 'system', text: 'Ask Invoker what you want to build.', tone: 'muted', createdAt: '2026-07-07T00:00:00.000Z' },
-          { id: 2, role: 'user', text: 'Continue the work', createdAt: '2026-07-07T00:01:00.000Z' },
-          { id: 3, role: 'system', text: 'Planner was interrupted before it could answer. Send another message to continue.', tone: 'error', createdAt: '2026-07-07T00:02:00.000Z' },
-        ],
-      })],
-    });
-
-    render(<App />);
-    await openPlanningTerminal('omp+claude');
-
-    await waitFor(() => {
-      expect(screen.getByTestId('invoker-terminal-transcript')).toHaveTextContent('Planner was interrupted before it could answer. Send another message to continue.');
-    });
-    expect(screen.queryByText('Working…')).not.toBeInTheDocument();
-    expect(screen.getByTestId('invoker-terminal-input')).toBeEnabled();
-
-    submitPlanningText('continue');
-
-    await waitFor(() => {
-      expect(mock.api.planningChatSend).toHaveBeenCalledWith({
-        sessionId: 'saved-interrupted',
-        message: 'continue',
-        presetKey: 'omp+claude',
-      });
-    });
-  });
-
-  it('restores submitted planning chats as read-only without a ready bar', async () => {
-    vi.mocked(mock.api.planningChatList).mockResolvedValueOnce({
-      ok: true,
-      sessions: [makePlanningSessionSummary({
-        id: 'saved-submitted',
-        title: 'Submitted saved chat',
-        status: 'submitted',
-        draftPlanAvailable: true,
-      })],
-    });
-
-    render(<App />);
-    await openPlanningTerminal();
-
-    await waitFor(() => {
-      expect(screen.getByRole('heading', { name: 'Submitted saved chat' })).toBeInTheDocument();
-    });
-    expect(screen.getByTestId('invoker-terminal-input')).toBeDisabled();
-    expect(screen.queryByTestId('invoker-terminal-ready-bar')).not.toBeInTheDocument();
-  });
   it('opens the expanded planning chat and Escape closes it without clearing transcript', async () => {
     render(<App />);
     await openPlanningTerminal();
@@ -453,5 +311,86 @@ describe('Invoker terminal (component)', () => {
       draftPlanAvailable: false,
     });
     await waitFor(() => expect(screen.getByTestId('invoker-terminal-input')).toHaveValue('second session request'));
+  });
+
+  it('follows new transcript lines until the user scrolls away from the bottom', async () => {
+    const props = {
+      activeConversationKey: 'chat-1',
+      lines: [{ id: 1, text: 'First line', role: 'system' as const }],
+      busy: false,
+      value: '',
+      selectedPresetKey: 'codex',
+      presetOptions: [{ key: 'codex', label: 'Codex' }],
+      draftPlanAvailable: false,
+      onValueChange: vi.fn(),
+      onSubmit: vi.fn(),
+      onSubmitDraft: vi.fn(),
+      onPresetChange: vi.fn(),
+      onExpand: vi.fn(),
+    };
+    const { rerender } = render(<InvokerTerminal {...props} />);
+    const transcript = screen.getByTestId('invoker-terminal-transcript');
+    Object.defineProperty(transcript, 'clientHeight', { configurable: true, value: 100 });
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 400 });
+
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 500 });
+    rerender(<InvokerTerminal {...props} lines={[...props.lines, { id: 2, text: 'Second line', role: 'assistant' as const }]} />);
+
+    await waitFor(() => expect(transcript.scrollTop).toBe(500));
+
+    transcript.scrollTop = 50;
+    fireEvent.scroll(transcript);
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 600 });
+    rerender(<InvokerTerminal {...props} lines={[
+      ...props.lines,
+      { id: 2, text: 'Second line', role: 'assistant' as const },
+      { id: 3, text: 'Third line', role: 'assistant' as const },
+    ]} />);
+
+    expect(transcript.scrollTop).toBe(50);
+
+    transcript.scrollTop = 500;
+    fireEvent.scroll(transcript);
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 700 });
+    rerender(<InvokerTerminal {...props} lines={[
+      ...props.lines,
+      { id: 2, text: 'Second line', role: 'assistant' as const },
+      { id: 3, text: 'Third line', role: 'assistant' as const },
+      { id: 4, text: 'Fourth line', role: 'assistant' as const },
+    ]} />);
+
+    await waitFor(() => expect(transcript.scrollTop).toBe(700));
+  });
+
+  it('resets transcript follow mode when the active planning conversation changes', async () => {
+    const props = {
+      activeConversationKey: 'chat-1',
+      lines: [{ id: 1, text: 'First chat', role: 'system' as const }],
+      busy: false,
+      value: '',
+      selectedPresetKey: 'codex',
+      presetOptions: [{ key: 'codex', label: 'Codex' }],
+      draftPlanAvailable: false,
+      onValueChange: vi.fn(),
+      onSubmit: vi.fn(),
+      onSubmitDraft: vi.fn(),
+      onPresetChange: vi.fn(),
+      onExpand: vi.fn(),
+    };
+    const { rerender } = render(<InvokerTerminal {...props} />);
+    const transcript = screen.getByTestId('invoker-terminal-transcript');
+    Object.defineProperty(transcript, 'clientHeight', { configurable: true, value: 100 });
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 400 });
+
+    transcript.scrollTop = 50;
+    fireEvent.scroll(transcript);
+    Object.defineProperty(transcript, 'scrollHeight', { configurable: true, value: 500 });
+    rerender(<InvokerTerminal
+      {...props}
+      activeConversationKey="chat-2"
+      lines={[{ id: 2, text: 'Second chat', role: 'system' as const }]}
+    />);
+
+    await waitFor(() => expect(transcript.scrollTop).toBe(500));
   });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 export interface InvokerTerminalLine {
   id: number;
@@ -10,6 +10,12 @@ export interface InvokerTerminalLine {
 interface PlanningPresetOptionView {
   key: string;
   label: string;
+}
+
+const TRANSCRIPT_BOTTOM_TOLERANCE_PX = 32;
+
+function isTranscriptNearBottom(element: HTMLDivElement): boolean {
+  return element.scrollHeight - element.scrollTop - element.clientHeight <= TRANSCRIPT_BOTTOM_TOLERANCE_PX;
 }
 
 interface InvokerTerminalProps {
@@ -30,6 +36,7 @@ interface InvokerTerminalProps {
   onExpand: () => void;
   onCloseExpanded?: () => void;
   onCollapse?: () => void;
+  activeConversationKey: string;
 }
 
 interface SubmitErrorView {
@@ -55,8 +62,34 @@ export function InvokerTerminal({
   onExpand,
   onCloseExpanded,
   onCollapse,
+  activeConversationKey,
 }: InvokerTerminalProps): JSX.Element {
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const transcriptRef = useRef<HTMLDivElement | null>(null);
+  const [shouldFollowTranscript, setShouldFollowTranscript] = useState(true);
+
+  const scrollTranscriptToBottom = useCallback((): void => {
+    const transcript = transcriptRef.current;
+    if (!transcript) return;
+    transcript.scrollTop = transcript.scrollHeight;
+  }, []);
+
+  useLayoutEffect(() => {
+    setShouldFollowTranscript(true);
+    scrollTranscriptToBottom();
+  }, [activeConversationKey, scrollTranscriptToBottom]);
+
+  useLayoutEffect(() => {
+    if (shouldFollowTranscript) {
+      scrollTranscriptToBottom();
+    }
+  }, [lines.length, scrollTranscriptToBottom, shouldFollowTranscript]);
+
+  const handleTranscriptScroll = useCallback((): void => {
+    const transcript = transcriptRef.current;
+    if (!transcript) return;
+    setShouldFollowTranscript(isTranscriptNearBottom(transcript));
+  }, []);
 
   useEffect(() => {
     if (!busy && !readOnly) {
@@ -113,7 +146,9 @@ export function InvokerTerminal({
       </div>
 
       <div
+        ref={transcriptRef}
         data-testid="invoker-terminal-transcript"
+        onScroll={handleTranscriptScroll}
         className={`min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-5 text-sm ${expanded ? '' : 'max-h-64'}`}
       >
         {lines.map((line) => {


### PR DESCRIPTION
## Summary

The planning chat transcript now follows new replies while the active conversation is already near the bottom.

When a user scrolls upward, the transcript holds position so older context stays readable.

Changing to another planning chat re-arms follow mode for that conversation.

## Review Claim

The planning terminal owns local transcript follow state and resets it when the active conversation changes.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This only touches renderer-side planning terminal state and its focused UI tests.

## Slice Rationale

The behavior is isolated from backend planning and later proof-only work.

## Non-goals

- Do not change planner backend behavior.
- Do not change planning persistence or workflow submission.
- Do not change non-planning terminal surfaces.

## Architecture

### Before

`InvokerTerminal` rendered transcript lines without knowing when the selected planning conversation changed or whether the user had scrolled away.

### After

`App` passes a stable conversation key into `InvokerTerminal`. The terminal uses local follow state to scroll new lines only while the transcript remains near the bottom.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`

</details>

## Visual Proof

![Planning terminal transcript with draft-ready composer](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260707-22a4b3/stacked-workflows.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert f6fc2cc`
- Post-revert steps: None
- Data migration? No

</details>
