### PR TITLE
[Worker Subscriptions](9c) Expose PR maintenance workers in headless runtime

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -18,7 +18,7 @@ import {
   acquireWorkerLock,
   createAutoFixAttemptLedger,
   createWorkerRegistry,
-  registerAutoFixWorker,
+  registerBuiltinWorkers,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
   type WorkerRuntimeDependencies,
@@ -424,7 +424,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
     deps.invokerConfig?.externalWorkers,
-    registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+    registerBuiltinWorkers(createWorkerRegistry<WorkerRuntimeDependencies>()),
   );
 
   if (subCommand === 'list') {
@@ -487,6 +487,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         attemptLedger: autoFixAttemptLedger,
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
+      prMaintenance: deps.invokerConfig?.prMaintenance,
     });
     await worker.tick('manual');
     await worker.stop();


### PR DESCRIPTION
## Summary

Registers the built-in PR maintenance workers in the standalone worker runtime so configured workers also run there.

## Review Claim

The standalone worker runtime registers the built-in PR maintenance workers.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice only registers the built-in workers in the standalone runtime; other runtimes are untouched.

## Slice Rationale

The runtime registration lands last, after the workers and config it wires together.

## Non-goals

No worker behavior change when unconfigured.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

<!-- ci-refresh -->
