### PR TITLE
[Approve Fix Visibility](2a) Add WorkflowMutationFailedEvent contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -466,6 +466,15 @@ export interface WorkflowMutationAcceptedResult {
   channel: string;
 }
 
+export interface WorkflowMutationFailedEvent {
+  intentId: number;
+  workflowId: string;
+  channel: string;
+  taskId?: string;
+  message: string;
+  failedAt: string;
+}
+
 export interface CancelResult {
   cancelled: string[];
   runningCancelled: string[];
@@ -1078,6 +1087,9 @@ export const IpcEventChannels = {
   },
   'invoker:terminal-exit': {} as {
     payload: TerminalExitEvent;
+  },
+  'invoker:workflow-mutation-failed': {} as {
+    payload: WorkflowMutationFailedEvent;
   },
 } as const;
 

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -607,7 +607,67 @@ describe('WorkflowInspector', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Reject Fix' }));
     expect(onReject).toHaveBeenCalledWith(task);
+
+    expect(screen.getByTestId('inspector-pending-fix-error')).toHaveTextContent('tests failed');
   });
+
+  it('surfaces an executor-selection failure captured in pendingFixError so approve dispatch errors are visible', () => {
+    const capabilityError =
+      'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"';
+    const task = makeTask({
+      status: 'awaiting_approval',
+      execution: {
+        pendingFixError: capabilityError,
+      },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={task}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    const panel = screen.getByTestId('inspector-pending-fix-error');
+    expect(panel).toHaveTextContent(/cannot run codex/);
+    expect(panel).toHaveTextContent(/missing execution harness "codex"/);
+  });
+
+  it('renders pendingFixError alongside execution.error when both are present', () => {
+    const task = makeTask({
+      status: 'awaiting_approval',
+      execution: {
+        error: 'exit 1',
+        exitCode: 1,
+        pendingFixError: 'Approval blocked: capability mismatch',
+      },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={task}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('exit 1')).toBeInTheDocument();
+    expect(screen.getByTestId('inspector-pending-fix-error')).toHaveTextContent(
+      'Approval blocked: capability mismatch',
+    );
+  });
+
   it('shows selected action graph node details', () => {
     render(
       <WorkflowInspector

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -463,6 +463,17 @@ export function WorkflowInspector({
           {!task?.execution.error && task?.execution.exitCode !== undefined && task.execution.exitCode !== 0 && (
             <p className="mt-2 text-xs text-red-300">Exit code: {task.execution.exitCode}</p>
           )}
+          {task?.execution.pendingFixError && (
+            <div
+              data-testid="inspector-pending-fix-error"
+              className="mt-3 rounded border border-amber-500/40 bg-amber-950/40 p-2"
+            >
+              <h3 className="text-[11px] uppercase tracking-wide text-amber-200">Fix Error</h3>
+              <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100">
+                {task.execution.pendingFixError}
+              </pre>
+            </div>
+          )}
           {showApprovalActions && task && (
             <div className="mt-3 flex gap-2 border-t border-gray-700 pt-3">
               <button


### PR DESCRIPTION
## Summary

Depends on #3469 (slice 1: inspector renders `pendingFixError`).

Adds the `WorkflowMutationFailedEvent` interface next to `WorkflowMutationAcceptedResult`, and registers `invoker:workflow-mutation-failed` in `IpcEventChannels`.

The preload registry auto-derives `window.invoker.onWorkflowMutationFailed` from the new channel entry, so no preload code changes here.

Emitter and subscriber land in the follow-up slices; this slice is the shared vocabulary.

## Review Claim

Introduce the `WorkflowMutationFailedEvent` shape and the `invoker:workflow-mutation-failed` event channel entry.

## Review Lane

behavior

## Review Unit

contract

## Safety Invariant

The event registry is read-only at build time by preload. Adding an entry cannot change runtime behavior until a producer or consumer references it. TypeScript picks up the new derived method on `InvokerAPI`; call sites that do not use the method are unaffected.

## Slice Rationale

Follow-up slices land the emitter and the UI reader; both import this type from `@invoker/contracts`. Landing the vocabulary alone lets a reviewer confirm the interface fields (`intentId`, `workflowId`, `channel`, `taskId?`, `message`, `failedAt`) before evaluating the plumbing.

## Non-goals

- Does not add any emitter. `PersistedWorkflowMutationCoordinator` still catches silently.
- Does not add any reader in the UI layer.
- Does not rename or refactor `WorkflowMutationAcceptedResult`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/contracts && pnpm test` — 8 files / 87 tests pass.
- [x] `pnpm run check:types` — clean; the new interface flows through the derived `InvokerAPI` `EventMethods`.
- [x] `pnpm run check:comments` — clean.
- [x] `pnpm run check:large-files` — clean.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 01ad11747`
- Post-revert steps: None. The type surface is additive.
- Data migration? No.

</details>
