### PR TITLE
[worker-decision-ledger](2) routing: workers record decisions + backend read path

### DIFF
--- a/packages/app/src/__tests__/formatter.test.ts
+++ b/packages/app/src/__tests__/formatter.test.ts
@@ -4,6 +4,7 @@ import {
   formatWorkflowStatus,
   formatEventLog,
   formatWorkerActions,
+  formatWorkerDecisions,
   serializeWorkflow,
   serializeTask,
   serializeEvent,
@@ -14,6 +15,7 @@ import {
 } from '../formatter.js';
 import type { TaskState } from '@invoker/workflow-core';
 import type { TaskEvent, WorkerActionRecord, Workflow } from '@invoker/data-store';
+import type { WorkerActionSummary } from '@invoker/contracts';
 
 // ── ANSI Code Constants ──────────────────────────────────────
 
@@ -215,6 +217,58 @@ describe('formatWorkerActions', () => {
     expect(output).toContain('auto\\nfix/fix\\ttask');
     expect(output).toContain('task=wf-1/task\\r1');
     expect(output).toContain('Retry\\nnext');
+  });
+});
+
+// ── formatWorkerDecisions ────────────────────────────────────
+
+describe('formatWorkerDecisions', () => {
+  const decisions: WorkerActionSummary[] = [
+    {
+      id: 'wd-act',
+      workerKind: 'autofix',
+      actionType: 'fix-task',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-1',
+      subjectType: 'task',
+      subjectId: 'wf-1/task-1',
+      externalKey: 'wf-1/task-1:g0:a1',
+      status: 'queued',
+      attemptCount: 1,
+      agentName: 'codex',
+      decision: 'act',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:01:00.000Z',
+    },
+    {
+      id: 'wd-skip',
+      workerKind: 'autofix',
+      actionType: 'fix-task',
+      workflowId: 'wf-1',
+      subjectType: 'task',
+      subjectId: 'wf-1/task-2',
+      externalKey: 'wf-1/task-2:g0:a1',
+      status: 'skipped',
+      attemptCount: 3,
+      reason: 'worker-retry-budget-exhausted',
+      decision: 'skip',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:02:00.000Z',
+    },
+  ];
+
+  it('handles empty worker decisions', () => {
+    expect(formatWorkerDecisions([])).toContain('No worker decisions found.');
+  });
+
+  it('renders decision class, agent, task, and skip reason', () => {
+    const output = formatWorkerDecisions(decisions);
+    expect(output).toContain('Worker decisions (2)');
+    expect(output).toContain('ACT');
+    expect(output).toContain('SKIP');
+    expect(output).toContain('agent=codex');
+    expect(output).toContain('task=wf-1/task-1');
+    expect(output).toContain('reason=worker-retry-budget-exhausted');
   });
 });
 

--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -8,10 +8,13 @@ import {
   type WorkerRuntimeDependencies,
 } from '@invoker/execution-engine';
 
+import type { WorkerActionRecord } from '@invoker/data-store';
 import {
   AUTO_STARTED_OWNER_WORKER_KINDS,
   createWorkerRuntimeController,
   listWorkerActionHistory,
+  listWorkerDecisions,
+  toWorkerActionSummary,
 } from '../worker-control.js';
 
 interface TestWorkerRuntime extends WorkerRuntime {
@@ -233,5 +236,60 @@ describe('createWorkerRuntimeController', () => {
       nextOffset: 6,
     });
     expect(listWorkerActions).toHaveBeenCalledWith({ workerKind: 'history', limit: 3, offset: 4 });
+  });
+});
+
+function decisionRow(overrides: Partial<WorkerActionRecord> = {}): WorkerActionRecord {
+  return {
+    id: 'wa',
+    workerKind: 'autofix',
+    actionType: 'auto-fix',
+    subjectType: 'task',
+    subjectId: 'wf-1/t',
+    externalKey: 'autofix:wf-1/t:0:a1',
+    status: 'queued',
+    attemptCount: 1,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('toWorkerActionSummary', () => {
+  it('derives decision from status and lifts reason from payload', () => {
+    const skip = toWorkerActionSummary(decisionRow({ id: 's', status: 'skipped', payload: { reason: 'not-eligible' } }));
+    expect(skip).toMatchObject({ decision: 'skip', reason: 'not-eligible' });
+    const act = toWorkerActionSummary(decisionRow({ id: 'a', status: 'queued', payload: {} }));
+    expect(act.decision).toBe('act');
+    expect(act.reason).toBeUndefined();
+  });
+});
+
+describe('listWorkerDecisions', () => {
+  it('scopes to a run and surfaces reason + decision on each summary', () => {
+    const listWorkerActions = vi.fn(() => [
+      decisionRow({ id: 'a1', status: 'queued', payload: {} }),
+      decisionRow({ id: 'a2', status: 'skipped', payload: { reason: 'worker-retry-budget-exhausted' } }),
+    ]);
+    const res = listWorkerDecisions({ listWorkerActions } as never, { workflowId: 'wf-1' });
+    expect(listWorkerActions).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 'wf-1' }));
+    expect(res.workflowId).toBe('wf-1');
+    expect(res.actions.map((action) => action.decision)).toEqual(['act', 'skip']);
+    expect(res.actions[1]?.reason).toBe('worker-retry-budget-exhausted');
+  });
+
+  it('passes the decision filter through to the query', () => {
+    const listWorkerActions = vi.fn(() => []);
+    listWorkerDecisions({ listWorkerActions } as never, { decision: 'skip', workerKind: 'autofix' });
+    expect(listWorkerActions).toHaveBeenCalledWith(expect.objectContaining({ decision: 'skip', workerKind: 'autofix' }));
+  });
+
+  it('post-filters by reason substring, case-insensitively', () => {
+    const listWorkerActions = vi.fn(() => [
+      decisionRow({ id: 'a1', status: 'skipped', payload: { reason: 'not-eligible' } }),
+      decisionRow({ id: 'a2', status: 'skipped', payload: { reason: 'worker-retry-budget-exhausted' } }),
+    ]);
+    const res = listWorkerDecisions({ listWorkerActions } as never, { reason: 'BUDGET' });
+    expect(res.actions.map((action) => action.id)).toEqual(['a2']);
   });
 });

