### PR TITLE
[Sidebar manual control](1) Keep sidebar width under the manual collapse toggle

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -596,7 +596,7 @@ test.describe('Visual proof capture', () => {
     }, { planYaml: plannedYaml, planName: 'Terminal Planned Flow', reply: fullPlanReply });
 
     await page.getByTestId('sidebar-planning').click();
-    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-16/);
+    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-60/);
     await expect(page.getByTestId('planning-session-rail')).toHaveClass(/w-64/);
     await expect(page.getByRole('heading', { name: 'Planning Terminal' })).toBeVisible();
     await page.getByTestId('invoker-terminal-input').fill('Add README');
@@ -660,7 +660,9 @@ test.describe('Visual proof capture', () => {
       await window.invoker.setTestPlanningChatResponse({ planYaml, planName, reply: 'I drafted the stacked plan.' });
     }, { planYaml: plannedYaml, planName: 'Workers Surface' });
 
-    await expect(page.getByRole('heading', { name: 'What do you want to build?' })).toBeVisible();
+    await page.getByTestId('sidebar-planning').click();
+    await expect(page.getByRole('heading', { name: 'Planning Terminal' })).toBeVisible();
+    await expect(page.getByTestId('planning-session-rail')).toBeVisible();
     await expect(page.getByTestId('invoker-terminal-input')).toBeVisible();
     await page.getByTestId('invoker-terminal-input').fill('Build the Workers Surface');
     await page.getByRole('button', { name: 'Send' }).click();
@@ -670,7 +672,6 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible();
     await expect(page.getByRole('button', { name: /Workers Surface Contracts/ })).toBeVisible();
     await expect(page.getByRole('button', { name: /Workers Surface UI/ })).toBeVisible();
