### PR TITLE
Route AI fix approval through an autoapprove worker

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -361,6 +361,9 @@ function buildRegisteredOwnerWorkerDeps(
       localPath: resolveInvokerHomeRoot(),
       remoteTargets,
     },
+    autoApprove: {
+      enabled: invokerConfig.autoApproveAIFixes === true,
+    },
   };
 }
 function createRegisteredWorkerRegistry(): WorkerRegistry<WorkerRuntimeDependencies> {

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -12,6 +12,7 @@ import type {
 import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
 import {
   AUTO_FIX_WORKER_KIND,
+  AUTO_APPROVE_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
   DISK_HEADROOM_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
@@ -24,7 +25,7 @@ import {
 
 import { collectRecoveryWorkerStatus } from './recovery-worker-observability.js';
 
-export const AUTO_STARTED_OWNER_WORKER_KINDS = [PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND, DISK_HEADROOM_WORKER_KIND, REQUEUE_WORKER_KIND] as const;
+export const AUTO_STARTED_OWNER_WORKER_KINDS = [PR_STATUS_WORKER_KIND, CI_FAILURE_WORKER_KIND, DISK_HEADROOM_WORKER_KIND, REQUEUE_WORKER_KIND, AUTO_APPROVE_WORKER_KIND] as const;
 
 export interface WorkerRuntimeController {
   startAutoStartedWorkers(): void;
@@ -144,6 +145,7 @@ const BUILT_IN_WORKER_KINDS = new Set<string>([
   CI_FAILURE_WORKER_KIND,
   DISK_HEADROOM_WORKER_KIND,
   REQUEUE_WORKER_KIND,
+  AUTO_APPROVE_WORKER_KIND,
 ]);
 
 export function createWorkerRuntimeController(options: {

--- a/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-approve-worker.test.ts
@@ -1,0 +1,225 @@
+import type { Logger } from '@invoker/contracts';
+import type { WorkerActionRecord, WorkerActionWrite, WorkflowMutationIntent } from '@invoker/data-store';
+import type { RecoveryWorkerWakeupHint } from '../lifecycle-events.js';
+import type { TaskState } from '@invoker/workflow-core';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  collectValidatedAutoApproveCandidates,
+  createAutoApproveTick,
+  isApproveIntentForTask,
+  listAutoApproveScanCandidates,
+  type AutoApproveCandidate,
+  type AutoApproveWorkerStore,
+} from '../workers/auto-approve-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+  child: vi.fn(),
+} as unknown as Logger;
+
+function task(overrides: Partial<TaskState> = {}): TaskState {
+  const { config, execution, ...rest } = overrides;
+  return {
+    id: 'wf-1/task-1',
+    description: 'Task 1',
+    status: 'awaiting_approval',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    config: { id: 'task-1', workflowId: 'wf-1', ...config },
+    execution: {
+      pendingFixError: 'boom',
+      generation: 1,
+      selectedAttemptId: 'attempt-1',
+      ...execution,
+    },
+    taskStateVersion: 4,
+    ...rest,
+  } as TaskState;
+}
+
+function intent(overrides: Partial<WorkflowMutationIntent>): WorkflowMutationIntent {
+  return {
+    id: 1,
+    workflowId: 'wf-1',
+    channel: 'invoker:approve',
+    args: ['wf-1/task-1'],
+    priority: 'normal',
+    status: 'queued',
+    createdAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function wakeup(overrides: Partial<RecoveryWorkerWakeupHint> = {}): RecoveryWorkerWakeupHint {
+  return {
+    eventKey: 'event-1',
+    eventKind: 'task.awaiting_approval',
+    workflowId: 'wf-1',
+    taskId: 'wf-1/task-1',
+    taskStateVersion: 4,
+    generation: 1,
+    attemptId: 'attempt-1',
+    createdAt: '2026-01-01T00:00:00Z',
+    reason: 'task_lifecycle',
+    authoritative: false,
+    ...overrides,
+  };
+}
+
+function makeStore(tasks: TaskState[], openIntents: WorkflowMutationIntent[] = []) {
+  const actions = new Map<string, WorkerActionRecord>();
+  const writes: WorkerActionWrite[] = [];
+  const store: AutoApproveWorkerStore = {
+    listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+    loadTasks: vi.fn(() => tasks),
+    loadTask: vi.fn((taskId: string) => tasks.find((candidate) => candidate.id === taskId)),
+    listWorkflowMutationIntents: vi.fn(() => openIntents),
+    getWorkerAction: vi.fn((workerKind: string, externalKey: string) => actions.get(`${workerKind}:${externalKey}`)),
+    upsertWorkerAction: vi.fn((write: WorkerActionWrite) => {
+      writes.push(write);
+      const now = new Date('2026-01-01T00:00:00Z').toISOString();
+      const record: WorkerActionRecord = {
+        attemptCount: 0,
+        createdAt: now,
+        updatedAt: now,
+        ...write,
+      };
+      actions.set(`${write.workerKind}:${write.externalKey}`, record);
+      return record;
+    }),
+    logEvent: vi.fn(),
+  };
+  return { store, writes };
+}
+
+function candidate(overrides: Partial<AutoApproveCandidate> = {}): AutoApproveCandidate {
+  return {
+    taskId: 'wf-1/task-1',
+    workflowId: 'wf-1',
+    generation: 1,
+    taskStateVersion: 4,
+    attemptId: 'attempt-1',
+    source: 'scan',
+    ...overrides,
+  };
+}
+
+describe('autoapprove worker', () => {
+  it('scan candidates include only awaiting approval tasks with pending fix errors', () => {
+    const eligible = task();
+    const noPendingFix = task({ id: 'wf-1/task-2', execution: { pendingFixError: undefined } });
+    const failed = task({ id: 'wf-1/task-3', status: 'failed' });
+    const { store } = makeStore([eligible, noPendingFix, failed]);
+
+    expect(listAutoApproveScanCandidates({ store })).toEqual([
+      expect.objectContaining({ taskId: 'wf-1/task-1', workflowId: 'wf-1', generation: 1, taskStateVersion: 4 }),
+    ]);
+  });
+
+  it('does not submit awaiting approval tasks without pending fix errors', async () => {
+    const { store } = makeStore([task({ execution: { pendingFixError: undefined } })]);
+    const submitter = { submit: vi.fn() };
+
+    await createAutoApproveTick({ store, submitter, logger, enabled: true })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+    });
+
+    expect(submitter.submit).not.toHaveBeenCalled();
+  });
+
+  it('skips review-ready tasks with pending fix errors as ambiguous', () => {
+    const { store, writes } = makeStore([task({ status: 'review_ready' })]);
+
+    expect(collectValidatedAutoApproveCandidates({ store, submitter: { submit: vi.fn() }, logger, enabled: true }, [candidate()])).toEqual([]);
+    expect(writes[0]).toMatchObject({ status: 'skipped', summary: 'Skipped AI fix approval: review-ready-ambiguous' });
+  });
+
+  it('skips stale workflow, generation, task-state version, and attempt snapshots', () => {
+    const cases: Array<[string, TaskState, AutoApproveCandidate]> = [
+      ['stale-workflow', task({ config: { workflowId: 'wf-2' } }), candidate()],
+      ['stale-generation', task({ execution: { generation: 2 } }), candidate()],
+      ['stale-task-state-version', task({ taskStateVersion: 5 }), candidate()],
+      ['stale-attempt', task({ execution: { selectedAttemptId: 'attempt-2' } }), candidate()],
+    ];
+
+    for (const [reason, latest, snapshot] of cases) {
+      const { store, writes } = makeStore([latest]);
+      const result = collectValidatedAutoApproveCandidates({ store, submitter: { submit: vi.fn() }, logger, enabled: true }, [snapshot]);
+      expect(result).toEqual([]);
+      expect(writes[0]).toMatchObject({ status: 'skipped', summary: `Skipped AI fix approval: ${reason}` });
+    }
+  });
+
+  it('dedupes duplicate wakeups for the same snapshot', async () => {
+    const { store } = makeStore([task()]);
+    const submitter = { submit: vi.fn(() => 42) };
+
+    await createAutoApproveTick({
+      store,
+      submitter,
+      logger,
+      enabled: true,
+      drainWakeupHints: () => [wakeup(), wakeup()],
+    })({ identity: { kind: 'autoapprove', instanceId: 'test' }, reason: 'wake', tickNumber: 1 });
+
+    expect(submitter.submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips open invoker and headless approval intents', () => {
+    const openInvoker = intent({ id: 10, channel: 'invoker:approve', args: ['wf-1/task-1'] });
+    const openHeadless = intent({ id: 11, channel: 'headless.exec', args: [{ args: ['approve', 'wf-1/task-1'] }] });
+    expect(isApproveIntentForTask(openInvoker, 'wf-1/task-1')).toBe(true);
+    expect(isApproveIntentForTask(openHeadless, 'wf-1/task-1')).toBe(true);
+
+    for (const openIntent of [openInvoker, openHeadless]) {
+      const { store, writes } = makeStore([task()], [openIntent]);
+      const result = collectValidatedAutoApproveCandidates({ store, submitter: { submit: vi.fn() }, logger, enabled: true }, [candidate()]);
+      expect(result).toEqual([]);
+      expect(writes[0]).toMatchObject({ status: 'skipped', summary: 'Skipped AI fix approval: already-queued-intent' });
+    }
+  });
+
+  it('submits a valid approval intent and records a queued worker action', async () => {
+    const { store, writes } = makeStore([task()]);
+    const submitter = { submit: vi.fn(() => 42) };
+
+    await createAutoApproveTick({ store, submitter, logger, enabled: true })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+    });
+
+    expect(submitter.submit).toHaveBeenCalledWith('wf-1', 'normal', 'invoker:approve', ['wf-1/task-1']);
+    expect(writes[0]).toMatchObject({
+      id: 'autoapprove:autoapprove:wf-1/task-1:1:4:attempt-1',
+      workerKind: 'autoapprove',
+      actionType: 'approve-ai-fix',
+      subjectType: 'task',
+      subjectId: 'wf-1/task-1',
+      status: 'queued',
+      summary: 'Queued AI fix approval',
+      intentId: '42',
+    });
+  });
+
+  it('does not scan or submit when disabled', async () => {
+    const { store } = makeStore([task()]);
+    const submitter = { submit: vi.fn() };
+
+    await createAutoApproveTick({ store, submitter, logger, enabled: false })({
+      identity: { kind: 'autoapprove', instanceId: 'test' },
+      reason: 'manual',
+      tickNumber: 1,
+    });
+
+    expect(store.listWorkflows).not.toHaveBeenCalled();
+    expect(submitter.submit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/execution-engine/src/__tests__/worker-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/worker-registry.test.ts
@@ -11,6 +11,7 @@ import { registerBuiltinWorkers } from '../builtin-workers.js';
 import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
 import { createWorkerRegistry } from '../worker-registry.js';
 import { CI_FAILURE_WORKER_KIND } from '../workers/ci-failure-worker.js';
+import { AUTO_APPROVE_WORKER_KIND } from '../workers/auto-approve-worker.js';
 import {
   CODERABBIT_ADDRESS_WORKER_KIND,
   PR_CONFLICT_REBASE_WORKER_KIND,
@@ -69,6 +70,7 @@ describe('worker registry', () => {
       PR_STATUS_WORKER_KIND,
       CI_FAILURE_WORKER_KIND,
       DISK_HEADROOM_WORKER_KIND,
+      AUTO_APPROVE_WORKER_KIND,
       CODERABBIT_ADDRESS_WORKER_KIND,
       PR_CONFLICT_REBASE_WORKER_KIND,
     ]);
@@ -77,6 +79,7 @@ describe('worker registry', () => {
     expect(registry.get(PR_STATUS_WORKER_KIND)).toBeDefined();
     expect(registry.get(CI_FAILURE_WORKER_KIND)).toBeDefined();
     expect(registry.get(DISK_HEADROOM_WORKER_KIND)).toBeDefined();
+    expect(registry.get(AUTO_APPROVE_WORKER_KIND)).toBeDefined();
     expect(registry.get(CODERABBIT_ADDRESS_WORKER_KIND)).toBeDefined();
     expect(registry.get(PR_CONFLICT_REBASE_WORKER_KIND)).toBeDefined();
   });

--- a/packages/execution-engine/src/builtin-workers.ts
+++ b/packages/execution-engine/src/builtin-workers.ts
@@ -1,4 +1,5 @@
 import { registerAutoFixWorker } from './auto-fix-recovery.js';
+import { registerAutoApproveWorker } from './workers/auto-approve-worker.js';
 import type { WorkerRuntimeDependencies } from './worker-runtime-dependencies.js';
 import type { WorkerRegistry } from './worker-registry.js';
 import { registerCiFailureWorker } from './workers/ci-failure-worker.js';
@@ -16,6 +17,7 @@ export function registerBuiltinWorkers(
   registerPrStatusWorker(registry);
   registerCiFailureWorker(registry);
   registerDiskHeadroomWorker(registry);
+  registerAutoApproveWorker(registry);
   registerPrMaintenanceWorkers(registry);
   return registry;
 }

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -49,6 +49,7 @@ export * from './builtin-workers.js';
 export * from './auto-fix-recovery.js';
 export * from './workers/pr-status-worker.js';
 export * from './workers/ci-failure-worker.js';
+export * from './workers/auto-approve-worker.js';
 export * from './workers/disk-headroom-worker.js';
 export * from './workers/disk-headroom-monitor.js';
 export * from './workers/disk-headroom.js';

--- a/packages/execution-engine/src/worker-runtime-dependencies.ts
+++ b/packages/execution-engine/src/worker-runtime-dependencies.ts
@@ -7,6 +7,11 @@ import type {
   AutoFixWorkerConfig,
 } from './auto-fix-recovery.js';
 import type { CiFailureWorkerStore, CiFailureWorkerSubmitter } from './workers/ci-failure-worker.js';
+import type {
+  AutoApproveWorkerStore,
+  AutoApproveWorkerSubmitter,
+  AutoApproveWorkerConfig,
+} from './workers/auto-approve-worker.js';
 import type { PrMaintenanceWorkerConfig } from './workers/pr-maintenance-workers.js';
 import type { DiskHeadroomWorkerConfig } from './workers/disk-headroom-worker.js';
 import type { PrStatusReviewGate } from './workers/pr-status-worker.js';
@@ -15,9 +20,9 @@ import type { RequeueWorkerConfig, RequeueWorkerSubmitter } from './workers/requ
 /** Dependencies injected into a built-in worker factory when its runtime is built. */
 export interface WorkerRuntimeDependencies {
   /** Persisted workflow/task state accessor. */
-  store: AutoFixRecoveryStore & CiFailureWorkerStore;
+  store: AutoFixRecoveryStore & CiFailureWorkerStore & AutoApproveWorkerStore;
   /** Action-output channel used to submit follow-up mutation intents. */
-  submitter: AutoFixRecoverySubmitter & CiFailureWorkerSubmitter & RequeueWorkerSubmitter;
+  submitter: AutoFixRecoverySubmitter & CiFailureWorkerSubmitter & RequeueWorkerSubmitter & AutoApproveWorkerSubmitter;
   /** Operator logger. */
   logger: Logger;
   /** Optional bus that turns lifecycle events into immediate wakeups. */
@@ -32,4 +37,6 @@ export interface WorkerRuntimeDependencies {
   prMaintenance?: PrMaintenanceWorkerConfig;
   /** Disk-headroom worker configuration (local/remote paths and thresholds). */
   diskHeadroom?: DiskHeadroomWorkerConfig;
+  /** Auto-approval tuning for worker-owned AI fix approvals. */
+  autoApprove?: AutoApproveWorkerConfig;
 }

--- a/packages/execution-engine/src/workers/auto-approve-worker.ts
+++ b/packages/execution-engine/src/workers/auto-approve-worker.ts
@@ -1,0 +1,492 @@
+import type { Logger } from '@invoker/contracts';
+import type {
+  WorkerActionRecord,
+  WorkerActionStatus,
+  WorkerActionWrite,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationPriority,
+} from '@invoker/data-store';
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+
+import type { RecoveryWorkerWakeupHint, WorkflowLifecycleEvent } from '../lifecycle-events.js';
+import type { WorkerRuntimeDependencies } from '../worker-runtime-dependencies.js';
+import type { WorkerRegistry } from '../worker-registry.js';
+import { createWorkerRuntime, type WorkerRuntime, type WorkerTick } from '../worker-runtime.js';
+
+export const AUTO_APPROVE_WORKER_KIND = 'autoapprove';
+export const DEFAULT_AUTO_APPROVE_WORKER_INTERVAL_MS = 60_000;
+const AUTO_APPROVE_COMMAND_CHANNEL = 'invoker:approve';
+const AUTO_APPROVE_ACTION_TYPE = 'approve-ai-fix';
+
+type AutoApproveActionStatus = WorkerActionStatus;
+
+export interface AutoApproveWorkerStore {
+  listWorkflows(): ReadonlyArray<{ id: string }>;
+  loadTasks(workflowId: string): TaskState[];
+  loadTask?(taskId: string): TaskState | undefined;
+  listWorkflowMutationIntents?(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[];
+  getWorkerAction?(workerKind: string, externalKey: string): WorkerActionRecord | undefined;
+  upsertWorkerAction?(action: WorkerActionWrite): WorkerActionRecord;
+  logEvent?(taskId: string, eventType: string, payload?: unknown): void;
+}
+
+export interface AutoApproveWorkerSubmitter {
+  submit(
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: typeof AUTO_APPROVE_COMMAND_CHANNEL,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ): number;
+}
+
+export interface AutoApproveWorkerConfig {
+  enabled?: boolean;
+}
+
+export interface AutoApproveWorkerPolicyOptions {
+  store: AutoApproveWorkerStore;
+  submitter: AutoApproveWorkerSubmitter;
+  logger: Logger;
+  enabled?: boolean;
+  drainWakeupHints?: () => RecoveryWorkerWakeupHint[];
+}
+
+export interface AutoApproveWorkerOptions {
+  logger: Logger;
+  instanceId?: string;
+  intervalMs?: number;
+  installSignalHandlers?: boolean;
+  tickOnStart?: boolean;
+  messageBus?: MessageBus;
+  autoApprove?: Omit<AutoApproveWorkerPolicyOptions, 'logger' | 'drainWakeupHints'>;
+  onTick?: WorkerTick;
+}
+
+export type AutoApproveCandidate = {
+  taskId: string;
+  workflowId: string;
+  generation: number;
+  taskStateVersion: number;
+  attemptId?: string;
+  source: 'scan' | 'wakeup';
+};
+
+type AutoApproveTaskRef = Omit<AutoApproveCandidate, 'source'>;
+
+type ValidatedAutoApproveCandidate = AutoApproveTaskRef & {
+  source: AutoApproveCandidate['source'];
+  task: TaskState;
+};
+
+type AutoApproveSnapshotMismatchReason =
+  | 'stale-workflow'
+  | 'stale-generation'
+  | 'stale-task-state-version'
+  | 'stale-attempt';
+
+type AutoApproveSnapshotComparison =
+  | { ok: true; ref: AutoApproveTaskRef }
+  | { ok: false; reason: AutoApproveSnapshotMismatchReason; details: Record<string, unknown> };
+
+export function registerAutoApproveWorker(
+  registry: WorkerRegistry<WorkerRuntimeDependencies>,
+): WorkerRegistry<WorkerRuntimeDependencies> {
+  registry.register({
+    kind: AUTO_APPROVE_WORKER_KIND,
+    note: 'Approves AI fixes that are awaiting approval after a pending fix error.',
+    factory: (deps: WorkerRuntimeDependencies): WorkerRuntime =>
+      createAutoApproveWorker({
+        logger: deps.logger,
+        messageBus: deps.messageBus,
+        autoApprove: {
+          store: deps.store,
+          submitter: deps.submitter,
+          enabled: deps.autoApprove?.enabled,
+        },
+      }),
+  });
+  return registry;
+}
+
+function workflowIdForTask(task: TaskState): string | undefined {
+  return task.config.workflowId ?? task.id.split('/')[0];
+}
+
+function taskRefFromTask(task: TaskState): AutoApproveTaskRef | undefined {
+  const workflowId = workflowIdForTask(task);
+  if (!workflowId) return undefined;
+  return {
+    taskId: task.id,
+    workflowId,
+    generation: task.execution.generation ?? 0,
+    taskStateVersion: task.taskStateVersion,
+    attemptId: task.execution.selectedAttemptId,
+  };
+}
+
+function candidateFromTask(task: TaskState): AutoApproveCandidate | undefined {
+  const ref = taskRefFromTask(task);
+  if (!ref) return undefined;
+  return { ...ref, source: 'scan' };
+}
+
+export function listAutoApproveScanCandidates(
+  options: Pick<AutoApproveWorkerPolicyOptions, 'store'>,
+): AutoApproveCandidate[] {
+  const candidates: AutoApproveCandidate[] = [];
+  for (const workflow of options.store.listWorkflows()) {
+    for (const task of options.store.loadTasks(workflow.id)) {
+      if (task.status !== 'awaiting_approval') continue;
+      if (task.execution.pendingFixError === undefined) continue;
+      const candidate = candidateFromTask(task);
+      if (candidate) candidates.push(candidate);
+    }
+  }
+  return candidates;
+}
+
+function candidateFromWakeup(wakeup: RecoveryWorkerWakeupHint): AutoApproveCandidate | undefined {
+  if (!wakeup.taskId || wakeup.taskStateVersion == null) return undefined;
+  return {
+    taskId: wakeup.taskId,
+    workflowId: wakeup.workflowId,
+    generation: wakeup.generation,
+    taskStateVersion: wakeup.taskStateVersion,
+    attemptId: wakeup.attemptId,
+    source: 'wakeup',
+  };
+}
+
+function dedupeCandidates(candidates: AutoApproveCandidate[]): AutoApproveCandidate[] {
+  const seen = new Set<string>();
+  const deduped: AutoApproveCandidate[] = [];
+  for (const candidate of candidates) {
+    const key = `${candidate.taskId}:${candidate.generation}:${candidate.taskStateVersion}:${candidate.attemptId ?? ''}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(candidate);
+  }
+  return deduped;
+}
+
+function loadLatestTask(
+  candidate: AutoApproveCandidate,
+  options: AutoApproveWorkerPolicyOptions,
+): TaskState | undefined {
+  const direct = options.store.loadTask?.(candidate.taskId);
+  if (direct) return direct;
+  return options.store.loadTasks(candidate.workflowId).find((task) => task.id === candidate.taskId);
+}
+
+function compareCandidateSnapshot(
+  candidate: AutoApproveCandidate,
+  latest: TaskState,
+): AutoApproveSnapshotComparison {
+  const latestRef = taskRefFromTask(latest);
+  if (!latestRef || latestRef.workflowId !== candidate.workflowId) {
+    return { ok: false, reason: 'stale-workflow', details: { latestWorkflowId: latestRef?.workflowId ?? null } };
+  }
+  if (latestRef.generation !== candidate.generation) {
+    return { ok: false, reason: 'stale-generation', details: { latestGeneration: latestRef.generation } };
+  }
+  if (latestRef.taskStateVersion !== candidate.taskStateVersion) {
+    return {
+      ok: false,
+      reason: 'stale-task-state-version',
+      details: { latestTaskStateVersion: latestRef.taskStateVersion },
+    };
+  }
+  if ((latestRef.attemptId ?? null) !== (candidate.attemptId ?? null)) {
+    return { ok: false, reason: 'stale-attempt', details: { latestAttemptId: latestRef.attemptId ?? null } };
+  }
+  return { ok: true, ref: latestRef };
+}
+
+function actionExternalKey(candidate: Pick<AutoApproveCandidate, 'taskId' | 'generation' | 'taskStateVersion' | 'attemptId'>): string {
+  return `autoapprove:${candidate.taskId}:${candidate.generation}:${candidate.taskStateVersion}:${candidate.attemptId ?? 'no-attempt'}`;
+}
+
+function actionIdForExternalKey(externalKey: string): string {
+  return `${AUTO_APPROVE_WORKER_KIND}:${externalKey}`;
+}
+
+function isOpenOrCompletedActionStatus(status: string): boolean {
+  return status === 'queued'
+    || status === 'pending'
+    || status === 'running'
+    || status === 'needs_input'
+    || status === 'review_ready'
+    || status === 'completed';
+}
+
+function coerceActionStatus(status: AutoApproveActionStatus): WorkerActionStatus {
+  return status;
+}
+
+function recordAutoApproveAction(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+  status: AutoApproveActionStatus,
+  summary: string,
+  payload: Record<string, unknown> = {},
+  intentId?: number | string,
+): WorkerActionRecord | undefined {
+  const externalKey = actionExternalKey(candidate);
+  const existing = options.store.getWorkerAction?.(AUTO_APPROVE_WORKER_KIND, externalKey);
+  const now = new Date().toISOString();
+  return options.store.upsertWorkerAction?.({
+    id: existing?.id ?? actionIdForExternalKey(externalKey),
+    workerKind: AUTO_APPROVE_WORKER_KIND,
+    actionType: AUTO_APPROVE_ACTION_TYPE,
+    workflowId: candidate.workflowId,
+    taskId: candidate.taskId,
+    subjectType: 'task',
+    subjectId: candidate.taskId,
+    externalKey,
+    status: coerceActionStatus(status),
+    attemptCount: status === 'queued' || status === 'failed'
+      ? (existing?.attemptCount ?? 0) + 1
+      : existing?.attemptCount ?? 0,
+    ...(intentId !== undefined ? { intentId: String(intentId) } : {}),
+    summary,
+    payload: {
+      taskId: candidate.taskId,
+      workflowId: candidate.workflowId,
+      generation: candidate.generation,
+      taskStateVersion: candidate.taskStateVersion,
+      selectedAttemptId: candidate.attemptId ?? null,
+      source: candidate.source,
+      ...payload,
+    },
+    updatedAt: now,
+    ...(status === 'skipped' || status === 'failed' || status === 'completed' ? { completedAt: now } : {}),
+  });
+}
+
+function logAutoApproveWorkerEvent(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+  phase: string,
+  details: Record<string, unknown>,
+): void {
+  const payload = {
+    phase,
+    worker: AUTO_APPROVE_WORKER_KIND,
+    workflowId: candidate.workflowId,
+    generation: candidate.generation,
+    taskStateVersion: candidate.taskStateVersion,
+    selectedAttemptId: candidate.attemptId ?? null,
+    source: candidate.source,
+    ...details,
+  };
+  options.store.logEvent?.(candidate.taskId, 'debug.autoapprove-worker', payload);
+  options.logger.debug?.(`[worker:${AUTO_APPROVE_WORKER_KIND}] ${phase}`, {
+    module: 'auto-approve-worker',
+    taskId: candidate.taskId,
+    ...payload,
+  });
+}
+
+function skipAutoApproveCandidate(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+  reason: string,
+  details: Record<string, unknown> = {},
+): void {
+  recordAutoApproveAction(
+    options,
+    candidate,
+    'skipped',
+    `Skipped AI fix approval: ${reason}`,
+    { reason, ...details },
+  );
+  logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-skip', { reason, ...details });
+}
+
+function hasAlreadyRecordedAction(
+  options: AutoApproveWorkerPolicyOptions,
+  candidate: AutoApproveCandidate,
+): boolean {
+  const externalKey = actionExternalKey(candidate);
+  const existing = options.store.getWorkerAction?.(AUTO_APPROVE_WORKER_KIND, externalKey);
+  if (!existing) return false;
+  if (!isOpenOrCompletedActionStatus(existing.status)) return false;
+  logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-skip', {
+    reason: 'already-recorded',
+    existingStatus: existing.status,
+    intentId: existing.intentId ?? null,
+  });
+  return true;
+}
+
+export function isApproveIntentForTask(intent: WorkflowMutationIntent, taskId: string): boolean {
+  if (intent.channel === AUTO_APPROVE_COMMAND_CHANNEL) return intent.args[0] === taskId;
+  if (intent.channel !== 'headless.exec') return false;
+  const firstArg = intent.args[0];
+  if (typeof firstArg !== 'object' || firstArg === null || Array.isArray(firstArg)) return false;
+  const args = (firstArg as { args?: unknown }).args;
+  return Array.isArray(args) && args[0] === 'approve' && args[1] === taskId;
+}
+
+function openApprovalIntents(
+  options: AutoApproveWorkerPolicyOptions,
+  workflowId: string,
+  taskId: string,
+): WorkflowMutationIntent[] {
+  const open = options.store.listWorkflowMutationIntents?.(workflowId, ['queued', 'running']) ?? [];
+  return open.filter((intent) => isApproveIntentForTask(intent, taskId));
+}
+
+function validateAutoApproveCandidate(
+  candidate: AutoApproveCandidate,
+  options: AutoApproveWorkerPolicyOptions,
+): ValidatedAutoApproveCandidate | undefined {
+  const latest = loadLatestTask(candidate, options);
+  if (!latest) {
+    skipAutoApproveCandidate(options, candidate, 'task-not-found');
+    return undefined;
+  }
+
+  const snapshotComparison = compareCandidateSnapshot(candidate, latest);
+  if (!snapshotComparison.ok) {
+    skipAutoApproveCandidate(options, candidate, snapshotComparison.reason, snapshotComparison.details);
+    return undefined;
+  }
+
+  if (latest.status === 'review_ready') {
+    skipAutoApproveCandidate(options, candidate, 'review-ready-ambiguous');
+    return undefined;
+  }
+  if (latest.status !== 'awaiting_approval') {
+    skipAutoApproveCandidate(options, candidate, 'status-changed', { status: latest.status });
+    return undefined;
+  }
+  if (latest.execution.pendingFixError === undefined) {
+    skipAutoApproveCandidate(options, candidate, 'no-pending-fix');
+    return undefined;
+  }
+
+  if (hasAlreadyRecordedAction(options, candidate)) return undefined;
+
+  const openIntents = openApprovalIntents(options, snapshotComparison.ref.workflowId, candidate.taskId);
+  if (openIntents.length > 0) {
+    skipAutoApproveCandidate(options, candidate, 'already-queued-intent', {
+      existingIntentIds: openIntents.map((intent) => intent.id),
+    });
+    return undefined;
+  }
+
+  return { ...snapshotComparison.ref, source: candidate.source, task: latest };
+}
+
+export function collectValidatedAutoApproveCandidates(
+  options: AutoApproveWorkerPolicyOptions,
+  candidates: AutoApproveCandidate[] = listAutoApproveScanCandidates(options),
+): ValidatedAutoApproveCandidate[] {
+  return candidates
+    .map((candidate) => validateAutoApproveCandidate(candidate, options))
+    .filter((candidate): candidate is ValidatedAutoApproveCandidate => Boolean(candidate));
+}
+
+export function createAutoApproveTick(options: AutoApproveWorkerPolicyOptions): WorkerTick {
+  return async (ctx) => {
+    if (options.enabled !== true) return;
+    const wakeups = options.drainWakeupHints?.() ?? [];
+    const wakeupCandidates = wakeups.map(candidateFromWakeup).filter((c): c is AutoApproveCandidate => Boolean(c));
+    const candidates = dedupeCandidates(
+      wakeupCandidates.length > 0 && ctx.reason === 'wake'
+        ? wakeupCandidates
+        : listAutoApproveScanCandidates(options),
+    );
+    const submittedThisTick = new Set<string>();
+
+    for (const candidate of collectValidatedAutoApproveCandidates(options, candidates)) {
+      if (submittedThisTick.has(candidate.taskId)) {
+        skipAutoApproveCandidate(options, candidate, 'duplicate-candidate');
+        continue;
+      }
+      const intentId = options.submitter.submit(
+        candidate.workflowId,
+        'normal',
+        AUTO_APPROVE_COMMAND_CHANNEL,
+        [candidate.taskId],
+      );
+      submittedThisTick.add(candidate.taskId);
+      recordAutoApproveAction(
+        options,
+        candidate,
+        'queued',
+        'Queued AI fix approval',
+        { channel: AUTO_APPROVE_COMMAND_CHANNEL },
+        intentId,
+      );
+      logAutoApproveWorkerEvent(options, candidate, 'worker-autoapprove-submitted', {
+        intentId,
+        channel: AUTO_APPROVE_COMMAND_CHANNEL,
+      });
+    }
+  };
+}
+
+function isAwaitingApprovalEvent(event: WorkflowLifecycleEvent): boolean {
+  return event.kind === 'task.awaiting_approval' && Boolean(event.taskId);
+}
+
+export function createAutoApproveWorker(options: AutoApproveWorkerOptions): WorkerRuntime {
+  const pendingWakeups: RecoveryWorkerWakeupHint[] = [];
+  let lifecycleUnsubscribe: Unsubscribe | undefined;
+  const onTick = options.onTick ?? (
+    options.autoApprove
+      ? createAutoApproveTick({
+        ...options.autoApprove,
+        logger: options.logger,
+        drainWakeupHints: () => pendingWakeups.splice(0),
+      })
+      : (() => {})
+  );
+  const runtime = createWorkerRuntime({
+    kind: AUTO_APPROVE_WORKER_KIND,
+    instanceId: options.instanceId,
+    logger: options.logger,
+    intervalMs: options.intervalMs ?? DEFAULT_AUTO_APPROVE_WORKER_INTERVAL_MS,
+    tickOnStart: options.tickOnStart ?? false,
+    installSignalHandlers: options.installSignalHandlers,
+    onTick,
+  });
+
+  if (!options.messageBus || !options.autoApprove || options.onTick) return runtime;
+
+  const start = (): void => {
+    if (!lifecycleUnsubscribe) {
+      lifecycleUnsubscribe = options.messageBus?.subscribe<WorkflowLifecycleEvent>(
+        Channels.WORKFLOW_LIFECYCLE,
+        (event) => {
+          if (!isAwaitingApprovalEvent(event)) return;
+          pendingWakeups.push(event.recoveryWakeup);
+          runtime.wake('wake');
+        },
+      );
+    }
+    runtime.start();
+  };
+  const stop = async (): Promise<void> => {
+    lifecycleUnsubscribe?.();
+    lifecycleUnsubscribe = undefined;
+    await runtime.stop();
+  };
+
+  return {
+    identity: runtime.identity,
+    start,
+    wake: runtime.wake,
+    tick: runtime.tick,
+    stop,
+    isRunning: runtime.isRunning,
+  };
+}


### PR DESCRIPTION
## Summary

Invoker can auto-approve AI fixes for you. This routes that approval through the current worker system.

A new owner worker watches for tasks that are paused waiting for approval after an AI fix, and approves them on your behalf.

It only acts when you turn on `autoApproveAIFixes`. With the flag off, nothing changes.

The feature previously lived on an old branch built on a worker model master has since replaced. This re-implements it on master's registry.

## Review Claim

Approve adding an `autoapprove` owner worker that routes approval of tasks awaiting an AI fix through the `invoker:approve` channel, gated on the existing `autoApproveAIFixes` config.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The worker self-gates: its tick returns immediately unless `autoApprove.enabled` is true, which `main.ts` sets from `autoApproveAIFixes` (default off). It only submits the existing `invoker:approve` channel already handled by the mutation dispatcher, and snapshot-checks each candidate (workflow, generation, task-state version, attempt) before acting, so a changed task is left alone. No existing worker, config default, or approval path changes.

## Slice Rationale

One cohesive claim: the worker plus the minimal registry and config wiring it needs to run. The old 7-PR stack's config-path and docs refactors were separate concerns tied to a superseded worker model, and are not revived here.

## Non-goals

- Does not change the default (`autoApproveAIFixes` stays off).
- Does not change the manual approve/reject UI or the `invoker:approve` handler.
- Does not touch the disk-headroom, pr-maintenance, ci-failure, requeue, or pr-status workers beyond adding one registration line.
- Does not revive the old stack's CLI/Slack shared-config-path or docs changes.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/auto-approve-worker.test.ts` — 8 tests: scan, snapshot freshness, dedupe, open-intent handling, submit.
- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/worker-registry.test.ts` — 6 tests: built-in registry now includes `autoapprove` in order.
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/worker-control.test.ts` — 12 tests: owner auto-start set includes the worker.
- [ ] `pnpm run check:types` — full workspace typecheck passes.
- [ ] `pnpm run check:deps` — 0 errors.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`.
- Post-revert steps: None. The worker is additive and off by default; reverting removes the registration and config wiring.
- Data migration? No.

</details>
