### PR TITLE
[App TSConfig](1) Stop tsc from clobbering the tsup-built dist

### DIFF
--- a/packages/app/tsconfig.json
+++ b/packages/app/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "noEmit": true,
     "outDir": "dist",
     "rootDir": "src",
     "module": "ESNext",


### PR DESCRIPTION
## Summary

Electron would not launch because the app's preload file on disk had been written as an ES module, which the sandboxed preload loader cannot run.

The build produces that file as CommonJS with tsup. But the TypeScript compiler was also writing ES module files into the same `dist` folder and clobbering it.

This adds `noEmit` to the app's TypeScript config so the compiler only checks the package and writes nothing. tsup remains the one tool that produces the bundle.

## Review Claim

Approve adding `noEmit` to the app's TypeScript config so the compiler never writes files into `dist` and cannot overwrite the tsup CommonJS bundle.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

tsup still produces every file in `packages/app/dist`. With `noEmit` the compiler emits nothing, so the CommonJS runtime bundle can no longer be replaced by ES module output. Checksums of `dist` stayed identical after running the compiler against this config.

## Slice Rationale

One config file with one job: the app's build output. It changes no product source and no other package, so it stands alone as a review.

## Non-goals

- Does not change any product runtime source or the preload script itself.
- Does not touch `packages/ui` or any other package's config.
- Does not fix the separate, pre-existing failure in `pnpm build:tsc` (unrelated `contracts` and `ui` project-reference errors).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app build` — rebuilds `dist` as CommonJS
- [ ] `node --check packages/app/dist/preload.js` — parses as CommonJS, no "import statement outside a module"
- [ ] `npx tsc -p packages/app/tsconfig.json` then `shasum packages/app/dist/preload.js` — checksum unchanged, compiler emitted nothing

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: rebuild with `pnpm --filter @invoker/app build` before running the app
- Data migration? No

</details>
