### PR TITLE
[UI approval reject-label](2) Fix reject button label for PR gate

### DIFF
--- a/packages/ui/src/__tests__/approval-modal.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal.test.tsx
@@ -883,12 +883,7 @@ describe('ApprovalModal', () => {
     expect(screen.getByText('Confirm Create PR')).toBeInTheDocument();
   });
 
-  // ── Bug 3 repro: reject-button label does not reflect onFinish ──────────
-  // Heading and approve button branch on onFinish (Confirm Pull Request /
-  // Confirm Create PR), but the reject button stays "Reject Merge" for a
-  // pull_request gate. The user is rejecting a PR-creation confirmation,
-  // not a merge, so the label reads wrong.
-  it.fails('reject button says "Reject PR" (not "Reject Merge") for onFinish="pull_request"', () => {
+  it('reject button says "Reject PR" (not "Reject Merge") for onFinish="pull_request"', () => {
     render(
       <ApprovalModal
         task={makeTask({ config: { isMergeNode: true } })}
@@ -901,7 +896,7 @@ describe('ApprovalModal', () => {
     expect(screen.getByRole('button', { name: 'Reject PR' })).toBeInTheDocument();
   });
 
-  it.fails('confirm-reject button says "Confirm Reject PR" for onFinish="pull_request"', () => {
+  it('confirm-reject button says "Confirm Reject PR" for onFinish="pull_request"', () => {
     render(
       <ApprovalModal
         task={makeTask({ config: { isMergeNode: true } })}

--- a/packages/ui/src/components/ApprovalModal.tsx
+++ b/packages/ui/src/components/ApprovalModal.tsx
@@ -179,9 +179,12 @@ export function ApprovalModal({
         : 'Approve Merge'
       : 'Approve';
 
+  const mergeRejectLabel = onFinish === 'pull_request' ? 'Reject PR' : 'Reject Merge';
+  const mergeConfirmRejectLabel =
+    onFinish === 'pull_request' ? 'Confirm Reject PR' : 'Confirm Reject Merge';
   const rejectButtonLabel = showRejectInput
-    ? (isFixApproval ? 'Confirm Reject Fix' : isMergeNode ? 'Confirm Reject Merge' : 'Confirm Reject')
-    : (isFixApproval ? 'Reject Fix' : isMergeNode ? 'Reject Merge' : 'Reject');
+    ? (isFixApproval ? 'Confirm Reject Fix' : isMergeNode ? mergeConfirmRejectLabel : 'Confirm Reject')
+    : (isFixApproval ? 'Reject Fix' : isMergeNode ? mergeRejectLabel : 'Reject');
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">


### PR DESCRIPTION
## Summary

Add the missing `onFinish='pull_request'` branch to the ApprovalModal's dismiss-button label. The button pair now matches the "Confirm Pull Request" heading and "Confirm Create PR" primary button.

Flip the two `.fails`-marked repro tests from the previous slice to plain `it(...)` calls; they now assert the fixed behavior.

The change is scoped to the pull_request branch only: `onFinish='merge'` and undefined `onFinish` keep their existing labels.

## Review Claim

When `onFinish='pull_request'`, the ApprovalModal's dismiss-button pair reads consistently with the heading and primary button.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The change is scoped to the merge-node branch on the dismiss-button label, and only for `onFinish='pull_request'`. Other cases (fix approval, plain approval, merge gate, undefined `onFinish`) keep their existing labels. No new IPC calls, no persistence changes.

## Slice Rationale

Behavior fix that flips the previously landed `.fails` repros to green. Kept separate from the proof slice so each slice carries a single review claim.

## Non-goals

- Does not touch the primary-button label branch.
- Does not modify the heading text.
- Does not change `TaskPanel` or `WorkflowInspector` labels (those lack `onFinish` context in scope; called out for future work).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test -- --run approval-modal`

</details>

## Visual Proof

Reference screenshot of the ApprovalModal open on a pull_request gate. The corrected dismiss-button labels now match the heading and primary button:

![ApprovalModal with pull_request gate showing corrected dismiss-button label](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-fe8282/approve-merge-modal-branch.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
