### PR TITLE
Install bundled skills into omp agent skill root

### DIFF
--- a/packages/app/src/__tests__/bundled-skills.test.ts
+++ b/packages/app/src/__tests__/bundled-skills.test.ts
@@ -102,6 +102,7 @@ describe('bundled-skills', () => {
         join(codexHome, '.codex', 'skills'),
         join(codexHome, '.claude', 'skills'),
         join(codexHome, '.cursor', 'skills-cursor'),
+        join(codexHome, '.omp', 'agent', 'skills'),
       ];
 
       for (const targetRoot of expectedTargets) {
@@ -127,7 +128,7 @@ describe('bundled-skills', () => {
       expect(mcpConfig.$schema).toBe('https://raw.githubusercontent.com/can1357/oh-my-pi/main/packages/coding-agent/src/config/mcp-schema.json');
       expect(mcpConfig.mcpServers.invoker).toEqual({ type: 'stdio', command: 'invoker-cli', args: ['mcp'] });
 
-      expect(installed.targets).toHaveLength(3);
+      expect(installed.targets).toHaveLength(4);
       expect(installed.commandTargets).toHaveLength(4);
       expect(installed.mcpTargets).toHaveLength(1);
       expect(installed.targets.every((target) => target.installed)).toBe(true);
@@ -148,6 +149,45 @@ describe('bundled-skills', () => {
       expect(status.commandTargets.every((target) => target.upToDate)).toBe(true);
       expect(status.mcpTargets.every((target) => target.upToDate)).toBe(true);
       expect(status.promptRecommended).toBe(false);
+    } finally {
+      if (originalHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = originalHome;
+      }
+    }
+  });
+
+  it('installs skills into the OMP agent skill root so omp resolves make-pr', () => {
+    const resourcesRoot = makeTempRoot('invoker-bundled-resources-');
+    const invokerHomeRoot = makeTempRoot('invoker-bundled-home-');
+    const repoRoot = makeTempRoot('invoker-bundled-repo-');
+    const ompHome = makeTempRoot('invoker-omp-home-');
+    const originalHome = process.env.HOME;
+    process.env.HOME = ompHome;
+
+    try {
+      writeSkill(resourcesRoot, 'make-pr');
+      writePlanToInvokerCommands(resourcesRoot);
+
+      const installed = installBundledSkills({
+        isPackaged: true,
+        repoRoot,
+        resourcesPath: resourcesRoot,
+        invokerHomeRoot,
+      });
+
+      // omp's bundledSkillRoot is ~/.omp/agent/skills; resolveSkillPathViaAgent
+      // checks <root>/invoker-make-pr/SKILL.md. Without this target omp fails PR
+      // publishing with `skill "invoker-make-pr" not installed` — the exact bug
+      // this target prevents. omp is the default execution + PR-authoring agent.
+      const ompSkillMd = join(ompHome, '.omp', 'agent', 'skills', 'invoker-make-pr', 'SKILL.md');
+      expect(existsSync(ompSkillMd)).toBe(true);
+
+      const ompTarget = installed.targets.find((target) => target.id === 'omp');
+      expect(ompTarget?.path).toBe(join(ompHome, '.omp', 'agent', 'skills'));
+      expect(ompTarget?.installed).toBe(true);
+      expect(ompTarget?.upToDate).toBe(true);
     } finally {
       if (originalHome === undefined) {
         delete process.env.HOME;

--- a/packages/app/src/bundled-skills.ts
+++ b/packages/app/src/bundled-skills.ts
@@ -115,8 +115,20 @@ function resolveCursorTarget(): BundledSkillTargetStatus {
   };
 }
 
+function resolveOmpSkillTarget(): BundledSkillTargetStatus {
+  return {
+    id: 'omp',
+    name: 'OMP',
+    path: path.join(homedir(), '.omp', 'agent', 'skills'),
+    available: true,
+    installed: false,
+    upToDate: false,
+    installedSkillNames: [],
+  };
+}
+
 function resolveManagedTargets(): BundledSkillTargetStatus[] {
-  return [resolveCodexTarget(), resolveClaudeTarget(), resolveCursorTarget()];
+  return [resolveCodexTarget(), resolveClaudeTarget(), resolveCursorTarget(), resolveOmpSkillTarget()];
 }
 
 function resolveManagedCommandTargets(): HarnessConfigState[] {


### PR DESCRIPTION
## Summary

Invoker's default agent, omp, could not open pull requests. Its skill folder was empty because setup filled the other agents but never omp.

Now setup also fills omp's skill folder, so the PR-authoring skill is present and omp can author PRs again.

## Review Claim

Setup now installs the bundled skills into omp's skill folder, the same folder omp reads at PR time.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Additive: it appends one destination to the existing setup step and copies the files already installed for the other agents. No other destination or file changes, so nothing that works today can break.

## Slice Rationale

One concern only: make omp a first-class skill destination in setup. Nothing else rides along.

## Non-goals

- No change to how the skill is found at PR time; omp already reads that folder.
- No change to command or MCP setup for any agent.
- No change to the other agents' skill destinations.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/bundled-skills.test.ts`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
