### PR TITLE
[Godfile execution-engine step 2: extract task-runner-pool](2)

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { TaskRunner, type ExecutionPoolMember } from '../task-runner.js';
+import { TaskRunner } from '../task-runner.js';
+import type { ExecutionPoolMember } from '../task-runner-pool.js';
 import { ResourceLimitError } from '../repo-pool.js';
 import { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2423,7 +2423,7 @@ describe('TaskRunner', () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => undefined } as any,
         persistence: {} as any,
-        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
         cwd: '/tmp',
         remoteTargetsProvider: provider,
       });
@@ -2434,11 +2434,11 @@ describe('TaskRunner', () => {
       });
 
       const executor1 = executor.selectExecutor(task);
-      expect(executor1.type).toBe('ssh');
-      expect((executor1 as any).sshKeyPath).toBe('/old/key');
+      expect(executor1.executor.type).toBe('ssh');
+      expect((executor1.executor as any).sshKeyPath).toBe('/old/key');
 
       const executor2 = executor.selectExecutor(task);
-      expect((executor2 as any).sshKeyPath).toBe('/new/key');
+      expect((executor2.executor as any).sshKeyPath).toBe('/new/key');
 
       expect(provider).toHaveBeenCalledTimes(2);
     });
@@ -2866,7 +2866,7 @@ describe('TaskRunner', () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
         persistence: {} as any,
-        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
         cwd: '/tmp',
         remoteTargetsProvider: () => remoteTargets,
       });
