### PR TITLE
Godfile app step 2: extract renderer-task-feed

### DIFF
--- a/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
+++ b/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
@@ -6,8 +6,9 @@
  * lines in ~/.invoker/invoker.log with no intervening recovery, after which
  * the selected workflow's mini-DAG renders blank until the user reloads.
  *
- * Owner-side root cause (current production code at
- * packages/app/src/main.ts:2896–2904):
+ * Owner-side root cause (the pre-fix owner recovery loop; the current loop
+ * lives in `applyTaskDeltaToOwnerCacheOrRecover` in
+ * packages/app/src/window/renderer-task-feed.ts):
  *
  *   const { quarantined } = applyDelta(d, lastKnownTaskStates);
  *   for (const taskId of quarantined) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -121,7 +121,6 @@ import {
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 import { FileAndDbLogger } from './logger.js';
-import type { TaskOutputData } from './types.js';
 import {
   DEFAULT_SLACK_HARNESS_PRESETS,
   loadConfig,
@@ -202,10 +201,7 @@ import { runInvokerCliSetup } from './invoker-cli-setup.js';
 import { resolveBundledCliPath } from './cli-helper.js';
 import { buildAppMenuTemplate } from './app-menu.js';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
-import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from './delta-merge.js';
 import { CoalescedWorkflowMetadataPublisher } from './workflow-metadata-invalidation.js';
-import { WorkflowRollupProjection } from './workflow-rollup-projection.js';
-import { seedTaskCachesFromSnapshot } from './viewer-cache-hydration.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -220,7 +216,6 @@ import {
   isDispatchableLaunch,
 } from './global-topup.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
-import { evaluateExecutingStall } from './executing-stall.js';
 
 
 import {
@@ -289,7 +284,8 @@ import {
   requireWiredTaskRunner,
   type TaskHandleMap,
 } from './execution/task-runner-wiring.js';
-import { createWorkflowTaskActions, parseExecutionDate } from './execution/workflow-task-actions.js';
+import { createWorkflowTaskActions } from './execution/workflow-task-actions.js';
+import { createRendererTaskFeed } from './window/renderer-task-feed.js';
 import {
   createMainWindow,
   registerMainWindowActivateHandler,
@@ -1998,11 +1994,9 @@ function createEmbeddedTerminalBackendFromConfig(
   // `activeExecutions` count now just reflects spawned execution
   // handles in `taskHandles`.
   const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
-  let dbPollInterval: ReturnType<typeof setInterval> | null = null;
-  let activityPollInterval: ReturnType<typeof setInterval> | null = null;
+  let dbPollStop: (() => void) | null = null;
+  let activityPollStop: (() => void) | null = null;
   let uiPerfLogInterval: ReturnType<typeof setInterval> | null = null;
-  const lastKnownTaskStates = new TaskSnapshotCache();
-  const workflowRollupProjection = new WorkflowRollupProjection();
   const deferredWorkflowLaunches = new Map<string, {
     timer: ReturnType<typeof setTimeout>;
     taskIds: string[];
@@ -2018,20 +2012,8 @@ function createEmbeddedTerminalBackendFromConfig(
       { module: 'ipc-delegate' },
     );
   };
-  const pendingOutputBuffers = new Map<string, string[]>();
-  const outputFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
   let workflowMetadataPublisher: CoalescedWorkflowMetadataPublisher | null = null;
-  let lastKnownWorkflowCount = 0;
-  let lastActivityLogId = 0;
   let startupWorkflowId: string | null = null;
-  // In detached viewer mode the local DB is an empty in-memory copy. Workflow
-  // metadata for the bootstrap getter comes from the owner snapshot; task state
-  // is derived live from `lastKnownTaskStates` (kept current by deltas).
-  let detachedViewerWorkflows: unknown[] | null = null;
-  // While the detached viewer hydrates, owner deltas are buffered here and
-  // replayed after the cache is seeded, so an update arriving mid-hydration is
-  // not applied against an empty cache (quarantined and dropped).
-  let detachedDeltaBuffer: TaskDelta[] | null = null;
   let uiInteractive = false;
   let deferredStartupTriggered = false;
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
@@ -2128,43 +2110,6 @@ function createEmbeddedTerminalBackendFromConfig(
     ts: new Date().toISOString(),
   });
 
-  const flushTaskOutput = (taskId: string): void => {
-    const timer = outputFlushTimers.get(taskId);
-    if (timer) {
-      clearTimeout(timer);
-      outputFlushTimers.delete(taskId);
-    }
-    const chunks = pendingOutputBuffers.get(taskId);
-    if (!chunks || chunks.length === 0) {
-      return;
-    }
-    pendingOutputBuffers.delete(taskId);
-    const data = chunks.join('');
-    if (traceTaskOutput) {
-      logger.info(`${taskId}: ${data.trimEnd()}`, { module: 'output' });
-    }
-    const outputData: TaskOutputData = { taskId, data };
-    messageBus.publish(Channels.TASK_OUTPUT, outputData);
-    try {
-      // Runner stream chunks land in the output spool only — task_output is
-      // reserved for explicit diagnostic writes (workflow actions, shutdown).
-      persistence.appendOutputChunk(taskId, data);
-    } catch (err) {
-      logger.error(`Failed to persist output for ${taskId}: ${err}`, { module: 'output' });
-    }
-  };
-
-  const enqueueTaskOutput = (taskId: string, data: string): void => {
-    const chunks = pendingOutputBuffers.get(taskId) ?? [];
-    chunks.push(data);
-    pendingOutputBuffers.set(taskId, chunks);
-    if (outputFlushTimers.has(taskId)) {
-      return;
-    }
-    const timer = setTimeout(() => flushTaskOutput(taskId), 100);
-    timer.unref?.();
-    outputFlushTimers.set(taskId, timer);
-  };
 
   const taskDeltaStream = createTaskDeltaStreamSequence();
   const getTaskDeltaStreamSequence = (): number => taskDeltaStream.current();
@@ -2185,30 +2130,6 @@ function createEmbeddedTerminalBackendFromConfig(
     onEvent: (event) => webBridge?.broadcast('invoker:task-graph-event', event),
   });
 
-  const publishTaskDeltaToRenderer = (delta: TaskDelta): void => {
-    const workflowRollups = workflowRollupProjection.applyDelta(delta);
-    taskGraphEventPublisher.publishDelta(delta, workflowRollups);
-  };
-
-  const applyTaskDeltaToOwnerCacheOrRecover = (delta: TaskDelta): TaskDelta[] => {
-    const { quarantined, accepted } = applyDelta(delta, lastKnownTaskStates);
-    if (quarantined.length === 0) {
-      return accepted ? [delta] : [];
-    }
-
-    const rendererDeltas: TaskDelta[] = [];
-    for (const taskId of quarantined) {
-      logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
-      const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
-        loadTask: loadTaskByIdFromPersistence,
-        getMergeNode: (workflowId) => orchestrator.getMergeNode(workflowId),
-      });
-      if (rendererDelta) {
-        rendererDeltas.push(rendererDelta);
-      }
-    }
-    return rendererDeltas;
-  };
 
   const requestWorkflowMetadataPublish = (reason: string): void => {
     uiPerfStats.workflowMetadataPublishRequests += 1;
@@ -2246,6 +2167,26 @@ function createEmbeddedTerminalBackendFromConfig(
     runWorkflowMutation,
   });
 
