### PR TITLE
fix(build): raise base tsconfig lib to ES2024

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,7 +7,7 @@
       "node"
     ],
     "lib": [
-      "ES2022"
+      "ES2024"
     ],
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

The local `run.sh` build broke on master because a type-checker setting lagged behind the code it had to check.

The disk-headroom worker calls `Promise.withResolvers()`. That method exists at runtime on modern Node but is only described by the ES2024 standard library.

The per-package declaration build inherits `tsconfig.base.json`, which still declared the older ES2022 library. So it did not recognize the method and failed with TS2550.

This raises the shared base library to ES2024, matching `tsconfig.typecheck.json`, the config CI already gates on. Emitted code is unchanged because the compile target stays ES2022.

## Review Claim

Raise the shared base tsconfig `lib` from ES2022 to ES2024 so per-package dts builds recognize the ES2024 runtime APIs already used across source.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

`lib` only widens which type declarations are visible; it does not change emitted output. `target` stays ES2022, so no JavaScript changes. The new value equals the ES2024 already set in `tsconfig.typecheck.json`, the CI-gating typecheck, so type resolution matches what CI enforces.

## Slice Rationale

One-line build-config fix touching only `tsconfig.base.json`. It carries no product, proof, or docs files, so it stands alone as a single tooling-policy slice.

## Non-goals

Does not change the compile `target`, runtime behavior, or emitted output. Does not modify any source file, including the disk-headroom worker. Does not upgrade TypeScript or Node.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/execution-engine build`
- [ ] `for p in core persistence execution-engine surfaces ui app; do pnpm --filter @invoker/$p build || break; done`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the ES2022 lib and reintroduces the dts build break.
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s TypeScript standard library target to a newer ECMAScript version for builds and type checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->