### PR TITLE
[PR maintenance workers Step 2: Wire PR maintenance workers into owner config](2) Wire PR-maintenance config into owner startup

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -132,6 +132,7 @@ import {
   resolveConfigFileState,
   resolveDefaultTaskExecutionSettings,
   resolveEmbeddedTerminalBackendConfig,
+  resolvePrMaintenanceWorkerConfig,
   type EmbeddedTerminalBackendConfig,
   type InvokerConfig,
 } from './config.js';
@@ -357,6 +358,7 @@ function buildRegisteredOwnerWorkerDeps(
       stallRequeueRetries: invokerConfig.stallRequeueRetries,
       stallRequeueBackoffMs: invokerConfig.stallRequeueBackoffMs,
     },
+    prMaintenance: resolvePrMaintenanceWorkerConfig(invokerConfig),
     diskHeadroom: {
       localPath: resolveInvokerHomeRoot(),
       remoteTargets,


### PR DESCRIPTION
## Summary

Thread the resolved `prMaintenance` launch config into owner worker dependency construction.

This makes enabled PR-maintenance settings available to the registered worker factories without adding a new control surface.

## Review Claim

Owner startup passes the resolved PR-maintenance launch config into registered worker dependencies.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The resolver still returns `undefined` unless `prMaintenance.enabled` is true, so existing owner startups keep the workers dormant.

## Slice Rationale

Owner startup wiring lands after the config resolver, so this slice only connects the already-gated value to registered worker dependencies.

## Non-goals

- Does not change the `prMaintenance` config schema.
- Does not add headless commands, worker-control UI, or backend implementation changes.

## Architecture

### Before

Owner registered-worker dependencies had no `prMaintenance` entry.

### After

`buildRegisteredOwnerWorkerDeps` passes `resolvePrMaintenanceWorkerConfig(invokerConfig)` as the worker runtime `prMaintenance` dependency.

## Visual Proof

No user-visible UI behavior changes in this slice; the touched `main.ts` path requires a visual proof artifact.

![Stacked workflows visual proof](https://github.com/Neko-Catpital-Labs/Invoker/blob/0e9b1278df53706df5d5e3eea562923208ebfbed/packages/app/e2e/visual-proof/after/stacked-workflows.png?raw=1)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts src/__tests__/registered-owner-workers.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert dd15c9e77270a93eae019a92b06e949b45e3485f`
- Post-revert steps: Re-run the focused app tests.
- Data migration? No

</details>
