### PR TITLE
[Refresh wallpaper](4) gate queue and worker polling on relevance

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -498,8 +498,9 @@ export function App() {
     [actionGraph],
   );
   const invoker = useInvoker();
-  const queueStatus = useQueueStatus();
-  const [workerStatus, refreshWorkerStatus] = useWorkerStatus();
+  const pollingRelevant = tasks.size > 0 || viewMode === 'queue';
+  const queueStatus = useQueueStatus(2000, pollingRelevant);
+  const [workerStatus, refreshWorkerStatus] = useWorkerStatus(2000, pollingRelevant);
   const handleStartWorker = useCallback(async (kind: string) => {
     await invoker.startWorker(kind);
     await refreshWorkerStatus();

--- a/packages/ui/src/components/LeftStatusColumn.tsx
+++ b/packages/ui/src/components/LeftStatusColumn.tsx
@@ -1,5 +1,6 @@
 import type { QueueStatus } from '@invoker/contracts';
 import type { JSX } from 'react';
+import { useMemo } from 'react';
 import type { TaskState, WorkflowMeta, WorkerStatusSnapshot } from '../types.js';
 import type { SidebarSurface } from '../lib/workflow-progress-surfaces.js';
 import { getAttentionTaskEntries, getRunningTaskEntries, getSortedWorkflows } from '../lib/workflow-progress-surfaces.js';
@@ -165,9 +166,12 @@ export function LeftStatusColumn({
   planningSessionCount,
   onOpenSettings,
 }: LeftStatusColumnProps): JSX.Element {
-  const workflowEntries = getSortedWorkflows(workflows, tasks);
-  const attentionEntries = getAttentionTaskEntries(tasks, workflows);
-  const runningEntries = getRunningTaskEntries(tasks, workflows, queueStatus);
+  const workflowEntries = useMemo(() => getSortedWorkflows(workflows, tasks), [workflows, tasks]);
+  const attentionEntries = useMemo(() => getAttentionTaskEntries(tasks, workflows), [tasks, workflows]);
+  const runningEntries = useMemo(
+    () => getRunningTaskEntries(tasks, workflows, queueStatus),
+    [tasks, workflows, queueStatus],
+  );
   const runningWorkers = workerStatus?.workers.filter((worker) => worker.lifecycle === 'running').length ?? 0;
   const registeredWorkers = workerStatus?.workers.length ?? 0;
   const activeWorkerActions = workerStatus ? countActiveWorkerActions(workerStatus.workers) : 0;

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -16,6 +16,7 @@ import {
   formatStatusLabel,
   getRunningPhaseLabel,
 } from '../lib/colors.js';
+import { useNow } from '../hooks/useNow.js';
 import { mergeGatePanelHeading } from '../lib/merge-gate.js';
 
 interface TaskAuditEvent {
@@ -157,16 +158,10 @@ function formatRepoUrl(url: string): string {
 }
 
 function HeartbeatTimingSection({ task, formatDate: fmtDate }: { task: TaskState; formatDate: (d?: Date | string) => string }) {
-  const [, setTick] = useState(0);
-
-  useEffect(() => {
-    if (task.status !== 'running' || !task.execution.lastHeartbeatAt) return;
-    const timer = setInterval(() => setTick(t => t + 1), 5_000);
-    return () => clearInterval(timer);
-  }, [task.status, task.execution.lastHeartbeatAt]);
+  const now = useNow(5_000, task.status === 'running' && Boolean(task.execution.lastHeartbeatAt));
 
   const heartbeatAge = task.execution.lastHeartbeatAt
-    ? Date.now() - (task.execution.lastHeartbeatAt instanceof Date ? task.execution.lastHeartbeatAt : new Date(task.execution.lastHeartbeatAt as unknown as string)).getTime()
+    ? now - (task.execution.lastHeartbeatAt instanceof Date ? task.execution.lastHeartbeatAt : new Date(task.execution.lastHeartbeatAt as unknown as string)).getTime()
     : null;
   const isHeartbeatStale = heartbeatAge !== null && heartbeatAge > 60_000;
 

--- a/packages/ui/src/components/TimelineView.tsx
+++ b/packages/ui/src/components/TimelineView.tsx
@@ -6,8 +6,8 @@
  * long and understanding execution parallelism.
  */
 
-import { useState, useEffect } from 'react';
 import type { TaskState } from '../types.js';
+import { useNow } from '../hooks/useNow.js';
 import {
   getStatusInlineColors,
   getEffectiveVisualStatus,
@@ -110,14 +110,8 @@ interface TimelineViewProps {
 }
 
 export function TimelineView({ tasks, onTaskClick, selectedTaskId }: TimelineViewProps) {
-  const [now, setNow] = useState(Date.now());
-
   const hasRunning = Array.from(tasks.values()).some((t) => t.status === 'running');
-  useEffect(() => {
-    if (!hasRunning) return;
-    const interval = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(interval);
-  }, [hasRunning]);
+  const now = useNow(1000, hasRunning);
 
   const taskList = sortTasksForTimeline(Array.from(tasks.values()));
   const bars = computeBarWidths(taskList, now);

--- a/packages/ui/src/hooks/useActionGraphSnapshot.ts
+++ b/packages/ui/src/hooks/useActionGraphSnapshot.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { ActionGraphResponse } from '@invoker/contracts';
+import { areStructurallyEqual } from './useDedupedState.js';
 
 export function useActionGraphSnapshot(pollMs = 2000, enabled = true): {
   graph: ActionGraphResponse | null;
@@ -14,7 +15,9 @@ export function useActionGraphSnapshot(pollMs = 2000, enabled = true): {
     try {
       const response = await window.invoker?.getActionGraph?.();
       if (response) {
-        setGraph(response);
+        setGraph((previous) =>
+          areStructurallyEqual(previous, response) ? previous : response,
+        );
         setError(null);
       }
     } catch (err) {
@@ -33,7 +36,9 @@ export function useActionGraphSnapshot(pollMs = 2000, enabled = true): {
       try {
         const response = await window.invoker?.getActionGraph?.();
         if (!cancelled && response) {
-          setGraph(response);
+          setGraph((previous) =>
+            areStructurallyEqual(previous, response) ? previous : response,
+          );
           setError(null);
         }
       } catch (err) {

--- a/packages/ui/src/hooks/useDedupedState.ts
+++ b/packages/ui/src/hooks/useDedupedState.ts
@@ -1,0 +1,56 @@
+/**
+ * Structural equality check for polling-hook payloads.
+ *
+ * Polling hooks in this package receive periodic responses from the main
+ * process. When the response has not changed, calling `setState` with the
+ * new object still churns identity, which invalidates downstream `useMemo`
+ * dependencies and forces the App tree to re-render every poll tick. This
+ * helper lets a hook skip the `setState` call when the incoming payload is
+ * structurally equal to the previous one.
+ *
+ * The comparison is deliberately small and dependency-free. It covers:
+ *   - primitives (Object.is semantics, so NaN === NaN)
+ *   - null / undefined
+ *   - Date instances (compared by getTime())
+ *   - Arrays (elementwise)
+ *   - Plain objects (own enumerable keys, recursive)
+ *
+ * Anything else falls back to reference identity. Callers should only pass
+ * plain data shapes (the polling responses in this repo are plain JSON).
+ */
+export function areStructurallyEqual<T>(a: T, b: T): boolean {
+  if (Object.is(a, b)) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== 'object' || typeof b !== 'object') return false;
+
+  if (a instanceof Date || b instanceof Date) {
+    if (!(a instanceof Date) || !(b instanceof Date)) return false;
+    return a.getTime() === b.getTime();
+  }
+
+  const aIsArray = Array.isArray(a);
+  const bIsArray = Array.isArray(b);
+  if (aIsArray !== bIsArray) return false;
+
+  if (aIsArray && bIsArray) {
+    const arrA = a as unknown as unknown[];
+    const arrB = b as unknown as unknown[];
+    if (arrA.length !== arrB.length) return false;
+    for (let i = 0; i < arrA.length; i += 1) {
+      if (!areStructurallyEqual(arrA[i], arrB[i])) return false;
+    }
+    return true;
+  }
+
+  const objA = a as Record<string, unknown>;
+  const objB = b as Record<string, unknown>;
+  const keysA = Object.keys(objA);
+  const keysB = Object.keys(objB);
+  if (keysA.length !== keysB.length) return false;
+
+  for (const key of keysA) {
+    if (!Object.prototype.hasOwnProperty.call(objB, key)) return false;
+    if (!areStructurallyEqual(objA[key], objB[key])) return false;
+  }
+  return true;
+}

--- a/packages/ui/src/hooks/useNow.ts
+++ b/packages/ui/src/hooks/useNow.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Subscribe to a shared clock tick.
+ *
+ * Cosmetic "time-ago" displays in the UI historically owned their own
+ * `setInterval` + `setState` pair (one per component), which meant every
+ * component ticked independently and paid its own React re-render even
+ * when the shared cadence was identical.
+ *
+ * `useNow(intervalMs, enabled)` returns the current millisecond time and
+ * re-renders the calling component on a cadence shared by every subscriber
+ * to the same `intervalMs`. Under the hood the module keeps one
+ * `setInterval` per interval value; new subscribers attach to the existing
+ * timer, and the timer is cleared when the last subscriber unsubscribes.
+ *
+ * When `enabled` is `false` the caller does not subscribe (no timer is
+ * started or ref-counted) but the hook still returns `Date.now()` from the
+ * subscribe attempt so callers can render a stable time string.
+ */
+
+interface ClockEntry {
+  timer: ReturnType<typeof globalThis.setInterval> | null;
+  subscribers: Set<(now: number) => void>;
+}
+
+const clocks = new Map<number, ClockEntry>();
+
+function subscribe(intervalMs: number, listener: (now: number) => void): () => void {
+  let entry = clocks.get(intervalMs);
+  if (!entry) {
+    entry = { timer: null, subscribers: new Set() };
+    clocks.set(intervalMs, entry);
+  }
+  entry.subscribers.add(listener);
+  if (entry.timer === null) {
+    entry.timer = globalThis.setInterval(() => {
+      const now = Date.now();
+      const current = clocks.get(intervalMs);
+      if (!current) return;
+      for (const fn of current.subscribers) {
+        fn(now);
+      }
+    }, intervalMs);
+  }
+  return () => {
+    const current = clocks.get(intervalMs);
+    if (!current) return;
+    current.subscribers.delete(listener);
+    if (current.subscribers.size === 0) {
+      if (current.timer !== null) {
+        globalThis.clearInterval(current.timer);
+      }
+      clocks.delete(intervalMs);
+    }
+  };
+}
+
+export function useNow(intervalMs: number, enabled: boolean = true): number {
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  useEffect(() => {
+    if (!enabled) return;
+    setNow(Date.now());
+    return subscribe(intervalMs, setNow);
+  }, [intervalMs, enabled]);
+
+  return now;
+}

--- a/packages/ui/src/hooks/useQueueStatus.ts
+++ b/packages/ui/src/hooks/useQueueStatus.ts
@@ -2,10 +2,11 @@ import { useEffect, useState } from 'react';
 import type { QueueStatus } from '../types.js';
 import { areStructurallyEqual } from './useDedupedState.js';
 
-export function useQueueStatus(pollMs = 2000): QueueStatus | null {
+export function useQueueStatus(pollMs = 2000, enabled = true): QueueStatus | null {
   const [queueStatus, setQueueStatus] = useState<QueueStatus | null>(null);
 
   useEffect(() => {
+    if (!enabled) return;
     let cancelled = false;
 
     const poll = async () => {
@@ -29,7 +30,7 @@ export function useQueueStatus(pollMs = 2000): QueueStatus | null {
       cancelled = true;
       window.clearInterval(interval);
     };
-  }, [pollMs]);
+  }, [enabled, pollMs]);
 
   return queueStatus;
 }

--- a/packages/ui/src/hooks/useQueueStatus.ts
+++ b/packages/ui/src/hooks/useQueueStatus.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import type { QueueStatus } from '../types.js';
+import { areStructurallyEqual } from './useDedupedState.js';
 
 export function useQueueStatus(pollMs = 2000): QueueStatus | null {
   const [queueStatus, setQueueStatus] = useState<QueueStatus | null>(null);
@@ -11,7 +12,9 @@ export function useQueueStatus(pollMs = 2000): QueueStatus | null {
       try {
         const status = await window.invoker?.getQueueStatus();
         if (!cancelled && status) {
-          setQueueStatus(status);
+          setQueueStatus((previous) =>
+            areStructurallyEqual(previous, status) ? previous : status,
+          );
         }
       } catch {
         // ignore polling errors

--- a/packages/ui/src/hooks/useWorkerStatus.ts
+++ b/packages/ui/src/hooks/useWorkerStatus.ts
@@ -2,7 +2,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { WorkerStatusSnapshot } from '../types.js';
 import { areStructurallyEqual } from './useDedupedState.js';
 
-export function useWorkerStatus(pollMs = 2000): readonly [snapshot: WorkerStatusSnapshot | null, refresh: () => Promise<void>] {
+export function useWorkerStatus(
+  pollMs = 2000,
+  enabled = true,
+): readonly [snapshot: WorkerStatusSnapshot | null, refresh: () => Promise<void>] {
   const [snapshot, setSnapshot] = useState<WorkerStatusSnapshot | null>(null);
   const mountedRef = useRef(true);
 
@@ -24,12 +27,13 @@ export function useWorkerStatus(pollMs = 2000): readonly [snapshot: WorkerStatus
   }, []);
 
   useEffect(() => {
+    if (!enabled) return;
     void fetchStatus();
     const interval = window.setInterval(() => {
       void fetchStatus();
     }, pollMs);
     return () => window.clearInterval(interval);
-  }, [fetchStatus, pollMs]);
+  }, [enabled, fetchStatus, pollMs]);
 
   return [snapshot, fetchStatus] as const;
 }

--- a/packages/ui/src/hooks/useWorkerStatus.ts
+++ b/packages/ui/src/hooks/useWorkerStatus.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { WorkerStatusSnapshot } from '../types.js';
+import { areStructurallyEqual } from './useDedupedState.js';
 
 export function useWorkerStatus(pollMs = 2000): readonly [snapshot: WorkerStatusSnapshot | null, refresh: () => Promise<void>] {
   const [snapshot, setSnapshot] = useState<WorkerStatusSnapshot | null>(null);
@@ -13,7 +14,9 @@ export function useWorkerStatus(pollMs = 2000): readonly [snapshot: WorkerStatus
     try {
       const status = await window.invoker?.getWorkerStatus();
       if (mountedRef.current && status) {
-        setSnapshot(status);
+        setSnapshot((previous) =>
+          areStructurallyEqual(previous, status) ? previous : status,
+        );
       }
     } catch {
       // ignore polling errors


### PR DESCRIPTION
## Summary

useQueueStatus and useWorkerStatus polled every 2s forever, even on an idle app with no tasks and no queue view open.

This slice exposes an optional enabled parameter on both hooks so their internal 2s setInterval only activates when the data is worth fetching.

App wires the parameter from a runtime-relevance predicate: any known task exists, or the queue view is currently open.

Together with slices (1)-(3), an idle app now performs effectively zero background re-renders in the Running view.

## Review Claim

useQueueStatus and useWorkerStatus accept an optional enabled parameter; when false, their internal setInterval does not activate; App drives the value from a runtime-relevance predicate.

## Review Lane

refactor

## Review Unit

activation-surface

## Safety Invariant

Behavior unchanged when enabled is true or omitted; App activates polling whenever any task exists or the queue view is open, which covers every case the polled data currently drives.

## Slice Rationale

Foundational hook-signature change plus its App activation. Kept together because the predicate is trivial and the signature is not consumed by any other file today.

## Architecture

### Before

useQueueStatus and useWorkerStatus start their 2s setInterval unconditionally on mount, so an idle App with no tasks and no queue view open still pays two polls every 2s.

```mermaid
graph LR
    A["App mount"] --> Q["useQueueStatus()"]
    A --> W["useWorkerStatus()"]
    Q --> QI["setInterval(2000) always"]
    W --> WI["setInterval(2000) always"]
    QI --> QP["poll queue status"]
    WI --> WP["poll worker status"]
```

### After

Both hooks accept an optional enabled parameter. App wires it from a pollingRelevant predicate ("any known task exists, or the queue view is open"), so the timers only exist when the polled data is worth fetching.

```mermaid
graph LR
    A["App render"] --> P["pollingRelevant = tasks.size > 0 || viewMode == queue"]
    P --> Q["useQueueStatus(2000, pollingRelevant)"]
    P --> W["useWorkerStatus(2000, pollingRelevant)"]
    Q --> QG{"enabled?"}
    W --> WG{"enabled?"}
    QG -->|"true"| QI["setInterval(2000)"]
    QG -->|"false"| QN["no timer"]
    WG -->|"true"| WI["setInterval(2000)"]
    WG -->|"false"| WN["no timer"]
```

## Non-goals

- No behavior change when polling is active.
- Replacing polling with push projections (deferred to Phase 2).
- Broader sidebar-based gating (requires reordering hook calls in App).
- Any consumer file changes beyond App.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] cd packages/ui && pnpm test

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>
