### PR TITLE
[PR maintenance workers Step 2: Wire PR maintenance workers into owner config](2) Thread owner worker dependencies

### DIFF
--- a/packages/app/src/__tests__/registered-owner-workers.test.ts
+++ b/packages/app/src/__tests__/registered-owner-workers.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+  createWorkerRegistry,
+  registerBuiltinWorkers,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
+import type { Logger } from '@invoker/contracts';
+
+import {
+  resolveRegisteredOwnerPrMaintenanceConfig,
+  type InvokerConfig,
+} from '../config.js';
+
+const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => silentLogger,
+};
+
+const emptyStore: WorkerRuntimeDependencies['store'] = {
+  listWorkflows: () => [],
+  loadTasks: () => [],
+  listWorkflowMutationIntents: () => [],
+};
+
+const noopSubmitter: WorkerRuntimeDependencies['submitter'] = {
+  submit: () => 0,
+};
+
+function buildOwnerDeps(config: InvokerConfig): WorkerRuntimeDependencies {
+  return {
+    store: emptyStore,
+    submitter: noopSubmitter,
+    logger: silentLogger,
+    prMaintenance: resolveRegisteredOwnerPrMaintenanceConfig(config),
+  };
+}
+
+describe('registered owner PR-maintenance workers', () => {
+  it('keeps owner PR-maintenance config disabled by default', () => {
+    expect(resolveRegisteredOwnerPrMaintenanceConfig({})).toBeUndefined();
+    expect(resolveRegisteredOwnerPrMaintenanceConfig({
+      prMaintenance: {
+        enabled: false,
+        repoRoot: '/srv/invoker',
+        intervalMs: 120_000,
+      },
+    })).toBeUndefined();
+    expect(resolveRegisteredOwnerPrMaintenanceConfig({
+      prMaintenance: {
+        enabled: true,
+        repoRoot: '/srv/invoker',
+        intervalMs: 120_000,
+        lockPath: '/tmp/pr-maintenance.lock',
+        shell: '/bin/zsh',
+        env: {
+          INVOKER_PR_TARGET: 'open',
+        },
+      },
+    })).toEqual({
+      repoRoot: '/srv/invoker',
+      intervalMs: 120_000,
+      lockPath: '/tmp/pr-maintenance.lock',
+      shell: '/bin/zsh',
+      env: {
+        INVOKER_PR_TARGET: 'open',
+      },
+    });
+  });
+
+  it('threads enabled owner config into registered PR-maintenance worker factories', () => {
+    const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
+    const deps = buildOwnerDeps({
+      prMaintenance: {
+        enabled: true,
+        repoRoot: '/srv/invoker',
+        intervalMs: 120_000,
+        lockPath: '/tmp/pr-maintenance.lock',
+      },
+    });
+
+    expect(deps.prMaintenance).toEqual({
+      repoRoot: '/srv/invoker',
+      intervalMs: 120_000,
+      lockPath: '/tmp/pr-maintenance.lock',
+    });
+    expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)?.factory(deps).identity.kind)
+      .toBe(CODERABBIT_ADDRESS_WORKER_KIND);
+    expect(registry.get(PR_CONFLICT_REBASE_WORKER_KIND)?.factory(deps).identity.kind)
+      .toBe(PR_CONFLICT_REBASE_WORKER_KIND);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -129,6 +129,7 @@ import {
   resolveConfigFileState,
   resolveDefaultTaskExecutionSettings,
   resolveEmbeddedTerminalBackendConfig,
+  resolveRegisteredOwnerPrMaintenanceConfig,
   type EmbeddedTerminalBackendConfig,
   type InvokerConfig,
 } from './config.js';
@@ -337,6 +338,7 @@ function buildRegisteredOwnerWorkerDeps(
       getAutoFixAgent: () => invokerConfig.autoFixAgent,
       getAutoFixExecutionModel: () => invokerConfig.defaultExecutionModel,
     },
+    prMaintenance: resolveRegisteredOwnerPrMaintenanceConfig(invokerConfig),
   };
 }
 function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependencies> {


### PR DESCRIPTION
## Summary

Thread enabled PR-maintenance config into the registered owner worker dependencies.

The owner still leaves the workers dormant until config explicitly enables them, and no command or UI surface changes.

<details>
<summary>Review metadata</summary>

Review Claim: Owner startup can build PR-maintenance worker dependencies from `InvokerConfig`.

Review Lane: behavior

Review Unit: routing

Safety Invariant: This only passes config into registered worker factories; no new control surface starts the workers.

Slice Rationale: Keep owner dependency wiring separate from the config contract and later operator surfaces.

</details>

## Non-goals

This slice does not change headless manual worker commands, worker-control surfaces, or the shell backend.

## Architecture

### Before

Registered owner worker dependencies did not include PR-maintenance settings.

### After

`buildRegisteredOwnerWorkerDeps` resolves enabled PR-maintenance config and supplies it to built-in worker factories.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts src/__tests__/registered-owner-workers.test.ts`

</details>

## Visual Proof

No visible UI behavior is intended to change; `main.ts` is touched only for owner dependency wiring.

![Existing app empty state](https://github.com/Neko-Catpital-Labs/Invoker/blob/master/packages/app/e2e/__screenshots__/visual-proof.spec.ts/empty-state.png?raw=1)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-pr-commit>`
- Post-revert steps: None
- Data migration? No

</details>


