### PR TITLE
[PR maintenance workers Step 2: Wire PR maintenance workers into owner config](1) Add owner PR-maintenance config and dependency resolver

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -210,6 +210,32 @@ describe('loadConfig', () => {
     expect(config.externalWorkers).toEqual(externalWorkers);
   });
 
+  it('defaults prMaintenance to undefined when absent', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ defaultBranch: 'main' }),
+    );
+    const config = loadConfig();
+    expect(config.prMaintenance).toBeUndefined();
+  });
+
+  it('reads prMaintenance config from user config', () => {
+    const prMaintenance = {
+      enabled: true,
+      repoRoot: '/srv/invoker',
+      env: { INVOKER_PR_CRON_LOCK: '/tmp/pr.lock' },
+      intervalMs: 120000,
+      lockPath: '/tmp/pr.lock',
+      shell: '/bin/bash',
+    };
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ prMaintenance }),
+    );
+    const config = loadConfig();
+    expect(config.prMaintenance).toEqual(prMaintenance);
+  });
+
   it('reads imageStorage from user config', () => {
     const imageStorage = {
       provider: 'r2',

--- a/packages/app/src/__tests__/registered-owner-workers.test.ts
+++ b/packages/app/src/__tests__/registered-owner-workers.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+  createWorkerRegistry,
+  registerBuiltinWorkers,
+  type WorkerRuntimeDependencies,
+} from '@invoker/execution-engine';
+import { resolvePrMaintenanceWorkerConfig, type InvokerConfig } from '../config.js';
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => silentLogger,
+};
+
+const emptyStore: WorkerRuntimeDependencies['store'] = {
+  listWorkflows: () => [],
+  loadTasks: () => [],
+  listWorkflowMutationIntents: () => [],
+};
+
+const noopSubmitter: WorkerRuntimeDependencies['submitter'] = {
+  submit: () => 0,
+};
+
+/** Mirror of the owner-startup PR-maintenance dependency construction. */
+function buildOwnerWorkerDeps(config: InvokerConfig): WorkerRuntimeDependencies {
+  return {
+    store: emptyStore,
+    submitter: noopSubmitter,
+    logger: silentLogger,
+    prMaintenance: resolvePrMaintenanceWorkerConfig(config),
+  };
+}
+
+describe('resolvePrMaintenanceWorkerConfig', () => {
+  it('returns undefined when prMaintenance is absent (disabled by default)', () => {
+    expect(resolvePrMaintenanceWorkerConfig({})).toBeUndefined();
+  });
+
+  it('returns undefined when prMaintenance is present but not enabled', () => {
+    expect(
+      resolvePrMaintenanceWorkerConfig({
+        prMaintenance: { repoRoot: '/srv/invoker', intervalMs: 60000 },
+      }),
+    ).toBeUndefined();
+    expect(
+      resolvePrMaintenanceWorkerConfig({
+        prMaintenance: { enabled: false, repoRoot: '/srv/invoker' },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('builds the launch config and drops the enabled gate when enabled', () => {
+    const resolved = resolvePrMaintenanceWorkerConfig({
+      prMaintenance: {
+        enabled: true,
+        repoRoot: '/srv/invoker',
+        env: { INVOKER_PR_CRON_LOCK: '/tmp/pr.lock' },
+        intervalMs: 120000,
+        lockPath: '/tmp/pr.lock',
+        shell: '/bin/bash',
+      },
+    });
+    expect(resolved).toEqual({
+      repoRoot: '/srv/invoker',
+      env: { INVOKER_PR_CRON_LOCK: '/tmp/pr.lock' },
+      intervalMs: 120000,
+      lockPath: '/tmp/pr.lock',
+      shell: '/bin/bash',
+    });
+    expect(resolved).not.toHaveProperty('enabled');
+  });
+
+  it('omits unset launch fields', () => {
+    expect(
+      resolvePrMaintenanceWorkerConfig({
+        prMaintenance: { enabled: true, repoRoot: '/srv/invoker' },
+      }),
+    ).toEqual({ repoRoot: '/srv/invoker' });
+  });
+});
+
+describe('registered owner PR-maintenance worker dependencies', () => {
+  it('leaves prMaintenance deps unset when config is disabled', () => {
+    expect(buildOwnerWorkerDeps({}).prMaintenance).toBeUndefined();
+  });
+
+  it('threads the resolved launch config into owner worker deps when enabled', () => {
+    const deps = buildOwnerWorkerDeps({
+      prMaintenance: { enabled: true, intervalMs: 90000, shell: '/bin/bash' },
+    });
+    expect(deps.prMaintenance).toEqual({ intervalMs: 90000, shell: '/bin/bash' });
+  });
+
+  it('builds both PR-maintenance workers from the owner deps without starting them', () => {
+    const registry = registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>());
+    const deps = buildOwnerWorkerDeps({
+      prMaintenance: { enabled: true, intervalMs: 90000 },
+    });
+
+    const coderabbit = registry.get(CODERABBIT_ADDRESS_WORKER_KIND)?.factory(deps);
+    const rebase = registry.get(PR_CONFLICT_REBASE_WORKER_KIND)?.factory(deps);
+
+    expect(coderabbit?.identity.kind).toBe(CODERABBIT_ADDRESS_WORKER_KIND);
+    expect(coderabbit?.isRunning()).toBe(false);
+    expect(rebase?.identity.kind).toBe(PR_CONFLICT_REBASE_WORKER_KIND);
+    expect(rebase?.isRunning()).toBe(false);
+  });
+});

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { validateInvokerConfig } from './config-validation.js';
+import type { PrMaintenanceWorkerConfig } from '@invoker/execution-engine';
 
 export type HarnessModelPolicy =
   | { kind: 'implicit' }
@@ -51,6 +52,32 @@ export interface DefaultExecutionConfig {
    * Only applied when the resolved task executionAgent matches this default agent.
    */
   executionModel?: string;
+}
+
+/**
+ * Owner-side PR-maintenance worker config.
+ *
+ * Disabled by default: the coderabbit-address and pr-conflict-rebase workers
+ * only receive launch dependencies when `enabled` is true. The remaining fields
+ * tune the shell entrypoint launch and fall back to the worker defaults when
+ * omitted.
+ */
+export interface PrMaintenanceConfig {
+  /**
+   * Gate for building PR-maintenance worker dependencies at owner startup.
+   * Default: false (workers get no launch config).
+   */
+  enabled?: boolean;
+  /** Repository root that owns the PR-maintenance shell scripts. Defaults to the Invoker repo root. */
+  repoRoot?: string;
+  /** Environment overrides forwarded to the shell entrypoint. `undefined` removes a variable. */
+  env?: Record<string, string | undefined>;
+  /** Poll cadence for both PR-maintenance workers in milliseconds. Defaults to five minutes. */
+  intervalMs?: number;
+  /** Shared cron lock path. Defaults to the shell script's INVOKER_PR_CRON_LOCK behavior. */
+  lockPath?: string;
+  /** Shell executable used to run the entrypoint. Defaults to bash. */
+  shell?: string;
 }
 
 export interface InvokerConfig {
@@ -297,6 +324,12 @@ export interface InvokerConfig {
    * The loader consumes this later; absent means no external workers.
    */
   externalWorkers?: ExternalWorkerConfig[];
+  /**
+   * Owner-side PR-maintenance worker config. Disabled by default; when
+   * `enabled` is true the owner builds coderabbit-address and pr-conflict-rebase
+   * worker launch dependencies from this block.
+   */
+  prMaintenance?: PrMaintenanceConfig;
 }
 export const DEFAULT_SLACK_HARNESS_PRESETS: NonNullable<InvokerConfig['slackHarnessPresets']> = {
   'cursor+claude': { tool: 'cursor', model: 'claude' },
@@ -394,4 +427,29 @@ export function resolveSecretsFilePath(config: InvokerConfig): string | undefine
   const fallback = join(homedir(), '.config', 'invoker', 'secrets.env');
   if (existsSync(fallback)) return fallback;
   return undefined;
+}
+
+/**
+ * Build PR-maintenance worker launch dependencies from config.
+ *
+ * Returns `undefined` when the block is absent or `enabled` is not true, so the
+ * owner keeps PR-maintenance workers disabled by default. When enabled, returns
+ * only the launch fields (the `enabled` gate is dropped) for injection as the
+ * worker runtime `prMaintenance` dependency; omitted fields fall back to the
+ * worker defaults.
+ */
+export function resolvePrMaintenanceWorkerConfig(
+  config: InvokerConfig,
+): PrMaintenanceWorkerConfig | undefined {
+  const prMaintenance = config.prMaintenance;
+  if (!prMaintenance?.enabled) {
+    return undefined;
+  }
+  const launch: PrMaintenanceWorkerConfig = {};
+  if (prMaintenance.repoRoot !== undefined) launch.repoRoot = prMaintenance.repoRoot;
+  if (prMaintenance.env !== undefined) launch.env = prMaintenance.env;
+  if (prMaintenance.intervalMs !== undefined) launch.intervalMs = prMaintenance.intervalMs;
+  if (prMaintenance.lockPath !== undefined) launch.lockPath = prMaintenance.lockPath;
+  if (prMaintenance.shell !== undefined) launch.shell = prMaintenance.shell;
+  return launch;
 }


### PR DESCRIPTION
## Summary

Add disabled-by-default `prMaintenance` owner config so operators can tune the new PR-maintenance workers without starting them by accident.

Add a resolver that strips the enable gate and hands only launch options to worker runtime dependencies.

## Review Claim

Owner config can represent PR-maintenance worker launch settings and resolve them only when explicitly enabled.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The new config stays disabled by default. Absent or disabled `prMaintenance` returns `undefined`, so owner startup cannot launch these workers from this slice alone.

## Slice Rationale

Config parsing and dependency resolution land before owner startup wiring, keeping the review focused on the shape and enable gate.

## Non-goals

- Does not start PR-maintenance workers from the owner process.
- Does not change headless worker commands, worker-control UI, or the shell backend.

## Architecture

### Before

`InvokerConfig` had no owner-side `prMaintenance` block, so PR-maintenance workers could not receive owner-provided launch options.

### After

`InvokerConfig.prMaintenance` stays behind an explicit enable gate. `resolvePrMaintenanceWorkerConfig` converts enabled config into `PrMaintenanceWorkerConfig`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts src/__tests__/registered-owner-workers.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 118af3924beb933f4d6b423f84ab29d8c7255301`
- Post-revert steps: Re-run the focused app tests.
- Data migration? No

</details>
