### PR TITLE
fix(ui): stop the browser-surface graph re-centering on every live update

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -856,6 +856,12 @@ export function App() {
   }, [miniDagTasks, selectedTask, selectedWorkflow, selectedWorkflowId, tasks.size, workflowSelectionDismissed]);
   const isSelectedWorkflowGraphRefreshing = displayedSelectedWorkflowGraph !== null
     && !(selectedWorkflow && miniDagTasks.size > 0);
+  // A stable "the browser-surface task graph has content" flag. It flips
+  // false→true once when the graph first appears and stays true across live
+  // task updates, whereas `displayedSelectedWorkflowGraph` is a brand-new object
+  // on every streamed tick. The browser-surface camera effect below keys off
+  // this boolean so it does not re-fire (and re-center) on every update.
+  const selectedWorkflowGraphAvailable = displayedSelectedWorkflowGraph !== null;
   const selectedTaskDagWorkflows = useMemo(() => {
     const workflowForDag = displayedSelectedWorkflowGraph?.workflow ?? selectedWorkflow;
     if (!workflowForDag || workflows.has(workflowForDag.id)) {
@@ -1515,8 +1521,14 @@ export function App() {
     if (selectedWorkerKind && workerStatus?.workers.some((worker) => worker.kind === selectedWorkerKind)) return;
     setSelectedWorkerKind(workerStatus?.workers[0]?.kind ?? null);
   }, [selectedWorkerKind, sidebarSurface, workerStatus]);
+  // On a browser surface (Needs Attention / Running / Workflows) frame the task
+  // graph once when the user lands on it, when its content first arrives, or
+  // when the selected task changes — then leave the camera alone. Keying on the
+  // stable `selectedWorkflowGraphAvailable` boolean (not the per-tick
+  // `displayedSelectedWorkflowGraph` object) is what stops live task updates
+  // from re-centering the graph on the selection while the user is panning it.
   useEffect(() => {
-    if (viewMode !== 'dag' || sidebarSurface === 'home' || displayedSelectedWorkflowGraph === null) {
+    if (viewMode !== 'dag' || sidebarSurface === 'home' || !selectedWorkflowGraphAvailable) {
       return;
     }
 
@@ -1540,9 +1552,9 @@ export function App() {
       cancelAnimationFrame(fitFrame);
     };
   }, [
-    displayedSelectedWorkflowGraph,
     issueCameraCommand,
     selectedTaskId,
+    selectedWorkflowGraphAvailable,
     sidebarSurface,
     viewMode,
   ]);

--- a/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
+++ b/packages/ui/src/__tests__/browser-surface-camera-resnap.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Regression: a browser surface (Needs Attention / Running / Workflows) must not
+ * re-center or re-fit the task graph on every live update.
+ *
+ * The browser-surface camera effect in App used to depend on
+ * `displayedSelectedWorkflowGraph`, which is a brand-new object on every streamed
+ * task delta. Each tick therefore re-issued fitInitial + centerSelection and
+ * yanked the viewport back to the selection while the user was panning the graph.
+ * The effect now keys off a stable "graph available" boolean, so a live update
+ * that changes neither the selection nor the graph topology issues no camera
+ * command.
+ *
+ * The effect is shared by every non-home browser surface (its guard only excludes
+ * `home`), so this drives the Workflows surface — the jsdom harness cannot render
+ * the Needs Attention surface (a separate, pre-existing empty-surface effect loop
+ * unrelated to this fix), and the mechanism under test is identical either way.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+import * as ReactFlowModule from '@xyflow/react';
+
+// vitest hoists vi.mock above imports and its factory cannot close over
+// top-level bindings, so the mock module is loaded dynamically here — a test
+// module-loading boundary, the sanctioned exception to static-import-only.
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
+const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
+const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
+
+// App must be imported AFTER vi.mock registers so it binds the mocked react-flow.
+const { App } = await import('../App.js');
+
+const workflows: WorkflowMeta[] = [
+  { id: 'wf-a', name: 'Alpha Workflow', status: 'running' },
+];
+
+const tasks = [
+  makeUITask({ id: 'wf-a/one', description: 'Task One', workflowId: 'wf-a', status: 'running', command: 'echo a' }),
+  makeUITask({ id: 'wf-a/two', description: 'Task Two', workflowId: 'wf-a', status: 'pending', command: 'echo b', dependencies: ['wf-a/one'] }),
+];
+
+/** Yield past `count` animation frames so scheduled camera moves can run. */
+async function flushFrames(count: number): Promise<void> {
+  for (let i = 0; i < count; i += 1) {
+    const { promise, resolve } = Promise.withResolvers<void>();
+    requestAnimationFrame(() => resolve());
+    await promise;
+  }
+}
+
+/**
+ * Drain the nested requestAnimationFrame chains the initial framing schedules
+ * (fitInitial + centerSelection re-issue commands, each consumed a frame later),
+ * returning once the camera-move count holds steady across several frames. This
+ * is what makes the post-update assertion deterministic: no late initial move
+ * can leak past the point where we start measuring.
+ */
+async function settleCamera(): Promise<void> {
+  let stable = 0;
+  let prev = setCenterMock.mock.calls.length + fitViewMock.mock.calls.length;
+  for (let i = 0; i < 40 && stable < 4; i += 1) {
+    await flushFrames(1);
+    const total = setCenterMock.mock.calls.length + fitViewMock.mock.calls.length;
+    if (total === prev) {
+      stable += 1;
+    } else {
+      stable = 0;
+      prev = total;
+    }
+  }
+}
+
+describe('Browser-surface camera (component)', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    // jsdom here ships without localStorage; App persists the camera lock there.
+    const store = new Map<string, string>();
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => { store.set(k, String(v)); },
+        removeItem: (k: string) => { store.delete(k); },
+        clear: () => { store.clear(); },
+        key: (i: number) => [...store.keys()][i] ?? null,
+        get length() { return store.size; },
+      },
+    });
+    mock = createMockInvoker();
+    mock.install();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    getZoomMock.mockReset();
+    getZoomMock.mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  });
+
+  it('does not re-center or re-fit on a live task update that leaves selection and topology unchanged', async () => {
+    mock.setTasks(tasks, workflows);
+    render(<App />);
+
+    // Open the Workflows browser surface and select a task node so the camera
+    // lock has a target — the initial framing centers it.
+    fireEvent.click(await screen.findByTestId('sidebar-workflows'));
+    await screen.findByTestId('selected-workflow-mini-dag');
+    fireEvent.click(await screen.findByTestId('rf__node-wf-a/one'));
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalled());
+
+    // Wait for every initial framing frame to drain, then measure from a clean
+    // baseline so only update-triggered camera moves count.
+    await settleCamera();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+
+    // A routine streamed status tick: an existing task's fields change (no new or
+    // removed node, and the selection is untouched). The tasks map identity churns
+    // but nothing about navigation changed.
+    mock.fireDelta({
+      type: 'updated',
+      taskId: 'wf-a/two',
+      changes: { description: 'Task Two (live update)' },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    });
+
+    // Wait until the update propagated and re-rendered (the node label updates),
+    // then drain the frames any (buggy) re-issued camera command would use.
+    await waitFor(() =>
+      expect(screen.getAllByText('Task Two (live update)').length).toBeGreaterThan(0),
+    );
+    await flushFrames(6);
+
+    // The camera must not move on a live update that changed no selection.
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

The Needs Attention, Running, and Workflows views frame the task graph when you open them, then let you pan and zoom the graph yourself.

A bug pulled the camera back onto the highlighted task on every live update, so the view you set kept getting yanked away while a workflow ran.

The framing effect watched the selected-workflow graph object, which is rebuilt on every streamed tick even when nothing you care about changed.

It now watches a stable "graph is ready" flag that only flips when the graph first appears.

So the graph frames once when you open a view or pick a different task, then holds still as updates stream in.

## Review Claim

The browser-surface framing effect no longer re-centers the task graph when only live task data changed.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The effect still frames the graph on real navigation: opening a view, the graph first appearing, or picking a different task. Only the redundant per-tick re-fire is dropped, and a component test asserts a status-only tick triggers no camera re-center.

## Slice Rationale

The fix and its regression test are one behavioral unit. The changelog note ships as a separate change per the repo's review-unit boundary.

## Non-goals

- Does not change the camera-lock keyboard controls or the home plan-graph framing.
- Does not touch the pre-existing empty-surface effect loop that blocks the jsdom harness from rendering Needs Attention.
- No changelog entry here; it ships as a separate change.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/ui exec vitest run src/__tests__/browser-surface-camera-resnap.test.tsx`
- [ ] `pnpm --filter @invoker/ui test`
- [ ] `pnpm exec tsc -p tsconfig.typecheck.json --noEmit`

</details>

## Visual Proof

Real captures from the actual UI (App mounted in a browser against a mock backend), driving the Needs Attention graph. Stills with the react-flow viewport transform read out for each state.

### Fixed build — camera holds still

Manual zoom-out, then four live status ticks arrive. The viewport transform holds at `matrix(0.3, 0, 0, 0.3, 180.86, 132.9)` across the ticks — the camera does not re-center.

![fixed build: manual zoom-out](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-9aef6d/fixed-1-manual-zoom.png)
![fixed build: viewport unchanged once four live ticks arrive](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-9aef6d/fixed-2-live-ticks.png)

### Buggy build (master) — camera snaps

The same manual zoom-out, then the same four live status ticks. The camera re-frames onto the highlighted task on its own: the viewport jumps from `matrix(0.3, 0, 0, 0.3, 147.2, 132.9)` to `matrix(0.527, 0, 0, 0.527, 414.6, 114.7)`.

![buggy build: manual zoom-out](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-9aef6d/buggy-1-manual-zoom.png)
![buggy build: re-framed once four live ticks arrive](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-9aef6d/buggy-2-live-ticks.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
