### PR TITLE
[Planning chat auto-follow proof](1) Add long-transcript visual proof

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -748,6 +748,69 @@ test.describe('Visual proof capture', () => {
     });
   });
 
+  test('planning chat long transcript — scrollable surface with follow pinned to bottom', async ({ page }) => {
+    // Render a long planning transcript by sending several user messages and
+    // returning a long assistant reply for each turn. This exercises the same
+    // setTestPlanningChatResponse helper used by the other planning proofs and
+    // produces a scrollable transcript surface suitable for a visual snapshot.
+    const longReplyLines = Array.from(
+      { length: 30 },
+      (_, index) => `Assistant line ${index + 1}: ${'lorem ipsum dolor sit amet '.repeat(4)}`,
+    );
+    const planYaml = yamlStringify({
+      name: 'Long Transcript Visual Proof',
+      repoUrl: E2E_REPO_URL,
+      onFinish: 'none' as const,
+      tasks: [
+        {
+          id: 'lt-proof',
+          description: 'Long transcript proof task',
+          command: 'echo ok',
+          dependencies: [] as string[],
+        },
+      ],
+    });
+
+    await page.getByTestId('sidebar-planning').click();
+    await expect(page.getByRole('heading', { name: 'Planning Terminal' })).toBeVisible();
+
+    const transcript = page.getByTestId('invoker-terminal-transcript');
+    await expect(transcript).toBeVisible();
+
+    const sendCount = 5;
+    for (let i = 0; i < sendCount; i += 1) {
+      const marker = `long-reply-marker-${i + 1}`;
+      const reply = [`${marker}`, ...longReplyLines].join('\n');
+      await page.evaluate(async ({ planYaml: py, replyText }) => {
+        await window.invoker.setTestPlanningChatResponse({ planYaml: py, reply: replyText });
+      }, { planYaml: planYaml, replyText: reply });
+
+      await page.getByTestId('invoker-terminal-input').fill(`Prompt ${i + 1}`);
+      await page.getByRole('button', { name: 'Send' }).click();
+      await expect(transcript).toContainText(marker);
+    }
+
+    await expect(transcript).toContainText('Prompt 1');
+    await expect(transcript).toContainText(`Prompt ${sendCount}`);
+    await expect(transcript).toContainText('Assistant line 30');
+
+    const { scrollHeight, clientHeight, scrollTop } = await transcript.evaluate((el) => ({
+      scrollHeight: el.scrollHeight,
+      clientHeight: el.clientHeight,
+      scrollTop: el.scrollTop,
+    }));
+    expect(scrollHeight).toBeGreaterThan(clientHeight);
+    // Follow mode should have kept the transcript pinned to the bottom after
+    // the last assistant reply arrived.
+    expect(scrollHeight - scrollTop - clientHeight).toBeLessThanOrEqual(1);
+
+    await captureScreenshot(page, 'planning-chat-long-transcript');
+
+    await page.evaluate(async () => {
+      await window.invoker.setTestPlanningChatResponse(null);
+    });
+  });
+
   test('terminal planning submits Workers Surface as stacked workflows', async ({ page }) => {
     const plannedYaml = yamlStringify(WORKERS_SURFACE_STACKED_PLAN);
     await page.evaluate(async ({ planYaml, planName }) => {


### PR DESCRIPTION
## Summary

Adds a planning chat visual-proof case with a deliberately long transcript.

The case drives multiple prompts, waits for long assistant replies, and asserts the transcript remains pinned at the bottom.

This gives reviewers a reusable screenshot surface for auto-follow regressions.

## Review Claim

Approve the long-transcript planning chat visual-proof case for the auto-follow contract.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

This slice only extends an e2e proof spec. It does not change planner runtime, renderer state logic, or production UI code.

## Slice Rationale

The proof lands after the auto-follow behavior so review can focus on visual evidence for the already-defined follow contract.

## Non-goals

- Does not change planner backend behavior.
- Does not reopen renderer follow-state logic.
- Does not add a new screenshot harness outside the standard visual-proof path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/invoker-terminal.test.tsx`
- [x] `bash scripts/ui-visual-proof.sh capture-after`
- [x] `pnpm run test:all`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 08520dd8af5c7032eece0fb88157b422f7fc83d4`
- Post-revert steps: None
- Data migration? No

</details>
