### PR TITLE
[Workers Surface](5) Require populated worker snapshot fields

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -236,10 +236,10 @@ export interface WorkerStatusEntry {
   stoppedAt?: string;
   lastError?: string;
   recentActions: WorkerActionSummary[];
-  recentLogs?: WorkerLogEntry[];
+  recentLogs: WorkerLogEntry[];
   recovery?: WorkerRecoverySummary;
-  source?: WorkerSource;
-  availability?: WorkerAvailability;
+  source: WorkerSource;
+  availability: WorkerAvailability;
   running?: boolean;
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2859,7 +2859,7 @@ export function App() {
 
     const copy = getWorkerDisplayCopy(selectedWorker.kind);
     const activeAction = getActiveWorkerAction(selectedWorker);
-    const recentLogs = selectedWorker.recentLogs ?? [];
+    const recentLogs = selectedWorker.recentLogs;
     const hasResponseHistory = selectedWorker.recentActions.length > 0 || recentLogs.length > 0;
 
     return (

--- a/packages/ui/src/components/WorkerActivityCard.tsx
+++ b/packages/ui/src/components/WorkerActivityCard.tsx
@@ -70,8 +70,7 @@ export function WorkerActivityCard({
             const showStart = worker.lifecycle !== 'running';
             const isControlDisabled = Boolean(disabledTitle);
             const selected = selectedWorkerKind === worker.kind;
-            const recentLogs = worker.recentLogs ?? [];
-            const latestLog = recentLogs[0];
+            const latestLog = worker.recentLogs[0];
             const latestAction = worker.recentActions[0];
             const footer = latestLog
               ? `Latest log: ${latestLog.summary ?? formatWorkerValue(latestLog.eventType ?? latestLog.actionType ?? latestLog.source)}`


### PR DESCRIPTION
## Summary

Makes recentLogs, source, and availability required on the worker snapshot contract now that every producer fills them in.

Drops the UI fallbacks that handled the old optional fields, since they can no longer be missing.

## Review Claim

Approve making the worker snapshot fields required and dropping the now-unneeded UI fallbacks.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Every producer already sets these fields, so requiring them changes only the contract, not any runtime value or stored data.

## Slice Rationale

The tightening lands last, after all producers populate the fields, so the required contract never breaks an earlier slice.

## Non-goals

Does not add fields, change producers, or alter the panel layout. No behavior change beyond the required fields.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/contracts && pnpm test`
- [ ] `cd packages/ui && pnpm test`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 3e61cbb1b79b6f05472f484af3e0a891ab620154`
- Post-revert steps: None
- Data migration? No

</details>
