### PR TITLE
[UI approval reject-label](1) Repro: reject button label mismatches PR gate

### DIFF
--- a/packages/ui/src/__tests__/approval-modal.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal.test.tsx
@@ -861,4 +861,36 @@ describe('ApprovalModal', () => {
     );
     expect(screen.getByText('Confirm Create PR')).toBeInTheDocument();
   });
+
+  // ── Bug 3 repro: reject-button label does not reflect onFinish ──────────
+  // Heading and approve button branch on onFinish (Confirm Pull Request /
+  // Confirm Create PR), but the reject button stays "Reject Merge" for a
+  // pull_request gate. The user is rejecting a PR-creation confirmation,
+  // not a merge, so the label reads wrong.
+  it.fails('reject button says "Reject PR" (not "Reject Merge") for onFinish="pull_request"', () => {
+    render(
+      <ApprovalModal
+        task={makeTask({ config: { isMergeNode: true } })}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onClose={vi.fn()}
+        onFinish="pull_request"
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Reject PR' })).toBeInTheDocument();
+  });
+
+  it.fails('confirm-reject button says "Confirm Reject PR" for onFinish="pull_request"', () => {
+    render(
+      <ApprovalModal
+        task={makeTask({ config: { isMergeNode: true } })}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onClose={vi.fn()}
+        onFinish="pull_request"
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /reject/i }));
+    expect(screen.getByRole('button', { name: 'Confirm Reject PR' })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

Land the failing regression tests for the ApprovalModal reject-button label mismatch as a standalone slice, ahead of the fix.

When `onFinish='pull_request'`, the modal heading already reads "Confirm Pull Request" and the approve button reads "Confirm Create PR". But both reject buttons still read "Reject Merge" and "Confirm Reject Merge".

Two `getByRole('button', { name })` assertions target the reject and confirm-reject buttons directly. Both are `it.fails`-marked so CI stays green until the fix slice lands.

## Review Claim

Two `it.fails`-marked assertions demonstrate the ApprovalModal reject button label ignores `onFinish` for pull_request gates.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. Product code is untouched and CI stays green because `it.fails` swallows the assertion failures.

## Slice Rationale

Evidence-before-change per the review-compression skill. Kept separate from the fix so each slice carries exactly one review claim.

## Non-goals

- Does not modify `ApprovalModal.tsx`.
- Does not change label wording for `onFinish='merge'` or undefined `onFinish`.
- Does not touch the approve-button branch.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test -- --run approval-modal`

</details>

## Visual Proof

Reference screenshot of the ApprovalModal open on a merge-gate task. The two new `it.fails` assertions target the same secondary-button element visible below (currently reading the master-branch labels):

![ApprovalModal open on a merge-gate task showing master-branch secondary-button labels](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-fe8282/approve-merge-modal-master.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
