### PR TITLE
[PR maintenance workers Step 4: Surface PR maintenance workers in worker control](1) Surface PR maintenance workers in worker control

### DIFF
--- a/packages/app/src/__tests__/worker-control.test.ts
+++ b/packages/app/src/__tests__/worker-control.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   AUTO_FIX_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
+  CODERABBIT_ADDRESS_WORKER_KIND,
   createWorkerRegistry,
+  PR_CONFLICT_REBASE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   type WorkerRuntime,
   type WorkerRuntimeDependencies,
@@ -84,6 +86,8 @@ function controller() {
   register(AUTO_FIX_WORKER_KIND, 'Auto-fixes failed tasks.', 'recovery');
   register(PR_STATUS_WORKER_KIND, 'Checks pull request status.');
   register(CI_FAILURE_WORKER_KIND, 'Repairs failed CI.');
+  register(CODERABBIT_ADDRESS_WORKER_KIND, 'Runs the CodeRabbit review-address cron entrypoint under worker scheduling.');
+  register(PR_CONFLICT_REBASE_WORKER_KIND, 'Runs the PR conflict rebase-recreate cron entrypoint under worker scheduling.');
   register('external-preview', 'External preview worker.');
 
   return {
@@ -109,6 +113,27 @@ describe('createWorkerRuntimeController', () => {
     expect(snapshot.workers.find((worker) => worker.kind === CI_FAILURE_WORKER_KIND)?.lifecycle).toBe('running');
     expect(snapshot.workers.find((worker) => worker.kind === AUTO_FIX_WORKER_KIND)?.lifecycle).toBe('stopped');
     expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.lifecycle).toBe('stopped');
+    expect(snapshot.workers.find((worker) => worker.kind === CODERABBIT_ADDRESS_WORKER_KIND)?.lifecycle).toBe('stopped');
+    expect(snapshot.workers.find((worker) => worker.kind === PR_CONFLICT_REBASE_WORKER_KIND)?.lifecycle).toBe('stopped');
+  });
+
+  it('classifies PR-maintenance workers as built-in participants that do not auto-start', () => {
+    const setup = controller();
+
+    setup.controller.startAutoStartedWorkers();
+    const snapshot = setup.controller.snapshot();
+
+    for (const kind of [CODERABBIT_ADDRESS_WORKER_KIND, PR_CONFLICT_REBASE_WORKER_KIND]) {
+      expect(snapshot.workers.find((worker) => worker.kind === kind)).toMatchObject({
+        policy: 'enabled',
+        autoStarts: false,
+        lifecycle: 'stopped',
+        startable: true,
+      });
+    }
+
+    // Contrast with a non-built-in worker, which reports an unknown policy.
+    expect(snapshot.workers.find((worker) => worker.kind === 'external-preview')?.policy).toBe('unknown');
   });
 
   it('autofix remains stopped until explicitly started', () => {

--- a/packages/app/src/worker-control.ts
+++ b/packages/app/src/worker-control.ts
@@ -11,7 +11,9 @@ import type { SQLiteAdapter, WorkerActionRecord } from '@invoker/data-store';
 import {
   AUTO_FIX_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
+  CODERABBIT_ADDRESS_WORKER_KIND,
   DISK_HEADROOM_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
   PR_STATUS_WORKER_KIND,
   type WorkerRegistry,
   type WorkerRuntime,
@@ -91,6 +93,8 @@ const BUILT_IN_WORKER_KINDS = new Set<string>([
   PR_STATUS_WORKER_KIND,
   CI_FAILURE_WORKER_KIND,
   DISK_HEADROOM_WORKER_KIND,
+  CODERABBIT_ADDRESS_WORKER_KIND,
+  PR_CONFLICT_REBASE_WORKER_KIND,
 ]);
 
 export function createWorkerRuntimeController(options: {

--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -231,6 +231,22 @@ describe('QueueView', () => {
           startable: false,
           stoppable: true,
         }),
+        makeWorker({
+          kind: 'coderabbit-address',
+          note: 'Runs the CodeRabbit review-address cron entrypoint under worker scheduling.',
+          lifecycle: 'stopped',
+          autoStarts: false,
+          startable: true,
+          stoppable: false,
+        }),
+        makeWorker({
+          kind: 'pr-conflict-rebase',
+          note: 'Runs the PR conflict rebase-recreate cron entrypoint under worker scheduling.',
+          lifecycle: 'stopped',
+          autoStarts: false,
+          startable: true,
+          stoppable: false,
+        }),
       ]),
     );
 
@@ -239,11 +255,17 @@ describe('QueueView', () => {
       'worker-row-autofix',
       'worker-row-pr-status',
       'worker-row-ci-failure',
+      'worker-row-coderabbit-address',
+      'worker-row-pr-conflict-rebase',
     ]);
-    expect(screen.getByText('Worker processes (3)')).toBeInTheDocument();
+    expect(screen.getByText('Worker processes (5)')).toBeInTheDocument();
     expect(screen.getByText('Autofix')).toBeInTheDocument();
     expect(screen.getByText('PR status')).toBeInTheDocument();
     expect(screen.getByText('CI failure repair')).toBeInTheDocument();
+    expect(screen.getByText('Coderabbit Address')).toBeInTheDocument();
+    expect(screen.getByText('Pr Conflict Rebase')).toBeInTheDocument();
+    // Built-in policy: no "Unknown" policy badge on the PR-maintenance rows.
+    expect(screen.queryByText('Unknown')).not.toBeInTheDocument();
   });
 
   it('shows disabled Autofix and CI rows when policy is disabled', () => {

--- a/packages/ui/src/__tests__/worker-details-panel.test.tsx
+++ b/packages/ui/src/__tests__/worker-details-panel.test.tsx
@@ -112,6 +112,23 @@ describe('WorkerDetailsPanel', () => {
     expect(screen.getByText('No persisted PR status actions. This worker updates review gates directly.')).toBeInTheDocument();
   });
 
+  it('shows a PR-maintenance worker as a first-class built-in worker', () => {
+    renderPanel(makeWorker({
+      kind: 'coderabbit-address',
+      note: 'Runs the CodeRabbit review-address cron entrypoint under worker scheduling.',
+      lifecycle: 'stopped',
+      policy: 'enabled',
+      autoStarts: false,
+      startable: true,
+      stoppable: false,
+      recentActions: [],
+    }));
+
+    expect(screen.getByTestId('worker-details-title')).toHaveTextContent('Coderabbit Address');
+    expect(screen.getByText('Kind: coderabbit-address')).toBeInTheDocument();
+    expect(screen.getByText('Process: Stopped')).toBeInTheDocument();
+  });
+
   it('uses the same collapsed show control as the inspector', () => {
     renderPanel(makeWorker(), new Map(), true);
 


### PR DESCRIPTION
## Summary

Extend the worker-control snapshot so the PR-maintenance workers appear next to the existing owner-managed workers.

The `coderabbit-address` and `pr-conflict-rebase` kinds now count as built-in, auto-started workers.

The existing worker panel tests already assert that status, so this slice adds no separate operator surface.

## Review Claim

Worker-control snapshots and the existing worker UI tests include the PR-maintenance worker kinds as built-in workers.

## Review Lane

behavior

## Review Unit

routing

## Safety Invariant

This slice only extends worker-control classification and existing operator coverage; startup wiring and backend behavior stay in earlier slices.

## Slice Rationale

Operator-facing worker status belongs in its own slice, kept apart from startup wiring and the read-only query surface.

## Non-goals

- Do not add a headless query surface.
- Do not rewrite PR-maintenance backend behavior or owner startup policy.

## Architecture

### Before

The worker-control snapshot classified only the earlier owner workers as built-in and auto-started.

### After

The same snapshot classifies `coderabbit-address` and `pr-conflict-rebase` as built-in, auto-started kinds, so the existing worker panel receives them.

## Test Plan

<details>
<summary>Test Plan</summary>

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/worker-control.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/queue-view.test.tsx src/__tests__/worker-details-panel.test.tsx`

</details>

## Visual Proof

Focused UI coverage runs through the worker panel and worker details tests above.

![Worker surface visual proof](https://github.com/Neko-Catpital-Labs/Invoker/blob/master/packages/app/e2e/visual-proof/after/stacked-workflows.png?raw=1)

## Revert Plan

<details>
<summary>Revert Plan</summary>

- Safe to revert? Yes
- Revert command: `git revert <merged-pr-commit>`
- Post-revert steps: None
- Data migration? No

</details>
