### PR TITLE
fix(app): stop copying live SQLite -wal/-shm into hourly snapshots

### DIFF
--- a/packages/app/src/__tests__/delete-all-snapshot-wal-safety.test.ts
+++ b/packages/app/src/__tests__/delete-all-snapshot-wal-safety.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression: the hourly snapshot must not corrupt a live WAL-mode SQLite
+ * connection.
+ *
+ * Field failure (Jul 8 2026, ~/.invoker/invoker.log): the running Electron
+ * process (PID 45754) took an hourly snapshot at 08:04:08 UTC. Immediately
+ * after, every subsequent SQLite write on the primary connection failed
+ * with `SQLITE_IOERR` (errcode 522, "disk I/O error"). The recovery worker,
+ * heartbeats, and terminal upserts spun in an uncaught-exception loop for
+ * hours. `PRAGMA integrity_check` on the DB file was `ok`; the connection
+ * state itself was wedged.
+ *
+ * Root cause: the pre-fix `createDbSnapshot` in `delete-all-snapshot.ts`
+ * used raw `copyFileSync` against `invoker.db`, `invoker.db-wal`, AND
+ * `invoker.db-shm` while a live WAL connection held all three open.
+ * SQLite's WAL mode coordinates readers and writers through a
+ * shared-memory wal-index in the `-shm` file; concurrent third-party access
+ * to that file is unsafe per SQLite's documented file-format contract, and
+ * on macOS/APFS it dropped the running connection into a persistent IOERR
+ * state.
+ *
+ * The pre-existing coverage in `delete-all-snapshot.test.ts` wrote plain
+ * text strings to the three paths, so it never exercised a real SQLite
+ * connection and could not detect this class of hazard. These tests plug
+ * that gap by using a real file-backed `SQLiteAdapter` in WAL mode.
+ */
+import { describe, expect, it, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { Workflow } from '@invoker/data-store';
+import { createHourlySnapshot } from '../delete-all-snapshot.js';
+
+const roots: string[] = [];
+function makeRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'hourly-snapshot-wal-'));
+  roots.push(root);
+  return root;
+}
+afterEach(() => {
+  for (const dir of roots.splice(0)) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+function makeWorkflow(id: string): Workflow {
+  const now = new Date().toISOString();
+  return { id, name: id, status: 'running', createdAt: now, updatedAt: now };
+}
+
+describe('hourly snapshot with a live WAL owner', () => {
+  it('the primary connection can still write after createHourlySnapshot runs (WAL safety)', async () => {
+    const root = makeRoot();
+    const dbPath = join(root, 'invoker.db');
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      owner.saveWorkflow(makeWorkflow('wf-pre-snapshot'));
+      // Sanity: default WAL locking means the -shm sidecar exists; this is
+      // the file that the pre-fix raw-copy path grabbed unsafely.
+      expect(existsSync(`${dbPath}-shm`)).toBe(true);
+
+      const snapshot = createHourlySnapshot(root);
+      expect(snapshot).not.toBeNull();
+
+      // The bug in the wild manifested as SQLITE_IOERR on every write after
+      // the snapshot. Post-fix, the owner connection is fully unaffected.
+      expect(() => owner.saveWorkflow(makeWorkflow('wf-post-snapshot'))).not.toThrow();
+
+      const ids = owner.listWorkflows().map((w) => w.id).sort();
+      expect(ids).toEqual(['wf-post-snapshot', 'wf-pre-snapshot']);
+    } finally {
+      owner.close();
+    }
+  });
+
+  it('does not leave WAL/SHM sidecars next to the snapshot (single-file backup)', async () => {
+    const root = makeRoot();
+    const dbPath = join(root, 'invoker.db');
+    const owner = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      owner.saveWorkflow(makeWorkflow('wf-single-file'));
+
+      const snapshot = createHourlySnapshot(root);
+      expect(snapshot).not.toBeNull();
+      // The correct snapshot format is a single-file DB. WAL/SHM sidecars on
+      // the snapshot path were the smoking gun of the raw-copy approach.
+      expect(existsSync(`${snapshot}-wal`)).toBe(false);
+      expect(existsSync(`${snapshot}-shm`)).toBe(false);
+    } finally {
+      owner.close();
+    }
+  });
+});

