### PR TITLE
[Fix sessions](7) Reclaim orphaned fixing_with_ai sessions

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3330,6 +3330,48 @@ function createEmbeddedTerminalBackendFromConfig(
                   }
                 }
 
+                // Stalled-fix-session watchdog: a fix session whose owner died
+                // mid-fix (heartbeat stopped, attempt lease expired) is invisible
+                // to the running-task path above because its status is
+                // `fixing_with_ai`, not `running`. Evaluate it as an executing
+                // task; a live fix refreshes its lease every 30s via
+                // withAttemptHeartbeat, so only an orphaned one is ever stalled.
+                if (task.status === 'fixing_with_ai') {
+                  const fixStartedAt = parseExecutionDate(task.execution.startedAt);
+                  const { executingStalled, staleReason } = evaluateExecutingStall({
+                    now,
+                    phase: 'executing',
+                    runnerKind: task.config.runnerKind,
+                    executingStartedAt: fixStartedAt,
+                    leaseExpiresAt,
+                    executorHeartbeatAt: previousHeartbeat,
+                    remoteHeartbeatAt: remoteHeartbeat,
+                    executingStallTimeoutMs,
+                  });
+                  if (executingStalled) {
+                    const fixAgeMs = fixStartedAt ? now.getTime() - fixStartedAt.getTime() : 0;
+                    const reason =
+                      `Fix session stalled: task remained in fixing_with_ai for ${Math.floor(fixAgeMs / 1000)}s ` +
+                      `without a live fix handle (${staleReason}).`;
+                    logger.error(`[fix-session-stall] reclaiming "${task.id}": ${reason}`, { module: 'db-poll' });
+                    const outcome = orchestrator.reclaimStalledFixSession(task.id, {
+                      reason,
+                      expectedLineage: {
+                        taskId: task.id,
+                        selectedAttemptId: task.execution.selectedAttemptId,
+                        generation: task.execution.generation ?? 0,
+                      },
+                    });
+                    logger.info(
+                      `[fix-session-stall] reclaim outcome=${outcome} task="${task.id}" ` +
+                        `selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
+                        `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'}`,
+                      { module: 'db-poll' },
+                    );
+                    continue;
+                  }
+                }
+
                 const snapshot = JSON.stringify(task);
                 const prev = lastKnownTaskStates.get(task.id);
                 if (!prev) {

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -721,6 +721,63 @@ describe('Orchestrator', () => {
     });
   });
 
