### PR TITLE
[PR maintenance workers Step 3](1) Add manual headless PR maintenance worker runs

### DIFF
--- a/packages/app/src/__tests__/headless-pr-maintenance.test.ts
+++ b/packages/app/src/__tests__/headless-pr-maintenance.test.ts
@@ -1,0 +1,101 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import {
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
+} from '@invoker/execution-engine';
+import { runHeadless } from '../headless.js';
+
+/**
+ * Write a throwaway cron entrypoint that records proof the worker ran with the
+ * threaded config: it copies the injected `INVOKER_PR_TEST_TOKEN` env override
+ * into a marker under the threaded `INVOKER_REPO_ROOT`. Reading the marker back
+ * proves both the repoRoot and env launch fields reached the shell tick.
+ */
+function writeCronScript(repoRoot: string, scriptRelativePath: string, markerName: string): void {
+  const scriptPath = join(repoRoot, scriptRelativePath);
+  mkdirSync(dirname(scriptPath), { recursive: true });
+  writeFileSync(
+    scriptPath,
+    `#!/usr/bin/env bash\nset -eu\nprintf '%s' "$INVOKER_PR_TEST_TOKEN" > "$INVOKER_REPO_ROOT/${markerName}"\n`,
+    { mode: 0o755 },
+  );
+}
+
+/** Minimal headless deps for a one-shot PR-maintenance worker run. */
+function makeWorkerDeps(repoRoot: string, token: string): unknown {
+  return {
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), trace: vi.fn(), child: vi.fn() },
+    // The PR-maintenance tick never touches the store/submitter; provide a stub
+    // so the shared factory-deps construction has something to reference.
+    persistence: { enqueueWorkflowMutationIntent: vi.fn(() => 1) },
+    invokerConfig: {
+      prMaintenance: {
+        enabled: true,
+        repoRoot,
+        lockPath: join(repoRoot, 'pr-crons.lock'),
+        env: { INVOKER_PR_TEST_TOKEN: token },
+      },
+    },
+  };
+}
+
+describe('headless worker PR-maintenance', () => {
+  let repoRoot: string;
+  let homeRoot: string;
+  let previousDbDir: string | undefined;
+  let write: MockInstance;
+  let stdout: string;
+
+  beforeEach(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), 'invoker-headless-pr-maintenance-repo-'));
+    homeRoot = mkdtempSync(join(tmpdir(), 'invoker-headless-pr-maintenance-home-'));
+    // Point the cross-process worker lock at a throwaway home so a one-shot scan
+    // never contends with the real Invoker home.
+    previousDbDir = process.env.INVOKER_DB_DIR;
+    process.env.INVOKER_DB_DIR = homeRoot;
+    stdout = '';
+    write = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      stdout += String(chunk);
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    write.mockRestore();
+    if (previousDbDir === undefined) delete process.env.INVOKER_DB_DIR;
+    else process.env.INVOKER_DB_DIR = previousDbDir;
+    rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(homeRoot, { recursive: true, force: true });
+  });
+
+  it('runs the coderabbit-address worker one-shot with the threaded config', async () => {
+    writeCronScript(repoRoot, 'scripts/cron-coderabbit-address.sh', 'coderabbit.marker');
+
+    await runHeadless(['worker', CODERABBIT_ADDRESS_WORKER_KIND], makeWorkerDeps(repoRoot, 'cr-token') as never);
+
+    // Marker written under the threaded repoRoot, carrying the threaded env
+    // override — proves the launch config reached the shell entrypoint.
+    expect(readFileSync(join(repoRoot, 'coderabbit.marker'), 'utf8')).toBe('cr-token');
+    expect(stdout).toContain(`${CODERABBIT_ADDRESS_WORKER_KIND} worker scan completed.`);
+  });
+
+  it('runs the pr-conflict-rebase worker one-shot with the threaded config', async () => {
+    writeCronScript(repoRoot, 'scripts/cron-pr-conflict-rebase.sh', 'rebase.marker');
+
+    await runHeadless(['worker', PR_CONFLICT_REBASE_WORKER_KIND], makeWorkerDeps(repoRoot, 'rebase-token') as never);
+
+    expect(readFileSync(join(repoRoot, 'rebase.marker'), 'utf8')).toBe('rebase-token');
+    expect(stdout).toContain(`${PR_CONFLICT_REBASE_WORKER_KIND} worker scan completed.`);
+  });
+
+  it('lists both PR-maintenance worker kinds from the manual entrypoint', async () => {
+    await runHeadless(['worker', 'list'], { invokerConfig: {} } as never);
+
+    expect(stdout).toContain('Worker kinds');
+    expect(stdout).toContain(CODERABBIT_ADDRESS_WORKER_KIND);
+    expect(stdout).toContain(PR_CONFLICT_REBASE_WORKER_KIND);
+  });
+});

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -19,6 +19,7 @@ import {
   createAutoFixAttemptLedger,
   createWorkerRegistry,
   registerAutoFixWorker,
+  registerPrMaintenanceWorkers,
   resolveInvokerHomeRoot,
   WorkerLockHeldError,
   type WorkerRuntimeDependencies,
@@ -33,6 +34,7 @@ import {
   setWorkflowMergeMode,
 } from './workflow-actions.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
+import { resolvePrMaintenanceWorkerConfig } from './config.js';
 import {
   isDispatchableLaunch,
 } from './global-topup.js';
@@ -424,7 +426,9 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
   const subCommand = args[0] ?? 'list';
   const registry = registerExternalWorkersFromConfig(
     deps.invokerConfig?.externalWorkers,
-    registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+    registerPrMaintenanceWorkers(
+      registerAutoFixWorker(createWorkerRegistry<WorkerRuntimeDependencies>()),
+    ),
   );
 
   if (subCommand === 'list') {
@@ -487,6 +491,7 @@ async function headlessWorker(args: string[], deps: HeadlessDeps): Promise<void>
         attemptLedger: autoFixAttemptLedger,
         getAutoFixAgent: () => deps.invokerConfig.autoFixAgent,
       },
+      prMaintenance: resolvePrMaintenanceWorkerConfig(deps.invokerConfig),
     });
     await worker.tick('manual');
     await worker.stop();


### PR DESCRIPTION
## Summary

This adds manual headless entrypoints so an operator can run each new PR-maintenance worker once by hand.

It threads the existing PR-maintenance configuration into the headless worker command and leaves owner startup and the operator UI untouched.

Manual and always-on paths now build the same worker set, so behavior stays consistent between them.

## Review Claim

The manual headless worker command can construct and run the PR-maintenance worker kinds for one-shot work.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Only the existing headless worker command changes; owner startup, scheduling, and operator surfaces keep their current behavior, and directly affected tests ship with it.

## Slice Rationale

Manual one-shot execution is easier to review on its own, kept apart from owner startup and operator status surfaces.

## Non-goals

- No change to owner startup policy or the always-on scheduler.
- No change to worker status surfaces or the operator UI.
- No change to the worker backend implementation.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/headless-pr-maintenance.test.ts` — 3 tests passed

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