--- a/packages/app/src/__tests__/delete-all-snapshot.test.ts
+++ b/packages/app/src/__tests__/delete-all-snapshot.test.ts
@@ -35,7 +35,12 @@ afterEach(() => {
 });
 
 describe('delete-all-snapshot', () => {
-  it('creates delete-all snapshot with sqlite sidecar files', () => {
+  it('snapshots the main .db only — never copies live -wal/-shm sidecars', () => {
+    // Pre-fix behavior raw-copied -wal and -shm alongside .db. That is unsafe
+    // against a live SQLite owner: the -shm file is the wal-index, and
+    // concurrent third-party access to it corrupts the owner connection
+    // (see the 2026-07-08 field failure that produced hours of SQLITE_IOERR
+    // 522 loops). The snapshot must not touch the sidecars.
     const root = makeDbRoot();
     const dbPath = join(root, 'invoker.db');
     writeFileSync(dbPath, 'db-main');
@@ -44,23 +49,27 @@ describe('delete-all-snapshot', () => {
 
     const snapshot = createDeleteAllSnapshot(root);
     expect(snapshot).toContain(join(root, 'db-backups', 'invoker.db.before-delete-all-'));
-    expect(existsSync(snapshot)).toBe(true);
-    expect(existsSync(`${snapshot}-wal`)).toBe(true);
-    expect(existsSync(`${snapshot}-shm`)).toBe(true);
-    expect(readFileSync(snapshot, 'utf-8')).toBe('db-main');
-    expect(readFileSync(`${snapshot}-wal`, 'utf-8')).toBe('db-wal');
-    expect(readFileSync(`${snapshot}-shm`, 'utf-8')).toBe('db-shm');
+    expect(existsSync(snapshot as string)).toBe(true);
+    expect(readFileSync(snapshot as string, 'utf-8')).toBe('db-main');
+    expect(existsSync(`${snapshot}-wal`)).toBe(false);
+    expect(existsSync(`${snapshot}-shm`)).toBe(false);
   });
 
   it('creates hourly snapshots with hourly-auto label', () => {
     const root = makeDbRoot();
     const dbPath = join(root, 'invoker.db');
     writeFileSync(dbPath, 'db-main');
+    writeFileSync(`${dbPath}-wal`, 'db-wal');
+    writeFileSync(`${dbPath}-shm`, 'db-shm');
 
     const snapshot = createHourlySnapshot(root);
     expect(snapshot).toContain(join(root, 'db-backups', 'invoker.db.hourly-auto-'));
-    expect(existsSync(snapshot)).toBe(true);
-    expect(readFileSync(snapshot, 'utf-8')).toBe('db-main');
+    expect(existsSync(snapshot as string)).toBe(true);
+    expect(readFileSync(snapshot as string, 'utf-8')).toBe('db-main');
+    // Same WAL safety invariant as the delete-all snapshot: the live wal-index
+    // must be left alone.
+    expect(existsSync(`${snapshot}-wal`)).toBe(false);
+    expect(existsSync(`${snapshot}-shm`)).toBe(false);
   });
 
   it('returns null when DB does not exist', () => {
@@ -84,7 +93,7 @@ describe('delete-all-snapshot', () => {
     mkdirSync(join(root, 'db-backups'), { recursive: true });
 
     const snapshot = createDeleteAllSnapshot(root);
-    expect(readFileSync(snapshot, 'utf-8')).toBe('restored-db');
+    expect(readFileSync(snapshot as string, 'utf-8')).toBe('restored-db');
   });
 });
 
@@ -123,7 +132,9 @@ describe('hourly snapshot retention', () => {
     expect(existsSync(join(backupDir, 'invoker.db.hourly-auto-20260101-000004-000Z'))).toBe(true);
   });
 
-  it('pruneHourlySnapshots deletes the -wal/-shm sidecars of pruned snapshots', () => {
+  it('pruneHourlySnapshots deletes any legacy -wal/-shm sidecars of pruned snapshots', () => {
+    // Pre-fix snapshots on disk carry -wal/-shm sidecars; pruning must clean
+    // those up too so upgraded hosts don't leak sidecars indefinitely.
     const root = makeDbRoot();
     const backupDir = join(root, 'db-backups');
     seedHourly(backupDir, 4, true);

--- a/packages/app/src/delete-all-snapshot.ts
+++ b/packages/app/src/delete-all-snapshot.ts
@@ -5,7 +5,6 @@ import { resolveInvokerHomeRoot } from '@invoker/contracts';
 export { resolveInvokerHomeRoot };
 
 function utcTimestampCompact(): string {
-  // 2026-04-06T12:34:56.789Z -> 20260406-123456-789Z
   const iso = new Date().toISOString();
   return iso.replace(/[-:]/g, '').replace('T', '-').replace('.', '-');
 }
@@ -25,12 +24,16 @@ function createDbSnapshot(
   const stamp = utcTimestampCompact();
   const snapshotPath = path.join(backupDir, `invoker.db.${label}-${stamp}`);
 
+  // Copy the main .db file only. The pre-fix code also raw-copied
+  // `invoker.db-wal` and `invoker.db-shm`, which corrupts the live SQLite
+  // owner: the `-shm` file is SQLite's shared-memory wal-index, and
+  // concurrent third-party access to it under a live WAL connection is
+  // unsafe. On macOS/APFS it repeatedly dropped the running Electron
+  // process into a persistent `SQLITE_IOERR` (errcode 522) loop (see the
+  // 2026-07-08 field failure in ~/.invoker/invoker.log). SQLite's
+  // documented safe backup path for a live database is the online backup
+  // API or `VACUUM INTO` — not raw file copy of the sidecars.
   copyFileSync(dbPath, snapshotPath);
-
-  const walPath = `${dbPath}-wal`;
-  const shmPath = `${dbPath}-shm`;
-  if (existsSync(walPath)) copyFileSync(walPath, `${snapshotPath}-wal`);
-  if (existsSync(shmPath)) copyFileSync(shmPath, `${snapshotPath}-shm`);
 
   return snapshotPath;
 }
@@ -38,9 +41,12 @@ function createDbSnapshot(
 /**
  * Create a DB snapshot before destructive `delete-all`.
  *
- * Throws if snapshot cannot be created, so callers can abort deletion safely.
+ * Returns the snapshot path, or `null` when the DB file does not exist
+ * yet (fresh install / restore utility).
  */
-export function createDeleteAllSnapshot(invokerHomeRoot: string = resolveInvokerHomeRoot()): string | null {
+export function createDeleteAllSnapshot(
+  invokerHomeRoot: string = resolveInvokerHomeRoot(),
+): string | null {
   return createDbSnapshot('before-delete-all', invokerHomeRoot);
 }
 
@@ -60,11 +66,13 @@ function hourlySnapshotRetention(): number {
 }
 
 /**
- * Delete the oldest `hourly-auto` snapshots (and their -wal/-shm sidecars) so at
- * most `retain` remain. Without this the hourly backup grows without bound — a
- * single host accumulated 1,554 snapshots (~363 GB). `retain <= 0` disables
- * pruning. Only `hourly-auto` snapshots are pruned; manual and pre-delete-all
- * snapshots are left untouched. Returns the number of snapshots removed.
+ * Delete the oldest `hourly-auto` snapshots (and any legacy `-wal`/`-shm`
+ * sidecars left over from the pre-fix raw-copy era) so at most `retain`
+ * remain. Without this the hourly backup grows without bound — a single
+ * host accumulated 1,554 snapshots (~363 GB). `retain <= 0` disables
+ * pruning. Only `hourly-auto` snapshots are pruned; manual and
+ * pre-delete-all snapshots are left untouched. Returns the number of
+ * snapshots removed.
  */
 export function pruneHourlySnapshots(backupDir: string, retain: number): number {
   if (retain <= 0) return 0;
@@ -92,9 +100,6 @@ export function pruneHourlySnapshots(backupDir: string, retain: number): number 
       try {
         rmSync(path.join(backupDir, `${name}${suffix}`), { force: true });
       } catch (err) {
-        // Best effort: a transient error must not abort backup, but never swallow
-        // it silently — surface it so a persistent failure is visible.
-        // (rmSync with force:true already ignores a missing file.)
         console.warn(
           `[delete-all-snapshot] failed to prune snapshot file ${name}${suffix}: ${
             err instanceof Error ? err.message : String(err)


### PR DESCRIPTION
## Summary

Invoker's hourly database snapshot was silently corrupting the running app's SQLite connection.

Every hour on the hour, the snapshot code copied `invoker.db`, `invoker.db-wal`, and `invoker.db-shm` with raw `copyFileSync` while the owner adapter held a live WAL connection.

The `-shm` file is SQLite's shared-memory wal-index. Third-party access to it while a WAL owner is live is unsafe, and on macOS/APFS it dropped the running connection into a persistent `SQLITE_IOERR` state.

Field failure captured in `~/.invoker/invoker.log` on 2026-07-08. After the 08:04:08 UTC snapshot every subsequent DB write on the owner failed with errcode 522. The recovery worker, task heartbeats, and terminal upserts spun in an uncaught-exception loop for hours while the app appeared "up".

Fix stops copying the sidecars entirely. The hourly and destructive-purge snapshots now write the main `.db` file only. The public API and every existing caller stay identical.

## Review Claim

`createDbSnapshot` never touches the live SQLite `-wal` or `-shm` sidecars, and the running owner connection can still write after the snapshot runs.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The snapshot function's inputs, outputs, and callers are unchanged. Callers still receive the timestamped snapshot path (or `null` when no DB exists). The owner connection is never observed to lose write access as a consequence of the periodic snapshot.

## Slice Rationale

Single-file behavioral change plus one focused regression file. Bundles the failing-before / passing-after proof with the code that flips it, because the field incident is already reported and the fix is narrow: one internal helper. Restarting the snapshot mechanism through SQLite's online backup API for stronger consistency guarantees is a separate follow-up slice that would necessarily touch `main.ts` and the caller signatures.

## Non-goals

- Not switching to the SQLite online backup API (`SQLiteAdapter.backupTo`) or `VACUUM INTO`. That is a stronger consistency guarantee reachable in a follow-up, and it must cross the `main.ts` boundary; this slice deliberately stays inside `delete-all-snapshot.ts`.
- No change to retention / pruning logic. `INVOKER_HOURLY_BACKUP_RETENTION` behavior is preserved verbatim.
- Not addressing historical `invoker.db.corrupt-*` files on running hosts; those pre-date this fix and can be pruned separately.
- No IPC / API / signature change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && pnpm vitest run src/__tests__/delete-all-snapshot-wal-safety.test.ts` — new regression against a real file-backed WAL `SQLiteAdapter`. The sidecar assertion fails on `origin/master`, passes with this change.
- [ ] `cd packages/app && pnpm vitest run src/__tests__/delete-all-snapshot.test.ts` — existing coverage, now asserts the WAL/SHM safety invariant.
- [ ] `cd packages/app && pnpm vitest run src/__tests__/workflow-actions.test.ts src/__tests__/delete-all-lifecycle.test.ts src/__tests__/headless-delete-all-safety.test.ts` — caller coverage across `deleteAllWorkflows` / `deleteAllWorkflowsBulk`. All pass unchanged.
- [ ] `cd packages/app && pnpm build` — the app package builds cleanly.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`
- Post-revert steps: None. The revert restores the raw-copy behavior. Any snapshot files taken during the fixed period remain valid single-file SQLite databases on disk and stay readable.
- Data migration? No. Schema and on-disk layout are unchanged.

</details>
