### PR TITLE
[PR maintenance workers Step 3: Add manual headless PR maintenance worker runs](1) Add manual worker entrypoints

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -209,6 +209,21 @@ describe('loadConfig', () => {
     const config = loadConfig();
     expect(config.externalWorkers).toEqual(externalWorkers);
   });
+  it('reads disabled PR-maintenance owner config from user config', () => {
+    const prMaintenance = {
+      enabled: false,
+      repoRoot: '/srv/invoker',
+      intervalMs: 120_000,
+      lockPath: '/tmp/pr-maintenance.lock',
+      shell: '/bin/zsh',
+      env: {
+        INVOKER_PR_TARGET: 'open',
+      },
+    };
+    writeUserConfig({ prMaintenance });
+    const config = loadConfig();
+    expect(config.prMaintenance).toEqual(prMaintenance);
+  });
 
   it('reads imageStorage from user config', () => {
     const imageStorage = {

--- a/packages/app/src/__tests__/headless-pr-maintenance.test.ts
+++ b/packages/app/src/__tests__/headless-pr-maintenance.test.ts
@@ -1,0 +1,186 @@
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    spawn: vi.fn(actual.spawn),
+    spawnSync: vi.fn(actual.spawnSync),
+  };
+});
+
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
+import type { ChildProcess, SpawnOptions, SpawnSyncReturns } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { PassThrough } from 'node:stream';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { Logger } from '@invoker/contracts';
+import {
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+} from '@invoker/execution-engine';
+
+import type { InvokerConfig } from '../config.js';
+import { runHeadless } from '../headless.js';
+import type { HeadlessDeps } from '../headless.js';
+
+type SpawnCall = {
+  command: string;
+  args: string[];
+  options: SpawnOptions;
+};
+
+function makeLogger(): Logger {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+  logger.child.mockReturnValue(logger);
+  return logger;
+}
+
+function makeSpawnHarness(options: { stdout?: string; stderr?: string; exitCode?: number } = {}) {
+  const calls: SpawnCall[] = [];
+  const spawnProcess = vi.fn((command: string, args: string[], spawnOptions: SpawnOptions) => {
+    calls.push({ command, args, options: spawnOptions });
+    const stdout = new PassThrough();
+    const stderr = new PassThrough();
+    const child = Object.assign(new EventEmitter(), {
+      stdout,
+      stderr,
+      stdin: null,
+      killed: false,
+      pid: 12345,
+      kill: vi.fn(),
+    }) as unknown as ChildProcess; // Test harness only needs the process fields the worker touches.
+
+    queueMicrotask(() => {
+      stdout.end(options.stdout ?? 'completed\n');
+      stderr.end(options.stderr ?? '');
+      child.emit('close', options.exitCode ?? 0, null);
+    });
+
+    return child;
+  });
+
+  return { calls, spawnProcess };
+}
+
+function makeSpawnSyncResult(status = 0): SpawnSyncReturns<Buffer> {
+  return {
+    pid: 12345,
+    output: [null, Buffer.alloc(0), Buffer.alloc(0)],
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+    status,
+    signal: null,
+  };
+}
+
+function makeHeadlessDeps(configOverrides: Partial<InvokerConfig> = {}): HeadlessDeps {
+  const deps = {
+    logger: makeLogger(),
+    persistence: {
+      enqueueWorkflowMutationIntent: vi.fn(() => 0),
+    },
+    invokerConfig: {
+      autoFixRetries: 3,
+      autoFixAgent: 'codex',
+      ...configOverrides,
+    },
+  };
+
+  // This command path only reads logger, persistence.enqueueWorkflowMutationIntent,
+  // and invokerConfig.
+  return deps as unknown as HeadlessDeps;
+}
+
+describe('headless PR-maintenance workers', () => {
+  const tmpRoots: string[] = [];
+  let previousDbDir: string | undefined;
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    if (previousDbDir === undefined) {
+      delete process.env.INVOKER_DB_DIR;
+    } else {
+      process.env.INVOKER_DB_DIR = previousDbDir;
+    }
+    previousDbDir = undefined;
+    while (tmpRoots.length > 0) {
+      const path = tmpRoots.pop();
+      if (path) rmSync(path, { recursive: true, force: true });
+    }
+  });
+
+  function makeTmpRoot(prefix: string): string {
+    const path = mkdtempSync(join(tmpdir(), prefix));
+    tmpRoots.push(path);
+    return path;
+  }
+
+  function setIsolatedHomeRoot(): void {
+    previousDbDir = process.env.INVOKER_DB_DIR;
+    process.env.INVOKER_DB_DIR = makeTmpRoot('invoker-headless-pr-maintenance-home-');
+  }
+
+  it('lists the PR-maintenance worker kinds on the existing worker entrypoint', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+
+    await runHeadless(['worker', 'list'], makeHeadlessDeps());
+
+    const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+    expect(output).toContain(CODERABBIT_ADDRESS_WORKER_KIND);
+    expect(output).toContain(PR_CONFLICT_REBASE_WORKER_KIND);
+  });
+
+  it.each([
+    [CODERABBIT_ADDRESS_WORKER_KIND, 'scripts/cron-coderabbit-address.sh'],
+    [PR_CONFLICT_REBASE_WORKER_KIND, 'scripts/cron-pr-conflict-rebase.sh'],
+  ] as const)('runs %s with the owner PR-maintenance config', async (kind, scriptRelativePath) => {
+    const repoRoot = makeTmpRoot(`invoker-headless-pr-maintenance-${kind}-`);
+    const lockPath = join(repoRoot, 'locks', `${kind}.lock`);
+    const spawnHarness = makeSpawnHarness();
+    const stdout = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    setIsolatedHomeRoot();
+    vi.mocked(spawn).mockImplementation(spawnHarness.spawnProcess);
+    vi.mocked(spawnSync).mockReturnValue(makeSpawnSyncResult(0));
+
+    await runHeadless(['worker', kind], makeHeadlessDeps({
+      prMaintenance: {
+        enabled: true,
+        repoRoot,
+        lockPath,
+        shell: '/bin/zsh',
+        env: {
+          INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
+          INVOKER_PR_CRON_AUTHOR: 'octocat',
+        },
+      },
+    }));
+
+    expect(spawnHarness.calls).toEqual([
+      expect.objectContaining({
+        command: '/bin/zsh',
+        args: [resolve(repoRoot, scriptRelativePath)],
+        options: expect.objectContaining({
+          cwd: repoRoot,
+          env: expect.objectContaining({
+            INVOKER_REPO_ROOT: repoRoot,
+            INVOKER_PR_CRON_LOCK: lockPath,
+            INVOKER_GITHUB_TARGET_REPO: 'owner/repo',
+            INVOKER_PR_CRON_AUTHOR: 'octocat',
+          }),
+        }),
+      }),
+    ]);
+    const output = stdout.mock.calls.map(([chunk]) => String(chunk)).join('');
+    expect(output).toContain(`${kind} worker scan completed.`);
+  });
+});

