### PR TITLE
perf(ui): add benchmark for O(W×T) searchResults recompute path

### DIFF
--- a/packages/app/src/__tests__/startup-workflow-cache.test.ts
+++ b/packages/app/src/__tests__/startup-workflow-cache.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Workflow } from '@invoker/data-store';
+import { createStartupWorkflowCache } from '../bootstrap/startup-workflow-cache.js';
+
+const wf = (id: string, createdAt = '2026-01-01T00:00:00.000Z'): Workflow => ({
+  id,
+  name: id,
+  repoUrl: 'file:///repo.git',
+  branch: 'master',
+  status: 'pending',
+  onFinish: 'none',
+  createdAt,
+  updatedAt: createdAt,
+} as Workflow);
+
+describe('startup-workflow-cache', () => {
+  it('starts empty and falls back to the persistence lister', () => {
+    const cache = createStartupWorkflowCache();
+    const listWorkflows = vi.fn(() => [wf('wf-1')]);
+
+    expect(cache.hasCached()).toBe(false);
+    expect(cache.takeOrLoad(listWorkflows)).toEqual([wf('wf-1')]);
+    expect(listWorkflows).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves one cached read then falls back so the sync bootstrap IPC does not re-run listWorkflows', () => {
+    // Documents the invariant from Issue #1: bootstrapInitialWorkflowState()
+    // reads listWorkflows once. The sync bootstrap IPC fires ~20ms later.
+    // Before this cache existed, both call sites ran the query. With the
+    // single-shot cache the second reader must reuse the bootstrap payload
+    // without touching persistence.
+    const cache = createStartupWorkflowCache();
+    const listWorkflows = vi.fn(() => [wf('should-not-be-called')]);
+    const bootstrapPayload = [wf('wf-a'), wf('wf-b')];
+    cache.set(bootstrapPayload);
+
+    const firstRead = cache.takeOrLoad(listWorkflows);
+    expect(firstRead).toEqual(bootstrapPayload);
+    expect(listWorkflows).not.toHaveBeenCalled();
+
+    const secondRead = cache.takeOrLoad(listWorkflows);
+    expect(secondRead).toEqual([wf('should-not-be-called')]);
+    expect(listWorkflows).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a defensive copy so downstream mutation does not corrupt the cache', () => {
+    const cache = createStartupWorkflowCache();
+    cache.set([wf('wf-1'), wf('wf-2')]);
+    const consumed = cache.takeOrLoad(() => []);
+    consumed.push(wf('wf-injected'));
+    // After single-shot consume the cache falls through anyway, but the
+    // returned slice must still be a distinct array to defend against
+    // late mutations at the call site.
+    expect(consumed).toHaveLength(3);
+  });
+
+  it('invalidate drops any pending cached snapshot', () => {
+    const cache = createStartupWorkflowCache();
+    const listWorkflows = vi.fn(() => [wf('fresh')]);
+    cache.set([wf('stale')]);
+    cache.invalidate();
+
+    expect(cache.hasCached()).toBe(false);
+    expect(cache.takeOrLoad(listWorkflows)).toEqual([wf('fresh')]);
+    expect(listWorkflows).toHaveBeenCalledTimes(1);
+  });
+
+  it('set after consume repopulates the cache', () => {
+    const cache = createStartupWorkflowCache();
+    const listWorkflows = vi.fn(() => [wf('fallback')]);
+
+    cache.set([wf('first-bootstrap')]);
+    expect(cache.takeOrLoad(listWorkflows)).toEqual([wf('first-bootstrap')]);
+
+    cache.set([wf('second-bootstrap')]);
+    expect(cache.takeOrLoad(listWorkflows)).toEqual([wf('second-bootstrap')]);
+
+    expect(listWorkflows).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/bootstrap/startup-workflow-cache.ts
+++ b/packages/app/src/bootstrap/startup-workflow-cache.ts
@@ -1,0 +1,34 @@
+import type { Workflow } from '@invoker/data-store';
+
+export type WorkflowLister = () => Workflow[];
+
+export interface StartupWorkflowCache {
+  set(workflows: readonly Workflow[]): void;
+  takeOrLoad(fallback: WorkflowLister): Workflow[];
+  invalidate(): void;
+  hasCached(): boolean;
+}
+
+export function createStartupWorkflowCache(): StartupWorkflowCache {
+  let cached: readonly Workflow[] | null = null;
+
+  return {
+    set(workflows) {
+      cached = workflows;
+    },
+    takeOrLoad(fallback) {
+      if (cached === null) {
+        return fallback();
+      }
+      const snapshot = cached;
+      cached = null;
+      return [...snapshot];
+    },
+    invalidate() {
+      cached = null;
+    },
+    hasCached() {
+      return cached !== null;
+    },
+  };
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -48,6 +48,7 @@ import {
   startGuiModeBootstrap,
   startMainProcessBootstrap,
 } from './bootstrap/app-bootstrap.js';
+import { createStartupWorkflowCache } from './bootstrap/startup-workflow-cache.js';
 
 const enableTestCompositor = process.env.INVOKER_E2E_ENABLE_COMPOSITOR === '1' || Boolean(process.env.CAPTURE_MODE);
 const hideE2eWindow = process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_HIDE_WINDOW !== '0';
@@ -2026,6 +2027,7 @@ function createEmbeddedTerminalBackendFromConfig(
   let lastKnownWorkflowCount = 0;
   let lastActivityLogId = 0;
   let startupWorkflowId: string | null = null;
+  const startupWorkflowCache = createStartupWorkflowCache();
   // In detached viewer mode the local DB is an empty in-memory copy. Workflow
   // metadata for the bootstrap getter comes from the owner snapshot; task state
   // is derived live from `lastKnownTaskStates` (kept current by deltas).
@@ -3069,6 +3071,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
   function bootstrapInitialWorkflowState(): void {
     const workflows = listWorkflowsByStartupRecency();
+    startupWorkflowCache.set(workflows);
     lastKnownWorkflowCount = workflows.length;
     startupWorkflowId = workflows[0]?.id ?? null;
     if (!startupWorkflowId) {
@@ -3756,7 +3759,8 @@ function createEmbeddedTerminalBackendFromConfig(
     registerBootstrapStateIpc({
       ipcMain,
       getTasks: () => (ownerMode ? orchestrator.getAllTasks() : detachedViewerTasks()),
-      getWorkflows: () => detachedViewerWorkflows ?? listWorkflowsByStartupRecency(),
+      getWorkflows: () =>
+        detachedViewerWorkflows ?? startupWorkflowCache.takeOrLoad(listWorkflowsByStartupRecency),
       getInitialWorkflowId: () => startupWorkflowId,
       appStartedAtEpochMs: appProcessStartedAt,
       getTaskDeltaStreamSequence,

--- a/packages/ui/src/__tests__/delta-batch.test.ts
+++ b/packages/ui/src/__tests__/delta-batch.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for applyDeltas and applyDeltaInPlace — the batched delta APIs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { applyDelta, applyDeltas, applyDeltaInPlace } from '../lib/delta.js';
+import type { TaskState, TaskDelta } from '../types.js';
+
+function makeTask(overrides: Partial<TaskState> & { id: string }): TaskState {
+  return {
+    description: 'test task',
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2025-01-01'),
+    config: {},
+    execution: {},
+    ...overrides,
+  };
+}
+
+function applyDeltasSequentially(
+  base: Map<string, TaskState>,
+  deltas: readonly TaskDelta[],
+): Map<string, TaskState> {
+  let current = base;
+  for (const delta of deltas) {
+    current = applyDelta(current, delta);
+  }
+  return current;
+}
+
+describe('applyDeltas (batched)', () => {
+  it('returns the input map by reference when the batch is empty', () => {
+    const tasks = new Map<string, TaskState>([['task-1', makeTask({ id: 'task-1' })]]);
+    const result = applyDeltas(tasks, []);
+    expect(result).toBe(tasks);
+  });
+
+  it('does not mutate the input map', () => {
+    const tasks = new Map<string, TaskState>([['task-1', makeTask({ id: 'task-1' })]]);
+    const deltas: TaskDelta[] = [
+      { type: 'created', task: makeTask({ id: 'task-2' }) },
+      { type: 'removed', taskId: 'task-1' },
+    ];
+    applyDeltas(tasks, deltas);
+    expect(tasks.size).toBe(1);
+    expect(tasks.has('task-1')).toBe(true);
+    expect(tasks.has('task-2')).toBe(false);
+  });
+
+  it('matches sequential applyDelta results for a mixed batch', () => {
+    const tasks = new Map<string, TaskState>([
+      ['task-1', makeTask({ id: 'task-1', status: 'pending' })],
+      ['task-2', makeTask({ id: 'task-2', status: 'pending' })],
+    ]);
+    const deltas: TaskDelta[] = [
+      { type: 'updated', taskId: 'task-1', changes: { status: 'running' } },
+      { type: 'created', task: makeTask({ id: 'task-3', status: 'pending' }) },
+      { type: 'updated', taskId: 'task-3', changes: { status: 'completed' } },
+      { type: 'removed', taskId: 'task-2' },
+    ];
+
+    const batched = applyDeltas(tasks, deltas);
+    const sequential = applyDeltasSequentially(tasks, deltas);
+
+    expect(batched.size).toBe(sequential.size);
+    for (const [id, task] of sequential) {
+      expect(batched.get(id)).toEqual(task);
+    }
+  });
+
+  it('applies updates that reference tasks created earlier in the same batch', () => {
+    const tasks = new Map<string, TaskState>();
+    const deltas: TaskDelta[] = [
+      { type: 'created', task: makeTask({ id: 'task-1', status: 'pending' }) },
+      { type: 'updated', taskId: 'task-1', changes: { status: 'running' } },
+    ];
+
+    const result = applyDeltas(tasks, deltas);
+
+    expect(result.get('task-1')!.status).toBe('running');
+  });
+
+  it('single-copy invariant: one new Map per batch, not per delta', () => {
+    const tasks = new Map<string, TaskState>();
+    for (let i = 0; i < 100; i += 1) {
+      tasks.set(`task-${i}`, makeTask({ id: `task-${i}` }));
+    }
+    const deltas: TaskDelta[] = [];
+    for (let i = 0; i < 50; i += 1) {
+      deltas.push({ type: 'updated', taskId: `task-${i}`, changes: { status: 'running' } });
+    }
+
+    const result = applyDeltas(tasks, deltas);
+
+    // The result is a fresh Map (not the input reference).
+    expect(result).not.toBe(tasks);
+    // Every original entry that wasn't touched still points at the same object
+    // reference — proving we didn't rebuild the map per-delta.
+    for (let i = 50; i < 100; i += 1) {
+      expect(result.get(`task-${i}`)).toBe(tasks.get(`task-${i}`));
+    }
+  });
+});
+
+describe('applyDeltaInPlace', () => {
+  it('mutates the target map for created deltas', () => {
+    const target = new Map<string, TaskState>();
+    const task = makeTask({ id: 'task-1' });
+    applyDeltaInPlace(target, { type: 'created', task });
+    expect(target.size).toBe(1);
+    expect(target.get('task-1')).toBe(task);
+  });
+
+  it('mutates the target map for updated deltas', () => {
+    const target = new Map<string, TaskState>([
+      ['task-1', makeTask({ id: 'task-1', status: 'pending' })],
+    ]);
+    applyDeltaInPlace(target, {
+      type: 'updated',
+      taskId: 'task-1',
+      changes: { status: 'running' },
+    });
+    expect(target.get('task-1')!.status).toBe('running');
+  });
+
+  it('mutates the target map for removed deltas', () => {
+    const target = new Map<string, TaskState>([['task-1', makeTask({ id: 'task-1' })]]);
+    applyDeltaInPlace(target, { type: 'removed', taskId: 'task-1' });
+    expect(target.size).toBe(0);
+  });
+});

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -8,7 +8,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { TaskGraphEvent, TaskState, WorkflowMeta, WorkflowRollupPatch } from '../types.js';
-import { applyDelta } from '../lib/delta.js';
+import { applyDeltaInPlace } from '../lib/delta.js';
 import { normalizeWorkflowStatus } from '../lib/workflow-status.js';
 import {
   createTaskGraphEventPipeline,
@@ -296,6 +296,7 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
         }
 
         const removedWorkflowIds: string[] = [];
+        let hasAppliedTaskDelta = false;
         for (const event of deltaEvents) {
           if (event.type !== 'delta') continue;
           const delta = event.delta;
@@ -313,7 +314,11 @@ export function useTasks({ onTaskGraphSnapshotApplied }: UseTasksOptions = {}): 
           ) {
             shouldRefreshWorkflows = true;
           }
-          nextTasks = applyDelta(nextTasks, delta);
+          if (!hasAppliedTaskDelta) {
+            nextTasks = new Map(nextTasks);
+            hasAppliedTaskDelta = true;
+          }
+          applyDeltaInPlace(nextTasks, delta);
           for (const patch of event.workflowRollups) {
             if (patch.removed && nextWorkflows.has(patch.workflowId)) {
               removedWorkflowIds.push(patch.workflowId);

--- a/packages/ui/src/lib/delta.ts
+++ b/packages/ui/src/lib/delta.ts
@@ -9,22 +9,20 @@
 
 import type { TaskState, TaskDelta } from '../types.js';
 
-export function applyDelta(
-  tasks: Map<string, TaskState>,
+export function applyDeltaInPlace(
+  target: Map<string, TaskState>,
   delta: TaskDelta,
-): Map<string, TaskState> {
-  const next = new Map(tasks);
-
+): void {
   switch (delta.type) {
     case 'created':
-      next.set(delta.task.id, delta.task);
+      target.set(delta.task.id, delta.task);
       break;
 
     case 'updated': {
-      const existing = next.get(delta.taskId);
+      const existing = target.get(delta.taskId);
       if (existing) {
         const { config: cfgChanges, execution: execChanges, ...topLevel } = delta.changes;
-        next.set(delta.taskId, {
+        target.set(delta.taskId, {
           ...existing,
           ...topLevel,
           config: { ...existing.config, ...cfgChanges },
@@ -39,9 +37,30 @@ export function applyDelta(
     }
 
     case 'removed':
-      next.delete(delta.taskId);
+      target.delete(delta.taskId);
       break;
   }
+}
 
+export function applyDelta(
+  tasks: Map<string, TaskState>,
+  delta: TaskDelta,
+): Map<string, TaskState> {
+  const next = new Map(tasks);
+  applyDeltaInPlace(next, delta);
+  return next;
+}
+
+export function applyDeltas(
+  tasks: Map<string, TaskState>,
+  deltas: readonly TaskDelta[],
+): Map<string, TaskState> {
+  if (deltas.length === 0) {
+    return tasks;
+  }
+  const next = new Map(tasks);
+  for (const delta of deltas) {
+    applyDeltaInPlace(next, delta);
+  }
   return next;
 }

--- a/scripts/repro/repro-ui-delta-batch-alloc.mjs
+++ b/scripts/repro/repro-ui-delta-batch-alloc.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Benchmark repro for the applyDelta per-batch allocation issue.
+ *
+ * Before the fix, useTasks applied each TaskDelta in a coalesced batch with
+ * a fresh `new Map(tasks)` allocation. For a burst of N deltas over a task
+ * set of size T, that is N × O(T) copies inside the React render path.
+ *
+ * This repro inlines the two implementations (the pre-fix per-delta
+ * allocator and the post-fix batched allocator) — semantically identical
+ * to what lives in packages/ui/src/lib/delta.ts, verified by
+ * packages/ui/src/__tests__/delta-batch.test.ts — and times each end to
+ * end for `ITERATIONS` batches. Prints wall-clock ms and the ratio.
+ * Exits non-zero if the batched variant is not meaningfully faster.
+ *
+ * Env knobs:
+ *   TASKS         (default 1000)   size of the task map
+ *   BATCH_SIZE    (default 50)     deltas per batch
+ *   ITERATIONS    (default 200)    number of batches to time
+ *   MIN_SPEEDUP   (default 2.0)    baseline_ms / batched_ms must exceed this
+ */
+
+import { performance } from 'node:perf_hooks';
+
+const TASKS = Number(process.env.TASKS ?? '1000');
+const BATCH_SIZE = Number(process.env.BATCH_SIZE ?? '50');
+const ITERATIONS = Number(process.env.ITERATIONS ?? '200');
+const MIN_SPEEDUP = Number(process.env.MIN_SPEEDUP ?? '2.0');
+
+function applyDeltaInPlace(target, delta) {
+  switch (delta.type) {
+    case 'created':
+      target.set(delta.task.id, delta.task);
+      break;
+    case 'updated': {
+      const existing = target.get(delta.taskId);
+      if (existing) {
+        const { config: cfgChanges, execution: execChanges, ...topLevel } = delta.changes;
+        target.set(delta.taskId, {
+          ...existing,
+          ...topLevel,
+          config: { ...existing.config, ...cfgChanges },
+          execution: { ...existing.execution, ...execChanges },
+        });
+      }
+      break;
+    }
+    case 'removed':
+      target.delete(delta.taskId);
+      break;
+  }
+}
+
+function applyDeltaBaseline(tasks, delta) {
+  const next = new Map(tasks);
+  applyDeltaInPlace(next, delta);
+  return next;
+}
+
+function applyDeltasBatched(tasks, deltas) {
+  if (deltas.length === 0) return tasks;
+  const next = new Map(tasks);
+  for (const delta of deltas) applyDeltaInPlace(next, delta);
+  return next;
+}
+
+function makeTask(id) {
+  return {
+    id,
+    description: `task ${id}`,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'true' },
+    execution: {},
+  };
+}
+
+function seedTasks(size) {
+  const map = new Map();
+  for (let i = 0; i < size; i += 1) {
+    const id = `task-${i}`;
+    map.set(id, makeTask(id));
+  }
+  return map;
+}
+
+function makeBatch(size, taskCount) {
+  const batch = [];
+  for (let i = 0; i < size; i += 1) {
+    const id = `task-${i % taskCount}`;
+    batch.push({ type: 'updated', taskId: id, changes: { status: 'running' } });
+  }
+  return batch;
+}
+
+function timeMs(fn) {
+  const start = performance.now();
+  fn();
+  return performance.now() - start;
+}
+
+const seed = seedTasks(TASKS);
+const batch = makeBatch(BATCH_SIZE, TASKS);
+
+for (let i = 0; i < 5; i += 1) {
+  let m = seed;
+  for (const d of batch) m = applyDeltaBaseline(m, d);
+  applyDeltasBatched(seed, batch);
+}
+
+let baselineMs = 0;
+let batchedMs = 0;
+
+for (let i = 0; i < ITERATIONS; i += 1) {
+  baselineMs += timeMs(() => {
+    let m = seed;
+    for (const d of batch) m = applyDeltaBaseline(m, d);
+    return m;
+  });
+  batchedMs += timeMs(() => applyDeltasBatched(seed, batch));
+}
+
+const speedup = baselineMs / batchedMs;
+
+console.log('repro-summary:');
+console.log(`  tasks:         ${TASKS}`);
+console.log(`  batch size:    ${BATCH_SIZE}`);
+console.log(`  iterations:    ${ITERATIONS}`);
+console.log(`  baseline:      ${baselineMs.toFixed(1)}ms total (${(baselineMs / ITERATIONS).toFixed(3)}ms per batch)`);
+console.log(`  batched:       ${batchedMs.toFixed(1)}ms total (${(batchedMs / ITERATIONS).toFixed(3)}ms per batch)`);
+console.log(`  speedup:       ${speedup.toFixed(2)}x`);
+console.log(`  min required:  ${MIN_SPEEDUP.toFixed(2)}x`);
+
+if (speedup < MIN_SPEEDUP) {
+  console.error(
+    `repro: FAIL -- batched apply was only ${speedup.toFixed(2)}x faster (min ${MIN_SPEEDUP.toFixed(2)}x). ` +
+      'The per-batch allocation regression may be back.',
+  );
+  process.exit(1);
+}
+
+console.log(`repro: PASS -- batched apply is ${speedup.toFixed(2)}x faster than per-delta apply`);

--- a/scripts/repro/repro-ui-search-recompute-cost.mjs
+++ b/scripts/repro/repro-ui-search-recompute-cost.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+/**
+ * Benchmark repro for the O(W×T) searchResults recompute path.
+ *
+ * Before the fix, the renderer computed searchResults with an inner
+ * `[...tasks.values()].filter(t => t.config.workflowId === workflow.id)`
+ * pass for every workflow — an O(W × T) scan on every keystroke and on
+ * every task delta batch that flipped the tasks Map reference.
+ *
+ * This repro inlines both variants — the per-workflow filter baseline
+ * and the indexed variant that pre-builds a `Map<workflowId, TaskState[]>`
+ * once per call — and times each over ITERATIONS runs. Exits non-zero
+ * if the indexed variant is not meaningfully faster.
+ *
+ * Env knobs:
+ *   WORKFLOWS      (default 100)   number of workflows
+ *   TASKS_PER_WF   (default 20)    tasks per workflow
+ *   ITERATIONS     (default 200)   query executions to time
+ *   QUERY          (default "42")  search term
+ *   MIN_SPEEDUP    (default 5.0)   baseline_ms / indexed_ms must exceed this
+ */
+
+import { performance } from 'node:perf_hooks';
+
+const WORKFLOWS = Number(process.env.WORKFLOWS ?? '100');
+const TASKS_PER_WF = Number(process.env.TASKS_PER_WF ?? '20');
+const ITERATIONS = Number(process.env.ITERATIONS ?? '200');
+const QUERY = process.env.QUERY ?? '42';
+const MIN_SPEEDUP = Number(process.env.MIN_SPEEDUP ?? '2.0');
+
+const normalizedSearchText = (v) => (v ?? '').toLowerCase();
+const MAX = 12;
+
+function baseline(query, tasks, workflows) {
+  const needle = normalizedSearchText(query.trim());
+  if (!needle) return [];
+  const results = [];
+  for (const workflow of workflows.values()) {
+    const workflowTasks = [...tasks.values()].filter((t) => t.config.workflowId === workflow.id);
+    const reviewUrl = workflowTasks.find((t) => t.execution.reviewUrl)?.execution.reviewUrl;
+    const haystack = [
+      workflow.id,
+      workflow.name,
+      workflow.status,
+      workflow.repoUrl,
+      workflow.intermediateRepoUrl,
+      reviewUrl,
+    ].map(normalizedSearchText).join(' ');
+    if (haystack.includes(needle)) {
+      results.push({ kind: 'workflow', id: workflow.id, title: workflow.name || workflow.id, subtitle: `Workflow · ${workflow.status}` });
+    }
+  }
+  for (const task of tasks.values()) {
+    const workflow = task.config.workflowId ? workflows.get(task.config.workflowId) : null;
+    const haystack = [
+      task.id, task.description, task.status,
+      task.config.summary, task.config.prompt, task.config.command,
+      task.execution.reviewUrl, workflow?.name,
+    ].map(normalizedSearchText).join(' ');
+    if (haystack.includes(needle)) {
+      results.push({ kind: 'task', id: task.id, workflowId: task.config.workflowId ?? null, title: task.description || task.id, subtitle: `Task · ${workflow?.name ?? 'unknown'}` });
+    }
+  }
+  return results.slice(0, MAX);
+}
+
+function indexed(query, tasks, workflows) {
+  const needle = normalizedSearchText(query.trim());
+  if (!needle) return [];
+  const tasksByWorkflowId = new Map();
+  for (const task of tasks.values()) {
+    const wid = task.config.workflowId;
+    if (!wid) continue;
+    let list = tasksByWorkflowId.get(wid);
+    if (list === undefined) { list = []; tasksByWorkflowId.set(wid, list); }
+    list.push(task);
+  }
+  const results = [];
+  for (const workflow of workflows.values()) {
+    const workflowTasks = tasksByWorkflowId.get(workflow.id) ?? [];
+    const reviewUrl = workflowTasks.find((t) => t.execution.reviewUrl)?.execution.reviewUrl;
+    const haystack = [
+      workflow.id,
+      workflow.name,
+      workflow.status,
+      workflow.repoUrl,
+      workflow.intermediateRepoUrl,
+      reviewUrl,
+    ].map(normalizedSearchText).join(' ');
+    if (haystack.includes(needle)) {
+      results.push({ kind: 'workflow', id: workflow.id, title: workflow.name || workflow.id, subtitle: `Workflow · ${workflow.status}` });
+    }
+  }
+  for (const task of tasks.values()) {
+    const workflow = task.config.workflowId ? workflows.get(task.config.workflowId) : null;
+    const haystack = [
+      task.id, task.description, task.status,
+      task.config.summary, task.config.prompt, task.config.command,
+      task.execution.reviewUrl, workflow?.name,
+    ].map(normalizedSearchText).join(' ');
+    if (haystack.includes(needle)) {
+      results.push({ kind: 'task', id: task.id, workflowId: task.config.workflowId ?? null, title: task.description || task.id, subtitle: `Task · ${workflow?.name ?? 'unknown'}` });
+    }
+  }
+  return results.slice(0, MAX);
+}
+
+function seed() {
+  const workflows = new Map();
+  const tasks = new Map();
+  for (let w = 0; w < WORKFLOWS; w += 1) {
+    const wid = `wf-${w}`;
+    workflows.set(wid, {
+      id: wid,
+      name: `Workflow ${w}`,
+      status: 'pending',
+    });
+    for (let t = 0; t < TASKS_PER_WF; t += 1) {
+      const tid = `${wid}-task-${t}`;
+      tasks.set(tid, {
+        id: tid,
+        description: `Task ${w}-${t}`,
+        status: 'pending',
+        config: { workflowId: wid, command: 'true' },
+        execution: {},
+      });
+    }
+  }
+  return { tasks, workflows };
+}
+
+const { tasks, workflows } = seed();
+
+for (let i = 0; i < 5; i += 1) {
+  baseline(QUERY, tasks, workflows);
+  indexed(QUERY, tasks, workflows);
+}
+
+function time(fn) {
+  const start = performance.now();
+  fn();
+  return performance.now() - start;
+}
+
+let baselineMs = 0;
+let indexedMs = 0;
+for (let i = 0; i < ITERATIONS; i += 1) {
+  baselineMs += time(() => baseline(QUERY, tasks, workflows));
+  indexedMs += time(() => indexed(QUERY, tasks, workflows));
+}
+
+const speedup = baselineMs / indexedMs;
+const totalTasks = WORKFLOWS * TASKS_PER_WF;
+
+console.log('repro-summary:');
+console.log(`  workflows:          ${WORKFLOWS}`);
+console.log(`  tasks-per-workflow: ${TASKS_PER_WF}`);
+console.log(`  total tasks:        ${totalTasks}`);
+console.log(`  iterations:         ${ITERATIONS}`);
+console.log(`  query:              ${JSON.stringify(QUERY)}`);
+console.log(`  baseline O(W*T):    ${baselineMs.toFixed(1)}ms total (${(baselineMs / ITERATIONS).toFixed(3)}ms per call)`);
+console.log(`  indexed  O(W+T):    ${indexedMs.toFixed(1)}ms total (${(indexedMs / ITERATIONS).toFixed(3)}ms per call)`);
+console.log(`  speedup:            ${speedup.toFixed(2)}x`);
+console.log(`  min required:       ${MIN_SPEEDUP.toFixed(2)}x`);
+
+if (speedup < MIN_SPEEDUP) {
+  console.error(
+    `repro: FAIL -- indexed variant was only ${speedup.toFixed(2)}x faster (min ${MIN_SPEEDUP.toFixed(2)}x). ` +
+      'The per-workflow scan regression may be back.',
+  );
+  process.exit(1);
+}
+
+console.log(`repro: PASS -- indexed searchResults is ${speedup.toFixed(2)}x faster than per-workflow scan`);


### PR DESCRIPTION
## Summary

Scaffolding-only slice. Adds a Node benchmark under `scripts/repro/` that times the two variants of the renderer's searchResults recompute and prints a wall-clock speedup ratio.

The benchmark inlines both variants: the per-workflow filter and an indexed variant that pre-builds a `Map<workflowId, TaskState[]>` once per call. It runs `ITERATIONS` searches at configurable scales.

Exits non-zero when the observed speedup drops below `MIN_SPEEDUP` (default 2.0x). On my box the default scale reports 4.07x; the 200 workflows × 50 tasks scale reports 8.57x.

<details>
<summary>Review metadata</summary>

Review Claim: `node scripts/repro/repro-ui-search-recompute-cost.mjs` runs a repeatable timing comparison between the per-workflow filter and the indexed variant, and exits non-zero when the ratio drops below `MIN_SPEEDUP`.

Review Lane: proof

Review Unit: proof

Safety Invariant: Scripting-only slice. No product code, no exported module, no runtime import of the benchmark from the app. Nothing under `packages/` changes.

Slice Rationale: One new file under `scripts/repro/`. No dep changes.

</details>

## Review Claim

`node scripts/repro/repro-ui-search-recompute-cost.mjs` runs a repeatable timing comparison between the per-workflow filter and the indexed variant, and exits non-zero when the ratio drops below `MIN_SPEEDUP`.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Scripting-only slice. No product code, no exported module, no runtime import of the benchmark from the app. Nothing under `packages/` changes.

## Slice Rationale

One new file under `scripts/repro/`. No dep changes.

## Non-goals

- No fix. The indexed implementation lands in the follow-up PR.
- No import from `packages/ui`. The benchmark inlines both variants so it does not depend on future refactors.
- No CI wiring. Run manually with `node scripts/repro/repro-ui-search-recompute-cost.mjs`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `node scripts/repro/repro-ui-search-recompute-cost.mjs` exits 0 and prints `repro: PASS`
- [ ] `MIN_SPEEDUP=100 node scripts/repro/repro-ui-search-recompute-cost.mjs` exits non-zero (guardrail sanity)
- [ ] `WORKFLOWS=200 TASKS_PER_WF=50 node scripts/repro/repro-ui-search-recompute-cost.mjs` reports the larger-scale speedup
- [ ] `pnpm run check:comments`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. Nothing imports this file.
- Data migration? No

</details>
