### PR TITLE
[Approve Fix Visibility](2b) Emit workflow-mutation-failed on coordinator throw

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1547,4 +1547,75 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(iterationsBeforeAbort).toBeGreaterThan(0);
     await expect(olderRunning).rejects.toThrow(/superseded by recreate intent/i);
   });
+
+  it('invokes onIntentFailed with intent metadata when the async handler throws', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const failureEvents: Array<{
+      intentId: number;
+      workflowId: string;
+      channel: string;
+      taskId?: string;
+      message: string;
+      failedAt: string;
+    }> = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async () => {
+        throw new Error('SSH target "remote_digital_ocean_3" cannot run codex');
+      },
+      {
+        onIntentFailed: (event) => {
+          failureEvents.push(event);
+        },
+      },
+    );
+
+    const attempt = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:approve', ['wf-1/task-alpha']);
+    await expect(attempt).rejects.toThrow(/cannot run codex/);
+
+    expect(failureEvents).toHaveLength(1);
+    const [event] = failureEvents;
+    expect(event.workflowId).toBe('wf-1');
+    expect(event.channel).toBe('invoker:approve');
+    expect(event.taskId).toBe('wf-1/task-alpha');
+    expect(event.intentId).toBeGreaterThan(0);
+    expect(event.message).toMatch(/cannot run codex/);
+    expect(typeof event.failedAt).toBe('string');
+    expect(Number.isFinite(Date.parse(event.failedAt))).toBe(true);
+  });
+
+  it('leaves onIntentFailed out of the successful-completion path', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const failureEvents: unknown[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async () => 'ok',
+      {
+        onIntentFailed: (event) => {
+          failureEvents.push(event);
+        },
+      },
+    );
+
+    await coordinator.enqueue<string>('wf-1', 'normal', 'invoker:approve', ['wf-1/task-alpha']);
+    expect(failureEvents).toEqual([]);
+  });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3513,7 +3513,13 @@ function createEmbeddedTerminalBackendFromConfig(
             activeMutationContext = undefined;
           }
         },
