### PR TITLE
[PR cron] Prune stale pr-cron-work checkouts

### DIFF
--- a/scripts/cron-coderabbit-address.sh
+++ b/scripts/cron-coderabbit-address.sh
@@ -20,6 +20,7 @@
 #      INVOKER_PR_CODERABBIT_MAX_ATTEMPTS (default 3),
 #      INVOKER_PR_CODERABBIT_STATE_FILE (ledger path),
 #      INVOKER_PR_CRON_WORKDIR (checkout root),
+#      INVOKER_PR_CRON_WORKDIR_MAX_AGE_DAYS (default 7),
 #      INVOKER_PR_CRON_OMP_MODEL (omp model, optional),
 #      INVOKER_OMP_COMMAND (omp binary, default omp),
 #      INVOKER_PR_CRON_DRY_RUN=1 (print intended actions only).
@@ -31,9 +32,11 @@ source "$(dirname "$0")/cron-pr-lib.sh"
 MAX_CODERABBIT_ATTEMPTS="${INVOKER_PR_CODERABBIT_MAX_ATTEMPTS:-3}"
 STATE_FILE="${INVOKER_PR_CODERABBIT_STATE_FILE:-${HOME}/.invoker/coderabbit-address-submissions.tsv}"
 WORKDIR="${INVOKER_PR_CRON_WORKDIR:-${HOME}/.invoker/pr-cron-work}"
+WORKDIR_MAX_AGE_DAYS="${INVOKER_PR_CRON_WORKDIR_MAX_AGE_DAYS:-7}"
 
 cron_lock
 ledger_init "$STATE_FILE"
