### PR TITLE
[Approval modal labels](1) Align create-PR heading with its button

### DIFF
--- a/packages/ui/src/__tests__/approval-modal.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal.test.tsx
@@ -823,7 +823,7 @@ describe('ApprovalModal', () => {
     expect(screen.getByRole('heading', { name: 'Confirm Merge' })).toBeInTheDocument();
   });
 
-  it('renders "Confirm Pull Request" heading for merge node with onFinish="pull_request"', () => {
+  it('renders "Confirm Create PR" heading for merge node with onFinish="pull_request"', () => {
     render(
       <ApprovalModal
         task={makeTask({ config: { isMergeNode: true } })}
@@ -833,7 +833,7 @@ describe('ApprovalModal', () => {
         onFinish="pull_request"
       />,
     );
-    expect(screen.getByRole('heading', { name: 'Confirm Pull Request' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Confirm Create PR' })).toBeInTheDocument();
   });
 
   it('shows a "Confirm Merge" *button* matching the heading for onFinish="merge"', () => {
@@ -859,7 +859,21 @@ describe('ApprovalModal', () => {
         onFinish="pull_request"
       />,
     );
-    expect(screen.getByText('Confirm Create PR')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm Create PR' })).toBeInTheDocument();
+  });
+
+  it('shows a "Confirm Create PR" heading and button that match for onFinish="pull_request"', () => {
+    render(
+      <ApprovalModal
+        task={makeTask({ config: { isMergeNode: true } })}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onClose={vi.fn()}
+        onFinish="pull_request"
+      />,
+    );
+    expect(screen.getByRole('heading', { name: 'Confirm Create PR' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm Create PR' })).toBeInTheDocument();
   });
 
   it('reject button says "Reject PR" (not "Reject Merge") for onFinish="pull_request"', () => {

--- a/packages/ui/src/components/ApprovalModal.tsx
+++ b/packages/ui/src/components/ApprovalModal.tsx
@@ -183,7 +183,7 @@ export function ApprovalModal({
       ? onFinish === 'merge'
         ? 'Confirm Merge'
         : onFinish === 'pull_request'
-          ? 'Confirm Pull Request'
+          ? 'Confirm Create PR'
           : 'Approve Merge'
       : 'Manual Approval Required';
 


### PR DESCRIPTION
## Summary

The approval modal for creating a pull request now shows the same words on its title and its button.

Before this change the title said "Confirm Pull Request" while the green button said "Confirm Create PR". Both confirm the same action, so the wording drifted.

This makes the title read "Confirm Create PR" to match the button. It mirrors the merge case, where the title and button both read "Confirm Merge".

## Review Claim

For an `onFinish='pull_request'` merge gate, the `ApprovalModal` heading and primary button both read "Confirm Create PR".

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

A one-line heading string change in `ApprovalModal.tsx`. The button logic and every other `onFinish` branch are unchanged, and it is guarded by a unit test plus a visual-proof capture.

## Slice Rationale

Follow-up to #3526, which fixed the merge-button mismatch and explicitly deferred this pre-existing create-PR heading/button mismatch as out of scope.

## Non-goals

- Does not change the primary button label, which already read "Confirm Create PR".
- Does not touch the `onFinish='merge'` branch or the generic (non-merge) approval branch.
- Does not change the reject or confirm-reject button labels.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/ui && pnpm exec vitest run approval-modal`

</details>

## Visual Proof

Approval modal for a create-PR gate. The heading and the primary green button both read "Confirm Create PR", and the reject button reads "Reject PR":

![Confirm Create PR approval modal](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-35966a/approval-modal-create-pr-heading.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