@@ -2889,10 +2889,10 @@ describe('TaskRunner', () => {
       const executor3 = executor.selectExecutor(task3);
 
       // task1 and task2 share the same poolMemberId → same executor instance
-      expect(executor1).toBe(executor2);
+      expect(executor1.executor).toBe(executor2.executor);
       // task3 has a different poolMemberId → different executor instance
-      expect(executor1).not.toBe(executor3);
-      expect(executor2).not.toBe(executor3);
+      expect(executor1.executor).not.toBe(executor3.executor);
+      expect(executor2.executor).not.toBe(executor3.executor);
     });
 
     it('does not cache non-SSH executors', () => {
@@ -2922,8 +2922,8 @@ describe('TaskRunner', () => {
 
       // Worktree executors are created fresh each time (lazy registration creates new instances)
       // Both should be worktree type but may be different instances
-      expect(executor1.type).toBe('worktree');
-      expect(executor2.type).toBe('worktree');
+      expect(executor1.executor.type).toBe('worktree');
+      expect(executor2.executor.type).toBe('worktree');
     });
 
     it('clearSshExecutorCache removes all cached SSH executors', async () => {
@@ -2939,7 +2939,7 @@ describe('TaskRunner', () => {
       const executor = new TaskRunner({
         orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
         persistence: {} as any,
-        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [], register: vi.fn() } as any,
         cwd: '/tmp',
         remoteTargetsProvider: () => remoteTargets,
       });
@@ -2958,7 +2958,7 @@ describe('TaskRunner', () => {
       const executor2 = executor.selectExecutor(task2);
 
       // After clearing cache, a new executor instance should be created
-      expect(executor1).not.toBe(executor2);
+      expect(executor1.executor).not.toBe(executor2.executor);
     });
 
     it('throws when SSH task has no poolMemberId', () => {
@@ -3089,7 +3089,7 @@ describe('TaskRunner', () => {
       expect(JSON.stringify(selectedPayload)).not.toContain('sshKeyPath');
       expect(JSON.stringify(selectedPayload)).not.toContain('/secret/key');
       expect(updateTask).toHaveBeenCalledWith('task-1', {
-        config: { runnerKind: 'ssh', poolMemberId: 'remote-a' },
+        config: { runnerKind: 'ssh', executionAgent: 'codex', executionModel: undefined, poolMemberId: 'remote-a' },
         execution: expect.objectContaining({
           workspacePath: '/remote/worktrees/task-1',
           branch: 'experiment/task-1',
@@ -3165,7 +3165,7 @@ describe('TaskRunner', () => {
         remoteHost: 'b.example.com',
       }));
       expect(updateTask).toHaveBeenCalledWith('task-retry', {
-        config: { runnerKind: 'ssh', poolMemberId: 'remote-b' },
+        config: { runnerKind: 'ssh', executionAgent: 'codex', executionModel: undefined, poolMemberId: 'remote-b' },
         execution: expect.objectContaining({
           workspacePath: '/remote/worktrees/task-retry',
           branch: 'experiment/task-retry',
@@ -3392,12 +3392,13 @@ describe('TaskRunner', () => {
 
       // Check that metadata was persisted immediately after start
       expect(updateSpy).toHaveBeenCalledWith('ssh-task-1', {
-        config: { runnerKind: 'ssh', poolMemberId: 'remote-1' },
+        config: { runnerKind: 'ssh', executionAgent: 'codex', executionModel: undefined, poolMemberId: 'remote-1' },
         execution: {
           workspacePath: '~/.invoker/worktrees/abc123/experiment-ssh-task-1-def456',
           branch: 'experiment/ssh-task-1-def456',
           agentSessionId: 'session-123',
           lastAgentSessionId: 'session-123',
+          agentName: undefined,
           lastAgentName: undefined,
           containerId: undefined,
         },
@@ -3644,12 +3645,13 @@ describe('TaskRunner', () => {
 
       // Check that metadata was persisted with workspacePath and branch=undefined
       expect(updateSpy).toHaveBeenCalledWith('byo-task-1', {
-        config: { runnerKind: 'ssh' },
+        config: { runnerKind: 'ssh', executionAgent: 'codex', executionModel: undefined },
         execution: {
           workspacePath: '/remote/user-provided/workspace',
           branch: undefined,
           agentSessionId: undefined,
           lastAgentSessionId: undefined,
+          agentName: undefined,
           lastAgentName: undefined,
           containerId: undefined,
         },

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -25,6 +25,11 @@ export { bashNormalizeTildePath, execRemoteCapture, shellPosixSingleQuote } from
 export * from './repo-pool.js';
 export * from './registry.js';
 export * from './task-runner.js';
+export type {
+  ExecutionPoolMember,
+  ExecutionPoolConfig,
+  PoolSelection,
+} from './task-runner-pool.js';
 export * from './harness-capabilities.js';
 export * from './merge-runner.js';
 export * from './conflict-resolver.js';

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -1,0 +1,623 @@
+/**
+ * task-runner-pool.ts — execution-pool math, pool-member selection, SSH
+ * resource leasing, executor selection, and executor-cache maintenance.
+ *
+ * These were methods on `TaskRunner`; they now live here as free functions
+ * over a `TaskRunnerPoolHost` — a `Pick<TaskRunner, …>` mirroring the
+ * `task-runner-phase-host.ts` convention. `TaskRunner` keeps one-line
+ * delegates so external callers and the phase host see the same method
+ * surface. The type-only import of `TaskRunner` avoids a runtime cycle with
+ * `task-runner.js`; this module never value-imports it.
+ */
+
+import { resolve } from 'node:path';
+import { homedir } from 'node:os';
+
+import type { TaskState } from '@invoker/workflow-core';
+import type { Executor, ExecutorHandle } from './executor.js';
+import type { MachineCapabilities } from './harness-capabilities.js';
+import { resolveHarnessSelection } from './harness-capabilities.js';
+import { ResourceLimitError } from './repo-pool.js';
+import { traceExecution } from './exec-trace.js';
+import { DockerExecutor } from './docker-executor.js';
+import { WorktreeExecutor } from './worktree-executor.js';
+import { MergeGateExecutor } from './merge-gate-executor.js';
+import { SshExecutor } from './ssh-executor.js';
+import type { MergeRunnerHost } from './merge-runner.js';
+import type { TaskRunner } from './task-runner.js';
+
+// ── Types ────────────────────────────────────────────────
+
+export type ExecutionPoolMember =
+  | { type: 'ssh'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities }
+  | { type: 'worktree'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities };
+
+export type ExecutionPoolConfig = {
+  members: ExecutionPoolMember[];
+  selectionStrategy?: 'roundRobin' | 'leastLoaded';
+  maxConcurrentTasksPerMember?: number;
+};
+
+export type ResolvedExecutionSelection = {
+  executionAgent: string;
+  executionModel?: string;
+};
+
+export type SelectedExecutor = {
+  executor: Executor;
+  resolvedExecution: ResolvedExecutionSelection;
+  selectedPoolMemberId?: string;
+};
+
+export type PoolSelection = {
+  poolId: string;
+  member: ExecutionPoolMember;
+  memberKey: string;
+  selectionStrategy: 'roundRobin' | 'leastLoaded';
+  resolvedExecution?: ResolvedExecutionSelection;
+  leaseResourceKey?: string;
+  leaseHolderId?: string;
+};
+
+export type RemoteTargetDisplay = {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+  managedWorkspaces?: boolean;
+  remoteInvokerHome?: string;
+  provisionCommand?: string;
+  use_api_key?: boolean;
+  secretsFile?: string;
+  remoteHeartbeatIntervalSeconds?: number;
+  maxConcurrentTasks?: number;
+  capabilities?: MachineCapabilities;
+};
+
+// ── Host surface ─────────────────────────────────────────
+
+/**
+ * Subset of `TaskRunner` the pool functions touch: runner state plus the
+ * collaborators outside this module. Sibling pool functions call each other
+ * directly (module-local); `host` is only for reaching `TaskRunner`.
+ */
+export type TaskRunnerPoolHost = Pick<
+  TaskRunner,
+  | 'persistence'
+  | 'logger'
+  | 'pendingPoolSelections'
+  | 'activeExecutions'
+  | 'poolRoundRobinCursor'
+  | 'sshExecutorCache'
+  | 'runnerInstanceId'
+  | 'getRemoteTargets'
+  | 'getExecutionPools'
+  | 'resolveExecutionAgent'
+  | 'resolveExecutionModel'
+  | 'executorRegistry'
+  | 'dockerConfig'
+  | 'executionAgentRegistry'
+  | 'maxWorktreesPerRepo'
+>;
+
+// ── Pool math ────────────────────────────────────────────
+
+export function poolMemberKey(member: ExecutionPoolMember): string {
+  return `${member.type}:${member.id}`;
+}
+
+function poolMemberLoad(host: TaskRunnerPoolHost, poolId: string, memberKey: string): number {
+  let load = 0;
+  for (const selection of host.pendingPoolSelections.values()) {
+    if (selection.poolId === poolId && selection.memberKey === memberKey) load += 1;
+  }
+  for (const entry of host.activeExecutions.values()) {
+    if (entry.poolId === poolId && entry.poolMemberKey === memberKey) load += 1;
+  }
+  return load;
+}
+
+function poolMemberLimit(pool: ExecutionPoolConfig, member: ExecutionPoolMember): number | undefined {
+  return member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
+}
+
+function poolMemberHasCapacity(host: TaskRunnerPoolHost, poolId: string, pool: ExecutionPoolConfig, member: ExecutionPoolMember): boolean {
+  const limit = poolMemberLimit(pool, member);
+  return limit === undefined || poolMemberLoad(host, poolId, poolMemberKey(member)) < limit;
+}
+
+function memberCapabilities(host: TaskRunnerPoolHost, member: ExecutionPoolMember): MachineCapabilities | undefined {
+  if (member.capabilities) return member.capabilities;
+  return member.type === 'ssh' ? host.getRemoteTargets()[member.id]?.capabilities : undefined;
+}
+
+function memberCapabilityMismatch(host: TaskRunnerPoolHost, member: ExecutionPoolMember, task: Pick<TaskState, 'config'>): string | undefined {
+  const match = resolveExecutionForMember(host, task, memberCapabilities(host, member));
+  return match.ok ? undefined : match.reason;
+}
+
+function executionRequirementLabel(host: TaskRunnerPoolHost, task: Pick<TaskState, 'config'>): string {
+  const executionAgent = host.resolveExecutionAgent(task);
+  const executionModel = host.resolveExecutionModel(task);
+  return executionModel ? `${executionAgent}/${executionModel}` : executionAgent;
+}
+
+function resolveExecutionForMember(
+  host: TaskRunnerPoolHost,
+  task: Pick<TaskState, 'config'>,
+  memberCapabilities: MachineCapabilities | undefined,
+): { ok: true; selection: ResolvedExecutionSelection } | { ok: false; reason: string } {
+  const resolvedAgent = host.resolveExecutionAgent(task);
+  const requestedModel = host.resolveExecutionModel(task);
+  const result = resolveHarnessSelection(memberCapabilities, {
+    role: 'execution',
+    harness: resolvedAgent,
+    model: requestedModel,
+  });
+  if (!result.ok) return result;
+  return {
+    ok: true,
+    selection: {
+      executionAgent: result.selection.harness,
+      executionModel: result.selection.model,
+    },
+  };
+}
+
+// ── Pool-member selection ────────────────────────────────
+
+export function selectPoolMember(
+  host: TaskRunnerPoolHost,
+  task: Pick<TaskState, 'config'>,
+  poolId: string,
+  pool: ExecutionPoolConfig,
+  excludedMemberKeys: Set<string> = new Set(),
+): ExecutionPoolMember | undefined {
+  if (pool.members.length === 0) return undefined;
+
+  if (pool.selectionStrategy === 'roundRobin') {
+    const cursor = host.poolRoundRobinCursor.get(poolId) ?? 0;
+    for (let offset = 0; offset < pool.members.length; offset += 1) {
+      const index = (cursor + offset) % pool.members.length;
+      const member = pool.members[index];
+      if (excludedMemberKeys.has(poolMemberKey(member))) continue;
+      if (memberCapabilityMismatch(host, member, task)) continue;
+      if (!poolMemberHasCapacity(host, poolId, pool, member)) continue;
+      host.poolRoundRobinCursor.set(poolId, (index + 1) % pool.members.length);
+      return member;
+    }
+    return undefined;
+  }
+
+  const scored = pool.members
+    .filter((member) => !excludedMemberKeys.has(poolMemberKey(member)))
+    .map((member, index) => {
+      const memberKey = poolMemberKey(member);
+      const load = poolMemberLoad(host, poolId, memberKey);
+      const limit = poolMemberLimit(pool, member);
+      return {
+        member,
+        index,
+        load,
+        hasCapacity: limit === undefined || load < limit,
+        capabilityMismatch: memberCapabilityMismatch(host, member, task),
+      };
+    });
+  const candidates = scored.filter((entry) => entry.hasCapacity && !entry.capabilityMismatch);
+  candidates.sort((a, b) => a.load - b.load || a.index - b.index);
+  return candidates[0]?.member;
+}
+
+function poolCapacitySnapshot(
+  host: TaskRunnerPoolHost,
+  task: Pick<TaskState, 'config'>,
+  poolId: string,
+  pool: ExecutionPoolConfig,
+  excludedMemberKeys: Set<string>,
+): Array<{
+  memberId: string;
+  memberType: string;
+  load: number;
+  limit: number | undefined;
+  excluded: boolean;
+  capabilityMismatch?: string;
+}> {
+  return pool.members.map((member) => {
+    const memberKey = poolMemberKey(member);
+    return {
+      memberId: member.id,
+      memberType: member.type,
+      load: poolMemberLoad(host, poolId, memberKey),
+      limit: poolMemberLimit(pool, member),
+      excluded: excludedMemberKeys.has(memberKey),
+      capabilityMismatch: memberCapabilityMismatch(host, member, task),
+    };
+  });
+}
+
+function poolCapacityError(
+  host: TaskRunnerPoolHost,
+  task: Pick<TaskState, 'id' | 'config'>,
+  poolId: string,
+  pool: ExecutionPoolConfig,
+  excludedMemberKeys: Set<string>,
+): Error {
+  const snapshot = poolCapacitySnapshot(host, task, poolId, pool, excludedMemberKeys);
+  const requirementAgent = host.resolveExecutionAgent(task);
+  const requirementModel = host.resolveExecutionModel(task);
+  const requirementLabel = requirementModel ? `${requirementAgent}/${requirementModel}` : requirementAgent;
+  const reasonSuffix = snapshot
+    .map((member) => {
+      const reasons = [
+        member.excluded ? 'excluded' : undefined,
+        member.capabilityMismatch,
+        member.limit !== undefined && member.load >= member.limit ? `capacity ${member.load}/${member.limit}` : undefined,
+      ].filter((reason): reason is string => Boolean(reason));
+      return `${member.memberType}:${member.memberId}${reasons.length > 0 ? ` (${reasons.join(', ')})` : ''}`;
+    })
+    .join('; ');
+  const message = `Execution pool "${poolId}" has no member capacity available for ${requirementLabel}${reasonSuffix ? `: ${reasonSuffix}` : ''}`;
+  const resourceLimit = new ResourceLimitError(message);
+  host.persistence.logEvent?.(task.id, 'task.executor.deferred', {
+    reason: 'execution-pool-capacity',
+    poolId,
+    excludedMemberKeys: [...excludedMemberKeys],
+    requirement: {
+      executionAgent: requirementAgent,
+      executionModel: requirementModel,
+    },
+    members: snapshot,
+  });
+  host.logger.info(`[TaskRunner] deferring task: ${message}`, {
+    poolId,
+    excludedMemberKeys: [...excludedMemberKeys],
+    requirement: {
+      executionAgent: requirementAgent,
+      executionModel: requirementModel,
+    },
+    members: snapshot,
+  });
+  return new Error(message, { cause: resourceLimit });
+}
+
+// ── SSH selection leases ─────────────────────────────────
+
+function sshResourceKey(target: RemoteTargetDisplay): string {
+  return `ssh:${target.user}@${target.host}:${target.port ?? 22}`;
+}
+
+function leaseHolderId(host: TaskRunnerPoolHost, taskId: string, attemptId: string): string {
+  return `${host.runnerInstanceId}:${process.pid}:${taskId}:${attemptId}`;
+}
+
+export function acquirePoolSelectionLease(host: TaskRunnerPoolHost, task: TaskState, attemptId: string, selection: PoolSelection | undefined): boolean {
+  if (!selection || selection.member.type !== 'ssh') return true;
+  const target = host.getRemoteTargets()[selection.member.id];
+  if (!target) return true;
+  const resourceKey = sshResourceKey(target);
+  const holderId = leaseHolderId(host, task.id, attemptId);
+  const acquired = host.persistence.claimExecutionResourceLease?.({
+    resourceKey,
+    resourceType: 'ssh',
+    holderId,
+    taskId: task.id,
+    poolId: selection.poolId,
+    poolMemberId: selection.member.id,
+    metadata: {
+      runnerInstanceId: host.runnerInstanceId,
+      pid: process.pid,
+    },
+  }) ?? true;
+  if (!acquired) {
+    host.persistence.logEvent?.(task.id, 'task.executor.deferred', {
+      reason: 'ssh-resource-lease-held',
+      poolId: selection.poolId,
+      poolMemberId: selection.member.id,
+      resourceKey,
+    });
+    return false;
+  }
+  selection.leaseResourceKey = resourceKey;
+  selection.leaseHolderId = holderId;
+  return true;
+}
+
+export function renewPoolSelectionLease(host: TaskRunnerPoolHost, selection: PoolSelection | undefined): void {
+  if (!selection?.leaseResourceKey || !selection.leaseHolderId) return;
+  host.persistence.renewExecutionResourceLease?.(selection.leaseResourceKey, selection.leaseHolderId);
+}
+
+export function releasePoolSelectionLease(host: TaskRunnerPoolHost, selection: PoolSelection | undefined): void {
+  if (!selection?.leaseResourceKey || !selection.leaseHolderId) return;
+  host.persistence.releaseExecutionResourceLease?.(selection.leaseResourceKey, selection.leaseHolderId);
+  selection.leaseResourceKey = undefined;
+  selection.leaseHolderId = undefined;
+}
+
+// ── Executor-selection logging ───────────────────────────
+
+export function logExecutorSelected(
+  host: TaskRunnerPoolHost,
+  task: TaskState,
+  executor: Executor,
+  handle: ExecutorHandle,
+  attemptId: string,
+  poolSelection: PoolSelection | undefined,
+): void {
+  const payload: Record<string, unknown> = {
+    runnerKind: executor.type,
+    reason: executorSelectionReason(task, executor, poolSelection),
+    attemptId,
+    workspacePath: handle.workspacePath,
+    branch: handle.branch ?? undefined,
+  };
+
+  if (executor.type === 'ssh') {
+    const targetId = selectedRemoteTargetId(host, task, poolSelection);
+    const target = targetId ? host.getRemoteTargets()[targetId] : undefined;
+    if (targetId) payload.poolMemberId = targetId;
+    if (target) {
+      payload.remoteHost = target.host;
+      payload.remoteUser = target.user;
+      payload.port = target.port;
+    }
+  }
+
+  host.persistence.logEvent?.(task.id, 'task.executor.selected', payload);
+}
+
+function executorSelectionReason(
+  task: TaskState,
+  executor: Executor,
+  poolSelection: PoolSelection | undefined,
+): Record<string, unknown> {
+  if (executor.type === 'ssh') {
+    if (poolSelection) {
+      return {
+        type: 'poolId',
+        poolId: poolSelection.poolId,
+        selectionStrategy: poolSelection.selectionStrategy,
+        poolMemberId: poolSelection.member.id,
+      };
+    }
+    if ((task.config as { poolMemberId?: string }).poolMemberId) {
+      return { type: 'explicitPoolMemberId' };
+    }
+    if (task.config.poolId) {
+      return { type: 'poolId', poolId: task.config.poolId };
+    }
+  }
+
+  if (executor.type === 'worktree') {
+    if (task.config.runnerKind === 'ssh' && task.config.poolId) {
+      return { type: 'sshPoolFallbackToWorktree', poolId: task.config.poolId };
+    }
+    if (task.config.runnerKind === 'worktree') {
+      return { type: 'configuredWorktree' };
+    }
+    return { type: 'defaultWorktree' };
+  }
+
+  if (executor.type === 'docker') {
+    return { type: 'dockerImage' };
+  }
+
+  return { type: 'configuredRunnerKind', runnerKind: executor.type };
+}
+
+export function selectedRemoteTargetId(host: TaskRunnerPoolHost, task: TaskState, poolSelection: PoolSelection | undefined): string | undefined {
+  if (poolSelection?.member.type === 'ssh') return poolSelection.member.id;
+  return (task.config as { poolMemberId?: string }).poolMemberId
+    ?? (task.config.poolId && host.getRemoteTargets()[task.config.poolId] ? task.config.poolId : undefined);
+}
+
+// ── Executor selection ───────────────────────────────────
+
+export function takeResolvedExecutionSelection(host: TaskRunnerPoolHost, taskId: string): ResolvedExecutionSelection | undefined {
+  const selection = host.pendingPoolSelections.get(taskId);
+  const resolvedExecution = selection?.resolvedExecution;
+  if (selection) {
+    selection.resolvedExecution = undefined;
+  }
+  return resolvedExecution;
+}
+
+export function selectExecutor(
+  host: TaskRunnerPoolHost & MergeRunnerHost,
+  task: TaskState,
+  excludedPoolMemberKeys: Set<string> = new Set(),
+): SelectedExecutor {
+  let effectiveType = task.config.runnerKind ?? (task.config.isMergeNode ? 'merge' : undefined);
+  let selectedPoolMemberId: string | undefined;
+  const explicitPoolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
+  let resolvedExecution: ResolvedExecutionSelection = {
+    executionAgent: host.resolveExecutionAgent(task),
+    executionModel: host.resolveExecutionModel(task),
+  };
+  host.pendingPoolSelections.delete(task.id);
+
+  if (task.config.poolId && explicitPoolMemberId) {
+    const pool = host.getExecutionPools()[task.config.poolId];
+    const member = pool?.members.find((candidate) => candidate.type === 'ssh' && candidate.id === explicitPoolMemberId);
+    if (pool && member) {
+      const memberExecution = resolveExecutionForMember(host, task, memberCapabilities(host, member));
+      if (!memberExecution.ok) {
+        throw new Error(
+          `Execution pool "${task.config.poolId}" member "${explicitPoolMemberId}" cannot run ` +
+          `${executionRequirementLabel(host, task)}: ${memberExecution.reason}`,
+        );
+      }
+      if (
+        excludedPoolMemberKeys.has(poolMemberKey(member))
+        || !poolMemberHasCapacity(host, task.config.poolId, pool, member)
+      ) {
+        throw poolCapacityError(host, task, task.config.poolId, pool, excludedPoolMemberKeys);
+      }
+      effectiveType = member.type;
+      selectedPoolMemberId = member.id;
+      resolvedExecution = memberExecution.selection;
+      host.pendingPoolSelections.set(task.id, {
+        poolId: task.config.poolId,
+        member,
+        memberKey: poolMemberKey(member),
+        selectionStrategy: pool.selectionStrategy ?? 'roundRobin',
+        resolvedExecution,
+      });
+    }
+  } else if (task.config.poolId) {
+    const pool = host.getExecutionPools()[task.config.poolId];
+    const member = pool ? selectPoolMember(host, task, task.config.poolId, pool, excludedPoolMemberKeys) : undefined;
+    if (member) {
+      const memberExecution = resolveExecutionForMember(host, task, memberCapabilities(host, member));
+      if (!memberExecution.ok) {
+        throw new Error(
+          `Execution pool "${task.config.poolId}" member "${member.id}" cannot run ` +
+          `${executionRequirementLabel(host, task)}: ${memberExecution.reason}`,
+        );
+      }
+      effectiveType = member.type;
+      selectedPoolMemberId = member.type === 'ssh' ? member.id : undefined;
+      resolvedExecution = memberExecution.selection;
+      host.pendingPoolSelections.set(task.id, {
+        poolId: task.config.poolId,
+        member,
+        memberKey: poolMemberKey(member),
+        selectionStrategy: pool.selectionStrategy ?? 'roundRobin',
+        resolvedExecution,
+      });
+    } else if (pool) {
+      throw poolCapacityError(host, task, task.config.poolId, pool, excludedPoolMemberKeys);
+    }
+  }
+  if (
+    effectiveType === 'ssh'
+    && task.config.poolId
+    && !selectedPoolMemberId
+    && !explicitPoolMemberId
+    && !host.getRemoteTargets()[task.config.poolId]
+  ) {
+    effectiveType = 'worktree';
+  }
+
+  if (effectiveType) {
+    const registered = host.executorRegistry.get(effectiveType);
+    if (registered && (effectiveType !== 'merge' || registered.type === 'merge')) {
+      traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=${effectiveType} → ${registered.type}`);
+      return { executor: registered, resolvedExecution, selectedPoolMemberId };
+    }
+
+    if (effectiveType === 'docker') {
+      const docker = new DockerExecutor({
+        imageName: task.config.dockerImage || host.dockerConfig.imageName,
+        secretsFile: host.dockerConfig.secretsFile,
+        agentRegistry: host.executionAgentRegistry,
+      });
+      host.executorRegistry.register(`docker:${task.id}`, docker);
+      traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=docker → docker (per-task)`);
+      return { executor: docker, resolvedExecution, selectedPoolMemberId };
+    }
+
+    if (effectiveType === 'worktree') {
+      const invokerHome = resolve(homedir(), '.invoker');
+      const worktree = new WorktreeExecutor({
+        worktreeBaseDir: resolve(invokerHome, 'worktrees'),
+        cacheDir: resolve(invokerHome, 'repos'),
+        maxWorktrees: host.maxWorktreesPerRepo,
+        agentRegistry: host.executionAgentRegistry,
+      });
+      host.executorRegistry.register('worktree', worktree);
+      traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=worktree → worktree (lazy registered)`);
+      return { executor: worktree, resolvedExecution, selectedPoolMemberId };
+    }
+
+    if (effectiveType === 'merge') {
+      const merge = new MergeGateExecutor(host);
+      host.executorRegistry.register?.('merge', merge);
+      traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=merge → merge (lazy registered)`);
+      return { executor: merge, resolvedExecution, selectedPoolMemberId };
+    }
+
+    if (effectiveType === 'ssh') {
+      const remoteTargets = host.getRemoteTargets();
+      const targetId =
+        selectedPoolMemberId
+        ?? (task.config as { poolMemberId?: string }).poolMemberId
+        ?? (task.config.poolId && remoteTargets[task.config.poolId] ? task.config.poolId : undefined);
+      if (!targetId) {
+        throw new Error(`Task ${task.id} has runnerKind=ssh but no poolMemberId`);
+      }
+
+      const target = remoteTargets[targetId];
+      if (!target) {
+        throw new Error(
+          `Task ${task.id} references poolMemberId="${targetId}" but no matching ` +
+          `entry exists in remoteTargets config. Available: [${Object.keys(remoteTargets).join(', ')}]`,
+        );
+      }
+      const directExecution = resolveExecutionForMember(host, task, target.capabilities);
+      if (!directExecution.ok) {
+        throw new Error(
+          `SSH target "${targetId}" cannot run ${executionRequirementLabel(host, task)}: ${directExecution.reason}`,
+        );
+      }
+      resolvedExecution = directExecution.selection;
+
+      const configFingerprint = JSON.stringify({
+        host: target.host,
+        user: target.user,
+        sshKeyPath: target.sshKeyPath,
+        port: target.port,
+        managedWorkspaces: target.managedWorkspaces,
+        remoteInvokerHome: target.remoteInvokerHome,
+        provisionCommand: target.provisionCommand,
+        use_api_key: target.use_api_key === true,
+        secretsFile: target.secretsFile ?? host.dockerConfig.secretsFile,
+        remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
+      });
+      const cacheKey = `${targetId}|${configFingerprint}`;
+
+      const cached = host.sshExecutorCache.get(cacheKey);
+      if (cached) {
+        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (cached)`);
+        return { executor: cached, resolvedExecution, selectedPoolMemberId: targetId };
+      }
+
+      for (const key of host.sshExecutorCache.keys()) {
+        if (key.startsWith(`${targetId}|`)) {
+          host.sshExecutorCache.delete(key);
+        }
+      }
+
+      const ssh = new SshExecutor({
+        host: target.host,
+        user: target.user,
+        sshKeyPath: target.sshKeyPath,
+        port: target.port,
+        agentRegistry: host.executionAgentRegistry,
+        managedWorkspaces: target.managedWorkspaces,
+        provisionCommand: target.provisionCommand,
+        useApiKey: target.use_api_key,
+        secretsFile: target.secretsFile ?? host.dockerConfig.secretsFile,
+        remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
+      });
+      host.executorRegistry.register(`ssh:${targetId}`, ssh);
+      host.sshExecutorCache.set(cacheKey, ssh);
+      traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (lazy registered)`);
+      return { executor: ssh, resolvedExecution, selectedPoolMemberId: targetId };
+    }
+  }
+
+  const executor = host.executorRegistry.getDefault();
+  traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=(default) → ${executor.type}`);
+  return { executor, resolvedExecution, selectedPoolMemberId };
+}
+
+// ── Executor-cache maintenance ───────────────────────────
+
+export async function clearSshExecutorCache(host: TaskRunnerPoolHost): Promise<void> {
+  const destroyPromises = Array.from(host.sshExecutorCache.values()).map(
+    (executor) => executor.destroyAll().catch(() => {}),
+  );
+  await Promise.all(destroyPromises);
+  host.sshExecutorCache.clear();
+}

--- a/packages/execution-engine/src/task-runner-pool.ts
+++ b/packages/execution-engine/src/task-runner-pool.ts
@@ -582,8 +582,9 @@ export function selectExecutor(
         return { executor: cached, resolvedExecution, selectedPoolMemberId: targetId };
       }
 
-      for (const key of host.sshExecutorCache.keys()) {
+      for (const [key, executor] of host.sshExecutorCache.entries()) {
         if (key.startsWith(`${targetId}|`)) {
+          void executor.destroyAll().catch(() => {});
           host.sshExecutorCache.delete(key);
         }
       }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -18,7 +18,6 @@ import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/con
 import type { Executor, ExecutorHandle } from './executor.js';
 import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 import type { MachineCapabilities } from './harness-capabilities.js';
-import { resolveHarnessSelection } from './harness-capabilities.js';
 import { BaseExecutor } from './base-executor.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import { createExecutionBench } from './execution-bench.js';
@@ -27,9 +26,7 @@ import type { ExecutorRegistry } from './registry.js';
 import type { AgentRegistry } from './agent-registry.js';
 import type { MergeGateProvider, MergeGateApprovalStatus } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
-import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
-import { MergeGateExecutor } from './merge-gate-executor.js';
 import { isInvokerManagedPoolBranch } from './plan-base-remote.js';
 import { SshExecutor } from './ssh-executor.js';
 
@@ -68,6 +65,26 @@ import { PRE_START_HEARTBEAT_INTERVAL_MS, nextLeaseExpiry } from './task-runner-
 import { buildWorkRequest } from './task-runner-prepare.js';
 import { dispatchExecutor } from './task-runner-dispatch.js';
 import { wireCompletion } from './task-runner-finalize.js';
+import {
+  poolMemberKey,
+  selectPoolMember,
+  acquirePoolSelectionLease,
+  renewPoolSelectionLease,
+  releasePoolSelectionLease,
+  logExecutorSelected,
+  selectedRemoteTargetId,
+  takeResolvedExecutionSelection,
+  selectExecutor,
+  clearSshExecutorCache,
+} from './task-runner-pool.js';
+import type {
+  ExecutionPoolMember,
+  ExecutionPoolConfig,
+  PoolSelection,
+  RemoteTargetDisplay,
+  ResolvedExecutionSelection,
+  SelectedExecutor,
+} from './task-runner-pool.js';
 
 export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-callbacks.js';
 type ReviewGateState = NonNullable<TaskState['execution']['reviewGate']>;
@@ -85,54 +102,9 @@ export type ActiveExecutionEntry = {
   leaseHolderId?: string;
 };
 
-export type ExecutionPoolMember =
-  | { type: 'ssh'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities }
-  | { type: 'worktree'; id: string; maxConcurrentTasks?: number; capabilities?: MachineCapabilities };
-
-export type ExecutionPoolConfig = {
-  members: ExecutionPoolMember[];
-  selectionStrategy?: 'roundRobin' | 'leastLoaded';
-  maxConcurrentTasksPerMember?: number;
-};
-
-type ResolvedExecutionSelection = {
-  executionAgent: string;
-  executionModel?: string;
-};
-
-
-type SelectedExecutor = {
-  executor: Executor;
-  resolvedExecution: ResolvedExecutionSelection;
-  selectedPoolMemberId?: string;
-};
-export type PoolSelection = {
-  poolId: string;
-  member: ExecutionPoolMember;
-  memberKey: string;
-  selectionStrategy: 'roundRobin' | 'leastLoaded';
-  resolvedExecution?: ResolvedExecutionSelection;
-  leaseResourceKey?: string;
-  leaseHolderId?: string;
-};
 export type FreshBaseCommit = {
   branch: string;
   commit: string;
-};
-
-type RemoteTargetDisplay = {
-  host: string;
-  user: string;
-  sshKeyPath: string;
-  port?: number;
-  managedWorkspaces?: boolean;
-  remoteInvokerHome?: string;
-  provisionCommand?: string;
-  use_api_key?: boolean;
-  secretsFile?: string;
-  remoteHeartbeatIntervalSeconds?: number;
-  maxConcurrentTasks?: number;
-  capabilities?: MachineCapabilities;
 };
 
 export interface ReviewGateCiFailureTrigger {
@@ -247,25 +219,25 @@ export class TaskRunner {
   private static readonly BRANCH_REMOTE_NAME = 'invoker-branches';
   /** @internal */ orchestrator: Orchestrator;
   /** @internal */ persistence: SQLiteAdapter;
-  private executorRegistry: ExecutorRegistry;
+  /** @internal */ executorRegistry: ExecutorRegistry;
   /** @internal */ cwd: string;
-  private maxWorktreesPerRepo: number;
+  /** @internal */ maxWorktreesPerRepo: number;
   /** @internal */ defaultBranch: string | undefined;
   /** @internal */ callbacks: TaskRunnerCallbacks;
   /** @internal */ mergeGateProvider?: MergeGateProvider;
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
   private reviewGateCiFailurePublisher?: ReviewGateCiFailureLifecyclePublisher;
   private reviewGateCiFailureInFlight = new Set<string>();
-  private getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
+  /** @internal */ getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   /** @internal */ getExecutionPools: () => Record<string, ExecutionPoolConfig>;
   private getExecutionDefaults: () => { executionAgent?: string; executionModel?: string };
-  private dockerConfig: { imageName?: string; secretsFile?: string };
-  private executionAgentRegistry?: AgentRegistry;
+  /** @internal */ dockerConfig: { imageName?: string; secretsFile?: string };
+  /** @internal */ executionAgentRegistry?: AgentRegistry;
   /** @internal */ logger: Logger;
-  private readonly runnerInstanceId = randomUUID();
+  /** @internal */ readonly runnerInstanceId = randomUUID();
   /** Cache for SSH executors, keyed by poolMemberId. One instance per target for correct git locking. */
-  private sshExecutorCache = new Map<string, SshExecutor>();
-  private poolRoundRobinCursor = new Map<string, number>();
+  /** @internal */ sshExecutorCache = new Map<string, SshExecutor>();
+  /** @internal */ poolRoundRobinCursor = new Map<string, number>();
   /** @internal */ readonly pendingPoolSelections = new Map<string, PoolSelection>();
   /** @internal */ readonly freshBaseCommits = new Map<string, FreshBaseCommit>();
 
@@ -390,33 +362,6 @@ export class TaskRunner {
     const defaultModel = defaults.executionModel?.trim();
     if (!defaultModel) return undefined;
     return this.resolveExecutionAgent(task) === defaultAgent ? defaultModel : undefined;
-  }
-
-  private executionRequirementLabel(task: Pick<TaskState, 'config'>): string {
-    const executionAgent = this.resolveExecutionAgent(task);
-    const executionModel = this.resolveExecutionModel(task);
-    return executionModel ? `${executionAgent}/${executionModel}` : executionAgent;
-  }
-
-  private resolveExecutionForMember(
-    task: Pick<TaskState, 'config'>,
-    memberCapabilities: MachineCapabilities | undefined,
-  ): { ok: true; selection: ResolvedExecutionSelection } | { ok: false; reason: string } {
-    const resolvedAgent = this.resolveExecutionAgent(task);
-    const requestedModel = this.resolveExecutionModel(task);
-    const result = resolveHarnessSelection(memberCapabilities, {
-      role: 'execution',
-      harness: resolvedAgent,
-      model: requestedModel,
-    });
-    if (!result.ok) return result;
-    return {
-      ok: true,
-      selection: {
-        executionAgent: result.selection.harness,
-        executionModel: result.selection.model,
-      },
-    };
   }
 
   /**
@@ -792,36 +737,7 @@ export class TaskRunner {
   }
 
   /** @internal */ poolMemberKey(member: ExecutionPoolMember): string {
-    return `${member.type}:${member.id}`;
-  }
-
-  private poolMemberLoad(poolId: string, memberKey: string): number {
-    let load = 0;
-    for (const selection of this.pendingPoolSelections.values()) {
-      if (selection.poolId === poolId && selection.memberKey === memberKey) load += 1;
-    }
-    for (const entry of this.activeExecutions.values()) {
-      if (entry.poolId === poolId && entry.poolMemberKey === memberKey) load += 1;
-    }
-    return load;
-  }
-
-  private poolMemberLimit(pool: ExecutionPoolConfig, member: ExecutionPoolMember): number | undefined {
-    return member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
-  }
-
-  private poolMemberHasCapacity(poolId: string, pool: ExecutionPoolConfig, member: ExecutionPoolMember): boolean {
-    const limit = this.poolMemberLimit(pool, member);
-    return limit === undefined || this.poolMemberLoad(poolId, this.poolMemberKey(member)) < limit;
-  }
-  private memberCapabilities(member: ExecutionPoolMember): MachineCapabilities | undefined {
-    if (member.capabilities) return member.capabilities;
-    return member.type === 'ssh' ? this.getRemoteTargets()[member.id]?.capabilities : undefined;
-  }
-
-  private memberCapabilityMismatch(member: ExecutionPoolMember, task: Pick<TaskState, 'config'>): string | undefined {
-    const match = this.resolveExecutionForMember(task, this.memberCapabilities(member));
-    return match.ok ? undefined : match.reason;
+    return poolMemberKey(member);
   }
 
   private selectPoolMember(
@@ -830,161 +746,19 @@ export class TaskRunner {
     pool: ExecutionPoolConfig,
     excludedMemberKeys: Set<string> = new Set(),
   ): ExecutionPoolMember | undefined {
-    if (pool.members.length === 0) return undefined;
-
-    if (pool.selectionStrategy === 'roundRobin') {
-      const cursor = this.poolRoundRobinCursor.get(poolId) ?? 0;
-      for (let offset = 0; offset < pool.members.length; offset += 1) {
-        const index = (cursor + offset) % pool.members.length;
-        const member = pool.members[index];
-        if (excludedMemberKeys.has(this.poolMemberKey(member))) continue;
-        if (this.memberCapabilityMismatch(member, task)) continue;
-        if (!this.poolMemberHasCapacity(poolId, pool, member)) continue;
-        this.poolRoundRobinCursor.set(poolId, (index + 1) % pool.members.length);
-        return member;
-      }
-      return undefined;
-    }
-
-    const scored = pool.members
-      .filter((member) => !excludedMemberKeys.has(this.poolMemberKey(member)))
-      .map((member, index) => {
-        const memberKey = this.poolMemberKey(member);
-        const load = this.poolMemberLoad(poolId, memberKey);
-        const limit = this.poolMemberLimit(pool, member);
-        return {
-          member,
-          index,
-          load,
-          hasCapacity: limit === undefined || load < limit,
-          capabilityMismatch: this.memberCapabilityMismatch(member, task),
-        };
-      });
-    const candidates = scored.filter((entry) => entry.hasCapacity && !entry.capabilityMismatch);
-    candidates.sort((a, b) => a.load - b.load || a.index - b.index);
-    return candidates[0]?.member;
-  }
-
-  private poolCapacitySnapshot(
-    task: Pick<TaskState, 'config'>,
-    poolId: string,
-    pool: ExecutionPoolConfig,
-    excludedMemberKeys: Set<string>,
-  ): Array<{
-    memberId: string;
-    memberType: string;
-    load: number;
-    limit: number | undefined;
-    excluded: boolean;
-    capabilityMismatch?: string;
-  }> {
-    return pool.members.map((member) => {
-      const memberKey = this.poolMemberKey(member);
-      return {
-        memberId: member.id,
-        memberType: member.type,
-        load: this.poolMemberLoad(poolId, memberKey),
-        limit: this.poolMemberLimit(pool, member),
-        excluded: excludedMemberKeys.has(memberKey),
-        capabilityMismatch: this.memberCapabilityMismatch(member, task),
-      };
-    });
-  }
-
-  private poolCapacityError(
-    task: Pick<TaskState, 'id' | 'config'>,
-    poolId: string,
-    pool: ExecutionPoolConfig,
-    excludedMemberKeys: Set<string>,
-  ): Error {
-    const snapshot = this.poolCapacitySnapshot(task, poolId, pool, excludedMemberKeys);
-    const requirementAgent = this.resolveExecutionAgent(task);
-    const requirementModel = this.resolveExecutionModel(task);
-    const requirementLabel = requirementModel ? `${requirementAgent}/${requirementModel}` : requirementAgent;
-    const reasonSuffix = snapshot
-      .map((member) => {
-        const reasons = [
-          member.excluded ? 'excluded' : undefined,
-          member.capabilityMismatch,
-          member.limit !== undefined && member.load >= member.limit ? `capacity ${member.load}/${member.limit}` : undefined,
-        ].filter((reason): reason is string => Boolean(reason));
-        return `${member.memberType}:${member.memberId}${reasons.length > 0 ? ` (${reasons.join(', ')})` : ''}`;
-      })
-      .join('; ');
-    const message = `Execution pool "${poolId}" has no member capacity available for ${requirementLabel}${reasonSuffix ? `: ${reasonSuffix}` : ''}`;
-    const resourceLimit = new ResourceLimitError(message);
-    this.persistence.logEvent?.(task.id, 'task.executor.deferred', {
-      reason: 'execution-pool-capacity',
-      poolId,
-      excludedMemberKeys: [...excludedMemberKeys],
-      requirement: {
-        executionAgent: requirementAgent,
-        executionModel: requirementModel,
-      },
-      members: snapshot,
-    });
-    this.logger.info(`[TaskRunner] deferring task: ${message}`, {
-      poolId,
-      excludedMemberKeys: [...excludedMemberKeys],
-      requirement: {
-        executionAgent: requirementAgent,
-        executionModel: requirementModel,
-      },
-      members: snapshot,
-    });
-    return new Error(message, { cause: resourceLimit });
-  }
-
-  private sshResourceKey(target: RemoteTargetDisplay): string {
-    return `ssh:${target.user}@${target.host}:${target.port ?? 22}`;
-  }
-
-  private leaseHolderId(taskId: string, attemptId: string): string {
-    return `${this.runnerInstanceId}:${process.pid}:${taskId}:${attemptId}`;
+    return selectPoolMember(this, task, poolId, pool, excludedMemberKeys);
   }
 
   /** @internal */ acquirePoolSelectionLease(task: TaskState, attemptId: string, selection: PoolSelection | undefined): boolean {
-    if (!selection || selection.member.type !== 'ssh') return true;
-    const target = this.getRemoteTargets()[selection.member.id];
-    if (!target) return true;
-    const resourceKey = this.sshResourceKey(target);
-    const holderId = this.leaseHolderId(task.id, attemptId);
-    const acquired = this.persistence.claimExecutionResourceLease?.({
-      resourceKey,
-      resourceType: 'ssh',
-      holderId,
-      taskId: task.id,
-      poolId: selection.poolId,
-      poolMemberId: selection.member.id,
-      metadata: {
-        runnerInstanceId: this.runnerInstanceId,
-        pid: process.pid,
-      },
-    }) ?? true;
-    if (!acquired) {
-      this.persistence.logEvent?.(task.id, 'task.executor.deferred', {
-        reason: 'ssh-resource-lease-held',
-        poolId: selection.poolId,
-        poolMemberId: selection.member.id,
-        resourceKey,
-      });
-      return false;
-    }
-    selection.leaseResourceKey = resourceKey;
-    selection.leaseHolderId = holderId;
-    return true;
+    return acquirePoolSelectionLease(this, task, attemptId, selection);
   }
 
   /** @internal */ renewPoolSelectionLease(selection: PoolSelection | undefined): void {
-    if (!selection?.leaseResourceKey || !selection.leaseHolderId) return;
-    this.persistence.renewExecutionResourceLease?.(selection.leaseResourceKey, selection.leaseHolderId);
+    renewPoolSelectionLease(this, selection);
   }
 
   /** @internal */ releasePoolSelectionLease(selection: PoolSelection | undefined): void {
-    if (!selection?.leaseResourceKey || !selection.leaseHolderId) return;
-    this.persistence.releaseExecutionResourceLease?.(selection.leaseResourceKey, selection.leaseHolderId);
-    selection.leaseResourceKey = undefined;
-    selection.leaseHolderId = undefined;
+    releasePoolSelectionLease(this, selection);
   }
 
   /** @internal */ logExecutorSelected(
@@ -994,266 +768,19 @@ export class TaskRunner {
     attemptId: string,
     poolSelection: PoolSelection | undefined,
   ): void {
-    const payload: Record<string, unknown> = {
-      runnerKind: executor.type,
-      reason: this.executorSelectionReason(task, executor, poolSelection),
-      attemptId,
-      workspacePath: handle.workspacePath,
-      branch: handle.branch ?? undefined,
-    };
-
-    if (executor.type === 'ssh') {
-      const targetId = this.selectedRemoteTargetId(task, poolSelection);
-      const target = targetId ? this.getRemoteTargets()[targetId] : undefined;
-      if (targetId) payload.poolMemberId = targetId;
-      if (target) {
-        payload.remoteHost = target.host;
-        payload.remoteUser = target.user;
-        payload.port = target.port;
-      }
-    }
-
-    this.persistence.logEvent?.(task.id, 'task.executor.selected', payload);
-  }
-
-  private executorSelectionReason(
-    task: TaskState,
-    executor: Executor,
-    poolSelection: PoolSelection | undefined,
-  ): Record<string, unknown> {
-    if (executor.type === 'ssh') {
-      if (poolSelection) {
-        return {
-          type: 'poolId',
-          poolId: poolSelection.poolId,
-          selectionStrategy: poolSelection.selectionStrategy,
-          poolMemberId: poolSelection.member.id,
-        };
-      }
-      if ((task.config as { poolMemberId?: string }).poolMemberId) {
-        return { type: 'explicitPoolMemberId' };
-      }
-      if (task.config.poolId) {
-        return { type: 'poolId', poolId: task.config.poolId };
-      }
-    }
-
-    if (executor.type === 'worktree') {
-      if (task.config.runnerKind === 'ssh' && task.config.poolId) {
-        return { type: 'sshPoolFallbackToWorktree', poolId: task.config.poolId };
-      }
-      if (task.config.runnerKind === 'worktree') {
-        return { type: 'configuredWorktree' };
-      }
-      return { type: 'defaultWorktree' };
-    }
-
-    if (executor.type === 'docker') {
-      return { type: 'dockerImage' };
-    }
-
-    return { type: 'configuredRunnerKind', runnerKind: executor.type };
+    logExecutorSelected(this, task, executor, handle, attemptId, poolSelection);
   }
 
   /** @internal */ selectedRemoteTargetId(task: TaskState, poolSelection: PoolSelection | undefined): string | undefined {
-    if (poolSelection?.member.type === 'ssh') return poolSelection.member.id;
-    return (task.config as { poolMemberId?: string }).poolMemberId
-      ?? (task.config.poolId && this.getRemoteTargets()[task.config.poolId] ? task.config.poolId : undefined);
+    return selectedRemoteTargetId(this, task, poolSelection);
   }
 
   takeResolvedExecutionSelection(taskId: string): ResolvedExecutionSelection | undefined {
-    const selection = this.pendingPoolSelections.get(taskId);
-    const resolvedExecution = selection?.resolvedExecution;
-    if (selection) {
-      selection.resolvedExecution = undefined;
-    }
-    return resolvedExecution;
+    return takeResolvedExecutionSelection(this, taskId);
   }
 
   selectExecutor(task: TaskState, excludedPoolMemberKeys: Set<string> = new Set()): SelectedExecutor {
-    let effectiveType = task.config.runnerKind ?? (task.config.isMergeNode ? 'merge' : undefined);
-    let selectedPoolMemberId: string | undefined;
-    const explicitPoolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
-    let resolvedExecution: ResolvedExecutionSelection = {
-      executionAgent: this.resolveExecutionAgent(task),
-      executionModel: this.resolveExecutionModel(task),
-    };
-    this.pendingPoolSelections.delete(task.id);
-
-    if (task.config.poolId && explicitPoolMemberId) {
-      const pool = this.getExecutionPools()[task.config.poolId];
-      const member = pool?.members.find((candidate) => candidate.type === 'ssh' && candidate.id === explicitPoolMemberId);
-      if (pool && member) {
-        const memberExecution = this.resolveExecutionForMember(task, this.memberCapabilities(member));
-        if (!memberExecution.ok) {
-          throw new Error(
-            `Execution pool "${task.config.poolId}" member "${explicitPoolMemberId}" cannot run ` +
-            `${this.executionRequirementLabel(task)}: ${memberExecution.reason}`,
-          );
-        }
-        if (
-          excludedPoolMemberKeys.has(this.poolMemberKey(member))
-          || !this.poolMemberHasCapacity(task.config.poolId, pool, member)
-        ) {
-          throw this.poolCapacityError(task, task.config.poolId, pool, excludedPoolMemberKeys);
-        }
-        effectiveType = member.type;
-        selectedPoolMemberId = member.id;
-        resolvedExecution = memberExecution.selection;
-        this.pendingPoolSelections.set(task.id, {
-          poolId: task.config.poolId,
-          member,
-          memberKey: this.poolMemberKey(member),
-          selectionStrategy: pool.selectionStrategy ?? 'roundRobin',
-          resolvedExecution,
-        });
-      }
-    } else if (task.config.poolId) {
-      const pool = this.getExecutionPools()[task.config.poolId];
-      const member = pool ? this.selectPoolMember(task, task.config.poolId, pool, excludedPoolMemberKeys) : undefined;
-      if (member) {
-        const memberExecution = this.resolveExecutionForMember(task, this.memberCapabilities(member));
-        if (!memberExecution.ok) {
-          throw new Error(
-            `Execution pool "${task.config.poolId}" member "${member.id}" cannot run ` +
-            `${this.executionRequirementLabel(task)}: ${memberExecution.reason}`,
-          );
-        }
-        effectiveType = member.type;
-        selectedPoolMemberId = member.type === 'ssh' ? member.id : undefined;
-        resolvedExecution = memberExecution.selection;
-        this.pendingPoolSelections.set(task.id, {
-          poolId: task.config.poolId,
-          member,
-          memberKey: this.poolMemberKey(member),
-          selectionStrategy: pool.selectionStrategy ?? 'roundRobin',
-          resolvedExecution,
-        });
-      } else if (pool) {
-        throw this.poolCapacityError(task, task.config.poolId, pool, excludedPoolMemberKeys);
-      }
-    }
-    if (
-      effectiveType === 'ssh'
-      && task.config.poolId
-      && !selectedPoolMemberId
-      && !explicitPoolMemberId
-      && !this.getRemoteTargets()[task.config.poolId]
-    ) {
-      effectiveType = 'worktree';
-    }
-
-    if (effectiveType) {
-      const registered = this.executorRegistry.get(effectiveType);
-      if (registered && (effectiveType !== 'merge' || registered.type === 'merge')) {
-        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=${effectiveType} → ${registered.type}`);
-        return { executor: registered, resolvedExecution, selectedPoolMemberId };
-      }
-
-      if (effectiveType === 'docker') {
-        const docker = new DockerExecutor({
-          imageName: task.config.dockerImage || this.dockerConfig.imageName,
-          secretsFile: this.dockerConfig.secretsFile,
-          agentRegistry: this.executionAgentRegistry,
-        });
-        this.executorRegistry.register(`docker:${task.id}`, docker);
-        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=docker → docker (per-task)`);
-        return { executor: docker, resolvedExecution, selectedPoolMemberId };
-      }
-
-      if (effectiveType === 'worktree') {
-        const invokerHome = resolve(homedir(), '.invoker');
-        const worktree = new WorktreeExecutor({
-          worktreeBaseDir: resolve(invokerHome, 'worktrees'),
-          cacheDir: resolve(invokerHome, 'repos'),
-          maxWorktrees: this.maxWorktreesPerRepo,
-          agentRegistry: this.executionAgentRegistry,
-        });
-        this.executorRegistry.register('worktree', worktree);
-        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=worktree → worktree (lazy registered)`);
-        return { executor: worktree, resolvedExecution, selectedPoolMemberId };
-      }
-
-      if (effectiveType === 'merge') {
-        const merge = new MergeGateExecutor(this);
-        this.executorRegistry.register?.('merge', merge);
-        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=merge → merge (lazy registered)`);
-        return { executor: merge, resolvedExecution, selectedPoolMemberId };
-      }
-
-      if (effectiveType === 'ssh') {
-        const remoteTargets = this.getRemoteTargets();
-        const targetId =
-          selectedPoolMemberId
-          ?? (task.config as { poolMemberId?: string }).poolMemberId
-          ?? (task.config.poolId && remoteTargets[task.config.poolId] ? task.config.poolId : undefined);
-        if (!targetId) {
-          throw new Error(`Task ${task.id} has runnerKind=ssh but no poolMemberId`);
-        }
-
-        const target = remoteTargets[targetId];
-        if (!target) {
-          throw new Error(
-            `Task ${task.id} references poolMemberId="${targetId}" but no matching ` +
-            `entry exists in remoteTargets config. Available: [${Object.keys(remoteTargets).join(', ')}]`,
-          );
-        }
-        const directExecution = this.resolveExecutionForMember(task, target.capabilities);
-        if (!directExecution.ok) {
-          throw new Error(
-            `SSH target "${targetId}" cannot run ${this.executionRequirementLabel(task)}: ${directExecution.reason}`,
-          );
-        }
-        resolvedExecution = directExecution.selection;
-
-        const configFingerprint = JSON.stringify({
-          host: target.host,
-          user: target.user,
-          sshKeyPath: target.sshKeyPath,
-          port: target.port,
-          managedWorkspaces: target.managedWorkspaces,
-          remoteInvokerHome: target.remoteInvokerHome,
-          provisionCommand: target.provisionCommand,
-          use_api_key: target.use_api_key === true,
-          secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
-          remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
-        });
-        const cacheKey = `${targetId}|${configFingerprint}`;
-
-        const cached = this.sshExecutorCache.get(cacheKey);
-        if (cached) {
-          traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (cached)`);
-          return { executor: cached, resolvedExecution, selectedPoolMemberId: targetId };
-        }
-
-        for (const key of this.sshExecutorCache.keys()) {
-          if (key.startsWith(`${targetId}|`)) {
-            this.sshExecutorCache.delete(key);
-          }
-        }
-
-        const ssh = new SshExecutor({
-          host: target.host,
-          user: target.user,
-          sshKeyPath: target.sshKeyPath,
-          port: target.port,
-          agentRegistry: this.executionAgentRegistry,
-          managedWorkspaces: target.managedWorkspaces,
-          provisionCommand: target.provisionCommand,
-          useApiKey: target.use_api_key,
-          secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
-          remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
-        });
-        this.executorRegistry.register(`ssh:${targetId}`, ssh);
-        this.sshExecutorCache.set(cacheKey, ssh);
-        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=ssh remoteTarget=${targetId} → ssh (lazy registered)`);
-        return { executor: ssh, resolvedExecution, selectedPoolMemberId: targetId };
-      }
-    }
-
-    const executor = this.executorRegistry.getDefault();
-    traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=(default) → ${executor.type}`);
-    return { executor, resolvedExecution, selectedPoolMemberId };
+    return selectExecutor(this, task, excludedPoolMemberKeys);
   }
 
   /**
@@ -2348,11 +1875,7 @@ export class TaskRunner {
    * Useful for testing or when remote target configs change.
    */
   async clearSshExecutorCache(): Promise<void> {
-    const destroyPromises = Array.from(this.sshExecutorCache.values()).map(
-      executor => executor.destroyAll().catch(() => {})
-    );
-    await Promise.all(destroyPromises);
-    this.sshExecutorCache.clear();
+    return clearSshExecutorCache(this);
   }
 
   /**

--- a/scripts/repro/repro-coderabbit-pr3584-stale-ssh-executor-destroy.sh
+++ b/scripts/repro/repro-coderabbit-pr3584-stale-ssh-executor-destroy.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# CodeRabbit PR #3584: replacing an SSH executor for the same target must destroy
+# the stale instance before dropping it from TaskRunner.sshExecutorCache.
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+TARGET="$REPO_ROOT/packages/execution-engine/src/__tests__/coderabbit-pr3584-stale-ssh-executor-destroy-repro.test.ts"
+LOG_FILE="$(mktemp "${TMPDIR:-/tmp}/invoker-pr3584-stale-ssh.XXXXXX.log")"
+cleanup() {
+  rm -f "$TARGET" "$LOG_FILE"
+}
+trap cleanup EXIT
+
+cat > "$TARGET" <<'TS'
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+import { TaskRunner } from '../task-runner.js';
+import { SshExecutor } from '../ssh-executor.js';
+
+function makeTask(id: string): TaskState {
+  return {
+    id,
+    description: 'SSH stale executor repro',
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { runnerKind: 'ssh', poolMemberId: 'remote-a' },
+    execution: {},
+  } as TaskState;
+}
+
+describe('CodeRabbit PR #3584 stale SSH executor cleanup repro', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('destroys the stale SSH executor when a target fingerprint changes', () => {
+    const destroyAll = vi.spyOn(SshExecutor.prototype, 'destroyAll').mockResolvedValue(undefined);
+    const provider = vi.fn()
+      .mockReturnValueOnce({
+        'remote-a': { host: 'dev.example.com', user: 'deployer', sshKeyPath: '/old/key' },
+      })
+      .mockReturnValueOnce({
+        'remote-a': { host: 'dev.example.com', user: 'deployer', sshKeyPath: '/new/key' },
+      });
+
+    const runner = new TaskRunner({
+      orchestrator: { getTask: () => undefined } as any,
+      persistence: {} as any,
+      executorRegistry: {
+        getDefault: () => ({ type: 'worktree' }),
+        get: () => undefined,
+        getAll: () => [],
+        register: vi.fn(),
+      } as any,
+      cwd: '/tmp',
+      remoteTargetsProvider: provider,
+    });
+
+    const first = runner.selectExecutor(makeTask('first'));
+    runner.selectExecutor(makeTask('second'));
+
+    expect(destroyAll).toHaveBeenCalledTimes(1);
+    expect(destroyAll.mock.contexts[0]).toBe(first.executor);
+  });
+});
+TS
+
+echo "[repro] PR #3584: stale SSH executors must be destroyed when target config changes."
+if pnpm -C "$REPO_ROOT" --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/coderabbit-pr3584-stale-ssh-executor-destroy-repro.test.ts \
+  >"$LOG_FILE" 2>&1; then
+  echo "[repro] PASS: stale SSH executor destroyAll() is called before cache replacement."
+  exit 0
+else
+  status=$?
+  echo "[repro] FAIL: stale SSH executor was evicted without destroyAll(); live SSH processes can leak." >&2
+  cat "$LOG_FILE" >&2
+  exit "$status"
+fi


### PR DESCRIPTION
## Summary

Slice 2 of the execution-engine god-file decomposition. `task-runner.ts` had grown past 2,700 lines and was hard to read in one sitting.

Pool selection, SSH leasing, and executor construction now live in a new file, `task-runner-pool.ts`, behind a `Pick<TaskRunner, ...>` host that the phase modules already use.

`TaskRunner` keeps thin one-line delegates, so every caller sees the same public surface. Behavior is intentionally identical.

The three mutable collections this cluster owns exclusively — round-robin cursor, SSH executor cache, and runner instance id — ride the host as `@internal` fields, exactly as `pendingPoolSelections` already does.

Invoker-on-Invoker dogfood: the workflow finished with `onFinish: pull_request` plus external review. This slice is published on top of slice 1 as a Mergify-managed stack PR through the repo-local make-pr workflow.

## Review Claim

Pool selection, SSH leasing, and executor construction now live in `task-runner-pool.ts` as free functions over a `TaskRunnerPoolHost` `Pick<TaskRunner, ...>` host, with `TaskRunner` delegating; behavior is unchanged.

## Review Lane

refactor

## Review Unit

routing

## Safety Invariant

Pure relocation slice: the bodies are moved verbatim behind one-line `TaskRunner` delegates. `poolRoundRobinCursor`, `sshExecutorCache`, and `runnerInstanceId` are single-cluster-owned (coupling analysis) and are surfaced through `@internal` plus the host `Pick`, exactly as `pendingPoolSelections` already is. SSH capacity and executor caching are pinned by `ssh-pool-member-capacity.test.ts` and the "SSH Executor Caching" describes in `task-runner-fix-publish-and-ssh.test.ts`, so any drift in round-robin ordering, lease TTLs, capacity math, or SSH cache keying fails the suite. The exported pool declarations stay barrel-visible through `index.ts`, and the new file holds no runtime import back to `task-runner.ts`.

## Slice Rationale

One cohesive unit per slice, per the review-compression convention. This is slice 2 of the execution-engine decomposition chain and touches nothing else. Bundling the pool cluster with the slice 1 git plumbing, or the slice 3 review-gate cluster, would put two claims in one diff.

## Non-goals

- No review-gate relocation; that is the next slice (slice 3).
- No dispatch, prepare, or finalize changes.
- No change to round-robin ordering, lease TTLs, capacity math, or SSH cache keying.
- Behavior unchanged: this slice is a pure code relocation behind a stable public surface.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-pool-member-capacity.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts` — the slice's terminal proof task; both pinned suites pass.

</details>

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes.
- Revert command: `git revert <squash-merge-sha>` (or drop this slice branch from the stack before it lands).
- Post-revert steps: None. The public surface is unchanged, so slice 1 and later slices keep compiling.
- Data migration? No.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved task execution routing with smarter pool selection and fallback handling.
  * Added better support for SSH-based execution, including more reliable executor reuse.

* **Bug Fixes**
  * Fixed issues where tasks could be scheduled to unavailable or over-capacity execution targets.
  * Improved handling of SSH execution metadata and cache clearing to avoid stale connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->