### PR TITLE
fix(omp): isolate per-task omp session dir so concurrent agents don't share one session store

### DIFF
--- a/packages/execution-engine/src/__tests__/omp-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/omp-execution-agent.test.ts
@@ -1,15 +1,20 @@
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { OmpExecutionAgent } from '../agents/omp-execution-agent.js';
 
+const ROOT = '/test-omp-sessions';
+
 describe('OmpExecutionAgent', () => {
-  it('builds print command with auto approve and model selector', () => {
-    const agent = new OmpExecutionAgent({ command: 'omp-test' });
+  it('builds print command with auto approve, isolated session dir, and model selector', () => {
+    const agent = new OmpExecutionAgent({ command: 'omp-test', sessionDirRoot: ROOT });
     const spec = agent.buildCommand('prompt text', { executionModel: 'openai/gpt-5.2' });
 
     expect(spec.cmd).toBe('omp-test');
     expect(spec.args).toEqual([
       '--no-title',
       '--auto-approve',
+      '--session-dir',
+      join(ROOT, spec.sessionId!),
       '--model',
       'openai/gpt-5.2',
       '-p',
@@ -19,22 +24,59 @@ describe('OmpExecutionAgent', () => {
     expect(spec.fullPrompt).toBe('prompt text');
   });
 
-  it('omits model args when executionModel is absent', () => {
-    const agent = new OmpExecutionAgent({ command: 'omp-test' });
-    expect(agent.buildCommand('prompt text').args).toEqual([
+  it('omits model args when executionModel is absent but keeps the session dir', () => {
+    const agent = new OmpExecutionAgent({ command: 'omp-test', sessionDirRoot: ROOT });
+    const spec = agent.buildCommand('prompt text');
+    expect(spec.args).toEqual([
       '--no-title',
       '--auto-approve',
+      '--session-dir',
+      join(ROOT, spec.sessionId!),
       '-p',
       'prompt text',
     ]);
   });
 
-  it('uses cwd-local continue for resume', () => {
-    const agent = new OmpExecutionAgent({ command: 'omp-test' });
-    expect(agent.buildResumeArgs('ignored-session')).toEqual({ cmd: 'omp-test', args: ['--continue'] });
+  it('gives each concurrent build its own session dir so agents do not share a session store', () => {
+    const agent = new OmpExecutionAgent({ command: 'omp-test', sessionDirRoot: ROOT });
+    const a = agent.buildCommand('a');
+    const b = agent.buildCommand('b');
+    const c = agent.buildFixCommand('c');
+
+    const dirOf = (args: string[]) => args[args.indexOf('--session-dir') + 1];
+    const dirs = [dirOf(a.args), dirOf(b.args), dirOf(c.args)];
+    expect(new Set(dirs).size).toBe(3);
+    for (const dir of dirs) expect(dir.startsWith(`${ROOT}/`)).toBe(true);
   });
 
-  it('mounts host OMP agent config into containers', () => {
+  it('scopes resume to the task session dir instead of a bare --continue', () => {
+    const agent = new OmpExecutionAgent({ command: 'omp-test', sessionDirRoot: ROOT });
+    expect(agent.buildResumeArgs('session-abc')).toEqual({
+      cmd: 'omp-test',
+      args: ['--session-dir', join(ROOT, 'session-abc'), '--continue'],
+    });
+  });
+
+  it('resume targets the same dir the initial command wrote (round-trip via sessionId)', () => {
+    const agent = new OmpExecutionAgent({ command: 'omp-test', sessionDirRoot: ROOT });
+    const spec = agent.buildCommand('do work');
+    // Executor persists spec.sessionId and later passes it back to buildResumeArgs.
+    const resume = agent.buildResumeArgs(spec.sessionId!);
+    const initialDir = spec.args[spec.args.indexOf('--session-dir') + 1];
+    const resumeDir = resume.args[resume.args.indexOf('--session-dir') + 1];
+    expect(resumeDir).toBe(initialDir);
+  });
+
+  it('defaults the session dir root to a cross-environment temp path', () => {
+    const agent = new OmpExecutionAgent({ command: 'omp-test' });
+    const spec = agent.buildCommand('prompt');
+    expect(spec.args).toContain('--session-dir');
+    expect(spec.args[spec.args.indexOf('--session-dir') + 1]).toBe(
+      join('/tmp/invoker-omp-sessions', spec.sessionId!),
+    );
+  });
+
+  it('mounts host OMP agent config into containers (session dir is not a mount)', () => {
     const agent = new OmpExecutionAgent({ configDir: '/host/.omp/agent', containerHomePath: '/home/invoker' });
     expect(agent.getContainerRequirements()).toEqual({
       mounts: [{ hostPath: '/host/.omp/agent', containerPath: '/home/invoker/.omp/agent' }],

--- a/packages/execution-engine/src/agents/omp-execution-agent.ts
+++ b/packages/execution-engine/src/agents/omp-execution-agent.ts
@@ -7,6 +7,7 @@ export interface OmpExecutionAgentConfig {
   command?: string;
   configDir?: string;
   containerHomePath?: string;
+  sessionDirRoot?: string;
 }
 
 const OMP_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
@@ -28,6 +29,8 @@ const OMP_SUPPORTED_MODELS: readonly ExecutionModelOption[] = [
   { id: 'ollama/gpt-oss:20b', label: 'Ollama GPT-OSS 20B' },
 ];
 
+const DEFAULT_SESSION_DIR_ROOT = '/tmp/invoker-omp-sessions';
+
 export class OmpExecutionAgent implements ExecutionAgent {
   readonly name = 'omp';
   readonly stdinMode = 'ignore' as const;
@@ -39,19 +42,21 @@ export class OmpExecutionAgent implements ExecutionAgent {
   private readonly command: string;
   private readonly configDir: string;
   private readonly containerHomePath: string;
+  private readonly sessionDirRoot: string;
 
   constructor(config: OmpExecutionAgentConfig = {}) {
     this.command = config.command ?? process.env.INVOKER_OMP_COMMAND ?? 'omp';
     this.configDir = config.configDir ?? join(homedir(), '.omp', 'agent');
     this.containerHomePath = config.containerHomePath ?? '/home/invoker';
     this.bundledSkillRoot = join(this.configDir, 'skills');
+    this.sessionDirRoot = config.sessionDirRoot ?? DEFAULT_SESSION_DIR_ROOT;
   }
 
   buildCommand(fullPrompt: string, options: AgentCommandBuildOptions = {}): AgentCommandSpec {
     const sessionId = randomUUID();
     return {
       cmd: this.command,
-      args: this.buildArgs(fullPrompt, options.executionModel),
+      args: this.buildArgs(fullPrompt, this.sessionDir(sessionId), options.executionModel),
       sessionId,
       fullPrompt,
     };
@@ -61,13 +66,13 @@ export class OmpExecutionAgent implements ExecutionAgent {
     const sessionId = randomUUID();
     return {
       cmd: this.command,
-      args: this.buildArgs(prompt, options.executionModel),
+      args: this.buildArgs(prompt, this.sessionDir(sessionId), options.executionModel),
       sessionId,
     };
   }
 
-  buildResumeArgs(_sessionId: string): { cmd: string; args: string[] } {
-    return { cmd: this.command, args: ['--continue'] };
+  buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
+    return { cmd: this.command, args: ['--session-dir', this.sessionDir(sessionId), '--continue'] };
   }
 
   getContainerRequirements(): {
@@ -85,10 +90,16 @@ export class OmpExecutionAgent implements ExecutionAgent {
     };
   }
 
-  private buildArgs(prompt: string, executionModel?: string): string[] {
+  private sessionDir(sessionId: string): string {
+    return join(this.sessionDirRoot, sessionId);
+  }
+
+  private buildArgs(prompt: string, sessionDir: string, executionModel?: string): string[] {
     return [
       '--no-title',
       '--auto-approve',
+      '--session-dir',
+      sessionDir,
       ...(executionModel ? ['--model', executionModel] : []),
       '-p',
       prompt,


### PR DESCRIPTION
## Summary

Invoker runs many omp agents at once on one machine. They all shared one omp session store, so resuming an agent could reattach to the wrong task's session.

A single omp agent object is reused across the local, SSH, and Docker executors. By default omp keeps every session under one shared store.

We saw seven omp agents running locally at the same moment, all sharing that store.

Because resume passed a bare `--continue`, omp reattached to whichever session was written most recently. Under concurrency that can be another task's session.

This change gives each task its own omp `--session-dir`, derived from its session id, and scopes `--continue` to that dir.

Credentials and skills still come from the shared agent dir, because only session storage is relocated, not the whole agent home.

## Review Claim

Each omp task gets an isolated `--session-dir` and resume points at that dir, so concurrent omp agents no longer share a session store or resume another task's session.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the omp session-storage path changes. `PI_CODING_AGENT_DIR` is untouched, so credentials and skills still resolve from the shared agent dir. The session-dir root is a plain writable temp path valid on host, SSH remote, and container, so no path is unwritable in any environment.

## Slice Rationale

One omp agent, one behavior change plus its unit tests. No executor or wiring changes are needed, because `--session-dir` is an existing omp flag added to the launch arguments already carried in the spec.

## Non-goals

Does not relocate `agent.db` (credentials/usage) or `history.db`; those stay shared because credentials live in `agent.db` and per-session copies would break OAuth refresh.

Does not add cleanup or garbage-collection of per-task session dirs.

Without changing SSH pool concurrency, Docker mounts, or other executor wiring.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && npx vitest run src/__tests__/omp-execution-agent.test.ts`
- [ ] `cd packages/execution-engine && npx vitest run src/__tests__/omp-session-driver.test.ts src/__tests__/agent-executor-matrix.test.ts src/__tests__/agent-registry.test.ts src/__tests__/conflict-resolver.test.ts`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>