### PR TITLE
[UI Responsiveness Guardrails Step 1](2) Make sidebar auto-collapse follow viewport width

### DIFF
--- a/packages/test-kit/src/mock-git.ts
+++ b/packages/test-kit/src/mock-git.ts
@@ -21,6 +21,7 @@ export class MockGit {
   private scripts: ScriptedResponse[] = [];
   private defaultBranch = 'master';
   private hasStagedChanges = false;
+  private remoteRefs = new Map<string, string>();
 
   /** Script a response for calls matching a predicate. */
   on(match: (args: string[]) => boolean, response: string | Error, once = false): this {
@@ -66,6 +67,7 @@ export class MockGit {
     this.scripts = [];
     this.calls = [];
     this.hasStagedChanges = false;
+    this.remoteRefs.clear();
     return this;
   }
 
@@ -132,7 +134,11 @@ export class MockGit {
     if (args[0] === 'branch') return '';
     if (args[0] === 'symbolic-ref') return `refs/remotes/origin/${this.defaultBranch}`;
     if (args[0] === 'rev-parse') return 'abc123';
-    if (args[0] === 'push') return '';
+    if (args[0] === 'push') {
+      this.recordPush(args);
+      return '';
+    }
+    if (args[0] === 'ls-remote') return this.lsRemote(args);
     // diff --cached --quiet exits non-zero when there are staged changes
     if (args[0] === 'diff' && args.includes('--cached') && args.includes('--quiet')) {
       if (this.hasStagedChanges) {
@@ -141,5 +147,21 @@ export class MockGit {
       return '';
     }
     return '';
+  }
+
+  private recordPush(args: string[]): void {
+    for (const arg of args) {
+      const [, destination] = arg.split(':');
+      if (!destination?.startsWith('refs/heads/')) continue;
+      this.remoteRefs.set(destination, 'abc123');
+    }
+  }
+
+  private lsRemote(args: string[]): string {
+    const headArg = args.at(-1);
+    if (!headArg || headArg === '--') return '';
+    const ref = headArg.startsWith('refs/heads/') ? headArg : `refs/heads/${headArg}`;
+    const sha = this.remoteRefs.get(ref);
+    return sha ? `${sha}\t${ref}\n` : '';
   }
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -678,6 +678,12 @@ export function App() {
     window.invoker?.terminalList?.().then((list) => {
       if (Array.isArray(list) && list.length > 0) {
         setTerminalSessions(list);
+        setActiveTerminalSessionId((prev) =>
+          prev && list.some((session) => session.sessionId === prev)
+            ? prev
+            : list[0]?.sessionId ?? null,
+        );
+        setTerminalDrawerState((prev) => prev === 'minimized' ? 'partial' : prev);
       }
     }).catch(() => {});
   }, []);
@@ -2114,6 +2120,7 @@ export function App() {
   const showStart = hasLoadedPlan && !hasStarted;
   const showStop = hasStarted && !allSettled;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
+  const autoCollapseSidebar = viewportWidth < 1440;
   const autoCollapseInspector = sidebarSurface !== 'home' && viewportWidth < 1440;
   const effectiveInspectorCollapsed = inspectorCollapsed || (autoCollapseInspector && !inspectorManualOpen);
   const showWorkerDetailsPanel = viewMode === 'queue' && sidebarSurface === 'workers';
@@ -2183,7 +2190,7 @@ export function App() {
     setGraphActionsMenuOpen(false);
     if (nextSurface === 'workers') {
       setSidebarSurface('workers');
-      setSidebarCollapsed(true);
+      if (autoCollapseSidebar) setSidebarCollapsed(true);
       setInspectorCollapsed(true);
       setInspectorManualOpen(false);
       setStatusFilters(new Set<WorkflowStatus>());
@@ -2193,23 +2200,23 @@ export function App() {
     setViewMode('dag');
     if (nextSurface === 'home') {
       setSidebarSurface('home');
-      setSidebarCollapsed(false);
+      if (autoCollapseSidebar) setSidebarCollapsed(false);
       setInspectorManualOpen(false);
       return;
     }
     setSidebarSurface(nextSurface);
-    setSidebarCollapsed(true);
+    if (autoCollapseSidebar) setSidebarCollapsed(true);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
-  }, []);
+  }, [autoCollapseSidebar]);
 
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
     setSidebarSurface('home');
-    setSidebarCollapsed(false);
+    if (autoCollapseSidebar) setSidebarCollapsed(false);
     setInspectorManualOpen(false);
     setViewMode('dag');
-  }, []);
+  }, [autoCollapseSidebar]);
 
   // ── Task actions ──────────────────────────────────────────
   const handleProvideInput = useCallback(
@@ -3347,4 +3354,3 @@ export function App() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary

The sidebar now stays open on wide screens. It only auto-collapses when the viewport is narrower than 1440px.

Before, opening the workers or a browser surface always forced the sidebar open or shut, even on a wide monitor with room to spare.

On load, the app also restores the previously active terminal session and reopens the terminal drawer when it was minimized.

The git test double gains push and ls-remote support so tests that publish branches behave like the real thing.

## Review Claim

Approve that sidebar collapse and expand are gated on `viewportWidth < 1440`, so wide viewports keep the sidebar visible while narrow ones still auto-collapse.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change only adds a width guard around existing collapse and expand calls plus a load-time terminal restore. The MockGit additions are test-only and cannot touch production behavior.

## Slice Rationale

This is the responsiveness behavior that the earlier measurement slice motivates. It lands after instrumentation so the perf markers already exist before we start changing layout behavior.

## Non-goals

No change to the perf markers from the first slice. No restyling of the sidebar itself. No change to inspector auto-collapse rules. No production git behavior — the git changes are confined to the test double.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui test` — renders `App` and covers sidebar surface switching behavior
- [ ] `pnpm --filter @invoker/test-kit test` — covers the `MockGit` push and ls-remote behavior

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — reverting restores the previous unconditional collapse behavior and removes the MockGit helpers together
- Data migration? No

</details>

Depends-On: #3421