### PR TITLE
[Recovery Lifecycle 2i Step 4: External worker plugin loader](1) Complete no-diff review gates

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2137,6 +2137,7 @@ describe('TaskRunner', () => {
         if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'deadbeef';
         if (args[0] === 'rev-parse' && args[1] === '--verify') return '';
         if (args[0] === 'merge-base' && args[1] === '--is-ancestor') throw new Error('not ancestor');
+        if (args[0] === 'diff' && args[1] === '--quiet') throw new Error('branch has changes');
         return '';
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
@@ -2470,6 +2471,7 @@ describe('TaskRunner', () => {
       gateWorkspacePath?: string | null;
       taskBranches?: TaskState[];
       repoUrl?: string;
+      featureHasDiff?: boolean;
     }) {
       const mergeTaskId = '__merge__wf-pub';
       const workflowId = 'wf-pub';
@@ -2533,6 +2535,9 @@ describe('TaskRunner', () => {
         if (args[0] === 'rev-parse' && args[1] === '--verify') return '';
         // merge-base --is-ancestor exits non-zero when branch is NOT an ancestor of HEAD
         if (args[0] === 'merge-base' && args[1] === '--is-ancestor') throw new Error('not ancestor');
+        if (args[0] === 'diff' && args[1] === '--quiet' && (opts.featureHasDiff ?? true)) {
+          throw new Error('branch has changes');
+        }
         return '';
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
@@ -2626,6 +2631,40 @@ describe('TaskRunner', () => {
         }),
       }), expect.objectContaining({ generation: 0 }));
     });
