### PR TITLE
Fix remote-ci-verify passing multi-word test command over ssh

### DIFF
--- a/scripts/test-remote-ci-verify-env-quoting.sh
+++ b/scripts/test-remote-ci-verify-env-quoting.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Regression test for skills/remote-ci-verify/scripts/run-remote-ci-verify.sh.
+#
+# The script passes env to the remote by prefixing `VAR=value ... bash -se` onto
+# the ssh command. ssh joins its args with spaces, so a multi-word value like
+# CI_VERIFY_REMOTE_TEST_COMMAND="pnpm run test:all" used to be re-split by the
+# remote shell into `CI_VERIFY_REMOTE_TEST_COMMAND=pnpm run test:all bash -se`,
+# leaving `run` to be executed as a command ("run: command not found").
+#
+# The fix single-quotes each value (sh_squote) into one REMOTE_ENV prefix. This
+# test exercises the real sh_squote from the script and guards the construction.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT/skills/remote-ci-verify/scripts/run-remote-ci-verify.sh"
+
+[[ -f "$SCRIPT" ]] || { echo "FAIL: script not found: $SCRIPT" >&2; exit 1; }
+
+# Syntax must be valid.
+bash -n "$SCRIPT"
+
+# Load the real sh_squote definition from the script (no duplicated logic).
+eval "$(sed -n '/^sh_squote() {/,/^}/p' "$SCRIPT")"
+
+assert_roundtrip() {
+  local value=$1
+  local quoted got
+  quoted=$(sh_squote "$value")
+  # Simulate the remote shell re-parsing `VAR=<quoted>; <cmd>` in a fresh shell,
+  # exactly as the remote `sh -c` parses the env prefix ssh sends it.
+  got=$(bash -c "VAR=$quoted; printf '%s' \"\$VAR\"")
+  if [[ "$got" != "$value" ]]; then
+    echo "FAIL: [$value] -> quoted [$quoted] -> remote-parsed [$got]" >&2
+    exit 1
+  fi
+  echo "ok: multi-token value survives remote re-parse: [$value]"
+}
+
+assert_roundtrip "pnpm run test:all"
+assert_roundtrip "pnpm run test:all:extended"
+assert_roundtrip "fix/liveness-stall-requeue-worker"
+assert_roundtrip ""
+assert_roundtrip "value with 'embedded' quotes"
+
+# Guard against reverting to the bare unquoted ssh arg that caused the bug.
+if grep -qE 'CI_VERIFY_REMOTE_TEST_COMMAND="\$REMOTE_TEST_CMD" \\' "$SCRIPT"; then
+  echo "FAIL: script passes CI_VERIFY_REMOTE_TEST_COMMAND as a bare (unquoted) ssh arg" >&2
+  exit 1
+fi
+
+# The fix must build a single quoted env prefix and pass it as one ssh argument.
+grep -q 'REMOTE_ENV=' "$SCRIPT" || { echo "FAIL: REMOTE_ENV prefix missing" >&2; exit 1; }
+grep -qF '"${REMOTE_ENV}bash -se"' "$SCRIPT" || { echo "FAIL: ssh does not pass REMOTE_ENV as one arg" >&2; exit 1; }
+
+echo "PASS: remote-ci-verify env quoting"

--- a/skills/remote-ci-verify/scripts/run-remote-ci-verify.sh
+++ b/skills/remote-ci-verify/scripts/run-remote-ci-verify.sh
@@ -149,24 +149,35 @@ fi
 echo "==> Selected target: $SELECTED_ID ($SELECTED_USER@$SELECTED_HOST:$SELECTED_PORT)"
 
 echo "==> Running remote CI-equivalent flow"
