### PR TITLE
[UI Responsiveness Guardrails Step 1](1) Instrument chat and terminal perf markers

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2059,6 +2059,15 @@ function createEmbeddedTerminalBackendFromConfig(
     workflowMetadataCoalescedRequests: 0,
     largeTaskDeltaBatches: 0,
     maxTaskDeltaBatchSize: 0,
+    // Chat + embedded-terminal hot-path markers (renderer → reportUiPerf).
+    maxChatInputRenderMs: 0,
+    chatInputRenderReports: 0,
+    maxTerminalAttachMs: 0,
+    terminalAttachReports: 0,
+    maxTerminalOutputWriteMs: 0,
+    maxTerminalOutputBurstBytes: 0,
+    maxTerminalOutputBurstChunks: 0,
+    terminalOutputBurstReports: 0,
   };
   const startupMarks = new Map<string, number>();
   const startupPhaseDetails: Array<Record<string, unknown>> = [];
@@ -2121,6 +2130,14 @@ function createEmbeddedTerminalBackendFromConfig(
     uiPerfStats.workflowMetadataCoalescedRequests = 0;
     uiPerfStats.largeTaskDeltaBatches = 0;
     uiPerfStats.maxTaskDeltaBatchSize = 0;
+    uiPerfStats.maxChatInputRenderMs = 0;
+    uiPerfStats.chatInputRenderReports = 0;
+    uiPerfStats.maxTerminalAttachMs = 0;
+    uiPerfStats.terminalAttachReports = 0;
+    uiPerfStats.maxTerminalOutputWriteMs = 0;
+    uiPerfStats.maxTerminalOutputBurstBytes = 0;
+    uiPerfStats.maxTerminalOutputBurstChunks = 0;
+    uiPerfStats.terminalOutputBurstReports = 0;
   };
 
   const getUiPerfStats = (): Record<string, unknown> => ({
@@ -4383,6 +4400,26 @@ function createEmbeddedTerminalBackendFromConfig(
       }
       if (metric === 'renderer_long_task' && typeof data?.durationMs === 'number') {
         uiPerfStats.maxRendererLongTaskMs = Math.max(uiPerfStats.maxRendererLongTaskMs, data.durationMs);
+      }
+      if (metric === 'chat_input_render' && typeof data?.latencyMs === 'number') {
+        uiPerfStats.maxChatInputRenderMs = Math.max(uiPerfStats.maxChatInputRenderMs, data.latencyMs);
+        uiPerfStats.chatInputRenderReports += 1;
+      }
+      if (metric === 'terminal_attach' && typeof data?.attachMs === 'number') {
+        uiPerfStats.maxTerminalAttachMs = Math.max(uiPerfStats.maxTerminalAttachMs, data.attachMs);
+        uiPerfStats.terminalAttachReports += 1;
+      }
+      if (metric === 'terminal_output_burst') {
+        if (typeof data?.maxWriteMs === 'number') {
+          uiPerfStats.maxTerminalOutputWriteMs = Math.max(uiPerfStats.maxTerminalOutputWriteMs, data.maxWriteMs);
+        }
+        if (typeof data?.bytes === 'number') {
+          uiPerfStats.maxTerminalOutputBurstBytes = Math.max(uiPerfStats.maxTerminalOutputBurstBytes, data.bytes);
+        }
+        if (typeof data?.chunks === 'number') {
+          uiPerfStats.maxTerminalOutputBurstChunks = Math.max(uiPerfStats.maxTerminalOutputBurstChunks, data.chunks);
+        }
+        uiPerfStats.terminalOutputBurstReports += 1;
       }
       uiPerfStats.rendererReports += 1;
       try {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -258,6 +258,7 @@ export function createMockInvoker(
     replaceTask: vi.fn(async () => accepted('invoker:replace-task')),
     getActivityLogs: vi.fn(async () => []),
     getEvents: vi.fn(async () => []),
+    reportUiPerf: vi.fn(async () => {}),
     openTerminal: vi.fn(async (taskId: string) => ({
       opened: true,
       session: {

--- a/packages/ui/src/__tests__/invoker-terminal.test.tsx
+++ b/packages/ui/src/__tests__/invoker-terminal.test.tsx
@@ -393,4 +393,22 @@ describe('Invoker terminal (component)', () => {
 
     await waitFor(() => expect(transcript.scrollTop).toBe(500));
   });
+
+  it('emits a chat render-churn marker while typing in the planning input', async () => {
+    render(<App />);
+    await openPlanningTerminal();
+
+    fireEvent.change(screen.getByTestId('invoker-terminal-input'), { target: { value: 'hello' } });
+
+    await waitFor(() => {
+      expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+        'chat_input_render',
+        expect.objectContaining({
+          latencyMs: expect.any(Number),
+          valueLength: 5,
+          lineCount: expect.any(Number),
+        }),
+      );
+    });
+  });
 });

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -432,4 +432,48 @@ describe('Terminal drawer (component)', () => {
       expect(mock.api.terminalClose).toHaveBeenCalledWith('mock-session-task-alpha');
     });
   });
+
+  it('emits a terminal_attach marker when a session pane mounts', () => {
+    const session = makeTerminalSession('task-alpha');
+    render(
+      <TerminalDrawer
+        state="maximized"
+        onCycle={vi.fn()}
+        sessions={[session]}
+        activeSessionId={session.sessionId}
+        onSelectSession={vi.fn()}
+        onCloseSession={vi.fn()}
+      />,
+    );
+
+    expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+      'terminal_attach',
+      expect.objectContaining({ attachMs: expect.any(Number), sessionId: session.sessionId }),
+    );
+  });
+
+  it('flushes a terminal_output_burst marker once a chunk burst fills the window', () => {
+    const session = makeTerminalSession('task-alpha');
+    render(
+      <TerminalDrawer
+        state="maximized"
+        onCycle={vi.fn()}
+        sessions={[session]}
+        activeSessionId={session.sessionId}
+        onSelectSession={vi.fn()}
+        onCloseSession={vi.fn()}
+      />,
+    );
+
+    act(() => {
+      for (let i = 0; i < 64; i += 1) {
+        mock.fireTerminalOutput({ sessionId: session.sessionId, taskId: session.taskId, data: 'x'.repeat(16) });
+      }
+    });
+
+    expect(mock.api.reportUiPerf).toHaveBeenCalledWith(
+      'terminal_output_burst',
+      expect.objectContaining({ chunks: 64, bytes: 64 * 16, sessionId: session.sessionId }),
+    );
+  });
 });

