### PR TITLE
perf(app): cache workflow list during bootstrap so sync IPC does not re-query

### DIFF
--- a/packages/app/src/__tests__/startup-workflow-cache.test.ts
+++ b/packages/app/src/__tests__/startup-workflow-cache.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Workflow } from '@invoker/data-store';
+import { createStartupWorkflowCache } from '../bootstrap/startup-workflow-cache.js';
+
+const wf = (id: string, createdAt = '2026-01-01T00:00:00.000Z'): Workflow => ({
+  id,
+  name: id,
+  repoUrl: 'file:///repo.git',
+  branch: 'master',
+  status: 'pending',
+  onFinish: 'none',
+  createdAt,
+  updatedAt: createdAt,
+} as Workflow);
+
+describe('startup-workflow-cache', () => {
+  it('starts empty and falls back to the persistence lister', () => {
+    const cache = createStartupWorkflowCache();
+    const listWorkflows = vi.fn(() => [wf('wf-1')]);
+
+    expect(cache.hasCached()).toBe(false);
+    expect(cache.takeOrLoad(listWorkflows)).toEqual([wf('wf-1')]);
+    expect(listWorkflows).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves one cached read then falls back so the sync bootstrap IPC does not re-run listWorkflows', () => {
+    // Documents the invariant from Issue #1: bootstrapInitialWorkflowState()
+    // reads listWorkflows once. The sync bootstrap IPC fires ~20ms later.
+    // Before this cache existed, both call sites ran the query. With the
+    // single-shot cache the second reader must reuse the bootstrap payload
+    // without touching persistence.
+    const cache = createStartupWorkflowCache();
+    const listWorkflows = vi.fn(() => [wf('should-not-be-called')]);
+    const bootstrapPayload = [wf('wf-a'), wf('wf-b')];
+    cache.set(bootstrapPayload);
+
+    const firstRead = cache.takeOrLoad(listWorkflows);
+    expect(firstRead).toEqual(bootstrapPayload);
+    expect(listWorkflows).not.toHaveBeenCalled();
+
+    const secondRead = cache.takeOrLoad(listWorkflows);
+    expect(secondRead).toEqual([wf('should-not-be-called')]);
+    expect(listWorkflows).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a defensive copy so downstream mutation does not corrupt the cache', () => {
+    const cache = createStartupWorkflowCache();
+    cache.set([wf('wf-1'), wf('wf-2')]);
+    const consumed = cache.takeOrLoad(() => []);
+    consumed.push(wf('wf-injected'));
+    // After single-shot consume the cache falls through anyway, but the
+    // returned slice must still be a distinct array to defend against
+    // late mutations at the call site.
+    expect(consumed).toHaveLength(3);
+  });
+
+  it('invalidate drops any pending cached snapshot', () => {
+    const cache = createStartupWorkflowCache();
+    const listWorkflows = vi.fn(() => [wf('fresh')]);
+    cache.set([wf('stale')]);
+    cache.invalidate();
+
+    expect(cache.hasCached()).toBe(false);
+    expect(cache.takeOrLoad(listWorkflows)).toEqual([wf('fresh')]);
+    expect(listWorkflows).toHaveBeenCalledTimes(1);
+  });
+
+  it('set after consume repopulates the cache', () => {
+    const cache = createStartupWorkflowCache();
+    const listWorkflows = vi.fn(() => [wf('fallback')]);
+
+    cache.set([wf('first-bootstrap')]);
+    expect(cache.takeOrLoad(listWorkflows)).toEqual([wf('first-bootstrap')]);
+
+    cache.set([wf('second-bootstrap')]);
+    expect(cache.takeOrLoad(listWorkflows)).toEqual([wf('second-bootstrap')]);
+
+    expect(listWorkflows).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/bootstrap/startup-workflow-cache.ts
+++ b/packages/app/src/bootstrap/startup-workflow-cache.ts
@@ -1,0 +1,34 @@
+import type { Workflow } from '@invoker/data-store';
+
+export type WorkflowLister = () => Workflow[];
+
+export interface StartupWorkflowCache {
+  set(workflows: readonly Workflow[]): void;
+  takeOrLoad(fallback: WorkflowLister): Workflow[];
+  invalidate(): void;
+  hasCached(): boolean;
+}
+
+export function createStartupWorkflowCache(): StartupWorkflowCache {
+  let cached: readonly Workflow[] | null = null;
+
+  return {
+    set(workflows) {
+      cached = workflows;
+    },
+    takeOrLoad(fallback) {
+      if (cached === null) {
+        return fallback();
+      }
+      const snapshot = cached;
+      cached = null;
+      return [...snapshot];
+    },
+    invalidate() {
+      cached = null;
+    },
+    hasCached() {
+      return cached !== null;
+    },
+  };
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -48,6 +48,7 @@ import {
   startGuiModeBootstrap,
   startMainProcessBootstrap,
 } from './bootstrap/app-bootstrap.js';
+import { createStartupWorkflowCache } from './bootstrap/startup-workflow-cache.js';
 
 const enableTestCompositor = process.env.INVOKER_E2E_ENABLE_COMPOSITOR === '1' || Boolean(process.env.CAPTURE_MODE);
 const hideE2eWindow = process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_HIDE_WINDOW !== '0';
@@ -2026,6 +2027,7 @@ function createEmbeddedTerminalBackendFromConfig(
   let lastKnownWorkflowCount = 0;
   let lastActivityLogId = 0;
   let startupWorkflowId: string | null = null;
+  const startupWorkflowCache = createStartupWorkflowCache();
   // In detached viewer mode the local DB is an empty in-memory copy. Workflow
   // metadata for the bootstrap getter comes from the owner snapshot; task state
   // is derived live from `lastKnownTaskStates` (kept current by deltas).
@@ -3069,6 +3071,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
   function bootstrapInitialWorkflowState(): void {
     const workflows = listWorkflowsByStartupRecency();
+    startupWorkflowCache.set(workflows);
     lastKnownWorkflowCount = workflows.length;
     startupWorkflowId = workflows[0]?.id ?? null;
     if (!startupWorkflowId) {
@@ -3756,7 +3759,8 @@ function createEmbeddedTerminalBackendFromConfig(
     registerBootstrapStateIpc({
       ipcMain,
       getTasks: () => (ownerMode ? orchestrator.getAllTasks() : detachedViewerTasks()),
-      getWorkflows: () => detachedViewerWorkflows ?? listWorkflowsByStartupRecency(),
+      getWorkflows: () =>
+        detachedViewerWorkflows ?? startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
       getInitialWorkflowId: () => startupWorkflowId,
       appStartedAtEpochMs: appProcessStartedAt,
       getTaskDeltaStreamSequence,


### PR DESCRIPTION
## Summary

Cold start currently runs the same `persistence.listWorkflows()` query twice. `bootstrapInitialWorkflowState()` reads it once. Twenty milliseconds later the renderer preload fires a synchronous IPC that re-runs the same query.

Real data from `~/.invoker/invoker.log` on my machine shows both calls landing back-to-back with matching durations. Each scan takes four hundred to seventeen hundred milliseconds depending on DB size.

The sync IPC is blocking. The renderer main thread waits for the second scan before the window can paint.

This slice introduces a small single-shot cache. Bootstrap captures the workflow list and hands it to the sync IPC once. Any later reader falls through to a fresh query.

<details>
<summary>Review metadata</summary>

Review Claim: The sync bootstrap IPC never re-runs `listWorkflows` after `bootstrapInitialWorkflowState()` has already run it in the same startup.

Review Lane: behavior

Review Unit: read-path

Safety Invariant: The cache is single-shot. The very first read consumes it; every read after that goes through the persistence lister exactly like before. No behavior changes for detached viewer mode, page reloads, or any post-startup caller.

Slice Rationale: Isolated single-purpose cache module plus one call-site swap in `main.ts`. No refactor, no schema change, no new IPC.

</details>

## Review Claim

The sync bootstrap IPC never re-runs `listWorkflows` after `bootstrapInitialWorkflowState()` has already run it in the same startup.

## Review Lane

behavior

## Review Unit

read-path

## Safety Invariant

The cache is single-shot. The very first read consumes it; every read after that goes through the persistence lister exactly like before. No behavior changes for detached viewer mode, page reloads, or any post-startup caller.

## Slice Rationale

Isolated single-purpose cache module plus one call-site swap in `main.ts`. No refactor, no schema change, no new IPC.

## Non-goals

- No change to `persistence.listWorkflows` itself. The SQLite scan is still slow on large DBs; that is a separate slice.
- No change to the sync IPC contract. The preload still fires `invoker:get-bootstrap-state-sync` and still receives the same payload shape.
- No change to detached viewer mode. That path continues to source workflows from `detachedViewerWorkflows`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/startup-workflow-cache.test.ts`
- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/ipc-registration.test.ts src/__tests__/app-bootstrap.test.ts`
- [ ] `pnpm run check:types`
- [ ] `pnpm run check:comments`
- [ ] `pnpm run check:deps`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Reverting restores the pre-existing double-query behavior with no data migration.
- Data migration? No

</details>