### PR TITLE
[Sidebar manual control](1) Stop sidebar width changes on nav switches

### DIFF
--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -127,6 +127,8 @@ describe('App launch (component)', () => {
     expect(screen.queryByText('What do you want to build?')).not.toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Workflows' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Partial terminal drawer' })).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('browser-rail-dismiss'));
+    expect(sidebar.className).toContain('w-16');
 
     fireEvent.click(screen.getByTestId('sidebar-home'));
     expect(sidebar.className).toContain('w-16');
@@ -149,6 +151,10 @@ describe('App launch (component)', () => {
       fireEvent.click(screen.getByTestId(`sidebar-${surface}`));
       expect(sidebar.className).toContain('w-16');
     }
+    fireEvent.click(screen.getByTestId('sidebar-workflows'));
+    expect(await screen.findByTestId('browser-rail')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('browser-return-home'));
+    expect(sidebar.className).toContain('w-16');
 
     fireEvent.click(toggle);
     expect(sidebar.className).toContain('w-60');
@@ -157,6 +163,10 @@ describe('App launch (component)', () => {
       fireEvent.click(screen.getByTestId(`sidebar-${surface}`));
       expect(sidebar.className).toContain('w-60');
     }
+    fireEvent.click(screen.getByTestId('sidebar-workflows'));
+    expect(await screen.findByTestId('browser-rail')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('browser-rail-dismiss'));
+    expect(sidebar.className).toContain('w-60');
   });
 
 


### PR DESCRIPTION
## Summary

Sidebar manual control — 2 tasks completed, 0 failed, 0 closed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1783372665107-1/fix-sidebar-manual-control | Stop sidebar width changes on nav switches | completed |
| wf-1783372665107-1/verify-sidebar-manual-control | Verify sidebar stays manual across nav changes | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1783372665107-1/fix-sidebar-manual-control — Stop sidebar width changes on nav switches

### wf-1783372665107-1/verify-sidebar-manual-control — Verify sidebar stays manual across nav changes

</details>

This slice adds component coverage for browser rail dismissal and left-rail switching.

It proves the sidebar stays collapsed or expanded until the explicit toggle changes it.

## Review Claim

Approve the component regression coverage that locks manual sidebar width across browser rail dismissal and left-rail navigation.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Only the component test changes. It exercises existing UI controls and asserts the sidebar width class after each navigation step.

## Slice Rationale

This slice keeps the fast component regression separate from the end-to-end visual proof so each review checks one proof layer.

## Non-goals

- Does not change runtime sidebar behavior.
- Does not change the collapse toggle.
- Does not alter the visual-proof Electron spec.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/ui test -- src/__tests__/app-launch.test.tsx`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`

</details>

## Visual Proof

[Walkthrough video: the sidebar remains wide after Needs Attention navigation, then remains collapsed after returning Home](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-a7e552/sidebar-manual-navigation-proof.mp4)

![Step 1: Workflows selected with the sidebar manually expanded](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-a7e552/sidebar-manual-1-workflows-expanded.png)

![Step 2: Needs Attention selected while the sidebar remains expanded](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-a7e552/sidebar-manual-2-attention-still-expanded.png)

![Step 3: Workflows selected after manually collapsing the sidebar](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-a7e552/sidebar-manual-3-workflows-collapsed.png)

![Step 4: Home selected while the sidebar remains collapsed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260712-a7e552/sidebar-manual-4-home-still-collapsed.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
