### PR TITLE
[Fix sessions](0) Harden merge-conflict error parsing

### DIFF
--- a/packages/workflow-core/src/merge-conflict-error.ts
+++ b/packages/workflow-core/src/merge-conflict-error.ts
@@ -60,21 +60,36 @@ function parseLineSeparatedFiles(value: string): string[] {
     .map((file) => file.trim())
     .filter(isRecoverableConflictFile);
 }
+function normalizeNewlines(value: string): string {
+  return value.split('\r\n').join('\n');
+}
+
 
 function parseLocalTextMergeConflict(value: string): ParsedMergeConflictError | undefined {
-  const match = value.match(/Merge conflict merging\s+(.+?):\s*([^\n]+)/);
-  const failedBranch = match?.[1]?.trim() ?? '';
-  const conflictFiles = parseCommaSeparatedFiles(match?.[2] ?? '');
+  const prefix = 'Merge conflict merging';
+  const prefixIndex = value.indexOf(prefix);
+  if (prefixIndex < 0) return undefined;
+  const afterPrefix = value.slice(prefixIndex + prefix.length).trimStart();
+  const colonIndex = afterPrefix.indexOf(':');
+  if (colonIndex <= 0) return undefined;
+  const failedBranch = afterPrefix.slice(0, colonIndex).trim();
+  const conflictLine = afterPrefix.slice(colonIndex + 1).split('\n', 1)[0]?.trim() ?? '';
+  const conflictFiles = parseCommaSeparatedFiles(conflictLine);
   if (!failedBranch || conflictFiles.length === 0) return undefined;
   return { failedBranch, conflictFiles };
 }
 
 function parseRemoteTextMergeConflict(value: string): ParsedMergeConflictError | undefined {
-  const match = value.match(
-    /Merge conflict merging upstream branch "([^"]+)" on remote\.\s*\r?\nConflicting files:\r?\n([\s\S]+)/,
-  );
-  const failedBranch = match?.[1]?.trim() ?? '';
-  const conflictFiles = parseLineSeparatedFiles(match?.[2] ?? '');
+  const normalized = normalizeNewlines(value);
+  const prefix = 'Merge conflict merging upstream branch "';
+  const prefixIndex = normalized.indexOf(prefix);
+  if (prefixIndex < 0) return undefined;
+  const branchStart = prefixIndex + prefix.length;
+  const branchEnd = normalized.indexOf('" on remote.\nConflicting files:\n', branchStart);
+  if (branchEnd < 0) return undefined;
+  const failedBranch = normalized.slice(branchStart, branchEnd).trim();
+  const filesStart = branchEnd + '" on remote.\nConflicting files:\n'.length;
+  const conflictFiles = parseLineSeparatedFiles(normalized.slice(filesStart));
   if (!failedBranch || conflictFiles.length === 0) return undefined;
   return { failedBranch, conflictFiles };
 }


### PR DESCRIPTION
## Summary

This hardens merge-conflict error parsing so it no longer depends on broad regular expressions over task output.

The parser now uses bounded string slicing for both the local and remote merge-conflict formats.

That keeps the existing parse behavior while clearing the CodeQL regex alert on the bottom stack slice.

## Review Claim

Merge-conflict error parsing now uses bounded string slicing instead of broad regular expressions over task output.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This preserves the same accepted merge-conflict text formats. Only the parsing strategy changes.

## Slice Rationale

This security hardening has to land before the first fix-session slice because CodeQL gates the bottom PR.

## Non-goals

This does not change fix-session state handling.

This does not change app or worker fix entrypoints.

This does not change any merge-gate recovery policy.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/merge-conflict-error.test.ts`
- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 7d9c08435`
- Post-revert steps: None
- Data migration? No

</details>
