### PR TITLE
[Recover planning chat drafts with missing closing fence](1) Recover a final YAML plan missing its closing fence

### DIFF
--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -28,6 +28,20 @@ tasks:
     command: echo second
 \`\`\``;
 
+const VALID_PLAN_WITHOUT_CLOSING_FENCE = `Here is the plan.
+
+\`\`\`yaml
+name: Mock Plan
+onFinish: none
+tasks:
+  - id: first
+    description: First task
+    command: echo first
+  - id: second
+    description: Second task
+    dependencies: [first]
+    command: echo second`;
+
 const WORKERS_SURFACE_STACKED_PLAN = `Here is the plan.
 
 \`\`\`yaml
@@ -340,6 +354,42 @@ describe('planning chat', () => {
     });
     expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
   });
+
+  it('submits a valid final draft plan without a closing YAML fence', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN_WITHOUT_CLOSING_FENCE);
+    const sessions = createInAppPlanningChatSessions();
+    const sent = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!sent.ok) throw new Error(sent.error);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+    });
+
+    await expect(submitPlanningChatDraft({
+      sessionId: sent.sessionId,
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({
+      ok: true,
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+    });
+    expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
+  });
+
   it('coalesces concurrent submit requests for one session', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
     const sessions = createInAppPlanningChatSessions();

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -264,10 +264,23 @@ Let me know if you'd like changes!`;
     expect(plan.tasks[0].prompt).toContain('```typescript');
   });
 
-  it('returns null for truncated YAML with no closing fence', () => {
-    const text = '```yaml\nname: "Truncated"\ntasks:\n  - id: t1\n    description: "test"\n    dependencies: []';
+  it('recovers a valid final YAML plan that ends at EOF without a closing fence', () => {
+    const text = '```yaml\nname: "Recoverable"\ntasks:\n  - id: t1\n    description: "test"\n    dependencies: []';
     const result = extractYamlPlan(text);
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    const plan = parsePlanText(result!);
+    expect(plan.name).toBe('Recoverable');
+    expect(plan.tasks[0].id).toBe('t1');
+  });
+
+  it('returns null for incomplete YAML with no closing fence', () => {
+    const text = '```yaml\nname: "Incomplete"\ntasks:\n  - id: t1\n    description: "test"\n    dependencies: [';
+    expect(extractYamlPlan(text)).toBeNull();
+  });
+
+  it('returns null for an invalid plan shape with no closing fence', () => {
+    const text = '```yaml\nname: "Invalid"\ntasks:\n  - id: t1';
+    expect(extractYamlPlan(text)).toBeNull();
   });
 
   it('extracts from the last YAML block when multiple exist', () => {
@@ -339,11 +352,9 @@ Does this look better?`;
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    it('logs when no closing fence found', () => {
-      extractYamlPlan('```yaml\nname: "Truncated"\ntasks:\n  - id: t1\n    description: "test"');
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('no closing fence found'),
-      );
+    it('does not log when a missing closing fence is recovered at EOF', () => {
+      extractYamlPlan('```yaml\nname: "Recovered"\ntasks:\n  - id: t1\n    description: "test"');
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it('logs on YAML parse error', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -605,13 +605,13 @@ export function extractYamlPlan(text: string): string | null {
   }
   const contentStart = fenceStart + '```yaml\n'.length;
   const rest = text.slice(contentStart);
-  // Find closing ``` at start of a line (not indented = not inside YAML block scalar)
+  // Find closing ``` at start of a line (not indented = not inside YAML block scalar).
+  // If the message ends before the closing fence, still try the rest of the
+  // message: the parse/shape checks below keep malformed and partial plans out.
   const closeMatch = rest.match(/^```\s*$/m);
-  if (!closeMatch || closeMatch.index === undefined) {
-    console.warn('extractYamlPlan: no closing fence found for ```yaml block');
-    return null;
-  }
-  const yamlContent = rest.slice(0, closeMatch.index);
+  const yamlContent = closeMatch && closeMatch.index !== undefined
+    ? rest.slice(0, closeMatch.index)
+    : rest;
 
   try {
     const raw = parseYaml(yamlContent);


### PR DESCRIPTION
## Summary

A planner reply can end with a complete YAML plan that lost only its final closing fence.

The parser used to reject that reply, so the finished plan never reached the draft.

Now the parser keeps the plan when the body still validates as a complete Invoker plan. Malformed or partial YAML stays rejected.

## Review Claim

The planning parser should keep a final YAML plan that reaches end-of-message with no closing fence, but only when the parsed plan still validates.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

Extraction stays strict for malformed or mid-block YAML. Only the end-of-message missing-fence case is recovered, and only when the parsed body validates as a complete plan.

## Slice Rationale

The bug lives behind one parser path. Hardening that path and its directly affected regressions belong in one slice; broader partial-output recovery is a different claim and stays out.

## Non-goals

- No broad partial-output or mid-stream recovery.
- No chat UI redesign.
- No change to how drafts are stored or displayed.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/surfaces run test src/__tests__/plan-conversation.test.ts`
- [x] `pnpm --filter @invoker/app run test src/__tests__/in-app-planner.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
