### PR TITLE
[UI regression guard](1) Restore sidebar width + terminal tabs reverted by #3347

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -523,7 +523,7 @@ export function App() {
   const graphActionsMenuRef = useRef<HTMLDivElement>(null);
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
   const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
-  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean | null>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkerKind, setSelectedWorkerKind] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
@@ -678,6 +678,8 @@ export function App() {
     window.invoker?.terminalList?.().then((list) => {
       if (Array.isArray(list) && list.length > 0) {
         setTerminalSessions(list);
+        setActiveTerminalSessionId(list[list.length - 1]?.sessionId ?? null);
+        setTerminalDrawerState('partial');
       }
     }).catch(() => {});
   }, []);
@@ -2065,7 +2067,7 @@ export function App() {
       setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
-      setSidebarCollapsed(false);
+      setSidebarCollapsed(null);
       setViewMode('dag');
       setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
@@ -2090,7 +2092,7 @@ export function App() {
       setHasStarted(false);
       setPlanName(null);
       setSidebarSurface('home');
-      setSidebarCollapsed(false);
+      setSidebarCollapsed(null);
       setViewMode('dag');
       setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
@@ -2114,6 +2116,8 @@ export function App() {
   const showStart = hasLoadedPlan && !hasStarted;
   const showStop = hasStarted && !allSettled;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
+  const autoCollapseSidebar = sidebarSurface !== 'home' && sidebarSurface !== 'planning' && viewportWidth < 1440;
+  const effectiveSidebarCollapsed = sidebarCollapsed ?? autoCollapseSidebar;
   const autoCollapseInspector = sidebarSurface !== 'home' && viewportWidth < 1440;
   const effectiveInspectorCollapsed = inspectorCollapsed || (autoCollapseInspector && !inspectorManualOpen);
   const showWorkerDetailsPanel = viewMode === 'queue' && sidebarSurface === 'workers';
@@ -2183,7 +2187,6 @@ export function App() {
     setGraphActionsMenuOpen(false);
     if (nextSurface === 'workers') {
       setSidebarSurface('workers');
-      setSidebarCollapsed(true);
       setInspectorCollapsed(true);
       setInspectorManualOpen(false);
       setStatusFilters(new Set<WorkflowStatus>());
@@ -2193,12 +2196,10 @@ export function App() {
     setViewMode('dag');
     if (nextSurface === 'home') {
       setSidebarSurface('home');
-      setSidebarCollapsed(false);
       setInspectorManualOpen(false);
       return;
     }
     setSidebarSurface(nextSurface);
-    setSidebarCollapsed(true);
     setInspectorManualOpen(false);
     setStatusFilters(new Set<WorkflowStatus>());
   }, []);
@@ -2206,7 +2207,6 @@ export function App() {
   const handleDismissBrowserSurface = useCallback(() => {
     setGraphActionsMenuOpen(false);
     setSidebarSurface('home');
-    setSidebarCollapsed(false);
     setInspectorManualOpen(false);
     setViewMode('dag');
   }, []);
@@ -3038,9 +3038,9 @@ export function App() {
           workerStatus={workerStatus}
           planningSessionCount={planningSessions.length}
           selectedSurface={sidebarSurface}
-          collapsed={sidebarCollapsed}
+          collapsed={effectiveSidebarCollapsed}
           onSelectSurface={handleSelectSidebarSurface}
-          onToggleCollapsed={() => setSidebarCollapsed((value) => !value)}
+          onToggleCollapsed={() => setSidebarCollapsed(!effectiveSidebarCollapsed)}
           onOpenSettings={() => {
             cancelPendingSystemSetupAutoOpen();
             setShowSystemSetup(true);


### PR DESCRIPTION
## Summary

Keeps the left sidebar at the width you chose when you switch surfaces.

A merge (#3347) branched off a pre-fix base and undid two earlier fixes, while leaving their tests in place.

This restores the sidebar width persistence and the embedded terminal tab restore.

The sidebar now only auto-collapses on a narrow window when you have not set a width yourself. Switching surfaces never overrides your choice.

## Review Claim

Restore the sidebar-width persistence and terminal-tab restore behavior that #3347 reverted.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Touches only `packages/ui/src/App.tsx`. `sidebarCollapsed` becomes `boolean | null` (null means "no manual choice"); switching surfaces no longer calls `setSidebarCollapsed`; the startup terminal effect re-selects the recovered session and opens the drawer. Existing regression tests (the app-launch guard and the `sidebar-collapse-state` visual-proof case) cover both behaviors and pass with this change.

## Slice Rationale

Behavior-only slice. The CI and merge-queue gate that stops this class of regression, and the changelog, are the next PRs in the stack, so each PR carries one lane.

## Non-goals

- Does not add or change the UI test gate (next PR in the stack).
- Does not touch the changelog (top PR in the stack).
- Does not address the unrelated worker-registry / SSH executor test failures.

## Visual Proof

A four-frame sequence (each frame shows a different surface, proving navigation happened, with the chosen width preserved beside it), plus a walkthrough video.

Frame 1 — Workflows surface, sidebar manually expanded (full-width rail with text labels):

![frame 1 — workflows, manually expanded](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-14e102/sidebar-collapse-state-1-workflows-manually-expanded.png)

Frame 2 — after navigating to Needs Attention, the sidebar stays expanded (width preserved across navigation):

![frame 2 — needs attention, still expanded](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-14e102/sidebar-collapse-state-2-attention-after-navigation.png)

Frame 3 — back on Workflows, sidebar manually collapsed (narrow icon-only rail):

![frame 3 — workflows, manually collapsed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-14e102/sidebar-collapse-state-3-workflows-manually-collapsed.png)

Frame 4 — after navigating to Home, the sidebar stays collapsed (collapse preserved across navigation):

![frame 4 — home, still collapsed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-14e102/sidebar-collapse-state-4-home-still-collapsed.png)

Walkthrough video (collapse toggle, then navigate across surfaces, width preserved throughout):

![sidebar width persistence walkthrough](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-14e102/sidebar-collapse-state-walkthrough.webm)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test` — the app-launch guard `keeps the manual app sidebar width while switching left rail surfaces` passes (598 tests).
- [x] `CAPTURE_MODE=after npx playwright test visual-proof.spec.ts -g "sidebar-collapse-state"` — the four-frame walkthrough passes and produced the proof above.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — reverting restores the prior (reverted) sidebar/terminal behavior; the regression tests would fail again, which is the expected signal.
- Data migration? No

</details>
