### PR TITLE
[Approve Fix Visibility](1) Surface pendingFixError in workflow inspector

### DIFF
--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -607,7 +607,67 @@ describe('WorkflowInspector', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Reject Fix' }));
     expect(onReject).toHaveBeenCalledWith(task);
+
+    expect(screen.getByTestId('inspector-pending-fix-error')).toHaveTextContent('tests failed');
   });
+
+  it('surfaces an executor-selection failure captured in pendingFixError so approve dispatch errors are visible', () => {
+    const capabilityError =
+      'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"';
+    const task = makeTask({
+      status: 'awaiting_approval',
+      execution: {
+        pendingFixError: capabilityError,
+      },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={task}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    const panel = screen.getByTestId('inspector-pending-fix-error');
+    expect(panel).toHaveTextContent(/cannot run codex/);
+    expect(panel).toHaveTextContent(/missing execution harness "codex"/);
+  });
+
+  it('renders pendingFixError alongside execution.error when both are present', () => {
+    const task = makeTask({
+      status: 'awaiting_approval',
+      execution: {
+        error: 'exit 1',
+        exitCode: 1,
+        pendingFixError: 'Approval blocked: capability mismatch',
+      },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={task}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('exit 1')).toBeInTheDocument();
+    expect(screen.getByTestId('inspector-pending-fix-error')).toHaveTextContent(
+      'Approval blocked: capability mismatch',
+    );
+  });
+
   it('shows selected action graph node details', () => {
     render(
       <WorkflowInspector

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -463,6 +463,17 @@ export function WorkflowInspector({
           {!task?.execution.error && task?.execution.exitCode !== undefined && task.execution.exitCode !== 0 && (
             <p className="mt-2 text-xs text-red-300">Exit code: {task.execution.exitCode}</p>
           )}
+          {task?.execution.pendingFixError && (
+            <div
+              data-testid="inspector-pending-fix-error"
+              className="mt-3 rounded border border-amber-500/40 bg-amber-950/40 p-2"
+            >
+              <h3 className="text-[11px] uppercase tracking-wide text-amber-200">Fix Error</h3>
+              <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100">
+                {task.execution.pendingFixError}
+              </pre>
+            </div>
+          )}
           {showApprovalActions && task && (
             <div className="mt-3 flex gap-2 border-t border-gray-700 pt-3">
               <button


### PR DESCRIPTION
## Summary

Clicking Approve Fix on a task appeared to do nothing. The owner had failed the mutation and rewritten `task.execution.pendingFixError`, but the inspector body never rendered that field.

The user was left with the task stuck in `awaiting_approval` and no visible cause. Two live examples: capability mismatches on `remote_digital_ocean_3` (missing `codex`) and `remote_digital_ocean_5` (missing `omp`).

This slice renders `pendingFixError` in an amber "Fix Error" section below the red Error panel, inside a `<pre>` so multi-line stack traces stay readable.

The next silent rewrite of `pendingFixError` becomes visible in the inspector immediately, without any coordinator, IPC, or executor change.

## Review Claim

Render `pendingFixError` in the workflow inspector so approve-fix owner-side failures become visible to the user.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

`task.execution.pendingFixError` is already populated by the owner and already reaches the renderer via the delta stream (covered by `packages/ui/src/__tests__/delta.test.ts`). This slice adds a new read-only DOM node conditional on the same field — no state change, no IPC change, no executor change.

## Slice Rationale

Making the async owner-side failure land as a top-level banner needs a new persisted-mutation hook plus a renderer subscriber plus a banner component, and that surface should ship on its own so a broken banner cannot mask the existing `pendingFixError` value. Keeping this slice narrow (inspector body only) lets a reviewer confirm the smaller behavior guarantee — an already-persisted field becomes visible — before the larger event-plumbing follow-up lands.

## Non-goals

- Does not change `PersistedWorkflowMutationCoordinator` or the workflow-scoped IPC surface. Async dispatch failures still do not reach the renderer as a toast or notification. Separate follow-up planned.
- Does not change `TaskRunner.selectExecutor` or execution capability resolution. Users with capability-mismatched SSH targets still need to fix config, reject the fix, or reassign the task, without any change to that mechanism.
- Does not change the ApprovalModal. `pendingFixError` continues to seed the reject reason as before, with no modification here.
- Does not touch `~/.invoker/config.json`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test -- src/__tests__/workflow-inspector.test.tsx` — 55 files / 600 tests pass; three new tests exercise the `pendingFixError` rendering and fail on `master`.
- [x] `pnpm run check:types` — clean.
- [x] `pnpm run check:comments` — no disallowed comments.
- [x] `pnpm run check:large-files` — clean.
- [x] `bash scripts/ui-visual-proof.sh capture-after` — screenshots captured on this branch; see Visual Proof.

</details>

## Visual Proof

Captured via `bash scripts/ui-visual-proof.sh capture-after` on this branch. The Playwright case at `packages/app/e2e/visual-proof.spec.ts:1707` seeds `task-beta` with `status: 'awaiting_approval'` and `execution.pendingFixError: 'Visual proof error line'`, then clicks the node to open the workflow inspector.

After (this branch):

![Workflow inspector for an awaiting-approval task with pendingFixError — the new amber Fix Error panel renders the message between Task Status and the Approve Fix / Reject Fix buttons](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-e3f3f8/approve-fix-task-panel-actions.png)

The amber "FIX ERROR" section reading `Visual proof error line` sits directly below the "TASK STATUS · awaiting approval" indicator and above the Approve Fix / Reject Fix buttons. On `master` the inspector renders TASK STATUS and the two buttons only — the `pendingFixError` field is populated in `task.execution` (visible in the DAG node's amber APPROVE FIX chip) but is not rendered in the inspector body.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 1d40cc65f`
- Post-revert steps: None. The added panel is additive and has no persistent side effects.
- Data migration? No

</details>