### PR TITLE
[DO e2e auto-fix](1) twice-daily worker that submits fixes through Invoker

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only && node scripts/fix-node-pty-spawn-helper.mjs",
-    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-ci-workflow-merge-queue-policy.mjs && node scripts/test-review-unit-classification.mjs && bash scripts/workspace-test.sh",
+    "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && node scripts/test-pr-diff-atomicity.mjs && node scripts/test-check-added-comments.mjs && node scripts/test-ci-workflow-merge-queue-policy.mjs && node scripts/test-review-unit-classification.mjs && bash scripts/workspace-test.sh && bash scripts/test-daily-e2e-do-submit.sh && bash scripts/test-install-daily-e2e-do-cron.sh",
     "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/test-invoker-ops-skill.sh && bash scripts/test-make-pr-skill.sh && node scripts/test-pr-body-rollout.mjs && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
     "test:low-resource": "pnpm run test",
     "test:low-resource:packages": "bash scripts/workspace-test.sh",

--- a/scripts/daily-e2e-do-submit.sh
+++ b/scripts/daily-e2e-do-submit.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Twice-daily worker (runs on the DO droplet "do1" via cron): refresh the
+# checkout to origin/master, run the FULL extended e2e battery, and for every
+# still-failing suite submit ONE single-task Invoker plan.
+#
+# This script does NOT fix anything or open PRs itself. It hands each failing
+# suite to Invoker as a plan with `onFinish: pull_request`. Invoker's own
+# auto-fix then repairs the suite with the configured agent and opens exactly
+# one PR per failing suite. Fix + PR + retry budget all live in Invoker.
+#
+# Enabling the fix is a do1 config concern, not this script's: set
+# `autoFixRetries` > 0 and `autoFixAgent: "omp"` in ~/.invoker/config.json. With
+# autoFixRetries=0 the plans still submit and run the suites, but Invoker never
+# dispatches the agent.
+#
+# Test seams: INVOKER_DAILY_E2E_SKIP_BATTERY=1 skips the refresh+battery and
+# reuses a pre-seeded state file; INVOKER_DAILY_E2E_SUBMIT_CMD overrides the
+# submit binary; INVOKER_DAILY_E2E_DRY_RUN=1 logs intended submissions only.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+STATE_FILE="${INVOKER_DAILY_E2E_STATE_FILE:-${TMPDIR:-/tmp}/daily-e2e-do-state.tsv}"
+WORK_DIR="${INVOKER_DAILY_E2E_WORK_DIR:-${TMPDIR:-/tmp}/daily-e2e-do}"
+SUBMIT_CMD="${INVOKER_DAILY_E2E_SUBMIT_CMD:-$REPO_ROOT/submit-plan.sh}"
+DRY_RUN="${INVOKER_DAILY_E2E_DRY_RUN:-0}"
+BASE_BRANCH="${INVOKER_DAILY_E2E_BASE:-master}"
+REPO_URL="${INVOKER_DAILY_E2E_REPO_URL:-$(git remote get-url origin 2>/dev/null || echo .)}"
+# Skip a suite already submitted within this many minutes, so the second daily
+# run does not open a duplicate PR while the morning fix is still in review.
+RESUBMIT_GUARD_MIN="${INVOKER_DAILY_E2E_RESUBMIT_GUARD_MIN:-1200}"
+
+log() { printf '[daily-e2e-do %s] %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+
+# 1. Refresh to latest master and rebuild the app (the extended battery's
+#    Playwright suite needs the built app), then run the battery.
+if [ "${INVOKER_DAILY_E2E_SKIP_BATTERY:-0}" != "1" ]; then
+  log "refreshing checkout to origin/$BASE_BRANCH"
+  git fetch origin --quiet
+  git reset --hard "origin/$BASE_BRANCH"
+  git clean -fd
+  pnpm install --frozen-lockfile
+  pnpm --filter @invoker/ui build
+  pnpm --filter @invoker/app build
+
+  rm -f "$STATE_FILE"
+  mkdir -p "$(dirname "$STATE_FILE")"
+  log "running extended e2e battery"
+  set +e
+  env INVOKER_TEST_ALL_EXTENDED=1 INVOKER_TEST_ALL_STATE_FILE="$STATE_FILE" bash scripts/run-all-tests.sh
+  log "battery finished (exit $?)"
+  set -e
+else
+  log "INVOKER_DAILY_E2E_SKIP_BATTERY=1: reusing state file $STATE_FILE"
+fi
+
+if [ ! -f "$STATE_FILE" ]; then
+  log "no state file at $STATE_FILE; nothing to do"
+  exit 0
+fi
+
+# 2. One single-task fix plan per failing extended suite.
+mkdir -p "$WORK_DIR"
+failing=0
+submitted=0
+skipped=0
+
+while IFS= read -r suite; do
+  [ -n "$suite" ] || continue
+  failing=$((failing + 1))
+
+  rel="${suite##*/scripts/test-suites/}"
+  slug="$(basename "$rel" .sh | tr 'A-Z' 'a-z' | tr -cs 'a-z0-9' '-' | sed -e 's/^-*//' -e 's/-*$//')"
+
+  # Resubmit guard: skip if we submitted this suite recently.
+  marker="$WORK_DIR/submitted-$slug"
+  if [ -n "$(find "$marker" -mmin "-$RESUBMIT_GUARD_MIN" 2>/dev/null)" ]; then
+    log "suite $rel: submitted within ${RESUBMIT_GUARD_MIN}m; skip"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  plan="$WORK_DIR/e2e-$slug.yaml"
+  cat > "$plan" <<YAML
+name: "Daily e2e fix: $rel"
+description: "Repair the failing extended e2e suite $rel (submitted by the do1 twice-daily worker)."
+repoUrl: $REPO_URL
+baseBranch: $BASE_BRANCH
+onFinish: pull_request
+tasks:
+  - id: e2e-fix-$slug
+    description: "Make 'bash scripts/test-suites/$rel' exit 0 by fixing the root cause. Do not weaken, skip, or delete assertions."
+    command: bash scripts/test-suites/$rel
+YAML
+
+  if [ "$DRY_RUN" = "1" ]; then
+    log "suite $rel: would submit fix plan $plan"
+    continue
+  fi
+
+  log "suite $rel: submitting fix plan"
+  if ( "$SUBMIT_CMD" "$plan" ); then
+    : > "$marker"
+    submitted=$((submitted + 1))
+    log "suite $rel: submitted to Invoker"
+  else
+    log "suite $rel: submit failed (continuing to next suite)"
+  fi
+done < <(awk -F '\t' '$1=="extended" && $3=="failed"{print $2}' "$STATE_FILE")
+
+log "summary: failing=$failing submitted=$submitted skipped=$skipped"

--- a/scripts/install-daily-e2e-do-cron.sh
+++ b/scripts/install-daily-e2e-do-cron.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Install (or update) the twice-daily cron entry on the DO droplet "do1" that
+# runs scripts/daily-e2e-do-submit.sh: run the extended e2e battery and submit
+# one Invoker fix plan per failing suite. Runs at 06:00 and 18:00 host-local.
+#
+# do1 prerequisites: a built Invoker checkout,
+# `gh auth` for PR creation, the agent (omp) installed and authed, and
+# ~/.invoker/config.json with `autoFixRetries` > 0 and `autoFixAgent: "omp"`.
+#
+# De-dupes by marker, so re-running is safe.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORKER_SCRIPT="$REPO_ROOT/scripts/daily-e2e-do-submit.sh"
+MARKER="# invoker-cron-daily-e2e-do"
+LOG_FILE="${HOME}/.invoker/daily-e2e-do.log"
+
+if [[ ! -f "$WORKER_SCRIPT" ]]; then
+  echo "ERROR: missing worker script at $WORKER_SCRIPT" >&2
+  exit 1
+fi
+# The cron line runs the worker via `bash`, so only readability is required.
+if [[ ! -r "$WORKER_SCRIPT" ]]; then
+  echo "ERROR: worker script is not readable at $WORKER_SCRIPT" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+CRON_LINE="0 6,18 * * * bash '$WORKER_SCRIPT' >> '$LOG_FILE' 2>&1 $MARKER"
+
+TMP_CRON="$(mktemp -t invoker-daily-e2e-do-cron.XXXXXX)"
+trap 'rm -f "$TMP_CRON"' EXIT
+
+if crontab -l >/dev/null 2>&1; then
+  # `|| true`: grep -Fv exits 1 when it filters out every line (our marker was
+  # the only entry), which pipefail would otherwise treat as fatal.
+  { crontab -l | grep -Fv "$MARKER" || true; } > "$TMP_CRON"
+else
+  : > "$TMP_CRON"
+fi
+
+printf '%s\n' "$CRON_LINE" >> "$TMP_CRON"
+crontab "$TMP_CRON"
+
+echo "Installed cron job:"
+echo "  $CRON_LINE"
+echo "Log file: $LOG_FILE"
+echo "Verify with: crontab -l | grep -F '$MARKER'"

--- a/scripts/test-daily-e2e-do-submit.sh
+++ b/scripts/test-daily-e2e-do-submit.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Behavior test for scripts/daily-e2e-do-submit.sh with the battery and the
+# Invoker submit path stubbed. No build, no real Invoker, no network.
+#
+# Covers:
+#   A. Dry-run: logs an intended submission for the FAILED suite only (never the
+#      passed one) and never calls the submit command; the generated plan YAML is
+#      a valid single-task plan with onFinish: pull_request.
+#   B. Real run: submits exactly once for the failing suite and records a marker.
+#   C. Resubmit guard: a fresh marker makes the suite skip (no submit).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WORKER="$REPO_ROOT/scripts/daily-e2e-do-submit.sh"
+FAIL_REL="required/20-e2e-dry-run.sh"
+FAIL_SLUG="20-e2e-dry-run"
+
+SANDBOXES=()
+cleanup() { local d; for d in ${SANDBOXES[@]+"${SANDBOXES[@]}"}; do rm -rf "$d"; done; return 0; }
+trap cleanup EXIT
+
+fail() { echo "FAIL: $1" >&2; [ -n "${2:-}" ] && { echo "----- log -----" >&2; cat "$2" >&2; }; exit 1; }
+
+# Run the worker in a fresh sandbox. Sets globals: sb (sandbox), calls (submit
+# call-record file), log (worker output). Control via exported env:
+# INVOKER_DAILY_E2E_DRY_RUN, and a pre-touched marker for the guard scenario.
+run_worker() {
+  sb="$(mktemp -d "${TMPDIR:-/tmp}/test-daily-e2e-do.XXXXXX")"
+  SANDBOXES+=("$sb")
+  mkdir -p "$sb/bin" "$sb/work"
+  calls="$sb/submit-calls"
+
+  # Stub submit command: record each plan path it was handed.
+  cat > "$sb/bin/submit-stub" <<STUB
+#!/usr/bin/env bash
+echo "\$1" >> "$calls"
+exit 0
+STUB
+  chmod +x "$sb/bin/submit-stub"
+
+  # Seed state: one FAILED and one PASSED extended row (absolute paths).
+  cat > "$sb/state.tsv" <<TSV
+extended	/x/scripts/test-suites/$FAIL_REL	failed
+extended	/x/scripts/test-suites/required/10-vitest-workspace.sh	passed
+TSV
+
+  log="$sb/worker.log"
+  env \
+    INVOKER_DAILY_E2E_SKIP_BATTERY=1 \
+    INVOKER_DAILY_E2E_STATE_FILE="$sb/state.tsv" \
+    INVOKER_DAILY_E2E_WORK_DIR="$sb/work" \
+    INVOKER_DAILY_E2E_SUBMIT_CMD="$sb/bin/submit-stub" \
+    INVOKER_DAILY_E2E_REPO_URL="git@github.com:Neko-Catpital-Labs/Invoker.git" \
+    bash "$WORKER" > "$log" 2>&1 || true
+}
+
+# ── A. Dry-run: failing suite only, no submit, valid plan YAML ────────────────
+unset INVOKER_DAILY_E2E_DRY_RUN 2>/dev/null || true
+export INVOKER_DAILY_E2E_DRY_RUN=1
+run_worker
+grep -q "suite $FAIL_REL: would submit fix plan" "$log" \
+  || fail "A: dry-run did not log intended submission for the failed suite" "$log"
+if grep -q "10-vitest-workspace" "$log"; then
+  fail "A: the passed suite must never be a submission target" "$log"
+fi
+[ ! -s "$calls" ] || fail "A: submit command must not run in dry-run" "$log"
+plan="$sb/work/e2e-$FAIL_SLUG.yaml"
+[ -f "$plan" ] || fail "A: expected plan YAML at $plan" "$log"
+PLAN="$plan" FAIL_REL="$FAIL_REL" FAIL_SLUG="$FAIL_SLUG" node -e '
+const YAML = require("yaml");
+const fs = require("fs");
+const d = YAML.parse(fs.readFileSync(process.env.PLAN, "utf8"));
+const t = d.tasks;
+if (d.onFinish !== "pull_request") throw new Error("onFinish=" + d.onFinish);
+if (d.baseBranch !== "master") throw new Error("baseBranch=" + d.baseBranch);
+if (!Array.isArray(t) || t.length !== 1) throw new Error("expected one task");
+if (t[0].command !== "bash scripts/test-suites/" + process.env.FAIL_REL) throw new Error("command=" + t[0].command);
+if (t[0].id !== "e2e-fix-" + process.env.FAIL_SLUG) throw new Error("id=" + t[0].id);
+' >/dev/null || fail "A: generated plan YAML is not the expected single-task shape" "$log"
+echo "  A ok: dry-run targets the failed suite only; plan YAML valid"
+
+# ── B. Real run: submits once, records marker ─────────────────────────────────
+unset INVOKER_DAILY_E2E_DRY_RUN
+export INVOKER_DAILY_E2E_DRY_RUN=0
+run_worker
+[ "$(wc -l < "$calls")" -eq 1 ] || fail "B: expected exactly one submission" "$log"
+grep -q "e2e-$FAIL_SLUG.yaml" "$calls" || fail "B: submitted the wrong plan" "$log"
+[ -f "$sb/work/submitted-$FAIL_SLUG" ] || fail "B: resubmit marker not written" "$log"
+grep -q "submitted=1" "$log" || fail "B: summary should report submitted=1" "$log"
+echo "  B ok: submits once for the failing suite and records a marker"
+
+# ── C. Resubmit guard: fresh marker -> skip ───────────────────────────────────
+export INVOKER_DAILY_E2E_DRY_RUN=0
+run_worker                              # creates sandbox
+touch "$sb/work/submitted-$FAIL_SLUG"   # pre-existing fresh marker
+# Re-run in the SAME sandbox so the marker is seen.
+env \
+  INVOKER_DAILY_E2E_SKIP_BATTERY=1 \
+  INVOKER_DAILY_E2E_STATE_FILE="$sb/state.tsv" \
+  INVOKER_DAILY_E2E_WORK_DIR="$sb/work" \
+  INVOKER_DAILY_E2E_SUBMIT_CMD="$sb/bin/submit-stub" \
+  bash "$WORKER" > "$sb/worker2.log" 2>&1 || true
+grep -q "submitted within" "$sb/worker2.log" \
+  || fail "C: fresh marker did not trigger the resubmit guard" "$sb/worker2.log"
+grep -q "skipped=1" "$sb/worker2.log" || fail "C: summary should report skipped=1" "$sb/worker2.log"
+echo "  C ok: resubmit guard skips a recently submitted suite"
+
+echo "PASS: daily-e2e-do-submit.sh behavior verified (dry-run, submit, resubmit-guard)"
+exit 0

--- a/scripts/test-install-daily-e2e-do-cron.sh
+++ b/scripts/test-install-daily-e2e-do-cron.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Test scripts/install-daily-e2e-do-cron.sh + uninstall against an isolated fake
+# `crontab` (a temp store), never the real user crontab:
+#   - install writes the marker, the 0 6,18 * * * schedule, and the worker path
+#   - install is idempotent (re-run keeps exactly one line)
+#   - uninstall removes it
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/test-daily-e2e-do-cron.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+fail() { echo "[test] FAIL: $1"; [ -n "${2:-}" ] && { echo "----- crontab -----"; echo "$2"; }; exit 1; }
+
+mkdir -p "$TMP/bin" "$TMP/home"
+export CRONTAB_STORE="$TMP/crontab.txt"
+cat > "$TMP/bin/crontab" <<'CT'
+#!/usr/bin/env bash
+store="${CRONTAB_STORE:?}"
+case "${1:-}" in
+  -l) [ -f "$store" ] && cat "$store" || { echo "no crontab for user" >&2; exit 1; } ;;
+  -r) rm -f "$store" ;;
+  "") cat > "$store" ;;
+  *)  cp "$1" "$store" ;;
+esac
+CT
+chmod +x "$TMP/bin/crontab"
+
+export PATH="$TMP/bin:$PATH"
+export HOME="$TMP/home"
+
+MARKER="# invoker-cron-daily-e2e-do"
+cron_now() { crontab -l 2>/dev/null || true; }
+
+bash scripts/install-daily-e2e-do-cron.sh >/dev/null
+
+cr="$(cron_now)"
+echo "$cr" | grep -F "$MARKER" | grep -q "scripts/daily-e2e-do-submit.sh" \
+  || fail "marker/worker missing" "$cr"
+echo "$cr" | grep -F "$MARKER" | grep -q '^0 6,18 \* \* \*' \
+  || fail "line missing '0 6,18 * * *' schedule" "$cr"
+
+count="$(cron_now | grep -c 'invoker-cron-daily-e2e-do' || true)"
+[ "$count" -eq 1 ] || fail "expected 1 cron line, found $count" "$(cron_now)"
+
+# Idempotency.
+bash scripts/install-daily-e2e-do-cron.sh >/dev/null
+count="$(cron_now | grep -c 'invoker-cron-daily-e2e-do' || true)"
+[ "$count" -eq 1 ] || fail "after re-install expected 1 cron line, found $count" "$(cron_now)"
+
+# Uninstall removes it.
+bash scripts/uninstall-daily-e2e-do-cron.sh >/dev/null
+count="$(cron_now | grep -c 'invoker-cron-daily-e2e-do' || true)"
+[ "$count" -eq 0 ] || fail "after uninstall expected 0 cron lines, found $count" "$(cron_now)"
+
+echo "[test] passed"

