### PR TITLE
fix(execution-engine): tick review-gate task heartbeat during status polls

### DIFF
--- a/packages/execution-engine/src/__tests__/review-gate-poll-heartbeat-db.test.ts
+++ b/packages/execution-engine/src/__tests__/review-gate-poll-heartbeat-db.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Integration proof: pollMergeGateTask writes `execution.lastHeartbeatAt`
+ * to SQLite when the review-gate status worker (or a manual PR check)
+ * touches an awaiting_approval / review_ready review-gate task.
+ *
+ * Unlike the mocked task-runner tests, this one wires up a real
+ * SQLiteAdapter + Orchestrator + SqliteTaskRepository and reads the
+ * task row back from the DB after the poll to confirm the write.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
+import type { Workflow } from '@invoker/data-store';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { OrchestratorMessageBus, TaskState } from '@invoker/workflow-core';
+import { TaskRunner } from '../task-runner.js';
+import type { MergeGateProvider, MergeGateApprovalStatus } from '../merge-gate-provider.js';
+
+class NoopBus implements OrchestratorMessageBus {
+  publish(): void {}
+}
+
+const WORKFLOW: Workflow = {
+  id: 'wf-heartbeat',
+  name: 'Review gate heartbeat proof',
+  status: 'running',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+function reviewGateTask(id: string, reviewId: string, status: TaskState['status']): TaskState {
+  return {
+    id,
+    description: 'Review gate for Sidebar manual control',
+    status,
+    dependencies: [],
+    createdAt: new Date('2026-07-08T06:00:00.000Z'),
+    config: { workflowId: WORKFLOW.id, isMergeNode: true },
+    execution: {
+      generation: 1,
+      selectedAttemptId: 'attempt-1',
+      reviewId,
+      workspacePath: '/workspace/heartbeat-gate',
+      // Old heartbeat: pretend the MergeGateExecutor's 30s timer last
+      // fired 20 minutes ago before it emitComplete'd.
+      lastHeartbeatAt: new Date('2026-07-08T06:59:05.000Z'),
+      heartbeatSource: 'executor',
+    },
+  } as TaskState;
+}
+
+function stubMergeGateProvider(overrides: Partial<MergeGateApprovalStatus> = {}): MergeGateProvider {
+  return {
+    name: 'stub-github',
+    createReview: vi.fn(async () => ({ url: 'https://github.com/foo/bar/pull/301', identifier: 'foo/bar#301' })),
+    checkApproval: vi.fn(async (): Promise<MergeGateApprovalStatus> => ({
+      lifecycle: 'open',
+      rejected: false,
+      statusText: 'Pending review',
+      url: 'https://github.com/foo/bar/pull/301',
+      ...overrides,
+    })),
+  };
+}
+
+describe('pollMergeGateTask → SQLite heartbeat persistence', () => {
+  let adapter: SQLiteAdapter;
+  let orchestrator: Orchestrator;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    adapter.saveWorkflow(WORKFLOW);
+    orchestrator = new Orchestrator({
+      persistence: adapter,
+      messageBus: new NoopBus(),
+      taskRepository: new SqliteTaskRepository(adapter),
+      maxConcurrency: 3,
+    });
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  it('checkMergeGateStatuses advances lastHeartbeatAt for an awaiting_approval task in SQLite', async () => {
+    const before = new Date('2026-07-08T06:59:05.000Z');
+    const task = reviewGateTask('merge-heartbeat', 'foo/bar#301', 'awaiting_approval');
+    adapter.saveTask(WORKFLOW.id, task);
+    orchestrator.syncFromDb(WORKFLOW.id);
+
+    // Sanity check: the DB row starts with the stale heartbeat, and the
+    // review-gate polling path has never written a fresh one.
+    const stale = adapter.loadTasks(WORKFLOW.id).find((t) => t.id === task.id)!;
+    expect(stale.status).toBe('awaiting_approval');
+    expect(stale.execution.lastHeartbeatAt?.toISOString()).toBe(before.toISOString());
+
+    const runner = new TaskRunner({
+      orchestrator,
+      persistence: adapter,
+      executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+      cwd: '/runner-base-cwd',
+      mergeGateProvider: stubMergeGateProvider(),
+    });
+
+    const beforePoll = Date.now();
+    await runner.checkMergeGateStatuses();
+    const afterPoll = Date.now();
+
+    const persisted = adapter.loadTasks(WORKFLOW.id).find((t) => t.id === task.id)!;
+    const heartbeat = persisted.execution.lastHeartbeatAt;
+    expect(heartbeat, 'lastHeartbeatAt should have been written to SQLite by pollMergeGateTask').toBeInstanceOf(Date);
+    const heartbeatMs = (heartbeat as Date).getTime();
+    expect(heartbeatMs).toBeGreaterThanOrEqual(beforePoll);
+    expect(heartbeatMs).toBeLessThanOrEqual(afterPoll);
+    expect(heartbeatMs).toBeGreaterThan(before.getTime());
+  });
+
+  it('checkPrApprovalNow advances lastHeartbeatAt for a review_ready task in SQLite', async () => {
+    const before = new Date('2026-07-08T06:59:05.000Z');
+    const task = reviewGateTask('manual-heartbeat', 'foo/bar#302', 'review_ready');
+    adapter.saveTask(WORKFLOW.id, task);
+    orchestrator.syncFromDb(WORKFLOW.id);
+
+    const runner = new TaskRunner({
+      orchestrator,
+      persistence: adapter,
+      executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+      cwd: '/runner-base-cwd',
+      mergeGateProvider: stubMergeGateProvider(),
+    });
+
+    const beforePoll = Date.now();
+    await runner.checkPrApprovalNow(task.id);
+    const afterPoll = Date.now();
+
+    const persisted = adapter.loadTasks(WORKFLOW.id).find((t) => t.id === task.id)!;
+    const heartbeat = persisted.execution.lastHeartbeatAt;
+    expect(heartbeat).toBeInstanceOf(Date);
+    const heartbeatMs = (heartbeat as Date).getTime();
+    expect(heartbeatMs).toBeGreaterThanOrEqual(beforePoll);
+    expect(heartbeatMs).toBeLessThanOrEqual(afterPoll);
+    expect(heartbeatMs).toBeGreaterThan(before.getTime());
+  });
+
+  it('does not touch lastHeartbeatAt when the task has no required review artifacts (nothing to poll)', async () => {
+    const before = new Date('2026-07-08T06:59:05.000Z');
+    const task: TaskState = {
+      ...reviewGateTask('no-artifacts', 'unused', 'awaiting_approval'),
+      execution: {
+        generation: 1,
+        selectedAttemptId: 'attempt-1',
+        workspacePath: '/workspace/heartbeat-gate',
+        lastHeartbeatAt: before,
+        heartbeatSource: 'executor',
+      },
+    } as TaskState;
+    adapter.saveTask(WORKFLOW.id, task);
+    orchestrator.syncFromDb(WORKFLOW.id);
+
+    const runner = new TaskRunner({
+      orchestrator,
+      persistence: adapter,
+      executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+      cwd: '/runner-base-cwd',
+      mergeGateProvider: stubMergeGateProvider(),
+    });
+
+    await runner.checkMergeGateStatuses();
+
+    const persisted = adapter.loadTasks(WORKFLOW.id).find((t) => t.id === task.id)!;
+    expect(persisted.execution.lastHeartbeatAt?.toISOString()).toBe(before.toISOString());
+  });
+});

--- a/packages/execution-engine/src/__tests__/review-gate-poll-heartbeat-db.test.ts
+++ b/packages/execution-engine/src/__tests__/review-gate-poll-heartbeat-db.test.ts
@@ -1,13 +1,3 @@
-/**
- * Integration proof: pollMergeGateTask writes `execution.lastHeartbeatAt`
- * to SQLite when the review-gate status worker (or a manual PR check)
- * touches an awaiting_approval / review_ready review-gate task.
- *
- * Unlike the mocked task-runner tests, this one wires up a real
- * SQLiteAdapter + Orchestrator + SqliteTaskRepository and reads the
- * task row back from the DB after the poll to confirm the write.
- */
-
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
 import type { Workflow } from '@invoker/data-store';
@@ -41,8 +31,6 @@ function reviewGateTask(id: string, reviewId: string, status: TaskState['status'
       selectedAttemptId: 'attempt-1',
       reviewId,
       workspacePath: '/workspace/heartbeat-gate',
-      // Old heartbeat: pretend the MergeGateExecutor's 30s timer last
-      // fired 20 minutes ago before it emitComplete'd.
       lastHeartbeatAt: new Date('2026-07-08T06:59:05.000Z'),
       heartbeatSource: 'executor',
     },
@@ -88,11 +76,9 @@ describe('pollMergeGateTask → SQLite heartbeat persistence', () => {
     adapter.saveTask(WORKFLOW.id, task);
     orchestrator.syncFromDb(WORKFLOW.id);
 
-    // Sanity check: the DB row starts with the stale heartbeat, and the
-    // review-gate polling path has never written a fresh one.
-    const stale = adapter.loadTasks(WORKFLOW.id).find((t) => t.id === task.id)!;
-    expect(stale.status).toBe('awaiting_approval');
-    expect(stale.execution.lastHeartbeatAt?.toISOString()).toBe(before.toISOString());
+    const seeded = adapter.loadTasks(WORKFLOW.id).find((t) => t.id === task.id)!;
+    expect(seeded.status).toBe('awaiting_approval');
+    expect(seeded.execution.lastHeartbeatAt?.toISOString()).toBe(before.toISOString());
 
     const runner = new TaskRunner({
       orchestrator,
@@ -108,7 +94,7 @@ describe('pollMergeGateTask → SQLite heartbeat persistence', () => {
 
     const persisted = adapter.loadTasks(WORKFLOW.id).find((t) => t.id === task.id)!;
     const heartbeat = persisted.execution.lastHeartbeatAt;
-    expect(heartbeat, 'lastHeartbeatAt should have been written to SQLite by pollMergeGateTask').toBeInstanceOf(Date);
+    expect(heartbeat).toBeInstanceOf(Date);
     const heartbeatMs = (heartbeat as Date).getTime();
     expect(heartbeatMs).toBeGreaterThanOrEqual(beforePoll);
     expect(heartbeatMs).toBeLessThanOrEqual(afterPoll);

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -5292,6 +5292,96 @@ console.log(JSON.stringify(out));
           cwd: '/runner-base-cwd',
         });
       });
+
+      it('records a task heartbeat when polling an awaiting_approval review-gate task', async () => {
+        const allTasks = [
+          makeTask({
+            id: 'merge-heartbeat',
+            status: 'awaiting_approval',
+            config: { isMergeNode: true },
+            execution: {
+              reviewId: 'owner/repo#301',
+              workspacePath: '/workspace/heartbeat-gate',
+            },
+          }),
+        ];
+
+        const orchestrator = {
+          getTask: (id: string) => allTasks.find((t) => t.id === id),
+          getAllTasks: () => allTasks,
+          approve: vi.fn(),
+          recordTaskHeartbeat: vi.fn(),
+        };
+        const persistence = { updateTask: vi.fn() };
+        const mergeGateProvider = {
+          checkApproval: vi.fn().mockResolvedValue({
+            lifecycle: 'open',
+            rejected: false,
+            statusText: 'Pending',
+          }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: persistence as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/runner-base-cwd',
+          mergeGateProvider: mergeGateProvider as any,
+        });
+
+        await executor.checkMergeGateStatuses();
+
+        expect(mergeGateProvider.checkApproval).toHaveBeenCalledTimes(1);
+        expect(orchestrator.recordTaskHeartbeat).toHaveBeenCalledTimes(1);
+        expect(orchestrator.recordTaskHeartbeat).toHaveBeenCalledWith(
+          'merge-heartbeat',
+          expect.objectContaining({ source: 'executor', at: expect.any(Date) }),
+        );
+      });
+
+      it('records a task heartbeat when checkPrApprovalNow polls a review-gate task manually', async () => {
+        const task = makeTask({
+          id: 'manual-heartbeat',
+          status: 'awaiting_approval',
+          config: { isMergeNode: true },
+          execution: {
+            reviewId: 'owner/repo#302',
+            workspacePath: '/workspace/manual-heartbeat-gate',
+          },
+        });
+
+        const orchestrator = {
+          getTask: (id: string) => (id === task.id ? task : undefined),
+          getAllTasks: () => [task],
+          approve: vi.fn(),
+          recordTaskHeartbeat: vi.fn(),
+        };
+        const persistence = { updateTask: vi.fn() };
+        const mergeGateProvider = {
+          checkApproval: vi.fn().mockResolvedValue({
+            lifecycle: 'open',
+            rejected: false,
+            statusText: 'Pending review',
+          }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: persistence as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/runner-base-cwd',
+          mergeGateProvider: mergeGateProvider as any,
+        });
+
+        await executor.checkPrApprovalNow('manual-heartbeat');
+
+        expect(orchestrator.recordTaskHeartbeat).toHaveBeenCalledTimes(1);
+        expect(orchestrator.recordTaskHeartbeat).toHaveBeenCalledWith(
+          'manual-heartbeat',
+          expect.objectContaining({ source: 'executor' }),
+        );
+      });
+
       it('polls all current reviewGate artifacts and approves only after every required artifact is approved', async () => {
         const downstream = makeTask({ id: 'downstream-after-stack', status: 'running' });
         const reviewGate = {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -2177,10 +2177,6 @@ export class TaskRunner {
     const artifacts = this.getCurrentRequiredReviewArtifacts(task);
     if (artifacts.length === 0) return;
 
-    // Safety invariant: this is the only place a review-gate task's
-    // lastHeartbeatAt advances after MergeGateExecutor.emitComplete kills
-    // its 30s executor timer. Removing this call re-freezes the heartbeat
-    // for the entire external review wait.
     this.orchestrator.recordTaskHeartbeat?.(task.id, { at: new Date(), source: 'executor' });
 
     let latestGate = task.execution.reviewGate;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -2177,6 +2177,12 @@ export class TaskRunner {
     const artifacts = this.getCurrentRequiredReviewArtifacts(task);
     if (artifacts.length === 0) return;
 
+    // Safety invariant: this is the only place a review-gate task's
+    // lastHeartbeatAt advances after MergeGateExecutor.emitComplete kills
+    // its 30s executor timer. Removing this call re-freezes the heartbeat
+    // for the entire external review wait.
+    this.orchestrator.recordTaskHeartbeat?.(task.id, { at: new Date(), source: 'executor' });
+
     let latestGate = task.execution.reviewGate;
     let approvedGate = false;
     for (const artifact of artifacts) {


### PR DESCRIPTION
## Summary

A review-gate task in `awaiting_approval` / `review_ready` shows a frozen `heartbeat: …` line in the WorkflowInspector Advanced metadata for the entire external review.

Once `MergeGateExecutor.emitComplete` fires, its 30s heartbeat timer is torn down. Nothing else was recording heartbeats.

The status worker's 60s refresh and the manual "check PR now" path both still touch the task. Neither called `recordTaskHeartbeat`, so `execution.lastHeartbeatAt` stayed at the last executor tick before completion.

Have `pollMergeGateTask` record the heartbeat at the start of the poll. Both the 60s worker and the manual check now advance `lastHeartbeatAt` whenever they actually contact the review provider.

## Review Claim

`pollMergeGateTask` records an `executor` heartbeat on every poll so the UI's Advanced metadata heartbeat updates while a review gate is awaiting approval.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The call sits before the provider loop so a provider failure still shows Invoker last checked at time T. `orchestrator.recordTaskHeartbeat` writes only `execution.lastHeartbeatAt` / `heartbeatSource` and republishes a `TASK_DELTA_CHANNEL` update; it does not mutate reviewGate artifacts, status, or attempt state. Approval, rejection, and closed lifecycles still key off the artifact status computed later in the same method.

## Slice Rationale

One behavior fix in one file (`task-runner.ts`), plus two targeted repro tests in the same package's existing `checkMergeGateStatuses` describe block. The publication path (`merge-runner.ts`) is deliberately untouched to satisfy the known review-boundary check that keeps publication and poll runtime in separate PRs.

## Non-goals

- Does not change how heartbeats are emitted while a merge-gate action is running (that path in `MergeGateExecutor` is unchanged).
- Does not change `MergeGateApprovalStatus`, `reviewGate.artifacts`, or any UI file. `heartbeat: …` in `WorkflowInspector` reads the same `execution.lastHeartbeatAt` field it always has.
- Does not change the review-gate status worker's interval or the manual `checkPrApprovalNow` API surface.
- Does not change persistence schema. Heartbeats already flow through `orchestrator.recordTaskHeartbeat` → `writeAndSync`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/execution-engine && ./node_modules/.bin/vitest run src/__tests__/task-runner.test.ts -t "records a task heartbeat"` (both new tests fail on master, pass with the fix)
- [x] `cd packages/execution-engine && ./node_modules/.bin/vitest run src/__tests__/task-runner.test.ts -t "checkMergeGateStatuses|checkPrApprovalNow|merge-gate"` — 26 passed (no regressions in the surrounding merge-gate suite)
- [x] `cd packages/execution-engine && ./node_modules/.bin/vitest run src/__tests__/task-runner.test.ts` — 140 passed (full file)

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the pre-fix behavior (frozen heartbeat during external review).
- Data migration? No — heartbeats are recorded through the existing `orchestrator.recordTaskHeartbeat` path, no schema change.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of merge-gate review tasks so they continue to show activity while waiting for approval.
  * Manual approval checks now keep task progress up to date, reducing the chance of tasks appearing stalled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->