### PR TITLE
[Main panel title clamp] Clamp running-task main panel title to two lines

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2912,8 +2912,13 @@ export function App() {
     <div className="flex-1 flex flex-col overflow-hidden">
       <div className="border-b border-gray-800 bg-gray-950/50 px-4 py-4">
         <div className="flex items-start justify-between gap-4">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-100">{browserSelectedTitle}</h2>
+          <div className="min-w-0 flex-1">
+            <h2
+              className="text-lg font-semibold text-gray-100 line-clamp-2"
+              title={browserSelectedTitle}
+            >
+              {browserSelectedTitle}
+            </h2>
             <p className="mt-1 text-sm text-gray-400">{browserSelectedContext}</p>
             <div className={`mt-2 inline-flex rounded-full px-2.5 py-1 text-[11px] font-medium ${browserStatusToneClass}`}>
               {browserSelectedStatus}


### PR DESCRIPTION
## Summary

Selecting a running task shows its description as the main-panel `<h2>` header.

Long descriptions previously wrapped freely and pushed the status chip and graph action buttons down each time selection changed.

Clamping the header to two lines with `line-clamp-2` (plus `min-w-0 flex-1` on its flex parent) fixes the layout jitter without hiding information.

The full description stays available on hover because the h2 also gains a `title=` attribute.

## Review Claim

The `renderBrowserDetailWorkspace` header keeps a stable two-line height for long task descriptions on the Running and Needs Attention surfaces.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

Pure Tailwind class change plus a `title=` attribute on one `<h2>` in `packages/ui/src/App.tsx`. No JS logic, no state, no data flow, no test fixtures. Short titles are visually identical to master.

## Slice Rationale

One header, one clamp; no other components changed and no unrelated CSS churn. The `WorkflowInspector` side-panel title and browser-rail list rows stay on their own single-line `truncate` behavior.

## Non-goals

- No change to the `WorkflowInspector` side-panel title (still 1-line `truncate`).
- No change to task-list rows in the browser rail (still 1-line `truncate`).
- No change to `TaskNode` DAG node titles.
- No new dependency; Tailwind 3.4 already exposes `line-clamp-2`.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `cd packages/ui && pnpm test` — 631 tests pass on this branch.
- [x] `cd packages/ui && pnpm build` — Vite build succeeds; `dist/assets/index-*.css` contains `-webkit-line-clamp:2` (Tailwind emitted the utility).
- [ ] Manual: pick a running task with a long description on the Running surface; the header clamps to two lines with an ellipsis and shows the full description on hover; Refresh / Full graph / More / Home buttons keep their normal position.

</details>

## Visual Proof

Rendered with the actual JSX from `renderBrowserDetailWorkspace` and the compiled Tailwind bundle from `packages/ui/dist/assets/index-*.css`. Top row is master today (no clamp); bottom row is this PR (`line-clamp-2` + `min-w-0 flex-1`). The compiled CSS confirms Tailwind emitted `-webkit-line-clamp:2` for the added utility.

![Main-panel header, master today vs this PR](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260709-bc5de7/combined-long-title.png)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert c51fe237a`
- Post-revert steps: None
- Data migration? No

</details>