--- a/packages/app/src/__tests__/worker-decisions-integration.test.ts
+++ b/packages/app/src/__tests__/worker-decisions-integration.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { SQLiteAdapter, type WorkerActionWrite } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import { listWorkerDecisions } from '../worker-control.js';
+import { formatWorkerDecisions } from '../formatter.js';
+
+describe('worker decisions end-to-end (real SQLite)', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    const now = new Date().toISOString();
+    adapter.saveWorkflow({ id: 'wf-1', name: 'Run', status: 'running', createdAt: now, updatedAt: now });
+    adapter.saveTask('wf-1', {
+      id: 'wf-1/task-a',
+      description: 'task a',
+      status: 'failed',
+      dependencies: [],
+      createdAt: new Date(),
+      config: {},
+      execution: {},
+      taskStateVersion: 1,
+    } as TaskState);
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  function write(overrides: Partial<WorkerActionWrite>): WorkerActionWrite {
+    return {
+      id: 'wa',
+      workerKind: 'autofix',
+      actionType: 'auto-fix',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      subjectType: 'task',
+      subjectId: 'wf-1/task-a',
+      externalKey: 'k',
+      status: 'queued',
+      attemptCount: 1,
+      updatedAt: '2026-01-01T00:00:01.000Z',
+      ...overrides,
+    };
+  }
+
+  it('reads autofix submit + skip decisions back with decision class and reason', () => {
+    adapter.upsertWorkerAction(write({
+      id: 'act-row',
+      externalKey: 'autofix:wf-1/task-a:0:a1',
+      status: 'queued',
+      agentName: 'claude',
+      intentId: '42',
+      summary: 'Queued auto-fix with agent',
+      payload: { channel: 'invoker:fix-with-agent' },
+      updatedAt: '2026-01-01T00:00:02.000Z',
+    }));
+    adapter.upsertWorkerAction(write({
+      id: 'skip-row',
+      externalKey: 'autofix:wf-1/task-a:1:a2',
+      status: 'skipped',
+      summary: 'Skipped auto-fix: retry-budget-disabled',
+      payload: { reason: 'retry-budget-disabled' },
+      updatedAt: '2026-01-01T00:00:03.000Z',
+    }));
+
+    const all = listWorkerDecisions(adapter, { workflowId: 'wf-1' });
+    expect([...all.actions.map((action) => action.decision)].sort()).toEqual(['act', 'skip']);
+
+    const skips = listWorkerDecisions(adapter, { workflowId: 'wf-1', decision: 'skip' });
+    expect(skips.actions).toHaveLength(1);
+    expect(skips.actions[0]).toMatchObject({ decision: 'skip', reason: 'retry-budget-disabled', taskId: 'wf-1/task-a' });
+
+    const byReason = listWorkerDecisions(adapter, { reason: 'budget' });
+    expect(byReason.actions.map((action) => action.id)).toEqual(['skip-row']);
+
+    const text = formatWorkerDecisions(all.actions);
+    expect(text).toContain('SKIP');
+    expect(text).toContain('reason=retry-budget-disabled');
+    expect(text).toContain('agent=claude');
+  });
+});

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -6,7 +6,7 @@
 
 import type { TaskState, TaskStatus } from '@invoker/workflow-core';
 import type { TaskEvent, WorkerActionRecord, Workflow } from '@invoker/data-store';
-import type { NormalizedCostEvent, CostRollup } from '@invoker/contracts';
+import type { NormalizedCostEvent, CostRollup, WorkerActionSummary } from '@invoker/contracts';
 import type { GroupedCostRollup } from './cost-rollup.js';
 
 // ── ANSI Color Codes ─────────────────────────────────────────
