### PR TITLE
[SQLite corruption recovery](1) Auto-restore corrupt DB from clean hourly snapshot + gate hourly snapshots on quick_check

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -803,6 +803,27 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
   });
   // Upgrade root logger with DB persistence now that SQLiteAdapter is ready.
   logger = new FileAndDbLogger({ module: 'main' }, { persistence });
+  // Surface auto-restore / empty-fallback loudly so a silent quarantine can never
+  // repeat the "boot shows zero tasks with no explanation" incident. Owner-only
+  // adapters carry `corruptionRecovery`; detached viewers never do.
+  if (persistence.corruptionRecovery) {
+    const { detectedAt, quarantinedPath, restoredFromSnapshot } = persistence.corruptionRecovery;
+    if (restoredFromSnapshot) {
+      logger.warn(
+        `[db-recovery] Corrupt database quarantined to ${quarantinedPath} at ${detectedAt}; ` +
+          `auto-restored from clean hourly snapshot ${restoredFromSnapshot}. ` +
+          'Activity between the snapshot timestamp and the corruption event is lost.',
+        { module: 'db-recovery' },
+      );
+    } else {
+      logger.error(
+        `[db-recovery] Corrupt database quarantined to ${quarantinedPath} at ${detectedAt}; ` +
+          'NO clean hourly snapshot available — started with an empty database. ' +
+          `Historical rows may still be recoverable from ${quarantinedPath} via sqlite3 .recover.`,
+        { module: 'db-recovery' },
+      );
+    }
+  }
   const shellEnv = await initializeShellEnvironment();
   if (process.platform === 'darwin') {
     const suffix = shellEnv.reason ? ` (${shellEnv.reason})` : '';
@@ -818,6 +839,19 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
       hourlyBackupInterval = setInterval(() => {
         void (async () => {
           try {
+            // Refuse to propagate a corrupt image into the snapshot ring. Once
+            // the live DB is damaged, every subsequent hourly snapshot rewrites
+            // the ring with the corrupt file, so the next boot has no clean
+            // candidate for `SQLiteAdapter.create`'s auto-restore invariant. A
+            // failed quick_check MUST skip that hour and log loudly.
+            if (!persistence.quickCheck()) {
+              logger.error(
+                'hourly snapshot skipped: source DB failed PRAGMA quick_check. ' +
+                  'The snapshot ring is preserved so the next boot can auto-restore from the last clean image.',
+                { module: 'backup' },
+              );
+              return;
+            }
             const snapshot = await createHourlySnapshot(invokerHomeRoot, backupViaOwner);
             if (snapshot) {
               logger.info(`hourly snapshot: ${snapshot}`, { module: 'backup' });

--- a/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter-corruption-recovery.test.ts
@@ -8,7 +8,7 @@ import {
   readdirSync,
   existsSync,
 } from 'node:fs';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SQLiteAdapter, isDatabaseCorruptionError } from '../sqlite-adapter.js';
 
@@ -30,6 +30,31 @@ function makeDir(): string {
 afterEach(() => {
   for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
 });
+
+/**
+ * Seed a valid SQLite snapshot at `snapshotPath` containing the caller-supplied
+ * `workflowIds`. Uses the adapter's own writer so schema + data are consistent
+ * with what {@link SQLiteAdapter.create} recovery reads back. Drops the WAL/SHM
+ * sidecars so the file behaves like a production `db-backups/*.hourly-auto-*`
+ * snapshot produced through `backupTo` (single-file, self-contained).
+ */
+async function seedSnapshot(snapshotPath: string, workflowIds: string[]): Promise<void> {
+  mkdirSync(join(snapshotPath, '..'), { recursive: true });
+  const seed = await SQLiteAdapter.create(snapshotPath, { ownerCapability: true });
+  try {
+    const now = new Date().toISOString();
+    for (const id of workflowIds) {
+      seed.saveWorkflow({ id, name: id, createdAt: now, updatedAt: now });
+    }
+    seed.checkpointWal('TRUNCATE');
+  } finally {
+    seed.close();
+  }
+  for (const suffix of ['-wal', '-shm']) {
+    const sidecar = `${snapshotPath}${suffix}`;
+    if (existsSync(sidecar)) rmSync(sidecar);
+  }
+}
 
 describe('isDatabaseCorruptionError', () => {
   it('treats SQLITE_CORRUPT (11), SQLITE_NOTADB (26) and their extended variants as corruption', () => {
@@ -94,5 +119,153 @@ describe('SQLiteAdapter.create recovery', () => {
 
     expect(readdirSync(dir).some((name) => name.includes('.corrupt-'))).toBe(false);
     expect(existsSync(join(dbPath, 'sentinel'))).toBe(true);
+  });
+});
+
+/**
+ * Data-preserving recovery: when the primary DB is corrupt AND a clean
+ * `db-backups/*.hourly-auto-*` snapshot exists next to it, the corruption
+ * branch of `SQLiteAdapter.create` MUST auto-restore from the newest clean
+ * snapshot instead of silently starting empty. The prior "start fresh" branch
+ * caused a real-world incident where 118 tasks / 35 workflows disappeared from
+ * the UI on the next launch (`~/.invoker/invoker.db.corrupt-1783551458868`).
+ */
+describe('SQLiteAdapter.create auto-restore from hourly snapshot', () => {
+  it('restores from the newest clean hourly snapshot when db-backups has one', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const backupDir = join(dir, 'db-backups');
+    mkdirSync(backupDir);
+
+    await seedSnapshot(
+      join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-090000-000Z`),
+      ['wf-older'],
+    );
+    await seedSnapshot(
+      join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-100000-000Z`),
+      ['wf-newer-1', 'wf-newer-2'],
+    );
+
+    writeFileSync(dbPath, Buffer.from('xx not a sqlite header xx '.repeat(50)));
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      const ids = adapter.listWorkflows().map((w) => w.id).sort();
+      expect(ids).toEqual(['wf-newer-1', 'wf-newer-2']);
+      expect(adapter.corruptionRecovery?.restoredFromSnapshot).toBe(
+        join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-100000-000Z`),
+      );
+      expect(adapter.corruptionRecovery?.quarantinedPath).toContain('.corrupt-');
+    } finally {
+      adapter.close();
+    }
+
+    const quarantined = readdirSync(dir).filter(
+      (n) => n.includes('.corrupt-') && !n.endsWith('-wal') && !n.endsWith('-shm'),
+    );
+    expect(quarantined).toHaveLength(1);
+  });
+
+  it('skips a corrupt snapshot and falls back to the next clean one', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const backupDir = join(dir, 'db-backups');
+    mkdirSync(backupDir);
+
+    await seedSnapshot(
+      join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-090000-000Z`),
+      ['wf-clean-older'],
+    );
+    writeFileSync(
+      join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-100000-000Z`),
+      Buffer.from('xx not a sqlite header xx '.repeat(50)),
+    );
+
+    writeFileSync(dbPath, Buffer.from('xx primary corrupt xx '.repeat(50)));
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      expect(adapter.listWorkflows().map((w) => w.id)).toEqual(['wf-clean-older']);
+      expect(adapter.corruptionRecovery?.restoredFromSnapshot).toBe(
+        join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-090000-000Z`),
+      );
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('falls back to an empty DB when db-backups has no clean snapshot', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const backupDir = join(dir, 'db-backups');
+    mkdirSync(backupDir);
+
+    for (const stamp of ['20260708-090000-000Z', '20260708-100000-000Z']) {
+      writeFileSync(
+        join(backupDir, `${basename(dbPath)}.hourly-auto-${stamp}`),
+        Buffer.from('xx not a sqlite header xx '.repeat(50)),
+      );
+    }
+
+    writeFileSync(dbPath, Buffer.from('xx primary corrupt xx '.repeat(50)));
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      expect(adapter.listWorkflows()).toEqual([]);
+      expect(adapter.corruptionRecovery?.restoredFromSnapshot).toBeNull();
+      expect(adapter.corruptionRecovery?.quarantinedPath).toContain('.corrupt-');
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('exposes null corruptionRecovery on a normal (non-recovered) open', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      expect(adapter.corruptionRecovery).toBeNull();
+    } finally {
+      adapter.close();
+    }
+  });
+});
+
+/**
+ * `quickCheck()` gives callers a cheap, deterministic way to gate destructive
+ * operations (e.g. hourly snapshots) on the live DB actually being intact.
+ * Without this the snapshot ring silently propagates a corrupt image for hours
+ * once corruption starts — every clean backup gets overwritten before the next
+ * boot triggers auto-restore, defeating the recovery invariant above.
+ */
+describe('SQLiteAdapter.quickCheck', () => {
+  it('returns true on a freshly created database', async () => {
+    const dir = makeDir();
+    const adapter = await SQLiteAdapter.create(join(dir, 'invoker.db'), { ownerCapability: true });
+    try {
+      expect(adapter.quickCheck()).toBe(true);
+    } finally {
+      adapter.close();
+    }
+  });
+
+  it('returns true after the auto-restore recovery finishes', async () => {
+    const dir = makeDir();
+    const dbPath = join(dir, 'invoker.db');
+    const backupDir = join(dir, 'db-backups');
+    mkdirSync(backupDir);
+    await seedSnapshot(
+      join(backupDir, `${basename(dbPath)}.hourly-auto-20260708-100000-000Z`),
+      ['wf-restored'],
+    );
+    writeFileSync(dbPath, Buffer.from('xx not a sqlite header xx '.repeat(50)));
+
+    const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+    try {
+      expect(adapter.quickCheck()).toBe(true);
+      expect(adapter.listWorkflows().map((w) => w.id)).toEqual(['wf-restored']);
+    } finally {
+      adapter.close();
+    }
   });
 });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -8,17 +8,19 @@
 import {
   appendFileSync,
   closeSync,
+  copyFileSync,
   existsSync,
   mkdirSync,
   openSync,
   readFileSync,
   readSync,
+  readdirSync,
   renameSync,
   rmSync,
   statSync,
 } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import type { DatabaseSync, StatementSync } from 'node:sqlite';
 import type {
   TaskState,
@@ -215,6 +217,74 @@ export function isDatabaseCorruptionError(err: unknown): boolean {
   // Fallback for runtimes that do not surface a numeric errcode.
   const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
   return message.includes('malformed') || message.includes('not a database');
+}
+
+/**
+ * Metadata attached to an adapter that opened via the corruption-recovery
+ * branch of {@link SQLiteAdapter.create}. `restoredFromSnapshot` is the source
+ * of the recovered data when auto-restore succeeded, or `null` when no clean
+ * hourly snapshot was available and the adapter fell back to an empty schema.
+ * `quarantinedPath` always points at the preserved pre-recovery file so the
+ * user can attempt manual `.recover` later.
+ */
+export interface CorruptionRecovery {
+  readonly detectedAt: string;
+  readonly quarantinedPath: string;
+  readonly restoredFromSnapshot: string | null;
+}
+
+/** Prefix produced by `createHourlySnapshot` in `packages/app/src/delete-all-snapshot.ts`. */
+const HOURLY_SNAPSHOT_LABEL = 'hourly-auto-';
+
+/**
+ * Run `PRAGMA quick_check` on the raw file at `dbPath`. Returns `true` iff the
+ * check reports a single `'ok'` row. Any open failure, IO error, or non-ok row
+ * yields `false` so callers can treat the file as unusable without unwrapping
+ * SQLite error taxonomy. The connection is closed before returning so we never
+ * leave a `-shm` mapping on a file we're about to copy or ignore.
+ */
+async function fileQuickCheckOk(dbPath: string): Promise<boolean> {
+  try {
+    const { DatabaseSync } = await loadNativeSqlite();
+    const db = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      const rows = db.prepare('PRAGMA quick_check').all() as Array<{ quick_check?: unknown }>;
+      return rows.length === 1 && rows[0]?.quick_check === 'ok';
+    } finally {
+      db.close();
+    }
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find the newest `<dbBasename>.hourly-auto-*` file in `backupDir` whose
+ * `quick_check` passes. Returns `null` when the directory is missing, has no
+ * matching snapshots, or every candidate is corrupt. Snapshot names embed an
+ * ISO-derived timestamp (`YYYYMMDD-HHMMSS-mmmZ`), so lexicographic descending
+ * order is chronologically newest-first.
+ */
+async function findLatestCleanHourlySnapshot(
+  backupDir: string,
+  dbBasename: string,
+): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = readdirSync(backupDir);
+  } catch {
+    return null;
+  }
+  const prefix = `${dbBasename}.${HOURLY_SNAPSHOT_LABEL}`;
+  const snapshots = entries
+    .filter((name) => name.startsWith(prefix) && !name.endsWith('-wal') && !name.endsWith('-shm'))
+    .sort()
+    .reverse();
+  for (const name of snapshots) {
+    const candidate = join(backupDir, name);
+    if (await fileQuickCheckOk(candidate)) return candidate;
+  }
+  return null;
 }
 
 class NativeStatementCompat {
@@ -464,8 +534,21 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private activityLogWritesSincePrune = 0;
   private readonly exclusiveLocking: boolean;
 
+  /**
+   * Non-null only when this adapter was opened via the corruption-recovery
+   * branch of {@link SQLiteAdapter.create}. Callers (e.g. `main.ts`) surface
+   * this to the user so a silent auto-restore or empty-DB fallback is never
+   * invisible again. Field, not method, so it's cheap to check on every boot.
+   */
+  readonly corruptionRecovery: CorruptionRecovery | null;
+
   /** Use SQLiteAdapter.create() instead. */
-  private constructor(db: DatabaseSync, dbPath: string | null, options?: SQLiteAdapterOptions) {
+  private constructor(
+    db: DatabaseSync,
+    dbPath: string | null,
+    options?: SQLiteAdapterOptions,
+    corruptionRecovery: CorruptionRecovery | null = null,
+  ) {
     this.nativeDb = db;
     this.db = new NativeDatabaseCompat(db);
     this.dbPath = dbPath;
@@ -474,6 +557,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.outputDir = options?.outputDir ?? this.resolveOutputDir(dbPath);
     this.activityLogMaxRows = options?.activityLogMaxRows ?? DEFAULT_ACTIVITY_LOG_MAX_ROWS;
     this.exclusiveLocking = options?.exclusiveLocking === true;
+    this.corruptionRecovery = corruptionRecovery;
     this.configureConnection(dbPath !== null);
     if (!this.readOnly) {
       this.initSchema();
@@ -548,19 +632,70 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (!isFile || options?.readOnly === true || !existsSync(dbPath) || !isDatabaseCorruptionError(err)) {
         throw err;
       }
+      const detectedAt = new Date().toISOString();
       const backupPath = `${dbPath}.corrupt-${Date.now()}`;
       console.error(
         `[SQLiteAdapter] Database corrupted (${err instanceof Error ? err.message : String(err)}). ` +
-        `Backing up to ${backupPath} and starting fresh.`,
+        `Quarantining to ${backupPath}.`,
       );
       renameSync(dbPath, backupPath);
       for (const suffix of ['-wal', '-shm']) {
         const sidecar = `${dbPath}${suffix}`;
         if (existsSync(sidecar)) renameSync(sidecar, `${backupPath}${suffix}`);
       }
+
+      // Data-preserving recovery: prefer the newest clean hourly snapshot over
+      // silently starting empty. The invariant only holds if the snapshot is
+      // itself intact (quick_check == ok), so we walk newest-first and skip
+      // any candidate whose pages are also damaged.
+      const backupDir = join(dirname(dbPath), 'db-backups');
+      const cleanSnapshot = await findLatestCleanHourlySnapshot(backupDir, basename(dbPath));
+      let restoredFromSnapshot: string | null = null;
+      if (cleanSnapshot) {
+        try {
+          copyFileSync(cleanSnapshot, dbPath);
+          restoredFromSnapshot = cleanSnapshot;
+          console.error(
+            `[SQLiteAdapter] Auto-restored ${dbPath} from clean snapshot ${cleanSnapshot}.`,
+          );
+        } catch (copyErr) {
+          console.error(
+            `[SQLiteAdapter] Failed to restore from ${cleanSnapshot}: ` +
+              (copyErr instanceof Error ? copyErr.message : String(copyErr)) +
+              '. Falling back to empty database.',
+          );
+        }
+      } else {
+        console.error(
+          `[SQLiteAdapter] No clean hourly snapshot in ${backupDir}; starting fresh empty database.`,
+        );
+      }
+
+      const recovery: CorruptionRecovery = {
+        detectedAt,
+        quarantinedPath: backupPath,
+        restoredFromSnapshot,
+      };
       const { DatabaseSync } = await loadNativeSqlite();
       const db = new DatabaseSync(dbPath);
-      return new SQLiteAdapter(db, dbPath, options);
+      return new SQLiteAdapter(db, dbPath, options, recovery);
+    }
+  }
+
+  /**
+   * Cheap ("~milliseconds on hundreds of MB") integrity gate for the live
+   * connection. Returns `true` iff SQLite's `PRAGMA quick_check` produces a
+   * single `'ok'` row. Callers use this to refuse destructive downstream work
+   * on a damaged DB — most importantly, to skip the hourly snapshot when the
+   * source is corrupt (otherwise the corruption propagates into every backup
+   * and defeats the auto-restore invariant in {@link SQLiteAdapter.create}).
+   */
+  quickCheck(): boolean {
+    try {
+      const rows = this.nativeDb.prepare('PRAGMA quick_check').all() as Array<{ quick_check?: unknown }>;
+      return rows.length === 1 && rows[0]?.quick_check === 'ok';
+    } catch {
+      return false;
     }
   }
 


### PR DESCRIPTION
## Summary

When `SQLiteAdapter.create` hit `SQLITE_CORRUPT` it quarantined the file and opened an empty database. The user saw zero tasks on the next launch and the only signal was a stderr line.

A 2026-07-08 field incident lost 118 tasks and 35 workflows this way. #3468 and #3470 stopped the underlying cause; this slice adds the safety net.

The corruption branch now walks `<dbDir>/db-backups/` newest-first, runs `PRAGMA quick_check` on each hourly candidate, and copies the first `ok` one into place before opening. The quarantined file is preserved untouched.

A new `corruptionRecovery` field carries `{ detectedAt, quarantinedPath, restoredFromSnapshot }`.

`main.ts` reads it right after open and logs `warn` (restored) or `error` (fell back to empty), so the event is never silent again.

`SQLiteAdapter.quickCheck()` returns `PRAGMA quick_check` as a boolean guard.

The hourly-snapshot interval in `main.ts` calls it first and aborts the hourly when the source is damaged. The snapshot ring is preserved instead of getting overwritten with corrupt copies.

Replayed against the 2026-07-08 timeline: the 11:00 UTC hourly aborts, so the clean 10:00 UTC hourly stays in the ring.

The 22:57 UTC boot auto-restores from that hourly, comes up with 118 tasks and 35 workflows, and logs one `warn` line about the intervening activity that was lost.

## Review Claim

On corruption at open, prefer the newest clean `db-backups/*.hourly-auto-*` file over silently opening empty; on every hourly, refuse to snapshot when the live DB fails `quick_check`.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

The auto-restore branch only runs after `isDatabaseCorruptionError` already fired, so the non-corruption open path is untouched. The quarantine step (rename primary + sidecars aside) is byte-identical to the pre-change branch, so no pre-recovery bytes are ever destroyed. Restore is a plain `copyFileSync` from a `quick_check == ok` file into the now-empty primary slot; any copy failure logs and falls through to the pre-change empty-DB branch. The hourly `quickCheck` gate can only abort a snapshot, never fabricate one.

## Slice Rationale

This is the recovery invariant only. Runtime fail-stop wrapping of `nativeDb.exec` / `.prepare` to abort in-session crash loops on `SQLITE_CORRUPT`, and the UI banner surfacing `corruptionRecovery` to the user, are deliberately separate follow-up slices — they touch executor internals and the bootstrap IPC surface respectively.

## Non-goals

- No change to what counts as corruption; `isDatabaseCorruptionError` (SQLITE_CORRUPT / SQLITE_NOTADB and their extended variants) is untouched.
- No change to the pre-existing quarantine step. `.corrupt-<ts>` naming, sidecar renames, and preservation semantics are byte-identical to the pre-change branch.
- No runtime fail-stop when `SQLITE_CORRUPT` fires mid-session. Statements still throw the way they do today; crash-loop containment is a separate follow-up.
- No UI surface for `corruptionRecovery`. Only logged for now; an in-app banner would require a bootstrap-IPC change.
- No change to `SnapshotBackupFn`, `createDeleteAllSnapshot`, `createHourlySnapshot`, or the snapshot pruning logic. `INVOKER_HOURLY_BACKUP_RETENTION` behavior is preserved verbatim.
- No historical migration. Pre-existing `.corrupt-*` files on running hosts are not auto-recovered by this change; users can still manually `sqlite3 <file> .recover` from them.

## Visual Proof

`main.ts` is the only "UI-impacting" file touched; the diff is limited to two blocks — post-open `corruptionRecovery` logging and the hourly-snapshot `quickCheck` gate — with no window, menu, or IPC changes. The user-visible outcome is entirely in the log output the invariant emits, rendered below from the real test-suite stderr plus the exact operator-level lines `main.ts` now writes.

![Corruption-recovery log output: real test stderr plus operator-level log lines emitted by main.ts](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260708-3e5f15/sqlite-invariants-proof.png)

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/data-store && pnpm test` — 370 tests pass, including 6 new tests in `sqlite-adapter-corruption-recovery.test.ts` covering auto-restore selection, corrupt-snapshot skip, empty-fallback, `corruptionRecovery` metadata, and `quickCheck` on fresh + post-restore adapters.
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/delete-all-snapshot.test.ts src/__tests__/delete-all-snapshot-wal-safety.test.ts src/__tests__/viewer-detached-db.test.ts src/__tests__/headless-delete-all-safety.test.ts` — 21 tests pass; confirms no regression in the snapshot and viewer-boundary callers.
- [ ] `pnpm exec tsc -p tsconfig.typecheck.json` — workspace typechecks with zero errors.
- [ ] `cd packages/app && pnpm build` — `dist/main.js` builds successfully; grep confirms `corruptionRecovery`, `findLatestCleanHourlySnapshot`, `quickCheck`, and `db-recovery` are bundled (13 occurrences).

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <sha>`.
- Post-revert steps: None. The revert restores the pre-change corruption branch (quarantine + open empty). Any `db-backups/*.hourly-auto-*` files produced during the fixed period are ordinary single-file SQLite databases and stay readable by hand.
- Data migration? No. Schema and on-disk layout are unchanged.

</details>
