### PR TITLE
[One Refactor Per PR](1) Canonical one-symbol-per-PR rule

### DIFF
--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -101,10 +101,12 @@ requires them. Split optional cleanup, special cases, behavior-plus-rename,
 default-flip-plus-deletion, benchmark-before-fix proof, refactor-before-fields,
 and product-code-plus-policy/docs follow-ups.
 
-Decomposition refactors split one move per workflow: create one module, move
-ONE cohesive unit (function/class/phase/command family), re-point references,
-keep the public surface stable; the next unit is the next workflow. A file that
-yields six helper modules is six chained workflows, not one "extract phases"
+Decomposition refactors split one refactor per workflow: create one module, move
+exactly ONE top-level symbol (one function, or one class with its methods — not
+method-by-method), re-point references in the same workflow, keep the public
+surface stable; the next symbol is the next workflow. Move a private helper the
+symbol depends on only when splitting them would break the build. A file that
+yields six extracted symbols is six chained workflows, not one "extract phases"
 task. See the **Decomposition & Extraction Refactors** section of
 `../review-compression/SKILL.md`.
 

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -95,15 +95,17 @@ Split changes when they introduce a different claim:
 - benchmark/repro/proof harness plus the fix it is meant to justify
 - product code plus planning/policy/docs updates
 - broad mechanical moves too large to inspect comfortably
-- multiple distinct extractions from one file (one move per slice)
+- multiple distinct extractions from one file (one top-level symbol move per slice)
 
 ## Decomposition & Extraction Refactors
 
-When you split a large file by extracting cohesive units (functions, classes,
-phases, command families) into new modules, treat each extraction as its own
-slice: create the target file, move ONE cohesive unit, re-point its references,
-and keep the public surface (facade, exports, dispatcher) stable. Do not batch
-several distinct extractions into one diff.
+When you split a large file by extracting units into new modules, do one
+refactor at a time: one PR moves exactly ONE top-level symbol. A function move
+is its own PR. A class moves as one PR with its methods riding along — one
+top-level symbol per PR, not method-by-method. Create the target file, move
+that one symbol, re-point its references in the same PR so behavior is
+preserved, and keep the public surface (facade, exports, dispatcher) stable. Do
+not batch several distinct extractions into one diff.
 
 Each move is a separate review claim. Every extraction has its own seam and its
 own "is behavior preserved?" question, so the reviewer checks one move at a
@@ -115,13 +117,20 @@ many files." That rule is one transformation applied to N call sites (one
 claim). Decomposition is N distinct transformations (N claims): different code,
 different seams, different risk.
 
+Dependency-cluster exception: if the moved symbol depends on a private helper in
+the same file that is not part of the public surface, and moving the symbol
+alone would break the build or force a throwaway re-export shim, move that
+minimal helper cluster together in the same PR. Keep the cluster as small as the
+build requires — this is still one cohesive move, not a licence to batch
+unrelated extractions.
+
 Slice shape for one move:
 
 - `Review claim:` "Move <unit> out of <file> into <new module>, behavior
   unchanged."
-- create the new module and move exactly one cohesive unit into it
-- update imports/facade so the public surface is byte-for-byte identical to
-  callers
+- create the new module and move exactly one top-level symbol into it
+- update imports/facade in the same PR so the public surface is byte-for-byte
+  identical to callers
 - keep directly affected tests with the move; they prove behavior is preserved
 - no behavior change in a move slice (Fowler's "two hats": never refactor and
   change behavior in the same diff)


### PR DESCRIPTION
## Summary

This edits our own PR-writing guidance, not any product code. It sharpens the rule for breaking a big file into smaller ones.

The old wording said move "one cohesive unit," which was loose enough to let several moves ride in one PR.

Now a single function move is its own PR. A class moves whole in one PR, methods along for the ride, never method-by-method.

The move and the update to its callers stay in the same PR, so each slice still behaves the same.

One escape hatch: a moved function may carry a private, unexported helper it needs, but only when leaving it behind would break the build.

Applying one identical change across many files, like a rename, is still a single PR. That grouping is unchanged.

## Review Claim

The canonical PR-splitting rule requires one top-level symbol move per PR, keeps the move and its re-pointing together, allows a minimal dependency-cluster exception, and does not split identical mechanical migrations.

## Review Lane

docs

## Review Unit

docs

## Safety Invariant

Documentation only. No code, runtime path, or build behavior changes. This slice is the canonical rule text in `review-compression` mirrored into `plan-to-invoker` task-patterns.

## Slice Rationale

This is the foundation slice: the canonical rule text lives in `review-compression`, and `plan-to-invoker` task-patterns restates it. The `make-pr` pointer and the guard test that locks these strings land on top, because that guard asserts wording introduced here.

## Non-goals

- No change to `skills/make-pr/SKILL.md` (top slice).
- No test changes (top slice).
- No change to the "same mechanical migration across many files" grouping.
- No product code or CLI behavior changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-plan-to-invoker-skill.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