+  const rendererTaskFeed = createRendererTaskFeed({
+    logger,
+    persistence,
+    orchestrator,
+    messageBus,
+    taskGraphEventPublisher,
+    uiPerfStats,
+    taskHandles,
+    getMainWindow: () => mainWindow,
+    getLaunchDispatcher: () => launchDispatcher,
+    requestWorkflowMetadataPublish,
+    scheduleAutoFix,
+    logAutoFixDebug,
+    setStartupWorkflowId: (workflowId) => { startupWorkflowId = workflowId; },
+    traceUiDeltaFlow,
+    traceDbPollPerTask,
+    traceTaskOutput,
+    executingStallTimeoutMs,
+  });
+
   registerMainWindowSecondInstanceHandler({
     app,
     getMainWindow: () => mainWindow,
@@ -2262,8 +2203,8 @@ function createEmbeddedTerminalBackendFromConfig(
       logger,
       messageBus,
       taskHandles,
-      enqueueTaskOutput,
-      flushTaskOutput,
+      enqueueTaskOutput: rendererTaskFeed.enqueueTaskOutput,
+      flushTaskOutput: rendererTaskFeed.flushTaskOutput,
       assertFatalExecutionCapacity,
       getTaskRunner: () => taskExecutor,
       setTaskRunner: (runner) => { taskExecutor = runner; },
@@ -2505,7 +2446,7 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'invoker:stop-worker':
         return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
-        const workflows = detachedViewerWorkflows ?? persistence.listWorkflows();
+        const workflows = rendererTaskFeed.getDetachedViewerWorkflows() ?? persistence.listWorkflows();
         const firstWorkflow = workflows[0] as { id?: unknown } | undefined;
         const workflowId = startupWorkflowId
           ?? (typeof firstWorkflow?.id === 'string' ? firstWorkflow.id : undefined);
@@ -2643,87 +2584,6 @@ function createEmbeddedTerminalBackendFromConfig(
     });
   }
 
-  function seedUiSnapshotCache(): void {
-    lastKnownWorkflowCount = persistence.listWorkflows().length;
-    seedTaskCachesFromSnapshot(orchestrator.getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
-  }
-
-  // Detached viewer: the local DB is empty, so seed the delta caches and
-  // bootstrap snapshot from the owner. Without this, the empty cache quarantines
-  // every `updated` delta for a task the viewer has not seen (dropping live
-  // updates), and bootstrap getters return nothing. Failures are non-fatal — the
-  // renderer's delegated reads still populate the view.
-  async function hydrateDetachedViewerFromOwner(): Promise<void> {
-    try {
-      const snapshot = await messageBus.request<{ kind: string }, { tasks?: TaskState[]; workflows?: unknown[] }>(
-        'headless.query',
-        { kind: 'tasks' },
-      );
-      const tasks = Array.isArray(snapshot?.tasks) ? snapshot.tasks : [];
-      const workflows = Array.isArray(snapshot?.workflows) ? snapshot.workflows : [];
-      detachedViewerWorkflows = workflows;
-      seedTaskCachesFromSnapshot(tasks, { lastKnownTaskStates, workflowRollupProjection });
-      lastKnownWorkflowCount = workflows.length;
-      startupWorkflowId = [...workflows]
-        .map((wf) => wf as { id?: string; updatedAt?: string; createdAt?: string })
-        .sort((left, right) => (Date.parse(right.updatedAt ?? '') || 0) - (Date.parse(left.updatedAt ?? '') || 0))[0]?.id ?? null;
-      logger.info(
-        `[init] Hydrated detached viewer from owner: ${tasks.length} tasks across ${workflows.length} workflows`,
-        { module: 'init' },
-      );
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.warn(`detached viewer hydration from owner failed; relying on delegated reads: ${message}`, { module: 'init' });
-    } finally {
-      // Resume direct delta processing and replay anything buffered during
-      // hydration (in arrival order). Always runs, so a hydration failure can
-      // never leave deltas buffered forever.
-      const buffered = detachedDeltaBuffer ?? [];
-      detachedDeltaBuffer = null;
-      for (const delta of buffered) processIncomingTaskDelta(delta);
-    }
-  }
-
-  // Current task states for the detached viewer's bootstrap getter, derived from
-  // the live delta cache so a renderer reload never sees the stale hydration
-  // snapshot.
-  function detachedViewerTasks(): TaskState[] {
-    return [...lastKnownTaskStates.keys()].map(
-      (taskId) => JSON.parse(lastKnownTaskStates.get(taskId) ?? '{}') as TaskState,
-    );
-  }
-
-  // Apply one owner task delta to the local cache and forward results to the
-  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
-  // can replay deltas that were buffered during hydration.
-  function processIncomingTaskDelta(d: TaskDelta): void {
-    uiPerfStats.mainDeltaToUi += 1;
-    if (traceUiDeltaFlow) {
-      logger.debug(`delta→ui: ${JSON.stringify(d)}`, { module: 'ui' });
-    }
-    const deltaTaskId = d.type === 'updated' || d.type === 'removed' ? d.taskId : undefined;
-    if (d.type === 'updated' && d.changes.status === 'failed') {
-      const cancellationError = shouldSkipAutoFixForError(d.changes.execution?.error);
-      const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(d.taskId);
-      logAutoFixDebug(d.taskId, 'delta-failed', {
-        shouldSkipForCancellation: cancellationError,
-        shouldAutoFixFromOrchestrator,
-      });
-      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
-        logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
-        scheduleAutoFix(deltaTaskId);
-      } else if (deltaTaskId) {
-        logAutoFixDebug(deltaTaskId, 'delta-skip', {
-          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
-          shouldSkipForCancellation: cancellationError,
-          shouldAutoFixFromOrchestrator,
-        });
-      }
-    }
-    for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(d)) {
-      publishTaskDeltaToRenderer(rendererDelta);
-    }
-  }
 
   function loadTaskByIdFromPersistence(taskId: string): TaskState | undefined {
     return persistence.loadTask(taskId);
@@ -2732,7 +2592,7 @@ function createEmbeddedTerminalBackendFromConfig(
   workflowMetadataPublisher = new CoalescedWorkflowMetadataPublisher({
     listWorkflows: () => persistence.listWorkflows(),
     publish: (workflows, stats) => {
-      lastKnownWorkflowCount = workflows.length;
+      rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
       uiPerfStats.workflowMetadataPublishes += 1;
       uiPerfStats.workflowMetadataCoalescedRequests += Math.max(0, stats.coalescedRequests - 1);
       if (stats.coalescedRequests > 1) {
@@ -2764,7 +2624,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
   function bootstrapInitialWorkflowState(): void {
     const workflows = listWorkflowsByStartupRecency();
-    lastKnownWorkflowCount = workflows.length;
+    rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
     startupWorkflowId = workflows[0]?.id ?? null;
     if (!startupWorkflowId) {
       logger.info('[init] No workflows available for initial startup bootstrap', { module: 'init' });
@@ -2819,21 +2679,21 @@ function createEmbeddedTerminalBackendFromConfig(
   function publishOrchestratorSnapshotToRenderer(): void {
     const workflows = persistence.listWorkflows();
     const tasks = orchestrator.getAllTasks();
-    const previousTaskIds = new Set(lastKnownTaskStates.keys());
-    lastKnownTaskStates.clear();
-    workflowRollupProjection.replaceAll(tasks);
+    const previousTaskIds = new Set(rendererTaskFeed.lastKnownTaskStates.keys());
+    rendererTaskFeed.lastKnownTaskStates.clear();
+    rendererTaskFeed.workflowRollupProjection.replaceAll(tasks);
     for (const task of tasks) {
       const snapshot = JSON.stringify(task);
       previousTaskIds.delete(task.id);
-      lastKnownTaskStates.set(task.id, snapshot);
+      rendererTaskFeed.lastKnownTaskStates.set(task.id, snapshot);
       if (mainWindow && !mainWindow.isDestroyed()) {
-        publishTaskDeltaToRenderer({ type: 'created', task });
+        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'created', task });
       }
     }
-    lastKnownWorkflowCount = workflows.length;
+    rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
     if (mainWindow && !mainWindow.isDestroyed()) {
       for (const removedTaskId of previousTaskIds) {
-        publishTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
+        rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
       }
       requestWorkflowMetadataPublish('orchestrator-snapshot');
     }
@@ -2936,146 +2796,9 @@ function createEmbeddedTerminalBackendFromConfig(
 
       setTimeout(() => {
         if (ownerMode) {
-          dbPollInterval = setInterval(() => {
-          if (!mainWindow || mainWindow.isDestroyed()) return;
-          try {
-            const workflows = persistence.listWorkflows();
-
-            if (workflows.length !== lastKnownWorkflowCount) {
-              const msg = `Workflow count changed: ${lastKnownWorkflowCount} → ${workflows.length}`;
-              logger.info(msg, { module: 'db-poll' });
-              try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-              lastKnownWorkflowCount = workflows.length;
-              requestWorkflowMetadataPublish('db-poll-count');
-
-              orchestrator.syncAllFromDb();
-              logger.info(`Synced orchestrator for all ${workflows.length} workflows`, { module: 'db-poll' });
-            }
-
-            for (const wf of workflows) {
-              if (wf.status === 'completed' || wf.status === 'failed') continue;
-              const tasks = persistence.loadTasks(wf.id);
-              for (const loadedTask of tasks) {
-                let task = loadedTask;
-                const now = new Date();
-                const previousHeartbeat = parseExecutionDate(task.execution.lastHeartbeatAt);
-                const selectedAttempt = task.execution.selectedAttemptId
-                  ? persistence.loadAttempt?.(task.execution.selectedAttemptId)
-                  : undefined;
-                const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
-                const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
-
-                if (task.status === 'running' || (task.status === 'pending' && task.execution.phase === 'launching')) {
-                  // CC.1: launch-stall watchdog removed. The
-                  // LaunchDispatcher's reapExpiredLeases /
-                  // abandonStuckLeases reapers (Phase B, CB.3) are the
-                  // sole recovery path for stalled launch claims.
-                  const executingStartedAt = parseExecutionDate(task.execution.startedAt);
-                  const executingAgeMs = executingStartedAt ? now.getTime() - executingStartedAt.getTime() : 0;
-                  const { heartbeatStale, leaseExpired, executingStalled, staleReason } = evaluateExecutingStall({
-                    now,
-                    phase: task.execution.phase,
-                    runnerKind: task.config.runnerKind,
-                    executingStartedAt,
-                    leaseExpiresAt,
-                    executorHeartbeatAt: previousHeartbeat,
-                    remoteHeartbeatAt: remoteHeartbeat,
-                    executingStallTimeoutMs,
-                  });
-
-                  if (executingStalled) {
-                    const selectedAttemptHeartbeat = parseExecutionDate(selectedAttempt?.lastHeartbeatAt);
-                    const executingError =
-                      `Execution stalled: task remained in running/executing for ${Math.floor(executingAgeMs / 1000)}s ` +
-                      `without a live execution handle and no completion signal from executor (${staleReason}).`;
-                    logger.info(
-                      `[executing-stall] detected task="${task.id}" phase=${task.execution.phase} executingAgeMs=${executingAgeMs} ` +
-                        `handlePresent=${taskHandles.has(task.id)} leaseExpired=${leaseExpired} heartbeatStale=${heartbeatStale} ` +
-                        `runnerKind=${task.config.runnerKind ?? 'none'} selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
-                        `attemptStatus=${selectedAttempt?.status ?? 'none'} executorHeartbeatAt=${previousHeartbeat?.toISOString() ?? 'none'} ` +
-                        `remoteHeartbeatAt=${remoteHeartbeat?.toISOString() ?? 'none'} attemptHeartbeatAt=${selectedAttemptHeartbeat?.toISOString() ?? 'none'} ` +
-                        `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'} launchStartedAt=${task.execution.launchStartedAt instanceof Date ? task.execution.launchStartedAt.toISOString() : task.execution.launchStartedAt ?? 'none'} ` +
-                        `launchCompletedAt=${task.execution.launchCompletedAt instanceof Date ? task.execution.launchCompletedAt.toISOString() : task.execution.launchCompletedAt ?? 'none'} ` +
-                        `startedAt=${executingStartedAt?.toISOString() ?? 'none'} completedAt=${task.execution.completedAt instanceof Date ? task.execution.completedAt.toISOString() : task.execution.completedAt ?? 'none'}`,
-                      { module: 'db-poll' },
-                    );
-                    const failedResponse: WorkResponse = {
-                      requestId: `executing-stall-${task.id}-${now.getTime()}`,
-                      actionId: task.id,
-                      attemptId: task.execution.selectedAttemptId,
-                      executionGeneration: task.execution.generation ?? 0,
-                      status: 'failed',
-                      outputs: {
-                        exitCode: 1,
-                        error: executingError,
-                      },
-                    };
-                    logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
-                    if (persistence) {
-                      persistShutdownDiagnostic(task, persistence, {
-                        flushPendingOutput: flushTaskOutput,
-                        forcedStopReason: executingError,
-                        label: task.execution.phase === 'launching'
-                          ? 'Startup Failure Diagnostic'
-                          : 'Shutdown Diagnostic',
-                      });
-                    }
-                    orchestrator.handleWorkerResponse(failedResponse);
-                    continue;
-                  }
-                }
-
-                const snapshot = JSON.stringify(task);
-                const prev = lastKnownTaskStates.get(task.id);
-                if (!prev) {
-                  if (traceDbPollPerTask) {
-                    const msg = `New task: ${task.id} (${task.status})`;
-                    logger.info(msg, { module: 'db-poll' });
-                    try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-                  }
-                  lastKnownTaskStates.set(task.id, snapshot);
-                  uiPerfStats.dbPollCreated += 1;
-                  publishTaskDeltaToRenderer({ type: 'created', task });
-                } else if (prev !== snapshot) {
-                  if (traceDbPollPerTask) {
-                    const msg = `Task updated: ${task.id} (${task.status})`;
-                    logger.info(msg, { module: 'db-poll' });
-                    try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
-                  }
-                  lastKnownTaskStates.set(task.id, snapshot);
-                  uiPerfStats.dbPollUpdatedAsCreated += 1;
-                  publishTaskDeltaToRenderer({ type: 'created', task });
-                }
-              }
-            }
-            if (launchDispatcher) {
-              try {
-                launchDispatcher.poll();
-              } catch (err) {
-                logger.warn(
-                  `[launch-dispatcher] poll() failed: ${err instanceof Error ? err.message : String(err)}`,
-                  { module: 'db-poll' },
-                );
-              }
-            }
-          } catch {
-            // DB might be locked — skip this tick
-          }
-          }, 2000);
+          dbPollStop = rendererTaskFeed.startDbPolling();
         }
-
-        activityPollInterval = setInterval(() => {
-          if (!mainWindow || mainWindow.isDestroyed()) return;
-          try {
-            const entries = persistence.getActivityLogs(lastActivityLogId);
-            if (entries.length > 0) {
-              lastActivityLogId = entries[entries.length - 1].id;
-              mainWindow.webContents.send('invoker:activity-log', entries);
-            }
-          } catch {
-            // DB might be locked — skip this tick
-          }
-        }, 2000);
+        activityPollStop = rendererTaskFeed.startActivityPolling();
       }, startupPollDelayMs).unref?.();
     }, 0);
   }
@@ -3363,17 +3086,18 @@ function createEmbeddedTerminalBackendFromConfig(
     // Forward deltas to renderer and keep snapshot cache in sync so
     // the db-poll doesn't re-emit deltas the messageBus already delivered.
     // Detached viewer: buffer owner deltas until hydration seeds the cache.
-    if (!ownerMode) {
-      detachedDeltaBuffer = [];
-    }
-    messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
-      const d = delta as TaskDelta;
-      if (detachedDeltaBuffer) {
-        detachedDeltaBuffer.push(d);
-        return;
+      if (!ownerMode) {
+        rendererTaskFeed.setDetachedDeltaBuffer([]);
       }
-      processIncomingTaskDelta(d);
-    });
+      messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
+        const d = delta as TaskDelta;
+        const buffer = rendererTaskFeed.getDetachedDeltaBuffer();
+        if (buffer) {
+          buffer.push(d);
+          return;
+        }
+        rendererTaskFeed.processIncomingTaskDelta(d);
+      });
 
     uiPerfLogInterval = setInterval(() => {
       const snapshot = {
@@ -3408,8 +3132,8 @@ function createEmbeddedTerminalBackendFromConfig(
 
     registerBootstrapStateIpc({
       ipcMain,
-      getTasks: () => (ownerMode ? orchestrator.getAllTasks() : detachedViewerTasks()),
-      getWorkflows: () => detachedViewerWorkflows ?? listWorkflowsByStartupRecency(),
+      getTasks: () => (ownerMode ? orchestrator.getAllTasks() : rendererTaskFeed.detachedViewerTasks()),
+      getWorkflows: () => rendererTaskFeed.getDetachedViewerWorkflows() ?? listWorkflowsByStartupRecency(),
       getInitialWorkflowId: () => startupWorkflowId,
       appStartedAtEpochMs: appProcessStartedAt,
       getTaskDeltaStreamSequence,
@@ -3558,7 +3282,7 @@ function createEmbeddedTerminalBackendFromConfig(
       const injectTaskStates = async (updates: Array<{ taskId: string; changes: TaskStateChanges }>): Promise<void> => {
         for (const { taskId, changes } of updates) {
           const before = orchestrator.getTask(taskId);
-          const previousSnapshot = lastKnownTaskStates.get(taskId);
+          const previousSnapshot = rendererTaskFeed.lastKnownTaskStates.get(taskId);
           const previousTaskStateVersion = previousSnapshot
             ? (
                 (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
@@ -3626,11 +3350,11 @@ function createEmbeddedTerminalBackendFromConfig(
 
       const allStarted = orchestrator.startExecution();
       const tasks = orchestrator.getAllTasks();
-      workflowRollupProjection.replaceAll(tasks);
+      rendererTaskFeed.workflowRollupProjection.replaceAll(tasks);
       for (const task of tasks) {
-        lastKnownTaskStates.set(task.id, JSON.stringify(task));
+        rendererTaskFeed.lastKnownTaskStates.set(task.id, JSON.stringify(task));
         if (mainWindow && !mainWindow.isDestroyed()) {
-          publishTaskDeltaToRenderer({ type: 'created', task });
+          rendererTaskFeed.publishTaskDeltaToRenderer({ type: 'created', task });
         }
       }
       logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
@@ -3655,7 +3379,7 @@ function createEmbeddedTerminalBackendFromConfig(
           if (isTaskInFlightForForcedStop(task)) {
             logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc' });
             persistShutdownDiagnostic(task, persistence, {
-              flushPendingOutput: flushTaskOutput,
+              flushPendingOutput: rendererTaskFeed.flushTaskOutput,
               forcedStopReason: 'Stopped by user',
             });
             orchestrator.handleWorkerResponse({
@@ -3696,9 +3420,9 @@ function createEmbeddedTerminalBackendFromConfig(
       );
       rebuildTaskRunner();
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.lastKnownTaskStates.clear();
+      rendererTaskFeed.workflowRollupProjection.clear();
+      rendererTaskFeed.setLastKnownWorkflowCount(0);
       requestWorkflowMetadataPublish('clear');
     });
 
@@ -3744,9 +3468,9 @@ function createEmbeddedTerminalBackendFromConfig(
       assertDeleteAllEnabled();
       await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.lastKnownTaskStates.clear();
+      rendererTaskFeed.workflowRollupProjection.clear();
+      rendererTaskFeed.setLastKnownWorkflowCount(0);
       requestWorkflowMetadataPublish('delete-all-workflows');
     });
 
@@ -3755,9 +3479,9 @@ function createEmbeddedTerminalBackendFromConfig(
       assertDeleteAllEnabled();
       await sharedDeleteAllWorkflowsBulk({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
-      lastKnownTaskStates.clear();
-      workflowRollupProjection.clear();
-      lastKnownWorkflowCount = 0;
+      rendererTaskFeed.lastKnownTaskStates.clear();
+      rendererTaskFeed.workflowRollupProjection.clear();
+      rendererTaskFeed.setLastKnownWorkflowCount(0);
       requestWorkflowMetadataPublish('delete-all-workflows-bulk');
     });
 
@@ -4418,7 +4142,7 @@ function createEmbeddedTerminalBackendFromConfig(
         throw err;
       }
       const workflows = persistence.listWorkflows();
-      lastKnownWorkflowCount = workflows.length;
+      rendererTaskFeed.setLastKnownWorkflowCount(workflows.length);
       requestWorkflowMetadataPublish('set-merge-mode');
     });
 
@@ -4897,9 +4621,9 @@ function createEmbeddedTerminalBackendFromConfig(
     );
 
     if (ownerMode) {
-      seedUiSnapshotCache();
+      rendererTaskFeed.seedUiSnapshotCache();
     } else {
-      await hydrateDetachedViewerFromOwner();
+      await rendererTaskFeed.hydrateDetachedViewerFromOwner();
     }
     createWindow();
     recordStartupMark('createWindow.end');
@@ -4955,8 +4679,8 @@ function createEmbeddedTerminalBackendFromConfig(
         if (apiServer) await apiServer.close().catch(() => {});
         embeddedTerminalManager.closeAll({ preserveForRestart: true });
         await workerRuntimeController?.stopAll();
-        if (dbPollInterval) clearInterval(dbPollInterval);
-        if (activityPollInterval) clearInterval(activityPollInterval);
+        if (dbPollStop) dbPollStop();
+        if (activityPollStop) activityPollStop();
         if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);
         if (hourlyBackupInterval) {
           clearInterval(hourlyBackupInterval);
@@ -4972,7 +4696,7 @@ function createEmbeddedTerminalBackendFromConfig(
             if (task.status === 'running' || task.status === 'fixing_with_ai') {
               if (persistence) {
                 persistShutdownDiagnostic(task, persistence, {
-                  flushPendingOutput: flushTaskOutput,
+                  flushPendingOutput: rendererTaskFeed.flushTaskOutput,
                   forcedStopReason: 'Application quit',
                 });
               }

--- a/packages/app/src/window/renderer-task-feed.ts
+++ b/packages/app/src/window/renderer-task-feed.ts
@@ -1,0 +1,423 @@
+import type { BrowserWindow } from 'electron';
+import type { Logger, WorkResponse } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { Orchestrator, TaskDelta, TaskState } from '@invoker/workflow-core';
+import { Channels } from '@invoker/transport';
+import type { MessageBus } from '@invoker/transport';
+import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from '../delta-merge.js';
+import { WorkflowRollupProjection } from '../workflow-rollup-projection.js';
+import { seedTaskCachesFromSnapshot } from '../viewer-cache-hydration.js';
+import { shouldSkipAutoFixForError } from '../auto-fix-gating.js';
+import { evaluateExecutingStall } from '../executing-stall.js';
+import { persistShutdownDiagnostic } from '../shutdown-diagnostic.js';
+import { parseExecutionDate } from '../execution/workflow-task-actions.js';
+import type { TaskGraphEventPublisher } from '../task-graph-event-publisher.js';
+import type { TaskHandleMap } from '../execution/task-runner-wiring.js';
+import type { LaunchDispatcher } from '../launch-dispatcher.js';
+import type { TaskOutputData } from '../types.js';
+
+/** The subset of the main-process UI perf counters this feed increments. */
+export interface RendererTaskFeedPerfStats {
+  mainDeltaToUi: number;
+  dbPollCreated: number;
+  dbPollUpdatedAsCreated: number;
+}
+
+export interface RendererTaskFeedDeps {
+  logger: Logger;
+  persistence: SQLiteAdapter;
+  orchestrator: Orchestrator;
+  messageBus: MessageBus;
+  /** Coalesced task-graph event fan-out to the renderer (owned by main.ts). */
+  taskGraphEventPublisher: TaskGraphEventPublisher;
+  uiPerfStats: RendererTaskFeedPerfStats;
+  taskHandles: TaskHandleMap;
+  getMainWindow: () => BrowserWindow | null;
+  getLaunchDispatcher: () => LaunchDispatcher | null;
+  requestWorkflowMetadataPublish: (reason: string) => void;
+  scheduleAutoFix: (taskId: string) => void;
+  logAutoFixDebug: (taskId: string, phase: string, details?: Record<string, unknown>) => void;
+  setStartupWorkflowId: (workflowId: string | null) => void;
+  traceUiDeltaFlow: boolean;
+  traceDbPollPerTask: boolean;
+  traceTaskOutput: boolean;
+  executingStallTimeoutMs: number;
+}
+
+/**
+ * The renderer task feed: the owner-side delta/output pipeline plus the db and
+ * activity poll loops that keep the renderer's task graph and activity log in
+ * sync. Owns the snapshot cache, workflow rollup projection, output buffers, and
+ * the detached-viewer hydration state block. `main.ts` delegates the renderer
+ * feed here and reads shared state through the exposed accessors.
+ */
+export interface RendererTaskFeed {
+  /** Owner snapshot cache; main.ts reconciles it during full-graph publishes. */
+  readonly lastKnownTaskStates: TaskSnapshotCache;
+  /** Per-workflow rollup projection kept in step with the snapshot cache. */
+  readonly workflowRollupProjection: WorkflowRollupProjection;
+  setLastKnownWorkflowCount: (count: number) => void;
+  getDetachedViewerWorkflows: () => unknown[] | null;
+  getDetachedDeltaBuffer: () => TaskDelta[] | null;
+  setDetachedDeltaBuffer: (buffer: TaskDelta[] | null) => void;
+  enqueueTaskOutput: (taskId: string, data: string) => void;
+  flushTaskOutput: (taskId: string) => void;
+  publishTaskDeltaToRenderer: (delta: TaskDelta) => void;
+  processIncomingTaskDelta: (delta: TaskDelta) => void;
+  seedUiSnapshotCache: () => void;
+  hydrateDetachedViewerFromOwner: () => Promise<void>;
+  detachedViewerTasks: () => TaskState[];
+  /** Start the 2s db poll; returns a stop handle the shutdown path clears. */
+  startDbPolling: () => () => void;
+  /** Start the 2s activity-log poll; returns a stop handle. */
+  startActivityPolling: () => () => void;
+}
+
+export function createRendererTaskFeed(deps: RendererTaskFeedDeps): RendererTaskFeed {
+  const {
+    logger,
+    persistence,
+    orchestrator,
+    messageBus,
+    taskGraphEventPublisher,
+    uiPerfStats,
+    taskHandles,
+    getMainWindow,
+    getLaunchDispatcher,
+    requestWorkflowMetadataPublish,
+    scheduleAutoFix,
+    logAutoFixDebug,
+    setStartupWorkflowId,
+    traceUiDeltaFlow,
+    traceDbPollPerTask,
+    traceTaskOutput,
+    executingStallTimeoutMs,
+  } = deps;
+
+  const lastKnownTaskStates = new TaskSnapshotCache();
+  const workflowRollupProjection = new WorkflowRollupProjection();
+  const pendingOutputBuffers = new Map<string, string[]>();
+  const outputFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  let lastKnownWorkflowCount = 0;
+  let lastActivityLogId = 0;
+  // In detached viewer mode the local DB is an empty in-memory copy. Workflow
+  // metadata for the bootstrap getter comes from the owner snapshot; task state
+  // is derived live from `lastKnownTaskStates` (kept current by deltas).
+  let detachedViewerWorkflows: unknown[] | null = null;
+  // While the detached viewer hydrates, owner deltas are buffered here and
+  // replayed after the cache is seeded, so an update arriving mid-hydration is
+  // not applied against an empty cache (quarantined and dropped).
+  let detachedDeltaBuffer: TaskDelta[] | null = null;
+
+  const flushTaskOutput = (taskId: string): void => {
+    const timer = outputFlushTimers.get(taskId);
+    if (timer) {
+      clearTimeout(timer);
+      outputFlushTimers.delete(taskId);
+    }
+    const chunks = pendingOutputBuffers.get(taskId);
+    if (!chunks || chunks.length === 0) {
+      return;
+    }
+    pendingOutputBuffers.delete(taskId);
+    const data = chunks.join('');
+    if (traceTaskOutput) {
+      logger.info(`${taskId}: ${data.trimEnd()}`, { module: 'output' });
+    }
+    const outputData: TaskOutputData = { taskId, data };
+    messageBus.publish(Channels.TASK_OUTPUT, outputData);
+    try {
+      // Runner stream chunks land in the output spool only — task_output is
+      // reserved for explicit diagnostic writes (workflow actions, shutdown).
+      persistence.appendOutputChunk(taskId, data);
+    } catch (err) {
+      logger.error(`Failed to persist output for ${taskId}: ${err}`, { module: 'output' });
+    }
+  };
+
+  const enqueueTaskOutput = (taskId: string, data: string): void => {
+    const chunks = pendingOutputBuffers.get(taskId) ?? [];
+    chunks.push(data);
+    pendingOutputBuffers.set(taskId, chunks);
+    if (outputFlushTimers.has(taskId)) {
+      return;
+    }
+    const timer = setTimeout(() => flushTaskOutput(taskId), 100);
+    timer.unref?.();
+    outputFlushTimers.set(taskId, timer);
+  };
+
+  const publishTaskDeltaToRenderer = (delta: TaskDelta): void => {
+    const workflowRollups = workflowRollupProjection.applyDelta(delta);
+    taskGraphEventPublisher.publishDelta(delta, workflowRollups);
+  };
+
+  const applyTaskDeltaToOwnerCacheOrRecover = (delta: TaskDelta): TaskDelta[] => {
+    const { quarantined, accepted } = applyDelta(delta, lastKnownTaskStates);
+    if (quarantined.length === 0) {
+      return accepted ? [delta] : [];
+    }
+
+    const rendererDeltas: TaskDelta[] = [];
+    for (const taskId of quarantined) {
+      logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
+      const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
+        loadTask: (id) => persistence.loadTask(id),
+        getMergeNode: (workflowId) => orchestrator.getMergeNode(workflowId),
+      });
+      if (rendererDelta) {
+        rendererDeltas.push(rendererDelta);
+      }
+    }
+    return rendererDeltas;
+  };
+
+  function seedUiSnapshotCache(): void {
+    lastKnownWorkflowCount = persistence.listWorkflows().length;
+    seedTaskCachesFromSnapshot(orchestrator.getAllTasks(), { lastKnownTaskStates, workflowRollupProjection });
+  }
+
+  // Detached viewer: the local DB is empty, so seed the delta caches and
+  // bootstrap snapshot from the owner. Without this, the empty cache quarantines
+  // every `updated` delta for a task the viewer has not seen (dropping live
+  // updates), and bootstrap getters return nothing. Failures are non-fatal — the
+  // renderer's delegated reads still populate the view.
+  async function hydrateDetachedViewerFromOwner(): Promise<void> {
+    try {
+      const snapshot = await messageBus.request<{ kind: string }, { tasks?: TaskState[]; workflows?: unknown[] }>(
+        'headless.query',
+        { kind: 'tasks' },
+      );
+      const tasks = Array.isArray(snapshot?.tasks) ? snapshot.tasks : [];
+      const workflows = Array.isArray(snapshot?.workflows) ? snapshot.workflows : [];
+      detachedViewerWorkflows = workflows;
+      seedTaskCachesFromSnapshot(tasks, { lastKnownTaskStates, workflowRollupProjection });
+      lastKnownWorkflowCount = workflows.length;
+      setStartupWorkflowId([...workflows]
+        .map((wf) => wf as { id?: string; updatedAt?: string; createdAt?: string })
+        .sort((left, right) => (Date.parse(right.updatedAt ?? '') || 0) - (Date.parse(left.updatedAt ?? '') || 0))[0]?.id ?? null);
+      logger.info(
+        `[init] Hydrated detached viewer from owner: ${tasks.length} tasks across ${workflows.length} workflows`,
+        { module: 'init' },
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.warn(`detached viewer hydration from owner failed; relying on delegated reads: ${message}`, { module: 'init' });
+    } finally {
+      // Resume direct delta processing and replay anything buffered during
+      // hydration (in arrival order). Always runs, so a hydration failure can
+      // never leave deltas buffered forever.
+      const buffered = detachedDeltaBuffer ?? [];
+      detachedDeltaBuffer = null;
+      for (const delta of buffered) processIncomingTaskDelta(delta);
+    }
+  }
+
+  // Current task states for the detached viewer's bootstrap getter, derived from
+  // the live delta cache so a renderer reload never sees the stale hydration
+  // snapshot.
+  function detachedViewerTasks(): TaskState[] {
+    return [...lastKnownTaskStates.keys()].map(
+      (taskId) => JSON.parse(lastKnownTaskStates.get(taskId) ?? '{}') as TaskState,
+    );
+  }
+
+  // Apply one owner task delta to the local cache and forward results to the
+  // renderer (and drive owner-side auto-fix). Extracted so the detached viewer
+  // can replay deltas that were buffered during hydration.
+  function processIncomingTaskDelta(d: TaskDelta): void {
+    uiPerfStats.mainDeltaToUi += 1;
+    if (traceUiDeltaFlow) {
+      logger.debug(`delta→ui: ${JSON.stringify(d)}`, { module: 'ui' });
+    }
+    const deltaTaskId = d.type === 'updated' || d.type === 'removed' ? d.taskId : undefined;
+    if (d.type === 'updated' && d.changes.status === 'failed') {
+      const cancellationError = shouldSkipAutoFixForError(d.changes.execution?.error);
+      const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(d.taskId);
+      logAutoFixDebug(d.taskId, 'delta-failed', {
+        shouldSkipForCancellation: cancellationError,
+        shouldAutoFixFromOrchestrator,
+      });
+      if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
+        logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
+        scheduleAutoFix(deltaTaskId);
+      } else if (deltaTaskId) {
+        logAutoFixDebug(deltaTaskId, 'delta-skip', {
+          reason: cancellationError ? 'cancellation-error' : 'shouldAutoFix-false',
+          shouldSkipForCancellation: cancellationError,
+          shouldAutoFixFromOrchestrator,
+        });
+      }
+    }
+    for (const rendererDelta of applyTaskDeltaToOwnerCacheOrRecover(d)) {
+      publishTaskDeltaToRenderer(rendererDelta);
+    }
+  }
+
+  function startDbPolling(): () => void {
+    const interval = setInterval(() => {
+      const mainWindow = getMainWindow();
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      try {
+        const workflows = persistence.listWorkflows();
+
+        if (workflows.length !== lastKnownWorkflowCount) {
+          const msg = `Workflow count changed: ${lastKnownWorkflowCount} → ${workflows.length}`;
+          logger.info(msg, { module: 'db-poll' });
+          try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
+          lastKnownWorkflowCount = workflows.length;
+          requestWorkflowMetadataPublish('db-poll-count');
+
+          orchestrator.syncAllFromDb();
+          logger.info(`Synced orchestrator for all ${workflows.length} workflows`, { module: 'db-poll' });
+        }
+
+        for (const wf of workflows) {
+          if (wf.status === 'completed' || wf.status === 'failed') continue;
+          const tasks = persistence.loadTasks(wf.id);
+          for (const loadedTask of tasks) {
+            const task = loadedTask;
+            const now = new Date();
+            const previousHeartbeat = parseExecutionDate(task.execution.lastHeartbeatAt);
+            const selectedAttempt = task.execution.selectedAttemptId
+              ? persistence.loadAttempt?.(task.execution.selectedAttemptId)
+              : undefined;
+            const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
+            const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
+
+            if (task.status === 'running' || (task.status === 'pending' && task.execution.phase === 'launching')) {
+              // CC.1: launch-stall watchdog removed. The
+              // LaunchDispatcher's reapExpiredLeases /
+              // abandonStuckLeases reapers (Phase B, CB.3) are the
+              // sole recovery path for stalled launch claims.
+              const executingStartedAt = parseExecutionDate(task.execution.startedAt);
+              const executingAgeMs = executingStartedAt ? now.getTime() - executingStartedAt.getTime() : 0;
+              const { heartbeatStale, leaseExpired, executingStalled, staleReason } = evaluateExecutingStall({
+                now,
+                phase: task.execution.phase,
+                runnerKind: task.config.runnerKind,
+                executingStartedAt,
+                leaseExpiresAt,
+                executorHeartbeatAt: previousHeartbeat,
+                remoteHeartbeatAt: remoteHeartbeat,
+                executingStallTimeoutMs,
+              });
+
+              if (executingStalled) {
+                const selectedAttemptHeartbeat = parseExecutionDate(selectedAttempt?.lastHeartbeatAt);
+                const executingError =
+                  `Execution stalled: task remained in running/executing for ${Math.floor(executingAgeMs / 1000)}s ` +
+                  `without a live execution handle and no completion signal from executor (${staleReason}).`;
+                logger.info(
+                  `[executing-stall] detected task="${task.id}" phase=${task.execution.phase} executingAgeMs=${executingAgeMs} ` +
+                    `handlePresent=${taskHandles.has(task.id)} leaseExpired=${leaseExpired} heartbeatStale=${heartbeatStale} ` +
+                    `runnerKind=${task.config.runnerKind ?? 'none'} selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
+                    `attemptStatus=${selectedAttempt?.status ?? 'none'} executorHeartbeatAt=${previousHeartbeat?.toISOString() ?? 'none'} ` +
+                    `remoteHeartbeatAt=${remoteHeartbeat?.toISOString() ?? 'none'} attemptHeartbeatAt=${selectedAttemptHeartbeat?.toISOString() ?? 'none'} ` +
+                    `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'} launchStartedAt=${task.execution.launchStartedAt instanceof Date ? task.execution.launchStartedAt.toISOString() : task.execution.launchStartedAt ?? 'none'} ` +
+                    `launchCompletedAt=${task.execution.launchCompletedAt instanceof Date ? task.execution.launchCompletedAt.toISOString() : task.execution.launchCompletedAt ?? 'none'} ` +
+                    `startedAt=${executingStartedAt?.toISOString() ?? 'none'} completedAt=${task.execution.completedAt instanceof Date ? task.execution.completedAt.toISOString() : task.execution.completedAt ?? 'none'}`,
+                  { module: 'db-poll' },
+                );
+                const failedResponse: WorkResponse = {
+                  requestId: `executing-stall-${task.id}-${now.getTime()}`,
+                  actionId: task.id,
+                  attemptId: task.execution.selectedAttemptId,
+                  executionGeneration: task.execution.generation ?? 0,
+                  status: 'failed',
+                  outputs: {
+                    exitCode: 1,
+                    error: executingError,
+                  },
+                };
+                logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
+                if (persistence) {
+                  persistShutdownDiagnostic(task, persistence, {
+                    flushPendingOutput: flushTaskOutput,
+                    forcedStopReason: executingError,
+                    label: task.execution.phase === 'launching'
+                      ? 'Startup Failure Diagnostic'
+                      : 'Shutdown Diagnostic',
+                  });
+                }
+                orchestrator.handleWorkerResponse(failedResponse);
+                continue;
+              }
+            }
+
+            const snapshot = JSON.stringify(task);
+            const prev = lastKnownTaskStates.get(task.id);
+            if (!prev) {
+              if (traceDbPollPerTask) {
+                const msg = `New task: ${task.id} (${task.status})`;
+                logger.info(msg, { module: 'db-poll' });
+                try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
+              }
+              lastKnownTaskStates.set(task.id, snapshot);
+              uiPerfStats.dbPollCreated += 1;
+              publishTaskDeltaToRenderer({ type: 'created', task });
+            } else if (prev !== snapshot) {
+              if (traceDbPollPerTask) {
+                const msg = `Task updated: ${task.id} (${task.status})`;
+                logger.info(msg, { module: 'db-poll' });
+                try { persistence.writeActivityLog('db-poll', 'info', msg); } catch { /* db locked */ }
+              }
+              lastKnownTaskStates.set(task.id, snapshot);
+              uiPerfStats.dbPollUpdatedAsCreated += 1;
+              publishTaskDeltaToRenderer({ type: 'created', task });
+            }
+          }
+        }
+        const launchDispatcher = getLaunchDispatcher();
+        if (launchDispatcher) {
+          try {
+            launchDispatcher.poll();
+          } catch (err) {
+            logger.warn(
+              `[launch-dispatcher] poll() failed: ${err instanceof Error ? err.message : String(err)}`,
+              { module: 'db-poll' },
+            );
+          }
+        }
+      } catch {
+        // DB might be locked — skip this tick
+      }
+    }, 2000);
+    return () => clearInterval(interval);
+  }
+
+  function startActivityPolling(): () => void {
+    const interval = setInterval(() => {
+      const mainWindow = getMainWindow();
+      if (!mainWindow || mainWindow.isDestroyed()) return;
+      try {
+        const entries = persistence.getActivityLogs(lastActivityLogId);
+        if (entries.length > 0) {
+          lastActivityLogId = entries[entries.length - 1].id;
+          mainWindow.webContents.send('invoker:activity-log', entries);
+        }
+      } catch {
+        // DB might be locked — skip this tick
+      }
+    }, 2000);
+    return () => clearInterval(interval);
+  }
+
+  return {
+    lastKnownTaskStates,
+    workflowRollupProjection,
+    setLastKnownWorkflowCount: (count) => { lastKnownWorkflowCount = count; },
+    getDetachedViewerWorkflows: () => detachedViewerWorkflows,
+    getDetachedDeltaBuffer: () => detachedDeltaBuffer,
+    setDetachedDeltaBuffer: (buffer) => { detachedDeltaBuffer = buffer; },
+    enqueueTaskOutput,
+    flushTaskOutput,
+    publishTaskDeltaToRenderer,
+    processIncomingTaskDelta,
+    seedUiSnapshotCache,
+    hydrateDetachedViewerFromOwner,
+    detachedViewerTasks,
+    startDbPolling,
+    startActivityPolling,
+  };
+}


### PR DESCRIPTION
## Summary

Slice 2 of the app god-file decomposition.

It moves the renderer task-feed pipeline out of `main.ts` into a new module, `window/renderer-task-feed.ts`, which now owns that pipeline's state.

The pipeline covers output buffering, task-delta publication, detached-viewer hydration, and the database and activity poll loops.

The two poll loops now hand back `stop()` handles that the existing shutdown path calls, so teardown still runs. Behavior is intentionally identical.

## Review Claim

Approve moving the renderer task-feed pipeline and its two poll loops from `main.ts` into `window/renderer-task-feed.ts`, which takes ownership of the shared state block, with behavior unchanged.

## Review Lane

refactor

## Review Unit

ownership-refactor

## Safety Invariant

Pure move slice. The delta pipeline is pinned by `delta-merge.test.ts` (which mirrors the main-process loop), `viewer-cache-hydration.test.ts`, `workflow-rollup-projection.test.ts`, and the synthetic-merge quarantine repro. The poll loops return `stop()` handles so the shutdown path keeps clearing them.

## Slice Rationale

One extraction per slice, per the review-compression convention. This is slice 2 of the app decomposition chain, stacked on step 1, and it moves one cohesive unit and nothing else.

## Non-goals

- No behavior change: delta-merge semantics, flush cadence, and detached-viewer recovery stay identical.
- No IPC mutation-handler moves; that is the next slice.
- No terminal or shutdown-sequence moves.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/delta-merge.test.ts src/__tests__/viewer-cache-hydration.test.ts src/__tests__/workflow-rollup-projection.test.ts src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None; the module is re-inlined into `main.ts` by the revert.
- Data migration? No

</details>