### PR TITLE
[Liveness stall requeue](1) Add failureClass to the work-response contract

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -5,7 +5,7 @@
  * Orchestrator writes a WorkRequest; executor runs the action;
  * executor returns a WorkResponse (via callback or IPC).
  */
-import type { ReviewGateArtifact, ReviewGateState, TaskStatus } from '@invoker/workflow-graph';
+import type { FailureClass, ReviewGateArtifact, ReviewGateState, TaskStatus } from '@invoker/workflow-graph';
 
 // ── Action Types ────────────────────────────────────────────
 
@@ -108,6 +108,7 @@ export type ResponseStatus =
 export interface WorkResponseOutputs {
   exitCode?: number;
   error?: string;
+  failureClass?: FailureClass;
   summary?: string;
   commitHash?: string;
   agentSessionId?: string;

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -171,6 +171,12 @@ export interface ReviewGateState {
   readonly artifacts: readonly ReviewGateArtifact[];
 }
 
+export type FailureClass = 'liveness_stall';
+
+export function isLivenessFailureClass(failureClass: FailureClass | undefined): boolean {
+  return failureClass === 'liveness_stall';
+}
+
 export interface TaskExecution {
   readonly generation?: number;
   readonly blockedBy?: string;


### PR DESCRIPTION
## Summary

Recovery workers cannot tell an infrastructure stall apart from a genuine bug today: a stalled task and a broken task both just look failed.

This adds a small `failureClass` marker to the work-response so a guard can label a failure. Nothing reads it yet.

The only value it can hold is `liveness_stall`, meaning a task's runner stopped sending heartbeats and a watchdog gave up on it.

## Review Claim

A failure can now carry an optional `failureClass` marker on the work-response, unset by default.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The new field is optional and unset by default, so existing failures and every stored task are byte-identical until a later slice sets it. No code branches on it in this slice.

## Slice Rationale

The shared marker lands first, alone, so the persistence and recovery slices that depend on it build on a stable base.

## Non-goals

- Does not persist the marker or change any recovery decision; later slices do that.
- Does not add the value to a task's stored state yet.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>