### PR TITLE
[Daily e2e autofix](1) battery worker, crons, and public status workflow

### DIFF
--- a/.github/workflows/daily-e2e-status.yml
+++ b/.github/workflows/daily-e2e-status.yml
@@ -1,0 +1,190 @@
+name: Daily e2e status
+
+# Public per-suite pass/fail surface for the FULL extended e2e battery. Runs once
+# a day (after ci.yml's 09:17 UTC scheduled run), publishes a per-suite table to
+# the run's step summary AND a single durable tracking issue, and goes red when
+# any suite fails. This is the reporting half; the private owner-host worker
+# (scripts/cron-daily-e2e-fix.sh) is what actually opens fix PRs.
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  NODE_VERSION: '26'
+
+jobs:
+  extended-battery:
+    runs-on: ubuntu-latest
+    timeout-minutes: 150
+    env:
+      INVOKER_TEST_ALL_EXTENDED: '1'
+      INVOKER_TEST_ALL_STATE_FILE: ${{ github.workspace }}/e2e-extended-state.tsv
+      SUMMARY_FILE: ${{ github.workspace }}/e2e-summary.md
+      TMPDIR: /tmp/invoker-tmp
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+          cache-dependency-path: |
+            pnpm-lock.yaml
+            .node-version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install test system packages
+        run: sudo apt-get update && sudo apt-get install -y xvfb jq
+
+      - name: Build UI and app
+        run: |
+          pnpm --filter @invoker/ui build
+          pnpm --filter @invoker/app build
+
+      - name: Run extended battery
+        run: |
+          mkdir -p "$TMPDIR"
+          chmod 1777 "$TMPDIR"
+          # Capture status but never abort before we surface the per-suite table.
+          status=0
+          bash scripts/run-all-tests.sh || status=$?
+          echo "BATTERY_EXIT=$status" >> "$GITHUB_ENV"
+          echo "extended battery exit: $status"
+
+      - name: Build per-suite summary
+        run: |
+          state="$INVOKER_TEST_ALL_STATE_FILE"
+          table="$SUMMARY_FILE"
+          {
+            echo "| Status | Suite |"
+            echo "| --- | --- |"
+          } > "$table"
+
+          emit() {
+            # emit <status> <icon>
+            awk -F '\t' -v want="$1" '$1=="extended" && $3==want {print $2}' "$state" 2>/dev/null \
+              | LC_ALL=C sort | while IFS= read -r suite; do
+                  [ -n "$suite" ] || continue
+                  rel="${suite##*/scripts/test-suites/}"
+                  printf '| %s %s | %s |\n' "$2" "$1" "$rel" >> "$table"
+                done
+          }
+          emit failed '🔴'
+          emit skipped-unavailable '⚪'
+          emit passed '🟢'
+
+          total="$(awk -F '\t' '$1=="extended"{c++} END{print c+0}' "$state" 2>/dev/null || echo 0)"
+          fail_count="$(awk -F '\t' '$1=="extended" && $3=="failed"{c++} END{print c+0}' "$state" 2>/dev/null || echo 0)"
+          echo "TOTAL_COUNT=$total" >> "$GITHUB_ENV"
+          echo "FAIL_COUNT=$fail_count" >> "$GITHUB_ENV"
+
+          {
+            echo "## Daily e2e status (extended battery)"
+            echo ""
+            if [ "$total" -eq 0 ]; then
+              echo "**No suite results were recorded** — the battery did not produce a state file (exit ${BATTERY_EXIT:-unknown}). Treating this run as failed."
+              echo ""
+            fi
+            cat "$table"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upsert tracking issue
+        uses: actions/github-script@v7
+        env:
+          FAIL_COUNT: ${{ env.FAIL_COUNT }}
+          TOTAL_COUNT: ${{ env.TOTAL_COUNT }}
+          BATTERY_EXIT: ${{ env.BATTERY_EXIT }}
+        with:
+          script: |
+            const fs = require('fs');
+            const LABEL = 'daily-e2e-status';
+            const { owner, repo } = context.repo;
+            const failCount = parseInt(process.env.FAIL_COUNT || '0', 10);
+            const totalCount = parseInt(process.env.TOTAL_COUNT || '0', 10);
+            // A zero-total run means the battery never produced results — red.
+            const red = failCount > 0 || totalCount === 0;
+            const prefix = red ? '🔴' : '🟢';
+            const title = `${prefix} Daily e2e status`;
+
+            let table = '';
+            try {
+              table = fs.readFileSync(process.env.SUMMARY_FILE, 'utf8');
+            } catch (err) {
+              console.error(`Could not read summary table: ${err.message}`);
+            }
+
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const stamp = new Date().toISOString();
+            const headline = totalCount === 0
+              ? `**No suite results recorded** (battery exit ${process.env.BATTERY_EXIT || 'unknown'}).`
+              : `**${failCount}** failing suite(s) of **${totalCount}** in the extended battery.`;
+            const body = [
+              headline,
+              '',
+              table,
+              '',
+              `Run: ${runUrl}`,
+              `Updated: ${stamp}`,
+            ].join('\n');
+
+            try {
+              // Ensure the dedupe label exists (create on first run).
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: LABEL });
+              } catch (err) {
+                if (err.status === 404) {
+                  await github.rest.issues.createLabel({
+                    owner, repo, name: LABEL, color: 'b60205',
+                    description: 'Durable per-suite status of the daily extended e2e battery',
+                  });
+                } else {
+                  throw err;
+                }
+              }
+
+              // One durable issue per repo: reuse the open labeled issue, else create.
+              const existing = await github.rest.issues.listForRepo({
+                owner, repo, labels: LABEL, state: 'open', per_page: 1,
+              });
+              if (existing.data.length > 0) {
+                const number = existing.data[0].number;
+                await github.rest.issues.update({ owner, repo, issue_number: number, title, body });
+                console.log(`Updated tracking issue #${number}`);
+              } else {
+                const created = await github.rest.issues.create({
+                  owner, repo, title, body, labels: [LABEL],
+                });
+                console.log(`Created tracking issue #${created.data.number}`);
+              }
+            } catch (err) {
+              // Never swallow: fail the step with context so the surface stays trustworthy.
+              core.setFailed(`Failed to upsert tracking issue: ${err.message}`);
+            }
+
+      - name: Fail run if any suite failed
+        run: |
+          if [ "${TOTAL_COUNT:-0}" -eq 0 ]; then
+            echo "extended battery produced no suite results (exit ${BATTERY_EXIT:-unknown})"
+            exit 1
+          fi
+          if [ "${FAIL_COUNT:-0}" -ne 0 ]; then
+            echo "extended battery failures: ${FAIL_COUNT}"
+            exit 1
+          fi
+          echo "all ${TOTAL_COUNT} extended suites passed or self-skipped"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",
-    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-ci-workflow-merge-queue-policy.mjs && node scripts/test-review-unit-classification.mjs && bash scripts/workspace-test.sh",
+    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-ci-workflow-merge-queue-policy.mjs && node scripts/test-review-unit-classification.mjs && bash scripts/workspace-test.sh && bash scripts/test-daily-e2e-fix-worker.sh && bash scripts/test-install-daily-e2e-cron.sh",
     "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
     "test:low-resource": "pnpm run test",
     "test:low-resource:packages": "bash scripts/workspace-test.sh",