@@ -232,6 +232,34 @@ export function formatWorkerActions(actions: WorkerActionRecord[]): string {
     lines.push(
       `  ${BOLD}${id}${RESET} [${action.status}] ${workerKind}/${actionType}` +
         `${workflow}${task}${attempts}${completed}${summary}`,
+    );
+  }
+  return lines.join('\n');
+}
+
+export function formatWorkerDecisions(actions: WorkerActionSummary[]): string {
+  if (actions.length === 0) {
+    return `${DIM}No worker decisions found.${RESET}`;
+  }
+
+  const lines: string[] = [];
+  lines.push(`${BOLD}Worker decisions (${actions.length})${RESET}`);
+  for (const action of actions) {
+    const decision = (action.decision ?? (action.status === 'skipped' ? 'skip' : 'act')).toUpperCase();
+    const id = escapeTerminalText(action.id);
+    const workerKind = escapeTerminalText(action.workerKind);
+    const actionType = escapeTerminalText(action.actionType);
+    const subject = action.taskId
+      ? ` task=${escapeTerminalText(action.taskId)}`
+      : ` ${escapeTerminalText(action.subjectType)}=${escapeTerminalText(action.subjectId)}`;
+    const workflow = action.workflowId ? ` workflow=${escapeTerminalText(action.workflowId)}` : '';
+    const attempts = ` attempts=${action.attemptCount}`;
+    const agent = action.agentName ? ` agent=${escapeTerminalText(action.agentName)}` : '';
+    const reason = action.reason ? ` reason=${escapeTerminalText(action.reason)}` : '';
+    const summary = action.summary ? ` — ${escapeTerminalText(action.summary)}` : '';
+    lines.push(
+      `  ${BOLD}${decision}${RESET} ${BOLD}${id}${RESET} [${action.status}] ${workerKind}/${actionType}` +
+        `${workflow}${subject}${attempts}${agent}${reason}${summary}`,
     );
   }
   return lines.join('\n');

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -1,5 +1,5 @@
 import type { IpcMain } from 'electron';
-import type { Logger, SearchOptions, WorkerActionHistoryRequest, WorkerActionHistoryResponse } from '@invoker/contracts';
+import type { Logger, SearchOptions, WorkerActionHistoryRequest, WorkerActionHistoryResponse, WorkerDecisionsRequest, WorkerDecisionsResponse } from '@invoker/contracts';
 import { resolveInvokerHomeRoot } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { DEFAULT_EXECUTION_AGENT, type AgentRegistry } from '@invoker/execution-engine';
@@ -8,7 +8,7 @@ import type { MessageBus } from '@invoker/transport';
 import { loadConfig } from './config.js';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { buildTaskGraphSnapshot } from './web/task-graph-snapshot.js';
-import { listWorkerActionHistory } from './worker-control.js';
+import { listWorkerActionHistory, listWorkerDecisions } from './worker-control.js';
 
 export interface RegisterReadOnlyIpcHandlersContext {
   ipcMain: IpcMain;
@@ -188,6 +188,13 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
       request as unknown as Record<string, unknown>,
       'workerActionHistory',
       () => listWorkerActionHistory(persistence, request),
+    ));
+  ipcMain.handle('invoker:get-worker-decisions', (_event, request: WorkerDecisionsRequest) =>
+    delegatedRead<WorkerDecisionsResponse>(
+      'worker-decisions',
+      request as unknown as Record<string, unknown>,
+      'workerDecisions',
+      () => listWorkerDecisions(persistence, request),
     ));
 
   ipcMain.handle('invoker:get-claude-session', async (_event, sessionId: string) => {

--- a/packages/app/src/owner-read-query.ts
+++ b/packages/app/src/owner-read-query.ts
@@ -1,10 +1,10 @@
 import type { Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { WorkerActionHistoryRequest, WorkerActionHistoryResponse, WorkerStatusSnapshot } from '@invoker/contracts';
+import type { WorkerActionHistoryRequest, WorkerActionHistoryResponse, WorkerDecisionsRequest, WorkerDecisionsResponse, WorkerStatusSnapshot } from '@invoker/contracts';
 import { buildReviewGateQueryResponse } from './review-gate-query.js';
 import { isHeadlessReadOnlyCommand } from './headless-command-classification.js';
 import { runReadOnlyHeadlessQueryToString, type HeadlessQueryDeps } from './headless-query-list.js';
-import { listWorkerActionHistory } from './worker-control.js';
+import { listWorkerActionHistory, listWorkerDecisions } from './worker-control.js';
 
 /**
  * Shared dispatcher for the owner's `headless.query` IPC channel.
@@ -30,6 +30,7 @@ export interface OwnerReadQueryHandlers {
   resetUiPerfStats: () => void;
   getQueueStatus: () => Record<string, unknown>;
   listWorkerActionHistory: (request: WorkerActionHistoryRequest) => WorkerActionHistoryResponse;
+  listWorkerDecisions: (request: WorkerDecisionsRequest) => WorkerDecisionsResponse;
   getWorkerStatus: () => WorkerStatusSnapshot;
   getWorkflowStatus: (workflowId?: string) => Record<string, unknown>;
   getTasksSnapshot: (opts: { refresh: boolean }) => Record<string, unknown>;
@@ -57,6 +58,8 @@ export function answerOwnerReadQuery(
     taskId?: string;
     fromOffset?: number;
     workerKind?: string;
+    decision?: string;
+    reason?: string;
     limit?: number;
     offset?: number;
   };
@@ -80,6 +83,14 @@ export function answerOwnerReadQuery(
     ...(body.limit !== undefined ? { limit: body.limit } : {}),
     ...(body.offset !== undefined ? { offset: body.offset } : {}),
   });
+  const workerDecisionsRequest = (): WorkerDecisionsRequest => ({
+    ...(typeof body.workflowId === 'string' ? { workflowId: body.workflowId } : {}),
+    ...(typeof body.workerKind === 'string' ? { workerKind: body.workerKind } : {}),
+    ...(body.decision === 'act' || body.decision === 'skip' ? { decision: body.decision } : {}),
+    ...(typeof body.reason === 'string' ? { reason: body.reason } : {}),
+    ...(body.limit !== undefined ? { limit: body.limit } : {}),
+    ...(body.offset !== undefined ? { offset: body.offset } : {}),
+  });
 
 
   switch (kind) {
@@ -92,6 +103,8 @@ export function answerOwnerReadQuery(
       return { workerStatus: handlers.getWorkerStatus() };
     case 'worker-action-history':
       return { workerActionHistory: handlers.listWorkerActionHistory(workerActionHistoryRequest()) };
+    case 'worker-decisions':
+      return { workerDecisions: handlers.listWorkerDecisions(workerDecisionsRequest()) };
     case 'workflow-status':
       return handlers.getWorkflowStatus(body.workflowId);
     case 'tasks':
@@ -193,6 +206,7 @@ export function buildOwnerReadQueryHandlers(deps: OwnerReadQueryDeps): OwnerRead
     getQueueStatus: () => orchestrator.getQueueStatus() as unknown as Record<string, unknown>,
     getWorkerStatus: deps.getWorkerStatus,
     listWorkerActionHistory: (request: WorkerActionHistoryRequest) => listWorkerActionHistory(persistence, request),
+    listWorkerDecisions: (request: WorkerDecisionsRequest) => listWorkerDecisions(persistence, request),
     getWorkflowStatus: (workflowId?: string) => orchestrator.getWorkflowStatus(workflowId) as unknown as Record<string, unknown>,
     getTasksSnapshot: ({ refresh }) => {
       if (refresh) orchestrator.syncAllFromDb();

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -2,6 +2,8 @@ import type {
   WorkerActionHistoryRequest,
   WorkerActionHistoryResponse,
   WorkerActionSummary,
+  WorkerDecisionsRequest,
+  WorkerDecisionsResponse,
   WorkerPolicyStatus,
   WorkerRecoverySummary,
   WorkerStatusEntry,
@@ -72,6 +74,55 @@ export function listWorkerActionHistory(
   const hasMore = rows.length > limit;
   return {
     workerKind,
+    actions,
+    limit,
+    offset,
+    hasMore,
+    ...(hasMore ? { nextOffset: offset + actions.length } : {}),
+  };
+}
+
+export function listWorkerDecisions(
+  persistence: Pick<SQLiteAdapter, 'listWorkerActions'>,
+  request: WorkerDecisionsRequest,
+): WorkerDecisionsResponse {
+  const workflowId = typeof request?.workflowId === 'string' && request.workflowId.trim().length > 0
+    ? request.workflowId.trim()
+    : undefined;
+  const workerKind = typeof request?.workerKind === 'string' && request.workerKind.trim().length > 0
+    ? request.workerKind.trim()
+    : undefined;
+  const decision = request?.decision === 'act' || request?.decision === 'skip' ? request.decision : undefined;
+  const reasonNeedle = typeof request?.reason === 'string' && request.reason.trim().length > 0
+    ? request.reason.trim().toLowerCase()
+    : undefined;
+  const limit = Math.min(
+    positiveIntegerOrDefault(request?.limit, DEFAULT_WORKER_ACTION_HISTORY_LIMIT),
+    MAX_WORKER_ACTION_HISTORY_LIMIT,
+  );
+  const offset = nonNegativeIntegerOrZero(request?.offset);
+  const baseFilters = {
+    ...(workflowId ? { workflowId } : {}),
+    ...(workerKind ? { workerKind } : {}),
+    ...(decision ? { decision } : {}),
+  };
+
+  let actions: WorkerActionSummary[];
+  let hasMore: boolean;
+  if (reasonNeedle) {
+    const matched = persistence.listWorkerActions(baseFilters)
+      .map(toWorkerActionSummary)
+      .filter((action) => (action.reason ?? '').toLowerCase().includes(reasonNeedle));
+    actions = matched.slice(offset, offset + limit);
+    hasMore = matched.length > offset + limit;
+  } else {
+    const rows = persistence.listWorkerActions({ ...baseFilters, limit: limit + 1, offset });
+    actions = rows.slice(0, limit).map(toWorkerActionSummary);
+    hasMore = rows.length > limit;
+  }
+
+  return {
+    ...(workflowId ? { workflowId } : {}),
     actions,
     limit,
     offset,
@@ -252,6 +303,11 @@ function getControlDisabledReason(canControl: boolean): string | undefined {
 }
 
 export function toWorkerActionSummary(action: WorkerActionRecord): WorkerActionSummary {
+  const payload = action.payload;
+  const rawReason = payload && typeof payload === 'object' && !Array.isArray(payload)
+    ? (payload as Record<string, unknown>).reason
+    : undefined;
+  const reason = typeof rawReason === 'string' && rawReason.length > 0 ? rawReason : undefined;
   return {
     id: action.id,
     workerKind: action.workerKind,
@@ -268,6 +324,8 @@ export function toWorkerActionSummary(action: WorkerActionRecord): WorkerActionS
     ...(action.executionModel ? { executionModel: action.executionModel } : {}),
     ...(action.sessionId ? { sessionId: action.sessionId } : {}),
     ...(action.summary ? { summary: action.summary } : {}),
+    ...(reason ? { reason } : {}),
+    decision: action.status === 'skipped' ? 'skip' : 'act',
     createdAt: action.createdAt,
     updatedAt: action.updatedAt,
     ...(action.completedAt ? { completedAt: action.completedAt } : {}),

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -177,6 +177,8 @@ export interface WorkerActionSummary {
   executionModel?: string;
   sessionId?: string;
   summary?: string;
+  reason?: string;
+  decision?: 'act' | 'skip';
   createdAt: string;
   updatedAt: string;
   completedAt?: string;
@@ -229,6 +231,23 @@ export interface WorkerActionHistoryRequest {
 
 export interface WorkerActionHistoryResponse {
   workerKind: string;
+  actions: WorkerActionSummary[];
+  limit: number;
+  offset: number;
+  hasMore: boolean;
+  nextOffset?: number;
+}
+export interface WorkerDecisionsRequest {
+  workflowId?: string;
+  workerKind?: string;
+  decision?: 'act' | 'skip';
+  reason?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface WorkerDecisionsResponse {
+  workflowId?: string;
   actions: WorkerActionSummary[];
   limit: number;
   offset: number;
@@ -944,6 +963,10 @@ export const IpcChannels = {
   'invoker:get-worker-action-history': {} as {
     request: [request: WorkerActionHistoryRequest];
     response: WorkerActionHistoryResponse;
+  },
+  'invoker:get-worker-decisions': {} as {
+    request: [request: WorkerDecisionsRequest];
+    response: WorkerDecisionsResponse;
   },
   'invoker:start-worker': {} as {
     request: [kind: string];

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -803,6 +803,15 @@ describe('SQLiteAdapter', () => {
       expect(adapter.listWorkerActions({ workerKind: 'autofix', limit: 1, offset: 1 }).map((action) => action.id)).toEqual(['wa-1']);
       expect(adapter.listWorkerActions({ limit: 0 })).toEqual([]);
     });
+
+    it('filters worker actions by decision class derived from status', () => {
+      adapter.upsertWorkerAction(makeWorkerAction({ id: 'wa-act', externalKey: 'dec-act', status: 'queued', updatedAt: '2026-01-01T00:00:01.000Z' }));
+      adapter.upsertWorkerAction(makeWorkerAction({ id: 'wa-skip', externalKey: 'dec-skip', status: 'skipped', updatedAt: '2026-01-01T00:00:02.000Z' }));
+      adapter.upsertWorkerAction(makeWorkerAction({ id: 'wa-done', externalKey: 'dec-done', status: 'completed', updatedAt: '2026-01-01T00:00:03.000Z' }));
+
+      expect(adapter.listWorkerActions({ decision: 'skip' }).map((action) => action.id)).toEqual(['wa-skip']);
+      expect(adapter.listWorkerActions({ decision: 'act' }).map((action) => action.id)).toEqual(['wa-done', 'wa-act']);
+    });
   });
 
   describe('execution resource leases', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -192,6 +192,7 @@ export interface WorkerActionListFilters {
   taskId?: string;
   workerKind?: string;
   status?: WorkerActionStatus | string;
+  decision?: 'act' | 'skip';
   limit?: number;
   offset?: number;
 }

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1989,6 +1989,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
       where.push('status = ?');
       params.push(normalizeWorkerActionStatus(String(filters.status)));
     }
+    if (filters.decision === 'skip') {
+      where.push("status = 'skipped'");
+    } else if (filters.decision === 'act') {
+      where.push("status != 'skipped'");
+    }
     let pageSql = '';
     if (limit !== undefined) {
       pageSql = ' LIMIT ?';

--- a/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-ci-workers.test.ts
@@ -282,9 +282,9 @@ describe('PR status and CI failure workers', () => {
     await tick({ identity: { kind: CI_FAILURE_WORKER_KIND, instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
 
     expect(harness.submit).not.toHaveBeenCalled();
-    expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toMatchObject({
-      status: 'skipped',
-      summary: expect.stringContaining('head-sha-changed'),
-    });
+    // Stale events are routine scan noise: logged, but NOT recorded as a durable
+    // decision row. Only meaningful skips (e.g. retry-budget-exhausted) persist.
+    expect(harness.actions.get(`${CI_FAILURE_WORKER_KIND}:${ciFailureActionKey(event)}`)).toBeUndefined();
+    expect(harness.store.upsertWorkerAction).not.toHaveBeenCalled();
   });
 });

--- a/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-maintenance-workers.test.ts
@@ -9,6 +9,7 @@ import { PassThrough } from 'node:stream';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Logger } from '@invoker/contracts';
+import type { WorkerActionRecord, WorkerActionWrite } from '@invoker/data-store';
 
 import {
   CODERABBIT_ADDRESS_WORKER_KIND,
@@ -189,6 +190,68 @@ describe('PR maintenance workers', () => {
         reason: 'test-lock-held',
       }),
     );
+  });
+
+  it('records running and completed decision rows for a successful run', async () => {
+    const repoRoot = makeRepoRoot();
+    const logger = makeLogger();
+    const spawnHarness = makeSpawnHarness({ exitCode: 0 });
+    const actions = new Map<string, WorkerActionRecord>();
+    const store = {
+      getWorkerAction: vi.fn((kind: string, key: string) => actions.get(`${kind}:${key}`)),
+      upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+        const mapKey = `${write.workerKind}:${write.externalKey}`;
+        const existing = actions.get(mapKey);
+        const saved = {
+          ...write,
+          attemptCount: write.attemptCount ?? 0,
+          id: existing?.id ?? write.id,
+          createdAt: existing?.createdAt ?? 'now',
+          updatedAt: 'now',
+        } as WorkerActionRecord;
+        actions.set(mapKey, saved);
+        return saved;
+      }),
+    };
+    const worker = createCoderabbitAddressWorker({
+      logger,
+      repoRoot,
+      spawnProcess: spawnHarness.spawnProcess,
+      lockProbe: () => ({ held: false }),
+      installSignalHandlers: false,
+      store,
+    });
+
+    await worker.tick();
+
+    const statuses = store.upsertWorkerAction.mock.calls.map((call) => call[0].status);
+    expect(statuses).toEqual(['running', 'completed']);
+    expect(store.upsertWorkerAction.mock.calls[0]?.[0]).toMatchObject({
+      workerKind: CODERABBIT_ADDRESS_WORKER_KIND,
+      actionType: 'pr-maintenance-run',
+      subjectType: 'repo',
+      subjectId: repoRoot,
+    });
+  });
+
+  it('does not record a decision row when the lock is held', async () => {
+    const repoRoot = makeRepoRoot();
+    const store = {
+      getWorkerAction: vi.fn(() => undefined),
+      upsertWorkerAction: vi.fn(),
+    };
+    const worker = createPrConflictRebaseWorker({
+      logger: makeLogger(),
+      repoRoot,
+      spawnProcess: makeSpawnHarness().spawnProcess,
+      lockProbe: () => ({ held: true, reason: 'lock-held' }),
+      installSignalHandlers: false,
+      store,
+    });
+
+    await worker.tick();
+
+    expect(store.upsertWorkerAction).not.toHaveBeenCalled();
   });
 
   it('polls on the five-minute default interval without ticking on start', async () => {

--- a/packages/execution-engine/src/__tests__/worker-decision-ledger.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-decision-ledger.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationPriority } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+import {
+  isMeaningfulSkipReason,
+  recordWorkerDecisionRow,
+} from '../worker-decision-ledger.js';
+import { createAutoFixRecoveryTick } from '../auto-fix-recovery.js';
+import { createAutoFixAttemptLedger } from '../auto-fix-attempt-ledger.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+};
+
+function makeActionStore() {
+  const actions = new Map<string, WorkerActionRecord>();
+  return {
+    actions,
+    getWorkerAction: vi.fn((kind: string, externalKey: string) => actions.get(`${kind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      const key = `${write.workerKind}:${write.externalKey}`;
+      const existing = actions.get(key);
+      const saved = {
+        ...write,
+        attemptCount: write.attemptCount ?? 0,
+        id: existing?.id ?? write.id,
+        createdAt: existing?.createdAt ?? '2026-01-01T00:00:00.000Z',
+        updatedAt: write.updatedAt ?? '2026-01-01T00:00:00.000Z',
+      } as WorkerActionRecord;
+      actions.set(key, saved);
+      return saved;
+    }),
+  };
+}
+
+describe('recordWorkerDecisionRow', () => {
+  it('derives the row id from workerKind/externalKey and folds reason into payload', () => {
+    const store = makeActionStore();
+    const row = recordWorkerDecisionRow(store, {
+      workerKind: 'autofix',
+      actionType: 'auto-fix',
+      externalKey: 'autofix:wf-1/t:0:a1',
+      subjectType: 'task',
+      subjectId: 'wf-1/t',
+      status: 'skipped',
+      summary: 'skipped it',
+      reason: 'not-eligible',
+    });
+    expect(row?.id).toBe('autofix:autofix:wf-1/t:0:a1');
+    expect(row?.status).toBe('skipped');
+    expect(row?.payload).toMatchObject({ reason: 'not-eligible' });
+    expect(row?.completedAt).toBeDefined();
+  });
+
+  it('preserves the id and increments attemptCount across ticks when requested', () => {
+    const store = makeActionStore();
+    const base = {
+      workerKind: 'autofix',
+      actionType: 'auto-fix',
+      externalKey: 'autofix:wf-1/t:0:a1',
+      subjectType: 'task',
+      subjectId: 'wf-1/t',
+      summary: 'queued',
+      incrementAttempt: true,
+    } as const;
+    const first = recordWorkerDecisionRow(store, { ...base, status: 'queued' });
+    const second = recordWorkerDecisionRow(store, { ...base, status: 'queued' });
+    expect(first?.attemptCount).toBe(1);
+    expect(second?.attemptCount).toBe(2);
+    expect(second?.id).toBe(first?.id);
+    // A non-terminal status leaves completedAt unset.
+    expect(second?.completedAt).toBeUndefined();
+  });
+
+  it('no-ops when the store cannot persist worker actions', () => {
+    const row = recordWorkerDecisionRow({}, {
+      workerKind: 'autofix',
+      actionType: 'auto-fix',
+      externalKey: 'k',
+      subjectType: 'task',
+      subjectId: 't',
+      status: 'queued',
+      summary: 's',
+    });
+    expect(row).toBeUndefined();
+  });
+});
+
+describe('isMeaningfulSkipReason', () => {
+  it('treats terminal/decision-grade reasons as meaningful', () => {
+    expect(isMeaningfulSkipReason('worker-retry-budget-exhausted')).toBe(true);
+    expect(isMeaningfulSkipReason('retry-budget-disabled')).toBe(true);
+    expect(isMeaningfulSkipReason('not-eligible')).toBe(true);
+  });
+
+  it('treats scan noise as routine (not recorded)', () => {
+    expect(isMeaningfulSkipReason('stale-generation')).toBe(false);
+    expect(isMeaningfulSkipReason('task-not-found')).toBe(false);
+    expect(isMeaningfulSkipReason('already-queued-intent')).toBe(false);
+    expect(isMeaningfulSkipReason('lock-held')).toBe(false);
+  });
+});
+
+function makeFailedTask(overrides: Partial<TaskState['execution']> = {}): TaskState {
+  return {
+    id: 'wf-1/task-a',
+    description: 'task a',
+    status: 'failed',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId: 'wf-1' },
+    execution: {
+      generation: 1,
+      selectedAttemptId: 'a1',
+      error: 'boom',
+      ...overrides,
+    },
+    taskStateVersion: 3,
+  } as TaskState;
+}
+
+function makeAutoFixHarness(options: {
+  latestTask?: TaskState | undefined;
+  scanTask?: TaskState;
+} = {}) {
+  const scanTask = options.scanTask ?? makeFailedTask();
+  const latestTask = 'latestTask' in options ? options.latestTask : scanTask;
+  const store = {
+    listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+    loadTasks: vi.fn((workflowId: string) => (workflowId === 'wf-1' ? [scanTask] : [])),
+    loadTask: vi.fn(() => latestTask),
+    listWorkflowMutationIntents: vi.fn(() => []),
+    getWorkerAction: vi.fn(() => undefined),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => ({
+      ...write,
+      attemptCount: write.attemptCount ?? 0,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    } as WorkerActionRecord)),
+    logEvent: vi.fn(),
+  };
+  const submit = vi.fn((_workflowId: string, _priority: WorkflowMutationPriority, _channel: string, _args: unknown[]) => 42);
+  return { store, submit };
+}
+
+const tickCtx = { identity: { kind: 'recovery', instanceId: 'test' }, reason: 'poll' as const, tickNumber: 1 };
+
+describe('autofix decision ledger', () => {
+  it('records a queued decision row when it submits an auto-fix', async () => {
+    const { store, submit } = makeAutoFixHarness();
+    const tick = createAutoFixRecoveryTick({
+      store,
+      submitter: { submit },
+      logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 2,
+      getAutoFixAgent: () => 'claude',
+    });
+
+    await tick(tickCtx);
+
+    expect(submit).toHaveBeenCalledTimes(1);
+    const write = store.upsertWorkerAction.mock.calls.at(-1)?.[0];
+    expect(write).toMatchObject({
+      workerKind: 'autofix',
+      actionType: 'auto-fix',
+      status: 'queued',
+      subjectType: 'task',
+      subjectId: 'wf-1/task-a',
+      attemptCount: 1,
+      intentId: '42',
+      agentName: 'claude',
+    });
+    expect(write?.externalKey).toBe('autofix:wf-1/task-a:1:a1');
+  });
+
+  it('records a skipped decision row for a meaningful skip (budget disabled)', async () => {
+    const { store, submit } = makeAutoFixHarness();
+    const tick = createAutoFixRecoveryTick({
+      store,
+      submitter: { submit },
+      logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 0,
+    });
+
+    await tick(tickCtx);
+
+    expect(submit).not.toHaveBeenCalled();
+    const write = store.upsertWorkerAction.mock.calls.at(-1)?.[0];
+    expect(write).toMatchObject({ status: 'skipped', subjectId: 'wf-1/task-a' });
+    expect(write?.payload).toMatchObject({ reason: 'retry-budget-disabled' });
+  });
+
+  it('does not record a row for a routine skip (stale generation)', async () => {
+    // Scan sees generation 1; the latest persisted task moved to generation 2.
+    const { store, submit } = makeAutoFixHarness({
+      scanTask: makeFailedTask({ generation: 1 }),
+      latestTask: makeFailedTask({ generation: 2 }),
+    });
+    const tick = createAutoFixRecoveryTick({
+      store,
+      submitter: { submit },
+      logger,
+      attemptLedger: createAutoFixAttemptLedger(),
+      defaultAutoFixRetries: 2,
+    });
+
+    await tick(tickCtx);
+
+    expect(submit).not.toHaveBeenCalled();
+    expect(store.upsertWorkerAction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/execution-engine/src/auto-fix-recovery.ts
+++ b/packages/execution-engine/src/auto-fix-recovery.ts
@@ -1,5 +1,8 @@
 import type { Logger } from '@invoker/contracts';
 import type {
+  WorkerActionRecord,
+  WorkerActionStatus,
+  WorkerActionWrite,
   WorkflowMutationIntent,
   WorkflowMutationIntentStatus,
   WorkflowMutationPriority,
@@ -21,6 +24,7 @@ import {
   shouldSkipAutoFixForError,
   isLivenessFailureTask,
 } from './auto-fix-gating.js';
+import { recordWorkerDecisionRow, isMeaningfulSkipReason } from './worker-decision-ledger.js';
 import type { WorkflowLifecycleEvent, RecoveryWorkerWakeupHint } from './lifecycle-events.js';
 import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
 import type { WorkerRegistry } from './worker-registry.js';
@@ -33,6 +37,7 @@ export const RECOVERY_WORKER_KIND = 'recovery';
 
 const DEFAULT_RECOVERY_POLL_INTERVAL_MS = 60_000;
 const AUTO_FIX_COMMAND_CHANNEL = 'invoker:fix-with-agent';
+const AUTO_FIX_ACTION_TYPE = 'auto-fix';
 
 const AUTO_FIX_WORKER_AUDIT_EVENTS: Record<string, { eventType: string; action: 'submit' | 'skip' }> = {
   'worker-autofix-submitted': { eventType: 'recovery.worker.submit', action: 'submit' },
@@ -47,6 +52,8 @@ export interface AutoFixRecoveryStore {
     workflowId?: string,
     statuses?: WorkflowMutationIntentStatus[],
   ): WorkflowMutationIntent[];
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
 }
 
@@ -259,6 +266,43 @@ function logAutoFixWorkerEvent(
   });
 }
 
+function recordAutoFixDecisionRow(
+  options: AutoFixRecoveryPolicyOptions,
+  candidate: AutoFixRecoveryCandidate,
+  fields: {
+    status: WorkerActionStatus;
+    summary: string;
+    reason?: string;
+    intentId?: number;
+    agentName?: string;
+    incrementAttempt?: boolean;
+    extraPayload?: Record<string, unknown>;
+  },
+): void {
+  recordWorkerDecisionRow(options.store, {
+    workerKind: AUTO_FIX_WORKER_KIND,
+    actionType: AUTO_FIX_ACTION_TYPE,
+    externalKey: `${AUTO_FIX_WORKER_KIND}:${candidate.taskId}:${candidate.generation}:${candidate.attemptId ?? ''}`,
+    subjectType: 'task',
+    subjectId: candidate.taskId,
+    workflowId: candidate.workflowId,
+    taskId: candidate.taskId,
+    status: fields.status,
+    summary: fields.summary,
+    reason: fields.reason,
+    intentId: fields.intentId,
+    agentName: fields.agentName,
+    incrementAttempt: fields.incrementAttempt,
+    payload: {
+      source: candidate.source,
+      generation: candidate.generation,
+      attemptId: candidate.attemptId ?? null,
+      taskStateVersion: candidate.taskStateVersion,
+      ...fields.extraPayload,
+    },
+  });
+}
+
 function skipAutoFixCandidate(
   options: AutoFixRecoveryPolicyOptions,
   candidate: AutoFixRecoveryCandidate,
@@ -274,6 +318,14 @@ function skipAutoFixCandidate(
     attemptId: candidate.attemptId ?? null,
     ...details,
   });
+  if (isMeaningfulSkipReason(reason)) {
+    recordAutoFixDecisionRow(options, candidate, {
+      status: 'skipped',
+      summary: `Skipped auto-fix: ${reason}`,
+      reason,
+      extraPayload: details,
+    });
+  }
 }
 
 function compareAutoFixCandidateSnapshot(
@@ -422,6 +474,17 @@ export function createAutoFixRecoveryTick(options: AutoFixRecoveryPolicyOptions)
         attemptId: candidate.attemptId ?? null,
         agent: selectedAgent ?? null,
         workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
+      });
+      recordAutoFixDecisionRow(options, candidate, {
+        status: 'queued',
+        summary: 'Queued auto-fix with agent',
+        intentId,
+        agentName: selectedAgent,
+        incrementAttempt: true,
+        extraPayload: {
+          channel: AUTO_FIX_COMMAND_CHANNEL,
+          workerRetryBudget: retryBudgetLabel(attemptDecision.workerRetryBudget),
+        },
       });
     }
   };

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -55,6 +55,7 @@ export * from './workers/disk-headroom.js';
 export * from './workers/pr-maintenance-workers.js';
 export * from './auto-fix-gating.js';
 export * from './auto-fix-attempt-ledger.js';
+export * from './worker-decision-ledger.js';
 export * from './auto-fix-intents.js';
 export * from './lifecycle-events.js';
 export * from './external-worker.js';

--- a/packages/execution-engine/src/worker-decision-ledger.ts
+++ b/packages/execution-engine/src/worker-decision-ledger.ts
@@ -1,0 +1,99 @@
+import type {
+  WorkerActionRecord,
+  WorkerActionStatus,
+  WorkerActionWrite,
+} from '@invoker/data-store';
+
+export interface WorkerDecisionStore {
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
+}
+
+const TERMINAL_ACTION_STATUSES: Record<string, true> = {
+  completed: true,
+  failed: true,
+  skipped: true,
+  abandoned: true,
+  cancelled: true,
+};
+
+const ROUTINE_SKIP_REASONS: Record<string, true> = {
+  'task-not-found': true,
+  'stale-workflow': true,
+  'stale-generation': true,
+  'stale-task-state-version': true,
+  'stale-attempt': true,
+  'workflow-changed': true,
+  'status-changed': true,
+  'review-changed': true,
+  'generation-changed': true,
+  'selected-attempt-changed': true,
+  'head-sha-changed': true,
+  'branch-changed': true,
+  'already-queued-intent': true,
+  'already-recorded': true,
+  'duplicate-candidate': true,
+  'lock-held': true,
+  'flock-held': true,
+  'mkdir-lock-held': true,
+  'mkdir-lock-held-without-pid': true,
+};
+
+export function isMeaningfulSkipReason(reason: string): boolean {
+  return ROUTINE_SKIP_REASONS[reason] !== true;
+}
+
+export interface WorkerDecisionRow {
+  workerKind: string;
+  actionType: string;
+  externalKey: string;
+  subjectType: string;
+  subjectId: string;
+  status: WorkerActionStatus;
+  workflowId?: string;
+  taskId?: string;
+  summary: string;
+  reason?: string;
+  intentId?: number | string;
+  agentName?: string;
+  executionModel?: string;
+  sessionId?: string;
+  payload?: Record<string, unknown>;
+  incrementAttempt?: boolean;
+  now?: string;
+}
+
+export function recordWorkerDecisionRow(
+  store: WorkerDecisionStore,
+  row: WorkerDecisionRow,
+): WorkerActionRecord | undefined {
+  if (!store.upsertWorkerAction) return undefined;
+  const existing = store.getWorkerAction?.(row.workerKind, row.externalKey);
+  const now = row.now ?? new Date().toISOString();
+  const attemptCount = row.incrementAttempt
+    ? (existing?.attemptCount ?? 0) + 1
+    : existing?.attemptCount ?? 0;
+  return store.upsertWorkerAction({
+    id: existing?.id ?? `${row.workerKind}:${row.externalKey}`,
+    workerKind: row.workerKind,
+    actionType: row.actionType,
+    ...(row.workflowId !== undefined ? { workflowId: row.workflowId } : {}),
+    ...(row.taskId !== undefined ? { taskId: row.taskId } : {}),
+    subjectType: row.subjectType,
+    subjectId: row.subjectId,
+    externalKey: row.externalKey,
+    status: row.status,
+    attemptCount,
+    ...(row.intentId !== undefined ? { intentId: String(row.intentId) } : {}),
+    ...(row.agentName !== undefined ? { agentName: row.agentName } : {}),
+    ...(row.executionModel !== undefined ? { executionModel: row.executionModel } : {}),
+    ...(row.sessionId !== undefined ? { sessionId: row.sessionId } : {}),
+    summary: row.summary,
+    payload: {
+      ...(row.reason !== undefined ? { reason: row.reason } : {}),
+      ...row.payload,
+    },
+    updatedAt: now,
+    ...(TERMINAL_ACTION_STATUSES[row.status] ? { completedAt: now } : {}),
+  });
+}

--- a/packages/execution-engine/src/workers/ci-failure-worker.ts
+++ b/packages/execution-engine/src/workers/ci-failure-worker.ts
@@ -25,6 +25,7 @@ import {
   type AutoFixAttemptLedger,
 } from '../auto-fix-attempt-ledger.js';
 import { normalizeAutoFixRetryBudget } from '../auto-fix-gating.js';
+import { recordWorkerDecisionRow } from '../worker-decision-ledger.js';
 import type {
   ReviewGateCiFailedLifecycleEvent,
   ReviewGateFailedCheck,
@@ -252,10 +253,6 @@ function staleReasonForEvent(
   };
 }
 
-function actionIdForKey(externalKey: string): string {
-  return `${CI_FAILURE_WORKER_KIND}:${externalKey}`;
-}
-
 function isOpenOrCompletedActionStatus(status: string): boolean {
   return status === 'queued'
     || status === 'pending'
@@ -263,10 +260,6 @@ function isOpenOrCompletedActionStatus(status: string): boolean {
     || status === 'needs_input'
     || status === 'review_ready'
     || status === 'completed';
-}
-
-function coerceActionStatus(status: CiFailureActionStatus): WorkerActionStatus {
-  return status;
 }
 
 function recordCiFailureAction(
@@ -279,26 +272,20 @@ function recordCiFailureAction(
   agentName?: string,
   executionModel?: string,
 ): WorkerActionRecord | undefined {
-  const externalKey = ciFailureActionKey(event);
-  const existing = options.store.getWorkerAction?.(CI_FAILURE_WORKER_KIND, externalKey);
-  const now = new Date().toISOString();
-  return options.store.upsertWorkerAction?.({
-    id: existing?.id ?? actionIdForKey(externalKey),
+  return recordWorkerDecisionRow(options.store, {
     workerKind: CI_FAILURE_WORKER_KIND,
     actionType: CI_FAILURE_ACTION_TYPE,
-    workflowId: event.workflowId,
-    taskId: event.taskId,
+    externalKey: ciFailureActionKey(event),
     subjectType: 'review',
     subjectId: event.reviewId,
-    externalKey,
-    status: coerceActionStatus(status),
-    attemptCount: status === 'queued' || status === 'failed'
-      ? (existing?.attemptCount ?? 0) + 1
-      : existing?.attemptCount ?? 0,
-    ...(intentId !== undefined ? { intentId: String(intentId) } : {}),
+    workflowId: event.workflowId,
+    taskId: event.taskId,
+    status,
+    summary,
+    intentId,
     agentName,
     executionModel,
-    summary,
+    incrementAttempt: status === 'queued' || status === 'failed',
     payload: {
       reviewId: event.reviewId,
       reviewUrl: event.reviewUrl,
@@ -312,8 +299,6 @@ function recordCiFailureAction(
       failedChecks: event.failedChecks.map((check) => ({ ...check })),
       ...payload,
     },
-    updatedAt: now,
-    ...(status === 'skipped' || status === 'failed' || status === 'completed' ? { completedAt: now } : {}),
   });
 }
 
@@ -446,9 +431,6 @@ async function handleCiFailureEvent(
 ): Promise<void> {
   const task = loadTaskForEvent(event, options);
   if (!task) {
-    recordCiFailureAction(options, event, 'skipped', 'Skipped CI repair because task no longer exists', {
-      reason: 'task-not-found',
-    });
     logCiFailureWorkerEvent(options, event, 'worker-ci-failure-skip', { reason: 'task-not-found' });
     return;
   }
@@ -461,10 +443,6 @@ async function handleCiFailureEvent(
 
   const stale = staleReasonForEvent(event, task);
   if (stale.stale) {
-    recordCiFailureAction(options, event, 'skipped', `Skipped stale CI repair: ${stale.reason}`, {
-      reason: stale.reason,
-      ...stale.details,
-    });
     logCiFailureWorkerEvent(options, event, 'worker-ci-failure-stale', {
       reason: stale.reason,
       ...stale.details,

--- a/packages/execution-engine/src/workers/pr-maintenance-workers.ts
+++ b/packages/execution-engine/src/workers/pr-maintenance-workers.ts
@@ -4,6 +4,9 @@ import { resolve } from 'node:path';
 import type { Readable } from 'node:stream';
 
 import { resolveRepoRoot, type Logger } from '@invoker/contracts';
+import type { WorkerActionStatus } from '@invoker/data-store';
+
+import { recordWorkerDecisionRow, type WorkerDecisionStore } from '../worker-decision-ledger.js';
 
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import type { WorkerRegistry } from '../worker-registry.js';
@@ -48,6 +51,7 @@ export interface PrMaintenanceWorkerConfig {
   lockPath?: string;
   /** Shell executable used to run the existing entrypoint. Defaults to `bash`. */
   shell?: string;
+  store?: WorkerDecisionStore;
 }
 
 export interface PrMaintenanceLockProbeOptions {
@@ -101,6 +105,7 @@ export function registerCoderabbitAddressWorker(
       createCoderabbitAddressWorker({
         logger: deps.logger,
         ...deps.prMaintenance,
+        store: deps.store,
       }),
   });
   return registry;
@@ -116,6 +121,7 @@ export function registerPrConflictRebaseWorker(
       createPrConflictRebaseWorker({
         logger: deps.logger,
         ...deps.prMaintenance,
+        store: deps.store,
       }),
   });
   return registry;
@@ -184,12 +190,15 @@ function createPrMaintenanceWorker(
       shell: options.shell,
       spawnProcess: options.spawnProcess,
       lockProbe: options.lockProbe,
+      store: options.store,
     }),
   });
 }
 
 async function runPrMaintenanceEntrypoint(options: PrMaintenanceTickOptions): Promise<void> {
   const repoRoot = resolvePrMaintenanceRepoRoot(options.repoRoot);
+  const startedAt = new Date().toISOString();
+  const runExternalKey = `${options.entrypoint.kind}:${repoRoot}:${startedAt}`;
   const env = buildPrMaintenanceEnv(repoRoot, options.env);
   const lockPath = options.lockPath ?? env.INVOKER_PR_CRON_LOCK ?? defaultPrCronLockPath(env);
   env.INVOKER_PR_CRON_LOCK = lockPath;
@@ -235,11 +244,16 @@ async function runPrMaintenanceEntrypoint(options: PrMaintenanceTickOptions): Pr
       worker: options.entrypoint.kind,
       err,
     });
