### PR TITLE
[Approve Fix Visibility](2c) Render workflow-mutation-failed banner in App

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1547,4 +1547,75 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(iterationsBeforeAbort).toBeGreaterThan(0);
     await expect(olderRunning).rejects.toThrow(/superseded by recreate intent/i);
   });
+
+  it('invokes onIntentFailed with intent metadata when the async handler throws', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const failureEvents: Array<{
+      intentId: number;
+      workflowId: string;
+      channel: string;
+      taskId?: string;
+      message: string;
+      failedAt: string;
+    }> = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async () => {
+        throw new Error('SSH target "remote_digital_ocean_3" cannot run codex');
+      },
+      {
+        onIntentFailed: (event) => {
+          failureEvents.push(event);
+        },
+      },
+    );
+
+    const attempt = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:approve', ['wf-1/task-alpha']);
+    await expect(attempt).rejects.toThrow(/cannot run codex/);
+
+    expect(failureEvents).toHaveLength(1);
+    const [event] = failureEvents;
+    expect(event.workflowId).toBe('wf-1');
+    expect(event.channel).toBe('invoker:approve');
+    expect(event.taskId).toBe('wf-1/task-alpha');
+    expect(event.intentId).toBeGreaterThan(0);
+    expect(event.message).toMatch(/cannot run codex/);
+    expect(typeof event.failedAt).toBe('string');
+    expect(Number.isFinite(Date.parse(event.failedAt))).toBe(true);
+  });
+
+  it('leaves onIntentFailed out of the successful-completion path', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const failureEvents: unknown[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async () => 'ok',
+      {
+        onIntentFailed: (event) => {
+          failureEvents.push(event);
+        },
+      },
+    );
+
+    await coordinator.enqueue<string>('wf-1', 'normal', 'invoker:approve', ['wf-1/task-alpha']);
+    expect(failureEvents).toEqual([]);
+  });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3513,7 +3513,13 @@ function createEmbeddedTerminalBackendFromConfig(
             activeMutationContext = undefined;
           }
         },
