### PR TITLE
[PR Maintenance Cron Cleanup](1) Remove cron script header comments

### DIFF
--- a/scripts/cron-coderabbit-address.sh
+++ b/scripts/cron-coderabbit-address.sh
@@ -1,29 +1,4 @@
 #!/usr/bin/env bash
-# Job 1 — CodeRabbit review address cron.
-#
-# Every 5 min: for open PRs by $PR_AUTHOR, look for NEW CodeRabbit review
-# comments (inline + summary). On the first PR with new feedback, launch a
-# standalone `omp` agent on a checkout of the PR head branch. The agent reads
-# the CodeRabbit comments + the branch commits + the Invoker tasks that
-# produced the PR + the PR summary, judges each concern, and — only for the
-# real ones — writes a bash repro proving the finding, fixes the branch, and
-# pushes the update. Invoker workflow state is never touched.
-#
-# At most ONE omp operation per tick (bounds the shared lock hold).
-#
-# Anti-loop guards:
-#   - new-since-last-run dedup (ledger max marker vs latest comment updated_at)
-#   - per-PR hard attempt cap ($MAX_CODERABBIT_ATTEMPTS)
-#
-# Env: INVOKER_GITHUB_TARGET_REPO, INVOKER_PR_CRON_AUTHOR,
-#      INVOKER_CODERABBIT_LOGIN (default coderabbitai[bot]),
-#      INVOKER_PR_CODERABBIT_MAX_ATTEMPTS (default 3),
-#      INVOKER_PR_CODERABBIT_STATE_FILE (ledger path),
-#      INVOKER_PR_CRON_WORKDIR (checkout root),
-#      INVOKER_PR_CRON_WORKDIR_MAX_AGE_DAYS (default 7),
-#      INVOKER_PR_CRON_OMP_MODEL (omp model, optional),
-#      INVOKER_OMP_COMMAND (omp binary, default omp),
-#      INVOKER_PR_CRON_DRY_RUN=1 (print intended actions only).
 set -euo pipefail
 
 # shellcheck source=scripts/cron-pr-lib.sh

--- a/scripts/cron-pr-conflict-rebase.sh
+++ b/scripts/cron-pr-conflict-rebase.sh
@@ -1,26 +1,4 @@
 #!/usr/bin/env bash
-# Job 2 — PR merge-conflict rebase cron.
-#
-# Every 5 min: find open PRs by $PR_AUTHOR whose GitHub merge state is
-# conflicting (mergeStateStatus == DIRTY or mergeable == CONFLICTING), map each
-# back to its Invoker workflow, and `rebase-recreate` it — but only ONCE per
-# (workflow, generation), capped at $MAX_REBASE_ATTEMPTS per workflow.
-#
-# Anti-loop guards (no separate in-flight query needed):
-#   1. shared flock/mkdir lock + synchronous dispatch — one cron op at a time.
-#   2. Invoker's per-workflow CommandService mutex — serializes owner-side.
-#   3. per-(workflow, generation) ledger dedup — a successful rebase-recreate
-#      bumps generation, so the next real conflict appears under a new
-#      generation and is allowed exactly once.
-#
-# At most ONE rebase-recreate runs per tick (bounds the lock hold); remaining
-# conflicting PRs are handled on later ticks.
-#
-# Env: INVOKER_GITHUB_TARGET_REPO, INVOKER_PR_CRON_AUTHOR,
-#      INVOKER_PR_REBASE_MAX_ATTEMPTS (default 3),
-#      INVOKER_PR_REBASE_CONFIRM_TIMEOUT (default 120s),
-#      INVOKER_PR_CONFLICT_STATE_FILE (ledger path),
-#      INVOKER_PR_CRON_DRY_RUN=1 (print intended actions only).
 set -euo pipefail
 
 # shellcheck source=scripts/cron-pr-lib.sh


### PR DESCRIPTION
## Summary

The two PR-maintenance cron scripts each opened with a large comment block. This removes those top-of-file header blocks.

The comments documented the job cadence, anti-loop guards, and environment variables. They are deleted here at the author's request.

No executable code changed. Both scripts still parse cleanly under `bash -n`.

## Review Claim

Only the top-of-file comment blocks in the two cron scripts are removed; no code or behavior changes.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The diff deletes only comment lines between the shebang and `set -euo pipefail`. `bash -n` passes on both scripts, so runtime behavior is unchanged.

## Slice Rationale

This is a standalone comment-only cleanup with no dependencies, so it ships as a single self-contained PR rather than as part of a larger stack.

## Non-goals

Does not change any cron logic, env-var handling, locking, ledger dedup, or dispatch. Does not touch the owner config wiring or the worker registration.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash -n scripts/cron-coderabbit-address.sh`
- [ ] `bash -n scripts/cron-pr-conflict-rebase.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
