### PR TITLE
[Refresh wallpaper](1) dedupe UI polling hook state writes

### DIFF
--- a/packages/ui/src/hooks/useActionGraphSnapshot.ts
+++ b/packages/ui/src/hooks/useActionGraphSnapshot.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { ActionGraphResponse } from '@invoker/contracts';
+import { areStructurallyEqual } from './useDedupedState.js';
 
 export function useActionGraphSnapshot(pollMs = 2000, enabled = true): {
   graph: ActionGraphResponse | null;
@@ -14,7 +15,9 @@ export function useActionGraphSnapshot(pollMs = 2000, enabled = true): {
     try {
       const response = await window.invoker?.getActionGraph?.();
       if (response) {
-        setGraph(response);
+        setGraph((previous) =>
+          areStructurallyEqual(previous, response) ? previous : response,
+        );
         setError(null);
       }
     } catch (err) {
@@ -33,7 +36,9 @@ export function useActionGraphSnapshot(pollMs = 2000, enabled = true): {
       try {
         const response = await window.invoker?.getActionGraph?.();
         if (!cancelled && response) {
-          setGraph(response);
+          setGraph((previous) =>
+            areStructurallyEqual(previous, response) ? previous : response,
+          );
           setError(null);
         }
       } catch (err) {

--- a/packages/ui/src/hooks/useDedupedState.ts
+++ b/packages/ui/src/hooks/useDedupedState.ts
@@ -1,0 +1,56 @@
+/**
+ * Structural equality check for polling-hook payloads.
+ *
+ * Polling hooks in this package receive periodic responses from the main
+ * process. When the response has not changed, calling `setState` with the
+ * new object still churns identity, which invalidates downstream `useMemo`
+ * dependencies and forces the App tree to re-render every poll tick. This
+ * helper lets a hook skip the `setState` call when the incoming payload is
+ * structurally equal to the previous one.
+ *
+ * The comparison is deliberately small and dependency-free. It covers:
+ *   - primitives (Object.is semantics, so NaN === NaN)
+ *   - null / undefined
+ *   - Date instances (compared by getTime())
+ *   - Arrays (elementwise)
+ *   - Plain objects (own enumerable keys, recursive)
+ *
+ * Anything else falls back to reference identity. Callers should only pass
+ * plain data shapes (the polling responses in this repo are plain JSON).
+ */
+export function areStructurallyEqual<T>(a: T, b: T): boolean {
+  if (Object.is(a, b)) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== 'object' || typeof b !== 'object') return false;
+
+  if (a instanceof Date || b instanceof Date) {
+    if (!(a instanceof Date) || !(b instanceof Date)) return false;
+    return a.getTime() === b.getTime();
+  }
+
+  const aIsArray = Array.isArray(a);
+  const bIsArray = Array.isArray(b);
+  if (aIsArray !== bIsArray) return false;
+
+  if (aIsArray && bIsArray) {
+    const arrA = a as unknown as unknown[];
+    const arrB = b as unknown as unknown[];
+    if (arrA.length !== arrB.length) return false;
+    for (let i = 0; i < arrA.length; i += 1) {
+      if (!areStructurallyEqual(arrA[i], arrB[i])) return false;
+    }
+    return true;
+  }
+
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+  if (keysA.length !== keysB.length) return false;
+
+  for (const key of keysA) {
+    if (!Object.prototype.hasOwnProperty.call(objB, key)) return false;
+    if (!areStructurallyEqual(objA[key], objB[key])) return false;
+  }
+  return true;
+}

--- a/packages/ui/src/hooks/useQueueStatus.ts
+++ b/packages/ui/src/hooks/useQueueStatus.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { QueueStatus } from '../types.js';
+import { areStructurallyEqual } from './useDedupedState.js';
 
 export function useQueueStatus(pollMs = 2000): QueueStatus | null {
   const [queueStatus, setQueueStatus] = useState<QueueStatus | null>(null);
@@ -11,7 +12,9 @@ export function useQueueStatus(pollMs = 2000): QueueStatus | null {
       try {
         const status = await window.invoker?.getQueueStatus();
         if (!cancelled && status) {
-          setQueueStatus(status);
+          setQueueStatus((previous) =>
+            areStructurallyEqual(previous, status) ? previous : status,
+          );
         }
       } catch {
         // ignore polling errors

--- a/packages/ui/src/hooks/useWorkerStatus.ts
+++ b/packages/ui/src/hooks/useWorkerStatus.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { WorkerStatusSnapshot } from '../types.js';
+import { areStructurallyEqual } from './useDedupedState.js';
 
 export function useWorkerStatus(pollMs = 2000): readonly [snapshot: WorkerStatusSnapshot | null, refresh: () => Promise<void>] {
   const [snapshot, setSnapshot] = useState<WorkerStatusSnapshot | null>(null);
@@ -13,7 +14,9 @@ export function useWorkerStatus(pollMs = 2000): readonly [snapshot: WorkerStatus
     try {
       const status = await window.invoker?.getWorkerStatus();
       if (mountedRef.current && status) {
-        setSnapshot(status);
+        setSnapshot((previous) =>
+          areStructurallyEqual(previous, status) ? previous : status,
+        );
       }
     } catch {
       // ignore polling errors


### PR DESCRIPTION
## Summary

Three UI polling hooks (useQueueStatus, useWorkerStatus, useActionGraphSnapshot) invoke setState on every 2s response, even when the response is byte-identical to the previous one.

That churns the returned object reference, invalidates downstream useMemo dependencies, and cascades into full App re-renders in the Running view.

This slice exposes a small helper, packages/ui/src/hooks/useDedupedState.ts::areStructurallyEqual, and each hook now returns the previous object reference when the incoming payload matches it structurally.

## Review Claim

Each polling hook returns the previous object reference when the incoming payload matches it structurally.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

Behavior unchanged; equal payloads already carried the same data, so downstream consumers observe the same values.

## Slice Rationale

Smallest change that removes the 2s identity churn in three independent polling hooks. Write-side only, no consumer file is touched.

## Architecture

### Before

Every 2s poll writes a fresh object, so downstream useMemo dependencies invalidate on identity even when the payload is byte-identical.

```mermaid
graph LR
    P["Poll (2s)"] --> S["setState(newPayload)"]
    S --> H["hook returns newRef"]
    H --> M["useMemo dep changes"]
    M --> R["App re-render"]
```

### After

The hook returns the previous object reference when the incoming payload matches structurally, so downstream useMemo dependencies stay stable across unchanged ticks.

```mermaid
graph LR
    P["Poll (2s)"] --> C{"areStructurallyEqual(prev, next)"}
    C -->|"equal"| K["keep prev ref"]
    C -->|"different"| S["setState(newPayload)"]
    K --> H["hook returns prevRef"]
    S --> H2["hook returns newRef"]
    H --> M["useMemo dep stable"]
    H2 --> M2["useMemo dep changes"]
    M --> N["no re-render"]
    M2 --> R["App re-render"]
```

## Non-goals

- No behavior change.
- Sidebar memoization (later slice).
- Shared clock extraction (later slice).
- Gating polls on relevance (later slice).
- Replacing polling with push projections (deferred to Phase 2).

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] cd packages/ui && pnpm test

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