--- a/scripts/uninstall-daily-e2e-do-cron.sh
+++ b/scripts/uninstall-daily-e2e-do-cron.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Remove the twice-daily DO e2e cron entry installed by
+# scripts/install-daily-e2e-do-cron.sh.
+set -euo pipefail
+
+MARKER="# invoker-cron-daily-e2e-do"
+TMP_CRON="$(mktemp -t invoker-daily-e2e-do-cron-remove.XXXXXX)"
+trap 'rm -f "$TMP_CRON"' EXIT
+
+if crontab -l >/dev/null 2>&1; then
+  # `|| true`: grep -Fv exits 1 when our entry was the only line, which pipefail
+  # would otherwise treat as fatal and skip the rewrite below.
+  { crontab -l | grep -Fv "$MARKER" || true; } > "$TMP_CRON"
+  crontab "$TMP_CRON"
+  echo "Removed DO e2e cron entry (if present):"
+  echo "  $MARKER"
+else
+  echo "No crontab found for current user; nothing to remove."
+fi


### PR DESCRIPTION
## Summary

This adds a cron worker on the DigitalOcean droplet that runs the extended end-to-end battery twice a day.

For each failing suite it submits a single-task Invoker plan, and Invoker opens one pull request per failing suite.

Invoker's own auto-fix repairs the suite and opens the pull request. The worker never runs the agent or opens pull requests itself.