-        { logger },
+        {
+          logger,
+          onIntentFailed: (event) => {
+            if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) return;
+            mainWindow.webContents.send('invoker:workflow-mutation-failed', event);
+          },
+        },
       );
       launchDispatcher = new LaunchDispatcher({
         persistence,

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -4,8 +4,10 @@ import {
   type WorkflowMutationIntent,
   type WorkflowMutationPriority,
 } from '@invoker/data-store';
-import type { Logger } from '@invoker/contracts';
+import type { Logger, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import { createWorkflowMutationTiming, type WorkflowMutationTiming } from './workflow-mutation-timing.js';
+
+export type WorkflowMutationFailedHandler = (event: WorkflowMutationFailedEvent) => void;
 
 type Deferred<T> = {
   resolve: (value: T) => void;
@@ -62,7 +64,7 @@ export class PersistedWorkflowMutationCoordinator {
     private readonly persistence: SQLiteAdapter,
     private readonly ownerId: string,
     private readonly dispatch: (channel: string, args: unknown[], context: WorkflowMutationContext) => Promise<unknown>,
-    private readonly options?: { logger?: Logger },
+    private readonly options?: { logger?: Logger; onIntentFailed?: WorkflowMutationFailedHandler },
   ) {
     this.enableTraceLogs = process.env.INVOKER_TRACE_MUTATION_QUEUE === '1';
   }
@@ -309,6 +311,7 @@ export class PersistedWorkflowMutationCoordinator {
         durationMs: Date.now() - intentStartedAtMs,
         error: error instanceof Error ? error.message : String(error),
       });
+      this.notifyIntentFailed(intent, message);
       deferred?.reject(error);
     } finally {
       clearInterval(leaseHeartbeat);
@@ -329,6 +332,28 @@ export class PersistedWorkflowMutationCoordinator {
       return -1;
     }
     return Date.now() - startedAt;
+  }
+
+  private notifyIntentFailed(intent: WorkflowMutationIntent, message: string): void {
+    const handler = this.options?.onIntentFailed;
+    if (!handler) return;
+    const firstArg = intent.args?.[0];
+    const taskId = typeof firstArg === 'string' ? firstArg : undefined;
+    try {
+      handler({
+        intentId: intent.id,
+        workflowId: intent.workflowId,
+        channel: intent.channel,
+        taskId,
+        message,
+        failedAt: new Date().toISOString(),
+      });
+    } catch (notifyError) {
+      this.options?.logger?.warn?.('workflow-mutation-failed handler threw', {
+        module: 'persisted-workflow-mutation-coordinator',
+        error: notifyError instanceof Error ? notifyError.message : String(notifyError),
+      });
+    }
   }
 
   private trace(message: string): void {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -466,6 +466,15 @@ export interface WorkflowMutationAcceptedResult {
   channel: string;
 }
 
+export interface WorkflowMutationFailedEvent {
+  intentId: number;
+  workflowId: string;
+  channel: string;
+  taskId?: string;
+  message: string;
+  failedAt: string;
+}
+
 export interface CancelResult {
   cancelled: string[];
   runningCancelled: string[];
@@ -1078,6 +1087,9 @@ export const IpcEventChannels = {
   },
   'invoker:terminal-exit': {} as {
     payload: TerminalExitEvent;
+  },
+  'invoker:workflow-mutation-failed': {} as {
+    payload: WorkflowMutationFailedEvent;
   },
 } as const;
 

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -607,7 +607,67 @@ describe('WorkflowInspector', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Reject Fix' }));
     expect(onReject).toHaveBeenCalledWith(task);
+
+    expect(screen.getByTestId('inspector-pending-fix-error')).toHaveTextContent('tests failed');
   });
+
+  it('surfaces an executor-selection failure captured in pendingFixError so approve dispatch errors are visible', () => {
+    const capabilityError =
+      'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"';
+    const task = makeTask({
+      status: 'awaiting_approval',
+      execution: {
+        pendingFixError: capabilityError,
+      },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={task}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    const panel = screen.getByTestId('inspector-pending-fix-error');
+    expect(panel).toHaveTextContent(/cannot run codex/);
+    expect(panel).toHaveTextContent(/missing execution harness "codex"/);
+  });
+
+  it('renders pendingFixError alongside execution.error when both are present', () => {
+    const task = makeTask({
+      status: 'awaiting_approval',
+      execution: {
+        error: 'exit 1',
+        exitCode: 1,
+        pendingFixError: 'Approval blocked: capability mismatch',
+      },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={task}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('exit 1')).toBeInTheDocument();
+    expect(screen.getByTestId('inspector-pending-fix-error')).toHaveTextContent(
+      'Approval blocked: capability mismatch',
+    );
+  });
+
   it('shows selected action graph node details', () => {
     render(
       <WorkflowInspector

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -463,6 +463,17 @@ export function WorkflowInspector({
           {!task?.execution.error && task?.execution.exitCode !== undefined && task.execution.exitCode !== 0 && (
             <p className="mt-2 text-xs text-red-300">Exit code: {task.execution.exitCode}</p>
           )}
+          {task?.execution.pendingFixError && (
+            <div
+              data-testid="inspector-pending-fix-error"
+              className="mt-3 rounded border border-amber-500/40 bg-amber-950/40 p-2"
+            >
+              <h3 className="text-[11px] uppercase tracking-wide text-amber-200">Fix Error</h3>
+              <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100">
+                {task.execution.pendingFixError}
+              </pre>
+            </div>
+          )}
           {showApprovalActions && task && (
             <div className="mt-3 flex gap-2 border-t border-gray-700 pt-3">
               <button


### PR DESCRIPTION
## Summary

Depends on #3510 (slice 2a) which introduces the `WorkflowMutationFailedEvent` shape and the event channel entry.

`PersistedWorkflowMutationCoordinator` catches inside `executeIntent` and marks the persisted intent row as `failed`. It has no other outlet — the operator is left with a task stuck in `awaiting_approval` and no visible cause.

This slice fires the newly-declared `invoker:workflow-mutation-failed` message from that same catch, then `main.ts` forwards it to the renderer with the same guard used for terminal-output and workflows-changed sends.

The renderer subscriber lands in slice (2c); this slice is the plumbing.

## Review Claim

Emit `WorkflowMutationFailedEvent` from the coordinator's async catch and forward it to the renderer channel.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The catch block already logged and persisted the failure via `failWorkflowMutationIntent`. Adding a callback plus a guarded `webContents.send` inside the same catch does not change persistence, the dispatcher, or the queued-intent lifecycle. The callback is wrapped in try/catch and its errors are logged only, so the persistence path stays authoritative.

## Slice Rationale

Landing the emit path alone keeps the diff auditable. A reviewer can confirm that (a) the emit runs only when `executeIntent` catches, (b) the guarded `webContents.send` matches the existing terminal-output/workflows-changed pattern, and (c) the persisted `failWorkflowMutationIntent` write remains the source of truth. The renderer read lands separately in (2c) so a bug in the UI banner cannot mask the persistence guarantees this slice preserves.

## Non-goals

- Does not modify `TaskRunner.selectExecutor` or capability resolution. Users with capability-mismatched SSH targets still need to fix config, reject the fix, or reassign the task, with no change to that mechanism.
- Does not change the `WorkflowMutationAcceptedResult` synchronous shape. `invoker.approve` still resolves immediately with the accepted result.
- Does not remove the SQLite `workflow_mutation_intents.error` write.
- Does not add any UI. The renderer subscriber lands in slice (2c).

## Visual Proof

This slice is not directly visible — it only sends a message to a channel that has no subscriber until slice (2c) lands. The end-to-end effect (with the reader from 2c) is captured at:

![Amber alert at the top of the app rendered from the workflow-mutation-failed message that slice (2b) sends](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-15ea8b/workflow-mutation-failed-banner.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/persisted-workflow-mutation-coordinator.test.ts` — 36 tests pass. Two new tests: the emit-on-throw path asserts `intentId`, `workflowId`, `channel`, `taskId`, `message`, and `failedAt`; the leave-alone-on-success path asserts the handler is not invoked when `executeIntent` resolves.
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/persisted-workflow-mutation-coordinator.test.ts src/__tests__/workflow-mutation-coordinator.test.ts src/__tests__/workflow-mutation-facade.test.ts src/__tests__/workflow-mutation-submit.test.ts src/__tests__/workflow-mutation-timing.test.ts src/__tests__/workflow-mutation-startup.test.ts` — 71 tests pass.
- [x] `pnpm run check:types` — clean.
- [x] `pnpm run check:comments` — clean.
- [x] `pnpm run check:large-files` — clean.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert a0177186c`
- Post-revert steps: None. The coordinator falls back to catch-log-persist; nothing downstream depends on the send yet.
- Data migration? No. `workflow_mutation_intents.error` is unchanged.

</details>
