### PR TITLE
[Codex fix error surface](1) Surface the real codex fix failure, not the stdin-read line

### DIFF
--- a/packages/execution-engine/src/__tests__/fix-prompt-transport.test.ts
+++ b/packages/execution-engine/src/__tests__/fix-prompt-transport.test.ts
@@ -304,5 +304,69 @@ describe('spawn errors during agent fix surface diagnostic info', () => {
     expect(caught!.message).toContain('137');
     expect(caught!.message).toContain('Killed');
   });
+
+  it('surfaces the codex --json stdout error, not the benign stdin noise, on non-zero exit', async () => {
+    const { spawn } = await import('node:child_process');
+    const agent = makeExecutionAgent((prompt) => ({
+      cmd: 'codex',
+      args: ['exec', '--json', '--dangerously-bypass-approvals-and-sandbox', prompt],
+      sessionId: 'sess-codex-fail',
+    }));
+    const driver = {
+      processOutput: () => '[assistant] Model refused: usage limit reached',
+      extractSessionId: () => undefined,
+      loadSession: () => null,
+      parseSession: () => [],
+      inspectSession: () => ({ state: 'error' as const }),
+    };
+
+    const { EventEmitter } = require('events');
+    const stdout = new EventEmitter();
+    const stderr = new EventEmitter();
+    const child = new EventEmitter();
+    (child as any).stdout = stdout;
+    (child as any).stderr = stderr;
+    (child as any).stdin = { write: vi.fn(), end: vi.fn() };
+    setTimeout(() => {
+      stdout.emit('data', Buffer.from('{"type":"error","message":"usage limit reached"}\n'));
+      stderr.emit('data', Buffer.from('Reading additional input from stdin...\n'));
+      child.emit('close', 1);
+    }, 0);
+    vi.mocked(spawn).mockReturnValueOnce(child as any);
+
+    let caught: Error | undefined;
+    try {
+      await spawnAgentFixViaRegistry('small prompt', '/tmp', agent, driver as any);
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toContain('codex fix exited with code 1');
+    expect(caught!.message).toContain('Model refused: usage limit reached');
+    expect(caught!.message).not.toContain('Reading additional input from stdin');
+  });
+
+  it('gives an actionable hint when codex exits non-zero emitting only the stdin/TTY noise', async () => {
+    const { spawn } = await import('node:child_process');
+    const agent = makeExecutionAgent((prompt) => ({
+      cmd: 'codex',
+      args: ['exec', '--json', prompt],
+      sessionId: 'sess-codex-notty',
+    }));
+
+    vi.mocked(spawn).mockReturnValueOnce(
+      mockSpawnChildExit(1, 'Reading additional input from stdin...\n') as any,
+    );
+
+    let caught: Error | undefined;
+    try {
+      await spawnAgentFixViaRegistry('small prompt', '/tmp', agent, undefined);
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toContain('without a controlling TTY');
+    expect(caught!.message).toContain('openai/codex#19945');
+  });
 });
 

--- a/packages/execution-engine/src/__tests__/process-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/process-utils.test.ts
@@ -223,3 +223,65 @@ describe('terminateChildProcessGroup', () => {
     await expect(killed).resolves.toBeUndefined();
   });
 });
+
+describe('buildAgentExitFailureDetail', () => {
+  it('surfaces the codex --json stdout error instead of the benign stdin noise', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const stdout = [
+      JSON.stringify({ type: 'thread.started', thread_id: 't1' }),
+      JSON.stringify({ type: 'item.completed', item: { type: 'agent_message', text: 'Model refused: quota exceeded' } }),
+    ].join('\n');
+    const displayStdout = '[assistant] Model refused: quota exceeded';
+    const detail = processUtils.buildAgentExitFailureDetail(
+      stdout,
+      'Reading additional input from stdin...\n',
+      displayStdout,
+    );
+    expect(detail).toBe('[assistant] Model refused: quota exceeded');
+    expect(detail).not.toContain('Reading additional input from stdin');
+  });
+
+  it('prefers meaningful stderr with the benign stdin noise stripped', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const detail = processUtils.buildAgentExitFailureDetail(
+      'stdout should be ignored when stderr has signal',
+      'Reading additional input from stdin...\npanic: boom at line 5\n',
+      'display',
+    );
+    expect(detail).toBe('panic: boom at line 5');
+  });
+
+  it('falls back to raw stdout when no driver-processed output is available', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const detail = processUtils.buildAgentExitFailureDetail(
+      'raw json line',
+      'Reading additional input from stdin...',
+      undefined,
+    );
+    expect(detail).toBe('raw json line');
+  });
+
+  it('returns an actionable hint when only the codex stdin/TTY noise was emitted', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const detail = processUtils.buildAgentExitFailureDetail(
+      '',
+      'Reading additional input from stdin...\n',
+      '',
+    );
+    expect(detail).toContain('without a controlling TTY');
+    expect(detail).toContain('openai/codex#19945');
+  });
+
+  it('returns (no output) when the process emitted nothing at all', async () => {
+    const { processUtils } = await loadProcessUtils();
+    expect(processUtils.buildAgentExitFailureDetail('', '', '')).toBe('(no output)');
+  });
+
+  it('tail-limits very long output to keep messages bounded', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const huge = 'x'.repeat(5000);
+    const detail = processUtils.buildAgentExitFailureDetail(huge, '', huge);
+    expect(detail.length).toBe(2000);
+    expect(detail).toBe(huge.slice(-2000));
+  });
+});

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -14,7 +14,7 @@ import { tmpdir } from 'node:os';
 import type { Orchestrator } from '@invoker/workflow-core';
 import { OrchestratorError, OrchestratorErrorCode, parseMergeConflictError } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import { cleanElectronEnv, resolveExecutableOnCurrentPath } from './process-utils.js';