--- a/packages/app/src/__tests__/registered-owner-workers.test.ts
+++ b/packages/app/src/__tests__/registered-owner-workers.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+  createWorkerRegistry,
+  registerBuiltinWorkers,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
+import type { Logger } from '@invoker/contracts';
+
+import {
+  resolveRegisteredOwnerPrMaintenanceConfig,
+  type InvokerConfig,
+} from '../config.js';
+
+const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => silentLogger,
+};
+
+const emptyStore: WorkerRuntimeDependencies['store'] = {
+  listWorkflows: () => [],
+  loadTasks: () => [],
+  listWorkflowMutationIntents: () => [],
+};
+
+const noopSubmitter: WorkerRuntimeDependencies['submitter'] = {
+  submit: () => 0,
+};
+
+function buildOwnerDeps(config: InvokerConfig): WorkerRuntimeDependencies {
+  return {
+    store: emptyStore,
+    submitter: noopSubmitter,
+    logger: silentLogger,
+    prMaintenance: resolveRegisteredOwnerPrMaintenanceConfig(config),
+  };
+}
+
+describe('registered owner PR-maintenance workers', () => {
+  it('keeps owner PR-maintenance config disabled by default', () => {
+    expect(resolveRegisteredOwnerPrMaintenanceConfig({})).toBeUndefined();
+    expect(resolveRegisteredOwnerPrMaintenanceConfig({
+      prMaintenance: {
+        enabled: false,
+        repoRoot: '/srv/invoker',
+        intervalMs: 120_000,
+      },
+    })).toBeUndefined();
+    expect(resolveRegisteredOwnerPrMaintenanceConfig({
+      prMaintenance: {
+        enabled: true,
+        repoRoot: '/srv/invoker',
+        intervalMs: 120_000,
+        lockPath: '/tmp/pr-maintenance.lock',
+        shell: '/bin/zsh',
+        env: {
+          INVOKER_PR_TARGET: 'open',
+        },
+      },
+    })).toEqual({
+      repoRoot: '/srv/invoker',
+      intervalMs: 120_000,
+      lockPath: '/tmp/pr-maintenance.lock',
+      shell: '/bin/zsh',
+      env: {
+        INVOKER_PR_TARGET: 'open',
+      },
+    });
+  });
+
+  it('threads enabled owner config into registered PR-maintenance worker factories', () => {
+    const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
+    const deps = buildOwnerDeps({
+      prMaintenance: {
+        enabled: true,
+        repoRoot: '/srv/invoker',
+        intervalMs: 120_000,
+        lockPath: '/tmp/pr-maintenance.lock',
+      },
+    });
+
+    expect(deps.prMaintenance).toEqual({
+      repoRoot: '/srv/invoker',
+      intervalMs: 120_000,
+      lockPath: '/tmp/pr-maintenance.lock',
+    });
+    expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)?.factory(deps).identity.kind)
+      .toBe(CODERABBIT_ADDRESS_WORKER_KIND);
+    expect(registry.get(PR_CONFLICT_REBASE_WORKER_KIND)?.factory(deps).identity.kind)
+      .toBe(PR_CONFLICT_REBASE_WORKER_KIND);
+  });
+});

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -8,8 +8,8 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
+import type { PrMaintenanceWorkerConfig } from '@invoker/execution-engine';
 import { validateInvokerConfig } from './config-validation.js';