+
+    it('external_review on Invoker completes without make-pr when the feature branch has no diff', async () => {
+      const completedTask = makeTask({
+        id: 'already-landed',
+        status: 'completed',
+        config: { workflowId: 'wf-pub' },
+        execution: { branch: 'invoker/already-landed' },
+        description: 'Already landed task',
+      });
+
+      const { executor, mergeTask, orchestrator, mergeGateProvider } = setupPublishAfterFix({
+        mergeMode: 'external_review',
+        featureBranch: 'plan/feature',
+        gateWorkspacePath: '/tmp/gate-clone',
+        taskBranches: [completedTask],
+        repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+        featureHasDiff: false,
+      });
+
+      (executor as any).publishReviewStackWithMakePrSkill = vi.fn();
+
+      await executor.publishAfterFix(mergeTask);
+
+      expect((executor as any).publishReviewStackWithMakePrSkill).not.toHaveBeenCalled();
+      expect(mergeGateProvider.createReview).not.toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).not.toHaveBeenCalled();
+      expect(orchestrator.handleWorkerResponse).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'completed',
+        outputs: expect.objectContaining({
+          branch: 'plan/feature',
+        }),
+      }));
+    });
+
     it('external_review mode: detaches HEAD, fetches, consolidates, creates PR', async () => {
       const completedTask = makeTask({
         id: 't1',
@@ -4593,6 +4632,74 @@ describe('TaskRunner', () => {
   });
 
   describe('external_review propagation of authored PR body', () => {
+    it('Invoker external_review completes without make-pr when consolidation has no reviewable diff', async () => {
+      const allTasks = [
+        makeTask({
+          id: 't1',
+          config: { workflowId: 'wf-1' },
+          status: 'completed',
+          execution: { branch: 'experiment/t1' },
+        }),
+      ];
+      const orchestrator = {
+        getTask: (id: string) => allTasks.find(t => t.id === id),
+        getAllTasks: () => allTasks,
+        handleWorkerResponse: vi.fn(() => []),
+        setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
+      };
+      const persistence = {
+        loadWorkflow: () => ({
+          id: 'wf-1',
+          onFinish: 'none',
+          mergeMode: 'external_review',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          name: 'Test Workflow',
+          repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker.git',
+        }),
+        updateTask: vi.fn(),
+      };
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+      });
+
+      (executor as any).execGitReadonly = async () => '';
+      (executor as any).execGitIn = async () => '';
+      (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
+      (executor as any).removeMergeWorktree = async () => {};
+      (executor as any).buildMergeSummary = vi.fn().mockResolvedValue('## Summary');
+      (executor as any).consolidateAndMerge = vi.fn().mockResolvedValue(undefined);
+      (executor as any).publishReviewStackWithMakePrSkill = vi.fn();
+
+      const mergeTask = makeTask({
+        id: '__merge__wf-1',
+        status: 'running',
+        dependencies: ['t1'],
+        config: { isMergeNode: true, workflowId: 'wf-1' },
+      });
+
+      await (executor as any).executeMergeNode(mergeTask);
+
+      expect((executor as any).publishReviewStackWithMakePrSkill).not.toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).not.toHaveBeenCalled();
+      expect(orchestrator.handleWorkerResponse).toHaveBeenCalledWith(expect.objectContaining({
+        status: 'completed',
+        outputs: expect.objectContaining({ branch: 'plan/feature' }),
+      }));
+      expect(persistence.updateTask).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
+        execution: expect.objectContaining({
+          branch: 'plan/feature',
+          workspacePath: '/tmp/mock-wt',
+          reviewGate: undefined,
+        }),
+      }));
+    });
+
     it('createReview receives the authored body, not the raw workflowSummary', async () => {
       const allTasks = [
         makeTask({
@@ -4641,7 +4748,10 @@ describe('TaskRunner', () => {
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
         return '';
       };
-      (executor as any).execGitIn = async () => '';
+      (executor as any).execGitIn = async (args: string[]) => {
+        if (args[0] === 'diff' && args[1] === '--quiet') throw new Error('branch has changes');
+        return '';
+      };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).buildMergeSummary = vi.fn().mockResolvedValue(rawSummary);
@@ -4716,7 +4826,10 @@ describe('TaskRunner', () => {
       });
 
       (executor as any).execGitReadonly = async () => '';
-      (executor as any).execGitIn = async () => '';
+      (executor as any).execGitIn = async (args: string[]) => {
+        if (args[0] === 'diff' && args[1] === '--quiet') throw new Error('branch has changes');
+        return '';
+      };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).buildMergeSummary = vi.fn().mockResolvedValue('## Summary\nWorkflow summary');

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -3506,6 +3506,7 @@ describe('TaskRunner', () => {
       (executor as any).execGitIn = async (args: string[], _dir: string) => {
         gitCalls.push(args);
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'diff' && args[1] === '--quiet') throw new Error('branch has changes');
         return '';
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
@@ -3646,6 +3647,7 @@ describe('TaskRunner', () => {
         if (args[0] === 'branch' && args[1] === '--show-current') {
           return currentBranchByDir.get(dir) ?? '';
         }
+        if (args[0] === 'diff' && args[1] === '--quiet') throw new Error('branch has changes');
         return '';
       };
       (executor as any).createMergeWorktree = vi.fn()
@@ -3791,6 +3793,7 @@ console.log(JSON.stringify(out));
         // pushed tip. Model that so the post-push retrievability check passes.
         if (args[0] === 'ls-remote') return `feature-sha\trefs/heads/${args[args.length - 1]}`;
         if (args[0] === 'merge-base' && args[1] === '--is-ancestor') throw new Error('not ancestor');
+        if (args[0] === 'diff' && args[1] === '--quiet') throw new Error('branch has changes');
         return '';
       };
       (executor as any).execGitReadonly = async (args: string[]) => {
@@ -3950,6 +3953,7 @@ console.log(JSON.stringify(out));
       };
       (executor as any).execGitIn = async (args: string[], _dir: string) => {
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'diff' && args[1] === '--quiet') throw new Error('branch has changes');
         return '';
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
@@ -4121,6 +4125,7 @@ console.log(JSON.stringify(out));
       };
       (executor as any).execGitIn = async (args: string[], _dir: string) => {
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'diff' && args[1] === '--quiet') throw new Error('branch has changes');
         return '';
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
@@ -4299,6 +4304,7 @@ console.log(JSON.stringify(out));
       };
       (executor as any).execGitIn = async (args: string[], _dir: string) => {
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'diff' && args[1] === '--quiet') throw new Error('branch has changes');
         return '';
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
@@ -4370,6 +4376,7 @@ console.log(JSON.stringify(out));
       };
       (executor as any).execGitIn = async (args: string[], _dir: string) => {
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'diff' && args[1] === '--quiet') throw new Error('branch has changes');
         return '';
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
@@ -4588,6 +4595,7 @@ console.log(JSON.stringify(out));
       };
       (executor as any).execGitIn = async (args: string[], _dir: string) => {
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'diff' && args[1] === '--quiet') throw new Error('branch has changes');
         return '';
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -240,6 +240,42 @@ async function syncGateWorkspaceToFeatureBranch(
   await execGitInMergeSafe(host, ['checkout', featureBranch], gateWorkspacePath);
 }
 
+async function ensureComparableBranchRef(
+  host: MergeRunnerHost,
+  dir: string,
+  branch: string,
+): Promise<void> {
+  try {
+    await execGitInMergeSafe(host, ['rev-parse', '--verify', `${branch}^{commit}`], dir);
+    return;
+  } catch {
+    // Missing locally; fetch the short branch from origin for comparison.
+  }
+
+  await execGitInMergeSafe(
+    host,
+    ['fetch', 'origin', `+refs/heads/${branch}:refs/heads/${branch}`],
+    dir,
+  );
+  await execGitInMergeSafe(host, ['rev-parse', '--verify', `${branch}^{commit}`], dir);
+}
+
+async function featureBranchHasReviewableChanges(
+  host: MergeRunnerHost,
+  dir: string,
+  baseBranch: string,
+  featureBranch: string,
+): Promise<boolean> {
+  await ensureComparableBranchRef(host, dir, baseBranch);
+  await ensureComparableBranchRef(host, dir, featureBranch);
+  try {
+    await execGitInMergeSafe(host, ['diff', '--quiet', `${baseBranch}...${featureBranch}`, '--'], dir);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
 // ── Host interface ───────────────────────────────────────
 
 /**
@@ -620,6 +656,7 @@ export async function runMergeGateActionImpl(
       reviewUrl: undefined,
       reviewId: undefined,
       reviewStatus: undefined,
+      reviewGate: undefined,
     },
   }, launchLineage);
 
@@ -715,6 +752,42 @@ export async function runMergeGateActionImpl(
           featureBranch,
         });
         await syncGateWorkspaceToFeatureBranch(host, gateWorkspacePath, featureBranch);
+        const hasReviewableChanges = await featureBranchHasReviewableChanges(
+          host,
+          gateWorkspacePath!,
+          baseBranch,
+          featureBranch!,
+        );
+        if (!hasReviewableChanges) {
+          logTaskProgress(host, task.id, 'info', 'No reviewable branch changes; completing merge gate', {
+            baseBranch,
+            featureBranch,
+          });
+          console.log(
+            `[merge] No reviewable changes between ${baseBranch} and ${featureBranch}; completing merge gate without review PR`,
+          );
+          response = {
+            requestId: `merge-${task.id}`,
+            actionId: task.id,
+            executionGeneration: task.execution.generation ?? 0,
+            status: 'completed',
+            outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
+          };
+          return {
+            response,
+            taskChanges: {
+              config: { summary },
+              execution: {
+                branch: featureBranch ?? undefined,
+                workspacePath: gateWorkspacePath,
+                reviewUrl: undefined,
+                reviewId: undefined,
+                reviewStatus: undefined,
+                reviewGate: undefined,
+              },
+            },
+          };
+        }
 
         const expectedGeneration = task.execution.generation ?? 0;
         let fullSummary = summary;
@@ -1316,6 +1389,47 @@ export async function publishAfterFixImpl(
       featureBranch,
     });
     await pushFeatureBranchWithRefLockRetry(host, consolidateDir, featureBranch);
+    const hasReviewableChanges = await featureBranchHasReviewableChanges(
+      host,
+      consolidateDir,
+      baseBranch,
+      featureBranch,
+    );
+    if (!hasReviewableChanges) {
+      logTaskProgress(host, task.id, 'info', 'No reviewable branch changes; completing merge gate', {
+        baseBranch,
+        featureBranch,
+      });
+      console.log(
+        `[merge] Post-fix: no reviewable changes between ${baseBranch} and ${featureBranch}; completing merge gate without review PR`,
+      );
+      updateMergeGateMetadataIfCurrent(host, task.id, {
+        config: { runnerKind: 'worktree', summary },
+        execution: {
+          branch: featureBranch,
+          workspacePath: gateWorkspacePath,
+          reviewUrl: undefined,
+          reviewId: undefined,
+          reviewStatus: undefined,
+          reviewGate: undefined,
+          fixedIntegrationSha: undefined,
+          fixedIntegrationRecordedAt: undefined,
+          fixedIntegrationSource: undefined,
+        },
+      }, captureMergeGateLineage(task));
+      const completedResponse: WorkResponse = {
+        requestId: `postfix-${task.id}`,
+        actionId: task.id,
+        executionGeneration: task.execution.generation ?? 0,
+        status: 'completed',
+        outputs: { exitCode: 0, summary, branch: featureBranch },
+      };
+      const newlyStarted = host.orchestrator.handleWorkerResponse(completedResponse) ?? [];
+      if (newlyStarted.length > 0) {
+        host.executeTasks(newlyStarted);
+      }
+      return;
+    }
 
     let fullSummary = summary;
     let vpMarkdownCapture2: string | undefined;


### PR DESCRIPTION
## Summary

External review gates now check whether the consolidated feature branch still differs from the base branch.

If no diff remains, the gate completes instead of publishing an empty Invoker review stack.

The same no-diff path also runs after an approved fix repushes the feature branch.

## Review Claim

External-review merge routing completes a gate without publishing review artifacts when the feature branch has no diff against base.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Branches with a real diff keep the existing PR publication path because the new comparison returns true before authoring begins.

## Slice Rationale

This is the review-gate routing slice for already-landed branches. It is separate from the worker-loader implementation slices.

## Non-goals

This slice does not change external-worker runtime behavior.

It does not change review approval polling or Mergify stack output when a diff exists.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/task-runner.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "completes without make-pr|no reviewable diff"`
- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/task-runner.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts` failed on existing SSH executor metadata expectations outside this slice.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a04a09b4988c9263ce6279ed01cca2ff9d083b87`
- Post-revert steps: None
- Data migration? No

</details>