### PR TITLE
[worker-decision-ledger](1) contract: decision DTOs, IPC channel, decision filter

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -177,6 +177,8 @@ export interface WorkerActionSummary {
   executionModel?: string;
   sessionId?: string;
   summary?: string;
+  reason?: string;
+  decision?: 'act' | 'skip';
   createdAt: string;
   updatedAt: string;
   completedAt?: string;
@@ -229,6 +231,23 @@ export interface WorkerActionHistoryRequest {
 
 export interface WorkerActionHistoryResponse {
   workerKind: string;
+  actions: WorkerActionSummary[];
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+  nextOffset?: number;
+}
+export interface WorkerDecisionsRequest {
+  workflowId?: string;
+  workerKind?: string;
+  decision?: 'act' | 'skip';
+  reason?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface WorkerDecisionsResponse {
+  workflowId?: string;
   actions: WorkerActionSummary[];
   limit: number;
   offset: number;
@@ -944,6 +963,10 @@ export const IpcChannels = {
   'invoker:get-worker-action-history': {} as {
     request: [request: WorkerActionHistoryRequest];
     response: WorkerActionHistoryResponse;
+  },
+  'invoker:get-worker-decisions': {} as {
+    request: [request: WorkerDecisionsRequest];
+    response: WorkerDecisionsResponse;
   },
   'invoker:start-worker': {} as {
     request: [kind: string];

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -803,6 +803,15 @@ describe('SQLiteAdapter', () => {
       expect(adapter.listWorkerActions({ workerKind: 'autofix', limit: 1, offset: 1 }).map((action) => action.id)).toEqual(['wa-1']);
       expect(adapter.listWorkerActions({ limit: 0 })).toEqual([]);
     });
+
+    it('filters worker actions by decision class derived from status', () => {
+      adapter.upsertWorkerAction(makeWorkerAction({ id: 'wa-act', externalKey: 'dec-act', status: 'queued', updatedAt: '2026-01-01T00:00:01.000Z' }));
+      adapter.upsertWorkerAction(makeWorkerAction({ id: 'wa-skip', externalKey: 'dec-skip', status: 'skipped', updatedAt: '2026-01-01T00:00:02.000Z' }));
+      adapter.upsertWorkerAction(makeWorkerAction({ id: 'wa-done', externalKey: 'dec-done', status: 'completed', updatedAt: '2026-01-01T00:00:03.000Z' }));
+
+      expect(adapter.listWorkerActions({ decision: 'skip' }).map((action) => action.id)).toEqual(['wa-skip']);
+      expect(adapter.listWorkerActions({ decision: 'act' }).map((action) => action.id)).toEqual(['wa-done', 'wa-act']);
+    });
   });
 
   describe('execution resource leases', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -192,6 +192,7 @@ export interface WorkerActionListFilters {
   taskId?: string;
   workerKind?: string;
   status?: WorkerActionStatus | string;
+  decision?: 'act' | 'skip';
   limit?: number;
   offset?: number;
 }

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1989,6 +1989,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
       where.push('status = ?');
       params.push(normalizeWorkerActionStatus(String(filters.status)));
     }
+    if (filters.decision === 'skip') {
+      where.push("status = 'skipped'");
+    } else if (filters.decision === 'act') {
+      where.push("status != 'skipped'");
+    }
     let pageSql = '';
     if (limit !== undefined) {
       pageSql = ' LIMIT ?';


### PR DESCRIPTION
## Summary

Add the type contract for a durable worker-decision ledger.

`WorkerActionSummary` gains a `reason` string and a derived `decision`. New request and response interfaces plus one IPC channel describe the run-scoped read.

The `worker_actions` query gains a single `decision` parameter, resolved inside the store.

Nothing consumes these types yet.

## Review Claim

Add worker-decision summary fields, request and response interfaces, an IPC channel, and one query parameter.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

Additive interfaces plus one query parameter; existing worker_actions reads and their callers keep identical results.

## Slice Rationale

The type contract lands first so later slices can build against these interfaces.

## Non-goals

No worker records decisions here. No CLI. No UI. No schema migration; the reason stays in the row payload.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/data-store && pnpm exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>