+    recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'failed', `Spawn failed for ${options.entrypoint.scriptRelativePath}`, {
+      reason: 'spawn-failed',
+      error: String(err),
+    });
     throw err;
   }
 
   attachChildStreamLogger(options, child.stdout, 'stdout');
   attachChildStreamLogger(options, child.stderr, 'stderr');
+  recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'running', `Started ${options.entrypoint.scriptRelativePath}`);
 
   await new Promise<void>((resolvePromise, rejectPromise) => {
     let settled = false;
@@ -256,6 +270,10 @@ async function runPrMaintenanceEntrypoint(options: PrMaintenanceTickOptions): Pr
           worker: options.entrypoint.kind,
           err,
         });
+        recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'failed', 'PR maintenance process error', {
+          reason: 'process-error',
+          error: String(err),
+        });
         rejectPromise(err);
       });
     });
@@ -270,15 +288,43 @@ async function runPrMaintenanceEntrypoint(options: PrMaintenanceTickOptions): Pr
         };
         if (code === 0) {
           options.logger.info(`[worker:${options.entrypoint.kind}] shell entrypoint completed`, fields);
+          recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'completed', 'PR maintenance run completed');
           resolvePromise();
           return;
         }
         const message = `PR maintenance worker ${options.entrypoint.kind} exited with code ${code ?? 'null'}`
           + (signal ? ` signal ${signal}` : '');
         options.logger.error(`[worker:${options.entrypoint.kind}] shell entrypoint failed`, fields);
