### PR TITLE
[UI modal approval fixes](1) Repro: Approve Merge button label mismatches heading

### DIFF
--- a/packages/ui/src/__tests__/approval-modal.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal.test.tsx
@@ -849,6 +849,27 @@ describe('ApprovalModal', () => {
     expect(screen.getByText('Confirm Merge')).toBeInTheDocument();
   });
 
+  // Repro: the modal heading says "Confirm Merge" but the primary button on
+  // master still says "Approve Merge". The two labels drift, which is
+  // misleading because clicking the button triggers an immediate destructive
+  // merge (matching the heading, not the button). Marked `.fails` so CI stays
+  // green until the fix slice flips it.
+  it.fails(
+    'shows a "Confirm Merge" *button* matching the heading for onFinish="merge"',
+    () => {
+      render(
+        <ApprovalModal
+          task={makeTask({ config: { isMergeNode: true } })}
+          onApprove={vi.fn()}
+          onReject={vi.fn()}
+          onClose={vi.fn()}
+          onFinish="merge"
+        />,
+      );
+      expect(screen.getByRole('button', { name: 'Confirm Merge' })).toBeInTheDocument();
+    },
+  );
+
   it('shows "Confirm Create PR" button label for merge node with onFinish="pull_request"', () => {
     render(
       <ApprovalModal


### PR DESCRIPTION
## Summary

Land the failing regression assertion for the Approve Merge button-label mismatch as a standalone slice, ahead of the fix.

The `ApprovalModal` heading says "Confirm Merge" for workflows with `onFinish='merge'` but the primary button still reads "Approve Merge". This slice adds a strict `getByRole('button', { name: 'Confirm Merge' })` expectation.

The new assertion is marked `it.fails` so it stays green on CI today. The next slice (2) removes the marker after fixing `approveButtonLabel`.

## Review Claim

The strict button-label expectation for `onFinish='merge'` fails on master; this slice makes that gap explicit as a regression test.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. Product code is unchanged and CI stays green because `it.fails` swallows the assertion failure until the fix slice flips it.

## Slice Rationale

Evidence-before-change per the review-compression skill: the strict expectation lands as its own slice so a reviewer can approve the regression proof independently from the behavior change that follows.

## Non-goals

- Does not change any product code.
- Does not touch `ApprovalModal.tsx` or any other component.
- Does not add or modify visual proof capture harnesses.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test -- --run approval-modal`

</details>

## Visual Proof

Screenshot from the state this proof is asserting against — heading says "Confirm Merge" while the primary button still reads "Approve Merge":

![Approve Merge modal on master](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-fe8282/approve-merge-modal-master.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
