### PR TITLE
[Godfile data-store step 1: extract sqlite-migrations](1)

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-migrations-error-logging.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-migrations-error-logging.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as migrations from '../sqlite-migrations.js';
+import type { SqliteExecutor } from '../sqlite-executor.js';
+
+/**
+ * Guards the CLAUDE.md invariant for this module: migrations tolerate missing
+ * tables and malformed rows so a partial upgrade never aborts startup, but a
+ * caught error is logged with context — never silently swallowed.
+ */
+function stubExecutor(overrides: Partial<SqliteExecutor> = {}): SqliteExecutor {
+  const notExist = (): never => {
+    throw new Error('no such table: tasks');
+  };
+  return {
+    queryOne: notExist,
+    queryAll: notExist,
+    execRun: () => {},
+    runTransaction: <T>(work: () => T): T => work(),
+    run: () => {},
+    getRowsModified: () => 0,
+    readOnly: false,
+    markDirty: () => {},
+    ...overrides,
+  };
+}
+
+describe('sqlite-migrations error logging', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces the caught error instead of swallowing when a query fails', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const cases: Array<[string, (exec: SqliteExecutor) => void]> = [
+      ['migrateTestCommands', migrations.migrateTestCommands],
+      ['migrateGatePolicyApprovedToCompleted', migrations.migrateGatePolicyApprovedToCompleted],
+      ['migrateTaskExternalDependenciesToWorkflows', migrations.migrateTaskExternalDependenciesToWorkflows],
+    ];
+    for (const [name, fn] of cases) {
+      warn.mockClear();
+      expect(() => fn(stubExecutor())).not.toThrow();
+      const messages = warn.mock.calls.map(([m]) => String(m));
+      expect(messages.some((m) => m.includes(`[sqlite-migrations] ${name}`))).toBe(true);
+      expect(messages.some((m) => m.includes('no such table'))).toBe(true);
+    }
+  });
+
+  it('logs and skips a malformed row while still migrating valid siblings', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const updates: unknown[][] = [];
+    const exec = stubExecutor({
+      queryAll: () => [
+        {
+          id: 'good',
+          external_dependencies: JSON.stringify([
+            { workflowId: 'wf', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'approved' },
+          ]),
+        },
+        { id: 'bad', external_dependencies: '{ not valid json' },
+      ],
+      execRun: (_sql, params) => {
+        updates.push(params ?? []);
+      },
+    });
+
+    expect(() => migrations.migrateGatePolicyApprovedToCompleted(exec)).not.toThrow();
+
+    // Valid row was rewritten to the completed gate policy.
+    expect(updates).toHaveLength(1);
+    expect(String(updates[0]![0])).toContain('"gatePolicy":"completed"');
+
+    // Malformed row was logged with its id, not silently dropped.
+    const messages = warn.mock.calls.map(([m]) => String(m));
+    expect(messages.some((m) => m.includes('[sqlite-migrations]') && m.includes('bad'))).toBe(true);
+  });
+
+  it('clears only tasks whose deps were promoted, leaving malformed and orphaned rows untouched', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const clearedIds: unknown[][] = [];
+    const validDep = JSON.stringify([
+      { workflowId: 'wf-1', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+    ]);
+    const orphanDep = JSON.stringify([
+      { workflowId: 'wf-missing', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+    ]);
+    const exec = stubExecutor({
+      queryAll: () => [
+        { id: 'promoted', workflow_id: 'wf-1', external_dependencies: validDep },
+        { id: 'malformed', workflow_id: 'wf-1', external_dependencies: '{ not json' },
+        { id: 'orphan', workflow_id: 'wf-missing', external_dependencies: orphanDep },
+      ],
+      queryOne: (_sql, params) => (params?.[0] === 'wf-1' ? { external_dependencies: null } : undefined),
+      execRun: (sql, params) => {
+        if (sql.includes('UPDATE tasks SET external_dependencies = NULL')) {
+          clearedIds.push(params ?? []);
+        }
+      },
+    });
+
+    expect(() => migrations.migrateTaskExternalDependenciesToWorkflows(exec)).not.toThrow();
+
+    // Only the promoted task is cleared; the malformed row and the orphan whose
+    // workflow is missing keep their external_dependencies intact.
+    expect(clearedIds).toHaveLength(1);
+    expect(clearedIds[0]).toEqual(['promoted']);
+
+    const messages = warn.mock.calls.map(([m]) => String(m));
+    expect(messages.some((m) => m.includes('[sqlite-migrations]') && m.includes('malformed'))).toBe(true);
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -28,7 +28,6 @@ import type {
   WorkflowDerivedStatus,
   WorkflowRollup,
   WorkflowRollupTaskSummary,
-  ExternalDependency,
   ExternalDependencyChange,
   DetachedExternalDependency,
 } from '@invoker/workflow-core';
@@ -63,13 +62,7 @@ import type {
   InAppPlanningSessionPatch,
   InAppPlanningSessionRecord,
 } from './adapter.js';
-import {
-  SCHEMA_DDL,
-  COLUMN_MIGRATIONS,
-  POST_MIGRATION_STATEMENTS,
-  WORKFLOWS_REBUILD_TABLE_DDL,
-  WORKFLOWS_REBUILD_INSERT_DDL,
-} from './sqlite-schema.js';
+import { SCHEMA_DDL } from './sqlite-schema.js';
 import {
   mapRowToWorkflow,
   mapRowToTask,
@@ -86,6 +79,8 @@ import {
   readSpoolLinesFromFile,
   readLastSpoolLinesFromFile,
 } from './sqlite-output-spool.js';
+import type { SqliteExecutor } from './sqlite-executor.js';
+import * as migrations from './sqlite-migrations.js';
 
 function normalizeWorkerActionStatus(status: string): string {
   return status === 'canceled' ? 'cancelled' : status;
@@ -129,25 +124,6 @@ const DEFAULT_ACTIVITY_LOG_MAX_ROWS = 100_000;
 const ACTIVITY_LOG_PRUNE_INTERVAL = 1_000; // prune at most once per N writes
 
 const OUTPUT_DIAGNOSTIC_TAIL_CHARS = 8_000;
-
-
-/**
- * Rewrite `pnpm test packages/<pkg>/...` (incorrect root-level invocation)
- * to `cd packages/<pkg> && pnpm test -- <relative-path>`.
- */
-function rewritePnpmTestCommand(cmd: string): string {
-  const withFile = cmd.match(/^(pnpm test)\s+(?:--\s+)?packages\/([^/\s]+)\/(\S+)(.*)/);
-  if (withFile) {
-    const [, , pkg, rest, suffix] = withFile;
-    return `cd packages/${pkg} && pnpm test -- ${rest}${suffix}`;
-  }
-  const pkgOnly = cmd.match(/^(pnpm test)\s+(?:--\s+)?packages\/([^/\s]+)(.*)/);
-  if (pkgOnly) {
-    const [, , pkg, suffix] = pkgOnly;
-    return `cd packages/${pkg} && pnpm test${suffix}`;
-  }
-  return cmd;
-}
 
 export interface OutputChunk {
   offset: number;
@@ -672,6 +648,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return this.runTransaction(work);
   }
 
+  private get migrationExecutor(): SqliteExecutor {
+    return {
+      queryOne: (sql, params) => this.queryOne(sql, params),
+      queryAll: (sql, params) => this.queryAll(sql, params),
+      execRun: (sql, params) => this.execRun(sql, params),
+      runTransaction: <T>(work: () => T): T => this.runTransaction<T>(work),
+      run: (sql, params) => this.db.run(sql, params),
+      getRowsModified: () => this.db.getRowsModified(),
+      readOnly: this.readOnly,
+      markDirty: () => {
+        this.dirty = true;
+      },
+    };
+  }
+
   runCompatibilityMigration(): {
     migratedFixingWithAiStatuses: number;
     normalizedMergeModes: number;
@@ -680,237 +671,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     normalizedLegacyAcknowledgedLaunchDispatches: number;
     backfilledMissingSshPoolMemberIds: number;
   } {
-    const report = {
-      migratedFixingWithAiStatuses: 0,
-      normalizedMergeModes: 0,
-      staleAutoFixExperimentTasks: 0,
-      normalizedStaleLaunchMetadata: 0,
-      normalizedLegacyAcknowledgedLaunchDispatches: 0,
-      backfilledMissingSshPoolMemberIds: 0,
-    };
-    this.runTransaction(() => {
-      this.db.run(
-        `UPDATE tasks
-         SET status = 'fixing_with_ai'
-         WHERE status = 'running' AND is_fixing_with_ai = 1`,
-      );
-      report.migratedFixingWithAiStatuses = this.db.getRowsModified();
-
-      this.db.run(
-        `UPDATE tasks
-         SET is_fixing_with_ai = 0
-         WHERE status = 'fixing_with_ai' AND is_fixing_with_ai != 0`,
-      );
-
-      this.db.run(
-        `UPDATE workflows
-         SET merge_mode = 'external_review'
-         WHERE merge_mode = 'github'`,
-      );
-      report.normalizedMergeModes = this.db.getRowsModified();
-
-      const staleAutoFixRows = this.queryAll(
-        `SELECT id FROM tasks
-         WHERE status != 'stale'
-           AND (
-             (parent_task IS NOT NULL AND id LIKE '%-exp-fix-%')
-             OR (
-               is_reconciliation = 1
-               AND parent_task IN (
-                 SELECT id FROM tasks
-                 WHERE parent_task IS NOT NULL AND id LIKE '%-exp-fix-%'
-               )
-             )
-           )`,
-      );
-      this.db.run(
-        `UPDATE tasks
-         SET status = 'stale',
-             error = 'Stale auto-fix experiment branch; migrated to modern retry model',
-             completed_at = COALESCE(completed_at, datetime('now')),
-             is_fixing_with_ai = 0
-         WHERE status != 'stale'
-           AND (
-             (parent_task IS NOT NULL AND id LIKE '%-exp-fix-%')
-             OR (
-               is_reconciliation = 1
-               AND parent_task IN (
-                 SELECT id FROM tasks
-                 WHERE parent_task IS NOT NULL AND id LIKE '%-exp-fix-%'
-               )
-             )
-           )`,
-      );
-      report.staleAutoFixExperimentTasks = staleAutoFixRows.length;
-
-      this.db.run(
-        `UPDATE tasks
-         SET launch_phase = NULL,
-             launch_started_at = NULL,
-             launch_completed_at = NULL
-         WHERE status IN ('completed', 'failed', 'needs_input', 'awaiting_approval', 'review_ready', 'stale')
-           AND launch_started_at IS NOT NULL
-           AND started_at IS NOT NULL
-           AND (julianday(started_at) - julianday(launch_started_at)) * 86400.0 > 3600.0`,
-      );
-      report.normalizedStaleLaunchMetadata = this.db.getRowsModified();
-
-      const nowIso = new Date().toISOString();
-      const stalePendingLaunchRows = this.queryAll(
-        `SELECT t.id, t.selected_attempt_id
-           FROM tasks t
-           LEFT JOIN attempts a ON a.id = t.selected_attempt_id
-          WHERE t.status = 'pending'
-            AND t.launch_phase = 'launching'
-            AND t.selected_attempt_id IS NOT NULL
-            AND TRIM(t.selected_attempt_id) != ''
-            AND NOT EXISTS (
-              SELECT 1
-                FROM task_launch_dispatch live
-               WHERE live.task_id = t.id
-                 AND live.attempt_id = t.selected_attempt_id
-                 AND live.state IN ('enqueued', 'leased')
-            )
-            AND (
-              a.id IS NULL
-              OR a.lease_expires_at IS NULL
-              OR a.lease_expires_at <= ?
-            )`,
-        [nowIso],
-      ) as Array<{ id: string; selected_attempt_id?: string | null }>;
-      if (stalePendingLaunchRows.length > 0) {
-        const taskIds = stalePendingLaunchRows.map((row) => String(row.id));
-        const taskPlaceholders = taskIds.map(() => '?').join(', ');
-        this.db.run(
-          `UPDATE tasks
-              SET launch_phase = NULL,
-                  launch_started_at = NULL,
-                  launch_completed_at = NULL,
-                  last_heartbeat_at = NULL
-            WHERE id IN (${taskPlaceholders})`,
-          taskIds,
-        );
-
-        const attemptIds = stalePendingLaunchRows
-          .map((row) => row.selected_attempt_id)
-          .filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
-        if (attemptIds.length > 0) {
-          const attemptPlaceholders = attemptIds.map(() => '?').join(', ');
-          this.db.run(
-            `UPDATE attempts
-                SET status = 'pending',
-                    claimed_at = NULL,
-                    last_heartbeat_at = NULL,
-                    lease_expires_at = NULL
-              WHERE id IN (${attemptPlaceholders})
-                AND status = 'claimed'`,
-            attemptIds,
-          );
-        }
-        report.normalizedStaleLaunchMetadata += stalePendingLaunchRows.length;
-      }
-
-      this.db.run(
-        `UPDATE task_launch_dispatch
-         SET state = 'abandoned',
-             completed_at = ?,
-             last_error = 'Legacy acknowledged launch dispatch is stale after acknowledgement removal',
-             dispatch_owner = NULL,
-             fenced_until = NULL
-         WHERE state = 'acknowledged'
-           AND (
-             NOT EXISTS (
-               SELECT 1
-               FROM tasks t
-               WHERE t.id = task_launch_dispatch.task_id
-                 AND t.status = 'pending'
-                 AND COALESCE(t.selected_attempt_id, '') = task_launch_dispatch.attempt_id
-                 AND COALESCE(t.execution_generation, 0) = task_launch_dispatch.generation
-             )
-             OR EXISTS (
-               SELECT 1
-               FROM task_launch_dispatch live
-               WHERE live.attempt_id = task_launch_dispatch.attempt_id
-                 AND live.id != task_launch_dispatch.id
-                 AND live.state IN ('enqueued', 'leased')
-             )
-           )`,
-        [nowIso],
-      );
-      report.normalizedLegacyAcknowledgedLaunchDispatches += this.db.getRowsModified();
-
-      this.db.run(
-        `UPDATE task_launch_dispatch
-         SET state = 'leased',
-             leased_at = COALESCE(leased_at, acknowledged_at, ?),
-             acknowledged_at = NULL
-         WHERE state = 'acknowledged'
-           AND fenced_until IS NOT NULL
-           AND fenced_until >= ?`,
-        [nowIso, nowIso],
-      );
-      report.normalizedLegacyAcknowledgedLaunchDispatches += this.db.getRowsModified();
-
-      this.db.run(
-        `UPDATE task_launch_dispatch
-         SET state = 'enqueued',
-             dispatch_owner = NULL,
-             leased_at = NULL,
-             acknowledged_at = NULL,
-             fenced_until = NULL
-         WHERE state = 'acknowledged'`,
-      );
-      report.normalizedLegacyAcknowledgedLaunchDispatches += this.db.getRowsModified();
-
-      // One-time compatibility backfill for SSH tasks created before
-      // pool_member_id was durably written to tasks. Runtime routing must use
-      // tasks.pool_member_id; this audit-event fallback is migration-only and
-      // can be deleted after old databases no longer need the backfill.
-      const missingSshPoolRows = this.queryAll(
-        `SELECT t.id, e.payload
-         FROM tasks t
-         JOIN events e ON e.id = (
-           SELECT MAX(id)
-           FROM events
-           WHERE task_id = t.id
-             AND event_type = 'task.executor.selected'
-         )
-         WHERE t.runner_kind = 'ssh'
-           AND (t.pool_member_id IS NULL OR TRIM(t.pool_member_id) = '')
-           AND t.workspace_path IS NOT NULL
-           AND TRIM(t.workspace_path) != ''
-           AND e.payload IS NOT NULL`,
-      ) as Array<{ id: string; payload?: string | null }>;
-      for (const row of missingSshPoolRows) {
-        const poolMemberId = this.parseExecutorSelectedPoolMemberId(row.payload);
-        if (!poolMemberId) continue;
-        this.db.run(
-          `UPDATE tasks
-           SET pool_member_id = ?,
-               task_state_version = task_state_version + 1
-           WHERE id = ?
-             AND runner_kind = 'ssh'
-             AND (pool_member_id IS NULL OR TRIM(pool_member_id) = '')
-             AND workspace_path IS NOT NULL
-             AND TRIM(workspace_path) != ''`,
-          [poolMemberId, row.id],
-        );
-        report.backfilledMissingSshPoolMemberIds += this.db.getRowsModified();
-      }
-    });
-    return report;
-  }
-
-  private parseExecutorSelectedPoolMemberId(payload: string | null | undefined): string | undefined {
-    if (!payload) return undefined;
-    try {
-      const parsed = JSON.parse(payload) as { poolMemberId?: unknown };
-      return typeof parsed.poolMemberId === 'string' && parsed.poolMemberId.trim()
-        ? parsed.poolMemberId.trim()
-        : undefined;
-    } catch {
-      return undefined;
-    }
+    return migrations.runCompatibilityMigration(this.migrationExecutor);
   }
 
   checkpointWal(mode: 'PASSIVE' | 'FULL' | 'RESTART' | 'TRUNCATE' = 'PASSIVE'): void {
@@ -939,166 +700,24 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.db.run(SCHEMA_DDL);
   }
 
-  /** Add columns that may not exist in older databases. */
   private migrate(): void {
-    for (const sql of COLUMN_MIGRATIONS) {
-      try {
-        this.db.run(sql);
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        if (!msg.includes('duplicate column name')) {
-          throw err;
-        }
-      }
-    }
-    this.migrateWorkflowStatusColumn();
-    this.dropTaskAutoFixAttemptsColumn();
-
-    if (!this.readOnly) {
-      this.reconcileTerminalSessionInvariants();
-    }
-
-    // Replace old attempt_number index with created_at index, etc.
-    for (const sql of POST_MIGRATION_STATEMENTS) {
-      this.db.run(sql);
-    }
-
-    if (!this.readOnly) {
-      this.migrateTestCommands();
-      this.migrateGatePolicyApprovedToCompleted();
-      this.migrateTaskExternalDependenciesToWorkflows();
-      this.runCompatibilityMigration();
-    }
+    migrations.migrate(this.migrationExecutor, () => this.reconcileTerminalSessionInvariants());
   }
 
   private migrateWorkflowStatusColumn(): void {
-    if (this.readOnly) return;
-    const columns = this.queryAll('PRAGMA table_info(workflows)') as Array<{ name: string }>;
-    if (!columns.some((column) => column.name === 'status')) return;
-
-    const foreignKeys = this.queryOne('PRAGMA foreign_keys') as { foreign_keys?: number } | undefined;
-    const foreignKeysEnabled = foreignKeys?.foreign_keys === 1;
-    if (foreignKeysEnabled) {
-      this.db.run('PRAGMA foreign_keys = OFF');
-    }
-    this.db.run(WORKFLOWS_REBUILD_TABLE_DDL);
-    this.db.run(WORKFLOWS_REBUILD_INSERT_DDL);
-    this.db.run('DROP TABLE workflows');
-    this.db.run('ALTER TABLE workflows_new RENAME TO workflows');
-    if (foreignKeysEnabled) {
-      this.db.run('PRAGMA foreign_keys = ON');
-    }
-    this.dirty = true;
+    migrations.migrateWorkflowStatusColumn(this.migrationExecutor);
   }
 
   private dropTaskAutoFixAttemptsColumn(): void {
-    if (this.readOnly) return;
-    const columns = this.queryAll('PRAGMA table_info(tasks)') as Array<{ name: string }>;
-    if (!columns.some((column) => column.name === 'auto_fix_attempts')) return;
-    this.db.run('ALTER TABLE tasks DROP COLUMN auto_fix_attempts');
-    this.dirty = true;
+    migrations.dropTaskAutoFixAttemptsColumn(this.migrationExecutor);
   }
 
-  /**
-   * Rewrite `pnpm test packages/<pkg>/...` (incorrect root-level invocation)
-   * to `cd packages/<pkg> && pnpm test -- <relative-path>`.
-   * Idempotent: already-rewritten commands won't match the LIKE pattern.
-   */
   private migrateTestCommands(): void {
-    try {
-      const rows = this.queryAll(
-        `SELECT id, command FROM tasks WHERE command LIKE 'pnpm test packages/%' OR command LIKE 'pnpm test -- packages/%'`,
-      ) as Array<{ id: string; command: string }>;
-
-      for (const row of rows) {
-        const fixed = rewritePnpmTestCommand(row.command);
-        if (fixed !== row.command) {
-          this.execRun('UPDATE tasks SET command = ? WHERE id = ?', [fixed, row.id]);
-        }
-      }
-    } catch {
-      // Table may not exist yet on first run
-    }
+    migrations.migrateTestCommands(this.migrationExecutor);
   }
 
-  /**
-   * Rewrite `gatePolicy: 'approved'` to `gatePolicy: 'completed'` in
-   * external_dependencies JSON column.
-   * Idempotent: subsequent runs find zero matches and do nothing.
-   */
   private migrateGatePolicyApprovedToCompleted(): void {
-    try {
-      const rows = this.queryAll(
-        `SELECT id, external_dependencies FROM tasks WHERE external_dependencies LIKE '%"gatePolicy":"approved"%'`,
-      ) as Array<{ id: string; external_dependencies: string }>;
-
-      for (const row of rows) {
-        try {
-          const deps = JSON.parse(row.external_dependencies) as Array<{
-            workflowId: string;
-            taskId?: string;
-            requiredStatus: string;
-            gatePolicy?: string;
-          }>;
-
-          let modified = false;
-          for (const dep of deps) {
-            if (dep.gatePolicy === 'approved') {
-              dep.gatePolicy = 'completed';
-              modified = true;
-            }
-          }
-
-          if (modified) {
-            const updated = JSON.stringify(deps);
-            this.execRun('UPDATE tasks SET external_dependencies = ? WHERE id = ?', [updated, row.id]);
-          }
-        } catch {
-          // Skip malformed JSON rows
-        }
-      }
-    } catch {
-      // Table may not exist yet on first run
-    }
-  }
-
-  private normalizeExternalDependencies(raw: unknown): ExternalDependency[] {
-    if (!Array.isArray(raw)) return [];
-    const normalized: ExternalDependency[] = [];
-    for (const item of raw) {
-      if (!item || typeof item !== 'object') continue;
-      const dep = item as Record<string, unknown>;
-      if (typeof dep.workflowId !== 'string' || dep.workflowId.trim() === '') continue;
-      const taskId = typeof dep.taskId === 'string' && dep.taskId.trim() !== '' ? dep.taskId.trim() : '__merge__';
-      const gatePolicy = dep.gatePolicy === 'review_ready' ? 'review_ready' : 'completed';
-      normalized.push({
-        workflowId: dep.workflowId.trim(),
-        taskId,
-        requiredStatus: 'completed',
-        gatePolicy,
-      });
-    }
-    return normalized;
-  }
-
-  private mergeExternalDependencySets(existing: ExternalDependency[], incoming: ExternalDependency[]): ExternalDependency[] {
-    const byKey = new Map<string, ExternalDependency>();
-    for (const dep of [...existing, ...incoming]) {
-      const taskId = dep.taskId?.trim() || '__merge__';
-      const key = `${dep.workflowId}::${taskId}`;
-      const previous = byKey.get(key);
-      const gatePolicy =
-        previous?.gatePolicy === 'completed' || dep.gatePolicy === 'completed'
-          ? 'completed'
-          : 'review_ready';
-      byKey.set(key, {
-        workflowId: dep.workflowId,
-        taskId,
-        requiredStatus: 'completed',
-        gatePolicy,
-      });
-    }
-    return Array.from(byKey.values());
+    migrations.migrateGatePolicyApprovedToCompleted(this.migrationExecutor);
   }
 
   private buildWorkflowAfterChanges(
@@ -1135,59 +754,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return after;
   }
 
-  /**
-   * Promote legacy per-task external dependencies to workflow metadata.
-   * This is intentionally idempotent: once task rows are cleared, later runs
-   * only see the workflow-level source of truth.
-   */
   private migrateTaskExternalDependenciesToWorkflows(): void {
-    try {
-      const rows = this.queryAll(
-        `SELECT id, workflow_id, external_dependencies FROM tasks WHERE external_dependencies IS NOT NULL AND external_dependencies != ''`,
-      ) as Array<{ id: string; workflow_id: string; external_dependencies: string }>;
-      if (rows.length === 0) return;
-
-      const incomingByWorkflow = new Map<string, ExternalDependency[]>();
-      for (const row of rows) {
-        try {
-          const deps = this.normalizeExternalDependencies(JSON.parse(row.external_dependencies));
-          if (deps.length === 0) continue;
-          incomingByWorkflow.set(row.workflow_id, [
-            ...(incomingByWorkflow.get(row.workflow_id) ?? []),
-            ...deps,
-          ]);
-        } catch {
-          // Skip malformed task JSON; do not clear it.
-        }
-      }
-
-      for (const [workflowId, incoming] of incomingByWorkflow) {
-        const wf = this.queryOne(
-          `SELECT external_dependencies FROM workflows WHERE id = ?`,
-          [workflowId],
-        ) as { external_dependencies?: string | null } | undefined;
-        if (!wf) continue;
-        let existing: ExternalDependency[] = [];
-        if (wf.external_dependencies) {
-          try {
-            existing = this.normalizeExternalDependencies(JSON.parse(wf.external_dependencies));
-          } catch {
-            existing = [];
-          }
-        }
-        const merged = this.mergeExternalDependencySets(existing, incoming);
-        this.execRun(
-          `UPDATE workflows SET external_dependencies = ?, updated_at = ? WHERE id = ?`,
-          [merged.length > 0 ? JSON.stringify(merged) : null, new Date().toISOString(), workflowId],
-        );
-      }
-
-      this.execRun(
-        `UPDATE tasks SET external_dependencies = NULL WHERE external_dependencies IS NOT NULL AND external_dependencies != ''`,
-      );
-    } catch {
-      // Tables/columns may not exist yet on first run.
-    }
+    migrations.migrateTaskExternalDependenciesToWorkflows(this.migrationExecutor);
   }
 
   private reconcileTerminalSessionInvariants(): void {

--- a/packages/data-store/src/sqlite-executor.ts
+++ b/packages/data-store/src/sqlite-executor.ts
@@ -1,0 +1,16 @@
+export interface SqliteExecutor {
+  queryOne(sql: string, params?: unknown[]): Record<string, unknown> | undefined;
+  queryAll(sql: string, params?: unknown[]): Record<string, unknown>[];
+  /** Run an INSERT/UPDATE/DELETE through the writable, dirty-tracking path. */
+  execRun(sql: string, params?: unknown[]): void;
+  /** Run `work` inside an immediate (or nested savepoint) write transaction. */
+  runTransaction<T>(work: () => T): T;
+  /** Raw connection run for PRAGMA/DDL statements issued by schema migrations. */
+  run(sql: string, params?: unknown[]): void;
+  /** Rows changed by the most recent {@link SqliteExecutor.run}. */
+  getRowsModified(): number;
+  /** True when the adapter is read-only; migrations short-circuit on it. */
+  readonly readOnly: boolean;
+  /** Mark the connection dirty after a raw DDL mutation. */
+  markDirty(): void;
+}

--- a/packages/data-store/src/sqlite-external-dependencies.ts
+++ b/packages/data-store/src/sqlite-external-dependencies.ts
@@ -1,0 +1,40 @@
+import type { ExternalDependency } from '@invoker/workflow-core';
+
+export function normalizeExternalDependencies(raw: unknown): ExternalDependency[] {
+  if (!Array.isArray(raw)) return [];
+  const normalized: ExternalDependency[] = [];
+  for (const item of raw) {
+    if (!item || typeof item !== 'object') continue;
+    const dep = item as Record<string, unknown>;
+    if (typeof dep.workflowId !== 'string' || dep.workflowId.trim() === '') continue;
+    const taskId = typeof dep.taskId === 'string' && dep.taskId.trim() !== '' ? dep.taskId.trim() : '__merge__';
+    const gatePolicy = dep.gatePolicy === 'review_ready' ? 'review_ready' : 'completed';
+    normalized.push({
+      workflowId: dep.workflowId.trim(),
+      taskId,
+      requiredStatus: 'completed',
+      gatePolicy,
+    });
+  }
+  return normalized;
+}
+
+export function mergeExternalDependencySets(existing: ExternalDependency[], incoming: ExternalDependency[]): ExternalDependency[] {
+  const byKey = new Map<string, ExternalDependency>();
+  for (const dep of [...existing, ...incoming]) {
+    const taskId = dep.taskId?.trim() || '__merge__';
+    const key = `${dep.workflowId}::${taskId}`;
+    const previous = byKey.get(key);
+    const gatePolicy =
+      previous?.gatePolicy === 'completed' || dep.gatePolicy === 'completed'
+        ? 'completed'
+        : 'review_ready';
+    byKey.set(key, {
+      workflowId: dep.workflowId,
+      taskId,
+      requiredStatus: 'completed',
+      gatePolicy,
+    });
+  }
+  return Array.from(byKey.values());
+}

--- a/packages/data-store/src/sqlite-migrations.ts
+++ b/packages/data-store/src/sqlite-migrations.ts
@@ -1,0 +1,483 @@
+import type { ExternalDependency } from '@invoker/workflow-core';
+import {
+  COLUMN_MIGRATIONS,
+  POST_MIGRATION_STATEMENTS,
+  WORKFLOWS_REBUILD_TABLE_DDL,
+  WORKFLOWS_REBUILD_INSERT_DDL,
+} from './sqlite-schema.js';
+import {
+  normalizeExternalDependencies,
+  mergeExternalDependencySets,
+} from './sqlite-external-dependencies.js';
+import type { SqliteExecutor } from './sqlite-executor.js';
+
+/**
+ * Log a caught migration error instead of dropping it silently. Migrations
+ * tolerate missing tables/columns and malformed rows so a partial upgrade never
+ * aborts startup, but the error is still surfaced with context to debug later.
+ */
+function logSwallowedMigrationError(context: string, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  console.warn(`[sqlite-migrations] ${context}: ${message}`);
+}
+
+/**
+ * Rewrite `pnpm test packages/<pkg>/...` (incorrect root-level invocation)
+ * to `cd packages/<pkg> && pnpm test -- <relative-path>`.
+ */
+function rewritePnpmTestCommand(cmd: string): string {
+  const withFile = cmd.match(/^(pnpm test)\s+(?:--\s+)?packages\/([^/\s]+)\/(\S+)(.*)/);
+  if (withFile) {
+    const [, , pkg, rest, suffix] = withFile;
+    return `cd packages/${pkg} && pnpm test -- ${rest}${suffix}`;
+  }
+  const pkgOnly = cmd.match(/^(pnpm test)\s+(?:--\s+)?packages\/([^/\s]+)(.*)/);
+  if (pkgOnly) {
+    const [, , pkg, suffix] = pkgOnly;
+    return `cd packages/${pkg} && pnpm test${suffix}`;
+  }
+  return cmd;
+}
+
+function parseExecutorSelectedPoolMemberId(payload: string | null | undefined): string | undefined {
+  if (!payload) return undefined;
+  try {
+    const parsed = JSON.parse(payload) as { poolMemberId?: unknown };
+    return typeof parsed.poolMemberId === 'string' && parsed.poolMemberId.trim()
+      ? parsed.poolMemberId.trim()
+      : undefined;
+  } catch (err) {
+    logSwallowedMigrationError(
+      'parseExecutorSelectedPoolMemberId: malformed task.executor.selected payload',
+      err,
+    );
+    return undefined;
+  }
+}
+
+export function migrate(exec: SqliteExecutor, reconcileTerminalSessionInvariants: () => void): void {
+  for (const sql of COLUMN_MIGRATIONS) {
+    try {
+      exec.run(sql);
+    } catch (err) {
+      // A "duplicate column name" error means the column already exists
+      // (idempotent re-run); rethrow anything else.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!msg.includes('duplicate column name')) {
+        throw err;
+      }
+    }
+  }
+  migrateWorkflowStatusColumn(exec);
+  dropTaskAutoFixAttemptsColumn(exec);
+
+  if (!exec.readOnly) {
+    reconcileTerminalSessionInvariants();
+  }
+
+  for (const sql of POST_MIGRATION_STATEMENTS) {
+    exec.run(sql);
+  }
+
+  if (!exec.readOnly) {
+    migrateTestCommands(exec);
+    migrateGatePolicyApprovedToCompleted(exec);
+    migrateTaskExternalDependenciesToWorkflows(exec);
+    runCompatibilityMigration(exec);
+  }
+}
+
+export function runCompatibilityMigration(exec: SqliteExecutor): {
+  migratedFixingWithAiStatuses: number;
+  normalizedMergeModes: number;
+  staleAutoFixExperimentTasks: number;
+  normalizedStaleLaunchMetadata: number;
+  normalizedLegacyAcknowledgedLaunchDispatches: number;
+  backfilledMissingSshPoolMemberIds: number;
+} {
+  const report = {
+    migratedFixingWithAiStatuses: 0,
+    normalizedMergeModes: 0,
+    staleAutoFixExperimentTasks: 0,
+    normalizedStaleLaunchMetadata: 0,
+    normalizedLegacyAcknowledgedLaunchDispatches: 0,
+    backfilledMissingSshPoolMemberIds: 0,
+  };
+  exec.runTransaction(() => {
+    exec.run(
+      `UPDATE tasks
+         SET status = 'fixing_with_ai'
+         WHERE status = 'running' AND is_fixing_with_ai = 1`,
+    );
+    report.migratedFixingWithAiStatuses = exec.getRowsModified();
+
+    exec.run(
+      `UPDATE tasks
+         SET is_fixing_with_ai = 0
+         WHERE status = 'fixing_with_ai' AND is_fixing_with_ai != 0`,
+    );
+
+    exec.run(
+      `UPDATE workflows
+         SET merge_mode = 'external_review'
+         WHERE merge_mode = 'github'`,
+    );
+    report.normalizedMergeModes = exec.getRowsModified();
+
+    const staleAutoFixRows = exec.queryAll(
+      `SELECT id FROM tasks
+         WHERE status != 'stale'
+           AND (
+             (parent_task IS NOT NULL AND id LIKE '%-exp-fix-%')
+             OR (
+               is_reconciliation = 1
+               AND parent_task IN (
+                 SELECT id FROM tasks
+                 WHERE parent_task IS NOT NULL AND id LIKE '%-exp-fix-%'
+               )
+             )
+           )`,
+    );
+    exec.run(
+      `UPDATE tasks
+         SET status = 'stale',
+             error = 'Stale auto-fix experiment branch; migrated to modern retry model',
+             completed_at = COALESCE(completed_at, datetime('now')),
+             is_fixing_with_ai = 0
+         WHERE status != 'stale'
+           AND (
+             (parent_task IS NOT NULL AND id LIKE '%-exp-fix-%')
+             OR (
+               is_reconciliation = 1
+               AND parent_task IN (
+                 SELECT id FROM tasks
+                 WHERE parent_task IS NOT NULL AND id LIKE '%-exp-fix-%'
+               )
+             )
+           )`,
+    );
+    report.staleAutoFixExperimentTasks = staleAutoFixRows.length;
+
+    exec.run(
+      `UPDATE tasks
+         SET launch_phase = NULL,
+             launch_started_at = NULL,
+             launch_completed_at = NULL
+         WHERE status IN ('completed', 'failed', 'needs_input', 'awaiting_approval', 'review_ready', 'stale')
+           AND launch_started_at IS NOT NULL
+           AND started_at IS NOT NULL
+           AND (julianday(started_at) - julianday(launch_started_at)) * 86400.0 > 3600.0`,
+    );
+    report.normalizedStaleLaunchMetadata = exec.getRowsModified();
+
+    const nowIso = new Date().toISOString();
+    const stalePendingLaunchRows = exec.queryAll(
+      `SELECT t.id, t.selected_attempt_id
+           FROM tasks t
+           LEFT JOIN attempts a ON a.id = t.selected_attempt_id
+          WHERE t.status = 'pending'
+            AND t.launch_phase = 'launching'
+            AND t.selected_attempt_id IS NOT NULL
+            AND TRIM(t.selected_attempt_id) != ''
+            AND NOT EXISTS (
+              SELECT 1
+                FROM task_launch_dispatch live
+               WHERE live.task_id = t.id
+                 AND live.attempt_id = t.selected_attempt_id
+                 AND live.state IN ('enqueued', 'leased')
+            )
+            AND (
+              a.id IS NULL
+              OR a.lease_expires_at IS NULL
+              OR a.lease_expires_at <= ?
+            )`,
+      [nowIso],
+    ) as Array<{ id: string; selected_attempt_id?: string | null }>;
+    if (stalePendingLaunchRows.length > 0) {
+      const taskIds = stalePendingLaunchRows.map((row) => String(row.id));
+      const taskPlaceholders = taskIds.map(() => '?').join(', ');
+      exec.run(
+        `UPDATE tasks
+              SET launch_phase = NULL,
+                  launch_started_at = NULL,
+                  launch_completed_at = NULL,
+                  last_heartbeat_at = NULL
+            WHERE id IN (${taskPlaceholders})`,
+        taskIds,
+      );
+
+      const attemptIds = stalePendingLaunchRows
+        .map((row) => row.selected_attempt_id)
+        .filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
+      if (attemptIds.length > 0) {
+        const attemptPlaceholders = attemptIds.map(() => '?').join(', ');
+        exec.run(
+          `UPDATE attempts
+                SET status = 'pending',
+                    claimed_at = NULL,
+                    last_heartbeat_at = NULL,
+                    lease_expires_at = NULL
+              WHERE id IN (${attemptPlaceholders})
+                AND status = 'claimed'`,
+          attemptIds,
+        );
+      }
+      report.normalizedStaleLaunchMetadata += stalePendingLaunchRows.length;
+    }
+
+    exec.run(
+      `UPDATE task_launch_dispatch
+         SET state = 'abandoned',
+             completed_at = ?,
+             last_error = 'Legacy acknowledged launch dispatch is stale after acknowledgement removal',
+             dispatch_owner = NULL,
+             fenced_until = NULL
+         WHERE state = 'acknowledged'
+           AND (
+             NOT EXISTS (
+               SELECT 1
+               FROM tasks t
+               WHERE t.id = task_launch_dispatch.task_id
+                 AND t.status = 'pending'
+                 AND COALESCE(t.selected_attempt_id, '') = task_launch_dispatch.attempt_id
+                 AND COALESCE(t.execution_generation, 0) = task_launch_dispatch.generation
+             )
+             OR EXISTS (
+               SELECT 1
+               FROM task_launch_dispatch live
+               WHERE live.attempt_id = task_launch_dispatch.attempt_id
+                 AND live.id != task_launch_dispatch.id
+                 AND live.state IN ('enqueued', 'leased')
+             )
+           )`,
+      [nowIso],
+    );
+    report.normalizedLegacyAcknowledgedLaunchDispatches += exec.getRowsModified();
+
+    exec.run(
+      `UPDATE task_launch_dispatch
+         SET state = 'leased',
+             leased_at = COALESCE(leased_at, acknowledged_at, ?),
+             acknowledged_at = NULL
+         WHERE state = 'acknowledged'
+           AND fenced_until IS NOT NULL
+           AND fenced_until >= ?`,
+      [nowIso, nowIso],
+    );
+    report.normalizedLegacyAcknowledgedLaunchDispatches += exec.getRowsModified();
+
+    exec.run(
+      `UPDATE task_launch_dispatch
+         SET state = 'enqueued',
+             dispatch_owner = NULL,
+             leased_at = NULL,
+             acknowledged_at = NULL,
+             fenced_until = NULL
+         WHERE state = 'acknowledged'`,
+    );
+    report.normalizedLegacyAcknowledgedLaunchDispatches += exec.getRowsModified();
+
+    // One-time compatibility backfill for SSH tasks created before
+    // pool_member_id was durably written to tasks. Runtime routing must use
+    // tasks.pool_member_id; this audit-event fallback is migration-only and
+    // can be deleted after old databases no longer need the backfill.
+    const missingSshPoolRows = exec.queryAll(
+      `SELECT t.id, e.payload
+         FROM tasks t
+         JOIN events e ON e.id = (
+           SELECT MAX(id)
+           FROM events
+           WHERE task_id = t.id
+             AND event_type = 'task.executor.selected'
+         )
+         WHERE t.runner_kind = 'ssh'
+           AND (t.pool_member_id IS NULL OR TRIM(t.pool_member_id) = '')
+           AND t.workspace_path IS NOT NULL
+           AND TRIM(t.workspace_path) != ''
+           AND e.payload IS NOT NULL`,
+    ) as Array<{ id: string; payload?: string | null }>;
+    for (const row of missingSshPoolRows) {
+      const poolMemberId = parseExecutorSelectedPoolMemberId(row.payload);
+      if (!poolMemberId) continue;
+      exec.run(
+        `UPDATE tasks
+           SET pool_member_id = ?,
+               task_state_version = task_state_version + 1
+           WHERE id = ?
+             AND runner_kind = 'ssh'
+             AND (pool_member_id IS NULL OR TRIM(pool_member_id) = '')
+             AND workspace_path IS NOT NULL
+             AND TRIM(workspace_path) != ''`,
+        [poolMemberId, row.id],
+      );
+      report.backfilledMissingSshPoolMemberIds += exec.getRowsModified();
+    }
+  });
+  return report;
+}
+
+export function migrateWorkflowStatusColumn(exec: SqliteExecutor): void {
+  if (exec.readOnly) return;
+  const columns = exec.queryAll('PRAGMA table_info(workflows)') as Array<{ name: string }>;
+  if (!columns.some((column) => column.name === 'status')) return;
+
+  const foreignKeys = exec.queryOne('PRAGMA foreign_keys') as { foreign_keys?: number } | undefined;
+  const foreignKeysEnabled = foreignKeys?.foreign_keys === 1;
+  if (foreignKeysEnabled) {
+    exec.run('PRAGMA foreign_keys = OFF');
+  }
+  exec.run(WORKFLOWS_REBUILD_TABLE_DDL);
+  exec.run(WORKFLOWS_REBUILD_INSERT_DDL);
+  exec.run('DROP TABLE workflows');
+  exec.run('ALTER TABLE workflows_new RENAME TO workflows');
+  if (foreignKeysEnabled) {
+    exec.run('PRAGMA foreign_keys = ON');
+  }
+  exec.markDirty();
+}
+
+export function dropTaskAutoFixAttemptsColumn(exec: SqliteExecutor): void {
+  if (exec.readOnly) return;
+  const columns = exec.queryAll('PRAGMA table_info(tasks)') as Array<{ name: string }>;
+  if (!columns.some((column) => column.name === 'auto_fix_attempts')) return;
+  exec.run('ALTER TABLE tasks DROP COLUMN auto_fix_attempts');
+  exec.markDirty();
+}
+
+/**
+ * Rewrite `pnpm test packages/<pkg>/...` (incorrect root-level invocation)
+ * to `cd packages/<pkg> && pnpm test -- <relative-path>`.
+ * Idempotent: already-rewritten commands won't match the LIKE pattern.
+ */
+export function migrateTestCommands(exec: SqliteExecutor): void {
+  try {
+    const rows = exec.queryAll(
+      `SELECT id, command FROM tasks WHERE command LIKE 'pnpm test packages/%' OR command LIKE 'pnpm test -- packages/%'`,
+    ) as Array<{ id: string; command: string }>;
+
+    for (const row of rows) {
+      const fixed = rewritePnpmTestCommand(row.command);
+      if (fixed !== row.command) {
+        exec.execRun('UPDATE tasks SET command = ? WHERE id = ?', [fixed, row.id]);
+      }
+    }
+  } catch (err) {
+    // Tolerate a missing tasks table (initSchema creates it first); surface anything else.
+    logSwallowedMigrationError('migrateTestCommands', err);
+  }
+}
+
+/**
+ * Rewrite `gatePolicy: 'approved'` to `gatePolicy: 'completed'` in
+ * external_dependencies JSON column.
+ * Idempotent: subsequent runs find zero matches and do nothing.
+ */
+export function migrateGatePolicyApprovedToCompleted(exec: SqliteExecutor): void {
+  try {
+    const rows = exec.queryAll(
+      `SELECT id, external_dependencies FROM tasks WHERE external_dependencies LIKE '%"gatePolicy":"approved"%'`,
+    ) as Array<{ id: string; external_dependencies: string }>;
+
+    for (const row of rows) {
+      try {
+        const deps = JSON.parse(row.external_dependencies) as Array<{
+          workflowId: string;
+          taskId?: string;
+          requiredStatus: string;
+          gatePolicy?: string;
+        }>;
+
+        let modified = false;
+        for (const dep of deps) {
+          if (dep.gatePolicy === 'approved') {
+            dep.gatePolicy = 'completed';
+            modified = true;
+          }
+        }
+
+        if (modified) {
+          const updated = JSON.stringify(deps);
+          exec.execRun('UPDATE tasks SET external_dependencies = ? WHERE id = ?', [updated, row.id]);
+        }
+      } catch (err) {
+        logSwallowedMigrationError(
+          `migrateGatePolicyApprovedToCompleted: skipping malformed external_dependencies for task ${row.id}`,
+          err,
+        );
+      }
+    }
+  } catch (err) {
+    logSwallowedMigrationError('migrateGatePolicyApprovedToCompleted', err);
+  }
+}
+
+/**
+ * Promote legacy per-task external dependencies to workflow metadata.
+ * This is intentionally idempotent: once task rows are cleared, later runs
+ * only see the workflow-level source of truth.
+ */
+export function migrateTaskExternalDependenciesToWorkflows(exec: SqliteExecutor): void {
+  try {
+    const rows = exec.queryAll(
+      `SELECT id, workflow_id, external_dependencies FROM tasks WHERE external_dependencies IS NOT NULL AND external_dependencies != ''`,
+    ) as Array<{ id: string; workflow_id: string; external_dependencies: string }>;
+    if (rows.length === 0) return;
+
+    const incomingByWorkflow = new Map<string, { deps: ExternalDependency[]; taskIds: string[] }>();
+    for (const row of rows) {
+      try {
+        const deps = normalizeExternalDependencies(JSON.parse(row.external_dependencies));
+        if (deps.length === 0) continue;
+        const entry = incomingByWorkflow.get(row.workflow_id) ?? { deps: [], taskIds: [] };
+        entry.deps.push(...deps);
+        entry.taskIds.push(row.id);
+        incomingByWorkflow.set(row.workflow_id, entry);
+      } catch (err) {
+        logSwallowedMigrationError(
+          `migrateTaskExternalDependenciesToWorkflows: skipping malformed external_dependencies for task ${row.id}`,
+          err,
+        );
+      }
+    }
+
+    const promotedTaskIds: string[] = [];
+    for (const [workflowId, incoming] of incomingByWorkflow) {
+      const wf = exec.queryOne(
+        `SELECT external_dependencies FROM workflows WHERE id = ?`,
+        [workflowId],
+      ) as { external_dependencies?: string | null } | undefined;
+      if (!wf) continue;
+      let existing: ExternalDependency[] = [];
+      if (wf.external_dependencies) {
+        try {
+          existing = normalizeExternalDependencies(JSON.parse(wf.external_dependencies));
+        } catch (err) {
+          logSwallowedMigrationError(
+            `migrateTaskExternalDependenciesToWorkflows: resetting unparseable workflow external_dependencies for workflow ${workflowId}`,
+            err,
+          );
+          existing = [];
+        }
+      }
+      const merged = mergeExternalDependencySets(existing, incoming.deps);
+      exec.execRun(
+        `UPDATE workflows SET external_dependencies = ?, updated_at = ? WHERE id = ?`,
+        [merged.length > 0 ? JSON.stringify(merged) : null, new Date().toISOString(), workflowId],
+      );
+      promotedTaskIds.push(...incoming.taskIds);
+    }
+
+    // Clear only tasks whose deps were promoted to an existing workflow; leave
+    // malformed rows and orphaned tasks (missing workflow) untouched so their
+    // dependency data is not silently lost.
+    if (promotedTaskIds.length > 0) {
+      const placeholders = promotedTaskIds.map(() => '?').join(', ');
+      exec.execRun(
+        `UPDATE tasks SET external_dependencies = NULL WHERE id IN (${placeholders})`,
+        promotedTaskIds,
+      );
+    }
+  } catch (err) {
+    logSwallowedMigrationError('migrateTaskExternalDependenciesToWorkflows', err);
+  }
+}


### PR DESCRIPTION
## Summary

Slice 1 of the data-store god-file decomposition.

This moves the SQLite migration routines out of the 3,906-line sqlite-adapter.ts into a new sqlite-migrations.ts module.

The adapter keeps the same public methods; each one now delegates to a free function over a narrow SqliteExecutor context.

A pure sqlite-external-dependencies.ts helper is also split out so a later repository slice can reuse it.

The moved code used to hide errors.

Several catch blocks discarded every caught error behind a "table may not exist yet" comment, which cannot happen because the tables are created before migrations run.

Those blocks now log the caught error with its function name and row context, so a real database or JSON failure is debuggable instead of silently vanishing.

Migrations still tolerate missing tables and never abort startup. The one added behavior is that caught errors now warn instead of vanishing.

The workflow-dependency migration also stops dropping data: it now clears a task's external_dependencies only when those deps were merged into an existing workflow.

## Review Claim

The migrate* logic moves from sqlite-adapter.ts to sqlite-migrations.ts as free functions over a SqliteExecutor context, the adapter methods become one-line delegates, every caught migration error is now logged with context instead of being silently swallowed, and the workflow-dependency migration clears only the tasks whose deps were promoted to an existing workflow.

## Review Lane

behavior

## Review Unit

ownership-refactor

## Safety Invariant

Migration order and control flow are unchanged: migrations run from the same call sites, still tolerate missing tables and malformed rows without aborting, and the COLUMN_MIGRATIONS loop still rethrows anything but the idempotent "duplicate column name". Two intended behavior changes: caught errors now log through `console.warn`, and `migrateTaskExternalDependenciesToWorkflows` clears `external_dependencies` only for tasks whose deps were promoted to an existing workflow, so malformed or orphaned rows are no longer silently dropped. Both are covered by `sqlite-migrations-error-logging.test.ts`.

## Slice Rationale

One extraction per slice, following the review-compression convention. The silent-swallow catch blocks were introduced into the new module by this very move, so repairing them belongs in the same slice rather than a follow-up; the change stays inside the extracted file plus a focused test for it.

## Non-goals

- No task/attempt or workflow repository extraction; those are later slices.
- No change to PersistenceAdapter (adapter.ts), the package barrel index.ts, or any SQL text.
- No new migrations and no reordering of migration execution.
- No change to migration order or the public SQLiteAdapter method surface.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-migrations-error-logging.test.ts src/__tests__/migrate-gate-policy.test.ts src/__tests__/sqlite-adapter.test.ts`
- [ ] `pnpm --filter @invoker/data-store exec vitest run` (full data-store suite: 362 passed)
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
