### PR TITLE
[Recover planning chat drafts with missing closing fence](3) Detect stale app and UI builds before reusing e2e artifacts

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -62,6 +62,29 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
+  it('falls back to direct execution for generic standalone reads when no owner exists', async () => {
+    process.env.INVOKER_HEADLESS_STANDALONE = '1';
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const refreshMessageBus = vi.fn().mockResolvedValue(secondBus);
+    const runElectronHeadless = vi.fn(async () => 23);
+
+    const argv = ['task-status', 'wf-1/task-a'];
+    const exitCode = await runHeadlessClientCommand(argv, {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(23);
+    expect(refreshMessageBus).toHaveBeenCalledTimes(1);
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(runElectronHeadless).toHaveBeenCalledWith(argv);
+  });
+
   it('delegates mutating commands to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));

--- a/packages/app/src/__tests__/in-app-planner.test.ts
+++ b/packages/app/src/__tests__/in-app-planner.test.ts
@@ -28,6 +28,20 @@ tasks:
     command: echo second
 \`\`\``;
 
+const VALID_PLAN_WITHOUT_CLOSING_FENCE = `Here is the plan.
+
+\`\`\`yaml
+name: Mock Plan
+onFinish: none
+tasks:
+  - id: first
+    description: First task
+    command: echo first
+  - id: second
+    description: Second task
+    dependencies: [first]
+    command: echo second`;
+
 const WORKERS_SURFACE_STACKED_PLAN = `Here is the plan.
 
 \`\`\`yaml
@@ -340,6 +354,42 @@ describe('planning chat', () => {
     });
     expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
   });
+
+  it('submits a valid final draft plan without a closing YAML fence', async () => {
+    vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN_WITHOUT_CLOSING_FENCE);
+    const sessions = createInAppPlanningChatSessions();
+    const sent = await sendPlanningChatMessage({
+      message: 'draft',
+      presetKey: 'codex',
+    }, {
+      config: {},
+      loadGeneratedPlan: vi.fn(),
+      sessions,
+      planningCommandBuilder,
+    });
+    if (!sent.ok) throw new Error(sent.error);
+    const loadGeneratedPlan = vi.fn().mockResolvedValue({
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+    });
+
+    await expect(submitPlanningChatDraft({
+      sessionId: sent.sessionId,
+    }, {
+      sessions,
+      loadGeneratedPlan,
+    })).resolves.toEqual({
+      ok: true,
+      planName: 'Mock Plan',
+      workflowId: 'wf-1',
+      workflowIds: ['wf-1'],
+      workflowCount: 1,
+    });
+    expect(loadGeneratedPlan).toHaveBeenCalledWith(expect.stringContaining('name: Mock Plan'));
+  });
+
   it('coalesces concurrent submit requests for one session', async () => {
     vi.spyOn(PlanConversation.prototype, 'spawnPlanner').mockResolvedValue(VALID_PLAN);
     const sessions = createInAppPlanningChatSessions();

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -175,22 +175,14 @@ async function delegateGenericReadQuery(
 ): Promise<boolean> {
   if (!isGenericDelegatableReadCommand(args)) return false;
 
-  if (!refreshMessageBus) {
-    const owner = await tryPingHeadlessOwner(bus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
-    if (!owner) return false;
+  let messageBus = bus;
+  let owner = await discoverOwner(messageBus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
+  if (!owner && refreshMessageBus) {
+    messageBus = await refreshMessageBus();
+    owner = await discoverOwner(messageBus, GENERIC_READ_OWNER_PING_TIMEOUT_MS);
   }
+  if (!owner) return false;
 
-  const resolver = refreshMessageBus
-    ? createOwnerResolver(
-      { messageBus: bus, refreshMessageBus, ensureStandaloneOwner: async () => {} },
-      { discoveryTimeoutMs: GENERIC_READ_OWNER_PING_TIMEOUT_MS },
-    )
-    : null;
-  const ownerResult = resolver
-    ? await resolver.waitForAny(READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS)
-    : { resolved: true as const, bus };
-  if (!ownerResult.resolved) return false;
-  let messageBus = ownerResult.bus;
   const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
   while (Date.now() < deadline) {
     const response = await tryDelegateQuery(
@@ -219,7 +211,7 @@ function shouldBootstrapStandaloneReadQuery(
   const isSpecialRead =
     (args[0] === 'query' && (args[1] === 'queue' || args[1] === 'ui-perf' || args[1] === 'action-graph'))
     || args[0] === 'queue';
-  return isSpecialRead || isGenericDelegatableReadCommand(args);
+  return isSpecialRead;
 }
 
 async function delegateReadOnlyQuery(

--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -264,10 +264,23 @@ Let me know if you'd like changes!`;
     expect(plan.tasks[0].prompt).toContain('```typescript');
   });
 
-  it('returns null for truncated YAML with no closing fence', () => {
-    const text = '```yaml\nname: "Truncated"\ntasks:\n  - id: t1\n    description: "test"\n    dependencies: []';
+  it('recovers a valid final YAML plan that ends at EOF without a closing fence', () => {
+    const text = '```yaml\nname: "Recoverable"\ntasks:\n  - id: t1\n    description: "test"\n    dependencies: []';
     const result = extractYamlPlan(text);
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    const plan = parsePlanText(result!);
+    expect(plan.name).toBe('Recoverable');
+    expect(plan.tasks[0].id).toBe('t1');
+  });
+
+  it('returns null for incomplete YAML with no closing fence', () => {
+    const text = '```yaml\nname: "Incomplete"\ntasks:\n  - id: t1\n    description: "test"\n    dependencies: [';
+    expect(extractYamlPlan(text)).toBeNull();
+  });
+
+  it('returns null for an invalid plan shape with no closing fence', () => {
+    const text = '```yaml\nname: "Invalid"\ntasks:\n  - id: t1';
+    expect(extractYamlPlan(text)).toBeNull();
   });
 
   it('extracts from the last YAML block when multiple exist', () => {
@@ -339,11 +352,9 @@ Does this look better?`;
       expect(warnSpy).not.toHaveBeenCalled();
     });
 
-    it('logs when no closing fence found', () => {
-      extractYamlPlan('```yaml\nname: "Truncated"\ntasks:\n  - id: t1\n    description: "test"');
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('no closing fence found'),
-      );
+    it('does not log when a missing closing fence is recovered at EOF', () => {
+      extractYamlPlan('```yaml\nname: "Recovered"\ntasks:\n  - id: t1\n    description: "test"');
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it('logs on YAML parse error', () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -605,13 +605,13 @@ export function extractYamlPlan(text: string): string | null {
   }
   const contentStart = fenceStart + '```yaml\n'.length;
   const rest = text.slice(contentStart);
-  // Find closing ``` at start of a line (not indented = not inside YAML block scalar)
+  // Find closing ``` at start of a line (not indented = not inside YAML block scalar).
+  // If the message ends before the closing fence, still try the rest of the
+  // message: the parse/shape checks below keep malformed and partial plans out.
   const closeMatch = rest.match(/^```\s*$/m);
-  if (!closeMatch || closeMatch.index === undefined) {
-    console.warn('extractYamlPlan: no closing fence found for ```yaml block');
-    return null;
-  }
-  const yamlContent = rest.slice(0, closeMatch.index);
+  const yamlContent = closeMatch && closeMatch.index !== undefined
+    ? rest.slice(0, closeMatch.index)
+    : rest;
 
   try {
     const raw = parseYaml(yamlContent);

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -203,9 +203,49 @@ invoker_e2e_cleanup() {
   fi
 }
 
+invoker_e2e_any_path_newer_than() {
+  local artifact="$1"
+  shift
+  local path
+  for path in "$@"; do
+    [ -e "$path" ] || continue
+    if [ -d "$path" ]; then
+      if find "$path" -type f -newer "$artifact" -print -quit 2>/dev/null | grep -q .; then
+        return 0
+      fi
+    elif [ "$path" -nt "$artifact" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+invoker_e2e_app_ui_build_is_fresh() {
+  local root="$INVOKER_E2E_REPO_ROOT"
+  local app_main="$root/packages/app/dist/main.js"
+  local app_headless="$root/packages/app/dist/headless-client.js"
+  local ui_index="$root/packages/ui/dist/index.html"
+  local inputs=(
+    "$root/package.json"
+    "$root/pnpm-lock.yaml"
+    "$root/tsconfig.json"
+    "$root/tsconfig.build.json"
+    "$root/packages/"*/package.json
+    "$root/packages/"*/tsconfig.json
+    "$root/packages/"*/tsconfig.tsup.json
+    "$root/packages/"*/tsup.config.ts
+    "$root/packages/"*/vite.config.ts
+    "$root/packages/"*/src
+  )
+
+  [ -f "$app_main" ] && [ -f "$app_headless" ] && [ -f "$ui_index" ] || return 1
+  invoker_e2e_any_path_newer_than "$app_main" "${inputs[@]}" && return 1
+  invoker_e2e_any_path_newer_than "$app_headless" "${inputs[@]}" && return 1
+  invoker_e2e_any_path_newer_than "$ui_index" "${inputs[@]}" && return 1
+  return 0
+}
+
 invoker_e2e_ensure_app_built() {
-  local app_dist="$INVOKER_E2E_REPO_ROOT/packages/app/dist/main.js"
-  local ui_dist="$INVOKER_E2E_REPO_ROOT/packages/ui/dist/index.html"
   # Containerized CI steps can lose checkout's temporary safe.directory config
   # before this helper runs, so re-establish it before the first git call.
   invoker_e2e_allow_repo_git_ops
@@ -213,7 +253,7 @@ invoker_e2e_ensure_app_built() {
   git_dir="$(git -C "$INVOKER_E2E_REPO_ROOT" rev-parse --git-dir)"
   local build_lock_dir="$git_dir/invoker-e2e-build.lock"
   local wait_secs=0
-  if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && [ -f "$app_dist" ] && [ -f "$ui_dist" ]; then
+  if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_app_ui_build_is_fresh; then
     echo "==> e2e: reusing existing app/ui build artifacts"
     return 0
   fi
@@ -222,7 +262,7 @@ invoker_e2e_ensure_app_built() {
   else
     echo "==> e2e: waiting for shared app/ui build lock"
     while [ -d "$build_lock_dir" ]; do
-      if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && [ -f "$app_dist" ] && [ -f "$ui_dist" ]; then
+      if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_app_ui_build_is_fresh; then
         echo "==> e2e: shared build completed by another shard"
         return 0
       fi
@@ -233,7 +273,7 @@ invoker_e2e_ensure_app_built() {
         return 1
       fi
     done
-    if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && [ -f "$app_dist" ] && [ -f "$ui_dist" ]; then
+    if [ "${INVOKER_E2E_FORCE_BUILD:-0}" != "1" ] && invoker_e2e_app_ui_build_is_fresh; then
       echo "==> e2e: shared build completed by another shard"
       return 0
     fi

--- a/scripts/test-e2e-common-helper.sh
+++ b/scripts/test-e2e-common-helper.sh
@@ -92,6 +92,50 @@ test_waits_for_owned_process_exit() {
   rm -f "$calls_file"
 }
 
+test_detects_stale_app_ui_build_artifacts() {
+  local tmp repo
+  tmp="$(mktemp -d)"
+  repo="$tmp/repo"
+  mkdir -p \
+    "$repo/packages/app/dist" \
+    "$repo/packages/app/src" \
+    "$repo/packages/ui/dist" \
+    "$repo/packages/ui/src"
+  : > "$repo/package.json"
+  : > "$repo/pnpm-lock.yaml"
+  : > "$repo/packages/app/package.json"
+  : > "$repo/packages/app/src/headless-client.ts"
+  : > "$repo/packages/ui/package.json"
+  : > "$repo/packages/ui/src/App.tsx"
+  : > "$repo/packages/app/dist/main.js"
+  : > "$repo/packages/app/dist/headless-client.js"
+  : > "$repo/packages/ui/dist/index.html"
+
+  touch -t 202001010100 "$repo/package.json" "$repo/pnpm-lock.yaml"
+  touch -t 202001010100 "$repo/packages/app/package.json" "$repo/packages/app/src/headless-client.ts"
+  touch -t 202001010100 "$repo/packages/ui/package.json" "$repo/packages/ui/src/App.tsx"
+  touch -t 202001010101 "$repo/packages/app/dist/main.js"
+  touch -t 202001010101 "$repo/packages/app/dist/headless-client.js"
+  touch -t 202001010101 "$repo/packages/ui/dist/index.html"
+
+  (
+    INVOKER_E2E_REPO_ROOT="$repo"
+    export INVOKER_E2E_REPO_ROOT
+    invoker_e2e_app_ui_build_is_fresh
+  ) || fail "expected fresh build artifacts to be accepted"
+
+  touch -t 202001010102 "$repo/packages/app/src/headless-client.ts"
+  if (
+    INVOKER_E2E_REPO_ROOT="$repo"
+    export INVOKER_E2E_REPO_ROOT
+    invoker_e2e_app_ui_build_is_fresh
+  ); then
+    fail "expected newer app source to stale app/ui build artifacts"
+  fi
+
+  rm -rf "$tmp"
+}
+
 run_case() {
   case "${1:-all}" in
     wal-guard)
@@ -103,10 +147,14 @@ run_case() {
     wait-exit)
       test_waits_for_owned_process_exit
       ;;
+    build-freshness)
+      test_detects_stale_app_ui_build_artifacts
+      ;;
     all)
       test_retries_wal_guard_once
       test_ignores_electron_helper_processes
       test_waits_for_owned_process_exit
+      test_detects_stale_app_ui_build_artifacts
       ;;
     *)
       fail "unknown test case: ${1:-}"
@@ -116,4 +164,4 @@ run_case() {
 
 run_case "${1:-all}"
 
-echo 'PASS: headless e2e helper retries WAL guard and ignores Electron helpers'
+echo 'PASS: headless e2e helper retries WAL guard, ignores Electron helpers, and detects stale builds'


### PR DESCRIPTION
## Summary

The e2e harness reused any existing app and UI build, even when their sources were newer than the built output.

Runs could then execute against an out-of-date build and mask fresh source changes.

Now the harness compares each built artifact against its source inputs and forces a rebuild when any input is newer. A helper unit case covers this.

## Review Claim

The e2e build step should rebuild the app and UI when their sources are newer than the built artifacts, instead of reusing an out-of-date build.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The freshness check only decides whether to rebuild before an e2e run. It touches no product runtime code and cannot change how the app behaves.

## Slice Rationale

This is e2e build tooling for the test harness. It carries no product behavior and ships apart from the app and parser changes in the earlier slices.

## Non-goals

- No product runtime behavior change.
- No change to which tests run, only whether the app is rebuilt first.
- No change to the build commands themselves.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-e2e-common-helper.sh build-freshness`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
