### PR TITLE
[Fix sessions](4) Remove the deprecated conflict-resolution fix surface

### DIFF
--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -110,9 +110,7 @@ import {
 import {
   recreateWorkflowFromFreshBaseImpl,
   getKnownFreshBaseCommitImpl,
-  beginConflictResolutionImpl,
   beginFixSessionImpl,
-  revertConflictResolutionImpl,
   revertFixSessionImpl,
   getMergeNodeImpl,
 } from './orchestrator/merge.js';
@@ -2638,27 +2636,6 @@ export class Orchestrator {
     },
   ): void {
     revertFixSessionImpl(this as unknown as MergeHost, taskId, opts);
-  }
-
-  /**
-   * @deprecated Use `beginFixSession`. Failed-only entry guard kept for
-   * callers not yet migrated; removed once call sites move over.
-   */
-  beginConflictResolution(taskId: string, expectedLineage?: TaskLineageExpectation): { savedError: string } {
-    return beginConflictResolutionImpl(this as unknown as MergeHost, taskId, expectedLineage);
-  }
-
-  /**
-   * @deprecated Use `revertFixSession`. Always restores `failed`; removed
-   * once call sites move over.
-   */
-  revertConflictResolution(
-    taskId: string,
-    savedError: string,
-    fixError?: string,
-    expectedLineage?: TaskLineageExpectation,
-  ): void {
-    revertConflictResolutionImpl(this as unknown as MergeHost, taskId, savedError, fixError, expectedLineage);
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/merge.ts
+++ b/packages/workflow-core/src/orchestrator/merge.ts
@@ -182,25 +182,6 @@ export function beginFixSessionImpl(
   return startFixSession(host, task, task.status, opts.savedError);
 }
 
-/**
- * @deprecated Use `beginFixSessionImpl`. Failed-only entry guard kept for
- * callers not yet migrated; removed once call sites move over.
- */
-export function beginConflictResolutionImpl(
-  host: MergeHost,
-  taskId: string,
-  expectedLineage?: TaskLineageExpectation,
-): { savedError: string } {
-  host.refreshFromDb();
-  const task = host.stateGetTask(taskId);
-  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-  if (!host.taskMatchesLineageExpectation(task, expectedLineage)) {
-    throw new Error(`Task ${taskId} lineage is stale for conflict resolution start`);
-  }
-  if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
-  return startFixSession(host, task, task.status, undefined);
-}
-
 function startFixSession(
   host: MergeHost,
   task: TaskState,
@@ -327,26 +308,6 @@ export function revertFixSessionImpl(
     fixError: opts.fixError ?? null,
   });
   publishTaskDelta(host.messageBus, delta);
-}
-
-/**
- * @deprecated Use `revertFixSessionImpl`. Always restores `failed`; removed
- * once call sites move over.
- */
-export function revertConflictResolutionImpl(
-  host: MergeHost,
-  taskId: string,
-  savedError: string,
-  fixError?: string,
-  expectedLineage?: TaskLineageExpectation,
-): void {
-  host.refreshFromDb();
-  const task = host.stateGetTask(taskId);
-  if (!task) {
-    throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-  }
-  if (!host.taskMatchesLineageExpectation(task, expectedLineage)) return;
-  restoreFailedEntry(host, task, savedError, fixError);
 }
 
 function restoreFailedEntry(


### PR DESCRIPTION
## Summary

This drops the old conflict-resolution shim names from the orchestrator.

Callers already use the shared fix-session primitives from earlier slices.

That leaves one entrypoint and one rollback path for fix sessions instead of two names for the same lifecycle.

## Review Claim

The old `beginConflictResolution` and `revertConflictResolution` shim names are gone now that all callers use fix sessions directly.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

This is a dead-surface cleanup after the caller migration. No live entrypoint still depends on the old names.

## Slice Rationale

Drop the compatibility surface only after the worker and app callsites have already switched, so the change is easy to review and easy to revert.

## Non-goals

No behavior change.

This does not add new caller migrations.

This does not add orphaned-session reclaim logic.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts src/__tests__/command-service.test.ts src/__tests__/orchestrator.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 84c55d124`
- Post-revert steps: None
- Data migration? No

</details>