+  describe('reclaimStalledFixSession (stalled-fix watchdog recovery)', () => {
+    beforeEach(() => {
+      orchestrator.loadPlan({
+        name: 'reclaim-plan',
+        tasks: [{ id: 'r1', description: 'Root task' }],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'r1', status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
+      );
+      expect(orchestrator.getTask('r1')!.status).toBe('failed');
+    });
+
+    const beginFix = () => {
+      orchestrator.beginFixSession('r1');
+      const task = orchestrator.getTask('r1')!;
+      expect(task.status).toBe('fixing_with_ai');
+      return {
+        taskId: task.id,
+        selectedAttemptId: task.execution.selectedAttemptId,
+        generation: task.execution.generation ?? 0,
+      };
+    };
+
+    it('leases the fix attempt so an orphaned session becomes reclaimable', () => {
+      orchestrator.beginFixSession('r1');
+      const attemptId = orchestrator.getTask('r1')!.execution.selectedAttemptId!;
+      expect(persistence.loadAttempt(attemptId)?.leaseExpiresAt).toBeInstanceOf(Date);
+    });
+
+    it('reverts a stalled fix session to its entry status', () => {
+      const expectedLineage = beginFix();
+      const outcome = orchestrator.reclaimStalledFixSession('r1', { reason: 'owner died', expectedLineage });
+      expect(outcome).toBe('reverted');
+      const task = orchestrator.getTask('r1')!;
+      expect(task.status).toBe('failed');
+      expect(task.execution.isFixingWithAI).toBeFalsy();
+    });
+
+    it('no-ops when the task is not in a fix session', () => {
+      const outcome = orchestrator.reclaimStalledFixSession('r1', { reason: 'x' });
+      expect(outcome).toBe('noop');
+      expect(orchestrator.getTask('r1')!.status).toBe('failed');
+      expect(orchestrator.getTask('r1')!.execution.fixSessionEntryStatus).toBeUndefined();
+    });
+
+    it('no-ops on lineage mismatch and leaves the live fix session untouched', () => {
+      const { taskId, generation } = beginFix();
+      const outcome = orchestrator.reclaimStalledFixSession('r1', {
+        reason: 'x',
+        expectedLineage: { taskId, selectedAttemptId: 'stale-attempt', generation },
+      });
+      expect(outcome).toBe('noop');
+      expect(orchestrator.getTask('r1')!.execution.fixSessionEntryStatus).toBe('failed');
+    });
+  });
+
   describe('beginFixSession / revertFixSession', () => {
     beforeEach(() => {
       orchestrator.loadPlan({

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -112,6 +112,7 @@ import {
   getKnownFreshBaseCommitImpl,
   beginFixSessionImpl,
   revertFixSessionImpl,
+  reclaimStalledFixSessionImpl,
   getMergeNodeImpl,
 } from './orchestrator/merge.js';
 import type { MergeHost } from './orchestrator/merge.js';
@@ -2636,6 +2637,17 @@ export class Orchestrator {
     },
   ): void {
     revertFixSessionImpl(this as unknown as MergeHost, taskId, opts);
+  }
+
+  /**
+   * Reclaim a fix session orphaned by owner death: revert it to its entry
+   * status. Driven by the stalled-fix-session watchdog.
+   */
+  reclaimStalledFixSession(
+    taskId: string,
+    opts: { reason: string; expectedLineage?: TaskLineageExpectation },
+  ): 'reverted' | 'noop' {
+    return reclaimStalledFixSessionImpl(this as unknown as MergeHost, taskId, opts);
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator/merge.ts
+++ b/packages/workflow-core/src/orchestrator/merge.ts
@@ -15,6 +15,7 @@
  */
 
 import type { TaskState, TaskDelta, TaskStateChanges, TaskStatus, Attempt } from '@invoker/workflow-graph';
+import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import type { Logger } from '@invoker/contracts';
 import { parseMergeConflictError } from '../merge-conflict-error.js';
 import type { TaskStateMachine } from '../state-machine.js';
@@ -212,6 +213,7 @@ function startFixSession(
     status: 'running',
     startedAt,
     lastHeartbeatAt: startedAt,
+    leaseExpiresAt: new Date(startedAt.getTime() + ATTEMPT_LEASE_MS),
     branch: task.execution.branch,
     commit: task.execution.commit,
     workspacePath: task.execution.workspacePath,
@@ -308,6 +310,45 @@ export function revertFixSessionImpl(
     fixError: opts.fixError ?? null,
   });
   publishTaskDelta(host.messageBus, delta);
+}
+
+/**
+ * Reclaim a fix session (`status: 'fixing_with_ai'`) whose owner process died
+ * mid-fix: its attempt lease has expired and no live executor is driving it.
+ *
+ * Reverts the session to its recorded entry status (via `revertFixSessionImpl`,
+ * so a `failed` task returns to `failed` and a `review_ready` merge gate returns
+ * to review polling). `expectedLineage` guards against reclaiming a newer,
+ * live session a concurrent restart re-dispatched between observation and
+ * revert.
+ *
+ * Returns `'reverted'` when it reclaimed the session, or `'noop'` when the task
+ * is no longer a stalled fix session or the lineage no longer matches.
+ */
+export function reclaimStalledFixSessionImpl(
+  host: MergeHost,
+  taskId: string,
+  opts: { reason: string; expectedLineage?: TaskLineageExpectation },
+): 'reverted' | 'noop' {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task || task.status !== 'fixing_with_ai') return 'noop';
+  if (!host.taskMatchesLineageExpectation(task, opts.expectedLineage)) return 'noop';
+
+  revertFixSessionImpl(host, taskId, {
+    savedError: task.execution.error ?? task.execution.pendingFixError ?? '',
+    fixError: opts.reason,
+    expectedLineage: opts.expectedLineage,
+  });
+
+  const reverted = host.stateGetTask(taskId);
+  if (!reverted || reverted.status === 'fixing_with_ai') return 'noop';
+
+  host.persistence.logEvent?.(taskId, 'task.fix_session_reclaimed', {
+    reason: opts.reason,
+    restoreStatus: reverted.status,
+  });
+  return 'reverted';
 }
 
 function restoreFailedEntry(


### PR DESCRIPTION
## Summary

This reclaims orphaned `fixing_with_ai` sessions instead of letting them hold executor capacity forever.

A fix session now gets a lease when it starts, and the app stall watchdog checks `fixing_with_ai` tasks the same way it already checks stalled `running` tasks.

When that lease expires, the watchdog reverts the fix session back to its entry state with a lineage guard, so live newer fixes are left alone.

## Review Claim

Orphaned `fixing_with_ai` sessions are now reclaimed by the existing stall watchdog and restored to their entry state.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This only reclaims dead fix sessions whose lease has expired. Live fixes still refresh their lease and keep running.

## Slice Rationale

The reclaim path depends on the shared fix-session state model, but it is still a separate watchdog behavior change from the earlier caller migrations.

## Non-goals

This does not start new fixes automatically.

This does not change CI-failure worker bookkeeping.

This does not reintroduce deprecated conflict-resolution shims.

## Architecture

### Before

```mermaid
graph TD
    A["Task enters fixing_with_ai"] --> B["Owner dies or session disappears"]
    B --> C["No watchdog path reclaims the orphaned fix session"]
```

### After

```mermaid
graph TD
    A["beginFixSession seeds a lease"] --> B["App watchdog evaluates fixing_with_ai stalls"]
    B --> C["reclaimStalledFixSession reverts to the entry state"]
```

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`
- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a718a7268`
- Post-revert steps: None
- Data migration? No

</details>
