### PR TITLE
[worker-decision-ledger](6) e2e proof: capture the worker-decisions panel

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -18,6 +18,7 @@ import {
   captureScreenshot,
   assertPageScreenshot,
   getTasks,
+  injectWorkerActions,
   E2E_REPO_URL,
 } from './fixtures/electron-app.js';
 import * as fs from 'node:fs/promises';
@@ -2385,5 +2386,30 @@ test.describe('Visual proof capture', () => {
     await expect(miniDag.locator('.react-flow__node[data-testid$="task-alpha"]')).toBeVisible();
     await expect(miniDag.locator('.react-flow__node[data-testid$="task-beta"]')).toBeVisible();
     await captureScreenshot(page, 'task-graph-keyboard-controls-selected');
+  });
+
+  test('worker decisions - Workers tab decisions panel', async ({ page }) => {
+    await page.setViewportSize({ width: 1200, height: 771 });
+    await injectWorkerActions(page, [
+      { id: 'wd-act-1', workerKind: 'autofix', actionType: 'auto-fix', subjectType: 'task', subjectId: 'wf-42/build-api', externalKey: 'autofix:wf-42/build-api:1:a1', status: 'queued', attemptCount: 1, agentName: 'claude', summary: 'Queued auto-fix with agent', payload: { channel: 'invoker:fix-with-agent' } },
+      { id: 'wd-skip-1', workerKind: 'autofix', actionType: 'auto-fix', subjectType: 'task', subjectId: 'wf-42/migrate-db', externalKey: 'autofix:wf-42/migrate-db:1:a2', status: 'skipped', summary: 'Skipped auto-fix: worker-retry-budget-exhausted', payload: { reason: 'worker-retry-budget-exhausted' } },
+      { id: 'wd-skip-2', workerKind: 'autofix', actionType: 'auto-fix', subjectType: 'task', subjectId: 'wf-42/lint-fix', externalKey: 'autofix:wf-42/lint-fix:1:a3', status: 'skipped', summary: 'Skipped auto-fix: not-eligible', payload: { reason: 'not-eligible' } },
+      { id: 'wd-act-2', workerKind: 'autofix', actionType: 'auto-fix', subjectType: 'task', subjectId: 'wf-42/typecheck', externalKey: 'autofix:wf-42/typecheck:2:a4', status: 'queued', attemptCount: 2, agentName: 'codex', summary: 'Queued auto-fix with agent' },
+    ]);
+
+    await page.getByTestId('sidebar-workers').click();
+    await expect(page.getByTestId('worker-processes-section')).toBeVisible();
+    await expect(page.getByTestId('worker-row-autofix')).toBeVisible();
+
+    const showDetails = page.getByRole('button', { name: 'Show details' });
+    if (await showDetails.count()) {
+      await showDetails.first().click();
+    }
+
+    await expect(page.getByTestId('worker-decisions-section')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('worker-decision-row').first()).toBeVisible({ timeout: 15000 });
+    await expect(page.getByTestId('worker-decision-row')).toHaveCount(4);
+
+    await captureScreenshot(page, 'worker-decisions-e2e');
   });
 });


### PR DESCRIPTION
## Summary

Prove the Workers-tab decisions panel with a real end-to-end capture.

The case seeds decisions through the test IPC, opens the actual panel, asserts the rows, and snapshots it.

So the visual-proof tooling and the merge gate can regenerate the shot on demand.

## Review Claim

Add an end-to-end case that captures the real Workers-tab decisions panel.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only; adds no product code and changes no runtime behavior.

## Slice Rationale

The capture is proof; it stays out of the runtime seeding slice it depends on.

## Non-goals

No product code. Does not change the panel or the seeding hook.

## Visual Proof

The panel this case captures, from the running app:

![Workers-tab decisions panel captured end-to-end](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-1d9da3/worker-decisions-e2e.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/app && CAPTURE_MODE=after pnpm exec playwright test visual-proof.spec.ts -g "worker decisions"`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