+prune_stale_pr_workdirs "$WORKDIR" "$WORKDIR_MAX_AGE_DAYS"
 
 # Fetch one comments endpoint, normalizing gh's per-page arrays into one array.
 fetch_cr_endpoint() {
@@ -78,6 +81,7 @@ prepare_checkout() {
     log_line "PR #$num: gh pr checkout failed" >&2
     return 1
   fi
+  touch "$dir/$PR_CRON_WORKDIR_STAMP_NAME" >/dev/null 2>&1 || true
   CHECKOUT_DIR="$dir"
 }
 

--- a/scripts/cron-pr-lib.sh
+++ b/scripts/cron-pr-lib.sh
@@ -13,7 +13,7 @@
 #              TARGET_REPO, PR_AUTHOR, CODERABBIT_LOGIN, CRON_LOCK, DRY_RUN
 #   Functions: log_line, cron_lock, ledger_init, ledger_record, ledger_count,
 #              ledger_marker_seen, ledger_max_marker, gh_json,
-#              resolve_workflow_for_pr
+#              resolve_workflow_for_pr, prune_stale_pr_workdirs
 #
 # Both jobs run their mutating operation SYNCHRONOUSLY while holding a single
 # shared lock, so only one PR cron operation runs at a time (the other exits
@@ -178,4 +178,71 @@ resolve_workflow_for_pr() {
     return
   fi
   headless_query query review-gate "$pr" --output json
+}
+
+# ---------------------------------------------------------------------------
+# Local disk guardrail: prune stale PR checkout workdirs.
+# This is only used by Job 1 (cron-coderabbit-address) today, but lives here so
+# both jobs share the same policy when/if Job 2 needs checkouts later.
+# ---------------------------------------------------------------------------
+
+PR_CRON_WORKDIR_STAMP_NAME=".invoker-pr-cron-last-used"
+
+_stat_mtime_epoch() {
+  local path="${1:?path required}"
+  if stat -c %Y "$path" >/dev/null 2>&1; then
+    stat -c %Y "$path"
+    return
+  fi
+  stat -f %m "$path"
+}
+
+prune_stale_pr_workdirs() {
+  # prune_stale_pr_workdirs <root> <max_age_days>
+  local root="${1:?workdir root required}"
+  local max_age_days="${2:-7}"
+
+  if [ -z "$root" ] || [ "$root" = "/" ] || [ "$root" = "$HOME" ]; then
+    log_line "prune: refusing to prune unsafe root \"$root\"" >&2
+    return 1
+  fi
+
+  if [[ ! "$max_age_days" =~ ^[0-9]+$ ]]; then
+    log_line "prune: invalid max age days \"$max_age_days\" (expected integer)" >&2
+    return 1
+  fi
+
+  [ -d "$root" ] || return 0
+
+  local now cutoff
+  now="$(date +%s)"
+  cutoff="$(( now - max_age_days * 24 * 60 * 60 ))"
+
+  shopt -s nullglob
+  local dir name stamp mtime
+  for dir in "$root"/*; do
+    [ -d "$dir" ] || continue
+    name="$(basename "$dir")"
+    [[ "$name" =~ ^[0-9]+$ ]] || continue
+
+    stamp="$dir/$PR_CRON_WORKDIR_STAMP_NAME"
+    if [ -e "$stamp" ]; then
+      mtime="$(_stat_mtime_epoch "$stamp" 2>/dev/null || true)"
+    else
+      mtime="$(_stat_mtime_epoch "$dir" 2>/dev/null || true)"
+    fi
+
+    [ -n "${mtime:-}" ] || continue
+    [[ "$mtime" =~ ^[0-9]+$ ]] || continue
+
+    if [ "$mtime" -lt "$cutoff" ]; then
+      if [ "$DRY_RUN" = "1" ]; then
+        log_line "prune: would remove stale pr workdir \"$dir\" (mtime=$mtime cutoff=$cutoff age_days=$max_age_days)"
+      else
+        rm -rf "$dir"
+        log_line "prune: removed stale pr workdir \"$dir\" (age_days=$max_age_days)"
+      fi
+    fi
+  done
+  shopt -u nullglob
 }

--- a/scripts/test-cron-prune-stale-workdirs.sh
+++ b/scripts/test-cron-prune-stale-workdirs.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+export INVOKER_PR_CRON_DRY_RUN=0
+
+# shellcheck source=scripts/cron-pr-lib.sh
+source "$REPO_ROOT/scripts/cron-pr-lib.sh"
+export PR_CRON_WORKDIR_STAMP_NAME
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP" 2>/dev/null || true' EXIT
+
+WORKDIR="$TMP/work"
+export WORKDIR
+mkdir -p "$WORKDIR"
+
+mkdir -p "$WORKDIR/111" "$WORKDIR/222" "$WORKDIR/333" "$WORKDIR/not-a-pr"
+touch "$WORKDIR/111/$PR_CRON_WORKDIR_STAMP_NAME"
+touch "$WORKDIR/222/$PR_CRON_WORKDIR_STAMP_NAME"
+
+python3 - <<'PY'
+import os
+import time
+
+base = os.environ["WORKDIR"]
+now = int(time.time())
+
+def set_mtime(path: str, days_ago: int) -> None:
+    t = now - days_ago * 24 * 60 * 60
+    os.utime(path, (t, t))
+
+set_mtime(os.path.join(base, "111", os.environ["PR_CRON_WORKDIR_STAMP_NAME"]), 10)
+set_mtime(os.path.join(base, "222", os.environ["PR_CRON_WORKDIR_STAMP_NAME"]), 1)
+set_mtime(os.path.join(base, "333"), 10)
+PY
+
+prune_stale_pr_workdirs "$WORKDIR" 7
+
+if [ -d "$WORKDIR/111" ]; then
+  echo "[test] FAIL: expected stale workdir 111 to be pruned" >&2
+  exit 1
+fi
+
+if [ ! -d "$WORKDIR/222" ]; then
+  echo "[test] FAIL: expected fresh workdir 222 to remain" >&2
+  exit 1
+fi
+
+if [ -d "$WORKDIR/333" ]; then
+  echo "[test] FAIL: expected unstamped stale workdir 333 to be pruned" >&2
+  exit 1
+fi
+
+if [ ! -d "$WORKDIR/not-a-pr" ]; then
+  echo "[test] FAIL: expected non-numeric workdir to remain" >&2
+  exit 1
+fi
+
+echo "[test] PASS: pr-cron-work stale sweep"


### PR DESCRIPTION
## Summary
- Bound the age of `~/.invoker/pr-cron-work/<pr>` checkouts used by PR maintenance cron.
- Use a stamp file to identify fresh checkouts; older numeric workdirs expire after `INVOKER_PR_CRON_WORKDIR_MAX_AGE_DAYS` (default 7).

## Review Claim
`pr-cron-work` is scratch space; bounding its retention window keeps disk usage predictable.

## Review Lane
policy

## Review Unit
tooling-policy

## Safety Invariant
Only deletes numeric workdirs under the configured root; non-numeric directories are never removed.

## Slice Rationale
Single slice: this guardrail lives with the PR cron scripts and can ship independently of the disk monitor.

## Non-goals
- GC of git objects within retained clones.
- Any changes to PR mutation behavior beyond removing stale local workdirs.

## Test Plan
<details>
<summary>Test Plan</summary>

- `bash -n scripts/cron-pr-lib.sh scripts/cron-coderabbit-address.sh scripts/test-cron-prune-stale-workdirs.sh`
- `bash scripts/test-cron-prune-stale-workdirs.sh`

</details>

## Revert Plan
<details>
<summary>Revert Plan</summary>

- Revert this PR.
- Existing `pr-cron-work` directories will no longer be removed automatically.

</details>
