### PR TITLE
[Sidebar manual control](1) Keep the app sidebar width under manual control

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -770,7 +770,7 @@ export function App() {
   const lastGoodSelectedWorkflowGraphRef = useRef<SelectedWorkflowGraphSnapshot | null>(null);
   const contextMenuTaskRef = useRef<TaskState | null>(null);
   const [sidebarSurface, setSidebarSurface] = useState<SidebarSurface>('home');
-  const [sidebarCollapsed, setSidebarCollapsed] = useState<boolean | null>(null);
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkerKind, setSelectedWorkerKind] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
@@ -2848,7 +2848,7 @@ export function App() {
       setHasLoadedPlan(false);
       setPlanName(null);
       setSidebarSurface('home');
-      setSidebarCollapsed(null);
+      setSidebarCollapsed(false);
       setViewMode('dag');
       setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
@@ -2872,7 +2872,7 @@ export function App() {
       setHasLoadedPlan(false);
       setPlanName(null);
       setSidebarSurface('home');
-      setSidebarCollapsed(null);
+      setSidebarCollapsed(false);
       setViewMode('dag');
       setGraphActionsMenuOpen(false);
       setSelectedTaskId(null);
@@ -2885,8 +2885,6 @@ export function App() {
   }, [clearTasks, invoker]);
   const showStartReadyControl = hasLoadedPlan || tasks.size > 0 || workflows.size > 0;
   const showEmptyGraphTutorial = sidebarSurface === 'home' && !hasLoadedPlan && tasks.size === 0 && workflows.size === 0;
-  const autoCollapseSidebar = viewportWidth < 1440;
-  const effectiveSidebarCollapsed = sidebarCollapsed ?? autoCollapseSidebar;
   const autoCollapseInspector = sidebarSurface !== 'home' && viewportWidth < 1440;
   const effectiveInspectorCollapsed = inspectorCollapsed || (autoCollapseInspector && !inspectorManualOpen);
   const showWorkerDetailsPanel = viewMode === 'queue' && sidebarSurface === 'workers';
@@ -4072,9 +4070,9 @@ export function App() {
           planningSessionCount={planningSessions.length}
           planningAttentionCount={planningAttentionCount}
           selectedSurface={sidebarSurface}
-          collapsed={effectiveSidebarCollapsed}
+          collapsed={sidebarCollapsed}
           onSelectSurface={handleSelectSidebarSurface}
-          onToggleCollapsed={() => setSidebarCollapsed(!effectiveSidebarCollapsed)}
+          onToggleCollapsed={() => setSidebarCollapsed((value) => !value)}
           onOpenSettings={() => {
             cancelPendingSystemSetupAutoOpen();
             setShowSystemSetup(true);

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -57,8 +57,11 @@ describe('App launch (component)', () => {
 
     render(<App />);
     act(() => window.dispatchEvent(new Event('resize')));
+    await screen.findByTestId('sidebar-planning');
 
-    const sidebar = await screen.findByTestId('app-sidebar');
+    fireEvent.click(screen.getByTestId('sidebar-collapse-toggle'));
+
+    const sidebar = screen.getByTestId('app-sidebar');
     expect(sidebar.className).toContain('w-16');
     expect(screen.getByTestId('sidebar-planning').textContent).toBe('');
 
@@ -174,29 +177,44 @@ describe('App launch (component)', () => {
     expect(await screen.findByText('Plan graph')).toBeInTheDocument();
     expect(screen.getByText('Alpha · running')).toBeInTheDocument();
   });
-  it('auto-collapses the app sidebar on narrow windows without changing width across surfaces', async () => {
-    Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true });
-
+  it('keeps sidebar width under explicit toggle control while surfaces change', async () => {
     render(<App />);
     await screen.findByTestId('sidebar-workflows');
-    act(() => window.dispatchEvent(new Event('resize')));
 
-    const sidebar = screen.getByTestId('app-sidebar');
-    expect(sidebar.className).toContain('w-16');
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-60');
 
     fireEvent.click(screen.getByTestId('sidebar-workflows'));
     expect(await screen.findByTestId('browser-rail')).toBeInTheDocument();
-    expect(sidebar.className).toContain('w-16');
-    expect(screen.queryByText('What do you want to build?')).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Workflows' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-60');
+
     fireEvent.click(screen.getByTestId('browser-rail-dismiss'));
-    expect(sidebar.className).toContain('w-16');
+    expect(await screen.findByText('Plan graph')).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-60');
+
+    fireEvent.click(screen.getByTestId('sidebar-collapse-toggle'));
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+
+    fireEvent.click(screen.getByTestId('sidebar-planning'));
+    expect(await screen.findByTestId('planning-session-rail')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Planning Terminal' })).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+
+    fireEvent.click(screen.getByTestId('sidebar-attention'));
+    expect(await screen.findByTestId('browser-rail')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Needs Attention' })).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
+
+    fireEvent.click(screen.getByTestId('sidebar-workers'));
+    expect(await screen.findByTestId('workers-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
 
     fireEvent.click(screen.getByTestId('sidebar-home'));
-    expect(sidebar.className).toContain('w-16');
+    expect(await screen.findByText('Plan graph')).toBeInTheDocument();
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-16');
 
-    Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });
+    fireEvent.click(screen.getByTestId('sidebar-collapse-toggle'));
+    expect(screen.getByTestId('app-sidebar').className).toContain('w-60');
   });
   it('keeps the manual app sidebar width while switching left rail surfaces', async () => {
     Object.defineProperty(window, 'innerWidth', { value: 1600, configurable: true });


### PR DESCRIPTION
## Summary

The app sidebar now keeps whatever width the user picked. Moving between Home, Workflows, Workers, and other surfaces no longer resizes it on its own.

Earlier the sidebar could shrink itself on narrow windows for some surfaces. That fought the user's collapse choice and felt jumpy.

Now the collapse toggle is the only thing that sets the width. The chosen width holds until the user clicks that toggle again.

## Review Claim

Approve making the app sidebar width a plain user-driven toggle so moving between surfaces never resizes it.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

This slice touches only the app shell's sidebar width in `App.tsx` and its paired component test. It changes no data flow and no other surface.

## Slice Rationale

The width fix ships on its own so the reviewer approves one shell behavior. The end-to-end walkthrough that guards it lands as the next slice.

## Non-goals

- Does not change the collapse toggle's icon, position, or keyboard handling.
- Does not change the inspector panel width behavior.
- Does not touch any individual surface's own content.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui test`

</details>

## Visual Proof

The sidebar keeps the width the user picked while the active surface changes.

Expanded width held while moving to Needs Attention:

![Sidebar stays expanded while the active surface changes](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-9b42dc/sidebar-collapse-state-2-attention-after-navigation.png)

Manually collapsed width held while moving to Home:

![Sidebar stays collapsed while the active surface changes](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-9b42dc/sidebar-collapse-state-4-home-still-collapsed.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
