### PR TITLE
[PR maintenance workers Step 2: Wire PR maintenance workers into owner config](1) Add prMaintenance owner config

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -209,6 +209,21 @@ describe('loadConfig', () => {
     const config = loadConfig();
     expect(config.externalWorkers).toEqual(externalWorkers);
   });
+  it('reads disabled PR-maintenance owner config from user config', () => {
+    const prMaintenance = {
+      enabled: false,
+      repoRoot: '/srv/invoker',
+      intervalMs: 120_000,
+      lockPath: '/tmp/pr-maintenance.lock',
+      shell: '/bin/zsh',
+      env: {
+        INVOKER_PR_TARGET: 'open',
+      },
+    };
+    writeUserConfig({ prMaintenance });
+    const config = loadConfig();
+    expect(config.prMaintenance).toEqual(prMaintenance);
+  });
 
   it('reads imageStorage from user config', () => {
     const imageStorage = {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -8,8 +8,8 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import type { PrMaintenanceWorkerConfig } from '@invoker/execution-engine';
 import { validateInvokerConfig } from './config-validation.js';
-
 export type HarnessModelPolicy =
   | { kind: 'implicit' }
   | { kind: 'fixed'; model: string }
@@ -51,6 +51,13 @@ export interface DefaultExecutionConfig {
    * Only applied when the resolved task executionAgent matches this default agent.
    */
   executionModel?: string;
+}
+export interface OwnerPrMaintenanceConfig extends PrMaintenanceWorkerConfig {
+  /**
+   * Disabled by default. Set true before owner-managed workers consume this
+   * config block.
+   */
+  enabled?: boolean;
 }
 
 export interface InvokerConfig {
@@ -293,6 +300,11 @@ export interface InvokerConfig {
     strategy?: 'enforce' | 'route';
   }>;
   /**
+   * Owner-managed PR-maintenance worker launch settings.
+   * Disabled by default until `enabled` is explicitly true.
+   */
+  prMaintenance?: OwnerPrMaintenanceConfig;
+  /**
    * Operator-declared external worker list, with each worker identified by registry kind.
    * The loader consumes this later; absent means no external workers.
    */
@@ -306,6 +318,16 @@ export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarn
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
 };
+export function resolveRegisteredOwnerPrMaintenanceConfig(
+  config: InvokerConfig,
+): PrMaintenanceWorkerConfig | undefined {
+  const prMaintenance = config.prMaintenance;
+  if (!prMaintenance || prMaintenance.enabled !== true) {
+    return undefined;
+  }
+  const { enabled: _enabled, ...workerConfig } = prMaintenance;
+  return workerConfig;
+}
 
 function readJsonSafe(path: string): InvokerConfig {
   if (!existsSync(path)) {


### PR DESCRIPTION
## Summary

Add disabled-by-default `prMaintenance` settings to `InvokerConfig`.

The loader now preserves owner PR-maintenance settings so later owner wiring can consume the same supported config shape.

<details>
<summary>Review metadata</summary>

Review Claim: `InvokerConfig` can carry disabled-by-default PR-maintenance owner settings.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: The new config is inert unless `enabled` is true, and no owner startup path consumes it in this slice.

Slice Rationale: Keep the config contract separate from owner worker registration and operator-facing surfaces.

</details>

## Non-goals

This slice does not start PR-maintenance workers, alter manual headless commands, or expose worker controls.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-pr-commit>`
- Post-revert steps: None
- Data migration? No

</details>