+import { buildAgentExitFailureDetail, cleanElectronEnv, resolveExecutableOnCurrentPath } from './process-utils.js';
 import { DEFAULT_EXECUTION_AGENT, type ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
 import type { AgentRegistry } from './agent-registry.js';
@@ -786,7 +786,7 @@ export function spawnAgentFixViaRegistry(
       } else {
         promptTransport.cleanup();
         reject(Object.assign(
-          new Error(`${agent.name} fix exited with code ${code}: ${stderr.trim()}`),
+          new Error(`${agent.name} fix exited with code ${code}: ${buildAgentExitFailureDetail(stdout, stderr, displayStdout)}`),
           {
             sessionId: effectiveSessionId,
             exitCode: code,

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -6,7 +6,7 @@ import { homedir, tmpdir } from 'node:os';
 
 import type { ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
-import { cleanElectronEnv, killProcessGroup, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS } from './process-utils.js';
+import { buildAgentExitFailureDetail, cleanElectronEnv, killProcessGroup, resolveExecutableOnCurrentPath, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 
 export interface MakePrStackArtifactOutput {
   readonly id: string;
@@ -680,7 +680,7 @@ export function spawnAgentPrAuthorViaRegistry(
             resolve({ body, stdout: displayStdout, sessionId: effectiveSessionId });
             return;
           }
-          reject(new Error(`${agent.name} PR authoring exited with code ${code}: ${stderr.trim()}`));
+          reject(new Error(`${agent.name} PR authoring exited with code ${code}: ${buildAgentExitFailureDetail(stdout, stderr, displayStdout)}`));
         } catch (err) {
           reject(err instanceof Error ? err : new Error(String(err)));
         }

--- a/packages/execution-engine/src/process-utils.ts
+++ b/packages/execution-engine/src/process-utils.ts
@@ -261,3 +261,40 @@ export function cleanElectronEnv(): NodeJS.ProcessEnv {
   env.PATH = getEffectivePath();
   return env;
 }
+
+const AGENT_OUTPUT_DETAIL_MAX_CHARS = 2000;
+
+const CODEX_STDIN_NOISE = /^Reading additional input from stdin\.\.\.$/;
+
+function nonEmptyTrimmedLines(text: string): string[] {
+  return text.split('\n').map((line) => line.trim()).filter(Boolean);
+}
+
+function tailChars(text: string): string {
+  return text.length <= AGENT_OUTPUT_DETAIL_MAX_CHARS
+    ? text
+    : text.slice(-AGENT_OUTPUT_DETAIL_MAX_CHARS);
+}
+
+export function buildAgentExitFailureDetail(
+  rawStdout: string,
+  stderr: string,
+  displayStdout?: string,
+): string {
+  const meaningfulStderr = nonEmptyTrimmedLines(stderr)
+    .filter((line) => !CODEX_STDIN_NOISE.test(line))
+    .join('\n');
+  const candidate = meaningfulStderr
+    || (displayStdout ?? '').trim()
+    || rawStdout.trim();
+  if (candidate) return tailChars(candidate);
+
+  const stderrLines = nonEmptyTrimmedLines(stderr);
+  if (stderrLines.length > 0 && stderrLines.every((line) => CODEX_STDIN_NOISE.test(line))) {
+    return 'agent exited non-zero with no captured output, emitting only '
+      + '"Reading additional input from stdin..." — a known codex CLI failure when it '
+      + 'runs without a controlling TTY (see openai/codex#19945 and #20919). '
+      + 'Retry; if it persists, update the codex CLI.';
+  }
+  return '(no output)';
+}


### PR DESCRIPTION
## Summary

When a coding agent's fix run fails, Invoker showed the wrong error text.

Codex prints a harmless "Reading additional input from stdin..." line to standard error on every non-interactive spawn.

Invoker built its failure message from standard error alone, so that line became the whole error a person saw.

The genuine cause of a failed run lands on the agent's `--json` output on standard out, not standard error.

So the useful detail was thrown away while the noise was surfaced.

A shared helper now assembles the failure detail from the agent's real output.

It drops the harmless line, keeps genuine standard-error text, then falls back to the agent's captured output.

When a run dies emitting only that harmless line, it returns a plain-English hint about the known Codex no-terminal failure, with links to the upstream issues.

## Review Claim

Approve building the agent fix failure message from the agent's real output instead of standard error alone.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

Only the text of a failure message changes. Success paths, exit codes, session handling, and the separate telemetry fields are untouched, and the SSH path already included this output.

## Slice Rationale

One self-contained change to how a failed agent run's error text is assembled. It touches only the execution-engine output helper and its two call sites, plus their unit tests.

## Non-goals

- Does not change how any agent is spawned, or how stdin is wired.
- Does not change success behavior, exit codes, or session persistence.
- Does not touch the CHANGELOG, which stays out to keep docs and behavior in separate slices.

## Test Plan

<details>
<summary>Test Plan</summary>

- [ ] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/process-utils.test.ts src/__tests__/fix-prompt-transport.test.ts src/__tests__/codex-resume-e2e.test.ts src/__tests__/remote-fix-process-output.test.ts src/__tests__/pr-authoring.test.ts`
- [ ] `pnpm run check:types`

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

</details>