+        recordPrMaintenanceRun(options, runExternalKey, repoRoot, 'failed', message, {
+          reason: 'nonzero-exit',
+          code,
+          signal,
+        });
         rejectPromise(new Error(message));
       });
     });
+  });
+}
+
+function recordPrMaintenanceRun(
+  options: PrMaintenanceTickOptions,
+  externalKey: string,
+  repoRoot: string,
+  status: WorkerActionStatus,
+  summary: string,
+  payload?: Record<string, unknown>,
+): void {
+  if (!options.store) return;
+  recordWorkerDecisionRow(options.store, {
+    workerKind: options.entrypoint.kind,
+    actionType: 'pr-maintenance-run',
+    externalKey,
+    subjectType: 'repo',
+    subjectId: repoRoot,
+    status,
+    summary,
+    incrementAttempt: status === 'running',
+    ...(payload ? { payload } : {}),
   });
 }
 


### PR DESCRIPTION
## Summary

Every worker now persists what it decides into the shared ledger.

A single helper writes each kept decision as one `worker_actions` row. Autofix, ci-failure, and the PR-maintenance crons all go through it.

Routine churn — superseded snapshots, repeats, lock contention — stays a debug event and never becomes a durable row.

The backend then turns those rows into a per-run decisions feed.

## Review Claim

Workers persist their decisions as worker_actions rows, and the backend serves them as a per-run feed.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Persisting is best-effort and no-ops when the store lacks worker-action methods; existing debug events and submission ordering are unchanged.

## Slice Rationale

The persistence and its backend read belong together; the user-facing surfaces land next.

## Non-goals

No CLI or UI. Does not change worker eligibility, retry-budget enforcement, or command submission ordering.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/worker-decision-ledger.test.ts src/__tests__/pr-ci-workers.test.ts src/__tests__/pr-maintenance-workers.test.ts`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/worker-control.test.ts src/__tests__/formatter.test.ts src/__tests__/worker-decisions-integration.test.ts`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #3492