A short guard stops a second same-day run from opening a repeat pull request while the earlier fix is still in review.

## Review Claim

Approve adding the DO cron worker, its install and uninstall scripts, and their tests as tooling policy.

## Review Lane

policy

## Review Unit

tooling-policy

## Safety Invariant

The worker, cron scripts, and tests are new and unreferenced by the app runtime; nothing runs until the cron is installed on the droplet. No product code changes, and `ci.yml` is untouched.

## Slice Rationale

Every file here is tooling policy for one feature — the worker, its cron install scripts, and their tests — so it belongs in a single policy review.

## Non-goals

Does not repair anything or open PRs on its own; Invoker does. Does not change product code or `ci.yml`. Does not run inside GitHub Actions. Enabling the agent is a droplet config change (`autoFixRetries`), not part of this diff.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `bash scripts/test-daily-e2e-do-submit.sh`
- [ ] `bash scripts/test-install-daily-e2e-do-cron.sh`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: run `bash scripts/uninstall-daily-e2e-do-cron.sh` on the droplet if the cron was installed
- Data migration? No

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated support for running a twice-daily end-to-end check on a dedicated environment.
  * Added setup and removal for the scheduled job used to manage that automation.

* **Tests**
  * Added end-to-end coverage for the new worker flow.
  * Added verification for installation, repeat installation, and removal of the scheduled job.

* **Bug Fixes**
  * The main test command now includes the new daily end-to-end checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->