--- a/packages/ui/src/components/InvokerTerminal.tsx
+++ b/packages/ui/src/components/InvokerTerminal.tsx
@@ -14,6 +14,9 @@ interface PlanningPresetOptionView {
 
 const TRANSCRIPT_BOTTOM_TOLERANCE_PX = 32;
 
+// Throttle chat render-churn markers so a fast typist emits at most ~2/sec.
+const CHAT_INPUT_REPORT_INTERVAL_MS = 500;
+
 function isTranscriptNearBottom(element: HTMLDivElement): boolean {
   return element.scrollHeight - element.scrollTop - element.clientHeight <= TRANSCRIPT_BOTTOM_TOLERANCE_PX;
 }
@@ -67,6 +70,11 @@ export function InvokerTerminal({
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const transcriptRef = useRef<HTMLDivElement | null>(null);
   const [shouldFollowTranscript, setShouldFollowTranscript] = useState(true);
+  // Timestamp + length of the last keystroke, consumed by the layout effect
+  // below to measure keystroke → committed-render latency. Null when the
+  // pending render was not driven by a keystroke (mount, programmatic clear).
+  const pendingKeystrokeRef = useRef<{ at: number; length: number } | null>(null);
+  const perfThrottleRef = useRef<Record<string, number>>({});
 
   const scrollTranscriptToBottom = useCallback((): void => {
     const transcript = transcriptRef.current;
@@ -84,6 +92,27 @@ export function InvokerTerminal({
       scrollTranscriptToBottom();
     }
   }, [lines.length, scrollTranscriptToBottom, shouldFollowTranscript]);
+
+  // Chat render churn: measure keystroke → committed-render latency. The parent
+  // (App) owns the planning value, so a keystroke round-trips through App's
+  // re-render before this layout effect fires — capturing the full owner render
+  // cost that produces beach-ball stalls while typing. Throttled to bound the
+  // ui-perf log volume; the owner accumulates the max across samples.
+  useLayoutEffect(() => {
+    const pending = pendingKeystrokeRef.current;
+    if (!pending) return;
+    pendingKeystrokeRef.current = null;
+    const latencyMs = performance.now() - pending.at;
+    const now = Date.now();
+    if (now - (perfThrottleRef.current.chat_input_render ?? 0) < CHAT_INPUT_REPORT_INTERVAL_MS) return;
+    perfThrottleRef.current.chat_input_render = now;
+    // Defensive: window.invoker is undefined in vitest/jsdom environments.
+    void window.invoker?.reportUiPerf?.('chat_input_render', {
+      latencyMs: Math.round(latencyMs),
+      valueLength: pending.length,
+      lineCount: lines.length,
+    });
+  }, [value, lines.length]);
 
   const handleTranscriptScroll = useCallback((): void => {
     const transcript = transcriptRef.current;
@@ -250,7 +279,10 @@ export function InvokerTerminal({
           value={value}
           disabled={busy || readOnly}
           rows={expanded ? 8 : 3}
-          onChange={(event) => onValueChange(event.target.value)}
+          onChange={(event) => {
+            pendingKeystrokeRef.current = { at: performance.now(), length: event.target.value.length };
+            onValueChange(event.target.value);
+          }}
           onKeyDown={(event) => {
             if (event.key === 'Enter' && !event.shiftKey && !event.nativeEvent.isComposing && !busy && !readOnly && value.trim()) {
               event.preventDefault();

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -15,6 +15,14 @@ import type { TerminalSessionDescriptor } from '@invoker/contracts';
 
 const DRAWER_BODY_HEIGHT_PX = 280;
 
+// Terminal output-burst pressure: xterm streams task output as many small
+// chunks. Rather than log every chunk, accumulate a rolling window and flush a
+// single marker once the window fills by count (a tight burst) or by time (a
+// slower trickle). Keeps the ui-perf log bounded while still exposing the
+// worst per-window write cost that stalls the renderer.
+const TERMINAL_OUTPUT_BURST_WINDOW_MS = 1000;
+const TERMINAL_OUTPUT_BURST_FLUSH_CHUNKS = 64;
+
 /**
  * The drawer has one explicit state model:
  *   - `minimized`: only the header/tab strip; no terminal body.
@@ -87,15 +95,71 @@ function seedTerminalOutputSnapshot(
   }
 }
 
+type TerminalOutputBurstState = {
+  windowStartedAt: number;
+  chunks: number;
+  bytes: number;
+  writeTotalMs: number;
+  maxWriteMs: number;
+};
+
+/**
+ * Fold one output chunk into the rolling burst window and flush a
+ * `terminal_output_burst` marker when the window fills by chunk count or
+ * elapsed time, then reset the window. `writeMs` is the cost of the xterm
+ * write that produced this chunk.
+ */
+function recordTerminalOutputBurst(
+  ref: { current: TerminalOutputBurstState },
+  sessionId: string,
+  bytes: number,
+  writeMs: number,
+): void {
+  const state = ref.current;
+  const now = performance.now();
+  if (state.windowStartedAt === 0) state.windowStartedAt = now;
+  state.chunks += 1;
+  state.bytes += bytes;
+  state.writeTotalMs += writeMs;
+  if (writeMs > state.maxWriteMs) state.maxWriteMs = writeMs;
+  const windowMs = now - state.windowStartedAt;
+  if (state.chunks < TERMINAL_OUTPUT_BURST_FLUSH_CHUNKS && windowMs < TERMINAL_OUTPUT_BURST_WINDOW_MS) {
+    return;
+  }
+  // Defensive: window.invoker is undefined in vitest/jsdom environments.
+  void window.invoker?.reportUiPerf?.('terminal_output_burst', {
+    sessionId,
+    windowMs: Math.round(windowMs),
+    chunks: state.chunks,
+    bytes: state.bytes,
+    writeTotalMs: Math.round(state.writeTotalMs),
+    maxWriteMs: Math.round(state.maxWriteMs),
+  });
+  state.windowStartedAt = 0;
+  state.chunks = 0;
+  state.bytes = 0;
+  state.writeTotalMs = 0;
+  state.maxWriteMs = 0;
+}
+
 function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPaneProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTermTerminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const seededSnapshotRef = useRef<SeededOutputSnapshot | null>(null);
+  const outputBurstRef = useRef<TerminalOutputBurstState>({
+    windowStartedAt: 0,
+    chunks: 0,
+    bytes: 0,
+    writeTotalMs: 0,
+    maxWriteMs: 0,
+  });
 
   useEffect(() => {
     const host = containerRef.current;
     if (!host) return;
+
+    const attachStartedAt = performance.now();
 
     let term: XTermTerminal;
     let fit: FitAddon;
@@ -117,6 +181,16 @@ function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPa
     termRef.current = term;
     fitRef.current = fit;
 
+    // Embedded xterm attach cost: construction + open into the DOM host, the
+    // synchronous work a task-terminal tab pays before it can stream output.
+    // Defensive: window.invoker is undefined in vitest/jsdom environments.
+    void window.invoker?.reportUiPerf?.('terminal_attach', {
+      attachMs: Math.round(performance.now() - attachStartedAt),
+      sessionId: session.sessionId,
+      hasSnapshot: Boolean(session.outputSnapshot),
+      snapshotBytes: session.outputSnapshot?.length ?? 0,
+    });
+
     seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
 
     const inputDisposable = term.onData((data) => {
@@ -126,11 +200,13 @@ function TerminalSessionPane({ session, isActive, hasHeader }: TerminalSessionPa
     const subscribeToOutput = window.__INVOKER_TEST_ON_TERMINAL_OUTPUT__ ?? window.invoker?.onTerminalOutput;
     const unsubscribeOutput = subscribeToOutput?.((event) => {
       if (event.sessionId !== session.sessionId) return;
+      const writeStartedAt = performance.now();
       try {
         term.write(event.data);
       } catch {
         /* terminal disposed */
       }
+      recordTerminalOutputBurst(outputBurstRef, session.sessionId, event.data.length, performance.now() - writeStartedAt);
     });
 
     const tryFit = () => {


### PR DESCRIPTION
## Summary

Planning chat and the embedded terminal now emit renderer perf markers, so we can see where typing and output bursts stall the UI.

The chat input records keystroke-to-render latency. The terminal records attach cost and output-burst pressure.

The owner process folds these markers into its existing `ui-perf` stats and activity log, so tests and headless reads see the worst-case numbers.

Nothing else changes: no new logging system, no change to how workflows run.

## Review Claim

Approve that chat and terminal emit `chat_input_render`, `terminal_attach`, and `terminal_output_burst` markers through the existing `reportUiPerf` path, and the owner folds them into `ui-perf` stats.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Every marker reuses `window.invoker.reportUiPerf` and is optional-chained, so jsdom tests without a bridge stay safe. The owner only adds max and count fields and reuses the current `ui-perf` activity log.

## Slice Rationale

Evidence first. Later responsiveness guardrails only mean something once typing, terminal attach, and output bursts already emit raw timing numbers, so this measurement slice lands before any threshold work.

## Non-goals

No thresholds, budgets, or alerts. No new logging backend. No change to workflow mutation, task lifecycle, or the terminal backend. No owner query surface beyond the added stat fields.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui test` — exercises the new `chat_input_render`, `terminal_attach`, and `terminal_output_burst` marker tests
- [ ] `pnpm --filter @invoker/app test` — exercises the owner-side `ui-perf` stats rollup in `main.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — the markers are additive, and reverting removes the emit sites and stat fields together
- Data migration? No

</details>