### PR TITLE
Require UI Vitest check before Mergify merges to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,41 @@ jobs:
       - name: Run quality check
         run: ${{ matrix.command }}
 
+  # UI component suite (@invoker/ui vitest, ~20s). Runs on every PR for early
+  # feedback AND on merge-queue refs, where `.mergify.yml` requires it — this is
+  # the gate that blocks behavioral UI regressions (e.g. the sidebar navigation
+  # guard) that still type-check. Scoped to @invoker/ui on purpose: the full
+  # Vitest Workspace is red on master (worker-registry + SSH executor drift).
+  ui-vitest:
+    name: UI Vitest
+    runs-on:
+      labels: Runner_2_4_core
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .node-version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run UI vitest
+        run: pnpm --filter @invoker/ui test
+
   quality-extra:
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'mergify/merge-queue/') }}
     runs-on:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,8 +19,11 @@ queue_rules:
       - "#approved-reviews-by >= 1"
       - -label=merge-hold
       - "#review-threads-unresolved = 0"
-    # Temporary queue stabilizer: heavy CI still runs on PRs, but does not block
-    # Mergify until the flaky queue-only failures are fixed.
+    # Heavy e2e proof and the full Vitest Workspace run on PRs but do NOT block
+    # Mergify (the whole-workspace suite is currently red on master — unrelated
+    # worker-registry + SSH executor drift). "UI Vitest" runs only @invoker/ui
+    # and IS required: it holds the UI component guards, so a UI regression
+    # cannot merge even when the diff still type-checks.
     merge_conditions:
       - check-success = build-artifacts
       - check-success = quality / Dependency Cruise
@@ -28,6 +31,7 @@ queue_rules:
       - check-success = quality / TypeScript Types
       - check-success = required-fast / Guardrails
       - check-success = required-fast / Submit Workflow Chain
+      - check-success = UI Vitest
       - "#review-threads-unresolved = 0"
 
   - name: admin-bypass
@@ -41,8 +45,11 @@ queue_rules:
       - label=admin-bypass
       - -label=merge-hold
       - "#review-threads-unresolved = 0"
-    # Temporary queue stabilizer: heavy CI still runs on PRs, but does not block
-    # Mergify until the flaky queue-only failures are fixed.
+    # Heavy e2e proof and the full Vitest Workspace run on PRs but do NOT block
+    # Mergify (the whole-workspace suite is currently red on master — unrelated
+    # worker-registry + SSH executor drift). "UI Vitest" runs only @invoker/ui
+    # and IS required: it holds the UI component guards, so a UI regression
+    # cannot merge even when the diff still type-checks.
     merge_conditions:
       - check-success = build-artifacts
       - check-success = quality / Dependency Cruise
@@ -50,6 +57,7 @@ queue_rules:
       - check-success = quality / TypeScript Types
       - check-success = required-fast / Guardrails
       - check-success = required-fast / Submit Workflow Chain
+      - check-success = UI Vitest
       - "#review-threads-unresolved = 0"
 
 pull_request_rules:


### PR DESCRIPTION
## Summary

Adds a required check so the UI tests can block a bad merge.

The `@invoker/ui` test suite already ran in CI, but the merge queue was never told to wait for it. So a UI regression that still compiled could merge anyway.

This adds a small `UI Vitest` job (~20s) that runs the UI tests on every PR and on merge-queue refs.

Both Mergify queue rules now require it to pass before merging.

It is scoped to the UI package on purpose.

The full workspace test run is currently red on master for unrelated reasons — worker-registry drift and SSH executor tests.

Requiring the whole suite would block every merge.

Merge ordering matters: this gate only passes once the sidebar and terminal-restore fixes are on master.

Landing it while master's UI suite is still red would make `UI Vitest` red for every PR and jam the queue. Merge the UI fixes first.

## Review Claim

The merge queue must require a green `@invoker/ui` test run before a PR can merge to master.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only CI workflow config and Mergify queue config change; no product or runtime code is touched. The new job has no `if` gate, so it also runs on ordinary PRs, and its job name (`UI Vitest`) matches the `check-success = UI Vitest` condition added to both queue rules.

## Slice Rationale

This carries only the merge-policy and CI change. The behavior fixes it protects (the sidebar and terminal restores) are a separate PR, so each PR holds one review claim and the diff-atomicity gate stays clean.

## Non-goals

- Does not fix the failing worker-registry + SSH executor tests, so the full Vitest Workspace stays advisory rather than gated.
- Does not include the sidebar / terminal restore fixes themselves (separate behavior PR).
- Does not change the existing advisory `required-fast / Vitest Workspace` job.
- No product or runtime code changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `python3 -c "import yaml; ..."` — `.github/workflows/ci.yml` and `.mergify.yml` parse; the `ui-vitest` job name (`UI Vitest`) matches the `check-success = UI Vitest` condition in both queue rules, and the job has no `if` gate.
- [x] `pnpm --filter @invoker/ui test` — the exact command the new job runs; 598 tests pass once the sidebar/terminal restores are present.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — reverting drops the `UI Vitest` job and its two queue conditions, returning the merge queue to its prior blocking set.
- Data migration? No

</details>
