### PR TITLE
[Worker Tab Scroll](1) Scroll the Worker tab's Worker Processes pane

### DIFF
--- a/packages/app/e2e/worker-tab-scroll.spec.ts
+++ b/packages/app/e2e/worker-tab-scroll.spec.ts
@@ -1,0 +1,37 @@
+// E2E regression guard: the Worker tab's Worker Processes pane must scroll when
+// it overflows. Before the flex-col wrapper fix the pane grew to content height
+// (clientHeight === scrollHeight) and could not scroll.
+
+import { test, expect } from './fixtures/electron-app.js';
+
+test.describe('Worker tab scroll', () => {
+  test('worker processes list scrolls when it overflows', async ({ page }) => {
+    // Short window so the built-in workers overflow the pane.
+    await page.setViewportSize({ width: 1100, height: 640 });
+
+    await page.getByTestId('sidebar-workers').click();
+
+    const section = page.getByTestId('worker-processes-section');
+    await expect(section).toBeVisible();
+    await expect(page.getByTestId('worker-row-autofix')).toBeVisible();
+
+    const pane = section.locator('> div').first();
+
+    const metrics = await pane.evaluate((el) => ({
+      clientHeight: el.clientHeight,
+      scrollHeight: el.scrollHeight,
+    }));
+    expect(metrics.scrollHeight).toBeGreaterThan(metrics.clientHeight);
+
+    // Scroll in steps so the walkthrough video shows motion.
+    const maxScroll = metrics.scrollHeight - metrics.clientHeight;
+    for (let step = 1; step <= 6; step += 1) {
+      await pane.evaluate((el, top) => {
+        el.scrollTop = top;
+      }, Math.round((maxScroll * step) / 6));
+      await page.waitForTimeout(150);
+    }
+
+    expect(await pane.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2975,7 +2975,7 @@ export function App() {
           </div>
         </div>
       </div>
-      <div className="min-h-0 flex-1 overflow-hidden">
+      <div className="min-h-0 flex-1 flex flex-col overflow-hidden">
         {renderGraphCanvas()}
       </div>
       {viewMode === 'dag' && renderGraphTerminalChrome()}


### PR DESCRIPTION
## Summary

The Worker tab could not scroll its Worker Processes panel. When more worker rows existed than fit on screen, the rows past the bottom edge were unreachable.

That panel sat inside a plain block wrapper. The canvas under it sizes its own height from a flex rule that only works inside a flex parent.

Outside a flex parent, the canvas grew to its full content height instead of staying within the window.

So the panel never got a fixed height, and its scrollbar never appeared.

The fix makes that one wrapper a flex column, matching the Home tab, so the canvas keeps the window height and both the Worker Processes and Worker Actions panels scroll.

## Review Claim

Approve making the browser-detail canvas wrapper a flex column so the Worker tab panels get a bounded height and scroll.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This is a one-class change on a single wrapper element. It adds a flex context that the Home surface already depends on, and it changes no data flow, no component behavior, and no other panel styling.

## Slice Rationale

The panel-height fix touches only the browser-detail canvas wrapper, and the short-window guard that pins the fix ships in the same slice. The changelog note lands separately, per the repo's one-lane-per-PR rule.

## Non-goals

Does not change worker data, worker controls, the Home or DAG surfaces, or any panel styling beyond the wrapper's flex context. Does not add a changelog entry (separate slice).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && CAPTURE_VIDEO=1 pnpm test:e2e worker-tab-scroll.spec.ts`
- [ ] Confirmed the same spec fails on the pre-fix build (`clientHeight === scrollHeight`, pane not scrollable).

</details>

## Visual Proof

Screen recording of the Worker tab scrolling through its Worker Processes panel with the fix applied (real Electron app, short window so the built-in workers overflow the pane):

[Worker tab scroll recording](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-efb79e/worker-tab-scroll.webm)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