+# Single-quote a value so the remote POSIX shell re-parses it as one token.
+# Without this, a multi-word value (e.g. CI_VERIFY_REMOTE_TEST_COMMAND="pnpm run
+# test:all") is split by the remote shell into `VAR=pnpm run test:all`, leaving
+# `run` to be executed as a command ("run: command not found").
+sh_squote() {
+  local s=${1-}
+  printf "'%s'" "${s//\'/\'\\\'\'}"
+}
+
+REMOTE_ENV=$(printf '%s ' \
+  "BRANCH=$(sh_squote "$BRANCH")" \
+  "REMOTE_NAME=$(sh_squote "$REMOTE_NAME")" \
+  "REPO_URL=$(sh_squote "$REPO_URL")" \
+  "REPO_SLUG=$(sh_squote "$REPO_SLUG")" \
+  "TARGET_ID=$(sh_squote "$SELECTED_ID")" \
+  "CI_VERIFY_REMOTE_BASE_DIR=$(sh_squote "$REMOTE_BASE_DIR")" \
+  "CI_VERIFY_REMOTE_INSTALL=$(sh_squote "$REMOTE_INSTALL")" \
+  "CI_VERIFY_REMOTE_BUILD_UI=$(sh_squote "$REMOTE_BUILD_UI")" \
+  "CI_VERIFY_REMOTE_INSTALL_PLAYWRIGHT_DEPS=$(sh_squote "$REMOTE_INSTALL_PLAYWRIGHT_DEPS")" \
+  "CI_VERIFY_KEEP_REMOTE_WORKTREE=$(sh_squote "$REMOTE_KEEP_WORKTREE")" \
+  "CI_VERIFY_REMOTE_TEST_COMMAND=$(sh_squote "$REMOTE_TEST_CMD")")
+
 ssh -tt \
   -i "$SELECTED_KEY" \
   -p "$SELECTED_PORT" \
   -o BatchMode=yes \
   -o StrictHostKeyChecking=accept-new \
   "$SELECTED_USER@$SELECTED_HOST" \
-  BRANCH="$BRANCH" \
-  REMOTE_NAME="$REMOTE_NAME" \
-  REPO_URL="$REPO_URL" \
-  REPO_SLUG="$REPO_SLUG" \
-  TARGET_ID="$SELECTED_ID" \
-  CI_VERIFY_REMOTE_BASE_DIR="$REMOTE_BASE_DIR" \
-  CI_VERIFY_REMOTE_INSTALL="$REMOTE_INSTALL" \
-  CI_VERIFY_REMOTE_BUILD_UI="$REMOTE_BUILD_UI" \
-  CI_VERIFY_REMOTE_INSTALL_PLAYWRIGHT_DEPS="$REMOTE_INSTALL_PLAYWRIGHT_DEPS" \
-  CI_VERIFY_KEEP_REMOTE_WORKTREE="$REMOTE_KEEP_WORKTREE" \
-  CI_VERIFY_REMOTE_TEST_COMMAND="$REMOTE_TEST_CMD" \
-  'bash -se' <<'REMOTE_EOF'
+  "${REMOTE_ENV}bash -se" <<'REMOTE_EOF'
 set -euo pipefail
 
 : "${BRANCH:?}"


### PR DESCRIPTION
## Summary

The `remote-ci-verify` helper never worked with its default test invocation. It handed each `VAR=value` pair to ssh as its own argument, and ssh joins those with spaces before the remote shell reads them.

So the multi-word default `CI_VERIFY_REMOTE_TEST_COMMAND="pnpm run test:all"` reached the remote as `CI_VERIFY_REMOTE_TEST_COMMAND=pnpm run test:all`. The remote shell took `=pnpm` as the value and then tried to execute `run`, which is not a program, so it aborted with `run: not found`.

The fix builds one single-quoted environment prefix and passes it to ssh as a single argument, so the remote shell reads each value back as one token.

A focused test guards the quoting and fails if the helper reverts to the old form.

## Review Claim

A multi-word `CI_VERIFY_REMOTE_TEST_COMMAND` reaches the remote shell as one value instead of being broken apart into a stray token.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

Only the local quoting of env values for the remote ssh invocation changes; the remote steps and the executed test invocation are otherwise identical. Every value is single-quoted, and embedded single quotes are handled.

## Slice Rationale

One cohesive fix — the quoting — plus its test. Nothing else in the helper needed changing.

## Non-goals

- Does not change which remote host is chosen or the busy-host guard.
- Does not change the remote clone, install, build, or test steps.
- Does not add PATH setup on remote hosts; the remote test invocation already runs under a login shell.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `bash scripts/test-remote-ci-verify-env-quoting.sh`
- [x] `bash -n skills/remote-ci-verify/scripts/run-remote-ci-verify.sh`
- [x] Ran the fixed helper against a remote host: it got past the previous immediate `run: not found` and proceeded through clone, `pnpm install --frozen-lockfile`, and `pnpm --filter @invoker/ui build`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
