### PR TITLE
fix(workflow-core): cancelled never-started dependents become blocked, not failed

### DIFF
--- a/packages/workflow-core/src/__tests__/cancel-task.test.ts
+++ b/packages/workflow-core/src/__tests__/cancel-task.test.ts
@@ -175,17 +175,33 @@ describe('cancelTask', () => {
     expect(task!.execution.error).toContain('Terminated by user');
   });
 
-  it('cascades cancel to pending dependents', () => {
+  it('cascades cancel to never-started dependents as blocked, not failed', () => {
     orchestrator.loadPlan(simplePlan());
 
     orchestrator.cancelTask('a');
 
+    const taskA = orchestrator.getTask('a');
     const taskB = orchestrator.getTask('b');
     const taskC = orchestrator.getTask('c');
-    expect(taskB!.status).toBe('failed');
-    expect(taskC!.status).toBe('failed');
-    expect(taskB!.execution.error).toContain('upstream task "a"');
-    expect(taskC!.execution.error).toContain('upstream task "a"');
+
+    // The cancel root stays failed — it is what the operator terminated.
+    expect(taskA!.status).toBe('failed');
+    expect(taskA!.execution.error).toContain('Terminated by user');
+
+    // Dependents that never started were only ever waiting on the terminated
+    // upstream, so they are blocked (not failed) and carry no error. A blocked
+    // dependent is retryable and self-clears once the upstream re-completes.
+    expect(taskB!.status).toBe('blocked');
+    expect(taskC!.status).toBe('blocked');
+    expect(taskB!.execution.blockedBy).toContain('upstream task "a"');
+    expect(taskC!.execution.blockedBy).toContain('upstream task "a"');
+    expect(taskB!.execution.error).toBeUndefined();
+    expect(taskC!.execution.error).toBeUndefined();
+
+    // The workflow still reports failed (the terminated root is failed, and
+    // `failed` outranks `blocked`), so nothing merges by mistake.
+    const wfId = taskA!.config.workflowId!;
+    expect(persistence.listWorkflows().find((w) => w.id === wfId)?.status).toBe('failed');
   });
 
   it('returns running tasks in runningCancelled', () => {
@@ -251,7 +267,10 @@ describe('cancelTask', () => {
 
     expect(orchestrator.getTask('b')!.status).toBe('completed');
     expect(orchestrator.getTask('c')!.status).toBe('failed');
-    expect(orchestrator.getTask('d')!.status).toBe('failed');
+    // D never started — it was only waiting on the terminated C, so it is
+    // blocked, not failed.
+    expect(orchestrator.getTask('d')!.status).toBe('blocked');
+    expect(orchestrator.getTask('d')!.execution.blockedBy).toContain('upstream task "c"');
     expect(result.cancelled).toContain(sid(orchestrator, 0, 'c'));
     expect(result.cancelled).toContain(sid(orchestrator, 0, 'd'));
     expect(result.cancelled).not.toContain(sid(orchestrator, 0, 'b'));

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3588,9 +3588,15 @@ export class Orchestrator {
   }
 
   /**
-   * Returns true if the workflow has any non-merge task in a live status
+   * Returns true if the workflow has any non-merge task doing live work
    * (`pending`, `running`, `fixing_with_ai`, `needs_input`,
-   * `awaiting_approval`, `review_ready`, `blocked`).
+   * `awaiting_approval`, `review_ready`, or a `blocked` task still held by an
+   * external cross-workflow gate).
+   *
+   * A task left `blocked` by a terminated/failed in-workflow upstream (with no
+   * external gate) is treated as NOT live: it is inert until the upstream is
+   * retried, so it must not keep an otherwise-dead workflow "live" and force
+   * `replaceTask` to fork instead of mutating in place.
    *
    * The merge node is excluded because it stays `pending` for the whole
    * workflow lifetime — including it would make every workflow live
@@ -3601,7 +3607,16 @@ export class Orchestrator {
     const tasks = this.stateMachine
       .getAllTasks()
       .filter((t) => t.config.workflowId === workflowId && !t.config.isMergeNode);
-    return tasks.some((t) => LIVE_TASK_STATUSES.has(t.status));
+    return tasks.some((t) => {
+      if (!LIVE_TASK_STATUSES.has(t.status)) return false;
+      // A cascade-blocked task (blocked by a cancelled/terminated upstream
+      // rather than a still-pending external gate) cannot progress on its
+      // own, so it does not count as live work.
+      if (t.status === 'blocked' && this.getExternalDependencyBlocker(t) === undefined) {
+        return false;
+      }
+      return true;
+    });
   }
 
   private assertMergeLeavesInvariant(workflowId: string): void {
@@ -3988,6 +4003,32 @@ export class Orchestrator {
         runningCancelled.push(id);
       }
       this.clearQueuedSchedulerEntries(id, t.execution.selectedAttemptId);
+
+      // A downstream dependent that never started running was not itself
+      // cancelled or failed — it was only ever waiting on the now-terminated
+      // upstream. Mark it `blocked` (honest, retryable, and self-clearing:
+      // when the upstream is retried to completion the scheduler unblocks it
+      // via getReadyNodes/autoStartReadyTasks) instead of `failed`, so its
+      // badge does not masquerade as a real run failure. The cancel root, and
+      // any dependent that was actually executing when the cascade reached it,
+      // stay `failed`.
+      const neverStarted =
+        id !== rootId &&
+        !t.execution.startedAt &&
+        (t.status === 'pending' || t.status === 'blocked');
+
+      if (neverStarted) {
+        const blockedChanges: TaskStateChanges = {
+          status: 'blocked',
+          execution: { blockedBy: `upstream task "${upstreamLabel}" was terminated` },
+        };
+        const blockedUpdated = this.writeAndSync(id, blockedChanges);
+        const blockedDelta: TaskDelta = this.buildUpdateDelta(t, blockedUpdated, blockedChanges);
+        this.persistence.logEvent?.(id, 'task.blocked', blockedChanges);
+        this.messageBus.publish(TASK_DELTA_CHANNEL, blockedDelta);
+        cancelled.push(id);
+        continue;
+      }
 
       // Mark as failed
       const errorMsg =


### PR DESCRIPTION
## Summary

When a running task is cancelled, Invoker used to mark every task waiting behind it as failed — even tasks that never started.

That red badge lied: it implied a run that never happened.

Now a never-started dependent of a cancelled task becomes blocked, with a short reason. Only the task you actually stopped stays failed.

A blocked dependent frees itself once the upstream finishes, and the workflow still reports failed, so nothing merges by mistake.

A smaller companion change keeps a workflow from looking active when its only leftover work is a dependent stuck behind a cancelled task.

That prevents an in-place graph edit from becoming an accidental fork.

## Review Claim

Approve turning a cancelled task's never-started dependents into blocked (not failed), and treating such stuck dependents as not-live so in-place replace is preserved.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Pure orchestrator logic, covered by workflow-core unit checks (840 pass) and a full typecheck. The dependency readiness gate is untouched, so ordering still holds and nothing can run before its upstream finishes; only the terminal-status labelling on cancel and the workflow-live predicate change. The task actually cancelled still ends failed, and `failed` outranks `blocked` in the rollup, so the workflow stays failed and the merge gate stays closed.

## Slice Rationale

This is one behavior fix plus its own regression test, kept as a single slice because it changes exactly one thing: what status a never-started dependent gets when its upstream is cancelled.

## Non-goals

- Does not change the status of the task you directly cancel; that task stays failed.
- Does not touch the dependency scheduler readiness gate, so a task still cannot run before its upstream finishes.
- Does not change the existing cross-workflow external-gate blocking path (those blocked tasks stay live).
- Does not add UI code; it reuses the existing `blocked` badge already rendered today.
- Does not add a changelog or documentation entry (kept out to preserve behavior-lane atomicity).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/workflow-core test`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
