### PR TITLE
[Recover planning chat drafts with missing closing fence](2) Fall back to direct execution for standalone read queries

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -62,6 +62,29 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
+  it('falls back to direct execution for generic standalone reads when no owner exists', async () => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const refreshMessageBus = vi.fn().mockResolvedValue(secondBus);
+    const runElectronHeadless = vi.fn(async () => 23);
+
+    const argv = ['task-status', 'wf-1/task-a'];
+    const exitCode = await runHeadlessClientCommand(argv, {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(23);
+    expect(refreshMessageBus).toHaveBeenCalledTimes(1);
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(runElectronHeadless).toHaveBeenCalledWith(argv);
+  });
+
   it('delegates mutating commands to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -28,6 +28,20 @@ tasks:
     command: echo second
 \`\`\``;
 
+const VALID_PLAN_WITHOUT_CLOSING_FENCE = `Here is the plan.
+
+\`\`\`yaml
+name: Mock Plan
+onFinish: none
+tasks:
+  - id: first
+    description: First task
+    command: echo first
+  - id: second
+    description: Second task
+    dependencies: [first]
+    command: echo second`;
+
 const WORKERS_SURFACE_STACKED_PLAN = `Here is the plan.
 
 \`\`\`yaml
@@ -340,6 +354,42 @@ describe('planning chat', () => {
     });
     expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
   });
+
+  it('submits a valid final draft plan without a closing YAML fence', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN_WITHOUT_CLOSING_FENCE);
+    const sessions = createInAppPlanningChatSessions();
+    const sent = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!sent.ok) throw new Error(sent.error);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+    });
+
+    await expect(submitPlanningChatDraft({
+      sessionId: sent.sessionId,
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({
+      ok: true,
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+    });
+    expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
+  });
+
   it('coalesces concurrent submit requests for one session', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
     const sessions = createInAppPlanningChatSessions();

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -175,22 +175,14 @@ async function delegateGenericReadQuery(
 ): Promise<boolean> {
   if (!isGenericDelegatableReadCommand(args)) return false;
 
-  if (!refreshMessageBus) {
-    const owner = await tryPingHeadlessOwner(bus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
-    if (!owner) return false;
+  let messageBus = bus;
+  let owner = await discoverOwner(messageBus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
+  if (!owner && refreshMessageBus) {
+    messageBus = await refreshMessageBus();
+    owner = await discoverOwner(messageBus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
   }
+  if (!owner) return false;
 
-  const resolver = refreshMessageBus
-    ? createOwnerResolver(
-      { messageBus: bus, refreshMessageBus, ensureStandaloneOwner: async () => {} },
-      { discoveryTimeoutMs: GENERIC_READ_OWNER_PING_TIMEOUT_MS },
-    )
-    : null;
-  const ownerResult = resolver
-    ? await resolver.waitForAny(READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS)
-    : { resolved: true as const, bus };
-  if (!ownerResult.resolved) return false;
-  let messageBus = ownerResult.bus;
   const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
   while (Date.now() < deadline) {
     const response = await tryDelegateQuery(
@@ -219,7 +211,7 @@ function shouldBootstrapStandaloneReadQuery(
   const isSpecialRead =
     (args[0] === 'query' && (args[1] === 'queue' || args[1] === 'ui-perf' || args[1] === 'action-graph'))
     || args[0] === 'queue';
-  return isSpecialRead || isGenericDelegatableReadCommand(args);
+  return isSpecialRead;
 }
 
 async function delegateReadOnlyQuery(

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -264,10 +264,23 @@ Let me know if you'd like changes!`;
     expect(plan.tasks[0].prompt).toContain('```typescript');
   });
 
-  it('returns null for truncated YAML with no closing fence', () => {
-    const text = '```yaml\nname: "Truncated"\ntasks:\n  - id: t1\n    description: "test"\n    dependencies: []';
+  it('recovers a valid final YAML plan that ends at EOF without a closing fence', () => {
+    const text = '```yaml\nname: "Recoverable"\ntasks:\n  - id: t1\n    description: "test"\n    dependencies: []';
     const result = extractYamlPlan(text);
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    const plan = parsePlanText(result!);
+    expect(plan.name).toBe('Recoverable');
+    expect(plan.tasks[0].id).toBe('t1');
+  });
+
+  it('returns null for incomplete YAML with no closing fence', () => {
+    const text = '```yaml\nname: "Incomplete"\ntasks:\n  - id: t1\n    description: "test"\n    dependencies: [';
+    expect(extractYamlPlan(text)).toBeNull();
+  });
+
+  it('returns null for an invalid plan shape with no closing fence', () => {
+    const text = '```yaml\nname: "Invalid"\ntasks:\n  - id: t1';
+    expect(extractYamlPlan(text)).toBeNull();
   });
 
   it('extracts from the last YAML block when multiple exist', () => {
@@ -339,11 +352,9 @@ Does this look better?`;
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    it('logs when no closing fence found', () => {
-      extractYamlPlan('```yaml\nname: "Truncated"\ntasks:\n  - id: t1\n    description: "test"');
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('no closing fence found'),
-      );
+    it('does not log when a missing closing fence is recovered at EOF', () => {
+      extractYamlPlan('```yaml\nname: "Recovered"\ntasks:\n  - id: t1\n    description: "test"');
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it('logs on YAML parse error', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -605,13 +605,13 @@ export function extractYamlPlan(text: string): string | null {
   }
   const contentStart = fenceStart + '```yaml\n'.length;
   const rest = text.slice(contentStart);
-  // Find closing ``` at start of a line (not indented = not inside YAML block scalar)
+  // Find closing ``` at start of a line (not indented = not inside YAML block scalar).
+  // If the message ends before the closing fence, still try the rest of the
+  // message: the parse/shape checks below keep malformed and partial plans out.
   const closeMatch = rest.match(/^```\s*$/m);
-  if (!closeMatch || closeMatch.index === undefined) {
-    console.warn('extractYamlPlan: no closing fence found for ```yaml block');
-    return null;
-  }
-  const yamlContent = rest.slice(0, closeMatch.index);
+  const yamlContent = closeMatch && closeMatch.index !== undefined
+    ? rest.slice(0, closeMatch.index)
+    : rest;
 
   try {
     const raw = parseYaml(yamlContent);


### PR DESCRIPTION
## Summary

Headless read-only commands try to hand a generic query to an owner process first.

When no owner answered, the command failed instead of doing the read itself.

Now the headless client refreshes its connection once, and if still no owner answers, it runs the read directly. Mutating commands are unchanged.

## Review Claim

A headless standalone read query should still run when no owner endpoint answers, by executing directly after one connection refresh.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Mutating commands keep their existing owner-delegation path. Only generic standalone reads gain the direct fallback, after one connection refresh, so no write ever runs without an owner.

## Slice Rationale

The headless client change is one behavior claim. The e2e build-freshness tooling is a different review unit and ships as its own slice.

## Non-goals

- No change to mutating command delegation.
- No change to owner resolution for the special reads (queue, ui-perf, action-graph).
- No new commands.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app run test src/__tests__/headless-client.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