-        { logger },
+        {
+          logger,
+          onIntentFailed: (event) => {
+            if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) return;
+            mainWindow.webContents.send('invoker:workflow-mutation-failed', event);
+          },
+        },
       );
       launchDispatcher = new LaunchDispatcher({
         persistence,

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -4,8 +4,10 @@ import {
   type WorkflowMutationIntent,
   type WorkflowMutationPriority,
 } from '@invoker/data-store';
-import type { Logger } from '@invoker/contracts';
+import type { Logger, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import { createWorkflowMutationTiming, type WorkflowMutationTiming } from './workflow-mutation-timing.js';
+
+export type WorkflowMutationFailedHandler = (event: WorkflowMutationFailedEvent) => void;
 
 type Deferred<T> = {
   resolve: (value: T) => void;
@@ -62,7 +64,7 @@ export class PersistedWorkflowMutationCoordinator {
     private readonly persistence: SQLiteAdapter,
     private readonly ownerId: string,
     private readonly dispatch: (channel: string, args: unknown[], context: WorkflowMutationContext) => Promise<unknown>,
-    private readonly options?: { logger?: Logger },
+    private readonly options?: { logger?: Logger; onIntentFailed?: WorkflowMutationFailedHandler },
   ) {
     this.enableTraceLogs = process.env.INVOKER_TRACE_MUTATION_QUEUE === '1';
   }
@@ -309,6 +311,7 @@ export class PersistedWorkflowMutationCoordinator {
         durationMs: Date.now() - intentStartedAtMs,
         error: error instanceof Error ? error.message : String(error),
       });
+      this.notifyIntentFailed(intent, message);
       deferred?.reject(error);
     } finally {
       clearInterval(leaseHeartbeat);
@@ -329,6 +332,28 @@ export class PersistedWorkflowMutationCoordinator {
       return -1;
     }
     return Date.now() - startedAt;
+  }
+
+  private notifyIntentFailed(intent: WorkflowMutationIntent, message: string): void {
+    const handler = this.options?.onIntentFailed;
+    if (!handler) return;
+    const firstArg = intent.args?.[0];
+    const taskId = typeof firstArg === 'string' ? firstArg : undefined;
+    try {
+      handler({
+        intentId: intent.id,
+        workflowId: intent.workflowId,
+        channel: intent.channel,
+        taskId,
+        message,
+        failedAt: new Date().toISOString(),
+      });
+    } catch (notifyError) {
+      this.options?.logger?.warn?.('workflow-mutation-failed handler threw', {
+        module: 'persisted-workflow-mutation-coordinator',
+        error: notifyError instanceof Error ? notifyError.message : String(notifyError),
+      });
+    }
   }
 
   private trace(message: string): void {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -466,6 +466,15 @@ export interface WorkflowMutationAcceptedResult {
   channel: string;
 }
 
+export interface WorkflowMutationFailedEvent {
+  intentId: number;
+  workflowId: string;
+  channel: string;
+  taskId?: string;
+  message: string;
+  failedAt: string;
+}
+
 export interface CancelResult {
   cancelled: string[];
   runningCancelled: string[];
@@ -1078,6 +1087,9 @@ export const IpcEventChannels = {
   },
   'invoker:terminal-exit': {} as {
     payload: TerminalExitEvent;
+  },
+  'invoker:workflow-mutation-failed': {} as {
+    payload: WorkflowMutationFailedEvent;
   },
 } as const;
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect, type RefObject } from 'react';
 import yaml from 'js-yaml';
-import type { ActionGraphNode, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor } from '@invoker/contracts';
+import type { ActionGraphNode, InAppPlanningSessionStatus, InAppPlanningSessionSummary, InvokerSetupRequest, InvokerSetupResult, ReviewGateQueryResponse, RuntimeStatus, TerminalSessionDescriptor, WorkflowMutationFailedEvent } from '@invoker/contracts';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { SidebarSurface } from './lib/workflow-progress-surfaces.js';
 import { useTasks } from './hooks/useTasks.js';
@@ -564,6 +564,7 @@ export function App() {
   const [systemDiagnostics, setSystemDiagnostics] = useState<SystemDiagnostics | null>(null);
   const [showSystemSetup, setShowSystemSetup] = useState(false);
   const [showSystemBanner, setShowSystemBanner] = useState(false);
+  const [mutationFailure, setMutationFailure] = useState<WorkflowMutationFailedEvent | null>(null);
   const [installSkillsPending, setInstallSkillsPending] = useState(false);
   const [installSkillsError, setInstallSkillsError] = useState<string | null>(null);
   const [updateCliPending, setUpdateCliPending] = useState(false);
@@ -698,6 +699,13 @@ export function App() {
             : session,
         ),
       );
+    });
+    return () => { unsubscribe?.(); };
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = window.invoker?.onWorkflowMutationFailed?.((event) => {
+      setMutationFailure(event);
     });
     return () => { unsubscribe?.(); };
   }, []);