--- a/scripts/cron-daily-e2e-fix.sh
+++ b/scripts/cron-daily-e2e-fix.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# TEMPORARY tooling — a stopgap daily job co-located with the Invoker owner that
+# runs the FULL extended e2e battery once a day and, for every still-failing
+# suite, launches an `omp` agent that repairs the tree and opens ONE schema-valid
+# PR upstream (never auto-landed — a human reviews/merges).
+#
+# Unlike the once-per-tick */5 PR-maintenance crons (cron-coderabbit-address.sh,
+# cron-pr-conflict-rebase.sh), this daily job processes EVERY failing suite in a
+# single run: a per-suite omp failure logs and continues to the next suite rather
+# than exiting the whole worker.
+#
+# Prerequisites on the owner host (same as the other PR crons): `gh auth login`
+# as the PR author, `omp` on PATH with creds, and the extended battery's local
+# infra (SSH targets, Playwright/xvfb, etc.). Missing infra makes those suites
+# self-skip or fail locally exactly as a manual `pnpm test:all:extended` would.
+#
+# Source cron-pr-lib.sh AFTER `set -euo pipefail`; it provides log_line,
+# cron_lock, gh_json, the ledger API, and the TARGET_REPO / PR_AUTHOR / DRY_RUN
+# config constants.
+set -euo pipefail
+
+# shellcheck source=scripts/cron-pr-lib.sh
+source "$(dirname "$0")/cron-pr-lib.sh"
+
+# ---------------------------------------------------------------------------
+# Configuration (all overridable via env)
+# ---------------------------------------------------------------------------
+
+# Bound on omp launches per run; also caps a runaway all-red battery.
+MAX_FIXES="${INVOKER_DAILY_E2E_MAX_FIXES:-5}"
+# Lifetime attempts per suite before we stop retrying (dedup key = suite slug).
+MAX_ATTEMPTS="${INVOKER_DAILY_E2E_MAX_ATTEMPTS:-5}"
+# Dedicated battery checkout, kept warm across runs.
+CHECKOUT="${INVOKER_DAILY_E2E_CHECKOUT:-${HOME}/.invoker/daily-e2e-work/repo}"
+# Per-run state TSV (mode<TAB>suite<TAB>status) written by run-all-tests.sh.
+STATE_FILE="${INVOKER_DAILY_E2E_STATE_FILE:-${HOME}/.invoker/daily-e2e-work/state.tsv}"
+# Durable append-only attempt ledger.
+LEDGER_FILE="${INVOKER_DAILY_E2E_LEDGER:-${HOME}/.invoker/daily-e2e-fix-submissions.tsv}"
+# Focused per-suite re-run logs.
+LOGDIR="${INVOKER_DAILY_E2E_LOGDIR:-${HOME}/.invoker/daily-e2e-work/logs}"
+OMP_CMD="${INVOKER_OMP_COMMAND:-omp}"
+OMP_TIMEOUT="${INVOKER_DAILY_E2E_OMP_TIMEOUT:-45m}"
+
+# Dedicated lock: do NOT share the */5 PR-cron lock, or this long daily run would
+# starve the frequent PR crons (and vice versa). cron_lock reads $CRON_LOCK at
+# call time, so reassigning it after sourcing the lib is honored.
+CRON_LOCK="${INVOKER_DAILY_E2E_CRON_LOCK:-${TMPDIR:-/tmp}/invoker-daily-e2e.lock}"
+cron_lock
+
+ledger_init "$LEDGER_FILE"
+
+TODAY="$(date -u +%Y-%m-%d)"
+
+# ---------------------------------------------------------------------------
+# Battery checkout: clone once, then hard-reset to origin/master and rebuild the
+# app the extended battery (Playwright) needs. Mirrors prepare_checkout in the
+# coderabbit worker, minus the PR-head checkout.
+# ---------------------------------------------------------------------------
+
+prepare_battery_checkout() {
+  mkdir -p "$(dirname "$CHECKOUT")"
+  if [ ! -d "$CHECKOUT/.git" ]; then
+    rm -rf "$CHECKOUT"
+    if ! gh repo clone "$TARGET_REPO" "$CHECKOUT" -- --quiet >/dev/null 2>&1; then
+      log_line "battery checkout: clone of $TARGET_REPO failed"
+      return 1
+    fi
+  fi
+  if ! ( cd "$CHECKOUT" && git fetch origin --quiet && git reset --hard origin/master && git clean -fd ) >/dev/null 2>&1; then
+    log_line "battery checkout: git fetch/reset/clean failed"
+    return 1
+  fi
+  if ! ( cd "$CHECKOUT" && pnpm install --frozen-lockfile && pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build ); then
+    log_line "battery checkout: pnpm install/build failed"
+    return 1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Run the extended battery. A non-zero exit (suites failed) is EXPECTED and must
+# not abort the worker, so capture it under set +e/set -e.
+# ---------------------------------------------------------------------------
+
+run_battery() {
+  mkdir -p "$(dirname "$STATE_FILE")"
+  rm -f "$STATE_FILE"
+  local rc=0
+  set +e
+  ( cd "$CHECKOUT" && env INVOKER_TEST_ALL_EXTENDED=1 INVOKER_TEST_ALL_STATE_FILE="$STATE_FILE" bash scripts/run-all-tests.sh )
+  rc=$?
+  set -e
+  log_line "extended battery finished (exit $rc)"
+}
+
+# ---------------------------------------------------------------------------
+# Re-run a single suite in isolation for a clean focused log and a flake filter.
+# INVOKER_DAILY_E2E_RERUN_CMD is a test seam: when set it is invoked as
+# "$INVOKER_DAILY_E2E_RERUN_CMD <rel>" instead of the real suite.
+# Returns the suite's exit status; output is captured to <logfile>.
+# ---------------------------------------------------------------------------
+
+rerun_suite() {
+  local rel="$1" logfile="$2"
+  if [ -n "${INVOKER_DAILY_E2E_RERUN_CMD:-}" ]; then
+    ( cd "$CHECKOUT" && "$INVOKER_DAILY_E2E_RERUN_CMD" "$rel" ) >"$logfile" 2>&1
+  else
+    ( cd "$CHECKOUT" && bash "scripts/test-suites/$rel" ) >"$logfile" 2>&1
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# The omp prompt: the failing suite IS the reproduction. Keep the diff in one
+# review lane and open exactly one PR upstream via create-pr.mjs.
+# ---------------------------------------------------------------------------
+
+build_prompt() {
+  # build_prompt <rel> <slug> <branch> <ctx_file>
+  local rel="$1" slug="$2" branch="$3" ctx="$4"
+  cat <<EOF
+You are fixing a failing end-to-end test suite in a fresh checkout of $TARGET_REPO.
+HEAD is already on branch $branch (base: origin/master); opening the PR via the
+create-pr CLI publishes that branch.
+
+Context JSON: $ctx
+Fields: .suite (the failing suite's repo-relative path), .slug, .branch, .base,
+        .targetRepo, .log (the captured failing run log from this session).
+
+The failing suite scripts/test-suites/$rel IS the reproduction. Do this, in order:
+
+1. Run it and confirm it fails:  bash scripts/test-suites/$rel
+   Read its captured log at the .log path for the failure detail. If the suite
+   PASSES, make NO commit and exit 0 (nothing to fix).
+2. Diagnose the root cause across the suite, the scripts it calls, and the product
+   code it exercises. Implement the MINIMAL fix so 'bash scripts/test-suites/$rel'
+   exits 0. Do NOT weaken, skip, or delete the assertion to make it pass.
+3. Keep the ENTIRE diff inside ONE review lane (scope rules in
+   scripts/validate-pr-body.mjs): packages/ -> product -> lane 'behavior' or
+   'refactor'; scripts/ -> 'policy'; scripts/repro/ -> 'proof'; skills, docs, and
+   *.md -> 'docs'. Do NOT mix lanes. A new scripts/repro/ file is usually
+   unnecessary — the suite already reproduces.
+4. If the fix unavoidably touches UI-impacting paths (packages/ui/,
+   packages/app/src/window/, main.ts, preload.ts, app-menu.ts), follow the
+   skills/visual-proof skill and add a '## Visual Proof' section to the PR body.
+   Otherwise avoid those paths.
+5. Author the PR body:  cp scripts/pr-body-template.md <tmp>  then fill EVERY
+   required section (## Summary, ## Review Claim, ## Review Lane, ## Review Unit,
+   ## Safety Invariant, ## Slice Rationale, ## Non-goals, ## Test Plan, ## Revert
+   Plan). Set ## Review Lane to the single matching lane. Validate and iterate:
+   node scripts/validate-pr-body.mjs --body-file <tmp>  until it exits 0.
+6. Commit the fix on the current branch ($branch), then open EXACTLY ONE PR
+   upstream:
+   node scripts/create-pr.mjs --title "<title>" --base master --body-file <tmp>
+   Do NOT land, merge, run 'mergify stack push', or add labels. If you CANNOT make
+   the suite pass, make no commit and exit non-zero.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Launch omp for one failing suite in the isolated branch. Returns omp's exit
+# status. Mirrors launch_omp in the coderabbit worker (ctx-file JSON, omp flags,
+# timeout wrap).
+# ---------------------------------------------------------------------------
+
+launch_omp_for_suite() {
+  # launch_omp_for_suite <rel> <slug> <branch> <logfile>
+  local rel="$1" slug="$2" branch="$3" logfile="$4"
+
+  local ctx_file
+  ctx_file="$(mktemp -t invoker-daily-e2e-ctx.XXXXXX)"
+  jq -n --arg suite "scripts/test-suites/$rel" --arg slug "$slug" \
+        --arg branch "$branch" --arg base "master" \
+        --arg targetRepo "$TARGET_REPO" --arg log "$logfile" '
+    { suite: $suite, slug: $slug, branch: $branch, base: $base,
+      targetRepo: $targetRepo, log: $log }
+  ' > "$ctx_file"
+
+  local prompt
+  prompt="$(build_prompt "$rel" "$slug" "$branch" "$ctx_file")"
+  local omp_args=(--no-title --auto-approve)
+  [ -n "${INVOKER_PR_CRON_OMP_MODEL:-}" ] && omp_args+=(--model "$INVOKER_PR_CRON_OMP_MODEL")
+  omp_args+=(-p "$prompt")
+
+  local omp_run=("$OMP_CMD" "${omp_args[@]}")
+  if command -v timeout >/dev/null 2>&1; then
+    omp_run=(timeout --kill-after=1m "$OMP_TIMEOUT" "$OMP_CMD" "${omp_args[@]}")
+  fi
+
+  log_line "suite $rel: launching omp on $CHECKOUT (branch $branch)"
+  local rc=0
+  ( cd "$CHECKOUT" && "${omp_run[@]}" ) || rc=$?
+  rm -f "$ctx_file"
+  return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if [ "${INVOKER_DAILY_E2E_SKIP_BATTERY:-0}" != "1" ]; then
+  if ! prepare_battery_checkout; then
+    log_line "battery checkout preparation failed; exiting"
+    exit 1
+  fi
+  run_battery
+else
+  log_line "INVOKER_DAILY_E2E_SKIP_BATTERY=1: using pre-seeded state file $STATE_FILE"
+fi
+
+if [ ! -f "$STATE_FILE" ]; then
+  log_line "no state file at $STATE_FILE; nothing to do"
+  exit 0
+fi
+
+attempted=0
+failing_count=0
+skipped_dedup=0
+opened=0
+
+while IFS= read -r suite; do
+  [ -z "$suite" ] && continue
+  failing_count=$((failing_count + 1))
+
+  rel="${suite##*/scripts/test-suites/}"
+  slug="$(basename "$rel" .sh | tr 'A-Z' 'a-z' | tr -cs 'a-z0-9' '-' | sed -e 's/^-*//' -e 's/-*$//')"
+  branch="autofix/e2e-$slug"
+
+  # Bound on omp launches this run (counts launches; break when reached).
+  if [ "$attempted" -ge "$MAX_FIXES" ]; then
+    log_line "reached max fixes ($MAX_FIXES) this run; stopping"
+    break
+  fi
+
+  # Same-day idempotency: never attempt the same suite twice in one calendar day.
+  if ledger_marker_seen daily-e2e-fix "$slug" "$TODAY"; then
+    log_line "suite $rel: already attempted today; skip"
+    skipped_dedup=$((skipped_dedup + 1))
+    continue
+  fi
+
+  # Open-PR dedup (primary): a fix is already in review for this suite's branch.
+  open_prs="$(gh_json pr list --repo "$TARGET_REPO" --author "$PR_AUTHOR" --state open \
+    --head "$branch" --json number 2>/dev/null || printf '[]')"
+  if [ "$(printf '%s' "$open_prs" | jq 'length' 2>/dev/null || printf '0')" -gt 0 ]; then
+    log_line "suite $rel: open PR on $branch already in review; skip"
+    skipped_dedup=$((skipped_dedup + 1))
+    continue
+  fi
+
+  # Lifetime attempt cap: stop retrying a suite we can never fix automatically.
+  if [ "$(ledger_count daily-e2e-fix "$slug")" -ge "$MAX_ATTEMPTS" ]; then
+    log_line "suite $rel: hit lifetime attempt cap ($MAX_ATTEMPTS); skip"
+    skipped_dedup=$((skipped_dedup + 1))
+    continue
+  fi
+
+  # Dry-run seam: log the intended action, mutate nothing (no ledger, omp, or gh).
+  if [ "$DRY_RUN" = "1" ]; then
+    log_line "suite $rel: would open PR $branch (dry-run)"
+    continue
+  fi
+
+  # Isolate the fix branch off a clean origin/master.
+  if ! ( cd "$CHECKOUT" && git reset --hard origin/master >/dev/null 2>&1 && git switch -C "$branch" >/dev/null 2>&1 ); then
+    log_line "suite $rel: failed to isolate branch $branch; skip"
+    continue
+  fi
+
+  # Flake filter: re-run the one suite in isolation. If it now passes, it was a
+  # flake (or already fixed) — record nothing and open no PR.
+  mkdir -p "$LOGDIR"
+  log="$LOGDIR/$slug.log"
+  if rerun_suite "$rel" "$log"; then
+    log_line "suite $rel: passed on isolated re-run (flake/already green); no PR"
+    continue
+  fi
+
+  # Count the attempt (incl. omp failures) so repeated failures hit the cap.
+  ledger_record daily-e2e-fix "$slug" "$TODAY"
+  attempted=$((attempted + 1))
+
+  if launch_omp_for_suite "$rel" "$slug" "$branch" "$log"; then
+    opened=$((opened + 1))
+    log_line "suite $rel: omp opened PR on $branch"
+  else
+    log_line "suite $rel: omp exited non-zero; no PR this run (retry a future day)"
+  fi
+done < <(awk -F '\t' '$1=="extended" && $3=="failed"{print $2}' "$STATE_FILE")
+
+log_line "daily-e2e summary: failing=$failing_count skipped-dedup=$skipped_dedup attempted=$attempted opened=$opened"

--- a/scripts/install-daily-e2e-cron.sh
+++ b/scripts/install-daily-e2e-cron.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# TEMPORARY tooling — install (or update) the daily cron job that runs the full
+# extended e2e battery and opens one fix PR per still-failing suite
+# (scripts/cron-daily-e2e-fix.sh). Runs once a day at 03:00 host-local.
+#
+# Must run on the Invoker owner host: `gh auth login` as the PR author, `omp` on
+# PATH with creds, and the extended battery's local infra (SSH targets,
+# Playwright/xvfb, etc.).
+#
+# De-dupes by marker, so re-running is safe (updates the line in place).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORKER_SCRIPT="$REPO_ROOT/scripts/cron-daily-e2e-fix.sh"
+MARKER="# invoker-cron-daily-e2e-fix"
+LOG_FILE="${HOME}/.invoker/daily-e2e-fix-cron.log"
+
+# The cron line invokes the worker via `bash`, so execute permission is not
+# required — only readability. An unconditional chmod +x would needlessly fail on
+# read-only or shared checkouts where the worker is still runnable.
+if [[ ! -f "$WORKER_SCRIPT" ]]; then
+  echo "ERROR: missing worker script at $WORKER_SCRIPT" >&2
+  exit 1
+fi
+if [[ ! -r "$WORKER_SCRIPT" ]]; then
+  echo "ERROR: worker script is not readable at $WORKER_SCRIPT" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+CRON_LINE="0 3 * * * bash '$WORKER_SCRIPT' >> '$LOG_FILE' 2>&1 $MARKER"
+
+TMP_CRON="$(mktemp -t invoker-daily-e2e-cron.XXXXXX)"
+trap 'rm -f "$TMP_CRON"' EXIT
+
+if crontab -l >/dev/null 2>&1; then
+  # `|| true`: grep -Fv exits 1 when it filters out every line (e.g. our marker
+  # was the only entry), which pipefail would otherwise treat as fatal and skip
+  # the rewrite below.
+  { crontab -l | grep -Fv "$MARKER" || true; } > "$TMP_CRON"
+else
+  : > "$TMP_CRON"
+fi
+
+printf '%s\n' "$CRON_LINE" >> "$TMP_CRON"
+crontab "$TMP_CRON"
+
+echo "Installed cron job:"
+echo "  $CRON_LINE"
+echo "Log file: $LOG_FILE"
+echo "Verify with: crontab -l | grep -F '$MARKER'"

--- a/scripts/repro/repro-coderabbit-pr3476-checkout-credentials.sh
+++ b/scripts/repro/repro-coderabbit-pr3476-checkout-credentials.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Repro: CodeRabbit PR #3476 — daily e2e status checkout must not persist
+# GITHUB_TOKEN credentials into .git/config. The workflow only needs repository
+# reads from checkout; issue writes go through actions/github-script.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKFLOW="$REPO_ROOT/.github/workflows/daily-e2e-status.yml"
+
+if awk '
+  function close_checkout() {
+    if (!in_checkout) {
+      return
+    }
+    found = 1
+    if (uses_checkout && persist_false) {
+      ok = 1
+    } else if (!uses_checkout) {
+      fail = "Checkout step does not use actions/checkout@v4."
+    } else {
+      fail = "Checkout step persists GitHub credentials; set persist-credentials: false."
+    }
+    in_checkout = 0
+    uses_checkout = 0
+    persist_false = 0
+  }
+
+  /^      - name:/ {
+    close_checkout()
+    if ($0 == "      - name: Checkout") {
+      in_checkout = 1
+    }
+    next
+  }
+
+  in_checkout && /^[[:space:]]*uses:[[:space:]]*actions\/checkout@v4[[:space:]]*$/ {
+    uses_checkout = 1
+  }
+
+  in_checkout && /^[[:space:]]*persist-credentials:[[:space:]]*false[[:space:]]*$/ {
+    persist_false = 1
+  }
+
+  END {
+    close_checkout()
+    if (!found) {
+      fail = "workflow has no Checkout step."
+    }
+    if (fail) {
+      print "[repro] FAIL: " fail > "/dev/stderr"
+      exit 1
+    }
+    if (!ok) {
+      print "[repro] FAIL: Checkout step missing credential persistence guard." > "/dev/stderr"
+      exit 1
+    }
+  }
+' "$WORKFLOW"; then
+  echo "[repro] PASS: daily e2e checkout disables persisted GitHub credentials."
+  exit 0
+fi
+
+exit 1

--- a/scripts/test-daily-e2e-fix-worker.sh
+++ b/scripts/test-daily-e2e-fix-worker.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Behavior test for scripts/cron-daily-e2e-fix.sh with the battery, the omp
+# agent, gh, and git all stubbed. No network, no real agent, no real git.
+#
+# Covers, per the daily-e2e plan:
+#   A. Dry-run logs the intended autofix/e2e-<slug> action for the FAILED suite
+#      only (never the passed one), and mutates nothing (no omp, no ledger).
+#   B. Open-PR dedup: a non-empty `gh pr list` for the head branch skips the suite
+#      before omp runs.
+#   C. INVOKER_DAILY_E2E_MAX_FIXES=0 yields zero attempted launches.
+#   D. Flake filter: when the isolated single-suite re-run passes, no PR is opened
+#      and no attempt is recorded.
+#   E. A repeated failure launches omp exactly once and records one attempt.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WORKER="$REPO_ROOT/scripts/cron-daily-e2e-fix.sh"
+FAIL_SLUG="20-e2e-dry-run"
+FAIL_BRANCH="autofix/e2e-$FAIL_SLUG"
+
+SANDBOXES=()
+cleanup() { local d; for d in ${SANDBOXES[@]+"${SANDBOXES[@]}"}; do rm -rf "$d"; done; return 0; }
+trap cleanup EXIT
+
+fail() { echo "FAIL: $1" >&2; [ -n "${2:-}" ] && { echo "----- worker log -----" >&2; cat "$2" >&2; }; exit 1; }
+
+# Run the worker in a fresh sandbox. Control knobs are read from the caller's
+# EXPORTED environment (env(1) inherits them): FAKE_GH_PRS, FAKE_OMP_EXIT,
+# FAKE_RERUN_EXIT, INVOKER_PR_CRON_DRY_RUN, INVOKER_DAILY_E2E_MAX_FIXES.
+# Sets the global `sb` to the sandbox path (must run directly, NOT in a command
+# substitution, or SANDBOXES would be appended in a throwaway subshell). The
+# worker's combined output is at "$sb/worker.log".
+run_worker() {
+  sb="$(mktemp -d "${TMPDIR:-/tmp}/repro-daily-e2e.XXXXXX")"
+  SANDBOXES+=("$sb")
+  mkdir -p "$sb/bin" "$sb/home" "$sb/checkout" "$sb/logs"
+
+  cat > "$sb/bin/gh" <<'GH'
+#!/usr/bin/env bash
+# The worker only uses `gh pr list ... --json number`; echo the configured JSON.
+printf '%s' "${FAKE_GH_PRS:-[]}"
+GH
+  cat > "$sb/bin/omp" <<'OMP'
+#!/usr/bin/env bash
+# One line per invocation (never echo $*: the -p prompt is multi-line).
+echo invoked >> "${OMP_CALLS_FILE:?OMP_CALLS_FILE unset}"
+exit "${FAKE_OMP_EXIT:-0}"
+OMP
+  cat > "$sb/bin/git" <<'GIT'
+#!/usr/bin/env bash
+# Fake git: branch isolation (reset/switch) succeeds against the temp checkout.
+exit 0
+GIT
+  cat > "$sb/bin/rerun-stub" <<'RS'
+#!/usr/bin/env bash
+# Deterministic single-suite re-run for the flake filter.
+exit "${FAKE_RERUN_EXIT:-1}"
+RS
+  chmod +x "$sb/bin/gh" "$sb/bin/omp" "$sb/bin/git" "$sb/bin/rerun-stub"
+
+  # Seed the state TSV: one FAILED and one PASSED extended row (absolute paths).
+  {
+    printf 'extended\t%s/scripts/test-suites/required/20-e2e-dry-run.sh\tfailed\n' "$sb/checkout"
+    printf 'extended\t%s/scripts/test-suites/required/10-vitest-workspace.sh\tpassed\n' "$sb/checkout"
+  } > "$sb/state.tsv"
+
+  env PATH="$sb/bin:$PATH" HOME="$sb/home" \
+    OMP_CALLS_FILE="$sb/omp-calls" \
+    INVOKER_OMP_COMMAND=omp \
+    INVOKER_DAILY_E2E_SKIP_BATTERY=1 \
+    INVOKER_DAILY_E2E_STATE_FILE="$sb/state.tsv" \
+    INVOKER_DAILY_E2E_LEDGER="$sb/ledger.tsv" \
+    INVOKER_DAILY_E2E_CRON_LOCK="$sb/lock" \
+    INVOKER_DAILY_E2E_CHECKOUT="$sb/checkout" \
+    INVOKER_DAILY_E2E_LOGDIR="$sb/logs" \
+    INVOKER_DAILY_E2E_RERUN_CMD="$sb/bin/rerun-stub" \
+    bash "$WORKER" > "$sb/worker.log" 2>&1 || true
+}
+
+reset_knobs() {
+  unset FAKE_GH_PRS FAKE_OMP_EXIT FAKE_RERUN_EXIT \
+        INVOKER_PR_CRON_DRY_RUN INVOKER_DAILY_E2E_MAX_FIXES 2>/dev/null || true
+}
+
+# ── A. Dry-run: intended action for the failed suite only, no mutation ────────
+reset_knobs
+export INVOKER_PR_CRON_DRY_RUN=1
+export FAKE_GH_PRS='[]'
+run_worker
+grep -q "would open PR $FAIL_BRANCH (dry-run)" "$sb/worker.log" \
+  || fail "A: dry-run did not log the intended PR action for the failed suite" "$sb/worker.log"
+if grep -q "10-vitest-workspace" "$sb/worker.log"; then
+  fail "A: the passed suite must never appear as an action target" "$sb/worker.log"
+fi
+grep -q "failing=1 " "$sb/worker.log" \
+  || fail "A: expected exactly one failing suite in the summary" "$sb/worker.log"
+[ ! -s "$sb/omp-calls" ] || fail "A: omp must not run in dry-run" "$sb/worker.log"
+[ ! -s "$sb/ledger.tsv" ] || fail "A: dry-run must not write the ledger" "$sb/worker.log"
+echo "  A ok: dry-run surfaces the failed suite only, mutates nothing"
+
+# ── B. Open-PR dedup: existing PR on the head branch skips before omp ─────────
+reset_knobs
+export INVOKER_PR_CRON_DRY_RUN=0
+export FAKE_GH_PRS='[{"number":1}]'
+run_worker
+grep -q "open PR on $FAIL_BRANCH already in review; skip" "$sb/worker.log" \
+  || fail "B: did not skip on existing open PR" "$sb/worker.log"
+[ ! -s "$sb/omp-calls" ] || fail "B: omp must not run when a PR already exists" "$sb/worker.log"
+echo "  B ok: open-PR dedup short-circuits before omp"
+
+# ── C. MAX_FIXES=0: zero attempted launches ──────────────────────────────────
+reset_knobs
+export INVOKER_PR_CRON_DRY_RUN=0
+export FAKE_GH_PRS='[]'
+export INVOKER_DAILY_E2E_MAX_FIXES=0
+run_worker
+grep -q "reached max fixes (0) this run; stopping" "$sb/worker.log" \
+  || fail "C: did not stop at max fixes 0" "$sb/worker.log"
+grep -q "attempted=0 " "$sb/worker.log" \
+  || fail "C: expected attempted=0 in the summary" "$sb/worker.log"
+[ ! -s "$sb/omp-calls" ] || fail "C: omp must not run when max fixes is 0" "$sb/worker.log"
+echo "  C ok: max-fixes=0 launches nothing"
+
+# ── D. Flake filter: isolated re-run passes -> no PR, no attempt recorded ─────
+reset_knobs
+export INVOKER_PR_CRON_DRY_RUN=0
+export FAKE_GH_PRS='[]'
+export FAKE_RERUN_EXIT=0
+run_worker
+grep -q "passed on isolated re-run (flake/already green); no PR" "$sb/worker.log" \
+  || fail "D: flake filter did not treat a passing re-run as a flake" "$sb/worker.log"
+[ ! -s "$sb/omp-calls" ] || fail "D: omp must not run on a flake" "$sb/worker.log"
+[ ! -s "$sb/ledger.tsv" ] || fail "D: a flake must not record an attempt" "$sb/worker.log"
+echo "  D ok: flake filter opens no PR and records no attempt"
+
+# ── E. Repeated failure: omp launches once, one attempt recorded ─────────────
+reset_knobs
+export INVOKER_PR_CRON_DRY_RUN=0
+export FAKE_GH_PRS='[]'
+export FAKE_RERUN_EXIT=1
+export FAKE_OMP_EXIT=0
+run_worker
+grep -q "omp opened PR on $FAIL_BRANCH" "$sb/worker.log" \
+  || fail "E: omp launch did not report an opened PR" "$sb/worker.log"
+[ -s "$sb/omp-calls" ] || fail "E: omp should have run on a repeated failure" "$sb/worker.log"
+[ "$(wc -l < "$sb/omp-calls")" -eq 1 ] || fail "E: omp should launch exactly once" "$sb/worker.log"
+awk -F '\t' -v s="$FAIL_SLUG" '$1=="daily-e2e-fix" && $2==s{f=1} END{exit f?0:1}' "$sb/ledger.tsv" \
+  || fail "E: the attempt was not recorded in the ledger" "$sb/worker.log"
+grep -q "attempted=1 opened=1" "$sb/worker.log" \
+  || fail "E: expected attempted=1 opened=1 in the summary" "$sb/worker.log"
+echo "  E ok: repeated failure launches omp once and records one attempt"
+
+echo "PASS: cron-daily-e2e-fix.sh behavior verified (dry-run, dedup, max-fixes, flake, launch)"
+exit 0

--- a/scripts/test-install-daily-e2e-cron.sh
+++ b/scripts/test-install-daily-e2e-cron.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Test scripts/install-daily-e2e-cron.sh + uninstall-daily-e2e-cron.sh against an
+# isolated fake `crontab` (a temp store), never the real user crontab:
+#   - install writes the marker, the 0 3 * * * schedule, and the worker path
+#   - install is idempotent (re-run keeps exactly one line)
+#   - uninstall removes it
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/test-daily-e2e-cron.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "[test] FAIL: $1"; [ -n "${2:-}" ] && echo "----- crontab -----" && echo "$2"; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/home"
+export CRONTAB_STORE="$TMP/crontab.txt"
+cat > "$TMP/bin/crontab" <<'CT'
+#!/usr/bin/env bash
+store="${CRONTAB_STORE:?}"
+case "${1:-}" in
+  -l) [ -f "$store" ] && cat "$store" || { echo "no crontab for user" >&2; exit 1; } ;;
+  -r) rm -f "$store" ;;
+  "") cat > "$store" ;;
+  *)  cp "$1" "$store" ;;
+esac
+CT
+chmod +x "$TMP/bin/crontab"
+
+export PATH="$TMP/bin:$PATH"
+export HOME="$TMP/home"
+
+MARKER="# invoker-cron-daily-e2e-fix"
+
+bash scripts/install-daily-e2e-cron.sh >/dev/null
+
+cron_now() { crontab -l 2>/dev/null || true; }
+
+cr="$(cron_now)"
+echo "$cr" | grep -F "$MARKER" | grep -q "scripts/cron-daily-e2e-fix.sh" \
+  || fail "daily-e2e marker/worker missing" "$cr"
+echo "$cr" | grep -F "$MARKER" | grep -q '^0 3 \* \* \*' \
+  || fail "daily-e2e line missing '0 3 * * *' schedule" "$cr"
+
+count="$(cron_now | grep -c 'invoker-cron-daily-e2e-fix' || true)"
+[ "$count" -eq 1 ] || fail "expected 1 cron line, found $count" "$(cron_now)"
+
+# Idempotency: re-run, still exactly one.
+bash scripts/install-daily-e2e-cron.sh >/dev/null
+count="$(cron_now | grep -c 'invoker-cron-daily-e2e-fix' || true)"
+[ "$count" -eq 1 ] || fail "after re-install expected 1 cron line, found $count" "$(cron_now)"
+
+# Uninstall removes it.
+bash scripts/uninstall-daily-e2e-cron.sh >/dev/null
+count="$(cron_now | grep -c 'invoker-cron-daily-e2e-fix' || true)"
+[ "$count" -eq 0 ] || fail "after uninstall expected 0 cron lines, found $count" "$(cron_now)"
+
+echo "[test] passed"

--- a/scripts/uninstall-daily-e2e-cron.sh
+++ b/scripts/uninstall-daily-e2e-cron.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Remove the daily e2e fix cron entry installed by
+# scripts/install-daily-e2e-cron.sh.
+set -euo pipefail
+
+MARKER="# invoker-cron-daily-e2e-fix"
+TMP_CRON="$(mktemp -t invoker-daily-e2e-cron-remove.XXXXXX)"
+trap 'rm -f "$TMP_CRON"' EXIT
+
+if crontab -l >/dev/null 2>&1; then
+  # `|| true`: grep -Fv exits 1 when it filters out every line (our entry was the
+  # only one), which pipefail would otherwise treat as fatal and skip the
+  # `crontab "$TMP_CRON"` below — leaving the entry in place.
+  { crontab -l | grep -Fv "$MARKER" || true; } > "$TMP_CRON"
+  crontab "$TMP_CRON"
+  echo "Removed daily e2e cron entry (if present):"
+  echo "  $MARKER"
+else
+  echo "No crontab found for current user; nothing to remove."
+fi


### PR DESCRIPTION
## Summary

This adds a daily automation that runs the full extended end-to-end battery once a day on the owner host.

When a suite fails, an agent repairs the tree and opens one pull request for that failure.

A separate GitHub Actions workflow runs the same battery and publishes a per-suite pass/fail table to the run summary and one tracking issue.

That workflow goes red whenever any suite fails, so the health of the battery is visible without reading logs.

Fixes are only opened as pull requests, never merged automatically, so a human reviews each one.

## Review Claim

Approve adding the daily-battery automation worker, its install and uninstall helper scripts, and the public status workflow as tooling policy.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The worker and the status workflow are new and unreferenced by the app runtime; nothing invokes them until the cron is installed or the workflow is dispatched. No product code changes, and `ci.yml` is untouched.

## Slice Rationale

Every file here is tooling and CI policy for one feature, so they belong in a single policy review. The behavior test ships alongside the tool it exercises.

## Non-goals

Does not auto-merge or land any fix. Does not change product code, and does not edit the existing `ci.yml`. Does not run the battery inside the app runtime.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-daily-e2e-fix-worker.sh`
- [ ] `bash scripts/test-install-daily-e2e-cron.sh`
- [ ] `node -e "require('yaml').parse(require('fs').readFileSync('.github/workflows/daily-e2e-status.yml','utf8'))"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: run `bash scripts/uninstall-daily-e2e-cron.sh` on the owner host if the cron was installed
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a daily scheduled workflow to run an extended end-to-end “battery,” generate a per-suite status table, and track results in a single durable issue.
  * Added scripts to install/uninstall a daily cron that runs an automated fix worker for failing suites.
* **Tests**
  * Added behavior tests for the daily fix worker, cron installation, and cron removal.
  * Extended the main test command to include the new daily end-to-end validation steps.
* **Chores**
  * Added a workflow consistency check to ensure credentials are not persisted during checkout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->