-    await expect(page.getByTestId('workflow-inspector-title')).toContainText('Workers Surface Contracts');
     await captureScreenshot(page, 'stacked-workflows');
 
     const stack = await page.evaluate(async () => {
@@ -711,7 +712,7 @@ test.describe('Visual proof capture', () => {
     await page.getByTestId('sidebar-workflows').click();
     await expect(page.getByRole('heading', { name: 'Workflows' })).toBeVisible();
     await expect(page.getByRole('button', { name: /Menu Proof Workflow/ }).first()).toBeVisible();
-    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-16/);
+    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-60/);
     await expect(page.getByText('Invoker Terminal')).toHaveCount(0);
     await captureScreenshot(page, 'workflows-browser');
 
@@ -741,7 +742,7 @@ test.describe('Visual proof capture', () => {
     await page.getByTestId('sidebar-attention').click();
     await expect(page.getByTestId('browser-rail')).toHaveClass(/w-64/);
     await expect(page.getByTestId('browser-rail').getByRole('heading', { name: 'Needs Attention' })).toBeVisible();
-    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-16/);
+    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-60/);
     await expect(page.getByRole('heading', { name: 'First test task' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Partial terminal drawer' })).toBeVisible();
     await expect(page.getByText('More needs attention')).toHaveCount(0);
@@ -776,18 +777,32 @@ test.describe('Visual proof capture', () => {
     await loadPlanAndSelectWorkflow(page, MENU_PROOF_PLAN);
     await page.getByTestId('sidebar-workflows').click();
     await expect(page.getByRole('heading', { name: 'Workflows' })).toBeVisible();
+    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-60/);
+
+    await page.getByTestId('sidebar-collapse-toggle').click();
     await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-16/);
     await captureScreenshot(page, 'collapsed-workflow-browsers');
+
+    await page.getByTestId('sidebar-home').click();
+    await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible();
+    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-16/);
+
+    await page.getByTestId('sidebar-workflows').click();
+    await expect(page.getByRole('heading', { name: 'Workflows' })).toBeVisible();
+    await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-16/);
 
     await page.getByTestId('sidebar-collapse-toggle').click();
     await expect(page.getByTestId('app-sidebar')).toHaveClass(/w-60/);
   });
 
   test('sidebar-collapse-state — manual sidebar width survives left rail navigation', async ({ page }) => {
-    await loadPlanAndSelectWorkflow(page, MENU_PROOF_PLAN);
     const sidebar = page.getByTestId('app-sidebar');
 
     await page.getByTestId('sidebar-workflows').click();
+    await expect(page.getByRole('heading', { name: 'Workflows' })).toBeVisible();
+    await expect(sidebar).toHaveClass(/w-60/);
+
+    await page.getByTestId('sidebar-collapse-toggle').click();
     await expect(sidebar).toHaveClass(/w-16/);
 
     await page.getByTestId('sidebar-collapse-toggle').click();
@@ -797,6 +812,7 @@ test.describe('Visual proof capture', () => {
     // Screenshots precede the width assertions so a buggy build still records
     // the snap-back frame (regression: navigation overwrote the manual choice).
     await page.getByTestId('sidebar-attention').click();
+    await expect(page.getByRole('heading', { name: 'Needs Attention' })).toBeVisible();
     await captureScreenshot(page, 'sidebar-collapse-state-2-attention-after-navigation');
     await expect(sidebar).toHaveClass(/w-60/);
 
@@ -810,6 +826,7 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'sidebar-collapse-state-3-workflows-manually-collapsed');
 
     await page.getByTestId('sidebar-home').click();
+    await expect(page.getByRole('heading', { name: 'Plan graph' })).toBeVisible();
     await captureScreenshot(page, 'sidebar-collapse-state-4-home-still-collapsed');
     await expect(sidebar).toHaveClass(/w-16/);
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2183,7 +2183,6 @@ export function App() {
     setGraphActionsMenuOpen(false);
     if (nextSurface === 'workers') {
       setSidebarSurface('workers');
-      setSidebarCollapsed(true);
       setInspectorCollapsed(true);
       setInspectorManualOpen(false);
       setStatusFilters(new Set<WorkflowStatus>());
@@ -2193,12 +2192,10 @@ export function App() {
     setViewMode('dag');
     if (nextSurface === 'home') {
       setSidebarSurface('home');
-      setSidebarCollapsed(false);
       setInspectorManualOpen(false);
       return;
     }
     setSidebarSurface(nextSurface);
-    setSidebarCollapsed(true);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
   }, []);
@@ -2206,7 +2203,6 @@ export function App() {
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
     setSidebarSurface('home');
-    setSidebarCollapsed(false);
     setInspectorManualOpen(false);
     setViewMode('dag');
   }, []);
@@ -3347,4 +3343,3 @@ export function App() {
     </div>
   );
 }
-

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -105,21 +105,48 @@ describe('App launch (component)', () => {
     expect(await screen.findByText('Plan graph')).toBeInTheDocument();
     expect(screen.getByText('Alpha · running')).toBeInTheDocument();
   });
-  it('auto-collapses the app sidebar for browser views on narrow windows', async () => {
-    Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
-
+  it('keeps sidebar width under explicit toggle control while surfaces change', async () => {
     render(<App />);
     await screen.findByTestId('sidebar-workflows');
-    act(() => window.dispatchEvent(new Event('resize')));
+
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-60');
 
     fireEvent.click(screen.getByTestId('sidebar-workflows'));
     expect(await screen.findByTestId('browser-rail')).toBeInTheDocument();
-    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
-    expect(screen.queryByText('What do you want to build?')).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Workflows' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-60');
 
-    Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
+    fireEvent.click(screen.getByTestId('browser-rail-dismiss'));
+    expect(await screen.findByText('Plan graph')).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-60');
+
+    fireEvent.click(screen.getByTestId('sidebar-collapse-toggle'));
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    expect(await screen.findByTestId('planning-session-rail')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Planning Terminal' })).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+
+    fireEvent.click(screen.getByTestId('sidebar-attention'));
+    expect(await screen.findByTestId('browser-rail')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Needs Attention' })).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+
+    fireEvent.click(screen.getByTestId('sidebar-running'));
+    expect(screen.getByRole('heading', { name: 'Running' })).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+
+    fireEvent.click(screen.getByTestId('sidebar-workers'));
+    expect(await screen.findByTestId('action-queue-section')).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+
+    fireEvent.click(screen.getByTestId('sidebar-home'));
+    expect(await screen.findByText('Plan graph')).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+
+    fireEvent.click(screen.getByTestId('sidebar-collapse-toggle'));
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-60');
   });
   it('keeps the manual app sidebar width while switching left rail surfaces', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });


### PR DESCRIPTION
## Summary

Switching sections in the left rail no longer snaps the app sidebar wider or narrower. The sidebar keeps the width you last picked.

Before, opening Workflows or Needs Attention forced the sidebar narrow, and going Home forced it wide, so your manual choice kept getting overwritten.

Now only the collapse toggle, plus the full reset flows like Clear, ever change the sidebar width.

## Review Claim

Approve that left-rail navigation and browser-surface dismissal never resize the app sidebar; only the collapse toggle and the reset flows do.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the four navigation-time `setSidebarCollapsed` calls are removed. The collapse toggle and the Clear / Delete-DB reset paths keep their width control. The rewritten component test and the end-to-end proof assert the width now persists across every left-rail surface switch.

## Slice Rationale

This slice carries the user-visible behavior change together with the component and end-to-end proofs that assert it; those proofs would break if held back. The pixel-screenshot harness tweak rides on top as its own slice.

## Non-goals

- Does not alter the collapse toggle itself or the Clear / Delete-DB reset flows.
- Does not touch the pixel-screenshot harness; that is the follow-up slice.
- Adds no new sidebar sections, icons, or styling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && npx vitest run src/__tests__/app-launch.test.tsx` — 14 passed, including "keeps sidebar width under explicit toggle control while surfaces change".
- [ ] `playwright / 1-of-3` shard exercising `e2e/visual-proof.spec.ts` "sidebar-collapse-state — manual sidebar width survives left rail navigation".

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
