### PR TITLE
[Worker Subscriptions](9a) Add PR maintenance worker config

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -209,6 +209,49 @@ describe('loadConfig', () => {
     const config = loadConfig();
     expect(config.externalWorkers).toEqual(externalWorkers);
   });
+  it('reads PR maintenance config from user config', () => {
+    const prMaintenance = {
+      githubPrEvents: {
+        enabled: true,
+        repo: 'owner/repo',
+        author: 'octocat',
+        coderabbitLogin: 'coderabbitai[bot]',
+        mergifyLogin: 'mergify[bot]',
+        pollIntervalMs: 60000,
+      },
+      coderabbitAddress: {
+        enabled: true,
+        repoRoot: '/repo',
+        repo: 'owner/repo',
+        author: 'octocat',
+        coderabbitLogin: 'coderabbitai[bot]',
+        trigger: 'subscription',
+      },
+      prConflictRebase: {
+        enabled: true,
+        repoRoot: '/repo',
+        repo: 'owner/repo',
+        author: 'octocat',
+        trigger: 'subscription',
+      },
+      mergifyRequeue: {
+        enabled: true,
+        repoRoot: '/repo',
+        repo: 'owner/repo',
+        author: 'octocat',
+        trigger: 'subscription',
+        pythonExecutable: '/usr/bin/python3',
+        stateFile: '/tmp/mergify-state.jsonl',
+        extraArgs: ['--dry-run'],
+      },
+    };
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ prMaintenance }),
+    );
+    const config = loadConfig();
+    expect(config.prMaintenance).toEqual(prMaintenance);
+  });
 
   it('reads imageStorage from user config', () => {
     const imageStorage = {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -40,6 +40,38 @@ export interface ExternalWorkerConfig {
   /** Process invocation used by the loader to start the external worker. */
   launch: ExternalWorkerLaunchConfig;
 }
+export interface PrProcessWorkerConfig {
+  enabled?: boolean;
+  repoRoot?: string;
+  repo?: string;
+  author?: string;
+  coderabbitLogin?: string;
+  pollIntervalMs?: number;
+  trigger?: 'subscription' | 'poll';
+  env?: Record<string, string>;
+}
+
+export interface MergifyRequeueConfig extends PrProcessWorkerConfig {
+  pythonExecutable?: string;
+  stateFile?: string;
+  extraArgs?: string[];
+}
+
+export interface PrMaintenanceEventSourceConfig {
+  enabled?: boolean;
+  repo: string;
+  author: string;
+  coderabbitLogin?: string;
+  mergifyLogin?: string;
+  pollIntervalMs?: number;
+}
+
+export interface PrMaintenanceConfig {
+  githubPrEvents?: PrMaintenanceEventSourceConfig;
+  coderabbitAddress?: PrProcessWorkerConfig;
+  prConflictRebase?: PrProcessWorkerConfig;
+  mergifyRequeue?: MergifyRequeueConfig;
+}
 export interface DefaultExecutionConfig {
   /**
    * Default task execution harness when a task omits executionAgent.
@@ -292,6 +324,8 @@ export interface InvokerConfig {
     /** Routing strategy. Defaults to "enforce". */
     strategy?: 'enforce' | 'route';
   }>;
+  /** Optional PR maintenance worker and GitHub event-source config. */
+  prMaintenance?: PrMaintenanceConfig;
   /**
    * Operator-declared external worker list, with each worker identified by registry kind.
    * The loader consumes this later; absent means no external workers.


### PR DESCRIPTION
## Summary

Adds optional PR maintenance worker configuration fields to the app config so operators can turn the workers on.

## Review Claim

The app config gains optional PR maintenance worker fields.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

This slice only adds optional config fields with safe defaults; existing config parsing is untouched.

## Slice Rationale

The config fields land before the workers and wiring that read them.

## Non-goals

No worker behavior change. Defaults keep the workers off.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app test config`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- ci-refresh -->
