### PR TITLE
[Liveness stall requeue](5) Keep attempt lease alive during publishAfterFix

### DIFF
--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1350,7 +1350,10 @@ export class TaskRunner {
   }
 
   async publishAfterFix(task: TaskState): Promise<void> {
-    return publishAfterFixImpl(this, task);
+    // Pump the attempt heartbeat/lease while the make-pr publisher runs, exactly
+    // as executeMergeNode does. A slow publish (large stack, loaded machine) must
+    // not be misread as a liveness stall by the executing-stall watchdog.
+    return this.withAttemptHeartbeat(task.id, () => publishAfterFixImpl(this, task));
   }
 
   async commitApprovedFix(task: TaskState): Promise<void> {


### PR DESCRIPTION
## Summary

A long fix-publish step could itself let a task's attempt lease expire, which the stall watchdog then treats as a stall.

This keeps the lease alive with heartbeats while that step runs, so a slow publish no longer masquerades as a liveness stall.

## Review Claim

The post-fix publish step heartbeats its attempt lease so a slow publish is not misread as a stall.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The heartbeat wrapper only extends the existing lease during `publishAfterFix`; it adds no new state and changes no decision beyond preventing a false stall.

## Slice Rationale

A one-line-scope behavior fix, kept on its own so it can be reverted independently of the worker.

## Non-goals

- Does not change stall detection thresholds.
- Does not touch the requeue worker.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>

Depends-On: #3505