-
 export type HarnessModelPolicy =
   | { kind: 'implicit' }
   | { kind: 'fixed'; model: string }
@@ -51,6 +51,13 @@ export interface DefaultExecutionConfig {
    * Only applied when the resolved task executionAgent matches this default agent.
    */
   executionModel?: string;
+}
+export interface OwnerPrMaintenanceConfig extends PrMaintenanceWorkerConfig {
+  /**
+   * Disabled by default. Set true before owner-managed workers consume this
+   * config block.
+   */
+  enabled?: boolean;
 }
 
 export interface InvokerConfig {
@@ -293,6 +300,11 @@ export interface InvokerConfig {
     strategy?: 'enforce' | 'route';
   }>;
   /**
+   * Owner-managed PR-maintenance worker launch settings.
+   * Disabled by default until `enabled` is explicitly true.
+   */
+  prMaintenance?: OwnerPrMaintenanceConfig;
+  /**
    * Operator-declared external worker list, with each worker identified by registry kind.
    * The loader consumes this later; absent means no external workers.
    */
@@ -306,6 +318,16 @@ export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarn
   omp: { tool: 'omp' },
   codex: { tool: 'codex' },
 };
+export function resolveRegisteredOwnerPrMaintenanceConfig(
+  config: InvokerConfig,
+): PrMaintenanceWorkerConfig | undefined {
+  const prMaintenance = config.prMaintenance;
+  if (!prMaintenance || prMaintenance.enabled !== true) {
+    return undefined;
+  }
+  const { enabled: _enabled, ...workerConfig } = prMaintenance;
+  return workerConfig;
+}
 
 function readJsonSafe(path: string): InvokerConfig {
   if (!existsSync(path)) {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -19,10 +19,11 @@ import {
   createAutoFixAttemptLedger,
   createWorkerRegistry,
   registerAutoFixWorker,
+  registerPrMaintenanceWorkers,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
-  type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
+import type { WorkerRuntimeDependencies } from '@invoker/execution-engine';
 import {
   parseMetadataValue,
   setTaskMetadata,
@@ -38,11 +39,10 @@ import {
 } from './global-topup.js';
 import { LaunchDispatcher } from './launch-dispatcher.js';
 import { formatHeadlessSetSubcommands } from './headless-command-registry.js';
-import {
-  collectRecoveryWorkerStatus,
-  type RecoveryWorkerStatus,
-} from './recovery-worker-observability.js';
+import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
+import type { RecoveryWorkerStatus } from './recovery-worker-observability.js';
 import { registerExternalWorkersFromConfig } from './external-worker-loader.js';
+import { resolveRegisteredOwnerPrMaintenanceConfig } from './config.js';
 
 export {
   DEFAULT_DELEGATION_TIMEOUT_MS,
@@ -58,8 +58,6 @@ export {
 export type { DelegationOutcome } from './headless-delegation.js';
 
 import {
-  type HeadlessDeps,
-  type QueryFlags,
   BOLD,
   RESET,
   YELLOW,
@@ -71,6 +69,7 @@ import {
   restoreWorkflowForTaskUnlessDeleteAllWon,
   withRestoredTaskUnlessDeleteAllWon,
 } from './headless-shared.js';
+import type { HeadlessDeps, QueryFlags } from './headless-shared.js';
 
 export { createHeadlessExecutor, wireHeadlessApproveHook, parseQueryFlags };
 export type { HeadlessDeps, QueryFlags };
@@ -424,7 +423,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
     deps.invokerConfig?.externalWorkers,
-    registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+    registerPrMaintenanceWorkers(registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>())),
   );
 
   if (subCommand === 'list') {
@@ -487,6 +486,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         attemptLedger: autoFixAttemptLedger,
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
+      prMaintenance: resolveRegisteredOwnerPrMaintenanceConfig(deps.invokerConfig),
     });
     await worker.tick('manual');
     await worker.stop();
@@ -607,7 +607,7 @@ ${BOLD}Lifecycle:${RESET}
   delete-all                                           Delete all workflows (requires INVOKER_ALLOW_DELETE_ALL=1)
   open-terminal <taskId>                              Open OS terminal for a task
   slack                                               Start Slack bot (long-running)
-  worker [kind|list|status]                           Run/list registry worker kinds (autofix scans failed tasks)
+  worker [kind|list|status]                           Run/list registry worker kinds (autofix and PR-maintenance one-shot workers)
 
 ${BOLD}Deprecated${RESET} (use new names above):
   list → query workflows       status → query tasks       task-status → query task

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -129,6 +129,7 @@ import {
   resolveConfigFileState,
   resolveDefaultTaskExecutionSettings,
   resolveEmbeddedTerminalBackendConfig,
+  resolveRegisteredOwnerPrMaintenanceConfig,
   type EmbeddedTerminalBackendConfig,
   type InvokerConfig,
 } from './config.js';
@@ -337,6 +338,7 @@ function buildRegisteredOwnerWorkerDeps(
       getAutoFixAgent: () => invokerConfig.autoFixAgent,
       getAutoFixExecutionModel: () => invokerConfig.defaultExecutionModel,
     },
+    prMaintenance: resolveRegisteredOwnerPrMaintenanceConfig(invokerConfig),
   };
 }
 function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependencies> {


### PR DESCRIPTION
## Summary

Add manual headless worker execution for the PR-maintenance worker kinds.

`coderabbit-address` and `pr-conflict-rebase` now flow through the existing one-shot worker path with configured PR-maintenance settings.

## Review Claim

Manual headless worker runs can construct the configured PR-maintenance worker kinds.

## Review Lane

- behavior

## Review Unit

- activation-surface

## Safety Invariant

This slice only changes the existing headless worker entrypoint; owner startup and operator UI are untouched.

## Slice Rationale

Manual one-shot execution is reviewed separately from owner startup and status surfaces.

## Non-goals

This slice does not change owner startup policy, operator status surfaces, or the PR-maintenance backend implementation.

## Architecture

### Before

The headless worker entrypoint could run registered worker kinds but did not thread PR-maintenance settings into those runs.

### After

The headless worker path can pass configured PR-maintenance settings when constructing `coderabbit-address` and `pr-conflict-rebase` workers.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-pr-maintenance.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-pr-commit>`
- Post-revert steps: None
- Data migration? No

</details>
