### PR TITLE
[UI approval double-click](2) Guard modal primary actions against double-click

### DIFF
--- a/packages/ui/src/__tests__/approval-modal-double-click.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal-double-click.test.tsx
@@ -38,7 +38,7 @@ afterEach(() => {
  * approvals against the same task id.
  */
 describe('Modal double-click guard (regression)', () => {
-  it.fails('ApprovalModal approve button fires onApprove once on rapid double-click', () => {
+  it('ApprovalModal approve button fires onApprove once on rapid double-click', () => {
     const onApprove = vi.fn();
     render(
       <ApprovalModal
@@ -54,7 +54,7 @@ describe('Modal double-click guard (regression)', () => {
     expect(onApprove).toHaveBeenCalledTimes(1);
   });
 
-  it.fails('InputModal submit button fires onSubmit once on rapid double-click', () => {
+  it('InputModal submit button fires onSubmit once on rapid double-click', () => {
     const onSubmit = vi.fn();
     render(
       <InputModal

--- a/packages/ui/src/components/ApprovalModal.tsx
+++ b/packages/ui/src/components/ApprovalModal.tsx
@@ -88,6 +88,7 @@ export function ApprovalModal({
   const [sessionReason, setSessionReason] = useState<string | undefined>(undefined);
   const [sessionLoading, setSessionLoading] = useState(false);
   const [sessionError, setSessionError] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
 
   useEffect(() => {
     if (task.execution.agentSessionId || task.execution.lastAgentSessionId || fallbackSessionId) return;
@@ -148,6 +149,8 @@ export function ApprovalModal({
   }, [sessionId, effectiveAgentName]);
 
   const handleApprove = () => {
+    if (submitting) return;
+    setSubmitting(true);
     onApprove(task.id);
     onClose();
   };
@@ -157,6 +160,8 @@ export function ApprovalModal({
       setShowRejectInput(true);
       return;
     }
+    if (submitting) return;
+    setSubmitting(true);
     onReject(task.id, reason || undefined);
     onClose();
   };
@@ -271,14 +276,16 @@ export function ApprovalModal({
             </button>
             <button
               onClick={handleReject}
-              className="px-4 py-2 bg-red-600 hover:bg-red-500 text-white rounded text-sm font-medium transition-colors"
+              disabled={submitting}
+              className="px-4 py-2 bg-red-600 hover:bg-red-500 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded text-sm font-medium transition-colors"
             >
               {rejectButtonLabel}
             </button>
             {!showRejectInput && (
               <button
                 onClick={handleApprove}
-                className="px-4 py-2 bg-green-600 hover:bg-green-500 text-white rounded text-sm font-medium transition-colors"
+                disabled={submitting}
+                className="px-4 py-2 bg-green-600 hover:bg-green-500 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded text-sm font-medium transition-colors"
               >
                 {approveButtonLabel}
               </button>

--- a/packages/ui/src/components/InputModal.tsx
+++ b/packages/ui/src/components/InputModal.tsx
@@ -15,9 +15,12 @@ interface InputModalProps {
 
 export function InputModal({ task, onSubmit, onClose }: InputModalProps) {
   const [input, setInput] = useState('');
+  const [submitting, setSubmitting] = useState(false);
 
   const handleSubmit = () => {
+    if (submitting) return;
     if (!input.trim()) return;
+    setSubmitting(true);
     onSubmit(task.id, input.trim());
     onClose();
   };
@@ -68,7 +71,7 @@ export function InputModal({ task, onSubmit, onClose }: InputModalProps) {
           </button>
           <button
             onClick={handleSubmit}
-            disabled={!input.trim()}
+            disabled={!input.trim() || submitting}
             className="px-4 py-2 bg-amber-600 hover:bg-amber-500 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded text-sm font-medium transition-colors"
           >
             Submit


### PR DESCRIPTION
## Summary

Add a component-local in-flight state to `ApprovalModal` and `InputModal`. The primary handlers each return early when the state is already true, then flip it before invoking the parent callback.

The primary buttons in each modal also carry a `disabled` prop bound to the same state, so a second click has no clickable target during the same render cycle.

Flip the two `.fails`-marked repro tests from the previous slice to plain `it(...)` calls; they now assert the fixed behavior.

## Review Claim

A rapid back-to-back click on the ApprovalModal Approve button or the InputModal primary button fires the parent callback exactly once.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The new state slot is component-local, resets on unmount, and never mutates outside the component. No new IPC calls, no persistence changes. The two-step reject flow still requires the second confirm click, and the confirm path is guarded the same way.

## Slice Rationale

Behavior fix that flips the previously landed `.fails` repros to green. Kept separate from the proof slice so each slice carries a single review claim.

## Non-goals

- Does not modify `ExperimentModal` or `ReplaceTaskModal` (called out for future work; those primary buttons already carry a stricter validity gate).
- Does not add spinner or "In-flight" wording to the disabled button (visual polish, out of scope).
- Does not change the parent's IPC call path.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm test -- --run approval-modal-double-click approval-modal`

</details>

## Visual Proof

Reference screenshot of the ApprovalModal open on a merge-gate task. After the fix, the primary button carries a `disabled` prop bound to the new in-flight state so a second click has no target:

![ApprovalModal open on a merge-gate task with the primary button visible](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-fe8282/approve-merge-modal-branch.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
