### PR TITLE
[Godfile app step 1: extract workflow-task-actions](1)

### DIFF
--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -3,10 +3,14 @@ import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 const mainSource = readFileSync(path.resolve(__dirname, '..', 'main.ts'), 'utf8');
+const workflowTaskActionsSource = readFileSync(
+  path.resolve(__dirname, '..', 'execution', 'workflow-task-actions.ts'),
+  'utf8',
+);
 
 function getTranslatorSource(): string {
   const start = mainSource.indexOf('function translateGuiMutationToHeadless');
-  const end = mainSource.indexOf('  async function performSharedApproveTask', start);
+  const end = mainSource.indexOf('  const guiMutationRegistrationContext', start);
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
   return mainSource.slice(start, end);
@@ -21,19 +25,27 @@ function getStandaloneClassifierSource(): string {
 }
 
 function getPerformDeleteWorkflowSource(): string {
-  const start = mainSource.indexOf('async function performDeleteWorkflow');
-  const end = mainSource.indexOf('  async function performDetachWorkflow', start);
+  const start = workflowTaskActionsSource.indexOf('async function performDeleteWorkflow');
+  const end = workflowTaskActionsSource.indexOf('  async function performDetachWorkflow', start);
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
-  return mainSource.slice(start, end);
+  return workflowTaskActionsSource.slice(start, end);
 }
 
 function getPerformDetachWorkflowSource(): string {
-  const start = mainSource.indexOf('async function performDetachWorkflow');
-  const end = mainSource.indexOf('  /** Orchestrator error codes', start);
+  const start = workflowTaskActionsSource.indexOf('async function performDetachWorkflow');
+  const end = workflowTaskActionsSource.indexOf('  const preemptSkipCodes', start);
   expect(start).toBeGreaterThanOrEqual(0);
   expect(end).toBeGreaterThan(start);
-  return mainSource.slice(start, end);
+  return workflowTaskActionsSource.slice(start, end);
+}
+
+function getPerformSharedApproveTaskSource(): string {
+  const start = workflowTaskActionsSource.indexOf('async function performSharedApproveTask');
+  const end = workflowTaskActionsSource.indexOf('  return {', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return workflowTaskActionsSource.slice(start, end);
 }
 
 function getSetMergeBranchSource(): string {
@@ -95,7 +107,17 @@ describe('GUI mutation translation', () => {
   it('publishes workflow metadata after every successful workflow detach', () => {
     const detachSource = getPerformDetachWorkflowSource();
     expect(detachSource).toMatch(
-      /if \(!result\.ok\) throw new Error\(result\.error\.message\);\s*logger\.info\(`performDetachWorkflow end workflow="\$\{workflowId\}" upstream="\$\{upstreamWorkflowId\}"`, \{ module: 'kill' \}\);\s*requestWorkflowMetadataPublish\('detach-workflow'\);/,
+      /if \(!result\.ok\) throw new Error\(result\.error\.message\);\s*getLogger\(\)\.info\(`performDetachWorkflow end workflow="\$\{workflowId\}" upstream="\$\{upstreamWorkflowId\}"`, \{ module: 'kill' \}\);\s*requestWorkflowMetadataPublish\('detach-workflow'\);/,
+    );
+  });
+
+  it('keeps API approvals on the surface approval envelope', () => {
+    const approveSource = getPerformSharedApproveTaskSource();
+    expect(approveSource).toMatch(
+      /const envelope = makeEnvelope\('approve', source === 'api' \? 'surface' : source, scope, \{ taskId \}\);/,
+    );
+    expect(approveSource).toMatch(
+      /return sharedApproveTask\(taskId, \{/,
     );
   });
 

--- a/packages/app/src/execution/workflow-task-actions.ts
+++ b/packages/app/src/execution/workflow-task-actions.ts
@@ -1,0 +1,415 @@
+import { OrchestratorErrorCode } from '@invoker/workflow-core';
+import type { CommandService, Orchestrator, TaskState } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import { CommandError, makeEnvelope } from '@invoker/contracts';
+import type { Logger } from '@invoker/contracts';
+import { DEFAULT_EXECUTION_AGENT, remoteFetchForPool, type TaskRunner } from '@invoker/execution-engine';
+import { loadConfig, type InvokerConfig } from '../config.js';
+import { assertExecutionCapacityInvariant, shouldFatalOnExecutionCapacityOvercommit } from '../execution-capacity.js';
+import {
+  approveTask as sharedApproveTask,
+  fixWithAgentAction,
+  selectFailureRecoveryRoute,
+  StaleLineageError,
+} from '../workflow-actions.js';
+import { dispatchStartedTasksWithGlobalTopup } from '../global-topup.js';
+import type { WorkflowCancelResult } from '../workflow-preemption.js';
+import { listOpenFixIntentsForTask, type ReviewGateCiContext } from '../auto-fix-intents.js';
+import {
+  buildRecoveryWorkerAuditPayload,
+  classifyAutoFixRecoveryPhase,
+  recoveryWorkerEventType,
+} from '../recovery-worker-observability.js';
+import type { WorkflowMutationPriority } from '../workflow-mutation-coordinator.js';
+import type {
+  PersistedWorkflowMutationCoordinator,
+  WorkflowMutationContext,
+} from '../persisted-workflow-mutation-coordinator.js';
+import type { TaskHandleMap } from './task-runner-wiring.js';
+
+export interface WorkflowTaskActionsDeps {
+  getOrchestrator: () => Orchestrator;
+  getPersistence: () => SQLiteAdapter;
+  getCommandService: () => CommandService;
+  getActiveMutationContext: () => WorkflowMutationContext | undefined;
+  getWorkflowMutationCoordinator: () => PersistedWorkflowMutationCoordinator | null;
+  getLogger: () => Logger;
+  invokerConfig: InvokerConfig;
+  taskHandles: TaskHandleMap;
+  workflowMutationDispatcher: Map<string, (...args: unknown[]) => Promise<unknown>>;
+  killRunningTask: (taskId: string) => Promise<void>;
+  cancelDeferredWorkflowLaunch: (workflowId: string, reason: string) => void;
+  requireTaskExecutor: () => TaskRunner;
+  requestWorkflowMetadataPublish: (reason: string) => void;
+  workflowIdForTaskArg: (taskIdArg: unknown) => string | undefined;
+  runWorkflowMutation: <T>(
+    workflowId: string | undefined,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+    op: () => Promise<T>,
+  ) => Promise<T>;
+}
+
+export function parseExecutionDate(value: unknown): Date | undefined {
+  if (!value) return undefined;
+  if (value instanceof Date) return value;
+  if (typeof value !== 'string') return undefined;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed;
+}
+
+export function createWorkflowTaskActions(deps: WorkflowTaskActionsDeps) {
+  const {
+    getOrchestrator,
+    getPersistence,
+    getCommandService,
+    getActiveMutationContext,
+    getWorkflowMutationCoordinator,
+    getLogger,
+    invokerConfig,
+    taskHandles,
+    workflowMutationDispatcher,
+    killRunningTask,
+    requireTaskExecutor,
+    requestWorkflowMetadataPublish,
+    workflowIdForTaskArg,
+    runWorkflowMutation,
+  } = deps;
+
+  const buildAutoFixQueueSnapshot = (taskId: string): Record<string, unknown> => {
+    const workflowId = workflowIdForTaskArg(taskId);
+    if (!workflowId) {
+      return {
+        workflowId: null,
+        openIntentCountForWorkflow: 0,
+        openFixIntentCountForWorkflow: 0,
+        openFixIntentCountForTask: 0,
+        openFixIntentForTask: false,
+        openFixIntentHead: null,
+        openFixIntentPreview: [],
+      };
+    }
+    const openIntents = getPersistence().listWorkflowMutationIntents(workflowId, ['queued', 'running']);
+    const openFixIntents = openIntents.filter((intent) => (
+      intent.channel === 'invoker:fix-with-agent' || intent.channel === 'headless.exec'
+    ));
+    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
+    return {
+      workflowId,
+      openIntentCountForWorkflow: openIntents.length,
+      openFixIntentCountForWorkflow: openFixIntents.length,
+      openFixIntentCountForTask: openTaskFixIntents.length,
+      openFixIntentForTask: openTaskFixIntents.length > 0,
+      openFixIntentHead: openTaskFixIntents[0]
+        ? {
+          id: openTaskFixIntents[0].id,
+          status: openTaskFixIntents[0].status,
+          channel: openTaskFixIntents[0].channel,
+        }
+        : null,
+      openFixIntentPreview: openTaskFixIntents.slice(0, 5).map((intent) => ({
+        id: intent.id,
+        status: intent.status,
+        channel: intent.channel,
+      })),
+    };
+  };
+
+  const logAutoFixDebug = (
+    taskId: string,
+    phase: string,
+    details: Record<string, unknown> = {},
+  ): void => {
+    const task = getOrchestrator().getTask(taskId);
+    const payload = {
+      phase,
+      status: task?.status ?? 'missing',
+      ...buildAutoFixQueueSnapshot(taskId),
+      ...details,
+    };
+    getPersistence().logEvent?.(taskId, 'debug.auto-fix', payload);
+    const recoveryAction = classifyAutoFixRecoveryPhase(phase, payload);
+    if (recoveryAction) {
+      getPersistence().logEvent?.(
+        taskId,
+        recoveryWorkerEventType(recoveryAction),
+        buildRecoveryWorkerAuditPayload(recoveryAction, phase, payload),
+      );
+    }
+    getLogger().info(
+      `[auto-fix-debug] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}`,
+      { module: 'auto-fix' },
+    );
+  };
+
+  const executeFixWithAgentMutation = async (
+    taskId: string,
+    agentName?: string,
+    source: 'ipc' | 'auto-fix' = 'ipc',
+    reviewGateContext?: ReviewGateCiContext,
+  ): Promise<TaskState[]> => {
+    const task = getOrchestrator().getTask(taskId);
+    if (!task) {
+      throw new Error(`Task ${taskId} not found`);
+    }
+    const savedError = task.execution.error ?? '';
+    const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
+    getLogger().info(
+      `fix-with-agent: "${taskId}" agent=${agentName ?? DEFAULT_EXECUTION_AGENT} source=${source} route=${recoveryRoute.kind}`,
+      { module: 'ipc' },
+    );
+
+    const result = await fixWithAgentAction(
+      taskId,
+      {
+        logger: getLogger(),
+        orchestrator: getOrchestrator(),
+        persistence: getPersistence(),
+        commandService: getCommandService(),
+        taskExecutor: requireTaskExecutor(),
+        mutationTiming: getActiveMutationContext()?.mutationTiming,
+        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+      },
+      {
+        agentName,
+        recoveryRoute,
+        recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
+        failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Codex'}`,
+        reviewGateContext,
+        signal: getActiveMutationContext()?.signal,
+      },
+    );
+    return result.started;
+  };
+
+  const scheduleAutoFix = (taskId: string): void => {
+    logAutoFixDebug(taskId, 'schedule-enter');
+    if (!getWorkflowMutationCoordinator()) {
+      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'no-workflow-mutation-coordinator' });
+      return;
+    }
+    if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
+      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'fix-handler-not-ready' });
+      return;
+    }
+    const workflowId = workflowIdForTaskArg(taskId);
+    if (!workflowId) {
+      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'workflow-not-found' });
+      return;
+    }
+    const shouldAutoFixNow = getOrchestrator().shouldAutoFix(taskId);
+    if (!shouldAutoFixNow) {
+      logAutoFixDebug(taskId, 'schedule-skip', {
+        reason: 'shouldAutoFix-false',
+        shouldAutoFix: shouldAutoFixNow,
+      });
+      return;
+    }
+    const openIntents = getPersistence().listWorkflowMutationIntents(workflowId, ['queued', 'running']);
+    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
+    if (openTaskFixIntents.length > 0) {
+      logAutoFixDebug(taskId, 'schedule-skip', {
+        reason: 'already-queued-intent',
+        existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
+      });
+      return;
+    }
+    const configuredAgent = loadConfig().autoFixAgent?.trim();
+    const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
+    logAutoFixDebug(taskId, 'schedule-enqueue');
+    logAutoFixDebug(taskId, 'schedule-enqueued');
+    void runWorkflowMutation(
+      workflowId,
+      'normal',
+      'invoker:fix-with-agent',
+      [taskId, selectedAgent],
+      async () => executeFixWithAgentMutation(taskId, selectedAgent, 'auto-fix'),
+    )
+      .then(() => {
+        logAutoFixDebug(taskId, 'schedule-dispatch-finished');
+      })
+      .catch((err) => {
+        if (err instanceof StaleLineageError) {
+          getLogger().info(`auto-fix discarded stale result for "${taskId}": ${err.message}`, { module: 'auto-fix' });
+          return;
+        }
+        logAutoFixDebug(taskId, 'schedule-dispatch-error', {
+          error: err instanceof Error ? err.stack ?? err.message : String(err),
+        });
+      });
+  };
+
+  function assertFatalExecutionCapacity(label: string): void {
+    if (!shouldFatalOnExecutionCapacityOvercommit()) return;
+    try {
+      assertExecutionCapacityInvariant({
+        config: loadConfig(),
+        activeExecutions: taskHandles.size,
+        label,
+      });
+    } catch (err) {
+      getLogger().error(err instanceof Error ? err.stack ?? err.message : String(err), { module: 'exec' });
+      setImmediate(() => {
+        throw err;
+      });
+      throw err;
+    }
+  }
+
+  async function performCancelTask(taskId: string): Promise<{ cancelled: string[]; runningCancelled: string[] }> {
+    const envelope = makeEnvelope('cancel-task', 'ui', 'task', { taskId });
+    const cmdResult = await getCommandService().cancelTask(envelope);
+    if (!cmdResult.ok) throw CommandError.fromResult(cmdResult.error);
+    for (const id of cmdResult.data.runningCancelled) {
+      await killRunningTask(id);
+    }
+    return cmdResult.data;
+  }
+
+  async function performDeleteTask(taskId: string): Promise<void> {
+    getLogger().info(`performDeleteTask begin task="${taskId}"`, { module: 'kill' });
+    const task = getOrchestrator().getTask(taskId);
+    const workflowId = task?.config.workflowId;
+    if (task && (task.status === 'running' || task.status === 'fixing_with_ai')) {
+      await killRunningTask(task.id);
+    }
+    if (workflowId) {
+      await requireTaskExecutor().closeWorkflowReview(workflowId);
+    }
+    const envelope = makeEnvelope('delete-task', 'ui', 'task', { taskId });
+    const result = await getCommandService().deleteTask(envelope);
+    if (!result.ok) throw CommandError.fromResult(result.error);
+    remoteFetchForPool.enabled = false;
+    try {
+      await dispatchStartedTasksWithGlobalTopup({
+        orchestrator: getOrchestrator(),
+        taskExecutor: requireTaskExecutor(),
+        logger: getLogger(),
+        context: 'ipc.delete-task',
+        started: result.data,
+        scopedTaskIds: result.data.map((startedTask) => startedTask.id),
+        mutationTiming: getActiveMutationContext()?.mutationTiming,
+      });
+    } finally {
+      remoteFetchForPool.enabled = true;
+    }
+    requestWorkflowMetadataPublish('delete-task');
+    getLogger().info(`performDeleteTask end task="${taskId}"`, { module: 'kill' });
+  }
+
+  async function performCancelWorkflow(workflowId: string): Promise<{ cancelled: string[]; runningCancelled: string[] }> {
+    getLogger().info(`performCancelWorkflow begin workflow="${workflowId}"`, { module: 'kill' });
+    const envelope = makeEnvelope('cancel-workflow', 'ui', 'workflow', { workflowId });
+    const cmdResult = await getCommandService().cancelWorkflow(envelope);
+    if (!cmdResult.ok) throw CommandError.fromResult(cmdResult.error);
+    getLogger().info(
+      `performCancelWorkflow commandService complete workflow="${workflowId}" cancelled=${cmdResult.data.cancelled.length} runningCancelled=${cmdResult.data.runningCancelled.length}`,
+      { module: 'kill' },
+    );
+    for (const id of cmdResult.data.runningCancelled) {
+      getLogger().info(`performCancelWorkflow killing running task "${id}"`, { module: 'kill' });
+      await killRunningTask(id);
+    }
+    getLogger().info(`performCancelWorkflow end workflow="${workflowId}"`, { module: 'kill' });
+    return cmdResult.data;
+  }
+
+  async function performDeleteWorkflow(workflowId: string): Promise<void> {
+    getLogger().info(`performDeleteWorkflow begin workflow="${workflowId}"`, { module: 'kill' });
+    const allTasks = getOrchestrator().getAllTasks();
+    const workflowTasks = allTasks.filter(
+      (t) =>
+        t.config.workflowId === workflowId &&
+        (t.status === 'running' || t.status === 'fixing_with_ai'),
+    );
+    for (const task of workflowTasks) {
+      await killRunningTask(task.id);
+    }
+    await requireTaskExecutor().closeWorkflowReview(workflowId);
+    const envelope = makeEnvelope('delete-workflow', 'ui', 'workflow', { workflowId });
+    const result = await getCommandService().deleteWorkflow(envelope);
+    if (!result.ok) throw new Error(result.error.message);
+    requestWorkflowMetadataPublish('delete-workflow');
+    getLogger().info(`performDeleteWorkflow end workflow="${workflowId}"`, { module: 'kill' });
+  }
+
+  async function performDetachWorkflow(workflowId: string, upstreamWorkflowId: string): Promise<void> {
+    getLogger().info(`performDetachWorkflow begin workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
+    const envelope = makeEnvelope('detach-workflow', 'ui', 'workflow', { workflowId, upstreamWorkflowId });
+    const result = await getCommandService().detachWorkflow(envelope);
+    if (!result.ok) throw new Error(result.error.message);
+    getLogger().info(`performDetachWorkflow end workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
+    requestWorkflowMetadataPublish('detach-workflow');
+  }
+
+  const preemptSkipCodes: Record<string, true> = {
+    [OrchestratorErrorCode.TASK_NOT_FOUND]: true,
+    [OrchestratorErrorCode.TASK_ALREADY_TERMINAL]: true,
+    [OrchestratorErrorCode.WORKFLOW_NOT_FOUND]: true,
+  };
+
+  async function preemptTaskSubgraph(taskId: string): Promise<void> {
+    try {
+      await performCancelTask(taskId);
+    } catch (err) {
+      if (err instanceof CommandError && preemptSkipCodes[err.code] === true) {
+        getLogger().info(`preemptTaskSubgraph skipped for "${taskId}": ${err.message}`, { module: 'ipc' });
+        return;
+      }
+      throw err;
+    }
+  }
+
+  async function preemptWorkflowExecution(workflowId: string): Promise<WorkflowCancelResult> {
+    try {
+      getLogger().info(`preemptWorkflowExecution begin for "${workflowId}"`, { module: 'ipc' });
+      const result = await performCancelWorkflow(workflowId);
+      getLogger().info(`preemptWorkflowExecution end for "${workflowId}"`, { module: 'ipc' });
+      return result;
+    } catch (err) {
+      if (err instanceof CommandError && preemptSkipCodes[err.code] === true) {
+        getLogger().info(`preemptWorkflowExecution skipped for "${workflowId}": ${err.message}`, { module: 'ipc' });
+        return { cancelled: [], runningCancelled: [] };
+      }
+      throw err;
+    }
+  }
+
+  async function performSharedApproveTask(
+    taskId: string,
+    source: 'ui' | 'surface' | 'api',
+    scope: 'task' | 'workflow' = 'task',
+  ): Promise<{ started: TaskState[] }> {
+    const envelope = makeEnvelope('approve', source === 'api' ? 'surface' : source, scope, { taskId });
+    return sharedApproveTask(taskId, {
+      orchestrator: getOrchestrator(),
+      taskExecutor: requireTaskExecutor(),
+      approve: async (approvedTaskId) => {
+        const result = await getCommandService().approve({ ...envelope, payload: { taskId: approvedTaskId } });
+        if (!result.ok) throw new Error(result.error.message);
+        return result.data;
+      },
+      resumeAfterFixApproval: async (approvedTaskId) => {
+        const result = await getCommandService().resumeTaskAfterFixApproval({ ...envelope, payload: { taskId: approvedTaskId } });
+        if (!result.ok) throw new Error(result.error.message);
+        return result.data;
+      },
+    });
+  }
+
+  return {
+    logAutoFixDebug,
+    scheduleAutoFix,
+    executeFixWithAgentMutation,
+    assertFatalExecutionCapacity,
+    performCancelTask,
+    performDeleteTask,
+    performCancelWorkflow,
+    performDeleteWorkflow,
+    performDetachWorkflow,
+    preemptTaskSubgraph,
+    preemptWorkflowExecution,
+    performSharedApproveTask,
+  };
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -73,7 +73,6 @@ import type {
 } from '@invoker/workflow-core';
 import {
   makeEnvelope,
-  CommandError,
   IpcChannels,
   resolveInvokerIpcSocketPath,
   resolveRepoRoot,
@@ -134,9 +133,7 @@ import {
 } from './config.js';
 import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
-  assertExecutionCapacityInvariant,
   resolveEffectiveMaxConcurrency,
-  shouldFatalOnExecutionCapacityOvercommit,
 } from './execution-capacity.js';
 import {
   createHourlySnapshot,
@@ -292,6 +289,7 @@ import {
   requireWiredTaskRunner,
   type TaskHandleMap,
 } from './execution/task-runner-wiring.js';
+import { createWorkflowTaskActions, parseExecutionDate } from './execution/workflow-task-actions.js';
 import {
   createMainWindow,
   registerMainWindowActivateHandler,
@@ -2217,193 +2215,36 @@ function createEmbeddedTerminalBackendFromConfig(
     workflowMetadataPublisher?.requestPublish(reason);
   };
 
-  const buildAutoFixQueueSnapshot = (taskId: string): Record<string, unknown> => {
-    const workflowId = workflowIdForTaskArg(taskId);
-    if (!workflowId) {
-      return {
-        workflowId: null,
-        openIntentCountForWorkflow: 0,
-        openFixIntentCountForWorkflow: 0,
-        openFixIntentCountForTask: 0,
-        openFixIntentForTask: false,
-        openFixIntentHead: null,
-        openFixIntentPreview: [],
-      };
-    }
-    const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-    const openFixIntents = openIntents.filter((intent) => (
-      intent.channel === 'invoker:fix-with-agent' || intent.channel === 'headless.exec'
-    ));
-    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-    return {
-      workflowId,
-      openIntentCountForWorkflow: openIntents.length,
-      openFixIntentCountForWorkflow: openFixIntents.length,
-      openFixIntentCountForTask: openTaskFixIntents.length,
-      openFixIntentForTask: openTaskFixIntents.length > 0,
-      openFixIntentHead: openTaskFixIntents[0]
-        ? {
-          id: openTaskFixIntents[0].id,
-          status: openTaskFixIntents[0].status,
-          channel: openTaskFixIntents[0].channel,
-        }
-        : null,
-      openFixIntentPreview: openTaskFixIntents.slice(0, 5).map((intent) => ({
-        id: intent.id,
-        status: intent.status,
-        channel: intent.channel,
-      })),
-    };
-  };
-
-  const logAutoFixDebug = (
-    taskId: string,
-    phase: string,
-    details: Record<string, unknown> = {},
-  ): void => {
-    const task = orchestrator.getTask(taskId);
-    const payload = {
-      phase,
-      status: task?.status ?? 'missing',
-      ...buildAutoFixQueueSnapshot(taskId),
-      ...details,
-    };
-    persistence.logEvent?.(taskId, 'debug.auto-fix', payload);
-    const recoveryAction = classifyAutoFixRecoveryPhase(phase, payload);
-    if (recoveryAction) {
-      persistence.logEvent?.(
-        taskId,
-        recoveryWorkerEventType(recoveryAction),
-        buildRecoveryWorkerAuditPayload(recoveryAction, phase, payload),
-      );
-    }
-    logger.info(
-      `[auto-fix-debug] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}`,
-      { module: 'auto-fix' },
-    );
-  };
-
-  const executeFixWithAgentMutation = async (
-    taskId: string,
-    agentName?: string,
-    source: 'ipc' | 'auto-fix' = 'ipc',
-    reviewGateContext?: ReviewGateCiContext,
-  ): Promise<TaskState[]> => {
-    const task = orchestrator.getTask(taskId);
-    if (!task) {
-      throw new Error(`Task ${taskId} not found`);
-    }
-    const savedError = task.execution.error ?? '';
-    const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
-    logger.info(
-      `fix-with-agent: "${taskId}" agent=${agentName ?? DEFAULT_EXECUTION_AGENT} source=${source} route=${recoveryRoute.kind}`,
-      { module: 'ipc' },
-    );
-
-    const result = await fixWithAgentAction(
-      taskId,
-      {
-        logger,
-        orchestrator,
-        persistence,
-        commandService,
-        taskExecutor: requireTaskExecutor(),
-        mutationTiming: activeMutationContext?.mutationTiming,
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
-      },
-      {
-        agentName,
-        recoveryRoute,
-        recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
-        failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Codex'}`,
-        reviewGateContext,
-        signal: activeMutationContext?.signal,
-      },
-    );
-    return result.started;
-  };
-
-  const scheduleAutoFix = (taskId: string): void => {
-    logAutoFixDebug(taskId, 'schedule-enter');
-    if (!workflowMutationCoordinator) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'no-workflow-mutation-coordinator' });
-      return;
-    }
-    if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'fix-handler-not-ready' });
-      return;
-    }
-    const workflowId = workflowIdForTaskArg(taskId);
-    if (!workflowId) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'workflow-not-found' });
-      return;
-    }
-    const shouldAutoFixNow = orchestrator.shouldAutoFix(taskId);
-    if (!shouldAutoFixNow) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'shouldAutoFix-false',
-        shouldAutoFix: shouldAutoFixNow,
-      });
-      return;
-    }
-    const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-    if (openTaskFixIntents.length > 0) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'already-queued-intent',
-        existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
-      });
-      return;
-    }
-    const configuredAgent = loadConfig().autoFixAgent?.trim();
-    const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
-    logAutoFixDebug(taskId, 'schedule-enqueue');
-    logAutoFixDebug(taskId, 'schedule-enqueued');
-    void runWorkflowMutation(
-      workflowId,
-      'normal',
-      'invoker:fix-with-agent',
-      [taskId, selectedAgent],
-      async () => executeFixWithAgentMutation(taskId, selectedAgent, 'auto-fix'),
-    )
-      .then(() => {
-        logAutoFixDebug(taskId, 'schedule-dispatch-finished');
-      })
-      .catch((err) => {
-        if (err instanceof StaleLineageError) {
-          logger.info(`auto-fix discarded stale result for "${taskId}": ${err.message}`, { module: 'auto-fix' });
-          return;
-        }
-        logAutoFixDebug(taskId, 'schedule-dispatch-error', {
-          error: err instanceof Error ? err.stack ?? err.message : String(err),
-        });
-      });
-  };
-
-  const parseExecutionDate = (value: unknown): Date | undefined => {
-    if (!value) return undefined;
-    if (value instanceof Date) return value;
-    if (typeof value !== 'string') return undefined;
-    const parsed = new Date(value);
-    return Number.isNaN(parsed.getTime()) ? undefined : parsed;
-  };
-
-  function assertFatalExecutionCapacity(label: string): void {
-    if (!shouldFatalOnExecutionCapacityOvercommit()) return;
-    try {
-      assertExecutionCapacityInvariant({
-        config: loadConfig(),
-        activeExecutions: taskHandles.size,
-        label,
-      });
-    } catch (err) {
-      logger.error(err instanceof Error ? err.stack ?? err.message : String(err), { module: 'exec' });
-      setImmediate(() => {
-        throw err;
-      });
-      throw err;
-    }
-  }
+  const {
+    logAutoFixDebug,
+    scheduleAutoFix,
+    executeFixWithAgentMutation,
+    assertFatalExecutionCapacity,
+    performCancelTask,
+    performDeleteTask,
+    performCancelWorkflow,
+    performDeleteWorkflow,
+    performDetachWorkflow,
+    preemptTaskSubgraph,
+    preemptWorkflowExecution,
+    performSharedApproveTask,
+  } = createWorkflowTaskActions({
+    getOrchestrator: () => orchestrator,
+    getPersistence: () => persistence,
+    getCommandService: () => commandService,
+    getActiveMutationContext: () => activeMutationContext,
+    getWorkflowMutationCoordinator: () => workflowMutationCoordinator,
+    getLogger: () => logger,
+    invokerConfig,
+    taskHandles,
+    workflowMutationDispatcher,
+    killRunningTask,
+    cancelDeferredWorkflowLaunch,
+    requireTaskExecutor,
+    requestWorkflowMetadataPublish,
+    workflowIdForTaskArg,
+    runWorkflowMutation,
+  });
 
   registerMainWindowSecondInstanceHandler({
     app,
@@ -2436,130 +2277,6 @@ function createEmbeddedTerminalBackendFromConfig(
       logger,
       taskHandles,
     }, taskId);
-  }
-
-  /** Cancel a task and cascade-kill all downstream DAG dependents. Shared by IPC, headless, and API. */
-  async function performCancelTask(taskId: string): Promise<{ cancelled: string[]; runningCancelled: string[] }> {
-    const envelope = makeEnvelope('cancel-task', 'ui', 'task', { taskId });
-    const cmdResult = await commandService.cancelTask(envelope);
-    if (!cmdResult.ok) throw CommandError.fromResult(cmdResult.error);
-    for (const id of cmdResult.data.runningCancelled) {
-      await killRunningTask(id);
-    }
-    return cmdResult.data;
-  }
-
-  async function performDeleteTask(taskId: string): Promise<void> {
-    logger.info(`performDeleteTask begin task="${taskId}"`, { module: 'kill' });
-    const task = orchestrator.getTask(taskId);
-    const workflowId = task?.config.workflowId;
-    if (task && (task.status === 'running' || task.status === 'fixing_with_ai')) {
-      await killRunningTask(task.id);
-    }
-    if (workflowId) {
-      await requireTaskExecutor().closeWorkflowReview(workflowId);
-    }
-    const envelope = makeEnvelope('delete-task', 'ui', 'task', { taskId });
-    const result = await commandService.deleteTask(envelope);
-    if (!result.ok) throw CommandError.fromResult(result.error);
-    remoteFetchForPool.enabled = false;
-    try {
-      await dispatchStartedTasksWithGlobalTopup({
-        orchestrator,
-        taskExecutor: requireTaskExecutor(),
-        logger,
-        context: 'ipc.delete-task',
-        started: result.data,
-        scopedTaskIds: result.data.map((startedTask) => startedTask.id),
-        mutationTiming: activeMutationContext?.mutationTiming,
-      });
-    } finally {
-      remoteFetchForPool.enabled = true;
-    }
-    requestWorkflowMetadataPublish('delete-task');
-    logger.info(`performDeleteTask end task="${taskId}"`, { module: 'kill' });
-  }
-
-  /** Cancel all active tasks in a workflow and kill any running processes. */
-  async function performCancelWorkflow(workflowId: string): Promise<{ cancelled: string[]; runningCancelled: string[] }> {
-    logger.info(`performCancelWorkflow begin workflow="${workflowId}"`, { module: 'kill' });
-    const envelope = makeEnvelope('cancel-workflow', 'ui', 'workflow', { workflowId });
-    const cmdResult = await commandService.cancelWorkflow(envelope);
-    if (!cmdResult.ok) throw CommandError.fromResult(cmdResult.error);
-    logger.info(
-      `performCancelWorkflow commandService complete workflow="${workflowId}" cancelled=${cmdResult.data.cancelled.length} runningCancelled=${cmdResult.data.runningCancelled.length}`,
-      { module: 'kill' },
-    );
-    for (const id of cmdResult.data.runningCancelled) {
-      logger.info(`performCancelWorkflow killing running task "${id}"`, { module: 'kill' });
-      await killRunningTask(id);
-    }
-    logger.info(`performCancelWorkflow end workflow="${workflowId}"`, { module: 'kill' });
-    return cmdResult.data;
-  }
-
-  async function performDeleteWorkflow(workflowId: string): Promise<void> {
-    logger.info(`performDeleteWorkflow begin workflow="${workflowId}"`, { module: 'kill' });
-    // Kill all running tasks belonging to the workflow (process management is outside orchestrator scope)
-    const allTasks = orchestrator.getAllTasks();
-    const workflowTasks = allTasks.filter(
-      (t) =>
-        t.config.workflowId === workflowId &&
-        (t.status === 'running' || t.status === 'fixing_with_ai'),
-    );
-    for (const task of workflowTasks) {
-      await killRunningTask(task.id);
-    }
-    await requireTaskExecutor().closeWorkflowReview(workflowId);
-    // Serialized via CommandService: DB delete + memory clear + scheduler cleanup + removal deltas
-    const envelope = makeEnvelope('delete-workflow', 'ui', 'workflow', { workflowId });
-    const result = await commandService.deleteWorkflow(envelope);
-    if (!result.ok) throw new Error(result.error.message);
-    requestWorkflowMetadataPublish('delete-workflow');
-    logger.info(`performDeleteWorkflow end workflow="${workflowId}"`, { module: 'kill' });
-  }
-
-  async function performDetachWorkflow(workflowId: string, upstreamWorkflowId: string): Promise<void> {
-    logger.info(`performDetachWorkflow begin workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
-    const envelope = makeEnvelope('detach-workflow', 'ui', 'workflow', { workflowId, upstreamWorkflowId });
-    const result = await commandService.detachWorkflow(envelope);
-    if (!result.ok) throw new Error(result.error.message);
-    logger.info(`performDetachWorkflow end workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
-    requestWorkflowMetadataPublish('detach-workflow');
-  }
-
-  /** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
-  const preemptSkipCodes: ReadonlySet<string> = new Set([
-    OrchestratorErrorCode.TASK_NOT_FOUND,
-    OrchestratorErrorCode.TASK_ALREADY_TERMINAL,
-    OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
-  ]);
-
-  async function preemptTaskSubgraph(taskId: string): Promise<void> {
-    try {
-      await performCancelTask(taskId);
-    } catch (err) {
-      if (err instanceof CommandError && preemptSkipCodes.has(err.code)) {
-        logger.info(`preemptTaskSubgraph skipped for "${taskId}": ${err.message}`, { module: 'ipc' });
-        return;
-      }
-      throw err;
-    }
-  }
-
-  async function preemptWorkflowExecution(workflowId: string): Promise<WorkflowCancelResult> {
-    try {
-      logger.info(`preemptWorkflowExecution begin for "${workflowId}"`, { module: 'ipc' });
-      const result = await performCancelWorkflow(workflowId);
-      logger.info(`preemptWorkflowExecution end for "${workflowId}"`, { module: 'ipc' });
-      return result;
-    } catch (err) {
-      if (err instanceof CommandError && preemptSkipCodes.has(err.code)) {
-        logger.info(`preemptWorkflowExecution skipped for "${workflowId}": ${err.message}`, { module: 'ipc' });
-        return { cancelled: [], runningCancelled: [] };
-      }
-      throw err;
-    }
   }
 
   function requireTaskExecutor(): TaskRunner {
@@ -2887,28 +2604,6 @@ function createEmbeddedTerminalBackendFromConfig(
       default:
         return null;
     }
-  }
-
-  async function performSharedApproveTask(
-    taskId: string,
-    source: 'ui' | 'surface' | 'api',
-    scope: 'task' | 'workflow' = 'task',
-  ): Promise<{ started: TaskState[] }> {
-    const envelope = makeEnvelope('approve', source === 'api' ? 'surface' : source, scope, { taskId });
-    return sharedApproveTask(taskId, {
-      orchestrator,
-      taskExecutor: requireTaskExecutor(),
-      approve: async (approvedTaskId) => {
-        const result = await commandService.approve({ ...envelope, payload: { taskId: approvedTaskId } });
-        if (!result.ok) throw new Error(result.error.message);
-        return result.data;
-      },
-      resumeAfterFixApproval: async (approvedTaskId) => {
-        const result = await commandService.resumeTaskAfterFixApproval({ ...envelope, payload: { taskId: approvedTaskId } });
-        if (!result.ok) throw new Error(result.error.message);
-        return result.data;
-      },
-    });
   }
 
   const guiMutationRegistrationContext: GuiMutationRegistrationContext = {


### PR DESCRIPTION
## Summary

Slice 1 of the app god-file decomposition. `packages/app/src/main.ts` is 5,039 lines and already delegates to subdirectory modules through deps objects with getter closures.

This slice relocates the GUI task and workflow action orchestration into a new `packages/app/src/execution/workflow-task-actions.ts` module, and re-points the source-pin test anchors that travel with it.

Behavior is intentionally identical. The new module sits beside the existing `execution/task-runner-wiring.ts` seam and shares the `taskHandles` map by reference.

## Review Claim

The `perform*`/`preempt*` task and workflow action orchestration, the auto-fix observability helpers, and the execution-capacity guard now live in `packages/app/src/execution/workflow-task-actions.ts` behind a deps object whose getters resolve the reassignable service singletons; behavior is unchanged.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Pure move slice. The module singletons (orchestrator, commandService, persistence) are reassigned by `initServices()`, so the deps object exposes getters, never captured values — the same convention as `execution/task-runner-wiring.ts`. The source-pin test `gui-mutation-translation.test.ts` is re-pointed at the new file in the same change, so its anchors keep asserting the same code.

## Slice Rationale

One code relocation per slice, per the review-compression convention. This is slice 1 of the app decomposition chain and touches nothing else: the new module sits beside `execution/task-runner-wiring.ts`, and the shared `taskHandles` map is passed by reference, so there is no dependency-direction change.

## Non-goals

- No IPC handler registration moves and no renderer-feed moves; those are later slices.
- No change to the shared `workflow-actions.ts` action bodies.
- No behavior change: the relocated orchestration passes through unchanged.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/gui-mutation-translation.test.ts src/__tests__/workflow-actions.test.ts src/__tests__/task-runner-wiring.test.ts` — exits 0 (verified green by the workflow verify task, slice 2).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <squash-merge-sha>`.
- Post-revert steps: None — pure relocation; callers fall back to the in-`main.ts` definitions.
- Data migration? No.

</details>
