### PR TITLE
[UI approval double-click](1) Repro: primary actions fire twice on double-click

### DIFF
--- a/packages/ui/src/__tests__/approval-modal-double-click.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal-double-click.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ApprovalModal } from '../components/ApprovalModal.js';
+import { InputModal } from '../components/InputModal.js';
+import type { TaskState } from '../types.js';
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id: 'task-1',
+    description: 'Run unit tests',
+    status: 'awaiting_approval',
+    dependencies: [],
+    createdAt: new Date(),
+    config: {},
+    execution: {},
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  (window as any).invoker = {
+    getClaudeSession: vi.fn().mockResolvedValue(null),
+    getAgentSession: vi.fn().mockResolvedValue(null),
+    getEvents: vi.fn().mockResolvedValue([]),
+  };
+});
+
+afterEach(() => {
+  delete (window as any).invoker;
+});
+
+/*
+ * Bug 4 repro: modal primary-action handlers do not guard against
+ * back-to-back clicks. `handleApprove` synchronously calls the parent
+ * callback and then `onClose`, but the button is still mounted for the
+ * millisecond between the two synchronous events, so a shaky click
+ * dispatches the callback twice. In production this queues two IPC
+ * approvals against the same task id.
+ */
+describe('Modal double-click guard (regression)', () => {
+  it.fails('ApprovalModal approve button fires onApprove once on rapid double-click', () => {
+    const onApprove = vi.fn();
+    render(
+      <ApprovalModal
+        task={makeTask()}
+        onApprove={onApprove}
+        onReject={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'Approve' });
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    expect(onApprove).toHaveBeenCalledTimes(1);
+  });
+
+  it.fails('InputModal submit button fires onSubmit once on rapid double-click', () => {
+    const onSubmit = vi.fn();
+    render(
+      <InputModal
+        task={makeTask({ execution: { inputPrompt: 'Give input' } })}
+        onSubmit={onSubmit}
+        onClose={vi.fn()}
+      />,
+    );
+    const textarea = screen.getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: 'ready' } });
+    const btn = screen.getByRole('button', { name: 'Submit' });
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Land two failing regression assertions that demonstrate `ApprovalModal` and `InputModal` primary actions fire twice on a rapid double-click.

Each handler synchronously invokes the parent callback and then `onClose`. Between the two synchronous events the primary button is still mounted, so a second `fireEvent.click` dispatches the same callback again.

Both assertions are `.fails`-marked so CI stays green until the fix slice lands.

## Review Claim

Two `.fails`-marked assertions demonstrate that the Approve and Submit buttons fire their parent callback twice on a back-to-back double click.

## Review Lane

proof

## Review Unit

proof

## Safety Invariant

Test-only change. Product code is untouched and CI stays green because `.fails` swallows the assertion failures.

## Slice Rationale

Evidence-before-change per the review-compression skill. Kept separate from the fix so each slice carries exactly one review claim.

## Non-goals

- Does not modify any modal component.
- Does not exercise the reject/confirm-reject two-step flow.
- Does not exercise `ExperimentModal` or `ReplaceTaskModal` (may add later).

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test -- --run approval-modal-double-click`

</details>

## Visual Proof

Reference screenshot of the ApprovalModal open with the primary button visible — the two new `.fails` assertions target this exact button element:

![ApprovalModal open on a merge-gate task with the primary button visible](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-fe8282/approve-merge-modal-branch.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
