### PR TITLE
[SQLite IOERR self-heal](2) Reopen and retry reads on transient SQLITE_IOERR

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
@@ -10,7 +10,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { SQLiteAdapter, isDatabaseCorruptionError } from '../sqlite-adapter.js';
+import { SQLiteAdapter, isDatabaseCorruptionError, isTransientIoError } from '../sqlite-adapter.js';
 
 /**
  * SQLiteAdapter.create() recovers a corrupt database by renaming it (and its
@@ -94,5 +94,115 @@ describe('SQLiteAdapter.create recovery', () => {
 
     expect(readdirSync(dir).some((name) => name.includes('.corrupt-'))).toBe(false);
     expect(existsSync(join(dbPath, 'sentinel'))).toBe(true);
+  });
+});
+
+describe('isTransientIoError', () => {
+  it('treats SQLITE_IOERR (10) and its extended variants as transient I/O', () => {
+    // SQLITE_IOERR=10, SQLITE_IOERR_READ=266, SQLITE_IOERR_SHORT_READ=522,
+    // SQLITE_IOERR_FSYNC=1034 — all carry 10 in the low byte.
+    for (const errcode of [10, 266, 522, 1034]) {
+      expect(isTransientIoError({ errcode })).toBe(true);
+    }
+  });
+
+  it('does NOT treat corruption or lock contention as transient I/O', () => {
+    // SQLITE_CORRUPT=11, SQLITE_NOTADB=26, SQLITE_BUSY=5, SQLITE_LOCKED=6,
+    // SQLITE_CANTOPEN=14, SQLITE_FULL=13 (disk full is not IOERR).
+    for (const errcode of [11, 26, 5, 6, 14, 13, 523]) {
+      expect(isTransientIoError({ errcode })).toBe(false);
+    }
+  });
+
+  it('falls back to message text when no numeric errcode is present', () => {
+    expect(isTransientIoError(new Error('disk I/O error'))).toBe(true);
+    expect(isTransientIoError(new Error('database disk image is malformed'))).toBe(false);
+    expect(isTransientIoError(new Error('database is locked'))).toBe(false);
+    expect(isTransientIoError('not even an error')).toBe(false);
+  });
+});
+
+describe('SQLiteAdapter read reconnect on transient I/O error', () => {
+  const workflow = {
+    id: 'wf-ioerr',
+    name: 'IO Error Workflow',
+    status: 'running' as const,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  function shortReadError(): Error {
+    const err = new Error('disk I/O error') as Error & { errcode: number };
+    err.errcode = 522; // SQLITE_IOERR_SHORT_READ
+    return err;
+  }
+
+  it('reopens the connection and retries a read after a transient SQLITE_IOERR', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      adapter.saveWorkflow(workflow); // committed to WAL before the fault
+
+      // Simulate a stale file descriptor: the next prepared read throws
+      // SHORT_READ. reopenConnection() swaps in a fresh handle, so this stub is
+      // hit once; the retry (and every later read) uses the fresh connection.
+      let faultReads = 0;
+      (adapter as unknown as { db: unknown }).db = {
+        prepare() {
+          faultReads += 1;
+          throw shortReadError();
+        },
+      };
+
+      const workflows = adapter.listWorkflows();
+      const afterReconnect = adapter.listWorkflows();
+
+      expect(faultReads).toBe(1); // faulted once, reconnected, never faulted again
+      expect(workflows.map((w) => w.id)).toContain('wf-ioerr');
+      expect(afterReconnect.map((w) => w.id)).toContain('wf-ioerr');
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('does NOT retry (propagates) when a write transaction is in flight', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    const realDb = (adapter as unknown as { db: unknown }).db;
+    try {
+      // Force writeTransactionDepth > 0 so a mid-transaction reopen (which would
+      // abandon the transaction) is refused and the error propagates.
+      (adapter as unknown as { writeTransactionDepth: number }).writeTransactionDepth = 1;
+      (adapter as unknown as { db: unknown }).db = {
+        prepare() {
+          throw shortReadError();
+        },
+      };
+      expect(() => adapter.listWorkflows()).toThrow(/disk I\/O error/);
+    } finally {
+      (adapter as unknown as { writeTransactionDepth: number }).writeTransactionDepth = 0;
+      (adapter as unknown as { db: unknown }).db = realDb;
+      adapter.close();
+    }
+  });
+
+  it('does NOT reopen an ephemeral (:memory:) database — the error propagates', async () => {
+    const adapter = await SQLiteAdapter.createEphemeral();
+    const realDb = (adapter as unknown as { db: unknown }).db;
+    try {
+      (adapter as unknown as { db: unknown }).db = {
+        prepare() {
+          throw shortReadError();
+        },
+      };
+      // Reopening :memory: would silently discard all data, so recovery is
+      // refused for non-file-backed connections and the error surfaces.
+      expect(() => adapter.listWorkflows()).toThrow(/disk I\/O error/);
+    } finally {
+      (adapter as unknown as { db: unknown }).db = realDb;
+      adapter.close();
+    }
   });
 });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -117,6 +117,14 @@ function loadNativeSqlite(): Promise<NativeSqlite> {
   nativeSqlite ??= import(nativeSqliteSpecifier) as Promise<NativeSqlite>;
   return nativeSqlite;
 }
+
+let cachedDatabaseSyncCtor: NativeSqlite['DatabaseSync'] | undefined;
+
+async function loadDatabaseSyncCtor(): Promise<NativeSqlite['DatabaseSync']> {
+  const { DatabaseSync } = await loadNativeSqlite();
+  cachedDatabaseSyncCtor = DatabaseSync;
+  return DatabaseSync;
+}
 const ACTION_GRAPH_RECENT_ATTEMPT_LIMIT = 3;
 
 // activity_log is capped to its most recent rows so the DB file stays bounded; 0 disables.
@@ -215,6 +223,17 @@ export function isDatabaseCorruptionError(err: unknown): boolean {
   // Fallback for runtimes that do not surface a numeric errcode.
   const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
   return message.includes('malformed') || message.includes('not a database');
+}
+
+const SQLITE_IOERR = 10;
+
+export function isTransientIoError(err: unknown): boolean {
+  const errcode = (err as { errcode?: unknown } | null)?.errcode;
+  if (typeof errcode === 'number') {
+    return (errcode & SQLITE_PRIMARY_RESULT_CODE_MASK) === SQLITE_IOERR;
+  }
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return message.includes('i/o error');
 }
 
 class NativeStatementCompat {
@@ -541,7 +560,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
 
     try {
-      const { DatabaseSync } = await loadNativeSqlite();
+      const DatabaseSync = await loadDatabaseSyncCtor();
       const db = new DatabaseSync(dbPath, { readOnly: options?.readOnly === true });
       return new SQLiteAdapter(db, isFile ? dbPath : null, options);
     } catch (err) {
@@ -558,7 +577,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         const sidecar = `${dbPath}${suffix}`;
         if (existsSync(sidecar)) renameSync(sidecar, `${backupPath}${suffix}`);
       }
-      const { DatabaseSync } = await loadNativeSqlite();
+      const DatabaseSync = await loadDatabaseSyncCtor();
       const db = new DatabaseSync(dbPath);
       return new SQLiteAdapter(db, dbPath, options);
     }
@@ -590,22 +609,63 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   /** Run a single-row SELECT, returning the row as an object or undefined. */
   private queryOne(sql: string, params: unknown[] = []): Record<string, unknown> | undefined {
-    const stmt = this.db.prepare(sql);
-    try {
-      return stmt.get(...(paramsToArgs(params) as any[])) as Record<string, unknown> | undefined;
-    } finally {
-      stmt.free();
-    }
+    return this.runRead(() => {
+      const stmt = this.db.prepare(sql);
+      try {
+        return stmt.get(...(paramsToArgs(params) as any[])) as Record<string, unknown> | undefined;
+      } finally {
+        stmt.free();
+      }
+    });
   }
 
   /** Run a multi-row SELECT, returning an array of row objects. */
   private queryAll(sql: string, params: unknown[] = []): Record<string, unknown>[] {
-    const stmt = this.db.prepare(sql);
+    return this.runRead(() => {
+      const stmt = this.db.prepare(sql);
+      try {
+        return stmt.all(...(paramsToArgs(params) as any[])) as Record<string, unknown>[];
+      } finally {
+        stmt.free();
+      }
+    });
+  }
+
+  private runRead<T>(run: () => T): T {
     try {
-      return stmt.all(...(paramsToArgs(params) as any[])) as Record<string, unknown>[];
-    } finally {
-      stmt.free();
+      return run();
+    } catch (err) {
+      if (this.dbPath === null || this.writeTransactionDepth > 0 || !isTransientIoError(err)) {
+        throw err;
+      }
+      console.error(
+        `[SQLiteAdapter] Transient I/O error reading ${this.dbPath} ` +
+          `(${err instanceof Error ? err.message : String(err)}); reopening connection and retrying once.`,
+      );
+      this.reopenConnection();
+      return run();
     }
+  }
+
+  private reopenConnection(): void {
+    if (this.dbPath === null) {
+      throw new Error('SQLiteAdapter: cannot reopen a non-file-backed database');
+    }
+    if (cachedDatabaseSyncCtor === undefined) {
+      throw new Error('SQLiteAdapter: native SQLite constructor unavailable for reopen');
+    }
+    try {
+      this.nativeDb.close();
+    } catch (closeErr) {
+      console.error(
+        `[SQLiteAdapter] Failed to close stale connection before reopen ` +
+          `(${closeErr instanceof Error ? closeErr.message : String(closeErr)}).`,
+      );
+    }
+    const db = new cachedDatabaseSyncCtor(this.dbPath, { readOnly: this.readOnly });
+    this.nativeDb = db;
+    this.db = new NativeDatabaseCompat(db);
+    this.configureConnection(true);
   }
 
   private ensureWritable(): void {


### PR DESCRIPTION
## Summary

A running Invoker owner process could spam `disk I/O error` (SQLite errcode 522) on every worker-status and queue-status poll, even though `invoker.db` on disk was perfectly fine.

The cause is that the live database files were changed underneath the open connection.

An in-place restore of a backup snapshot, or the manual-recovery churn in `~/.invoker`, truncates or replaces the `-wal` the connection is still reading.

In WAL mode that surfaces as a short read, errcode 522. Nothing retried, so the same error repeated on every poll until the app was restarted.

Now a read that hits a transient I/O error reopens the connection against the current file and retries once.

When the file is intact, as it was in the incident, the retry succeeds and the spam stops.

## Review Claim

On a transient `SQLITE_IOERR`, `SQLiteAdapter` read paths reopen the connection and retry once, recovering when the on-disk file is intact.

## Review Lane

behavior

## Review Unit

validation-policy

## Safety Invariant

The retry is guarded so it can only fire when safe: file-backed connections only (never an in-memory `:memory:` database, which a reopen would wipe), only outside a write transaction (a reopen would abandon it), and only for `SQLITE_IOERR` (primary code 10). Corruption (`SQLITE_CORRUPT`) and lock contention (`SQLITE_BUSY`) are classified out and propagate untouched, so the existing corrupt-DB recovery and busy-timeout paths are unchanged. The retry runs at most once, then rethrows.

## Slice Rationale

Builds on the repro in PR (1), which proves the 522 failure mode and that a reopened connection recovers. This slice is the behavior change plus its adapter-level regression tests; the repro (proof lane) and this fix (behavior lane) are kept separate.

## Non-goals

- Does not change the backup or restore implementation that produces the torn files.
- Does not retry writes, or reads issued inside a write transaction.
- Does not alter corruption recovery or busy-timeout handling.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/data-store && pnpm test -- src/__tests__/sqlite-adapter-corruption-recovery.test.ts` (368 passed), including:
  - `isTransientIoError` classifies IOERR (10 / 266 / 522 / 1034) as transient, and CORRUPT / NOTADB / BUSY / LOCKED / CANTOPEN / FULL as not
  - reopens and retries a read after a transient `SQLITE_IOERR`
  - does NOT retry inside a write transaction (propagates)
  - does NOT reopen an ephemeral `:memory:` database (propagates)
- [x] `pnpm run check:types`
- [x] `node scripts/check-added-comments.mjs`
- [x] `pnpm --filter @invoker/data-store build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None; reads return to throwing on transient I/O errors as before
- Data migration? No

</details>
