### PR TITLE
[Approval Modal](1) Scroll large task descriptions so the fix buttons stay reachable

### DIFF
--- a/packages/ui/src/__tests__/approval-modal.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal.test.tsx
@@ -116,6 +116,35 @@ describe('ApprovalModal', () => {
     expect(screen.getByText('Approve AI Fix')).toBeInTheDocument();
   });
 
+  it('keeps the heading pinned and scrolls a large task description', () => {
+    const longDescription = 'Extract workflow task actions. '.repeat(200).trim();
+    render(
+      <ApprovalModal
+        task={makeTask({
+          id: 'wf-1783449124770-10/extract-workflow-task-actions',
+          description: longDescription,
+          execution: { pendingFixError: 'Test failed: expected 1 but got 2' },
+        })}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    // A large description must live inside the scrollable region so it can
+    // never push the footer action buttons off-screen.
+    const description = screen.getByText(longDescription);
+    expect(description.closest('.overflow-y-auto')).not.toBeNull();
+
+    // The heading stays pinned outside the scroll region.
+    const heading = screen.getByRole('heading', { name: 'Approve AI Fix' });
+    expect(heading.closest('.overflow-y-auto')).toBeNull();
+
+    // Action buttons remain reachable (pinned footer).
+    expect(screen.getByRole('button', { name: 'Approve Fix' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Reject Fix' })).toBeInTheDocument();
+  });
+
   it('pre-fills rejection reason with session and error for fix approval', () => {
     render(
       <ApprovalModal

--- a/packages/ui/src/components/ApprovalModal.tsx
+++ b/packages/ui/src/components/ApprovalModal.tsx
@@ -188,17 +188,19 @@ export function ApprovalModal({
       <div className="bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col border border-gray-700">
         {/* Header */}
         <div className="p-6 pb-0 shrink-0">
-          <h2 className="text-lg font-semibold text-gray-100 mb-2 shrink-0">
+          <h2 className="text-lg font-semibold text-gray-100">
             {heading}
           </h2>
-          <p className="text-sm text-gray-300 mb-1">
-            Task: <span className="font-mono text-gray-200">{task.id}</span>
-          </p>
-          <p className="text-sm text-gray-400">{task.description}</p>
         </div>
 
         {/* Scrollable content */}
         <div className="flex-1 overflow-y-auto min-h-0 px-6 py-4 space-y-4">
+          <div>
+            <p className="text-sm text-gray-300 mb-1">
+              Task: <span className="font-mono text-gray-200">{task.id}</span>
+            </p>
+            <p className="text-sm text-gray-400 break-words">{task.description}</p>
+          </div>
           {sessionId && (
             <div className="bg-gray-700/50 rounded p-3" data-testid="claude-session-context">
               <h3 className="text-sm font-medium text-gray-300 mb-2">{agentLabel} Session</h3>


### PR DESCRIPTION
## Summary

The Approve AI Fix dialog now scrolls when a task has a long description, so its action buttons at the bottom stay reachable.

Before, the description sat inside the dialog's fixed header. A long one grew taller than the screen and pushed the buttons out of view, with nothing to scroll.

The fix keeps only the title pinned at the top and renders the task id and description inside the dialog's scrollable area.

## Review Claim

Rendering the task id and description inside the dialog's scroll area fixes the hidden-buttons bug and changes nothing else about the dialog.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Pure layout change in one component. The heading stays pinned; the task id and description relocate from the fixed header into the sibling scroll region that was already present. No props, data flow, or approve/reject/merge logic changes. A new test asserts the description renders inside the scroll container, the heading stays outside it, and both action buttons are present.

## Slice Rationale

One UI bug fix plus its regression test, in a single component. Nothing else is bundled.

## Non-goals

Does not change approve, reject, or merge logic, session loading, or any other modal. Does not touch non-UI packages or any unrelated in-flight edits.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm exec vitest run src/__tests__/approval-modal.test.tsx`
- [ ] `cd packages/ui && pnpm exec vitest run src/__tests__/merge-gate-approval-flow.test.tsx`

</details>

## Visual Proof

Rendered against the real `ApprovalModal` with a large task description at a 920x620 viewport.

Scroll walkthrough (after fix): the title "Approve AI Fix" and the Approve Fix / Reject Fix buttons stay pinned while the description scrolls through the middle. [scroll walkthrough video](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-67b320/approval-modal-scroll-walkthrough.webm)

Before — the description overflows the viewport and the Approve Fix / Reject Fix / Cancel buttons are pushed off-screen with no scrollbar:

![before: fix buttons pushed below the viewport, unreachable](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-a7e078/before-approval-modal-large-title.png)

After — the description scrolls inside the dialog and the green Approve Fix / red Reject Fix buttons sit at the bottom, visible:

![after: Approve Fix and Reject Fix buttons visible at the bottom of the dialog](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-a7e078/after-approval-modal-large-title.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
