### PR TITLE
[Fix sessions](1) Add an explicit fix-session mechanism to the orchestrator

### DIFF
--- a/packages/data-store/src/__tests__/orchestrator-sqlite-worker-response.test.ts
+++ b/packages/data-store/src/__tests__/orchestrator-sqlite-worker-response.test.ts
@@ -167,7 +167,7 @@ describe('Orchestrator + SQLite worker response persistence', () => {
     expect(row.execution.error).toContain('attempt failed first');
   });
 
-  it('beginConflictResolution persists fixing_with_ai and clears error/exit/completed', () => {
+  it('beginFixSession persists fixing_with_ai and clears error/exit/completed', () => {
     adapter.saveTask(wf.id, baseTask('task-fix'));
     orchestrator.syncFromDb(wf.id);
 
@@ -181,7 +181,7 @@ describe('Orchestrator + SQLite worker response persistence', () => {
     });
     orchestrator.syncFromDb(wf.id);
 
-    orchestrator.beginConflictResolution('task-fix');
+    orchestrator.beginFixSession('task-fix');
 
     const row = adapter.loadTasks(wf.id).find((t) => t.id === 'task-fix')!;
     expect(row.status).toBe('fixing_with_ai');

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -33,7 +33,7 @@ import type {
   DetachedExternalDependency,
 } from '@invoker/workflow-core';
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
-import type { InAppPlanningChatLine, InAppPlanningPlanSummary, InAppPlanningSessionStatus, SearchResultItem, SearchOptions } from '@invoker/contracts';
+import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 import {
   assertTaskConsistent,
   assertWorkflowConsistent,
@@ -60,8 +60,6 @@ import type {
   WorkerActionWrite,
   TerminalSessionPatch,
   TerminalSessionRecord,
-  InAppPlanningSessionPatch,
-  InAppPlanningSessionRecord,
 } from './adapter.js';
 import {
   SCHEMA_DDL,
@@ -393,28 +391,6 @@ type TerminalSessionRow = {
   updated_at?: unknown;
 };
 
-type InAppPlanningSessionRow = {
-  session_id?: unknown;
-  title?: unknown;
-  preset_key?: unknown;
-  status?: unknown;
-  draft_plan_summary_json?: unknown;
-  submitted_workflow_id?: unknown;
-  submitted_plan_name?: unknown;
-  pending_response?: unknown;
-  created_at?: unknown;
-  updated_at?: unknown;
-};
-
-type InAppPlanningMessageRow = {
-  session_id?: unknown;
-  message_id?: unknown;
-  role?: unknown;
-  text?: unknown;
-  tone?: unknown;
-  created_at?: unknown;
-};
-
 function parseTerminalArgsJson(value: unknown): string[] {
   if (typeof value !== 'string' || value.length === 0) return [];
   try {
@@ -423,53 +399,6 @@ function parseTerminalArgsJson(value: unknown): string[] {
   } catch {
     return [];
   }
-}
-
-function isInAppPlanningSessionStatus(value: unknown): value is InAppPlanningSessionStatus {
-  return value === 'still_discussing'
-    || value === 'waiting_for_answer'
-    || value === 'draft_ready'
-    || value === 'submitted';
-}
-
-function isInAppPlanningMessageRole(value: unknown): value is InAppPlanningChatLine['role'] {
-  return value === 'user' || value === 'assistant' || value === 'system';
-}
-
-function isInAppPlanningMessageTone(value: unknown): value is InAppPlanningChatLine['tone'] {
-  return value === undefined
-    || value === null
-    || value === 'muted'
-    || value === 'error'
-    || value === 'success';
-}
-
-function parseInAppPlanningPlanSummary(value: unknown): InAppPlanningPlanSummary | undefined {
-  if (value === null || value === undefined) return undefined;
-  if (typeof value !== 'string' || value.length === 0) return undefined;
-  const parsed = JSON.parse(value) as unknown;
-  if (!parsed || typeof parsed !== 'object') {
-    throw new Error('planning summary must be an object');
-  }
-  const candidate = parsed as Partial<InAppPlanningPlanSummary>;
-  if (
-    typeof candidate.name !== 'string'
-    || typeof candidate.taskCount !== 'number'
-    || !Array.isArray(candidate.steps)
-    || !candidate.steps.every((step) => typeof step === 'string')
-    || (
-      candidate.workflowCount !== undefined
-      && typeof candidate.workflowCount !== 'number'
-    )
-  ) {
-    throw new Error('planning summary has invalid shape');
-  }
-  return {
-    name: candidate.name,
-    taskCount: candidate.taskCount,
-    ...(candidate.workflowCount === undefined ? {} : { workflowCount: candidate.workflowCount }),
-    steps: candidate.steps,
-  };
 }
 
 export class SQLiteAdapter implements PersistenceAdapter {
@@ -947,10 +876,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.migrateWorkflowStatusColumn();
     this.dropTaskAutoFixAttemptsColumn();
 
-    if (!this.readOnly) {
-      this.reconcileTerminalSessionInvariants();
-    }
-
     // Replace old attempt_number index with created_at index, etc.
     for (const sql of POST_MIGRATION_STATEMENTS) {
       this.db.run(sql);
@@ -1181,38 +1106,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
     } catch {
       // Tables/columns may not exist yet on first run.
     }
-  }
-
-  private reconcileTerminalSessionInvariants(): void {
-    const rows = this.queryAll(
-      `SELECT session_id, target_key
-       FROM terminal_sessions
-       WHERE status = 'running'
-       ORDER BY target_key ASC, updated_at DESC, created_at DESC, session_id DESC`,
-    ) as Array<{ session_id: string; target_key: string }>;
-
-    const seenTargets = new Set<string>();
-    const now = new Date().toISOString();
-    for (const row of rows) {
-      if (!row.target_key || !row.session_id) continue;
-      if (!seenTargets.has(row.target_key)) {
-        seenTargets.add(row.target_key);
-        continue;
-      }
-      this.db.run(
-        `UPDATE terminal_sessions
-            SET status = 'exited',
-                updated_at = ?
-          WHERE session_id = ?`,
-        [now, row.session_id],
-      );
-    }
-
-    this.db.run(
-      `CREATE UNIQUE INDEX IF NOT EXISTS idx_terminal_sessions_running_target
-         ON terminal_sessions(target_key)
-         WHERE status = 'running'`,
-    );
   }
 
   // ── Workflows ─────────────────────────────────────────
@@ -1522,7 +1415,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         last_agent_session_id, last_agent_name,
         action_request_id, experiments,
         created_at, launch_phase, launch_started_at, launch_completed_at, started_at, completed_at, last_heartbeat_at,
-        utilization, pending_fix_error,
+        utilization, pending_fix_error, fix_session_entry_status,
         review_url, review_id, review_status, review_provider_id, review_gate,
         is_fixing_with_ai,
         execution_generation,
@@ -1542,7 +1435,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ?, ?,
         ?, ?, ?,
         ?, ?, ?, ?, ?, ?, ?, ?,
-        ?, ?,
+        ?, ?, ?,
         ?, ?,
         ?, ?, ?, ?,
         ?, ?,
@@ -1599,6 +1492,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       exec.lastHeartbeatAt?.toISOString() ?? null,
       null,
       exec.pendingFixError ?? null,
+      exec.fixSessionEntryStatus ?? null,
       exec.reviewUrl ?? null,
       exec.reviewId ?? null,
       exec.reviewStatus ?? null,
@@ -1702,6 +1596,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         containerId: 'container_id',
         selectedExperiment: 'selected_experiment',
         pendingFixError: 'pending_fix_error',
+        fixSessionEntryStatus: 'fix_session_entry_status',
         reviewUrl: 'review_url',
         reviewId: 'review_id',
         reviewStatus: 'review_status',
@@ -1926,124 +1821,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.ensureWritable();
     this.db.run('DELETE FROM terminal_sessions WHERE session_id = ?', [sessionId]);
     this.dirty = true;
-  }
-
-  upsertInAppPlanningSession(record: InAppPlanningSessionRecord): void {
-    this.runTransaction(() => {
-      this.db.run(
-        `INSERT INTO in_app_planning_sessions (
-          session_id,
-          title,
-          preset_key,
-          status,
-          draft_plan_summary_json,
-          submitted_workflow_id,
-          submitted_plan_name,
-          pending_response,
-          created_at,
-          updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        ON CONFLICT(session_id) DO UPDATE SET
-          title = excluded.title,
-          preset_key = excluded.preset_key,
-          status = excluded.status,
-          draft_plan_summary_json = excluded.draft_plan_summary_json,
-          submitted_workflow_id = excluded.submitted_workflow_id,
-          submitted_plan_name = excluded.submitted_plan_name,
-          pending_response = excluded.pending_response,
-          created_at = excluded.created_at,
-          updated_at = excluded.updated_at`,
-        [
-          record.id,
-          record.title,
-          record.presetKey,
-          record.status,
-          record.draftPlanSummary ? JSON.stringify(record.draftPlanSummary) : null,
-          record.submittedWorkflowId ?? null,
-          record.submittedPlanName ?? null,
-          record.pendingResponse ? 1 : 0,
-          record.createdAt,
-          record.updatedAt,
-        ],
-      );
-      this.replaceInAppPlanningMessages(record.id, record.messages, record.updatedAt);
-    });
-  }
-
-  listInAppPlanningSessions(): InAppPlanningSessionRecord[] {
-    const rows = this.queryAll(
-      'SELECT * FROM in_app_planning_sessions ORDER BY updated_at DESC, created_at DESC',
-    ) as InAppPlanningSessionRow[];
-    const records: InAppPlanningSessionRecord[] = [];
-    for (const row of rows) {
-      const record = this.mapInAppPlanningSessionRow(row);
-      if (record) records.push(record);
-    }
-    return records;
-  }
-
-  loadInAppPlanningSession(sessionId: string): InAppPlanningSessionRecord | undefined {
-    const row = this.queryOne('SELECT * FROM in_app_planning_sessions WHERE session_id = ?', [sessionId]);
-    return row ? this.mapInAppPlanningSessionRow(row as InAppPlanningSessionRow) : undefined;
-  }
-
-  updateInAppPlanningSession(sessionId: string, patch: InAppPlanningSessionPatch): void {
-    this.ensureWritable();
-    const updateSession = (): void => {
-      const setClauses: string[] = [];
-      const values: unknown[] = [];
-      if (Object.hasOwn(patch, 'title')) {
-        setClauses.push('title = ?');
-        values.push(patch.title ?? null);
-      }
-      if (Object.hasOwn(patch, 'status')) {
-        setClauses.push('status = ?');
-        values.push(patch.status ?? null);
-      }
-      if (Object.hasOwn(patch, 'draftPlanSummary')) {
-        setClauses.push('draft_plan_summary_json = ?');
-        values.push(patch.draftPlanSummary ? JSON.stringify(patch.draftPlanSummary) : null);
-      }
-      if (Object.hasOwn(patch, 'submittedWorkflowId')) {
-        setClauses.push('submitted_workflow_id = ?');
-        values.push(patch.submittedWorkflowId ?? null);
-      }
-      if (Object.hasOwn(patch, 'submittedPlanName')) {
-        setClauses.push('submitted_plan_name = ?');
-        values.push(patch.submittedPlanName ?? null);
-      }
-      if (Object.hasOwn(patch, 'pendingResponse')) {
-        setClauses.push('pending_response = ?');
-        values.push(patch.pendingResponse ? 1 : 0);
-      }
-      if (Object.hasOwn(patch, 'updatedAt')) {
-        setClauses.push('updated_at = ?');
-        values.push(patch.updatedAt ?? null);
-      }
-      if (setClauses.length > 0) {
-        values.push(sessionId);
-        this.db.run(`UPDATE in_app_planning_sessions SET ${setClauses.join(', ')} WHERE session_id = ?`, values);
-      }
-      if (patch.messages) {
-        const updatedAt = patch.updatedAt ?? new Date().toISOString();
-        this.replaceInAppPlanningMessages(sessionId, patch.messages, updatedAt);
-      }
-    };
-
-    if (patch.messages) {
-      this.runTransaction(updateSession);
-      return;
-    }
-
-    updateSession();
-    this.dirty = true;
-  }
-
-  deleteInAppPlanningSession(sessionId: string): void {
-    this.runTransaction(() => {
-      this.db.run('DELETE FROM in_app_planning_messages WHERE session_id = ?', [sessionId]);
-      this.db.run('DELETE FROM in_app_planning_sessions WHERE session_id = ?', [sessionId]);
-    });
   }
 
   private getTaskIdsForWorkflow(workflowId: string): string[] {
@@ -3285,98 +3062,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
       createdAt,
       updatedAt,
     };
-  }
-
-  private replaceInAppPlanningMessages(
-    sessionId: string,
-    messages: InAppPlanningChatLine[],
-    fallbackCreatedAt: string,
-  ): void {
-    this.db.run('DELETE FROM in_app_planning_messages WHERE session_id = ?', [sessionId]);
-    for (const message of messages) {
-      this.db.run(
-        `INSERT INTO in_app_planning_messages (
-          session_id,
-          message_id,
-          role,
-          text,
-          tone,
-          created_at
-        ) VALUES (?, ?, ?, ?, ?, ?)`,
-        [
-          sessionId,
-          message.id,
-          message.role,
-          message.text,
-          message.tone ?? null,
-          message.createdAt ?? fallbackCreatedAt,
-        ],
-      );
-    }
-  }
-
-
-  private mapInAppPlanningSessionRow(row: InAppPlanningSessionRow): InAppPlanningSessionRecord | undefined {
-    try {
-      const id = typeof row.session_id === 'string' ? row.session_id : '';
-      const title = typeof row.title === 'string' ? row.title : '';
-      const presetKey = typeof row.preset_key === 'string' ? row.preset_key : '';
-      const createdAt = typeof row.created_at === 'string' ? row.created_at : '';
-      const updatedAt = typeof row.updated_at === 'string' ? row.updated_at : '';
-      if (!id || !title || !presetKey || !createdAt || !updatedAt || !isInAppPlanningSessionStatus(row.status)) {
-        return undefined;
-      }
-      if (
-        row.status === 'submitted'
-        && (
-          typeof row.submitted_workflow_id !== 'string'
-          || typeof row.submitted_plan_name !== 'string'
-        )
-      ) {
-        return undefined;
-      }
-
-      const messageRows = this.queryAll(
-        'SELECT * FROM in_app_planning_messages WHERE session_id = ? ORDER BY message_id ASC',
-        [id],
-      ) as InAppPlanningMessageRow[];
-      const draftPlanSummary = parseInAppPlanningPlanSummary(row.draft_plan_summary_json);
-      const messages: InAppPlanningChatLine[] = [];
-      for (const messageRow of messageRows) {
-        if (
-          typeof messageRow.message_id !== 'number'
-          || !isInAppPlanningMessageRole(messageRow.role)
-          || typeof messageRow.text !== 'string'
-          || typeof messageRow.created_at !== 'string'
-          || !isInAppPlanningMessageTone(messageRow.tone)
-        ) {
-          return undefined;
-        }
-        messages.push({
-          id: messageRow.message_id,
-          role: messageRow.role,
-          text: messageRow.text,
-          ...(messageRow.tone ? { tone: messageRow.tone } : {}),
-          createdAt: messageRow.created_at,
-        });
-      }
-
-      return {
-        id,
-        title,
-        presetKey,
-        status: row.status,
-        messages,
-        ...(draftPlanSummary ? { draftPlanSummary } : {}),
-        ...(typeof row.submitted_workflow_id === 'string' ? { submittedWorkflowId: row.submitted_workflow_id } : {}),
-        ...(typeof row.submitted_plan_name === 'string' ? { submittedPlanName: row.submitted_plan_name } : {}),
-        pendingResponse: row.pending_response === 1,
-        createdAt,
-        updatedAt,
-      };
-    } catch {
-      return undefined;
-    }
   }
 
   private rowToAttempt(row: any): Attempt {

--- a/packages/data-store/src/sqlite-row-mappers.ts
+++ b/packages/data-store/src/sqlite-row-mappers.ts
@@ -114,6 +114,7 @@ export function mapRowToTask(row: any): TaskState {
       selectedExperiments: row.selected_experiments ? JSON.parse(row.selected_experiments) : undefined,
       experimentResults: row.experiment_results ? JSON.parse(row.experiment_results) : undefined,
       pendingFixError: row.pending_fix_error ?? undefined,
+      fixSessionEntryStatus: row.fix_session_entry_status ?? undefined,
       reviewUrl: row.review_url ?? undefined,
       reviewId: row.review_id ?? undefined,
       reviewStatus: row.review_status ?? undefined,

--- a/packages/data-store/src/sqlite-schema.ts
+++ b/packages/data-store/src/sqlite-schema.ts
@@ -141,36 +141,6 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_conv_messages_thread
         ON conversation_messages(thread_ts, seq);
 
-      CREATE TABLE IF NOT EXISTS in_app_planning_sessions (
-        session_id TEXT PRIMARY KEY,
-        title TEXT NOT NULL,
-        preset_key TEXT NOT NULL,
-        status TEXT NOT NULL CHECK (status IN ('still_discussing', 'waiting_for_answer', 'draft_ready', 'submitted')),
-        draft_plan_summary_json TEXT CHECK (draft_plan_summary_json IS NULL OR json_valid(draft_plan_summary_json)),
-        submitted_workflow_id TEXT,
-        submitted_plan_name TEXT,
-        pending_response INTEGER NOT NULL DEFAULT 0 CHECK (pending_response IN (0, 1)),
-        created_at TEXT NOT NULL,
-        updated_at TEXT NOT NULL
-      );
-
-      CREATE TABLE IF NOT EXISTS in_app_planning_messages (
-        session_id TEXT NOT NULL,
-        message_id INTEGER NOT NULL,
-        role TEXT NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
-        text TEXT NOT NULL,
-        tone TEXT CHECK (tone IS NULL OR tone IN ('muted', 'error', 'success')),
-        created_at TEXT NOT NULL,
-        PRIMARY KEY (session_id, message_id),
-        FOREIGN KEY (session_id) REFERENCES in_app_planning_sessions(session_id)
-      );
-
-      CREATE INDEX IF NOT EXISTS idx_in_app_planning_sessions_updated
-        ON in_app_planning_sessions(updated_at);
-
-      CREATE INDEX IF NOT EXISTS idx_in_app_planning_messages_session
-        ON in_app_planning_messages(session_id, message_id);
-
       CREATE TABLE IF NOT EXISTS workflow_channels (
         workflow_id TEXT PRIMARY KEY,
         channel_id TEXT NOT NULL,
@@ -398,6 +368,9 @@ export const SCHEMA_DDL = `
       CREATE INDEX IF NOT EXISTS idx_terminal_sessions_status_updated
         ON terminal_sessions(status, updated_at);
 
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_terminal_sessions_running_target
+        ON terminal_sessions(target_key)
+        WHERE status = 'running';
     `;
 
 /** Idempotent `ALTER TABLE ... ADD COLUMN` migrations for older databases. */
@@ -466,6 +439,8 @@ export const COLUMN_MIGRATIONS = [
   'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
   'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
   'ALTER TABLE tasks ADD COLUMN task_state_version INTEGER NOT NULL DEFAULT 1',
+  // fix_session_entry_status: resting status recorded while a fix session is open
+  'ALTER TABLE tasks ADD COLUMN fix_session_entry_status TEXT',
 ];
 
 /**

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -26,7 +26,7 @@ function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
     resumeTaskAfterFixApproval: vi.fn().mockResolvedValue([] as TaskState[]),
     reject: vi.fn(),
     getTask: vi.fn().mockReturnValue(undefined),
-    revertConflictResolution: vi.fn(),
+    revertFixSession: vi.fn(),
     provideInput: vi.fn(),
     retryTask: vi.fn().mockReturnValue([]),
     recreateTask: vi.fn().mockReturnValue([]),
@@ -114,10 +114,10 @@ describe('CommandService', () => {
 
       expect(result).toEqual({ ok: true, data: undefined });
       expect(orchestrator.reject).toHaveBeenCalledWith('t-1', 'bad');
-      expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+      expect(orchestrator.revertFixSession).not.toHaveBeenCalled();
     });
 
-    it('calls revertConflictResolution when pendingFixError exists', async () => {
+    it('calls revertFixSession when pendingFixError exists', async () => {
       (orchestrator.getTask as ReturnType<typeof vi.fn>).mockReturnValue({
         execution: { pendingFixError: 'merge conflict' },
       });
@@ -125,9 +125,9 @@ describe('CommandService', () => {
       const result = await service.reject(envelope);
 
       expect(result).toEqual({ ok: true, data: undefined });
-      expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith(
+      expect(orchestrator.revertFixSession).toHaveBeenCalledWith(
         't-1',
-        'merge conflict',
+        { savedError: 'merge conflict' },
       );
       expect(orchestrator.reject).not.toHaveBeenCalled();
     });

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -563,7 +563,7 @@ describe('Orchestrator', () => {
     });
   });
 
-  describe('beginConflictResolution / revertConflictResolution', () => {
+  describe('beginFixSession / revertFixSession (failed entry)', () => {
     const mergeConflictError = JSON.stringify({
       type: 'merge_conflict',
       failedBranch: 'experiment/upstream-branch-abc123',
@@ -598,7 +598,7 @@ describe('Orchestrator', () => {
 
     it('sets task to fixing_with_ai, clears terminal execution fields, and emits delta', () => {
       const failedAttemptId = orchestrator.getTask('t2')!.execution.selectedAttemptId;
-      orchestrator.beginConflictResolution('t2');
+      orchestrator.beginFixSession('t2');
 
       const task = orchestrator.getTask('t2')!;
       const fixAttemptId = task.execution.selectedAttemptId;
@@ -623,7 +623,7 @@ describe('Orchestrator', () => {
 
     it('resets startedAt and lastHeartbeatAt timestamps', () => {
       const before = Date.now();
-      orchestrator.beginConflictResolution('t2');
+      orchestrator.beginFixSession('t2');
       const after = Date.now();
 
       const task = orchestrator.getTask('t2')!;
@@ -636,17 +636,17 @@ describe('Orchestrator', () => {
     });
 
     it('returns savedError for later revert', () => {
-      const { savedError } = orchestrator.beginConflictResolution('t2');
+      const { savedError } = orchestrator.beginFixSession('t2');
       expect(savedError).toBe(mergeConflictError);
     });
 
-    it('revertConflictResolution restores failed state with mergeConflict', () => {
-      const { savedError } = orchestrator.beginConflictResolution('t2');
+    it('revertFixSession restores failed state with mergeConflict', () => {
+      const { savedError } = orchestrator.beginFixSession('t2');
       const fixAttemptId = orchestrator.getTask('t2')!.execution.selectedAttemptId;
       expect(orchestrator.getTask('t2')!.status).toBe('fixing_with_ai');
 
       publishedDeltas = [];
-      orchestrator.revertConflictResolution('t2', savedError);
+      orchestrator.revertFixSession('t2', { savedError: savedError });
 
       const task = orchestrator.getTask('t2')!;
       expect(task.status).toBe('failed');
@@ -667,17 +667,17 @@ describe('Orchestrator', () => {
       expect(failedDeltas).toHaveLength(1);
     });
 
-    it('revertConflictResolution uses agent-agnostic fix failure prefix', () => {
-      const { savedError } = orchestrator.beginConflictResolution('t2');
-      orchestrator.revertConflictResolution('t2', savedError, 'startup failed');
+    it('revertFixSession uses agent-agnostic fix failure prefix', () => {
+      const { savedError } = orchestrator.beginFixSession('t2');
+      orchestrator.revertFixSession('t2', { savedError: savedError, fixError: 'startup failed' });
       const task = orchestrator.getTask('t2')!;
       expect(task.execution.error).toContain('[Fix with Agent failed] startup failed');
     });
 
-    it('revertConflictResolution does not duplicate an existing fix failure wrapper', () => {
+    it('revertFixSession does not duplicate an existing fix failure wrapper', () => {
       const wrappedSavedError =
         '[Fix with Claude failed] first attempt failed\n\n' + mergeConflictError;
-      orchestrator.revertConflictResolution('t2', wrappedSavedError, 'second attempt failed');
+      orchestrator.revertFixSession('t2', { savedError: wrappedSavedError, fixError: 'second attempt failed' });
       const task = orchestrator.getTask('t2')!;
       expect(task.execution.error).toContain('[Fix with Agent failed] second attempt failed');
       expect(task.execution.error).not.toContain('first attempt failed');
@@ -687,14 +687,14 @@ describe('Orchestrator', () => {
       });
     });
 
-    it('throws if task is not failed', () => {
-      expect(() => orchestrator.beginConflictResolution('t1')).toThrow(
-        'is not failed',
+    it('throws if task is not in a fix-session entry state', () => {
+      expect(() => orchestrator.beginFixSession('t1')).toThrow(
+        'not in a fix-session entry state',
       );
     });
 
     it('throws if task does not exist', () => {
-      expect(() => orchestrator.beginConflictResolution('nonexistent')).toThrow(
+      expect(() => orchestrator.beginFixSession('nonexistent')).toThrow(
         'not found',
       );
     });
@@ -710,14 +710,135 @@ describe('Orchestrator', () => {
         }),
       );
 
-      const { savedError } = orchestrator.beginConflictResolution('t2');
-      orchestrator.revertConflictResolution('t2', savedError);
+      const { savedError } = orchestrator.beginFixSession('t2');
+      orchestrator.revertFixSession('t2', { savedError: savedError });
 
       const task = orchestrator.getTask('t2')!;
       expect(task.status).toBe('failed');
       expect(task.execution.error).toBe('plain error string');
       expect(task.execution.mergeConflict).toBeUndefined();
       expect(task.execution.isFixingWithAI).toBeFalsy();
+    });
+  });
+
+  describe('beginFixSession / revertFixSession', () => {
+    beforeEach(() => {
+      orchestrator.loadPlan({
+        name: 'fix-session-plan',
+        tasks: [
+          { id: 's1', description: 'Root task' },
+          { id: 's2', description: 'Downstream task', dependencies: ['s1'] },
+        ],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 's1', status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 's2', status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
+      );
+      publishedDeltas = [];
+    });
+
+    function mergeGateInReviewReady(): string {
+      const mergeId = orchestrator.getAllTasks().find((t) => t.config.isMergeNode)!.id;
+      persistence.updateTask(mergeId, { status: 'review_ready', execution: { error: undefined } });
+      orchestrator.getWorkflowStatus(); // force refreshFromDb
+      expect(orchestrator.getTask(mergeId)!.status).toBe('review_ready');
+      return mergeId;
+    }
+
+    it('records the entry status and restores review_ready on revert', () => {
+      const mergeId = mergeGateInReviewReady();
+      const { savedError } = orchestrator.beginFixSession(mergeId);
+
+      const during = orchestrator.getTask(mergeId)!;
+      expect(during.status).toBe('fixing_with_ai');
+      expect(during.execution.fixSessionEntryStatus).toBe('review_ready');
+      const bumpedGeneration = during.execution.generation ?? 0;
+      expect(bumpedGeneration).toBeGreaterThan(0);
+
+      orchestrator.revertFixSession(mergeId, { savedError, fixError: 'agent exploded' });
+
+      const after = orchestrator.getTask(mergeId)!;
+      expect(after.status).toBe('review_ready');
+      expect(after.execution.error).toBeUndefined();
+      expect(after.execution.pendingFixError).toBeUndefined();
+      expect(after.execution.fixSessionEntryStatus).toBeUndefined();
+      // Monotonic fields stay monotonic: revert is not a time machine.
+      expect(after.execution.generation).toBe(bumpedGeneration);
+      expect(persistence.loadAttempt(during.execution.selectedAttemptId!)?.status).toBe('failed');
+    });
+
+    it('restores failed entries with the wrapped error and clears the session', () => {
+      const { savedError } = orchestrator.beginFixSession('s2');
+      expect(orchestrator.getTask('s2')!.execution.fixSessionEntryStatus).toBe('failed');
+
+      orchestrator.revertFixSession('s2', { savedError, fixError: 'startup failed' });
+
+      const task = orchestrator.getTask('s2')!;
+      expect(task.status).toBe('failed');
+      expect(task.execution.error).toContain('[Fix with Agent failed] startup failed');
+      expect(task.execution.fixSessionEntryStatus).toBeUndefined();
+    });
+
+    it('reverts a parked fix (reject path) back to the recorded review_ready entry', () => {
+      const mergeId = mergeGateInReviewReady();
+      const { savedError } = orchestrator.beginFixSession(mergeId);
+      orchestrator.setFixAwaitingApproval(mergeId, savedError || 'ci failed');
+
+      const parked = orchestrator.getTask(mergeId)!;
+      expect(parked.status).toBe('awaiting_approval');
+      expect(parked.execution.fixSessionEntryStatus).toBe('review_ready');
+
+      orchestrator.revertFixSession(mergeId, { savedError: parked.execution.pendingFixError ?? '' });
+
+      const after = orchestrator.getTask(mergeId)!;
+      expect(after.status).toBe('review_ready');
+      expect(after.execution.pendingFixError).toBeUndefined();
+      expect(after.execution.fixSessionEntryStatus).toBeUndefined();
+    });
+
+    it('refuses to begin while a pending fix is parked', () => {
+      const { savedError } = orchestrator.beginFixSession('s2');
+      orchestrator.setFixAwaitingApproval('s2', savedError || 'boom');
+      expect(() => orchestrator.beginFixSession('s2')).toThrow('pending fix awaiting approval');
+    });
+
+    it('refuses to begin from non-entry states', () => {
+      expect(() => orchestrator.beginFixSession('s1')).toThrow(
+        'not in a fix-session entry state',
+      );
+    });
+
+    it('revert without a session on a review gate is an idempotent no-op', () => {
+      const mergeId = mergeGateInReviewReady();
+      orchestrator.revertFixSession(mergeId, { savedError: '', fixError: 'nothing began' });
+      expect(orchestrator.getTask(mergeId)!.status).toBe('review_ready');
+    });
+
+    it('legacy sessions without a recorded entry restore failed', () => {
+      orchestrator.beginFixSession('s2');
+      // Simulate a row written before the entry status existed.
+      persistence.updateTask('s2', { execution: { fixSessionEntryStatus: undefined } });
+      orchestrator.getWorkflowStatus();
+
+      orchestrator.revertFixSession('s2', { savedError: 'boom', fixError: 'legacy' });
+      const task = orchestrator.getTask('s2')!;
+      expect(task.status).toBe('failed');
+      expect(task.execution.error).toContain('[Fix with Agent failed] legacy');
+    });
+
+    it('approve of a parked fix clears the recorded entry', async () => {
+      const mergeId = mergeGateInReviewReady();
+      const { savedError } = orchestrator.beginFixSession(mergeId);
+      orchestrator.setFixAwaitingApproval(mergeId, savedError || 'ci failed');
+
+      await orchestrator.resumeTaskAfterFixApproval(mergeId);
+
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.execution.pendingFixError).toBeUndefined();
+      expect(task.execution.fixSessionEntryStatus).toBeUndefined();
     });
   });
 
@@ -746,7 +867,7 @@ describe('Orchestrator', () => {
     });
 
     it('setFixAwaitingApproval transitions to awaiting_approval with pendingFixError', () => {
-      orchestrator.beginConflictResolution('f2');
+      orchestrator.beginFixSession('f2');
       expect(orchestrator.getTask('f2')!.status).toBe('fixing_with_ai');
       expect(orchestrator.getTask('f2')!.execution.isFixingWithAI).toBeFalsy();
       const fixAttemptId = orchestrator.getTask('f2')!.execution.selectedAttemptId;
@@ -759,7 +880,7 @@ describe('Orchestrator', () => {
     });
 
     it('setFixAwaitingApproval delta includes agentSessionId from DB', () => {
-      orchestrator.beginConflictResolution('f2');
+      orchestrator.beginFixSession('f2');
       // Simulate conflict-resolver persisting sessionId directly to DB
       persistence.updateTask('f2', {
         execution: {
@@ -786,7 +907,7 @@ describe('Orchestrator', () => {
     });
 
     it('pendingFixError is readable via getTask', () => {
-      orchestrator.beginConflictResolution('f2');
+      orchestrator.beginFixSession('f2');
       orchestrator.setFixAwaitingApproval('f2', 'original error');
       expect(orchestrator.getTask('f2')!.execution.pendingFixError).toBe('original error');
     });
@@ -796,7 +917,7 @@ describe('Orchestrator', () => {
     });
 
     it('restartTask clears the fix state', () => {
-      orchestrator.beginConflictResolution('f2');
+      orchestrator.beginFixSession('f2');
       orchestrator.setFixAwaitingApproval('f2', 'error');
       orchestrator.retryTask('f2');
       const task = orchestrator.getTask('f2')!;
@@ -805,10 +926,10 @@ describe('Orchestrator', () => {
       expect(task.execution.pendingFixError).toBeUndefined();
     });
 
-    it('revertConflictResolution restores failed state', () => {
-      orchestrator.beginConflictResolution('f2');
+    it('revertFixSession restores failed state', () => {
+      orchestrator.beginFixSession('f2');
       orchestrator.setFixAwaitingApproval('f2', 'test failed: expected 1 to be 2');
-      orchestrator.revertConflictResolution('f2', 'test failed: expected 1 to be 2');
+      orchestrator.revertFixSession('f2', { savedError: 'test failed: expected 1 to be 2' });
       const task = orchestrator.getTask('f2')!;
       expect(task.status).toBe('failed');
       expect(task.execution.error).toBe('test failed: expected 1 to be 2');
@@ -825,7 +946,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('f2')!.config.isMergeNode).toBeFalsy();
       expect(orchestrator.getTask('f2')!.status).toBe('failed');
 
-      const { savedError } = orchestrator.beginConflictResolution('f2');
+      const { savedError } = orchestrator.beginFixSession('f2');
       expect(savedError).toBe(mergeConflictError);
       expect(orchestrator.getTask('f2')!.status).toBe('fixing_with_ai');
       const fixAttemptId = orchestrator.getTask('f2')!.execution.selectedAttemptId;
@@ -848,7 +969,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('f2')!.config.isMergeNode).toBeFalsy();
       expect(orchestrator.getTask('f2')!.status).toBe('failed');
 
-      const { savedError } = orchestrator.beginConflictResolution('f2');
+      const { savedError } = orchestrator.beginFixSession('f2');
       expect(savedError).toBe(plainTextError);
       expect(orchestrator.getTask('f2')!.status).toBe('fixing_with_ai');
       const fixAttemptId = orchestrator.getTask('f2')!.execution.selectedAttemptId;
@@ -915,7 +1036,7 @@ describe('Orchestrator', () => {
       // Move fd2 through the fix attempt into awaiting_approval
       // with a pendingFixError. This is exactly the state an
       // `approveTask` invocation lands on in the fix flow.
-      const { savedError } = orchestrator.beginConflictResolution('fd2');
+      const { savedError } = orchestrator.beginFixSession('fd2');
       // Hydrate workspace lineage on the task so the preservation
       // half of the assertion is meaningful (the in-memory mock
       // does not synthesize branch/workspacePath itself).
@@ -974,8 +1095,8 @@ describe('Orchestrator', () => {
       expect(cancelWorkflowSpy).not.toHaveBeenCalled();
     });
 
-    it('reject (revertConflictResolution): status -> failed (original error), generation unchanged on edited task and dependents, no retry/recreate/cancel spy fires', () => {
-      const { savedError } = orchestrator.beginConflictResolution('fd2');
+    it('reject (revertFixSession): status -> failed (original error), generation unchanged on edited task and dependents, no retry/recreate/cancel spy fires', () => {
+      const { savedError } = orchestrator.beginFixSession('fd2');
       orchestrator.setFixAwaitingApproval('fd2', savedError);
       expect(orchestrator.getTask('fd2')!.status).toBe('awaiting_approval');
       expect(orchestrator.getTask('fd2')!.execution.pendingFixError).toBe(savedError);
@@ -992,7 +1113,7 @@ describe('Orchestrator', () => {
       const cancelTaskSpy = vi.spyOn(orchestrator, 'cancelTask');
       const cancelWorkflowSpy = vi.spyOn(orchestrator, 'cancelWorkflow');
 
-      orchestrator.revertConflictResolution('fd2', savedError);
+      orchestrator.revertFixSession('fd2', { savedError: savedError });
 
       const fd2After = orchestrator.getTask('fd2')!;
       expect(fd2After.status).toBe('failed');
@@ -1016,7 +1137,7 @@ describe('Orchestrator', () => {
       // Non-fix path: a task parked in `awaiting_approval` without
       // a `pendingFixError`. This is the branch `rejectTask` takes
       // when the task is NOT in a fix flow (it routes to
-      // `Orchestrator.reject` instead of `revertConflictResolution`).
+      // `Orchestrator.reject` instead of `revertFixSession`).
       orchestrator.retryTask('fd2');
       expect(orchestrator.getTask('fd2')!.status).toBe('running');
       orchestrator.setTaskAwaitingApproval('fd2');
@@ -1073,7 +1194,7 @@ describe('Orchestrator', () => {
           outputs: { exitCode: 1, error: 'merge conflict' },
         }),
       );
-      orchestrator.beginConflictResolution(mergeNode.id);
+      orchestrator.beginFixSession(mergeNode.id);
       orchestrator.setFixAwaitingApproval(mergeNode.id, 'merge conflict');
       return mergeNode.id;
     }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2716,7 +2716,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('a2')!.status).toBe('pending');
 
       // Fix with Claude → awaiting_approval
-      orchestrator.beginConflictResolution('a1');
+      orchestrator.beginFixSession('a1');
       orchestrator.setFixAwaitingApproval('a1', 'some error');
       expect(orchestrator.getTask('a1')!.status).toBe('awaiting_approval');
 
@@ -8120,8 +8120,8 @@ describe('Orchestrator', () => {
   // while `fixing_with_ai`" maps the `fixContext` mutation to
   // InvalidationAction = 'retryTask' with InvalidationScope = 'task'
   // applied to the failed/fixing task. Step 10 lifts the previously
-  // bespoke fix-session handling (`beginConflictResolution` /
-  // `revertConflictResolution`) into a proper orchestrator policy
+  // bespoke fix-session handling (`beginFixSession` /
+  // `revertFixSession`) into a proper orchestrator policy
   // seam: `Orchestrator.editTaskFixContext` owns the same-content
   // no-op detection, cancel-first interruption when the task is
   // actively running an AI fix (`fixing_with_ai`), the
@@ -8171,7 +8171,7 @@ describe('Orchestrator', () => {
     }
 
     function driveTaskToFixingWithAi(taskId: string): void {
-      orchestrator.beginConflictResolution(taskId);
+      orchestrator.beginFixSession(taskId);
       expect(orchestrator.getTask(taskId)?.status).toBe('fixing_with_ai');
       publishedDeltas = [];
     }

--- a/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/task-reset-policy.test.ts
@@ -39,6 +39,7 @@ const expectedExecutionFields = [
   'selectedExperiments',
   'experimentResults',
   'pendingFixError',
+  'fixSessionEntryStatus',
   'isFixingWithAI',
   'reviewUrl',
   'reviewId',

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -105,10 +105,11 @@ export class CommandService {
       () => {
         const task = this.orchestrator.getTask(envelope.payload.taskId);
         if (task?.execution.pendingFixError !== undefined) {
-          this.orchestrator.revertConflictResolution(
-            envelope.payload.taskId,
-            task.execution.pendingFixError,
-          );
+          // Revert the fix session to its recorded entry status: rejecting a
+          // review-gate fix returns the gate to review_ready, not failed.
+          this.orchestrator.revertFixSession(envelope.payload.taskId, {
+            savedError: task.execution.pendingFixError,
+          });
         } else {
           this.orchestrator.reject(
             envelope.payload.taskId,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -111,8 +111,9 @@ import {
   recreateWorkflowFromFreshBaseImpl,
   getKnownFreshBaseCommitImpl,
   beginConflictResolutionImpl,
-  beginAutoFixSessionImpl,
+  beginFixSessionImpl,
   revertConflictResolutionImpl,
+  revertFixSessionImpl,
   getMergeNodeImpl,
 } from './orchestrator/merge.js';
 import type { MergeHost } from './orchestrator/merge.js';
@@ -1864,7 +1865,7 @@ export class Orchestrator {
 
     const changes: TaskStateChanges = {
       status: 'completed',
-      execution: { completedAt: new Date() },
+      execution: { completedAt: new Date(), fixSessionEntryStatus: undefined },
     };
     const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
@@ -1913,7 +1914,7 @@ export class Orchestrator {
     const now = new Date();
     const changes: TaskStateChanges = {
       status: 'running',
-      execution: { pendingFixError: undefined, startedAt: now, lastHeartbeatAt: now },
+      execution: { pendingFixError: undefined, fixSessionEntryStatus: undefined, startedAt: now, lastHeartbeatAt: now },
     };
     const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
@@ -1937,7 +1938,7 @@ export class Orchestrator {
 
     const changes: TaskStateChanges = {
       status: 'failed',
-      execution: { error: reason ?? 'Rejected', completedAt: new Date() },
+      execution: { error: reason ?? 'Rejected', completedAt: new Date(), fixSessionEntryStatus: undefined },
     };
     const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
@@ -2610,29 +2611,46 @@ export class Orchestrator {
   }
 
   /**
-   * Transition a failed task to fixing_with_ai before an async conflict resolution.
-   * Clears terminal failure fields on the row so SQLite does not show stale error/exit/completed.
-   * Returns the saved error string so the caller can revert on failure.
+   * Begin a fix session from an explicit resting state (`failed`,
+   * `review_ready`, or `awaiting_approval`). Records the entry status on the
+   * task so `revertFixSession` — possibly running after a restart, from an
+   * approve/reject surface — restores exactly where the session started.
+   * Refuses to begin while a pending fix is parked awaiting approval.
+   */
+  beginFixSession(
+    taskId: string,
+    opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
+  ): { savedError: string } {
+    return beginFixSessionImpl(this as unknown as MergeHost, taskId, opts);
+  }
+
+  /**
+   * Revert a fix session to its recorded entry status. Sessions with no
+   * recorded entry (legacy rows) restore `failed`; a revert with no session
+   * evidence is an idempotent no-op.
+   */
+  revertFixSession(
+    taskId: string,
+    opts: {
+      savedError: string;
+      fixError?: string;
+      expectedLineage?: TaskLineageExpectation;
+    },
+  ): void {
+    revertFixSessionImpl(this as unknown as MergeHost, taskId, opts);
+  }
+
+  /**
+   * @deprecated Use `beginFixSession`. Failed-only entry guard kept for
+   * callers not yet migrated; removed once call sites move over.
    */
   beginConflictResolution(taskId: string, expectedLineage?: TaskLineageExpectation): { savedError: string } {
     return beginConflictResolutionImpl(this as unknown as MergeHost, taskId, expectedLineage);
   }
 
   /**
-   * Begin an AI fix session from either a failed task or an external review
-   * gate state. Review-gate CI failures use this path because the merge task
-   * may still be review_ready/awaiting_approval while the PR checks are red.
-   */
-  beginAutoFixSession(
-    taskId: string,
-    opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
-  ): { savedError: string } {
-    return beginAutoFixSessionImpl(this as unknown as MergeHost, taskId, opts);
-  }
-
-  /**
-   * Revert a conflict resolution attempt: restore the task to failed
-   * with its original error and re-parsed mergeConflict field.
+   * @deprecated Use `revertFixSession`. Always restores `failed`; removed
+   * once call sites move over.
    */
   revertConflictResolution(
     taskId: string,
@@ -2985,7 +3003,7 @@ export class Orchestrator {
    * "only command edit has explicit handling today; no general
    * fix-context mutation policy" and the chart's "Fix-session
    * inconsistency" subsection calls out the bespoke
-   * `beginConflictResolution` / `revertConflictResolution` rollback
+   * `beginFixSession` / `revertFixSession` rollback
    * as "one special active invalidation mechanism, not a general
    * one". Step 10 lifts that bespoke fix-session handling into a
    * proper orchestrator policy seam (`Orchestrator.editTaskFixContext`)

--- a/packages/workflow-core/src/orchestrator/merge.ts
+++ b/packages/workflow-core/src/orchestrator/merge.ts
@@ -14,7 +14,7 @@
  * exactly so merge/experiment behavior and the TASK_DELTA contract stay stable.
  */
 
-import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskStatus, Attempt } from '@invoker/workflow-graph';
 import type { Logger } from '@invoker/contracts';
 import { parseMergeConflictError } from '../merge-conflict-error.js';
 import type { TaskStateMachine } from '../state-machine.js';
@@ -127,6 +127,65 @@ export function getKnownFreshBaseCommitImpl(host: MergeHost, workflowId: string)
   return host.knownFreshBaseCommits.get(workflowId);
 }
 
+/**
+ * Resting states a fix session may begin from — and therefore the only
+ * states `revertFixSessionImpl` will ever restore. Explicit allow-list:
+ *
+ * - `failed`             — the classic fix-a-broken-task flow.
+ * - `review_ready`       — a merge gate with an open review whose PR checks
+ *                          went red; the gate task itself never failed.
+ * - `awaiting_approval`  — a manual gate waiting on a human.
+ *
+ * Everything else is deliberately out: `pending`/`running`/`needs_input`/
+ * `blocked` belong to the launch and input lifecycles (restoring `running`
+ * would claim a live process that does not exist), and `completed`/`closed`/
+ * `stale` are terminal — a revert that resurrects finished work is a
+ * different, dangerous operation.
+ */
+export const FIX_SESSION_ENTRY_STATUSES = ['failed', 'review_ready', 'awaiting_approval'] as const;
+export type FixSessionEntryStatus = (typeof FIX_SESSION_ENTRY_STATUSES)[number];
+
+function isFixSessionEntryStatus(status: TaskStatus): status is FixSessionEntryStatus {
+  return (FIX_SESSION_ENTRY_STATUSES as readonly TaskStatus[]).includes(status);
+}
+
+/**
+ * Begin a fix session: record the entry status on the task (persisted, so a
+ * later revert — possibly after a restart, from an approve/reject surface —
+ * knows exactly where to return), then move the task to `fixing_with_ai`.
+ *
+ * At most one session may be open per task: beginning while a pending fix is
+ * parked (`pendingFixError` set) is refused; the human must approve or reject
+ * the parked fix first.
+ */
+export function beginFixSessionImpl(
+  host: MergeHost,
+  taskId: string,
+  opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
+): { savedError: string } {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+  if (!host.taskMatchesLineageExpectation(task, opts.expectedLineage)) {
+    throw new Error(`Task ${taskId} lineage is stale for fix session start`);
+  }
+  if (task.execution.pendingFixError !== undefined) {
+    throw new Error(
+      `Task ${taskId} already has a pending fix awaiting approval or rejection; approve or reject it before starting another fix`,
+    );
+  }
+  if (!isFixSessionEntryStatus(task.status)) {
+    throw new Error(
+      `Task ${taskId} is not in a fix-session entry state (status: ${task.status}; allowed: ${FIX_SESSION_ENTRY_STATUSES.join(', ')})`,
+    );
+  }
+  return startFixSession(host, task, task.status, opts.savedError);
+}
+
+/**
+ * @deprecated Use `beginFixSessionImpl`. Failed-only entry guard kept for
+ * callers not yet migrated; removed once call sites move over.
+ */
 export function beginConflictResolutionImpl(
   host: MergeHost,
   taskId: string,
@@ -139,68 +198,19 @@ export function beginConflictResolutionImpl(
     throw new Error(`Task ${taskId} lineage is stale for conflict resolution start`);
   }
   if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
-
-  const savedError = task.execution.error ?? '';
-  const startedAt = new Date();
-
-  const id = task.id;
-  const changes: TaskStateChanges = {
-    status: 'fixing_with_ai',
-    execution: {
-      error: undefined,
-      exitCode: undefined,
-      completedAt: undefined,
-      mergeConflict: undefined,
-      isFixingWithAI: false,
-      startedAt,
-      lastHeartbeatAt: startedAt,
-    },
-  };
-  const changesWithGeneration = host.withBumpedExecutionGeneration(task, changes);
-  const conflictUpdated = host.writeAndSync(taskId, changesWithGeneration);
-  const attemptId = host.replaceSelectedAttempt(task);
-  host.taskRepository.updateAttempt(attemptId, {
-    status: 'running',
-    startedAt,
-    lastHeartbeatAt: startedAt,
-    branch: task.execution.branch,
-    commit: task.execution.commit,
-    workspacePath: task.execution.workspacePath,
-    agentSessionId: task.execution.agentSessionId,
-    containerId: task.execution.containerId,
-    mergeConflict: undefined,
-    error: undefined,
-    exitCode: undefined,
-  });
-  const delta: TaskDelta = host.buildUpdateDelta(task, conflictUpdated, changesWithGeneration);
-  host.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
-  publishTaskDelta(host.messageBus, delta);
-
-  return { savedError };
+  return startFixSession(host, task, task.status, undefined);
 }
 
-export function beginAutoFixSessionImpl(
+function startFixSession(
   host: MergeHost,
-  taskId: string,
-  opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
+  task: TaskState,
+  entryStatus: FixSessionEntryStatus,
+  savedErrorOverride: string | undefined,
 ): { savedError: string } {
-  host.refreshFromDb();
-  const task = host.stateGetTask(taskId);
-  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-  if (!host.taskMatchesLineageExpectation(task, opts.expectedLineage)) {
-    throw new Error(`Task ${taskId} lineage is stale for auto-fix start`);
-  }
-  if (
-    task.status !== 'failed' &&
-    task.status !== 'review_ready' &&
-    task.status !== 'awaiting_approval'
-  ) {
-    throw new Error(`Task ${taskId} is not in an auto-fixable state (status: ${task.status})`);
-  }
-
-  const savedError = opts.savedError ?? task.execution.error ?? '';
+  const savedError = savedErrorOverride ?? task.execution.error ?? '';
   const startedAt = new Date();
   const id = task.id;
+
   const changes: TaskStateChanges = {
     status: 'fixing_with_ai',
     execution: {
@@ -209,6 +219,7 @@ export function beginAutoFixSessionImpl(
       completedAt: undefined,
       mergeConflict: undefined,
       isFixingWithAI: false,
+      fixSessionEntryStatus: entryStatus,
       startedAt,
       lastHeartbeatAt: startedAt,
     },
@@ -232,9 +243,96 @@ export function beginAutoFixSessionImpl(
   const delta: TaskDelta = host.buildUpdateDelta(task, updated, changesWithGeneration);
   host.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
   publishTaskDelta(host.messageBus, delta);
+
   return { savedError };
 }
 
+/**
+ * Revert a fix session to the entry status recorded by `beginFixSessionImpl`.
+ *
+ * Valid at two points of the session: while the fix runs (`fixing_with_ai`)
+ * and after it parked awaiting a human (`awaiting_approval` +
+ * `pendingFixError`, the reject path). Restore means "status equals entry
+ * status" — monotonic fields stay monotonic: the execution generation stays
+ * bumped (it guards against orphaned async work) and the replaced attempt
+ * stays replaced, marked failed.
+ *
+ * Legacy rows (a session begun before the entry status was recorded) restore
+ * `failed`, which is exact: every pre-existing session came through the
+ * failed-only guard. A revert with no session and no legacy evidence is an
+ * idempotent no-op — reverts run inside catch blocks and retried mutation
+ * intents, where throwing would mask the original error.
+ */
+export function revertFixSessionImpl(
+  host: MergeHost,
+  taskId: string,
+  opts: {
+    savedError: string;
+    fixError?: string;
+    expectedLineage?: TaskLineageExpectation;
+  },
+): void {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) {
+    throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+  }
+  if (!host.taskMatchesLineageExpectation(task, opts.expectedLineage)) return;
+
+  const recorded = task.execution.fixSessionEntryStatus;
+  const entryStatus: FixSessionEntryStatus | undefined =
+    recorded !== undefined && isFixSessionEntryStatus(recorded)
+      ? recorded
+      : task.status === 'fixing_with_ai' ||
+          task.status === 'failed' ||
+          task.execution.pendingFixError !== undefined
+        ? 'failed' // legacy session or failed-task error rewrite: pre-column behavior
+        : undefined;
+  if (entryStatus === undefined) {
+    host.persistence.logEvent?.(task.id, 'task.fix_session_revert_noop', {
+      status: task.status,
+      fixError: opts.fixError ?? null,
+    });
+    return;
+  }
+
+  if (entryStatus === 'failed') {
+    restoreFailedEntry(host, task, opts.savedError, opts.fixError);
+    return;
+  }
+
+  const completedAt = new Date();
+  const attemptError = opts.fixError
+    ? `[Fix with Agent failed] ${opts.fixError}`
+    : opts.savedError;
+  const changes: TaskStateChanges = {
+    status: entryStatus,
+    execution: {
+      error: undefined,
+      isFixingWithAI: false,
+      pendingFixError: undefined,
+      fixSessionEntryStatus: undefined,
+      completedAt,
+    },
+  };
+  const updated = host.writeAndSync(taskId, changes);
+  host.updateSelectedAttempt(taskId, {
+    status: 'failed',
+    error: attemptError,
+    completedAt,
+  });
+  const delta: TaskDelta = host.buildUpdateDelta(task, updated, changes);
+  host.persistence.logEvent?.(task.id, 'task.fix_session_reverted', {
+    restoreStatus: entryStatus,
+    fixError: opts.fixError ?? null,
+  });
+  publishTaskDelta(host.messageBus, delta);
+}
+
+/**
+ * @deprecated Use `revertFixSessionImpl`. Always restores `failed`; removed
+ * once call sites move over.
+ */
 export function revertConflictResolutionImpl(
   host: MergeHost,
   taskId: string,
@@ -248,8 +346,16 @@ export function revertConflictResolutionImpl(
     throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
   }
   if (!host.taskMatchesLineageExpectation(task, expectedLineage)) return;
-  const id = task.id;
+  restoreFailedEntry(host, task, savedError, fixError);
+}
 
+function restoreFailedEntry(
+  host: MergeHost,
+  task: TaskState,
+  savedError: string,
+  fixError?: string,
+): void {
+  const id = task.id;
   const normalizedSavedError = stripFixFailureWrapper(savedError);
   const mergeConflict = parseMergeConflictError(normalizedSavedError);
 
@@ -263,11 +369,13 @@ export function revertConflictResolutionImpl(
       error: displayError,
       mergeConflict,
       isFixingWithAI: false,
+      pendingFixError: undefined,
+      fixSessionEntryStatus: undefined,
       completedAt,
     },
   };
-  const revertUpdated = host.writeAndSync(taskId, changes);
-  host.updateSelectedAttempt(taskId, {
+  const revertUpdated = host.writeAndSync(id, changes);
+  host.updateSelectedAttempt(id, {
     status: 'failed',
     error: displayError,
     mergeConflict,

--- a/packages/workflow-core/src/task-reset-policy.ts
+++ b/packages/workflow-core/src/task-reset-policy.ts
@@ -80,6 +80,7 @@ export const TASK_EXECUTION_RESET_RULES = {
   selectedExperiments: preserve,
   experimentResults: preserve,
   pendingFixError: clearFor(['detach', 'retryTask', 'retryWorkflow', 'newAttempt']),
+  fixSessionEntryStatus: clearFor(['detach', 'retryTask', 'retryWorkflow', 'newAttempt']),
   isFixingWithAI: falseFor(['detach', 'retryTask', 'retryWorkflow', 'newAttempt']),
   reviewUrl: clearFor(['recreate', 'detach']),
   reviewId: clearFor(['recreate', 'detach']),

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -201,6 +201,13 @@ export interface TaskExecution {
   readonly selectedExperiments?: readonly string[];
   readonly experimentResults?: readonly ExperimentResultEntry[];
   readonly pendingFixError?: string;
+  /**
+   * Resting status recorded when a fix session began (`failed`,
+   * `review_ready`, or `awaiting_approval`). Present only while the session
+   * is open (fixing or parked awaiting approval); `revertFixSession` restores
+   * this status and every session exit clears it.
+   */
+  readonly fixSessionEntryStatus?: TaskStatus;
   readonly isFixingWithAI?: boolean;
   readonly reviewUrl?: string;
   readonly reviewId?: string;


### PR DESCRIPTION
## Summary

This adds an explicit fix-session state machine to the orchestrator.

A fix now starts only from an allow-listed entry state and records that entry so every exit can restore the right status.

That lets later slices use one shared fix-session path instead of caller-specific restore logic.

## Review Claim

Fix sessions now begin from an explicit entry-state allow-list and always restore their recorded entry state on exit.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The new path only changes tasks inside a fix session. Tasks outside that state keep the old execution and review flow.

## Slice Rationale

This foundational state model has to exist before later slices can use one shared fix-session path.

## Non-goals

This does not move app or worker callers yet.

This does not delete the old conflict-resolution surface yet.

This does not change budgeting.

## Architecture

### Before

```mermaid
graph TD
    A["Task enters an ad hoc fix path"] --> B["Exit path hard-codes failed or review_ready"]
    B --> C["Callers must keep their own restore logic"]
```

### After

```mermaid
graph TD
    A["beginFixSession records fix_session_entry_status"] --> B["Task runs inside fixing_with_ai"]
    B --> C["revertFixSession restores the recorded entry state"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/command-service.test.ts src/__tests__/orchestrator.test.ts src/__tests__/task-reset-policy.test.ts`
- [x] `cd packages/data-store && pnpm exec vitest run src/__tests__/orchestrator-sqlite-worker-response.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