@@ -2975,6 +2983,55 @@ export function App() {
         >
           <span className="font-semibold text-blue-50">Read-only mode.</span>{' '}
           This window can browse workflows, but it cannot make changes until the write owner is available.
+        </div>
+      )}
+      {mutationFailure && (
+        <div
+          role="alert"
+          aria-live="assertive"
+          data-testid="workflow-mutation-failed-banner"
+          className="px-4 py-3 border-b border-amber-700 bg-amber-950/60 flex items-start justify-between gap-4"
+        >
+          <div className="text-sm text-amber-100 min-w-0">
+            <div className="font-semibold text-amber-50">
+              {mutationFailure.channel === 'invoker:approve'
+                ? 'Approve failed'
+                : mutationFailure.channel === 'invoker:reject'
+                  ? 'Reject failed'
+                  : `Mutation failed (${mutationFailure.channel})`}
+            </div>
+            <div
+              data-testid="workflow-mutation-failed-message"
+              className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100/90"
+            >
+              {mutationFailure.message}
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {mutationFailure.taskId && tasks.get(mutationFailure.taskId) && (
+              <button
+                type="button"
+                onClick={() => {
+                  const targetTaskId = mutationFailure.taskId;
+                  if (!targetTaskId) return;
+                  selectTaskById(targetTaskId);
+                  setMutationFailure(null);
+                }}
+                data-testid="workflow-mutation-failed-open-task"
+                className="px-3 py-1.5 bg-amber-600 hover:bg-amber-500 text-white rounded text-xs font-medium transition-colors"
+              >
+                Open task
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={() => setMutationFailure(null)}
+              data-testid="workflow-mutation-failed-dismiss"
+              className="px-2 py-1 text-amber-200 hover:text-white text-xs"
+            >
+              Dismiss
+            </button>
+          </div>
         </div>
       )}
 

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -16,7 +16,7 @@ import type {
   TaskConfig,
   TaskExecution,
 } from '../../types.js';
-import type { ActionGraphResponse, InAppPlanningSessionSummary, RuntimeStatus, TerminalOutputEvent, WorkerStatusEntry, WorkerStatusSnapshot, WorkflowMutationAcceptedResult } from '@invoker/contracts';
+import type { ActionGraphResponse, InAppPlanningSessionSummary, RuntimeStatus, TerminalOutputEvent, WorkerStatusEntry, WorkerStatusSnapshot, WorkflowMutationAcceptedResult, WorkflowMutationFailedEvent } from '@invoker/contracts';
 
 export interface MockInvoker {
   /** The mock InvokerAPI object installed on window.invoker. */
@@ -31,6 +31,8 @@ export interface MockInvoker {
   fireWorkflowsChanged: (workflows: WorkflowMeta[]) => void;
   /** Fire an embedded terminal output event to subscribers. */
   fireTerminalOutput: (event: TerminalOutputEvent) => void;
+  /** Fire a workflow-mutation-failed event to subscribers. */
+  fireWorkflowMutationFailed: (event: WorkflowMutationFailedEvent) => void;
   /** Replace the action graph snapshot returned by getActionGraph. */
   setActionGraph: (response: ActionGraphResponse) => void;
   /** Replace the runtime status returned by getRuntimeStatus. */
@@ -89,6 +91,7 @@ export function createMockInvoker(
   let graphEventCallback: ((event: TaskGraphEvent) => void) | undefined;
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
   const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
+  const workflowMutationFailedCallbacks = new Set<(event: WorkflowMutationFailedEvent) => void>();
   let actionGraphSnapshot: ActionGraphResponse = {
     generatedAt: '2026-01-01T00:00:00.000Z',
     stallThresholdMs: 60_000,
@@ -278,6 +281,10 @@ export function createMockInvoker(
       return () => { terminalOutputCallbacks.delete(cb); };
     }),
     onTerminalExit: vi.fn(() => () => {}),
+    onWorkflowMutationFailed: vi.fn((cb: (event: WorkflowMutationFailedEvent) => void) => {
+      workflowMutationFailedCallbacks.add(cb);
+      return () => { workflowMutationFailedCallbacks.delete(cb); };
+    }),
     resumeWorkflow: vi.fn(async () => null),
     listWorkflows: vi.fn(async () => workflowSnapshot),
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),
@@ -370,6 +377,12 @@ export function createMockInvoker(
     }
   }
 
+  function fireWorkflowMutationFailed(event: WorkflowMutationFailedEvent) {
+    for (const callback of workflowMutationFailedCallbacks) {
+      callback(event);
+    }
+  }
+
   function install() {
     (window as unknown as { invoker: InvokerAPI }).invoker = api;
     (window as unknown as { __INVOKER_BOOTSTRAP__?: { tasks: TaskState[]; workflows: WorkflowMeta[]; runtimeStatus?: RuntimeStatus } }).__INVOKER_BOOTSTRAP__ = {
@@ -383,6 +396,7 @@ export function createMockInvoker(
     delete (window as unknown as { invoker?: InvokerAPI }).invoker;
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
     terminalOutputCallbacks.clear();
+    workflowMutationFailedCallbacks.clear();
   }
 
   return {
@@ -395,6 +409,7 @@ export function createMockInvoker(
     fireGraphEvent,
     fireWorkflowsChanged,
     fireTerminalOutput,
+    fireWorkflowMutationFailed,
     install,
     cleanup,
   };

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -607,7 +607,67 @@ describe('WorkflowInspector', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Reject Fix' }));
     expect(onReject).toHaveBeenCalledWith(task);
+
+    expect(screen.getByTestId('inspector-pending-fix-error')).toHaveTextContent('tests failed');
   });
+
+  it('surfaces an executor-selection failure captured in pendingFixError so approve dispatch errors are visible', () => {
+    const capabilityError =
+      'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"';
+    const task = makeTask({
+      status: 'awaiting_approval',
+      execution: {
+        pendingFixError: capabilityError,
+      },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={task}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    const panel = screen.getByTestId('inspector-pending-fix-error');
+    expect(panel).toHaveTextContent(/cannot run codex/);
+    expect(panel).toHaveTextContent(/missing execution harness "codex"/);
+  });
+
+  it('renders pendingFixError alongside execution.error when both are present', () => {
+    const task = makeTask({
+      status: 'awaiting_approval',
+      execution: {
+        error: 'exit 1',
+        exitCode: 1,
+        pendingFixError: 'Approval blocked: capability mismatch',
+      },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={task}
+        collapsed={false}
+        advancedExpanded={false}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('exit 1')).toBeInTheDocument();
+    expect(screen.getByTestId('inspector-pending-fix-error')).toHaveTextContent(
+      'Approval blocked: capability mismatch',
+    );
+  });
+
   it('shows selected action graph node details', () => {
     render(
       <WorkflowInspector

--- a/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
+++ b/packages/ui/src/__tests__/workflow-mutation-failed-banner.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Integration test: workflow-mutation-failed banner in <App />.
+ *
+ * Reproduces the "Approve Fix does nothing" symptom by firing the
+ * onWorkflowMutationFailed event that the owner-side coordinator now emits when
+ * an intent dispatch throws. The renderer must surface the failure so the user
+ * knows the mutation did not actually run.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+const targetTask = makeUITask({
+  id: 'wf-1/verify-worker-summary-surface',
+  description: 'Verify worker summary surface',
+  status: 'awaiting_approval',
+  workflowId: 'wf-1',
+});
+
+const workflow: WorkflowMeta = {
+  id: 'wf-1',
+  name: 'Local test plan',
+  status: 'running',
+};
+
+describe('Workflow mutation failed banner', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('renders an alert with the coordinator message when onWorkflowMutationFailed fires', async () => {
+    render(<App />);
+    act(() => mock.setTasks([targetTask], [workflow]));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
+    });
+
+    act(() => {
+      mock.fireWorkflowMutationFailed({
+        intentId: 42,
+        workflowId: 'wf-1',
+        channel: 'invoker:approve',
+        taskId: 'wf-1/verify-worker-summary-surface',
+        message: 'Error: SSH target "remote_digital_ocean_3" cannot run codex: missing execution harness "codex"',
+        failedAt: '2026-07-08T10:00:00.000Z',
+      });
+    });
+
+    const banner = await screen.findByTestId('workflow-mutation-failed-banner');
+    expect(banner).toHaveAttribute('role', 'alert');
+    expect(banner).toHaveTextContent('Approve failed');
+    expect(screen.getByTestId('workflow-mutation-failed-message')).toHaveTextContent(
+      /missing execution harness "codex"/,
+    );
+  });
+
+  it('clears the banner when Dismiss is clicked', async () => {
+    render(<App />);
+    act(() => mock.setTasks([targetTask], [workflow]));
+
+    act(() => {
+      mock.fireWorkflowMutationFailed({
+        intentId: 43,
+        workflowId: 'wf-1',
+        channel: 'invoker:approve',
+        taskId: 'wf-1/verify-worker-summary-surface',
+        message: 'dispatch blew up',
+        failedAt: '2026-07-08T10:00:00.000Z',
+      });
+    });
+
+    const banner = await screen.findByTestId('workflow-mutation-failed-banner');
+    expect(banner).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId('workflow-mutation-failed-dismiss'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
+    });
+  });
+
+  it('selects the failing task when the operator clicks Open task', async () => {
+    render(<App />);
+    act(() => mock.setTasks([targetTask], [workflow]));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-1')).toBeInTheDocument();
+    });
+
+    act(() => {
+      mock.fireWorkflowMutationFailed({
+        intentId: 44,
+        workflowId: 'wf-1',
+        channel: 'invoker:approve',
+        taskId: 'wf-1/verify-worker-summary-surface',
+        message: 'dispatch blew up',
+        failedAt: '2026-07-08T10:00:00.000Z',
+      });
+    });
+
+    const openTask = await screen.findByTestId('workflow-mutation-failed-open-task');
+    fireEvent.click(openTask);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('workflow-mutation-failed-banner')).not.toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Verify worker summary surface');
+    });
+  });
+
+  it('labels the banner "Mutation failed (invoker:reject)" when the channel is not approve', async () => {
+    render(<App />);
+    act(() => mock.setTasks([targetTask], [workflow]));
+
+    act(() => {
+      mock.fireWorkflowMutationFailed({
+        intentId: 45,
+        workflowId: 'wf-1',
+        channel: 'invoker:edit-task-command',
+        taskId: 'wf-1/verify-worker-summary-surface',
+        message: 'edit failed',
+        failedAt: '2026-07-08T10:00:00.000Z',
+      });
+    });
+
+    const banner = await screen.findByTestId('workflow-mutation-failed-banner');
+    expect(banner).toHaveTextContent('Mutation failed (invoker:edit-task-command)');
+  });
+});

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -463,6 +463,17 @@ export function WorkflowInspector({
           {!task?.execution.error && task?.execution.exitCode !== undefined && task.execution.exitCode !== 0 && (
             <p className="mt-2 text-xs text-red-300">Exit code: {task.execution.exitCode}</p>
           )}
+          {task?.execution.pendingFixError && (
+            <div
+              data-testid="inspector-pending-fix-error"
+              className="mt-3 rounded border border-amber-500/40 bg-amber-950/40 p-2"
+            >
+              <h3 className="text-[11px] uppercase tracking-wide text-amber-200">Fix Error</h3>
+              <pre className="mt-1 whitespace-pre-wrap break-words font-mono text-xs text-amber-100">
+                {task.execution.pendingFixError}
+              </pre>
+            </div>
+          )}
           {showApprovalActions && task && (
             <div className="mt-3 flex gap-2 border-t border-gray-700 pt-3">
               <button


### PR DESCRIPTION
## Summary

Depends on #3511 (slice 2b) which fires `invoker:workflow-mutation-failed` from the owner-side catch.

`App.tsx` subscribes via `window.invoker.onWorkflowMutationFailed`, holds the most recent failure in a state slot, and paints a top-of-viewport amber alert with the coordinator message so the operator sees the real reason the click did not run.

The Open task button calls `selectTaskById` when the task id is known to the current task map. The Dismiss button clears state. The alert sits under the read-only banner so the read-only affordance still reads first.

The operator now sees the SSH-target-cannot-run-codex message immediately instead of a silent stuck-in-awaiting-approval state.

## Review Claim

Render the workflow-mutation-failed alert in `App.tsx` when the owner emits an intent failure.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The alert is additive read-only DOM. It never blocks input, never touches persistence, and never issues an IPC. The subscription is cleaned up on unmount. When `taskId` is not in the current task map, the Open task button is omitted, so the click cannot select a task the app does not know about.

## Slice Rationale

Landing the reader alone lets a reviewer confirm the DOM layout, the state lifecycle, and the click handlers against the already-emitting producer that landed in (2b). Because both the producer and the reader are needed for the operator to see anything, keeping them separate is the smallest reviewable unit per surface.

## Non-goals

- Does not modify `TaskRunner.selectExecutor` or capability resolution.
- Does not modify `invoker.approve` result handling in `App.tsx`. The synchronous accepted-result path is unchanged.
- Does not persist alert state across window reloads. A reload clears it, which matches other in-memory affordances.
- Does not add a system tray or notification-center integration.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/workflow-mutation-failed-banner.test.tsx` — 4 new tests: appear on event, dismiss clears, open-task selects the failing task, non-approve channels show `Mutation failed (<channel>)`.
- [x] `cd packages/ui && pnpm test` — 55 files / 603 tests pass.
- [x] `pnpm run check:types` — clean.
- [x] `pnpm run check:comments` — clean.
- [x] `pnpm run check:large-files` — clean.
- [x] `bash scripts/ui-visual-proof.sh capture-after` — captured on this branch with a helper test that seeds the state via a test-only IPC. See Visual Proof.

</details>

## Visual Proof

Captured via `bash scripts/ui-visual-proof.sh capture-after` on this branch. A one-off Playwright case fires the `invoker:workflow-mutation-failed` event with the exact SSH-target-cannot-run-codex message that surfaced the underlying bug.

![Amber alert at the top of the app: bold "Approve failed" title on the left with the SSH-target-cannot-run-codex message in monospace, and a Dismiss button on the right. Below: the Invoker sidebar, plan graph, and workflow inspector for the awaiting-approval task](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-ffb2b3/workflow-mutation-failed-banner.png)

On `master` the same failed click produces no visible affordance in the UI at all; the operator has to inspect the SQLite `workflow_mutation_intents.error` row to see the message.

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert 9a9b7ba56`
- Post-revert steps: None. The DOM is additive.
- Data migration? No.

</details>
