### PR TITLE
[Planning Chat Raw Stream Step 2](1) Bridge live planner text across desktop and web

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -5,12 +5,14 @@ import {
   createPlanningCommandBuilderFromRegistry,
   listInAppPlanningPresets,
   planFromGoal,
+  listPlanningChatSessions,
   resetPlanningChat,
   restorePlanningChatSessions,
   sendPlanningChatMessage,
   submitPlanningChatDraft,
   type LoadedGeneratedPlan,
 } from '../in-app-planner.js';
+import type { PlannerStreamEvent } from '@invoker/contracts';
 import { ConversationRepository, SQLiteAdapter, type InAppPlanningSessionRecord } from '@invoker/data-store';
 
 const VALID_PLAN = `Here is the plan.
@@ -525,6 +527,99 @@ tasks:
       sessions,
       loadGeneratedPlan: vi.fn(),
     })).resolves.toEqual({ ok: false, error: 'I found a draft plan but could not read it. Ask the AI to regenerate the plan, then submit again.' });
+  });
+
+  describe('live planner stream', () => {
+    const emitChunk = (self: unknown, chunk: string): void => {
+      (self as { onRawPlannerOutput?: (c: string) => void }).onRawPlannerOutput?.(chunk);
+    };
+
+    it('streams raw chunks off-transcript and clears transient text on success', async () => {
+      vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockImplementation(async function (this: PlanConversation) {
+        emitChunk(this, 'thinking');
+        emitChunk(this, ' harder');
+        return 'Final reply.';
+      });
+      const events: PlannerStreamEvent[] = [];
+      const sessions = createInAppPlanningChatSessions();
+
+      const result = await sendPlanningChatMessage({ message: 'hi', presetKey: 'codex' }, {
+        config: {},
+        loadGeneratedPlan: vi.fn(),
+        sessions,
+        planningCommandBuilder,
+        onPlannerStream: (event) => events.push(event),
+      });
+
+      if (!result.ok) throw new Error(result.error);
+      expect(events.map((e) => e.chunk)).toEqual(['thinking', ' harder']);
+      expect(events.map((e) => e.text)).toEqual(['thinking', 'thinking harder']);
+      expect(events.every((e) => e.sessionId === result.sessionId)).toBe(true);
+
+      const session = sessions.get(result.sessionId);
+      // Transcript keeps only the final reply; live raw text never lands in messages.
+      expect(session?.messages.at(-1)?.text).toBe('Final reply.');
+      expect(session?.messages.some((m) => m.text.includes('thinking'))).toBe(false);
+      expect(session?.transientStreamText).toBeUndefined();
+    });
+
+    it('preserves transient text on failure and keeps it out of persisted history', async () => {
+      vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockImplementation(async function (this: PlanConversation) {
+        emitChunk(this, 'partial output');
+        throw new Error('planner blew up');
+      });
+      const adapter = await SQLiteAdapter.create(':memory:');
+      try {
+        const sessions = createInAppPlanningChatSessions();
+        const result = await sendPlanningChatMessage({ message: 'hi', presetKey: 'codex' }, {
+          config: {},
+          loadGeneratedPlan: vi.fn(),
+          sessions,
+          planningCommandBuilder,
+          onPlannerStream: vi.fn(),
+          planningSessionStore: adapter,
+        });
+
+        expect(result.ok).toBe(false);
+        const sessionId = result.sessionId as string;
+        const session = sessions.get(sessionId);
+        expect(session?.transientStreamText).toBe('partial output');
+        expect(session?.messages.some((m) => m.text.includes('partial output'))).toBe(false);
+
+        // Exposed on the live summary, but the persisted record stays final-only.
+        expect(listPlanningChatSessions({ sessions }).sessions[0]?.transientStreamText).toBe('partial output');
+        expect(JSON.stringify(adapter.loadInAppPlanningSession(sessionId))).not.toContain('partial output');
+      } finally {
+        adapter.close();
+      }
+    });
+
+    it('resets stale transient text at the start of the next send', async () => {
+      vi.spyOn(PlanConversation.prototype, 'spawnPlanner')
+        .mockImplementationOnce(async function (this: PlanConversation) {
+          emitChunk(this, 'leftover');
+          throw new Error('first fail');
+        })
+        .mockImplementationOnce(async () => {
+          throw new Error('second fail');
+        });
+      const sessions = createInAppPlanningChatSessions();
+
+      const first = await sendPlanningChatMessage({ message: 'hi', presetKey: 'codex' }, {
+        config: {}, loadGeneratedPlan: vi.fn(), sessions, planningCommandBuilder, onPlannerStream: vi.fn(),
+      });
+      expect(first.ok).toBe(false);
+      const sessionId = first.sessionId as string;
+      expect(sessions.get(sessionId)?.transientStreamText).toBe('leftover');
+
+      const second = await sendPlanningChatMessage({ sessionId, message: 'again' }, {
+        config: {}, loadGeneratedPlan: vi.fn(), sessions, planningCommandBuilder, onPlannerStream: vi.fn(),
+      });
+      // Second send also fails (so clear-on-success never runs), yet the leftover
+      // is gone → the reset at send start cleared it.
+      expect(second.ok).toBe(false);
+      expect(sessions.get(sessionId)?.transientStreamText).toBeUndefined();
+    });
   });
 
 

--- a/packages/app/src/__tests__/web-bridge-server.test.ts
+++ b/packages/app/src/__tests__/web-bridge-server.test.ts
@@ -197,6 +197,37 @@ describe('startWebBridge', () => {
     expect(received).toContain('event: invoker:task-output');
     expect(received).toContain('"taskId":"wf-1/task-1"');
   });
+
+  it('streams PLANNER_STREAM bus events over /events as invoker:planner-stream', async () => {
+    const { port, bus } = await startBridge();
+    const { promise, resolve } = Promise.withResolvers<string>();
+    const req = http.request(
+      { host: '127.0.0.1', port, path: '/events', headers: { cookie: `invoker_web=${TOKEN}` } },
+      (res) => {
+        expect(res.statusCode).toBe(200);
+        let buffer = '';
+        res.on('data', (c) => {
+          buffer += (c as Buffer).toString('utf8');
+          if (buffer.includes('event: invoker:planner-stream')) {
+            req.destroy();
+            resolve(buffer);
+          }
+        });
+      },
+    );
+    req.on('error', () => { /* destroyed after resolve */ });
+    req.end();
+    await new Promise((r) => setTimeout(r, 50));
+    // Channels.PLANNER_STREAM === 'planner.stream'
+    bus.publish('planner.stream', { sessionId: 'sess-1', chunk: 'draft', text: 'draft' });
+    const received = await Promise.race([
+      promise,
+      new Promise<string>((_, rej) => setTimeout(() => rej(new Error('SSE timeout')), 2000)),
+    ]);
+    expect(received).toContain('event: invoker:planner-stream');
+    expect(received).toContain('"sessionId":"sess-1"');
+    expect(received).toContain('"chunk":"draft"');
+  });
 });
 
 describe('startWebBridge static serving', () => {

--- a/packages/app/src/__tests__/web-invoker-dispatch.test.ts
+++ b/packages/app/src/__tests__/web-invoker-dispatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { buildWebInvokerDispatch } from '../web/web-invoker-dispatch.js';
+import { createInAppPlanningChatSessions, type InAppPlanningChatSessions } from '../in-app-planner.js';
 
 function makeTask(id: string) {
   return {
@@ -110,5 +111,51 @@ describe('buildWebInvokerDispatch', () => {
   it('an unknown channel rejects with code unknown_channel', async () => {
     const { dispatch } = makeDispatch();
     await expect(dispatch('invoker:does-not-exist', [])).rejects.toMatchObject({ code: 'unknown_channel' });
+  });
+
+  function makePlannerRuntime(sessions: InAppPlanningChatSessions) {
+    return {
+      sessions,
+      config: {},
+      planningCommandBuilder: vi.fn(() => ({ command: 'planner', args: ['prompt'] })),
+      loadGeneratedPlan: vi.fn(),
+    };
+  }
+
+  it('planning-chat-create routes to the shared planner runtime', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const { dispatch } = makeDispatch({ getPlannerRuntime: () => makePlannerRuntime(sessions) });
+    const result = await dispatch('invoker:planning-chat-create', [{ presetKey: 'codex' }]) as { ok: boolean };
+    expect(result.ok).toBe(true);
+    expect(sessions.size).toBe(1);
+  });
+
+  it('planning-chat-list returns sessions created through the runtime', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const { dispatch } = makeDispatch({ getPlannerRuntime: () => makePlannerRuntime(sessions) });
+    const created = await dispatch('invoker:planning-chat-create', [{ presetKey: 'codex', title: 'My plan' }]) as {
+      ok: true; session: { id: string };
+    };
+    const list = await dispatch('invoker:planning-chat-list', []) as { ok: true; sessions: Array<{ id: string }> };
+    expect(list.ok).toBe(true);
+    expect(list.sessions.map((s) => s.id)).toEqual([created.session.id]);
+  });
+
+  it('planning-chat-reset removes a session from the runtime', async () => {
+    const sessions = createInAppPlanningChatSessions();
+    const { dispatch } = makeDispatch({ getPlannerRuntime: () => makePlannerRuntime(sessions) });
+    const created = await dispatch('invoker:planning-chat-create', [{ presetKey: 'codex' }]) as {
+      ok: true; session: { id: string };
+    };
+    expect(sessions.size).toBe(1);
+    expect(await dispatch('invoker:planning-chat-reset', [{ sessionId: created.session.id }])).toEqual({ ok: true });
+    expect(sessions.size).toBe(0);
+  });
+
+  it('planning-chat channels are unsupported when no planner runtime is wired', async () => {
+    const { dispatch } = makeDispatch();
+    await expect(dispatch('invoker:planning-chat-create', [{}])).rejects.toMatchObject({ code: 'unsupported_on_web' });
+    await expect(dispatch('invoker:planning-chat-list', [])).rejects.toMatchObject({ code: 'unsupported_on_web' });
+    await expect(dispatch('invoker:planning-chat-send', [{ message: 'hi' }])).rejects.toMatchObject({ code: 'unsupported_on_web' });
   });
 });

--- a/packages/app/src/in-app-planner.ts
+++ b/packages/app/src/in-app-planner.ts
@@ -15,6 +15,7 @@ import type {
   InAppPlanningSessionSummary,
   InAppPlanningSubmitRequest,
   InAppPlanningSubmitResponse,
+  PlannerStreamEvent,
   PlanningPresetOption,
 } from '@invoker/contracts';
 import type {
@@ -24,7 +25,7 @@ import type {
   InAppPlanningSessionRecord,
 } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
-import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder } from '@invoker/surfaces';
+import type { HarnessPreset, PlanConversation, PlanConversationConfig, PlanningCommandBuilder, RawPlannerOutputHandler } from '@invoker/surfaces';
 import type { InvokerConfig } from './config.js';
 
 export interface LoadedGeneratedPlan {
@@ -40,6 +41,8 @@ export interface InAppPlanningSessionStore {
   deleteInAppPlanningSession(sessionId: string): void;
 }
 
+export type PlannerStreamSink = (event: PlannerStreamEvent) => void;
+
 export interface InAppPlannerDeps {
   config: InvokerConfig;
   loadGeneratedPlan: (planText: string) => LoadedGeneratedPlan | Promise<LoadedGeneratedPlan>;
@@ -47,6 +50,7 @@ export interface InAppPlannerDeps {
   planningCommandBuilder?: PlanningCommandBuilder;
   conversationRepo?: ConversationRepository;
   plannerReplyOverride?: (formattedMessage: string) => Promise<string>;
+  onPlannerStream?: PlannerStreamSink;
 }
 
 export interface InAppPlanningChatSession {
@@ -58,6 +62,7 @@ export interface InAppPlanningChatSession {
   conversation: PlanConversation;
   draftPlanSummary?: InAppPlanningPlanSummary;
   draftPlanText?: string;
+  transientStreamText?: string;
   submittedWorkflowId?: string;
   submittedPlanName?: string;
   createdAt: string;
@@ -203,6 +208,7 @@ function sessionToSummary(session: InAppPlanningChatSession): InAppPlanningSessi
     draftPlanSummary: session.draftPlanSummary,
     submittedWorkflowId: session.submittedWorkflowId,
     submittedPlanName: session.submittedPlanName,
+    transientStreamText: session.transientStreamText,
     createdAt: session.createdAt,
     updatedAt: session.updatedAt,
   };
@@ -275,10 +281,25 @@ function formatConversationalPlanningMessage(message: string): string {
   ].join('\n');
 }
 
+function makePlannerStreamHandler(
+  sessionId: string,
+  deps: { sessions: InAppPlanningChatSessions; onPlannerStream?: PlannerStreamSink },
+): RawPlannerOutputHandler | undefined {
+  const sink = deps.onPlannerStream;
+  if (!sink) return undefined;
+  return (chunk: string): void => {
+    const session = deps.sessions.get(sessionId);
+    if (!session) return;
+    session.transientStreamText = (session.transientStreamText ?? '') + chunk;
+    sink({ sessionId, chunk, text: session.transientStreamText });
+  };
+}
+
 function planConversationConfig(
   preset: HarnessPreset,
   deps: Pick<InAppPlannerDeps, 'config' | 'workingDir' | 'planningCommandBuilder' | 'conversationRepo'>,
   threadTs: string,
+  onRawPlannerOutput?: RawPlannerOutputHandler,
 ): PlanConversationConfig {
   return {
     threadTs,
@@ -292,6 +313,7 @@ function planConversationConfig(
     experimentalPlanner: deps.config.experimentalPlanner,
     preferStackedWorkflows: true,
     planningCommandBuilder: deps.planningCommandBuilder,
+    onRawPlannerOutput,
   };
 }
 
@@ -328,7 +350,7 @@ async function createSession(
       tone: 'muted',
       createdAt,
     }],
-    conversation: new PlanConversation(planConversationConfig(preset, deps, id)),
+    conversation: new PlanConversation(planConversationConfig(preset, deps, id, makePlannerStreamHandler(id, deps))),
     createdAt,
     updatedAt: createdAt,
     nextMessageId: 2,
@@ -461,6 +483,7 @@ export async function sendPlanningChatMessage(
     const activeSession = session;
     const previousSend = activeSession.pendingSend ?? Promise.resolve();
     const turn = previousSend.then(async (): Promise<InAppPlanningChatResponse> => {
+      activeSession.transientStreamText = undefined;
       appendSessionMessage(activeSession, 'user', message);
       if (activeSession.title === 'Untitled plan') {
         activeSession.title = titleFromMessage(message);
@@ -476,6 +499,7 @@ export async function sendPlanningChatMessage(
         if (deps.plannerReplyOverride) {
           saveOverrideConversation(deps.conversationRepo, activeSession.id, formattedMessage, reply);
         }
+        activeSession.transientStreamText = undefined;
         const planText = activeSession.conversation.getDraftedPlan() ?? extractYamlPlan(reply);
         if (!planText) {
           activeSession.draftPlanSummary = undefined;
@@ -624,7 +648,9 @@ export async function restorePlanningChatSessions(
     const preset = presets[record.presetKey];
     if (!preset) continue;
 
-    const conversation = new PlanConversation(planConversationConfig(preset, deps, record.id));
+    const conversation = new PlanConversation(
+      planConversationConfig(preset, deps, record.id, makePlannerStreamHandler(record.id, deps)),
+    );
     await conversation.init();
 
     const nextMessageId = Math.max(0, ...record.messages.map((message) => message.id)) + 1;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -86,6 +86,7 @@ import type {
   InAppPlanningChatRequest,
   InAppPlanningResetRequest,
   InAppPlanningSubmitRequest,
+  PlannerStreamEvent,
   Logger,
   WorkflowMeta,
   WorkflowMutationAcceptedResult,
@@ -247,7 +248,7 @@ import {
 } from './worker-control.js';
 import { startSurfaceEventRelay } from './surface-event-relay.js';
 import { createTaskGraphEventPublisher } from './task-graph-event-publisher.js';
-import { buildWebInvokerDispatch } from './web/web-invoker-dispatch.js';
+import { buildWebInvokerDispatch, type WebPlannerRuntime } from './web/web-invoker-dispatch.js';
 import { startWebBridge, resolveWebUiDistDir, type WebBridge } from './web/web-bridge-server.js';
 import { resolveWebToken, resolveWebHost, resolveWebPort } from './web/start-web-surface.js';
 import {
@@ -433,6 +434,10 @@ let commandService: CommandService;
 // resolve via this getter at cancel-in-flight time.
 let latestTaskExecutor: TaskRunner | null = null;
 let guiUsingDaemonOwner = false;
+
+function publishPlannerStream(event: PlannerStreamEvent): void {
+  messageBus.publish(Channels.PLANNER_STREAM, event);
+}
 
 function buildCommandServiceInvalidationDeps() {
   return buildWorkflowInvalidationDeps({
@@ -1124,6 +1129,7 @@ function startHeadlessMode(): void {
         loadGeneratedPlan,
         conversationRepo: planningConversationRepo,
         planningSessionStore: readOnlyMode ? undefined : persistence,
+        onPlannerStream: publishPlannerStream,
       });
 
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
@@ -1167,6 +1173,7 @@ function startHeadlessMode(): void {
               loadGeneratedPlan,
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
+              onPlannerStream: publishPlannerStream,
             });
           }
           case 'invoker:planning-chat-list': {
@@ -1181,6 +1188,7 @@ function startHeadlessMode(): void {
               loadGeneratedPlan,
               conversationRepo: planningConversationRepo,
               planningSessionStore: readOnlyMode ? undefined : persistence,
+              onPlannerStream: publishPlannerStream,
             });
           }
           case 'invoker:planning-chat-submit': {
@@ -1910,6 +1918,7 @@ function createEmbeddedTerminalBackendFromConfig(
   let workerRuntimeController: WorkerRuntimeController | null = null;
   let apiServer: ApiServer | null = null;
   let webBridge: WebBridge | null = null;
+  let resolveWebPlannerRuntime: (() => WebPlannerRuntime) | undefined;
   let ownerMode = true;
   const taskHandles: TaskHandleMap = new Map();
   const embeddedTerminalManager = new EmbeddedTerminalManager({
@@ -3214,6 +3223,7 @@ function createEmbeddedTerminalBackendFromConfig(
             presets: invokerConfig.slackHarnessPresets ?? DEFAULT_SLACK_HARNESS_PRESETS,
             defaultPreset: invokerConfig.defaultSlackHarnessPreset ?? 'cursor+claude',
           }),
+          getPlannerRuntime: () => resolveWebPlannerRuntime?.(),
           logger,
         });
         webBridge = startWebBridge({
@@ -3700,6 +3710,12 @@ function createEmbeddedTerminalBackendFromConfig(
       }
     });
 
+    messageBus.subscribe(Channels.PLANNER_STREAM, (data: unknown) => {
+      if (mainWindow && !mainWindow.isDestroyed() && uiInteractive) {
+        mainWindow.webContents.send('invoker:planner-stream', data);
+      }
+    });
+
     // Register IPC handlers
     const computeRuntimeStatus = () => (
       process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_FORCE_READ_ONLY_STATUS === '1'
@@ -3782,6 +3798,16 @@ function createEmbeddedTerminalBackendFromConfig(
       warn: (message) => logger.warn(message, { module: 'planning-chat' }),
       error: (message) => logger.error(message, { module: 'planning-chat' }),
     });
+    resolveWebPlannerRuntime = () => ({
+      config: invokerConfig,
+      workingDir: repoRoot,
+      sessions: planningChatSessions,
+      planningCommandBuilder,
+      loadGeneratedPlan: loadGeneratedPlanPreview,
+      conversationRepo: planningConversationRepo,
+      planningSessionStore: ownerMode ? persistence : undefined,
+      onPlannerStream: publishPlannerStream,
+    });
     await restorePlanningChatSessions(persistence.listInAppPlanningSessions(), {
       config: invokerConfig,
       workingDir: repoRoot,
@@ -3790,6 +3816,7 @@ function createEmbeddedTerminalBackendFromConfig(
       loadGeneratedPlan: loadGeneratedPlanPreview,
       conversationRepo: planningConversationRepo,
       planningSessionStore: ownerMode ? persistence : undefined,
+      onPlannerStream: publishPlannerStream,
     });
     let testPlanFromGoalResponse: { planYaml: string; planName: string } | null = null;
     let testPlanningChatResponse: { planYaml: string; planName: string; reply?: string } | null = null;
@@ -3817,6 +3844,7 @@ function createEmbeddedTerminalBackendFromConfig(
         loadGeneratedPlan: loadGeneratedPlanPreview,
         conversationRepo: planningConversationRepo,
         planningSessionStore: ownerMode ? persistence : undefined,
+        onPlannerStream: publishPlannerStream,
       });
     });
     registerGuiMutationHandler('invoker:planning-chat-list', async () => {
@@ -3835,6 +3863,7 @@ function createEmbeddedTerminalBackendFromConfig(
         loadGeneratedPlan: loadGeneratedPlanPreview,
         conversationRepo: planningConversationRepo,
         planningSessionStore: ownerMode ? persistence : undefined,
+        onPlannerStream: publishPlannerStream,
         plannerReplyOverride,
       });
     });

--- a/packages/app/src/web/web-bridge-server.ts
+++ b/packages/app/src/web/web-bridge-server.ts
@@ -310,6 +310,10 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
     broadcast('invoker:task-output', payload);
   });
 
+  const unsubscribePlannerStream = messageBus.subscribe(Channels.PLANNER_STREAM, (payload: unknown) => {
+    broadcast('invoker:planner-stream', payload);
+  });
+
   let activityWatermark = 0;
   const activityTimer = setInterval(() => {
     try {
@@ -357,6 +361,7 @@ export function startWebBridge(deps: WebBridgeDeps): WebBridge {
     clearInterval(workflowsTimer);
     clearInterval(pingTimer);
     unsubscribeOutput?.();
+    unsubscribePlannerStream?.();
     for (const client of clients) client.end();
     clients.clear();
     const { promise, resolve } = Promise.withResolvers<void>();

--- a/packages/app/src/web/web-invoker-dispatch.ts
+++ b/packages/app/src/web/web-invoker-dispatch.ts
@@ -15,20 +15,47 @@
 
 import type {
   BundledSkillsStatus,
+  InAppPlanningChatRequest,
+  InAppPlanningCreateSessionRequest,
+  InAppPlanningResetRequest,
+  InAppPlanningSubmitRequest,
   Logger,
   SystemDiagnostics,
 } from '@invoker/contracts';
-import type { SQLiteAdapter } from '@invoker/data-store';
+import type { ConversationRepository, SQLiteAdapter } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
+import type { PlanningCommandBuilder } from '@invoker/surfaces';
 import type { ExternalGatePolicyUpdate, Orchestrator } from '@invoker/workflow-core';
 import { resolveDefaultTaskExecutionSettings, type InvokerConfig } from '../config.js';
-import { listInAppPlanningPresets } from '../in-app-planner.js';
+import {
+  createPlanningChatSession,
+  listInAppPlanningPresets,
+  listPlanningChatSessions,
+  resetPlanningChat,
+  sendPlanningChatMessage,
+  submitPlanningChatDraft,
+  type InAppPlanningChatSessions,
+  type InAppPlanningSessionStore,
+  type LoadedGeneratedPlan,
+  type PlannerStreamSink,
+} from '../in-app-planner.js';
 import type { ApiMutationFacade } from '../api-server.js';
 import { buildReviewGateQueryResponse } from '../review-gate-query.js';
 import { buildCurrentActionGraphSnapshot } from '../action-graph-snapshot.js';
 import { collectSystemDiagnostics } from '../system-diagnostics.js';
 import { resolveAgentSession } from '../headless-query-list.js';
 import { buildTaskGraphSnapshot } from './task-graph-snapshot.js';
+
+export interface WebPlannerRuntime {
+  config: InvokerConfig;
+  workingDir?: string;
+  sessions: InAppPlanningChatSessions;
+  planningCommandBuilder: PlanningCommandBuilder;
+  loadGeneratedPlan: (planText: string) => LoadedGeneratedPlan | Promise<LoadedGeneratedPlan>;
+  conversationRepo?: ConversationRepository;
+  planningSessionStore?: InAppPlanningSessionStore;
+  onPlannerStream?: PlannerStreamSink;
+}
 
 export interface WebInvokerDispatchDeps {
   orchestrator: Orchestrator;
@@ -46,6 +73,7 @@ export interface WebInvokerDispatchDeps {
   getSystemDiagnostics?: () => SystemDiagnostics;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
   checkPrStatuses?: () => void | Promise<void>;
+  getPlannerRuntime?: () => WebPlannerRuntime | undefined;
   logger?: Logger;
 }
 
@@ -78,6 +106,12 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
     if (!workflow) return null;
     const tasks = persistence.loadTasks(workflowId);
     return buildReviewGateQueryResponse({ workflowId, workflow, tasks });
+  };
+
+  const requirePlannerRuntime = (channel: string): WebPlannerRuntime => {
+    const runtime = deps.getPlannerRuntime?.();
+    if (!runtime) unsupported(channel);
+    return runtime;
   };
 
   return async function dispatch(channel: string, args: unknown[]): Promise<unknown> {
@@ -139,6 +173,34 @@ export function buildWebInvokerDispatch(deps: WebInvokerDispatchDeps): WebInvoke
         return agentRegistry.listExecutionHarnesses();
       case 'invoker:get-planning-presets':
         return listInAppPlanningPresets(deps.loadConfig());
+
+      case 'invoker:planning-chat-create':
+        return createPlanningChatSession(
+          args[0] as InAppPlanningCreateSessionRequest | undefined,
+          requirePlannerRuntime(channel),
+        );
+      case 'invoker:planning-chat-list':
+        return listPlanningChatSessions({ sessions: requirePlannerRuntime(channel).sessions });
+      case 'invoker:planning-chat-send':
+        return sendPlanningChatMessage(
+          args[0] as InAppPlanningChatRequest,
+          requirePlannerRuntime(channel),
+        );
+      case 'invoker:planning-chat-submit': {
+        const runtime = requirePlannerRuntime(channel);
+        return submitPlanningChatDraft(args[0] as InAppPlanningSubmitRequest, {
+          sessions: runtime.sessions,
+          loadGeneratedPlan: runtime.loadGeneratedPlan,
+          planningSessionStore: runtime.planningSessionStore,
+        });
+      }
+      case 'invoker:planning-chat-reset': {
+        const runtime = requirePlannerRuntime(channel);
+        return resetPlanningChat(args[0] as InAppPlanningResetRequest, {
+          sessions: runtime.sessions,
+          planningSessionStore: runtime.planningSessionStore,
+        });
+      }
       case 'invoker:get-execution-defaults':
         return resolveDefaultTaskExecutionSettings(deps.loadConfig());
       case 'invoker:get-system-diagnostics':

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -373,8 +373,15 @@ export interface InAppPlanningSessionSummary {
   draftPlanSummary?: InAppPlanningPlanSummary;
   submittedWorkflowId?: string;
   submittedPlanName?: string;
+  transientStreamText?: string;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface PlannerStreamEvent {
+  sessionId: string;
+  chunk: string;
+  text: string;
 }
 
 export interface InAppPlanningCreateSessionRequest {
@@ -1066,6 +1073,9 @@ export const IpcEventChannels = {
   },
   'invoker:task-output': {} as {
     payload: TaskOutputData;
+  },
+  'invoker:planner-stream': {} as {
+    payload: PlannerStreamEvent;
   },
   'invoker:activity-log': {} as {
     payload: ActivityLogEntry[];

--- a/packages/transport/src/message-bus.ts
+++ b/packages/transport/src/message-bus.ts
@@ -47,4 +47,5 @@ export const Channels = {
   EXPERIMENT_SELECTED: 'experiment.selected',
   /** Orchestrator → surface events (workflow progress cards, etc.) for out-of-process surfaces. */
   SURFACE_EVENT: 'surface.event',
+  PLANNER_STREAM: 'planner.stream',
 } as const;


### PR DESCRIPTION
## Summary

Planning chat can now show the planner's live output as it streams, on the desktop app and the web surface, without saving that raw text into chat history.

The owner process broadcasts each new chunk of planner text over the message bus. The web bridge relays those chunks to browser clients.

The same wiring now reaches the web dispatch path, which previously could not create or run planning chat sessions at all.

## Review Claim

The owner process and web bridge can deliver live planner text to desktop and web clients over the message bus without changing saved chat transcripts.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only adds a new planner-stream event type, transient session fields kept apart from saved messages, and delivery wiring plus tests. It does not touch how saved transcripts render, so existing planning chat behavior is unchanged.

## Slice Rationale

The delivery path must exist before any renderer can subscribe over the message bus to display the live planner panel, so this bridge lands before the UI slice.

## Non-goals

- Does not change how the planning transcript renders in any UI surface.
- Does not add the renderer-side live output panel; that is a later slice.
- Does not persist the transient planner text to the database.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/in-app-planner.test.ts src/__tests__/web-invoker-dispatch.test.ts src/__tests__/web-bridge-server.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No

</details>
